### PR TITLE
Don't allow timezone offsets for timestamps

### DIFF
--- a/docs/spec/errors/error.json
+++ b/docs/spec/errors/error.json
@@ -92,6 +92,7 @@
         "timestamp": {
             "type": "string",
             "format": "date-time",
+            "pattern": "Z$",
             "description": "Recorded time of the error, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
         }
     },

--- a/docs/spec/transactions/transaction.json
+++ b/docs/spec/transactions/transaction.json
@@ -28,6 +28,7 @@
         },
         "timestamp": {
             "type": "string",
+            "pattern": "Z$",
             "format": "date-time",
             "description": "Recorded time of the transaction, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
         },

--- a/processor/error/schema.go
+++ b/processor/error/schema.go
@@ -470,6 +470,7 @@ var errorSchema = `{
         "timestamp": {
             "type": "string",
             "format": "date-time",
+            "pattern": "Z$",
             "description": "Recorded time of the error, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
         }
     },

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -323,6 +323,7 @@ var transactionSchema = `{
         },
         "timestamp": {
             "type": "string",
+            "pattern": "Z$",
             "format": "date-time",
             "description": "Recorded time of the transaction, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
         },

--- a/tests/data/invalid/error/invalid_timestamp2.json
+++ b/tests/data/invalid/error/invalid_timestamp2.json
@@ -1,6 +1,6 @@
 {
     "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-    "timestamp": "2017-05-30T18:53:27.",
+    "timestamp": "2017-05-30T18:53:27.000+00:20",
     "exception": {
         "message": ""
     }

--- a/tests/data/invalid/transaction/invalid_timestamp2.json
+++ b/tests/data/invalid/transaction/invalid_timestamp2.json
@@ -4,6 +4,6 @@
     "name": "GET /api/types",
     "type": "request",
     "duration": 2.0,
-    "timestamp": "2017-05-30T18:53:27.",
+    "timestamp": "2017-05-30T18:53:27.000+00:20",
     "traces": []
 }

--- a/tests/json_schema_test.go
+++ b/tests/json_schema_test.go
@@ -99,10 +99,10 @@ func TestTransactionSchema(t *testing.T) {
 		{File: "no_timestamp.json", Error: `missing properties: "timestamp"`},
 		{File: "invalid_id.json", Error: "[#/properties/id/pattern] does not match pattern"},
 		{File: "invalid_timestamp.json", Error: "is not valid \"date-time\""},
-		{File: "invalid_timestamp2.json", Error: "is not valid \"date-time\""},
+		{File: "invalid_timestamp2.json", Error: "I[#/timestamp] S[#/properties/timestamp/pattern] does not match pattern"},
 		{File: "invalid_timestamp3.json", Error: "is not valid \"date-time\""},
 		{File: "invalid_timestamp4.json", Error: "is not valid \"date-time\""},
-		{File: "invalid_timestamp5.json", Error: "is not valid \"date-time\""},
+		{File: "invalid_timestamp5.json", Error: "I[#/timestamp] S[#/properties/timestamp/pattern] does not match pattern"},
 	}
 	testDataAgainstSchema(t, testData, "transactions/transaction", "transaction", `"$ref": "../docs/spec/transactions/`)
 }
@@ -119,10 +119,10 @@ func TestErrorSchema(t *testing.T) {
 	testData := []schemaTestData{
 		{File: "invalid_id.json", Error: "[#/properties/id/pattern] does not match pattern"},
 		{File: "invalid_timestamp.json", Error: "is not valid \"date-time\""},
-		{File: "invalid_timestamp2.json", Error: "is not valid \"date-time\""},
+		{File: "invalid_timestamp2.json", Error: "I[#/timestamp] S[#/properties/timestamp/pattern] does not match pattern"},
 		{File: "invalid_timestamp3.json", Error: "is not valid \"date-time\""},
 		{File: "invalid_timestamp4.json", Error: "is not valid \"date-time\""},
-		{File: "invalid_timestamp5.json", Error: "is not valid \"date-time\""},
+		{File: "invalid_timestamp5.json", Error: "I[#/timestamp] S[#/properties/timestamp/pattern] does not match pattern"},
 		{File: "no_log_message.json", Error: "missing properties: \"message\""},
 		{File: "no_exception_message.json", Error: "missing properties: \"message\""},
 		{File: "no_log_or_exception.json", Error: "missing properties: \"exception\""},

--- a/tests/system/test_requests.py
+++ b/tests/system/test_requests.py
@@ -47,6 +47,14 @@ class Test(ServerBaseTest):
         assert r.status_code == 400, r.status_code
         assert "Problem validating JSON document against schema" in r.content, r.content
 
+    def test_validation_2_fail(self):
+        transactions = self.get_transaction_payload()
+        # timezone offsets not allowed
+        transactions["transactions"][0]["timestamp"] = "2017-05-30T18:53:27.154+00:20"
+        r = requests.post(self.transactions_url, json=transactions)
+        assert r.status_code == 400, r.status_code
+        assert "Problem validating JSON document against schema" in r.content, r.content
+
     def test_healthcheck(self):
         healtcheck_url = 'http://localhost:8200/healthcheck'
         r = requests.get(healtcheck_url)


### PR DESCRIPTION
This complements `date-format` used for proper date validation with a `Z$` regex to make sure that timezone offsets are not allowed (as per spec)