### PR TITLE
Update beats to 1ee5c9 in 6.0 branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ TEST_ENVIRONMENT=true
 ES_BEATS?=./_beats
 PREFIX?=.
 NOTICE_FILE=NOTICE
-BEATS_VERSION?=master
+BEATS_VERSION?=6.x
 
 # Path to the libbeat Makefile
 -include $(ES_BEATS)/libbeat/scripts/Makefile
@@ -15,6 +15,7 @@ BEATS_VERSION?=master
 # updates beats updates the framework part and go parts of beats
 update-beats:
 	govendor fetch github.com/elastic/beats/...@$(BEATS_VERSION)
+	wget https://raw.githubusercontent.com/elastic/beats/6.0/libbeat/version/version.go -O ./vendor/github.com/elastic/beats/libbeat/version/version.go
 	BEATS_VERSION=$(BEATS_VERSION) sh _beats/update.sh
 	$(MAKE) update
 

--- a/NOTICE
+++ b/NOTICE
@@ -181,8 +181,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 --------------------------------------------------------------------
 Dependency: github.com/elastic/beats
-Version: master
-Revision: fc67bbbb67e4c0c1160e53167fff814802bade70
+Version: 6.x
+Revision: 1ee5c98d4dc1809288b1fcd748a39705f2f50623
 License type (autodetected): Apache License 2.0
 ./vendor/github.com/elastic/beats/LICENSE:
 --------------------------------------------------------------------

--- a/_beats/dev-tools/packer/platforms/debian/run.sh.j2
+++ b/_beats/dev-tools/packer/platforms/debian/run.sh.j2
@@ -7,6 +7,10 @@ cd /build
 # the init scripts needs to have the right name
 cp ${RUNID}.init /tmp/{{.beat_pkg_name}}.init
 
+# create script to reload systemd config
+echo "#!/bin/bash" > /tmp/systemd-daemon-reload.sh
+echo "systemctl daemon-reload 2> /dev/null || true" >> /tmp/systemd-daemon-reload.sh
+
 # add SNAPSHOT if it was requested
 VERSION="{{.version}}"
 if [ "$SNAPSHOT" = "yes" ]; then
