### PR TITLE
Minor improvements to SSL handling

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -10,9 +10,17 @@ type Config struct {
 	ReadTimeout     time.Duration `config:"read_timeout"`
 	WriteTimeout    time.Duration `config:"write_timeout"`
 	SecretToken     string        `config:"secret_token"`
-	SSLEnabled      *bool         `config:"ssl.enabled"`
-	SSLPrivateKey   string        `config:"ssl.key"`
-	SSLCert         string        `config:"ssl.certificate"`
+	SSL             *SSLConfig    `config:"ssl"`
+}
+
+type SSLConfig struct {
+	Enabled    *bool  `config:"enabled"`
+	PrivateKey string `config:"key"`
+	Cert       string `config:"certificate"`
+}
+
+func (c *SSLConfig) IsEnabled() bool {
+	return c != nil && (c.Enabled == nil || *c.Enabled)
 }
 
 var defaultConfig = Config{

--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"compress/gzip"
 	"compress/zlib"
 	"context"
 	"crypto/subtle"
@@ -11,8 +12,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
-
-	"compress/gzip"
 
 	"github.com/elastic/apm-server/processor"
 	"github.com/elastic/beats/libbeat/beat"
@@ -77,17 +76,10 @@ func (s *Server) create(successCallback func([]beat.Event), host string) *http.S
 	}
 }
 
-func enableSSL(config Config) bool {
-	if config.SSLEnabled == nil {
-		return config.SSLCert != "" && config.SSLPrivateKey != ""
-	}
-	return *config.SSLEnabled
-}
-
 func (s *Server) Start(successCallback func([]beat.Event), host string) {
 	s.http = s.create(successCallback, host)
-	if enableSSL(s.config) {
-		go s.http.ListenAndServeTLS(s.config.SSLCert, s.config.SSLPrivateKey)
+	if s.config.SSL.IsEnabled() {
+		go s.http.ListenAndServeTLS(s.config.SSL.Cert, s.config.SSL.PrivateKey)
 	} else {
 		go s.http.ListenAndServe()
 	}


### PR DESCRIPTION
* Use same behaviour in SSL.IsEnabled() as in the rest of beats. No ucfg magic is used as unpacking SSL separately is overkill here.
* Move tests to port 5555 (could be anything else). In case a local apm-server is running during the tests, tests would otherwise fail.
* Cleanup go imports