### PR TITLE
[6.x] Push transactions and errors to different indices, fixes #279

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -19,6 +19,7 @@ https://github.com/elastic/apm-server/compare/4daa36bd5c144cf9182afc62dc8042af66
 ==== Added
 
 - Enriched data with IP and UserAgent {pull}393[393], {pull}701[701].
+- Push errors and transactions to different ES indices {pull}706[706].
 
 ==== Deprecated
 

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -83,6 +83,14 @@ output.elasticsearch:
       when.contains:
         processor.event: "sourcemap"
 
+    - index: "apm-%{[beat.version]}-error-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.name: "error"
+
+    - index: "apm-%{[beat.version]}-transaction-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.name: "transaction"
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "elastic"

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -83,6 +83,14 @@ output.elasticsearch:
       when.contains:
         processor.event: "sourcemap"
 
+    - index: "apm-%{[beat.version]}-error-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.name: "error"
+
+    - index: "apm-%{[beat.version]}-transaction-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.name: "transaction"
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "elastic"

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -67,6 +67,17 @@ output.elasticsearch:
       when.contains:
         processor.event: "sourcemap"
   {% endif %}
+
+  {% if index_name_transaction and index_name_error %}
+  indices:
+    - index: {{ index_name_transaction }}
+      when.contains:
+        processor.name: "transaction"
+    - index: {{ index_name_error }}
+      when.contains:
+        processor.name: "error"
+  {% endif %}
+
 {% endif %}
 
 ############################# Beat #########################################

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -2,7 +2,7 @@ import os
 import unittest
 
 from apmserver import ElasticTest, ExpvarBaseTest
-from apmserver import ClientSideBaseTest, SmapIndexBaseTest, SmapCacheBaseTest
+from apmserver import ClientSideBaseTest, SmapIndexBaseTest, SmapCacheBaseTest, SplitIndicesTest
 from beat.beat import INTEGRATION_TESTS
 import json
 
@@ -102,7 +102,7 @@ class Test(ElasticTest):
         return json.dumps(data, indent=4, separators=(',', ': '))
 
 
-class FrontendEnabledIntegrationTest(ElasticTest, ClientSideBaseTest):
+class FrontendEnabledIntegrationTest(ClientSideBaseTest):
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_backend_error(self):
         self.load_docs_with_template(self.get_error_payload_path(name="payload.json"),
@@ -208,7 +208,26 @@ class FrontendEnabledIntegrationTest(ElasticTest, ClientSideBaseTest):
                 lf["empty"] += 1
 
 
-class SourcemappingIntegrationTest(ElasticTest, ClientSideBaseTest):
+class SplitIndicesIntegrationTest(SplitIndicesTest):
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_error_index(self):
+        self.load_docs_with_template(self.get_error_payload_path(name="payload.json"),
+                                     'http://localhost:8200/v1/errors',
+                                     'error',
+                                     4,
+                                     query_index="test-apm-error-12-12-2017")
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_transaction_index(self):
+        self.load_docs_with_template(self.get_transaction_payload_path(name="payload.json"),
+                                     'http://localhost:8200/v1/transactions',
+                                     'transaction',
+                                     9,
+                                     query_index="test-apm-transaction-12-12-2017")
+
+
+class SourcemappingIntegrationTest(ClientSideBaseTest):
+
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_backend_error(self):
         path = 'http://localhost:8000/test/e2e/general-usecase/bundle.js.map'
@@ -377,7 +396,7 @@ class SourcemappingIntegrationTest(ElasticTest, ClientSideBaseTest):
         self.check_frontend_error_sourcemap(True)
 
 
-class SourcemappingIntegrationChangedConfigTest(ElasticTest, SmapIndexBaseTest):
+class SourcemappingIntegrationChangedConfigTest(SmapIndexBaseTest):
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_frontend_error_changed_index(self):
@@ -396,7 +415,7 @@ class SourcemappingIntegrationChangedConfigTest(ElasticTest, SmapIndexBaseTest):
         self.check_frontend_error_sourcemap(True)
 
 
-class SourcemappingCacheIntegrationTest(ElasticTest, SmapCacheBaseTest):
+class SourcemappingCacheIntegrationTest(SmapCacheBaseTest):
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_sourcemap_cache_expiration(self):
         path = 'http://localhost:8000/test/e2e/general-usecase/bundle.js.map'


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Push transactions and errors to different indices, fixes #279 (f33412d)
 - Add missing changelog entry for indices separation (#721)