### PR TITLE
Added docs on docker and repositories

### DIFF
--- a/docs/configuring.asciidoc
+++ b/docs/configuring.asciidoc
@@ -1,8 +1,8 @@
 [[configuring]]
-== Step 2: Configuring and running APM Server 
+== Configuring and running APM Server 
 
 In a production environment,
-you would put APM Server on it's own machines,
+you would put APM Server on its own machines,
 similar to how you run Elasticsearch.
 You _can_ run it on the same machines as Elasticsearch,
 but this is not recommended,
@@ -17,7 +17,7 @@ To start APM Server, run:
 
 You should see APM Server start up.
 It will try to connect to Elasticsearch on localhost port 9200 and expose an API to agents on port 8200.
-You can change the defaults by supplying a different addresses on the command line:
+You can change the defaults by supplying a different address on the command line:
 
 [source,bash]
 ----------------------------------

--- a/docs/configuring.asciidoc
+++ b/docs/configuring.asciidoc
@@ -36,7 +36,7 @@ output:
     hosts: ElasticsearchAddress:9200
 ----------------------------------
 
-See `apm-server.yml` for more configuration options.
+See https://github.com/elastic/apm-server/blob/{doc-branch}/apm-server.reference.yml[`apm-server.reference.yml`] for more configuration options.
 
 include::./security.asciidoc[]
 

--- a/docs/configuring.asciidoc
+++ b/docs/configuring.asciidoc
@@ -1,0 +1,45 @@
+[[configuring]]
+== Step 2: Configuring and running APM Server 
+
+In a production environment,
+you would put APM Server on it's own machines,
+similar to how you run Elasticsearch.
+You _can_ run it on the same machines as Elasticsearch,
+but this is not recommended,
+as the processes will be competing for resources.
+
+To start APM Server, run:
+
+[source,bash]
+----------------------------------
+./apm-server -e
+----------------------------------
+
+You should see APM Server start up.
+It will try to connect to Elasticsearch on localhost port 9200 and expose an API to agents on port 8200.
+You can change the defaults by supplying a different addresses on the command line:
+
+[source,bash]
+----------------------------------
+./apm-server -e -E output.elasticsearch.hosts=ElasticsearchAddress:9200 -E apm-server.host=localhost:8200
+----------------------------------
+
+Or you can update the `apm-server.yml` configuration file to change the defaults.
+
+[source,yaml]
+----------------------------------
+apm-server:
+  host: localhost:8200
+
+output:
+  elasticsearch:
+    hosts: ElasticsearchAddress:9200
+----------------------------------
+
+See `apm-server.yml` for more configuration options.
+
+include::./security.asciidoc[]
+
+include::./high-availability.asciidoc[]
+
+include::./index_pattern.asciidoc[]

--- a/docs/copied-from-beats/repositories.asciidoc
+++ b/docs/copied-from-beats/repositories.asciidoc
@@ -1,0 +1,140 @@
+//////////////////////////////////////////////////////////////////////////
+//// This content is shared by all Elastic Beats. Make sure you keep the
+//// descriptions here generic enough to work for all Beats that include
+//// this file. When using cross references, make sure that the cross
+//// references resolve correctly for any files that include this one.
+//// Use the appropriate variables defined in the index.asciidoc file to
+//// resolve Beat names: beatname_uc and beatname_lc.
+//// Use the following include to pull this content into a doc file:
+//// include::../../libbeat/docs/setup-repositories.asciidoc[]
+//////////////////////////////////////////////////////////////////////////
+
+[[setup-repositories]]
+=== Repositories for APT and YUM
+
+We have repositories available for APT and YUM-based distributions. Note that we
+provide binary packages, but no source packages.
+
+We use the PGP key https://pgp.mit.edu/pks/lookup?op=vindex&search=0xD27D666CD88E42B4[D88E42B4],
+Elasticsearch Signing Key, with fingerprint
+
+    4609 5ACC 8548 582C 1A26 99A9 D27D 666C D88E 42B4
+
+to sign all our packages. It is available from https://pgp.mit.edu.
+
+[float]
+==== APT
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of Beats has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+To add the Beats repository for APT:
+
+. Download and install the Public Signing Key:
++
+[source,sh]
+--------------------------------------------------
+wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add -
+--------------------------------------------------
+
+. You may need to install the `apt-transport-https` package on Debian before proceeding:
++
+[source,sh]
+--------------------------------------------------
+sudo apt-get install apt-transport-https
+--------------------------------------------------
+
+. Save the repository definition to  +/etc/apt/sources.list.d/elastic-6.x-prerelease.list+:
++
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+echo "deb https://artifacts.elastic.co/packages/6.x-prerelease/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x-prerelease.list
+--------------------------------------------------
++
+[WARNING]
+==================================================
+To add the Elastic repository, make sure that you use the `echo` method  shown
+in the example. Do not use `add-apt-repository` because it will add a `deb-src`
+entry, but we do not provide a source package.
+
+If you have added the `deb-src` entry by mistake, you will see an error like
+the following:
+
+    Unable to find expected entry 'main/source/Sources' in Release file (Wrong sources.list entry or malformed file)
+
+Simply delete the `deb-src` entry from the `/etc/apt/sources.list` file, and the installation should work as expected.
+==================================================
+
+. Run `apt-get update`, and the repository is ready for use. For example, you can
+install {beatname_uc} by running:
++
+["source","sh",subs="attributes"]
+--------------------------------------------------
+sudo apt-get update && sudo apt-get install {beatname_pkg}
+--------------------------------------------------
+
+. To configure the Beat to start automatically during boot, run:
++
+["source","sh",subs="attributes"]
+--------------------------------------------------
+sudo update-rc.d {beatname_pkg} defaults 95 10
+--------------------------------------------------
+
+endif::[]
+
+[float]
+==== YUM
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {stack-version} of Beats has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+To add the Beats repository for YUM:
+
+. Download and install the public signing key:
++
+[source,sh]
+--------------------------------------------------
+sudo rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch
+--------------------------------------------------
+
+. Create a file with a `.repo` extension (for example, `elastic.repo`) in
+your `/etc/yum.repos.d/` directory and add the following lines:
++
+["source","sh",subs="attributes,callouts"]
+--------------------------------------------------
+[elastic-6.x-prerelease]
+name=Elastic repository for 6.x prerelease packages
+baseurl=https://artifacts.elastic.co/packages/6.x-prerelease/yum
+gpgcheck=1
+gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+enabled=1
+autorefresh=1
+type=rpm-md
+--------------------------------------------------
++
+Your repository is ready to use. For example, you can install {beatname_uc} by
+running:
++
+["source","sh",subs="attributes"]
+--------------------------------------------------
+sudo yum install {beatname_pkg}
+--------------------------------------------------
+
+. To configure the Beat to start automatically during boot, run:
++
+["source","sh",subs="attributes"]
+--------------------------------------------------
+sudo chkconfig --add {beatname_pkg}
+--------------------------------------------------
+
+endif::[]

