### PR TITLE
[6.x] Update docs copied from beats to use variables. (#591)

### DIFF
--- a/docs/copied-from-beats/getting-help.asciidoc
+++ b/docs/copied-from-beats/getting-help.asciidoc
@@ -9,18 +9,16 @@
 //// include::../../libbeat/docs/getting-help.asciidoc[]
 //////////////////////////////////////////////////////////////////////////
 
-Start by searching the https://discuss.elastic.co/c/apm[discussion forum] for your issue. 
-If you can't find a resolution, open a new issue or add a comment to an existing one. 
-Make sure you provide the following information, and we'll help
+Start by searching the https://discuss.elastic.co/c/{discuss_forum}[{beatname_uc} discussion forum] for your issue. If you can't find a resolution, open a new issue or add a comment to an existing one. Make sure you provide the following information, and we'll help
 you troubleshoot the problem:
 
 * {beatname_uc} version
 * Operating System
 * Configuration
 * Any supporting information, such as debugging output, that will help us diagnose your
-problem. See <<enable-debugging>> for more details.
+problem. See <<enable-{beatname_lc}-debugging>> for more details.
 
 If you're sure you found a bug, you can open a ticket on
-https://github.com/elastic/apm-server/issues?state=open[GitHub]. 
-Note, however, that we close GitHub issues containing questions or requests for help if they
+https://github.com/elastic/{github_repo_name}/issues?state=open[GitHub]. Note, however,
+that we close GitHub issues containing questions or requests for help if they
 don't indicate the presence of a bug.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -9,6 +9,8 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :has_ml_jobs: no
 :dockerimage: docker.elastic.co/apm/{beatname_lc}:{version}
 :dockergithub: https://github.com/elastic/apm-server-docker/tree/{doc-branch}
+:discuss_forum: apm
+:github_repo_name: apm-server
 
 ifdef::env-github[]
 NOTE: For the best reading experience,

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -11,7 +11,7 @@ If you have issues installing or running APM Server,
 read the following tips:
 
 * <<getting-help>>
-* <<enable-debugging>>
+* <<enable-apm-server-debugging>>
 
 //sets block macro for getting-help.asciidoc included in next section
 
@@ -24,7 +24,7 @@ include::copied-from-beats/getting-help.asciidoc[]
 
 //sets block macro for debugging.asciidoc included in next section
 
-[[enable-debugging]]
+[[enable-apm-server-debugging]]
 == Debug
 
 include::copied-from-beats/debugging.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Update docs copied from beats to use variables.  (#591)