### PR TITLE
Refactor Event creation and enhancer utility method.

### DIFF
--- a/model/process.go
+++ b/model/process.go
@@ -18,12 +18,11 @@ func (p *Process) Transform() common.MapStr {
 	if p == nil {
 		return nil
 	}
-	enhancer := utility.NewMapStrEnhancer()
 	svc := common.MapStr{}
-	enhancer.Add(svc, "pid", p.Pid)
-	enhancer.Add(svc, "ppid", p.Ppid)
-	enhancer.Add(svc, "title", p.Title)
-	enhancer.Add(svc, "argv", p.Argv)
+	utility.Add(svc, "pid", p.Pid)
+	utility.Add(svc, "ppid", p.Ppid)
+	utility.Add(svc, "title", p.Title)
+	utility.Add(svc, "argv", p.Argv)
 
 	return svc
 }

--- a/model/service.go
+++ b/model/service.go
@@ -46,25 +46,24 @@ func (s *Service) MinimalTransform() common.MapStr {
 }
 
 func (s *Service) Transform() common.MapStr {
-	enhancer := utility.NewMapStrEnhancer()
 	svc := s.MinimalTransform()
-	enhancer.Add(svc, "version", s.Version)
-	enhancer.Add(svc, "environment", s.Environment)
+	utility.Add(svc, "version", s.Version)
+	utility.Add(svc, "environment", s.Environment)
 
 	lang := common.MapStr{}
-	enhancer.Add(lang, "name", s.Language.Name)
-	enhancer.Add(lang, "version", s.Language.Version)
-	enhancer.Add(svc, "language", lang)
+	utility.Add(lang, "name", s.Language.Name)
+	utility.Add(lang, "version", s.Language.Version)
+	utility.Add(svc, "language", lang)
 
 	runtime := common.MapStr{}
-	enhancer.Add(runtime, "name", s.Runtime.Name)
-	enhancer.Add(runtime, "version", s.Runtime.Version)
-	enhancer.Add(svc, "runtime", runtime)
+	utility.Add(runtime, "name", s.Runtime.Name)
+	utility.Add(runtime, "version", s.Runtime.Version)
+	utility.Add(svc, "runtime", runtime)
 
 	framework := common.MapStr{}
-	enhancer.Add(framework, "name", s.Framework.Name)
-	enhancer.Add(framework, "version", s.Framework.Version)
-	enhancer.Add(svc, "framework", framework)
+	utility.Add(framework, "name", s.Framework.Name)
+	utility.Add(framework, "version", s.Framework.Version)
+	utility.Add(svc, "framework", framework)
 
 	return svc
 }

