### PR TITLE
Add Experimental to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Apm-Server
+# Apm-Server (Experimental)
 
-This is the Apm-Server.
+The Apm-Server receives data from the elastic apm-agents and stores the data into Elasticsearch.
+
+By default the Apm-Server listens on `localhost` for incoming events. For further options check the configuration file.
 
 ## Getting Started with Apm-Server
 


### PR DESCRIPTION
Having Experimental here makes it clear that the apm-server is not meant for production and currently not supported. We have the same header for Hearbeat here: https://github.com/elastic/beats/tree/master/heartbeat

I also added a quick description on what the apm-server is for.