### PR TITLE
Fix system tests setup order

### DIFF
--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -6,8 +6,6 @@ sys.path.append('../../_beats/libbeat/tests/system')
 from beat.beat import TestCase
 from elasticsearch import Elasticsearch
 
-# TODO: rework system tests in go
-
 
 class BaseTest(TestCase):
 
@@ -39,6 +37,8 @@ class ServerBaseTest(BaseTest):
 
     def setUp(self):
         super(ServerBaseTest, self).setUp()
+        shutil.copy(self.beat_path + "/fields.yml", self.working_dir)
+
         self.render_config_template(**self.config())
         self.apmserver_proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("starting apm-server"))
@@ -83,7 +83,6 @@ class ElasticTest(ServerBaseTest):
         return cfg
 
     def setUp(self):
-        super(ElasticTest, self).setUp()
 
         self.es = Elasticsearch([self.get_elasticsearch_url()])
 
@@ -100,7 +99,7 @@ class ElasticTest(ServerBaseTest):
         except:
             pass
 
-        shutil.copy(self.beat_path + "/fields.yml", self.working_dir)
+        super(ElasticTest, self).setUp()
 
     def get_elasticsearch_url(self):
         """

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -4,6 +4,7 @@ import os
 import json
 import requests
 import unittest
+import time
 
 
 class Test(ElasticTest):
@@ -48,6 +49,9 @@ class Test(ElasticTest):
             lambda: self.log_contains("Elasticsearch template with name 'apm-server-tests' loaded"))
 
         self.wait_until(lambda: self.es.indices.exists(self.index_name))
+        # Quick wait to give documents some time to be sent to the index
+        # This is not required but speeds up the tests
+        time.sleep(0.1)
         self.es.indices.refresh(index=self.index_name)
 
         self.wait_until(


### PR DESCRIPTION
For the system tests with es, first the apm-server was started and then the index and the template were cleaned up. This leaded to a race where the apm-server loaded the template but it was directly removed again which made some of the tests flaky.

A small tweak was made to the integration tests. The documents are loaded in multiple batches, means when the index exists not necessarly all docs are in. A very short is wait to get all documents available. This does work most of the time and speeds up tests. Assuming not all documents are in the tests still work, but the wait time until the index is refreshed is a bit longer and depends on Elasticsearch.