### PR TITLE
Add context.request.http_version property

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -11,10 +11,10 @@ https://github.com/elastic/apm-server/compare/x...master[View commits]
 - changed type of `context.request.body` from `object` to `text`. {pull}27[27]
 
 
-
 ==== Added
 
 - apm-server now returns JSON error responses when the Accept header allows for it.
+- Added `context.request.http_version` property {pull}52[52]
 
 
 ==== Deprecated

--- a/_meta/fields.common.yml
+++ b/_meta/fields.common.yml
@@ -88,6 +88,11 @@
                 description: >
                   The hash of the request URL, e.g. "top".
 
+          - name: http_version
+            type: keyword
+            description: >
+              The http version of the request leading to this event.
+
           - name: method
             type: keyword
             description: >

--- a/docs/data/elasticsearch/error.json
+++ b/docs/data/elasticsearch/error.json
@@ -58,6 +58,7 @@
                 "some-other-header": "foo",
                 "user-agent": "Mozilla Chrome Edge"
             },
+            "http_version": "1.1",
             "method": "POST",
             "socket": {
                 "encrypted": true,

--- a/docs/data/elasticsearch/transaction.json
+++ b/docs/data/elasticsearch/transaction.json
@@ -58,6 +58,7 @@
                 "some-other-header": "foo",
                 "user-agent": "Mozilla Chrome Edge"
             },
+            "http_version": "1.1",
             "method": "POST",
             "socket": {
                 "encrypted": true,

--- a/docs/data/intake-api/generated/error/payload.json
+++ b/docs/data/intake-api/generated/error/payload.json
@@ -162,6 +162,7 @@
                         "remote_address": "12.53.12.1",
                         "encrypted": true
                     },
+                    "http_version": "1.1",
                     "method": "POST",
                     "url": {
                         "protocol": "https:",

--- a/docs/data/intake-api/generated/transaction/payload.json
+++ b/docs/data/intake-api/generated/transaction/payload.json
@@ -45,6 +45,7 @@
                         "remote_address": "12.53.12.1",
                         "encrypted": true
                     },
+                    "http_version": "1.1",
                     "method": "POST",
                     "url": {
                         "protocol": "https:",

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -147,6 +147,14 @@ The hash of the request URL, e.g. "top".
 
 
 [float]
+=== `context.request.http_version`
+
+type: keyword
+
+The http version of the request leading to this event.
+
+
+[float]
 === `context.request.method`
 
 type: keyword

--- a/docs/spec/request.json
+++ b/docs/spec/request.json
@@ -30,6 +30,11 @@
               }
           }
         },
+        "http_version": {
+            "description": "HTTP version.",
+            "type": "string",
+            "maxLength": 1024
+        },
         "method": {
             "description": "HTTP method.",
             "type": "string",

--- a/processor/error/package_tests/TestProcessErrorFull.approved.json
+++ b/processor/error/package_tests/TestProcessErrorFull.approved.json
@@ -60,6 +60,7 @@
                         "some-other-header": "foo",
                         "user-agent": "Mozilla Chrome Edge"
                     },
+                    "http_version": "1.1",
                     "method": "POST",
                     "socket": {
                         "encrypted": true,

--- a/processor/error/schema.go
+++ b/processor/error/schema.go
@@ -189,6 +189,11 @@ var errorSchema = `{
               }
           }
         },
+        "http_version": {
+            "description": "HTTP version.",
+            "type": "string",
+            "maxLength": 1024
+        },
         "method": {
             "description": "HTTP method.",
             "type": "string",

--- a/processor/transaction/package_tests/TestProcessTransactionFull.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionFull.approved.json
@@ -60,6 +60,7 @@
                         "some-other-header": "foo",
                         "user-agent": "Mozilla Chrome Edge"
                     },
+                    "http_version": "1.1",
                     "method": "POST",
                     "socket": {
                         "encrypted": true,

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -212,6 +212,11 @@ var transactionSchema = `{
               }
           }
         },
+        "http_version": {
+            "description": "HTTP version.",
+            "type": "string",
+            "maxLength": 1024
+        },
         "method": {
             "description": "HTTP method.",
             "type": "string",

--- a/tests/data/valid/error/payload.json
+++ b/tests/data/valid/error/payload.json
@@ -162,6 +162,7 @@
                         "remote_address": "12.53.12.1",
                         "encrypted": true
                     },
+                    "http_version": "1.1",
                     "method": "POST",
                     "url": {
                         "protocol": "https:",

--- a/tests/data/valid/transaction/payload.json
+++ b/tests/data/valid/transaction/payload.json
@@ -45,6 +45,7 @@
                         "remote_address": "12.53.12.1",
                         "encrypted": true
                     },
+                    "http_version": "1.1",
                     "method": "POST",
                     "url": {
                         "protocol": "https:",


### PR DESCRIPTION
We had talked about this previously, but I forgot to add it to the schema and API.

I thought about splitting the version up into its [major and minor components](https://tools.ietf.org/html/rfc2145), but I don't currently see any querying use-case for this, plus HTTP/2 [have actually dropped the use of minor all together](https://http2.github.io/faq/#is-it-http20-or-http2).