### PR TITLE
Make timestamp and app.agent optional

### DIFF
--- a/docs/spec/app.json
+++ b/docs/spec/app.json
@@ -87,5 +87,5 @@
             "maxLength": 1024
         }
     },
-    "required": ["agent", "name"]
+    "required": ["name"]
 }

--- a/docs/spec/errors/error.json
+++ b/docs/spec/errors/error.json
@@ -101,7 +101,6 @@
             "pattern": "^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})(\\.\\d{1,6})?Z"
         }
     },
-    "required": ["timestamp"],
     "anyOf": [
       { "required": ["exception"] },
       { "required": ["log"] }

--- a/docs/spec/transactions/transaction.json
+++ b/docs/spec/transactions/transaction.json
@@ -44,5 +44,5 @@
             "maxLength": 1024
         }
     },
-    "required": ["id", "name", "duration", "type", "timestamp"]
+    "required": ["id", "name", "duration", "type"]
 }

--- a/processor/error/integration_tests/processor_test.go
+++ b/processor/error/integration_tests/processor_test.go
@@ -37,7 +37,6 @@ func TestProcessorFailedValidation(t *testing.T) {
 		{"no_exception_message.json", "missing properties: \"message\""},
 		{"no_log_or_exception.json", "missing properties: \"exception\""},
 		{"no_log_or_exception.json", "missing properties: \"log\""},
-		{"no_timestamp.json", "missing properties: \"timestamp\""},
 		{"no_app.json", "missing properties: \"app\""},
 		{"no_http_url.json", "missing properties: \"url\""},
 		{"no_http_method.json", "missing properties: \"method\""},

--- a/processor/error/schema.go
+++ b/processor/error/schema.go
@@ -100,7 +100,7 @@ var errorSchema = `{
             "maxLength": 1024
         }
     },
-    "required": ["agent", "name"]
+    "required": ["name"]
         },
         "errors": {
             "type": "array",
@@ -473,7 +473,6 @@ var errorSchema = `{
             "pattern": "^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})(\\.\\d{1,6})?Z"
         }
     },
-    "required": ["timestamp"],
     "anyOf": [
       { "required": ["exception"] },
       { "required": ["log"] }

--- a/processor/transaction/integration_tests/processor_test.go
+++ b/processor/transaction/integration_tests/processor_test.go
@@ -38,7 +38,6 @@ func TestTransactionProcessorValidationFailed(t *testing.T) {
 		{"app/runtime_no_name.json", "missing properties: \"name\""},
 		{"app/runtime_no_version.json", "missing properties: \"version\""},
 		{"app/no_name.json", "missing properties: \"name\""},
-		{"app/no_agent.json", "missing properties: \"agent\""},
 		{"no_app.json", "missing properties: \"app\""},
 		{"empty_payload.json", "minimum 1 items allowed"},
 		{"invalid_id.json", "[#/properties/transactions/items/properties/id/pattern] does not match pattern"},
@@ -52,7 +51,7 @@ func TestTransactionProcessorValidationFailed(t *testing.T) {
 		assert.Nil(t, err)
 		p := transaction.NewProcessor()
 		err = p.Validate(bytes.NewReader(data))
-		assert.NotNil(t, err)
+		assert.NotNil(t, err, fmt.Sprintf("file %v passed, but should have failed", dataRow[0]))
 		assert.True(t, strings.Contains(err.Error(), dataRow[1]), fmt.Sprintf("'%v' not found in '%v'", dataRow[1], err.Error()))
 	}
 }

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -100,7 +100,7 @@ var transactionSchema = `{
             "maxLength": 1024
         }
     },
-    "required": ["agent", "name"]
+    "required": ["name"]
         },
         "system": {
                 "$schema": "http://json-schema.org/draft-04/schema#",
@@ -437,7 +437,7 @@ var transactionSchema = `{
             "maxLength": 1024
         }
     },
-    "required": ["id", "name", "duration", "type", "timestamp"]
+    "required": ["id", "name", "duration", "type"]
             },
             "minItems": 1
         }


### PR DESCRIPTION
This is a proposal to make timestamp and app.agent optional.

Timestamp will eventually become optional anyway because unfortunately we cannot trust people's browser to have their clock set correctly.

Agent data is "nice to have", but hardly required.
In total, this takes the simplest payload from:

    {"app": {"name": "app1", "agent": {"name": "test", "version": "1.0"}}, "errors": [{"timestamp": "2017-01-01T10:00:00Z", "exception": {"message": "hello"}}]}

to just:

    {"app": {"name": "app1"}, "errors": [{"exception": {"message": "hello"}}]}

when using CURL in testing or in our documentation.