### PR TITLE
Move beats dependency inside docs folder.

### DIFF
--- a/docs/copied-from-beats/version.asciidoc
+++ b/docs/copied-from-beats/version.asciidoc
@@ -1,0 +1,7 @@
+:stack-version: 7.0.0-alpha1
+:doc-branch: master
+:go-version: 1.8.3
+:release-state: unreleased
+:python: 2.7.9
+:docker: 1.12
+:docker-compose: 1.11

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,5 +1,5 @@
 :branch: current
-include::../_beats/libbeat/docs/version.asciidoc[]
+include::./copied-from-beats/version.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 :version: {stack-version}


### PR DESCRIPTION
The change is necessary as the folder outside of `docs` is not available by default.