### PR TITLE
Add support to checkout out specific version of beats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,15 @@ TEST_ENVIRONMENT=true
 ES_BEATS?=./_beats
 PREFIX?=.
 NOTICE_FILE=NOTICE
+BEATS_VERSION?=master
 
 # Path to the libbeat Makefile
 -include $(ES_BEATS)/libbeat/scripts/Makefile
 
 # updates beats updates the framework part and go parts of beats
 update-beats:
-	govendor fetch github.com/elastic/beats/...
-	sh _beats/update.sh
+	govendor fetch github.com/elastic/beats/...@$(BEATS_VERSION)
+	BEATS_VERSION=$(BEATS_VERSION) sh _beats/update.sh
 	$(MAKE) update
 
 # This is called by the beats packer before building starts

--- a/README.md
+++ b/README.md
@@ -111,9 +111,15 @@ Govendor will automatically pick the files needed.
 
 ### Framework Update
 
-To update the beats framework run `make update-framework`. This will fetch the most recent version of beats from master and copy
+To update the beats framework run `make update-beats`. This will fetch the most recent version of beats from master and copy
 the files which are needed for the framework part to the `_beats` directory. These are files like libbeat config files and
 scripts which are used for testing or packaging.
+
+To update the dependency to a specific commit or branch run command as following:
+
+```
+BEATS_VERSION=f240148065af94d55c5149e444482b9635801f27 make update-beats
+```
 
 ## Test environment
 

--- a/_beats/update.sh
+++ b/_beats/update.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+BEATS_VERSION?=master
 # Move to directory
 BASEDIR=$(dirname "$0")
 cd $BASEDIR
@@ -10,6 +11,10 @@ rm -rf dev-tools script libbeat testing repo
 # Check out master repo for updating
 GIT_CLONE=./repo
 git clone https://github.com/elastic/beats.git $GIT_CLONE
+
+cd $GIT_CLONE
+git checkout $BEATS_VERSION
+cd ..
 
 # TODO: allow to check out specific branch / tag
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -549,6 +549,18 @@
 			"revisionTime": "2017-07-28T07:19:26Z"
 		},
 		{
+			"checksumSHA1": "fn+kbDtM+S2J80sBO8l+BvJbvN4=",
+			"path": "github.com/elastic/beats/libbeat/publisher/queue",
+			"revision": "23d9fe69e8a4367fc31915553596129a2ca8267b",
+			"revisionTime": "2017-08-03T08:00:47Z"
+		},
+		{
+			"checksumSHA1": "Nvy4Zq0CDl9sJjTgsxDJg0MUTXM=",
+			"path": "github.com/elastic/beats/libbeat/publisher/queue/memqueue",
+			"revision": "23d9fe69e8a4367fc31915553596129a2ca8267b",
+			"revisionTime": "2017-08-03T08:00:47Z"
+		},
+		{
 			"checksumSHA1": "kT9MLdbYAKYJ0lWfjqX8fbrZTiY=",
 			"path": "github.com/elastic/beats/libbeat/service",
 			"revision": "f240148065af94d55c5149e444482b9635801f27",
@@ -557,8 +569,8 @@
 		{
 			"checksumSHA1": "Vk8ZhOtmPC8B2hzBayRKSeq8HTM=",
 			"path": "github.com/elastic/beats/libbeat/setup/kibana",
-			"revision": "f240148065af94d55c5149e444482b9635801f27",
-			"revisionTime": "2017-07-28T07:19:26Z"
+			"revision": "23d9fe69e8a4367fc31915553596129a2ca8267b",
+			"revisionTime": "2017-08-03T08:00:47Z"
 		},
 		{
 			"checksumSHA1": "/x+/ly2ewMYm13s+ziFKg+ahSyk=",
@@ -569,8 +581,8 @@
 		{
 			"checksumSHA1": "7PJnZYfyxNG+Qz2Sx/G/sdJfujQ=",
 			"path": "github.com/elastic/beats/libbeat/testing",
-			"revision": "f240148065af94d55c5149e444482b9635801f27",
-			"revisionTime": "2017-07-28T07:19:26Z"
+			"revision": "23d9fe69e8a4367fc31915553596129a2ca8267b",
+			"revisionTime": "2017-08-03T08:00:47Z"
 		},
 		{
 			"checksumSHA1": "HviBA/yN/8aYDJSnP7lk004sbM0=",


### PR DESCRIPTION
This allows to update the beats framework dependencies to a specific version instead of just master. This is required as soon as we start doing release tags and release branches to fix the dependency to a given version.

In case we create a `6.x` branch, the Makefile must be updated with `BEATS_VERSION?=6.x` to make sure this branch is also tied to this version of beats.

To update the dependency to a specific commit or branch run command as following:

```
BEATS_VERSION=f240148065af94d55c5149e444482b9635801f27 make update-beats
```

This will update the framework part and the go dependencies to version to the git hash `f240148065af94d55c5149e444482b9635801f27`.

An additional benefit of this change is that in case the `_beats/update.sh` script is changed, it is not required to update to master at the same time and only add the files which are newly updated / modified.