### PR TITLE
[6.x] Make transaction.name optional. (#554)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -51,6 +51,7 @@ https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828
 - Expose expvar {pull}509[509]
 - Add `process.ppid` as optional field {pull}564[564]
 - Change `error.culprit` after successfully applying sourcemapping {pull}520[520]
+- Make `transaction.name` optional {pull}554[554]
 
 ==== Deprecated
 

--- a/docs/data/intake-api/generated/transaction/frontend.json
+++ b/docs/data/intake-api/generated/transaction/frontend.json
@@ -11,7 +11,6 @@
         {
             "id": "611f4fa9-50f0-4631-9306-43399c0dc3db",
             "timestamp": "2017-12-08T12:52:53.681Z",
-            "name": "Unknown",
             "type": "page-load",
             "duration": 643,
             "spans": [

--- a/docs/data/intake-api/generated/transaction/minimal_payload.json
+++ b/docs/data/intake-api/generated/transaction/minimal_payload.json
@@ -9,7 +9,6 @@
     "transactions": [
         {
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
             "timestamp": "2017-05-09T15:04:05.999999Z"

--- a/docs/data/intake-api/generated/transaction/minimal_process.json
+++ b/docs/data/intake-api/generated/transaction/minimal_process.json
@@ -15,7 +15,6 @@
   "transactions": [
       {
           "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-          "name": "GET /api/types",
           "type": "request",
           "duration": 32.592981,
           "timestamp": "2017-05-30T18:53:27.154Z"

--- a/docs/data/intake-api/generated/transaction/minimal_service.json
+++ b/docs/data/intake-api/generated/transaction/minimal_service.json
@@ -12,7 +12,6 @@
     "transactions": [
         {
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
             "timestamp": "2017-05-30T18:53:27.154Z"

--- a/docs/data/intake-api/generated/transaction/minimal_span.json
+++ b/docs/data/intake-api/generated/transaction/minimal_span.json
@@ -9,7 +9,6 @@
     "transactions": [
         {
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
             "timestamp": "2017-05-30T18:53:27.154Z",

--- a/docs/data/intake-api/generated/transaction/null_values.json
+++ b/docs/data/intake-api/generated/transaction/null_values.json
@@ -26,7 +26,6 @@
     "transactions": [
         {
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
             "timestamp": "2017-05-30T18:53:27.154Z",
@@ -38,7 +37,6 @@
         },
         {
             "id": "85925e55-b43f-4340-a8e0-df1906ecbf78",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 13.980558,
             "timestamp": "2017-05-30T18:53:42Z",
@@ -54,7 +52,6 @@
         },
         {
             "id": "85925e55-b43f-4340-a8e0-df1906ecbfa9",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 13.980558,
             "timestamp": "2017-05-30T18:53:42.281999Z",
@@ -98,7 +95,6 @@
         },
         {
             "id": "85925e55-b43f-4340-a8e0-df1906ecbf7a",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 13.980558,
             "timestamp": "2017-05-30T18:53:42.281Z",

--- a/docs/data/intake-api/generated/transaction/process_null.json
+++ b/docs/data/intake-api/generated/transaction/process_null.json
@@ -10,7 +10,6 @@
     "transactions": [
         {
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
             "timestamp": "2017-05-09T15:04:05.999999Z",

--- a/docs/data/intake-api/generated/transaction/system_null.json
+++ b/docs/data/intake-api/generated/transaction/system_null.json
@@ -10,7 +10,6 @@
     "transactions": [
         {
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
             "timestamp": "2017-05-09T15:04:05.999999Z",

--- a/docs/data/intake-api/generated/transaction/transaction_empty_values.json
+++ b/docs/data/intake-api/generated/transaction/transaction_empty_values.json
@@ -12,7 +12,6 @@
     "transactions": [
         {
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
             "start": 24.01,

--- a/docs/spec/transactions/transaction.json
+++ b/docs/spec/transactions/transaction.json
@@ -17,7 +17,7 @@
             "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
         },
         "name": {
-            "type": "string",
+            "type": ["string","null"],
             "description": "Generic designation of a transaction in the scope of a single service (eg: 'GET /users/:id')",
             "maxLength": 1024
         },
@@ -75,5 +75,5 @@
             }
         }
     },
-    "required": ["id", "name", "duration", "type", "timestamp"]
+    "required": ["id", "duration", "type", "timestamp"]
 }

--- a/processor/transaction/event.go
+++ b/processor/transaction/event.go
@@ -9,7 +9,7 @@ import (
 
 type Event struct {
 	Id        string
-	Name      string
+	Name      *string
 	Type      string
 	Result    *string
 	Duration  float64

--- a/processor/transaction/event_test.go
+++ b/processor/transaction/event_test.go
@@ -18,6 +18,7 @@ func TestEventTransform(t *testing.T) {
 	result := "tx result"
 	sampled := false
 	dropped := 5
+	name := "mytransaction"
 
 	tests := []struct {
 		Event  Event
@@ -28,7 +29,6 @@ func TestEventTransform(t *testing.T) {
 			Event: Event{},
 			Output: common.MapStr{
 				"id":       "",
-				"name":     "",
 				"type":     "",
 				"duration": common.MapStr{"us": 0},
 				"sampled":  true,
@@ -38,7 +38,7 @@ func TestEventTransform(t *testing.T) {
 		{
 			Event: Event{
 				Id:        id,
-				Name:      "mytransaction",
+				Name:      &name,
 				Type:      "tx",
 				Result:    &result,
 				Timestamp: time.Now(),

--- a/processor/transaction/package_tests/TestProcessProcessNull.approved.json
+++ b/processor/transaction/package_tests/TestProcessProcessNull.approved.json
@@ -20,7 +20,6 @@
                     "us": 32592
                 },
                 "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-                "name": "GET /api/types",
                 "sampled": true,
                 "type": "request"
             }

--- a/processor/transaction/package_tests/TestProcessSystemNull.approved.json
+++ b/processor/transaction/package_tests/TestProcessSystemNull.approved.json
@@ -20,7 +20,6 @@
                     "us": 32592
                 },
                 "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-                "name": "GET /api/types",
                 "sampled": true,
                 "type": "request"
             }

--- a/processor/transaction/package_tests/TestProcessTransactionEmpty.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionEmpty.approved.json
@@ -21,7 +21,6 @@
                     "us": 32592
                 },
                 "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-                "name": "GET /api/types",
                 "sampled": true,
                 "type": "request"
             }

--- a/processor/transaction/package_tests/TestProcessTransactionFrontend.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionFrontend.approved.json
@@ -46,7 +46,6 @@
                     "us": 643000
                 },
                 "id": "611f4fa9-50f0-4631-9306-43399c0dc3db",
-                "name": "Unknown",
                 "sampled": true,
                 "type": "page-load"
             }

--- a/processor/transaction/package_tests/TestProcessTransactionMinimalPayload.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionMinimalPayload.approved.json
@@ -20,7 +20,6 @@
                     "us": 32592
                 },
                 "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-                "name": "GET /api/types",
                 "sampled": true,
                 "type": "request"
             }

--- a/processor/transaction/package_tests/TestProcessTransactionMinimalProcess.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionMinimalProcess.approved.json
@@ -26,7 +26,6 @@
                     "us": 32592
                 },
                 "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-                "name": "GET /api/types",
                 "sampled": true,
                 "type": "request"
             }

--- a/processor/transaction/package_tests/TestProcessTransactionMinimalService.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionMinimalService.approved.json
@@ -23,7 +23,6 @@
                     "us": 32592
                 },
                 "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-                "name": "GET /api/types",
                 "sampled": true,
                 "type": "request"
             }

--- a/processor/transaction/package_tests/TestProcessTransactionMinimalSpan.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionMinimalSpan.approved.json
@@ -20,7 +20,6 @@
                     "us": 32592
                 },
                 "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-                "name": "GET /api/types",
                 "sampled": true,
                 "type": "request"
             }

--- a/processor/transaction/package_tests/TestProcessTransactionNullValues.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionNullValues.approved.json
@@ -24,7 +24,6 @@
                     "us": 32592
                 },
                 "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-                "name": "GET /api/types",
                 "result": "200",
                 "sampled": true,
                 "type": "request"
@@ -59,7 +58,6 @@
                     "us": 13980
                 },
                 "id": "85925e55-b43f-4340-a8e0-df1906ecbf78",
-                "name": "GET /api/types",
                 "sampled": true,
                 "type": "request"
             }
@@ -119,7 +117,6 @@
                     "us": 13980
                 },
                 "id": "85925e55-b43f-4340-a8e0-df1906ecbfa9",
-                "name": "GET /api/types",
                 "sampled": true,
                 "type": "request"
             }
@@ -179,7 +176,6 @@
                     "us": 13980
                 },
                 "id": "85925e55-b43f-4340-a8e0-df1906ecbf7a",
-                "name": "GET /api/types",
                 "sampled": true,
                 "type": "request"
             }

