### PR TITLE
[6.x] Detect library_frames for frontend stacktraces. (#481)

### DIFF
--- a/_meta/beat.reference.yml
+++ b/_meta/beat.reference.yml
@@ -35,6 +35,10 @@ apm-server:
     # If an item in the list is a single *, everything will be allowed
     #allow_origins : *
 
+    # Regexp to be matched against a stacktrace frame's `file_name` and `abs_path` attributes,
+    # If the regexp matches, the stacktrace frame is considered to be a library frame.
+    #library_pattern: "node_modules|bower_components|~"
+
     #sourcemapping:
 
       # Source Maps are are fetched from Elasticsearch and then kept in an in-memory cache for a certain time.

--- a/apm-server.reference.yml
+++ b/apm-server.reference.yml
@@ -35,6 +35,10 @@ apm-server:
     # If an item in the list is a single *, everything will be allowed
     #allow_origins : *
 
+    # Regexp to be matched against a stacktrace frame's `file_name` and `abs_path` attributes,
+    # If the regexp matches, the stacktrace frame is considered to be a library frame.
+    #library_pattern: "node_modules|bower_components|~"
+
     #sourcemapping:
 
       # Source Maps are are fetched from Elasticsearch and then kept in an in-memory cache for a certain time.

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -59,6 +59,7 @@ func TestBeatConfig(t *testing.T) {
 						},
 						"index": "apm-test*",
 					},
+					"library_pattern": "^custom",
 				},
 			},
 			beaterConf: &Config{
@@ -78,6 +79,7 @@ func TestBeatConfig(t *testing.T) {
 						Cache: &Cache{Expiration: 5 * time.Minute},
 						Index: "apm-test*",
 					},
+					LibraryPattern: "^custom",
 				},
 				ConcurrentRequests: 15,
 			},
@@ -89,7 +91,7 @@ func TestBeatConfig(t *testing.T) {
 				"max_unzipped_size": 64,
 				"secret_token":      "1234random",
 				"ssl": map[string]interface{}{
-					"enabled": false,
+					"enabled": true,
 				},
 				"concurrent_requests": 15,
 				"frontend": map[string]interface{}{
@@ -109,7 +111,7 @@ func TestBeatConfig(t *testing.T) {
 				WriteTimeout:    2000000000,
 				ShutdownTimeout: 5000000000,
 				SecretToken:     "1234random",
-				SSL:             &SSLConfig{Enabled: new(bool)},
+				SSL:             &SSLConfig{Enabled: &truthy, PrivateKey: "", Cert: ""},
 				Frontend: &FrontendConfig{
 					Enabled:      &truthy,
 					RateLimit:    10,
@@ -120,6 +122,7 @@ func TestBeatConfig(t *testing.T) {
 						},
 						Index: "apm",
 					},
+					LibraryPattern: "node_modules|bower_components|~",
 				},
 				ConcurrentRequests: 15,
 			},

--- a/beater/config.go
+++ b/beater/config.go
@@ -21,10 +21,11 @@ type Config struct {
 }
 
 type FrontendConfig struct {
-	Enabled       *bool          `config:"enabled"`
-	RateLimit     int            `config:"rate_limit"`
-	AllowOrigins  []string       `config:"allow_origins"`
-	Sourcemapping *Sourcemapping `config:"sourcemapping"`
+	Enabled        *bool          `config:"enabled"`
+	RateLimit      int            `config:"rate_limit"`
+	AllowOrigins   []string       `config:"allow_origins"`
+	LibraryPattern string         `config:"library_pattern"`
+	Sourcemapping  *Sourcemapping `config:"sourcemapping"`
 }
 
 type Sourcemapping struct {
@@ -104,6 +105,7 @@ func defaultConfig() *Config {
 				},
 				Index: "apm",
 			},
+			LibraryPattern: "node_modules|bower_components|~",
 		},
 	}
 }

--- a/beater/config_test.go
+++ b/beater/config_test.go
@@ -40,7 +40,8 @@ func TestConfig(t *testing.T) {
 							"expiration": 10m,
 						},
 						"index": "apm-test*"
