### PR TITLE
Fix panic when a signal is delivered before the server is instantiated

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -20,7 +20,8 @@ https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828
 ==== Bug fixes
 - Updated systemd doc url {pull}354[354]
 - Updated readme doc urls {pull}356[356]
-- Use updated stack trace frame values for calculating error `grouping_keys` {pull}485[485] 
+- Use updated stack trace frame values for calculating error `grouping_keys` {pull}485[485]
+- Fix panic when a SIGINT is delivered before the server is instantiated {pull}580[580]
 
 ==== Added
 - Include build time and revision in version information {pull}396[396]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -21,7 +21,7 @@ https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828
 - Updated systemd doc url {pull}354[354]
 - Updated readme doc urls {pull}356[356]
 - Use updated stack trace frame values for calculating error `grouping_keys` {pull}485[485]
-- Fix panic when a SIGINT is delivered before the server is instantiated {pull}580[580]
+- Fix panic when a signal is delivered before the server is instantiated {pull}580[580]
 
 ==== Added
 - Include build time and revision in version information {pull}396[396]

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -7,14 +7,18 @@ import (
 	"net/http"
 	"regexp"
 
+	"sync"
+
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 )
 
 type beater struct {
-	config *Config
-	server *http.Server
+	config  *Config
+	server  *http.Server
+	mutex   sync.RWMutex
+	stopped bool
 }
 
 // Creates beater
@@ -36,7 +40,8 @@ func New(b *beat.Beat, ucfg *common.Config) (beat.Beater, error) {
 	}
 
 	bt := &beater{
-		config: beaterConfig,
+		config:  beaterConfig,
+		stopped: false,
 	}
 	return bt, nil
 }
@@ -57,7 +62,14 @@ func (bt *beater) Run(b *beat.Beat) error {
 	}
 	go notifyListening(bt.config, pub.Send)
 
+	bt.mutex.Lock()
+	if bt.stopped {
+		defer bt.mutex.Unlock()
+		return nil
+	}
+
 	bt.server = newServer(bt.config, pub.Send)
+	bt.mutex.Unlock()
 
 	err = run(bt.server, lis, bt.config)
 	if err == http.ErrServerClosed {
@@ -70,5 +82,10 @@ func (bt *beater) Run(b *beat.Beat) error {
 // Graceful shutdown
 func (bt *beater) Stop() {
 	logp.Info("stopping apm-server...")
-	stop(bt.server, bt.config.ShutdownTimeout)
+	bt.mutex.Lock()
+	if bt.server != nil {
+		stop(bt.server, bt.config.ShutdownTimeout)
+	}
+	bt.stopped = true
+	bt.mutex.Unlock()
 }

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"regexp"
-
 	"sync"
 
 	"github.com/elastic/beats/libbeat/beat"
@@ -16,8 +15,8 @@ import (
 
 type beater struct {
 	config  *Config
+	mutex   sync.RWMutex // guards server and stopped
 	server  *http.Server
-	mutex   sync.RWMutex
 	stopped bool
 }
 

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -15,7 +15,7 @@ import (
 
 type beater struct {
 	config  *Config
-	mutex   sync.RWMutex // guards server and stopped
+	mutex   sync.Mutex // guards server and stopped
 	server  *http.Server
 	stopped bool
 }


### PR DESCRIPTION
Introduce a flag and a mutex in the beater so that we can't stop the server before assigning it (ie. read before write)

fixes #514