### PR TITLE
[6.2] Fix broken link and remove beta label (#596)

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -148,7 +148,7 @@ The HTTP API exposed by APM Server listens on `localhost` and port 8200 by defau
 If you change the listen address from `localhost` to something that is accessible from outside of the machine,
 we recommend setting up firewall rules to ensure that only your own systems can access the API.
 Alternatively,
-you can use the {apm-server-ref}/configuring.html#security[secret token and TLS] to secure access to APM Server API.
+you can use the {apm-server-ref}/security.html[secret token and TLS] to secure access to APM Server API.
 
 [[kibana-dashboards]]
 [float]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -15,7 +15,7 @@ please view this documentation at https://www.elastic.co/guide/en/apm/server[ela
 endif::[]
 
 [[apm-server]]
-= APM Server Docs (Beta)
+= APM Server Reference
 
 include::./overview.asciidoc[]
 


### PR DESCRIPTION
Backports the following commits to 6.2:
 - Fix broken link and remove beta label  (#596)