### PR TITLE
Move the healthcheck handler to the root and include about info.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,6 +8,7 @@
 https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828e0761d\...master[View commits]
 
 ==== Breaking changes
+- Move the healthcheck URK `/healthcheck` to `/` and include some `about` info if the request is authenticated {pull}395[395].
 - Renaming and reverse boolean `in_app` to `library_frame` {pull}385[385].
 - Renaming `app` to `service` {pull}377[377]
 - Move `trace.transaction_id` to `transaction.id` {pull}345[345], {pull}347[347], {pull}371[371]

--- a/beater/about/about.go
+++ b/beater/about/about.go
@@ -1,0 +1,16 @@
+package about
+
+import "github.com/elastic/beats/libbeat/logp"
+
+var about = make(map[string]interface{})
+
+func SetAbout(version string) {
+	logp.Info("APM Server Version %s  Git Ref %s Updated on %s", version, gitRef, updated)
+	about["version"] = version
+	about["git_ref"] = gitRef
+	about["updated"] = updated
+}
+
+func About() map[string]interface{} {
+	return about
+}

--- a/beater/about/generated.go
+++ b/beater/about/generated.go
@@ -1,0 +1,4 @@
+package about
+
+const gitRef = "6819aa06a0ed7ecc18f9bb7291d65b1ca50917fd"
+const updated = "2017-12-12 13:30:20 +0000 UTC"

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/elastic/apm-server/beater/about"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
@@ -36,10 +37,11 @@ func (bt *beater) Run(b *beat.Beat) error {
 	}
 	defer pub.Stop()
 
+	about.SetAbout(b.Info.Version)
+
 	go notifyListening(bt.config, pub.Send)
 
 	bt.server = newServer(bt.config, pub.Send)
