### PR TITLE
Add dedicated "cookies" object to request with parsed cookies

### DIFF
--- a/docs/data/elasticsearch/error.json
+++ b/docs/data/elasticsearch/error.json
@@ -40,6 +40,10 @@
         },
         "request": {
             "body": "Hello World",
+            "cookies": {
+                "c1": "v1",
+                "c2": "v2"
+            },
             "env": {
                 "GATEWAY_INTERFACE": "CGI/1.1",
                 "SERVER_SOFTWARE": "nginx"
@@ -51,7 +55,7 @@
                     "baz"
                 ],
                 "content-type": "text/html",
-                "cookies": "c1=v1;c2=v2",
+                "cookie": "c1=v1; c2=v2",
                 "some-other-header": "foo",
                 "user-agent": "Mozilla Chrome Edge"
             },

--- a/docs/data/elasticsearch/transaction.json
+++ b/docs/data/elasticsearch/transaction.json
@@ -40,6 +40,10 @@
         },
         "request": {
             "body": "Hello World",
+            "cookies": {
+                "c1": "v1",
+                "c2": "v2"
+            },
             "env": {
                 "GATEWAY_INTERFACE": "CGI/1.1",
                 "SERVER_SOFTWARE": "nginx"
@@ -51,7 +55,7 @@
                     "baz"
                 ],
                 "content-type": "text/html",
-                "cookies": "c1=v1;c2=v2",
+                "cookie": "c1=v1; c2=v2",
                 "some-other-header": "foo",
                 "user-agent": "Mozilla Chrome Edge"
             },

--- a/docs/data/intake-api/generated/error/payload.json
+++ b/docs/data/intake-api/generated/error/payload.json
@@ -175,13 +175,17 @@
                     "headers": {
                         "user-agent": "Mozilla Chrome Edge",
                         "content-type": "text/html",
-                        "cookies": "c1=v1;c2=v2",
+                        "cookie": "c1=v1; c2=v2",
                         "some-other-header": "foo",
                         "array": [
                             "foo",
                             "bar",
                             "baz"
                         ]
+                    },
+                    "cookies": {
+                        "c1": "v1",
+                        "c2": "v2"
                     },
                     "env": {
                         "SERVER_SOFTWARE": "nginx",

--- a/docs/data/intake-api/generated/transaction/payload.json
+++ b/docs/data/intake-api/generated/transaction/payload.json
@@ -58,13 +58,17 @@
                     "headers": {
                         "user-agent": "Mozilla Chrome Edge",
                         "content-type": "text/html",
-                        "cookies": "c1=v1;c2=v2",
+                        "cookie": "c1=v1; c2=v2",
                         "some-other-header": "foo",
                         "array": [
                             "foo",
                             "bar",
                             "baz"
                         ]
+                    },
+                    "cookies": {
+                        "c1": "v1",
+                        "c2": "v2"
                     },
                     "env": {
                         "SERVER_SOFTWARE": "nginx",

--- a/docs/spec/request.json
+++ b/docs/spec/request.json
@@ -21,7 +21,7 @@
               "content-type": {
                   "type": ["string", "null"]
               },
-              "cookies": {
+              "cookie": {
                   "description": "Cookies sent with the request. It is expected to have values delimited by semicolons.",
                   "type": ["string", "null"]
               },
@@ -73,6 +73,10 @@
                     "type": ["string", "null"]
                 }
             }
+        },
+        "cookies": {
+            "description": "A parsed key-value object of cookies",
+            "type": ["object", "null"]
         }
     },
     "required": ["url", "method"]

--- a/processor/error/integration_tests/TestProcessErrorFull.approved.json
+++ b/processor/error/integration_tests/TestProcessErrorFull.approved.json
@@ -42,6 +42,10 @@
                 },
                 "request": {
                     "body": "Hello World",
+                    "cookies": {
+                        "c1": "v1",
+                        "c2": "v2"
+                    },
                     "env": {
                         "GATEWAY_INTERFACE": "CGI/1.1",
                         "SERVER_SOFTWARE": "nginx"
@@ -53,7 +57,7 @@
                             "baz"
                         ],
                         "content-type": "text/html",
-                        "cookies": "c1=v1;c2=v2",
+                        "cookie": "c1=v1; c2=v2",
                         "some-other-header": "foo",
                         "user-agent": "Mozilla Chrome Edge"
                     },

