### PR TITLE
[6.x] Send sourcemap docs to own index by default. (#582)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -54,6 +54,7 @@ https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828
 - Change `error.culprit` after successfully applying sourcemapping {pull}520[520]
 - Make `transaction.name` optional {pull}554[554]
 - Remove config files from beats. Manually add relevant config options {pull}578[578]
+- Use seperate index for uploaded `source maps` {pull}582[582].
 
 ==== Deprecated
 

--- a/_meta/beat.reference.yml
+++ b/_meta/beat.reference.yml
@@ -64,10 +64,10 @@ apm-server:
       #cache:
         #expiration: 5m
 
-      # Source maps are stored in the same index as transaction and error documents.
-      # If the default index pattern at 'outputs.elasticsearch.index' is changed,
-      # a matching index pattern needs to be specified here.
-      #index_pattern: "apm-*"
+      # Source maps are stored in a seperate index.
+      # If the default index pattern for source maps at 'outputs.elasticsearch.indices'
+      # is changed, a matching index pattern needs to be specified here.
+      #index_pattern: "apm-*-sourcemap*"
 
   # golang expvar support - https://golang.org/pkg/expvar/
   #expvar:
@@ -134,9 +134,29 @@ output.elasticsearch:
   #worker: 1
 
   # Optional index name. The default is "apm" plus version plus date
-  # and generates apm-version-YYYY.MM.DD keys.
-  # In case you modify this pattern you must update setup.template.name and setup.template.pattern accordingly.
+  # and generates apm-%{[beat.version]}-YYYY.MM.DD keys.
+  # In case you modify this pattern you must update following configuration accordingly:
+  # * `setup.template.name`
+  # * `setup.template.pattern`
+  # * `setup.dashboards.index`
+  #
   #index: "apm-%{[beat.version]}-%{+yyyy.MM.dd}"
+
+  # By specifying additional indices documents matching the criteria are indexed in a seperate index.
+  # In case you are uploading source map documents (which is currently an experimental feature),
+  # source map documents are going to their own index with the configuration below.
+  #
+  # Be aware that there is only one Elasticsearch template and one Kibana Index Pattern,
+  # which needs to match against indices for ingested documents as well as for source maps.
+  # In case you modify the index patterns you must ensure to use the same prefix for all indices,
+  # and to accordingly set:
+  # * `setup.template.name`
+  # * `setup.template.pattern`
+  # * `setup.dashboards.index`
+  #indices:
+    #- index: "apm-%{[beat.version]}-sourcemap"
+      #when.contains:
+        #processor.event: "sourcemap"
 
   # Optional ingest node pipeline. By default no pipeline will be used.
   #pipeline: ""
@@ -256,6 +276,7 @@ output.elasticsearch:
 
 # The Elasticsearch index name. This overwrites the index name defined in the
 # dashboards and index pattern. Example: testbeat-*
+# The dashboards.index needs to be changed in case the elasticsearch index pattern is modified.
 #setup.dashboards.index:
 
 # Always use the Kibana API for loading the dashboards instead of autodetecting

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -25,11 +25,13 @@ apm-server:
   #ssl.key : "path/to/private_key"
 
 #==================== Elasticsearch template setting ==========================
+
 setup.template.settings:
   index.number_of_shards: 1
   index.codec: best_compression
 
 #============================== Dashboards =====================================
+#
 # These settings control loading the sample dashboards to the Kibana index. Loading
 # the dashboards is disabled by default and can be enabled either by setting the
 # options here, or by using the `-setup` CLI flag or the `setup` command.
@@ -55,6 +57,31 @@ setup.kibana:
 output.elasticsearch:
   # Array of hosts to connect to.
   hosts: ["localhost:9200"]
+
+  # Optional index name. The default is "apm" plus version plus date
+  # and generates apm-%{[beat.version]}-YYYY.MM.DD keys.
+  # In case you modify this pattern you must update following configuration accordingly:
+  # * `setup.template.name`
+  # * `setup.template.pattern`
+  # * `setup.dashboards.index`
+  #
+  #index: "apm-%{[beat.version]}-%{+yyyy.MM.dd}"
+
+  # By specifying additional indices documents matching the criteria are indexed in a seperate index.
+  # In case you are uploading source map documents (which is currently an experimental feature),
+  # source map documents are going to their own index with the configuration below.
+  #
+  # Be aware that there is only one Elasticsearch template and one Kibana Index Pattern,
+  # which needs to match against indices for ingested documents as well as for source maps.
+  # In case you modify the index patterns you must ensure to use the same prefix for all indices,
+  # and to accordingly set:
+  # * `setup.template.name`
+  # * `setup.template.pattern`
+  # * `setup.dashboards.index`
+  indices:
+    - index: "apm-%{[beat.version]}-sourcemap"
+      when.contains:
+        processor.event: "sourcemap"
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"

--- a/apm-server.reference.yml
+++ b/apm-server.reference.yml
@@ -64,10 +64,10 @@ apm-server:
       #cache:
         #expiration: 5m
 
-      # Source maps are stored in the same index as transaction and error documents.
-      # If the default index pattern at 'outputs.elasticsearch.index' is changed,
-      # a matching index pattern needs to be specified here.
-      #index_pattern: "apm-*"
+      # Source maps are stored in a seperate index.
+      # If the default index pattern for source maps at 'outputs.elasticsearch.indices'
+      # is changed, a matching index pattern needs to be specified here.
+      #index_pattern: "apm-*-sourcemap*"
 
   # golang expvar support - https://golang.org/pkg/expvar/
   #expvar:
@@ -134,9 +134,29 @@ output.elasticsearch:
   #worker: 1
 
   # Optional index name. The default is "apm" plus version plus date
-  # and generates apm-version-YYYY.MM.DD keys.
-  # In case you modify this pattern you must update setup.template.name and setup.template.pattern accordingly.
+  # and generates apm-%{[beat.version]}-YYYY.MM.DD keys.
+  # In case you modify this pattern you must update following configuration accordingly:
+  # * `setup.template.name`
+  # * `setup.template.pattern`
+  # * `setup.dashboards.index`
+  #
   #index: "apm-%{[beat.version]}-%{+yyyy.MM.dd}"
+
+  # By specifying additional indices documents matching the criteria are indexed in a seperate index.
+  # In case you are uploading source map documents (which is currently an experimental feature),
+  # source map documents are going to their own index with the configuration below.
+  #
+  # Be aware that there is only one Elasticsearch template and one Kibana Index Pattern,
+  # which needs to match against indices for ingested documents as well as for source maps.
+  # In case you modify the index patterns you must ensure to use the same prefix for all indices,
+  # and to accordingly set:
+  # * `setup.template.name`
+  # * `setup.template.pattern`
+  # * `setup.dashboards.index`
+  #indices:
+    #- index: "apm-%{[beat.version]}-sourcemap"
+      #when.contains:
+        #processor.event: "sourcemap"
 
   # Optional ingest node pipeline. By default no pipeline will be used.
   #pipeline: ""
@@ -256,6 +276,7 @@ output.elasticsearch:
 
 # The Elasticsearch index name. This overwrites the index name defined in the
 # dashboards and index pattern. Example: testbeat-*
+# The dashboards.index needs to be changed in case the elasticsearch index pattern is modified.
 #setup.dashboards.index:
 
 # Always use the Kibana API for loading the dashboards instead of autodetecting

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -25,11 +25,13 @@ apm-server:
   #ssl.key : "path/to/private_key"
 
 #==================== Elasticsearch template setting ==========================
+
 setup.template.settings:
   index.number_of_shards: 1
   index.codec: best_compression
 
 #============================== Dashboards =====================================
+#
 # These settings control loading the sample dashboards to the Kibana index. Loading
 # the dashboards is disabled by default and can be enabled either by setting the
 # options here, or by using the `-setup` CLI flag or the `setup` command.
@@ -55,6 +57,31 @@ setup.kibana:
 output.elasticsearch:
   # Array of hosts to connect to.
   hosts: ["localhost:9200"]
+
+  # Optional index name. The default is "apm" plus version plus date
+  # and generates apm-%{[beat.version]}-YYYY.MM.DD keys.
+  # In case you modify this pattern you must update following configuration accordingly:
+  # * `setup.template.name`
+  # * `setup.template.pattern`
+  # * `setup.dashboards.index`
+  #
+  #index: "apm-%{[beat.version]}-%{+yyyy.MM.dd}"
+
+  # By specifying additional indices documents matching the criteria are indexed in a seperate index.
+  # In case you are uploading source map documents (which is currently an experimental feature),
+  # source map documents are going to their own index with the configuration below.
+  #
+  # Be aware that there is only one Elasticsearch template and one Kibana Index Pattern,
+  # which needs to match against indices for ingested documents as well as for source maps.
+  # In case you modify the index patterns you must ensure to use the same prefix for all indices,
+  # and to accordingly set:
+  # * `setup.template.name`
+  # * `setup.template.pattern`
+  # * `setup.dashboards.index`
+  indices:
+    - index: "apm-%{[beat.version]}-sourcemap"
+      when.contains:
+        processor.event: "sourcemap"
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -22,7 +22,7 @@ type beater struct {
 
 // Creates beater
 func New(b *beat.Beat, ucfg *common.Config) (beat.Beater, error) {
-	beaterConfig := defaultConfig()
+	beaterConfig := defaultConfig(b.Info.Version)
 	if err := ucfg.Unpack(beaterConfig); err != nil {
 		return nil, fmt.Errorf("Error reading config file: %v", err)
 	}

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -27,11 +27,12 @@ func TestBeatConfig(t *testing.T) {
 	tests := []struct {
 		conf       map[string]interface{}
 		beaterConf *Config
+		SmapIndex  string
 		msg        string
 	}{
 		{
 			conf:       map[string]interface{}{},
-			beaterConf: defaultConfig(),
+			beaterConf: defaultConfig("6.2.0"),
 			msg:        "Default config created for empty config.",
 		},
 		{
@@ -85,11 +86,12 @@ func TestBeatConfig(t *testing.T) {
 					RateLimit:    1000,
 					AllowOrigins: []string{"example*"},
 					SourceMapping: &SourceMapping{
-						Cache: &Cache{Expiration: 5 * time.Minute},
-						Index: "apm-test*",
+						Cache:        &Cache{Expiration: 5 * time.Minute},
+						IndexPattern: "apm-test*",
 					},
 					LibraryPattern:      "^custom",
 					ExcludeFromGrouping: "^grouping",
+					beatVersion:         "6.2.0",
 				},
 				ConcurrentRequests: 15,
 			},
@@ -137,10 +139,11 @@ func TestBeatConfig(t *testing.T) {
 						Cache: &Cache{
 							Expiration: 7 * time.Second,
 						},
-						Index: "apm-*",
+						IndexPattern: "apm-*-sourcemap*",
 					},
 					LibraryPattern:      "node_modules|bower_components|~",
 					ExcludeFromGrouping: "^/webpack",
+					beatVersion:         "6.2.0",
 				},
 				ConcurrentRequests: 40,
 			},
@@ -151,7 +154,7 @@ func TestBeatConfig(t *testing.T) {
 	for _, test := range tests {
 		ucfgConfig, err := common.NewConfigFrom(test.conf)
 		assert.NoError(t, err)
-		btr, err := New(&beat.Beat{}, ucfgConfig)
+		btr, err := New(&beat.Beat{Info: beat.Info{Version: "6.2.0"}}, ucfgConfig)
 		assert.NoError(t, err)
 		assert.NotNil(t, btr)
 		bt := btr.(*beater)
@@ -226,7 +229,7 @@ func SetupServer(b *testing.B) *http.ServeMux {
 	if err != nil {
 		b.Fatal(err)
 	}
-	return newMuxer(defaultConfig(), pub.Send)
+	return newMuxer(defaultConfig("7.0.0"), pub.Send)
 }
 
 func pluralize(entity string) string {

--- a/beater/config_test.go
+++ b/beater/config_test.go
@@ -59,8 +59,8 @@ func TestConfig(t *testing.T) {
 					RateLimit:    1000,
 					AllowOrigins: []string{"example*"},
 					SourceMapping: &SourceMapping{
-						Cache: &Cache{Expiration: 10 * time.Minute},
-						Index: "apm-test*",
+						Cache:        &Cache{Expiration: 10 * time.Minute},
+						IndexPattern: "apm-test*",
 					},
 					LibraryPattern:      "pattern",
 					ExcludeFromGrouping: "group_pattern",
@@ -99,7 +99,7 @@ func TestConfig(t *testing.T) {
 					RateLimit:    0,
 					AllowOrigins: nil,
 					SourceMapping: &SourceMapping{
-						Index: "",
+						IndexPattern: "",
 					},
 				},
 			},
@@ -155,5 +155,21 @@ func TestIsEnabled(t *testing.T) {
 			isEnabled := test.config.isEnabled()
 			assert.Equal(t, b, isEnabled, "ssl config but should be %v", b)
 		})
+	}
+}
+
+func TestReplaceBeatVersion(t *testing.T) {
+	cases := []struct {
+		version      string
+		indexPattern string
+		replaced     string
+	}{
+		{version: "", indexPattern: "", replaced: ""},
+		{version: "6.2.0", indexPattern: "apm-%{[beat.version]}", replaced: "apm-6.2.0"},
+		{version: "6.2.0", indexPattern: "apm-smap", replaced: "apm-smap"},
+	}
+	for _, test := range cases {
+		out := replaceVersion(test.indexPattern, test.version)
+		assert.Equal(t, test.replaced, out)
 	}
 }

--- a/beater/handlers.go
+++ b/beater/handlers.go
@@ -98,7 +98,7 @@ func backendHandler(pf ProcessorFactory, config *Config, report reporter) http.H
 }
 
 func frontendHandler(pf ProcessorFactory, config *Config, report reporter) http.Handler {
-	smapper, err := config.Frontend.SmapMapper()
+	smapper, err := config.Frontend.memoizedSmapMapper()
 	if err != nil {
 		logp.NewLogger("handler").Error(err.Error())
 	}
@@ -115,7 +115,7 @@ func frontendHandler(pf ProcessorFactory, config *Config, report reporter) http.
 }
 
 func sourcemapHandler(pf ProcessorFactory, config *Config, report reporter) http.Handler {
-	smapper, err := config.Frontend.SmapMapper()
+	smapper, err := config.Frontend.memoizedSmapMapper()
 	if err != nil {
 		logp.NewLogger("handler").Error(err.Error())
 	}

--- a/beater/onboarding_test.go
+++ b/beater/onboarding_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNotifyUpServerDown(t *testing.T) {
-	config := defaultConfig()
+	config := defaultConfig("7.0.0")
 	var saved []beat.Event
 	var reporter = func(events []beat.Event) error {
 		saved = append(saved, events...)

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -220,7 +220,7 @@ func setupServer(t *testing.T, ssl *SSLConfig) (*http.Server, func()) {
 	lis, err := net.Listen("tcp", "localhost:0")
 	assert.NoError(t, err)
 
-	cfg := defaultConfig()
+	cfg := defaultConfig("7.0.0")
 	cfg.Host = lis.Addr().String()
 	cfg.SSL = ssl
 

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -303,11 +303,27 @@ class SmapCacheBaseTest(ClientSideBaseTest):
         return cfg
 
 
+class SmapIndexBaseTest(ClientSideBaseTest):
+    @classmethod
+    def setUpClass(cls):
+        super(SmapIndexBaseTest, cls).setUpClass()
+        cls.index_name = "apm-test"
+        cls.smap_index_pattern = "apm-*-sourcemap*"
+        cls.smap_index = "apm-test-sourcemap"
+
+    def config(self):
+        cfg = super(SmapIndexBaseTest, self).config()
+        cfg.update({"index_name": "apm-test",
+                    "smap_index_pattern": "apm-*-sourcemap*",
+                    "smap_index": "apm-test-sourcemap"})
+        return cfg
+
+
 class ExpvarBaseTest(ServerBaseTest):
     config_overrides = {}
 
     def config(self):
-        cfg = super(ServerBaseTest, self).config()
+        cfg = super(ExpvarBaseTest, self).config()
         cfg.update(self.config_overrides)
         return cfg
 

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -13,10 +13,14 @@ apm-server:
   frontend.allow_origins: {{ allow_origins }}
   frontend.library_pattern: "~/test|library"
   frontend.exclude_from_grouping: "~/test"
-  {% if smap_index_pattern%}
-  frontend.source_mapping.index_pattern: {{ smap_index_pattern}}
+
+  {% if smap_cache_expiration%}
   frontend.source_mapping.cache.expiration: {{ smap_cache_expiration}}
   {% endif %}
+  {% if smap_index_pattern%}
+  frontend.source_mapping.index_pattern: {{ smap_index_pattern}}
+  {% endif %}
+
   {% if expvar_enabled %}
   expvar.enabled: {{ expvar_enabled }}
   {% endif %}
@@ -53,8 +57,16 @@ output.file:
   #number_of_files: 7
 
 {% if elasticsearch_host %}
-output.elasticsearch.hosts: ["{{ elasticsearch_host }}"]
-output.elasticsearch.index: {{ index_name }}
+output.elasticsearch:
+  hosts: ["{{ elasticsearch_host }}"]
+
+  index: {{ index_name }}
+  {% if smap_index %}
+  indices:
+    - index: {{ smap_index }}
+      when.contains:
+        processor.event: "sourcemap"
+  {% endif %}
 {% endif %}
 
 ############################# Beat #########################################

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -1,7 +1,8 @@
 import os
 import unittest
 
-from apmserver import ElasticTest, ExpvarBaseTest, ClientSideBaseTest, SmapCacheBaseTest
+from apmserver import ElasticTest, ExpvarBaseTest
+from apmserver import ClientSideBaseTest, SmapIndexBaseTest, SmapCacheBaseTest
 from beat.beat import INTEGRATION_TESTS
 
 
@@ -275,6 +276,24 @@ class SourcemappingIntegrationTest(ElasticTest, ClientSideBaseTest):
 
         # insert document,
         # fetching sourcemap without errors, so it must be fetched from cache
+        self.load_docs_with_template(self.get_error_payload_path(),
+                                     self.errors_url,
+                                     'error',
+                                     1)
+        self.assert_no_logged_warnings()
+        self.check_frontend_error_sourcemap(True)
+
+
+class SourcemappingIntegrationChangedConfigTest(ElasticTest, SmapIndexBaseTest):
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_frontend_error_changed_index(self):
+        # use an uncleaned path to test that path is cleaned in upload
+        path = 'http://localhost:8000/test/e2e/../e2e/general-usecase/bundle.js.map'
+        r = self.upload_sourcemap(file_name='bundle.js.map', bundle_filepath=path)
+        assert r.status_code == 202, r.status_code
+        self.wait_for_sourcemaps()
+
         self.load_docs_with_template(self.get_error_payload_path(),
                                      self.errors_url,
                                      'error',


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Send sourcemap docs to own index by default.  (#582)