### PR TITLE
[6.x] Avoid overwriting default config of beat. (#464)

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -10,19 +10,19 @@ import (
 )
 
 type beater struct {
-	config Config
+	config *Config
 	server *http.Server
 }
 
 // Creates beater
 func New(b *beat.Beat, ucfg *common.Config) (beat.Beater, error) {
-	beaterConfig := defaultConfig
-	if err := ucfg.Unpack(&beaterConfig); err != nil {
+	beaterConfig := defaultConfig()
+	if err := ucfg.Unpack(beaterConfig); err != nil {
 		return nil, fmt.Errorf("Error reading config file: %v", err)
 	}
 
-	if b.Config.Output.Name() == "elasticsearch" {
-		beaterConfig.Frontend.Sourcemapping.elasticsearch = b.Config.Output.Config()
+	if b.Config != nil && b.Config.Output.Name() == "elasticsearch" {
+		beaterConfig.setElasticsearch(b.Config.Output.Config())
 	}
 
 	bt := &beater{

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -7,9 +7,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/apm-server/tests"
 	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/monitoring"
 	"github.com/elastic/beats/libbeat/outputs"
 	pubs "github.com/elastic/beats/libbeat/publisher"
@@ -17,6 +21,124 @@ import (
 	"github.com/elastic/beats/libbeat/publisher/queue"
 	"github.com/elastic/beats/libbeat/publisher/queue/memqueue"
 )
+
+func TestBeatConfig(t *testing.T) {
+	truthy := true
+	tests := []struct {
+		conf       map[string]interface{}
+		beaterConf *Config
+		msg        string
+	}{
+		{
+			conf:       map[string]interface{}{},
+			beaterConf: defaultConfig(),
+			msg:        "Default config created for empty config.",
+		},
+		{
+			conf: map[string]interface{}{
+				"host":              "localhost:3000",
+				"max_unzipped_size": 64,
+				"max_header_bytes":  8,
+				"read_timeout":      3 * time.Second,
+				"write_timeout":     4 * time.Second,
+				"shutdown_timeout":  9 * time.Second,
+				"secret_token":      "1234random",
+				"ssl": map[string]interface{}{
+					"enabled":     true,
+					"key":         "1234key",
+					"certificate": "1234cert",
+				},
+				"concurrent_requests": 15,
+				"frontend": map[string]interface{}{
+					"enabled":       true,
+					"rate_limit":    1000,
+					"allow_origins": []string{"example*"},
+					"sourcemapping": map[string]interface{}{
+						"cache": map[string]interface{}{
+							"expiration":       10,
+							"cleanup_interval": 20,
+						},
+						"index": "apm-test*",
+					},
+				},
+			},
+			beaterConf: &Config{
+				Host:            "localhost:3000",
+				MaxUnzippedSize: 64,
+				MaxHeaderBytes:  8,
+				ReadTimeout:     3000000000,
+				WriteTimeout:    4000000000,
+				ShutdownTimeout: 9000000000,
+				SecretToken:     "1234random",
+				SSL:             &SSLConfig{Enabled: &truthy, PrivateKey: "1234key", Cert: "1234cert"},
+				Frontend: &FrontendConfig{
+					Enabled:      &truthy,
+					RateLimit:    1000,
+					AllowOrigins: []string{"example*"},
+					Sourcemapping: &Sourcemapping{
+						Cache: &Cache{Expiration: 10 * time.Second, CleanupInterval: 20 * time.Second},
+						Index: "apm-test*",
+					},
+				},
+				ConcurrentRequests: 15,
+			},
+			msg: "Given config overwrites default",
+		},
+		{
+			conf: map[string]interface{}{
+				"host":              "localhost:3000",
+				"max_unzipped_size": 64,
+				"secret_token":      "1234random",
+				"ssl": map[string]interface{}{
+					"enabled": false,
+				},
+				"concurrent_requests": 15,
+				"frontend": map[string]interface{}{
+					"enabled": true,
+					"sourcemapping": map[string]interface{}{
+						"cache": map[string]interface{}{
+							"expiration": 10,
+						},
+					},
+				},
+			},
+			beaterConf: &Config{
+				Host:            "localhost:3000",
+				MaxUnzippedSize: 64,
+				MaxHeaderBytes:  1048576,
+				ReadTimeout:     2000000000,
+				WriteTimeout:    2000000000,
+				ShutdownTimeout: 5000000000,
+				SecretToken:     "1234random",
+				SSL:             &SSLConfig{Enabled: new(bool)},
+				Frontend: &FrontendConfig{
+					Enabled:      &truthy,
+					RateLimit:    10,
+					AllowOrigins: []string{"*"},
+					Sourcemapping: &Sourcemapping{
+						Cache: &Cache{
+							Expiration:      10 * time.Second,
+							CleanupInterval: 600 * time.Second,
+						},
+						Index: "apm",
+					},
+				},
+				ConcurrentRequests: 15,
+			},
+			msg: "Given config merged with default",
+		},
+	}
+
+	for _, test := range tests {
+		ucfgConfig, err := common.NewConfigFrom(test.conf)
+		assert.NoError(t, err)
+		btr, err := New(&beat.Beat{}, ucfgConfig)
+		assert.NoError(t, err)
+		assert.NotNil(t, btr)
+		bt := btr.(*beater)
+		assert.Equal(t, test.beaterConf, bt.config, test.msg)
+	}
+}
 
 /*
 Run the benchmarks as follows:
@@ -85,7 +207,7 @@ func SetupServer(b *testing.B) *http.ServeMux {
 	if err != nil {
 		b.Fatal(err)
 	}
-	return newMuxer(defaultConfig, pub.Send)
+	return newMuxer(defaultConfig(), pub.Send)
 }
 
 func pluralize(entity string) string {

--- a/beater/config_test.go
+++ b/beater/config_test.go
@@ -3,6 +3,7 @@ package beater
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -30,16 +31,37 @@ func TestConfig(t *testing.T) {
 					"certificate": "1234cert",
 				},
         "concurrent_requests": 15,
+				"frontend": {
+					"enabled": true,
+					"rate_limit": 1000,
+					"allow_origins": ["example*"],
+					"sourcemapping": {
+						"cache": {
+							"expiration": 10,
+							"cleanup_interval": 20
+						},
+						"index": "apm-test*"
+					}
+				}
       }`),
 			expectedConfig: Config{
-				Host:               "localhost:3000",
-				MaxUnzippedSize:    64,
-				MaxHeaderBytes:     8,
-				ReadTimeout:        3000000000,
-				WriteTimeout:       4000000000,
-				ShutdownTimeout:    9000000000,
-				SecretToken:        "1234random",
-				SSL:                &SSLConfig{Enabled: &truthy, PrivateKey: "1234key", Cert: "1234cert"},
+				Host:            "localhost:3000",
+				MaxUnzippedSize: 64,
+				MaxHeaderBytes:  8,
+				ReadTimeout:     3000000000,
+				WriteTimeout:    4000000000,
+				ShutdownTimeout: 9000000000,
+				SecretToken:     "1234random",
+				SSL:             &SSLConfig{Enabled: &truthy, PrivateKey: "1234key", Cert: "1234cert"},
+				Frontend: &FrontendConfig{
+					Enabled:      &truthy,
+					RateLimit:    1000,
+					AllowOrigins: []string{"example*"},
+					Sourcemapping: &Sourcemapping{
+						Cache: &Cache{Expiration: 10 * time.Second, CleanupInterval: 20 * time.Second},
+						Index: "apm-test*",
+					},
+				},
 				ConcurrentRequests: 15,
 			},
 		},
@@ -53,6 +75,12 @@ func TestConfig(t *testing.T) {
         "shutdown_timeout": 5s,
 				"secret_token": "1234random",
         "concurrent_requests": 20,
+				"ssl": {},
+				"frontend": {
+					"sourcemapping": {
+						"cache": {},
+					}
+				}
       }`),
 			expectedConfig: Config{
 				Host:               "localhost:8200",
@@ -62,8 +90,17 @@ func TestConfig(t *testing.T) {
 				WriteTimeout:       2000000000,
 				ShutdownTimeout:    5000000000,
 				SecretToken:        "1234random",
-				SSL:                nil,
+				SSL:                &SSLConfig{Enabled: nil, PrivateKey: "", Cert: ""},
 				ConcurrentRequests: 20,
+				Frontend: &FrontendConfig{
+					Enabled:      nil,
+					RateLimit:    0,
+					AllowOrigins: nil,
+					Sourcemapping: &Sourcemapping{
+						Cache: &Cache{Expiration: 0 * time.Second, CleanupInterval: 0 * time.Second},
+						Index: "",
+					},
+				},
 			},
 		},
 		{
@@ -78,6 +115,7 @@ func TestConfig(t *testing.T) {
 				SecretToken:        "",
 				SSL:                nil,
 				ConcurrentRequests: 0,
+				Frontend:           nil,
 			},
 		},
 	}

--- a/beater/onboarding.go
+++ b/beater/onboarding.go
@@ -8,7 +8,7 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 )
 
-func notifyListening(config Config, reporter reporter) {
+func notifyListening(config *Config, reporter reporter) {
 
 	var isServerUp = func() bool {
 		secure := config.SSL.isEnabled()

--- a/beater/onboarding_test.go
+++ b/beater/onboarding_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNotifyUpServerDown(t *testing.T) {
-	config := defaultConfig
+	config := defaultConfig()
 	var saved []beat.Event
 	var reporter = func(events []beat.Event) error {
 		saved = append(saved, events...)

--- a/beater/server.go
+++ b/beater/server.go
@@ -12,7 +12,7 @@ import (
 
 type reporter func([]beat.Event) error
 
-func newServer(config Config, report reporter) *http.Server {
+func newServer(config *Config, report reporter) *http.Server {
 	mux := newMuxer(config, report)
 
 	return &http.Server{
@@ -24,7 +24,7 @@ func newServer(config Config, report reporter) *http.Server {
 	}
 }
 
-func run(server *http.Server, config Config) error {
+func run(server *http.Server, config *Config) error {
 	logp.Info("Starting apm-server [%s]. Hit CTRL-C to stop it.", version.String())
 	logp.Info("Listening on: %s", server.Addr)
 	switch config.Frontend.isEnabled() {

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -73,14 +73,14 @@ func TestServerFrontendSwitch(t *testing.T) {
 	rec := httptest.NewRecorder()
 	apm.Handler.ServeHTTP(rec, req)
 	apm.Handler = newMuxer(
-		Config{
+		&Config{
 			Frontend: &FrontendConfig{Enabled: new(bool), AllowOrigins: []string{"*"}}},
 		nil)
 	assert.Equal(t, http.StatusForbidden, rec.Code, rec.Body.String())
 
 	true := true
 	apm.Handler = newMuxer(
-		Config{
+		&Config{
 			Frontend: &FrontendConfig{Enabled: &true, AllowOrigins: []string{"*"}}},
 		nil)
 	rec = httptest.NewRecorder()
@@ -133,7 +133,7 @@ func TestServerCORS(t *testing.T) {
 
 	for idx, test := range tests {
 		apm.Handler = newMuxer(
-			Config{
+			&Config{
 				MaxUnzippedSize: 1024 * 1024,
 				Frontend: &FrontendConfig{
 					Enabled:      &true,
@@ -218,7 +218,7 @@ func setupServer(t *testing.T, ssl *SSLConfig) (*http.Server, func()) {
 	}
 
 	host := randomAddr()
-	cfg := defaultConfig
+	cfg := defaultConfig()
 	cfg.Host = host
 	cfg.SSL = ssl
 


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Avoid overwriting default config of beat.  (#464)