### PR TITLE
Reduce type conversions in the processing pipeline.

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1079,6 +1079,34 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 --------------------------------------------------------------------
+Dependency: github.com/mitchellh/mapstructure
+Revision: 06020f85339e21b2478f756a78e295255ffa4d6a
+License type (autodetected): MIT
+./vendor/github.com/mitchellh/mapstructure/LICENSE:
+--------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2013 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+--------------------------------------------------------------------
 Dependency: github.com/opencontainers/go-digest
 Revision: 2463fd833024b2782962b18060ce642af2bdf1f4
 License type (autodetected): CC-BY-SA-4.0
@@ -2151,7 +2179,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/santhosh-tekuri/jsonschema
-Revision: 3968f5a2fa9b81399766f843162c5c06ee1e6aba
+Revision: 63accc9deedeee33b7caf4e241f8a9ebdf031069
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/santhosh-tekuri/jsonschema/LICENSE:
 --------------------------------------------------------------------

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -92,7 +92,7 @@ func pluralize(entity string) string {
 	return entity + "s"
 }
 func createPayload(entitytype string, numEntities int) []byte {
-	data, err := tests.LoadValidDataAsInterface(entitytype)
+	data, err := tests.LoadValidData(entitytype)
 	if err != nil {
 		panic(err)
 	}

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -92,20 +92,18 @@ func pluralize(entity string) string {
 	return entity + "s"
 }
 func createPayload(entitytype string, numEntities int) []byte {
-	data, err := tests.LoadValidData(entitytype)
+	data, err := tests.LoadValidDataAsInterface(entitytype)
 	if err != nil {
 		panic(err)
 	}
-	var payload map[string]interface{}
-	err = json.Unmarshal(data, &payload)
 	var entityList []interface{}
-	testEntities := payload[pluralize(entitytype)].([]interface{})
+	testEntities := data[pluralize(entitytype)].([]interface{})
 
 	for i := 0; i < numEntities; i++ {
 		entityList = append(entityList, testEntities[i%len(testEntities)])
 	}
-	payload[pluralize(entitytype)] = entityList
-	out, err := json.Marshal(payload)
+	data[pluralize(entitytype)] = entityList
+	out, err := json.Marshal(data)
 	if err != nil {
 		panic(err)
 	}

--- a/beater/handlers.go
+++ b/beater/handlers.go
@@ -3,7 +3,6 @@ package beater
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 
 	"github.com/elastic/apm-server/processor"
@@ -272,16 +271,16 @@ func processRequest(r *http.Request, pf ProcessorFactory, maxSize int64, report 
 		return http.StatusMethodNotAllowed, errPOSTRequestOnly
 	}
 
-	buf, err := decode(r)
+	data, err := decode(r)
 	if err != nil {
 		return http.StatusBadRequest, errors.New(fmt.Sprintf("Decoding error: %s", err.Error()))
 	}
 
-	if err = processor.Validate(buf); err != nil {
+	if err = processor.Validate(data); err != nil {
 		return http.StatusBadRequest, err
 	}
 
-	list, err := processor.Transform(buf)
+	list, err := processor.Transform(data)
 	if err != nil {
 		return http.StatusBadRequest, err
 	}
@@ -293,10 +292,10 @@ func processRequest(r *http.Request, pf ProcessorFactory, maxSize int64, report 
 	return http.StatusAccepted, nil
 }
 
-type decoder func(req *http.Request) ([]byte, error)
+type decoder func(req *http.Request) (map[string]interface{}, error)
 
 func decodeLimitJSONData(maxSize int64) decoder {
-	return func(req *http.Request) ([]byte, error) {
+	return func(req *http.Request) (map[string]interface{}, error) {
 
 		contentType := req.Header.Get("Content-Type")
 		if contentType != "application/json" {
@@ -323,16 +322,13 @@ func decodeLimitJSONData(maxSize int64) decoder {
 				return nil, err
 			}
 		}
-
-		// Limit size of request to prevent for example zip bombs
-		limitedReader := io.LimitReader(reader, maxSize)
-		buf, err := ioutil.ReadAll(limitedReader)
+		v := make(map[string]interface{})
+		err := json.NewDecoder(io.LimitReader(reader, maxSize)).Decode(&v)
 		if err != nil {
 			// If we run out of memory, for example
 			return nil, errors.New(fmt.Sprintf("Data read error: %s", err.Error()))
 		}
-
-		return buf, nil
+		return v, nil
 	}
 }
 

--- a/beater/handlers_test.go
+++ b/beater/handlers_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestDecode(t *testing.T) {
-	transactionBytes, err := tests.LoadValidData("transaction")
+	transactionBytes, err := tests.LoadValidDataAsBytes("transaction")
 	assert.Nil(t, err)
 	buffer := bytes.NewReader(transactionBytes)
 	var data map[string]interface{}

--- a/beater/handlers_test.go
+++ b/beater/handlers_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"encoding/json"
+
 	"github.com/elastic/apm-server/tests"
 )
 
@@ -18,6 +20,8 @@ func TestDecode(t *testing.T) {
 	transactionBytes, err := tests.LoadValidData("transaction")
 	assert.Nil(t, err)
 	buffer := bytes.NewReader(transactionBytes)
+	var data map[string]interface{}
+	json.Unmarshal(transactionBytes, &data)
 
 	req, err := http.NewRequest("POST", "_", buffer)
 	req.Header.Add("Content-Type", "application/json")
@@ -25,7 +29,7 @@ func TestDecode(t *testing.T) {
 
 	body, err := decodeLimitJSONData(1024 * 1024)(req)
 	assert.Nil(t, err)
-	assert.Equal(t, transactionBytes, body)
+	assert.Equal(t, data, body)
 }
 
 func TestJSONFailureResponse(t *testing.T) {

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -233,8 +233,8 @@ func setupServer(t *testing.T, ssl *SSLConfig) (*http.Server, func()) {
 
 var noSSL *SSLConfig
 
-var testData []byte = func() []byte {
-	d, err := tests.LoadValidData("transaction")
+var testData = func() []byte {
+	d, err := tests.LoadValidDataAsBytes("transaction")
 	if err != nil {
 		panic(err)
 	}

--- a/model/service.go
+++ b/model/service.go
@@ -6,33 +6,33 @@ import (
 )
 
 type Service struct {
-	Name         string    `json:"name"`
-	Version      *string   `json:"version"`
-	Pid          *int      `json:"pid"`
-	ProcessTitle *string   `json:"process_title"`
-	Environment  *string   `json:"environment"`
-	Argv         []string  `json:"argv"`
-	Language     Language  `json:"language"`
-	Runtime      Runtime   `json:"runtime"`
-	Framework    Framework `json:"framework"`
-	Agent        Agent     `json:"agent"`
+	Name         string
+	Version      *string
+	Pid          *int
+	ProcessTitle *string `mapstructure:"process_title"`
+	Environment  *string
+	Argv         []string
+	Language     Language
+	Runtime      Runtime
+	Framework    Framework
+	Agent        Agent
 }
 
 type Language struct {
-	Name    *string `json:"name"`
-	Version *string `json:"version"`
+	Name    *string
+	Version *string
 }
 type Runtime struct {
-	Name    *string `json:"name"`
-	Version *string `json:"version"`
+	Name    *string
+	Version *string
 }
 type Framework struct {
-	Name    *string `json:"name"`
-	Version *string `json:"version"`
+	Name    *string
+	Version *string
 }
 type Agent struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	Name    string
+	Version string
 }
 
 type TransformService func(a *Service) common.MapStr

--- a/model/stacktrace_frame.go
+++ b/model/stacktrace_frame.go
@@ -6,17 +6,17 @@ import (
 )
 
 type StacktraceFrame struct {
-	AbsPath     *string       `json:"abs_path"`
-	Filename    string        `json:"filename"`
-	Lineno      int           `json:"lineno"`
-	Colno       *int          `json:"colno"`
-	ContextLine *string       `json:"context_line"`
-	Module      *string       `json:"module"`
-	Function    *string       `json:"function"`
-	InApp       *bool         `json:"in_app"`
-	Vars        common.MapStr `json:"vars"`
-	PreContext  []string      `json:"pre_context"`
-	PostContext []string      `json:"post_context"`
+	AbsPath     *string `mapstructure:"abs_path"`
+	Filename    string
+	Lineno      int
+	Colno       *int
+	ContextLine *string `mapstructure:"context_line"`
+	Module      *string
+	Function    *string
+	InApp       *bool `mapstructure:"in_app"`
+	Vars        common.MapStr
+	PreContext  []string `mapstructure:"pre_context"`
+	PostContext []string `mapstructure:"post_context"`
 }
 
 type TransformStacktraceFrame func(s *StacktraceFrame) common.MapStr

--- a/model/system.go
+++ b/model/system.go
@@ -6,9 +6,9 @@ import (
 )
 
 type System struct {
-	Hostname     *string `json:"hostname"`
-	Architecture *string `json:"architecture"`
-	Platform     *string `json:"platform"`
+	Hostname     *string
+	Architecture *string
+	Platform     *string
 }
 
 func (s *System) Transform() common.MapStr {

--- a/processor/error/benchmark_test.go
+++ b/processor/error/benchmark_test.go
@@ -9,7 +9,7 @@ import (
 func BenchmarkEventWithFileLoading(b *testing.B) {
 	processor := NewProcessor()
 	for i := 0; i < b.N; i++ {
-		data, _ := tests.LoadValidDataAsInterface("error")
+		data, _ := tests.LoadValidData("error")
 		err := processor.Validate(data)
 		if err != nil {
 			panic(err)
@@ -21,7 +21,7 @@ func BenchmarkEventWithFileLoading(b *testing.B) {
 
 func BenchmarkEventFileLoadingOnce(b *testing.B) {
 	processor := NewProcessor()
-	data, _ := tests.LoadValidDataAsInterface("error")
+	data, _ := tests.LoadValidData("error")
 	for i := 0; i < b.N; i++ {
 		err := processor.Validate(data)
 		if err != nil {

--- a/processor/error/benchmark_test.go
+++ b/processor/error/benchmark_test.go
@@ -9,7 +9,7 @@ import (
 func BenchmarkEventWithFileLoading(b *testing.B) {
 	processor := NewProcessor()
 	for i := 0; i < b.N; i++ {
-		data, _ := tests.LoadValidData("error")
+		data, _ := tests.LoadValidDataAsInterface("error")
 		err := processor.Validate(data)
 		if err != nil {
 			panic(err)
@@ -21,7 +21,7 @@ func BenchmarkEventWithFileLoading(b *testing.B) {
 
 func BenchmarkEventFileLoadingOnce(b *testing.B) {
 	processor := NewProcessor()
-	data, _ := tests.LoadValidData("error")
+	data, _ := tests.LoadValidDataAsInterface("error")
 	for i := 0; i < b.N; i++ {
 		err := processor.Validate(data)
 		if err != nil {

--- a/processor/error/event.go
+++ b/processor/error/event.go
@@ -15,12 +15,12 @@ import (
 )
 
 type Event struct {
-	Id        *string       `json:"id"`
-	Culprit   *string       `json:"culprit"`
-	Context   common.MapStr `json:"context"`
-	Exception *Exception    `json:"exception"`
-	Log       *Log          `json:"log"`
-	Timestamp time.Time     `json:"timestamp"`
+	Id        *string
+	Culprit   *string
+	Context   common.MapStr
+	Exception *Exception
+	Log       *Log
+	Timestamp time.Time
 
 	enhancer            utility.MapStrEnhancer
 	data                common.MapStr
@@ -28,21 +28,21 @@ type Event struct {
 }
 
 type Exception struct {
-	Code             interface{}        `json:"code"`
-	Message          string             `json:"message"`
-	Module           *string            `json:"module"`
-	Attributes       interface{}        `json:"attributes"`
-	StacktraceFrames m.StacktraceFrames `json:"stacktrace"`
-	Type             *string            `json:"type"`
-	Uncaught         *bool              `json:"uncaught"`
+	Code             interface{}
+	Message          string
+	Module           *string
+	Attributes       interface{}
+	StacktraceFrames m.StacktraceFrames `mapstructure:"stacktrace"`
+	Type             *string
+	Uncaught         *bool
 }
 
 type Log struct {
-	Level            *string            `json:"level"`
-	Message          string             `json:"message"`
-	ParamMessage     *string            `json:"param_message"`
-	LoggerName       *string            `json:"logger_name"`
-	StacktraceFrames m.StacktraceFrames `json:"stacktrace"`
+	Level            *string
+	Message          string
+	ParamMessage     *string            `mapstructure:"param_message"`
+	LoggerName       *string            `mapstructure:"logger_name"`
+	StacktraceFrames m.StacktraceFrames `mapstructure:"stacktrace"`
 }
 
 func (e *Event) DocType() string {

--- a/processor/error/package_tests/json_schema_test.go
+++ b/processor/error/package_tests/json_schema_test.go
@@ -48,3 +48,11 @@ func TestJsonSchemaKeywordLimitation(t *testing.T) {
 	)
 	tests.TestJsonSchemaKeywordLimitation(t, fieldsPaths, er.Schema(), exceptions)
 }
+
+func TestErrorPayloadSchema(t *testing.T) {
+	testData := []tests.SchemaTestData{
+		{File: "data/invalid/error_payload/no_service.json", Error: "missing properties: \"service\""},
+		{File: "data/invalid/error_payload/no_errors.json", Error: "missing properties: \"errors\""},
+	}
+	tests.TestDataAgainstProcessor(t, er.NewProcessor(), testData)
+}

--- a/processor/error/package_tests/processor_test.go
+++ b/processor/error/package_tests/processor_test.go
@@ -23,7 +23,7 @@ func TestProcessorOK(t *testing.T) {
 
 // ensure invalid documents fail the json schema validation already
 func TestProcessorFailedValidation(t *testing.T) {
-	data, err := tests.LoadInvalidData("error")
+	data, err := tests.LoadInvalidDataAsInterface("error")
 	assert.Nil(t, err)
 	err = er.NewProcessor().Validate(data)
 	assert.NotNil(t, err)

--- a/processor/error/package_tests/processor_test.go
+++ b/processor/error/package_tests/processor_test.go
@@ -12,18 +12,18 @@ import (
 // ensure all valid documents pass through the whole validation and transformation process
 func TestProcessorOK(t *testing.T) {
 	requestInfo := []tests.RequestInfo{
-		{Name: "TestProcessErrorMinimalPayloadException", Path: "tests/data/valid/error/minimal_payload_exception.json"},
-		{Name: "TestProcessErrorMinimalPayloadLog", Path: "tests/data/valid/error/minimal_payload_log.json"},
-		{Name: "TestProcessErrorMinimalService", Path: "tests/data/valid/error/minimal_service.json"},
-		{Name: "TestProcessErrorFull", Path: "tests/data/valid/error/payload.json"},
-		{Name: "TestProcessErrorNullValues", Path: "tests/data/valid/error/null_values.json"},
+		{Name: "TestProcessErrorMinimalPayloadException", Path: "data/valid/error/minimal_payload_exception.json"},
+		{Name: "TestProcessErrorMinimalPayloadLog", Path: "data/valid/error/minimal_payload_log.json"},
+		{Name: "TestProcessErrorMinimalService", Path: "data/valid/error/minimal_service.json"},
+		{Name: "TestProcessErrorFull", Path: "data/valid/error/payload.json"},
+		{Name: "TestProcessErrorNullValues", Path: "data/valid/error/null_values.json"},
 	}
 	tests.TestProcessRequests(t, er.NewProcessor(), requestInfo, map[string]string{})
 }
 
 // ensure invalid documents fail the json schema validation already
 func TestProcessorFailedValidation(t *testing.T) {
-	data, err := tests.LoadInvalidDataAsInterface("error")
+	data, err := tests.LoadInvalidData("error")
 	assert.Nil(t, err)
 	err = er.NewProcessor().Validate(data)
 	assert.NotNil(t, err)

--- a/processor/error/payload.go
+++ b/processor/error/payload.go
@@ -14,8 +14,8 @@ var (
 
 type payload struct {
 	Service m.Service
-	System *m.System
-	Events []Event `mapstructure:"errors"`
+	System  *m.System
+	Events  []Event `mapstructure:"errors"`
 }
 
 func (pa *payload) transform() []beat.Event {

--- a/processor/error/payload.go
+++ b/processor/error/payload.go
@@ -13,9 +13,9 @@ var (
 )
 
 type payload struct {
-	Service m.Service `json:"service"`
-	System  *m.System `json:"system"`
-	Events  []Event   `json:"errors"`
+	Service m.Service
+	System *m.System
+	Events []Event `mapstructure:"errors"`
 }
 
 func (pa *payload) transform() []beat.Event {

--- a/processor/error/processor.go
+++ b/processor/error/processor.go
@@ -1,11 +1,12 @@
 package error
 
 import (
-	"encoding/json"
-
 	"github.com/santhosh-tekuri/jsonschema"
 
+	"github.com/mitchellh/mapstructure"
+
 	pr "github.com/elastic/apm-server/processor"
+	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/monitoring"
 )
@@ -31,19 +32,26 @@ type processor struct {
 	schema *jsonschema.Schema
 }
 
-func (p *processor) Validate(buf []byte) error {
+func (p *processor) Validate(raw map[string]interface{}) error {
 	validationCount.Inc()
-	err := pr.Validate(buf, p.schema)
+	err := pr.Validate(raw, p.schema)
 	if err != nil {
 		validationError.Inc()
 	}
 	return err
 }
 
-func (p *processor) Transform(buf []byte) ([]beat.Event, error) {
+func (p *processor) Transform(raw interface{}) ([]beat.Event, error) {
 	transformations.Inc()
 	var pa payload
-	err := json.Unmarshal(buf, &pa)
+
+	decoder, _ := mapstructure.NewDecoder(
+		&mapstructure.DecoderConfig{
+			DecodeHook: utility.RFC3339DecoderHook,
+			Result:     &pa,
+		},
+	)
+	err := decoder.Decode(raw)
 	if err != nil {
 		return nil, err
 	}

--- a/processor/healthcheck/processor.go
+++ b/processor/healthcheck/processor.go
@@ -15,11 +15,11 @@ func NewProcessor() pr.Processor {
 
 type processor struct{}
 
-func (p *processor) Validate(buf []byte) error {
+func (p *processor) Validate(_ map[string]interface{}) error {
 	return nil
 }
 
-func (p *processor) Transform(buf []byte) ([]beat.Event, error) {
+func (p *processor) Transform(_ interface{}) ([]beat.Event, error) {
 	return nil, nil
 }
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -11,8 +11,8 @@ import (
 type NewProcessor func() Processor
 
 type Processor interface {
-	Validate([]byte) error
-	Transform([]byte) ([]beat.Event, error)
+	Validate(map[string]interface{}) error
+	Transform(interface{}) ([]beat.Event, error)
 	Name() string
 }
 

--- a/processor/sourcemap/decoder.go
+++ b/processor/sourcemap/decoder.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func DecodeSourcemapFormData(req *http.Request) ([]byte, error) {
+func DecodeSourcemapFormData(req *http.Request) (map[string]interface{}, error) {
 	contentType := req.Header.Get("Content-Type")
 	if !strings.Contains(contentType, "multipart/form-data") {
 		return nil, fmt.Errorf("invalid content type: %s", req.Header.Get("Content-Type"))
@@ -32,10 +32,5 @@ func DecodeSourcemapFormData(req *http.Request) ([]byte, error) {
 		"bundle_filepath": req.FormValue("bundle_filepath"),
 	}
 
-	buf, err := json.Marshal(payload)
-	if err != nil {
-		return nil, err
-	}
-
-	return buf, nil
+	return payload, nil
 }

--- a/processor/sourcemap/decoder_test.go
+++ b/processor/sourcemap/decoder_test.go
@@ -2,7 +2,6 @@ package sourcemap
 
 import (
 	"bytes"
-	"encoding/json"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -37,11 +36,7 @@ func TestDecodeSourcemapFormData(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NoError(t, err)
-	buf, err := DecodeSourcemapFormData(req)
-	assert.NoError(t, err)
-
-	var data map[string]interface{}
-	err = json.Unmarshal(buf, &data)
+	data, err := DecodeSourcemapFormData(req)
 	assert.NoError(t, err)
 
 	assert.Len(t, data, 4)

--- a/processor/sourcemap/decoder_test.go
+++ b/processor/sourcemap/decoder_test.go
@@ -17,7 +17,7 @@ func TestDecodeSourcemapFormData(t *testing.T) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
-	fileBytes, err := tests.LoadData("tests/data/valid/sourcemap/bundle.min.map")
+	fileBytes, err := tests.LoadDataAsBytes("data/valid/sourcemap/bundle.min.map")
 	assert.NoError(t, err)
 	part, err := writer.CreateFormFile("sourcemap", "bundle.min.map")
 	assert.NoError(t, err)

--- a/processor/sourcemap/package_tests/json_schema_test.go
+++ b/processor/sourcemap/package_tests/json_schema_test.go
@@ -18,3 +18,13 @@ func TestPayloadAttributesInSchema(t *testing.T) {
 			"sourcemap.mappings", "sourcemap.sourcesContent", "sourcemap.version"),
 		sourcemap.Schema())
 }
+
+func TestSourcemapPayloadSchema(t *testing.T) {
+	testData := []tests.SchemaTestData{
+		{File: "data/invalid/sourcemap/no_service_version.json", Error: "missing properties: \"service_version\""},
+		{File: "data/invalid/sourcemap/no_bundle_filepath.json", Error: "missing properties: \"bundle_filepath\""},
+		{File: "data/invalid/sourcemap/not_allowed_empty_values.json", Error: "length must be >= 1, but got 0"},
+		{File: "data/invalid/sourcemap/not_allowed_null_values.json", Error: "expected string, but got null"},
+	}
+	tests.TestDataAgainstProcessor(t, sourcemap.NewProcessor(), testData)
+}

--- a/processor/sourcemap/package_tests/processor_test.go
+++ b/processor/sourcemap/package_tests/processor_test.go
@@ -12,15 +12,15 @@ import (
 // ensure all valid documents pass through the whole validation and transformation process
 func TestSourcemapProcessorOK(t *testing.T) {
 	requestInfo := []tests.RequestInfo{
-		{Name: "TestProcessSourcemapFull", Path: "tests/data/valid/sourcemap/payload.json"},
-		{Name: "TestProcessSourcemapMinimalPayload", Path: "tests/data/valid/sourcemap/minimal_payload.json"},
+		{Name: "TestProcessSourcemapFull", Path: "data/valid/sourcemap/payload.json"},
+		{Name: "TestProcessSourcemapMinimalPayload", Path: "data/valid/sourcemap/minimal_payload.json"},
 	}
 	tests.TestProcessRequests(t, sourcemap.NewProcessor(), requestInfo, map[string]string{"@timestamp": "***IGNORED***"})
 }
 
 // ensure invalid documents fail the json schema validation already
 func TestSourcemapProcessorValidationFailed(t *testing.T) {
-	data, err := tests.LoadInvalidDataAsInterface("sourcemap")
+	data, err := tests.LoadInvalidData("sourcemap")
 	assert.Nil(t, err)
 	p := sourcemap.NewProcessor()
 	err = p.Validate(data)

--- a/processor/sourcemap/package_tests/processor_test.go
+++ b/processor/sourcemap/package_tests/processor_test.go
@@ -19,8 +19,8 @@ func TestSourcemapProcessorOK(t *testing.T) {
 }
 
 // ensure invalid documents fail the json schema validation already
-func TestTransactionProcessorValidationFailed(t *testing.T) {
-	data, err := tests.LoadInvalidData("sourcemap")
+func TestSourcemapProcessorValidationFailed(t *testing.T) {
+	data, err := tests.LoadInvalidDataAsInterface("sourcemap")
 	assert.Nil(t, err)
 	p := sourcemap.NewProcessor()
 	err = p.Validate(data)

--- a/processor/sourcemap/payload.go
+++ b/processor/sourcemap/payload.go
@@ -13,14 +13,14 @@ import (
 var sourcemapCounter = monitoring.NewInt(sourcemapUploadMetrics, "counter")
 
 type payload struct {
-	ServiceName    string        `json:"service_name"`
-	ServiceVersion string        `json:"service_version"`
-	Sourcemap      common.MapStr `json:"sourcemap"`
-	BundleFilepath string        `json:"bundle_filepath"`
+	ServiceName        string `mapstructure:"service_name"`
+	ServiceVersion     string `mapstructure:"service_version"`
+	Sourcemap      common.MapStr
+	BundleFilepath string `mapstructure:"bundle_filepath"`
 }
 
 func (pa *payload) transform() []beat.Event {
-	var events []beat.Event = []beat.Event{pr.CreateDoc(mappings(pa))}
+	var events = []beat.Event{pr.CreateDoc(mappings(pa))}
 	sourcemapCounter.Add(1)
 	return events
 }

--- a/processor/sourcemap/payload.go
+++ b/processor/sourcemap/payload.go
@@ -13,8 +13,8 @@ import (
 var sourcemapCounter = monitoring.NewInt(sourcemapUploadMetrics, "counter")
 
 type payload struct {
-	ServiceName        string `mapstructure:"service_name"`
-	ServiceVersion     string `mapstructure:"service_version"`
+	ServiceName    string `mapstructure:"service_name"`
+	ServiceVersion string `mapstructure:"service_version"`
 	Sourcemap      common.MapStr
 	BundleFilepath string `mapstructure:"bundle_filepath"`
 }

--- a/processor/sourcemap/payload_test.go
+++ b/processor/sourcemap/payload_test.go
@@ -3,8 +3,6 @@ package sourcemap
 import (
 	"testing"
 
-	"encoding/json"
-
 	"time"
 
 	s "github.com/go-sourcemap/sourcemap"
@@ -34,12 +32,12 @@ func getStrSlice(data common.MapStr, key string) []string {
 }
 
 func TestPayloadTransform(t *testing.T) {
-	var payload payload
-	fileBytes, err := tests.LoadValidData("sourcemap")
-	assert.NoError(t, err)
-	json.Unmarshal(fileBytes, &payload)
 
-	rs := payload.transform()
+	data, err := tests.LoadValidDataAsInterface("sourcemap")
+	assert.NoError(t, err)
+
+	rs, err := NewProcessor().Transform(data)
+	assert.NoError(t, err)
 
 	assert.Len(t, rs, 1)
 	event := rs[0]

--- a/processor/sourcemap/payload_test.go
+++ b/processor/sourcemap/payload_test.go
@@ -33,7 +33,7 @@ func getStrSlice(data common.MapStr, key string) []string {
 
 func TestPayloadTransform(t *testing.T) {
 
-	data, err := tests.LoadValidDataAsInterface("sourcemap")
+	data, err := tests.LoadValidData("sourcemap")
 	assert.NoError(t, err)
 
 	rs, err := NewProcessor().Transform(data)
@@ -71,7 +71,7 @@ func TestPayloadTransform(t *testing.T) {
 }
 
 func TestParseSourcemaps(t *testing.T) {
-	fileBytes, err := tests.LoadData("tests/data/valid/sourcemap/bundle.min.map")
+	fileBytes, err := tests.LoadDataAsBytes("data/valid/sourcemap/bundle.min.map")
 	assert.NoError(t, err)
 	parser, err := s.Parse("", fileBytes)
 	assert.NoError(t, err)

--- a/processor/transaction/benchmark_test.go
+++ b/processor/transaction/benchmark_test.go
@@ -9,7 +9,7 @@ import (
 func BenchmarkWithFileLoading(b *testing.B) {
 	processor := NewProcessor()
 	for i := 0; i < b.N; i++ {
-		data, _ := tests.LoadValidData("transaction")
+		data, _ := tests.LoadValidDataAsInterface("transaction")
 		err := processor.Validate(data)
 		if err != nil {
 			b.Fatalf("Error: %v", err)
@@ -20,7 +20,7 @@ func BenchmarkWithFileLoading(b *testing.B) {
 
 func BenchmarkTransactionFileLoadingOnce(b *testing.B) {
 	processor := NewProcessor()
-	data, _ := tests.LoadValidData("transaction")
+	data, _ := tests.LoadValidDataAsInterface("transaction")
 	for i := 0; i < b.N; i++ {
 		err := processor.Validate(data)
 		if err != nil {

--- a/processor/transaction/benchmark_test.go
+++ b/processor/transaction/benchmark_test.go
@@ -9,7 +9,7 @@ import (
 func BenchmarkWithFileLoading(b *testing.B) {
 	processor := NewProcessor()
 	for i := 0; i < b.N; i++ {
-		data, _ := tests.LoadValidDataAsInterface("transaction")
+		data, _ := tests.LoadValidData("transaction")
 		err := processor.Validate(data)
 		if err != nil {
 			b.Fatalf("Error: %v", err)
@@ -20,7 +20,7 @@ func BenchmarkWithFileLoading(b *testing.B) {
 
 func BenchmarkTransactionFileLoadingOnce(b *testing.B) {
 	processor := NewProcessor()
-	data, _ := tests.LoadValidDataAsInterface("transaction")
+	data, _ := tests.LoadValidData("transaction")
 	for i := 0; i < b.N; i++ {
 		err := processor.Validate(data)
 		if err != nil {

--- a/processor/transaction/event.go
+++ b/processor/transaction/event.go
@@ -9,14 +9,14 @@ import (
 )
 
 type Event struct {
-	Id        string        `json:"id"`
-	Name      string        `json:"name"`
-	Type      string        `json:"type"`
-	Result    *string       `json:"result"`
-	Duration  float64       `json:"duration"`
-	Timestamp time.Time     `json:"timestamp"`
-	Context   common.MapStr `json:"context"`
-	Spans     []Span        `json:"spans"`
+	Id        string
+	Name      string
+	Type      string
+	Result    *string
+	Duration  float64
+	Timestamp time.Time
+	Context   common.MapStr
+	Spans     []Span
 }
 
 func (t *Event) DocType() string {

--- a/processor/transaction/package_tests/json_schema_test.go
+++ b/processor/transaction/package_tests/json_schema_test.go
@@ -41,3 +41,11 @@ func TestJsonSchemaKeywordLimitation(t *testing.T) {
 	exceptions := set.New("processor.event", "processor.name", "context.service.name", "transaction.id", "listening")
 	tests.TestJsonSchemaKeywordLimitation(t, fieldsPaths, transaction.Schema(), exceptions)
 }
+
+func TestTransactionPayloadSchema(t *testing.T) {
+	testData := []tests.SchemaTestData{
+		{File: "data/invalid/transaction_payload/no_service.json", Error: "missing properties: \"service\""},
+		{File: "data/invalid/transaction_payload/no_transactions.json", Error: "minimum 1 items allowed"},
+	}
+	tests.TestDataAgainstProcessor(t, transaction.NewProcessor(), testData)
+}

--- a/processor/transaction/package_tests/processor_test.go
+++ b/processor/transaction/package_tests/processor_test.go
@@ -25,7 +25,7 @@ func TestTransactionProcessorOK(t *testing.T) {
 
 // ensure invalid documents fail the json schema validation already
 func TestTransactionProcessorValidationFailed(t *testing.T) {
-	data, err := tests.LoadInvalidData("transaction")
+	data, err := tests.LoadInvalidDataAsInterface("transaction")
 	assert.Nil(t, err)
 	p := transaction.NewProcessor()
 	err = p.Validate(data)

--- a/processor/transaction/package_tests/processor_test.go
+++ b/processor/transaction/package_tests/processor_test.go
@@ -12,20 +12,20 @@ import (
 // ensure all valid documents pass through the whole validation and transformation process
 func TestTransactionProcessorOK(t *testing.T) {
 	requestInfo := []tests.RequestInfo{
-		{Name: "TestProcessTransactionFull", Path: "tests/data/valid/transaction/payload.json"},
-		{Name: "TestProcessTransactionNullValues", Path: "tests/data/valid/transaction/null_values.json"},
-		{Name: "TestProcessSystemNull", Path: "tests/data/valid/transaction/system_null.json"},
-		{Name: "TestProcessTransactionMinimalPayload", Path: "tests/data/valid/transaction/minimal_payload.json"},
-		{Name: "TestProcessTransactionMinimalSpan", Path: "tests/data/valid/transaction/minimal_span.json"},
-		{Name: "TestProcessTransactionMinimalService", Path: "tests/data/valid/transaction/minimal_service.json"},
-		{Name: "TestProcessTransactionEmpty", Path: "tests/data/valid/transaction/transaction_empty_values.json"},
+		{Name: "TestProcessTransactionFull", Path: "data/valid/transaction/payload.json"},
+		{Name: "TestProcessTransactionNullValues", Path: "data/valid/transaction/null_values.json"},
+		{Name: "TestProcessSystemNull", Path: "data/valid/transaction/system_null.json"},
+		{Name: "TestProcessTransactionMinimalPayload", Path: "data/valid/transaction/minimal_payload.json"},
+		{Name: "TestProcessTransactionMinimalSpan", Path: "data/valid/transaction/minimal_span.json"},
+		{Name: "TestProcessTransactionMinimalService", Path: "data/valid/transaction/minimal_service.json"},
+		{Name: "TestProcessTransactionEmpty", Path: "data/valid/transaction/transaction_empty_values.json"},
 	}
 	tests.TestProcessRequests(t, transaction.NewProcessor(), requestInfo, map[string]string{})
 }
 
 // ensure invalid documents fail the json schema validation already
 func TestTransactionProcessorValidationFailed(t *testing.T) {
-	data, err := tests.LoadInvalidDataAsInterface("transaction")
+	data, err := tests.LoadInvalidData("transaction")
 	assert.Nil(t, err)
 	p := transaction.NewProcessor()
 	err = p.Validate(data)

--- a/processor/transaction/payload.go
+++ b/processor/transaction/payload.go
@@ -15,8 +15,8 @@ var (
 
 type payload struct {
 	Service m.Service
-	System *m.System
-	Events []Event `mapstructure:"transactions"`
+	System  *m.System
+	Events  []Event `mapstructure:"transactions"`
 }
 
 func (pa *payload) transform() []beat.Event {

--- a/processor/transaction/payload.go
+++ b/processor/transaction/payload.go
@@ -14,9 +14,9 @@ var (
 )
 
 type payload struct {
-	Service m.Service `json:"service"`
-	System  *m.System `json:"system"`
-	Events  []Event   `json:"transactions"`
+	Service m.Service
+	System *m.System
+	Events []Event `mapstructure:"transactions"`
 }
 
 func (pa *payload) transform() []beat.Event {

--- a/processor/transaction/span.go
+++ b/processor/transaction/span.go
@@ -9,14 +9,14 @@ import (
 )
 
 type Span struct {
-	Id               *int               `json:"id"`
-	Name             string             `json:"name"`
-	Type             string             `json:"type"`
-	Start            float64            `json:"start"`
-	Duration         float64            `json:"duration"`
-	StacktraceFrames m.StacktraceFrames `json:"stacktrace"`
-	Context          common.MapStr      `json:"context"`
-	Parent           *int               `json:"parent"`
+	Id               *int
+	Name             string
+	Type             string
+	Start            float64
+	Duration         float64
+	StacktraceFrames m.StacktraceFrames `mapstructure:"stacktrace"`
+	Context          common.MapStr
+	Parent           *int
 
 	TransformStacktrace m.TransformStacktrace
 }

--- a/processor/validator.go
+++ b/processor/validator.go
@@ -1,7 +1,6 @@
 package processor
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 
@@ -20,9 +19,8 @@ func CreateSchema(schemaData string, url string) *jsonschema.Schema {
 	return schema
 }
 
-func Validate(buf []byte, schema *jsonschema.Schema) error {
-	reader := bytes.NewReader(buf)
-	if err := schema.Validate(reader); err != nil {
+func Validate(raw interface{}, schema *jsonschema.Schema) error {
+	if err := schema.ValidateInterface(raw); err != nil {
 		return fmt.Errorf("Problem validating JSON document against schema: %v", err)
 	}
 	return nil

--- a/processor/validator_test.go
+++ b/processor/validator_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/beat"
-	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestCreateSchemaInvalidResource(t *testing.T) {
@@ -25,7 +24,7 @@ func TestCreateSchemaOK(t *testing.T) {
 }
 
 func TestValidateFails(t *testing.T) {
-	data := []byte(common.MapStr{"age": 12}.String())
+	data := map[string]interface{}{"age": 12}
 	schema := CreateSchema(validSchema, "myschema")
 	err := Validate(data, schema)
 	assert.NotNil(t, err)
@@ -33,7 +32,7 @@ func TestValidateFails(t *testing.T) {
 }
 
 func TestValidateOK(t *testing.T) {
-	data := []byte(common.MapStr{"name": "john"}.String())
+	data := map[string]interface{}{"name": "john"}
 	schema := CreateSchema(validSchema, "myschema")
 	err := Validate(data, schema)
 	assert.Nil(t, err)

--- a/script/output_data/output_data.go
+++ b/script/output_data/output_data.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/elastic/apm-server/beater"
+	"github.com/elastic/apm-server/tests"
 )
 
 func main() {
@@ -34,18 +35,7 @@ func generate() error {
 
 		p := mapping.ProcessorFactory()
 
-		// Remove version from name and and s at the end
-		name := p.Name()
-
-		// Create path to test docs
-		path := filepath.Join(basepath, name, filename)
-
-		f, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-
-		data, err := ioutil.ReadAll(f)
+		data, err := tests.LoadDataAsInterface(filepath.Join(basepath, p.Name(), filename))
 		if err != nil {
 			return err
 		}

--- a/script/output_data/output_data.go
+++ b/script/output_data/output_data.go
@@ -22,7 +22,7 @@ func main() {
 
 func generate() error {
 	filename := "payload.json"
-	basepath := "tests/data/valid"
+	basePath := "data/valid"
 	outputPath := "docs/data/elasticsearch/"
 
 	var checked = map[string]struct{}{}
@@ -35,7 +35,7 @@ func generate() error {
 
 		p := mapping.ProcessorFactory()
 
-		data, err := tests.LoadDataAsInterface(filepath.Join(basepath, p.Name(), filename))
+		data, err := tests.LoadData(filepath.Join(basePath, p.Name(), filename))
 		if err != nil {
 			return err
 		}

--- a/tests/approvals.go
+++ b/tests/approvals.go
@@ -95,7 +95,7 @@ type RequestInfo struct {
 func TestProcessRequests(t *testing.T, p processor.Processor, requestInfo []RequestInfo, ignored map[string]string) {
 	assert := assert.New(t)
 	for _, info := range requestInfo {
-		data, err := LoadData(info.Path)
+		data, err := LoadDataAsInterface(info.Path)
 		assert.Nil(err)
 
 		err = p.Validate(data)

--- a/tests/approvals.go
+++ b/tests/approvals.go
@@ -95,7 +95,7 @@ type RequestInfo struct {
 func TestProcessRequests(t *testing.T, p processor.Processor, requestInfo []RequestInfo, ignored map[string]string) {
 	assert := assert.New(t)
 	for _, info := range requestInfo {
-		data, err := LoadDataAsInterface(info.Path)
+		data, err := LoadData(info.Path)
 		assert.Nil(err)
 
 		err = p.Validate(data)

--- a/tests/common.go
+++ b/tests/common.go
@@ -8,9 +8,11 @@ import (
 	"runtime"
 )
 
-func UnmarshalData(file string, data interface{}) error {
-	_, current, _, _ := runtime.Caller(0)
-	return unmarshalData(filepath.Join(filepath.Dir(current), "..", file), data)
+func LoadDataAsInterface(file string) (map[string]interface{}, error) {
+	bytes, _ := LoadData(file)
+	data := make(map[string]interface{})
+	err := json.Unmarshal(bytes, &data)
+	return data, err
 }
 
 func LoadData(file string) ([]byte, error) {
@@ -26,24 +28,28 @@ func LoadValidData(dataType string) ([]byte, error) {
 	return ioutil.ReadFile(path)
 }
 
-func LoadInvalidData(dataType string) ([]byte, error) {
+func LoadValidDataAsInterface(dataType string) (map[string]interface{}, error) {
+	path, err := buildPath(dataType, true)
+	if err != nil {
+		return nil, err
+	}
+	var data map[string]interface{}
+	unmarshalData(path, &data)
+	return data, nil
+}
+
+func LoadInvalidDataAsInterface(dataType string) (map[string]interface{}, error) {
 	path, err := buildPath(dataType, false)
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadFile(path)
+	var data map[string]interface{}
+	unmarshalData(path, &data)
+	return data, nil
 }
 
 func UnmarshalValidData(dataType string, data interface{}) error {
 	path, err := buildPath(dataType, true)
-	if err != nil {
-		return err
-	}
-	return unmarshalData(path, data)
-}
-
-func UnmarshalInvalidData(dataType string, data interface{}) error {
-	path, err := buildPath(dataType, false)
 	if err != nil {
 		return err
 	}

--- a/tests/common.go
+++ b/tests/common.go
@@ -8,62 +8,46 @@ import (
 	"runtime"
 )
 
-func LoadDataAsInterface(file string) (map[string]interface{}, error) {
-	bytes, _ := LoadData(file)
-	data := make(map[string]interface{})
-	err := json.Unmarshal(bytes, &data)
-	return data, err
-}
-
-func LoadData(file string) ([]byte, error) {
+func findFile(fileName string) (string, error) {
 	_, current, _, _ := runtime.Caller(0)
-	return ioutil.ReadFile(filepath.Join(filepath.Dir(current), "..", file))
+	return filepath.Join(filepath.Dir(current), fileName), nil
 }
 
-func LoadValidData(dataType string) ([]byte, error) {
-	path, err := buildPath(dataType, true)
+func readFile(filePath string, err error) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.ReadFile(path)
+	return ioutil.ReadFile(filePath)
 }
 
-func LoadValidDataAsInterface(dataType string) (map[string]interface{}, error) {
-	path, err := buildPath(dataType, true)
-	if err != nil {
-		return nil, err
-	}
-	var data map[string]interface{}
-	unmarshalData(path, &data)
-	return data, nil
+func LoadData(fileName string) (map[string]interface{}, error) {
+	return unmarshalData(findFile(fileName))
 }
 
-func LoadInvalidDataAsInterface(dataType string) (map[string]interface{}, error) {
-	path, err := buildPath(dataType, false)
-	if err != nil {
-		return nil, err
-	}
-	var data map[string]interface{}
-	unmarshalData(path, &data)
-	return data, nil
+func LoadDataAsBytes(fileName string) ([]byte, error) {
+	return readFile(findFile(fileName))
 }
 
-func UnmarshalValidData(dataType string, data interface{}) error {
-	path, err := buildPath(dataType, true)
-	if err != nil {
-		return err
-	}
-	return unmarshalData(path, data)
+func LoadValidDataAsBytes(processorName string) ([]byte, error) {
+	return readFile(buildPath(processorName, true))
 }
 
-func buildPath(dataType string, validData bool) (string, error) {
+func LoadValidData(processorName string) (map[string]interface{}, error) {
+	return unmarshalData(buildPath(processorName, true))
+}
+
+func LoadInvalidData(processorName string) (map[string]interface{}, error) {
+	return unmarshalData(buildPath(processorName, false))
+}
+
+func buildPath(processorName string, validData bool) (string, error) {
 	valid := "valid"
 	if !validData {
 		valid = "invalid"
 	}
 
 	var file string
-	switch dataType {
+	switch processorName {
 	case "error":
 		if validData {
 			file = "error/payload.json"
@@ -83,19 +67,18 @@ func buildPath(dataType string, validData bool) (string, error) {
 			file = "sourcemap/no_service_version.json"
 		}
 	default:
-		return "", errors.New("data type not specified.")
+		return "", errors.New("data type not specified")
 	}
-	_, current, _, _ := runtime.Caller(0)
-	curDir := filepath.Dir(current)
-	return filepath.Join(curDir, "data", valid, file), nil
+	return findFile(filepath.Join("data", valid, file))
 }
 
-func unmarshalData(file string, data interface{}) error {
-	input, err := ioutil.ReadFile(file)
-	if err != nil {
-		return err
+func unmarshalData(filePath string, err error) (map[string]interface{}, error) {
+	var data map[string]interface{}
+	input, err := readFile(filePath, err)
+	if err == nil {
+		err = json.Unmarshal(input, &data)
 	}
-	return json.Unmarshal(input, &data)
+	return data, err
 }
 
 func StrConcat(pre string, post string, delimiter string) string {

--- a/tests/fields.go
+++ b/tests/fields.go
@@ -69,7 +69,7 @@ func TestDocumentedFieldsInEvent(t *testing.T, fieldPaths []string, fn processor
 
 func fetchEventNames(fn processor.NewProcessor, blacklisted *set.Set) (*set.Set, error) {
 	p := fn()
-	data, _ := LoadValidDataAsInterface(p.Name())
+	data, _ := LoadValidData(p.Name())
 	err := p.Validate(data)
 	if err != nil {
 		return nil, err

--- a/tests/fields.go
+++ b/tests/fields.go
@@ -69,7 +69,7 @@ func TestDocumentedFieldsInEvent(t *testing.T, fieldPaths []string, fn processor
 
 func fetchEventNames(fn processor.NewProcessor, blacklisted *set.Set) (*set.Set, error) {
 	p := fn()
-	data, _ := LoadValidData(p.Name())
+	data, _ := LoadValidDataAsInterface(p.Name())
 	err := p.Validate(data)
 	if err != nil {
 		return nil, err

--- a/tests/json_schema.go
+++ b/tests/json_schema.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/fatih/set"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-server/processor"
 )
 
 type Schema struct {
@@ -25,8 +27,7 @@ type Mapping struct {
 }
 
 func TestPayloadAttributesInSchema(t *testing.T, name string, undocumentedAttrs *set.Set, schema string) {
-	var payload interface{}
-	UnmarshalValidData(name, &payload)
+	payload, _ := LoadValidData(name)
 	jsonNames := set.New()
 	flattenJsonKeys(payload, "", jsonNames)
 	jsonNamesDoc := set.Difference(jsonNames, undocumentedAttrs).(*set.Set)
@@ -142,4 +143,18 @@ func addLengthRestrictedPropNames(s *Schema) bool {
 		return true
 	}
 	return false
+}
+
+type SchemaTestData struct {
+	File  string
+	Error string
+}
+
+func TestDataAgainstProcessor(t *testing.T, p processor.Processor, testData []SchemaTestData) {
+	for _, d := range testData {
+		data, err := LoadData(d.File)
+		assert.Nil(t, err)
+		err = p.Validate(data)
+		assert.Contains(t, err.Error(), d.Error)
+	}
 }

--- a/tests/json_schema_test.go
+++ b/tests/json_schema_test.go
@@ -181,7 +181,7 @@ func testDataAgainstSchema(t *testing.T, testData []schemaTestData, schemaPath s
 
 func testDataAgainstProcessor(t *testing.T, p processor.Processor, testData []schemaTestData, filePath string) {
 	for _, d := range testData {
-		data, err := ioutil.ReadFile(filepath.Join("data/invalid", filePath, d.File))
+		data, err := LoadDataAsInterface(filepath.Join("tests/data/invalid", filePath, d.File))
 		assert.Nil(t, err)
 		err = p.Validate(data)
 		assert.Contains(t, err.Error(), d.Error)

--- a/utility/map_str_enhancer_test.go
+++ b/utility/map_str_enhancer_test.go
@@ -11,10 +11,6 @@ import (
 const addKey = "added"
 
 func TestAdd(t *testing.T) {
-	/*TODO: check if/how to test the error cases,
-	  it looks like the common.MapStr.Put() cannot really send back an error
-	*/
-
 	base := common.MapStr{"existing": "foo"}
 	addTrue, updateTrue, expectedTrue := true, false, common.MapStr{"existing": "foo", addKey: true}
 	addFalse, updateFalse, expectedFalse := false, true, common.MapStr{"existing": "foo", addKey: false}
@@ -28,16 +24,16 @@ func TestAdd(t *testing.T) {
 	var addStrNil *string
 	var addStrArrNil []string
 	testData := [][]interface{}{
-		[]interface{}{&addTrue, &updateTrue, expectedTrue},
-		[]interface{}{&addFalse, &updateFalse, expectedFalse},
-		[]interface{}{&addInt, &updateInt, expectedInt},
-		[]interface{}{&addStr, &updateStr, expectedStr},
-		[]interface{}{addCommonMapStr, updateCommonMapStr, expectedCommonMapStr},
-		[]interface{}{addCommonMapStrEmpty, updateCommonMapStrEmpty, expectedCommonMapStrEmpty},
-		[]interface{}{addBoolNil, addBoolNil, base},
-		[]interface{}{addIntNil, addIntNil, base},
-		[]interface{}{addStrNil, addStrNil, base},
-		[]interface{}{addStrArrNil, []string{"something"}, base},
+		{&addTrue, &updateTrue, expectedTrue},
+		{&addFalse, &updateFalse, expectedFalse},
+		{&addInt, &updateInt, expectedInt},
+		{&addStr, &updateStr, expectedStr},
+		{addCommonMapStr, updateCommonMapStr, expectedCommonMapStr},
+		{addCommonMapStrEmpty, updateCommonMapStrEmpty, expectedCommonMapStrEmpty},
+		{addBoolNil, addBoolNil, base},
+		{addIntNil, addIntNil, base},
+		{addStrNil, addStrNil, base},
+		{addStrArrNil, []string{"something"}, base},
 	}
 	for _, testDataRow := range testData {
 		assert, enhancer, base := setup(t)

--- a/utility/rfc3399decoder.go
+++ b/utility/rfc3399decoder.go
@@ -1,0 +1,14 @@
+package utility
+
+import (
+	"reflect"
+	"time"
+)
+
+func RFC3339DecoderHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+	// stolen from https://github.com/mitchellh/mapstructure/issues/41
+	if t == reflect.TypeOf(time.Time{}) && f == reflect.TypeOf("") {
+		return time.Parse(time.RFC3339, data.(string))
+	}
+	return data, nil
+}

--- a/vendor/github.com/mitchellh/mapstructure/LICENSE
+++ b/vendor/github.com/mitchellh/mapstructure/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/mitchellh/mapstructure/README.md
+++ b/vendor/github.com/mitchellh/mapstructure/README.md
@@ -1,0 +1,46 @@
+# mapstructure
+
+mapstructure is a Go library for decoding generic map values to structures
+and vice versa, while providing helpful error handling.
+
+This library is most useful when decoding values from some data stream (JSON,
+Gob, etc.) where you don't _quite_ know the structure of the underlying data
+until you read a part of it. You can therefore read a `map[string]interface{}`
+and use this library to decode it into the proper underlying native Go
+structure.
+
+## Installation
+
+Standard `go get`:
+
+```
+$ go get github.com/mitchellh/mapstructure
+```
+
+## Usage & Example
+
+For usage and examples see the [Godoc](http://godoc.org/github.com/mitchellh/mapstructure).
+
+The `Decode` function has examples associated with it there.
+
+## But Why?!
+
+Go offers fantastic standard libraries for decoding formats such as JSON.
+The standard method is to have a struct pre-created, and populate that struct
+from the bytes of the encoded format. This is great, but the problem is if
+you have configuration or an encoding that changes slightly depending on
+specific fields. For example, consider this JSON:
+
+```json
+{
+  "type": "person",
+  "name": "Mitchell"
+}
+```
+
+Perhaps we can't populate a specific structure without first reading
+the "type" field from the JSON. We could always do two passes over the
+decoding of the JSON (reading the "type" first, and the rest later).
+However, it is much simpler to just decode this into a `map[string]interface{}`
+structure, read the "type" key, then use something like this library
+to decode it into the proper structure.

--- a/vendor/github.com/mitchellh/mapstructure/decode_hooks.go
+++ b/vendor/github.com/mitchellh/mapstructure/decode_hooks.go
@@ -1,0 +1,152 @@
+package mapstructure
+
+import (
+	"errors"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// typedDecodeHook takes a raw DecodeHookFunc (an interface{}) and turns
+// it into the proper DecodeHookFunc type, such as DecodeHookFuncType.
+func typedDecodeHook(h DecodeHookFunc) DecodeHookFunc {
+	// Create variables here so we can reference them with the reflect pkg
+	var f1 DecodeHookFuncType
+	var f2 DecodeHookFuncKind
+
+	// Fill in the variables into this interface and the rest is done
+	// automatically using the reflect package.
+	potential := []interface{}{f1, f2}
+
+	v := reflect.ValueOf(h)
+	vt := v.Type()
+	for _, raw := range potential {
+		pt := reflect.ValueOf(raw).Type()
+		if vt.ConvertibleTo(pt) {
+			return v.Convert(pt).Interface()
+		}
+	}
+
+	return nil
+}
+
+// DecodeHookExec executes the given decode hook. This should be used
+// since it'll naturally degrade to the older backwards compatible DecodeHookFunc
+// that took reflect.Kind instead of reflect.Type.
+func DecodeHookExec(
+	raw DecodeHookFunc,
+	from reflect.Type, to reflect.Type,
+	data interface{}) (interface{}, error) {
+	switch f := typedDecodeHook(raw).(type) {
+	case DecodeHookFuncType:
+		return f(from, to, data)
+	case DecodeHookFuncKind:
+		return f(from.Kind(), to.Kind(), data)
+	default:
+		return nil, errors.New("invalid decode hook signature")
+	}
+}
+
+// ComposeDecodeHookFunc creates a single DecodeHookFunc that
+// automatically composes multiple DecodeHookFuncs.
+//
+// The composed funcs are called in order, with the result of the
+// previous transformation.
+func ComposeDecodeHookFunc(fs ...DecodeHookFunc) DecodeHookFunc {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		var err error
+		for _, f1 := range fs {
+			data, err = DecodeHookExec(f1, f, t, data)
+			if err != nil {
+				return nil, err
+			}
+
+			// Modify the from kind to be correct with the new data
+			f = nil
+			if val := reflect.ValueOf(data); val.IsValid() {
+				f = val.Type()
+			}
+		}
+
+		return data, nil
+	}
+}
+
+// StringToSliceHookFunc returns a DecodeHookFunc that converts
+// string to []string by splitting on the given sep.
+func StringToSliceHookFunc(sep string) DecodeHookFunc {
+	return func(
+		f reflect.Kind,
+		t reflect.Kind,
+		data interface{}) (interface{}, error) {
+		if f != reflect.String || t != reflect.Slice {
+			return data, nil
+		}
+
+		raw := data.(string)
+		if raw == "" {
+			return []string{}, nil
+		}
+
+		return strings.Split(raw, sep), nil
+	}
+}
+
+// StringToTimeDurationHookFunc returns a DecodeHookFunc that converts
+// strings to time.Duration.
+func StringToTimeDurationHookFunc() DecodeHookFunc {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+		if t != reflect.TypeOf(time.Duration(5)) {
+			return data, nil
+		}
+
+		// Convert it by parsing
+		return time.ParseDuration(data.(string))
+	}
+}
+
+// WeaklyTypedHook is a DecodeHookFunc which adds support for weak typing to
+// the decoder.
+//
+// Note that this is significantly different from the WeaklyTypedInput option
+// of the DecoderConfig.
+func WeaklyTypedHook(
+	f reflect.Kind,
+	t reflect.Kind,
+	data interface{}) (interface{}, error) {
+	dataVal := reflect.ValueOf(data)
+	switch t {
+	case reflect.String:
+		switch f {
+		case reflect.Bool:
+			if dataVal.Bool() {
+				return "1", nil
+			}
+			return "0", nil
+		case reflect.Float32:
+			return strconv.FormatFloat(dataVal.Float(), 'f', -1, 64), nil
+		case reflect.Int:
+			return strconv.FormatInt(dataVal.Int(), 10), nil
+		case reflect.Slice:
+			dataType := dataVal.Type()
+			elemKind := dataType.Elem().Kind()
+			if elemKind == reflect.Uint8 {
+				return string(dataVal.Interface().([]uint8)), nil
+			}
+		case reflect.Uint:
+			return strconv.FormatUint(dataVal.Uint(), 10), nil
+		}
+	}
+
+	return data, nil
+}

--- a/vendor/github.com/mitchellh/mapstructure/error.go
+++ b/vendor/github.com/mitchellh/mapstructure/error.go
@@ -1,0 +1,50 @@
+package mapstructure
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Error implements the error interface and can represents multiple
+// errors that occur in the course of a single decode.
+type Error struct {
+	Errors []string
+}
+
+func (e *Error) Error() string {
+	points := make([]string, len(e.Errors))
+	for i, err := range e.Errors {
+		points[i] = fmt.Sprintf("* %s", err)
+	}
+
+	sort.Strings(points)
+	return fmt.Sprintf(
+		"%d error(s) decoding:\n\n%s",
+		len(e.Errors), strings.Join(points, "\n"))
+}
+
+// WrappedErrors implements the errwrap.Wrapper interface to make this
+// return value more useful with the errwrap and go-multierror libraries.
+func (e *Error) WrappedErrors() []error {
+	if e == nil {
+		return nil
+	}
+
+	result := make([]error, len(e.Errors))
+	for i, e := range e.Errors {
+		result[i] = errors.New(e)
+	}
+
+	return result
+}
+
+func appendErrors(errors []string, err error) []string {
+	switch e := err.(type) {
+	case *Error:
+		return append(errors, e.Errors...)
+	default:
+		return append(errors, e.Error())
+	}
+}

--- a/vendor/github.com/mitchellh/mapstructure/mapstructure.go
+++ b/vendor/github.com/mitchellh/mapstructure/mapstructure.go
@@ -1,0 +1,834 @@
+// Package mapstructure exposes functionality to convert an arbitrary
+// map[string]interface{} into a native Go structure.
+//
+// The Go structure can be arbitrarily complex, containing slices,
+// other structs, etc. and the decoder will properly decode nested
+// maps and so on into the proper structures in the native Go struct.
+// See the examples to see what the decoder is capable of.
+package mapstructure
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// DecodeHookFunc is the callback function that can be used for
+// data transformations. See "DecodeHook" in the DecoderConfig
+// struct.
+//
+// The type should be DecodeHookFuncType or DecodeHookFuncKind.
+// Either is accepted. Types are a superset of Kinds (Types can return
+// Kinds) and are generally a richer thing to use, but Kinds are simpler
+// if you only need those.
+//
+// The reason DecodeHookFunc is multi-typed is for backwards compatibility:
+// we started with Kinds and then realized Types were the better solution,
+// but have a promise to not break backwards compat so we now support
+// both.
+type DecodeHookFunc interface{}
+
+// DecodeHookFuncType is a DecodeHookFunc which has complete information about
+// the source and target types.
+type DecodeHookFuncType func(reflect.Type, reflect.Type, interface{}) (interface{}, error)
+
+// DecodeHookFuncKind is a DecodeHookFunc which knows only the Kinds of the
+// source and target types.
+type DecodeHookFuncKind func(reflect.Kind, reflect.Kind, interface{}) (interface{}, error)
+
+// DecoderConfig is the configuration that is used to create a new decoder
+// and allows customization of various aspects of decoding.
+type DecoderConfig struct {
+	// DecodeHook, if set, will be called before any decoding and any
+	// type conversion (if WeaklyTypedInput is on). This lets you modify
+	// the values before they're set down onto the resulting struct.
+	//
+	// If an error is returned, the entire decode will fail with that
+	// error.
+	DecodeHook DecodeHookFunc
+
+	// If ErrorUnused is true, then it is an error for there to exist
+	// keys in the original map that were unused in the decoding process
+	// (extra keys).
+	ErrorUnused bool
+
+	// ZeroFields, if set to true, will zero fields before writing them.
+	// For example, a map will be emptied before decoded values are put in
+	// it. If this is false, a map will be merged.
+	ZeroFields bool
+
+	// If WeaklyTypedInput is true, the decoder will make the following
+	// "weak" conversions:
+	//
+	//   - bools to string (true = "1", false = "0")
+	//   - numbers to string (base 10)
+	//   - bools to int/uint (true = 1, false = 0)
+	//   - strings to int/uint (base implied by prefix)
+	//   - int to bool (true if value != 0)
+	//   - string to bool (accepts: 1, t, T, TRUE, true, True, 0, f, F,
+	//     FALSE, false, False. Anything else is an error)
+	//   - empty array = empty map and vice versa
+	//   - negative numbers to overflowed uint values (base 10)
+	//   - slice of maps to a merged map
+	//   - single values are converted to slices if required. Each
+	//     element is weakly decoded. For example: "4" can become []int{4}
+	//     if the target type is an int slice.
+	//
+	WeaklyTypedInput bool
+
+	// Metadata is the struct that will contain extra metadata about
+	// the decoding. If this is nil, then no metadata will be tracked.
+	Metadata *Metadata
+
+	// Result is a pointer to the struct that will contain the decoded
+	// value.
+	Result interface{}
+
+	// The tag name that mapstructure reads for field names. This
+	// defaults to "mapstructure"
+	TagName string
+}
+
+// A Decoder takes a raw interface value and turns it into structured
+// data, keeping track of rich error information along the way in case
+// anything goes wrong. Unlike the basic top-level Decode method, you can
+// more finely control how the Decoder behaves using the DecoderConfig
+// structure. The top-level Decode method is just a convenience that sets
+// up the most basic Decoder.
+type Decoder struct {
+	config *DecoderConfig
+}
+
+// Metadata contains information about decoding a structure that
+// is tedious or difficult to get otherwise.
+type Metadata struct {
+	// Keys are the keys of the structure which were successfully decoded
+	Keys []string
+
+	// Unused is a slice of keys that were found in the raw value but
+	// weren't decoded since there was no matching field in the result interface
+	Unused []string
+}
+
+// Decode takes a map and uses reflection to convert it into the
+// given Go native structure. val must be a pointer to a struct.
+func Decode(m interface{}, rawVal interface{}) error {
+	config := &DecoderConfig{
+		Metadata: nil,
+		Result:   rawVal,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(m)
+}
+
+// WeakDecode is the same as Decode but is shorthand to enable
+// WeaklyTypedInput. See DecoderConfig for more info.
+func WeakDecode(input, output interface{}) error {
+	config := &DecoderConfig{
+		Metadata:         nil,
+		Result:           output,
+		WeaklyTypedInput: true,
+	}
+
+	decoder, err := NewDecoder(config)
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(input)
+}
+
+// NewDecoder returns a new decoder for the given configuration. Once
+// a decoder has been returned, the same configuration must not be used
+// again.
+func NewDecoder(config *DecoderConfig) (*Decoder, error) {
+	val := reflect.ValueOf(config.Result)
+	if val.Kind() != reflect.Ptr {
+		return nil, errors.New("result must be a pointer")
+	}
+
+	val = val.Elem()
+	if !val.CanAddr() {
+		return nil, errors.New("result must be addressable (a pointer)")
+	}
+
+	if config.Metadata != nil {
+		if config.Metadata.Keys == nil {
+			config.Metadata.Keys = make([]string, 0)
+		}
+
+		if config.Metadata.Unused == nil {
+			config.Metadata.Unused = make([]string, 0)
+		}
+	}
+
+	if config.TagName == "" {
+		config.TagName = "mapstructure"
+	}
+
+	result := &Decoder{
+		config: config,
+	}
+
+	return result, nil
+}
+
+// Decode decodes the given raw interface to the target pointer specified
+// by the configuration.
+func (d *Decoder) Decode(raw interface{}) error {
+	return d.decode("", raw, reflect.ValueOf(d.config.Result).Elem())
+}
+
+// Decodes an unknown data type into a specific reflection value.
+func (d *Decoder) decode(name string, data interface{}, val reflect.Value) error {
+	if data == nil {
+		// If the data is nil, then we don't set anything.
+		return nil
+	}
+
+	dataVal := reflect.ValueOf(data)
+	if !dataVal.IsValid() {
+		// If the data value is invalid, then we just set the value
+		// to be the zero value.
+		val.Set(reflect.Zero(val.Type()))
+		return nil
+	}
+
+	if d.config.DecodeHook != nil {
+		// We have a DecodeHook, so let's pre-process the data.
+		var err error
+		data, err = DecodeHookExec(
+			d.config.DecodeHook,
+			dataVal.Type(), val.Type(), data)
+		if err != nil {
+			return fmt.Errorf("error decoding '%s': %s", name, err)
+		}
+	}
+
+	var err error
+	dataKind := getKind(val)
+	switch dataKind {
+	case reflect.Bool:
+		err = d.decodeBool(name, data, val)
+	case reflect.Interface:
+		err = d.decodeBasic(name, data, val)
+	case reflect.String:
+		err = d.decodeString(name, data, val)
+	case reflect.Int:
+		err = d.decodeInt(name, data, val)
+	case reflect.Uint:
+		err = d.decodeUint(name, data, val)
+	case reflect.Float32:
+		err = d.decodeFloat(name, data, val)
+	case reflect.Struct:
+		err = d.decodeStruct(name, data, val)
+	case reflect.Map:
+		err = d.decodeMap(name, data, val)
+	case reflect.Ptr:
+		err = d.decodePtr(name, data, val)
+	case reflect.Slice:
+		err = d.decodeSlice(name, data, val)
+	case reflect.Func:
+		err = d.decodeFunc(name, data, val)
+	default:
+		// If we reached this point then we weren't able to decode it
+		return fmt.Errorf("%s: unsupported type: %s", name, dataKind)
+	}
+
+	// If we reached here, then we successfully decoded SOMETHING, so
+	// mark the key as used if we're tracking metadata.
+	if d.config.Metadata != nil && name != "" {
+		d.config.Metadata.Keys = append(d.config.Metadata.Keys, name)
+	}
+
+	return err
+}
+
+// This decodes a basic type (bool, int, string, etc.) and sets the
+// value to "data" of that type.
+func (d *Decoder) decodeBasic(name string, data interface{}, val reflect.Value) error {
+	dataVal := reflect.ValueOf(data)
+	if !dataVal.IsValid() {
+		dataVal = reflect.Zero(val.Type())
+	}
+
+	dataValType := dataVal.Type()
+	if !dataValType.AssignableTo(val.Type()) {
+		return fmt.Errorf(
+			"'%s' expected type '%s', got '%s'",
+			name, val.Type(), dataValType)
+	}
+
+	val.Set(dataVal)
+	return nil
+}
+
+func (d *Decoder) decodeString(name string, data interface{}, val reflect.Value) error {
+	dataVal := reflect.ValueOf(data)
+	dataKind := getKind(dataVal)
+
+	converted := true
+	switch {
+	case dataKind == reflect.String:
+		val.SetString(dataVal.String())
+	case dataKind == reflect.Bool && d.config.WeaklyTypedInput:
+		if dataVal.Bool() {
+			val.SetString("1")
+		} else {
+			val.SetString("0")
+		}
+	case dataKind == reflect.Int && d.config.WeaklyTypedInput:
+		val.SetString(strconv.FormatInt(dataVal.Int(), 10))
+	case dataKind == reflect.Uint && d.config.WeaklyTypedInput:
+		val.SetString(strconv.FormatUint(dataVal.Uint(), 10))
+	case dataKind == reflect.Float32 && d.config.WeaklyTypedInput:
+		val.SetString(strconv.FormatFloat(dataVal.Float(), 'f', -1, 64))
+	case dataKind == reflect.Slice && d.config.WeaklyTypedInput:
+		dataType := dataVal.Type()
+		elemKind := dataType.Elem().Kind()
+		switch {
+		case elemKind == reflect.Uint8:
+			val.SetString(string(dataVal.Interface().([]uint8)))
+		default:
+			converted = false
+		}
+	default:
+		converted = false
+	}
+
+	if !converted {
+		return fmt.Errorf(
+			"'%s' expected type '%s', got unconvertible type '%s'",
+			name, val.Type(), dataVal.Type())
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeInt(name string, data interface{}, val reflect.Value) error {
+	dataVal := reflect.ValueOf(data)
+	dataKind := getKind(dataVal)
+	dataType := dataVal.Type()
+
+	switch {
+	case dataKind == reflect.Int:
+		val.SetInt(dataVal.Int())
+	case dataKind == reflect.Uint:
+		val.SetInt(int64(dataVal.Uint()))
+	case dataKind == reflect.Float32:
+		val.SetInt(int64(dataVal.Float()))
+	case dataKind == reflect.Bool && d.config.WeaklyTypedInput:
+		if dataVal.Bool() {
+			val.SetInt(1)
+		} else {
+			val.SetInt(0)
+		}
+	case dataKind == reflect.String && d.config.WeaklyTypedInput:
+		i, err := strconv.ParseInt(dataVal.String(), 0, val.Type().Bits())
+		if err == nil {
+			val.SetInt(i)
+		} else {
+			return fmt.Errorf("cannot parse '%s' as int: %s", name, err)
+		}
+	case dataType.PkgPath() == "encoding/json" && dataType.Name() == "Number":
+		jn := data.(json.Number)
+		i, err := jn.Int64()
+		if err != nil {
+			return fmt.Errorf(
+				"error decoding json.Number into %s: %s", name, err)
+		}
+		val.SetInt(i)
+	default:
+		return fmt.Errorf(
+			"'%s' expected type '%s', got unconvertible type '%s'",
+			name, val.Type(), dataVal.Type())
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeUint(name string, data interface{}, val reflect.Value) error {
+	dataVal := reflect.ValueOf(data)
+	dataKind := getKind(dataVal)
+
+	switch {
+	case dataKind == reflect.Int:
+		i := dataVal.Int()
+		if i < 0 && !d.config.WeaklyTypedInput {
+			return fmt.Errorf("cannot parse '%s', %d overflows uint",
+				name, i)
+		}
+		val.SetUint(uint64(i))
+	case dataKind == reflect.Uint:
+		val.SetUint(dataVal.Uint())
+	case dataKind == reflect.Float32:
+		f := dataVal.Float()
+		if f < 0 && !d.config.WeaklyTypedInput {
+			return fmt.Errorf("cannot parse '%s', %f overflows uint",
+				name, f)
+		}
+		val.SetUint(uint64(f))
+	case dataKind == reflect.Bool && d.config.WeaklyTypedInput:
+		if dataVal.Bool() {
+			val.SetUint(1)
+		} else {
+			val.SetUint(0)
+		}
+	case dataKind == reflect.String && d.config.WeaklyTypedInput:
+		i, err := strconv.ParseUint(dataVal.String(), 0, val.Type().Bits())
+		if err == nil {
+			val.SetUint(i)
+		} else {
+			return fmt.Errorf("cannot parse '%s' as uint: %s", name, err)
+		}
+	default:
+		return fmt.Errorf(
+			"'%s' expected type '%s', got unconvertible type '%s'",
+			name, val.Type(), dataVal.Type())
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeBool(name string, data interface{}, val reflect.Value) error {
+	dataVal := reflect.ValueOf(data)
+	dataKind := getKind(dataVal)
+
+	switch {
+	case dataKind == reflect.Bool:
+		val.SetBool(dataVal.Bool())
+	case dataKind == reflect.Int && d.config.WeaklyTypedInput:
+		val.SetBool(dataVal.Int() != 0)
+	case dataKind == reflect.Uint && d.config.WeaklyTypedInput:
+		val.SetBool(dataVal.Uint() != 0)
+	case dataKind == reflect.Float32 && d.config.WeaklyTypedInput:
+		val.SetBool(dataVal.Float() != 0)
+	case dataKind == reflect.String && d.config.WeaklyTypedInput:
+		b, err := strconv.ParseBool(dataVal.String())
+		if err == nil {
+			val.SetBool(b)
+		} else if dataVal.String() == "" {
+			val.SetBool(false)
+		} else {
+			return fmt.Errorf("cannot parse '%s' as bool: %s", name, err)
+		}
+	default:
+		return fmt.Errorf(
+			"'%s' expected type '%s', got unconvertible type '%s'",
+			name, val.Type(), dataVal.Type())
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeFloat(name string, data interface{}, val reflect.Value) error {
+	dataVal := reflect.ValueOf(data)
+	dataKind := getKind(dataVal)
+	dataType := dataVal.Type()
+
+	switch {
+	case dataKind == reflect.Int:
+		val.SetFloat(float64(dataVal.Int()))
+	case dataKind == reflect.Uint:
+		val.SetFloat(float64(dataVal.Uint()))
+	case dataKind == reflect.Float32:
+		val.SetFloat(dataVal.Float())
+	case dataKind == reflect.Bool && d.config.WeaklyTypedInput:
+		if dataVal.Bool() {
+			val.SetFloat(1)
+		} else {
+			val.SetFloat(0)
+		}
+	case dataKind == reflect.String && d.config.WeaklyTypedInput:
+		f, err := strconv.ParseFloat(dataVal.String(), val.Type().Bits())
+		if err == nil {
+			val.SetFloat(f)
+		} else {
+			return fmt.Errorf("cannot parse '%s' as float: %s", name, err)
+		}
+	case dataType.PkgPath() == "encoding/json" && dataType.Name() == "Number":
+		jn := data.(json.Number)
+		i, err := jn.Float64()
+		if err != nil {
+			return fmt.Errorf(
+				"error decoding json.Number into %s: %s", name, err)
+		}
+		val.SetFloat(i)
+	default:
+		return fmt.Errorf(
+			"'%s' expected type '%s', got unconvertible type '%s'",
+			name, val.Type(), dataVal.Type())
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeMap(name string, data interface{}, val reflect.Value) error {
+	valType := val.Type()
+	valKeyType := valType.Key()
+	valElemType := valType.Elem()
+
+	// By default we overwrite keys in the current map
+	valMap := val
+
+	// If the map is nil or we're purposely zeroing fields, make a new map
+	if valMap.IsNil() || d.config.ZeroFields {
+		// Make a new map to hold our result
+		mapType := reflect.MapOf(valKeyType, valElemType)
+		valMap = reflect.MakeMap(mapType)
+	}
+
+	// Check input type
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
+	if dataVal.Kind() != reflect.Map {
+		// In weak mode, we accept a slice of maps as an input...
+		if d.config.WeaklyTypedInput {
+			switch dataVal.Kind() {
+			case reflect.Array, reflect.Slice:
+				// Special case for BC reasons (covered by tests)
+				if dataVal.Len() == 0 {
+					val.Set(valMap)
+					return nil
+				}
+
+				for i := 0; i < dataVal.Len(); i++ {
+					err := d.decode(
+						fmt.Sprintf("%s[%d]", name, i),
+						dataVal.Index(i).Interface(), val)
+					if err != nil {
+						return err
+					}
+				}
+
+				return nil
+			}
+		}
+
+		return fmt.Errorf("'%s' expected a map, got '%s'", name, dataVal.Kind())
+	}
+
+	// Accumulate errors
+	errors := make([]string, 0)
+
+	for _, k := range dataVal.MapKeys() {
+		fieldName := fmt.Sprintf("%s[%s]", name, k)
+
+		// First decode the key into the proper type
+		currentKey := reflect.Indirect(reflect.New(valKeyType))
+		if err := d.decode(fieldName, k.Interface(), currentKey); err != nil {
+			errors = appendErrors(errors, err)
+			continue
+		}
+
+		// Next decode the data into the proper type
+		v := dataVal.MapIndex(k).Interface()
+		currentVal := reflect.Indirect(reflect.New(valElemType))
+		if err := d.decode(fieldName, v, currentVal); err != nil {
+			errors = appendErrors(errors, err)
+			continue
+		}
+
+		valMap.SetMapIndex(currentKey, currentVal)
+	}
+
+	// Set the built up map to the value
+	val.Set(valMap)
+
+	// If we had errors, return those
+	if len(errors) > 0 {
+		return &Error{errors}
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodePtr(name string, data interface{}, val reflect.Value) error {
+	// Create an element of the concrete (non pointer) type and decode
+	// into that. Then set the value of the pointer to this type.
+	valType := val.Type()
+	valElemType := valType.Elem()
+
+	realVal := val
+	if realVal.IsNil() || d.config.ZeroFields {
+		realVal = reflect.New(valElemType)
+	}
+
+	if err := d.decode(name, data, reflect.Indirect(realVal)); err != nil {
+		return err
+	}
+
+	val.Set(realVal)
+	return nil
+}
+
+func (d *Decoder) decodeFunc(name string, data interface{}, val reflect.Value) error {
+	// Create an element of the concrete (non pointer) type and decode
+	// into that. Then set the value of the pointer to this type.
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
+	if val.Type() != dataVal.Type() {
+		return fmt.Errorf(
+			"'%s' expected type '%s', got unconvertible type '%s'",
+			name, val.Type(), dataVal.Type())
+	}
+	val.Set(dataVal)
+	return nil
+}
+
+func (d *Decoder) decodeSlice(name string, data interface{}, val reflect.Value) error {
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
+	dataValKind := dataVal.Kind()
+	valType := val.Type()
+	valElemType := valType.Elem()
+	sliceType := reflect.SliceOf(valElemType)
+
+	valSlice := val
+	if valSlice.IsNil() || d.config.ZeroFields {
+		// Check input type
+		if dataValKind != reflect.Array && dataValKind != reflect.Slice {
+			if d.config.WeaklyTypedInput {
+				switch {
+				// Empty maps turn into empty slices
+				case dataValKind == reflect.Map:
+					if dataVal.Len() == 0 {
+						val.Set(reflect.MakeSlice(sliceType, 0, 0))
+						return nil
+					}
+
+				// All other types we try to convert to the slice type
+				// and "lift" it into it. i.e. a string becomes a string slice.
+				default:
+					// Just re-try this function with data as a slice.
+					return d.decodeSlice(name, []interface{}{data}, val)
+				}
+			}
+
+			return fmt.Errorf(
+				"'%s': source data must be an array or slice, got %s", name, dataValKind)
+
+		}
+
+		// Make a new slice to hold our result, same size as the original data.
+		valSlice = reflect.MakeSlice(sliceType, dataVal.Len(), dataVal.Len())
+	}
+
+	// Accumulate any errors
+	errors := make([]string, 0)
+
+	for i := 0; i < dataVal.Len(); i++ {
+		currentData := dataVal.Index(i).Interface()
+		for valSlice.Len() <= i {
+			valSlice = reflect.Append(valSlice, reflect.Zero(valElemType))
+		}
+		currentField := valSlice.Index(i)
+
+		fieldName := fmt.Sprintf("%s[%d]", name, i)
+		if err := d.decode(fieldName, currentData, currentField); err != nil {
+			errors = appendErrors(errors, err)
+		}
+	}
+
+	// Finally, set the value to the slice we built up
+	val.Set(valSlice)
+
+	// If there were errors, we return those
+	if len(errors) > 0 {
+		return &Error{errors}
+	}
+
+	return nil
+}
+
+func (d *Decoder) decodeStruct(name string, data interface{}, val reflect.Value) error {
+	dataVal := reflect.Indirect(reflect.ValueOf(data))
+
+	// If the type of the value to write to and the data match directly,
+	// then we just set it directly instead of recursing into the structure.
+	if dataVal.Type() == val.Type() {
+		val.Set(dataVal)
+		return nil
+	}
+
+	dataValKind := dataVal.Kind()
+	if dataValKind != reflect.Map {
+		return fmt.Errorf("'%s' expected a map, got '%s'", name, dataValKind)
+	}
+
+	dataValType := dataVal.Type()
+	if kind := dataValType.Key().Kind(); kind != reflect.String && kind != reflect.Interface {
+		return fmt.Errorf(
+			"'%s' needs a map with string keys, has '%s' keys",
+			name, dataValType.Key().Kind())
+	}
+
+	dataValKeys := make(map[reflect.Value]struct{})
+	dataValKeysUnused := make(map[interface{}]struct{})
+	for _, dataValKey := range dataVal.MapKeys() {
+		dataValKeys[dataValKey] = struct{}{}
+		dataValKeysUnused[dataValKey.Interface()] = struct{}{}
+	}
+
+	errors := make([]string, 0)
+
+	// This slice will keep track of all the structs we'll be decoding.
+	// There can be more than one struct if there are embedded structs
+	// that are squashed.
+	structs := make([]reflect.Value, 1, 5)
+	structs[0] = val
+
+	// Compile the list of all the fields that we're going to be decoding
+	// from all the structs.
+	type field struct {
+		field reflect.StructField
+		val   reflect.Value
+	}
+	fields := []field{}
+	for len(structs) > 0 {
+		structVal := structs[0]
+		structs = structs[1:]
+
+		structType := structVal.Type()
+
+		for i := 0; i < structType.NumField(); i++ {
+			fieldType := structType.Field(i)
+			fieldKind := fieldType.Type.Kind()
+
+			// If "squash" is specified in the tag, we squash the field down.
+			squash := false
+			tagParts := strings.Split(fieldType.Tag.Get(d.config.TagName), ",")
+			for _, tag := range tagParts[1:] {
+				if tag == "squash" {
+					squash = true
+					break
+				}
+			}
+
+			if squash {
+				if fieldKind != reflect.Struct {
+					errors = appendErrors(errors,
+						fmt.Errorf("%s: unsupported type for squash: %s", fieldType.Name, fieldKind))
+				} else {
+					structs = append(structs, val.FieldByName(fieldType.Name))
+				}
+				continue
+			}
+
+			// Normal struct field, store it away
+			fields = append(fields, field{fieldType, structVal.Field(i)})
+		}
+	}
+
+	// for fieldType, field := range fields {
+	for _, f := range fields {
+		field, fieldValue := f.field, f.val
+		fieldName := field.Name
+
+		tagValue := field.Tag.Get(d.config.TagName)
+		tagValue = strings.SplitN(tagValue, ",", 2)[0]
+		if tagValue != "" {
+			fieldName = tagValue
+		}
+
+		rawMapKey := reflect.ValueOf(fieldName)
+		rawMapVal := dataVal.MapIndex(rawMapKey)
+		if !rawMapVal.IsValid() {
+			// Do a slower search by iterating over each key and
+			// doing case-insensitive search.
+			for dataValKey := range dataValKeys {
+				mK, ok := dataValKey.Interface().(string)
+				if !ok {
+					// Not a string key
+					continue
+				}
+
+				if strings.EqualFold(mK, fieldName) {
+					rawMapKey = dataValKey
+					rawMapVal = dataVal.MapIndex(dataValKey)
+					break
+				}
+			}
+
+			if !rawMapVal.IsValid() {
+				// There was no matching key in the map for the value in
+				// the struct. Just ignore.
+				continue
+			}
+		}
+
+		// Delete the key we're using from the unused map so we stop tracking
+		delete(dataValKeysUnused, rawMapKey.Interface())
+
+		if !fieldValue.IsValid() {
+			// This should never happen
+			panic("field is not valid")
+		}
+
+		// If we can't set the field, then it is unexported or something,
+		// and we just continue onwards.
+		if !fieldValue.CanSet() {
+			continue
+		}
+
+		// If the name is empty string, then we're at the root, and we
+		// don't dot-join the fields.
+		if name != "" {
+			fieldName = fmt.Sprintf("%s.%s", name, fieldName)
+		}
+
+		if err := d.decode(fieldName, rawMapVal.Interface(), fieldValue); err != nil {
+			errors = appendErrors(errors, err)
+		}
+	}
+
+	if d.config.ErrorUnused && len(dataValKeysUnused) > 0 {
+		keys := make([]string, 0, len(dataValKeysUnused))
+		for rawKey := range dataValKeysUnused {
+			keys = append(keys, rawKey.(string))
+		}
+		sort.Strings(keys)
+
+		err := fmt.Errorf("'%s' has invalid keys: %s", name, strings.Join(keys, ", "))
+		errors = appendErrors(errors, err)
+	}
+
+	if len(errors) > 0 {
+		return &Error{errors}
+	}
+
+	// Add the unused keys to the list of unused keys if we're tracking metadata
+	if d.config.Metadata != nil {
+		for rawKey := range dataValKeysUnused {
+			key := rawKey.(string)
+			if name != "" {
+				key = fmt.Sprintf("%s.%s", name, key)
+			}
+
+			d.config.Metadata.Unused = append(d.config.Metadata.Unused, key)
+		}
+	}
+
+	return nil
+}
+
+func getKind(val reflect.Value) reflect.Kind {
+	kind := val.Kind()
+
+	switch {
+	case kind >= reflect.Int && kind <= reflect.Int64:
+		return reflect.Int
+	case kind >= reflect.Uint && kind <= reflect.Uint64:
+		return reflect.Uint
+	case kind >= reflect.Float32 && kind <= reflect.Float64:
+		return reflect.Float32
+	default:
+		return kind
+	}
+}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/README.md
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/README.md
@@ -38,6 +38,10 @@ compiler := jsonschema.NewCompiler()
 compler.Draft = jsonschema.Draft4
 ```
 
+you can also validate go value using `schema.ValidateInterface(interface{})` method.  
+but the argument should not be user-defined struct.
+
+
 This package supports loading json-schema from filePath and fileURL.
 
 To load json-schema from HTTPURL, add following import:
@@ -58,7 +62,7 @@ compiler := jsonschema.NewCompiler()
 if err := compiler.AddResource(url, strings.NewReader(data)); err != nil {
     return err
 }
-schema, err := jsonschema.Compile(url)
+schema, err := compiler.Compile(url)
 if err != nil {
     return err
 }

--- a/vendor/github.com/santhosh-tekuri/jsonschema/doc.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/doc.go
@@ -30,6 +30,9 @@ You can force to use draft4 when `$schema` is missing, as follows:
 	compiler := jsonschema.NewCompiler()
 	compler.Draft = jsonschema.Draft4
 
+you can also validate go value using schema.ValidateInterface(interface{}) method.
+but the argument should not be user-defined struct.
+
 This package supports loading json-schema from filePath and fileURL.
 
 To load json-schema from HTTPURL, add following import:
@@ -47,7 +50,7 @@ To load json-schema from in-memory:
 	if err := compiler.AddResource(url, strings.NewReader(data)); err != nil {
 		return err
 	}
-	schema, err := jsonschema.Compile(url)
+	schema, err := compiler.Compile(url)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/resource.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/resource.go
@@ -21,7 +21,10 @@ type resource struct {
 	schemas map[string]*Schema
 }
 
-func decodeJSON(r io.Reader) (interface{}, error) {
+// DecodeJSON decodes json document from r.
+//
+// Note that number is decoded into json.Number instead of as a float64
+func DecodeJSON(r io.Reader) (interface{}, error) {
 	decoder := json.NewDecoder(r)
 	decoder.UseNumber()
 	var doc interface{}
@@ -38,7 +41,7 @@ func newResource(base string, r io.Reader) (*resource, error) {
 	if strings.IndexByte(base, '#') != -1 {
 		panic(fmt.Sprintf("BUG: newResource(%q)", base))
 	}
-	doc, err := decodeJSON(r)
+	doc, err := DecodeJSON(r)
 	if err != nil {
 		return nil, fmt.Errorf("parsing %q failed. Reason: %v", base, err)
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1218,6 +1218,12 @@
 			"revisionTime": "2017-06-28T12:00:33Z"
 		},
 		{
+			"checksumSHA1": "gILp4IL+xwXLH6tJtRLrnZ56F24=",
+			"path": "github.com/mitchellh/mapstructure",
+			"revision": "06020f85339e21b2478f756a78e295255ffa4d6a",
+			"revisionTime": "2017-10-17T17:18:08Z"
+		},
+		{
 			"checksumSHA1": "2AyUkWjutec6p+470tgio8mYOxI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/go-digest",
 			"path": "github.com/opencontainers/go-digest",
@@ -1279,22 +1285,22 @@
 			"revisionTime": "2017-01-28T01:21:29Z"
 		},
 		{
-			"checksumSHA1": "DO1gvD4W/Yzr1vI6xNvmlsj5ESE=",
+			"checksumSHA1": "7IhJTQp7vzGrgo24rRkG6VkgvvA=",
 			"path": "github.com/santhosh-tekuri/jsonschema",
-			"revision": "3968f5a2fa9b81399766f843162c5c06ee1e6aba",
-			"revisionTime": "2017-06-28T13:19:22Z"
+			"revision": "63accc9deedeee33b7caf4e241f8a9ebdf031069",
+			"revisionTime": "2017-11-30T20:27:46Z"
 		},
 		{
 			"checksumSHA1": "wu+Masd8AYe2EzCsiq370Sl0wqw=",
 			"path": "github.com/santhosh-tekuri/jsonschema/formats",
-			"revision": "3968f5a2fa9b81399766f843162c5c06ee1e6aba",
-			"revisionTime": "2017-06-28T13:19:22Z"
+			"revision": "63accc9deedeee33b7caf4e241f8a9ebdf031069",
+			"revisionTime": "2017-11-30T20:27:46Z"
 		},
 		{
 			"checksumSHA1": "zFQ2S0Rrw59P/cy1rONHf/grceM=",
 			"path": "github.com/santhosh-tekuri/jsonschema/loader",
-			"revision": "3968f5a2fa9b81399766f843162c5c06ee1e6aba",
-			"revisionTime": "2017-06-28T13:19:22Z"
+			"revision": "63accc9deedeee33b7caf4e241f8a9ebdf031069",
+			"revisionTime": "2017-11-30T20:27:46Z"
 		},
 		{
 			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",


### PR DESCRIPTION
This is an attempt to simplify data processing by removing (some) duplicated type conversions.

Right now, we convert `reader` to `[]byte` in the handler, and we pass that byte array to the `Validate` and `Transform` interfaces. 
In `Validate`, `[]byte` is converted back to `reader`, and that `reader` to a `map[string]interface{}` (this happens inside the validation library).
During `Transform`ation we also convert `[]byte` to a `struct`.
The sourcemaps processor is more convoluted, it has (I think) 6 (un)marshal steps.

This PR converts `reader` directly to a `map[string]interface{}`, which is passed as-is to the `Validate` and `Transform` interfaces. 
In `Validate` no more conversions happen.
In `Transform` `map[string]interface{}` is converted to a `struct`. 
This also removes 2 type conversions in the sourcemap processors.

This is possible now thanks to a recent addition in the json schema validation library (https://github.com/santhosh-tekuri/jsonschema/commit/b7a5b2f2d7c3acfbee30bd8c3779f4f163832b21).

Ideas more than welcome as usual (particularly for further simplification of the sourcemap processor  ). 
