### PR TITLE
Improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is the Apm-Server.
 
 ```
 cd ${GOPATH}/src/github.com/elastic/
-git clone https://github.com/[USER]/apm-server
+git clone git@github.com:[USER]/apm-server.git
 ```
 Note that it should be cloned from the fork (replace [USER] with your Github user), not from origin.
 


### PR DESCRIPTION
The old git clone URL used http instead of ssh for accessing GitHub, which for most people would prompt for the GitHub username and password instead of using the local ssh keys in the key chain