### PR TITLE
[6.x] Set array item types to string

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -13,6 +13,8 @@ https://github.com/elastic/apm-server/compare/4daa36bd5c144cf9182afc62dc8042af66
 ==== Bug fixes
 
 - Accept charset in request's content type {pull}677[677].
+- Use type integer instead of number in JSON schemas where applicable {pull}641[641].
+- Set array item types to string in JSON schemas {pull}651[651].
 
 ==== Added
 
@@ -46,7 +48,6 @@ https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828
 - Updated readme doc urls {pull}356[356]
 - Use updated stack trace frame values for calculating error `grouping_keys` {pull}485[485]
 - Fix panic when a signal is delivered before the server is instantiated {pull}580[580]
-- Use type integer instead of number in JSON schemas where applicable {pull}641[641]
 
 ==== Added
 - service.environment {pull}366[366]

--- a/docs/spec/process.json
+++ b/docs/spec/process.json
@@ -19,7 +19,10 @@
       "argv": {
         "description": "Command line arguments used to start this process",
         "type": ["array", "null"],
-        "minItems": 0
+        "minItems": 0,
+        "items": {
+           "type": "string"
+        }
     }
   },
   "required": ["pid"]

--- a/docs/spec/stacktrace_frame.json
+++ b/docs/spec/stacktrace_frame.json
@@ -40,12 +40,18 @@
         "post_context": {
             "description": "The lines of code after the stack frame",
             "type": ["array", "null"],
-            "minItems": 0
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
         },
         "pre_context": {
             "description": "The lines of code before the stack frame",
-             "type": ["array", "null"],
-            "minItems": 0
+            "type": ["array", "null"],
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
         },
         "vars": {
             "description": "Local variables for this stack frame",

--- a/processor/error/schema.go
+++ b/processor/error/schema.go
@@ -119,7 +119,10 @@ var errorSchema = `{
       "argv": {
         "description": "Command line arguments used to start this process",
         "type": ["array", "null"],
-        "minItems": 0
+        "minItems": 0,
+        "items": {
+           "type": "string"
+        }
     }
   },
   "required": ["pid"]
@@ -387,12 +390,18 @@ var errorSchema = `{
         "post_context": {
             "description": "The lines of code after the stack frame",
             "type": ["array", "null"],
-            "minItems": 0
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
         },
         "pre_context": {
             "description": "The lines of code before the stack frame",
-             "type": ["array", "null"],
-            "minItems": 0
+            "type": ["array", "null"],
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
         },
         "vars": {
             "description": "Local variables for this stack frame",
@@ -491,12 +500,18 @@ var errorSchema = `{
         "post_context": {
             "description": "The lines of code after the stack frame",
             "type": ["array", "null"],
-            "minItems": 0
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
         },
         "pre_context": {
             "description": "The lines of code before the stack frame",
-             "type": ["array", "null"],
-            "minItems": 0
+            "type": ["array", "null"],
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
         },
         "vars": {
             "description": "Local variables for this stack frame",

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -119,7 +119,10 @@ var transactionSchema = `{
       "argv": {
         "description": "Command line arguments used to start this process",
         "type": ["array", "null"],
-        "minItems": 0
+        "minItems": 0,
+        "items": {
+           "type": "string"
+        }
     }
   },
   "required": ["pid"]
@@ -463,12 +466,18 @@ var transactionSchema = `{
         "post_context": {
             "description": "The lines of code after the stack frame",
             "type": ["array", "null"],
-            "minItems": 0
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
         },
         "pre_context": {
             "description": "The lines of code before the stack frame",
-             "type": ["array", "null"],
-            "minItems": 0
+            "type": ["array", "null"],
+            "minItems": 0,
+            "items": {
+                "type": "string"
+            }
         },
         "vars": {
             "description": "Local variables for this stack frame",


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Set array item types to string (#651)