### PR TITLE
Include timestamp in approval tests

### DIFF
--- a/processor/error/package_tests/TestProcessErrorFull.approved.json
+++ b/processor/error/package_tests/TestProcessErrorFull.approved.json
@@ -1,6 +1,7 @@
 {
     "events": [
         {
+            "@timestamp": "2017-05-09T15:04:05.999999Z",
             "context": {
                 "app": {
                     "agent": {
@@ -245,6 +246,7 @@
             }
         },
         {
+            "@timestamp": "2017-05-09T15:04:05.1Z",
             "context": {
                 "app": {
                     "agent": {
@@ -293,6 +295,7 @@
             }
         },
         {
+            "@timestamp": "2017-05-09T15:04:05Z",
             "context": {
                 "app": {
                     "agent": {
@@ -340,6 +343,7 @@
             }
         },
         {
+            "@timestamp": "2017-05-09T15:04:05.999Z",
             "context": {
                 "app": {
                     "agent": {

--- a/processor/error/package_tests/TestProcessErrorMininmalPayloadException.approved.json
+++ b/processor/error/package_tests/TestProcessErrorMininmalPayloadException.approved.json
@@ -1,6 +1,7 @@
 {
     "events": [
         {
+            "@timestamp": "2017-05-09T15:04:05.999999Z",
             "context": {
                 "app": {
                     "agent": {

--- a/processor/error/package_tests/TestProcessErrorMininmalPayloadLog.approved.json
+++ b/processor/error/package_tests/TestProcessErrorMininmalPayloadLog.approved.json
@@ -1,6 +1,7 @@
 {
     "events": [
         {
+            "@timestamp": "2017-05-09T15:04:05.999999Z",
             "context": {
                 "app": {
                     "agent": {

--- a/processor/transaction/package_tests/TestProcessTransactionEmpty.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionEmpty.approved.json
@@ -1,6 +1,7 @@
 {
     "events": [
         {
+            "@timestamp": "2017-05-09T15:04:05.999999Z",
             "context": {
                 "app": {
                     "agent": {

--- a/processor/transaction/package_tests/TestProcessTransactionFull.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionFull.approved.json
@@ -1,6 +1,7 @@
 {
     "events": [
         {
+            "@timestamp": "2017-05-30T18:53:27.154Z",
             "context": {
                 "app": {
                     "agent": {
@@ -113,6 +114,7 @@
             }
         },
         {
+            "@timestamp": "2017-05-30T18:53:27.154Z",
             "context": {
                 "app": {
                     "agent": {
@@ -181,6 +183,7 @@
             }
         },
         {
+            "@timestamp": "2017-05-30T18:53:27.154Z",
             "context": {
                 "app": {
                     "agent": {
@@ -210,6 +213,7 @@
             }
         },
         {
+            "@timestamp": "2017-05-30T18:53:27.154Z",
             "context": {
                 "app": {
                     "agent": {
@@ -239,6 +243,7 @@
             }
         },
         {
+            "@timestamp": "2017-05-30T18:53:27.154Z",
             "context": {
                 "app": {
                     "agent": {
@@ -268,6 +273,7 @@
             }
         },
         {
+            "@timestamp": "2017-05-30T18:53:42.281Z",
             "context": {
                 "app": {
                     "agent": {
@@ -316,6 +322,7 @@
             }
         },
         {
+            "@timestamp": "2017-05-30T18:53:42Z",
             "context": {
                 "app": {
                     "agent": {
@@ -364,6 +371,7 @@
             }
         },
         {
+            "@timestamp": "2017-05-30T18:53:42.281999Z",
             "context": {
                 "app": {
                     "agent": {
@@ -412,6 +420,7 @@
             }
         },
         {
+            "@timestamp": "2017-05-30T18:53:42.281999Z",
             "context": {
                 "app": {
                     "agent": {

--- a/processor/transaction/package_tests/TestProcessTransactionMinimalPayload.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionMinimalPayload.approved.json
@@ -1,6 +1,7 @@
 {
     "events": [
         {
+            "@timestamp": "2017-05-09T15:04:05.999999Z",
             "context": {
                 "app": {
                     "agent": {

--- a/processor/transaction/package_tests/TestProcessTransactionMinimalTrace.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionMinimalTrace.approved.json
@@ -1,6 +1,7 @@
 {
     "events": [
         {
+            "@timestamp": "2017-05-30T18:53:27.154Z",
             "context": {
                 "app": {
                     "agent": {
@@ -24,6 +25,7 @@
             }
         },
         {
+            "@timestamp": "2017-05-30T18:53:27.154Z",
             "context": {
                 "app": {
                     "agent": {

--- a/processor/transaction/package_tests/TestProcessTransactionNull.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionNull.approved.json
@@ -1,6 +1,7 @@
 {
     "events": [
         {
+            "@timestamp": "2017-05-09T15:04:05.999999Z",
             "context": {
                 "app": {
                     "agent": {

--- a/tests/approvals.go
+++ b/tests/approvals.go
@@ -78,6 +78,7 @@ func TestProcessRequests(t *testing.T, fn processor.NewProcessor, requestInfo []
 		eventFields := make([]common.MapStr, len(events))
 		for idx, event := range events {
 			eventFields[idx] = event.Fields
+			eventFields[idx]["@timestamp"] = event.Timestamp
 		}
 
 		receivedJson := map[string]interface{}{"events": eventFields}


### PR DESCRIPTION
with the beat.Event introduction, we no longer put @timestamp in the generated documents, but we should still test timestamps