### PR TITLE
Fix apm-server build

### DIFF
--- a/_beats/libbeat/docs/version.asciidoc
+++ b/_beats/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 6.1.0
+:stack-version: 7.0.0-alpha1
 :doc-branch: master
 :go-version: 1.8.3
 :release-state: unreleased

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,5 +18,5 @@ var RootCmd *cmd.BeatsRootCmd
 
 func init() {
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
-	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "0.2.0", beater.New, runFlags)
+	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "7.0.0-alpha1", beater.New, runFlags)
 }


### PR DESCRIPTION
Because of the libbeat dependency apm-server was built with 6.0.0-beta1 instead of 7.0.0-alpha1 from master. This is a manual fix which will be automated in a follow up PR.