### PR TITLE
Add isAuthorized unit tests

### DIFF
--- a/beater/handlers_test.go
+++ b/beater/handlers_test.go
@@ -92,3 +92,26 @@ func TestFailureResponseNoAcceptHeader(t *testing.T) {
 	assert.Equal(t, body, []byte(`Cannot compare apples to oranges`))
 	assert.Equal(t, "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
 }
+
+func TestIsAuthorized(t *testing.T) {
+	reqAuth := func(auth string) *http.Request {
+		req, err := http.NewRequest("POST", "/", nil)
+		assert.Nil(t, err)
+		req.Header.Add("Authorization", auth)
+		return req
+	}
+
+	reqNoAuth, err := http.NewRequest("POST", "/", nil)
+	assert.Nil(t, err)
+
+	// Successes
+	assert.True(t, isAuthorized(reqNoAuth, ""))
+	assert.True(t, isAuthorized(reqAuth("foo"), ""))
+	assert.True(t, isAuthorized(reqAuth("Bearer foo"), "foo"))
+
+	// Failures
+	assert.False(t, isAuthorized(reqNoAuth, "foo"))
+	assert.False(t, isAuthorized(reqAuth("Bearer bar"), "foo"))
+	assert.False(t, isAuthorized(reqAuth("Bearer foo extra"), "foo"))
+	assert.False(t, isAuthorized(reqAuth("foo"), "foo"))
+}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -11,9 +11,9 @@ import (
 type NewProcessor func() Processor
 
 const (
-	Backend     = iota
-	Frontend    = iota
-	HealthCheck = iota
+	Backend = iota
+	Frontend
+	HealthCheck
 )
 
 type Processor interface {


### PR DESCRIPTION
Hi @simitt and @jalvz .  Per our discussion, I was playing around with a fail delay in isAuthorized(). I ultimately decided that such a delay could actually cause more problems than it would prevent in the case of a highly parallel attack (tying up goroutines).  But I'd already written up the unit tests for that function, so feel free to use them if you want.

Thanks,
Jim