### PR TITLE
Revert "Make transaction.result a mandatory field. (#250)"

### DIFF
--- a/docs/data/elasticsearch/transaction.json
+++ b/docs/data/elasticsearch/transaction.json
@@ -105,7 +105,7 @@
         },
         "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
         "name": "GET /api/types",
-        "result": "200",
+        "result": "success",
         "type": "request"
     }
 }

--- a/docs/data/intake-api/generated/transaction/minimal_app.json
+++ b/docs/data/intake-api/generated/transaction/minimal_app.json
@@ -15,7 +15,6 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
-            "result": "200",
             "timestamp": "2017-05-30T18:53:27.154Z"
         }
     ]

--- a/docs/data/intake-api/generated/transaction/minimal_payload.json
+++ b/docs/data/intake-api/generated/transaction/minimal_payload.json
@@ -11,7 +11,6 @@
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
             "name": "GET /api/types",
             "type": "request",
-            "result": "success",
             "duration": 32.592981,
             "timestamp": "2017-05-09T15:04:05.999999Z"
         }

--- a/docs/data/intake-api/generated/transaction/minimal_trace.json
+++ b/docs/data/intake-api/generated/transaction/minimal_trace.json
@@ -11,7 +11,6 @@
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
             "name": "GET /api/types",
             "type": "request",
-            "result": "success",
             "duration": 32.592981,
             "timestamp": "2017-05-30T18:53:27.154Z",
             "traces": [

--- a/docs/data/intake-api/generated/transaction/null_values.json
+++ b/docs/data/intake-api/generated/transaction/null_values.json
@@ -38,7 +38,6 @@
             "type": "request",
             "duration": 13.980558,
             "timestamp": "2017-05-30T18:53:42Z",
-            "result": "200",
             "context": {
                 "request": null,
                 "response": null,
@@ -53,7 +52,6 @@
             "type": "request",
             "duration": 13.980558,
             "timestamp": "2017-05-30T18:53:42.281999Z",
-            "result": "200",
             "context": {
                 "request": {
                     "socket": null,
@@ -93,7 +91,6 @@
             "type": "request",
             "duration": 13.980558,
             "timestamp": "2017-05-30T18:53:42.281Z",
-            "result": "200",
             "context": {
                 "request": {
                     "socket": {

--- a/docs/data/intake-api/generated/transaction/payload.json
+++ b/docs/data/intake-api/generated/transaction/payload.json
@@ -36,7 +36,6 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
-            "result": "success",
             "timestamp": "2017-05-30T18:53:27.154Z",
             "result": "200",
             "context": {
@@ -184,7 +183,6 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 13.980558,
-            "result": "failure",
             "timestamp": "2017-05-30T18:53:42.281Z",
             "traces": []
         },
@@ -193,7 +191,6 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 13.980558,
-            "result": "200",
             "timestamp": "2017-05-30T18:53:42Z"
         },
         {
@@ -201,7 +198,6 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 13.980558,
-            "result": "200",
             "timestamp": "2017-05-30T18:53:42.281999Z",
             "traces": [
                 {

--- a/docs/data/intake-api/generated/transaction/payload.json
+++ b/docs/data/intake-api/generated/transaction/payload.json
@@ -36,8 +36,8 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
+            "result": "success",
             "timestamp": "2017-05-30T18:53:27.154Z",
-            "result": "200",
             "context": {
                 "request": {
                     "socket": {
@@ -183,6 +183,7 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 13.980558,
+            "result": "failure",
             "timestamp": "2017-05-30T18:53:42.281Z",
             "traces": []
         },
@@ -191,6 +192,7 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 13.980558,
+            "result": "200",
             "timestamp": "2017-05-30T18:53:42Z"
         },
         {
@@ -198,6 +200,7 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 13.980558,
+            "result": "200",
             "timestamp": "2017-05-30T18:53:42.281999Z",
             "traces": [
                 {

--- a/docs/data/intake-api/generated/transaction/system_null.json
+++ b/docs/data/intake-api/generated/transaction/system_null.json
@@ -13,7 +13,6 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
-            "result": "200",
             "timestamp": "2017-05-09T15:04:05.999999Z",
             "context": null,
             "traces": null

--- a/docs/data/intake-api/generated/transaction/transaction_empty_values.json
+++ b/docs/data/intake-api/generated/transaction/transaction_empty_values.json
@@ -15,7 +15,6 @@
             "type": "request",
             "duration": 32.592981,
             "start": 24.01,
-            "result": "200",
             "timestamp": "2017-05-09T15:04:05.999999Z",
             "traces": []
         }

--- a/docs/spec/transactions/transaction.json
+++ b/docs/spec/transactions/transaction.json
@@ -45,5 +45,5 @@
             "maxLength": 1024
         }
     },
-    "required": ["id", "name", "duration", "type", "timestamp", "result"]
+    "required": ["id", "name", "duration", "type", "timestamp"]
 }

--- a/processor/transaction/package_tests/TestProcessSystemNull.approved.json
+++ b/processor/transaction/package_tests/TestProcessSystemNull.approved.json
@@ -21,7 +21,6 @@
                 },
                 "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
                 "name": "GET /api/types",
-                "result": "200",
                 "type": "request"
             }
         }

--- a/processor/transaction/package_tests/TestProcessTransactionEmpty.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionEmpty.approved.json
@@ -22,7 +22,6 @@
                 },
                 "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
                 "name": "GET /api/types",
-                "result": "200",
                 "type": "request"
             }
         }

--- a/processor/transaction/package_tests/TestProcessTransactionFull.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionFull.approved.json
@@ -312,7 +312,6 @@
                 },
                 "id": "85925e55-b43f-4340-a8e0-df1906ecbf7a",
                 "name": "GET /api/types",
-                "result": "failure",
                 "type": "request"
             }
         },
