### PR TITLE
Cleanup logging for PR #94

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -2,7 +2,6 @@ package beater
 
 import (
 	"fmt"
-
 	"net/http"
 
 	"github.com/elastic/beats/libbeat/beat"
@@ -46,8 +45,6 @@ func (bt *beater) Run(b *beat.Beat) error {
 
 	bt.server = newServer(bt.config, callback)
 	err = run(bt.server, bt.config.SSL)
-	logp.Err(err.Error())
-
 	if err == http.ErrServerClosed {
 		return nil
 	}
@@ -57,5 +54,9 @@ func (bt *beater) Run(b *beat.Beat) error {
 // Graceful shutdown
 func (bt *beater) Stop() {
 	logp.Info("stopping apm-server...")
-	stop(bt.server, bt.config.ShutdownTimeout)
+
+	err := stop(bt.server, bt.config.ShutdownTimeout)
+	if err != nil {
+		logp.Err("Error stopping apm-server: %s", err.Error())
+	}
 }


### PR DESCRIPTION
Address review comments from https://github.com/elastic/apm-server/pull/94

* In any case on shutdown the apm-server was logging an error even if it was shut down nicely. The logging message was removed because if it is an error, it will be logged by the beat anyways.
* Cleanup imports
* Logging should happen as late as possible. This makes also testing easier. Stop logging was moved out.