### PR TITLE
Add test for updating beats framework.

### DIFF
--- a/script/jenkins/update-beats.sh
+++ b/script/jenkins/update-beats.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+: "${HOME:?Need to set HOME to a non-empty value.}"
+: "${WORKSPACE:?Need to set WORKSPACE to a non-empty value.}"
+
+# Setup Go.
+export GOPATH=${WORKSPACE}
+export PATH=${GOPATH}/bin:${PATH}
+go_file="_beats/.go-version"
+if [ -f "$go_file" ]; then
+  eval "$(gvm $(cat $go_file))"
+else
+  eval "$(gvm 1.8.3)"
+fi
+
+# Workaround for Python virtualenv path being too long.
+TEMP_PYTHON_ENV=$(mktemp -d)
+export PYTHON_ENV="${TEMP_PYTHON_ENV}/python-env"
+
+cleanup() {
+  rm -rf $TEMP_PYTHON_ENV
+  make stop-environment fix-permissions
+}
+trap cleanup EXIT
+
+RACE_DETECTOR=1 make update-beats clean check testsuite


### PR DESCRIPTION
Run testsuite when beats framework is updated to ensure compatibility with the beats framework.

This gets triggered after a PR is merged into `beats` `master` or `release` branch, see https://github.com/elastic/infra/pull/3006, and allows to get rid of the dependency in `beats` (https://github.com/elastic/beats/pull/5099).