### PR TITLE
[6.x] Keep original values when transforming. (#647)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -76,6 +76,7 @@ https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828
 - Make `transaction.name` optional {pull}554[554]
 - Remove config files from beats. Manually add relevant config options {pull}578[578]
 - Use seperate index for uploaded `source maps` {pull}582[582].
+- Store original values when applying source mapping or changing `library_frame` value {pull}647[647]
 
 ==== Deprecated
 

--- a/docs/data/intake-api/generated/error/frontend.json
+++ b/docs/data/intake-api/generated/error/frontend.json
@@ -31,6 +31,7 @@
             "abs_path": "http://localhost:8000/test/../test/e2e/general-usecase/bundle.js.map",
             "filename": "test/e2e/general-usecase/bundle.js.map",
             "function": "<anonymous>",
+            "library_frame": true,
             "lineno": 1,
             "colno": 18
           },
@@ -38,6 +39,7 @@
             "abs_path": "http://localhost:8000/test/./e2e/general-usecase/bundle.js.map",
             "filename": "~/test/e2e/general-usecase/bundle.js.map",
             "function": "invokeTask",
+            "library_frame": false,
             "lineno": 1,
             "colno": 181
           },

--- a/model/stacktrace_test.go
+++ b/model/stacktrace_test.go
@@ -160,6 +160,13 @@ func TestStacktraceTransformWithSourcemapping(t *testing.T) {
 					"line":                  common.MapStr{"column": 100, "number": 400},
 					"exclude_from_grouping": false,
 					"sourcemap":             common.MapStr{"updated": true},
+					"original": common.MapStr{
+						"abs_path": "original path",
+						"colno":    1,
+						"filename": "original filename",
+						"function": "original function",
+						"lineno":   4,
+					},
 				},
 				{
 					"abs_path": "original path", "filename": "", "function": "original function",
@@ -177,12 +184,25 @@ func TestStacktraceTransformWithSourcemapping(t *testing.T) {
 					"line":                  common.MapStr{"column": 100, "number": 500},
 					"exclude_from_grouping": false,
 					"sourcemap":             common.MapStr{"updated": true},
+					"original": common.MapStr{
+						"abs_path": "original path",
+						"colno":    1,
+						"filename": "original filename",
+						"function": "original function",
+						"lineno":   5,
+					},
 				},
 				{
 					"abs_path": "changed path", "filename": "changed filename", "function": "<anonymous>",
 					"line":                  common.MapStr{"column": 100, "number": 400},
 					"exclude_from_grouping": false,
 					"sourcemap":             common.MapStr{"updated": true},
+					"original": common.MapStr{
+						"abs_path": "original path",
+						"colno":    1,
+						"filename": "/webpack",
+						"lineno":   4,
+					},
 				},
 			},
 			Msg: "Stacktrace with sourcemapping",
@@ -190,6 +210,8 @@ func TestStacktraceTransformWithSourcemapping(t *testing.T) {
 	}
 
 	for idx, test := range tests {
+		// run `Stacktrace.Transform` twice to ensure method is idempotent
+		test.Stacktrace.Transform(&pr.Config{SmapMapper: &FakeMapper{}}, service)
 		output := test.Stacktrace.Transform(&pr.Config{SmapMapper: &FakeMapper{}}, service)
 		assert.Equal(t, test.Output, output, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 	}

--- a/processor/error/package_tests/TestProcessErrorFrontend.approved.json
+++ b/processor/error/package_tests/TestProcessErrorFrontend.approved.json
@@ -41,6 +41,14 @@
                                 "column": 0,
                                 "number": 5
                             },
+                            "original": {
+                                "abs_path": "http://localhost:8000/test/../test/e2e/general-usecase/bundle.js.map",
+                                "colno": 18,
+                                "filename": "test/e2e/general-usecase/bundle.js.map",
+                                "function": "\u003canonymous\u003e",
+                                "library_frame": true,
+                                "lineno": 1
+                            },
                             "sourcemap": {
                                 "updated": true
                             }
@@ -54,6 +62,14 @@
                             "line": {
                                 "column": 0,
                                 "number": 33
+                            },
+                            "original": {
+                                "abs_path": "http://localhost:8000/test/./e2e/general-usecase/bundle.js.map",
+                                "colno": 181,
+                                "filename": "~/test/e2e/general-usecase/bundle.js.map",
+                                "function": "invokeTask",
+                                "library_frame": false,
+                                "lineno": 1
                             },
                             "sourcemap": {
                                 "updated": true
@@ -69,6 +85,13 @@
                                 "column": 0,
                                 "number": 5
                             },
+                            "original": {
+                                "abs_path": "http://localhost:8000/test/e2e/general-usecase/bundle.js.map",
+                                "colno": 15,
+                                "filename": "~/test/e2e/general-usecase/bundle.js.map",
+                                "function": "runTask",
+                                "lineno": 1
+                            },
                             "sourcemap": {
                                 "updated": true
                             }
@@ -83,6 +106,13 @@
                                 "column": 0,
                                 "number": 39
                             },
