### PR TITLE
Improve logging for production

### DIFF
--- a/beater/server.go
+++ b/beater/server.go
@@ -75,7 +75,7 @@ func createHandler(p processor.Processor, config Config, publish successCallback
 		logp.Debug("handler", "Request: URI=%s, method=%s, content-length=%d", r.RequestURI, r.Method, r.ContentLength)
 
 		if !checkSecretToken(r, config.SecretToken) {
-			sendError(w, r, 401, "Invalid token", true)
+			sendError(w, r, 401, "Invalid token", false)
 			return
 		}
 
@@ -86,7 +86,7 @@ func createHandler(p processor.Processor, config Config, publish successCallback
 
 		reader, err := decodeData(r)
 		if err != nil {
-			sendError(w, r, 400, fmt.Sprintf("Decoding error: %s", err.Error()), true)
+			sendError(w, r, 400, fmt.Sprintf("Decoding error: %s", err.Error()), false)
 			return
 		}
 		defer reader.Close()
@@ -102,12 +102,11 @@ func createHandler(p processor.Processor, config Config, publish successCallback
 
 		err = p.Validate(buf)
 		if err != nil {
-			sendError(w, r, 400, fmt.Sprintf("Data validation error: %s", err), true)
+			sendError(w, r, 400, fmt.Sprintf("Data validation error: %s", err), false)
 			return
 		}
 
 		list, err := p.Transform(buf)
-
 		if err != nil {
 			sendError(w, r, 500, fmt.Sprintf("Data transformation error: %s", err), true)
 			return
@@ -121,6 +120,8 @@ func createHandler(p processor.Processor, config Config, publish successCallback
 func sendError(w http.ResponseWriter, r *http.Request, code int, error string, log bool) {
 	if log {
 		logp.Err(error)
+	} else {
+		logp.Info("%s, code=%d", error, code)
 	}
 
 	w.WriteHeader(code)


### PR DESCRIPTION
In production I expect a log message on the error level that I have to do something. For our 400 response no changes are needed on the server as the problem is potentially on the agent side.

Now only if 500 happens an error is logged, all other are logged on debug level if enabled. Otherwise the production log could be flooded with error messages because of invalid requests or tokens which can be pretty normal if the server has a public API.