### PR TITLE
Update beats framework to 7dd818f

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -11,7 +11,7 @@ Third party libraries used by the Apm Server project:
 
 --------------------------------------------------------------------
 Dependency: github.com/davecgh/go-spew
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/github.com/davecgh/go-spew/LICENSE:
 --------------------------------------------------------------------
@@ -31,7 +31,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/docker/distribution
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): Apache-2.0
 ./vendor/github.com/docker/distribution/LICENSE:
 --------------------------------------------------------------------
@@ -40,7 +40,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/docker/docker
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): Apache-2.0
 ./vendor/github.com/docker/docker/LICENSE:
 --------------------------------------------------------------------
@@ -69,7 +69,7 @@ See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.
 
 --------------------------------------------------------------------
 Dependency: github.com/docker/go-connections
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): Apache-2.0
 ./vendor/github.com/docker/go-connections/LICENSE:
 --------------------------------------------------------------------
@@ -78,7 +78,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/docker/go-units
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): Apache-2.0
 ./vendor/github.com/docker/go-units/LICENSE:
 --------------------------------------------------------------------
@@ -87,7 +87,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/docker/libtrust
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): Apache-2.0
 ./vendor/github.com/docker/libtrust/LICENSE:
 --------------------------------------------------------------------
@@ -96,7 +96,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/eapache/go-resiliency
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/github.com/eapache/go-resiliency/LICENSE:
 --------------------------------------------------------------------
@@ -125,7 +125,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/eapache/go-xerial-snappy
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/github.com/eapache/go-xerial-snappy/LICENSE:
 --------------------------------------------------------------------
@@ -153,7 +153,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/eapache/queue
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/github.com/eapache/queue/LICENSE:
 --------------------------------------------------------------------
@@ -181,7 +181,7 @@ SOFTWARE.
 --------------------------------------------------------------------
 Dependency: github.com/elastic/beats
 Version: 6.2
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/beats/LICENSE.txt:
 --------------------------------------------------------------------
@@ -190,7 +190,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-lumber
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-lumber/LICENSE:
 --------------------------------------------------------------------
@@ -199,7 +199,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-ucfg
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-ucfg/LICENSE:
 --------------------------------------------------------------------
@@ -208,7 +208,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/gosigar
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/gosigar/LICENSE:
 --------------------------------------------------------------------
@@ -226,7 +226,7 @@ subcomponents is subject to the terms and conditions of the
 subcomponent's license, as noted in the LICENSE file.
 --------------------------------------------------------------------
 Dependency: github.com/ericchiang/k8s
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): Apache-2.0
 ./vendor/github.com/ericchiang/k8s/LICENSE:
 --------------------------------------------------------------------
@@ -289,7 +289,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/garyburd/redigo
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): Apache-2.0
 ./vendor/github.com/garyburd/redigo/LICENSE:
 --------------------------------------------------------------------
@@ -298,7 +298,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/ghodss/yaml
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/github.com/ghodss/yaml/LICENSE:
 --------------------------------------------------------------------
@@ -387,7 +387,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/golang/protobuf
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/golang/protobuf/LICENSE:
 --------------------------------------------------------------------
@@ -425,7 +425,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/golang/snappy
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/golang/snappy/LICENSE:
 --------------------------------------------------------------------
@@ -828,7 +828,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 
 --------------------------------------------------------------------
 Dependency: github.com/inconshreveable/mousetrap
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): Apache-2.0
 ./vendor/github.com/inconshreveable/mousetrap/LICENSE:
 --------------------------------------------------------------------
@@ -837,7 +837,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/joeshaw/multierror
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/github.com/joeshaw/multierror/LICENSE:
 --------------------------------------------------------------------
@@ -899,7 +899,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/klauspost/compress
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/klauspost/compress/LICENSE:
 --------------------------------------------------------------------
@@ -933,7 +933,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/klauspost/cpuid
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/github.com/klauspost/cpuid/LICENSE:
 --------------------------------------------------------------------
@@ -962,7 +962,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/klauspost/crc32
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/klauspost/crc32/LICENSE:
 --------------------------------------------------------------------
@@ -997,7 +997,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/mattn/go-colorable
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/github.com/mattn/go-colorable/LICENSE:
 --------------------------------------------------------------------
@@ -1025,7 +1025,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/mattn/go-isatty
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/github.com/mattn/go-isatty/LICENSE:
 --------------------------------------------------------------------
@@ -1041,7 +1041,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 --------------------------------------------------------------------
 Dependency: github.com/Microsoft/go-winio
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/github.com/Microsoft/go-winio/LICENSE:
 --------------------------------------------------------------------
@@ -1070,7 +1070,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/mitchellh/hashstructure
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/github.com/mitchellh/hashstructure/LICENSE:
 --------------------------------------------------------------------
@@ -1126,7 +1126,7 @@ THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/opencontainers/go-digest
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): CC-BY-SA-4.0
 ./vendor/github.com/opencontainers/go-digest/LICENSE.docs:
 --------------------------------------------------------------------
@@ -1558,7 +1558,7 @@ Creative Commons may be contacted at creativecommons.org.
 
 --------------------------------------------------------------------
 Dependency: github.com/opencontainers/go-digest
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): CC-BY-SA-4.0
 ./vendor/github.com/opencontainers/go-digest/LICENSE.docs:
 --------------------------------------------------------------------
