### PR TITLE
Revert "Use embedded structs over nested structs. (#688)"

### DIFF
--- a/model/service.go
+++ b/model/service.go
@@ -9,10 +9,10 @@ type Service struct {
 	Name        string
 	Version     *string
 	Environment *string
-	Language
-	Runtime
-	Framework
-	Agent
+	Language    Language
+	Runtime     Runtime
+	Framework   Framework
+	Agent       Agent
 }
 
 type Language struct {

--- a/model/stacktrace_frame.go
+++ b/model/stacktrace_frame.go
@@ -25,8 +25,8 @@ type StacktraceFrame struct {
 
 	ExcludeFromGrouping bool
 
-	Sourcemap
-	Original
+	Sourcemap Sourcemap
+	Original  Original
 }
 
 type Sourcemap struct {

--- a/processor/error/event.go
+++ b/processor/error/event.go
@@ -16,13 +16,15 @@ import (
 )
 
 type Event struct {
-	Id      *string
-	Culprit *string
-	Context common.MapStr
-	*Exception
-	*Log
-	*Transaction
-	Timestamp time.Time
+	Id          *string
+	Culprit     *string
+	Context     common.MapStr
+	Exception   *Exception
+	Log         *Log
+	Timestamp   time.Time
+	Transaction *struct {
+		Id string
+	}
 
 	data common.MapStr
 }
@@ -43,10 +45,6 @@ type Log struct {
 	ParamMessage *string      `mapstructure:"param_message"`
 	LoggerName   *string      `mapstructure:"logger_name"`
 	Stacktrace   m.Stacktrace `mapstructure:"stacktrace"`
-}
-
-type Transaction struct {
-	Id string
 }
 
 func (e *Event) Transform(config *pr.Config, service m.Service) common.MapStr {

--- a/processor/error/event_test.go
+++ b/processor/error/event_test.go
@@ -167,7 +167,7 @@ func TestEventTransform(t *testing.T) {
 				Context:     context,
 				Exception:   &exception,
 				Log:         &log,
-				Transaction: &Transaction{Id: "945254c5-67a5-417e-8a4e-aa29efcbfb79"},
+				Transaction: &struct{ Id string }{Id: "945254c5-67a5-417e-8a4e-aa29efcbfb79"},
 			},
 			Output: common.MapStr{
 				"id":      "45678",

--- a/processor/error/payload_test.go
+++ b/processor/error/payload_test.go
@@ -57,7 +57,7 @@ func TestPayloadTransform(t *testing.T) {
 						Message:    "exception message",
 						Stacktrace: m.Stacktrace{&m.StacktraceFrame{Filename: "myFile"}},
 					},
-					Transaction: &Transaction{Id: "945254c5-67a5-417e-8a4e-aa29efcbfb79"},
+					Transaction: &struct{ Id string }{Id: "945254c5-67a5-417e-8a4e-aa29efcbfb79"},
 				}},
 			},
 			Output: []common.MapStr{


### PR DESCRIPTION
This reverts commit 4feb3b5b0f487a93dee087a026f88259dfd7b8cf.

According to discussions on PR #688 .