### PR TITLE
Rename registry getter methods

### DIFF
--- a/beater/server.go
+++ b/beater/server.go
@@ -26,7 +26,7 @@ type successCallback func([]beat.Event)
 func newServer(config Config, publish successCallback) *http.Server {
 	mux := http.NewServeMux()
 
-	for path, p := range processor.Registry.GetProcessors() {
+	for path, p := range processor.Registry.Processors() {
 
 		handler := createHandler(p, config, publish)
 

--- a/processor/error/processor_test.go
+++ b/processor/error/processor_test.go
@@ -17,6 +17,6 @@ func TestImplementProcessorInterface(t *testing.T) {
 }
 
 func TestAddProcessorToRegistryOnInit(t *testing.T) {
-	p := pr.Registry.GetProcessor("/v1/errors")
+	p := pr.Registry.Processor("/v1/errors")
 	assert.NotNil(t, p)
 }

--- a/processor/registry.go
+++ b/processor/registry.go
@@ -25,10 +25,10 @@ func (r *Register) AddProcessor(path string, p Processor) {
 }
 
 // GetProcessors returns a list of all currently registered processors
-func (r *Register) GetProcessors() map[string]Processor {
+func (r *Register) Processors() map[string]Processor {
 	return r.processors
 }
 
-func (r *Register) GetProcessor(name string) Processor {
+func (r *Register) Processor(name string) Processor {
 	return r.processors[name]
 }

--- a/processor/transaction/processor_test.go
+++ b/processor/transaction/processor_test.go
@@ -17,6 +17,6 @@ func TestImplementProcessorInterface(t *testing.T) {
 }
 
 func TestAddProcessorToRegistryOnInit(t *testing.T) {
-	p := pr.Registry.GetProcessor(Endpoint)
+	p := pr.Registry.Processor(Endpoint)
 	assert.NotNil(t, p)
 }

--- a/script/output_data/output_data.go
+++ b/script/output_data/output_data.go
@@ -25,7 +25,7 @@ func generate() error {
 	basepath := "tests/data/valid"
 	outputPath := "docs/data/elasticsearch/"
 
-	processors := processor.Registry.GetProcessors()
+	processors := processor.Registry.Processors()
 
 	var checked = map[string]struct{}{}
 


### PR DESCRIPTION
Renames registry getter methods to follow go naming.

@ruflin

Fixes #74