### PR TITLE
Add note to docs for dashboard loading.

### DIFF
--- a/docs/copied-from-beats/dashboardsconfig.asciidoc
+++ b/docs/copied-from-beats/dashboardsconfig.asciidoc
@@ -92,6 +92,8 @@ is `".kibana"`
 The Elasticsearch index name. This setting overwrites the index name defined
 in the dashboards and index pattern. Example: `"testbeat-*"`
 
+NOTE: This setting only works for Kibana 6.0 and newer.
+
 [float]
 ==== `setup.dashboards.always_kibana`
 


### PR DESCRIPTION
Describe that `setup.dashboards.index`
only works for >= 6.0
closes #519 

As elastic/beats#6197 was merged, I updated it also in apm-server.