### PR TITLE
Split app spec in 2 files

### DIFF
--- a/docs/spec/app.json
+++ b/docs/spec/app.json
@@ -3,85 +3,110 @@
     "$id": "doc/spec/app.json",
     "title": "App",
     "type": "object",
-    "properties": {
-        "agent": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "maxLength": 1024
+    "allOf": [
+        {"$ref": "app_core.json"},
+        {"properties": {
+            "agent": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 1024
+                    },
+                    "version": {
+                        "type": "string",
+                        "maxLength": 1024
+                    }
                 },
-                "version": {
-                    "type": "string",
-                    "maxLength": 1024
-                }
+                "required": [
+                    "name",
+                    "version"
+                ]
             },
-            "required": ["name", "version"]
-        },
-        "argv": {
-            "type": ["array", "null"],
-            "minItems": 0
-        },
-        "framework": {
-            "type": ["object", "null"],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "maxLength": 1024
+            "argv": {
+                "type": [
+                    "array",
+                    "null"
+                ],
+                "minItems": 0
+            },
+            "framework": {
+                "type": [
+                    "object",
+                    "null"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 1024
+                    },
+                    "version": {
+                        "type": "string",
+                        "maxLength": 1024
+                    }
                 },
-                "version": {
-                    "type": "string",
-                    "maxLength": 1024
-                }
+                "required": [
+                    "name",
+                    "version"
+                ]
             },
-            "required": ["name", "version"]
-        },
-        "language": {
-            "type": ["object", "null"],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "maxLength": 1024
+            "language": {
+                "type": [
+                    "object",
+                    "null"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 1024
+                    },
+                    "version": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 1024
+                    }
                 },
-                "version": {
-                    "type": ["string", "null"],
-                    "maxLength": 1024
-                }
+                "required": [
+                    "name"
+                ]
             },
-            "required": ["name"]
-        },
-        "name": {
-            "description": "Immutable name of the app emitting this event",
-            "type": "string",
-            "pattern": "^[a-zA-Z0-9 _-]+$",
-            "maxLength": 1024
-        },
-        "pid": {
-            "type": ["number", "null"]
-        },
-        "process_title": {
-            "type": ["string", "null"],
-            "maxLength": 1024
-        },
-        "runtime": {
-            "type": ["object", "null"],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "maxLength": 1024
+            "pid": {
+                "type": [
+                    "number",
+                    "null"
+                ]
+            },
+            "process_title": {
+                "type": [
+                    "string",
+                    "null"
+                ],
+                "maxLength": 1024
+            },
+            "runtime": {
+                "type": [
+                    "object",
+                    "null"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 1024
+                    },
+                    "version": {
+                        "type": "string",
+                        "maxLength": 1024
+                    }
                 },
-                "version": {
-                    "type": "string",
-                    "maxLength": 1024
-                }
-            },
-            "required": ["name", "version"]
+                "required": [
+                    "name",
+                    "version"
+                ]
+            }
         },
-        "version": {
-            "description": "Version of the app emitting this event",
-            "type": ["string", "null"],
-            "maxLength": 1024
+        "required": ["agent"]
         }
-    },
-    "required": ["agent", "name"]
+    ]
 }

--- a/docs/spec/app_core.json
+++ b/docs/spec/app_core.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "doc/spec/app_core.json",
+    "title": "App core properties",
+    "type": "object",
+    "properties": {
+        "name": {
+            "description": "Immutable name of the app emitting this event",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9 _-]+$",
+            "maxLength": 1024
+        },
+        "version": {
+            "description": "Version of the app emitting this event",
+            "type": [
+                "string",
+                "null"
+            ],
+            "maxLength": 1024
+        }
+    },
+    "required": ["name"]
+}

--- a/processor/error/package_tests/json_schema_test.go
+++ b/processor/error/package_tests/json_schema_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/fatih/set"
 
-	er "github.com/elastic/apm-server/processor/error"
 	"github.com/elastic/apm-server/tests"
 )
 
