### PR TITLE
Fix docs to have a valid doc build

### DIFF
--- a/docs/api.asciidoc
+++ b/docs/api.asciidoc
@@ -1,0 +1,10 @@
+== API Docs
+
+Details about the different API Endpoints can be found below:
+
+
+include::./transaction-api.asciidoc[Transaction API]
+
+include::./error-api.asciidoc[Error API]
+
+include::./elasticsearch-docs.asciidoc[Elasticsearch]

--- a/docs/elasticsearch-docs.asciidoc
+++ b/docs/elasticsearch-docs.asciidoc
@@ -1,6 +1,7 @@
-= Elasticsearch
+[[elasticsearch-docs]]
+== Elasticsearch
 
-== Example docs
+=== Example docs
 
 The following are example documents sent to Elasticsearch from the APM Server.
 
@@ -10,8 +11,8 @@ link:./data/elasticsearch/trace.json[Trace Document]
 
 link:./data/elasticsearch/error.json[Error Document]
 
-== Indexed Fields
-link:fields.asciidoc[See indexed fields in Elasticsearch]
 
-== Changing the Index-Pattern
-link:index_pattern.asiidoc[Index-Pattern]
+
+include::./fields.asciidoc[See indexed fields in Elasticsearch]
+
+include::./index_pattern.asciidoc[Index-Pattern]

--- a/docs/error-api.asciidoc
+++ b/docs/error-api.asciidoc
@@ -1,12 +1,14 @@
-= Error API
+== Error API
 
 To send error records you need to send a HTTP POST request to the APM Server `errors` endpoint. Information pertaining to the error record must be sent as a JSON object to the endpoint.
 
-link:spec/errors/payload.json[JSON Schema]
+link:./spec/errors/payload.json[JSON Schema]
 
-== Example
-....
+=== Example
+
+["source","sh",subs="attributes"]
+------------------------------------------------------------
 $ curl http://localhost:8080/v1/errors --header "Content-Type:application/json" --data @docs/data/intake-api/generated/error/payload.json
-....
+------------------------------------------------------------
 
-link:data/intake-api/generated/error/payload.json[Example Payload]
+link:./data/intake-api/generated/error/payload.json[Example Payload]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,11 +1,6 @@
 = APM Server Docs
 
-Welcome to the APM Server documentation.
+== APM Server
+Welcome to the APM Server Docs.
 
-== API Description
-link:transaction-api.asciidoc[Transaction API]
-
-link:error-api.asciidoc[Error API]
-
-link:elasticsearch-docs.asciidoc[Elasticsearch]
-
+include::./api.asciidoc[API]

--- a/docs/index_pattern.asciidoc
+++ b/docs/index_pattern.asciidoc
@@ -1,4 +1,4 @@
-== Configuring Index Pattern
+=== Configuring Index Pattern
 
 The same APM Server process can handle data from multiple apps. If you want to send data from each app to separate indices, you can include the app name in the Elasticsearch index pattern in the following manner:
 

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -1,12 +1,14 @@
-= Transaction API
+== Transaction API
 
 To send transaction records you need to send a HTTP POST request to the APM Server `transactions` endpoint. Information pertaining to the record must be sent as a JSON object to the endpoint.
 
-link:spec/transactions/payload.json[JSON Schema]
+link:./spec/transactions/payload.json[JSON Schema]
 
-== Example
-....
+=== Example
+
+["source","sh",subs="attributes"]
+------------------------------------------------------------
 $ curl http://localhost:8080/v1/transactions --header "Content-Type:application/json" --data @docs/data/intake-api/generated/transaction/payload.json
-....
+------------------------------------------------------------
 
-link:data/intake-api/generated/transaction/payload.json[Example Payload]
+link:./data/intake-api/generated/transaction/payload.json[Example Payload]


### PR DESCRIPTION
Run `make docs` didn't work with the previous structure. I mainly fixed titles etc. to be a valid asciidoc format for our doc build. It is not the intention to fix the doc structure in this PR but being able to start with the doc build integration which requires a green doc build to start with.