### PR TITLE
Disable (vendored) urllib3 warnings

### DIFF
--- a/tests/system/test_requests.py
+++ b/tests/system/test_requests.py
@@ -117,9 +117,19 @@ class Test(ServerBaseTest):
 class SecureTest(SecureServerBaseTest):
 
     def test_https_ok(self):
-        import urllib3
 
-        urllib3.disable_warnings()
+        try:
+            import urllib3
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        except ImportError:
+            pass
+
+        try:
+            from requests.packages.urllib3.exceptions import InsecureRequestWarning
+            requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+        except ImportError:
+            pass
+
         transactions = self.get_transaction_payload()
         r = requests.post("https://localhost:8200/v1/transactions",
                           json=transactions, verify=False)


### PR DESCRIPTION
urllib3 might or might not be vendored inside requests, this disables urllib warnings in any case to keep CI happy.