### PR TITLE
[6.x] Cleanup sourcemap config. (#475)

### DIFF
--- a/_meta/beat.reference.yml
+++ b/_meta/beat.reference.yml
@@ -36,9 +36,12 @@ apm-server:
     #allow_origins : *
 
     #sourcemapping:
+
+      # Source Maps are are fetched from Elasticsearch and then kept in an in-memory cache for a certain time.
+      # The `cache.expiration` determines how long a Source Map should be cached before fetching it again from Elasticsearch.
+      # Note that values configured without a time unit will be interpreted as seconds.
       #cache:
-        #expiration: 300 #seconds
-        #cleanup_interval: 600 #seconds
+        #expiration: 5m
 
       # Sourcemaps are stored in the same index as transaction and error documents.
       # If the default index pattern at 'outputs.elasticsearch.index' is changed,

--- a/apm-server.reference.yml
+++ b/apm-server.reference.yml
@@ -36,9 +36,12 @@ apm-server:
     #allow_origins : *
 
     #sourcemapping:
+
+      # Source Maps are are fetched from Elasticsearch and then kept in an in-memory cache for a certain time.
+      # The `cache.expiration` determines how long a Source Map should be cached before fetching it again from Elasticsearch.
+      # Note that values configured without a time unit will be interpreted as seconds.
       #cache:
-        #expiration: 300 #seconds
-        #cleanup_interval: 600 #seconds
+        #expiration: 5m
 
       # Sourcemaps are stored in the same index as transaction and error documents.
       # If the default index pattern at 'outputs.elasticsearch.index' is changed,

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -55,8 +55,7 @@ func TestBeatConfig(t *testing.T) {
 					"allow_origins": []string{"example*"},
 					"sourcemapping": map[string]interface{}{
 						"cache": map[string]interface{}{
-							"expiration":       10,
-							"cleanup_interval": 20,
+							"expiration": 5 * time.Minute,
 						},
 						"index": "apm-test*",
 					},
@@ -76,7 +75,7 @@ func TestBeatConfig(t *testing.T) {
 					RateLimit:    1000,
 					AllowOrigins: []string{"example*"},
 					Sourcemapping: &Sourcemapping{
-						Cache: &Cache{Expiration: 10 * time.Second, CleanupInterval: 20 * time.Second},
+						Cache: &Cache{Expiration: 5 * time.Minute},
 						Index: "apm-test*",
 					},
 				},
@@ -97,7 +96,7 @@ func TestBeatConfig(t *testing.T) {
 					"enabled": true,
 					"sourcemapping": map[string]interface{}{
 						"cache": map[string]interface{}{
-							"expiration": 10,
+							"expiration": 7,
 						},
 					},
 				},
@@ -117,8 +116,7 @@ func TestBeatConfig(t *testing.T) {
 					AllowOrigins: []string{"*"},
 					Sourcemapping: &Sourcemapping{
 						Cache: &Cache{
-							Expiration:      10 * time.Second,
-							CleanupInterval: 600 * time.Second,
+							Expiration: 7 * time.Second,
 						},
 						Index: "apm",
 					},

--- a/beater/config.go
+++ b/beater/config.go
@@ -36,8 +36,7 @@ type Sourcemapping struct {
 }
 
 type Cache struct {
-	Expiration      time.Duration `config:"expiration"`
-	CleanupInterval time.Duration `config:"cleanup_interval"`
+	Expiration time.Duration `config:"expiration"`
 }
 
 type SSLConfig struct {
@@ -73,10 +72,9 @@ func (c *FrontendConfig) SmapMapper() (sourcemap.Mapper, error) {
 		return c.Sourcemapping.mapper, nil
 	}
 	smapConfig := sourcemap.Config{
-		CacheExpiration:      smap.Cache.Expiration,
-		CacheCleanupInterval: smap.Cache.CleanupInterval,
-		ElasticsearchConfig:  smap.esConfig,
-		Index:                smap.Index + "*",
+		CacheExpiration:     smap.Cache.Expiration,
+		ElasticsearchConfig: smap.esConfig,
+		Index:               smap.Index + "*",
 	}
 	smapMapper, err := sourcemap.NewSmapMapper(smapConfig)
 	if err != nil {
@@ -102,8 +100,7 @@ func defaultConfig() *Config {
 			AllowOrigins: []string{"*"},
 			Sourcemapping: &Sourcemapping{
 				Cache: &Cache{
-					Expiration:      300 * time.Second,
-					CleanupInterval: 600 * time.Second,
+					Expiration: 5 * time.Minute,
 				},
 				Index: "apm",
 			},

--- a/beater/config_test.go
+++ b/beater/config_test.go
@@ -37,8 +37,7 @@ func TestConfig(t *testing.T) {
 					"allow_origins": ["example*"],
 					"sourcemapping": {
 						"cache": {
-							"expiration": 10,
-							"cleanup_interval": 20
+							"expiration": 10m,
 						},
 						"index": "apm-test*"
 					}
@@ -58,7 +57,7 @@ func TestConfig(t *testing.T) {
 					RateLimit:    1000,
 					AllowOrigins: []string{"example*"},
 					Sourcemapping: &Sourcemapping{
-						Cache: &Cache{Expiration: 10 * time.Second, CleanupInterval: 20 * time.Second},
+						Cache: &Cache{Expiration: 10 * time.Minute},
 						Index: "apm-test*",
 					},
 				},
@@ -97,7 +96,7 @@ func TestConfig(t *testing.T) {
 					RateLimit:    0,
 					AllowOrigins: nil,
 					Sourcemapping: &Sourcemapping{
-						Cache: &Cache{Expiration: 0 * time.Second, CleanupInterval: 0 * time.Second},
+						Cache: &Cache{Expiration: 0 * time.Second},
 						Index: "",
 					},
 				},

--- a/sourcemap/accessor.go
+++ b/sourcemap/accessor.go
@@ -26,8 +26,7 @@ func NewSmapAccessor(config Config) (*SmapAccessor, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	cache, err := newCache(config.CacheExpiration, config.CacheCleanupInterval)
+	cache, err := newCache(config.CacheExpiration)
 	if err != nil {
 		return nil, err
 	}

--- a/sourcemap/accessor_test.go
+++ b/sourcemap/accessor_test.go
@@ -158,9 +158,8 @@ func getFakeSmap() *sourcemap.Consumer {
 
 func getFakeConfig() Config {
 	return Config{
-		ElasticsearchConfig:  getFakeESConfig(nil),
-		CacheExpiration:      1 * time.Second,
-		CacheCleanupInterval: 100 * time.Second,
-		Index:                "test-index",
+		ElasticsearchConfig: getFakeESConfig(nil),
+		CacheExpiration:     1 * time.Second,
+		Index:               "test-index",
 	}
 }

--- a/sourcemap/mapper.go
+++ b/sourcemap/mapper.go
@@ -17,10 +17,9 @@ type SmapMapper struct {
 }
 
 type Config struct {
-	CacheExpiration      time.Duration //seconds
-	CacheCleanupInterval time.Duration //seconds
-	ElasticsearchConfig  *common.Config
-	Index                string
+	CacheExpiration     time.Duration
+	ElasticsearchConfig *common.Config
+	Index               string
 }
 
 type Mapping struct {


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Cleanup sourcemap config.  (#475)