### PR TITLE
create listener separate from starting server

### DIFF
--- a/beater/onboarding_test.go
+++ b/beater/onboarding_test.go
@@ -1,6 +1,7 @@
 package beater
 
 import (
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,11 +17,16 @@ func TestNotifyUpServerDown(t *testing.T) {
 		return nil
 	}
 
+	lis, err := net.Listen("tcp", "localhost:0")
+	assert.NoError(t, err)
+	defer lis.Close()
+	config.Host = lis.Addr().String()
+
 	server := newServer(config, reporter)
-	go run(server, config)
+	go run(server, lis, config)
 
 	notifyListening(config, reporter)
 
 	listening := saved[0].Fields["listening"].(string)
-	assert.Equal(t, "localhost:8200", listening)
+	assert.Equal(t, config.Host, listening)
 }


### PR DESCRIPTION
Inspired by #466, this doesn't perfectly resolve that, but makes it even less likely.  This does resolve issues running `server_test`s while port 8200 is already in use - that currently hangs until `waitForServer` times out.  It also eliminates suspected issues from opening a random port, closing it, and immediately reopening it via `randomAddr()`.