--- a/processor/error/integration_tests/schema_payload_validation_test.go
+++ b/processor/error/integration_tests/schema_payload_validation_test.go
@@ -36,6 +36,8 @@ func TestPayloadAttributesInSchema(t *testing.T) {
 		"errors.context.request.headers.array",
 		"errors.context.request.env.SERVER_SOFTWARE",
 		"errors.context.request.env.GATEWAY_INTERFACE",
+		"errors.context.request.cookies.c1",
+		"errors.context.request.cookies.c2",
 		"errors.context.tags.organization_uuid",
 	}
 	jsonKeysDoc, _ := tests.ArrayDiff(jsonKeys, undocumented)

--- a/processor/error/schema.go
+++ b/processor/error/schema.go
@@ -164,7 +164,7 @@ var errorSchema = `{
               "content-type": {
                   "type": ["string", "null"]
               },
-              "cookies": {
+              "cookie": {
                   "description": "Cookies sent with the request. It is expected to have values delimited by semicolons.",
                   "type": ["string", "null"]
               },
@@ -216,6 +216,10 @@ var errorSchema = `{
                     "type": ["string", "null"]
                 }
             }
+        },
+        "cookies": {
+            "description": "A parsed key-value object of cookies",
+            "type": ["object", "null"]
         }
     },
     "required": ["url", "method"]

--- a/processor/transaction/integration_tests/TestProcessTransactionFull.approved.json
+++ b/processor/transaction/integration_tests/TestProcessTransactionFull.approved.json
@@ -42,6 +42,10 @@
                 },
                 "request": {
                     "body": "Hello World",
+                    "cookies": {
+                        "c1": "v1",
+                        "c2": "v2"
+                    },
                     "env": {
                         "GATEWAY_INTERFACE": "CGI/1.1",
                         "SERVER_SOFTWARE": "nginx"
@@ -53,7 +57,7 @@
                             "baz"
                         ],
                         "content-type": "text/html",
-                        "cookies": "c1=v1;c2=v2",
+                        "cookie": "c1=v1; c2=v2",
                         "some-other-header": "foo",
                         "user-agent": "Mozilla Chrome Edge"
                     },

--- a/processor/transaction/integration_tests/schema_payload_validation_test.go
+++ b/processor/transaction/integration_tests/schema_payload_validation_test.go
@@ -31,6 +31,8 @@ func TestPayloadAttributesInSchema(t *testing.T) {
 		"transactions.context.request.env.SERVER_SOFTWARE",
 		"transactions.context.request.env.GATEWAY_INTERFACE",
 		"transactions.context.request.body",
+		"transactions.context.request.cookies.c1",
+		"transactions.context.request.cookies.c2",
 		"transactions.context.custom",
 		"transactions.context.custom.my_key",
 		"transactions.context.custom.some_other_value",

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -184,7 +184,7 @@ var transactionSchema = `{
               "content-type": {
                   "type": ["string", "null"]
               },
-              "cookies": {
+              "cookie": {
                   "description": "Cookies sent with the request. It is expected to have values delimited by semicolons.",
                   "type": ["string", "null"]
               },
@@ -236,6 +236,10 @@ var transactionSchema = `{
                     "type": ["string", "null"]
                 }
             }
+        },
+        "cookies": {
+            "description": "A parsed key-value object of cookies",
+            "type": ["object", "null"]
         }
     },
     "required": ["url", "method"]

--- a/tests/data/valid/error/payload.json
+++ b/tests/data/valid/error/payload.json
@@ -175,13 +175,17 @@
                     "headers": {
                         "user-agent": "Mozilla Chrome Edge",
                         "content-type": "text/html",
-                        "cookies": "c1=v1;c2=v2",
+                        "cookie": "c1=v1; c2=v2",
                         "some-other-header": "foo",
                         "array": [
                             "foo",
                             "bar",
                             "baz"
                         ]
+                    },
+                    "cookies": {
+                        "c1": "v1",
+                        "c2": "v2"
                     },
                     "env": {
                         "SERVER_SOFTWARE": "nginx",

--- a/tests/data/valid/transaction/payload.json
+++ b/tests/data/valid/transaction/payload.json
@@ -58,13 +58,17 @@
                     "headers": {
                         "user-agent": "Mozilla Chrome Edge",
                         "content-type": "text/html",
-                        "cookies": "c1=v1;c2=v2",
+                        "cookie": "c1=v1; c2=v2",
                         "some-other-header": "foo",
                         "array": [
                             "foo",
                             "bar",
                             "baz"
                         ]
+                    },
+                    "cookies": {
+                        "c1": "v1",
+                        "c2": "v2"
                     },
                     "env": {
                         "SERVER_SOFTWARE": "nginx",


### PR DESCRIPTION
This allows agents to supply parsed cookies, in addition or
instead of the "cookie" header. If a request has cookies, it should
always supply it as parsed object. The original `cookie` header is
optional.

The rationale behind this is that some frameworks (e.g. Django)
remove the cookie header, so it's not accessible by our agent.