### PR TITLE
Improve Documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ trying out APM and have feedback or problems, please post them on the [Discuss f
 
 To run Elastic APM for your own applications you need the following setup:
 
-* Install & Run [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/_installation.html) and [Kibana](https://www.elastic.co/guide/en/kibana/6.0/install.html)
-* Build and run the APM Server
+* Install & run [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/_installation.html) and [Kibana](https://www.elastic.co/guide/en/kibana/6.0/install.html)
+* Install, build and run the [APM Server](#apm-server-development)
 * Install the [Node.js](https://github.com/elastic/apm-agent-nodejs) or [Python](https://github.com/elastic/apm-agent-python) APM Agent. The agents are libraries in your application that run inside of your application process.
 * Load UI dashboards into Kibana. The dashboards will give you an overview of application response times, requests per minutes, error occurrences and more.
 
@@ -132,10 +132,7 @@ BEATS_VERSION=f240148065af94d55c5149e444482b9635801f27 make update-beats
 ```
 
 ## Documentation
-
-A JSON-Schema spec for the API lives in `docs/spec`. 
-ElasticSearch fields are defined in `_meta/fields.generated.yml`.
-Examples of input and output documents can be found at `docs/data/intake-api` and `docs/data/elasticsearch` respectively.
+The [Documentation](docs/index.asciidoc) for the Intake-API and Elasticsearch can be found in `docs/data`. 
 
 ## Help
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,42 +1,30 @@
 # APM Server-Testing
 
 ## Automated Testing
-To run the full testsuite of APM Server, run:
+The tests are built on top of the [Beats Test Framework](https://github.com/elastic/beats/blob/master/docs/devguide/testing.asciidoc), where you can find a detailed description on how to run the test suite.
+
+### Quick Overview
+Run the full test suite of APM Server, which needs all dependencies to run locally or in a Docker environment:
 
 ```
 make testsuite
 ```
 
-
-Alternatively only specific tests can be run:
+Only run unit tests without external dependencies:
 
 ```
 make unit
 ```
 
-Runs tests not relying on external dependencies. If tests coverage should be printed, run `make unit-tests` instead.
-
-```
-make integration-tests
-```
-
-Runs tests labeled as integration tests. Integration tests can depend on external systems. If tests should be run inside a virtual environment, run `make integration-tests-environment`. This can be run on any docker-machine (local, remote). If no environment is attached only tests are run which do not require an environment. 
-
-```
-make system-tests
-```
-
-Runs end-to-end system tests, that depend on externals systems. If tests should be run inside a virtual environment, run `make system-tests-environment`. This can be run on any docker-machine (local, remote). If no environment is attached only tests are run which do not require an environment. If you want to run system tests with your local environment, you would have to run `INTEGRATION_TESTS=1 make system-tests`.
-
 ## Coverage Report
 For insights about test-coverage, run `make coverage-report`. The test coverage is reported in the folder `./build/coverage/`
 
-
 ## Snapshot-Testing
-Some tests make use of the concept of snapshot testing. If those tests were run and the snapshot changed, the `approvals` tool can be used to to update the snapshots. Following workflow is intended to approve newly created or changed snapshots.
-* running tests as described above will create a `*.received.json` file for every newly created of changed snapshot.
-* run `make update` to create the `approvals` binary that supports viewing the changes. 
-* run `./approvals` to review and interactively accept the changes. 
+Some tests make use of the concept of _snapshot_ or _approvals testing_. If running tests leads to changed snapshots, you can use the `approvals` tool to update the snapshots.
+Following workflow is intended:
+* Run `make update` to create the `approvals` binary that supports reviewing changes. 
+* Run `make unit` to create a `*.received.json` file for every newly created or changed snapshot.
+* Run `./approvals` to review and interactively accept the changes. 
 
 ## Manual Testing
 


### PR DESCRIPTION
- proper linking within the _README_ file
- linking to beats test description from _TESTING_ and only giving a very short summary for APM Server testing, hence how to run the tests is all based on and coform with the beats framework.