--- a/docs/copied-from-beats/running-on-docker.asciidoc
+++ b/docs/copied-from-beats/running-on-docker.asciidoc
@@ -1,0 +1,61 @@
+[[running-on-docker]]
+=== Running {beatname_uc} on Docker
+
+Docker images for {beatname_uc} are available from the Elastic Docker
+registry. You can retrieve an image with a `docker pull` command.
+
+ifeval::["{release-state}"=="unreleased"]
+
+However, version {stack-version} of {beatname_uc} has not yet been
+released, so no Docker image is currently available for this version.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+["source", "sh", subs="attributes"]
+------------------------------------------------
+docker pull {dockerimage}
+------------------------------------------------
+
+endif::[]
+
+The base image is https://hub.docker.com/_/centos/[centos:7] and the source
+code can be found on
+{dockergithub}[GitHub].
+
+[float]
+==== Configure {beatname_uc} on Docker
+
+The Docker image provides several methods for configuring {beatname_uc}. The
+conventional approach is to provide a configuration file via a bind-mounted
+volume, but it's also possible to create a custom image with your
+configuration included.
+
+[float]
+===== Bind-mounted configuration
+
+One way to configure {beatname_uc} on Docker is to provide +{beatname_lc}.yml+ via bind-mounting.
+With +docker run+, the bind-mount can be specified like this:
+
+["source", "sh", subs="attributes"]
+--------------------------------------------
+docker run \
+  -v ~/{beatname_lc}.yml:/usr/share/{beatname_lc}/{beatname_lc}.yml \
+  {dockerimage}
+--------------------------------------------
+
+[float]
+===== Custom image configuration
+
+It's possible to embed your {beatname_uc} configuration in a custom image.
+Here is an example Dockerfile to achieve this:
+
+["source", "dockerfile", subs="attributes"]
+--------------------------------------------
+FROM {dockerimage}
+COPY {beatname_lc}.yml /usr/share/{beatname_lc}/{beatname_lc}.yml
+USER root
+RUN chown {beatname_lc} /usr/share/{beatname_lc}/{beatname_lc}.yml
+USER {beatname_lc}
+--------------------------------------------

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,5 +1,13 @@
 :branch: current
+include::../_beats/libbeat/docs/version.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
+:version: {stack-version}
+:beatname_lc: apm-server
+:beatname_uc: APM Server
+:beatname_pkg: {beatname_lc}
+:dockerimage: docker.elastic.co/apm/{beatname_lc}:{version}
+:dockergithub: https://github.com/elastic/apm-server-docker/tree/{doc-branch}
 
 ifdef::env-github[]
 NOTE: For the best reading experience,
@@ -7,9 +15,13 @@ please view this documentation at https://www.elastic.co/guide/en/apm/server[ela
 endif::[]
 
 [[apm-server]]
-= APM Server Docs (Experimental)
+= APM Server Docs (Alpha)
 
 include::./overview.asciidoc[]
+
+include::./installing.asciidoc[]
+
+include::./configuring.asciidoc[]
 
 include::./transaction-api.asciidoc[]
 

--- a/docs/installing.asciidoc
+++ b/docs/installing.asciidoc
@@ -1,5 +1,5 @@
 [[installing]]
-== Step 1: Installing APM Server
+== Installing APM Server
 
 https://www.elastic.co/downloads/apm/apm-server[Download APM Server] for your operating system and extract the package.
 

--- a/docs/installing.asciidoc
+++ b/docs/installing.asciidoc
@@ -1,0 +1,12 @@
+[[installing]]
+== Step 1: Installing APM Server
+
+https://www.elastic.co/downloads/apm/apm-server[Download APM Server] for your operating system and extract the package.
+
+You can also install APM Server from our repositories or run it through docker.
+
+* <<running-on-docker>>
+* <<setup-repositories>>
+
+include::./copied-from-beats/running-on-docker.asciidoc[]
+include::./copied-from-beats/repositories.asciidoc[]

--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -28,12 +28,6 @@ and as such it shares many of the same configuration options as beats.
 
 In the following you can read more about 
 
-* <<security>>
-* <<high-availability>>
-* <<index-pattern>>
+* <<installing>>
+* <<configuring>>
 
-include::./security.asciidoc[]
-
-include::./high-availability.asciidoc[]
-
-include::./index_pattern.asciidoc[]


### PR DESCRIPTION
Reorganized into two steps: installing + configuring and running.

Closes https://github.com/elastic/apm-server/issues/210
Relies on https://github.com/elastic/beats/pull/5460.