### PR TITLE
Add restrictions for tag names.

### DIFF
--- a/docs/spec/app.json
+++ b/docs/spec/app.json
@@ -58,7 +58,7 @@
         "name": {
             "description": "Immutable name of the app emitting this event",
             "type": "string",
-            "pattern": "^[a-zA-Z0-9 _\\-]+$"
+            "pattern": "^[a-zA-Z0-9 _-]+$"
         },
         "pid": {
             "type": ["number", "null"]

--- a/docs/spec/context.json
+++ b/docs/spec/context.json
@@ -47,7 +47,7 @@
       "type": ["object", "null"],
       "regexProperties": true,
       "patternProperties": {
-        "^[^.*]*$": {
+        "^[^.*\"]*$": {
             "type": "string",
             "maxLength": 1024
           }

--- a/processor/error/schema.go
+++ b/processor/error/schema.go
@@ -71,7 +71,7 @@ var errorSchema = `{
         "name": {
             "description": "Immutable name of the app emitting this event",
             "type": "string",
-            "pattern": "^[a-zA-Z0-9 _\\-]+$"
+            "pattern": "^[a-zA-Z0-9 _-]+$"
         },
         "pid": {
             "type": ["number", "null"]
@@ -247,7 +247,7 @@ var errorSchema = `{
       "type": ["object", "null"],
       "regexProperties": true,
       "patternProperties": {
-        "^[^.*]*$": {
+        "^[^.*\"]*$": {
             "type": "string",
             "maxLength": 1024
           }

--- a/processor/transaction/package_tests/processor_test.go
+++ b/processor/transaction/package_tests/processor_test.go
@@ -41,6 +41,7 @@ func TestTransactionProcessorValidationFailed(t *testing.T) {
 		{"app/no_agent.json", "missing properties: \"agent\""},
 		{"no_app.json", "missing properties: \"app\""},
 		{"invalid_tag_dot.json", "[#/properties/transactions/items/properties/context/properties/tags/additionalProperties]"},
+		{"invalid_tag_quote.json", "[#/properties/transactions/items/properties/context/properties/tags/additionalProperties]"},
 		{"invalid_tag_asterisk.json", "[#/properties/transactions/items/properties/context/properties/tags/additionalProperties]"},
 		{"empty_payload.json", "minimum 1 items allowed"},
 		{"invalid_id.json", "[#/properties/transactions/items/properties/id/pattern] does not match pattern"},

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -71,7 +71,7 @@ var transactionSchema = `{
         "name": {
             "description": "Immutable name of the app emitting this event",
             "type": "string",
-            "pattern": "^[a-zA-Z0-9 _\\-]+$"
+            "pattern": "^[a-zA-Z0-9 _-]+$"
         },
         "pid": {
             "type": ["number", "null"]
@@ -270,7 +270,7 @@ var transactionSchema = `{
       "type": ["object", "null"],
       "regexProperties": true,
       "patternProperties": {
-        "^[^.*]*$": {
+        "^[^.*\"]*$": {
             "type": "string",
             "maxLength": 1024
           }

--- a/tests/data/invalid/transaction/invalid_tag_quote.json
+++ b/tests/data/invalid/transaction/invalid_tag_quote.json
@@ -1,0 +1,23 @@
+{
+    "app": {
+        "name": "1234_app-12a3",
+        "agent": {
+            "name": "opbeat-node",
+            "version": "3.14.0"
+        }
+    },
+    "transactions": [
+        {
+            "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
+            "name": "GET /api/types",
+            "type": "request",
+            "duration": 32.592981,
+            "timestamp": "2017-05-30T18:53:27.154Z",
+            "context": {
+                "tags": {
+                    "organization\"uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8"
+                }
+            }
+        }
+    ]
+}

--- a/tests/data/invalid/transaction/invalid_tag_space.json
+++ b/tests/data/invalid/transaction/invalid_tag_space.json
@@ -1,0 +1,23 @@
+{
+    "app": {
+        "name": "1234_app-12a3",
+        "agent": {
+            "name": "opbeat-node",
+            "version": "3.14.0"
+        }
+    },
+    "transactions": [
+        {
+            "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
+            "name": "GET /api/types",
+            "type": "request",
+            "duration": 32.592981,
+            "timestamp": "2017-05-30T18:53:27.154Z",
+            "context": {
+                "tags": {
+                    "organization uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Forbid _dot,asterisk,quote_ to be part of tag names to avoid confusion when querying.

Indexing special characters in key names and querying with Kibana worked just fine. However since _dot_ and _space_ have special meaning, and _quotes_ need to be escaped when querying the suggestion is to forbid those characters in tag names. 