### PR TITLE
[6.x] Adapt changelog to add optional process.ppid (#564)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -48,6 +48,8 @@ https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828
 - Increase default 'ConcurrentRequests' from 20 to 40 {pull}492[492]
 - Change config option `frontend.sourcemapping.index` to `frontend.source_mapping.index_pattern` and remove adding a '*' by default.{pull}492[492].
 - Add Config option for excluding stack trace frames from `grouping_key` calculation {pull}482[482]
+- Expose expvar {pull}509[509]
+- Add `process.ppid` as optional field {pull}564[564]
 
 ==== Deprecated
 


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Adapt changelog to add optional process.ppid  (#564)