### PR TITLE
update readme doc urls

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -16,6 +16,7 @@ https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828
 
 ==== Bug fixes
 - Updated systemd doc url {pull}354[354]
+- Updated readme doc urls {pull}356[356]
 
 ==== Added
 - Support for uploading sourcemaps {pull}302[302].

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ update-beats:
 	rm -rf vendor/github.com/elastic/beats
 	@govendor fetch github.com/elastic/beats/...@$(BEATS_VERSION)
 	@govendor fetch github.com/elastic/beats/libbeat/kibana/@$(BEATS_VERSION)
-	rm -rf _beats
-	@BEATS_VERSION=$(BEATS_VERSION) sh script/update_beats.sh
+	@BEATS_VERSION=$(BEATS_VERSION) script/update_beats.sh
 	@$(MAKE) update
 	@echo --- Use this commit message: Update beats framework to `cat vendor/vendor.json | python -c 'import sys, json; print([p["revision"] for p in json.load(sys.stdin)["package"] if p["path"] == "github.com/elastic/beats/libbeat/beat"][0][:7])'`
 

--- a/_beats/dev-tools/packer/readme.md.j2
+++ b/_beats/dev-tools/packer/readme.md.j2
@@ -8,16 +8,12 @@ To get started with {{.beat_name}}, you need to set up Elasticsearch on your loc
 
      ./{{.beat_name}} -c {{.beat_name}}.yml -e
 
-This will start the beat and send the data to your Elasticsearch instance. To load the dashboards for {{.beat_name}} into Kibana, run:
+This will start {{.beat_name}} and send the data to your Elasticsearch instance. To load the dashboards for {{.beat_name}} into Kibana, run:
 
     ./{{.beat_name}} setup -e
 
-For further steps visit the [Getting started](https://www.elastic.co/guide/en/beats/{{.beat_name}}/{{.doc_branch}}/{{.beat_name}}-getting-started.html) guide.
+For further steps visit the [Getting started](https://www.elastic.co/guide/en/apm/get-started/{{.doc_branch}}/) guide.
 
 ## Documentation
 
-Visit [Elastic.co Docs](https://www.elastic.co/guide/en/beats/{{.beat_name}}/{{.doc_branch}}/index.html) for the full {{.beat_name}} documentation.
-
-## Release notes
-
-https://www.elastic.co/guide/en/beats/libbeat/{{.doc_branch}}/release-notes-{{.version}}.html
+Visit [Elastic.co Docs](https://www.elastic.co/guide/en/apm/server/{{.doc_branch}}/) for the full {{.beat_name}} documentation.

--- a/script/update_beats.sh
+++ b/script/update_beats.sh
@@ -9,6 +9,8 @@ cd $BASEDIR
 
 # Check out beats repo for updating
 GIT_CLONE=repo
+trap "{ rm -rf ${GIT_CLONE}; }" EXIT
+
 git clone --depth 1 --branch ${BEATS_VERSION} https://github.com/elastic/beats.git ${GIT_CLONE}
 
 # sync
@@ -28,5 +30,3 @@ rsync -crpv --delete \
     --include="testing/***" \
     --exclude="*" \
     ${GIT_CLONE}/ .
-
-rm -rf ${GIT_CLONE}

--- a/script/update_beats.sh
+++ b/script/update_beats.sh
@@ -14,6 +14,7 @@ git clone --depth 1 --branch ${BEATS_VERSION} https://github.com/elastic/beats.g
 # sync
 rsync -crpv --delete \
     --exclude=.gitignore \
+    --exclude=dev-tools/packer/readme.md.j2 \
     --include="script/***" \
     --include="dev-tools/***" \
     --include="libbeat/scripts/***" \

--- a/script/update_beats.sh
+++ b/script/update_beats.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -ex
 
 BEATS_VERSION="${BEATS_VERSION:-master}"
 
@@ -7,52 +7,25 @@ BASEDIR=$(dirname "$0")/../_beats
 mkdir -p $BASEDIR
 cd $BASEDIR
 
-# Cleanup all files to fetch a fresh copy
-rm -rf dev-tools script libbeat testing repo
+# Check out beats repo for updating
+GIT_CLONE=repo
+git clone --depth 1 --branch ${BEATS_VERSION} https://github.com/elastic/beats.git ${GIT_CLONE}
 
-# Check out master repo for updating
-GIT_CLONE=./repo
-git clone https://github.com/elastic/beats.git $GIT_CLONE
+# sync
+rsync -crpv --delete \
+    --exclude=.gitignore \
+    --include="script/***" \
+    --include="dev-tools/***" \
+    --include="libbeat/scripts/***" \
+    --include="libbeat/_meta/***" \
+    --include=libbeat/Makefile \
+    --include="libbeat/processors/*/_meta/***" \
+    --include=libbeat/tests/system/requirements.txt \
+    --include="libbeat/tests/system/beat/***" \
+    --include=libbeat/docs/version.asciidoc \
+    --include=.go-version \
+    --include="testing/***" \
+    --exclude="*" \
+    ${GIT_CLONE}/ .
 
-cd $GIT_CLONE
-git checkout $BEATS_VERSION
-cd ..
-
-# TODO: allow to check out specific branch / tag
-
-# Copy top level files
-cp -r $GIT_CLONE/script script
-cp -r $GIT_CLONE/dev-tools dev-tools
-
-# Fetch libbeat dependencies
-mkdir libbeat
-cp -r $GIT_CLONE/libbeat/scripts libbeat/scripts
-cp -r $GIT_CLONE/libbeat/_meta libbeat/_meta
-cp $GIT_CLONE/libbeat/Makefile libbeat/Makefile
-
-# Only get _meta directories here
-cp -r $GIT_CLONE/libbeat/processors/ libbeat/processors/
-rm -r libbeat/processors/*.go
-rm -r libbeat/processors/*/*.go
-
-# Get system test dependencies
-mkdir -p libbeat/tests/system
-cp $GIT_CLONE/libbeat/tests/system/requirements.txt libbeat/tests/system/requirements.txt
-cp -r $GIT_CLONE/libbeat/tests/system/beat libbeat/tests/system/beat
-
-# Add version.asciidoc for packaging
-mkdir -p libbeat/docs
-cp $GIT_CLONE/libbeat/docs/version.asciidoc libbeat/docs/version.asciidoc
-
-# Add go version file for CI
-cp $GIT_CLONE/.go-version .go-version
-
-# Get system test dependencies
-cp -r $GIT_CLONE/testing testing
-
-# Generate .gitignore file
-echo "libbeat/_meta/fields.generated.yml" > .gitignore
-echo "libbeat/fields.yml" >> .gitignore
-
-# Remove temp repo
-rm -rf repo
+rm -rf ${GIT_CLONE}


### PR DESCRIPTION
This moves control of `_beats/dev-tools/packer/readme.md.j2` into the apm repo rather than trying to templatize it under beats.  README ends up as:

```
# Welcome to apm-server 7.0.0-alpha1

Sends events to Elasticsearch or Logstash

## Getting Started

To get started with apm-server, you need to set up Elasticsearch on your localhost first. After that, start apm-server with:

     ./apm-server -c apm-server.yml -e

This will start apm-server and send the data to your Elasticsearch instance. To load the dashboards for apm-server into Kibana, run:

    ./apm-server setup -e

For further steps visit the [Getting started](https://www.elastic.co/guide/en/apm/get-started/master/) guide.

## Documentation

Visit [Elastic.co Docs](https://www.elastic.co/guide/en/apm/server/master/) for the full apm-server documentation.
```
 
closes #356