### PR TITLE
[6.x] Change error.culprit after successful source mapping. (#520)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -50,6 +50,7 @@ https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828
 - Add Config option for excluding stack trace frames from `grouping_key` calculation {pull}482[482]
 - Expose expvar {pull}509[509]
 - Add `process.ppid` as optional field {pull}564[564]
+- Change `error.culprit` after successfully applying sourcemapping {pull}520[520]
 
 ==== Deprecated
 

--- a/model/stacktrace_frame_test.go
+++ b/model/stacktrace_frame_test.go
@@ -221,6 +221,24 @@ func TestApplySourcemap(t *testing.T) {
 	}
 }
 
+func TestIsLibraryFrame(t *testing.T) {
+	assert.False(t, (&StacktraceFrame{}).IsLibraryFrame())
+	assert.False(t, (&StacktraceFrame{LibraryFrame: new(bool)}).IsLibraryFrame())
+	libFrame := true
+	assert.True(t, (&StacktraceFrame{LibraryFrame: &libFrame}).IsLibraryFrame())
+}
+
+func TestIsSourcemapApplied(t *testing.T) {
+	assert.False(t, (&StacktraceFrame{}).IsSourcemapApplied())
+
+	fr := StacktraceFrame{Sourcemap: Sourcemap{Updated: new(bool)}}
+	assert.False(t, fr.IsSourcemapApplied())
+
+	libFrame := true
+	fr = StacktraceFrame{Sourcemap: Sourcemap{Updated: &libFrame}}
+	assert.True(t, fr.IsSourcemapApplied())
+}
+
 func TestExcludeFromGroupingKey(t *testing.T) {
 	tests := []struct {
 		fr      StacktraceFrame

--- a/processor/error/package_tests/TestProcessErrorFrontend.approved.json
+++ b/processor/error/package_tests/TestProcessErrorFrontend.approved.json
@@ -27,7 +27,7 @@
                 }
             },
             "error": {
-                "culprit": "test/e2e/general-usecase/bundle.js.map",
+                "culprit": "webpack:///webpack/bootstrap 6002740481c9666b0d38 in \u003canonymous\u003e",
                 "exception": {
                     "message": "Uncaught Error: timeout test error",
                     "stacktrace": [
@@ -36,7 +36,7 @@
                             "exclude_from_grouping": false,
                             "filename": "webpack:///webpack/bootstrap 6002740481c9666b0d38",
                             "function": "__webpack_require__",
-                            "library_frame": true,
+                            "library_frame": false,
                             "line": {
                                 "column": 0,
                                 "number": 5
@@ -50,7 +50,7 @@
                             "exclude_from_grouping": false,
                             "filename": "webpack:///webpack/bootstrap 6002740481c9666b0d38",
                             "function": "\u003cunknown\u003e",
-                            "library_frame": true,
+                            "library_frame": false,
                             "line": {
                                 "column": 0,
                                 "number": 33
@@ -64,7 +64,7 @@
                             "exclude_from_grouping": false,
                             "filename": "webpack:///webpack/bootstrap 6002740481c9666b0d38",
                             "function": "\u003cunknown\u003e",
-                            "library_frame": true,
+                            "library_frame": false,
                             "line": {
                                 "column": 0,
                                 "number": 5
@@ -78,7 +78,7 @@
                             "exclude_from_grouping": false,
                             "filename": "webpack:///webpack/bootstrap 6002740481c9666b0d38",
                             "function": "moduleId",
-                            "library_frame": true,
+                            "library_frame": false,
                             "line": {
                                 "column": 0,
                                 "number": 39
@@ -92,7 +92,7 @@
                             "exclude_from_grouping": false,
                             "filename": "webpack:///webpack/bootstrap 6002740481c9666b0d38",
                             "function": "\u003canonymous\u003e",
-                            "library_frame": true,
+                            "library_frame": false,
                             "line": {
                                 "column": 0,
                                 "number": 8
@@ -114,7 +114,7 @@
                             "exclude_from_grouping": false,
                             "filename": "webpack:///webpack/bootstrap 6002740481c9666b0d38",
                             "function": "\u003canonymous\u003e",
-                            "library_frame": true,
+                            "library_frame": false,
                             "line": {
                                 "column": 0,
                                 "number": 5

--- a/processor/error/package_tests/TestProcessErrorFrontendMinifiedSmap.approved.json
+++ b/processor/error/package_tests/TestProcessErrorFrontendMinifiedSmap.approved.json
@@ -35,7 +35,7 @@
                 }
             },
             "error": {
-                "culprit": "test/e2e/general-usecase/app.e2e-bundle.min.js",
+                "culprit": "webpack:///./test/e2e/general-usecase/app.js in generateError",
                 "exception": {
                     "message": "Uncaught Error: timeout test error",
                     "stacktrace": [
@@ -44,7 +44,7 @@
                             "exclude_from_grouping": false,
                             "filename": "webpack:///./test/e2e/general-usecase/app.js",
                             "function": "generateError",
-                            "library_frame": true,
+                            "library_frame": false,
                             "line": {
                                 "column": 0,
                                 "number": 17
@@ -58,7 +58,7 @@
                             "exclude_from_grouping": false,
                             "filename": "webpack:///./test/e2e/general-usecase/app.js",
                             "function": "apply",
-                            "library_frame": true,
+                            "library_frame": false,
                             "line": {
                                 "column": 0,
                                 "number": 21
@@ -72,7 +72,7 @@
                             "exclude_from_grouping": false,
                             "filename": "webpack:///./dist/bundles/elastic-apm-js-base.umd.js",
                             "function": "invokeTask",
-                            "library_frame": true,
+                            "library_frame": false,
                             "line": {
                                 "column": 0,
                                 "number": 3609
@@ -86,7 +86,7 @@
                             "exclude_from_grouping": false,
                             "filename": "webpack:///./dist/bundles/elastic-apm-js-base.umd.js",
                             "function": "runTask",
-                            "library_frame": true,
+                            "library_frame": false,
                             "line": {
                                 "column": 0,
                                 "number": 3412
@@ -100,7 +100,7 @@
                             "exclude_from_grouping": false,
                             "filename": "webpack:///./dist/bundles/elastic-apm-js-base.umd.js",
                             "function": "apply",
-                            "library_frame": true,
+                            "library_frame": false,
                             "line": {
                                 "column": 0,
                                 "number": 3679
@@ -114,7 +114,7 @@
                             "exclude_from_grouping": false,
                             "filename": "webpack:///./dist/bundles/elastic-apm-js-base.umd.js",
                             "function": "apply",
-                            "library_frame": true,
+                            "library_frame": false,
                             "line": {
                                 "column": 0,
                                 "number": 3668
@@ -128,7 +128,7 @@
                             "exclude_from_grouping": false,
                             "filename": "webpack:///./dist/bundles/elastic-apm-js-base.umd.js",
                             "function": "\u003canonymous\u003e",
-                            "library_frame": true,
+                            "library_frame": false,
                             "line": {
                                 "column": 0,
                                 "number": 5180

--- a/processor/error/package_tests/TestProcessErrorFrontendNoSmap.approved.json
+++ b/processor/error/package_tests/TestProcessErrorFrontendNoSmap.approved.json
@@ -82,7 +82,7 @@
                             "exclude_from_grouping": true,
                             "filename": "/webpack/test/e2e/general-usecase/app.e2e-bundle.js",
                             "function": "timer",
-                            "library_frame": true,
+                            "library_frame": false,
                             "line": {
                                 "column": 33,
                                 "number": 4737

--- a/processor/error/package_tests/processor_test.go
+++ b/processor/error/package_tests/processor_test.go
@@ -39,7 +39,7 @@ func TestProcessorFrontendMinifiedSmapOK(t *testing.T) {
 	mapper := sourcemap.SmapMapper{Accessor: &fakeAcc{}}
 	conf := processor.Config{
 		SmapMapper:          &mapper,
-		LibraryPattern:      regexp.MustCompile("/test/e2e|~"),
+		LibraryPattern:      regexp.MustCompile("^test/e2e|~"),
 		ExcludeFromGrouping: regexp.MustCompile("^\\s*$|^/webpack|^[/][^/]*$"),
 	}
 	tests.TestProcessRequests(t, er.NewProcessor(&conf), requestInfo, map[string]string{})


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Change error.culprit after successful source mapping.  (#520)