+                            "original": {
+                                "abs_path": "http://localhost:8000/test/e2e/general-usecase/bundle.js.map",
+                                "colno": 199,
+                                "filename": "~/test/e2e/general-usecase/bundle.js.map",
+                                "function": "invoke",
+                                "lineno": 1
+                            },
                             "sourcemap": {
                                 "updated": true
                             }
@@ -96,6 +126,13 @@
                             "line": {
                                 "column": 0,
                                 "number": 8
+                            },
+                            "original": {
+                                "abs_path": "http://localhost:8000/test/e2e/general-usecase/bundle.js.map",
+                                "colno": 33,
+                                "filename": "~/test/e2e/general-usecase/bundle.js.map",
+                                "function": "timer",
+                                "lineno": 1
                             },
                             "sourcemap": {
                                 "updated": true
@@ -118,6 +155,13 @@
                             "line": {
                                 "column": 0,
                                 "number": 5
+                            },
+                            "original": {
+                                "abs_path": "http://localhost:8000/test/e2e/general-usecase/bundle.js.map",
+                                "colno": 18,
+                                "filename": "~/test/e2e/general-usecase/bundle.js.map",
+                                "function": "\u003canonymous\u003e",
+                                "lineno": 1
                             },
                             "sourcemap": {
                                 "updated": true

--- a/processor/error/package_tests/TestProcessErrorFrontendMinifiedSmap.approved.json
+++ b/processor/error/package_tests/TestProcessErrorFrontendMinifiedSmap.approved.json
@@ -49,6 +49,13 @@
                                 "column": 0,
                                 "number": 17
                             },
+                            "original": {
+                                "abs_path": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js",
+                                "colno": 5778,
+                                "filename": "test/e2e/general-usecase/app.e2e-bundle.min.js",
+                                "function": "r",
+                                "lineno": 71
+                            },
                             "sourcemap": {
                                 "updated": true
                             }
@@ -62,6 +69,13 @@
                             "line": {
                                 "column": 0,
                                 "number": 21
+                            },
+                            "original": {
+                                "abs_path": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js",
+                                "colno": 6175,
+                                "filename": "test/e2e/general-usecase/app.e2e-bundle.min.js",
+                                "function": "\u003canonymous\u003e",
+                                "lineno": 71
                             },
                             "sourcemap": {
                                 "updated": true
@@ -77,6 +91,13 @@
                                 "column": 0,
                                 "number": 3609
                             },
+                            "original": {
+                                "abs_path": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js",
+                                "colno": 8087,
+                                "filename": "test/e2e/general-usecase/app.e2e-bundle.min.js",
+                                "function": "invokeTask",
+                                "lineno": 36
+                            },
                             "sourcemap": {
                                 "updated": true
                             }
@@ -90,6 +111,13 @@
                             "line": {
                                 "column": 0,
                                 "number": 3412
+                            },
+                            "original": {
+                                "abs_path": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js",
+                                "colno": 3261,
+                                "filename": "test/e2e/general-usecase/app.e2e-bundle.min.js",
+                                "function": "runTask",
+                                "lineno": 36
                             },
                             "sourcemap": {
                                 "updated": true
@@ -105,6 +133,13 @@
                                 "column": 0,
                                 "number": 3679
                             },
+                            "original": {
+                                "abs_path": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js",
+                                "colno": 9162,
+                                "filename": "test/e2e/general-usecase/app.e2e-bundle.min.js",
+                                "function": "invokeTask",
+                                "lineno": 36
+                            },
                             "sourcemap": {
                                 "updated": true
                             }
@@ -119,6 +154,13 @@
                                 "column": 0,
                                 "number": 3668
                             },
+                            "original": {
+                                "abs_path": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js",
+                                "colno": 9050,
+                                "filename": "test/e2e/general-usecase/app.e2e-bundle.min.js",
+                                "function": "invoke",
+                                "lineno": 36
+                            },
                             "sourcemap": {
                                 "updated": true
                             }
@@ -132,6 +174,13 @@
                             "line": {
                                 "column": 0,
                                 "number": 5180
+                            },
+                            "original": {
+                                "abs_path": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js",
+                                "colno": 7848,
+                                "filename": "test/e2e/general-usecase/app.e2e-bundle.min.js",
+                                "function": "(anonymous function)",
+                                "lineno": 8
                             },
                             "sourcemap": {
                                 "updated": true

--- a/tests/data/valid/error/frontend.json
+++ b/tests/data/valid/error/frontend.json
@@ -31,6 +31,7 @@
             "abs_path": "http://localhost:8000/test/../test/e2e/general-usecase/bundle.js.map",
             "filename": "test/e2e/general-usecase/bundle.js.map",
             "function": "<anonymous>",
+            "library_frame": true,
             "lineno": 1,
             "colno": 18
           },
@@ -38,6 +39,7 @@
             "abs_path": "http://localhost:8000/test/./e2e/general-usecase/bundle.js.map",
             "filename": "~/test/e2e/general-usecase/bundle.js.map",
             "function": "invokeTask",
+            "library_frame": false,
             "lineno": 1,
             "colno": 181
           },


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Keep original values when transforming.  (#647)