### PR TITLE
[WIP/Idea] Remove Validate from Processor

### DIFF
--- a/beater/server.go
+++ b/beater/server.go
@@ -78,7 +78,7 @@ func stop(server *http.Server) error {
 
 type handler func(w http.ResponseWriter, r *http.Request)
 
-func createHandler(p processor.Processor, config Config, publish successCallback) handler {
+func createHandler(p processor.ProcessorData, config Config, publish successCallback) handler {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logp.Debug("handler", "Request: URI=%s, method=%s, content-length=%d", r.RequestURI, r.Method, r.ContentLength)
 
@@ -108,13 +108,13 @@ func createHandler(p processor.Processor, config Config, publish successCallback
 			sendError(w, r, 500, fmt.Sprintf("Data read error: %s", err), true)
 		}
 
-		err = p.Validate(buf)
+		err = processor.Validate(buf, p.Schema)
 		if err != nil {
 			sendError(w, r, 400, fmt.Sprintf("Data validation error: %s", err), true)
 			return
 		}
 
-		list, err := p.Transform(buf)
+		list, err := p.Processor.Transform(buf)
 
 		if err != nil {
 			sendError(w, r, 500, fmt.Sprintf("Data transformation error: %s", err), true)

--- a/processor/error/processor.go
+++ b/processor/error/processor.go
@@ -3,14 +3,12 @@ package error
 import (
 	"encoding/json"
 
-	"github.com/santhosh-tekuri/jsonschema"
-
 	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/beats/libbeat/beat"
 )
 
 func init() {
-	pr.Registry.AddProcessor("/v1/errors", NewProcessor())
+	pr.Registry.AddProcessor("/v1/errors", NewProcessor(), errorSchema)
 }
 
 const (
@@ -18,17 +16,17 @@ const (
 )
 
 func NewProcessor() pr.Processor {
-	schema := pr.CreateSchema(errorSchema, processorName)
-	return &processor{schema}
+	//schema := pr.CreateSchema(errorSchema, processorName)
+	return &processor{}
 }
 
 type processor struct {
-	schema *jsonschema.Schema
+	//schema *jsonschema.Schema
 }
 
-func (p *processor) Validate(buf []byte) error {
+/*func (p *processor) Validate(buf []byte) error {
 	return pr.Validate(buf, p.schema)
-}
+}*/
 
 func (p *processor) Transform(buf []byte) ([]beat.Event, error) {
 	var pa payload

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -12,7 +12,7 @@ import (
 type NewProcessor func() Processor
 
 type Processor interface {
-	Validate([]byte) error
+	//Validate([]byte) error
 	Transform([]byte) ([]beat.Event, error)
 	Name() string
 }

--- a/processor/registry.go
+++ b/processor/registry.go
@@ -1,11 +1,13 @@
 package processor
 
 import (
+	"github.com/santhosh-tekuri/jsonschema"
+
 	"github.com/elastic/beats/libbeat/logp"
 )
 
 type Register struct {
-	processors map[string]Processor
+	processors map[string]ProcessorData
 }
 
 // Registry is a global registry that contains all processors
@@ -14,21 +16,36 @@ var Registry = newRegister()
 // NewRegister creates a new register for the processors
 func newRegister() *Register {
 	return &Register{
-		processors: map[string]Processor{},
+		processors: map[string]ProcessorData{},
 	}
 }
 
+type ProcessorData struct {
+	Name      string
+	Path      string
+	Schema    *jsonschema.Schema
+	Processor Processor
+}
+
 // AddProcessor adds a processor listening on the given path
-func (r *Register) AddProcessor(path string, p Processor) {
+func (r *Register) AddProcessor(path string, p Processor, schema string) {
 	logp.Info("Processor for path registered: %s", path)
-	r.processors[path] = p
+
+	procData := ProcessorData{
+		Schema:    CreateSchema(schema, p.Name()),
+		Processor: p,
+		Path:      path,
+		Name:      p.Name(),
+	}
+
+	r.processors[path] = procData
 }
 
 // GetProcessors returns a list of all currently registered processors
-func (r *Register) Processors() map[string]Processor {
+func (r *Register) Processors() map[string]ProcessorData {
 	return r.processors
 }
 
-func (r *Register) Processor(name string) Processor {
+func (r *Register) Processor(name string) ProcessorData {
 	return r.processors[name]
 }

--- a/processor/transaction/processor.go
+++ b/processor/transaction/processor.go
@@ -5,12 +5,10 @@ import (
 
 	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/beats/libbeat/beat"
-
-	"github.com/santhosh-tekuri/jsonschema"
 )
 
 func init() {
-	pr.Registry.AddProcessor(Endpoint, NewProcessor())
+	pr.Registry.AddProcessor(Endpoint, NewProcessor(), transactionSchema)
 }
 
 const (
@@ -19,18 +17,16 @@ const (
 )
 
 func NewProcessor() pr.Processor {
-	return &processor{
-		schema: pr.CreateSchema(transactionSchema, processorName),
-	}
+	return &processor{}
 }
 
 type processor struct {
-	schema *jsonschema.Schema
+	//schema *jsonschema.Schema
 }
 
-func (p *processor) Validate(buf []byte) error {
+/*func (p *processor) Validate(buf []byte) error {
 	return pr.Validate(buf, p.schema)
-}
+}*/
 
 func (p *processor) Transform(buf []byte) ([]beat.Event, error) {
 	var pa payload

--- a/script/output_data/output_data.go
+++ b/script/output_data/output_data.go
@@ -32,7 +32,7 @@ func generate() error {
 	for _, p := range processors {
 
 		// Remove version from name and and s at the end
-		name := p.Name()
+		name := p.Name
 
 		// Create path to test docs
 		path := filepath.Join(basepath, name, filename)
@@ -47,12 +47,12 @@ func generate() error {
 			return err
 		}
 
-		err = p.Validate(data)
+		err = processor.Validate(data, p.Schema)
 		if err != nil {
 			return err
 		}
 
-		events, err := p.Transform(data)
+		events, err := p.Processor.Transform(data)
 
 		if err != nil {
 			return err

--- a/tests/approvals.go
+++ b/tests/approvals.go
@@ -60,16 +60,16 @@ type RequestInfo struct {
 	Path string
 }
 
-func TestProcessRequests(t *testing.T, p processor.Processor, requestInfo []RequestInfo) {
+func TestProcessRequests(t *testing.T, p processor.ProcessorData, requestInfo []RequestInfo) {
 	assert := assert.New(t)
 	for _, info := range requestInfo {
 		data, err := LoadData(info.Path)
 		assert.Nil(err)
 
-		err = p.Validate(data)
+		err = processor.Validate(data, p.Schema)
 		assert.NoError(err)
 
-		events, err := p.Transform(data)
+		events, err := p.Processor.Transform(data)
 		assert.NoError(err)
 
 		// extract Fields and write to received.json

--- a/tests/fields.go
+++ b/tests/fields.go
@@ -63,10 +63,6 @@ func TestDocumentedFieldsInEvent(t *testing.T, fieldPaths []string, fn processor
 func fetchEventNames(fn processor.NewProcessor, blacklisted *set.Set) (*set.Set, error) {
 	p := fn()
 	data, _ := LoadValidData(p.Name())
-	err := p.Validate(data)
-	if err != nil {
-		return nil, err
-	}
 
 	events, err := p.Transform(data)
 	if err != nil {

--- a/tests/system/test_requests.py
+++ b/tests/system/test_requests.py
@@ -5,6 +5,7 @@ from requests.exceptions import SSLError
 import requests
 import zlib
 import gzip
+import time
 try:
     from StringIO import StringIO
 except ImportError:
@@ -16,8 +17,11 @@ class Test(ServerBaseTest):
 
     def test_ok(self):
         transactions = self.get_transaction_payload()
+        print "aaa"
         r = requests.post(self.transactions_url, data=transactions,
                           headers={'Content-Type': 'application/json'})
+        print r
+        time.sleep(1)
         assert r.status_code == 202, r.status_code
 
     def test_empty(self):


### PR DESCRIPTION
Currently each processor requires to have a validate function. It kind of bugged me that these Validate functions are exactly the same. This change moves the Validate out of the processor by adding the schema to the processor registry. Like this also schema creating and handling is outside the processor.

I initially expected it to be a small change but it has lots of dependencies so it got more complex.

Pro:

* Schema handling outside of processor
* Schema is not persisted in processor itself
* Smaller interface

Cons:

* ProcessorData is not nice -> better name?
* Having schema inside processor would allow to use different "schemas" which are not json

I was initially playing with the idea to make `Schema()` an interface method on the processor like we have for `Name()` but as the schema is only use in one place, I prefer to pass it directly to the registry.

The current code is working, tests are not. I want to use this PR to discuss if this idea is something that we want to move forward with or drop.