### PR TITLE
Push onboarding doc on startup

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -14,6 +14,7 @@ https://github.com/elastic/apm-server/compare/f9a2086ceed0b918e1a0b3d8ddc140fc21
 
 
 ==== Added
+- Send document to output on start of server {pull}117[117]
 
 
 ==== Deprecated

--- a/_meta/fields.common.yml
+++ b/_meta/fields.common.yml
@@ -2,6 +2,10 @@
   title: General APM fields
   description:
   fields:
+    - name: listening
+      type: keyword
+      description: >
+        Address the server is listening on.
     - name: processor.name
       type: keyword
       description: Processor name.
@@ -20,7 +24,7 @@
         - name: tags
           type: object
           object_type: keyword
-          dynamic: true 
+          dynamic: true
           description: >
             Flat mapping of user-defined tags.
 
@@ -107,8 +111,8 @@
             description: >
               Http response status code.
 
-          - name: finished 
-            type: boolean 
+          - name: finished
+            type: boolean
 
         - name: system
           type: group
@@ -176,7 +180,7 @@
                 description: >
                   Language version.
 
-            - name: runtime 
+            - name: runtime
               type: group
               fields:
 
@@ -190,7 +194,7 @@
                 description: >
                   Runtime version.
 
-            - name: framework 
+            - name: framework
               type: group
               fields:
 
@@ -204,7 +208,7 @@
                 description: >
                   Framework version.
 
-            - name: agent 
+            - name: agent
               type: group
               fields:
 

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -2,7 +2,6 @@ package beater
 
 import (
 	"fmt"
-
 	"net/http"
 
 	"github.com/elastic/beats/libbeat/beat"
@@ -37,11 +36,13 @@ func (bt *beater) Run(b *beat.Beat) error {
 	}
 	defer pub.Stop()
 
-	bt.server = newServer(bt.config, pub.Send)
-	err = run(bt.server, bt.config.SSL)
-	logp.Err(err.Error())
+	go notifyListening(bt.config, pub.Send)
 
+	bt.server = newServer(bt.config, pub.Send)
+
+	err = run(bt.server, bt.config.SSL)
 	if err == http.ErrServerClosed {
+		logp.Info("Listener stopped: %s", err.Error())
 		return nil
 	}
 	return err

--- a/beater/client.go
+++ b/beater/client.go
@@ -1,0 +1,38 @@
+package beater
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+func insecureClient() *http.Client {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	return &http.Client{Transport: tr}
+}
+
+func isServerUp(secure bool, host string, numRetries int, retryInterval time.Duration) bool {
+	client := insecureClient()
+	var check = func() bool {
+		url := url.URL{Scheme: "http", Host: host, Path: "healthcheck"}
+		if secure {
+			url.Scheme = "https"
+		}
+		res, err := client.Get(url.String())
+		return err == nil && res.StatusCode == 200
+	}
+
+	for i := 0; i <= numRetries; i++ {
+		if check() {
+			logp.Info("HTTP Server ready")
+			return true
+		}
+		time.Sleep(retryInterval)
+	}
+	return false
+}

--- a/beater/onboarding.go
+++ b/beater/onboarding.go
@@ -1,0 +1,28 @@
+package beater
+
+import (
+	"time"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+func notifyListening(config Config, reporter reporter) {
+
+	var isServerUp = func() bool {
+		secure := config.SSL.isEnabled()
+		return isServerUp(secure, config.Host, 10, time.Second)
+	}
+
+	if isServerUp() {
+		logp.Info("Publishing onboarding document")
+
+		event := beat.Event{
+			Timestamp: time.Now(),
+			Fields:    common.MapStr{"listening": config.Host},
+		}
+		events := []beat.Event{event}
+		reporter(events)
+	}
+}

--- a/beater/onboarding_test.go
+++ b/beater/onboarding_test.go
@@ -1,0 +1,26 @@
+package beater
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/beat"
+)
+
+func TestNotifyUpServerDown(t *testing.T) {
+	config := defaultConfig
+	var saved []beat.Event
+	var reporter = func(events []beat.Event) error {
+		saved = append(saved, events...)
+		return nil
+	}
+
+	server := newServer(config, reporter)
+	go run(server, config.SSL)
+
+	notifyListening(config, reporter)
+
+	listening := saved[0].Fields["listening"].(string)
+	assert.Equal(t, "localhost:8200", listening)
+}

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -2,7 +2,6 @@ package beater
 
 import (
 	"bytes"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -277,13 +276,6 @@ func randomAddr() string {
 	l, _ := net.Listen("tcp", "localhost:0")
 	l.Close()
 	return l.Addr().String()
-}
-
-func insecureClient() *http.Client {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	return &http.Client{Transport: tr}
 }
 
 func waitForServer(secure bool, host string) {

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -29,6 +29,14 @@ None
 
 
 [float]
+=== `listening`
+
+type: keyword
+
+Address the server is listening on.
+
+
+[float]
 === `processor.name`
 
 type: keyword

--- a/processor/error/package_tests/fields_test.go
+++ b/processor/error/package_tests/fields_test.go
@@ -21,6 +21,8 @@ func TestFields(t *testing.T) {
 		"context.db.statement",
 		"context.db.user",
 		"context.db.type",
-		"context.db")
+		"context.db",
+		"listening",
+	)
 	tests.TestDocumentedFieldsInEvent(t, fieldsPaths, er.NewProcessor, notInEvent)
 }

--- a/processor/error/package_tests/json_schema_test.go
+++ b/processor/error/package_tests/json_schema_test.go
@@ -36,6 +36,6 @@ func TestJsonSchemaKeywordLimitation(t *testing.T) {
 		"./../../../_meta/fields.common.yml",
 		"./../_meta/fields.yml",
 	}
-	exceptions := set.New("processor.event", "processor.name", "error.id", "error.log.level", "error.grouping_key")
+	exceptions := set.New("processor.event", "processor.name", "error.id", "error.log.level", "error.grouping_key", "listening")
 	tests.TestJsonSchemaKeywordLimitation(t, fieldsPaths, er.Schema(), exceptions)
 }

