### PR TITLE
Deny defined pattern for `context.tag` key names.

### DIFF
--- a/docs/spec/context.json
+++ b/docs/spec/context.json
@@ -45,10 +45,14 @@
     },
     "tags": {
       "type": ["object", "null"],
-      "additionalProperties": {
-        "type": "string",
-        "maxLength": 1024
-      }
+      "regexProperties": true,
+      "patternProperties": {
+        "^[^.*]*$": {
+            "type": "string",
+            "maxLength": 1024
+          }
+      },
+      "additionalProperties": false
     },
     "user":{
       "$ref": "user.json"

--- a/processor/error/schema.go
+++ b/processor/error/schema.go
@@ -245,10 +245,14 @@ var errorSchema = `{
     },
     "tags": {
       "type": ["object", "null"],
-      "additionalProperties": {
-        "type": "string",
-        "maxLength": 1024
-      }
+      "regexProperties": true,
+      "patternProperties": {
+        "^[^.*]*$": {
+            "type": "string",
+            "maxLength": 1024
+          }
+      },
+      "additionalProperties": false
     },
     "user":{
           "$schema": "http://json-schema.org/draft-04/schema#",

--- a/processor/transaction/package_tests/processor_test.go
+++ b/processor/transaction/package_tests/processor_test.go
@@ -40,6 +40,8 @@ func TestTransactionProcessorValidationFailed(t *testing.T) {
 		{"app/no_name.json", "missing properties: \"name\""},
 		{"app/no_agent.json", "missing properties: \"agent\""},
 		{"no_app.json", "missing properties: \"app\""},
+		{"invalid_tag_dot.json", "[#/properties/transactions/items/properties/context/properties/tags/additionalProperties]"},
+		{"invalid_tag_asterisk.json", "[#/properties/transactions/items/properties/context/properties/tags/additionalProperties]"},
 		{"empty_payload.json", "minimum 1 items allowed"},
 		{"invalid_id.json", "[#/properties/transactions/items/properties/id/pattern] does not match pattern"},
 		{"invalid_timestamp.json", "[#/properties/transactions/items/properties/timestamp/pattern] does not match pattern"},

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -268,10 +268,14 @@ var transactionSchema = `{
     },
     "tags": {
       "type": ["object", "null"],
-      "additionalProperties": {
-        "type": "string",
-        "maxLength": 1024
-      }
+      "regexProperties": true,
+      "patternProperties": {
+        "^[^.*]*$": {
+            "type": "string",
+            "maxLength": 1024
+          }
+      },
+      "additionalProperties": false
     },
     "user":{
           "$schema": "http://json-schema.org/draft-04/schema#",

--- a/tests/data/invalid/transaction/invalid_tag_asterisk.json
+++ b/tests/data/invalid/transaction/invalid_tag_asterisk.json
@@ -1,0 +1,23 @@
+{
+    "app": {
+        "name": "1234_app-12a3",
+        "agent": {
+            "name": "opbeat-node",
+            "version": "3.14.0"
+        }
+    },
+    "transactions": [
+        {
+            "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
+            "name": "GET /api/types",
+            "type": "request",
+            "duration": 32.592981,
+            "timestamp": "2017-05-30T18:53:27.154Z",
+            "context": {
+                "tags": {
+                    "organizati*onuuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8"
+                }
+            }
+        }
+    ]
+}

--- a/tests/data/invalid/transaction/invalid_tag_dot.json
+++ b/tests/data/invalid/transaction/invalid_tag_dot.json
@@ -1,0 +1,23 @@
+{
+    "app": {
+        "name": "1234_app-12a3",
+        "agent": {
+            "name": "opbeat-node",
+            "version": "3.14.0"
+        }
+    },
+    "transactions": [
+        {
+            "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
+            "name": "GET /api/types",
+            "type": "request",
+            "duration": 32.592981,
+            "timestamp": "2017-05-30T18:53:27.154Z",
+            "context": {
+                "tags": {
+                    "organization.uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8"
+                }
+            }
+        }
+    ]
+}

--- a/tests/json_schema.go
+++ b/tests/json_schema.go
@@ -15,6 +15,7 @@ type Schema struct {
 	Title                string
 	Properties           map[string]*Schema
 	AdditionalProperties map[string]interface{}
+	PatternProperties    map[string]interface{}
 	Items                *Schema
 	MaxLength            int
 }
@@ -128,8 +129,17 @@ func addLengthRestrictedPropNames(s *Schema) bool {
 	} else if val, ok := s.AdditionalProperties["maxLength"]; ok {
 		if valF, okF := val.(float64); okF && valF == 1024 {
 			return true
-
 		}
+	} else if len(s.PatternProperties) > 0 {
+		for _, v := range s.PatternProperties {
+			val, ok := v.(map[string]interface{})["maxLength"]
+			if ok && val.(float64) == 1024 {
+				continue
+			} else {
+				return false
+			}
+		}
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
Do not allow key names to include '.' and '*'.