-
 	err = run(bt.server, bt.config)
 	if err == http.ErrServerClosed {
 		logp.Info("Listener stopped: %s", err.Error())

--- a/beater/client.go
+++ b/beater/client.go
@@ -19,7 +19,7 @@ func insecureClient() *http.Client {
 func isServerUp(secure bool, host string, numRetries int, retryInterval time.Duration) bool {
 	client := insecureClient()
 	var check = func() bool {
-		url := url.URL{Scheme: "http", Host: host, Path: "healthcheck"}
+		url := url.URL{Scheme: "http", Host: host, Path: "/"}
 		if secure {
 			url.Scheme = "https"
 		}

--- a/beater/handlers_test.go
+++ b/beater/handlers_test.go
@@ -39,12 +39,12 @@ func TestJSONFailureResponse(t *testing.T) {
 	req.Header.Set("Accept", "application/json")
 	w := httptest.NewRecorder()
 
-	sendStatus(w, req, 400, errors.New("Cannot compare apples to oranges"))
+	sendStatus(w, req, 400, responseError(errors.New("Cannot compare apples to oranges")))
 
 	resp := w.Result()
 	body, _ := ioutil.ReadAll(resp.Body)
 	assert.Equal(t, 400, w.Code)
-	assert.Equal(t, body, []byte(`{"error":"Cannot compare apples to oranges"}`))
+	assert.Equal(t, []byte(`{"error":"Cannot compare apples to oranges"}`), body)
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 }
 
@@ -54,12 +54,12 @@ func TestJSONFailureResponseWhenAcceptingAnything(t *testing.T) {
 	req.Header.Set("Accept", "*/*")
 	w := httptest.NewRecorder()
 
-	sendStatus(w, req, 400, errors.New("Cannot compare apples to oranges"))
+	sendStatus(w, req, 400, responseError("Cannot compare apples to oranges"))
 
 	resp := w.Result()
 	body, _ := ioutil.ReadAll(resp.Body)
 	assert.Equal(t, 400, w.Code)
-	assert.Equal(t, body, []byte(`{"error":"Cannot compare apples to oranges"}`))
+	assert.Equal(t, []byte(`{"error":"Cannot compare apples to oranges"}`), body)
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
 }
 
@@ -69,12 +69,12 @@ func TestHTMLFailureResponse(t *testing.T) {
 	req.Header.Set("Accept", "text/html")
 	w := httptest.NewRecorder()
 
-	sendStatus(w, req, 400, errors.New("Cannot compare apples to oranges"))
+	sendStatus(w, req, 400, responseError("Cannot compare apples to oranges"))
 
 	resp := w.Result()
 	body, _ := ioutil.ReadAll(resp.Body)
 	assert.Equal(t, 400, w.Code)
-	assert.Equal(t, body, []byte(`Cannot compare apples to oranges`))
+	assert.Equal(t, []byte(`map[error:Cannot compare apples to oranges]`), body)
 	assert.Equal(t, "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
 }
 
@@ -85,12 +85,12 @@ func TestFailureResponseNoAcceptHeader(t *testing.T) {
 	req.Header.Del("Accept")
 
 	w := httptest.NewRecorder()
-	sendStatus(w, req, 400, errors.New("Cannot compare apples to oranges"))
+	sendStatus(w, req, 400, responseError("Cannot compare apples to oranges"))
 
 	resp := w.Result()
 	body, _ := ioutil.ReadAll(resp.Body)
 	assert.Equal(t, 400, w.Code)
-	assert.Equal(t, body, []byte(`Cannot compare apples to oranges`))
+	assert.Equal(t, []byte(`map[error:Cannot compare apples to oranges]`), body)
 	assert.Equal(t, "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
 }
 

--- a/docs/high-availability.asciidoc
+++ b/docs/high-availability.asciidoc
@@ -2,25 +2,25 @@
 [float]
 === High Availability
 
-The API exposed by APM Server is a regular HTTP JSON API. 
-To achieve high availability, 
+The API exposed by APM Server is a regular HTTP JSON API.
+To achieve high availability,
 you can place multiple instances of APM Server behind a regular HTTP load balancer,
 for example HAProxy or nginx.
 
-If an instance of APM Server should fail, 
+If an instance of APM Server should fail,
 the load balancer will remove it from the load balancing rotation after a short period of time.
 
-APM Server endpoint `/healthcheck` always returns a `HTTP 200`.
-You can configure your load balancer to send HTTP requests to this endpoint 
+APM Server endpoint `/` always returns a `HTTP 200`.
+You can configure your load balancer to send HTTP requests to this endpoint
 to determine if a given APM Server is up and running.
 
-APM Server maintains a small buffer internally. 
+APM Server maintains a small buffer internally.
 Data coming from agents is kept here until it can be delivered to Elasticsearch.
 Under normal circumstance, data is forwarded to Elasticsearch immediately.
-In situations in which Elasticsearch is down briefly 
-or in situations where there is a sudden influx of data and Elasticsearch cannot ingest it all at once, 
+In situations in which Elasticsearch is down briefly
+or in situations where there is a sudden influx of data and Elasticsearch cannot ingest it all at once,
 the buffer acts as a temporary storage until the data can be ingested by Elasticsearch.
 
-This also means that if a given APM Server process fails, 
-for example because the machine its running on experiences an issue, 
+This also means that if a given APM Server process fails,
+for example because the machine its running on experiences an issue,
 the data that has not yet been forwarded to Elasticsearch is lost.

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 //go:generate go run script/inline_schemas/inline_schemas.go
 //go:generate go run script/output_data/output_data.go
+//go:generate go run script/about/write_about.go
 
 import (
 	"os"

--- a/script/about/write_about.go
+++ b/script/about/write_about.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func main() {
+
+	p := exec.Command("git", "rev-parse", "HEAD")
+	out, err := p.Output()
+	if err != nil {
+		panic(err)
+	}
+
+	ref := strings.TrimSpace(string(out))
+	source := fmt.Sprintf(`package about
+
+const gitRef = "%s"
+const updated = "%s"
+`, ref, time.Now().UTC().Truncate(time.Second))
+
+	err = ioutil.WriteFile("./beater/about/generated.go", []byte(source), 0644)
+
+	if err != nil {
+		panic(err)
+	}
+}

--- a/tests/system/test_requests.py
+++ b/tests/system/test_requests.py
@@ -66,8 +66,8 @@ class Test(ServerBaseTest):
         assert r.status_code == 403, r.status_code
 
     def test_healthcheck(self):
-        healtcheck_url = 'http://localhost:8200/healthcheck'
-        r = requests.get(healtcheck_url)
+        healthcheck_url = 'http://localhost:8200'
+        r = requests.get(healthcheck_url)
         assert r.status_code == 200, r.status_code
 
     def test_gzip(self):


### PR DESCRIPTION
About info contains the version, git ref and build date(*), and is returned only if a request is authenticated.

About is also printed on startup.
The git ref and the updated timestamp are generated with `make update`.

Closes #375

(*) @beniwohli asked for the build date. This is not exactly the build date, but the timestamp of when you run `make update`. Im not sure how I would get the build date...