### PR TITLE
Refactor Transformation to use Pointer everywhere.

### DIFF
--- a/docs/data/elasticsearch/transaction.json
+++ b/docs/data/elasticsearch/transaction.json
@@ -116,7 +116,7 @@
             },
             "performance": {}
         },
-        "name": "GET /api/types",
+        "name": "GET /api/types/first",
         "result": "success",
         "sampled": true,
         "span_count": {
@@ -124,6 +124,6 @@
                 "total": 2
             }
         },
-        "type": "request"
+        "type": "GET request"
     }
 }

--- a/docs/data/intake-api/generated/transaction/payload.json
+++ b/docs/data/intake-api/generated/transaction/payload.json
@@ -37,8 +37,8 @@
     "transactions": [
         {
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-            "name": "GET /api/types",
-            "type": "request",
+            "name": "GET /api/types/first",
+            "type": "GET request",
             "duration": 32.592981,
             "result": "success",
             "timestamp": "2017-05-30T18:53:27.154Z",
@@ -162,7 +162,7 @@
                 {
                     "id": 1,
                     "parent": 0,
-                    "name": "GET /api/types",
+                    "name": "GET /api/types/span",
                     "type": "request",
                     "start": 0,
                     "duration": 32.592981
@@ -170,8 +170,8 @@
                 {
                     "id": 2,
                     "parent": 1,
-                    "name": "GET /api/types",
-                    "type": "request",
+                    "name": "db query",
+                    "type": "db query",
                     "start": 1.845,
                     "duration": 3.5642981,
                     "stacktrace": [],
@@ -209,8 +209,8 @@
         },
         {
             "id": "85925e55-b43f-4340-a8e0-df1906ecbf78",
-            "name": "GET /api/types",
-            "type": "request",
+            "name": "GET /api/types/123",
+            "type": "get request",
             "duration": 13.980558,
             "result": "200",
             "timestamp": "2017-05-30T18:53:42Z",
@@ -218,8 +218,8 @@
         },
         {
             "id": "85925e55-b43f-4340-a8e0-df1906ecbfa9",
-            "name": "GET /api/types",
-            "type": "request",
+            "name": "POST /api/types/1",
+            "type": "post request",
             "duration": 13.980558,
             "result": "200",
             "timestamp": "2017-05-30T18:53:42.281999Z",
@@ -231,6 +231,7 @@
             },
             "spans": [
                 {
+                    "id": 1,
                     "name": "SELECT FROM product_types",
                     "type": "db.postgresql.query",
                     "start": 2.83092,

--- a/model/process.go
+++ b/model/process.go
@@ -6,24 +6,21 @@ import (
 )
 
 type Process struct {
-	Pid   int
+	Pid   *int
 	Ppid  *int
 	Title *string
 	Argv  []string
 }
 
-type TransformProcess func(a *Process) common.MapStr
-
 func (p *Process) Transform() common.MapStr {
 	if p == nil {
 		return nil
 	}
-	enhancer := utility.NewMapStrEnhancer()
 	svc := common.MapStr{}
-	enhancer.Add(svc, "pid", p.Pid)
-	enhancer.Add(svc, "ppid", p.Ppid)
-	enhancer.Add(svc, "title", p.Title)
-	enhancer.Add(svc, "argv", p.Argv)
+	utility.AddIntPtr(svc, "pid", p.Pid)
+	utility.AddIntPtr(svc, "ppid", p.Ppid)
+	utility.AddStrPtr(svc, "title", p.Title)
+	utility.AddStrArray(svc, "argv", p.Argv)
 
 	return svc
 }

--- a/model/process_test.go
+++ b/model/process_test.go
@@ -8,37 +8,37 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
-func TestProcessTransformDefinition(t *testing.T) {
-	myfn := func(fn TransformProcess) string { return "ok" }
-	res := myfn((*Process).Transform)
-	assert.Equal(t, "ok", res)
-}
-
 func TestProcessTransform(t *testing.T) {
+	var process *Process
+
 	pid := 1234
+	ppid := 45234
 	processTitle := "node"
-	argv := []string{
-		"node",
-		"server.js",
-	}
+	argv := []string{"node", "server.js"}
 
 	tests := []struct {
-		Process Process
+		Process *Process
 		Output  common.MapStr
 	}{
 		{
-			Process: Process{},
-			Output:  common.MapStr{"pid": 0},
+			Process: process,
+			Output:  nil,
 		},
 		{
-			Process: Process{
-				Pid:   pid,
+			Process: &Process{},
+			Output:  common.MapStr{},
+		},
+		{
+			Process: &Process{
+				Pid:   &pid,
+				Ppid:  &ppid,
 				Title: &processTitle,
 				Argv:  argv,
 			},
 			Output: common.MapStr{
-				"pid":   pid,
-				"title": processTitle,
+				"pid":   &pid,
+				"ppid":  &ppid,
+				"title": &processTitle,
 				"argv":  argv,
 			},
 		},

--- a/model/service.go
+++ b/model/service.go
@@ -6,65 +6,67 @@ import (
 )
 
 type Service struct {
-	Name        string
+	Name        *string
 	Version     *string
 	Environment *string
-	Language    Language
-	Runtime     Runtime
-	Framework   Framework
-	Agent       Agent
+	Agent       struct {
+		Name    *string
+		Version *string
+	}
+	Language struct {
+		Name    *string
+		Version *string
+	}
+	Runtime struct {
+		Name    *string
+		Version *string
+	}
+	Framework struct {
+		Name    *string
+		Version *string
+	}
 }
-
-type Language struct {
-	Name    *string
-	Version *string
-}
-type Runtime struct {
-	Name    *string
-	Version *string
-}
-type Framework struct {
-	Name    *string
-	Version *string
-}
-type Agent struct {
-	Name    string
-	Version string
-}
-
-type TransformService func(a *Service) common.MapStr
 
 func (s *Service) MinimalTransform() common.MapStr {
-	svc := common.MapStr{
-		"name": s.Name,
-		"agent": common.MapStr{
-			"name":    s.Agent.Name,
-			"version": s.Agent.Version,
-		},
+	if s == nil {
+		return nil
+	}
+	svc := common.MapStr{}
+	utility.AddStrPtr(svc, "name", s.Name)
+	ag := common.MapStr{}
+	utility.AddStrPtr(ag, "name", s.Agent.Name)
+	utility.AddStrPtr(ag, "version", s.Agent.Version)
+	utility.AddCommonMapStr(svc, "agent", ag)
+	if len(svc) == 0 {
+		return nil
 	}
 	return svc
 }
 
 func (s *Service) Transform() common.MapStr {
-	enhancer := utility.NewMapStrEnhancer()
+	if s == nil {
+		return nil
+	}
 	svc := s.MinimalTransform()
-	enhancer.Add(svc, "version", s.Version)
-	enhancer.Add(svc, "environment", s.Environment)
+	utility.AddStrPtr(svc, "version", s.Version)
+	utility.AddStrPtr(svc, "environment", s.Environment)
 
-	lang := common.MapStr{}
-	enhancer.Add(lang, "name", s.Language.Name)
-	enhancer.Add(lang, "version", s.Language.Version)
-	enhancer.Add(svc, "language", lang)
+	m := common.MapStr{}
+	utility.AddStrPtr(m, "name", s.Language.Name)
+	utility.AddStrPtr(m, "version", s.Language.Version)
+	utility.AddCommonMapStr(svc, "language", m)
 
-	runtime := common.MapStr{}
-	enhancer.Add(runtime, "name", s.Runtime.Name)
-	enhancer.Add(runtime, "version", s.Runtime.Version)
-	enhancer.Add(svc, "runtime", runtime)
+	m = common.MapStr{}
+	utility.AddStrPtr(m, "name", s.Runtime.Name)
+	utility.AddStrPtr(m, "version", s.Runtime.Version)
+	utility.AddCommonMapStr(svc, "runtime", m)
 
-	framework := common.MapStr{}
-	enhancer.Add(framework, "name", s.Framework.Name)
-	enhancer.Add(framework, "version", s.Framework.Version)
-	enhancer.Add(svc, "framework", framework)
-
+	m = common.MapStr{}
+	utility.AddStrPtr(m, "name", s.Framework.Name)
+	utility.AddStrPtr(m, "version", s.Framework.Version)
+	utility.AddCommonMapStr(svc, "framework", m)
+	if len(svc) == 0 {
+		return nil
+	}
 	return svc
 }

--- a/model/service_test.go
+++ b/model/service_test.go
@@ -8,14 +8,10 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
-func TestServiceTransformDefinition(t *testing.T) {
-	myfn := func(fn TransformService) string { return "ok" }
-	res := myfn((*Service).Transform)
-	assert.Equal(t, "ok", res)
-}
-
 func TestServiceTransform(t *testing.T) {
+	var service *Service
 
+	name := "myService"
 	version := "5.1.3"
 	environment := "staging"
 	langName := "ecmascript"
@@ -27,60 +23,70 @@ func TestServiceTransform(t *testing.T) {
 	agentName := "elastic-node"
 	agentVersion := "1.0.0"
 	tests := []struct {
-		Service Service
+		Service *Service
 		Output  common.MapStr
 	}{
 		{
-			Service: Service{},
-			Output: common.MapStr{
-				"agent": common.MapStr{
-					"name":    "",
-					"version": "",
-				},
-				"name": "",
-			},
+			Service: service,
+			Output:  nil,
 		},
 		{
-			Service: Service{
-				Name:        "myService",
+			Service: &Service{},
+			Output:  nil,
+		},
+		{
+			Service: &Service{
+				Name:        &name,
 				Version:     &version,
 				Environment: &environment,
-				Language: Language{
+				Language: struct {
+					Name    *string
+					Version *string
+				}{
 					Name:    &langName,
 					Version: &langVersion,
 				},
-				Runtime: Runtime{
+				Runtime: struct {
+					Name    *string
+					Version *string
+				}{
 					Name:    &rtName,
 					Version: &rtVersion,
 				},
-				Framework: Framework{
+				Framework: struct {
+					Name    *string
+					Version *string
+				}{
 					Name:    &fwName,
 					Version: &fwVersion,
 				},
-				Agent: Agent{
-					Name:    agentName,
-					Version: agentVersion,
+				Agent: struct {
+					Name    *string
+					Version *string
+				}{
+					Name:    &agentName,
+					Version: &agentVersion,
 				},
 			},
 			Output: common.MapStr{
-				"name":        "myService",
-				"version":     "5.1.3",
-				"environment": "staging",
+				"name":        &name,
+				"version":     &version,
+				"environment": &environment,
 				"language": common.MapStr{
-					"name":    "ecmascript",
-					"version": "8",
+					"name":    &langName,
+					"version": &langVersion,
 				},
 				"runtime": common.MapStr{
-					"name":    "node",
-					"version": "8.0.0",
+					"name":    &rtName,
+					"version": &rtVersion,
 				},
 				"framework": common.MapStr{
-					"name":    "Express",
-					"version": "1.2.3",
+					"name":    &fwName,
+					"version": &fwVersion,
 				},
 				"agent": common.MapStr{
-					"name":    "elastic-node",
-					"version": "1.0.0",
+					"name":    &agentName,
+					"version": &agentVersion,
 				},
 			},
 		},

--- a/model/system.go
+++ b/model/system.go
@@ -12,14 +12,13 @@ type System struct {
 }
 
 func (s *System) Transform() common.MapStr {
-	if s == nil {
+	if s == nil || (s.Hostname == nil && s.Architecture == nil && s.Platform == nil) {
 		return nil
 	}
-	enhancer := utility.NewMapStrEnhancer()
 	system := common.MapStr{}
-	enhancer.Add(system, "hostname", s.Hostname)
-	enhancer.Add(system, "architecture", s.Architecture)
-	enhancer.Add(system, "platform", s.Platform)
+	utility.AddStrPtr(system, "hostname", s.Hostname)
+	utility.AddStrPtr(system, "architecture", s.Architecture)
+	utility.AddStrPtr(system, "platform", s.Platform)
 
 	return system
 }

--- a/model/system_test.go
+++ b/model/system_test.go
@@ -9,39 +9,33 @@ import (
 )
 
 func TestSystemTransform(t *testing.T) {
-
+	var system *System
 	architecture := "x64"
 	hostname := "a.b.com"
 	platform := "darwin"
 
 	tests := []struct {
-		System System
+		System *System
 		Output common.MapStr
 	}{
 		{
-			System: System{},
-			Output: common.MapStr{},
+			System: system,
+			Output: nil,
 		},
 		{
-			System: System{
+			System: &System{},
+			Output: nil,
+		},
+		{
+			System: &System{
 				Architecture: &architecture,
 				Hostname:     &hostname,
 				Platform:     &platform,
 			},
 			Output: common.MapStr{
-				"hostname":     hostname,
-				"architecture": architecture,
-				"platform":     platform,
-			},
-		},
-		{
-			System: System{
-				Architecture: &architecture,
-				Hostname:     &hostname,
-			},
-			Output: common.MapStr{
-				"hostname":     hostname,
-				"architecture": architecture,
+				"hostname":     &hostname,
+				"architecture": &architecture,
+				"platform":     &platform,
 			},
 		},
 	}

--- a/processor/error/package_tests/TestProcessErrorNullValues.approved.json
+++ b/processor/error/package_tests/TestProcessErrorNullValues.approved.json
@@ -12,8 +12,7 @@
                         "name": "ruby"
                     },
                     "name": "1234_service-12a3"
-                },
-                "system": {}
+                }
             },
             "error": {
                 "exception": {
@@ -70,7 +69,6 @@
                     },
                     "name": "1234_service-12a3"
                 },
-                "system": {},
                 "tags": {
                     "organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8"
                 }
@@ -125,7 +123,6 @@
                     },
                     "name": "1234_service-12a3"
                 },
-                "system": {},
                 "user": {
                     "email": null,
                     "id": null,
@@ -159,7 +156,6 @@
                     },
                     "name": "1234_service-12a3"
                 },
-                "system": {},
                 "tags": null,
                 "user": null
             },

--- a/processor/error/payload.go
+++ b/processor/error/payload.go
@@ -16,7 +16,7 @@ type payload struct {
 	Service m.Service
 	System  *m.System
 	Process *m.Process
-	Events  []Event `mapstructure:"errors"`
+	Events  []*Event `mapstructure:"errors"`
 }
 
 func (pa *payload) transform(config *pr.Config) []beat.Event {
@@ -27,6 +27,7 @@ func (pa *payload) transform(config *pr.Config) []beat.Event {
 	errorCounter.Add(int64(len(pa.Events)))
 	for _, e := range pa.Events {
 		events = append(events, pr.CreateDoc(e.Mappings(config, pa)))
+		e = nil
 	}
 	return events
 }

--- a/processor/transaction/event.go
+++ b/processor/transaction/event.go
@@ -7,15 +7,18 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
+const transactionDocType = "transaction"
+
 type Event struct {
-	Id        string
-	Name      *string
-	Type      string
-	Result    *string
-	Duration  float64
+	Id        *string
+	Type      *string
 	Timestamp time.Time
+
+	Name      *string
+	Result    *string
+	Duration  *float64
 	Context   common.MapStr
-	Spans     []Span
+	Spans     []*Span
 	Marks     common.MapStr
 	Sampled   *bool
 	SpanCount SpanCount `mapstructure:"span_count"`
@@ -27,42 +30,42 @@ type Dropped struct {
 	Total *int
 }
 
-func (ev *Event) DocType() string {
-	return "transaction"
-}
-
 func (ev *Event) Transform() common.MapStr {
-	enh := utility.NewMapStrEnhancer()
-	tx := common.MapStr{"id": ev.Id}
-	enh.Add(tx, "name", ev.Name)
-	enh.Add(tx, "duration", utility.MillisAsMicros(ev.Duration))
-	enh.Add(tx, "type", ev.Type)
-	enh.Add(tx, "result", ev.Result)
-	enh.Add(tx, "marks", ev.Marks)
+	if ev == nil {
+		return nil
+	}
+	tx := common.MapStr{}
+	utility.AddStrPtr(tx, "id", ev.Id)
+	utility.AddStrPtr(tx, "name", ev.Name)
+	utility.AddMillis(tx, "duration", ev.Duration)
+	utility.AddStrPtr(tx, "type", ev.Type)
+	utility.AddStrPtr(tx, "result", ev.Result)
+	utility.AddCommonMapStr(tx, "marks", ev.Marks)
 
 	if ev.Sampled == nil {
-		enh.Add(tx, "sampled", true)
-	} else {
-		enh.Add(tx, "sampled", ev.Sampled)
+		sampled := true
+		ev.Sampled = &sampled
 	}
+	utility.AddBoolPtr(tx, "sampled", ev.Sampled)
 
 	if ev.SpanCount.Dropped.Total != nil {
 		s := common.MapStr{
 			"dropped": common.MapStr{
-				"total": *ev.SpanCount.Dropped.Total,
+				"total": ev.SpanCount.Dropped.Total,
 			},
 		}
-		enh.Add(tx, "span_count", s)
+		utility.AddCommonMapStr(tx, "span_count", s)
 	}
+
 	return tx
 }
 
 func (t *Event) Mappings(pa *payload) (time.Time, []utility.DocMapping) {
 	mapping := []utility.DocMapping{
 		{Key: "processor", Apply: func() common.MapStr {
-			return common.MapStr{"name": processorName, "event": t.DocType()}
+			return common.MapStr{"name": processorName, "event": transactionDocType}
 		}},
-		{Key: t.DocType(), Apply: t.Transform},
+		{Key: transactionDocType, Apply: t.Transform},
 		{Key: "context", Apply: func() common.MapStr { return t.Context }},
 		{Key: "context.service", Apply: pa.Service.Transform},
 		{Key: "context.system", Apply: pa.System.Transform},

--- a/processor/transaction/event_test.go
+++ b/processor/transaction/event_test.go
@@ -3,59 +3,63 @@ package transaction
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"time"
 
 	"github.com/elastic/beats/libbeat/common"
 )
 
-//TODO: use test enhancer as argument and test error case
 func TestEventTransform(t *testing.T) {
+	var ev *Event
 
 	id := "123"
 	result := "tx result"
 	sampled := false
 	dropped := 5
 	name := "mytransaction"
+	eventType := "request"
+	duration := 65.98
+	durationMicros := 65980
+	truthy := true
+	sid1, name1 := 111, "io"
 
 	tests := []struct {
-		Event  Event
+		Event  *Event
 		Output common.MapStr
 		Msg    string
 	}{
 		{
-			Event: Event{},
-			Output: common.MapStr{
-				"id":       "",
-				"type":     "",
-				"duration": common.MapStr{"us": 0},
-				"sampled":  true,
-			},
-			Msg: "Empty Event",
+			Event:  ev,
+			Output: nil,
+			Msg:    "Nil Event",
 		},
 		{
-			Event: Event{
-				Id:        id,
+			Event:  &Event{},
+			Output: common.MapStr{"sampled": &truthy},
+			Msg:    "Empty Event",
+		},
+		{
+			Event: &Event{
+				Id:        &id,
 				Name:      &name,
-				Type:      "tx",
+				Type:      &eventType,
 				Result:    &result,
 				Timestamp: time.Now(),
-				Duration:  65.98,
+				Duration:  &duration,
 				Context:   common.MapStr{"foo": "bar"},
-				Spans:     []Span{},
+				Spans:     []*Span{&Span{Id: &sid1, Name: &name1}},
 				Sampled:   &sampled,
 				SpanCount: SpanCount{Dropped: Dropped{Total: &dropped}},
 			},
 			Output: common.MapStr{
-				"id":         id,
-				"name":       "mytransaction",
-				"type":       "tx",
-				"result":     "tx result",
-				"duration":   common.MapStr{"us": 65980},
-				"span_count": common.MapStr{"dropped": common.MapStr{"total": 5}},
-				"sampled":    false,
+				"id":         &id,
+				"name":       &name,
+				"type":       &eventType,
+				"result":     &result,
+				"duration":   common.MapStr{"us": &durationMicros},
+				"span_count": common.MapStr{"dropped": common.MapStr{"total": &dropped}},
+				"sampled":    new(bool),
 			},
 			Msg: "Full Event",
 		},

--- a/processor/transaction/package_tests/TestProcessTransactionFull.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionFull.approved.json
@@ -119,7 +119,7 @@
                     },
                     "performance": {}
                 },
-                "name": "GET /api/types",
+                "name": "GET /api/types/first",
                 "result": "success",
                 "sampled": true,
                 "span_count": {
@@ -127,7 +127,7 @@
                         "total": 2
                     }
                 },
-                "type": "request"
+                "type": "GET request"
             }
         },
         {
@@ -222,7 +222,7 @@
                     "us": 32592
                 },
                 "id": 1,
-                "name": "GET /api/types",
+                "name": "GET /api/types/span",
                 "parent": 0,
                 "start": {
                     "us": 0
@@ -253,12 +253,12 @@
                     "us": 3564
                 },
                 "id": 2,
-                "name": "GET /api/types",
+                "name": "db query",
                 "parent": 1,
                 "start": {
                     "us": 1845
                 },
-                "type": "request"
+                "type": "db query"
             },
             "transaction": {
                 "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79"
@@ -397,10 +397,10 @@
                     "us": 13980
                 },
                 "id": "85925e55-b43f-4340-a8e0-df1906ecbf78",
-                "name": "GET /api/types",
+                "name": "GET /api/types/123",
                 "result": "200",
                 "sampled": false,
-                "type": "request"
+                "type": "get request"
             }
         },
         {
@@ -451,7 +451,7 @@
                     "us": 13980
                 },
                 "id": "85925e55-b43f-4340-a8e0-df1906ecbfa9",
-                "name": "GET /api/types",
+                "name": "POST /api/types/1",
                 "result": "200",
                 "sampled": true,
                 "span_count": {
@@ -459,7 +459,7 @@
                         "total": 258
                     }
                 },
-                "type": "request"
+                "type": "post request"
             }
         },
         {
@@ -487,6 +487,7 @@
                 "duration": {
                     "us": 3781
                 },
+                "id": 1,
                 "name": "SELECT FROM product_types",
                 "start": {
                     "us": 2830

--- a/processor/transaction/package_tests/TestProcessTransactionNullValues.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionNullValues.approved.json
@@ -12,8 +12,7 @@
                         "name": "ruby"
                     },
                     "name": "1234_service-12a3"
-                },
-                "system": {}
+                }
             },
             "processor": {
                 "event": "transaction",
@@ -45,7 +44,6 @@
                     },
                     "name": "1234_service-12a3"
                 },
-                "system": {},
                 "tags": null,
                 "user": null
             },
@@ -101,7 +99,6 @@
                     },
                     "name": "1234_service-12a3"
                 },
-                "system": {},
                 "user": {
                     "email": null,
                     "id": null,
@@ -162,7 +159,6 @@
                     },
                     "name": "1234_service-12a3"
                 },
