### PR TITLE
docs: fix typo in 6.1 doc page header

### DIFF
--- a/docs/guide/page_header.html
+++ b/docs/guide/page_header.html
@@ -1,1 +1,1 @@
-You are looking at documentation for an beta release.
+You are looking at documentation for a beta release.

--- a/docs/page_header.html
+++ b/docs/page_header.html
@@ -1,1 +1,1 @@
-You are looking at documentation for an beta release.
+You are looking at documentation for a beta release.


### PR DESCRIPTION
I hope this is the correct approach for fixing something directly on a version branch