### PR TITLE
[6.x] remove deprecated usages of logp (#583)

### DIFF
--- a/beater/client.go
+++ b/beater/client.go
@@ -29,7 +29,7 @@ func isServerUp(secure bool, host string, numRetries int, retryInterval time.Dur
 
 	for i := 0; i <= numRetries; i++ {
 		if check() {
-			logp.Info("HTTP Server ready")
+			logp.NewLogger("http_client").Info("HTTP Server ready")
 			return true
 		}
 		time.Sleep(retryInterval)

--- a/beater/onboarding.go
+++ b/beater/onboarding.go
@@ -16,7 +16,7 @@ func notifyListening(config *Config, reporter reporter) {
 	}
 
 	if isServerUp() {
-		logp.Info("Publishing onboarding document")
+		logp.NewLogger("onboarding").Info("Publishing onboarding document")
 
 		event := beat.Event{
 			Timestamp: time.Now(),

--- a/beater/server.go
+++ b/beater/server.go
@@ -25,13 +25,14 @@ func newServer(config *Config, report reporter) *http.Server {
 }
 
 func run(server *http.Server, lis net.Listener, config *Config) error {
-	logp.Info("Starting apm-server! Hit CTRL-C to stop it.")
-	logp.Info("Listening on: %s", server.Addr)
+	logger := logp.NewLogger("server")
+	logger.Infof("Starting apm-server. Hit CTRL-C to stop it.")
+	logger.Infof("Listening on: %s", server.Addr)
 	switch config.Frontend.isEnabled() {
 	case true:
-		logp.Info("Frontend endpoints enabled!")
+		logger.Info("Frontend endpoints enabled!")
 	case false:
-		logp.Info("Frontend endpoints disabled")
+		logger.Info("Frontend endpoints disabled")
 	}
 
 	ssl := config.SSL
@@ -39,7 +40,7 @@ func run(server *http.Server, lis net.Listener, config *Config) error {
 		return server.ServeTLS(lis, ssl.Cert, ssl.PrivateKey)
 	}
 	if config.SecretToken != "" {
-		logp.Warn("Secret token is set, but SSL is not enabled.")
+		logger.Warn("Secret token is set, but SSL is not enabled.")
 	}
 	return server.Serve(lis)
 }
@@ -48,12 +49,13 @@ func stop(server *http.Server, timeout time.Duration) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
+	logger := logp.NewLogger("server")
 	err := server.Shutdown(ctx)
 	if err != nil {
-		logp.Err(err.Error())
+		logger.Error(err.Error())
 		err = server.Close()
 		if err != nil {
-			logp.Err(err.Error())
+			logger.Error(err.Error())
 		}
 	}
 }

--- a/model/stacktrace_frame.go
+++ b/model/stacktrace_frame.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"fmt"
 	"regexp"
 
 	pr "github.com/elastic/apm-server/processor"
@@ -97,9 +96,9 @@ func (s *StacktraceFrame) applySourcemap(mapper sourcemap.Mapper, service Servic
 	sourcemapId := s.buildSourcemapId(service)
 	mapping, err := mapper.Apply(sourcemapId, s.Lineno, *s.Colno)
 	if err != nil {
-		logp.Err(fmt.Sprintf("failed to apply sourcemap %s", err.Error()))
-		e, issourcemapError := err.(sourcemap.Error)
-		if !issourcemapError || e.Kind == sourcemap.MapError || e.Kind == sourcemap.KeyError {
+		logp.NewLogger("stacktrace").Errorf("failed to apply sourcemap %s", err.Error())
+		e, isSourcemapError := err.(sourcemap.Error)
+		if !isSourcemapError || e.Kind == sourcemap.MapError || e.Kind == sourcemap.KeyError {
 			s.updateError(err.Error())
 		}
 		return prevFunction
@@ -133,7 +132,7 @@ func (s *StacktraceFrame) buildSourcemapId(service Service) sourcemap.Id {
 }
 
 func (s *StacktraceFrame) updateError(errMsg string) {
-	logp.Err(errMsg)
+	logp.NewLogger("stacktrace").Error(errMsg)
 	s.Sourcemap.Error = &errMsg
 	s.updateSmap(false)
 }

--- a/processor/error/payload.go
+++ b/processor/error/payload.go
@@ -22,7 +22,7 @@ type payload struct {
 func (pa *payload) transform(config *pr.Config) []beat.Event {
 	var events []beat.Event
 
-	logp.Debug("error", "Transform error events: events=%d, service=%s, agent=%s:%s", len(pa.Events), pa.Service.Name, pa.Service.Agent.Name, pa.Service.Agent.Version)
+	logp.NewLogger("transform").Debugf("Transform error events: events=%d, service=%s, agent=%s:%s", len(pa.Events), pa.Service.Name, pa.Service.Agent.Name, pa.Service.Agent.Version)
 
 	errorCounter.Add(int64(len(pa.Events)))
 	for _, e := range pa.Events {

--- a/processor/sourcemap/payload.go
+++ b/processor/sourcemap/payload.go
@@ -26,7 +26,7 @@ func (pa *payload) transform(config *pr.Config) []beat.Event {
 	sourcemapCounter.Add(1)
 
 	if config == nil || config.SmapMapper == nil {
-		logp.Err("Sourcemap Accessor is nil, cache cannot be invalidated.")
+		logp.NewLogger("sourcemap").Error("Sourcemap Accessor is nil, cache cannot be invalidated.")
 	} else {
 		config.SmapMapper.NewSourcemapAdded(smap.Id{
 			ServiceName:    pa.ServiceName,

--- a/processor/transaction/payload.go
+++ b/processor/transaction/payload.go
@@ -23,7 +23,7 @@ type payload struct {
 func (pa *payload) transform(config *pr.Config) []beat.Event {
 	var events []beat.Event
 
-	logp.Debug("transaction", "Transform transaction events: events=%d, service=%s, agent=%s:%s", len(pa.Events), pa.Service.Name, pa.Service.Agent.Name, pa.Service.Agent.Version)
+	logp.NewLogger("transaction").Debugf("Transform transaction events: events=%d, service=%s, agent=%s:%s", len(pa.Events), pa.Service.Name, pa.Service.Agent.Name, pa.Service.Agent.Version)
 
 	transactionCounter.Add(int64(len(pa.Events)))
 	for _, event := range pa.Events {

--- a/sourcemap/accessor.go
+++ b/sourcemap/accessor.go
@@ -20,7 +20,7 @@ type SmapAccessor struct {
 }
 
 func NewSmapAccessor(config Config) (*SmapAccessor, error) {
-	logp.Debug("sourcemap", "NewSmapAccessor created at Time.now %v for index", time.Now().Unix(), config.Index)
+	logp.NewLogger("sourcemap").Debugf("NewSmapAccessor created at Time.now %v for index", time.Now().Unix(), config.Index)
 
 	es, err := NewElasticsearch(config.ElasticsearchConfig, config.Index)
 	if err != nil {

--- a/sourcemap/cache.go
+++ b/sourcemap/cache.go
@@ -10,7 +10,10 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 )
 
-const MIN_CLEANUP_INTERVAL_SECONDS float64 = 60
+const (
+	MinCleanupIntervalSeconds float64 = 60
+	LoggerSelector                    = "sourcemap"
+)
 
 type cache struct {
 	goca *gocache.Cache
@@ -28,12 +31,12 @@ func newCache(expiration time.Duration) (*cache, error) {
 
 func (c *cache) add(id Id, consumer *sourcemap.Consumer) {
 	c.goca.Set(id.Key(), consumer, gocache.DefaultExpiration)
-	logp.Debug("sourcemap", "Added id %v. Cache now has %v entries.", id.Key(), c.goca.ItemCount())
+	logp.NewLogger(LoggerSelector).Debugf("Added id %v. Cache now has %v entries.", id.Key(), c.goca.ItemCount())
 }
 
 func (c *cache) remove(id Id) {
 	c.goca.Delete(id.Key())
-	logp.Debug("sourcemap", "Removed id %v. Cache now has %v entries.", id.Key(), c.goca.ItemCount())
+	logp.NewLogger(LoggerSelector).Debugf("Removed id %v. Cache now has %v entries.", id.Key(), c.goca.ItemCount())
 }
 
 func (c *cache) fetch(id Id) (*sourcemap.Consumer, bool) {
@@ -49,5 +52,5 @@ func (c *cache) fetch(id Id) (*sourcemap.Consumer, bool) {
 }
 
 func cleanupInterval(ttl time.Duration) time.Duration {
-	return time.Duration(math.Max(ttl.Seconds(), MIN_CLEANUP_INTERVAL_SECONDS)) * time.Second
+	return time.Duration(math.Max(ttl.Seconds(), MinCleanupIntervalSeconds)) * time.Second
 }


### PR DESCRIPTION
Backports the following commits to 6.x:
 - remove deprecated usages of logp  (#583)