### PR TITLE
Re-add sourcemap description.

### DIFF
--- a/docs/frontend.asciidoc
+++ b/docs/frontend.asciidoc
@@ -11,3 +11,9 @@ and a guide on how to enable experimental frontend support.
 === Enable Frontend Support
 To try out experimental frontend support, set the `apm-server.frontend.enabled` to `true`.
 See https://github.com/elastic/apm-server/blob/{doc-branch}/apm-server.reference.yml[`apm-server.reference.yml`] for more configuration options.
+
+Read more about frontend specific features:
+
+* <<sourcemap>>
+
+include::./sourcemaps.asciidoc[]


### PR DESCRIPTION
I accidentially removed the link to sourcemaps with a previous docs update. 