### PR TITLE
update beats' deps too

### DIFF
--- a/script/update_beats.sh
+++ b/script/update_beats.sh
@@ -1,17 +1,24 @@
-#!/usr/bin/env bash -ex
+#!/usr/bin/env bash
+
+set -ex
 
 BEATS_VERSION="${BEATS_VERSION:-master}"
 
 # Find basedir and change to it
-BASEDIR=$(dirname "$0")/../_beats
+DIRNAME=$(dirname "$0")
+BASEDIR=${DIRNAME}/../_beats
 mkdir -p $BASEDIR
-cd $BASEDIR
+pushd $BASEDIR
 
 # Check out beats repo for updating
 GIT_CLONE=repo
-trap "{ rm -rf ${GIT_CLONE}; }" EXIT
+trap "{ rm -rf ${BASEDIR}/${GIT_CLONE}; }" EXIT
 
-git clone --depth 1 --branch ${BEATS_VERSION} https://github.com/elastic/beats.git ${GIT_CLONE}
+git clone https://github.com/elastic/beats.git ${GIT_CLONE}
+(
+    cd ${GIT_CLONE}
+    git checkout ${BEATS_VERSION}
+)
 
 # sync
 rsync -crpv --delete \
@@ -30,3 +37,9 @@ rsync -crpv --delete \
     --include="testing/***" \
     --exclude="*" \
     ${GIT_CLONE}/ .
+
+popd
+
+# use exactly the same beats revision rather than $BEATS_VERSION
+BEATS_REVISION=$(GIT_DIR=${BASEDIR}/${GIT_CLONE}/.git git rev-parse HEAD)
+${DIRNAME}/update_govendor_deps.py ${BEATS_REVISION}

--- a/script/update_beats.sh
+++ b/script/update_beats.sh
@@ -12,7 +12,7 @@ pushd $BASEDIR
 
 # Check out beats repo for updating
 GIT_CLONE=repo
-trap "{ rm -rf ${BASEDIR}/${GIT_CLONE}; }" EXIT
+trap "{ set +e;popd >/dev/null;set -e;rm -rf ${BASEDIR}/${GIT_CLONE}; }" EXIT
 
 git clone https://github.com/elastic/beats.git ${GIT_CLONE}
 (

--- a/script/update_govendor_deps.py
+++ b/script/update_govendor_deps.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+"""
+Update dependencies of the given govendor'd package.  For https://github.com/elastic/apm-server/issues/450.
+
+"""
+from __future__ import print_function
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+
+def find_packages(fp, origin, revision):
+    """generate list of packages for the given origin prefix not already on revision"""
+    j = json.load(fp)
+    for pkg in j['package']:
+        if pkg['revision'] != revision and pkg.get('origin', '').startswith(origin):
+            yield pkg['path']
+
+
+def main():
+    default_vendor_file = os.path.join(os.path.abspath(os.path.dirname(sys.argv[0])), '..', 'vendor', 'vendor.json')
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-f', '--vendor-file',
+                        default=default_vendor_file, type=argparse.FileType(mode='r'), help='path to vendor.json')
+    parser.add_argument('-n', '--dryrun', action='store_true',
+                        help='do not perform updates, just list what would be updated')
+    parser.add_argument('--origin', default='github.com/elastic/beats/', help='update deps of this origin prefix')
+    parser.add_argument('-q', '--quiet', dest='verbose', action='store_false', help='work quietly')
+    parser.add_argument('revision', help='update deps to this revision')
+    args = parser.parse_args()
+
+    packages = find_packages(args.vendor_file, args.origin, args.revision)
+
+    if args.dryrun:
+        for pkg in sorted(packages):
+            print(pkg)
+        return
+
+    # much faster to call govendor once and minimize the git reset & status calls it makes
+    update = ['{pkg}@{revision}'.format(pkg=pkg, revision=args.revision) for pkg in packages]
+    cmd = ['govendor', 'fetch'] + update
+    if args.verbose:
+        print(' '.join(cmd))
+    subprocess.check_call(cmd)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
fixes #450.  Adds 45 seconds to `make update-beats` on my machine.

includes 2 bug fixes too introduced in #449:
* `#!/usr/bin/env bash -ex` is not portable apparently, switched to `env bash` and a `set -ex`
* `BEATS_VERSION` specification only worked for branches
  
  