### PR TITLE
Refactor request.status object to request.status_code number

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -5,6 +5,7 @@ https://github.com/elastic/apm-server/compare/x...master[View commits]
 - Changed response status code in the API from 201 to 202 {pull}34[34]
 - Set dynamic mapping to false, enable only for `context.tags`. Fix issues with indexing. Removed from index: `request.headers_sent`, `app.argv`. Changes take place with {pull}43[43], after updating beats framework. 
 - Remove `context.db.sql` and add `context.db.instance`, `context.db.statement`, `context.db.type` and `context.db.user` instead {pull}38[38].
+- Changed `context.response.status` object to simply storing `context.response.status_code` as a number {pull}49[49]
 
 ==== Bugfixes
 - changed `context.system.title` to `context.system.process_title`, removed `transaction.context`, `trace.context` (already available on top level). {pull}10[10]

--- a/_meta/fields.common.yml
+++ b/_meta/fields.common.yml
@@ -97,19 +97,10 @@
           type: group
           fields:
 
-          - name: status 
-            type: group
-            fields:
-
-            - name: code
-              type: long
-              description: >
-                Http response status code.
-
-            - name: message
-              type: text
-              description: >
-                Http response status message.
+          - name: status_code
+            type: long
+            description: >
+              Http response status code.
 
           - name: finished 
             type: boolean 

--- a/docs/data/elasticsearch/error.json
+++ b/docs/data/elasticsearch/error.json
@@ -79,10 +79,7 @@
                 "content-type": "application/json"
             },
             "headers_sent": true,
-            "status": {
-                "code": 200,
-                "message": "OK"
-            }
+            "status_code": 200
         },
         "system": {
             "architecture": "x64",

--- a/docs/data/elasticsearch/transaction.json
+++ b/docs/data/elasticsearch/transaction.json
@@ -79,10 +79,7 @@
                 "content-type": "application/json"
             },
             "headers_sent": true,
-            "status": {
-                "code": 200,
-                "message": "OK"
-            }
+            "status_code": 200
         },
         "system": {
             "architecture": "x64",

--- a/docs/data/intake-api/generated/error/payload.json
+++ b/docs/data/intake-api/generated/error/payload.json
@@ -194,10 +194,7 @@
                     "body": "Hello World"
                 },
                 "response": {
-                    "status": {
-                        "code": 200,
-                        "message": "OK"
-                    },
+                    "status_code": 200,
                     "headers": {
                         "content-type": "application/json"
                     },

--- a/docs/data/intake-api/generated/transaction/payload.json
+++ b/docs/data/intake-api/generated/transaction/payload.json
@@ -77,10 +77,7 @@
                     "body": "Hello World"
                 },
                 "response": {
-                    "status": {
-                        "code": 200,
-                        "message": "OK"
-                    },
+                    "status_code": 200,
                     "headers": {
                         "content-type": "application/json"
                     },

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -155,21 +155,12 @@ The http method of the request leading to this event.
 
 
 
-
 [float]
-=== `context.response.status.code`
+=== `context.response.status_code`
 
 type: long
 
 Http response status code.
-
-
-[float]
-=== `context.response.status.message`
-
-type: text
-
-Http response status message.
 
 
 [float]

--- a/docs/spec/context.json
+++ b/docs/spec/context.json
@@ -31,16 +31,8 @@
             "headers_sent": {
                 "type": ["boolean", "null"]
             },
-            "status": {
-                "type": ["object","null"],
-                "properties": {
-                    "code": {
-                        "type": ["number", "null"]
-                    },
-                    "message": {
-                        "type": ["string", "null"]
-                    }
-                }
+            "status_code": {
+                "type": ["number", "null"]
             }
         }
     },

--- a/processor/error/package_tests/TestProcessErrorFull.approved.json
+++ b/processor/error/package_tests/TestProcessErrorFull.approved.json
@@ -81,10 +81,7 @@
                         "content-type": "application/json"
                     },
                     "headers_sent": true,
-                    "status": {
-                        "code": 200,
-                        "message": "OK"
-                    }
+                    "status_code": 200
                 },
                 "system": {
                     "architecture": "x64",

--- a/processor/error/schema.go
+++ b/processor/error/schema.go
@@ -144,16 +144,8 @@ var errorSchema = `{
             "headers_sent": {
                 "type": ["boolean", "null"]
             },
-            "status": {
-                "type": ["object","null"],
-                "properties": {
-                    "code": {
-                        "type": ["number", "null"]
-                    },
-                    "message": {
-                        "type": ["string", "null"]
-                    }
-                }
+            "status_code": {
+                "type": ["number", "null"]
             }
         }
     },

--- a/processor/transaction/package_tests/TestProcessTransactionFull.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionFull.approved.json
@@ -81,10 +81,7 @@
                         "content-type": "application/json"
                     },
                     "headers_sent": true,
-                    "status": {
-                        "code": 200,
-                        "message": "OK"
-                    }
+                    "status_code": 200
                 },
                 "system": {
                     "architecture": "x64",

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -167,16 +167,8 @@ var transactionSchema = `{
             "headers_sent": {
                 "type": ["boolean", "null"]
             },
-            "status": {
-                "type": ["object","null"],
-                "properties": {
-                    "code": {
-                        "type": ["number", "null"]
-                    },
-                    "message": {
-                        "type": ["string", "null"]
-                    }
-                }
+            "status_code": {
+                "type": ["number", "null"]
             }
         }
     },

--- a/tests/data/valid/error/payload.json
+++ b/tests/data/valid/error/payload.json
@@ -194,10 +194,7 @@
                     "body": "Hello World"
                 },
                 "response": {
-                    "status": {
-                        "code": 200,
-                        "message": "OK"
-                    },
+                    "status_code": 200,
                     "headers": {
                         "content-type": "application/json"
                     },

--- a/tests/data/valid/transaction/payload.json
+++ b/tests/data/valid/transaction/payload.json
@@ -77,10 +77,7 @@
                     "body": "Hello World"
                 },
                 "response": {
-                    "status": {
-                        "code": 200,
-                        "message": "OK"
-                    },
+                    "status_code": 200,
                     "headers": {
                         "content-type": "application/json"
                     },


### PR DESCRIPTION
After thinking about this for a while, I really don't see why we want to store the status message. So I'd like to suggest that we refactor the `request.status` object which used look like this:

```json
"status": {
  "code": 200,
  "message": "OK"
}
```

To instead simply be a number and look like this:

```json
"status_code": 200
```

Thoughts?