### PR TITLE
Add note for dashboards

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -147,7 +147,9 @@ To install those run the following command:
 ./apm-server setup
 ----------------------------------
 
-If you are using an X-Pack secured version of Elastic Stack,
+NOTE: Due to a bug in Kibana 6.0.0.-rc2 the dashboards don't work in Kibana 6.0.0-rc2.
+
+NOTE: If you are using an X-Pack secured version of Elastic Stack,
 add `-E output.elasticsearch.username=user -E output.elasticsearch.password=pass` to the command.
 
 See an example screenshot of a Kibana dashboard:

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -139,31 +139,16 @@ you can use the {apm-server-ref}/overview.html#security[secret token and TLS] to
 [[kibana-dashboards]]
 [float]
 ==== Install the Kibana dashboards
-APM Server comes with predefined Kibana dashboards for the APM data.
-To install the Kibana dashboards for the 6.x releases,
-run the following command:
+APM Server comes with predefined Kibana dashboards and index templates for the APM data.
+To install those run the following command:
 
 [source,bash]
 ----------------------------------
-curl -X POST http://localhost:5601/api/kibana/dashboards/import \
-  -H 'Content-type: application/json' \
-  -H 'kbn-xsrf: true' \
-  -d @./kibana/default/dashboard/apm-dashboards.json
-----------------------------------
-
-If you are running Kibana 5.6, you need to download the dashboard file first and then load it:
-
-[source,bash]
-----------------------------------
-curl -o apm-dashboards.json https://raw.githubusercontent.com/elastic/apm-server/3177ec4203cc6cab1d85d0c18a2a6a6c2fcc13be/_meta/kibana/5.x/dashboard/apm-dashboards.json
-curl -X POST http://localhost:5601/api/kibana/dashboards/import \
-  -H 'Content-type: application/json' \
-  -H 'kbn-xsrf: true' \
-  -d @./apm-dashboards.json
+./apm-server setup
 ----------------------------------
 
 If you are using an X-Pack secured version of Elastic Stack,
-add `--user user:pass` to the command.
+add `-E output.elasticsearch.username=user -E output.elasticsearch.password=pass` to the command.
 
 See an example screenshot of a Kibana dashboard:
 


### PR DESCRIPTION
Revert commit for documenting how to load dashboards.
Add note that rc1 of Kibana is required for the dashboards to work properly. 