### PR TITLE
Use Stacktrace Frame pointers.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -19,6 +19,7 @@ https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828
 ==== Bug fixes
 - Updated systemd doc url {pull}354[354]
 - Updated readme doc urls {pull}356[356]
+- Use updated stack trace frame values for calculating error `grouping_keys` {pull}485[485] 
 
 ==== Added
 - Include build time and revision in version information {pull}396[396]

--- a/model/stacktrace.go
+++ b/model/stacktrace.go
@@ -5,7 +5,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
-type Stacktrace []StacktraceFrame
+type Stacktrace []*StacktraceFrame
 
 func (st *Stacktrace) Transform(config *pr.Config, service Service) []common.MapStr {
 	var frames []common.MapStr

--- a/model/stacktrace_test.go
+++ b/model/stacktrace_test.go
@@ -19,7 +19,7 @@ func TestStacktraceTransform(t *testing.T) {
 		Msg        string
 	}{
 		{
-			Stacktrace: Stacktrace{StacktraceFrame{}},
+			Stacktrace: Stacktrace{&StacktraceFrame{}},
 			Output: []common.MapStr{
 				{"filename": "", "line": common.MapStr{"number": 0}},
 			},

--- a/processor/error/package_tests/TestProcessErrorFrontendMinified.approved.json
+++ b/processor/error/package_tests/TestProcessErrorFrontendMinified.approved.json
@@ -99,7 +99,7 @@
                     ],
                     "type": "Error"
                 },
-                "grouping_key": "52fbc9c2d1a61bf905b4a11c708006fd",
+                "grouping_key": "6fc01af659d163aac0cf5348dd2daae5",
                 "id": "aba2688e-0338-48ce-9c4e-4005f1caa534",
                 "log": {
                     "message": "Uncaught Error: log timeout test error",

--- a/processor/error/payload_test.go
+++ b/processor/error/payload_test.go
@@ -55,7 +55,7 @@ func TestPayloadTransform(t *testing.T) {
 					Log:       baseLog(),
 					Exception: &Exception{
 						Message:    "exception message",
-						Stacktrace: m.Stacktrace{m.StacktraceFrame{Filename: "myFile"}},
+						Stacktrace: m.Stacktrace{&m.StacktraceFrame{Filename: "myFile"}},
 					},
 					Transaction: &struct{ Id string }{Id: "945254c5-67a5-417e-8a4e-aa29efcbfb79"},
 				}},

--- a/processor/transaction/span_test.go
+++ b/processor/transaction/span_test.go
@@ -40,7 +40,7 @@ func TestSpanTransform(t *testing.T) {
 				Type:     "myspantype",
 				Start:    0.65,
 				Duration: 1.20,
-				Stacktrace: []m.StacktraceFrame{
+				Stacktrace: []*m.StacktraceFrame{
 					{AbsPath: &path},
 				},
 				Context: common.MapStr{"key": "val"},


### PR DESCRIPTION
Allow using transformed stack trace frame values for calculation.

Right now we change the values of stacktrace frames in the `Transform` method, but as the `stacktrace` doesn't hold pointer references to the stacktrace frames the changed values are not available for the `error` objects holding `stacktraces`. This leads to the usage of the wrong frame information, in case it was changed, as e.g. for sourcemapping.  