### PR TITLE
disable urllib warnings so that it doesn't break tests with unexpected exit code 2

### DIFF
--- a/tests/system/test_requests.py
+++ b/tests/system/test_requests.py
@@ -10,7 +10,6 @@ import time
 from datetime import datetime
 from collections import defaultdict
 import threading
-import urllib3
 
 try:
     from StringIO import StringIO
@@ -118,6 +117,8 @@ class Test(ServerBaseTest):
 class SecureTest(SecureServerBaseTest):
 
     def test_https_ok(self):
+        import urllib3
+
         urllib3.disable_warnings()
         transactions = self.get_transaction_payload()
         r = requests.post("https://localhost:8200/v1/transactions",

--- a/tests/system/test_requests.py
+++ b/tests/system/test_requests.py
@@ -10,6 +10,7 @@ import time
 from datetime import datetime
 from collections import defaultdict
 import threading
+import urllib3
 
 try:
     from StringIO import StringIO
@@ -117,6 +118,7 @@ class Test(ServerBaseTest):
 class SecureTest(SecureServerBaseTest):
 
     def test_https_ok(self):
+        urllib3.disable_warnings()
         transactions = self.get_transaction_payload()
         r = requests.post("https://localhost:8200/v1/transactions",
                           json=transactions, verify=False)


### PR DESCRIPTION
eg: https://beats-ci.elastic.co/job/elastic+apm-server+pull-request+multijob-windows/349/beat=apm-server,label=windows/testReport/junit/test_requests/SecureTest/test_https_ok/