### PR TITLE
Disable urllib3 ssl warnings (again) at class level.

### DIFF
--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -51,6 +51,22 @@ class ServerBaseTest(BaseTest):
 
 class SecureServerBaseTest(ServerBaseTest):
 
+    @classmethod
+    def setUpClass(cls):
+        super(SecureServerBaseTest, cls).setUpClass()
+
+        try:
+            import urllib3
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        except ImportError:
+            pass
+
+        try:
+            from requests.packages import urllib3
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        except ImportError:
+            pass
+
     def config(self):
         cfg = super(SecureServerBaseTest, self).config()
         cfg.update({

--- a/tests/system/test_requests.py
+++ b/tests/system/test_requests.py
@@ -117,19 +117,6 @@ class Test(ServerBaseTest):
 class SecureTest(SecureServerBaseTest):
 
     def test_https_ok(self):
-
-        try:
-            import urllib3
-            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-        except ImportError:
-            pass
-
-        try:
-            from requests.packages.urllib3.exceptions import InsecureRequestWarning
-            requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
-        except ImportError:
-            pass
-
         transactions = self.get_transaction_payload()
         r = requests.post("https://localhost:8200/v1/transactions",
                           json=transactions, verify=False)


### PR DESCRIPTION
This is needed so windows tests don't break with an unexpected exit code.
This might happen inside the test, or during tearDown, so disabling needs to happen for the whole class.
urllib3 might or might not be vendored inside the requests package.