--- a/processor/transaction/payload_test.go
+++ b/processor/transaction/payload_test.go
@@ -41,7 +41,6 @@ func TestPayloadTransform(t *testing.T) {
 		"transaction": common.MapStr{
 			"duration": common.MapStr{"us": 0},
 			"id":       "",
-			"name":     "",
 			"type":     "",
 			"sampled":  true,
 		},
@@ -55,7 +54,6 @@ func TestPayloadTransform(t *testing.T) {
 		"transaction": common.MapStr{
 			"duration": common.MapStr{"us": 0},
 			"id":       "",
-			"name":     "",
 			"type":     "",
 			"sampled":  true,
 		},
@@ -80,7 +78,6 @@ func TestPayloadTransform(t *testing.T) {
 		"transaction": common.MapStr{
 			"duration": common.MapStr{"us": 0},
 			"id":       "",
-			"name":     "",
 			"type":     "",
 			"sampled":  true,
 		},

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -351,7 +351,7 @@ var transactionSchema = `{
             "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
         },
         "name": {
-            "type": "string",
+            "type": ["string","null"],
             "description": "Generic designation of a transaction in the scope of a single service (eg: 'GET /users/:id')",
             "maxLength": 1024
         },
@@ -543,7 +543,7 @@ var transactionSchema = `{
             }
         }
     },
-    "required": ["id", "name", "duration", "type", "timestamp"]
+    "required": ["id", "duration", "type", "timestamp"]
             },
             "minItems": 1
         }