-                "system": {},
                 "tags": {
                     "organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8"
                 }

--- a/processor/transaction/payload.go
+++ b/processor/transaction/payload.go
@@ -17,7 +17,7 @@ type payload struct {
 	Service m.Service
 	System  *m.System
 	Process *m.Process
-	Events  []Event `mapstructure:"transactions"`
+	Events  []*Event `mapstructure:"transactions"`
 }
 
 func (pa *payload) transform(config *pr.Config) []beat.Event {
@@ -34,6 +34,7 @@ func (pa *payload) transform(config *pr.Config) []beat.Event {
 		for _, sp := range event.Spans {
 			events = append(events, pr.CreateDoc(sp.Mappings(config, pa, event)))
 		}
+		event = nil
 	}
 
 	return events

--- a/processor/transaction/payload_test.go
+++ b/processor/transaction/payload_test.go
@@ -3,10 +3,9 @@ package transaction
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"time"
 
 	m "github.com/elastic/apm-server/model"
 	pr "github.com/elastic/apm-server/processor"
@@ -14,36 +13,55 @@ import (
 )
 
 func TestPayloadTransform(t *testing.T) {
+	serviceName := "myservice"
+	service := m.Service{Name: &serviceName}
+
 	hostname := "a.b.c"
 	architecture := "darwin"
 	platform := "x64"
 	timestamp := time.Now()
+	id, userId := "111", 55
+	truthy := true
 
-	service := m.Service{Name: "myservice"}
 	system := &m.System{
 		Hostname:     &hostname,
 		Architecture: &architecture,
 		Platform:     &platform,
 	}
+	spName, spName2, spType, spType2 := "s1", "s2", "t1", "t2"
 
-	txValid := Event{Timestamp: timestamp}
-	txValidEs := common.MapStr{
-		"context": common.MapStr{
-			"service": common.MapStr{
-				"name":  "myservice",
-				"agent": common.MapStr{"name": "", "version": ""},
-			},
+	spans := []*Span{
+		{Name: &spName, Type: &spType},
+		{Name: &spName2, Type: &spType2},
+	}
+	txValidWithSpan := &Event{Timestamp: timestamp, Id: &id, Spans: spans}
+	spanEs1 := common.MapStr{
+		"context": common.MapStr{"service": common.MapStr{"name": &serviceName}},
+		"processor": common.MapStr{
+			"event": "span",
+			"name":  "transaction",
 		},
+		"span":        common.MapStr{"type": &spType, "name": &spName},
+		"transaction": common.MapStr{"id": &id},
+	}
+	spanEs2 := common.MapStr{
+		"context": common.MapStr{"service": common.MapStr{"name": &serviceName}},
+		"processor": common.MapStr{
+			"event": "span",
+			"name":  "transaction",
+		},
+		"span":        common.MapStr{"type": &spType2, "name": &spName2},
+		"transaction": common.MapStr{"id": &id},
+	}
+
+	txValid := &Event{Timestamp: timestamp, Id: &id}
+	txValidEs := common.MapStr{
+		"context": common.MapStr{"service": common.MapStr{"name": &serviceName}},
 		"processor": common.MapStr{
 			"event": "transaction",
 			"name":  "transaction",
 		},
-		"transaction": common.MapStr{
-			"duration": common.MapStr{"us": 0},
-			"id":       "",
-			"type":     "",
-			"sampled":  true,
-		},
+		"transaction": common.MapStr{"sampled": &truthy, "id": &id},
 	}
 
 	txValidWithSystem := common.MapStr{
@@ -51,103 +69,70 @@ func TestPayloadTransform(t *testing.T) {
 			"event": "transaction",
 			"name":  "transaction",
 		},
-		"transaction": common.MapStr{
-			"duration": common.MapStr{"us": 0},
-			"id":       "",
-			"type":     "",
-			"sampled":  true,
-		},
+		"transaction": common.MapStr{"sampled": &truthy, "id": &id},
 		"context": common.MapStr{
+			"service": common.MapStr{"name": &serviceName},
 			"system": common.MapStr{
-				"hostname":     hostname,
-				"architecture": architecture,
-				"platform":     platform,
-			},
-			"service": common.MapStr{
-				"name":  "myservice",
-				"agent": common.MapStr{"name": "", "version": ""},
+				"hostname":     &hostname,
+				"architecture": &architecture,
+				"platform":     &platform,
 			},
 		},
 	}
-	txWithContext := Event{Timestamp: timestamp, Context: common.MapStr{"foo": "bar", "user": common.MapStr{"id": "55"}}}
+
+	txWithContext := &Event{
+		Timestamp: timestamp,
+		Context:   common.MapStr{"foo": "bar", "user": common.MapStr{"id": &userId}},
+	}
 	txWithContextEs := common.MapStr{
 		"processor": common.MapStr{
 			"event": "transaction",
 			"name":  "transaction",
 		},
-		"transaction": common.MapStr{
-			"duration": common.MapStr{"us": 0},
-			"id":       "",
-			"type":     "",
-			"sampled":  true,
-		},
+		"transaction": common.MapStr{"sampled": &truthy},
 		"context": common.MapStr{
-			"foo": "bar", "user": common.MapStr{"id": "55"},
-			"service": common.MapStr{
-				"name":  "myservice",
-				"agent": common.MapStr{"name": "", "version": ""},
-			},
+			"foo": "bar", "user": common.MapStr{"id": &userId},
+			"service": common.MapStr{"name": &serviceName},
 			"system": common.MapStr{
-				"hostname":     "a.b.c",
-				"architecture": "darwin",
-				"platform":     "x64",
+				"hostname":     &hostname,
+				"architecture": &architecture,
+				"platform":     &platform,
 			},
 		},
-	}
-	spans := []Span{{}}
-	txValidWithSpan := Event{Timestamp: timestamp, Spans: spans}
-	spanEs := common.MapStr{
-		"context": common.MapStr{
-			"service": common.MapStr{
-				"name":  "myservice",
-				"agent": common.MapStr{"name": "", "version": ""},
-			},
-		},
-		"processor": common.MapStr{
-			"event": "span",
-			"name":  "transaction",
-		},
-		"span": common.MapStr{
-			"duration": common.MapStr{"us": 0},
-			"name":     "",
-			"start":    common.MapStr{"us": 0},
-			"type":     "",
-		},
-		"transaction": common.MapStr{"id": ""},
 	}
 
 	tests := []struct {
-		Payload payload
+		Payload *payload
 		Output  []common.MapStr
 		Msg     string
 	}{
 		{
-			Payload: payload{Service: service, Events: []Event{}},
+			Payload: &payload{Service: service, Events: []*Event{}},
 			Output:  nil,
 			Msg:     "Payload with empty Event Array",
 		},
 		{
-			Payload: payload{
+			Payload: &payload{
 				Service: service,
-				Events:  []Event{txValid, txValidWithSpan},
+				Events:  []*Event{txValid, txValidWithSpan},
 			},
-			Output: []common.MapStr{txValidEs, txValidEs, spanEs},
+			Output: []common.MapStr{txValidEs, txValidEs, spanEs1, spanEs2},
 			Msg:    "Payload with multiple Events",
 		},
 		{
-			Payload: payload{
+			Payload: &payload{
 				Service: service,
 				System:  system,
-				Events:  []Event{txValid},
+				Events:  []*Event{txValid},
 			},
 			Output: []common.MapStr{txValidWithSystem},
 			Msg:    "Payload with System and Event",
 		},
 		{
-			Payload: payload{
+			Payload: &payload{
 				Service: service,
 				System:  system,
-				Events:  []Event{txWithContext},
+				Events:  []*Event{txWithContext},
 			},
 			Output: []common.MapStr{txWithContextEs},
 			Msg:    "Payload with Service, System and Event with context",

--- a/processor/transaction/span.go
+++ b/processor/transaction/span.go
@@ -10,27 +10,26 @@ import (
 )
 
 type Span struct {
+	Name     *string
+	Type     *string
+	Start    *float64
+	Duration *float64
+
 	Id         *int
-	Name       string
-	Type       string
-	Start      float64
-	Duration   float64
 	Stacktrace m.Stacktrace `mapstructure:"stacktrace"`
 	Context    common.MapStr
 	Parent     *int
 }
 
-func (s *Span) DocType() string {
-	return "span"
-}
+const spanDocType = "span"
 
-func (s *Span) Mappings(config *pr.Config, pa *payload, tx Event) (time.Time, []utility.DocMapping) {
+func (s *Span) Mappings(config *pr.Config, pa *payload, tx *Event) (time.Time, []utility.DocMapping) {
 	return tx.Timestamp,
 		[]utility.DocMapping{
 			{Key: "processor", Apply: func() common.MapStr {
-				return common.MapStr{"name": processorName, "event": s.DocType()}
+				return common.MapStr{"name": processorName, "event": spanDocType}
 			}},
-			{Key: s.DocType(), Apply: func() common.MapStr { return s.Transform(config, pa.Service) }},
+			{Key: spanDocType, Apply: func() common.MapStr { return s.Transform(config, pa.Service) }},
 			{Key: "transaction", Apply: func() common.MapStr { return common.MapStr{"id": tx.Id} }},
 			{Key: "context", Apply: func() common.MapStr { return s.Context }},
 			{Key: "context.service", Apply: pa.Service.MinimalTransform},
@@ -38,17 +37,22 @@ func (s *Span) Mappings(config *pr.Config, pa *payload, tx Event) (time.Time, []
 }
 
 func (s *Span) Transform(config *pr.Config, service m.Service) common.MapStr {
-	enhancer := utility.NewMapStrEnhancer()
+	if s == nil {
+		return nil
+	}
 	tr := common.MapStr{}
-	enhancer.Add(tr, "id", s.Id)
-	enhancer.Add(tr, "name", s.Name)
-	enhancer.Add(tr, "type", s.Type)
-	enhancer.Add(tr, "start", utility.MillisAsMicros(s.Start))
-	enhancer.Add(tr, "duration", utility.MillisAsMicros(s.Duration))
-	enhancer.Add(tr, "parent", s.Parent)
+	utility.AddIntPtr(tr, "id", s.Id)
+	utility.AddStrPtr(tr, "name", s.Name)
+	utility.AddStrPtr(tr, "type", s.Type)
+	utility.AddMillis(tr, "start", s.Start)
+	utility.AddMillis(tr, "duration", s.Duration)
+	utility.AddIntPtr(tr, "parent", s.Parent)
 	st := s.Stacktrace.Transform(config, service)
 	if len(st) > 0 {
-		enhancer.Add(tr, "stacktrace", st)
+		utility.AddCommonMapStrArray(tr, "stacktrace", st)
+	}
+	if len(tr) == 0 {
+		return nil
 	}
 	return tr
 }

--- a/tests/data/valid/transaction/payload.json
+++ b/tests/data/valid/transaction/payload.json
@@ -37,8 +37,8 @@
     "transactions": [
         {
             "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79",
-            "name": "GET /api/types",
-            "type": "request",
+            "name": "GET /api/types/first",
+            "type": "GET request",
             "duration": 32.592981,
             "result": "success",
             "timestamp": "2017-05-30T18:53:27.154Z",
@@ -162,7 +162,7 @@
                 {
                     "id": 1,
                     "parent": 0,
-                    "name": "GET /api/types",
+                    "name": "GET /api/types/span",
                     "type": "request",
                     "start": 0,
                     "duration": 32.592981
@@ -170,8 +170,8 @@
                 {
                     "id": 2,
                     "parent": 1,
-                    "name": "GET /api/types",
-                    "type": "request",
+                    "name": "db query",
+                    "type": "db query",
                     "start": 1.845,
                     "duration": 3.5642981,
                     "stacktrace": [],
@@ -209,8 +209,8 @@
         },
         {
             "id": "85925e55-b43f-4340-a8e0-df1906ecbf78",
-            "name": "GET /api/types",
-            "type": "request",
+            "name": "GET /api/types/123",
+            "type": "get request",
             "duration": 13.980558,
             "result": "200",
             "timestamp": "2017-05-30T18:53:42Z",
@@ -218,8 +218,8 @@
         },
         {
             "id": "85925e55-b43f-4340-a8e0-df1906ecbfa9",
-            "name": "GET /api/types",
-            "type": "request",
+            "name": "POST /api/types/1",
+            "type": "post request",
             "duration": 13.980558,
             "result": "200",
             "timestamp": "2017-05-30T18:53:42.281999Z",
@@ -231,6 +231,7 @@
             },
             "spans": [
                 {
+                    "id": 1,
                     "name": "SELECT FROM product_types",
                     "type": "db.postgresql.query",
                     "start": 2.83092,

--- a/utility/map_str_enhancer.go
+++ b/utility/map_str_enhancer.go
@@ -4,52 +4,60 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
-type MapStrEnhancer struct{}
-
-func NewMapStrEnhancer() MapStrEnhancer {
-	return MapStrEnhancer{}
+func AddStrPtr(m common.MapStr, key string, val *string) {
+	if val != nil {
+		m[key] = val
+	}
 }
 
-func (enh MapStrEnhancer) AddStrWithDefault(m common.MapStr, key string, val *string, defaultVal string) {
+func AddStrPtrWithDefault(m common.MapStr, key string, val *string, defaultVal *string) {
 	if val != nil {
-		m[key] = *val
-	} else if defaultVal != "" {
+		m[key] = val
+	} else if defaultVal != nil {
 		m[key] = defaultVal
 	}
 }
 
-func (enh MapStrEnhancer) Add(m common.MapStr, key string, val interface{}) {
-
-	switch val.(type) {
-	case *bool:
-		if newVal := val.(*bool); newVal != nil {
-			m[key] = *newVal
-		}
-	case *int:
-		if newVal := val.(*int); newVal != nil {
-			m[key] = *newVal
-		}
-	case *string:
-		if newVal := val.(*string); newVal != nil {
-			m[key] = *newVal
-		}
-	case common.MapStr:
-		if valMap := val.(common.MapStr); len(valMap) > 0 {
-			m[key] = valMap
-		}
-	case []string:
-		if valArr := val.([]string); len(valArr) > 0 {
-			m[key] = valArr
-		}
-	default:
-		if val != nil {
-			m[key] = val
-		}
+func AddStrArray(m common.MapStr, key string, val []string) {
+	if len(val) > 0 {
+		m[key] = val
 	}
 }
 
-func MillisAsMicros(ms float64) common.MapStr {
-	m := common.MapStr{}
-	m["us"] = int(ms * 1000)
-	return m
+func AddIntPtr(m common.MapStr, key string, val *int) {
+	if val != nil {
+		m[key] = val
+	}
+}
+
+func AddBoolPtr(m common.MapStr, key string, val *bool) {
+	if val != nil {
+		m[key] = val
+	}
+}
+
+func AddInterface(m common.MapStr, key string, val interface{}) {
+	if val != nil {
+		m[key] = val
+	}
+}
+
+func AddCommonMapStr(m common.MapStr, key string, val common.MapStr) {
+	if len(val) > 0 {
+		m[key] = val
+	}
+}
+
+func AddCommonMapStrArray(m common.MapStr, key string, val []common.MapStr) {
+	if len(val) > 0 {
+		m[key] = val
+	}
+}
+
+func AddMillis(m common.MapStr, key string, val *float64) {
+	if val == nil {
+		return
+	}
+	ms := int(*val * 1000)
+	m[key] = common.MapStr{"us": &ms}
 }

--- a/utility/map_str_enhancer_test.go
+++ b/utility/map_str_enhancer_test.go
@@ -10,56 +10,193 @@ import (
 
 const addKey = "added"
 
-func TestAdd(t *testing.T) {
-	base := common.MapStr{"existing": "foo"}
-	addTrue, updateTrue, expectedTrue := true, false, common.MapStr{"existing": "foo", addKey: true}
-	addFalse, updateFalse, expectedFalse := false, true, common.MapStr{"existing": "foo", addKey: false}
-	addInt, updateInt, expectedInt := 1, 2, common.MapStr{"existing": "foo", addKey: 1}
-	addStr, updateStr, expectedStr := "foo", "bar", common.MapStr{"existing": "foo", addKey: "foo"}
-	addCommonMapStr, updateCommonMapStr, expectedCommonMapStr := common.MapStr{"foo": "bar"}, common.MapStr{"john": "doe"}, common.MapStr{"existing": "foo", addKey: common.MapStr{"foo": "bar"}}
-	addCommonMapStrEmpty, updateCommonMapStrEmpty, expectedCommonMapStrEmpty := common.MapStr{}, common.MapStr{}, base
+//func TestAdd(t *testing.T) {
+//base := common.MapStr{"existing": "foo"}
+//addTrue, updateTrue, expectedTrue := true, false, common.MapStr{"existing": "foo", addKey: true}
+//addFalse, updateFalse, expectedFalse := false, true, common.MapStr{"existing": "foo", addKey: false}
+//addInt, updateInt, expectedInt := 1, 2, common.MapStr{"existing": "foo", addKey: 1}
+//addStr, updateStr, expectedStr := "foo", "bar", common.MapStr{"existing": "foo", addKey: "foo"}
+//addCommonMapStr, updateCommonMapStr, expectedCommonMapStr := common.MapStr{"foo": "bar"}, common.MapStr{"john": "doe"}, common.MapStr{"existing": "foo", addKey: common.MapStr{"foo": "bar"}}
+//addCommonMapStrEmpty, updateCommonMapStrEmpty, expectedCommonMapStrEmpty := common.MapStr{}, common.MapStr{}, base
 
-	var addBoolNil *bool
-	var addIntNil *int
-	var addStrNil *string
-	var addStrArrNil []string
-	testData := [][]interface{}{
-		{&addTrue, &updateTrue, expectedTrue},
-		{&addFalse, &updateFalse, expectedFalse},
-		{&addInt, &updateInt, expectedInt},
-		{&addStr, &updateStr, expectedStr},
-		{addCommonMapStr, updateCommonMapStr, expectedCommonMapStr},
-		{addCommonMapStrEmpty, updateCommonMapStrEmpty, expectedCommonMapStrEmpty},
-		{addBoolNil, addBoolNil, base},
-		{addIntNil, addIntNil, base},
-		{addStrNil, addStrNil, base},
-		{addStrArrNil, []string{"something"}, base},
-	}
-	for _, testDataRow := range testData {
-		assert, enhancer, base := setup(t)
+//var addBoolNil *bool
+//var addIntNil *int
+//var addStrNil *string
+//var addStrArrNil []string
+//testData := [][]interface{}{
+//{&addTrue, &updateTrue, expectedTrue},
+//{&addFalse, &updateFalse, expectedFalse},
+//{&addInt, &updateInt, expectedInt},
+//{&addStr, &updateStr, expectedStr},
+//{addCommonMapStr, updateCommonMapStr, expectedCommonMapStr},
+//{addCommonMapStrEmpty, updateCommonMapStrEmpty, expectedCommonMapStrEmpty},
+//{addBoolNil, addBoolNil, base},
+//{addIntNil, addIntNil, base},
+//{addStrNil, addStrNil, base},
+//{addStrArrNil, []string{"something"}, base},
+//}
+//for _, testDataRow := range testData {
+//assert, enhancer, base := setup(t)
 
-		enhancer.Add(base, addKey, testDataRow[0])
-		assert.Equal(testDataRow[2], base)
-	}
+//enhancer.Add(base, addKey, testDataRow[0])
+//assert.Equal(testDataRow[2], base)
+//}
+//}
+
+func TestStringPtr(t *testing.T) {
+	old := "foo"
+	new := "bar"
+
+	//sets the new value
+	m := common.MapStr{"existing": &old}
+	AddStrPtr(m, addKey, &new)
+	expectedMap := common.MapStr{"existing": &old, addKey: &new}
+	assert.Equal(t, expectedMap, m)
+
+	//overrides existing value
+	m = common.MapStr{"existing": &old, addKey: &old}
+	AddStrPtr(m, addKey, &new)
+	expectedMap = common.MapStr{"existing": &old, addKey: &new}
+	assert.Equal(t, expectedMap, m)
 }
 
-func TestStringWithDefault(t *testing.T) {
-	assert, enhancer, base := setup(t)
+func TestStringPtrWithDefault(t *testing.T) {
+	old := "foo"
+	new := "bar"
+	def := "def"
 
-	add := "foo"
-	newMap := common.MapStr{"existing": "foo", "added": "foo"}
-	enhancer.AddStrWithDefault(base, addKey, &add, "bar")
-	assert.Equal(newMap, base)
+	//sets the new value
+	m := common.MapStr{"existing": &old}
+	AddStrPtrWithDefault(m, addKey, &new, &def)
+	expectedMap := common.MapStr{"existing": &old, addKey: &new}
+	assert.Equal(t, expectedMap, m)
 
-	assert, enhancer, base = setup(t)
-	enhancer.AddStrWithDefault(base, addKey, nil, "bar")
-	newMap = common.MapStr{"existing": "foo", "added": "bar"}
-	assert.Equal(newMap, base)
+	//overrides existing value
+	m = common.MapStr{"existing": &old, addKey: &old}
+	AddStrPtrWithDefault(m, addKey, &new, &def)
+	expectedMap = common.MapStr{"existing": &old, addKey: &new}
+	assert.Equal(t, expectedMap, m)
+
+	//sets default value if no value given
+	AddStrPtrWithDefault(m, addKey, nil, &def)
+	expectedMap = common.MapStr{"existing": &old, addKey: &def}
+	assert.Equal(t, expectedMap, m)
 }
 
-func setup(t *testing.T) (*assert.Assertions, MapStrEnhancer, common.MapStr) {
-	a := assert.New(t)
-	enhancer := NewMapStrEnhancer()
-	base := common.MapStr{"existing": "foo"}
-	return a, enhancer, base
+func TestStringArray(t *testing.T) {
+	old := []string{"foo"}
+	new := []string{"bar"}
+
+	//sets the new value
+	m := common.MapStr{"existing": old}
+	AddStrArray(m, addKey, new)
+	expectedMap := common.MapStr{"existing": old, addKey: new}
+	assert.Equal(t, expectedMap, m)
+
+	//overrides existing value
+	m = common.MapStr{"existing": old, addKey: old}
+	AddStrArray(m, addKey, new)
+	expectedMap = common.MapStr{"existing": old, addKey: new}
+	assert.Equal(t, expectedMap, m)
+}
+
+func TestIntPtr(t *testing.T) {
+	old := 123
+	new := 456
+
+	//sets the new value
+	m := common.MapStr{"existing": &old}
+	AddIntPtr(m, addKey, &new)
+	expectedMap := common.MapStr{"existing": &old, addKey: &new}
+	assert.Equal(t, expectedMap, m)
+
+	//overrides existing value
+	m = common.MapStr{"existing": &old, addKey: &old}
+	AddIntPtr(m, addKey, &new)
+	expectedMap = common.MapStr{"existing": &old, addKey: &new}
+	assert.Equal(t, expectedMap, m)
+}
+
+func TestBoolPtr(t *testing.T) {
+	old := false
+	new := true
+
+	//sets the new value
+	m := common.MapStr{"existing": &old}
+	AddBoolPtr(m, addKey, &new)
+	expectedMap := common.MapStr{"existing": &old, addKey: &new}
+	assert.Equal(t, expectedMap, m)
+
+	//overrides existing value
+	m = common.MapStr{"existing": &old, addKey: &old}
+	AddBoolPtr(m, addKey, &new)
+	expectedMap = common.MapStr{"existing": &old, addKey: &new}
+	assert.Equal(t, expectedMap, m)
+}
+
+func TestMillis(t *testing.T) {
+	old, new := 1.3, 4.5
+	newMicros := 4500
+
+	//sets the new value
+	m := common.MapStr{"existing": &old}
+	AddMillis(m, addKey, &new)
+	expectedMap := common.MapStr{"existing": &old, addKey: common.MapStr{"us": &newMicros}}
+	assert.Equal(t, expectedMap, m)
+
+	//overrides existing value
+	m = common.MapStr{"existing": &old, addKey: &old}
+	AddMillis(m, addKey, &new)
+	expectedMap = common.MapStr{"existing": &old, addKey: common.MapStr{"us": &newMicros}}
+	assert.Equal(t, expectedMap, m)
+}
+
+func TestInterface(t *testing.T) {
+	var old, new interface{}
+	old, new = "foo", "bar"
+
+	//sets the new value
+	m := common.MapStr{"existing": old}
+	AddInterface(m, addKey, new)
+	expectedMap := common.MapStr{"existing": old, addKey: new}
+	assert.Equal(t, expectedMap, m)
+
+	//overrides existing value
+	m = common.MapStr{"existing": old, addKey: old}
+	AddInterface(m, addKey, new)
+	expectedMap = common.MapStr{"existing": old, addKey: new}
+	assert.Equal(t, expectedMap, m)
+}
+
+func TestAddCommonMapStr(t *testing.T) {
+	old, new := common.MapStr{"a": "foo"}, common.MapStr{"b": "bar"}
+
+	//sets the new value
+	m := common.MapStr{"existing": old}
+	AddCommonMapStr(m, addKey, new)
+	expectedMap := common.MapStr{"existing": old, addKey: new}
+	assert.Equal(t, expectedMap, m)
+
+	//overrides existing value
+	m = common.MapStr{"existing": old, addKey: old}
+	AddCommonMapStr(m, addKey, new)
+	expectedMap = common.MapStr{"existing": old, addKey: new}
+	assert.Equal(t, expectedMap, m)
+}
+
+func TestAddCommonMapStrArray(t *testing.T) {
+	old := []common.MapStr{{"a": "foo"}}
+	new := []common.MapStr{{"b": "bar"}}
+
+	//sets the new value
+	m := common.MapStr{"existing": old}
+	AddCommonMapStrArray(m, addKey, new)
+	expectedMap := common.MapStr{"existing": old, addKey: new}
+	assert.Equal(t, expectedMap, m)
+
+	//overrides existing value
+	m = common.MapStr{"existing": old, addKey: old}
+	AddCommonMapStrArray(m, addKey, new)
+	expectedMap = common.MapStr{"existing": old, addKey: new}
+	assert.Equal(t, expectedMap, m)
 }


### PR DESCRIPTION
* Use Pointer everywhere in transform methods.
* Refactor enhancer utility method to use pointer.


Memory measurements using:
```
var mem runtime.MemStats

runtime.ReadMemStats(&mem)
h2 := mem.HeapAlloc / 1024
l.Infof("HEAP Transform middle : %v", h2)

ttt := pa.transform(p.config) 

runtime.ReadMemStats(&mem)
h3 := mem.HeapAlloc / 1024
l.Infof("HEAP Transform after: %v, %v", h3, h3-h2)
```

Running APM Server with turned off GC `GOGC=off ./apm-server` to see how much memory is allocated for the `pa.transform(p.config)` action leads to following results, comparing this branch to `master`:

* [Transaction Test example](https://github.com/elastic/apm-server/blob/master/tests/data/valid/transaction/payload.json), decoded size 56 KB:
`master`: 43 KB
`memory-remove-mapper`: 40 KB

* [Error Test example](https://github.com/elastic/apm-server/blob/master/tests/data/valid/error/payload.json), decoded size 55 KB:
`master`: 29 KB
`memory-remove-mapper`: 26 KB

* Transaction: 2 Transactions, with Spans and Stacktrace, decoded size 1110 KB:
`master`: 454 KB
`memory-remove-mapper`:  404 KB

* Transaction: 1 Transaction, no Span, decoded size 18 KB:
`master`: 6 KB
`memory-remove-mapper`: 5 KB

* Transaction: 3 Transactions, no Span, decoded size 38 KB:
`master`: 15 KB
`memory-remove-mapper`: 13 KB

* Error: 1 Error with Stacktrace, decoded size 81 KB:
`master`: 33 KB
`memory-remove-mapper`: 31 KB


As you can see, except for one case (multiple transactions with spans and stacktrace) this does not improve memory handling a lot, but it might introduce more error-proneness as it is dealing with pointers instead of values in all the transform methods.

@graphaelli @jalvz would love to get some feedback from you on this. 