-					}
+					},
+					"library_pattern": "pattern",
 				}
       }`),
 			expectedConfig: Config{
@@ -60,6 +61,7 @@ func TestConfig(t *testing.T) {
 						Cache: &Cache{Expiration: 10 * time.Minute},
 						Index: "apm-test*",
 					},
+					LibraryPattern: "pattern",
 				},
 				ConcurrentRequests: 15,
 			},
@@ -77,7 +79,6 @@ func TestConfig(t *testing.T) {
 				"ssl": {},
 				"frontend": {
 					"sourcemapping": {
-						"cache": {},
 					}
 				}
       }`),
@@ -96,7 +97,6 @@ func TestConfig(t *testing.T) {
 					RateLimit:    0,
 					AllowOrigins: nil,
 					Sourcemapping: &Sourcemapping{
-						Cache: &Cache{Expiration: 0 * time.Second},
 						Index: "",
 					},
 				},

--- a/beater/handlers.go
+++ b/beater/handlers.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"regexp"
 	"strings"
 
 	lru "github.com/hashicorp/golang-lru"
@@ -94,7 +95,10 @@ func frontendHandler(pf ProcessorFactory, config *Config, report reporter) http.
 	if err != nil {
 		logp.Err(err.Error())
 	}
-	prConfig := processor.Config{SmapMapper: smapper}
+	prConfig := processor.Config{
+		SmapMapper:     smapper,
+		LibraryPattern: regexp.MustCompile(config.Frontend.LibraryPattern),
+	}
 	return logHandler(
 		killSwitchHandler(config.Frontend.isEnabled(),
 			ipRateLimitHandler(config.Frontend.RateLimit,

--- a/processor/error/package_tests/TestProcessErrorFrontendMinified.approved.json
+++ b/processor/error/package_tests/TestProcessErrorFrontendMinified.approved.json
@@ -35,6 +35,7 @@
                             "abs_path": "http://localhost:8000/test/e2e/general-usecase/bundle.js.map",
                             "filename": "webpack:///webpack/bootstrap 6002740481c9666b0d38",
                             "function": "\u003canonymous\u003e",
+                            "library_frame": true,
                             "line": {
                                 "column": 0,
                                 "number": 5
@@ -47,6 +48,7 @@
                             "abs_path": "http://localhost:8000/test/e2e/general-usecase/bundle.js.map",
                             "filename": "webpack:///webpack/bootstrap 6002740481c9666b0d38",
                             "function": "__webpack_require__",
+                            "library_frame": true,
                             "line": {
                                 "column": 0,
                                 "number": 33
@@ -59,6 +61,7 @@
                             "abs_path": "http://localhost:8000/test/e2e/general-usecase/bundle.js.map",
                             "filename": "webpack:///webpack/bootstrap 6002740481c9666b0d38",
                             "function": "runTask",
+                            "library_frame": true,
                             "line": {
                                 "column": 0,
                                 "number": 5
@@ -71,6 +74,7 @@
                             "abs_path": "http://localhost:8000/test/e2e/general-usecase/bundle.js.map",
                             "filename": "webpack:///webpack/bootstrap 6002740481c9666b0d38",
                             "function": "invoke",
+                            "library_frame": true,
                             "line": {
                                 "column": 0,
                                 "number": 39
@@ -83,6 +87,7 @@
                             "abs_path": "http://localhost:8000/test/e2e/general-usecase/bundle.js.map",
                             "filename": "webpack:///webpack/bootstrap 6002740481c9666b0d38",
                             "function": "moduleId",
+                            "library_frame": true,
                             "line": {
                                 "column": 0,
                                 "number": 8
@@ -103,6 +108,7 @@
                             "abs_path": "http://localhost:8000/test/e2e/general-usecase/bundle.js.map",
                             "filename": "webpack:///webpack/bootstrap 6002740481c9666b0d38",
                             "function": "\u003canonymous\u003e",
+                            "library_frame": true,
                             "line": {
                                 "column": 0,
                                 "number": 5

--- a/processor/error/package_tests/TestProcessErrorFrontendNoSmap.approved.json
+++ b/processor/error/package_tests/TestProcessErrorFrontendNoSmap.approved.json
@@ -21,6 +21,7 @@
                             "abs_path": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.js.map",
                             "filename": "test/e2e/general-usecase/app.e2e-bundle.js",
                             "function": "\u003canonymous\u003e",
+                            "library_frame": true,
                             "line": {
                                 "column": 9,
                                 "number": 5463
@@ -34,6 +35,7 @@
                             "abs_path": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.js.map",
                             "filename": "test/e2e/general-usecase/app.e2e-bundle.js",
                             "function": "invokeTask",
+                            "library_frame": true,
                             "line": {
                                 "column": 181,
                                 "number": 3630
@@ -47,6 +49,7 @@
                             "abs_path": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.js.map",
                             "filename": "test/e2e/general-usecase/app.e2e-bundle.js",
                             "function": "runTask",
+                            "library_frame": true,
                             "line": {
                                 "column": 51,
                                 "number": 3433
@@ -60,6 +63,7 @@
                             "abs_path": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.js.map",
                             "filename": "test/e2e/general-usecase/app.e2e-bundle.js",
                             "function": "invoke",
+                            "library_frame": true,
                             "line": {
                                 "column": 42,
                                 "number": 3689
@@ -73,6 +77,7 @@
                             "abs_path": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.js.map",
                             "filename": "test/e2e/general-usecase/app.e2e-bundle.js",
                             "function": "timer",
+                            "library_frame": true,
                             "line": {
                                 "column": 33,
                                 "number": 4737

--- a/processor/error/package_tests/processor_test.go
+++ b/processor/error/package_tests/processor_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	s "github.com/go-sourcemap/sourcemap"
@@ -34,7 +35,9 @@ func TestProcessorFrontendMinifiedSmapOK(t *testing.T) {
 		{Name: "TestProcessErrorFrontendNoSmap", Path: "data/valid/error/frontend_app.e2e-bundle.json"},
 	}
 	mapper := sourcemap.SmapMapper{Accessor: &fakeAcc{}}
-	conf := processor.Config{SmapMapper: &mapper}
+	conf := processor.Config{
+		SmapMapper:     &mapper,
+		LibraryPattern: regexp.MustCompile("/test/e2e|~")}
 	tests.TestProcessRequests(t, er.NewProcessor(&conf), requestInfo, map[string]string{})
 }
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"regexp"
 	"time"
 
 	"github.com/elastic/apm-server/sourcemap"
@@ -18,7 +19,8 @@ type Processor interface {
 }
 
 type Config struct {
-	SmapMapper sourcemap.Mapper
+	SmapMapper     sourcemap.Mapper
+	LibraryPattern *regexp.Regexp
 }
 
 func CreateDoc(timestamp time.Time, docMappings []utility.DocMapping) beat.Event {

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -11,6 +11,7 @@ apm-server:
   frontend.enabled: {{ enable_frontend }}
   frontend.rate_limit: 3
   frontend.allow_origins: {{ allow_origins }}
+  frontend.library_pattern: "~/test|library"
   {% if smap_index_name %}
   frontend.sourcemapping.index: {{ smap_index_name }}
   frontend.sourcemapping.cache.expiration: {{ smap_cache_expiration}}

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -63,6 +63,40 @@ class Test(ElasticTest):
         self.check_backend_error_sourcemap(count=4)
 
 
+class FrontendEnabledIntegrationTest(ElasticTest, ClientSideBaseTest):
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_backend_error(self):
+        self.load_docs_with_template(self.get_error_payload_path(name="payload.json"),
+                                     'http://localhost:8200/v1/errors',
+                                     'error',
+                                     4)
+        self.check_library_frames({"true": 1, "false": 1, "empty": 2}, "error")
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_frontend_error(self):
+        self.load_docs_with_template(self.get_error_payload_path(),
+                                     self.errors_url,
+                                     'error',
+                                     1)
+        self.check_library_frames({"true": 5, "false": 1, "empty": 0}, "error")
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_backend_transaction(self):
+        self.load_docs_with_template(self.get_transaction_payload_path(name="payload.json"),
+                                     'http://localhost:8200/v1/transactions',
+                                     'transaction',
+                                     9)
+        self.check_library_frames({"true": 1, "false": 0, "empty": 1}, "span")
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_frontend_transaction(self):
+        self.load_docs_with_template(self.get_transaction_payload_path(),
+                                     self.transactions_url,
+                                     'transaction',
+                                     2)
+        self.check_library_frames({"true": 1, "false": 1, "empty": 0}, "span")
+
+
 class SourcemappingIntegrationTest(ElasticTest, ClientSideBaseTest):
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_backend_error(self):


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Detect library_frames for frontend stacktraces.  (#481)