### PR TITLE
Add missing test for additional attr length restriction.

### DIFF
--- a/tests/fields.go
+++ b/tests/fields.go
@@ -153,7 +153,7 @@ func addOnlyDisabledFields(f template.Field) bool {
 }
 
 func addKeywordFields(f template.Field) bool {
-	if f.Type == "keyword" {
+	if f.Type == "keyword" || f.ObjectType == "keyword" {
 		return true
 	} else if len(f.MultiFields) > 0 {
 		for _, mf := range f.MultiFields {

--- a/tests/json_schema.go
+++ b/tests/json_schema.go
@@ -12,10 +12,11 @@ import (
 )
 
 type Schema struct {
-	Title      string
-	Properties map[string]*Schema
-	Items      *Schema
-	MaxLength  int
+	Title                string
+	Properties           map[string]*Schema
+	AdditionalProperties map[string]interface{}
+	Items                *Schema
+	MaxLength            int
 }
 type Mapping struct {
 	from string
@@ -124,6 +125,11 @@ func addAllPropNames(s *Schema) bool { return true }
 func addLengthRestrictedPropNames(s *Schema) bool {
 	if s.MaxLength == 1024 {
 		return true
+	} else if val, ok := s.AdditionalProperties["maxLength"]; ok {
+		if valF, okF := val.(float64); okF && valF == 1024 {
+			return true
+
+		}
 	}
 	return false
 }


### PR DESCRIPTION
Add a check that also ensures keyword length restrictions on additional
attributes in the json schema.