### PR TITLE
Change docs for automatic loading of dashboards.

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -139,31 +139,16 @@ you can use the {apm-server-ref}/overview.html#security[secret token and TLS] to
 [[kibana-dashboards]]
 [float]
 ==== Install the Kibana dashboards
-APM Server comes with predefined Kibana dashboards for the APM data.
-To install the Kibana dashboards for the 6.x releases,
-run the following command:
+APM Server comes with predefined Kibana dashboards and index templates for the APM data.
+To install those run the following command:
 
 [source,bash]
 ----------------------------------
-curl -X POST http://localhost:5601/api/kibana/dashboards/import \
-  -H 'Content-type: application/json' \
-  -H 'kbn-xsrf: true' \
-  -d @./kibana/default/dashboard/apm-dashboards.json
-----------------------------------
-
-If you are running Kibana 5.6, you need to download the dashboard file first and then load it:
-
-[source,bash]
-----------------------------------
-curl -o apm-dashboard.json https://raw.githubusercontent.com/elastic/apm-server/master/_meta/kibana/5.x/dashboard/apm-dashboards.json
-curl -X POST http://localhost:5601/api/kibana/dashboards/import \
-  -H 'Content-type: application/json' \
-  -H 'kbn-xsrf: true' \
-  -d @./apm-dashboards.json
+./apm-server setup
 ----------------------------------
 
 If you are using an X-Pack secured version of Elastic Stack,
-add `--user user:pass` to the command.
+add `-E output.elasticsearch.username=user -E output.elasticsearch.password=pass` to the command.
 
 See an example screenshot of a Kibana dashboard:
 


### PR DESCRIPTION
@makwarth , @ruflin this is a follow up for changing the docs. Unfortunately the changes in PR #147 were applied to a file that does not exist anymore, since we moved it to the docs folder. 

The thing that I am not certain of is how to actually pass in `user` and `password` for x-pack secured systems.
@ruflin can you help out here? I tried all listed config options..