### PR TITLE
[6.2] Re-add sourcemap description. (#595)

### DIFF
--- a/docs/frontend.asciidoc
+++ b/docs/frontend.asciidoc
@@ -11,3 +11,9 @@ and a guide on how to enable experimental frontend support.
 === Enable Frontend Support
 To try out experimental frontend support, set the `apm-server.frontend.enabled` to `true`.
 See https://github.com/elastic/apm-server/blob/{doc-branch}/apm-server.reference.yml[`apm-server.reference.yml`] for more configuration options.
+
+Read more about frontend specific features:
+
+* <<sourcemap>>
+
+include::./sourcemaps.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 6.2:
 - Re-add sourcemap description.  (#595)