@@ -28,23 +27,5 @@ func TestPayloadAttributesInSchema(t *testing.T) {
 		"errors.context.request.cookies.c2",
 		"errors.context.tags.organization_uuid",
 	)
-	tests.TestPayloadAttributesInSchema(t, "error", undocumented, er.Schema())
-}
-
-func TestJsonSchemaKeywordLimitation(t *testing.T) {
-	fieldsPaths := []string{
-		"./../../../_meta/fields.common.yml",
-		"./../_meta/fields.yml",
-	}
-	exceptions := set.New(
-		"processor.event",
-		"processor.name",
-		"error.id",
-		"error.log.level",
-		"error.grouping_key",
-		"listening",
-		"error id icon",
-		"view errors",
-	)
-	tests.TestJsonSchemaKeywordLimitation(t, fieldsPaths, er.Schema(), exceptions)
+	tests.TestPayloadAttributesInSchema(t, "error/payload.json", undocumented, "errors/payload.json")
 }

--- a/processor/error/schema.go
+++ b/processor/error/schema.go
@@ -16,87 +16,132 @@ var errorSchema = `{
     "$id": "doc/spec/app.json",
     "title": "App",
     "type": "object",
+    "allOf": [
+        {    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "doc/spec/app_core.json",
+    "title": "App core properties",
+    "type": "object",
     "properties": {
-        "agent": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "maxLength": 1024
-                },
-                "version": {
-                    "type": "string",
-                    "maxLength": 1024
-                }
-            },
-            "required": ["name", "version"]
-        },
-        "argv": {
-            "type": ["array", "null"],
-            "minItems": 0
-        },
-        "framework": {
-            "type": ["object", "null"],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "maxLength": 1024
-                },
-                "version": {
-                    "type": "string",
-                    "maxLength": 1024
-                }
-            },
-            "required": ["name", "version"]
-        },
-        "language": {
-            "type": ["object", "null"],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "maxLength": 1024
-                },
-                "version": {
-                    "type": ["string", "null"],
-                    "maxLength": 1024
-                }
-            },
-            "required": ["name"]
-        },
         "name": {
             "description": "Immutable name of the app emitting this event",
             "type": "string",
             "pattern": "^[a-zA-Z0-9 _-]+$",
             "maxLength": 1024
         },
-        "pid": {
-            "type": ["number", "null"]
-        },
-        "process_title": {
-            "type": ["string", "null"],
-            "maxLength": 1024
-        },
-        "runtime": {
-            "type": ["object", "null"],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "maxLength": 1024
-                },
-                "version": {
-                    "type": "string",
-                    "maxLength": 1024
-                }
-            },
-            "required": ["name", "version"]
-        },
         "version": {
             "description": "Version of the app emitting this event",
-            "type": ["string", "null"],
+            "type": [
+                "string",
+                "null"
+            ],
             "maxLength": 1024
         }
     },
-    "required": ["agent", "name"]
+    "required": ["name"]},
+        {"properties": {
+            "agent": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 1024
+                    },
+                    "version": {
+                        "type": "string",
+                        "maxLength": 1024
+                    }
+                },
+                "required": [
+                    "name",
+                    "version"
+                ]
+            },
+            "argv": {
+                "type": [
+                    "array",
+                    "null"
+                ],
+                "minItems": 0
+            },
+            "framework": {
+                "type": [
+                    "object",
+                    "null"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 1024
+                    },
+                    "version": {
+                        "type": "string",
+                        "maxLength": 1024
+                    }
+                },
+                "required": [
+                    "name",
+                    "version"
+                ]
+            },
+            "language": {
+                "type": [
+                    "object",
+                    "null"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 1024
+                    },
+                    "version": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 1024
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "pid": {
+                "type": [
+                    "number",
+                    "null"
+                ]
+            },
+            "process_title": {
+                "type": [
+                    "string",
+                    "null"
+                ],
+                "maxLength": 1024
+            },
+            "runtime": {
+                "type": [
+                    "object",
+                    "null"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 1024
+                    },
+                    "version": {
+                        "type": "string",
+                        "maxLength": 1024
+                    }
+                },
+                "required": [
+                    "name",
+                    "version"
+                ]
+            }
+        },
+        "required": ["agent"]
+        }
+    ]
         },
         "errors": {
             "type": "array",

--- a/processor/transaction/package_tests/json_schema_test.go
+++ b/processor/transaction/package_tests/json_schema_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/fatih/set"
 
-	"github.com/elastic/apm-server/processor/transaction"
 	"github.com/elastic/apm-server/tests"
 )
 
@@ -19,25 +18,13 @@ func TestPayloadAttributesInSchema(t *testing.T) {
 		"transactions.context.request.headers.array",
 		"transactions.context.request.env.SERVER_SOFTWARE",
 		"transactions.context.request.env.GATEWAY_INTERFACE",
-		"transactions.context.request.body",
 		"transactions.context.request.cookies.c1",
 		"transactions.context.request.cookies.c2",
-		"transactions.context.custom",
 		"transactions.context.custom.my_key",
 		"transactions.context.custom.some_other_value",
 		"transactions.context.custom.and_objects",
 		"transactions.context.custom.and_objects.foo",
-		"transactions.context.tags",
 		"transactions.context.tags.organization_uuid",
 	)
-	tests.TestPayloadAttributesInSchema(t, "transaction", undocumented, transaction.Schema())
-}
-
-func TestJsonSchemaKeywordLimitation(t *testing.T) {
-	fieldsPaths := []string{
-		"./../../../_meta/fields.common.yml",
-		"./../_meta/fields.yml",
-	}
-	exceptions := set.New("processor.event", "processor.name", "context.app.name", "transaction.id", "trace.transaction_id", "listening")
-	tests.TestJsonSchemaKeywordLimitation(t, fieldsPaths, transaction.Schema(), exceptions)
+	tests.TestPayloadAttributesInSchema(t, "transaction/payload.json", undocumented, "transactions/payload.json")
 }

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -16,87 +16,132 @@ var transactionSchema = `{
     "$id": "doc/spec/app.json",
     "title": "App",
     "type": "object",
+    "allOf": [
+        {    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$id": "doc/spec/app_core.json",
+    "title": "App core properties",
+    "type": "object",
     "properties": {
-        "agent": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "maxLength": 1024
-                },
-                "version": {
-                    "type": "string",
-                    "maxLength": 1024
-                }
-            },
-            "required": ["name", "version"]
-        },
-        "argv": {
-            "type": ["array", "null"],
-            "minItems": 0
-        },
-        "framework": {
-            "type": ["object", "null"],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "maxLength": 1024
-                },
-                "version": {
-                    "type": "string",
-                    "maxLength": 1024
-                }
-            },
-            "required": ["name", "version"]
-        },
-        "language": {
-            "type": ["object", "null"],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "maxLength": 1024
-                },
-                "version": {
-                    "type": ["string", "null"],
-                    "maxLength": 1024
-                }
-            },
-            "required": ["name"]
-        },
         "name": {
             "description": "Immutable name of the app emitting this event",
             "type": "string",
             "pattern": "^[a-zA-Z0-9 _-]+$",
             "maxLength": 1024
         },
