### PR TITLE
Rename `error.checksum` to `error.grouping_key`.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -5,7 +5,8 @@ https://github.com/elastic/apm-server/compare/x...master[View commits]
 - Changed response status code in the API from 201 to 202 {pull}34[34]
 - Set dynamic mapping to false, enable only for `context.tags`. Fix issues with indexing. Removed from index: `request.headers_sent`, `app.argv`. Changes take place with {pull}43[43], after updating beats framework. 
 - Remove `context.db.sql` and add `context.db.instance`, `context.db.statement`, `context.db.type` and `context.db.user` instead {pull}38[38].
-- Changed `context.response.status` object to simply storing `context.response.status_code` as a number {pull}49[49]
+- Changed `context.response.status` object to simply storing `context.response.status_code` as a number {pull}49[49].
+- Changed `error.checksum` to `error.grouping_field` {pull}83[49].
 
 ==== Bugfixes
 - changed `context.system.title` to `context.system.process_title`, removed `transaction.context`, `trace.context` (already available on top level). {pull}10[10]

--- a/docs/data/elasticsearch/error.json
+++ b/docs/data/elasticsearch/error.json
@@ -97,7 +97,6 @@
         }
     },
     "error": {
-        "checksum": "4cfd552c0f4a291894c3558466f92151",
         "culprit": "my.module.function_name",
         "exception": {
             "attributes": {
@@ -169,6 +168,7 @@
             "type": "DbError",
             "uncaught": true
         },
+        "grouping_key": "4cfd552c0f4a291894c3558466f92151",
         "id": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8",
         "log": {
             "level": "warning",

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -384,11 +384,11 @@ type: text
 Function call which was the primary perpetrator of this event.
 
 [float]
-=== `error.checksum`
+=== `error.grouping_key`
 
 type: keyword
 
-Checksum of the logged error for use in grouping.
+GroupingKey of the logged error for use in grouping.
 
 
 [float]

--- a/processor/error/_meta/fields.yml
+++ b/processor/error/_meta/fields.yml
@@ -16,10 +16,10 @@
           type: text
           description: Function call which was the primary perpetrator of this event.
 
-        - name: checksum
+        - name: grouping_key 
           type: keyword
           description: >
-            Checksum of the logged error for use in grouping.
+            GroupingKey of the logged error for use in grouping.
 
         - name: exception
           type: group

--- a/processor/error/event.go
+++ b/processor/error/event.go
@@ -69,7 +69,7 @@ func (e *Event) Transform() common.MapStr {
 
 	e.addException()
 	e.addLog()
-	e.addChecksum()
+	e.addGroupingKey()
 
 	return e.data
 }
@@ -128,11 +128,11 @@ func (e *Event) transformStacktrace(frames m.StacktraceFrames) []common.MapStr {
 	return e.TransformStacktrace(&st)
 }
 
-func (e *Event) addChecksum() {
-	e.add("checksum", e.calcChecksum())
+func (e *Event) addGroupingKey() {
+	e.add("grouping_key", e.calcGroupingKey())
 }
 
-func (e *Event) calcChecksum() string {
+func (e *Event) calcGroupingKey() string {
 	hash := md5.New()
 
 	add := func(s *string) bool {

--- a/processor/error/package_tests/TestProcessErrorFull.approved.json
+++ b/processor/error/package_tests/TestProcessErrorFull.approved.json
@@ -99,7 +99,6 @@
                 }
             },
             "error": {
-                "checksum": "4cfd552c0f4a291894c3558466f92151",
                 "culprit": "my.module.function_name",
                 "exception": {
                     "attributes": {
@@ -171,6 +170,7 @@
                     "type": "DbError",
                     "uncaught": true
                 },
+                "grouping_key": "4cfd552c0f4a291894c3558466f92151",
                 "id": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8",
                 "log": {
                     "level": "warning",
@@ -280,11 +280,11 @@
                 }
             },
             "error": {
-                "checksum": "d41d8cd98f00b204e9800998ecf8427e",
                 "exception": {
                     "code": "35",
                     "message": "foo is not defined"
                 },
+                "grouping_key": "d41d8cd98f00b204e9800998ecf8427e",
                 "id": "9f0e9d68-c185-4d21-a6f4-4673ed561ec8"
             },
             "processor": {
@@ -328,10 +328,10 @@
                 }
             },
             "error": {
-                "checksum": "d41d8cd98f00b204e9800998ecf8427e",
                 "exception": {
                     "message": "foo.bar is not a function"
                 },
+                "grouping_key": "d41d8cd98f00b204e9800998ecf8427e",
                 "id": "9f0e9d68-c185-4d21-a6f4-4673ed561ec8"
             },
             "processor": {
@@ -375,7 +375,7 @@
                 }
             },
             "error": {
-                "checksum": "d41d8cd98f00b204e9800998ecf8427e",
+                "grouping_key": "d41d8cd98f00b204e9800998ecf8427e",
                 "id": "9f0e9d67-c185-4d21-a6f4-4673ed561ec8",
                 "log": {
                     "message": "Cannot read property 'baz' of undefined"

--- a/processor/error/package_tests/TestProcessErrorMininmalPayloadException.approved.json
+++ b/processor/error/package_tests/TestProcessErrorMininmalPayloadException.approved.json
@@ -11,10 +11,10 @@
                 }
             },
             "error": {
-                "checksum": "d41d8cd98f00b204e9800998ecf8427e",
                 "exception": {
                     "message": ""
-                }
+                },
+                "grouping_key": "d41d8cd98f00b204e9800998ecf8427e"
             },
             "processor": {
                 "event": "error",

--- a/processor/error/package_tests/TestProcessErrorMininmalPayloadLog.approved.json
+++ b/processor/error/package_tests/TestProcessErrorMininmalPayloadLog.approved.json
@@ -11,7 +11,7 @@
                 }
             },
             "error": {
-                "checksum": "d41d8cd98f00b204e9800998ecf8427e",
+                "grouping_key": "d41d8cd98f00b204e9800998ecf8427e",
                 "log": {
                     "message": ""
                 }

--- a/processor/error/package_tests/json_schema_test.go
+++ b/processor/error/package_tests/json_schema_test.go
@@ -36,6 +36,6 @@ func TestJsonSchemaKeywordLimitation(t *testing.T) {
 		"./../../../_meta/fields.common.yml",
 		"./../_meta/fields.yml",
 	}
-	exceptions := set.New("processor.event", "processor.name", "error.id", "error.log.level", "error.checksum")
+	exceptions := set.New("processor.event", "processor.name", "error.id", "error.log.level", "error.grouping_key")
 	tests.TestJsonSchemaKeywordLimitation(t, fieldsPaths, er.Schema(), exceptions)
 }

--- a/processor/error/payload_test.go
+++ b/processor/error/payload_test.go
@@ -38,7 +38,7 @@ func TestPayloadTransform(t *testing.T) {
 						},
 					},
 					"error": common.MapStr{
-						"checksum": "d41d8cd98f00b204e9800998ecf8427e",
+						"grouping_key": "d41d8cd98f00b204e9800998ecf8427e",
 					},
 					"processor": common.MapStr{"event": "error", "name": "error"},
 				},
@@ -65,9 +65,9 @@ func TestPayloadTransform(t *testing.T) {
 						},
 					},
 					"error": common.MapStr{
-						"checksum":  "d41d8cd98f00b204e9800998ecf8427e",
-						"exception": common.MapStr{"message": "exception message"},
-						"log":       common.MapStr{"message": "error log message"},
+						"grouping_key": "d41d8cd98f00b204e9800998ecf8427e",
+						"exception":    common.MapStr{"message": "exception message"},
+						"log":          common.MapStr{"message": "error log message"},
 					},
 					"processor": common.MapStr{"event": "error", "name": "error"},
 				},


### PR DESCRIPTION
Renamed to unify names in the ES data model and in the UI.
closes #82