--- a/model/stacktrace_frame.go
+++ b/model/stacktrace_frame.go
@@ -46,49 +46,48 @@ type Original struct {
 }
 
 func (s *StacktraceFrame) Transform(config *pr.Config) common.MapStr {
-	enhancer := utility.NewMapStrEnhancer()
 	m := common.MapStr{}
-	enhancer.Add(m, "filename", s.Filename)
-	enhancer.Add(m, "abs_path", s.AbsPath)
-	enhancer.Add(m, "module", s.Module)
-	enhancer.Add(m, "function", s.Function)
-	enhancer.Add(m, "vars", s.Vars)
+	utility.Add(m, "filename", s.Filename)
+	utility.Add(m, "abs_path", s.AbsPath)
+	utility.Add(m, "module", s.Module)
+	utility.Add(m, "function", s.Function)
+	utility.Add(m, "vars", s.Vars)
 	if config != nil && config.LibraryPattern != nil {
 		s.setLibraryFrame(config.LibraryPattern)
 	}
-	enhancer.Add(m, "library_frame", s.LibraryFrame)
+	utility.Add(m, "library_frame", s.LibraryFrame)
 
 	if config != nil && config.ExcludeFromGrouping != nil {
 		s.setExcludeFromGrouping(config.ExcludeFromGrouping)
 	}
-	enhancer.Add(m, "exclude_from_grouping", s.ExcludeFromGrouping)
+	utility.Add(m, "exclude_from_grouping", s.ExcludeFromGrouping)
 
 	context := common.MapStr{}
-	enhancer.Add(context, "pre", s.PreContext)
-	enhancer.Add(context, "post", s.PostContext)
-	enhancer.Add(m, "context", context)
+	utility.Add(context, "pre", s.PreContext)
+	utility.Add(context, "post", s.PostContext)
+	utility.Add(m, "context", context)
 
 	line := common.MapStr{}
-	enhancer.Add(line, "number", s.Lineno)
-	enhancer.Add(line, "column", s.Colno)
-	enhancer.Add(line, "context", s.ContextLine)
-	enhancer.Add(m, "line", line)
+	utility.Add(line, "number", s.Lineno)
+	utility.Add(line, "column", s.Colno)
+	utility.Add(line, "context", s.ContextLine)
+	utility.Add(m, "line", line)
 
 	sm := common.MapStr{}
-	enhancer.Add(sm, "updated", s.Sourcemap.Updated)
-	enhancer.Add(sm, "error", s.Sourcemap.Error)
-	enhancer.Add(m, "sourcemap", sm)
+	utility.Add(sm, "updated", s.Sourcemap.Updated)
+	utility.Add(sm, "error", s.Sourcemap.Error)
+	utility.Add(m, "sourcemap", sm)
 
 	orig := common.MapStr{}
-	enhancer.Add(orig, "library_frame", s.Original.LibraryFrame)
+	utility.Add(orig, "library_frame", s.Original.LibraryFrame)
 	if s.Sourcemap.Updated != nil && *(s.Sourcemap.Updated) {
-		enhancer.Add(orig, "filename", s.Original.Filename)
-		enhancer.Add(orig, "abs_path", s.Original.AbsPath)
-		enhancer.Add(orig, "function", s.Original.Function)
-		enhancer.Add(orig, "colno", s.Original.Colno)
-		enhancer.Add(orig, "lineno", s.Original.Lineno)
+		utility.Add(orig, "filename", s.Original.Filename)
+		utility.Add(orig, "abs_path", s.Original.AbsPath)
+		utility.Add(orig, "function", s.Original.Function)
+		utility.Add(orig, "colno", s.Original.Colno)
+		utility.Add(orig, "lineno", s.Original.Lineno)
 	}
-	enhancer.Add(m, "original", orig)
+	utility.Add(m, "original", orig)
 
 	return m
 }

--- a/model/system.go
+++ b/model/system.go
@@ -16,12 +16,11 @@ func (s *System) Transform() common.MapStr {
 	if s == nil {
 		return nil
 	}
-	enhancer := utility.NewMapStrEnhancer()
 	system := common.MapStr{}
-	enhancer.Add(system, "hostname", s.Hostname)
-	enhancer.Add(system, "architecture", s.Architecture)
-	enhancer.Add(system, "platform", s.Platform)
-	enhancer.Add(system, "ip", s.IP)
+	utility.Add(system, "hostname", s.Hostname)
+	utility.Add(system, "architecture", s.Architecture)
+	utility.Add(system, "platform", s.Platform)
+	utility.Add(system, "ip", s.IP)
 
 	return system
 }

--- a/processor/error/event.go
+++ b/processor/error/event.go
@@ -26,8 +26,7 @@ type Event struct {
 		Id string
 	}
 
