### PR TITLE
Backport to 6.0: support OPTIONS method needed for preflight browser requests (#244)

### DIFF
--- a/_meta/beat.reference.yml
+++ b/_meta/beat.reference.yml
@@ -20,3 +20,9 @@ apm-server:
   #ssl.enabled: false
   #ssl.certificate : "path/to/cert"
   #ssl.key : "path/to/private_key"
+
+  # Comma separated list of permitted origins for frontend. User-agents will send
+  # a origin header that will be validated against this list.
+  # An origin is made of a protocol scheme, host and port, without the url path.
+  # If an item in the list is a single *, everything will be allowed
+  #allow_origins : *

--- a/apm-server.reference.yml
+++ b/apm-server.reference.yml
@@ -21,6 +21,12 @@ apm-server:
   #ssl.certificate : "path/to/cert"
   #ssl.key : "path/to/private_key"
 
+  # Comma separated list of permitted origins for frontend. User-agents will send
+  # a origin header that will be validated against this list.
+  # An origin is made of a protocol scheme, host and port, without the url path.
+  # If an item in the list is a single *, everything will be allowed
+  #allow_origins : *
+
 #================================ General ======================================
 
 # The name of the shipper that publishes the network data. It can be used to group

--- a/beater/config.go
+++ b/beater/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	SSL                *SSLConfig    `config:"ssl"`
 	ConcurrentRequests int           `config:"concurrent_requests" validate:"min=1"`
 	EnableFrontend     bool          `config:"enable_frontend"`
+	AllowOrigins       []string      `config:"allow_origins"`
 }
 
 type SSLConfig struct {
@@ -36,4 +37,5 @@ var defaultConfig = Config{
 	WriteTimeout:       2 * time.Second,
 	ShutdownTimeout:    5 * time.Second,
 	SecretToken:        "",
+	AllowOrigins:       []string{"*"},
 }

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -79,6 +79,14 @@ class ClientSideBaseTest(ServerBaseTest):
         return cfg
 
 
+class CorsBaseTest(ClientSideBaseTest):
+
+    def config(self):
+        cfg = super(CorsBaseTest, self).config()
+        cfg.update({"allow_origins": ["http://www.elastic.co"]})
+        return cfg
+
+
 class ElasticTest(ServerBaseTest):
 
     @classmethod

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -4,6 +4,7 @@ apm-server:
   host: "localhost:8200"
   secret_token: {{ secret_token }}
   enable_frontend: {{ enable_frontend }}
+  allow_origins: {{ allow_origins }}
   ssl.enabled: {{ ssl_enabled }}
   ssl.certificate:  {{ ssl_cert }}
   ssl.key: {{ ssl_key }}

--- a/tests/system/test_requests.py
+++ b/tests/system/test_requests.py
@@ -1,6 +1,6 @@
 from nose.tools import raises
 
-from apmserver import ServerBaseTest, SecureServerBaseTest, ClientSideBaseTest
+from apmserver import ServerBaseTest, SecureServerBaseTest, ClientSideBaseTest, CorsBaseTest
 from requests.exceptions import SSLError
 import requests
 import json
@@ -129,3 +129,47 @@ class ClientSideTest(ClientSideBaseTest):
         transactions = self.get_transaction_payload()
         r = requests.post(self.transactions_url, json=transactions)
         assert r.status_code == 202, r.status_code
+
+
+class CorsTest(CorsBaseTest):
+
+    def test_ok(self):
+        transactions = self.get_transaction_payload()
+        r = requests.post(self.transactions_url, json=transactions, headers={'Origin': 'http://www.elastic.co'})
+        assert r.headers['Access-Control-Allow-Origin'] == 'http://www.elastic.co', r.headers
+        assert r.status_code == 202, r.status_code
+
+    def test_bad_origin(self):
+        # origin must include protocol and match exactly the allowed origin
+        transactions = self.get_transaction_payload()
+        r = requests.post(self.transactions_url, json=transactions, headers={'Origin': 'www.elastic.co'})
+        assert r.status_code == 403, r.status_code
+
+    def test_no_origin(self):
+        transactions = self.get_transaction_payload()
+        r = requests.post(self.transactions_url, json=transactions)
+        assert r.status_code == 403, r.status_code
+
+    def test_preflight(self):
+        transactions = self.get_transaction_payload()
+        r = requests.options(self.transactions_url,
+                             json=transactions,
+                             headers={'Origin': 'http://www.elastic.co',
+                                      'Access-Control-Request-Method': 'POST',
+                                      'Access-Control-Request-Headers': 'Content-Type, Content-Encoding'})
+        assert r.status_code == 200, r.status_code
+        assert r.headers['Access-Control-Allow-Origin'] == 'http://www.elastic.co', r.headers
+        assert r.headers['Access-Control-Allow-Headers'] == 'Content-Type, Content-Encoding, Accept', r.headers
+        assert r.headers['Access-Control-Allow-Methods'] == 'POST, OPTIONS', r.headers
+        assert r.headers['Vary'] == 'Origin', r.headers
+        assert r.headers['Content-Length'] == '0', r.headers
+        assert r.headers['Access-Control-Max-Age'] == '3600', r.headers
+
+    def test_preflight_bad_headers(self):
+        transactions = self.get_transaction_payload()
+        for h in [{'Access-Control-Request-Method': 'POST'}, {'Origin': 'www.elastic.co'}]:
+            r = requests.options(self.transactions_url, json=transactions, headers=h)
+            assert r.status_code == 200, r.status_code
+            assert 'Access-Control-Allow-Origin' not in r.headers.keys(), r.headers
+            assert r.headers['Access-Control-Allow-Headers'] == 'Content-Type, Content-Encoding, Accept', r.headers
+            assert r.headers['Access-Control-Allow-Methods'] == 'POST, OPTIONS', r.headers


### PR DESCRIPTION
This allows users to configure a valid origin, so that the apm-server won't accept requests from different origins. It handles preflight OPTIONS as per CORS spec.

It makes it possible to specify a list of allowed origins as well as `*` for any origin.