### PR TITLE
Make apm-server to fail fast

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -15,6 +15,8 @@ https://github.com/elastic/apm-server/compare/x...master[View commits]
 - changed `context.system.title` to `context.system.process_title`, removed `transaction.context`, `trace.context` (already available on top level). {pull}10[10]
 - changed type of `context.request.body` from `object` to `text`. {pull}27[27]
 - incoming transactions and errors could reuse data from previous POSTs due to payload state being kept in processors {pull}98[98].
+- forced apm-server to stop if/when the underlying http server is not running. Exit code is 0 for SIGINT / SIGTERM, 1 otherwise. {pull}94[94]
+
 
 ==== Added
 

--- a/beater/server.go
+++ b/beater/server.go
@@ -62,18 +62,21 @@ func newServer(config Config, publish successCallback) *http.Server {
 	}
 }
 
-func start(server *http.Server, ssl *SSLConfig) {
+func run(server *http.Server, ssl *SSLConfig) error {
+	logp.Info("starting apm-server! Hit CTRL-C to stop it.")
 	if ssl.isEnabled() {
-		go server.ListenAndServeTLS(ssl.Cert, ssl.PrivateKey)
+		return server.ListenAndServeTLS(ssl.Cert, ssl.PrivateKey)
 	} else {
-		go server.ListenAndServe()
+		return server.ListenAndServe()
 	}
 }
 
-func stop(server *http.Server) error {
+func stop(server *http.Server) {
 	c := context.TODO()
 	err := server.Shutdown(c)
-	return err
+	if err != nil {
+		logp.Err(err.Error())
+	}
 }
 
 type handler func(w http.ResponseWriter, r *http.Request)

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -41,7 +41,7 @@ class ServerBaseTest(BaseTest):
         super(ServerBaseTest, self).setUp()
         self.render_config_template(**self.config())
         self.apmserver_proc = self.start_beat()
-        self.wait_until(lambda: self.log_contains("apm-server is running"))
+        self.wait_until(lambda: self.log_contains("starting apm-server"))
 
     def tearDown(self):
         super(ServerBaseTest, self).tearDown()


### PR DESCRIPTION
Current behaviour is e.g. that apm-server can happily start with a port already used. 
In such case a socket cannot be opened and the apm-server stays up without complaint, albeit not being able to accept requests.

This makes the apm-server to finish with an error when the underlying http server connection fails.