--- a/tests/data/invalid/transaction/invalid_id.json
+++ b/tests/data/invalid/transaction/invalid_id.json
@@ -1,6 +1,5 @@
 {
     "id": "85925e55-b483f-7340-a8e0-df1906ecbfa9",
-    "name": "GET /api/types",
     "type": "request",
     "duration": 1.0,
     "timestamp": "2017-05-30T18:53:27.154Z",

--- a/tests/data/invalid/transaction/invalid_mark_asterisk.json
+++ b/tests/data/invalid/transaction/invalid_mark_asterisk.json
@@ -1,6 +1,5 @@
 {
     "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-    "name": "GET /api/types",
     "type": "request",
     "duration": 1.0,
     "timestamp": "2017-05-30T18:53:27.154Z",

--- a/tests/data/invalid/transaction/invalid_mark_dot.json
+++ b/tests/data/invalid/transaction/invalid_mark_dot.json
@@ -1,6 +1,5 @@
 {
     "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-    "name": "GET /api/types",
     "type": "request",
     "duration": 1.0,
     "timestamp": "2017-05-30T18:53:27.154Z",

--- a/tests/data/invalid/transaction/invalid_mark_group_asterisk.json
+++ b/tests/data/invalid/transaction/invalid_mark_group_asterisk.json
@@ -1,6 +1,5 @@
 {
     "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-    "name": "GET /api/types",
     "type": "request",
     "duration": 1.0,
     "timestamp": "2017-05-30T18:53:27.154Z",

--- a/tests/data/invalid/transaction/invalid_mark_group_dot.json
+++ b/tests/data/invalid/transaction/invalid_mark_group_dot.json
@@ -1,6 +1,5 @@
 {
     "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-    "name": "GET /api/types",
     "type": "request",
     "duration": 1.0,
     "timestamp": "2017-05-30T18:53:27.154Z",

--- a/tests/data/invalid/transaction/invalid_mark_group_quote.json
+++ b/tests/data/invalid/transaction/invalid_mark_group_quote.json
@@ -1,6 +1,5 @@
 {
     "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-    "name": "GET /api/types",
     "type": "request",
     "duration": 1.0,
     "timestamp": "2017-05-30T18:53:27.154Z",

--- a/tests/data/invalid/transaction/invalid_mark_group_type.json
+++ b/tests/data/invalid/transaction/invalid_mark_group_type.json
@@ -1,6 +1,5 @@
 {
     "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-    "name": "GET /api/types",
     "type": "request",
     "duration": 1.0,
     "timestamp": "2017-05-30T18:53:27.154Z",

--- a/tests/data/invalid/transaction/invalid_mark_quote.json
+++ b/tests/data/invalid/transaction/invalid_mark_quote.json
@@ -1,6 +1,5 @@
 {
     "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-    "name": "GET /api/types",
     "type": "request",
     "duration": 1.0,
     "timestamp": "2017-05-30T18:53:27.154Z",

--- a/tests/data/invalid/transaction/invalid_mark_type.json
+++ b/tests/data/invalid/transaction/invalid_mark_type.json
@@ -1,6 +1,5 @@
 {
     "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-    "name": "GET /api/types",
     "type": "request",
     "duration": 1.0,
     "timestamp": "2017-05-30T18:53:27.154Z",

--- a/tests/data/invalid/transaction/invalid_timestamp.json
+++ b/tests/data/invalid/transaction/invalid_timestamp.json
@@ -1,6 +1,5 @@
 {
     "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-    "name": "GET /api/types",
     "type": "request",
     "duration": 2.0,
     "timestamp": "2017-05-30T18:53Z",

--- a/tests/data/invalid/transaction/invalid_timestamp2.json
+++ b/tests/data/invalid/transaction/invalid_timestamp2.json
@@ -1,7 +1,6 @@
 
 {
     "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-    "name": "GET /api/types",
     "type": "request",
     "duration": 2.0,
     "timestamp": "2017-05-30T18:53:27.000+00:20",

--- a/tests/data/invalid/transaction/invalid_timestamp3.json
+++ b/tests/data/invalid/transaction/invalid_timestamp3.json
@@ -1,6 +1,5 @@
 {
     "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-    "name": "GET /api/types",
     "type": "request",
     "duration": 2.0,
     "timestamp": "2017-05-30T18:53:27.Z",

--- a/tests/data/invalid/transaction/invalid_timestamp4.json
+++ b/tests/data/invalid/transaction/invalid_timestamp4.json
@@ -1,6 +1,5 @@
 {
     "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-    "name": "GET /api/types",
     "type": "request",
     "duration": 2.0,
     "timestamp": "2017-05-30T18:53:27a123Z",

--- a/tests/data/invalid/transaction/invalid_timestamp5.json
+++ b/tests/data/invalid/transaction/invalid_timestamp5.json
@@ -1,6 +1,5 @@
 {
   "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-  "name": "GET /api/types",
   "type": "request",
   "duration": 2.0,
   "timestamp": "2017-05-30T18:53:27ZNOTCORRECT",

--- a/tests/data/invalid/transaction/no_duration.json
+++ b/tests/data/invalid/transaction/no_duration.json
@@ -1,6 +1,5 @@
 {
     "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-    "name": "GET /api/types",
     "type": "request",
     "timestamp": "2017-05-30T18:53:27.154Z",
     "spans": []

--- a/tests/data/invalid/transaction/no_id.json
+++ b/tests/data/invalid/transaction/no_id.json
@@ -1,5 +1,4 @@
 {
-    "name": "GET /api/types",
     "type": "request",
     "duration": 1.0,
     "timestamp": "2017-05-30T18:53:27.154Z",

--- a/tests/data/invalid/transaction/no_name.json
+++ b/tests/data/invalid/transaction/no_name.json
@@ -1,7 +1,0 @@
-{
-    "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-    "type": "request",
-    "duration": 1.0,
-    "timestamp": "2017-05-30T18:53:27.154Z",
-    "spans": []
-}

--- a/tests/data/invalid/transaction/no_timestamp.json
+++ b/tests/data/invalid/transaction/no_timestamp.json
@@ -1,6 +1,5 @@
 {
     "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-    "name": "GET /api/types",
     "type": "request",
     "duration": 1.0,
     "spans": []

--- a/tests/data/invalid/transaction/no_type.json
+++ b/tests/data/invalid/transaction/no_type.json
@@ -1,6 +1,5 @@
 {
     "id": "85915e55-b43f-4340-a8e0-df1906ecbfa9",
-    "name": "GET /api/types",
     "duration": 1.0,
     "timestamp": "2017-05-30T18:53:27.154Z",
     "spans": []

--- a/tests/data/valid/transaction/frontend.json
+++ b/tests/data/valid/transaction/frontend.json
@@ -11,7 +11,6 @@
         {
             "id": "611f4fa9-50f0-4631-9306-43399c0dc3db",
             "timestamp": "2017-12-08T12:52:53.681Z",
-            "name": "Unknown",
             "type": "page-load",
             "duration": 643,
             "spans": [

--- a/tests/data/valid/transaction/minimal_payload.json
+++ b/tests/data/valid/transaction/minimal_payload.json
@@ -9,7 +9,6 @@
     "transactions": [
         {
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
             "timestamp": "2017-05-09T15:04:05.999999Z"

--- a/tests/data/valid/transaction/minimal_process.json
+++ b/tests/data/valid/transaction/minimal_process.json
@@ -15,7 +15,6 @@
   "transactions": [
       {
           "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-          "name": "GET /api/types",
           "type": "request",
           "duration": 32.592981,
           "timestamp": "2017-05-30T18:53:27.154Z"

--- a/tests/data/valid/transaction/minimal_service.json
+++ b/tests/data/valid/transaction/minimal_service.json
@@ -12,7 +12,6 @@
     "transactions": [
         {
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
             "timestamp": "2017-05-30T18:53:27.154Z"

--- a/tests/data/valid/transaction/minimal_span.json
+++ b/tests/data/valid/transaction/minimal_span.json
@@ -9,7 +9,6 @@
     "transactions": [
         {
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
             "timestamp": "2017-05-30T18:53:27.154Z",

--- a/tests/data/valid/transaction/null_values.json
+++ b/tests/data/valid/transaction/null_values.json
@@ -26,7 +26,6 @@
     "transactions": [
         {
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
             "timestamp": "2017-05-30T18:53:27.154Z",
@@ -38,7 +37,6 @@
         },
         {
             "id": "85925e55-b43f-4340-a8e0-df1906ecbf78",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 13.980558,
             "timestamp": "2017-05-30T18:53:42Z",
@@ -54,7 +52,6 @@
         },
         {
             "id": "85925e55-b43f-4340-a8e0-df1906ecbfa9",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 13.980558,
             "timestamp": "2017-05-30T18:53:42.281999Z",
@@ -98,7 +95,6 @@
         },
         {
             "id": "85925e55-b43f-4340-a8e0-df1906ecbf7a",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 13.980558,
             "timestamp": "2017-05-30T18:53:42.281Z",

--- a/tests/data/valid/transaction/process_null.json
+++ b/tests/data/valid/transaction/process_null.json
@@ -10,7 +10,6 @@
     "transactions": [
         {
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
             "timestamp": "2017-05-09T15:04:05.999999Z",

--- a/tests/data/valid/transaction/system_null.json
+++ b/tests/data/valid/transaction/system_null.json
@@ -10,7 +10,6 @@
     "transactions": [
         {
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
             "timestamp": "2017-05-09T15:04:05.999999Z",

--- a/tests/data/valid/transaction/transaction_empty_values.json
+++ b/tests/data/valid/transaction/transaction_empty_values.json
@@ -12,7 +12,6 @@
     "transactions": [
         {
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-            "name": "GET /api/types",
             "type": "request",
             "duration": 32.592981,
             "start": 24.01,

--- a/tests/json_schema_test.go
+++ b/tests/json_schema_test.go
@@ -87,7 +87,6 @@ func TestSpanSchema(t *testing.T) {
 func TestTransactionSchema(t *testing.T) {
 	testData := []SchemaTestData{
 		{File: "no_id.json", Error: `missing properties: "id"`},
-		{File: "no_name.json", Error: `missing properties: "name"`},
 		{File: "no_duration.json", Error: `missing properties: "duration"`},
 		{File: "no_type.json", Error: `missing properties: "type"`},
 		{File: "no_timestamp.json", Error: `missing properties: "timestamp"`},


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Make transaction.name optional.  (#554)