### PR TITLE
Introduce metrics to apm-server

### DIFF
--- a/processor/error/payload.go
+++ b/processor/error/payload.go
@@ -5,6 +5,11 @@ import (
 	m "github.com/elastic/apm-server/processor/model"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/monitoring"
+)
+
+var (
+	errorCounter = monitoring.NewInt(errorMetrics, "counter")
 )
 
 type payload struct {
@@ -18,6 +23,7 @@ func (pa *payload) transform() []beat.Event {
 
 	logp.Debug("error", "Transform error events: events=%d, app=%s, agent=%s:%s", len(pa.Events), pa.App.Name, pa.App.Agent.Name, pa.App.Agent.Version)
 
+	errorCounter.Add(int64(len(pa.Events)))
 	for _, e := range pa.Events {
 		events = append(events, pr.CreateDoc(e.Mappings(pa)))
 	}

--- a/processor/transaction/payload.go
+++ b/processor/transaction/payload.go
@@ -5,6 +5,12 @@ import (
 	m "github.com/elastic/apm-server/processor/model"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/monitoring"
+)
+
+var (
+	transactionCounter = monitoring.NewInt(transactionMetrics, "counter")
+	traceCounter       = monitoring.NewInt(transactionMetrics, "traces")
 )
 
 type payload struct {
@@ -18,10 +24,12 @@ func (pa *payload) transform() []beat.Event {
 
 	logp.Debug("transaction", "Transform transaction events: events=%d, app=%s, agent=%s:%s", len(pa.Events), pa.App.Name, pa.App.Agent.Name, pa.App.Agent.Version)
 
+	transactionCounter.Add(int64(len(pa.Events)))
 	for _, tx := range pa.Events {
 
 		events = append(events, pr.CreateDoc(tx.Mappings(pa)))
 
+		traceCounter.Add(int64(len(tx.Traces)))
 		for _, tr := range tx.Traces {
 			events = append(events, pr.CreateDoc(tr.Mappings(pa, tx)))
 		}

--- a/processor/transaction/processor.go
+++ b/processor/transaction/processor.go
@@ -5,6 +5,7 @@ import (
 
 	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/monitoring"
 
 	"github.com/santhosh-tekuri/jsonschema"
 )
@@ -12,6 +13,13 @@ import (
 func init() {
 	pr.Registry.AddProcessor(Endpoint, NewProcessor())
 }
+
+var (
+	transactionMetrics = monitoring.Default.NewRegistry("apm-server.processor.transaction")
+	transformations    = monitoring.NewInt(transactionMetrics, "transformations")
+	validationCount    = monitoring.NewInt(transactionMetrics, "validation.count")
+	validationError    = monitoring.NewInt(transactionMetrics, "validation.errors")
+)
 
 const (
 	Endpoint      = "/v1/transactions"
@@ -29,11 +37,17 @@ type processor struct {
 }
 
 func (p *processor) Validate(buf []byte) error {
-	return pr.Validate(buf, p.schema)
+	validationCount.Inc()
+	err := pr.Validate(buf, p.schema)
+	if err != nil {
+		validationError.Inc()
+	}
+	return err
 }
 
 func (p *processor) Transform(buf []byte) ([]beat.Event, error) {
 	var pa payload
+	transformations.Inc()
 	err := json.Unmarshal(buf, &pa)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This is a first take at adding metrics to the APM server. This is a basic set of metrics to get stats for requests, response and processor internals. We should adjust, add and modify these metrics over time when we see which ones are valuable in production, which ones are not and which ones are missing. This only sets the foundation.

These metrics can be later used to be shipped for monitoring. To access the metrics right now start apm-server as following:

```
./apm-server -e -E http.enabled=true
```

Then you can access the metrics under http://localhost:5066/stats?pretty

Closes https://github.com/elastic/apm-server/issues/99