### PR TITLE
[6.x] accept application/json; charset=UTF-8 as contentType in the request, fixes #676

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -20,7 +20,7 @@ type Decoder func(req *http.Request) (map[string]interface{}, error)
 func DecodeLimitJSONData(maxSize int64) Decoder {
 	return func(req *http.Request) (map[string]interface{}, error) {
 		contentType := req.Header.Get("Content-Type")
-		if contentType != "application/json" {
+		if !strings.Contains(contentType, "application/json") {
 			return nil, fmt.Errorf("invalid content type: %s", req.Header.Get("Content-Type"))
 		}
 

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -32,6 +32,22 @@ func TestDecode(t *testing.T) {
 	assert.Equal(t, data, body)
 }
 
+func TestDecodeContentType(t *testing.T) {
+	transactionBytes, err := loader.LoadValidDataAsBytes("transaction")
+	assert.Nil(t, err)
+	buffer := bytes.NewReader(transactionBytes)
+	var data map[string]interface{}
+	json.Unmarshal(transactionBytes, &data)
+
+	req, err := http.NewRequest("POST", "_", buffer)
+	req.Header.Add("Content-Type", "application/json; charset=UTF-8")
+	assert.Nil(t, err)
+
+	body, err := DecodeLimitJSONData(1024 * 1024)(req)
+	assert.Nil(t, err)
+	assert.Equal(t, data, body)
+}
+
 func TestDecodeSizeLimit(t *testing.T) {
 	minimalValid := func() *http.Request {
 		req, err := http.NewRequest("POST", "_", strings.NewReader("{}"))


### PR DESCRIPTION
Backports the following commits to 6.x:
 - accept application/json; charset=UTF-8 as contentType in the request, fixes #676 (#677)