### PR TITLE
Document setting user+pwd in config file

### DIFF
--- a/docs/configuring.asciidoc
+++ b/docs/configuring.asciidoc
@@ -36,6 +36,19 @@ output:
     hosts: ElasticsearchAddress:9200
 ----------------------------------
 
+
+NOTE: If you are using an X-Pack secured version of Elastic Stack,
+you need to specify credentials in the config file before you run the commands that set up and start APM Server.
+For example:
+
+[source,yaml]
+----
+output.elasticsearch:
+  hosts: ["ElasticsearchAddress:9200"]
+  username: "elastic"
+  password: "elastic"
+----
+
 See https://github.com/elastic/apm-server/blob/{doc-branch}/apm-server.reference.yml[`apm-server.reference.yml`] for more configuration options.
 
 include::./security.asciidoc[]

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -127,6 +127,20 @@ output:
     hosts: ElasticsearchAddress:9200
 ----------------------------------
 
+NOTE: If you are using an X-Pack secured version of Elastic Stack,
+you need to specify credentials in the config file before you run the commands that set up and start APM Server.
+For example:
+
+[source,yaml]
+----
+output.elasticsearch:
+  hosts: ["ElasticsearchAddress:9200"]
+  username: "elastic"
+  password: "elastic"
+----
+
+
+
 [[secure-api-access]]
 [float]
 ==== Secure access to the API
@@ -149,8 +163,6 @@ To install those run the following command:
 
 NOTE: Due to a bug in Kibana 6.0.0.-rc2 the dashboards don't work in Kibana 6.0.0-rc2.
 
-NOTE: If you are using an X-Pack secured version of Elastic Stack,
-add `-E output.elasticsearch.username=user -E output.elasticsearch.password=pass` to the command.
 
 See an example screenshot of a Kibana dashboard:
 


### PR DESCRIPTION
Closes #387.

APM Server docs:
<img width="778" alt="screenshot 2017-12-21 16 00 36" src="https://user-images.githubusercontent.com/744/34261096-6063d894-e668-11e7-90a1-20f390419842.png">

Getting started guide: 
<img width="771" alt="screenshot 2017-12-21 16 06 10" src="https://user-images.githubusercontent.com/744/34261275-eda0ac28-e668-11e7-9d26-675e67ef6e34.png">
