### PR TITLE
Fix command for loading dashboards in docs

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -148,7 +148,7 @@ run the following command:
 curl -X POST http://localhost:5601/api/kibana/dashboards/import \
   -H 'Content-type: application/json' \
   -H 'kbn-xsrf: true' \
-  -d @./_meta/kibana/default/dashboard/apm-dashboards.json
+  -d @./kibana/default/dashboard/apm-dashboards.json
 ----------------------------------
 
 If you are using an X-Pack secured version of Elastic Stack,


### PR DESCRIPTION
The command contained the `_meta` directory as this is needed when loading directly from the repository. When download the binary the _meta directory does not exist.