### PR TITLE
Improve Node.js agent test

### DIFF
--- a/tests/agent/nodejs/express/app.js
+++ b/tests/agent/nodejs/express/app.js
@@ -1,7 +1,8 @@
 'use strict'
 
 var apm = require('elastic-apm-node').start({
-  appName: 'test-app', flushInterval: 1
+  appName: 'test-app',
+  maxQueueSize: 1
 })
 
 


### PR DESCRIPTION
Use the new maxQueueSize instead of the flushInterval.

This will flush the queue instantly instead of after one second