### PR TITLE
[6.x] Update License to 2018 (#558)

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Elasticsearch BV
+   Copyright 2018 Elasticsearch BV
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Update License to 2018  (#558)