### PR TITLE
Backporting from master to 6.0

### DIFF
--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -51,6 +51,22 @@ class ServerBaseTest(BaseTest):
 
 class SecureServerBaseTest(ServerBaseTest):
 
+    @classmethod
+    def setUpClass(cls):
+        super(SecureServerBaseTest, cls).setUpClass()
+
+        try:
+            import urllib3
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        except ImportError:
+            pass
+
+        try:
+            from requests.packages import urllib3
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        except ImportError:
+            pass
+
     def config(self):
         cfg = super(SecureServerBaseTest, self).config()
         cfg.update({


### PR DESCRIPTION
@roncohen @jalvz this is the only commit that I would backport as a bugfix to `6.0` right now. 

There have been some structural changes in master (e.g. moving up `models` by one level) which could lead to conflicts in the future when not backporting them, but I'd not do that now as it is not a bugfix. What do you think?