### PR TITLE
[6.x] Add `process.ppid` as optional field. (#557)

### DIFF
--- a/_meta/fields.common.yml
+++ b/_meta/fields.common.yml
@@ -146,11 +146,15 @@
           description: >
             Information pertaining to the running process where the data was collected
           fields:
-
             - name: pid
               type: long
               description: >
                 Numeric process ID of the service process.
+
+            - name: ppid
+              type: long
+              description: >
+                Numeric ID of the service's parent process.
 
             - name: title
               type: keyword

--- a/docs/data/elasticsearch/error.json
+++ b/docs/data/elasticsearch/error.json
@@ -16,6 +16,7 @@
                 "server.js"
             ],
             "pid": 1234,
+            "ppid": 7788,
             "title": "node"
         },
         "request": {

--- a/docs/data/elasticsearch/transaction.json
+++ b/docs/data/elasticsearch/transaction.json
@@ -16,6 +16,7 @@
                 "server.js"
             ],
             "pid": 1234,
+            "ppid": 6789,
             "title": "node"
         },
         "request": {

--- a/docs/data/intake-api/generated/error/payload.json
+++ b/docs/data/intake-api/generated/error/payload.json
@@ -22,6 +22,7 @@
     },
     "process": {
         "pid": 1234,
+        "ppid": 7788,
         "title": "node",
         "argv": [
             "node",

--- a/docs/data/intake-api/generated/transaction/payload.json
+++ b/docs/data/intake-api/generated/transaction/payload.json
@@ -22,6 +22,7 @@
     },
     "process": {
         "pid": 1234,
+        "ppid": 6789,
         "title": "node",
         "argv": [
             "node",

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -243,6 +243,14 @@ Numeric process ID of the service process.
 
 
 [float]
+=== `context.process.ppid`
+
+type: long
+
+Numeric ID of the service's parent process.
+
+
+[float]
 === `context.process.title`
 
 type: keyword

--- a/docs/spec/process.json
+++ b/docs/spec/process.json
@@ -8,6 +8,10 @@
           "description": "Process ID of the service",
           "type": ["number"]
       },
+      "ppid": {
+          "description": "Parent process ID of the service",
+          "type": ["number", "null"]
+      },
       "title": {
           "type": ["string", "null"],
           "maxLength": 1024

--- a/model/process.go
+++ b/model/process.go
@@ -7,6 +7,7 @@ import (
 
 type Process struct {
 	Pid   int
+	Ppid  *int
 	Title *string
 	Argv  []string
 }
@@ -20,6 +21,7 @@ func (p *Process) Transform() common.MapStr {
 	enhancer := utility.NewMapStrEnhancer()
 	svc := common.MapStr{}
 	enhancer.Add(svc, "pid", p.Pid)
+	enhancer.Add(svc, "ppid", p.Ppid)
 	enhancer.Add(svc, "title", p.Title)
 	enhancer.Add(svc, "argv", p.Argv)
 

--- a/processor/error/package_tests/TestProcessErrorFull.approved.json
+++ b/processor/error/package_tests/TestProcessErrorFull.approved.json
@@ -19,6 +19,7 @@
                         "server.js"
                     ],
                     "pid": 1234,
+                    "ppid": 7788,
                     "title": "node"
                 },
                 "request": {
@@ -262,6 +263,7 @@
                         "server.js"
                     ],
                     "pid": 1234,
+                    "ppid": 7788,
                     "title": "node"
                 },
                 "service": {
@@ -313,6 +315,7 @@
                         "server.js"
                     ],
                     "pid": 1234,
+                    "ppid": 7788,
                     "title": "node"
                 },
                 "service": {
@@ -363,6 +366,7 @@
                         "server.js"
                     ],
                     "pid": 1234,
+                    "ppid": 7788,
                     "title": "node"
                 },
                 "service": {

--- a/processor/error/schema.go
+++ b/processor/error/schema.go
@@ -108,6 +108,10 @@ var errorSchema = `{
           "description": "Process ID of the service",
           "type": ["number"]
       },
+      "ppid": {
+          "description": "Parent process ID of the service",
+          "type": ["number", "null"]
+      },
       "title": {
           "type": ["string", "null"],
           "maxLength": 1024

--- a/processor/transaction/package_tests/TestProcessTransactionFull.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionFull.approved.json
@@ -19,6 +19,7 @@
                         "server.js"
                     ],
                     "pid": 1234,
+                    "ppid": 6789,
                     "title": "node"
                 },
                 "request": {
@@ -303,6 +304,7 @@
                         "server.js"
                     ],
                     "pid": 1234,
+                    "ppid": 6789,
                     "title": "node"
                 },
                 "service": {
@@ -356,6 +358,7 @@
                         "server.js"
                     ],
                     "pid": 1234,
+                    "ppid": 6789,
                     "title": "node"
                 },
                 "service": {
@@ -409,6 +412,7 @@
                         "server.js"
                     ],
                     "pid": 1234,
+                    "ppid": 6789,
                     "title": "node"
                 },
                 "service": {

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -108,6 +108,10 @@ var transactionSchema = `{
           "description": "Process ID of the service",
           "type": ["number"]
       },
+      "ppid": {
+          "description": "Parent process ID of the service",
+          "type": ["number", "null"]
+      },
       "title": {
           "type": ["string", "null"],
           "maxLength": 1024

--- a/tests/data/valid/error/payload.json
+++ b/tests/data/valid/error/payload.json
@@ -22,6 +22,7 @@
     },
     "process": {
         "pid": 1234,
+        "ppid": 7788,
         "title": "node",
         "argv": [
             "node",

--- a/tests/data/valid/transaction/payload.json
+++ b/tests/data/valid/transaction/payload.json
@@ -22,6 +22,7 @@
     },
     "process": {
         "pid": 1234,
+        "ppid": 6789,
         "title": "node",
         "argv": [
             "node",


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Add `process.ppid` as optional field.  (#557)