--- a/processor/transaction/package_tests/fields_test.go
+++ b/processor/transaction/package_tests/fields_test.go
@@ -16,5 +16,5 @@ func TestEsDocumentation(t *testing.T) {
 	}
 	processorFn := transaction.NewProcessor
 	tests.TestEventAttrsDocumentedInFields(t, fieldsPaths, processorFn)
-	tests.TestDocumentedFieldsInEvent(t, fieldsPaths, processorFn, set.New())
+	tests.TestDocumentedFieldsInEvent(t, fieldsPaths, processorFn, set.New("listening"))
 }

--- a/processor/transaction/package_tests/json_schema_test.go
+++ b/processor/transaction/package_tests/json_schema_test.go
@@ -38,6 +38,6 @@ func TestJsonSchemaKeywordLimitation(t *testing.T) {
 		"./../../../_meta/fields.common.yml",
 		"./../_meta/fields.yml",
 	}
-	exceptions := set.New("processor.event", "processor.name", "context.app.name", "transaction.id", "trace.transaction_id")
+	exceptions := set.New("processor.event", "processor.name", "context.app.name", "transaction.id", "trace.transaction_id", "listening")
 	tests.TestJsonSchemaKeywordLimitation(t, fieldsPaths, transaction.Schema(), exceptions)
 }

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -10,6 +10,21 @@ import time
 class Test(ElasticTest):
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_onboarding_doc(self):
+        """
+        This test starts the beat and checks that the onboarding doc has been published to ES
+        """
+        self.wait_until(lambda: self.es.indices.exists(self.index_name))
+        self.es.indices.refresh(index=self.index_name)
+
+        self.wait_until(
+            lambda: (self.es.count(index=self.index_name)['count'] == 1)
+        )
+
+        # Makes sure no error or warnings were logged
+        self.assert_no_logged_warnings()
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_load_docs_with_template_and_add_transaction(self):
         """
         This test starts the beat with a loaded template and sends transaction data to elasticsearch.
@@ -22,6 +37,14 @@ class Test(ElasticTest):
                                          'transaction',
                                          'payload.json'))
         self.load_docs_with_template(f, 'transactions', 9)
+
+        rs = self.es.count(index=self.index_name, body={
+                           "query": {"term": {"processor.event": "transaction"}}})
+        assert rs['count'] == 4, "found {} documents".format(rs['count'])
+
+        rs = self.es.count(index=self.index_name, body={
+                           "query": {"term": {"processor.event": "trace"}}})
+        assert rs['count'] == 5, "found {} documents".format(rs['count'])
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_load_docs_with_template_and_add_error(self):
@@ -36,6 +59,10 @@ class Test(ElasticTest):
                                          'error',
                                          'payload.json'))
         self.load_docs_with_template(f, 'errors', 4)
+
+        rs = self.es.count(index=self.index_name, body={
+                           "query": {"term": {"processor.event": "error"}}})
+        assert rs['count'] == 4, "found {} documents".format(rs['count'])
 
     def load_docs_with_template(self, data_path, endpoint, expected_events_count):
 
@@ -54,13 +81,12 @@ class Test(ElasticTest):
         time.sleep(0.1)
         self.es.indices.refresh(index=self.index_name)
 
+        # Waits for the docs + 1. The additional document is the onboarding document
         self.wait_until(
             lambda: (self.es.count(index=self.index_name)['count'] ==
-                     expected_events_count)
+                     expected_events_count + 1)
         )
 
-        res = self.es.count(index=self.index_name)
-        assert expected_events_count == res['count']
         # Makes sure no error or warnings were logged
         self.assert_no_logged_warnings()
 


### PR DESCRIPTION
For the UI an onboarding doc is needed to see when the server is actually started. A doc is pushed with the field `up: true` and the `@timestamp` when it was pushed. This happens on each startup.

The code checks that the HTTP Server is running and as soon as this is the case, sends the doc.

This PR takes over the previous work from #110