### PR TITLE
Bump version to 6.0.0

### DIFF
--- a/_beats/dev-tools/packer/version.yml
+++ b/_beats/dev-tools/packer/version.yml
@@ -1,1 +1,1 @@
-version: "6.0.0-rc2"
+version: "6.0.0"


### PR DESCRIPTION
This commit bumps the version on the apm-server artifact to 6.0.0.