### PR TITLE
[6.x] Push transactions and errors to different indices, fixes #279

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -83,6 +83,14 @@ output.elasticsearch:
       when.contains:
         processor.event: "sourcemap"
 
+    - index: "apm-%{[beat.version]}-%{+yyyy.MM.dd}-error"
+      when.contains:
+        processor.name: "error"
+
+    - index: "apm-%{[beat.version]}-%{+yyyy.MM.dd}-transaction"
+      when.contains:
+        processor.name: "transaction"
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "elastic"

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -83,11 +83,11 @@ output.elasticsearch:
       when.contains:
         processor.event: "sourcemap"
 
-    - index: "apm-%{[beat.version]}-%{+yyyy.MM.dd}-error"
+    - index: "apm-%{[beat.version]}-error-%{+yyyy.MM.dd}"
       when.contains:
         processor.name: "error"
 
-    - index: "apm-%{[beat.version]}-%{+yyyy.MM.dd}-transaction"
+    - index: "apm-%{[beat.version]}-transaction-%{+yyyy.MM.dd}"
       when.contains:
         processor.name: "transaction"
 

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -83,6 +83,14 @@ output.elasticsearch:
       when.contains:
         processor.event: "sourcemap"
 
+    - index: "apm-%{[beat.version]}-%{+yyyy.MM.dd}-error"
+      when.contains:
+        processor.name: "error"
+
+    - index: "apm-%{[beat.version]}-%{+yyyy.MM.dd}-transaction"
+      when.contains:
+        processor.name: "transaction"
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "elastic"

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -83,11 +83,11 @@ output.elasticsearch:
       when.contains:
         processor.event: "sourcemap"
 
-    - index: "apm-%{[beat.version]}-%{+yyyy.MM.dd}-error"
+    - index: "apm-%{[beat.version]}-error-%{+yyyy.MM.dd}"
       when.contains:
         processor.name: "error"
 
-    - index: "apm-%{[beat.version]}-%{+yyyy.MM.dd}-transaction"
+    - index: "apm-%{[beat.version]}-transaction-%{+yyyy.MM.dd}"
       when.contains:
         processor.name: "transaction"
 

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -306,8 +306,8 @@ class SplitIndicesTest(ElasticTest):
     def setUpClass(cls):
         super(SplitIndicesTest, cls).setUpClass()
 
-        cls.index_name_transaction = "test-apm-12-12-2017-transaction"
-        cls.index_name_error = "test-apm-12-12-2017-error"
+        cls.index_name_transaction = "test-apm-transaction-12-12-2017"
+        cls.index_name_error = "test-apm-error-12-12-2017"
 
     def config(self):
         cfg = super(SplitIndicesTest, self).config()

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -134,7 +134,7 @@ class ElasticTest(ServerBaseTest):
         cfg.update({
             "elasticsearch_host": self.get_elasticsearch_url(),
             "file_enabled": "false",
-            "index_name": self.index_name
+            "index_name": self.index_name,
         })
         return cfg
 
@@ -162,7 +162,10 @@ class ElasticTest(ServerBaseTest):
             port=os.getenv("ES_PORT", "9200"),
         )
 
-    def load_docs_with_template(self, data_path, url, endpoint, expected_events_count):
+    def load_docs_with_template(self, data_path, url, endpoint, expected_events_count, query_index=None):
+
+        if query_index is None:
+            query_index = self.index_name
 
         payload = json.loads(open(data_path).read())
         r = requests.post(url, json=payload)
@@ -173,14 +176,14 @@ class ElasticTest(ServerBaseTest):
             lambda: self.log_contains(
                 "Elasticsearch template with name \'{}\' loaded".format(self.index_name)),
             max_timeout=20)
-        self.wait_until(lambda: self.es.indices.exists(self.index_name))
+        self.wait_until(lambda: self.es.indices.exists(query_index))
         # Quick wait to give documents some time to be sent to the index
         # This is not required but speeds up the tests
         time.sleep(0.1)