@@ -1990,7 +1990,7 @@ Creative Commons may be contacted at creativecommons.org.
 
 --------------------------------------------------------------------
 Dependency: github.com/opencontainers/image-spec
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): Apache-2.0
 ./vendor/github.com/opencontainers/image-spec/LICENSE:
 --------------------------------------------------------------------
@@ -2025,7 +2025,7 @@ THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/pierrec/lz4
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/pierrec/lz4/LICENSE:
 --------------------------------------------------------------------
@@ -2060,7 +2060,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/pierrec/xxHash
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/pierrec/xxHash/LICENSE:
 --------------------------------------------------------------------
@@ -2095,7 +2095,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/pkg/errors
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): BSD-2-Clause
 ./vendor/github.com/pkg/errors/LICENSE:
 --------------------------------------------------------------------
@@ -2159,7 +2159,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/rcrowley/go-metrics
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): BSD-2-Clause
 ./vendor/github.com/rcrowley/go-metrics/LICENSE:
 --------------------------------------------------------------------
@@ -2256,7 +2256,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------------------------------
 Dependency: github.com/satori/go.uuid
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/github.com/satori/go.uuid/LICENSE:
 --------------------------------------------------------------------
@@ -2310,7 +2310,7 @@ DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/Shopify/sarama
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/github.com/Shopify/sarama/LICENSE:
 --------------------------------------------------------------------
@@ -2337,7 +2337,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/Sirupsen/logrus
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/github.com/Sirupsen/logrus/LICENSE:
 --------------------------------------------------------------------
@@ -2365,7 +2365,7 @@ THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/spf13/cobra
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): Apache-2.0
 ./vendor/github.com/spf13/cobra/LICENSE.txt:
 --------------------------------------------------------------------
@@ -2374,7 +2374,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/spf13/pflag
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/spf13/pflag/LICENSE:
 --------------------------------------------------------------------
@@ -2409,7 +2409,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/StackExchange/wmi
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/github.com/StackExchange/wmi/LICENSE:
 --------------------------------------------------------------------
@@ -2466,7 +2466,7 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/urso/go-structform
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): Apache-2.0
 ./vendor/github.com/urso/go-structform/LICENSE:
 --------------------------------------------------------------------
@@ -2706,7 +2706,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 --------------------------------------------------------------------
 Dependency: go.uber.org/atomic
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/go.uber.org/atomic/LICENSE.txt:
 --------------------------------------------------------------------
@@ -2732,7 +2732,7 @@ THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: go.uber.org/multierr
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/go.uber.org/multierr/LICENSE.txt:
 --------------------------------------------------------------------
@@ -2758,7 +2758,7 @@ THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: go.uber.org/zap
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/go.uber.org/zap/LICENSE.txt:
 --------------------------------------------------------------------
@@ -2784,7 +2784,7 @@ THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: golang.org/x/crypto
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): BSD-3-Clause
 ./vendor/golang.org/x/crypto/LICENSE:
 --------------------------------------------------------------------
@@ -2818,7 +2818,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: golang.org/x/net
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): BSD-3-Clause
 ./vendor/golang.org/x/net/LICENSE:
 --------------------------------------------------------------------
@@ -2852,7 +2852,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: golang.org/x/sys
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): BSD-3-Clause
 ./vendor/golang.org/x/sys/LICENSE:
 --------------------------------------------------------------------
@@ -2920,7 +2920,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: gopkg.in/yaml.v2
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/gopkg.in/yaml.v2/LICENSE.libyaml:
 --------------------------------------------------------------------
@@ -2958,7 +2958,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: gopkg.in/yaml.v2
-Revision: a21dcdd98073ce3734783d4b46427ebd75ef87f4
+Revision: 7dd818f8568a68057572fe5727537e5684bed065
 License type (autodetected): MIT
 ./vendor/gopkg.in/yaml.v2/LICENSE.libyaml:
 --------------------------------------------------------------------

--- a/_beats/testing/environments/args.yml
+++ b/_beats/testing/environments/args.yml
@@ -6,5 +6,5 @@ services:
     build:
       args:
         DOWNLOAD_URL: https://snapshots.elastic.co/downloads
-        ELASTIC_VERSION: 6.2.1-SNAPSHOT
-        CACHE_BUST: 20180108
+        ELASTIC_VERSION: 6.2.2-SNAPSHOT
+        CACHE_BUST: 20180208

--- a/_beats/testing/environments/docker/kibana/Dockerfile
+++ b/_beats/testing/environments/docker/kibana/Dockerfile
@@ -6,7 +6,7 @@ EXPOSE 5601
 
 ### Beats specific args ####
 ARG DOWNLOAD_URL=https://snapshots.elastic.co/downloads
-ARG ELASTIC_VERSION=7.0.0-alpha1-SNAPSHOT
+ARG ELASTIC_VERSION=6.2.2-SNAPSHOT
 ARG CACHE_BUST=1
 ARG XPACK=1
 

