### PR TITLE
Revert "Update docs build to 6.0.1."

### DIFF
--- a/docs/copied-from-beats/version.asciidoc
+++ b/docs/copied-from-beats/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 6.0.1
+:stack-version: 6.0.0
 :doc-branch: 6.0
 :go-version: 1.8.3
 :release-state: alpha


### PR DESCRIPTION
Reverts elastic/apm-server#322

This was too early. Docs are being built from this branch and there's no 6.0.1 yet.
![running_apm_server_on_docker___apm_server_docs__alpha___6_0____elastic](https://user-images.githubusercontent.com/744/33078487-1e47e75e-ced3-11e7-8519-483a1d42740a.png)