@@ -361,7 +360,6 @@
                 },
                 "id": "85925e55-b43f-4340-a8e0-df1906ecbf78",
                 "name": "GET /api/types",
-                "result": "200",
                 "type": "request"
             }
         },
@@ -410,7 +408,6 @@
                 },
                 "id": "85925e55-b43f-4340-a8e0-df1906ecbfa9",
                 "name": "GET /api/types",
-                "result": "200",
                 "type": "request"
             }
         },

--- a/processor/transaction/package_tests/TestProcessTransactionFull.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionFull.approved.json
@@ -108,7 +108,7 @@
                 },
                 "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
                 "name": "GET /api/types",
-                "result": "200",
+                "result": "success",
                 "type": "request"
             }
         },
@@ -312,6 +312,7 @@
                 },
                 "id": "85925e55-b43f-4340-a8e0-df1906ecbf7a",
                 "name": "GET /api/types",
+                "result": "failure",
                 "type": "request"
             }
         },
@@ -360,6 +361,7 @@
                 },
                 "id": "85925e55-b43f-4340-a8e0-df1906ecbf78",
                 "name": "GET /api/types",
+                "result": "200",
                 "type": "request"
             }
         },
@@ -408,6 +410,7 @@
                 },
                 "id": "85925e55-b43f-4340-a8e0-df1906ecbfa9",
                 "name": "GET /api/types",
+                "result": "200",
                 "type": "request"
             }
         },

--- a/processor/transaction/package_tests/TestProcessTransactionMinimalApp.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionMinimalApp.approved.json
@@ -24,7 +24,6 @@
                 },
                 "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
                 "name": "GET /api/types",
-                "result": "200",
                 "type": "request"
             }
         }

--- a/processor/transaction/package_tests/TestProcessTransactionMinimalPayload.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionMinimalPayload.approved.json
@@ -21,7 +21,6 @@
                 },
                 "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
                 "name": "GET /api/types",
-                "result": "success",
                 "type": "request"
             }
         }

--- a/processor/transaction/package_tests/TestProcessTransactionMinimalTrace.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionMinimalTrace.approved.json
@@ -21,7 +21,6 @@
                 },
                 "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
                 "name": "GET /api/types",
-                "result": "success",
                 "type": "request"
             }
         },

--- a/processor/transaction/package_tests/TestProcessTransactionNullValues.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionNullValues.approved.json
@@ -59,7 +59,6 @@
                 },
                 "id": "85925e55-b43f-4340-a8e0-df1906ecbf78",
                 "name": "GET /api/types",
-                "result": "200",
                 "type": "request"
             }
         },
@@ -118,7 +117,6 @@
                 },
                 "id": "85925e55-b43f-4340-a8e0-df1906ecbfa9",
                 "name": "GET /api/types",
-                "result": "200",
                 "type": "request"
             }
         },
@@ -178,7 +176,6 @@
                 },
                 "id": "85925e55-b43f-4340-a8e0-df1906ecbf7a",
                 "name": "GET /api/types",