--- a/vendor/github.com/elastic/beats/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/vendor/github.com/elastic/beats/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -161,6 +161,8 @@ func (r *reporter) initLoop() {
 		if err == nil {
 			closing(client)
 			break
+		} else {
+			logp.Err("Monitoring could not connect to elasticsearch, failed with %v", err)
 		}
 
 		select {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -6,492 +6,492 @@
 			"checksumSHA1": "AzjRkOQtVBTwIw4RJLTygFhJs3s=",
 			"origin": "github.com/elastic/beats/vendor/github.com/Microsoft/go-winio",
 			"path": "github.com/Microsoft/go-winio",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "jVDEyP/iraz6r173/GzkXF24ijQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/Shopify/sarama",
 			"path": "github.com/Shopify/sarama",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "DYv6Q1+VfnUVxMwvk5IshAClLvw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/Sirupsen/logrus",
 			"path": "github.com/Sirupsen/logrus",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "Te1xRugxHQMAg7EvbIUuPWm8fvU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/StackExchange/wmi",
 			"path": "github.com/StackExchange/wmi",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "5rPfda8jFccr3A6heL+JAmi9K9g=",
 			"origin": "github.com/elastic/beats/vendor/github.com/davecgh/go-spew/spew",
 			"path": "github.com/davecgh/go-spew/spew",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "Gj+xR1VgFKKmFXYOJMnAczC3Znk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/distribution/digestset",
 			"path": "github.com/docker/distribution/digestset",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "2Fe4D6PGaVE2he4fUeenLmhC1lE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/distribution/reference",
 			"path": "github.com/docker/distribution/reference",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "UL2NF1EGiSsQoEfvycnuZIcUbZY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api",
 			"path": "github.com/docker/docker/api",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "KMFpbV3mlrbc41d2DYnq05QYpSc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types",
 			"path": "github.com/docker/docker/api/types",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "jVJDbe0IcyjoKc2xbohwzQr+FF0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/blkiodev",
 			"path": "github.com/docker/docker/api/types/blkiodev",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "AeSC0BOu1uapkGqfSXtfVSpwJzs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/container",
 			"path": "github.com/docker/docker/api/types/container",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "4XuWn5+wgYwUsw604jvYMklq4Hc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/events",
 			"path": "github.com/docker/docker/api/types/events",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "J2OKngfI3vgswudr9PZVUFcRRu0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/filters",
 			"path": "github.com/docker/docker/api/types/filters",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "yeB781yxPhnN6OXQ9/qSsyih3ek=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/image",
 			"path": "github.com/docker/docker/api/types/image",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "UK+VdM648oWzyqE4OqttgmPqjoA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/mount",
 			"path": "github.com/docker/docker/api/types/mount",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "Gskp+nvbVe8Gk1xPLHylZvNmqTg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/network",
 			"path": "github.com/docker/docker/api/types/network",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "r2vWq7Uc3ExKzMqYgH0b4AKjLKY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/registry",
 			"path": "github.com/docker/docker/api/types/registry",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "VTxWyFud/RedrpllGdQonVtGM/A=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/strslice",
 			"path": "github.com/docker/docker/api/types/strslice",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "ZaizCpJ3eBcfR9ywpLaJd4AhM9k=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/swarm",
 			"path": "github.com/docker/docker/api/types/swarm",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "B7ZwKzrv3t3Vlox6/bYMHhMjsM8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/time",
 			"path": "github.com/docker/docker/api/types/time",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "uDPQ3nHsrvGQc9tg/J9OSC4N5dQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/versions",
 			"path": "github.com/docker/docker/api/types/versions",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "IBJy2zPEnYmcFJ3lM1eiRWnCxTA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/volume",
 			"path": "github.com/docker/docker/api/types/volume",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "c6OyeEvpQDvVLhrJSxgjEZv1tF8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/client",
 			"path": "github.com/docker/docker/client",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "jmo/t2zXAxirEPoFucNPXA/1SEc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/ioutils",
 			"path": "github.com/docker/docker/pkg/ioutils",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "ndnAFCfsGC3upNQ6jAEwzxcurww=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/longpath",
 			"path": "github.com/docker/docker/pkg/longpath",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "kr46EAa+FsUcWxOq6edyX6BUzE4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/system",
 			"path": "github.com/docker/docker/pkg/system",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "8I0Ez+aUYGpsDEVZ8wN/Ztf6Zqs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/tlsconfig",
 			"path": "github.com/docker/docker/pkg/tlsconfig",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "JbiWTzH699Sqz25XmDlsARpMN9w=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-connections/nat",
 			"path": "github.com/docker/go-connections/nat",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "jUfDG3VQsA2UZHvvIXncgiddpYA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-connections/sockets",
 			"path": "github.com/docker/go-connections/sockets",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "tuSzlS1UQ03+5Fvtqr5hI5sLLhA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-connections/tlsconfig",
 			"path": "github.com/docker/go-connections/tlsconfig",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "ambe8F4AofPxChCJssXXwWphQQ8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-units",
 			"path": "github.com/docker/go-units",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "sNAU9ojYVUhO6dVXey6T3JhRQpw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/libtrust",
 			"path": "github.com/docker/libtrust",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "y2Kh4iPlgCPXSGTCcFpzePYdzzg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/eapache/go-resiliency/breaker",
 			"path": "github.com/eapache/go-resiliency/breaker",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "WHl96RVZlOOdF4Lb1OOadMpw8ls=",
 			"origin": "github.com/elastic/beats/vendor/github.com/eapache/go-xerial-snappy",
 			"path": "github.com/eapache/go-xerial-snappy",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "oCCs6kDanizatplM5e/hX76busE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/eapache/queue",
 			"path": "github.com/eapache/queue",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "jO3LUqx5sKP8SMh052PUpAKAnS0=",
 			"path": "github.com/elastic/beats/libbeat/api",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "i+uHzsLvmaC6TbE1ViYhJTK9XLE=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "mvMbWi8jMCS5ZDCiWv+GkUzsmEw=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/meta",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "Gp/+KwhRYSZxVYYNObuLFHJSn9s=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/providers/docker",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "ipLA00wNb2e2Y0JCCKTq6LRL3JM=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/providers/kubernetes",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "2sZQ2RjQpeYI5l615G+W3ODSVRk=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/template",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "0lO6JkylG++k5f4AWzEgQ67UHgo=",
 			"path": "github.com/elastic/beats/libbeat/beat",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "xk8rkIPmXFqMpKdow17KuNHsZbM=",
 			"path": "github.com/elastic/beats/libbeat/cfgfile",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "kcJBPeHVyLhstApfy7Smi6fcxrg=",
 			"path": "github.com/elastic/beats/libbeat/cloudid",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "TNVaV0NTAkAR3F9ydhTTubOQeNE=",
 			"path": "github.com/elastic/beats/libbeat/cmd",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "b1jzseq9b5NzIaMYk6D1W1xA5MU=",
 			"path": "github.com/elastic/beats/libbeat/cmd/export",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "CY+1Kty6Fnn2VbSg/E7BaoICGv0=",
 			"path": "github.com/elastic/beats/libbeat/cmd/instance",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "hnrALZ/owH5lcue6u3G9p0/K4ag=",
 			"path": "github.com/elastic/beats/libbeat/cmd/test",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "5cXiuNi2aNCWF5xaSOr1dwG4sCE=",
 			"path": "github.com/elastic/beats/libbeat/common",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "SS/yBENBeoNVCAu+TQcDylo4CPg=",
 			"path": "github.com/elastic/beats/libbeat/common/atomic",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "I5ABLC2bPeiBbL2fKqLsQNe4DSQ=",
 			"path": "github.com/elastic/beats/libbeat/common/bus",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "5Y5WqKnrBD4VBRXCRn2JgFDvMV8=",
 			"path": "github.com/elastic/beats/libbeat/common/cfgwarn",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "pcyIn2gzdvx6y3Icc8N9ij2FRAU=",
 			"path": "github.com/elastic/beats/libbeat/common/cli",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "gGB9FaK8K+1w4kD0HsF1OpnN9eM=",
 			"path": "github.com/elastic/beats/libbeat/common/docker",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "7bGcM14M5R8BuQLqKdWfbbQaKEM=",
 			"path": "github.com/elastic/beats/libbeat/common/dtfmt",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "jnjiRowimBwicqurgxbUIBEtaIU=",
 			"path": "github.com/elastic/beats/libbeat/common/file",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "7WSOY58klc0crUF/5UZx/pLFIR0=",
 			"path": "github.com/elastic/beats/libbeat/common/fmtstr",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "pdFJ+DF0STunSGRopAMwn9n9ZlY=",
 			"path": "github.com/elastic/beats/libbeat/common/jsontransform",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "pL4Q1oJ2LwzJBywN++Nf39kLgSs=",
 			"path": "github.com/elastic/beats/libbeat/common/kubernetes",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "43jcD3PFE0qBsP40iA4kb/g94MU=",
 			"path": "github.com/elastic/beats/libbeat/common/match",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "8exGjSEBI+fSKXMHdWI2e2lX5D0=",
 			"path": "github.com/elastic/beats/libbeat/common/schema",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "WmqoD6kF9VraYUmjXacgWSHd2v4=",
 			"path": "github.com/elastic/beats/libbeat/common/schema/mapstriface",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "zi4xMJ43/IzPCPNXs8iBc0WI2sE=",
 			"path": "github.com/elastic/beats/libbeat/common/streambuf",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "1k581NuOkCx0xoGSrGV0vD6i+PA=",
 			"path": "github.com/elastic/beats/libbeat/common/terminal",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "hS/BvyAfk6/DTuu7+XWrx/gCvak=",
 			"path": "github.com/elastic/beats/libbeat/dashboards",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "Ie2zbuch+Jx2IrpjstO1jJeiV8o=",
 			"path": "github.com/elastic/beats/libbeat/keystore",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
@@ -506,120 +506,120 @@
 		{
 			"checksumSHA1": "z8VztKgyYSA7eyVuhNocdpav6zA=",
 			"path": "github.com/elastic/beats/libbeat/kibana/",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "Ol8fiOfQ+qh0cvwEI7kRFjRaNHY=",
 			"path": "github.com/elastic/beats/libbeat/logp",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "/fSZH8iFO9jqRiSSxzM593zMS4Y=",
 			"path": "github.com/elastic/beats/libbeat/logp/configure",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "3rCxbiMynIdSdQe7h95cuTKEXbY=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/cpu",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "2zYwb3Ycma7Ep8yGNRfnm4hvODA=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/memory",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "r7Cyj6XP4JE23i47GpOKPeDi2Wk=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/process",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "kZBPfX0Pv2dLMP5Iho9Mx/hXz9o=",
 			"path": "github.com/elastic/beats/libbeat/monitoring",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "tRfILb+3nS9S5xf1GTqyGVbvGnU=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/adapter",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "9OgsegLCw7fQSbzm92h5SSLJSqo=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
-			"checksumSHA1": "4AmFzDuUi9F3AUSCJdVoTb0cLtQ=",
+			"checksumSHA1": "unvMHHTCkeHv3h3Kr02WucKeck0=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report/elasticsearch",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "O0mqYi92UChneQIZItpvDf+egYM=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report/log",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "P72p6i7s+3eRkfSxD/oYFbATnxY=",
 			"path": "github.com/elastic/beats/libbeat/outputs",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "/g/IAXGizefK4Zw3Zw11f1Gw5Gw=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "vjVLDyWbKmCR6e2OayNshujneSI=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec/format",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "j57gNFrdsjPGmF7AHx3dHdvB7qE=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec/json",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
@@ -638,40 +638,40 @@
 		{
 			"checksumSHA1": "JGP5bMcL1KyJRJCR1kW11gZhPhk=",
 			"path": "github.com/elastic/beats/libbeat/outputs/console",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "FXyBV4GWd0zPalEN4AunM86+zss=",
 			"path": "github.com/elastic/beats/libbeat/outputs/elasticsearch",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "S1nJaQZExaATn2Xpin4eY7Oyr34=",
 			"path": "github.com/elastic/beats/libbeat/outputs/fileout",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "iI6dpKLMOnY+0KdVizQhgSlKq0M=",
 			"path": "github.com/elastic/beats/libbeat/outputs/kafka",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "Wpvv92+QT4zveD+nlAx91aKq5OE=",
 			"path": "github.com/elastic/beats/libbeat/outputs/logstash",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
@@ -702,88 +702,88 @@
 		{
 			"checksumSHA1": "UEGH5mAXdKBysIjODuTxHKlzqsY=",
 			"path": "github.com/elastic/beats/libbeat/outputs/outil",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "j11eTg831Fs7uxEz2dRA/DJmKoU=",
 			"path": "github.com/elastic/beats/libbeat/outputs/redis",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "N8FWsJ68uJ5Haxc5vp8eS2Cp8jw=",
 			"path": "github.com/elastic/beats/libbeat/outputs/transport",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "d5b9Ra0zcwznwemxEJmyW28FZJ0=",
 			"path": "github.com/elastic/beats/libbeat/paths",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "2ef0H1yIcmjczaj6LsUc17/ss6I=",
 			"path": "github.com/elastic/beats/libbeat/plugin",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "gGNyFGQLyg9NpEQnoy7Pyat76NA=",
 			"path": "github.com/elastic/beats/libbeat/processors",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "JBWiLNZylmEHFiAbNXJAYa9D8fw=",
 			"path": "github.com/elastic/beats/libbeat/processors/actions",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "rI+RcxALfhqftyApiHM1AgSjQ8U=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_cloud_metadata",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "Z0GJcCgthM2W9FligSojRZNJ+fQ=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_docker_metadata",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "l05ya6VFiI+pELhcojE7VEUSlKQ=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_kubernetes_metadata",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "UCfWJFoOVRzY1nQ+mAHT+mpGYv4=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_locale",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
@@ -796,8 +796,8 @@
 		{
 			"checksumSHA1": "3kyV9PwlSwcLnK9SWKX97Gh7c00=",
 			"path": "github.com/elastic/beats/libbeat/publisher",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
@@ -836,72 +836,72 @@
 		{
 			"checksumSHA1": "btf3XhwPROVy4JtECpH0eL3nGwg=",
 			"path": "github.com/elastic/beats/libbeat/publisher/includes",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "vSCFcYhsiCm0U4o1XyboWf9IL7M=",
 			"path": "github.com/elastic/beats/libbeat/publisher/pipeline",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "k/1pxNUislJBfsjb/yZVG7+YP28=",
 			"path": "github.com/elastic/beats/libbeat/publisher/queue",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "dRlFNTjIKtVHBmkyTOiOhWxCWws=",
 			"path": "github.com/elastic/beats/libbeat/publisher/queue/memqueue",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "kT9MLdbYAKYJ0lWfjqX8fbrZTiY=",
 			"path": "github.com/elastic/beats/libbeat/service",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "semQzHqIR5CoJmXvPQmjtZnwwkA=",
 			"path": "github.com/elastic/beats/libbeat/setup/kibana",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "BVrLP+2Vd0A3dhTfKTMIEvdVg4Q=",
 			"path": "github.com/elastic/beats/libbeat/template",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "p+um0Jv/tT4q7+rCQS7dxq50Ws0=",
 			"path": "github.com/elastic/beats/libbeat/testing",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "KJgxicvx/AUJWgxm50oX0UFZt28=",
 			"path": "github.com/elastic/beats/libbeat/version",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z",
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
@@ -909,295 +909,295 @@
 			"checksumSHA1": "3jizmlZPCyo6FAZY8Trk9jA8NH4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-lumber/client/v2",
 			"path": "github.com/elastic/go-lumber/client/v2",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "m6HLKpDAZlkTTQMqabf3aT6TQ/s=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-lumber/protocol/v2",
 			"path": "github.com/elastic/go-lumber/protocol/v2",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "61XUpyQ3zWnJ7Tlj0xLsHtnzwJY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg",
 			"path": "github.com/elastic/go-ucfg",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "8cr5YhslUMgpvF2JebYvKC+Ezr4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/cfgutil",
 			"path": "github.com/elastic/go-ucfg/cfgutil",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "Q2qrc/nI9d1tNzWTmfrkWvBNqsc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/flag",
 			"path": "github.com/elastic/go-ucfg/flag",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "uOrhvj7stlb0foxGZ5vbC1XJeto=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/internal/parse",
 			"path": "github.com/elastic/go-ucfg/internal/parse",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "sMBM95+VYBPhwtNVHqqN1yrvk1o=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/json",
 			"path": "github.com/elastic/go-ucfg/json",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "qvzj0KzxrWvYhHIbo+FwBxUNDFw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/yaml",
 			"path": "github.com/elastic/go-ucfg/yaml",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "2F9EiHAqPu6y4I/uNQWTS27VeGw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar",
 			"path": "github.com/elastic/gosigar",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "TX9y4oPL5YmT4Gb/OU4GIPTdQB4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/cgroup",
 			"path": "github.com/elastic/gosigar/cgroup",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "2VhOsaR4sv3S79HO6X+6dEphNKU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/sys/linux",
 			"path": "github.com/elastic/gosigar/sys/linux",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "qDsgp2kAeI9nhj565HUScaUyjU4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/sys/windows",
 			"path": "github.com/elastic/gosigar/sys/windows",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "xS5tIena63lzjTziIsbJbdTeue0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s",
 			"path": "github.com/ericchiang/k8s",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "uQuMoUlS7hAWsB+Mwr/1B7+35BU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/api/resource",
 			"path": "github.com/ericchiang/k8s/api/resource",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "XN1tbPrI03O0ishnZyfkWtTnrcQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/api/unversioned",
 			"path": "github.com/ericchiang/k8s/api/unversioned",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "yfTg3/Qn7KiizNJ39JmPBFi9YDQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/api/v1",
 			"path": "github.com/ericchiang/k8s/api/v1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "uw/3eB6WiVCSrQZS9ZZs/1kyu1I=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/apps/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/apps/v1alpha1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "GPnvYx9Uxhpwmv01iygWR6+naTI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/apps/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/apps/v1beta1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "Jjw5tBYv4k+Es+qPp03rnzyzRWA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authentication/v1",
 			"path": "github.com/ericchiang/k8s/apis/authentication/v1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "uR4S43Wc80fhS0vMDE3Z3hFg7J8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authentication/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/authentication/v1beta1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "aM2KSDZbHn8jJomPPeG6LKpMwhs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authorization/v1",
 			"path": "github.com/ericchiang/k8s/apis/authorization/v1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "4yWZvduAw2JNdHd1cXjTJBUy0lw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authorization/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/authorization/v1beta1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "1nMeCVQImIo1CpRRyOYMIqLoPBc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/autoscaling/v1",
 			"path": "github.com/ericchiang/k8s/apis/autoscaling/v1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "kUXiQQA99K7zquvG9es3yauVjYw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/autoscaling/v2alpha1",
 			"path": "github.com/ericchiang/k8s/apis/autoscaling/v2alpha1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "vMWsdmHlmaAQZIT0c26dwxe9pDw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/batch/v1",
 			"path": "github.com/ericchiang/k8s/apis/batch/v1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "bqaX0T9jycmp9ao1Ov41dfPn0Ng=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/batch/v2alpha1",
 			"path": "github.com/ericchiang/k8s/apis/batch/v2alpha1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "9GRVPI+Tf4RrlX2aveUGEUHKIrM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/certificates/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/certificates/v1alpha1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "k1dF56GRoEg6rooFKO7UvEJvBcE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/certificates/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/certificates/v1beta1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "4pDHINIk6BdPBYWGF20IwHNCg2Q=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/extensions/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/extensions/v1beta1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "NAL7OeKSEzTOoXHBFnC1B1VmBVs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/imagepolicy/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/imagepolicy/v1alpha1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "Vg1/xjzLJHZlvuheWC4abghACwQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/meta/v1",
 			"path": "github.com/ericchiang/k8s/apis/meta/v1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "wYSNb+W2L5gJlGO8n6mGOGft8R8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/policy/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/policy/v1alpha1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "ioJ28pdUN6fDkOp8dT+Tg3HSqmk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/policy/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/policy/v1beta1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "UErnBsjjtmg3oYjLYU1S80oi3sk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/rbac/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/rbac/v1alpha1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "Xl+Tm8ZOz0cMOrfLaQvu/lsWObU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/rbac/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/rbac/v1beta1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "YyZyaF0k2NAQAZvsCOVdhAkfVU0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/settings/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/settings/v1alpha1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "vUc3mf0rE7CQ3B52wfrMDyspLgA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/storage/v1",
 			"path": "github.com/ericchiang/k8s/apis/storage/v1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "7/oj1z0vG1pvRza+UuKQ6txdleI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/storage/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/storage/v1beta1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "mm5iTFmLQ6h98DKgiUuTCpHP9H4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/runtime",
 			"path": "github.com/ericchiang/k8s/runtime",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "Kk1UDqUx2Pr1LyvIIgcJBApTlCk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/runtime/schema",
 			"path": "github.com/ericchiang/k8s/runtime/schema",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "LoxBND74egHIasOX6z98FeeW0zI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/util/intstr",
 			"path": "github.com/ericchiang/k8s/util/intstr",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "fobEKiMk5D7IGvCSwh4HdG1o98c=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/watch/versioned",
 			"path": "github.com/ericchiang/k8s/watch/versioned",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "AANTVr9CVVyzsgviODY6Wi2thuM=",
@@ -1215,36 +1215,36 @@
 			"checksumSHA1": "2UmMbNHc8FBr98mJFN1k8ISOIHk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/garyburd/redigo/internal",
 			"path": "github.com/garyburd/redigo/internal",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "507OiSqTxfGCje7xDT5eq9CCaNQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/garyburd/redigo/redis",
 			"path": "github.com/garyburd/redigo/redis",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "ImX1uv6O09ggFeBPUJJ2nu7MPSA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ghodss/yaml",
 			"path": "github.com/ghodss/yaml",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "lfNGgtGL2Yrw+mVUexmA25lBYhY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/go-ole/go-ole",
 			"path": "github.com/go-ole/go-ole",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "Q0ZOcJW0fqOefDzEdn+PJHOeSgI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/go-ole/go-ole/oleutil",
 			"path": "github.com/go-ole/go-ole/oleutil",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "zF83b/btagb1yQnrxoNwL2+mqpQ=",
@@ -1262,15 +1262,15 @@
 			"checksumSHA1": "kBeNcaKk56FguvPSUCEaH6AxpRc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/golang/protobuf/proto",
 			"path": "github.com/golang/protobuf/proto",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "p/8vSviYF91gFflhrt5vkyksroo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/golang/snappy",
 			"path": "github.com/golang/snappy",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "d9PxF1XQGLMJZRct2R8qVM/eYlE=",
@@ -1288,15 +1288,15 @@
 			"checksumSHA1": "40vJyUB4ezQSn/NSadsKEOrudMc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/inconshreveable/mousetrap",
 			"path": "github.com/inconshreveable/mousetrap",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "l9wW52CYGbmO/NGwYZ/Op2QTmaA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/joeshaw/multierror",
 			"path": "github.com/joeshaw/multierror",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "pa+ZwMzIv+u+BlL8Q2xgL9cQtJg=",
@@ -1308,50 +1308,50 @@
 			"checksumSHA1": "KKxbAKrKrfd33YPpkNsDmTN3S+M=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/compress/flate",
 			"path": "github.com/klauspost/compress/flate",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "+azPXaZpPF14YHRghNAer13ThQU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/compress/zlib",
 			"path": "github.com/klauspost/compress/zlib",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "R6zKqn31GjJH1G8W/api7fAW0RU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/cpuid",
 			"path": "github.com/klauspost/cpuid",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "BM6ZlNJmtKy3GBoWwg2X55gnZ4A=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/crc32",
 			"path": "github.com/klauspost/crc32",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "qNkx9+OTwZI6aFv7K9zuFCGODUw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/mattn/go-colorable",
 			"path": "github.com/mattn/go-colorable",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "U6lX43KDDlNOn+Z0Yyww+ZzHfFo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/mattn/go-isatty",
 			"path": "github.com/mattn/go-isatty",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "sWdAYPKyaT4SW8hNQNpRS0sU4lU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/mitchellh/hashstructure",
 			"path": "github.com/mitchellh/hashstructure",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "gILp4IL+xwXLH6tJtRLrnZ56F24=",
@@ -1363,22 +1363,22 @@
 			"checksumSHA1": "2AyUkWjutec6p+470tgio8mYOxI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/go-digest",
 			"path": "github.com/opencontainers/go-digest",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "eOMCORUm8KxiGSy0hBuQsMsxauo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/image-spec/specs-go",
 			"path": "github.com/opencontainers/image-spec/specs-go",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "9YujSsJjiLGkQMzwWycsjqR340k=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/image-spec/specs-go/v1",
 			"path": "github.com/opencontainers/image-spec/specs-go/v1",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "JVGDxPn66bpe6xEiexs1r+y6jF0=",
@@ -1390,22 +1390,22 @@
 			"checksumSHA1": "WmrPO1ovmQ7t7hs9yZGbr2SAoM4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pierrec/lz4",
 			"path": "github.com/pierrec/lz4",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "IT4sX58d+e8osXHV5U6YCSdB/uE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pierrec/xxHash/xxHash32",
 			"path": "github.com/pierrec/xxHash/xxHash32",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "PdQm3s8DoVJ17Vk8n7o5iPa7PK0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pkg/errors",
 			"path": "github.com/pkg/errors",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
@@ -1417,8 +1417,8 @@
 			"checksumSHA1": "KAzbLjI9MzW2tjfcAsK75lVRp6I=",
 			"origin": "github.com/elastic/beats/vendor/github.com/rcrowley/go-metrics",
 			"path": "github.com/rcrowley/go-metrics",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "6JP37UqrI0H80Gpk0Y2P+KXgn5M=",
@@ -1448,8 +1448,8 @@
 			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/satori/go.uuid",
 			"path": "github.com/satori/go.uuid",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "v7C+aJ1D/z3MEeCte6bxvpoGjM4=",
@@ -1461,15 +1461,15 @@
 			"checksumSHA1": "e7mAb9jMke2ASQGZepFgOmfBFzM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/spf13/cobra",
 			"path": "github.com/spf13/cobra",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "STxYqRb4gnlSr3mRpT+Igfdz/kM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/spf13/pflag",
 			"path": "github.com/spf13/pflag",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "q1qqfgDOGwfEuMlbHWNjYf09ACM=",
@@ -1483,36 +1483,36 @@
 			"checksumSHA1": "ci7skUhpD1VwkoR0tKVdggTkYrE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/urso/go-structform",
 			"path": "github.com/urso/go-structform",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "AkYoBxV+Imq2EBwNcb53hEGh7sQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/urso/go-structform/gotype",
 			"path": "github.com/urso/go-structform/gotype",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "m9H8/w6okS+8ixvkq+eYLd/Kk3g=",
 			"origin": "github.com/elastic/beats/vendor/github.com/urso/go-structform/internal/unsafe",
 			"path": "github.com/urso/go-structform/internal/unsafe",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "UXf4TzYK1UB8xAa6Phy9CvkvWL0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/urso/go-structform/json",
 			"path": "github.com/urso/go-structform/json",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "MytQct/960akBAZm7xmbpi2BKGs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/urso/go-structform/visitors",
 			"path": "github.com/urso/go-structform/visitors",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "8Kj0VH496b0exuyv4wAF4CXa7Y4=",
@@ -1537,162 +1537,162 @@
 			"checksumSHA1": "HedK9m8E8iyib4bIBtIX7xprOgo=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/atomic",
 			"path": "go.uber.org/atomic",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "JDGx7hehaQunZySwPs7yvdUs2m8=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/multierr",
 			"path": "go.uber.org/multierr",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "5BYbiKEkYykvfjSaNYDuQpBqglo=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap",
 			"path": "go.uber.org/zap",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "HYo/9nwrY08NQA+2ItPOAH8IFW8=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/buffer",
 			"path": "go.uber.org/zap/buffer",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "MuxOAtZEsJitlWBzhmpm2vGiHok=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/internal/bufferpool",
 			"path": "go.uber.org/zap/internal/bufferpool",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "uC0L9eCSAYcCWNC8udJk/t1vvIU=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/internal/color",
 			"path": "go.uber.org/zap/internal/color",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "b80CJExrVpXu3SA1iCQ6uLqTn2c=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/internal/exit",
 			"path": "go.uber.org/zap/internal/exit",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "mRD6lujPvXPkbC3+byNwO/bNVu8=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/zapcore",
 			"path": "go.uber.org/zap/zapcore",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "gyBmIfDZslmQGKnqisJ/p7oHbQc=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/zaptest/observer",
 			"path": "go.uber.org/zap/zaptest/observer",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "1MGpGDQqnUoRpv7VEcQrXOBydXE=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/crypto/pbkdf2",
 			"path": "golang.org/x/crypto/pbkdf2",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "X1NTlfcau2XcV6WtAHF6b/DECOA=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/crypto/ssh/terminal",
 			"path": "golang.org/x/crypto/ssh/terminal",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "Y+HGqEkYM15ir+J93MEaHdyFy0c=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/context",
 			"path": "golang.org/x/net/context",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "WHc3uByvGaMcnSoI21fhzYgbOgg=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/context/ctxhttp",
 			"path": "golang.org/x/net/context/ctxhttp",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "SPYGC6DQrH9jICccUsOfbvvhB4g=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/http2",
 			"path": "golang.org/x/net/http2",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "EYNaHp7XdLWRydUCE0amEkKAtgk=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/http2/hpack",
 			"path": "golang.org/x/net/http2/hpack",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "yhndhWXMs/VSEDLks4dNyFMQStA=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/lex/httplex",
 			"path": "golang.org/x/net/lex/httplex",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "LvdVRE0FqdR68SvVpRkHs1rxhcA=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/proxy",
 			"path": "golang.org/x/net/proxy",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "l/AvVB/e1LjZ28XXItkdOW9tKMQ=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/unix",
 			"path": "golang.org/x/sys/unix",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "cQoW6a5F9mbu10APPXM39YJtv48=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows",
 			"path": "golang.org/x/sys/windows",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "Qvq4DjtYrcpGgBT0O1s8nTTeFWQ=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/registry",
 			"path": "golang.org/x/sys/windows/registry",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "IRqLaXM/VQRzkbXPuiqOxTb2W0Y=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/svc",
 			"path": "golang.org/x/sys/windows/svc",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "1ouiyoHRaaMDNeq/nap9B0UuQw4=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/svc/debug",
 			"path": "golang.org/x/sys/windows/svc/debug",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "uVlUSSKplihZG7N+QJ6fzDZ4Kh8=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/svc/eventlog",
 			"path": "golang.org/x/sys/windows/svc/eventlog",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		},
 		{
 			"checksumSHA1": "vGfePfr0+weQUeTM/71mu+LCFuE=",
@@ -1704,8 +1704,8 @@
 			"checksumSHA1": "fALlQNY1fM99NesfLJ50KguWsio=",
 			"origin": "github.com/elastic/beats/vendor/gopkg.in/yaml.v2",
 			"path": "gopkg.in/yaml.v2",
-			"revision": "a21dcdd98073ce3734783d4b46427ebd75ef87f4",
-			"revisionTime": "2018-02-08T20:39:42Z"
+			"revision": "7dd818f8568a68057572fe5727537e5684bed065",
+			"revisionTime": "2018-02-13T15:25:32Z"
 		}
 	],
 	"rootPath": "github.com/elastic/apm-server"


### PR DESCRIPTION
fixes test setup that relied on older 6.2 elastic stack snapshots