### PR TITLE
Use type integer instead of number where applicable

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828
 - Updated readme doc urls {pull}356[356]
 - Use updated stack trace frame values for calculating error `grouping_keys` {pull}485[485]
 - Fix panic when a signal is delivered before the server is instantiated {pull}580[580]
+- Use type integer instead of number in JSON schemas where applicable {pull}641[641]
 
 ==== Added
 - Include build time and revision in version information {pull}396[396]

--- a/docs/spec/context.json
+++ b/docs/spec/context.json
@@ -35,7 +35,7 @@
                 },
                 "status_code": {
                     "description": "The HTTP status code of the response.",
-                    "type": ["number", "null"]
+                    "type": ["integer", "null"]
                 }
             }
         },

--- a/docs/spec/errors/error.json
+++ b/docs/spec/errors/error.json
@@ -16,7 +16,7 @@
             "type": ["object", "null"],
             "properties": {
                 "code": {
-                    "type": ["string", "number", "null"],
+                    "type": ["string", "integer", "null"],
                     "maxLength": 1024,
                     "description": "The error code set when the error happened, e.g. database error code."
                 },

--- a/docs/spec/process.json
+++ b/docs/spec/process.json
@@ -6,11 +6,11 @@
   "properties": {
       "pid": {
           "description": "Process ID of the service",
-          "type": ["number"]
+          "type": ["integer"]
       },
       "ppid": {
           "description": "Parent process ID of the service",
-          "type": ["number", "null"]
+          "type": ["integer", "null"]
       },
       "title": {
           "type": ["string", "null"],

--- a/docs/spec/stacktrace_frame.json
+++ b/docs/spec/stacktrace_frame.json
@@ -11,7 +11,7 @@
         },
         "colno": {
             "description": "Column number",
-            "type": ["number", "null"]
+            "type": ["integer", "null"]
         },
         "context_line": {
             "description": "The line of code part of the stack frame",
@@ -31,7 +31,7 @@
         },
         "lineno": {
             "description": "The line number of code part of the stack frame, used e.g. to do error checksumming",
-            "type": "number"
+            "type": "integer"
         },
         "module": {
             "description": "The module to which frame belongs to",

--- a/docs/spec/transactions/span.json
+++ b/docs/spec/transactions/span.json
@@ -4,7 +4,7 @@
     "type": "object",
     "properties": {
         "id": {
-            "type": ["number", "null"],
+            "type": ["integer", "null"],
             "description": "The locally unique ID of the span."
         },
         "context": {
@@ -45,7 +45,7 @@
             "maxLength": 1024
         },
         "parent": {
-            "type": ["number", "null"],
+            "type": ["integer", "null"],
             "description": "The locally unique ID of the parent of the span."
         },
         "stacktrace": {

--- a/docs/spec/transactions/transaction.json
+++ b/docs/spec/transactions/transaction.json
@@ -49,7 +49,7 @@
             "description": "A mark captures the timing of a significant event during the lifetime of a transaction. Marks are organized into groups and can be set by the user or the agent.",
             "regexProperties": true,
             "patternProperties": {
-                "^[^.*\"]*$": { 
+                "^[^.*\"]*$": {
                     "$ref": "mark.json",
                     "maxLength": 1024
                 }
@@ -67,7 +67,7 @@
                     "type": ["object", "null"],
                     "properties": {
                         "total": {
-                            "type": ["number","null"],
+                            "type": ["integer","null"],
                             "description": "Number of spans that have been dropped by the agent recording the transaction."
                         }
                     }

--- a/docs/spec/user.json
+++ b/docs/spec/user.json
@@ -7,9 +7,9 @@
     "properties": {
         "id": {
             "description": "Identifier of the logged in user, e.g. the primary key of the user",
-            "type": ["string", "number", "null"],
+            "type": ["string", "integer", "null"],
             "maxLength": 1024
-        },    
+        },
         "email": {
             "description": "Email of the logged in user",
             "type": ["string", "null"],

--- a/processor/error/schema.go
+++ b/processor/error/schema.go
@@ -106,11 +106,11 @@ var errorSchema = `{
   "properties": {
       "pid": {
           "description": "Process ID of the service",
-          "type": ["number"]
+          "type": ["integer"]
       },
       "ppid": {
           "description": "Parent process ID of the service",
-          "type": ["number", "null"]
+          "type": ["integer", "null"]
       },
       "title": {
           "type": ["string", "null"],
@@ -169,7 +169,7 @@ var errorSchema = `{
                 },
                 "status_code": {
                     "description": "The HTTP status code of the response.",
-                    "type": ["number", "null"]
+                    "type": ["integer", "null"]
                 }
             }
         },
@@ -301,9 +301,9 @@ var errorSchema = `{
     "properties": {
         "id": {
             "description": "Identifier of the logged in user, e.g. the primary key of the user",
-            "type": ["string", "number", "null"],
+            "type": ["string", "integer", "null"],
             "maxLength": 1024
-        },    
+        },
         "email": {
             "description": "Email of the logged in user",
             "type": ["string", "null"],
@@ -327,7 +327,7 @@ var errorSchema = `{
             "type": ["object", "null"],
             "properties": {
                 "code": {
-                    "type": ["string", "number", "null"],
+                    "type": ["string", "integer", "null"],
                     "maxLength": 1024,
                     "description": "The error code set when the error happened, e.g. database error code."
                 },
@@ -358,7 +358,7 @@ var errorSchema = `{
         },
         "colno": {
             "description": "Column number",
-            "type": ["number", "null"]
+            "type": ["integer", "null"]
         },
         "context_line": {
             "description": "The line of code part of the stack frame",
@@ -378,7 +378,7 @@ var errorSchema = `{
         },
         "lineno": {
             "description": "The line number of code part of the stack frame, used e.g. to do error checksumming",
-            "type": "number"
+            "type": "integer"
         },
         "module": {
             "description": "The module to which frame belongs to",
@@ -462,7 +462,7 @@ var errorSchema = `{
         },
         "colno": {
             "description": "Column number",
-            "type": ["number", "null"]
+            "type": ["integer", "null"]
         },
         "context_line": {
             "description": "The line of code part of the stack frame",
@@ -482,7 +482,7 @@ var errorSchema = `{
         },
         "lineno": {
             "description": "The line number of code part of the stack frame, used e.g. to do error checksumming",
-            "type": "number"
+            "type": "integer"
         },
         "module": {
             "description": "The module to which frame belongs to",

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -106,11 +106,11 @@ var transactionSchema = `{
   "properties": {
       "pid": {
           "description": "Process ID of the service",
-          "type": ["number"]
+          "type": ["integer"]
       },
       "ppid": {
           "description": "Parent process ID of the service",
-          "type": ["number", "null"]
+          "type": ["integer", "null"]
       },
       "title": {
           "type": ["string", "null"],
@@ -192,7 +192,7 @@ var transactionSchema = `{
                 },
                 "status_code": {
                     "description": "The HTTP status code of the response.",
-                    "type": ["number", "null"]
+                    "type": ["integer", "null"]
                 }
             }
         },
@@ -324,9 +324,9 @@ var transactionSchema = `{
     "properties": {
         "id": {
             "description": "Identifier of the logged in user, e.g. the primary key of the user",
-            "type": ["string", "number", "null"],
+            "type": ["string", "integer", "null"],
             "maxLength": 1024
-        },    
+        },
         "email": {
             "description": "Email of the logged in user",
             "type": ["string", "null"],
@@ -374,7 +374,7 @@ var transactionSchema = `{
     "type": "object",
     "properties": {
         "id": {
-            "type": ["number", "null"],
+            "type": ["integer", "null"],
             "description": "The locally unique ID of the span."
         },
         "context": {
@@ -415,7 +415,7 @@ var transactionSchema = `{
             "maxLength": 1024
         },
         "parent": {
-            "type": ["number", "null"],
+            "type": ["integer", "null"],
             "description": "The locally unique ID of the parent of the span."
         },
         "stacktrace": {
@@ -434,7 +434,7 @@ var transactionSchema = `{
         },
         "colno": {
             "description": "Column number",
-            "type": ["number", "null"]
+            "type": ["integer", "null"]
         },
         "context_line": {
             "description": "The line of code part of the stack frame",
@@ -454,7 +454,7 @@ var transactionSchema = `{
         },
         "lineno": {
             "description": "The line number of code part of the stack frame, used e.g. to do error checksumming",
-            "type": "number"
+            "type": "integer"
         },
         "module": {
             "description": "The module to which frame belongs to",
@@ -509,7 +509,7 @@ var transactionSchema = `{
             "description": "A mark captures the timing of a significant event during the lifetime of a transaction. Marks are organized into groups and can be set by the user or the agent.",
             "regexProperties": true,
             "patternProperties": {
-                "^[^.*\"]*$": { 
+                "^[^.*\"]*$": {
                         "$schema": "http://json-schema.org/draft-04/schema#",
     "$id": "docs/spec/transactions/mark.json",
     "type": ["object", "null"],
@@ -535,7 +535,7 @@ var transactionSchema = `{
                     "type": ["object", "null"],
                     "properties": {
                         "total": {
-                            "type": ["number","null"],
+                            "type": ["integer","null"],
                             "description": "Number of spans that have been dropped by the agent recording the transaction."
                         }
                     }

--- a/tests/json_schema_test.go
+++ b/tests/json_schema_test.go
@@ -33,7 +33,7 @@ func TestServiceSchema(t *testing.T) {
 
 func TestUserSchema(t *testing.T) {
 	testData := []SchemaTestData{
-		{File: "invalid_type_id.json", Error: "expected string or number or null"},
+		{File: "invalid_type_id.json", Error: "expected string or integer or null"},
 		{File: "invalid_type_email.json", Error: "expected string or null"},
 		{File: "invalid_type_username.json", Error: "expected string or null"},
 	}
@@ -121,7 +121,7 @@ func TestErrorSchema(t *testing.T) {
 		{File: "no_log_or_exception.json", Error: "missing properties: \"exception\""},
 		{File: "no_log_or_exception.json", Error: "missing properties: \"log\""},
 		{File: "no_timestamp.json", Error: "missing properties: \"timestamp\""},
-		{File: "invalid_code.json", Error: "expected string or number or null"},
+		{File: "invalid_code.json", Error: "expected string or integer or null"},
 	}
 	testDataAgainstSchema(t, testData, "errors/error", "error", `"$ref": "../docs/spec/errors/`)
 }


### PR DESCRIPTION
In most cases where type: number has been used in the json schema files,
floating point numbers are not neccessary.

This change allows automated tools like the jsonschema2pojo converter to
generate Integer instead of Double fields.

In these instances, I didn't change `number` to `integer`:

```
transactions/Mark.patternProperties
transactions/Span.duration
transactions/Span.start
transactions/Transaction.duration
```