### PR TITLE
graceful shutdown of apm server

### DIFF
--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -227,7 +227,7 @@ func SetupServer(b *testing.B) *http.ServeMux {
 		b.Fatalf("error initializing publisher: %v", err)
 	}
 
-	pub, err := newPublisher(pip, 1)
+	pub, err := newPublisher(pip, 1, time.Duration(0))
 
 	if err != nil {
 		b.Fatal(err)

--- a/beater/pub.go
+++ b/beater/pub.go
@@ -2,6 +2,7 @@ package beater
 
 import (
 	"errors"
+	"sync"
 	"time"
 
 	"github.com/elastic/beats/libbeat/beat"
@@ -15,9 +16,10 @@ import (
 // number requests(events) active in the system can exceed the queue size. Only
 // the number of concurrent HTTP requests trying to publish at the same time is limited.
 type publisher struct {
-	events chan []beat.Event
-	client beat.Client
-	done   chan struct{}
+	events  chan []beat.Event
+	client  beat.Client
+	m       sync.RWMutex
+	stopped bool
 }
 
 var (
@@ -29,7 +31,7 @@ var (
 // newPublisher creates a new publisher instance. A new go-routine is started
 // for forwarding events to libbeat. Stop must be called to close the
 // beat.Client and free resources.
-func newPublisher(pipeline beat.Pipeline, N int) (*publisher, error) {
+func newPublisher(pipeline beat.Pipeline, N int, shutdownTimeout time.Duration) (*publisher, error) {
 	if N <= 0 {
 		return nil, errInvalidBufferSize
 	}
@@ -37,10 +39,8 @@ func newPublisher(pipeline beat.Pipeline, N int) (*publisher, error) {
 	client, err := pipeline.ConnectWith(beat.ClientConfig{
 		PublishMode: beat.GuaranteedSend,
 
-		// TODO: We want to wait for events in pipeline on shutdown?
 		//       If set >0 `Close` will block for the duration or until pipeline is empty
-		WaitClose: 0,
-
+		WaitClose:         shutdownTimeout,
 		SkipNormalization: true,
 	})
 	if err != nil {
@@ -49,7 +49,7 @@ func newPublisher(pipeline beat.Pipeline, N int) (*publisher, error) {
 
 	p := &publisher{
 		client: client,
-		done:   make(chan struct{}),
+
 		// Set channel size to N - 1. One request will be actively processed by the
 		// worker, while the other concurrent requests will be buffered in the queue.
 		events: make(chan []beat.Event, N-1),
@@ -62,32 +62,25 @@ func newPublisher(pipeline beat.Pipeline, N int) (*publisher, error) {
 // Stop closes all channels and waits for the the worker to stop.
 // The worker will drain the queue on shutdown, but no more events
 // will be published.
-func (p *publisher) Stop(d time.Duration) {
-	close(p.done)
-	p.drain(d)
+func (p *publisher) Stop() {
+	p.m.Lock()
+	p.stopped = true
+	p.m.Unlock()
 	close(p.events)
 	p.client.Close()
-}
-
-// drain waits until the events queue is empty or apm-server.shutdown_timeout seconds have elapsed
-func (p *publisher) drain(d time.Duration) {
-	delta := time.Second / 2
-	for t := time.Duration(0); t < d; t = t + delta {
-		time.Sleep(delta)
-		if len(p.events) == 0 {
-			return
-		}
-	}
 }
 
 // Send tries to forward events to the publishers worker. If the queue is full,
 // an error is returned.
 // Calling send after Stop will return an error.
 func (p *publisher) Send(batch []beat.Event) error {
+	p.m.RLock()
+	defer p.m.RUnlock()
+	if p.stopped {
+		return errChanneClosed
+	}
 
 	select {
-	case <-p.done:
-		return errChanneClosed
 	case p.events <- batch:
 		return nil
 	case <-time.After(time.Second * 1): // this forces the go scheduler to try something else for a while

--- a/beater/server.go
+++ b/beater/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net"
 	"net/http"
-	"time"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/logp"
@@ -46,12 +45,9 @@ func run(server *http.Server, lis net.Listener, config *Config) error {
 	return server.Serve(lis)
 }
 
-func stop(server *http.Server, timeout time.Duration) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
+func stop(server *http.Server) {
 	logger := logp.NewLogger("server")
-	err := server.Shutdown(ctx)
+	err := server.Shutdown(context.Background())
 	if err != nil {
 		logger.Error(err.Error())
 		err = server.Close()

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -230,7 +230,7 @@ func setupServer(t *testing.T, ssl *SSLConfig) (*http.Server, func()) {
 	secure := cfg.SSL != nil
 	waitForServer(secure, cfg.Host)
 
-	return apm, func() { stop(apm, time.Second) }
+	return apm, func() { stop(apm) }
 }
 
 var noSSL *SSLConfig


### PR DESCRIPTION
Fixes #671

This uses the `apm-server.shutdown_timeout` config option to wait for the events buffer to drain, instead of as a timeout for the HTTP server. The HTTP server is closed immediately, instead.

