### PR TITLE
Make error attributes optional/required to conform the spec.

### DIFF
--- a/docs/data/elasticsearch/error.json
+++ b/docs/data/elasticsearch/error.json
@@ -96,7 +96,7 @@
         }
     },
     "error": {
-        "checksum": "c7e028d3a68b04d07cfc04aa5a8260af",
+        "checksum": "4cfd552c0f4a291894c3558466f92151",
         "culprit": "my.module.function_name",
         "exception": {
             "attributes": {

--- a/processor/error/integration_tests/TestProcessErrorFull.approved.json
+++ b/processor/error/integration_tests/TestProcessErrorFull.approved.json
@@ -98,7 +98,7 @@
                 }
             },
             "error": {
-                "checksum": "c7e028d3a68b04d07cfc04aa5a8260af",
+                "checksum": "4cfd552c0f4a291894c3558466f92151",
                 "culprit": "my.module.function_name",
                 "exception": {
                     "attributes": {

--- a/processor/error/payload_test.go
+++ b/processor/error/payload_test.go
@@ -13,7 +13,6 @@ import (
 func TestPayloadTransform(t *testing.T) {
 	app := m.App{Name: "myapp"}
 	ts := "2017-05-09T15:04:05.999999Z"
-	msg := ""
 
 	tests := []struct {
 		Payload Payload
@@ -50,8 +49,8 @@ func TestPayloadTransform(t *testing.T) {
 				Events: []Event{{
 					Timestamp: ts,
 					Context:   common.MapStr{"foo": "bar", "user": common.MapStr{"email": "m@m.com"}},
-					Exception: Exception{Message: &msg},
-					Log:       Log{Message: &msg},
+					Exception: baseException(),
+					Log:       baseLog(),
 				}},
 			},
 			Output: []common.MapStr{
@@ -67,8 +66,8 @@ func TestPayloadTransform(t *testing.T) {
 					},
 					"error": common.MapStr{
 						"checksum":  "d41d8cd98f00b204e9800998ecf8427e",
-						"exception": common.MapStr{"message": ""},
-						"log":       common.MapStr{"message": ""},
+						"exception": common.MapStr{"message": "exception message"},
+						"log":       common.MapStr{"message": "error log message"},
 					},
 					"processor": common.MapStr{"event": "error", "name": "error"},
 				},


### PR DESCRIPTION
Previous implementation was correct, but based on assumptions that might be broken in the future.
Checksums change as a result of an (irrelevant) order swap.