-	enhancer utility.MapStrEnhancer
-	data     common.MapStr
+	data common.MapStr
 }
 
 type Exception struct {
@@ -48,34 +47,7 @@ type Log struct {
 	Stacktrace   m.Stacktrace `mapstructure:"stacktrace"`
 }
 
-func (e *Event) DocType() string {
-	return "error"
-}
-
-func (e *Event) Mappings(config *pr.Config, pa *payload) (time.Time, []utility.DocMapping) {
-	mapping := []utility.DocMapping{
-		{Key: "processor", Apply: func() common.MapStr {
-			return common.MapStr{"name": processorName, "event": e.DocType()}
-		}},
-		{Key: e.DocType(), Apply: func() common.MapStr { return e.Transform(config, pa.Service) }},
-		{Key: "context", Apply: func() common.MapStr { return e.contextTransform(pa) }},
-		{Key: "context.service", Apply: pa.Service.Transform},
-		{Key: "context.system", Apply: pa.System.Transform},
-		{Key: "context.process", Apply: pa.Process.Transform},
-	}
-
-	if e.Transaction != nil {
-		mapping = append(mapping, utility.DocMapping{
-			Key:   "transaction",
-			Apply: func() common.MapStr { return common.MapStr{"id": e.Transaction.Id} },
-		})
-	}
-
-	return e.Timestamp, mapping
-}
-
 func (e *Event) Transform(config *pr.Config, service m.Service) common.MapStr {
-	e.enhancer = utility.MapStrEnhancer{}
 	e.data = common.MapStr{}
 	e.add("id", e.Id)
 
@@ -134,24 +106,24 @@ func (e *Event) addException(config *pr.Config, service m.Service) {
 		return
 	}
 	ex := common.MapStr{}
-	e.enhancer.Add(ex, "message", e.Exception.Message)
-	e.enhancer.Add(ex, "module", e.Exception.Module)
-	e.enhancer.Add(ex, "attributes", e.Exception.Attributes)
-	e.enhancer.Add(ex, "type", e.Exception.Type)
-	e.enhancer.Add(ex, "handled", e.Exception.Handled)
+	utility.Add(ex, "message", e.Exception.Message)
+	utility.Add(ex, "module", e.Exception.Module)
+	utility.Add(ex, "attributes", e.Exception.Attributes)
+	utility.Add(ex, "type", e.Exception.Type)
+	utility.Add(ex, "handled", e.Exception.Handled)
 
 	switch e.Exception.Code.(type) {
 	case int:
-		e.enhancer.Add(ex, "code", strconv.Itoa(e.Exception.Code.(int)))
+		utility.Add(ex, "code", strconv.Itoa(e.Exception.Code.(int)))
 	case float64:
-		e.enhancer.Add(ex, "code", fmt.Sprintf("%.0f", e.Exception.Code))
+		utility.Add(ex, "code", fmt.Sprintf("%.0f", e.Exception.Code))
 	case string:
-		e.enhancer.Add(ex, "code", e.Exception.Code.(string))
+		utility.Add(ex, "code", e.Exception.Code.(string))
 	}
 
 	st := e.Exception.Stacktrace.Transform(config, service)
 	if len(st) > 0 {
-		e.enhancer.Add(ex, "stacktrace", st)
+		utility.Add(ex, "stacktrace", st)
 	}
 
 	e.add("exception", ex)
@@ -162,13 +134,13 @@ func (e *Event) addLog(config *pr.Config, service m.Service) {
 		return
 	}
 	log := common.MapStr{}
-	e.enhancer.Add(log, "message", e.Log.Message)
-	e.enhancer.Add(log, "param_message", e.Log.ParamMessage)
-	e.enhancer.Add(log, "logger_name", e.Log.LoggerName)
-	e.enhancer.Add(log, "level", e.Log.Level)
+	utility.Add(log, "message", e.Log.Message)
+	utility.Add(log, "param_message", e.Log.ParamMessage)
+	utility.Add(log, "logger_name", e.Log.LoggerName)
+	utility.Add(log, "level", e.Log.Level)
 	st := e.Log.Stacktrace.Transform(config, service)
 	if len(st) > 0 {
-		e.enhancer.Add(log, "stacktrace", st)
+		utility.Add(log, "stacktrace", st)
 	}
 
 	e.add("log", log)
@@ -246,5 +218,5 @@ func (e *Event) calcGroupingKey() string {
 }
 
 func (e *Event) add(key string, val interface{}) {
-	e.enhancer.Add(e.data, key, val)
+	utility.Add(e.data, key, val)
 }

--- a/processor/error/event.go
+++ b/processor/error/event.go
@@ -122,9 +122,7 @@ func (e *Event) addException(config *pr.Config, service m.Service) {
 	}
 
 	st := e.Exception.Stacktrace.Transform(config, service)
-	if len(st) > 0 {
-		utility.Add(ex, "stacktrace", st)
-	}
+	utility.Add(ex, "stacktrace", st)
 
 	e.add("exception", ex)
 }
@@ -139,9 +137,7 @@ func (e *Event) addLog(config *pr.Config, service m.Service) {
 	utility.Add(log, "logger_name", e.Log.LoggerName)
 	utility.Add(log, "level", e.Log.Level)
 	st := e.Log.Stacktrace.Transform(config, service)
-	if len(st) > 0 {
-		utility.Add(log, "stacktrace", st)
-	}
+	utility.Add(log, "stacktrace", st)
 
 	e.add("log", log)
 }

--- a/processor/error/package_tests/TestProcessErrorNullValues.approved.json
+++ b/processor/error/package_tests/TestProcessErrorNullValues.approved.json
@@ -12,8 +12,7 @@
                         "name": "ruby"
                     },
                     "name": "1234_service-12a3"
