### PR TITLE
Avoid cmd output from Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ BEATS_VERSION?=master
 
 # updates beats updates the framework part and go parts of beats
 update-beats:
-	govendor fetch github.com/elastic/beats/...@$(BEATS_VERSION)
-	BEATS_VERSION=$(BEATS_VERSION) sh _beats/update.sh
-	$(MAKE) update
+	@govendor fetch github.com/elastic/beats/...@$(BEATS_VERSION)
+	@BEATS_VERSION=$(BEATS_VERSION) sh _beats/update.sh
+	@$(MAKE) update
 
 # This is called by the beats packer before building starts
 .PHONY: before-build
@@ -29,35 +29,35 @@ collect: imports fields go-generate create-docs notice
 # Generates imports for all modules and metricsets
 .PHONY: imports
 imports:
-	mkdir -p include
-	mkdir -p processor
-	python ${GOPATH}/src/${BEAT_PATH}/script/generate_imports.py ${BEAT_PATH} > include/list.go
+	@mkdir -p include
+	@mkdir -p processor
+	@python ${GOPATH}/src/${BEAT_PATH}/script/generate_imports.py ${BEAT_PATH} > include/list.go
 
 .PHONY: fields
 fields:
-	cat _meta/fields.common.yml > _meta/fields.generated.yml
-	cat processor/*/_meta/fields.yml >> _meta/fields.generated.yml
+	@cat _meta/fields.common.yml > _meta/fields.generated.yml
+	@cat processor/*/_meta/fields.yml >> _meta/fields.generated.yml
 
 .PHONY: go-generate
 go-generate:
-	go generate
-	go build tests/scripts/approvals.go
+	@go generate
+	@go build tests/scripts/approvals.go
 
 .PHONY: create-docs
 create-docs:
-	mkdir -p docs/data/intake-api/generated/error
-	mkdir -p docs/data/intake-api/generated/transaction
-	cp tests/data/valid/error/* docs/data/intake-api/generated/error/
-	cp tests/data/valid/transaction/* docs/data/intake-api/generated/transaction/
+	@mkdir -p docs/data/intake-api/generated/error
+	@mkdir -p docs/data/intake-api/generated/transaction
+	@cp tests/data/valid/error/* docs/data/intake-api/generated/error/
+	@cp tests/data/valid/transaction/* docs/data/intake-api/generated/transaction/
 
 # Start manual testing environment with agents
 start-env:
-	docker-compose -f tests/docker-compose.yml build
-	docker-compose -f tests/docker-compose.yml up -d
+	@docker-compose -f tests/docker-compose.yml build
+	@docker-compose -f tests/docker-compose.yml up -d
 
 # Stop manual testing environment with agents
 stop-env:
-	docker-compose -f tests/docker-compose.yml down -v
+	@docker-compose -f tests/docker-compose.yml down -v
 
 check-full: check
 	@# Validate that all updates were committed


### PR DESCRIPTION
Only Info, Warning and Errors should be printed, instead of every
command.