### PR TITLE
Fix manual testing environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,12 +49,14 @@ create-docs:
 	cp tests/data/valid/error/* docs/data/intake-api/generated/error/
 	cp tests/data/valid/transaction/* docs/data/intake-api/generated/transaction/
 
+# Start manual testing environment with agents
 start-env:
-	docker-compose build
-	docker-compose up -d
+	docker-compose -f tests/docker-compose.yml build
+	docker-compose -f tests/docker-compose.yml up -d
 
+# Stop manual testing environment with agents
 stop-env:
-	docker-compose down -v
+	docker-compose -f tests/docker-compose.yml down -v
 
 check-full: check
 	@# Validate that all updates were committed

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -12,20 +12,20 @@ services:
 
   elasticsearch:
     extends:
-      file: _beats/testing/environments/snapshot.yml
+      file: ../_beats/testing/environments/snapshot.yml
       service: elasticsearch
     ports:
       - "9200:9200"
 
   kibana:
     extends:
-      file: _beats/testing/environments/snapshot.yml
+      file: ../_beats/testing/environments/snapshot.yml
       service: kibana
     ports:
       - "5601:5601"
 
   agent-python:
-    build: ./tests/agent/python
+    build: ./agent/python
     ports:
       - "8000:8000"
     environment:


### PR DESCRIPTION
The manual testing environment was moved under tests as the one in the top directory is needed for the automated testing. This god broken earlier when the compose file was moved.