### PR TITLE
Added instructions for installing on Windows.

### DIFF
--- a/docs/installing-on-windows.asciidoc
+++ b/docs/installing-on-windows.asciidoc
@@ -1,0 +1,32 @@
+[[installing-on-windows]]
+=== Installing {beatname_uc} on Windows
+
+ifeval::["{release-state}"=="unreleased"]
+
+Version {version} of {beatname_uc} has not yet been released.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+. Download the APM Server Windows zip file from the
+https://www.elastic.co/downloads/apm/apm-server[downloads page].
+
+. Extract the contents of the zip file into `C:\Program Files`.
+
+. Rename the `apm-server-<version>-windows` directory to `APM-Server`.
+
+. Open a PowerShell prompt as an Administrator (right-click the PowerShell icon and select *Run As Administrator*). If you are running Windows XP, you may need to download and install PowerShell.
+
+. From the PowerShell prompt, run the following commands to install APM Server as a
+Windows service:
++
+[source,shell]
+----------------------------------------------------------------------
+PS > cd 'C:\Program Files\APM-Server'
+PS C:\Program Files\APM-Server> .\install-service-apm-server.ps1
+----------------------------------------------------------------------
+
+NOTE: If script execution is disabled on your system, you need to set the execution policy for the current session to allow the script to run. For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-apm-server.ps1`.
+
+endif::[]

--- a/docs/installing.asciidoc
+++ b/docs/installing.asciidoc
@@ -2,11 +2,14 @@
 == Installing APM Server
 
 https://www.elastic.co/downloads/apm/apm-server[Download APM Server] for your operating system and extract the package.
+Then follow the instructions on <<configuring>>
 
-You can also install APM Server from our repositories or run it through docker.
+You can also install APM Server from our repositories, run it through docker or install as a service on Windows:
 
 * <<running-on-docker>>
 * <<setup-repositories>>
+* <<installing-on-windows>>
 
 include::./copied-from-beats/running-on-docker.asciidoc[]
 include::./copied-from-beats/repositories.asciidoc[]
+include::./installing-on-windows.asciidoc[]


### PR DESCRIPTION
Tested instructions for installing on windows.
The instructions are more or less copied from https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-installation.html

![image](https://user-images.githubusercontent.com/744/33440319-f8b76f40-d5ef-11e7-80ed-accd7c6b8943.png)
