### PR TITLE
[6.x] graceful shutdown of apm server (#704)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -15,6 +15,7 @@ https://github.com/elastic/apm-server/compare/4daa36bd5c144cf9182afc62dc8042af66
 - Accept charset in request's content type {pull}677[677].
 - Use type integer instead of number in JSON schemas where applicable {pull}641[641].
 - Set array item types to string in JSON schemas {pull}651[651].
+- Fix issue preventing server from being stopped {pull}704[704].
 
 ==== Added
 

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -227,7 +227,7 @@ func SetupServer(b *testing.B) *http.ServeMux {
 		b.Fatalf("error initializing publisher: %v", err)
 	}
 
-	pub, err := newPublisher(pip, 1)
+	pub, err := newPublisher(pip, 1, time.Duration(0))
 
 	if err != nil {
 		b.Fatal(err)

--- a/beater/server.go
+++ b/beater/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net"
 	"net/http"
-	"time"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/logp"
@@ -45,12 +44,9 @@ func run(server *http.Server, lis net.Listener, config *Config) error {
 	return server.Serve(lis)
 }
 
-func stop(server *http.Server, timeout time.Duration) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
+func stop(server *http.Server) {
 	logger := logp.NewLogger("server")
-	err := server.Shutdown(ctx)
+	err := server.Shutdown(context.Background())
 	if err != nil {
 		logger.Error(err.Error())
 		err = server.Close()

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -230,7 +230,7 @@ func setupServer(t *testing.T, ssl *SSLConfig) (*http.Server, func()) {
 	secure := cfg.SSL != nil
 	waitForServer(secure, cfg.Host)
 
-	return apm, func() { stop(apm, time.Second) }
+	return apm, func() { stop(apm) }
 }
 
 var noSSL *SSLConfig


### PR DESCRIPTION
Backports the following commits to 6.x:
 - graceful shutdown of apm server  (#704)
 - update changelog (#728)