-                "result": "200",
                 "type": "request"
             }
         },

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -460,7 +460,7 @@ var transactionSchema = `{
             "maxLength": 1024
         }
     },
-    "required": ["id", "name", "duration", "type", "timestamp", "result"]
+    "required": ["id", "name", "duration", "type", "timestamp"]
             },
             "minItems": 1
         }

--- a/tests/data/invalid/transaction/invalid_id.json
+++ b/tests/data/invalid/transaction/invalid_id.json
@@ -3,7 +3,6 @@
     "name": "GET /api/types",
     "type": "request",
     "duration": 1.0,
-    "result": "200",
     "timestamp": "2017-05-30T18:53:27.154Z",
     "traces": []
 }

--- a/tests/data/invalid/transaction/invalid_timestamp.json
+++ b/tests/data/invalid/transaction/invalid_timestamp.json
@@ -3,7 +3,6 @@
     "name": "GET /api/types",
     "type": "request",
     "duration": 2.0,
-    "result": "200",
     "timestamp": "2017-05-30T18:53Z",
     "traces": []
 }

--- a/tests/data/invalid/transaction/invalid_timestamp2.json
+++ b/tests/data/invalid/transaction/invalid_timestamp2.json
@@ -4,7 +4,6 @@
     "name": "GET /api/types",
     "type": "request",
     "duration": 2.0,
-    "result": "200",
     "timestamp": "2017-05-30T18:53:27.000+00:20",
     "traces": []
 }

--- a/tests/data/invalid/transaction/invalid_timestamp3.json
+++ b/tests/data/invalid/transaction/invalid_timestamp3.json
@@ -3,7 +3,6 @@
     "name": "GET /api/types",
     "type": "request",
     "duration": 2.0,
-    "result": "200",
     "timestamp": "2017-05-30T18:53:27.Z",
     "traces": []
 }

--- a/tests/data/invalid/transaction/invalid_timestamp4.json
+++ b/tests/data/invalid/transaction/invalid_timestamp4.json
@@ -3,7 +3,6 @@
     "name": "GET /api/types",
     "type": "request",
     "duration": 2.0,
-    "result": "200",
     "timestamp": "2017-05-30T18:53:27a123Z",
     "traces": []
 }

--- a/tests/data/invalid/transaction/invalid_timestamp5.json
+++ b/tests/data/invalid/transaction/invalid_timestamp5.json
@@ -3,7 +3,6 @@
   "name": "GET /api/types",
   "type": "request",
   "duration": 2.0,
-    "result": "200",
   "timestamp": "2017-05-30T18:53:27ZNOTCORRECT",
   "traces": []
 }

--- a/tests/data/invalid/transaction/no_duration.json
+++ b/tests/data/invalid/transaction/no_duration.json
@@ -2,7 +2,6 @@
     "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
     "name": "GET /api/types",
     "type": "request",
-    "result": "200",
     "timestamp": "2017-05-30T18:53:27.154Z",
     "traces": []
 }

--- a/tests/data/invalid/transaction/no_id.json
+++ b/tests/data/invalid/transaction/no_id.json
@@ -2,7 +2,6 @@
     "name": "GET /api/types",
     "type": "request",
     "duration": 1.0,
-    "result": "200",
     "timestamp": "2017-05-30T18:53:27.154Z",
     "traces": []
 }

--- a/tests/data/invalid/transaction/no_name.json
+++ b/tests/data/invalid/transaction/no_name.json
@@ -2,7 +2,6 @@
     "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
     "type": "request",
     "duration": 1.0,
-    "result": "200",
     "timestamp": "2017-05-30T18:53:27.154Z",
     "traces": []
 }

--- a/tests/data/invalid/transaction/no_result.json
+++ b/tests/data/invalid/transaction/no_result.json
@@ -1,8 +1,0 @@
-{
-    "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-    "type": "request",
-    "name": "GET /api/types",
-    "duration": 1.0,
-    "timestamp": "2017-05-30T18:53:27.154Z",
-    "traces": []
-}

--- a/tests/data/invalid/transaction/no_timestamp.json
+++ b/tests/data/invalid/transaction/no_timestamp.json
@@ -3,6 +3,5 @@
     "name": "GET /api/types",
     "type": "request",
     "duration": 1.0,
-    "result": "200",
     "traces": []
 }

--- a/tests/data/invalid/transaction/no_type.json
+++ b/tests/data/invalid/transaction/no_type.json
@@ -3,6 +3,5 @@
     "name": "GET /api/types",
     "duration": 1.0,
     "timestamp": "2017-05-30T18:53:27.154Z",
-    "result": "200",
     "traces": []
 }

--- a/tests/data/valid/transaction/minimal_app.json
+++ b/tests/data/valid/transaction/minimal_app.json
@@ -15,7 +15,6 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
-            "result": "200",
             "timestamp": "2017-05-30T18:53:27.154Z"
         }
     ]

--- a/tests/data/valid/transaction/minimal_payload.json
+++ b/tests/data/valid/transaction/minimal_payload.json
@@ -11,7 +11,6 @@
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
             "name": "GET /api/types",
             "type": "request",
-            "result": "success",
             "duration": 32.592981,
             "timestamp": "2017-05-09T15:04:05.999999Z"
         }

--- a/tests/data/valid/transaction/minimal_trace.json
+++ b/tests/data/valid/transaction/minimal_trace.json
@@ -11,7 +11,6 @@
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
             "name": "GET /api/types",
             "type": "request",
-            "result": "success",
             "duration": 32.592981,
             "timestamp": "2017-05-30T18:53:27.154Z",
             "traces": [

--- a/tests/data/valid/transaction/null_values.json
+++ b/tests/data/valid/transaction/null_values.json
@@ -38,7 +38,6 @@
             "type": "request",
             "duration": 13.980558,
             "timestamp": "2017-05-30T18:53:42Z",
-            "result": "200",
             "context": {
                 "request": null,
                 "response": null,
@@ -53,7 +52,6 @@
             "type": "request",
             "duration": 13.980558,
             "timestamp": "2017-05-30T18:53:42.281999Z",
-            "result": "200",
             "context": {
                 "request": {
                     "socket": null,
@@ -93,7 +91,6 @@
             "type": "request",
             "duration": 13.980558,
             "timestamp": "2017-05-30T18:53:42.281Z",
-            "result": "200",
             "context": {
                 "request": {
                     "socket": {

--- a/tests/data/valid/transaction/payload.json
+++ b/tests/data/valid/transaction/payload.json
@@ -36,7 +36,6 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
-            "result": "success",
             "timestamp": "2017-05-30T18:53:27.154Z",
             "result": "200",
             "context": {
@@ -184,7 +183,6 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 13.980558,
-            "result": "failure",
             "timestamp": "2017-05-30T18:53:42.281Z",
             "traces": []
         },
@@ -193,7 +191,6 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 13.980558,
-            "result": "200",
             "timestamp": "2017-05-30T18:53:42Z"
         },
         {
@@ -201,7 +198,6 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 13.980558,
-            "result": "200",
             "timestamp": "2017-05-30T18:53:42.281999Z",
             "traces": [
                 {

--- a/tests/data/valid/transaction/payload.json
+++ b/tests/data/valid/transaction/payload.json
@@ -36,8 +36,8 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
+            "result": "success",
             "timestamp": "2017-05-30T18:53:27.154Z",
-            "result": "200",
             "context": {
                 "request": {
                     "socket": {
@@ -183,6 +183,7 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 13.980558,
+            "result": "failure",
             "timestamp": "2017-05-30T18:53:42.281Z",
             "traces": []
         },
@@ -191,6 +192,7 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 13.980558,
+            "result": "200",
             "timestamp": "2017-05-30T18:53:42Z"
         },
         {
@@ -198,6 +200,7 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 13.980558,
+            "result": "200",
             "timestamp": "2017-05-30T18:53:42.281999Z",
             "traces": [
                 {

--- a/tests/data/valid/transaction/system_null.json
+++ b/tests/data/valid/transaction/system_null.json
@@ -13,7 +13,6 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
-            "result": "200",
             "timestamp": "2017-05-09T15:04:05.999999Z",
             "context": null,
             "traces": null

--- a/tests/data/valid/transaction/transaction_empty_values.json
+++ b/tests/data/valid/transaction/transaction_empty_values.json
@@ -15,7 +15,6 @@
             "type": "request",
             "duration": 32.592981,
             "start": 24.01,
-            "result": "200",
             "timestamp": "2017-05-09T15:04:05.999999Z",
             "traces": []
         }

--- a/tests/json_schema_test.go
+++ b/tests/json_schema_test.go
@@ -95,7 +95,6 @@ func TestTransactionSchema(t *testing.T) {
 		{File: "no_name.json", Error: `missing properties: "name"`},
 		{File: "no_duration.json", Error: `missing properties: "duration"`},
 		{File: "no_type.json", Error: `missing properties: "type"`},
-		{File: "no_result.json", Error: `missing properties: "result"`},
 		{File: "no_timestamp.json", Error: `missing properties: "timestamp"`},
 		{File: "invalid_id.json", Error: "[#/properties/id/pattern] does not match pattern"},
 		{File: "invalid_timestamp.json", Error: "is not valid \"date-time\""},


### PR DESCRIPTION
This reverts commit 11af2e8f9bc936fbd26d5bf444cdd77c6c8ab48d.

As the mandatory field does not make sense for frontend agents, which share the same schema as backend agents, this field is going to be optional again. 