### PR TITLE
[DOCS] Updated doc-branch version

### DIFF
--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,5 +1,5 @@
 :stack-version: 6.2.0
-:doc-branch: 6.x
+:doc-branch: 6.2
 :go-version: 1.9.2
 :release-state: unreleased
 :python: 2.7.9


### PR DESCRIPTION
This PR updates the "doc-branch" attribute value from "6.x" to "6.2". 
