### PR TITLE
Add scripts for jenkins builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ stop-env:
 check-full: check
 	@# Validate that all updates were committed
 	@$(MAKE) update
+	@$(MAKE) check
 	@git diff | cat
 	@git update-index --refresh
 	@git diff-index --exit-code HEAD --

--- a/processor/error/event.go
+++ b/processor/error/event.go
@@ -50,13 +50,13 @@ func (e *Event) DocType() string {
 func (e *Event) Mappings(pa *Payload) (string, []m.SMapping, []m.FMapping) {
 	return e.Timestamp,
 		[]m.SMapping{
-			{"processor.name", processorName},
-			{"processor.event", e.DocType()},
+			{Key: "processor.name", Value: processorName},
+			{Key: "processor.event", Value: e.DocType()},
 		}, []m.FMapping{
-			{e.DocType(), e.Transform},
-			{"context", func() common.MapStr { return e.Context }},
-			{"context.app", pa.App.Transform},
-			{"context.system", pa.System.Transform},
+			{Key: e.DocType(), Apply: e.Transform},
+			{Key: "context", Apply: func() common.MapStr { return e.Context }},
+			{Key: "context.app", Apply: pa.App.Transform},
+			{Key: "context.system", Apply: pa.System.Transform},
 		}
 }
 

--- a/processor/transaction/event.go
+++ b/processor/transaction/event.go
@@ -34,12 +34,12 @@ func (t *Event) Transform() common.MapStr {
 func (t *Event) Mappings(pa *Payload) (string, []m.SMapping, []m.FMapping) {
 	return t.Timestamp,
 		[]m.SMapping{
-			{"processor.name", processorName},
-			{"processor.event", t.DocType()},
+			{Key: "processor.name", Value: processorName},
+			{Key: "processor.event", Value: t.DocType()},
 		}, []m.FMapping{
-			{t.DocType(), t.Transform},
-			{"context", func() common.MapStr { return t.Context }},
-			{"context.app", pa.App.Transform},
-			{"context.system", pa.System.Transform},
+			{Key: t.DocType(), Apply: t.Transform},
+			{Key: "context", Apply: func() common.MapStr { return t.Context }},
+			{Key: "context.app", Apply: pa.App.Transform},
+			{Key: "context.system", Apply: pa.System.Transform},
 		}
 }

--- a/processor/transaction/trace.go
+++ b/processor/transaction/trace.go
@@ -42,12 +42,12 @@ func (t *Trace) Transform(transactionId string) common.MapStr {
 
 func (t *Trace) Mappings(pa *Payload, tx Event) (string, []m.SMapping, []m.FMapping) {
 	return tx.Timestamp, []m.SMapping{
-			{"processor.name", processorName},
-			{"processor.event", t.DocType()},
+			{Key: "processor.name", Value: processorName},
+			{Key: "processor.event", Value: t.DocType()},
 		}, []m.FMapping{
-			{t.DocType(), func() common.MapStr { return t.Transform(tx.Id) }},
-			{"context", func() common.MapStr { return t.Context }},
-			{"context.app", pa.App.MinimalTransform},
+			{Key: t.DocType(), Apply: func() common.MapStr { return t.Transform(tx.Id) }},
+			{Key: "context", Apply: func() common.MapStr { return t.Context }},
+			{Key: "context.app", Apply: pa.App.MinimalTransform},
 		}
 }
 

--- a/script/jenkins/ci.ps1
+++ b/script/jenkins/ci.ps1
@@ -1,0 +1,48 @@
+function Exec
+{
+    param(
+        [Parameter(Position=0,Mandatory=1)][scriptblock]$cmd,
+        [Parameter(Position=1,Mandatory=0)][string]$errorMessage = ($msgs.error_bad_command -f $cmd)
+    )
+
+    & $cmd
+    if ($LastExitCode -ne 0) {
+        Write-Error $errorMessage
+        exit $LastExitCode
+    }
+}
+
+# Setup Go.
+$env:GOPATH = $env:WORKSPACE
+$env:PATH = "$env:GOPATH\bin;C:\tools\mingw64\bin;$env:PATH"
+if (Test-Path -PathType leaf .go-version) {
+    & gvm --format=powershell $(Get-Content .go-version) | Invoke-Expression
+} else {
+    & gvm --format=powershell 1.8.3 | Invoke-Expression
+}
+
+if (Test-Path "build") { Remove-Item -Recurse -Force build }
+New-Item -ItemType directory -Path build\coverage | Out-Null
+New-Item -ItemType directory -Path build\system-tests | Out-Null
+New-Item -ItemType directory -Path build\system-tests\run | Out-Null
+
+exec { go get -u github.com/jstemmer/go-junit-report }
+
+echo "Building $env:beat"
+exec { go build } "Build FAILURE"
+
+
+cp .\_meta\fields.common.yml .\_meta\fields.generated.yml
+cat processors\*\_meta\fields.yml | Out-File -append -encoding UTF8 -filepath .\_meta\fields.generated.yml
+cp .\_meta\fields.generated.yml .\fields.yml
+
+
+
+echo "Unit testing $env:beat"
+go test -v $(go list ./... | select-string -Pattern "vendor" -NotMatch) 2>&1 | Out-File -encoding UTF8 build/TEST-go-unit.out
+exec { Get-Content build/TEST-go-unit.out | go-junit-report.exe -set-exit-code | Out-File -encoding UTF8 build/TEST-go-unit.xml } "Unit test FAILURE"
+
+echo "System testing $env:beat"
+exec { go test -race -c -cover -covermode=atomic -coverpkg ./... }
+exec { cd tests/system }
+exec { nosetests --with-timer --with-xunit --xunit-file=../../build/TEST-system.xml } "System test FAILURE"

--- a/script/jenkins/ci.sh
+++ b/script/jenkins/ci.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+: "${HOME:?Need to set HOME to a non-empty value.}"
+: "${WORKSPACE:?Need to set WORKSPACE to a non-empty value.}"
+
+# Setup Go.
+export GOPATH=${WORKSPACE}
+export PATH=${GOPATH}/bin:${PATH}
+if [ -f ".go-version" ]; then
+  eval "$(gvm $(cat .go-version))"
+else
+  eval "$(gvm 1.8.3)"
+fi
+
+# Workaround for Python virtualenv path being too long.
+TEMP_PYTHON_ENV=$(mktemp -d)
+export PYTHON_ENV="${TEMP_PYTHON_ENV}/python-env"
+
+cleanup() {
+  rm -rf $TEMP_PYTHON_ENV
+  make stop-environment fix-permissions
+}
+trap cleanup EXIT
+
+RACE_DETECTOR=1 make clean check testsuite

--- a/script/jenkins/intake.sh
+++ b/script/jenkins/intake.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+: "${HOME:?Need to set HOME to a non-empty value.}"
+: "${WORKSPACE:?Need to set WORKSPACE to a non-empty value.}"
+
+# Setup Go.
+export GOPATH=${WORKSPACE}
+export PATH=${GOPATH}/bin:${PATH}
+if [ -f ".go-version" ]; then
+  eval "$(gvm $(cat .go-version))"
+else
+  eval "$(gvm 1.8.3)"
+fi
+
+# Workaround for Python virtualenv path being too long.
+TEMP_PYTHON_ENV=$(mktemp -d)
+export PYTHON_ENV="${TEMP_PYTHON_ENV}/python-env"
+
+cleanup() {
+  rm -rf $TEMP_PYTHON_ENV
+}
+trap cleanup EXIT
+
+make check-full


### PR DESCRIPTION
These scripts are required for the jenkins build. The advantage of having these script in the repository instead of Jenkins itself is that over time in case the script changes for newer release, Jenkins still works for the older builds as each version contains the working script.

For each PR and merged commits, Jenkins is running a full build on Linux and Windows.

To make the Jenkins builds pass am additional change was needed:

* Accidentially `check-full` didn't run `check` so some code check issues slipped through. Since Golang (1.8?) it is encourage to always define the keys in mapping. Missing keys were added.