### PR TITLE
Use format instead of a regex in json schema to validate timestamps 

### DIFF
--- a/docs/spec/errors/error.json
+++ b/docs/spec/errors/error.json
@@ -77,7 +77,7 @@
                     "description": "A parametrized message. E.g. Could not connect to %s. The property message is still required, and should be equal to the param_message, but with placeholders replaced. In some situations the param_message is used to group errors together. The string is not interpreted, so feel free to use whichever placeholders makes sense in the client languange.",
                     "type": ["string", "null"],
                     "maxLength": 1024
-                
+
                 },
                 "stacktrace": {
                     "type": ["array", "null"],
@@ -91,8 +91,8 @@
         },
         "timestamp": {
             "type": "string",
-            "description": "Recorded time of the error, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ",
-            "pattern": "^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})(\\.\\d{1,6})?Z$"
+            "format": "date-time",
+            "description": "Recorded time of the error, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
         }
     },
     "required": ["timestamp"],

--- a/docs/spec/transactions/transaction.json
+++ b/docs/spec/transactions/transaction.json
@@ -28,8 +28,8 @@
         },
         "timestamp": {
             "type": "string",
-            "description": "Recorded time of the transaction, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ",
-            "pattern": "^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})(\\.\\d{1,6})?Z$"
+            "format": "date-time",
+            "description": "Recorded time of the transaction, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
         },
         "traces": {
             "type": ["array", "null"],

--- a/processor/error/schema.go
+++ b/processor/error/schema.go
@@ -402,7 +402,7 @@ var errorSchema = `{
                     "description": "A parametrized message. E.g. Could not connect to %s. The property message is still required, and should be equal to the param_message, but with placeholders replaced. In some situations the param_message is used to group errors together. The string is not interpreted, so feel free to use whichever placeholders makes sense in the client languange.",
                     "type": ["string", "null"],
                     "maxLength": 1024
-                
+
                 },
                 "stacktrace": {
                     "type": ["array", "null"],
@@ -469,8 +469,8 @@ var errorSchema = `{
         },
         "timestamp": {
             "type": "string",
-            "description": "Recorded time of the error, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ",
-            "pattern": "^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})(\\.\\d{1,6})?Z$"
+            "format": "date-time",
+            "description": "Recorded time of the error, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
         }
     },
     "required": ["timestamp"],

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -323,8 +323,8 @@ var transactionSchema = `{
         },
         "timestamp": {
             "type": "string",
-            "description": "Recorded time of the transaction, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ",
-            "pattern": "^(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})(\\.\\d{1,6})?Z$"
+            "format": "date-time",
+            "description": "Recorded time of the transaction, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
         },
         "traces": {
             "type": ["array", "null"],

--- a/tests/json_schema_test.go
+++ b/tests/json_schema_test.go
@@ -98,11 +98,11 @@ func TestTransactionSchema(t *testing.T) {
 		{File: "no_type.json", Error: `missing properties: "type"`},
 		{File: "no_timestamp.json", Error: `missing properties: "timestamp"`},
 		{File: "invalid_id.json", Error: "[#/properties/id/pattern] does not match pattern"},
-		{File: "invalid_timestamp.json", Error: "[#/properties/timestamp/pattern] does not match pattern"},
-		{File: "invalid_timestamp2.json", Error: "[#/properties/timestamp/pattern] does not match pattern"},
-		{File: "invalid_timestamp3.json", Error: "[#/properties/timestamp/pattern] does not match pattern"},
-		{File: "invalid_timestamp4.json", Error: "[#/properties/timestamp/pattern] does not match pattern"},
-		{File: "invalid_timestamp5.json", Error: "[#/properties/timestamp/pattern] does not match pattern"},
+		{File: "invalid_timestamp.json", Error: "is not valid \"date-time\""},
+		{File: "invalid_timestamp2.json", Error: "is not valid \"date-time\""},
+		{File: "invalid_timestamp3.json", Error: "is not valid \"date-time\""},
+		{File: "invalid_timestamp4.json", Error: "is not valid \"date-time\""},
+		{File: "invalid_timestamp5.json", Error: "is not valid \"date-time\""},
 	}
 	testDataAgainstSchema(t, testData, "transactions/transaction", "transaction", `"$ref": "../docs/spec/transactions/`)
 }
@@ -118,11 +118,11 @@ func TestTransactionPayloadSchema(t *testing.T) {
 func TestErrorSchema(t *testing.T) {
 	testData := []schemaTestData{
 		{File: "invalid_id.json", Error: "[#/properties/id/pattern] does not match pattern"},
-		{File: "invalid_timestamp.json", Error: "[#/properties/timestamp/pattern] does not match pattern"},
-		{File: "invalid_timestamp2.json", Error: "[#/properties/timestamp/pattern] does not match pattern"},
-		{File: "invalid_timestamp3.json", Error: "[#/properties/timestamp/pattern] does not match pattern"},
-		{File: "invalid_timestamp4.json", Error: "[#/properties/timestamp/pattern] does not match pattern"},
-		{File: "invalid_timestamp5.json", Error: "[#/properties/timestamp/pattern] does not match pattern"},
+		{File: "invalid_timestamp.json", Error: "is not valid \"date-time\""},
+		{File: "invalid_timestamp2.json", Error: "is not valid \"date-time\""},
+		{File: "invalid_timestamp3.json", Error: "is not valid \"date-time\""},
+		{File: "invalid_timestamp4.json", Error: "is not valid \"date-time\""},
+		{File: "invalid_timestamp5.json", Error: "is not valid \"date-time\""},
 		{File: "no_log_message.json", Error: "missing properties: \"message\""},
 		{File: "no_exception_message.json", Error: "missing properties: \"message\""},
 		{File: "no_log_or_exception.json", Error: "missing properties: \"exception\""},

--- a/tests/system/test_requests.py
+++ b/tests/system/test_requests.py
@@ -39,13 +39,13 @@ class Test(ServerBaseTest):
         r = requests.post(self.transactions_url, json="not json")
         assert r.status_code == 400, r.status_code
 
-    def test_bad_transformation(self):
+    def test_validation_fail(self):
         transactions = self.get_transaction_payload()
         # month and day swapped
         transactions["transactions"][0]["timestamp"] = "2017-30-05T18:53:27.154Z"
         r = requests.post(self.transactions_url, json=transactions)
         assert r.status_code == 400, r.status_code
-        assert "Data transformation error: parsing time" in r.content, r.content
+        assert "Problem validating JSON document against schema" in r.content, r.content
 
     def test_healthcheck(self):
         healtcheck_url = 'http://localhost:8200/healthcheck'


### PR DESCRIPTION
Depends on #144 