@@ -23,7 +27,7 @@ FPM_ARGS=(
         --description "{{.beat_description}}"
         --url {{.beat_url}}
         --deb-init /tmp/{{.beat_pkg_name}}.init
-        --deb-systemd ${RUNID}.service
+        --after-install /tmp/systemd-daemon-reload.sh
         --config-files /etc/{{.beat_name}}/{{.beat_name}}.yml
         homedir/=/usr/share/{{.beat_name}}
         beatname-${RUNID}.sh=/usr/bin/{{.beat_name}}
@@ -31,6 +35,7 @@ FPM_ARGS=(
         {{.beat_name}}-linux.yml=/etc/{{.beat_name}}/{{.beat_name}}.yml
         {{.beat_name}}-linux.reference.yml=/etc/{{.beat_name}}/{{.beat_name}}.reference.yml
         fields.yml=/etc/{{.beat_name}}/fields.yml
+        ${RUNID}.service=/lib/systemd/system/{{.beat_pkg_name}}.service
         god-linux-{{.arch}}=/usr/share/{{.beat_name}}/bin/{{.beat_name}}-god
   )
 

--- a/_beats/dev-tools/packer/version.yml
+++ b/_beats/dev-tools/packer/version.yml
@@ -1,1 +1,1 @@
-version: "7.0.0-alpha1"
+version: "6.0.0-rc1"

--- a/_beats/libbeat/_meta/kibana/default/index-pattern/libbeat.json
+++ b/_beats/libbeat/_meta/kibana/default/index-pattern/libbeat.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.0.0-alpha1", 
+  "version": "6.1.0", 
   "objects": [
     {
       "attributes": {

--- a/_beats/libbeat/docs/version.asciidoc
+++ b/_beats/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 7.0.0-alpha1
+:stack-version: 6.1.0
 :doc-branch: master
 :go-version: 1.8.3
 :release-state: unreleased

--- a/_beats/libbeat/scripts/Makefile
+++ b/_beats/libbeat/scripts/Makefile
@@ -355,6 +355,8 @@ env-logs:
 HOME_PREFIX?=/tmp/${BEAT_NAME}
 .PHONY: install-home
 install-home:
+	install -d -m 755 ${HOME_PREFIX}/scripts/
+	install -m 755 ${ES_BEATS}/libbeat/scripts/migrate_beat_config_1_x_to_5_0.py ${HOME_PREFIX}/scripts/
 	if [ -a ${NOTICE_FILE} ]; then \
 		install -m 644 ${NOTICE_FILE} ${HOME_PREFIX}/; \
 	fi

--- a/_beats/libbeat/scripts/migrate_beat_config_1_x_to_5_0.py
+++ b/_beats/libbeat/scripts/migrate_beat_config_1_x_to_5_0.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python
+import argparse
+import os
+import re
+
+
+def collect_lines(fn):
+    return lambda content: "\n".join(fn(content)) + "\n"
+
+
+def process_lines(fn):
+    def go(content):
+        return (l for line in content.splitlines() for l in fn(line))
+    return collect_lines(go)
+
+
+@process_lines
+def migrate_packetbeat(line):
+    """
+    Changes things like `interfaces:` to `packetbeat.interfaces:`
+    at the top level.
+    """
+    sections = ["interfaces", "protocols", "procs",
+                "runoptions", "ignore_outgoing"]
+    for sec in sections:
+        if line.startswith(sec + ":"):
+            return ["packetbeat." + line]
+    return [line]
+
+
+@collect_lines
+def migrate_shipper(content):
+    """
+    Moves everything under the `shipper:` section to be top level.
+    """
+    state = "out"
+    for line in content.splitlines():
+        if state == "out":
+            if line.startswith("shipper:"):
+                state = "in"
+                # eat line
+            else:
+                yield line
+        elif state == "in":
+            if line.startswith("  "):
+                yield line[2:]
+            elif line.startswith("\t"):
+                yield line[1:]
+            elif line == "":
+                yield line
+            else:
+                yield line
+                state = "out"
+
+
+@collect_lines
+def migrate_tls_settings(content):
+    """
+    Updates tls section, changing tls to ssl and adapting field changes.
+    """
+    state = "out"
+    indent = 0
+    comments = []
+
+    keep_settings = [
+        'certificate_authorities',
+        'certificate',
+        'cipher_suites',
+        'curve_types'
+    ]
+
+    rename_settings = {
+        "certificate_key": "key",
+    }
+
+    regex_replace_settings = {
+        "insecure": [
+            [re.compile(".*insecure.*false"), "verification_mode: full"],
+            [re.compile(".*insecure.*true"), "verification_mode: none"],
+        ]
+    }
+
+    version_indent = [None]
+    min_version = [None]
+    max_version = [None]
+    min_version_used = max_version_used = False
+
+    ssl_versions_old = {"SSL-3.0": 0, "1.0": 1, "1.1": 2, "1.2": 3}
+    ssl_versions_new = ["SSLv3", "TLSv1.0", "TLSv1.1", "TLSv1.2"]
+
+    def get_old_tls_version(v, default):
+        if v not in ssl_versions_old:
+            return ssl_versions_old[default]
+        return ssl_versions_old[v]
+
+    def make_version_info():
+        if version_indent[0] is None:
+            return
+
+        indent = version_indent[0]
+        commented_out = not (min_version_used or max_version_used)
+        v_start = min_version[0]
+        v_end = max_version[0]
+
+        if min_version_used != max_version_used:
+            if not min_version_used:
+                v_start = "1.0"
+            if not max_version_used:
+                v_end = "1.2"
+
+        v_start = get_old_tls_version(v_start, "1.0")
+        v_end = get_old_tls_version(v_end, "1.2")
+        versions = (ssl_versions_new[i] for i in xrange(v_start, v_end + 1))
+
+        line = indent * ' ' + ('#' if commented_out else '')
+        line += "supported_protocols:"
+        line += "[" + ", ".join(versions) + "]"
+
+        yield ""
+        yield line
+
+        version_indent[0] = None
+        min_version[0] = None
+        max_version[0] = None
+
+    for line in content.splitlines():
+        tmp = line.expandtabs()
+        line_indent = len(tmp) - len(tmp.lstrip())
+        line_start = tmp.lstrip()
+        tmp = line_start.split(':', 1)
+        setting = None
+        value = None
+        commented_out = len(line_start) > 0 and line_start[0] == '#'
+        if len(tmp) > 1:
+            setting = tmp[0]
+            value = tmp[1].strip()
+            if setting[0] == '#':
+                setting = setting[1:]
+
+        def create_setting(l):
+            return (line_indent * " ") + ('#' if commented_out else '') + l
+
+        if state == "out":
+            if setting == "tls":
+                state = "in"
+                indent = line_indent
+                yield create_setting("ssl:")
+            else:
+                yield line
+        elif state == "in":
+            if setting is not None and line_indent <= indent:
+                for l in make_version_info():
+                    yield l
+                # last few comments have been part of next line -> print
+                for l in comments:
+                    yield l
+                yield line
+                comments = []
+                state = "out"
+            elif setting is None:
+                comments.append(line)
+            elif setting in keep_settings:
+                for c in comments:
+                    yield c
+                comments = []
+                yield line
+            elif setting in rename_settings:
+                new_name = rename_settings[setting]
+                for c in comments:
+                    yield c
+                comments = []
+                yield line.replace(setting, new_name, 1)
+            elif setting in regex_replace_settings:
+                # drop comments and add empty line before new setting
+                comments = []
+                yield ""
+
+                for pattern in regex_replace_settings[setting]:
+                    regex, val = pattern
+                    if regex.match(line):
+                        yield create_setting(regex.sub(line, val, 1))
+                        break
+            elif setting == 'min_version':
+                comments = []
+                min_version[0] = value
+                min_version_used = not commented_out
+                version_indent[0] = line_indent
+            elif setting == 'max_version':
+                comments = []
+                max_version[0] = value
+                max_version_used = not commented_out
+                version_indent[0] = line_indent
+            else:
+                yield line
+        else:
+            yield line
+
+    # add version info in case end of output is SSL/TLS section
+    if state == 'in':
+        for l in make_version_info():
+            yield l
+
+
+def main():
+    # List of migrations to apply. Shipper must be migrated first for
+    # ignore_outgoing to be applied properly
+    migrations = [
+        migrate_shipper,
+        migrate_packetbeat,
+        migrate_tls_settings]
+
+    parser = argparse.ArgumentParser(
+        description="Migrates beats configuration from 1.x to 5.0")
+    parser.add_argument("file",
+                        help="Configuration file to migrate")
+    parser.add_argument("--dry", action="store_true",
+                        help="Don't do any changes, just print the" +
+                             " modified config to the screen")
+    args = parser.parse_args()
+
+    with open(args.file, "r") as f:
+        content = f.read()
+        for m in migrations:
+            content = m(content)
+
+    if args.dry:
+        print(content)
+    else:
+        os.rename(args.file, args.file + ".bak")
+        print("Backup file created: {}".format(args.file + ".bak"))
+        with open(args.file, "w") as f:
+            f.write(content)
+
+
+if __name__ == "__main__":
+    main()
+
+
+def test_migrate_packetbeat():
+    test = """
+# Select the network interfaces to sniff the data. You can use the "any"
+# keyword to sniff on all connected interfaces.
+interfaces:
+  device: en0
+
+############################# Protocols #######################################
+protocols:
+  dns:
+    # Configure the ports where to listen for DNS traffic. You can disable
+    # the DNS protocol by commenting out the list of ports.
+    ports: [53]
+runoptions:
+procs:
+ignore_outgoing: true
+"""
+
+    output = migrate_packetbeat(test)
+    assert output == """
+# Select the network interfaces to sniff the data. You can use the "any"
+# keyword to sniff on all connected interfaces.
+packetbeat.interfaces:
+  device: en0
+
+############################# Protocols #######################################
+packetbeat.protocols:
+  dns:
+    # Configure the ports where to listen for DNS traffic. You can disable
+    # the DNS protocol by commenting out the list of ports.
+    ports: [53]
+packetbeat.runoptions:
+packetbeat.procs:
+packetbeat.ignore_outgoing: true
+"""
+
+
+def test_migrate_shipper():
+    test = """
+############################# Shipper #########################################
+
+shipper:
+  # The name of the shipper that publishes the network data. It can be used to group
+  # all the transactions sent by a single shipper in the web interface.
+  # If this options is not defined, the hostname is used.
+  name:
+
+  # The tags of the shipper are included in their own field with each
+  # transaction published. Tags make it easy to group servers by different
+  # logical properties.
+  #tags: ["service-X", "web-tier"]
+test:
+"""
+    output = migrate_shipper(test)
+    assert output == """
+############################# Shipper #########################################
+
+# The name of the shipper that publishes the network data. It can be used to group
+# all the transactions sent by a single shipper in the web interface.
+# If this options is not defined, the hostname is used.
+name:
+
+# The tags of the shipper are included in their own field with each
+# transaction published. Tags make it easy to group servers by different
+# logical properties.
+#tags: ["service-X", "web-tier"]
+test:
+"""
+
+
+def test_migrate_tls_settings():
+    test = """
+output:
+  # Elasticsearch output
+  elasticsearch:
+    # tls configuration. By default is off.
+    tls:
+      # List of root certificates for HTTPS server verifications
+      certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+      # Certificate for TLS client authentication
+      #certificate: "/etc/pki/client/cert.pem"
+
+      # Client Certificate Key
+      #certificate_key: "/etc/pki/client/cert.key"
+
+      # Controls whether the client verifies server certificates and host name.
+      # If insecure is set to true, all server host names and certificates will be
+      # accepted. In this mode TLS based connections are susceptible to
+      # man-in-the-middle attacks. Use only for testing.
+      #insecure: true
+
+      # Configure cipher suites to be used for TLS connections
+      #cipher_suites: []
+
+      # Configure curve types for ECDHE based cipher suites
+      #curve_types: []
+
+      # Configure minimum TLS version allowed for connection to logstash
+      min_version: 1.1
+
+      # Configure maximum TLS version allowed for connection to logstash
+      max_version: 1.2
+
+  # Logstash output.
+  #logstash:
+    # tls configuration. By default is off.
+    #tls:
+      # List of root certificates for HTTPS server verifications
+      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+      # Certificate for TLS client authentication
+      #certificate: "/etc/pki/client/cert.pem"
+
+      # Client Certificate Key
+      #certificate_key: "/etc/pki/client/cert.key"
+
+      # Controls whether the client verifies server certificates and host name.
+      # If insecure is set to true, all server host names and certificates will be
+      # accepted. In this mode TLS based connections are susceptible to
+      # man-in-the-middle attacks. Use only for testing.
+      #insecure: true
+
+      # Configure cipher suites to be used for TLS connections
+      #cipher_suites: []
+
+      # Configure curve types for ECDHE based cipher suites
+      #curve_types: []
+
+      # Configure minimum TLS version allowed for connection to logstash
+      #min_version: 1.0
+
+      # Configure maximum TLS version allowed for connection to logstash
+      #max_version: 1.2
+
+  # Redis output
+  redis:
+    tls:
+      # List of root certificates for HTTPS server verifications
+      certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+      # Certificate for TLS client authentication
+      certificate: "/etc/pki/client/cert.pem"
+
+      # Client Certificate Key
+      certificate_key: "/etc/pki/client/cert.key"
+
+      # Controls whether the client verifies server certificates and host name.
+      # If insecure is set to true, all server host names and certificates will be
+      # accepted. In this mode TLS based connections are susceptible to
+      # man-in-the-middle attacks. Use only for testing.
+      insecure: false
+
+      # Configure cipher suites to be used for TLS connections
+      #cipher_suites: []
+
+      # Configure curve types for ECDHE based cipher suites
+      #curve_types: []
+
+      # Configure minimum TLS version allowed for connection to logstash
+      #min_version: 1.1
+
+      # Configure maximum TLS version allowed for connection to logstash
+      max_version: 1.1
+    """
+
+    output = migrate_tls_settings(test)
+    assert output == """
+output:
+  # Elasticsearch output
+  elasticsearch:
+    # tls configuration. By default is off.
+    ssl:
+      # List of root certificates for HTTPS server verifications
+      certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+      # Certificate for TLS client authentication
+      #certificate: "/etc/pki/client/cert.pem"
+
+      # Client Certificate Key
+      #key: "/etc/pki/client/cert.key"
+
+      #verification_mode: none
+
+      # Configure cipher suites to be used for TLS connections
+      #cipher_suites: []
+
+      # Configure curve types for ECDHE based cipher suites
+      #curve_types: []
+
+      supported_protocols:[TLSv1.1, TLSv1.2]
+
+  # Logstash output.
+  #logstash:
+    # tls configuration. By default is off.
+    #ssl:
+      # List of root certificates for HTTPS server verifications
+      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+      # Certificate for TLS client authentication
+      #certificate: "/etc/pki/client/cert.pem"
+
+      # Client Certificate Key
+      #key: "/etc/pki/client/cert.key"
+
+      #verification_mode: none
+
+      # Configure cipher suites to be used for TLS connections
+      #cipher_suites: []
+
+      # Configure curve types for ECDHE based cipher suites
+      #curve_types: []
+
+      #supported_protocols:[TLSv1.0, TLSv1.1, TLSv1.2]
+
+  # Redis output
+  redis:
+    ssl:
+      # List of root certificates for HTTPS server verifications
+      certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+      # Certificate for TLS client authentication
+      certificate: "/etc/pki/client/cert.pem"
+
+      # Client Certificate Key
+      key: "/etc/pki/client/cert.key"
+
+      verification_mode: full
+
+      # Configure cipher suites to be used for TLS connections
+      #cipher_suites: []
+
+      # Configure curve types for ECDHE based cipher suites
+      #curve_types: []
+
+      supported_protocols:[TLSv1.0, TLSv1.1]
+"""

--- a/_beats/update.sh
+++ b/_beats/update.sh
@@ -16,11 +16,14 @@ cd $GIT_CLONE
 git checkout $BEATS_VERSION
 cd ..
 
+
 # TODO: allow to check out specific branch / tag
 
 # Copy top level files
 cp -r $GIT_CLONE/script script
 cp -r $GIT_CLONE/dev-tools dev-tools
+
+wget https://raw.githubusercontent.com/elastic/beats/6.0/dev-tools/packer/version.yml -O dev-tools/packer/version.yml
 
 # Fetch libbeat dependencies
 mkdir libbeat

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,5 +18,5 @@ var RootCmd *cmd.BeatsRootCmd
 
 func init() {
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
-	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "7.0.0-alpha1", beater.New, runFlags)
+	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "", beater.New, runFlags)
 }

--- a/vendor/github.com/elastic/beats/libbeat/cfgfile/reload.go
+++ b/vendor/github.com/elastic/beats/libbeat/cfgfile/reload.go
@@ -150,9 +150,8 @@ func (rl *Reloader) Run(runnerFactory RunnerFactory) {
 					if runner != nil && rl.registry.Has(runner.ID()) {
 						debugf("Remove module from stoplist: %v", runner.ID())
 						delete(stopList, runner.ID())
-					} else {
-						logp.Err("Error creating module: %s", err)
 					}
+					logp.Err("Error creating module: %s", err)
 					continue
 				}
 

--- a/vendor/github.com/elastic/beats/libbeat/publisher/pipeline/batch.go
+++ b/vendor/github.com/elastic/beats/libbeat/publisher/pipeline/batch.go
@@ -15,7 +15,7 @@ type Batch struct {
 }
 
 type batchContext struct {
-	observer outputObserver
+	observer *observer
 	retryer  *retryer
 }
 

--- a/vendor/github.com/elastic/beats/libbeat/publisher/pipeline/controller.go
+++ b/vendor/github.com/elastic/beats/libbeat/publisher/pipeline/controller.go
@@ -12,7 +12,7 @@ import (
 // - reload
 type outputController struct {
 	logger   *logp.Logger
-	observer outputObserver
+	observer *observer
 
 	queue queue.Queue
 
@@ -40,7 +40,7 @@ type outputWorker interface {
 
 func newOutputController(
 	log *logp.Logger,
-	observer outputObserver,
+	observer *observer,
 	b queue.Queue,
 ) *outputController {
 	c := &outputController{
@@ -52,7 +52,7 @@ func newOutputController(
 	ctx := &batchContext{}
 	c.consumer = newEventConsumer(log, b, ctx)
 	c.retryer = newRetryer(log, observer, nil, c.consumer)
-	ctx.observer = observer
+	ctx.observer = c.observer
 	ctx.retryer = c.retryer
 
 	c.consumer.sigContinue()

--- a/vendor/github.com/elastic/beats/libbeat/publisher/pipeline/monitoring.go
+++ b/vendor/github.com/elastic/beats/libbeat/publisher/pipeline/monitoring.go
@@ -2,48 +2,13 @@ package pipeline
 
 import "github.com/elastic/beats/libbeat/monitoring"
 
-type observer interface {
-	pipelineObserver
-	clientObserver
-	queueObserver
-	outputObserver
-
-	cleanup()
-}
-
-type pipelineObserver interface {
-	clientConnected()
-	clientClosing()
-	clientClosed()
-}
-
-type clientObserver interface {
-	newEvent()
-	filteredEvent()
-	publishedEvent()
-	failedPublishEvent()
-}
-
-type queueObserver interface {
-	queueACKed(n int)
-}
-
-type outputObserver interface {
-	updateOutputGroup()
-	eventsFailed(int)
-	eventsDropped(int)
-	eventsRetry(int)
-	outBatchSend(int)
-	outBatchACKed(int)
-}
-
-// metricsObserver is used by many component in the publisher pipeline, to report
+// observer is used by many component in the publisher pipeline, to report
 // internal events. The oberserver can call registered global event handlers or
 // updated shared counters/metrics for reporting.
 // All events required for reporting events/metrics on the pipeline-global level
 // are defined by observer. The components are only allowed to serve localized
 // event-handlers only (e.g. the client centric events callbacks)
-type metricsObserver struct {
+type observer struct {
 	metrics *monitoring.Registry
 
 	// clients metrics
@@ -58,13 +23,14 @@ type metricsObserver struct {
 	ackedQueue *monitoring.Uint
 }
 
-func newMetricsObserver(metrics *monitoring.Registry) *metricsObserver {
+func (o *observer) init(metrics *monitoring.Registry) {
+	o.metrics = metrics
 	reg := metrics.GetRegistry("pipeline")
 	if reg == nil {
 		reg = metrics.NewRegistry("pipeline")
 	}
 
-	return &metricsObserver{
+	*o = observer{
 		metrics: metrics,
 		clients: monitoring.NewUint(reg, "clients"),
 
@@ -81,10 +47,8 @@ func newMetricsObserver(metrics *monitoring.Registry) *metricsObserver {
 	}
 }
 
-func (o *metricsObserver) cleanup() {
-	if o.metrics != nil {
-		o.metrics.Remove("pipeline") // drop all metrics from registry
-	}
+func (o *observer) cleanup() {
+	o.metrics.Remove("pipeline") // drop all metrics from registry
 }
 
 //
@@ -92,37 +56,37 @@ func (o *metricsObserver) cleanup() {
 //
 
 // (pipeline) pipeline did finish creating a new client instance
-func (o *metricsObserver) clientConnected() { o.clients.Inc() }
+func (o *observer) clientConnected() { o.clients.Inc() }
 
 // (client) close being called on client
-func (o *metricsObserver) clientClosing() {}
+func (o *observer) clientClosing() {}
 
 // (client) client finished processing close
-func (o *metricsObserver) clientClosed() { o.clients.Dec() }
+func (o *observer) clientClosed() { o.clients.Dec() }
 
 //
 // client publish events
 //
 
 // (client) client is trying to publish a new event
-func (o *metricsObserver) newEvent() {
+func (o *observer) newEvent() {
 	o.events.Inc()
 	o.activeEvents.Inc()
 }
 
 // (client) event is filtered out (on purpose or failed)
-func (o *metricsObserver) filteredEvent() {
+func (o *observer) filteredEvent() {
 	o.filtered.Inc()
 	o.activeEvents.Dec()
 }
 
 // (client) managed to push an event into the publisher pipeline
-func (o *metricsObserver) publishedEvent() {
+func (o *observer) publishedEvent() {
 	o.published.Inc()
 }
 
 // (client) client closing down or DropIfFull is set
-func (o *metricsObserver) failedPublishEvent() {
+func (o *observer) failedPublishEvent() {
 	o.failed.Inc()
 	o.activeEvents.Dec()
 }
@@ -132,7 +96,7 @@ func (o *metricsObserver) failedPublishEvent() {
 //
 
 // (queue) number of events ACKed by the queue/broker in use
-func (o *metricsObserver) queueACKed(n int) {
+func (o *observer) queueACKed(n int) {
 	o.ackedQueue.Add(uint64(n))
 	o.activeEvents.Sub(uint64(n))
 }
@@ -142,43 +106,23 @@ func (o *metricsObserver) queueACKed(n int) {
 //
 
 // (controller) new output group is about to be loaded
-func (o *metricsObserver) updateOutputGroup() {}
+func (o *observer) updateOutputGroup() {}
 
 // (retryer) new failed batch has been received
-func (o *metricsObserver) eventsFailed(int) {}
+func (o *observer) eventsFailed(int) {}
 
 // (retryer) number of events dropped by retryer
-func (o *metricsObserver) eventsDropped(n int) {
+func (o *observer) eventsDropped(n int) {
 	o.dropped.Add(uint64(n))
 }
 
 // (retryer) number of events pushed to the output worker queue
-func (o *metricsObserver) eventsRetry(n int) {
+func (o *observer) eventsRetry(n int) {
 	o.retry.Add(uint64(n))
 }
 
 // (output) number of events to be forwarded to the output client
-func (o *metricsObserver) outBatchSend(int) {}
+func (o *observer) outBatchSend(int) {}
 
 // (output) number of events acked by the output batch
-func (o *metricsObserver) outBatchACKed(int) {}
-
-type emptyObserver struct{}
-
-var nilObserver observer = (*emptyObserver)(nil)
-
-func (*emptyObserver) cleanup()            {}
-func (*emptyObserver) clientConnected()    {}
-func (*emptyObserver) clientClosing()      {}
-func (*emptyObserver) clientClosed()       {}
-func (*emptyObserver) newEvent()           {}
-func (*emptyObserver) filteredEvent()      {}
-func (*emptyObserver) publishedEvent()     {}
-func (*emptyObserver) failedPublishEvent() {}
-func (*emptyObserver) queueACKed(n int)    {}
-func (*emptyObserver) updateOutputGroup()  {}
-func (*emptyObserver) eventsFailed(int)    {}
-func (*emptyObserver) eventsDropped(int)   {}
-func (*emptyObserver) eventsRetry(int)     {}
-func (*emptyObserver) outBatchSend(int)    {}
-func (*emptyObserver) outBatchACKed(int)   {}
+func (o *observer) outBatchACKed(int) {}

--- a/vendor/github.com/elastic/beats/libbeat/publisher/pipeline/output.go
+++ b/vendor/github.com/elastic/beats/libbeat/publisher/pipeline/output.go
@@ -8,7 +8,7 @@ import (
 
 // clientWorker manages output client of type outputs.Client, not supporting reconnect.
 type clientWorker struct {
-	observer outputObserver
+	observer *observer
 	qu       workQueue
 	client   outputs.Client
 	closed   atomic.Bool
@@ -16,7 +16,7 @@ type clientWorker struct {
 
 // netClientWorker manages reconnectable output clients of type outputs.NetworkClient.
 type netClientWorker struct {
-	observer outputObserver
+	observer *observer
 	qu       workQueue
 	client   outputs.NetworkClient
 	closed   atomic.Bool
@@ -25,13 +25,13 @@ type netClientWorker struct {
 	batchSizer func() int
 }
 
-func makeClientWorker(observer outputObserver, qu workQueue, client outputs.Client) outputWorker {
+func makeClientWorker(observer *observer, qu workQueue, client outputs.Client) outputWorker {
 	if nc, ok := client.(outputs.NetworkClient); ok {
 		c := &netClientWorker{observer: observer, qu: qu, client: nc}
 		go c.run()
 		return c
 	}
-	c := &clientWorker{observer: observer, qu: qu, client: client}
+	c := &clientWorker{qu: qu, client: client}
 	go c.run()
 	return c
 }

--- a/vendor/github.com/elastic/beats/libbeat/publisher/pipeline/retry.go
+++ b/vendor/github.com/elastic/beats/libbeat/publisher/pipeline/retry.go
@@ -14,7 +14,7 @@ import (
 // outputs.
 type retryer struct {
 	logger   *logp.Logger
-	observer outputObserver
+	observer *observer
 
 	done chan struct{}
 
@@ -54,7 +54,7 @@ const (
 
 func newRetryer(
 	log *logp.Logger,
-	observer outputObserver,
+	observer *observer,
 	out workQueue,
 	c *eventConsumer,
 ) *retryer {

--- a/vendor/github.com/elastic/beats/libbeat/template/field.go
+++ b/vendor/github.com/elastic/beats/libbeat/template/field.go
@@ -131,9 +131,7 @@ func (f *Field) text() common.MapStr {
 	}
 
 	if len(f.MultiFields) > 0 {
-		fields := common.MapStr{}
-		f.MultiFields.process("", f.esVersion, fields)
-		properties["fields"] = fields
+		properties["fields"] = f.MultiFields.process("", f.esVersion)
 	}
 
 	return properties

--- a/vendor/github.com/elastic/beats/libbeat/template/template.go
+++ b/vendor/github.com/elastic/beats/libbeat/template/template.go
@@ -99,10 +99,7 @@ func (t *Template) Load(file string) (common.MapStr, error) {
 	}
 
 	// Start processing at the root
-	properties := common.MapStr{}
-	if err := fields.process("", t.esVersion, properties); err != nil {
-		return nil, err
-	}
+	properties := fields.process("", t.esVersion)
 	output := t.generate(properties, dynamicTemplates)
 
 	return output, nil

--- a/vendor/github.com/elastic/beats/libbeat/version/version.go
+++ b/vendor/github.com/elastic/beats/libbeat/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const defaultBeatVersion = "7.0.0-alpha1"
+const defaultBeatVersion = "6.0.0-rc1"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -245,482 +245,482 @@
 		{
 			"checksumSHA1": "Cqf46jG1S/Ps+nCyNjkFRnujAVU=",
 			"path": "github.com/elastic/beats/libbeat/api",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "0Paj+UTn9cyAkLsPuVpAxzqw8Qw=",
 			"path": "github.com/elastic/beats/libbeat/beat",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
-			"checksumSHA1": "YBj3pZcInKd7cArY7YtU+Q46HcY=",
+			"checksumSHA1": "MDBESe+A4gBSnGcg3ehNPV79Hik=",
 			"path": "github.com/elastic/beats/libbeat/cfgfile",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "kcJBPeHVyLhstApfy7Smi6fcxrg=",
 			"path": "github.com/elastic/beats/libbeat/cloudid",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "Lvie/h3l7T5x4FlgE4i3621ffuA=",
 			"path": "github.com/elastic/beats/libbeat/cmd",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "2tIx7fQyFrscfg0nRHYRbVV2H8Y=",
 			"path": "github.com/elastic/beats/libbeat/cmd/export",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "glvYhIIj8gUA4we9xghamtXXliQ=",
 			"path": "github.com/elastic/beats/libbeat/cmd/instance",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "Ss/kCqcC6CkoEMQfUB2AeIUmGj8=",
 			"path": "github.com/elastic/beats/libbeat/cmd/test",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "l4N/u4uXIjnQZ2h3Cf7dHwcUVmk=",
 			"path": "github.com/elastic/beats/libbeat/common",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "SS/yBENBeoNVCAu+TQcDylo4CPg=",
 			"path": "github.com/elastic/beats/libbeat/common/atomic",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "kbrbRXK+vEBW+gBucQX1gmn07nE=",
 			"path": "github.com/elastic/beats/libbeat/common/cfgwarn",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "7bGcM14M5R8BuQLqKdWfbbQaKEM=",
 			"path": "github.com/elastic/beats/libbeat/common/dtfmt",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "3GxLcVX/OFwXDi0VJNnJrafkq8A=",
 			"path": "github.com/elastic/beats/libbeat/common/file",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "7WSOY58klc0crUF/5UZx/pLFIR0=",
 			"path": "github.com/elastic/beats/libbeat/common/fmtstr",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "pdFJ+DF0STunSGRopAMwn9n9ZlY=",
 			"path": "github.com/elastic/beats/libbeat/common/jsontransform",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "+djyNKl6NRWKJFOBZGTiXliyBm8=",
 			"path": "github.com/elastic/beats/libbeat/common/match",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "CGDTSl2i0mxPNln+8qLD9aEgqzI=",
 			"path": "github.com/elastic/beats/libbeat/common/op",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "8exGjSEBI+fSKXMHdWI2e2lX5D0=",
 			"path": "github.com/elastic/beats/libbeat/common/schema",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "WmqoD6kF9VraYUmjXacgWSHd2v4=",
 			"path": "github.com/elastic/beats/libbeat/common/schema/mapstriface",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "zi4xMJ43/IzPCPNXs8iBc0WI2sE=",
 			"path": "github.com/elastic/beats/libbeat/common/streambuf",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "WDCWOJT0MZbho4Z9IXcZ69sQB4s=",
 			"path": "github.com/elastic/beats/libbeat/dashboards",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "wC9sNrhYx1dr3mz2cXKQIBFZlxo=",
 			"path": "github.com/elastic/beats/libbeat/logp",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "kZBPfX0Pv2dLMP5Iho9Mx/hXz9o=",
 			"path": "github.com/elastic/beats/libbeat/monitoring",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "tRfILb+3nS9S5xf1GTqyGVbvGnU=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/adapter",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "6Y1rk4L0vIJZODy2wXGLa3liVDU=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "DTQdPn57PVDSVGOU+b8XXPaZWbM=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report/elasticsearch",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "ewNLeJsjP1vTG7AfUzOlPcRS9wY=",
 			"path": "github.com/elastic/beats/libbeat/outputs",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "J+EURQTncE5oX+elZeul1pcr7cc=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "0vfh0G0gpdo6Q7EbLpSr1rSG/xs=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec/format",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "5wM0MvVLW/druU7J/6Q2n9QWhMw=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec/json",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "eNHiKpEj8ngyFpoeRI/YvU5d3YI=",
 			"path": "github.com/elastic/beats/libbeat/outputs/console",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "pl2mujHKZLIYCTPjEDUlg2cEntg=",
 			"path": "github.com/elastic/beats/libbeat/outputs/elasticsearch",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "m6ahHL7Ihn2HMaEF31NqyNXQkWY=",
 			"path": "github.com/elastic/beats/libbeat/outputs/fileout",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "vS8pCCeNhYwynbaaD/O+gpBL+Bo=",
 			"path": "github.com/elastic/beats/libbeat/outputs/kafka",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "wSc8XLWpp6sf08FhK6JxJY4Pf/s=",
 			"path": "github.com/elastic/beats/libbeat/outputs/logstash",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "UEGH5mAXdKBysIjODuTxHKlzqsY=",
 			"path": "github.com/elastic/beats/libbeat/outputs/outil",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "z6GWNd5s0+t5ObS8puEUtjvqVeU=",
 			"path": "github.com/elastic/beats/libbeat/outputs/redis",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "DXyLGeGve0QaVS9H0GjrS0pbZhs=",
 			"path": "github.com/elastic/beats/libbeat/outputs/transport",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "d5b9Ra0zcwznwemxEJmyW28FZJ0=",
 			"path": "github.com/elastic/beats/libbeat/paths",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "2ef0H1yIcmjczaj6LsUc17/ss6I=",
 			"path": "github.com/elastic/beats/libbeat/plugin",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "f5rbaafOe7lJk+ahzKkJzTeCfZU=",
 			"path": "github.com/elastic/beats/libbeat/processors",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "JBWiLNZylmEHFiAbNXJAYa9D8fw=",
 			"path": "github.com/elastic/beats/libbeat/processors/actions",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "HMyzMv+rJ9hovpEs+2ubIDVK+NI=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_cloud_metadata",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "0mNdN64yg6KRXHo5LXhu78/z7NI=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_docker_metadata",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "IZIEt20M2OxAAxvZHz8WBzBV8jo=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_kubernetes_metadata",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "UCfWJFoOVRzY1nQ+mAHT+mpGYv4=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_locale",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "jVIZcmI+VyHbivKqZ4qDtiP/W80=",
 			"path": "github.com/elastic/beats/libbeat/publisher",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "ftmsSpe94KKRIei+hfi9GVDfkuU=",
 			"path": "github.com/elastic/beats/libbeat/publisher/bc/publisher",
 			"revision": "f240148065af94d55c5149e444482b9635801f27",
 			"revisionTime": "2017-07-28T07:19:26Z",
-			"version": "master",
-			"versionExact": "master"
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "lDzOqs8+fRo5uTYqBocUpafrXg8=",
 			"path": "github.com/elastic/beats/libbeat/publisher/beat",
 			"revision": "0008c722eba848c3e48be81c4a270e51b024ace2",
 			"revisionTime": "2017-08-08T09:57:48Z",
-			"version": "master",
-			"versionExact": "master"
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "h/FWcbUZrr4jSczVEsSH9SsaCGU=",
 			"path": "github.com/elastic/beats/libbeat/publisher/broker",
 			"revision": "f240148065af94d55c5149e444482b9635801f27",
 			"revisionTime": "2017-07-28T07:19:26Z",
-			"version": "master",
-			"versionExact": "master"
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "anYB4tIWyeRa73+pYq/TkqEv0CE=",
 			"path": "github.com/elastic/beats/libbeat/publisher/broker/membroker",
 			"revision": "f240148065af94d55c5149e444482b9635801f27",
 			"revisionTime": "2017-07-28T07:19:26Z",
-			"version": "master",
-			"versionExact": "master"
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "btf3XhwPROVy4JtECpH0eL3nGwg=",
 			"path": "github.com/elastic/beats/libbeat/publisher/includes",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
-			"checksumSHA1": "CygrBtNvz9jkqO5UEtYzV/yMu3Q=",
+			"checksumSHA1": "A9s/iRNAvWjTzanRffe5lpmuHUk=",
 			"path": "github.com/elastic/beats/libbeat/publisher/pipeline",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "k/1pxNUislJBfsjb/yZVG7+YP28=",
 			"path": "github.com/elastic/beats/libbeat/publisher/queue",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "/AoPj3R6Kx0PWBKx1P2ppvqeBU4=",
 			"path": "github.com/elastic/beats/libbeat/publisher/queue/memqueue",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "kT9MLdbYAKYJ0lWfjqX8fbrZTiY=",
 			"path": "github.com/elastic/beats/libbeat/service",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "h28LQ4I1AWvlPNhNIaBjpki/cxs=",
 			"path": "github.com/elastic/beats/libbeat/setup/kibana",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
-			"checksumSHA1": "+OmbWN/6zABmJKL318JqofQXB7I=",
+			"checksumSHA1": "uY+f6jKvnNQQcajGKGhhBodMI4M=",
 			"path": "github.com/elastic/beats/libbeat/template",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "7PJnZYfyxNG+Qz2Sx/G/sdJfujQ=",
 			"path": "github.com/elastic/beats/libbeat/testing",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
-			"checksumSHA1": "HviBA/yN/8aYDJSnP7lk004sbM0=",
+			"checksumSHA1": "35zCW8hVuaUxEi+Nvjbqot5Xtm4=",
 			"path": "github.com/elastic/beats/libbeat/version",
-			"revision": "fc67bbbb67e4c0c1160e53167fff814802bade70",
-			"revisionTime": "2017-09-04T10:00:09Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "1ee5c98d4dc1809288b1fcd748a39705f2f50623",
+			"revisionTime": "2017-08-31T12:49:58Z",
+			"version": "6.x",
+			"versionExact": "6.x"
 		},
 		{
 			"checksumSHA1": "3jizmlZPCyo6FAZY8Trk9jA8NH4=",


### PR DESCRIPTION
A small trick is applied to still get beats code from the 6.x branch but have the versions from the 6.0 branch. The two required files are fetched seperately. The changes were made in the code instead of modifying the two files manually to be able to just run `make update-beats` also in the future without overwriting it again.