### PR TITLE
override TESTIFY_TOOL_REPO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ PREFIX?=.
 BEATS_VERSION?=6.x
 NOTICE_FILE=NOTICE.txt
 LICENSE_FILE=LICENSE.txt
+TESTIFY_TOOL_REPO?=github.com/elastic/beats/vendor/github.com/stretchr/testify/assert
 
 # Path to the libbeat Makefile
 -include $(ES_BEATS)/libbeat/scripts/Makefile


### PR DESCRIPTION
now that apm ci is split out from beats, use the direct apm-server dep