### PR TITLE
Minor logging fixes

### DIFF
--- a/beater/server.go
+++ b/beater/server.go
@@ -119,7 +119,7 @@ func processRequest(r *http.Request, p processor.Processor, maxSize int64, repor
 
 	reader, err := decodeData(r)
 	if err != nil {
-		return 400, err
+		return 400, errors.New(fmt.Sprintf("Decoding error: %s", err.Error()))
 	}
 	defer reader.Close()
 
@@ -128,7 +128,8 @@ func processRequest(r *http.Request, p processor.Processor, maxSize int64, repor
 	buf, err := ioutil.ReadAll(limitedReader)
 	if err != nil {
 		// If we run out of memory, for example
-		return 500, err
+		return 500, errors.New(fmt.Sprintf("Data read error: %s", err.Error()))
+
 	}
 
 	if err = p.Validate(buf); err != nil {


### PR DESCRIPTION
+ Logs `202` responses with debug level
+ Fixes monitoring counting (503 were counted as valid _and_ invalid)
+ Removes unused param and named return args from method
+ Removes duplicated messages from errors (eg: something like "data validation error" is already in the original error, there is no need to wrap it)
+ Simplifies code a bit
