### PR TITLE
opbeans master is now configured for elastic, no need to switch branch

### DIFF
--- a/tests/agent/python/Dockerfile
+++ b/tests/agent/python/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir -p /app
 
 WORKDIR /app
 
-RUN git clone https://github.com/opbeat/opbeans-python.git . && git checkout feature/elastic-apm
+RUN git clone https://github.com/opbeat/opbeans-python.git . 
 
 RUN pip install -Ur requirements.txt
 


### PR DESCRIPTION
I just merged the `feature/elastic-apm` branch into master on the opbeans repo, making this switch unnecessary. 