### PR TITLE
fix env causing mkdir: invalid option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,12 @@ RUN set -x && \
     apt-get clean
 
 # Setup work environment
-ENV apm-server_PATH /go/src/github.com/elastic/apm-server
+ENV APM_SERVER_PATH /go/src/github.com/elastic/apm-server
 
-RUN mkdir -p $apm-server_PATH
-WORKDIR $apm-server_PATH
+RUN mkdir -p $APM_SERVER_PATH
+WORKDIR $APM_SERVER_PATH
 
-COPY . $apm-server_PATH
+COPY . $APM_SERVER_PATH
 
 RUN make
 


### PR DESCRIPTION
Before this change I was getting this error on OSX.

```
Step 5/10 : RUN mkdir -p $apm-server_PATH
 ---> Running in 503d035a8229
mkdir: invalid option -- 's'
Try 'mkdir --help' for more information.
```