### PR TITLE
Attempt at generating a 503 if queue is full

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -11,6 +11,7 @@ apm-server:
   #read_timeout: 2s
   #write_timeout: 2s
   #shutdown_timeout: 5s
+  #concurrent_requests: 20
 
   # Authorization token to be checked. If a token is set here the agents must
   # send their token in the following format: Authorization: Bearer <secret-token>

--- a/apm-server.reference.yml
+++ b/apm-server.reference.yml
@@ -11,6 +11,7 @@ apm-server:
   #read_timeout: 2s
   #write_timeout: 2s
   #shutdown_timeout: 5s
+  #concurrent_requests: 20
 
   # Authorization token to be checked. If a token is set here the agents must
   # send their token in the following format: Authorization: Bearer <secret-token>

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -11,6 +11,7 @@ apm-server:
   #read_timeout: 2s
   #write_timeout: 2s
   #shutdown_timeout: 5s
+  #concurrent_requests: 20
 
   # Authorization token to be checked. If a token is set here the agents must
   # send their token in the following format: Authorization: Bearer <secret-token>

--- a/beater/config.go
+++ b/beater/config.go
@@ -5,14 +5,15 @@ import (
 )
 
 type Config struct {
-	Host            string        `config:"host"`
-	MaxUnzippedSize int64         `config:"max_unzipped_size"`
-	MaxHeaderBytes  int           `config:"max_header_bytes"`
-	ReadTimeout     time.Duration `config:"read_timeout"`
-	WriteTimeout    time.Duration `config:"write_timeout"`
-	ShutdownTimeout time.Duration `config:"shutdown_timeout"`
-	SecretToken     string        `config:"secret_token"`
-	SSL             *SSLConfig    `config:"ssl"`
+	Host               string        `config:"host"`
+	MaxUnzippedSize    int64         `config:"max_unzipped_size"`
+	MaxHeaderBytes     int           `config:"max_header_bytes"`
+	ReadTimeout        time.Duration `config:"read_timeout"`
+	WriteTimeout       time.Duration `config:"write_timeout"`
+	ShutdownTimeout    time.Duration `config:"shutdown_timeout"`
+	SecretToken        string        `config:"secret_token"`
+	SSL                *SSLConfig    `config:"ssl"`
+	ConcurrentRequests int           `config:"concurrent_requests" validate:"min=1"`
 }
 
 type SSLConfig struct {
@@ -26,11 +27,12 @@ func (c *SSLConfig) isEnabled() bool {
 }
 
 var defaultConfig = Config{
-	Host:            "localhost:8200",
-	MaxUnzippedSize: 10 * 1024 * 1024, // 10mb
-	MaxHeaderBytes:  1048576,          // 1mb
-	ReadTimeout:     2 * time.Second,
-	WriteTimeout:    2 * time.Second,
-	ShutdownTimeout: 5 * time.Second,
-	SecretToken:     "",
+	Host:               "localhost:8200",
+	MaxUnzippedSize:    10 * 1024 * 1024, // 10mb
+	MaxHeaderBytes:     1048576,          // 1mb
+	ConcurrentRequests: 20,
+	ReadTimeout:        2 * time.Second,
+	WriteTimeout:       2 * time.Second,
+	ShutdownTimeout:    5 * time.Second,
+	SecretToken:        "",
 }

--- a/beater/pub.go
+++ b/beater/pub.go
@@ -1,0 +1,86 @@
+package beater
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/elastic/beats/libbeat/beat"
+)
+
+// publisher forwards batches of events to libbeat. It uses GuaranteedSend
+// to enable infinite retry of events being processed.
+// If the publisher's input channel is full, an error is returned immediately.
+// Number of concurrent requests waiting for processing do depend on the configured
+// queue size. As the publisher is not waiting for the outputs ACK, the total
+// number requests(events) active in the system can exceed the queue size. Only
+// the number of concurrent HTTP requests trying to publish at the same time is limited.
+type publisher struct {
+	events chan []beat.Event
+	client beat.Client
+	wg     sync.WaitGroup
+}
+
+var (
+	errFull              = errors.New("Queue is full")
+	errInvalidBufferSize = errors.New("Request buffer must be > 0")
+)
+
+// newPublisher creates a new publisher instance. A new go-routine is started
+// for forwarding events to libbeat. Stop must be called to close the
+// beat.Client and free resources.
+func newPublisher(pipeline beat.Pipeline, N int) (*publisher, error) {
+	if N <= 0 {
+		return nil, errInvalidBufferSize
+	}
+
+	client, err := pipeline.ConnectWith(beat.ClientConfig{
+		PublishMode: beat.GuaranteedSend,
+
+		// TODO: We want to wait for events in pipeline on shutdown?
+		//       If set >0 `Close` will block for the duration or until pipeline is empty
+		WaitClose: 0,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	p := &publisher{
+		client: client,
+
+		// Set channel size to N - 1. One request will be actively processed by the
+		// worker, while the other concurrent requests will be buffered in the queue.
+		events: make(chan []beat.Event, N-1),
+	}
+
+	p.wg.Add(1)
+	go p.run()
+	return p, nil
+}
+
+// Stop closes all channels and waits for the the worker to stop.
+// The worker will drain the queue on shutdown, but no more events
+// will be published.
+func (p *publisher) Stop() {
+	close(p.events)
+	p.client.Close()
+	p.wg.Wait()
+}
+
+// Send tries to forward events to the publishers worker. If the queue is full,
+// an error is returned.
+// Calling send after Stop will cause a panic.
+func (p *publisher) Send(batch []beat.Event) error {
+	select {
+	case p.events <- batch:
+		return nil
+	default:
+		return errFull
+	}
+}
+
+func (p *publisher) run() {
+	defer p.wg.Done()
+	for batch := range p.events {
+		p.client.PublishAll(batch)
+	}
+}

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -3,6 +3,8 @@ package beater
 import (
 	"bytes"
 	"crypto/tls"
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -40,24 +42,182 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func setupHTTP(t *testing.T) (*http.Server, *http.Request) {
-	if testing.Short() {
-		t.Skip("skipping server test")
-	}
-
-	host := randomAddr()
-	cfg := defaultConfig
-	cfg.Host = host
-	apm := newServer(cfg, func(_ []beat.Event) {})
-	go run(apm, cfg.SSL)
-	waitForServer(false, host)
-	data, _ := tests.LoadValidData("transaction")
-	req, err := http.NewRequest("POST", transaction.Endpoint, bytes.NewReader(data))
+func TestDecode(t *testing.T) {
+	transactionBytes, err := tests.LoadValidData("transaction")
 	assert.Nil(t, err)
-	return apm, req
+	buffer := bytes.NewReader(transactionBytes)
+
+	req, err := http.NewRequest("POST", "_", buffer)
+	req.Header.Add("Content-Type", "application/json")
+	assert.Nil(t, err)
+
+	res, err := decodeData(req)
+	assert.Nil(t, err)
+	assert.NotNil(t, res)
+
+	body, err := ioutil.ReadAll(res)
+	assert.Nil(t, err)
+	assert.Equal(t, transactionBytes, body)
 }
 
-func setupHTTPS(t *testing.T, useCert bool, domain string) (*http.Server, string, []byte) {
+func TestServerOk(t *testing.T) {
+	apm, teardown := setupServer(t, noSSL)
+	defer teardown()
+
+	req := makeTestRequest(t)
+	req.Header.Add("Content-Type", "application/json")
+
+	rr := httptest.NewRecorder()
+	apm.Handler.ServeHTTP(rr, req)
+	assert.Equal(t, 202, rr.Code, rr.Body.String())
+}
+
+func TestServerNoContentType(t *testing.T) {
+	apm, teardown := setupServer(t, noSSL)
+	defer teardown()
+
+	rr := httptest.NewRecorder()
+	apm.Handler.ServeHTTP(rr, makeTestRequest(t))
+	assert.Equal(t, 400, rr.Code, rr.Body.String())
+}
+
+func TestServerSecureUnknownCA(t *testing.T) {
+	apm, teardown := setupServer(t, withSSL(t, "127.0.0.1"))
+	defer teardown()
+
+	_, err := postTestRequest(t, apm, nil, "https")
+	assert.Contains(t, err.Error(), "x509: certificate signed by unknown authority")
+}
+
+func TestServerSecureSkipVerify(t *testing.T) {
+	apm, teardown := setupServer(t, withSSL(t, "127.0.0.1"))
+	defer teardown()
+
+	res, err := postTestRequest(t, apm, insecureClient(), "https")
+	assert.Nil(t, err)
+	assert.Equal(t, res.StatusCode, 202)
+}
+
+func TestServerSecureBadDomain(t *testing.T) {
+	apm, teardown := setupServer(t, withSSL(t, "ELASTIC"))
+	defer teardown()
+
+	_, err := postTestRequest(t, apm, nil, "https")
+
+	msgs := []string{
+		"x509: certificate signed by unknown authority",
+		"x509: cannot validate certificate for 127.0.0.1",
+	}
+	checkErrMsg := strings.Contains(err.Error(), msgs[0]) || strings.Contains(err.Error(), msgs[1])
+	assert.True(t, checkErrMsg, err.Error())
+}
+
+func TestServerSecureBadIP(t *testing.T) {
+	apm, teardown := setupServer(t, withSSL(t, "192.168.10.11"))
+	defer teardown()
+
+	_, err := postTestRequest(t, apm, nil, "https")
+	msgs := []string{
+		"x509: certificate signed by unknown authority",
+		"x509: certificate is valid for 192.168.10.11, not 127.0.0.1",
+	}
+	checkErrMsg := strings.Contains(err.Error(), msgs[0]) || strings.Contains(err.Error(), msgs[1])
+	assert.True(t, checkErrMsg, err.Error())
+}
+
+func TestServerBadProtocol(t *testing.T) {
+	apm, teardown := setupServer(t, withSSL(t, "localhost"))
+	defer teardown()
+
+	_, err := postTestRequest(t, apm, nil, "http")
+	assert.Contains(t, err.Error(), "malformed HTTP response")
+}
+
+func TestSSLEnabled(t *testing.T) {
+	truthy := true
+	falsy := false
+
+	cases := []struct {
+		config   *SSLConfig
+		expected bool
+	}{
+		{nil, false},
+		{&SSLConfig{Enabled: &truthy}, true},
+		{&SSLConfig{Enabled: &falsy}, false},
+		{&SSLConfig{Cert: "Cert"}, true},
+		{&SSLConfig{Cert: "Cert", PrivateKey: "key"}, true},
+		{&SSLConfig{Cert: "Cert", PrivateKey: "key", Enabled: &falsy}, false},
+	}
+
+	for i, test := range cases {
+		name := fmt.Sprintf("%v %v->%v", i, test.config, test.expected)
+		t.Run(name, func(t *testing.T) {
+			b := test.expected
+			isEnabled := test.config.isEnabled()
+			assert.Equal(t, b, isEnabled, "ssl config but should be %v", b)
+		})
+	}
+}
+
+func TestJSONFailureResponse(t *testing.T) {
+	req, err := http.NewRequest("POST", "/transactions", nil)
+	assert.Nil(t, err)
+
+	req.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+
+	sendStatus(w, req, 400, errors.New("Cannot compare apples to oranges"))
+
+	resp := w.Result()
+	body, _ := ioutil.ReadAll(resp.Body)
+	assert.Equal(t, 400, w.Code)
+	assert.Equal(t, body, []byte(`{"error":"Cannot compare apples to oranges"}`))
+}
+
+func TestJSONFailureResponseWhenAcceptingAnything(t *testing.T) {
+	req, err := http.NewRequest("POST", "/transactions", nil)
+	assert.Nil(t, err)
+	req.Header.Set("Accept", "*/*")
+	w := httptest.NewRecorder()
+
+	sendStatus(w, req, 400, errors.New("Cannot compare apples to oranges"))
+
+	resp := w.Result()
+	body, _ := ioutil.ReadAll(resp.Body)
+	assert.Equal(t, 400, w.Code)
+	assert.Equal(t, body, []byte(`{"error":"Cannot compare apples to oranges"}`))
+}
+
+func TestHTMLFailureResponse(t *testing.T) {
+	req, err := http.NewRequest("POST", "/transactions", nil)
+	assert.Nil(t, err)
+	req.Header.Set("Accept", "text/html")
+	w := httptest.NewRecorder()
+
+	sendStatus(w, req, 400, errors.New("Cannot compare apples to oranges"))
+
+	resp := w.Result()
+	body, _ := ioutil.ReadAll(resp.Body)
+	assert.Equal(t, 400, w.Code)
+	assert.Equal(t, body, []byte(`Cannot compare apples to oranges`))
+}
+
+func TestFailureResponseNoAcceptHeader(t *testing.T) {
+	req, err := http.NewRequest("POST", "/transactions", nil)
+	assert.Nil(t, err)
+
+	req.Header.Del("Accept")
+
+	w := httptest.NewRecorder()
+	sendStatus(w, req, 400, errors.New("Cannot compare apples to oranges"))
+
+	resp := w.Result()
+	body, _ := ioutil.ReadAll(resp.Body)
+	assert.Equal(t, 400, w.Code)
+	assert.Equal(t, body, []byte(`Cannot compare apples to oranges`))
+}
+
+func setupServer(t *testing.T, ssl *SSLConfig) (*http.Server, func()) {
 	if testing.Short() {
 		t.Skip("skipping server test")
 	}
@@ -65,23 +225,52 @@ func setupHTTPS(t *testing.T, useCert bool, domain string) (*http.Server, string
 	host := randomAddr()
 	cfg := defaultConfig
 	cfg.Host = host
-	apm := newServer(cfg, func(_ []beat.Event) {})
-	if useCert {
-		cert := path.Join(tmpCertPath, t.Name()+".crt")
-		key := strings.Replace(cert, ".crt", ".key", -1)
-		t.Log("generating certificate in ", cert)
-		httpscerts.Generate(cert, key, domain)
-		cfg.SSL = &SSLConfig{Cert: cert, PrivateKey: key}
-	}
+	cfg.SSL = ssl
 
-	t.Log("Starting server on ", host)
+	apm := newServer(cfg, nopReporter)
 	go run(apm, cfg.SSL)
 
-	waitForServer(true, host)
+	secure := cfg.SSL != nil
+	waitForServer(secure, host)
 
-	data, _ := tests.LoadValidData("transaction")
+	return apm, func() { stop(apm, time.Second) }
+}
 
-	return apm, host, data
+var noSSL *SSLConfig
+
+var testData []byte = func() []byte {
+	d, err := tests.LoadValidData("transaction")
+	if err != nil {
+		panic(err)
+	}
+	return d
+}()
+
+func withSSL(t *testing.T, domain string) *SSLConfig {
+	cert := path.Join(tmpCertPath, t.Name()+".crt")
+	key := path.Join(tmpCertPath, t.Name()+".key")
+	t.Log("generating certificate in ", cert)
+	httpscerts.Generate(cert, key, domain)
+
+	return &SSLConfig{Cert: cert, PrivateKey: key}
+}
+
+func makeTestRequest(t *testing.T) *http.Request {
+	req, err := http.NewRequest("POST", transaction.Endpoint, bytes.NewReader(testData))
+	if err != nil {
+		t.Fatalf("Failed to create test request object: %v", err)
+	}
+
+	return req
+}
+
+func postTestRequest(t *testing.T, apm *http.Server, client *http.Client, schema string) (*http.Response, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	addr := fmt.Sprintf("%s://%s%s", schema, apm.Addr, transaction.Endpoint)
+	return client.Post(addr, "application/json", bytes.NewReader(testData))
 }
 
 func randomAddr() string {
@@ -122,177 +311,4 @@ func waitForServer(secure bool, host string) {
 	panic("server run timeout (10 seconds)")
 }
 
-func TestDecode(t *testing.T) {
-	transactionBytes, err := tests.LoadValidData("transaction")
-	assert.Nil(t, err)
-	buffer := bytes.NewReader(transactionBytes)
-
-	req, err := http.NewRequest("POST", "_", buffer)
-	req.Header.Add("Content-Type", "application/json")
-	assert.Nil(t, err)
-
-	res, err := decodeData(req)
-	assert.Nil(t, err)
-	assert.NotNil(t, res)
-
-	body, err := ioutil.ReadAll(res)
-	assert.Nil(t, err)
-	assert.Equal(t, transactionBytes, body)
-}
-
-func TestServerOk(t *testing.T) {
-	apm, req := setupHTTP(t)
-	req.Header.Add("Content-Type", "application/json")
-	defer stop(apm, time.Second)
-
-	rr := httptest.NewRecorder()
-	apm.Handler.ServeHTTP(rr, req)
-	assert.Equal(t, 202, rr.Code, rr.Body.String())
-}
-
-func TestServerNoContentType(t *testing.T) {
-	apm, req := setupHTTP(t)
-	defer stop(apm, time.Second)
-
-	rr := httptest.NewRecorder()
-	apm.Handler.ServeHTTP(rr, req)
-	assert.Equal(t, 400, rr.Code, rr.Body.String())
-}
-
-func TestServerSecureUnknownCA(t *testing.T) {
-
-	apm, host, data := setupHTTPS(t, true, "127.0.0.1")
-	defer stop(apm, time.Second)
-
-	_, err := http.Post("https://"+host+transaction.Endpoint, "application/json", bytes.NewReader(data))
-
-	assert.Contains(t, err.Error(), "x509: certificate signed by unknown authority")
-}
-
-func TestServerSecureSkipVerify(t *testing.T) {
-
-	apm, host, data := setupHTTPS(t, true, "127.0.0.1")
-	defer stop(apm, time.Second)
-
-	res, err := insecureClient().Post("https://"+host+transaction.Endpoint, "application/json", bytes.NewReader(data))
-
-	assert.Nil(t, err)
-	assert.Equal(t, res.StatusCode, 202)
-}
-
-func TestServerSecureBadDomain(t *testing.T) {
-
-	apm, host, data := setupHTTPS(t, true, "ELASTIC")
-	defer stop(apm, time.Second)
-
-	_, err := http.Post("https://"+host+transaction.Endpoint, "application/json", bytes.NewReader(data))
-
-	msgs := []string{
-		"x509: certificate signed by unknown authority",
-		"x509: cannot validate certificate for 127.0.0.1",
-	}
-	checkErrMsg := strings.Contains(err.Error(), msgs[0]) || strings.Contains(err.Error(), msgs[1])
-	assert.True(t, checkErrMsg, err.Error())
-}
-
-func TestServerSecureBadIP(t *testing.T) {
-
-	apm, host, data := setupHTTPS(t, true, "192.168.10.11")
-	defer stop(apm, time.Second)
-
-	_, err := http.Post("https://"+host+transaction.Endpoint, "application/json", bytes.NewReader(data))
-
-	msgs := []string{
-		"x509: certificate signed by unknown authority",
-		"x509: certificate is valid for 192.168.10.11, not 127.0.0.1",
-	}
-	checkErrMsg := strings.Contains(err.Error(), msgs[0]) || strings.Contains(err.Error(), msgs[1])
-	assert.True(t, checkErrMsg, err.Error())
-}
-
-func TestServerBadProtocol(t *testing.T) {
-
-	apm, host, data := setupHTTPS(t, true, "localhost")
-	defer stop(apm, time.Second)
-
-	_, err := http.Post("http://"+host+transaction.Endpoint, "application/json", bytes.NewReader(data))
-
-	assert.Contains(t, err.Error(), "malformed HTTP response")
-}
-
-func TestSSLEnabled(t *testing.T) {
-	truthy := true
-	falsy := false
-
-	cases := [][]interface{}{
-		{Config{}, false},
-		{Config{SSL: &SSLConfig{Enabled: &truthy}}, true},
-		{Config{SSL: &SSLConfig{Enabled: &falsy}}, false},
-		{Config{SSL: &SSLConfig{Cert: "Cert"}}, true},
-		{Config{SSL: &SSLConfig{Cert: "Cert", PrivateKey: "key"}}, true},
-		{Config{SSL: &SSLConfig{Cert: "Cert", PrivateKey: "key", Enabled: &falsy}}, false},
-	}
-
-	for idx, testCase := range cases {
-		config := testCase[0].(Config)
-		expected := testCase[1].(bool)
-		assert.Equal(t, expected, config.SSL.isEnabled(), "Test Case %d should be %t", idx, expected)
-	}
-}
-
-func TestJSONFailureResponse(t *testing.T) {
-	req, err := http.NewRequest("POST", "/transactions", nil)
-	assert.Nil(t, err)
-	req.Header.Set("Accept", "application/json")
-	w := httptest.NewRecorder()
-
-	sendError(w, req, 400, "Cannot compare apples to oranges", false)
-
-	resp := w.Result()
-	body, _ := ioutil.ReadAll(resp.Body)
-	assert.Equal(t, 400, w.Code)
-	assert.Equal(t, body, []byte(`{"error":"Cannot compare apples to oranges"}`))
-}
-
-func TestJSONFailureResponseWhenAcceptingAnything(t *testing.T) {
-	req, err := http.NewRequest("POST", "/transactions", nil)
-	assert.Nil(t, err)
-	req.Header.Set("Accept", "*/*")
-	w := httptest.NewRecorder()
-
-	sendError(w, req, 400, "Cannot compare apples to oranges", false)
-
-	resp := w.Result()
-	body, _ := ioutil.ReadAll(resp.Body)
-	assert.Equal(t, 400, w.Code)
-	assert.Equal(t, body, []byte(`{"error":"Cannot compare apples to oranges"}`))
-}
-
-func TestHTMLFailureResponse(t *testing.T) {
-	req, err := http.NewRequest("POST", "/transactions", nil)
-	assert.Nil(t, err)
-	req.Header.Set("Accept", "text/html")
-	w := httptest.NewRecorder()
-
-	sendError(w, req, 400, "Cannot compare apples to oranges", false)
-
-	resp := w.Result()
-	body, _ := ioutil.ReadAll(resp.Body)
-	assert.Equal(t, 400, w.Code)
-	assert.Equal(t, body, []byte(`Cannot compare apples to oranges`))
-}
-
-func TestFailureResponseNoAcceptHeader(t *testing.T) {
-	req, err := http.NewRequest("POST", "/transactions", nil)
-	assert.Nil(t, err)
-
-	req.Header.Del("Accept")
-
-	w := httptest.NewRecorder()
-	sendError(w, req, 400, "Cannot compare apples to oranges", false)
-
-	resp := w.Result()
-	body, _ := ioutil.ReadAll(resp.Body)
-	assert.Equal(t, 400, w.Code)
-	assert.Equal(t, body, []byte(`Cannot compare apples to oranges`))
-}
+func nopReporter(_ []beat.Event) error { return nil }


### PR DESCRIPTION
This solution uses an intermediate go-routine accepting batches of events from the http handlers and forwarding these as single events to the beats publisher pipeline. The events are forwarded with infinite retrying enabled. Sending events to the go-routine's channel fails immediately if the channel is full. In this case a 503 response will be returned to the agent.