### PR TITLE
[6.2] Fix broken doc links. (#628)

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -10,6 +10,10 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :dockerimage: docker.elastic.co/apm/{beatname_lc}:{version}
 :dockergithub: https://github.com/elastic/apm-server-docker/tree/{doc-branch}
 
+:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
+:logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
+:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
+
 ifdef::env-github[]
 NOTE: For the best reading experience,
 please view this documentation at https://www.elastic.co/guide/en/apm/server[elastic.co]


### PR DESCRIPTION
Backports the following commits to 6.2:
 - Fix broken doc links.  (#628)