### PR TITLE
Add link to official documentation when viewing docs on GitHub

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,6 +1,11 @@
 :branch: current
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
+ifdef::env-github[]
+NOTE: For the best reading experience,
+please view this documentation at https://www.elastic.co/guide/en/apm/server[elastic.co]
+endif::[]
+
 = APM Server Docs (Experimental)
 
 == Overview


### PR DESCRIPTION
This adds the following notice to the top of the index.asciidoc page if viewed on GitHub:

<img width="994" alt="screen shot 2017-09-19 at 10 12 29" src="https://user-images.githubusercontent.com/10602/30582210-2eba3be6-9d23-11e7-8c2d-9919b7c850ed.png">

I had to write the URL in full instead of using asciidoc references as those are not resolved when the asciidoc is rendered by GitHub.