### PR TITLE
[6.x] Set :branch: to :doc-branch: from version.asciidoc (#601)

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -1,4 +1,4 @@
-:branch: 6.x
+include::../version.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 [[gettting-started]]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,3 @@
-:branch: 6.x
 include::./version.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,5 +1,6 @@
 :stack-version: 6.2.0
 :doc-branch: 6.x
+:branch: {doc-branch}
 :go-version: 1.9.2
 :release-state: unreleased
 :python: 2.7.9


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Set :branch: to :doc-branch: from version.asciidoc  (#601)