### PR TITLE
Add ignored key list to approval check.

### DIFF
--- a/processor/error/package_tests/processor_test.go
+++ b/processor/error/package_tests/processor_test.go
@@ -3,6 +3,7 @@ package package_tests
 import (
 	"testing"
 
+	"github.com/fatih/set"
 	"github.com/stretchr/testify/assert"
 
 	er "github.com/elastic/apm-server/processor/error"
@@ -18,7 +19,7 @@ func TestProcessorOK(t *testing.T) {
 		{Name: "TestProcessErrorFull", Path: "tests/data/valid/error/payload.json"},
 		{Name: "TestProcessErrorNullValues", Path: "tests/data/valid/error/null_values.json"},
 	}
-	tests.TestProcessRequests(t, er.NewProcessor(), requestInfo)
+	tests.TestProcessRequests(t, er.NewProcessor(), requestInfo, *set.New())
 }
 
 // ensure invalid documents fail the json schema validation already

--- a/processor/transaction/package_tests/processor_test.go
+++ b/processor/transaction/package_tests/processor_test.go
@@ -3,6 +3,7 @@ package package_tests
 import (
 	"testing"
 
+	"github.com/fatih/set"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/apm-server/processor/transaction"
@@ -20,7 +21,7 @@ func TestTransactionProcessorOK(t *testing.T) {
 		{Name: "TestProcessTransactionMinimalApp", Path: "tests/data/valid/transaction/minimal_app.json"},
 		{Name: "TestProcessTransactionEmpty", Path: "tests/data/valid/transaction/transaction_empty_values.json"},
 	}
-	tests.TestProcessRequests(t, transaction.NewProcessor(), requestInfo)
+	tests.TestProcessRequests(t, transaction.NewProcessor(), requestInfo, *set.New())
 }
 
 // ensure invalid documents fail the json schema validation already

--- a/tests/scripts/approvals.go
+++ b/tests/scripts/approvals.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/fatih/set"
 	"github.com/yudai/gojsondiff/formatter"
 
 	"github.com/elastic/apm-server/tests"
@@ -23,7 +24,7 @@ func approval() int {
 
 	for _, rf := range receivedFiles {
 		path := strings.Replace(rf, tests.ReceivedSuffix, "", 1)
-		approved, d, err := tests.Compare(path)
+		_, approved, d, err := tests.Compare(path, *set.New())
 
 		if err != nil {
 			fmt.Println("Could not create diff ", err)


### PR DESCRIPTION
Allow to ignore defined keys when comparing two files with approvals.