### PR TITLE
do not change version globally, just print it on startup

### DIFF
--- a/beater/server.go
+++ b/beater/server.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/elastic/apm-server/version"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/logp"
 )
@@ -24,7 +25,7 @@ func newServer(config Config, report reporter) *http.Server {
 }
 
 func run(server *http.Server, config Config) error {
-	logp.Info("Starting apm-server! Hit CTRL-C to stop it.")
+	logp.Info("Starting apm-server [%s]. Hit CTRL-C to stop it.", version.String())
 	logp.Info("Listening on: %s", server.Addr)
 	switch config.Frontend.isEnabled() {
 	case true:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,14 +1,10 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/pflag"
 
 	"github.com/elastic/apm-server/beater"
-	"github.com/elastic/apm-server/version"
 	"github.com/elastic/beats/libbeat/cmd"
-	libbeat "github.com/elastic/beats/libbeat/version"
 )
 
 // Name of the beat (apm-server).
@@ -22,6 +18,5 @@ var RootCmd *cmd.BeatsRootCmd
 
 func init() {
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
-	version := fmt.Sprintf("%s [%s]", libbeat.GetDefaultVersion(), version.String())
-	RootCmd = cmd.GenRootCmdWithIndexPrefixWithRunFlags(Name, IdxPattern, version, beater.New, runFlags)
+	RootCmd = cmd.GenRootCmdWithIndexPrefixWithRunFlags(Name, IdxPattern, "", beater.New, runFlags)
 }


### PR DESCRIPTION
In #396 I introduced a bug where the index name contained invalid characters
that were added to the global version.