### PR TITLE
[6.x] Follow up on #731 (#738)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,7 +23,9 @@ https://github.com/elastic/apm-server/compare/4daa36bd5c144cf9182afc62dc8042af66
 - Enriched data with IP and UserAgent {pull}393[393], {pull}701[701].
 - Push errors and transactions to different ES indices {pull}706[706].
 - Allow custom `error.log.level` {pull}712[712].
-- Change `concurrent_request` default from 40 to 5{pull}731[731].
+- Change `concurrent_request` default from 40 to 5 {pull}731[731].
+- Change `max_unzipped_size` default from 50mb to 30mb {pull}731[731].
+
 
 ==== Deprecated
 

--- a/beater/config.go
+++ b/beater/config.go
@@ -109,7 +109,7 @@ func replaceVersion(pattern, version string) string {
 func defaultConfig(beatVersion string) *Config {
 	return &Config{
 		Host:                "localhost:8200",
-		MaxUnzippedSize:     30 * 1024 * 1024, // 50mb
+		MaxUnzippedSize:     30 * 1024 * 1024, // 30mb
 		MaxHeaderSize:       1 * 1024 * 1024,  // 1mb
 		ConcurrentRequests:  5,
 		MaxRequestQueueTime: 2 * time.Second,

--- a/beater/handlers.go
+++ b/beater/handlers.go
@@ -127,8 +127,8 @@ func frontendHandler(pf ProcessorFactory, config *Config, report reporter) http.
 		ExcludeFromGrouping: regexp.MustCompile(config.Frontend.ExcludeFromGrouping),
 	}
 	return logHandler(
-		concurrencyLimitHandler(config,
-			killSwitchHandler(config.Frontend.isEnabled(),
+		killSwitchHandler(config.Frontend.isEnabled(),
+			concurrencyLimitHandler(config,
 				ipRateLimitHandler(config.Frontend.RateLimit,
 					corsHandler(config.Frontend.AllowOrigins,
 						processRequestHandler(pf, &prConfig, report,


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Follow up on #731  (#738)