### PR TITLE
Fix index and template deletion for testing.

### DIFF
--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -128,17 +128,11 @@ class ElasticTest(ServerBaseTest):
         self.es = Elasticsearch([self.get_elasticsearch_url()])
 
         # Cleanup index and template first
-        try:
-            self.es.indices.delete(index=self.index_name)
-        except:
-            pass
+        self.es.indices.delete(index=self.index_name, ignore=[400, 404])
         self.wait_until(lambda: not self.es.indices.exists(self.index_name))
 
-        try:
-            self.es.indices.delete_template(
-                name=self.index_name)
-        except:
-            pass
+        self.es.indices.delete_template(name=self.index_name, ignore=[400, 404])
+        self.wait_until(lambda: not self.es.indices.exists_template(self.index_name))
 
         super(ElasticTest, self).setUp()
 

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -73,9 +73,11 @@ class Test(ElasticTest):
 
         # make sure template is loaded
         self.wait_until(
-            lambda: self.log_contains("Elasticsearch template with name 'apm-server-tests' loaded"))
+            lambda: self.log_contains("Elasticsearch template with name 'apm-server-tests' loaded"),
+            max_timeout=20)
 
-        self.wait_until(lambda: self.es.indices.exists(self.index_name))
+        self.wait_until(lambda: self.es.indices.exists(self.index_name),
+                        max_timeout=20)
         # Quick wait to give documents some time to be sent to the index
         # This is not required but speeds up the tests
         time.sleep(0.1)


### PR DESCRIPTION
This fixes the currently failing tests for the `6.x` branch, by increasing the timeout for server startup and ensuring clean startup by deleting index and template at setup. 

Should be backported to `6.1` afterwards.