### PR TITLE
Fix wrong content-type in response.

### DIFF
--- a/beater/server.go
+++ b/beater/server.go
@@ -217,16 +217,22 @@ func acceptsJSON(r *http.Request) bool {
 }
 
 func sendStatus(w http.ResponseWriter, r *http.Request, code int, err error) {
+	content_type := "text/plain; charset=utf-8"
+	if acceptsJSON(r) {
+		content_type = "application/json"
+	}
+	w.Header().Set("Content-Type", content_type)
 	w.WriteHeader(code)
-	if err != nil {
-		responseErrors.Inc()
-		if acceptsJSON(r) {
-			w.Header().Add("Content-Type", "application/json")
-			sendJSON(w, map[string]interface{}{"error": err.Error()})
-		} else {
-			w.Header().Add("Content-Type", "text/plain; charset=UTF-8")
-			sendPlain(w, err.Error())
-		}
+
+	if err == nil {
+		return
+	}
+
+	responseErrors.Inc()
+	if acceptsJSON(r) {
+		sendJSON(w, map[string]interface{}{"error": err.Error()})
+	} else {
+		sendPlain(w, err.Error())
 	}
 }
 

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -171,6 +171,7 @@ func TestJSONFailureResponse(t *testing.T) {
 	body, _ := ioutil.ReadAll(resp.Body)
 	assert.Equal(t, 400, w.Code)
 	assert.Equal(t, body, []byte(`{"error":"Cannot compare apples to oranges"}`))
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 }
 
 func TestJSONFailureResponseWhenAcceptingAnything(t *testing.T) {
@@ -185,6 +186,7 @@ func TestJSONFailureResponseWhenAcceptingAnything(t *testing.T) {
 	body, _ := ioutil.ReadAll(resp.Body)
 	assert.Equal(t, 400, w.Code)
 	assert.Equal(t, body, []byte(`{"error":"Cannot compare apples to oranges"}`))
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 }
 
 func TestHTMLFailureResponse(t *testing.T) {
@@ -199,6 +201,7 @@ func TestHTMLFailureResponse(t *testing.T) {
 	body, _ := ioutil.ReadAll(resp.Body)
 	assert.Equal(t, 400, w.Code)
 	assert.Equal(t, body, []byte(`Cannot compare apples to oranges`))
+	assert.Equal(t, "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
 }
 
 func TestFailureResponseNoAcceptHeader(t *testing.T) {
@@ -214,6 +217,7 @@ func TestFailureResponseNoAcceptHeader(t *testing.T) {
 	body, _ := ioutil.ReadAll(resp.Body)
 	assert.Equal(t, 400, w.Code)
 	assert.Equal(t, body, []byte(`Cannot compare apples to oranges`))
+	assert.Equal(t, "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
 }
 
 func setupServer(t *testing.T, ssl *SSLConfig) (*http.Server, func()) {


### PR DESCRIPTION
WriteHeader(code) needs to be called after headers are set.
closes #167.