### PR TITLE
Streamline logging

### DIFF
--- a/beater/handlers.go
+++ b/beater/handlers.go
@@ -113,7 +113,7 @@ func healthCheckHandler(_ ProcessorFactory, _ Config, _ reporter) http.Handler {
 
 type logContextKey string
 
-var loggerContextKey = logContextKey("logger")
+var reqLoggerContextKey = logContextKey("requestLogger")
 
 func logHandler(h http.Handler) http.Handler {
 	logger := logp.NewLogger("request")
@@ -126,9 +126,9 @@ func logHandler(h http.Handler) http.Handler {
 		reqLogger := logger.With("request_id", reqID)
 
 		lr := r.WithContext(
-			context.WithValue(r.Context(), loggerContextKey, reqLogger),
+			context.WithValue(r.Context(), reqLoggerContextKey, reqLogger),
 		)
-		lr.Context().Value(loggerContextKey)
+		lr.Context().Value(reqLoggerContextKey)
 
 		lw := utility.NewRecordingResponseWriter(w)
 
@@ -366,7 +366,7 @@ func sendStatus(w http.ResponseWriter, r *http.Request, code int, err error) {
 		return
 	}
 
-	logger, ok := r.Context().Value(loggerContextKey).(*logp.Logger)
+	logger, ok := r.Context().Value(reqLoggerContextKey).(*logp.Logger)
 	if ok {
 		logger.Errorw("error handling request", "error", err.Error())
 	} else {

--- a/beater/handlers.go
+++ b/beater/handlers.go
@@ -128,7 +128,6 @@ func logHandler(h http.Handler) http.Handler {
 		lr := r.WithContext(
 			context.WithValue(r.Context(), reqLoggerContextKey, reqLogger),
 		)
-		lr.Context().Value(reqLoggerContextKey)
 
 		lw := utility.NewRecordingResponseWriter(w)
 
@@ -139,9 +138,9 @@ func logHandler(h http.Handler) http.Handler {
 			"remote_address", extractIP(r), "user_agent", r.Header.Get("User-Agent"))
 
 		if lw.Code > 399 {
-			responseValid.Inc()
-		} else {
 			responseErrors.Inc()
+		} else {
+			responseValid.Inc()
 		}
 	})
 

--- a/utility/handlers.go
+++ b/utility/handlers.go
@@ -1,0 +1,17 @@
+package utility
+
+import "net/http"
+
+type recordingResponseWriter struct {
+	http.ResponseWriter
+	Code int
+}
+
+func NewRecordingResponseWriter(w http.ResponseWriter) *recordingResponseWriter {
+	return &recordingResponseWriter{w, http.StatusOK}
+}
+
+func (lrw *recordingResponseWriter) WriteHeader(code int) {
+	lrw.ResponseWriter.WriteHeader(code)
+	lrw.Code = code
+}


### PR DESCRIPTION
Initial work on streamlining logging and moving towards structured logging.

beats introduced structured logging. The fact that we output JSON on the command line was part of this and it's already merged in beats.

This PR only deals with what we can control in APM Server. I'm looking into if we can use a key-value style instead of the JSON when started with `-e`.

With this, we will always log something like this for each request:
```
2018-01-05T16:19:39.317+0100	INFO	[request]	beater/handlers.go:137	handled request	{"request_id": "180acb9f-2128-4955-97e6-2485b6330d8c", "response_code": 200, "method": "GET", "URL": "/healthcheck", "content_length": 0, "remote_address": "127.0.0.1", "user_agent": "Go-http-client/1.1"}
```

Errors get another line:

```
2018-01-05T16:19:52.433+0100	ERROR	[request]	beater/handlers.go:365	error handling request	{"request_id": "b54dde2e-590e-4084-9ffe-cded450de649", "error": "Problem validating JSON document against schema: I[#] S[#] doesn't validate with \"error#\"\n  I[#] S[#/required] missing properties: \"service\", \"errors\""}
2018-01-05T16:19:52.434+0100	INFO	[request]	beater/handlers.go:137	handled request	{"request_id": "b54dde2e-590e-4084-9ffe-cded450de649", "response_code": 400, "method": "POST", "URL": "/v1/errors", "content_length": 132, "remote_address": "127.0.0.1", "user_agent": "curl/7.54.0"}
```

closes https://github.com/elastic/apm-server/issues/431

  