### PR TITLE
Fix naming and desc of stacktrace json schema.

### DIFF
--- a/docs/spec/errors/error.json
+++ b/docs/spec/errors/error.json
@@ -34,7 +34,7 @@
                 "stacktrace": {
                     "type": ["array","null"],
                     "items": {
-                        "$ref": "./../stacktrace.json"
+                        "$ref": "./../stacktrace_frame.json"
                     },
                     "minItems": 0
                 },
@@ -88,7 +88,7 @@
                 "stacktrace": {
                     "type": ["array","null"],
                     "items": {
-                        "$ref": "./../stacktrace.json"
+                        "$ref": "./../stacktrace_frame.json"
                     },
                     "minItems": 0
                 }

--- a/docs/spec/stacktrace_frame.json
+++ b/docs/spec/stacktrace_frame.json
@@ -3,7 +3,7 @@
     "$id": "docs/spec/stacktrace.json",
     "title": "Stacktrace",
     "type": "object",
-    "description": "A stacktrace contains a list of stack frames, each with various bits (most optional) describing the context of that frame",
+    "description": "A stacktrace frame, contains various bits (most optional) describing the context of the frame",
     "properties":{
         "abs_path": {
             "description": "The absolute path of the file involved in the stack frame",

--- a/docs/spec/transactions/trace.json
+++ b/docs/spec/transactions/trace.json
@@ -33,7 +33,7 @@
             "type": ["array", "null"],
             "description": "List of stack frames with variable attributes (eg: lineno, filename, etc)",
             "items": {
-                "$ref": "./../stacktrace.json"
+                "$ref": "./../stacktrace_frame.json"
             },
             "minItems": 0
         },

--- a/processor/error/schema.go
+++ b/processor/error/schema.go
@@ -304,7 +304,7 @@ var errorSchema = `{
     "$id": "docs/spec/stacktrace.json",
     "title": "Stacktrace",
     "type": "object",
-    "description": "A stacktrace contains a list of stack frames, each with various bits (most optional) describing the context of that frame",
+    "description": "A stacktrace frame, contains various bits (most optional) describing the context of the frame",
     "properties":{
         "abs_path": {
             "description": "The absolute path of the file involved in the stack frame",
@@ -411,7 +411,7 @@ var errorSchema = `{
     "$id": "docs/spec/stacktrace.json",
     "title": "Stacktrace",
     "type": "object",
-    "description": "A stacktrace contains a list of stack frames, each with various bits (most optional) describing the context of that frame",
+    "description": "A stacktrace frame, contains various bits (most optional) describing the context of the frame",
     "properties":{
         "abs_path": {
             "description": "The absolute path of the file involved in the stack frame",

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -361,7 +361,7 @@ var transactionSchema = `{
     "$id": "docs/spec/stacktrace.json",
     "title": "Stacktrace",
     "type": "object",
-    "description": "A stacktrace contains a list of stack frames, each with various bits (most optional) describing the context of that frame",
+    "description": "A stacktrace frame, contains various bits (most optional) describing the context of the frame",
     "properties":{
         "abs_path": {
             "description": "The absolute path of the file involved in the stack frame",

--- a/tests/json_schema_test.go
+++ b/tests/json_schema_test.go
@@ -88,10 +88,7 @@ var test_schema = `{
                         "type": ["array", "null"],
                         "items": {
                             "$schema": "http://json-schema.org/draft-04/schema#",
-                            "$id": "docs/spec/stacktrace.json",
-                            "title": "Stacktrace",
                             "type": "object",
-                            "description": "A stacktrace contains a list of stack frames, each with various bits (most optional) describing the context of that frame",
                             "properties":{
                                 "abs_path": {
                                   "description": "The absolute path of the file involved in the stack frame",


### PR DESCRIPTION
Rename to `stacktrace_frame` and fix description accordingly.
closes #12.