### PR TITLE
Fixed link to the config file format in the beats reference.

### DIFF
--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -34,7 +34,7 @@ There's also a full example configuration file at
 +/etc/{beatname_lc}/{beatname_lc}.reference.yml+ that shows all non-deprecated
 options. For mac and win, look in the archive that you extracted.
 
-See the _Beats Platform Reference_ for more about the structure of the config file.
+See {libbeat}/config-file-format.html[Config File Format] in _Beats Platform Reference_ for more about the structure of the config file.
 
 [source,yaml]
 ----------------------------------


### PR DESCRIPTION
Link for config file reference was broken in several places.