### PR TITLE
[6.x] sync default sourcemapping index pattern with default outputs.elastic…

### DIFF
--- a/_meta/beat.reference.yml
+++ b/_meta/beat.reference.yml
@@ -68,7 +68,7 @@ apm-server:
       # Source maps are stored in the same index as transaction and error documents.
       # If the default index pattern at 'outputs.elasticsearch.index' is changed,
       # a matching index pattern needs to be specified here.
-      #index_pattern: "apm*"
+      #index_pattern: "apm-*"
 
 #================================ General ======================================
 
@@ -390,4 +390,3 @@ logging.files:
 
 # Set to true to log messages in json format.
 #logging.json: false
->>>>>>> 716df43... Remove untested options from config inherited from beats.

--- a/apm-server.reference.yml
+++ b/apm-server.reference.yml
@@ -68,7 +68,7 @@ apm-server:
       # Source maps are stored in the same index as transaction and error documents.
       # If the default index pattern at 'outputs.elasticsearch.index' is changed,
       # a matching index pattern needs to be specified here.
-      #index_pattern: "apm*"
+      #index_pattern: "apm-*"
 
 #================================ General ======================================
 
@@ -390,4 +390,3 @@ logging.files:
 
 # Set to true to log messages in json format.
 #logging.json: false
->>>>>>> 716df43... Remove untested options from config inherited from beats.

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -121,7 +121,7 @@ func TestBeatConfig(t *testing.T) {
 						Cache: &Cache{
 							Expiration: 7 * time.Second,
 						},
-						Index: "apm",
+						Index: "apm-*",
 					},
 					LibraryPattern:      "node_modules|bower_components|~",
 					ExcludeFromGrouping: "^/webpack",

--- a/beater/config.go
+++ b/beater/config.go
@@ -104,7 +104,7 @@ func defaultConfig() *Config {
 				Cache: &Cache{
 					Expiration: 5 * time.Minute,
 				},
-				Index: "apm",
+				Index: "apm-*",
 			},
 			LibraryPattern:      "node_modules|bower_components|~",
 			ExcludeFromGrouping: "^/webpack",


### PR DESCRIPTION
…search.index (#516)