### PR TITLE
Remove non-indexed entry from fields.yml.

### DIFF
--- a/_meta/fields.common.yml
+++ b/_meta/fields.common.yml
@@ -221,29 +221,3 @@
                 type: keyword
                 description: >
                   Agent version.
-
-        - name: db
-          type: group
-          enabled: false
-          description: >
-              An object containing contextual data for database traces
-          fields:
-            - name: instance
-              type: text
-              description: >
-                  Database instance name
-
-            - name: statement
-              type: text
-              description: >
-                  A database statement (e.g. query) for the given database type
-
-            - name: type
-              type: text
-              description: >
-                  Database type. For any SQL database, "sql". For others, the lower-case database category, e.g. "cassandra", "hbase", or "redis"
-
-            - name: user
-              type: text
-              description: >
-                  Username for accessing database

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -330,45 +330,6 @@ type: keyword
 Agent version.
 
 
-[float]
-== db fields
-
-An object containing contextual data for database traces
-
-
-
-[float]
-=== `context.db.instance`
-
-type: text
-
-Database instance name
-
-
-[float]
-=== `context.db.statement`
-
-type: text
-
-A database statement (e.g. query) for the given database type
-
-
-[float]
-=== `context.db.type`
-
-type: text
-
-Database type. For any SQL database, "sql". For others, the lower-case database category, e.g. "cassandra", "hbase", or "redis"
-
-
-[float]
-=== `context.db.user`
-
-type: text
-
-Username for accessing database
-
-
 [[exported-fields-apm-error]]
 == APM Error fields
 

--- a/tests/fields.go
+++ b/tests/fields.go
@@ -37,7 +37,11 @@ func TestEventAttrsDocumentedInFields(t *testing.T, fieldPaths []string, fn proc
 		"error.exception.stacktrace",
 		"error.log.stacktrace",
 		"trace.stacktrace",
-		"context.sql",
+		"context.db",
+		"context.db.statement",
+		"context.db.type",
+		"context.db.instance",
+		"context.db.user",
 	)
 	blacklistedFieldNames := set.Union(disabledFieldNames, undocumentedFieldNames).(*set.Set)
 


### PR DESCRIPTION
To be aligned with documentation of other non-indexed fields and to
avoid unwanted side effects in indexing, remove `context.db` from fields.yml.