### PR TITLE
[6.x] Add type to description for `context.tags`, `transaction.marks`. (#493)

### DIFF
--- a/_meta/fields.common.yml
+++ b/_meta/fields.common.yml
@@ -26,7 +26,7 @@
           object_type: keyword
           dynamic: true
           description: >
-            A flat mapping of user-defined tags with values.
+            A flat mapping of user-defined tags with string values.
 
         - name: user
           type: group

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -63,7 +63,7 @@ Any arbitrary contextual information regarding the event, captured by the agent,
 
 type: object
 
-A flat mapping of user-defined tags with values.
+A flat mapping of user-defined tags with string values.
 
 
 
@@ -659,7 +659,7 @@ The result of the transaction. HTTP status code for HTTP-related transactions.
 
 type: object
 
-A user-defined mapping of groups of marks. 
+A user-defined mapping of groups of marks in milliseconds.
 
 
 [float]

--- a/docs/spec/context.json
+++ b/docs/spec/context.json
@@ -44,7 +44,7 @@
         },
         "tags": {
             "type": ["object", "null"],
-            "description": "A flat mapping of user-defined tags with values.",
+            "description": "A flat mapping of user-defined tags with string values.",
             "regexProperties": true,
             "patternProperties": {
                 "^[^.*\"]*$": {

--- a/docs/spec/transactions/mark.json
+++ b/docs/spec/transactions/mark.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "$id": "docs/spec/transactions/mark.json",
     "type": ["object", "null"],
-    "description": "A mark captures the timing of a significant event during the lifetime of a transaction. Every mark is a simple key value pair and can be set by the user or the agent.",
+    "description": "A mark captures the timing in milliseconds of a significant event during the lifetime of a transaction. Every mark is a simple key value pair, where the value has to be a number, and can be set by the user or the agent.",
     "regexProperties": true,
     "patternProperties": {
         "^[^.*\"]*$": { "type": "number" }

--- a/processor/error/schema.go
+++ b/processor/error/schema.go
@@ -278,7 +278,7 @@ var errorSchema = `{
         },
         "tags": {
             "type": ["object", "null"],
-            "description": "A flat mapping of user-defined tags with values.",
+            "description": "A flat mapping of user-defined tags with string values.",
             "regexProperties": true,
             "patternProperties": {
                 "^[^.*\"]*$": {

--- a/processor/transaction/_meta/fields.yml
+++ b/processor/transaction/_meta/fields.yml
@@ -43,7 +43,7 @@
           object_type: keyword
           dynamic: true
           description: >
-            A user-defined mapping of groups of marks. 
+            A user-defined mapping of groups of marks in milliseconds.
 
         - name: sampled
           type: boolean

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -301,7 +301,7 @@ var transactionSchema = `{
         },
         "tags": {
             "type": ["object", "null"],
-            "description": "A flat mapping of user-defined tags with values.",
+            "description": "A flat mapping of user-defined tags with string values.",
             "regexProperties": true,
             "patternProperties": {
                 "^[^.*\"]*$": {
@@ -509,7 +509,7 @@ var transactionSchema = `{
                         "$schema": "http://json-schema.org/draft-04/schema#",
     "$id": "docs/spec/transactions/mark.json",
     "type": ["object", "null"],
-    "description": "A mark captures the timing of a significant event during the lifetime of a transaction. Every mark is a simple key value pair and can be set by the user or the agent.",
+    "description": "A mark captures the timing in milliseconds of a significant event during the lifetime of a transaction. Every mark is a simple key value pair, where the value has to be a number, and can be set by the user or the agent.",
     "regexProperties": true,
     "patternProperties": {
         "^[^.*\"]*$": { "type": "number" }


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Add type to description for `context.tags`, `transaction.marks`.  (#493)