### PR TITLE
Fix swallowed error in tests package

### DIFF
--- a/tests/json_schema_test.go
+++ b/tests/json_schema_test.go
@@ -160,6 +160,7 @@ func testDataAgainstSchema(t *testing.T, testData []schemaTestData, schemaPath s
 	}
 	path := filepath.Join("data/invalid/", filePath)
 	filesInDir, err := ioutil.ReadDir(path)
+	assert.Nil(t, err)
 	for _, f := range filesInDir {
 		assert.True(t, filesToTest.Has(f.Name()), fmt.Sprintf("Did you miss to add the file %v to `json_schema_tests`?", filepath.Join(path, f.Name())))
 	}


### PR DESCRIPTION
json_schema_test.go was missing an assert on a defined error.