### PR TITLE
Ensure libbeat infrastructure has time to run before returning 503

### DIFF
--- a/beater/pub.go
+++ b/beater/pub.go
@@ -3,6 +3,7 @@ package beater
 import (
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/elastic/beats/libbeat/beat"
 )
@@ -73,7 +74,7 @@ func (p *publisher) Send(batch []beat.Event) error {
 	select {
 	case p.events <- batch:
 		return nil
-	default:
+	case <-time.After(time.Second * 1): // this forces the go scheduler to try something else for a while
 		return errFull
 	}
 }


### PR DESCRIPTION
In benchmarks (we've not reproduced this outside, yet), we sometimes get a full-queue even though we've using a "null" output. This happens because the go scheduler is not running the go routines that take events out of the queue as much time as we'd like it to. By introducing a one second timeout, this is an attempt at giving the go runtime some time to run those go routines some time to run. 

I'm not a big fan of the UX of taking an extra second to return a 503 to the user in the case where the queue is really full, but it might be the best solution for now. 