-        self.es.indices.refresh(index=self.index_name)
+        self.es.indices.refresh(index=query_index)
 
         self.wait_until(
-            lambda: (self.es.count(index=self.index_name, body={
+            lambda: (self.es.count(index=query_index, body={
                 "query": {"term": {"processor.name": endpoint}}}
             )['count'] == expected_events_count)
         )
@@ -212,7 +215,7 @@ class ElasticTest(ServerBaseTest):
             assert "sourcemap" not in frame
 
 
-class ClientSideBaseTest(ServerBaseTest):
+class ClientSideBaseTest(ElasticTest):
 
     transactions_url = 'http://localhost:8200/v1/client-side/transactions'
     errors_url = 'http://localhost:8200/v1/client-side/errors'
@@ -295,6 +298,22 @@ class ClientSideBaseTest(ServerBaseTest):
             else:
                 assert err in smap["error"]
             assert smap["updated"] == updated
+
+
+class SplitIndicesTest(ElasticTest):
+
+    @classmethod
+    def setUpClass(cls):
+        super(SplitIndicesTest, cls).setUpClass()
+
+        cls.index_name_transaction = "test-apm-12-12-2017-transaction"
+        cls.index_name_error = "test-apm-12-12-2017-error"
+
+    def config(self):
+        cfg = super(SplitIndicesTest, self).config()
+        cfg.update({"index_name_transaction": self.index_name_transaction,
+                    "index_name_error": self.index_name_error})
+        return cfg
 
 
 class CorsBaseTest(ClientSideBaseTest):

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -68,7 +68,7 @@ output.elasticsearch:
         processor.event: "sourcemap"
   {% endif %}
 
-  {% if index_name_transaction %}
+  {% if index_name_transaction and index_name_error %}
   indices:
     - index: {{ index_name_transaction }}
       when.contains:

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -67,6 +67,17 @@ output.elasticsearch:
       when.contains:
         processor.event: "sourcemap"
   {% endif %}
+
+  {% if index_name_transaction %}
+  indices:
+    - index: {{ index_name_transaction }}
+      when.contains:
+        processor.name: "transaction"
+    - index: {{ index_name_error }}
+      when.contains:
+        processor.name: "error"
+  {% endif %}
+
 {% endif %}
 
 ############################# Beat #########################################

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -10,6 +10,21 @@ import json
 class Test(ElasticTest):
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_onboarding_doc(self):
+        """
+        This test starts the beat and checks that the onboarding doc has been published to ES
+        """
+        self.wait_until(lambda: self.es.indices.exists(self.index_name))
+        self.es.indices.refresh(index=self.index_name)
+
+        self.wait_until(
+            lambda: (self.es.count(index=self.index_name)['count'] == 1)
+        )
+
+        # Makes sure no error or warnings were logged
+        self.assert_no_logged_warnings()
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_load_docs_with_template_and_add_transaction(self):
         """
         This test starts the beat with a loaded template and sends transaction data to elasticsearch.
@@ -40,9 +55,6 @@ class Test(ElasticTest):
         self.check_docs(approved, rs['hits']['hits'], 'span')
 
         self.check_backend_transaction_sourcemap(count=5)
-
-        total_count = self.es.count(index=self.index_name)['count']
-        assert total_count == 10, total_count  # 9 events + onboarding doc
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_load_docs_with_template_and_add_error(self):

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -203,7 +203,7 @@ class SplitIndicesIntegrationTest(SplitIndicesTest):
                                      'http://localhost:8200/v1/errors',
                                      'error',
                                      4,
-                                     query_index="test-apm-12-12-2017-error")
+                                     query_index="test-apm-error-12-12-2017")
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_transaction_index(self):
@@ -211,7 +211,7 @@ class SplitIndicesIntegrationTest(SplitIndicesTest):
                                      'http://localhost:8200/v1/transactions',
                                      'transaction',
                                      9,
-                                     query_index="test-apm-12-12-2017-transaction")
+                                     query_index="test-apm-transaction-12-12-2017")
 
 
 class SourcemappingIntegrationTest(ClientSideBaseTest):

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -2,27 +2,12 @@ import os
 import unittest
 
 from apmserver import ElasticTest, ExpvarBaseTest
-from apmserver import ClientSideBaseTest, SmapIndexBaseTest, SmapCacheBaseTest
+from apmserver import ClientSideBaseTest, SmapIndexBaseTest, SmapCacheBaseTest, SplitIndicesTest
 from beat.beat import INTEGRATION_TESTS
 import json
 
 
 class Test(ElasticTest):
-
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    def test_onboarding_doc(self):
-        """
-        This test starts the beat and checks that the onboarding doc has been published to ES
-        """
-        self.wait_until(lambda: self.es.indices.exists(self.index_name))
-        self.es.indices.refresh(index=self.index_name)
-
-        self.wait_until(
-            lambda: (self.es.count(index=self.index_name)['count'] == 1)
-        )
-
-        # Makes sure no error or warnings were logged
-        self.assert_no_logged_warnings()
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_load_docs_with_template_and_add_transaction(self):
@@ -55,6 +40,9 @@ class Test(ElasticTest):
         self.check_docs(approved, rs['hits']['hits'], 'span')
 
         self.check_backend_transaction_sourcemap(count=5)
+
+        total_count = self.es.count(index=self.index_name)['count']
+        assert total_count == 10, total_count  # 9 events + onboarding doc
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_load_docs_with_template_and_add_error(self):
@@ -102,7 +90,7 @@ class Test(ElasticTest):
         return json.dumps(data, indent=4, separators=(',', ': '))
 
 
-class FrontendEnabledIntegrationTest(ElasticTest, ClientSideBaseTest):
+class FrontendEnabledIntegrationTest(ClientSideBaseTest):
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_backend_error(self):
         self.load_docs_with_template(self.get_error_payload_path(name="payload.json"),
@@ -208,7 +196,27 @@ class FrontendEnabledIntegrationTest(ElasticTest, ClientSideBaseTest):
                 lf["empty"] += 1
 
 
-class SourcemappingIntegrationTest(ElasticTest, ClientSideBaseTest):
+class SplitIndicesIntegrationTest(SplitIndicesTest):
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_error_index(self):
+        self.load_docs_with_template(self.get_error_payload_path(name="payload.json"),
+                                     'http://localhost:8200/v1/errors',
+                                     'error',
+                                     4,
+                                     query_index="test-apm-12-12-2017-error")
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_transaction_index(self):
+        self.load_docs_with_template(self.get_transaction_payload_path(name="payload.json"),
+                                     'http://localhost:8200/v1/transactions',
+                                     'transaction',
+                                     9,
+                                     query_index="test-apm-12-12-2017-transaction")
+
+
+class SourcemappingIntegrationTest(ClientSideBaseTest):
+
+
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_backend_error(self):
         path = 'http://localhost:8000/test/e2e/general-usecase/bundle.js.map'
@@ -377,7 +385,7 @@ class SourcemappingIntegrationTest(ElasticTest, ClientSideBaseTest):
         self.check_frontend_error_sourcemap(True)
 
 
-class SourcemappingIntegrationChangedConfigTest(ElasticTest, SmapIndexBaseTest):
+class SourcemappingIntegrationChangedConfigTest(SmapIndexBaseTest):
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_frontend_error_changed_index(self):
@@ -396,7 +404,7 @@ class SourcemappingIntegrationChangedConfigTest(ElasticTest, SmapIndexBaseTest):
         self.check_frontend_error_sourcemap(True)
 
 
-class SourcemappingCacheIntegrationTest(ElasticTest, SmapCacheBaseTest):
+class SourcemappingCacheIntegrationTest(SmapCacheBaseTest):
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_sourcemap_cache_expiration(self):
         path = 'http://localhost:8000/test/e2e/general-usecase/bundle.js.map'


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Push transactions and errors to different indices, fixes #279 (#706)
 - Leave the date at the end (#706)
 - implement code review changes (#706)