### PR TITLE
Add preliminary header to get started documents.

### DIFF
--- a/docs/guide/page_header.html
+++ b/docs/guide/page_header.html
@@ -1,0 +1,1 @@
+You are looking at preliminary documentation for a future release.


### PR DESCRIPTION
The header for preliminary docs was missing for the getting started guide for APM.