### PR TITLE
Adapt note for Kibana dashboards.

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -144,10 +144,8 @@ To install those run the following command:
 
 [source,bash]
 ----------------------------------
-./apm-server setup
+./apm-server setup -E setup.kibana.host=KibanaAddress:5601
 ----------------------------------
-
-NOTE: If you are using the Elastic stack 6.x please be aware that the dashboards currently only work in Kibana 6.0.0-rc1.
 
 NOTE: If you are using an X-Pack secured version of Elastic Stack,
 add `-E output.elasticsearch.username=user -E output.elasticsearch.password=pass` to the command.


### PR DESCRIPTION
Remove note about Kibana incompatibility.
Add information for loading dashboards when Kibana is not running on localhost.