### PR TITLE
[6.2] Fix broken links in apm getting started

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -1,4 +1,4 @@
-include::{docdir}/../version.asciidoc[]
+include::../version.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 [[gettting-started]]


### PR DESCRIPTION
Backports the following commits to 6.2:
 - Fix broken links in apm getting started (#632)