### PR TITLE
[6.x] Log a warning for sourcemap uploads and fetches with duplicated caching keys (#610)

### DIFF
--- a/sourcemap/elasticsearch.go
+++ b/sourcemap/elasticsearch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-sourcemap/sourcemap"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 	es "github.com/elastic/beats/libbeat/outputs/elasticsearch"
 )
 
@@ -61,6 +62,10 @@ func (e *smapElasticsearch) runESQuery(body map[string]interface{}) (*es.SearchR
 func parseResult(result *es.SearchResults, id Id) (*sourcemap.Consumer, error) {
 	if result.Hits.Total == 0 {
 		return nil, nil
+	}
+	if result.Hits.Total > 1 {
+		logp.NewLogger("sourcemap").Warnf("Multiple sourcemaps found for service %s version %s and file %s , fetching the last uploaded one",
+			id.ServiceName, id.ServiceVersion, id.Path)
 	}
 	smap, err := parseSmap(result.Hits.Hits[0])
 	if err != nil {

--- a/sourcemap/mapper.go
+++ b/sourcemap/mapper.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 type Mapper interface {
@@ -63,5 +64,10 @@ func (m *SmapMapper) Apply(id Id, lineno, colno int) (*Mapping, error) {
 }
 
 func (m *SmapMapper) NewSourcemapAdded(id Id) {
+	_, err := m.Accessor.Fetch(id)
+	if err == nil {
+		logp.NewLogger("sourcemap").Warnf("Overriding sourcemap for service %s version %s and file %s",
+			id.ServiceName, id.ServiceVersion, id.Path)
+	}
 	m.Accessor.Remove(id)
 }

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import shutil
 import sys
 
@@ -62,20 +63,21 @@ class ServerSetUpBaseTest(BaseTest):
         self.apmserver_proc = self.start_beat()
         self.wait_until(lambda: self.log_contains("Starting apm-server"))
 
-    def assert_no_logged_warnings(self, replace=None):
+    def assert_no_logged_warnings(self, suppress=None):
         """
         Assert that the log file contains no ERR or WARN lines.
         """
-        log = self.get_log()
-        log = log.replace("WARN EXPERIMENTAL", "")
-        log = log.replace("WARN BETA", "")
+        if suppress == None:
+            suppress = []
+
         # Jenkins runs as a Windows service and when Jenkins executes theses
         # tests the Beat is confused since it thinks it is running as a service.
-        log = log.replace(
-            "ERR Error: The service process could not connect to the service controller.", "")
-        if replace:
-            for r in replace:
-                log = log.replace(r, "")
+        winErr = "ERR Error: The service process could not connect to the service controller."
+
+        suppress = suppress + ["WARN EXPERIMENTAL", "WARN BETA", winErr]
+        log = self.get_log()
+        for s in suppress:
+            log = re.sub(s, "", log)
         self.assertNotRegexpMatches(log, "ERR|WARN")
 
 
@@ -143,8 +145,10 @@ class ElasticTest(ServerBaseTest):
         self.es.indices.delete(index=self.index_name, ignore=[400, 404])
         self.wait_until(lambda: not self.es.indices.exists(self.index_name))
 
-        self.es.indices.delete_template(name=self.index_name, ignore=[400, 404])
-        self.wait_until(lambda: not self.es.indices.exists_template(self.index_name))
+        self.es.indices.delete_template(
+            name=self.index_name, ignore=[400, 404])
+        self.wait_until(
+            lambda: not self.es.indices.exists_template(self.index_name))
 
         super(ElasticTest, self).setUp()
 
@@ -166,7 +170,8 @@ class ElasticTest(ServerBaseTest):
 
         # make sure template is loaded
         self.wait_until(
-            lambda: self.log_contains("Elasticsearch template with name \'{}\' loaded".format(self.index_name)),
+            lambda: self.log_contains(
+                "Elasticsearch template with name \'{}\' loaded".format(self.index_name)),
             max_timeout=20)
         self.wait_until(lambda: self.es.indices.exists(self.index_name))
         # Quick wait to give documents some time to be sent to the index
@@ -183,7 +188,8 @@ class ElasticTest(ServerBaseTest):
     def check_backend_error_sourcemap(self, count=1):
         rs = self.es.search(index=self.index_name, body={
             "query": {"term": {"processor.event": "error"}}})
-        assert rs['hits']['total'] == count, "found {} documents, expected {}".format(rs['hits']['total'], count)
+        assert rs['hits']['total'] == count, "found {} documents, expected {}".format(
+            rs['hits']['total'], count)
         for doc in rs['hits']['hits']:
             err = doc["_source"]["error"]
             if "exception" in err:
@@ -194,7 +200,8 @@ class ElasticTest(ServerBaseTest):
     def check_backend_transaction_sourcemap(self, count=1):
         rs = self.es.search(index=self.index_name, body={
             "query": {"term": {"processor.event": "span"}}})
-        assert rs['hits']['total'] == count, "found {} documents, expected {}".format(rs['hits']['total'], count)
+        assert rs['hits']['total'] == count, "found {} documents, expected {}".format(
+            rs['hits']['total'], count)
         for doc in rs['hits']['hits']:
             self.check_for_no_smap(doc["_source"]["span"])
 
@@ -260,7 +267,8 @@ class ClientSideBaseTest(ServerBaseTest):
     def check_frontend_error_sourcemap(self, updated, expected_err=None, count=1):
         rs = self.es.search(index=self.index_name, body={
             "query": {"term": {"processor.event": "error"}}})
-        assert rs['hits']['total'] == count, "found {} documents, expected {}".format(rs['hits']['total'], count)
+        assert rs['hits']['total'] == count, "found {} documents, expected {}".format(
+            rs['hits']['total'], count)
         for doc in rs['hits']['hits']:
             err = doc["_source"]["error"]
             if "exception" in err:
@@ -271,7 +279,8 @@ class ClientSideBaseTest(ServerBaseTest):
     def check_frontend_transaction_sourcemap(self, updated, expected_err=None, count=1):
         rs = self.es.search(index=self.index_name, body={
             "query": {"term": {"processor.event": "span"}}})
-        assert rs['hits']['total'] == count, "found {} documents, expected {}".format(rs['hits']['total'], count)
+        assert rs['hits']['total'] == count, "found {} documents, expected {}".format(
+            rs['hits']['total'], count)
         for doc in rs['hits']['hits']:
             span = doc["_source"]["span"]
             self.check_smap(span, updated, expected_err)

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -34,7 +34,8 @@ class Test(ElasticTest):
                                          'valid',
                                          'transaction',
                                          'payload.json'))
-        self.load_docs_with_template(f, self.transactions_url, 'transaction', 9)
+        self.load_docs_with_template(
+            f, self.transactions_url, 'transaction', 9)
         self.assert_no_logged_warnings()
 
         rs = self.es.count(index=self.index_name, body={
@@ -128,7 +129,8 @@ class FrontendEnabledIntegrationTest(ElasticTest, ClientSideBaseTest):
             elif "span" in doc["_source"]:
                 span = doc["_source"]["span"]
                 self.count_library_frames(span, l_frames)
-        assert l_frames == library_frames, "found {}, expected {}".format(l_frames, library_frames)
+        assert l_frames == library_frames, "found {}, expected {}".format(
+            l_frames, library_frames)
 
     def count_library_frames(self, doc, lf):
         if "stacktrace" not in doc:
@@ -145,7 +147,8 @@ class SourcemappingIntegrationTest(ElasticTest, ClientSideBaseTest):
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_backend_error(self):
         path = 'http://localhost:8000/test/e2e/general-usecase/bundle.js.map'
-        r = self.upload_sourcemap(file_name='bundle.js.map', bundle_filepath=path)
+        r = self.upload_sourcemap(
+            file_name='bundle.js.map', bundle_filepath=path)
         assert r.status_code == 202, r.status_code
         self.wait_for_sourcemaps()
 
@@ -157,10 +160,31 @@ class SourcemappingIntegrationTest(ElasticTest, ClientSideBaseTest):
         self.check_backend_error_sourcemap()
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_duplicated_sourcemap_warning(self):
+        path = 'http://localhost:8000/test/e2e/general-usecase/bundle.js.map'
+
+        self.upload_sourcemap(file_name='bundle.js.map', bundle_filepath=path)
+        self.wait_for_sourcemaps()
+
+        self.upload_sourcemap(file_name='bundle.js.map', bundle_filepath=path)
+        self.wait_for_sourcemaps(2)
+        assert self.log_contains(
+            "Overriding sourcemap"), "A log should be written when a sourcemap is overwritten"
+
+        self.upload_sourcemap(file_name='bundle.js.map', bundle_filepath=path)
+        self.wait_for_sourcemaps(3)
+        assert self.log_contains(
+            "Multiple sourcemaps found"), "the 3rd fetch should query ES and find that there are 2 sourcemaps with the same caching key"
+
+        self.assert_no_logged_warnings(
+            ["WARN.*Overriding sourcemap", "WARN.*Multiple sourcemaps"])
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_frontend_error(self):
         # use an uncleaned path to test that path is cleaned in upload
         path = 'http://localhost:8000/test/e2e/../e2e/general-usecase/bundle.js.map'
-        r = self.upload_sourcemap(file_name='bundle.js.map', bundle_filepath=path)
+        r = self.upload_sourcemap(
+            file_name='bundle.js.map', bundle_filepath=path)
         assert r.status_code == 202, r.status_code
         self.wait_for_sourcemaps()
 
@@ -209,7 +233,8 @@ class SourcemappingIntegrationTest(ElasticTest, ClientSideBaseTest):
                                      self.errors_url,
                                      'error',
                                      1)
-        self.check_frontend_error_sourcemap(False, expected_err="No Sourcemap available for")
+        self.check_frontend_error_sourcemap(
+            False, expected_err="No Sourcemap available for")
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_no_matching_sourcemap(self):
@@ -223,14 +248,16 @@ class SourcemappingIntegrationTest(ElasticTest, ClientSideBaseTest):
     def test_fetch_latest_of_multiple_sourcemaps(self):
         # upload sourcemap file that finds no matchings
         path = 'http://localhost:8000/test/e2e/general-usecase/bundle.js.map'
-        r = self.upload_sourcemap(file_name='bundle_no_mapping.js.map', bundle_filepath=path)
+        r = self.upload_sourcemap(
+            file_name='bundle_no_mapping.js.map', bundle_filepath=path)
         assert r.status_code == 202, r.status_code
         self.wait_for_sourcemaps()
         self.load_docs_with_template(self.get_error_payload_path(),
                                      self.errors_url,
                                      'error',
                                      1)
-        self.check_frontend_error_sourcemap(False, expected_err="No Sourcemap found for")
+        self.check_frontend_error_sourcemap(
+            False, expected_err="No Sourcemap found for")
 
         # remove existing document
         self.es.delete_by_query(index=self.index_name,
@@ -245,7 +272,8 @@ class SourcemappingIntegrationTest(ElasticTest, ClientSideBaseTest):
         # that actually leads to proper matchings
         # this also tests that the cache gets invalidated,
         # as otherwise the former sourcemap would be taken from the cache.
-        r = self.upload_sourcemap(file_name='bundle.js.map', bundle_filepath=path)
+        r = self.upload_sourcemap(
+            file_name='bundle.js.map', bundle_filepath=path)
         assert r.status_code == 202, r.status_code
         self.wait_for_sourcemaps(expected_ct=2)
         self.load_docs_with_template(self.get_error_payload_path(),
@@ -257,7 +285,8 @@ class SourcemappingIntegrationTest(ElasticTest, ClientSideBaseTest):
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_sourcemap_mapping_cache_usage(self):
         path = 'http://localhost:8000/test/e2e/general-usecase/bundle.js.map'
-        r = self.upload_sourcemap(file_name='bundle.js.map', bundle_filepath=path)
+        r = self.upload_sourcemap(
+            file_name='bundle.js.map', bundle_filepath=path)
         assert r.status_code == 202, r.status_code
         self.wait_for_sourcemaps()
 
@@ -284,10 +313,12 @@ class SourcemappingIntegrationTest(ElasticTest, ClientSideBaseTest):
 
 
 class SourcemappingCacheIntegrationTest(ElasticTest, SmapCacheBaseTest):
+
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_sourcemap_cache_expiration(self):
         path = 'http://localhost:8000/test/e2e/general-usecase/bundle.js.map'
-        r = self.upload_sourcemap(file_name='bundle.js.map', bundle_filepath=path)
+        r = self.upload_sourcemap(
+            file_name='bundle.js.map', bundle_filepath=path)
         assert r.status_code == 202, r.status_code
         self.wait_for_sourcemaps()
 
@@ -308,7 +339,8 @@ class SourcemappingCacheIntegrationTest(ElasticTest, SmapCacheBaseTest):
                                      self.errors_url,
                                      'error',
                                      1)
-        self.check_frontend_error_sourcemap(False, expected_err="No Sourcemap available for")
+        self.check_frontend_error_sourcemap(
+            False, expected_err="No Sourcemap available for")
 
 
 class ExpvarDisabledIntegrationTest(ExpvarBaseTest):


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Log a warning for sourcemap uploads and fetches with duplicated caching keys  (#610)