### PR TITLE
Stricter Json Schema validation: set additionalProperties to high level json entities.

### DIFF
--- a/docs/data/intake-api/generated/transaction/transaction_empty_values.json
+++ b/docs/data/intake-api/generated/transaction/transaction_empty_values.json
@@ -14,7 +14,6 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
-            "start": 24.01,
             "timestamp": "2017-05-09T15:04:05.999999Z",
             "spans": []
         }

--- a/docs/spec/errors/error.json
+++ b/docs/spec/errors/error.json
@@ -96,6 +96,7 @@
             "description": "Recorded time of the error, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
         }
     },
+    "additionalProperties": false,
     "required": ["timestamp"],
     "anyOf": [
         {

--- a/docs/spec/errors/payload.json
+++ b/docs/spec/errors/payload.json
@@ -19,5 +19,6 @@
             "$ref": "../system.json"
         }
     },
+    "additionalProperties": false,
     "required": ["service", "errors"]
 }

--- a/docs/spec/transactions/payload.json
+++ b/docs/spec/transactions/payload.json
@@ -19,5 +19,6 @@
             "minItems": 1
         }
     },
+    "additionalProperties": false,
     "required": ["service", "transactions"]
 }

--- a/docs/spec/transactions/span.json
+++ b/docs/spec/transactions/span.json
@@ -66,6 +66,7 @@
             "maxLength": 1024
         }
     },
+    "additionalProperties": false,
     "dependencies": {
         "parent": {
             "required": ["id"]

--- a/docs/spec/transactions/transaction.json
+++ b/docs/spec/transactions/transaction.json
@@ -45,5 +45,6 @@
             "maxLength": 1024
         }
     },
+    "additionalProperties": false,
     "required": ["id", "name", "duration", "type", "timestamp"]
 }

--- a/processor/error/schema.go
+++ b/processor/error/schema.go
@@ -473,6 +473,7 @@ var errorSchema = `{
             "description": "Recorded time of the error, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ"
         }
     },
+    "additionalProperties": false,
     "required": ["timestamp"],
     "anyOf": [
         {
@@ -509,6 +510,7 @@ var errorSchema = `{
     }
         }
     },
+    "additionalProperties": false,
     "required": ["service", "errors"]
 }
 `

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -449,6 +449,7 @@ var transactionSchema = `{
             "maxLength": 1024
         }
     },
+    "additionalProperties": false,
     "dependencies": {
         "parent": {
             "required": ["id"]
@@ -464,11 +465,13 @@ var transactionSchema = `{
             "maxLength": 1024
         }
     },
+    "additionalProperties": false,
     "required": ["id", "name", "duration", "type", "timestamp"]
             },
             "minItems": 1
         }
     },
+    "additionalProperties": false,
     "required": ["service", "transactions"]
 }
 `

--- a/tests/data/valid/transaction/transaction_empty_values.json
+++ b/tests/data/valid/transaction/transaction_empty_values.json
@@ -14,7 +14,6 @@
             "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
-            "start": 24.01,
             "timestamp": "2017-05-09T15:04:05.999999Z",
             "spans": []
         }


### PR DESCRIPTION
This will allow us eg. to detect if someone is using an agent sending `traces` to a server expecting `spans` (since `spans` are optional and `traces` are ignored; right now validation succeeds if someone uses an invalid agent, and the only symptom would be missing traces in Kibana).

It also serves to detect inconsistencies in our tests etc.

This has the drawback that any addition will be a breaking change (that is why I did it only for `payloads`, `transactions`, `spans` and `errors`).