### PR TITLE
Bump version to 6.2

### DIFF
--- a/_beats/dev-tools/packer/version.yml
+++ b/_beats/dev-tools/packer/version.yml
@@ -1,1 +1,1 @@
-version: "6.1.0"
+version: "6.2.0"

--- a/vendor/github.com/elastic/beats/libbeat/version/version.go
+++ b/vendor/github.com/elastic/beats/libbeat/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const defaultBeatVersion = "6.1.0"
+const defaultBeatVersion = "6.2.0"


### PR DESCRIPTION
This commit bumps the version on the apm-server artifact to 6.2.0.