### PR TITLE
Remove fixed version from apm-server

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,5 +18,5 @@ var RootCmd *cmd.BeatsRootCmd
 
 func init() {
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
-	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "7.0.0-alpha1", beater.New, runFlags)
+	RootCmd = cmd.GenRootCmdWithRunFlags(Name, "", beater.New, runFlags)
 }


### PR DESCRIPTION
The correct version is automatically inherited from beats. As our master branch depends on the beats master branch again, having our own version in here is not needed anymore.