### PR TITLE
Avoid overwriting default config of beat.

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -10,14 +10,14 @@ import (
 )
 
 type beater struct {
-	config Config
+	config *Config
 	server *http.Server
 }
 
 // Creates beater
 func New(b *beat.Beat, ucfg *common.Config) (beat.Beater, error) {
 	beaterConfig := defaultConfig()
-	if err := ucfg.Unpack(&beaterConfig); err != nil {
+	if err := ucfg.Unpack(beaterConfig); err != nil {
 		return nil, fmt.Errorf("Error reading config file: %v", err)
 	}
 

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -21,8 +21,8 @@ func New(b *beat.Beat, ucfg *common.Config) (beat.Beater, error) {
 		return nil, fmt.Errorf("Error reading config file: %v", err)
 	}
 
-	if b.Config != nil && b.Config.Output.Name() != "elasticsearch" {
-		beaterConfig.Frontend.Sourcemapping.elasticsearch = b.Config.Output.Config()
+	if b.Config != nil && b.Config.Output.Name() == "elasticsearch" {
+		beaterConfig.setElasticsearch(b.Config.Output.Config())
 	}
 
 	bt := &beater{

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -21,7 +21,7 @@ func New(b *beat.Beat, ucfg *common.Config) (beat.Beater, error) {
 		return nil, fmt.Errorf("Error reading config file: %v", err)
 	}
 
-	if b.Config != nil && b.Config.Output.Name() != "" {
+	if b.Config != nil && b.Config.Output.Name() != "elasticsearch" {
 		beaterConfig.Frontend.Sourcemapping.elasticsearch = b.Config.Output.Config()
 	}
 

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -16,12 +16,12 @@ type beater struct {
 
 // Creates beater
 func New(b *beat.Beat, ucfg *common.Config) (beat.Beater, error) {
-	beaterConfig := defaultConfig
+	beaterConfig := defaultConfig()
 	if err := ucfg.Unpack(&beaterConfig); err != nil {
 		return nil, fmt.Errorf("Error reading config file: %v", err)
 	}
 
-	if b.Config.Output.Name() == "elasticsearch" {
+	if b.Config != nil && b.Config.Output.Name() != "" {
 		beaterConfig.Frontend.Sourcemapping.elasticsearch = b.Config.Output.Config()
 	}
 

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -22,14 +22,6 @@ import (
 	"github.com/elastic/beats/libbeat/publisher/queue/memqueue"
 )
 
-func TestEmptyBeatConfig(t *testing.T) {
-	b := beat.Beat{}
-	ucfgConfig := common.NewConfig()
-	beatBeater, err := New(&b, ucfgConfig)
-	assert.NoError(t, err)
-	assert.NotNil(t, beatBeater)
-}
-
 func TestBeatConfig(t *testing.T) {
 	truthy := true
 	tests := []struct {

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -26,7 +26,7 @@ func TestBeatConfig(t *testing.T) {
 	truthy := true
 	tests := []struct {
 		conf       map[string]interface{}
-		beaterConf Config
+		beaterConf *Config
 		msg        string
 	}{
 		{
@@ -62,7 +62,7 @@ func TestBeatConfig(t *testing.T) {
 					},
 				},
 			},
-			beaterConf: Config{
+			beaterConf: &Config{
 				Host:            "localhost:3000",
 				MaxUnzippedSize: 64,
 				MaxHeaderBytes:  8,
@@ -102,7 +102,7 @@ func TestBeatConfig(t *testing.T) {
 					},
 				},
 			},
-			beaterConf: Config{
+			beaterConf: &Config{
 				Host:            "localhost:3000",
 				MaxUnzippedSize: 64,
 				MaxHeaderBytes:  1048576,

--- a/beater/config.go
+++ b/beater/config.go
@@ -33,8 +33,8 @@ type Sourcemapping struct {
 	Cache *Cache `config:"cache"`
 	Index string `config:"index"`
 
-	elasticsearch *common.Config
-	accessor      utility.SmapAccessor
+	esConfig *common.Config
+	accessor utility.SmapAccessor
 }
 
 type Cache struct {
@@ -48,6 +48,12 @@ type SSLConfig struct {
 	Cert       string `config:"certificate"`
 }
 
+func (c *Config) setElasticsearch(esConfig *common.Config) {
+	if c != nil && c.Frontend.isEnabled() && c.Frontend.Sourcemapping != nil {
+		c.Frontend.Sourcemapping.esConfig = esConfig
+	}
+}
+
 func (c *SSLConfig) isEnabled() bool {
 	return c != nil && (c.Enabled == nil || *c.Enabled)
 }
@@ -57,7 +63,7 @@ func (c *FrontendConfig) isEnabled() bool {
 }
 
 func (s *Sourcemapping) isSetup() bool {
-	return s != nil && (s.elasticsearch != nil)
+	return s != nil && (s.esConfig != nil)
 }
 
 func (c *FrontendConfig) SmapAccessor() utility.SmapAccessor {
@@ -67,7 +73,7 @@ func (c *FrontendConfig) SmapAccessor() utility.SmapAccessor {
 			smapConfig := utility.SmapConfig{
 				CacheExpiration:      smap.Cache.Expiration,
 				CacheCleanupInterval: smap.Cache.CleanupInterval,
-				ElasticsearchConfig:  smap.elasticsearch,
+				ElasticsearchConfig:  smap.esConfig,
 				Index:                smap.Index,
 			}
 			smapAccessor, err := utility.NewSourcemapAccessor(smapConfig)

--- a/beater/config.go
+++ b/beater/config.go
@@ -81,25 +81,27 @@ func (c *FrontendConfig) SmapAccessor() utility.SmapAccessor {
 	return nil
 }
 
-var defaultConfig = Config{
-	Host:               "localhost:8200",
-	MaxUnzippedSize:    50 * 1024 * 1024, // 50mb
-	MaxHeaderBytes:     1048576,          // 1mb
-	ConcurrentRequests: 20,
-	ReadTimeout:        2 * time.Second,
-	WriteTimeout:       2 * time.Second,
-	ShutdownTimeout:    5 * time.Second,
-	SecretToken:        "",
-	Frontend: &FrontendConfig{
-		Enabled:      new(bool),
-		RateLimit:    10,
-		AllowOrigins: []string{"*"},
-		Sourcemapping: &Sourcemapping{
-			Cache: &Cache{
-				Expiration:      300,
-				CleanupInterval: 600,
+func defaultConfig() Config {
+	return Config{
+		Host:               "localhost:8200",
+		MaxUnzippedSize:    50 * 1024 * 1024, // 50mb
+		MaxHeaderBytes:     1048576,          // 1mb
+		ConcurrentRequests: 20,
+		ReadTimeout:        2 * time.Second,
+		WriteTimeout:       2 * time.Second,
+		ShutdownTimeout:    5 * time.Second,
+		SecretToken:        "",
+		Frontend: &FrontendConfig{
+			Enabled:      new(bool),
+			RateLimit:    10,
+			AllowOrigins: []string{"*"},
+			Sourcemapping: &Sourcemapping{
+				Cache: &Cache{
+					Expiration:      300 * time.Second,
+					CleanupInterval: 600 * time.Second,
+				},
+				Index: "apm",
 			},
-			Index: "apm",
 		},
-	},
+	}
 }

--- a/beater/config.go
+++ b/beater/config.go
@@ -87,8 +87,8 @@ func (c *FrontendConfig) SmapAccessor() utility.SmapAccessor {
 	return nil
 }
 
-func defaultConfig() Config {
-	return Config{
+func defaultConfig() *Config {
+	return &Config{
 		Host:               "localhost:8200",
 		MaxUnzippedSize:    50 * 1024 * 1024, // 50mb
 		MaxHeaderBytes:     1048576,          // 1mb

--- a/beater/config_test.go
+++ b/beater/config_test.go
@@ -3,6 +3,7 @@ package beater
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -30,16 +31,37 @@ func TestConfig(t *testing.T) {
 					"certificate": "1234cert",
 				},
         "concurrent_requests": 15,
+				"frontend": {
+					"enabled": true,
+					"rate_limit": 1000,
+					"allow_origins": ["example*"],
+					"sourcemapping": {
+						"cache": {
+							"expiration": 10,
+							"cleanup_interval": 20
+						},
+						"index": "apm-test*"
+					}
+				}
       }`),
 			expectedConfig: Config{
-				Host:               "localhost:3000",
-				MaxUnzippedSize:    64,
-				MaxHeaderBytes:     8,
-				ReadTimeout:        3000000000,
-				WriteTimeout:       4000000000,
-				ShutdownTimeout:    9000000000,
-				SecretToken:        "1234random",
-				SSL:                &SSLConfig{Enabled: &truthy, PrivateKey: "1234key", Cert: "1234cert"},
+				Host:            "localhost:3000",
+				MaxUnzippedSize: 64,
+				MaxHeaderBytes:  8,
+				ReadTimeout:     3000000000,
+				WriteTimeout:    4000000000,
+				ShutdownTimeout: 9000000000,
+				SecretToken:     "1234random",
+				SSL:             &SSLConfig{Enabled: &truthy, PrivateKey: "1234key", Cert: "1234cert"},
+				Frontend: &FrontendConfig{
+					Enabled:      &truthy,
+					RateLimit:    1000,
+					AllowOrigins: []string{"example*"},
+					Sourcemapping: &Sourcemapping{
+						Cache: &Cache{Expiration: 10 * time.Second, CleanupInterval: 20 * time.Second},
+						Index: "apm-test*",
+					},
+				},
 				ConcurrentRequests: 15,
 			},
 		},
@@ -53,6 +75,12 @@ func TestConfig(t *testing.T) {
         "shutdown_timeout": 5s,
 				"secret_token": "1234random",
         "concurrent_requests": 20,
+				"ssl": {},
+				"frontend": {
+					"sourcemapping": {
+						"cache": {},
+					}
+				}
       }`),
 			expectedConfig: Config{
 				Host:               "localhost:8200",
@@ -62,8 +90,17 @@ func TestConfig(t *testing.T) {
 				WriteTimeout:       2000000000,
 				ShutdownTimeout:    5000000000,
 				SecretToken:        "1234random",
-				SSL:                nil,
+				SSL:                &SSLConfig{Enabled: nil, PrivateKey: "", Cert: ""},
 				ConcurrentRequests: 20,
+				Frontend: &FrontendConfig{
+					Enabled:      nil,
+					RateLimit:    0,
+					AllowOrigins: nil,
+					Sourcemapping: &Sourcemapping{
+						Cache: &Cache{Expiration: 0 * time.Second, CleanupInterval: 0 * time.Second},
+						Index: "",
+					},
+				},
 			},
 		},
 		{
@@ -78,6 +115,7 @@ func TestConfig(t *testing.T) {
 				SecretToken:        "",
 				SSL:                nil,
 				ConcurrentRequests: 0,
+				Frontend:           nil,
 			},
 		},
 	}

--- a/beater/onboarding.go
+++ b/beater/onboarding.go
@@ -8,7 +8,7 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 )
 
-func notifyListening(config Config, reporter reporter) {
+func notifyListening(config *Config, reporter reporter) {
 
 	var isServerUp = func() bool {
 		secure := config.SSL.isEnabled()

--- a/beater/onboarding_test.go
+++ b/beater/onboarding_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNotifyUpServerDown(t *testing.T) {
-	config := defaultConfig
+	config := defaultConfig()
 	var saved []beat.Event
 	var reporter = func(events []beat.Event) error {
 		saved = append(saved, events...)

--- a/beater/server.go
+++ b/beater/server.go
@@ -12,7 +12,7 @@ import (
 
 type reporter func([]beat.Event) error
 
-func newServer(config Config, report reporter) *http.Server {
+func newServer(config *Config, report reporter) *http.Server {
 	mux := newMuxer(config, report)
 
 	return &http.Server{
@@ -24,7 +24,7 @@ func newServer(config Config, report reporter) *http.Server {
 	}
 }
 
-func run(server *http.Server, config Config) error {
+func run(server *http.Server, config *Config) error {
 	logp.Info("Starting apm-server [%s]. Hit CTRL-C to stop it.", version.String())
 	logp.Info("Listening on: %s", server.Addr)
 	switch config.Frontend.isEnabled() {

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -218,7 +218,7 @@ func setupServer(t *testing.T, ssl *SSLConfig) (*http.Server, func()) {
 	}
 
 	host := randomAddr()
-	cfg := defaultConfig
+	cfg := defaultConfig()
 	cfg.Host = host
 	cfg.SSL = ssl
 

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -73,14 +73,14 @@ func TestServerFrontendSwitch(t *testing.T) {
 	rec := httptest.NewRecorder()
 	apm.Handler.ServeHTTP(rec, req)
 	apm.Handler = newMuxer(
-		Config{
+		&Config{
 			Frontend: &FrontendConfig{Enabled: new(bool), AllowOrigins: []string{"*"}}},
 		nil)
 	assert.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
 
 	true := true
 	apm.Handler = newMuxer(
-		Config{
+		&Config{
 			Frontend: &FrontendConfig{Enabled: &true, AllowOrigins: []string{"*"}}},
 		nil)
 	rec = httptest.NewRecorder()
@@ -133,7 +133,7 @@ func TestServerCORS(t *testing.T) {
 
 	for idx, test := range tests {
 		apm.Handler = newMuxer(
-			Config{
+			&Config{
 				MaxUnzippedSize: 1024 * 1024,
 				Frontend: &FrontendConfig{
 					Enabled:      &true,


### PR DESCRIPTION
* Add config tests
* Change handling to not overwrite default config values.

The `defaultConfig` is only used once in production code. However, adding the config tests revealed that the beater currently changes the `defaultConfig` when [unpacking the ucfg](https://github.com/simitt/apm-server/blob/master/beater/beater.go#L19).
This change avoids having the `defaultConfig` overwritten, which could lead to issues in the future when used after initializing the beat.