### PR TITLE
Add system.ip field to context

### DIFF
--- a/_meta/fields.common.yml
+++ b/_meta/fields.common.yml
@@ -125,6 +125,11 @@
               description: >
                 The host that records the event.
 
+            - name: ip
+              type: ip
+              description: >
+                IP of the host that records the event.
+
             - name: architecture
               type: keyword
               description: >

--- a/beater/handlers_test.go
+++ b/beater/handlers_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/apm-server/tests"
-	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestDecode(t *testing.T) {
@@ -112,43 +111,4 @@ func TestIsAuthorized(t *testing.T) {
 	assert.False(t, isAuthorized(reqAuth("Bearer bar"), "foo"))
 	assert.False(t, isAuthorized(reqAuth("Bearer foo extra"), "foo"))
 	assert.False(t, isAuthorized(reqAuth("foo"), "foo"))
-}
-
-func TestExtractRequestData(t *testing.T) {
-	req, _ := http.NewRequest("POST", "_", nil)
-	req.RemoteAddr = "10.11.12.13:8080"
-	result, err := extractRequestData(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expected := common.MapStr{}
-	expected.Put("context.system.ip", "10.11.12.13")
-	assert.Equal(t, expected, result)
-}
-
-func TestExtractIP(t *testing.T) {
-	var req = func(real *string, forward *string) *http.Request {
-		req, _ := http.NewRequest("POST", "_", nil)
-		req.RemoteAddr = "10.11.12.13:8080"
-		if real != nil {
-			req.Header.Add("X-Real-IP", *real)
-		}
-		if forward != nil {
-			req.Header.Add("X-Forwarded-For", *forward)
-		}
-		return req
-	}
-
-	real := "54.55.101.102"
-	assert.Equal(t, real, extractIP(req(&real, nil)))
-
-	forwardedFor := "54.56.103.104"
-	assert.Equal(t, real, extractIP(req(&real, &forwardedFor)))
-	assert.Equal(t, forwardedFor, extractIP(req(nil, &forwardedFor)))
-
-	forwardedForMultiple := "54.56.103.104 , 54.57.105.106 , 54.58.107.108"
-	assert.Equal(t, forwardedFor, extractIP(req(nil, &forwardedForMultiple)))
-
-	assert.Equal(t, "10.11.12.13", extractIP(req(nil, nil)))
-	assert.Equal(t, "10.11.12.13", extractIP(req(new(string), new(string))))
 }

--- a/beater/handlers_test.go
+++ b/beater/handlers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/apm-server/tests"
+	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestDecode(t *testing.T) {
@@ -111,6 +112,18 @@ func TestIsAuthorized(t *testing.T) {
 	assert.False(t, isAuthorized(reqAuth("Bearer bar"), "foo"))
 	assert.False(t, isAuthorized(reqAuth("Bearer foo extra"), "foo"))
 	assert.False(t, isAuthorized(reqAuth("foo"), "foo"))
+}
+
+func TestExtractRequestData(t *testing.T) {
+	req, _ := http.NewRequest("POST", "_", nil)
+	req.RemoteAddr = "10.11.12.13:8080"
+	result, err := extractRequestData(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := common.MapStr{}
+	expected.Put("context.system.ip", "10.11.12.13")
+	assert.Equal(t, expected, result)
 }
 
 func TestExtractIP(t *testing.T) {

--- a/docs/data/elasticsearch/error.json
+++ b/docs/data/elasticsearch/error.json
@@ -84,6 +84,7 @@
         "system": {
             "architecture": "x64",
             "hostname": "prod1.example.com",
+            "ip": "192.0.2.1",
             "platform": "darwin"
         },
         "tags": {

--- a/docs/data/elasticsearch/transaction.json
+++ b/docs/data/elasticsearch/transaction.json
@@ -84,6 +84,7 @@
         "system": {
             "architecture": "x64",
             "hostname": "prod1.example.com",
+            "ip": "192.0.2.1",
             "platform": "darwin"
         },
         "tags": {

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -201,6 +201,14 @@ The host that records the event.
 
 
 [float]
+=== `context.system.ip`
+
+type: ip
+
+IP of the host that records the event.
+
+
+[float]
 === `context.system.architecture`
 
 type: keyword

--- a/model/system.go
+++ b/model/system.go
@@ -9,6 +9,7 @@ type System struct {
 	Hostname     *string `json:"hostname"`
 	Architecture *string `json:"architecture"`
 	Platform     *string `json:"platform"`
+	IP           *string `json:"ip"`
 }
 
 func (s *System) Transform() common.MapStr {
@@ -20,6 +21,7 @@ func (s *System) Transform() common.MapStr {
 	enhancer.Add(system, "hostname", s.Hostname)
 	enhancer.Add(system, "architecture", s.Architecture)
 	enhancer.Add(system, "platform", s.Platform)
+	enhancer.Add(system, "ip", s.IP)
 
 	return system
 }

--- a/model/system_test.go
+++ b/model/system_test.go
@@ -13,6 +13,7 @@ func TestSystemTransform(t *testing.T) {
 	architecture := "x64"
 	hostname := "a.b.com"
 	platform := "darwin"
+	ip := "127.0.0.1"
 
 	tests := []struct {
 		System System
@@ -42,6 +43,18 @@ func TestSystemTransform(t *testing.T) {
 			Output: common.MapStr{
 				"hostname":     hostname,
 				"architecture": architecture,
+			},
+		},
+		{
+			System: System{
+				Architecture: &architecture,
+				Hostname:     &hostname,
+				IP:           &ip,
+			},
+			Output: common.MapStr{
+				"hostname":     hostname,
+				"architecture": architecture,
+				"ip":           ip,
 			},
 		},
 	}

--- a/processor/error/benchmark_test.go
+++ b/processor/error/benchmark_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func BenchmarkEventWithFileLoading(b *testing.B) {
-	processor := NewProcessor()
+	processor := NewProcessor(nil)
 	for i := 0; i < b.N; i++ {
 		data, _ := tests.LoadValidData("error")
 		err := processor.Validate(data)
@@ -20,7 +20,7 @@ func BenchmarkEventWithFileLoading(b *testing.B) {
 }
 
 func BenchmarkEventFileLoadingOnce(b *testing.B) {
-	processor := NewProcessor()
+	processor := NewProcessor(nil)
 	data, _ := tests.LoadValidData("error")
 	for i := 0; i < b.N; i++ {
 		err := processor.Validate(data)

--- a/processor/error/package_tests/TestProcessErrorFull.approved.json
+++ b/processor/error/package_tests/TestProcessErrorFull.approved.json
@@ -87,6 +87,7 @@
                 "system": {
                     "architecture": "x64",
                     "hostname": "prod1.example.com",
+                    "ip": "192.0.2.1",
                     "platform": "darwin"
                 },
                 "tags": {
@@ -276,6 +277,7 @@
                 "system": {
                     "architecture": "x64",
                     "hostname": "prod1.example.com",
+                    "ip": "192.0.2.1",
                     "platform": "darwin"
                 }
             },
@@ -324,6 +326,7 @@
                 "system": {
                     "architecture": "x64",
                     "hostname": "prod1.example.com",
+                    "ip": "192.0.2.1",
                     "platform": "darwin"
                 }
             },
@@ -371,6 +374,7 @@
                 "system": {
                     "architecture": "x64",
                     "hostname": "prod1.example.com",
+                    "ip": "192.0.2.1",
                     "platform": "darwin"
                 }
             },

--- a/processor/error/package_tests/TestProcessErrorNullValues.approved.json
+++ b/processor/error/package_tests/TestProcessErrorNullValues.approved.json
@@ -13,7 +13,9 @@
                     },
                     "name": "1234_app-12a3"
                 },
-                "system": {}
+                "system": {
+                    "ip": "192.0.2.1"
+                }
             },
             "error": {
                 "exception": {
@@ -70,7 +72,9 @@
                         "content-type": null
                     }
                 },
-                "system": {},
+                "system": {
+                    "ip": "192.0.2.1"
+                },
                 "tags": {
                     "organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8"
                 }
@@ -124,7 +128,9 @@
                     "headers_sent": null,
                     "status_code": null
                 },
-                "system": {},
+                "system": {
+                    "ip": "192.0.2.1"
+                },
                 "user": {
                     "email": null,
                     "id": null,
@@ -158,7 +164,9 @@
                 "custom": null,
                 "request": null,
                 "response": null,
-                "system": {},
+                "system": {
+                    "ip": "192.0.2.1"
+                },
                 "tags": null,
                 "user": null
             },

--- a/processor/error/package_tests/processor_test.go
+++ b/processor/error/package_tests/processor_test.go
@@ -1,6 +1,7 @@
 package package_tests
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,13 +19,16 @@ func TestProcessorOK(t *testing.T) {
 		{Name: "TestProcessErrorFull", Path: "tests/data/valid/error/payload.json"},
 		{Name: "TestProcessErrorNullValues", Path: "tests/data/valid/error/null_values.json"},
 	}
-	tests.TestProcessRequests(t, er.NewProcessor(), requestInfo, map[string]string{})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	tests.TestProcessRequests(t, er.NewProcessor(req), requestInfo, map[string]string{})
 }
 
 // ensure invalid documents fail the json schema validation already
 func TestProcessorFailedValidation(t *testing.T) {
 	data, err := tests.LoadInvalidData("error")
 	assert.Nil(t, err)
-	err = er.NewProcessor().Validate(data)
+	req := httptest.NewRequest("GET", "/", nil)
+	err = er.NewProcessor(req).Validate(data)
 	assert.NotNil(t, err)
 }

--- a/processor/error/payload.go
+++ b/processor/error/payload.go
@@ -1,8 +1,11 @@
 package error
 
 import (
+	"net/http"
+
 	m "github.com/elastic/apm-server/model"
 	pr "github.com/elastic/apm-server/processor"
+	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
@@ -18,10 +21,16 @@ type payload struct {
 	Events []Event   `json:"errors"`
 }
 
-func (pa *payload) transform() []beat.Event {
+func (pa *payload) transform(r *http.Request) []beat.Event {
 	var events []beat.Event
 
 	logp.Debug("error", "Transform error events: events=%d, app=%s, agent=%s:%s", len(pa.Events), pa.App.Name, pa.App.Agent.Name, pa.App.Agent.Version)
+
+	// Inject system ip from the request
+	if pa.System != nil {
+		ip := utility.ExtractIP(r)
+		pa.System.IP = &ip
+	}
 
 	errorCounter.Add(int64(len(pa.Events)))
 	for _, e := range pa.Events {

--- a/processor/error/payload_test.go
+++ b/processor/error/payload_test.go
@@ -76,7 +76,7 @@ func TestPayloadTransform(t *testing.T) {
 	}
 
 	for idx, test := range tests {
-		outputEvents := test.Payload.transform()
+		outputEvents := test.Payload.transform(nil)
 		for j, outputEvent := range outputEvents {
 			assert.Equal(t, test.Output[j], outputEvent.Fields, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 			assert.Equal(t, timestamp, outputEvent.Timestamp, fmt.Sprintf("Bad timestamp at idx %v; %s", idx, test.Msg))

--- a/processor/error/processor.go
+++ b/processor/error/processor.go
@@ -2,6 +2,7 @@ package error
 
 import (
 	"encoding/json"
+	"net/http"
 
 	"github.com/santhosh-tekuri/jsonschema"
 
@@ -23,12 +24,13 @@ const (
 
 var schema = pr.CreateSchema(errorSchema, processorName)
 
-func NewProcessor() pr.Processor {
-	return &processor{schema}
+func NewProcessor(r *http.Request) pr.Processor {
+	return &processor{schema: schema, req: r}
 }
 
 type processor struct {
 	schema *jsonschema.Schema
+	req    *http.Request
 }
 
 func (p *processor) Validate(buf []byte) error {
@@ -48,7 +50,7 @@ func (p *processor) Transform(buf []byte) ([]beat.Event, error) {
 		return nil, err
 	}
 
-	return pa.transform(), nil
+	return pa.transform(p.req), nil
 }
 
 func (p *processor) Name() string {

--- a/processor/error/processor_test.go
+++ b/processor/error/processor_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestImplementProcessorInterface(t *testing.T) {
-	p := NewProcessor()
+	p := NewProcessor(nil)
 	assert.NotNil(t, p)
 	_, ok := p.(pr.Processor)
 	assert.True(t, ok)

--- a/processor/healthcheck/processor.go
+++ b/processor/healthcheck/processor.go
@@ -1,6 +1,8 @@
 package healthcheck
 
 import (
+	"net/http"
+
 	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/beats/libbeat/beat"
 )
@@ -9,7 +11,7 @@ const (
 	processorName = "healthcheck"
 )
 
-func NewProcessor() pr.Processor {
+func NewProcessor(*http.Request) pr.Processor {
 	return &processor{}
 }
 

--- a/processor/healthcheck/processor_test.go
+++ b/processor/healthcheck/processor_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestImplementProcessorInterface(t *testing.T) {
-	p := NewProcessor()
+	p := NewProcessor(nil)
 	assert.NotNil(t, p)
 	_, ok := p.(pr.Processor)
 	assert.True(t, ok)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"net/http"
 	"time"
 
 	m "github.com/elastic/apm-server/model"
@@ -8,7 +9,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
-type NewProcessor func() Processor
+type NewProcessor func(*http.Request) Processor
 
 type Processor interface {
 	Validate([]byte) error

--- a/processor/sourcemap/package_tests/processor_test.go
+++ b/processor/sourcemap/package_tests/processor_test.go
@@ -15,14 +15,14 @@ func TestSourcemapProcessorOK(t *testing.T) {
 		{Name: "TestProcessSourcemapFull", Path: "tests/data/valid/sourcemap/payload.json"},
 		{Name: "TestProcessSourcemapMinimalPayload", Path: "tests/data/valid/sourcemap/minimal_payload.json"},
 	}
-	tests.TestProcessRequests(t, sourcemap.NewProcessor(), requestInfo, map[string]string{"@timestamp": "***IGNORED***"})
+	tests.TestProcessRequests(t, sourcemap.NewProcessor(nil), requestInfo, map[string]string{"@timestamp": "***IGNORED***"})
 }
 
 // ensure invalid documents fail the json schema validation already
 func TestTransactionProcessorValidationFailed(t *testing.T) {
 	data, err := tests.LoadInvalidData("sourcemap")
 	assert.Nil(t, err)
-	p := sourcemap.NewProcessor()
+	p := sourcemap.NewProcessor(nil)
 	err = p.Validate(data)
 	assert.NotNil(t, err)
 }

--- a/processor/sourcemap/processor.go
+++ b/processor/sourcemap/processor.go
@@ -2,6 +2,7 @@ package sourcemap
 
 import (
 	"encoding/json"
+	"net/http"
 
 	"github.com/santhosh-tekuri/jsonschema"
 
@@ -29,7 +30,7 @@ type processor struct {
 	schema *jsonschema.Schema
 }
 
-func NewProcessor() pr.Processor {
+func NewProcessor(*http.Request) pr.Processor {
 	return &processor{schema}
 }
 

--- a/processor/sourcemap/processor_test.go
+++ b/processor/sourcemap/processor_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestImplementProcessorInterface(t *testing.T) {
-	p := NewProcessor()
+	p := NewProcessor(nil)
 	assert.NotNil(t, p)
 	_, ok := p.(pr.Processor)
 	assert.True(t, ok)

--- a/processor/transaction/benchmark_test.go
+++ b/processor/transaction/benchmark_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func BenchmarkWithFileLoading(b *testing.B) {
-	processor := NewProcessor()
+	processor := NewProcessor(nil)
 	for i := 0; i < b.N; i++ {
 		data, _ := tests.LoadValidData("transaction")
 		err := processor.Validate(data)
@@ -19,7 +19,7 @@ func BenchmarkWithFileLoading(b *testing.B) {
 }
 
 func BenchmarkTransactionFileLoadingOnce(b *testing.B) {
-	processor := NewProcessor()
+	processor := NewProcessor(nil)
 	data, _ := tests.LoadValidData("transaction")
 	for i := 0; i < b.N; i++ {
 		err := processor.Validate(data)

--- a/processor/transaction/package_tests/TestProcessTransactionFull.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionFull.approved.json
@@ -87,6 +87,7 @@
                 "system": {
                     "architecture": "x64",
                     "hostname": "prod1.example.com",
+                    "ip": "192.0.2.1",
                     "platform": "darwin"
                 },
                 "tags": {
@@ -307,6 +308,7 @@
                 "system": {
                     "architecture": "x64",
                     "hostname": "prod1.example.com",
+                    "ip": "192.0.2.1",
                     "platform": "darwin"
                 }
             },
@@ -356,6 +358,7 @@
                 "system": {
                     "architecture": "x64",
                     "hostname": "prod1.example.com",
+                    "ip": "192.0.2.1",
                     "platform": "darwin"
                 }
             },
@@ -405,6 +408,7 @@
                 "system": {
                     "architecture": "x64",
                     "hostname": "prod1.example.com",
+                    "ip": "192.0.2.1",
                     "platform": "darwin"
                 }
             },

--- a/processor/transaction/package_tests/TestProcessTransactionNullValues.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionNullValues.approved.json
@@ -13,7 +13,9 @@
                     },
                     "name": "1234_app-12a3"
                 },
-                "system": {}
+                "system": {
+                    "ip": "192.0.2.1"
+                }
             },
             "processor": {
                 "event": "transaction",
@@ -45,7 +47,9 @@
                 "custom": null,
                 "request": null,
                 "response": null,
-                "system": {},
+                "system": {
+                    "ip": "192.0.2.1"
+                },
                 "tags": null,
                 "user": null
             },
@@ -100,7 +104,9 @@
                     "headers_sent": null,
                     "status_code": null
                 },
-                "system": {},
+                "system": {
+                    "ip": "192.0.2.1"
+                },
                 "user": {
                     "email": null,
                     "id": null,
@@ -161,7 +167,9 @@
                         "content-type": null
                     }
                 },
-                "system": {},
+                "system": {
+                    "ip": "192.0.2.1"
+                },
                 "tags": {
                     "organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8"
                 }

--- a/processor/transaction/package_tests/processor_test.go
+++ b/processor/transaction/package_tests/processor_test.go
@@ -1,6 +1,7 @@
 package package_tests
 
 import (
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,14 +21,17 @@ func TestTransactionProcessorOK(t *testing.T) {
 		{Name: "TestProcessTransactionMinimalApp", Path: "tests/data/valid/transaction/minimal_app.json"},
 		{Name: "TestProcessTransactionEmpty", Path: "tests/data/valid/transaction/transaction_empty_values.json"},
 	}
-	tests.TestProcessRequests(t, transaction.NewProcessor(), requestInfo, map[string]string{})
+
+	req := httptest.NewRequest("GET", "/", nil)
+	tests.TestProcessRequests(t, transaction.NewProcessor(req), requestInfo, map[string]string{})
 }
 
 // ensure invalid documents fail the json schema validation already
 func TestTransactionProcessorValidationFailed(t *testing.T) {
 	data, err := tests.LoadInvalidData("transaction")
 	assert.Nil(t, err)
-	p := transaction.NewProcessor()
+	req := httptest.NewRequest("GET", "/", nil)
+	p := transaction.NewProcessor(req)
 	err = p.Validate(data)
 	assert.NotNil(t, err)
 }

--- a/processor/transaction/payload.go
+++ b/processor/transaction/payload.go
@@ -1,8 +1,11 @@
 package transaction
 
 import (
+	"net/http"
+
 	m "github.com/elastic/apm-server/model"
 	pr "github.com/elastic/apm-server/processor"
+	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
@@ -19,10 +22,16 @@ type payload struct {
 	Events []Event   `json:"transactions"`
 }
 
-func (pa *payload) transform() []beat.Event {
+func (pa *payload) transform(r *http.Request) []beat.Event {
 	var events []beat.Event
 
 	logp.Debug("transaction", "Transform transaction events: events=%d, app=%s, agent=%s:%s", len(pa.Events), pa.App.Name, pa.App.Agent.Name, pa.App.Agent.Version)
+
+	// Inject system ip from the request
+	if pa.System != nil {
+		ip := utility.ExtractIP(r)
+		pa.System.IP = &ip
+	}
 
 	transactionCounter.Add(int64(len(pa.Events)))
 	for _, tx := range pa.Events {

--- a/processor/transaction/payload_test.go
+++ b/processor/transaction/payload_test.go
@@ -2,6 +2,7 @@ package transaction
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,6 +17,7 @@ func TestPayloadTransform(t *testing.T) {
 	hostname := "a.b.c"
 	architecture := "darwin"
 	platform := "x64"
+	ip := "192.168.0.2"
 	timestamp := time.Now()
 
 	app := m.App{Name: "myapp"}
@@ -61,6 +63,7 @@ func TestPayloadTransform(t *testing.T) {
 				"hostname":     hostname,
 				"architecture": architecture,
 				"platform":     platform,
+				"ip":           ip,
 			},
 			"app": common.MapStr{
 				"name":  "myapp",
@@ -90,6 +93,7 @@ func TestPayloadTransform(t *testing.T) {
 				"hostname":     "a.b.c",
 				"architecture": "darwin",
 				"platform":     "x64",
+				"ip":           "192.168.0.2",
 			},
 		},
 	}
@@ -153,8 +157,13 @@ func TestPayloadTransform(t *testing.T) {
 		},
 	}
 
+	req, err := http.NewRequest("GET", "_", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.RemoteAddr = ip
 	for idx, test := range tests {
-		outputEvents := test.Payload.transform()
+		outputEvents := test.Payload.transform(req)
 		for j, outputEvent := range outputEvents {
 			assert.Equal(t, test.Output[j], outputEvent.Fields, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 			assert.Equal(t, timestamp, outputEvent.Timestamp)

--- a/processor/transaction/processor.go
+++ b/processor/transaction/processor.go
@@ -2,6 +2,7 @@ package transaction
 
 import (
 	"encoding/json"
+	"net/http"
 
 	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/beats/libbeat/beat"
@@ -23,12 +24,13 @@ const (
 
 var schema = pr.CreateSchema(transactionSchema, processorName)
 
-func NewProcessor() pr.Processor {
-	return &processor{schema: schema}
+func NewProcessor(r *http.Request) pr.Processor {
+	return &processor{schema: schema, req: r}
 }
 
 type processor struct {
 	schema *jsonschema.Schema
+	req    *http.Request
 }
 
 func (p *processor) Validate(buf []byte) error {
@@ -48,7 +50,7 @@ func (p *processor) Transform(buf []byte) ([]beat.Event, error) {
 		return nil, err
 	}
 
-	return pa.transform(), nil
+	return pa.transform(p.req), nil
 }
 
 func (p *processor) Name() string {

--- a/processor/transaction/processor_test.go
+++ b/processor/transaction/processor_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestImplementProcessorInterface(t *testing.T) {
-	p := NewProcessor()
+	p := NewProcessor(nil)
 	assert.NotNil(t, p)
 	_, ok := p.(pr.Processor)
 	assert.True(t, ok)

--- a/script/output_data/output_data.go
+++ b/script/output_data/output_data.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 
@@ -32,7 +33,7 @@ func generate() error {
 			continue
 		}
 
-		p := mapping.ProcessorFactory()
+		p := mapping.ProcessorFactory(httptest.NewRequest("GET", "/", nil))
 
 		// Remove version from name and and s at the end
 		name := p.Name()

--- a/tests/fields.go
+++ b/tests/fields.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"fmt"
 	"io/ioutil"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -68,7 +69,7 @@ func TestDocumentedFieldsInEvent(t *testing.T, fieldPaths []string, fn processor
 }
 
 func fetchEventNames(fn processor.NewProcessor, blacklisted *set.Set) (*set.Set, error) {
-	p := fn()
+	p := fn(httptest.NewRequest("GET", "/", nil))
 	data, _ := LoadValidData(p.Name())
 	err := p.Validate(data)
 	if err != nil {

--- a/tests/json_schema_test.go
+++ b/tests/json_schema_test.go
@@ -88,7 +88,7 @@ func TestSourcemapPayloadSchema(t *testing.T) {
 		{File: "not_allowed_empty_values.json", Error: "length must be >= 1, but got 0"},
 		{File: "not_allowed_null_values.json", Error: "expected string, but got null"},
 	}
-	testDataAgainstProcessor(t, sourcemap.NewProcessor(), testData, "sourcemap")
+	testDataAgainstProcessor(t, sourcemap.NewProcessor(nil), testData, "sourcemap")
 }
 
 func TestSpanSchema(t *testing.T) {
@@ -124,7 +124,7 @@ func TestTransactionPayloadSchema(t *testing.T) {
 		{File: "no_app.json", Error: "missing properties: \"app\""},
 		{File: "no_transactions.json", Error: "minimum 1 items allowed"},
 	}
-	testDataAgainstProcessor(t, transaction.NewProcessor(), testData, "transaction_payload")
+	testDataAgainstProcessor(t, transaction.NewProcessor(nil), testData, "transaction_payload")
 }
 
 func TestErrorSchema(t *testing.T) {
@@ -150,7 +150,7 @@ func TestErrorPayloadSchema(t *testing.T) {
 		{File: "no_app.json", Error: "missing properties: \"app\""},
 		{File: "no_errors.json", Error: "missing properties: \"errors\""},
 	}
-	testDataAgainstProcessor(t, err.NewProcessor(), testData, "error_payload")
+	testDataAgainstProcessor(t, err.NewProcessor(nil), testData, "error_payload")
 }
 
 func testDataAgainstSchema(t *testing.T, testData []schemaTestData, schemaPath string, filePath string, replace string) {

--- a/utility/extract_ip.go
+++ b/utility/extract_ip.go
@@ -1,0 +1,36 @@
+package utility
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// ExtractIP returns source ip from a given request, honoring X-Forwarded-For and X-Real-IP headers
+func ExtractIP(r *http.Request) string {
+	var remoteAddr = func() string {
+		ip, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			return r.RemoteAddr
+		}
+		return ip
+	}
+
+	var forwarded = func() string {
+		forwardedFor := r.Header.Get("X-Forwarded-For")
+		client := strings.Split(forwardedFor, ",")[0]
+		return strings.TrimSpace(client)
+	}
+
+	var real = func() string {
+		return r.Header.Get("X-Real-IP")
+	}
+
+	if ip := real(); ip != "" {
+		return ip
+	}
+	if ip := forwarded(); ip != "" {
+		return ip
+	}
+	return remoteAddr()
+}

--- a/utility/extract_ip_test.go
+++ b/utility/extract_ip_test.go
@@ -1,0 +1,35 @@
+package utility
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractIP(t *testing.T) {
+	var req = func(real *string, forward *string) *http.Request {
+		req, _ := http.NewRequest("POST", "_", nil)
+		req.RemoteAddr = "10.11.12.13:8080"
+		if real != nil {
+			req.Header.Add("X-Real-IP", *real)
+		}
+		if forward != nil {
+			req.Header.Add("X-Forwarded-For", *forward)
+		}
+		return req
+	}
+
+	real := "54.55.101.102"
+	assert.Equal(t, real, ExtractIP(req(&real, nil)))
+
+	forwardedFor := "54.56.103.104"
+	assert.Equal(t, real, ExtractIP(req(&real, &forwardedFor)))
+	assert.Equal(t, forwardedFor, ExtractIP(req(nil, &forwardedFor)))
+
+	forwardedForMultiple := "54.56.103.104 , 54.57.105.106 , 54.58.107.108"
+	assert.Equal(t, forwardedFor, ExtractIP(req(nil, &forwardedForMultiple)))
+
+	assert.Equal(t, "10.11.12.13", ExtractIP(req(nil, nil)))
+	assert.Equal(t, "10.11.12.13", ExtractIP(req(new(string), new(string))))
+}


### PR DESCRIPTION
This PR adds `context.system.ip` field. This expose IP of the app serving received traces and will enable matching it by source in the future

closes #349