### PR TITLE
[6.2] Add troubleshooting section to docs. (#551)

### DIFF
--- a/docs/copied-from-beats/debugging.asciidoc
+++ b/docs/copied-from-beats/debugging.asciidoc
@@ -1,0 +1,44 @@
+//////////////////////////////////////////////////////////////////////////
+//// This content is shared by all Elastic Beats. Make sure you keep the
+//// descriptions here generic enough to work for all Beats that include
+//// this file. When using cross references, make sure that the cross
+//// references resolve correctly for any files that include this one.
+//// Use the appropriate variables defined in the index.asciidoc file to
+//// resolve Beat names: beatname_uc and beatname_lc.
+//// Use the following include to pull this content into a doc file:
+//// include::../../libbeat/docs/debugging.asciidoc[]
+//////////////////////////////////////////////////////////////////////////
+
+By default, {beatname_uc} sends all its output to syslog. When you run {beatname_uc} in
+the foreground, you can use the `-e` command line flag to redirect the output to
+standard error instead. For example:
+
+["source","sh",subs="attributes"]
+-----------------------------------------------
+{beatname_lc} -e
+-----------------------------------------------
+
+The default configuration file is {beatname_lc}.yml (the location of the file varies by
+platform). You can use a different configuration file by specifying the `-c` flag. For example:
+
+["source","sh",subs="attributes"]
+------------------------------------------------------------
+{beatname_lc} -e -c my{beatname_lc}config.yml
+------------------------------------------------------------
+
+You can increase the verbosity of debug messages by enabling one or more debug
+selectors. For example, to view the published transactions, you can start {beatname_uc}
+with the `publish` selector like this:
+
+["source","sh",subs="attributes"]
+------------------------------------------------------------
+{beatname_lc} -e -d "publish"
+------------------------------------------------------------
+
+If you want all the debugging output (fair warning, it's quite a lot), you can
+use `*`, like this:
+
+["source","sh",subs="attributes"]
+------------------------------------------------------------
+{beatname_lc} -e -d "*"
+------------------------------------------------------------

--- a/docs/copied-from-beats/getting-help.asciidoc
+++ b/docs/copied-from-beats/getting-help.asciidoc
@@ -1,0 +1,26 @@
+//////////////////////////////////////////////////////////////////////////
+//// This content is shared by all Elastic Beats. Make sure you keep the
+//// descriptions here generic enough to work for all Beats that include
+//// this file. When using cross references, make sure that the cross
+//// references resolve correctly for any files that include this one.
+//// Use the appropriate variables defined in the index.asciidoc file to
+//// resolve Beat names: beatname_uc and beatname_lc.
+//// Use the following include to pull this content into a doc file:
+//// include::../../libbeat/docs/getting-help.asciidoc[]
+//////////////////////////////////////////////////////////////////////////
+
+Start by searching the https://discuss.elastic.co/c/apm[discussion forum] for your issue. 
+If you can't find a resolution, open a new issue or add a comment to an existing one. 
+Make sure you provide the following information, and we'll help
+you troubleshoot the problem:
+
+* {beatname_uc} version
+* Operating System
+* Configuration
+* Any supporting information, such as debugging output, that will help us diagnose your
+problem. See <<enable-debugging>> for more details.
+
+If you're sure you found a bug, you can open a ticket on
+https://github.com/elastic/apm-server/issues?state=open[GitHub]. 
+Note, however, that we close GitHub issues containing questions or requests for help if they
+don't indicate the presence of a bug.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -32,3 +32,5 @@ include::./frontend.asciidoc[]
 include::./generated-docs.asciidoc[]
 
 include::./fields.asciidoc[]
+
+include::./troubleshooting.asciidoc[]

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -1,0 +1,30 @@
+//////////////////////////////////////////////////////////////////////////
+//// This content is mainly copied from filebeat and adapted for apm-server
+//////////////////////////////////////////////////////////////////////////
+
+[[troubleshooting]]
+= Troubleshooting
+
+[partintro]
+--
+If you have issues installing or running APM Server, 
+read the following tips:
+
+* <<getting-help>>
+* <<enable-debugging>>
+
+//sets block macro for getting-help.asciidoc included in next section
+
+--
+
+[[getting-help]]
+== Get help
+
+include::copied-from-beats/getting-help.asciidoc[]
+
+//sets block macro for debugging.asciidoc included in next section
+
+[[enable-debugging]]
+== Debug
+
+include::copied-from-beats/debugging.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 6.2:
 - Add troubleshooting section to docs.  (#551)