### PR TITLE
Fix broken doc links.

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -12,6 +12,10 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :discuss_forum: apm
 :github_repo_name: apm-server
 
+:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
+:logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
+:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
+
 ifdef::env-github[]
 NOTE: For the best reading experience,
 please view this documentation at https://www.elastic.co/guide/en/apm/server[elastic.co]


### PR DESCRIPTION
fixes #627 

Fixed: 
<img width="543" alt="screen shot 2018-02-06 at 17 12 57" src="https://user-images.githubusercontent.com/5555349/35870163-3d3dcc62-0b61-11e8-8bde-4d4d59ba5d0b.png">


released atm:
<img width="574" alt="screen shot 2018-02-06 at 17 13 28" src="https://user-images.githubusercontent.com/5555349/35870141-2cfad5c0-0b61-11e8-9653-cad0a22b7752.png">