-                },
-                "system": {}
+                }
             },
             "error": {
                 "exception": {
@@ -70,7 +69,6 @@
                     },
                     "name": "1234_service-12a3"
                 },
-                "system": {},
                 "tags": {
                     "organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8"
                 }
@@ -125,7 +123,6 @@
                     },
                     "name": "1234_service-12a3"
                 },
-                "system": {},
                 "user": {
                     "email": null,
                     "id": null,
@@ -159,7 +156,6 @@
                     },
                     "name": "1234_service-12a3"
                 },
-                "system": {},
                 "tags": null,
                 "user": null
             },

--- a/processor/error/payload.go
+++ b/processor/error/payload.go
@@ -3,13 +3,16 @@ package error
 import (
 	m "github.com/elastic/apm-server/model"
 	pr "github.com/elastic/apm-server/processor"
+	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
 )
 
 var (
-	errorCounter = monitoring.NewInt(errorMetrics, "counter")
+	errorCounter   = monitoring.NewInt(errorMetrics, "counter")
+	processorEntry = common.MapStr{"name": processorName, "event": errorDocType}
 )
 
 type payload struct {
@@ -22,12 +25,35 @@ type payload struct {
 
 func (pa *payload) transform(config *pr.Config) []beat.Event {
 	var events []beat.Event
+	service := pa.Service.Transform()
+	system := pa.System.Transform()
+	process := pa.Process.Transform()
 
 	logp.NewLogger("transform").Debugf("Transform error events: events=%d, service=%s, agent=%s:%s", len(pa.Events), pa.Service.Name, pa.Service.Agent.Name, pa.Service.Agent.Version)
 
 	errorCounter.Add(int64(len(pa.Events)))
-	for _, e := range pa.Events {
-		events = append(events, pr.CreateDoc(e.Mappings(config, pa)))
+	for _, event := range pa.Events {
+		context := event.contextTransform(pa)
+		if context == nil {
+			context = common.MapStr{}
+		}
+		utility.Add(context, "service", service)
+		utility.Add(context, "system", system)
+		utility.Add(context, "process", process)
+
+		ev := beat.Event{
+			Fields: common.MapStr{
+				"processor":  processorEntry,
+				errorDocType: event.Transform(config, pa.Service),
+				"context":    context,
+			},
+			Timestamp: event.Timestamp,
+		}
+		if event.Transaction != nil {
+			ev.Fields["transaction"] = common.MapStr{"id": event.Transaction.Id}
+		}
+
+		events = append(events, ev)
 	}
 	return events
 }

--- a/processor/error/processor.go
+++ b/processor/error/processor.go
@@ -20,6 +20,7 @@ var (
 
 const (
 	processorName = "error"
+	errorDocType  = "error"
 )
 
 var schema = pr.CreateSchema(errorSchema, processorName)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -2,12 +2,9 @@ package processor
 
 import (
 	"regexp"
-	"time"
 
 	"github.com/elastic/apm-server/sourcemap"
-	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/beats/libbeat/beat"
-	"github.com/elastic/beats/libbeat/common"
 )
 
 type NewProcessor func(conf *Config) Processor
@@ -22,18 +19,4 @@ type Config struct {
 	SmapMapper          sourcemap.Mapper
 	LibraryPattern      *regexp.Regexp
 	ExcludeFromGrouping *regexp.Regexp
-}
-
-func CreateDoc(timestamp time.Time, docMappings []utility.DocMapping) beat.Event {
-	doc := common.MapStr{}
-	for _, mapping := range docMappings {
-		if out := mapping.Apply(); out != nil {
-			doc.Put(mapping.Key, out)
-		}
-	}
-
-	return beat.Event{
-		Fields:    doc,
-		Timestamp: timestamp,
-	}
 }

--- a/processor/sourcemap/processor.go
+++ b/processor/sourcemap/processor.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	processorName = "sourcemap"
+	smapDocType   = "sourcemap"
 )
 
 var (

--- a/processor/transaction/event_test.go
+++ b/processor/transaction/event_test.go
@@ -44,7 +44,7 @@ func TestEventTransform(t *testing.T) {
 				Timestamp: time.Now(),
 				Duration:  65.98,
 				Context:   common.MapStr{"foo": "bar"},
-				Spans:     []Span{},
+				Spans:     []*Span{},
 				Sampled:   &sampled,
 				SpanCount: SpanCount{Dropped: Dropped{Total: &dropped}},
 			},

--- a/processor/transaction/package_tests/TestProcessTransactionNullValues.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionNullValues.approved.json
@@ -12,8 +12,7 @@
                         "name": "ruby"
                     },
                     "name": "1234_service-12a3"
-                },
-                "system": {}
+                }
             },
             "processor": {
                 "event": "transaction",
@@ -45,7 +44,6 @@
                     },
                     "name": "1234_service-12a3"
                 },
