### PR TITLE
[6.x] Remove enum for error.log.level (#712)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -19,6 +19,8 @@ https://github.com/elastic/apm-server/compare/4daa36bd5c144cf9182afc62dc8042af66
 ==== Added
 
 - Enriched data with IP and UserAgent {pull}393[393], {pull}701[701].
+- Push errors and transactions to different ES indices {pull}706[706].
+- Allow custom `error.log.level` {pull}712[712].
 
 ==== Deprecated
 

--- a/docs/data/intake-api/generated/error/payload.json
+++ b/docs/data/intake-api/generated/error/payload.json
@@ -246,6 +246,7 @@
             "id": "0f0e9d67-c185-4d21-a6f4-4673ed561ec8",
             "timestamp": "2017-05-09T15:04:05.999Z",
             "log": {
+                "level": "custom log level",
                 "message": "Cannot read property 'baz' of undefined"
             }
         }

--- a/docs/spec/errors/error.json
+++ b/docs/spec/errors/error.json
@@ -62,8 +62,6 @@
                 "level": {
                     "description": "The severity of the record.",
                     "type": ["string", "null"],
-                    "default": "error",
-                    "enum": ["debug", "info", "warning", "error", "fatal", null],
                     "maxLength": 1024
                 },
                 "logger_name": {

--- a/processor/error/package_tests/TestProcessErrorFull.approved.json
+++ b/processor/error/package_tests/TestProcessErrorFull.approved.json
@@ -400,6 +400,7 @@
                 "grouping_key": "d6b3f958dfea98dc9ed2b57d5f0c48bb",
                 "id": "0f0e9d67-c185-4d21-a6f4-4673ed561ec8",
                 "log": {
+                    "level": "custom log level",
                     "message": "Cannot read property 'baz' of undefined"
                 }
             },

--- a/processor/error/schema.go
+++ b/processor/error/schema.go
@@ -436,8 +436,6 @@ var errorSchema = `{
                 "level": {
                     "description": "The severity of the record.",
                     "type": ["string", "null"],
-                    "default": "error",
-                    "enum": ["debug", "info", "warning", "error", "fatal", null],
                     "maxLength": 1024
                 },
                 "logger_name": {

--- a/tests/data/valid/error/payload.json
+++ b/tests/data/valid/error/payload.json
@@ -246,6 +246,7 @@
             "id": "0f0e9d67-c185-4d21-a6f4-4673ed561ec8",
             "timestamp": "2017-05-09T15:04:05.999Z",
             "log": {
+                "level": "custom log level",
                 "message": "Cannot read property 'baz' of undefined"
             }
         }

--- a/tests/system/error.approved.json
+++ b/tests/system/error.approved.json
@@ -449,7 +449,8 @@
                 "grouping_key": "d6b3f958dfea98dc9ed2b57d5f0c48bb",
                 "id": "0f0e9d67-c185-4d21-a6f4-4673ed561ec8",
                 "log": {
-                    "message": "Cannot read property 'baz' of undefined"
+                    "message": "Cannot read property 'baz' of undefined",
+                    "level": "custom log level"
                 }
             }
         },


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Remove enum for error.log.level  (#712)