### PR TITLE
Remove apm-server specific version

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,5 +18,5 @@ var RootCmd *cmd.BeatsRootCmd
 
 func init() {
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
-	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "0.2.0", beater.New, runFlags)
+	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "", beater.New, runFlags)
 }


### PR DESCRIPTION
This removes the version in apm-server which we used previously for internal release tracking. apm-server from now on automatically follows the version of the elastic stack given by libbeat.