-        "pid": {
-            "type": ["number", "null"]
-        },
-        "process_title": {
-            "type": ["string", "null"],
-            "maxLength": 1024
-        },
-        "runtime": {
-            "type": ["object", "null"],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "maxLength": 1024
-                },
-                "version": {
-                    "type": "string",
-                    "maxLength": 1024
-                }
-            },
-            "required": ["name", "version"]
-        },
         "version": {
             "description": "Version of the app emitting this event",
-            "type": ["string", "null"],
+            "type": [
+                "string",
+                "null"
+            ],
             "maxLength": 1024
         }
     },
-    "required": ["agent", "name"]
+    "required": ["name"]},
+        {"properties": {
+            "agent": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 1024
+                    },
+                    "version": {
+                        "type": "string",
+                        "maxLength": 1024
+                    }
+                },
+                "required": [
+                    "name",
+                    "version"
+                ]
+            },
+            "argv": {
+                "type": [
+                    "array",
+                    "null"
+                ],
+                "minItems": 0
+            },
+            "framework": {
+                "type": [
+                    "object",
+                    "null"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 1024
+                    },
+                    "version": {
+                        "type": "string",
+                        "maxLength": 1024
+                    }
+                },
+                "required": [
+                    "name",
+                    "version"
+                ]
+            },
+            "language": {
+                "type": [
+                    "object",
+                    "null"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 1024
+                    },
+                    "version": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "maxLength": 1024
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "pid": {
+                "type": [
+                    "number",
+                    "null"
+                ]
+            },
+            "process_title": {
+                "type": [
+                    "string",
+                    "null"
+                ],
+                "maxLength": 1024
+            },
+            "runtime": {
+                "type": [
+                    "object",
+                    "null"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 1024
+                    },
+                    "version": {
+                        "type": "string",
+                        "maxLength": 1024
+                    }
+                },
+                "required": [
+                    "name",
+                    "version"
+                ]
+            }
+        },
+        "required": ["agent"]
+        }
+    ]
         },
         "system": {
                 "$schema": "http://json-schema.org/draft-04/schema#",

--- a/tests/common.go
+++ b/tests/common.go
@@ -8,11 +8,6 @@ import (
 	"runtime"
 )
 
-func UnmarshalData(file string, data interface{}) error {
-	_, current, _, _ := runtime.Caller(0)
-	return unmarshalData(filepath.Join(filepath.Dir(current), "..", file), data)
-}
-
 func LoadData(file string) ([]byte, error) {
 	_, current, _, _ := runtime.Caller(0)
 	return ioutil.ReadFile(filepath.Join(filepath.Dir(current), "..", file))
@@ -34,19 +29,10 @@ func LoadInvalidData(dataType string) ([]byte, error) {
 	return ioutil.ReadFile(path)
 }
 
-func UnmarshalValidData(dataType string, data interface{}) error {
-	path, err := buildPath(dataType, true)
-	if err != nil {
-		return err
-	}
-	return unmarshalData(path, data)
-}
-
-func UnmarshalInvalidData(dataType string, data interface{}) error {
-	path, err := buildPath(dataType, false)
-	if err != nil {
-		return err
-	}
+func UnmarshalValidData(json string, data interface{}) error {
+	_, current, _, _ := runtime.Caller(0)
+	curDir := filepath.Dir(current)
+	path := filepath.Join(curDir, "data/valid", json)
 	return unmarshalData(path, data)
 }
 
@@ -91,4 +77,16 @@ func StrConcat(pre string, post string, delimiter string) string {
 		return post
 	}
 	return pre + delimiter + post
+}
+
+func Contains(seq []string, match string) bool {
+	if seq == nil {
+		return false
+	}
+	for _, item := range seq {
+		if match == item {
+			return true
+		}
+	}
+	return false
 }

--- a/tests/json_schema.go
+++ b/tests/json_schema.go
@@ -3,9 +3,13 @@ package tests
 import (
 	"encoding/json"
 	"fmt"
-	"io"
-	"strings"
+
 	"testing"
+
+	"io/ioutil"
+
+	"path/filepath"
+	"runtime"
 
 	"github.com/fatih/set"
 	"github.com/stretchr/testify/assert"
@@ -24,18 +28,25 @@ type Mapping struct {
 	to   string
 }
 
-func TestPayloadAttributesInSchema(t *testing.T, name string, undocumentedAttrs *set.Set, schema string) {
-	var payload interface{}
+// not exhaustive list, just the words currently used in our spec
+var jsonSchemaReservedWords = []string{"$schema", "$id", "type", "description", "anyOf", "required", "title", "items",
+	"minItems", "allOf", "properties", "maxLength", "pattern", "enum", "default", "format", "additionalProperties",
+	"regexProperties", "dependencies"}
+
+func TestPayloadAttributesInSchema(t *testing.T, name string, undocumented *set.Set, specDir string) {
+
+	schema, specDir := loadSchema(specDir, "")
+	schemaNames := set.New()
+	flattenJsonKeys(schemaNames, schema, specDir, "")
+
+	var payload map[string]interface{}
 	UnmarshalValidData(name, &payload)
 	jsonNames := set.New()
-	flattenJsonKeys(payload, "", jsonNames)
-	jsonNamesDoc := set.Difference(jsonNames, undocumentedAttrs).(*set.Set)
+	flattenJsonKeys(jsonNames, payload, "", "")
+	jsonNames = set.Difference(jsonNames, undocumented).(*set.Set)
 
-	schemaStruct, _ := schemaStruct(strings.NewReader(schema))
-	schemaNames := set.New()
-	flattenSchemaNames(schemaStruct, "", addAllPropNames, schemaNames)
+	missing := set.Difference(jsonNames, schemaNames).(*set.Set)
 
-	missing := set.Difference(jsonNamesDoc, schemaNames).(*set.Set)
 	if missing.Size() > 0 {
 		msg := fmt.Sprintf("Json Transaction Payload fields missing in Schema %v", missing)
 		assert.Fail(t, msg)
@@ -48,98 +59,48 @@ func TestPayloadAttributesInSchema(t *testing.T, name string, undocumentedAttrs 
 	}
 }
 
-func TestJsonSchemaKeywordLimitation(t *testing.T, fieldPaths []string, schema string, exceptions *set.Set) {
-	fieldNames, err := fetchFlattenedFieldNames(fieldPaths, addKeywordFields)
-	assert.NoError(t, err)
-
-	schemaStruct, _ := schemaStruct(strings.NewReader(schema))
-	schemaNames := set.New()
-	flattenSchemaNames(schemaStruct, "", addLengthRestrictedPropNames, schemaNames)
-
-	mapping := []Mapping{
-		{"errors.context", "context"},
-		{"transactions.context", "context"},
-		{"errors", "error"},
-		{"transactions.traces", "trace"},
-		{"transactions", "transaction"},
-		{"app", "context.app"},
-		{"system", "context.system"},
+// loads jsonSchema file (.json) given a current directory, and returns its contents and directory
+// current directories need to be propagate across calls to loadSchema because $ref paths are relative
+func loadSchema(spec string, currentDir string) (map[string]interface{}, string) {
+	if currentDir == "" {
+		_, current, _, _ := runtime.Caller(0)
+		currentDir = filepath.Join(filepath.Dir(current), "../docs/spec/")
 	}
-
-	mappedSchemaNames := set.New()
-	for _, k := range schemaNames.List() {
-		name := k.(string)
-		for _, m := range mapping {
-			if strings.HasPrefix(name, m.from) {
-				k = strings.Replace(name, m.from, m.to, 1)
-				break
-			}
-		}
-		mappedSchemaNames.Add(k)
-	}
-	found := set.Union(mappedSchemaNames, exceptions).(*set.Set)
-	diff := set.SymmetricDifference(fieldNames, found).(*set.Set)
-
-	errMsg := fmt.Sprintf("Missing json schema length limit 1024 for: %v", diff)
-	assert.Equal(t, 0, diff.Size(), errMsg)
+	specFile := filepath.Join(currentDir, spec)
+	schemaData, _ := ioutil.ReadFile(specFile)
+	var schema map[string]interface{}
+	json.Unmarshal(schemaData, &schema)
+	return schema, filepath.Dir(specFile)
 }
 
-func schemaStruct(reader io.Reader) (*Schema, error) {
-	decoder := json.NewDecoder(reader)
-	var schema Schema
-	err := decoder.Decode(&schema)
-	return &schema, err
-}
-
-func flattenSchemaNames(s *Schema, prefix string, addFn addProperty, flattened *set.Set) {
-	if len(s.Properties) > 0 {
-		for k, v := range s.Properties {
-			flattenedKey := StrConcat(prefix, k, ".")
-			if addFn(v) {
-				flattened.Add(flattenedKey)
-			}
-			flattenSchemaNames(v, flattenedKey, addFn, flattened)
-		}
-	} else if s.Items != nil {
-		flattenSchemaNames(s.Items, prefix, addFn, flattened)
-	}
-}
-
-func flattenJsonKeys(data interface{}, prefix string, flattened *set.Set) {
+// walks a json collecting nested keys separated by dots, ie. {a:{b:c:{d:1}} ==> a.b.c.d
+// accumulates the result in the first argument, which is mutated recursively
+// it has some rudimentary knowledge of jsonSchema.
+// jsonSchema keys are traversed, but not accumulated in the result
+func flattenJsonKeys(flattened *set.Set, data interface{}, currentSpecDir string, keyPrefix string) {
 	if d, ok := data.(map[string]interface{}); ok {
 		for k, v := range d {
-			key := StrConcat(prefix, k, ".")
-			flattened.Add(key)
-			flattenJsonKeys(v, key, flattened)
+			key := StrConcat(keyPrefix, k, ".")
+			if Contains(jsonSchemaReservedWords, k) {
+				// if we find a jsonSchema key, we walk it down without "capturing" the key
+				// eg: {properties: { app {properties: name: {...}}}} becomes just app.name
+				flattenJsonKeys(flattened, v, currentSpecDir, keyPrefix)
+			} else if k == "$ref" {
+				// if we find a reference to another file, we load it and continue from there
+				schema, newCurrentSpecDir := loadSchema(v.(string), currentSpecDir)
+				flattenJsonKeys(flattened, schema, newCurrentSpecDir, keyPrefix)
+			} else if k == "patternProperties" {
+				// jsonSchema allows values as keys under patternProperties key
+				// we need to stop here so to not confuse arbitrary regex values with actual keys
+				continue
+			} else {
+				flattened.Add(key)
+				flattenJsonKeys(flattened, v, currentSpecDir, key)
+			}
 		}
 	} else if d, ok := data.([]interface{}); ok {
 		for _, v := range d {
-			flattenJsonKeys(v, prefix, flattened)
+			flattenJsonKeys(flattened, v, currentSpecDir, keyPrefix)
 		}
 	}
-}
-
-type addProperty func(s *Schema) bool
-
-func addAllPropNames(s *Schema) bool { return true }
-
-func addLengthRestrictedPropNames(s *Schema) bool {
-	if s.MaxLength == 1024 {
-		return true
-	} else if val, ok := s.AdditionalProperties["maxLength"]; ok {
-		if valF, okF := val.(float64); okF && valF == 1024 {
-			return true
-		}
-	} else if len(s.PatternProperties) > 0 {
-		for _, v := range s.PatternProperties {
-			val, ok := v.(map[string]interface{})["maxLength"]
-			if ok && val.(float64) == 1024 {
-				continue
-			} else {
-				return false
-			}
-		}
-		return true
-	}
-	return false
 }

--- a/tests/json_schema_test.go
+++ b/tests/json_schema_test.go
@@ -33,7 +33,7 @@ func TestAppSchema(t *testing.T) {
 		{File: "no_agent.json", Error: "missing properties: \"agent\""},
 	}
 	path := "app"
-	testDataAgainstSchema(t, testData, path, path, "")
+	testDataAgainstSchema(t, testData, path, path, `"$ref": "../docs/spec/`)
 }
 
 func TestUserSchema(t *testing.T) {
@@ -165,103 +165,3 @@ func testDataAgainstSchema(t *testing.T, testData []schemaTestData, schemaPath s
 		assert.True(t, filesToTest.Has(f.Name()), fmt.Sprintf("Did you miss to add the file %v to `json_schema_tests`?", filepath.Join(path, f.Name())))
 	}
 }
-
-func TestGetSchemaProperties(t *testing.T) {
-	schema, err := schemaStruct(strings.NewReader(test_schema))
-	assert.Nil(t, err)
-	flattened := set.New()
-	addFn := func(s *Schema) bool { return false }
-	flattenSchemaNames(schema, "", addFn, flattened)
-	assert.Equal(t, set.New(), flattened)
-
-	addFn = func(s *Schema) bool { return true }
-	flattenSchemaNames(schema, "", addFn, flattened)
-	expected := set.New("app", "app.name", "app.version", "app.argv", "app.language", "app.language.name", "app.language.version", "errors", "errors.timestamp", "errors.message", "errors.stacktrace", "errors.stacktrace.abs_path", "errors.stacktrace.filename", "errors.id")
-
-	assert.Equal(t, 0, set.Difference(expected, flattened).(*set.Set).Size())
-
-}
-
-var test_schema = `{
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "$id": "docs/spec/errors/wrapper.json",
-    "title": "Errors Wrapper",
-    "description": "List of errors wrapped in an object containing some other attributes normalized away form the errors themselves",
-    "type": "object",
-    "properties": {
-        "app": {
-            "$schema": "http://json-schema.org/draft-04/schema#",
-            "$id": "doc/spec/application.json",
-            "title": "App",
-            "type": "object",
-            "properties": {
-                "name": {
-                    "description": "Immutable name of the app emitting this transaction",
-                    "type": "string"
-                },
-                "version": {
-                    "description": "Version of the app emitting this transaction",
-                    "type": "string"
-                },
-                "argv": {
-                    "type": ["array","null"],
-                    "minItems": 0
-                },
-                "language": {
-                    "type": "object",
-                    "properties": {
-                        "name": {
-                            "type": "string"
-                        },
-                        "version": {
-                            "type": "string"
-                        }
-                    },
-                    "required": ["name", "version"]
-                }
-            },
-            "required": ["name", "agent"]
-        },
-        "errors": {
-            "type": "array",
-            "items": {
-                "$schema": "http://json-schema.org/draft-04/schema#",
-                "$id": "docs/spec/errors/error.json",
-                "type": "object",
-                "description": "Data captured by an agent representing an event occurring in a monitored app",
-                "properties": {
-                    "id": {
-                      "type": "string",
-                      "description": "UUID for the error"
-                    },
-                    "timestamp": {
-                        "type": "string",
-                        "description": "Recorded time of the error, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
-                    },
-                    "message": {
-                        "description": "The exception's error message.",
-                        "type": "string"
-                    },
-                    "stacktrace": {
-                        "type": ["array", "null"],
-                        "items": {
-                            "$schema": "http://json-schema.org/draft-04/schema#",
-                            "type": "object",
-                            "properties":{
-                                "abs_path": {
-                                  "description": "The absolute path of the file involved in the stack frame",
-                                  "type": ["string", "null"]
-                                },
-                                "filename": {
-                                    "description": "The relative filename of the code involved in the stack frame",
-                                    "type": "string"
-                                }
-									    	    }
-												}
-										}
-								}
-						}
-				}
-		}
-}
-`


### PR DESCRIPTION
Background: the upcoming `sourcemap` data model will need some app attributes, but not all.
This splits the `app` spec in 2, `app_core` that will be used by `sourcemap`, and `app` that references `app_core` and includes all the other attributes.

This doesn't change current functionality / data models.
_____

To "merge" 2 sets of attributes at the same level, this uses the `allOf` keyword at the top of the spec file, which is legal jsonSchema. 
However, we never did this before and the package tests didn't know how to handle the new semantics.
I had to rework the `TestPayloadAttributesInSchema` to use the original schema files instead of the generated strings. There is less code (eg. `flattenSchemaNames` and `TestGetSchemaProperties` got removed), but is not necessarily simpler. 
There is probably a better way, but after trying all week,  I settled on this.

On the other hand I had to remove the `TestJsonSchemaKeywordLimitation` tests, I couldn't make them work. It would be feasible if _all_ the strings were limited to 1024, but having to cross-check the keywords in the `fields.yml` is too much and I haven't been able to use that code.

I am unsure of the value of these tests, tbh. They are useful, but they basically require a jsonschema compliant parser which is probably more complex than the thing under test. 
I think we can keep the ones that they are working, but if in the future they give more problems I vote to remove them.

There are of course ways around (we could eg. duplicate the app attributes instead of embedding one spec into another) but doesn't change the fact that they are hard to maintain.

 We should also get rid of the generated string-ified schemas when we get a chance.