### PR TITLE
Fix "update beats" message.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ update-beats:
 	rm -rf _beats
 	@BEATS_VERSION=$(BEATS_VERSION) sh script/update_beats.sh
 	@$(MAKE) update
-	echo --- Use this commit message: Update beats framework to `cd vendor/github.com/elastic/beats/ && git rev-parse --short HEAD`
+	@echo --- Use this commit message: Update beats framework to `cat vendor/vendor.json | python -c 'import sys, json; print([p["revision"] for p in json.load(sys.stdin)["package"] if p["path"] == "github.com/elastic/beats/libbeat/beat"][0][:7])'`
 
 # This is called by the beats packer before building starts
 .PHONY: before-build


### PR DESCRIPTION
Fixed: The message printed would have the wrong git commit hash. 