-                "system": {},
                 "tags": null,
                 "user": null
             },
@@ -101,7 +99,6 @@
                     },
                     "name": "1234_service-12a3"
                 },
-                "system": {},
                 "user": {
                     "email": null,
                     "id": null,
@@ -162,7 +159,6 @@
                     },
                     "name": "1234_service-12a3"
                 },
-                "system": {},
                 "tags": {
                     "organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8"
                 }

--- a/processor/transaction/payload.go
+++ b/processor/transaction/payload.go
@@ -3,14 +3,18 @@ package transaction
 import (
 	m "github.com/elastic/apm-server/model"
 	pr "github.com/elastic/apm-server/processor"
+	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
 )
 
 var (
-	transactionCounter = monitoring.NewInt(transactionMetrics, "counter")
-	spanCounter        = monitoring.NewInt(transactionMetrics, "spans")
+	transactionCounter  = monitoring.NewInt(transactionMetrics, "counter")
+	spanCounter         = monitoring.NewInt(transactionMetrics, "spans")
+	processorTransEntry = common.MapStr{"name": processorName, "event": transactionDocType}
+	processorSpanEntry  = common.MapStr{"name": processorName, "event": spanDocType}
 )
 
 type payload struct {
@@ -23,17 +27,52 @@ type payload struct {
 
 func (pa *payload) transform(config *pr.Config) []beat.Event {
 	var events []beat.Event
+	spanService := pa.Service.MinimalTransform()
+	service := pa.Service.Transform()
+	system := pa.System.Transform()
+	process := pa.Process.Transform()
 
 	logp.NewLogger("transaction").Debugf("Transform transaction events: events=%d, service=%s, agent=%s:%s", len(pa.Events), pa.Service.Name, pa.Service.Agent.Name, pa.Service.Agent.Version)
 
 	transactionCounter.Add(int64(len(pa.Events)))
 	for _, event := range pa.Events {
+		context := event.contextTransform(pa)
+		if context == nil {
+			context = common.MapStr{}
+		}
+		utility.Add(context, "service", service)
+		utility.Add(context, "system", system)
+		utility.Add(context, "process", process)
 
-		events = append(events, pr.CreateDoc(event.Mappings(pa)))
+		ev := beat.Event{
+			Fields: common.MapStr{
+				"processor":        processorTransEntry,
+				transactionDocType: event.Transform(),
+				"context":          context,
+			},
+			Timestamp: event.Timestamp,
+		}
+		events = append(events, ev)
 
+		trId := common.MapStr{"id": event.Id}
 		spanCounter.Add(int64(len(event.Spans)))
 		for _, sp := range event.Spans {
-			events = append(events, pr.CreateDoc(sp.Mappings(config, pa, event)))
+			c := sp.Context
+			if c == nil && spanService != nil {
+				c = common.MapStr{}
+			}
+			utility.Add(c, "service", spanService)
+
+			ev := beat.Event{
+				Fields: common.MapStr{
+					"processor":   processorSpanEntry,
+					spanDocType:   sp.Transform(config, pa.Service),
+					"transaction": trId,
+					"context":     c,
+				},
+				Timestamp: event.Timestamp,
+			}
+			events = append(events, ev)
 		}
 	}
 

--- a/processor/transaction/payload_test.go
+++ b/processor/transaction/payload_test.go
@@ -94,7 +94,7 @@ func TestPayloadTransform(t *testing.T) {
 			},
 		},
 	}
-	spans := []Span{{}}
+	spans := []*Span{{}}
 	txValidWithSpan := Event{Timestamp: timestamp, Spans: spans}
 	spanEs := common.MapStr{
 		"context": common.MapStr{

--- a/processor/transaction/processor.go
+++ b/processor/transaction/processor.go
@@ -20,7 +20,10 @@ var (
 )
 
 const (
-	processorName = "transaction"
+	eventName          = "processor"
+	processorName      = "transaction"
+	transactionDocType = "transaction"
+	spanDocType        = "span"
 )
 
 var schema = pr.CreateSchema(transactionSchema, processorName)

--- a/processor/transaction/span.go
+++ b/processor/transaction/span.go
@@ -1,8 +1,6 @@
 package transaction
 
 import (
-	"time"
-
 	m "github.com/elastic/apm-server/model"
 	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/apm-server/utility"
@@ -20,35 +18,15 @@ type Span struct {
 	Parent     *int
 }
 
-func (s *Span) DocType() string {
-	return "span"
-}
-
-func (s *Span) Mappings(config *pr.Config, pa *payload, tx Event) (time.Time, []utility.DocMapping) {
-	return tx.Timestamp,
-		[]utility.DocMapping{
-			{Key: "processor", Apply: func() common.MapStr {
-				return common.MapStr{"name": processorName, "event": s.DocType()}
-			}},
-			{Key: s.DocType(), Apply: func() common.MapStr { return s.Transform(config, pa.Service) }},
-			{Key: "transaction", Apply: func() common.MapStr { return common.MapStr{"id": tx.Id} }},
-			{Key: "context", Apply: func() common.MapStr { return s.Context }},
-			{Key: "context.service", Apply: pa.Service.MinimalTransform},
-		}
-}
-
 func (s *Span) Transform(config *pr.Config, service m.Service) common.MapStr {
-	enhancer := utility.NewMapStrEnhancer()
 	tr := common.MapStr{}
-	enhancer.Add(tr, "id", s.Id)
-	enhancer.Add(tr, "name", s.Name)
-	enhancer.Add(tr, "type", s.Type)
-	enhancer.Add(tr, "start", utility.MillisAsMicros(s.Start))
-	enhancer.Add(tr, "duration", utility.MillisAsMicros(s.Duration))
-	enhancer.Add(tr, "parent", s.Parent)
+	utility.Add(tr, "id", s.Id)
+	utility.Add(tr, "name", s.Name)
+	utility.Add(tr, "type", s.Type)
+	utility.Add(tr, "start", utility.MillisAsMicros(s.Start))
+	utility.Add(tr, "duration", utility.MillisAsMicros(s.Duration))
+	utility.Add(tr, "parent", s.Parent)
 	st := s.Stacktrace.Transform(config, service)
-	if len(st) > 0 {
-		enhancer.Add(tr, "stacktrace", st)
-	}
+	utility.Add(tr, "stacktrace", st)
 	return tr
 }

--- a/utility/doc_mapping.go
+++ b/utility/doc_mapping.go
@@ -1,8 +1,0 @@
-package utility
-
-import "github.com/elastic/beats/libbeat/common"
-
-type DocMapping struct {
-	Key   string
-	Apply func() common.MapStr
-}

--- a/utility/map_str_enhancer.go
+++ b/utility/map_str_enhancer.go
@@ -4,13 +4,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
-type MapStrEnhancer struct{}
-
-func NewMapStrEnhancer() MapStrEnhancer {
-	return MapStrEnhancer{}
-}
-
-func (enh MapStrEnhancer) AddStrWithDefault(m common.MapStr, key string, val *string, defaultVal string) {
+func AddStrWithDefault(m common.MapStr, key string, val *string, defaultVal string) {
 	if val != nil {
 		m[key] = *val
 	} else if defaultVal != "" {
@@ -18,7 +12,7 @@ func (enh MapStrEnhancer) AddStrWithDefault(m common.MapStr, key string, val *st
 	}
 }
 
-func (enh MapStrEnhancer) Add(m common.MapStr, key string, val interface{}) {
+func Add(m common.MapStr, key string, val interface{}) {
 
 	switch val.(type) {
 	case *bool:
@@ -39,6 +33,10 @@ func (enh MapStrEnhancer) Add(m common.MapStr, key string, val interface{}) {
 		}
 	case []string:
 		if valArr := val.([]string); len(valArr) > 0 {
+			m[key] = valArr
+		}
+	case []common.MapStr:
+		if valArr := val.([]common.MapStr); len(valArr) > 0 {
 			m[key] = valArr
 		}
 	default:

--- a/utility/map_str_enhancer_test.go
+++ b/utility/map_str_enhancer_test.go
@@ -36,30 +36,26 @@ func TestAdd(t *testing.T) {
 		{addStrArrNil, []string{"something"}, base},
 	}
 	for _, testDataRow := range testData {
-		assert, enhancer, base := setup(t)
+		base := baseMapStr()
 
-		enhancer.Add(base, addKey, testDataRow[0])
-		assert.Equal(testDataRow[2], base)
+		Add(base, addKey, testDataRow[0])
+		assert.Equal(t, testDataRow[2], base)
 	}
 }
 
 func TestStringWithDefault(t *testing.T) {
-	assert, enhancer, base := setup(t)
-
+	base := baseMapStr()
 	add := "foo"
 	newMap := common.MapStr{"existing": "foo", "added": "foo"}
-	enhancer.AddStrWithDefault(base, addKey, &add, "bar")
-	assert.Equal(newMap, base)
+	AddStrWithDefault(base, addKey, &add, "bar")
+	assert.Equal(t, newMap, base)
 
-	assert, enhancer, base = setup(t)
-	enhancer.AddStrWithDefault(base, addKey, nil, "bar")
+	base = baseMapStr()
+	AddStrWithDefault(base, addKey, nil, "bar")
 	newMap = common.MapStr{"existing": "foo", "added": "bar"}
-	assert.Equal(newMap, base)
+	assert.Equal(t, newMap, base)
 }
 
-func setup(t *testing.T) (*assert.Assertions, MapStrEnhancer, common.MapStr) {
-	a := assert.New(t)
-	enhancer := NewMapStrEnhancer()
-	base := common.MapStr{"existing": "foo"}
-	return a, enhancer, base
+func baseMapStr() common.MapStr {
+	return common.MapStr{"existing": "foo"}
 }


### PR DESCRIPTION
* get rid of docMapper for memory improvement
* refactor enhancer utility method
* adapt transaction spans to be an []*Span instead of []Span


Memory measurements using:
```
var mem runtime.MemStats

runtime.ReadMemStats(&mem)
h2 := mem.HeapAlloc / 1024
l.Infof("HEAP Transform middle : %v", h2)

ttt := pa.transform(p.config) 

runtime.ReadMemStats(&mem)
h3 := mem.HeapAlloc / 1024
l.Infof("HEAP Transform after: %v, %v", h3, h3-h2)
```

Running APM Server with turned off GC `GOGC=off ./apm-server` to see how much memory is allocated for the `pa.transform(p.config)` action leads to following results, comparing this branch to `master`:

* [Transaction Test example](https://github.com/elastic/apm-server/blob/master/tests/data/valid/transaction/payload.json), decoded size 56 KB:
`master`: 43KB
`memory-remove-mapper`: 24KB

* [Error Test example](https://github.com/elastic/apm-server/blob/master/tests/data/valid/error/payload.json), decoded size 55 KB:
`master`: 29KB
`memory-remove-mapper`: 17KB

* Transaction: 2 Transactions, with Spans and Stacktrace, decoded size 1110 KB:
`master`: 454 KB
`memory-remove-mapper`: 404 KB

* Transaction: 1 Transaction, no Span, decoded size 18 KB:
`master`: 6 KB
`memory-remove-mapper`: 5 KB

* Transaction: 3 Transactions, no Span, decoded size 38 KB:
`master`: 15 KB
`memory-remove-mapper`: 9 KB

* Error: 1 Error with Stacktrace, decoded size 81 KB:
`master`: 33 KB
`memory-remove-mapper`: 32 KB