### PR TITLE
Early return to caller.

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -91,7 +91,7 @@ func (bt *beater) Run(b *beat.Beat) error {
 		return nil
 	}
 
-	go notifyListening(bt.config, pub.Send)
+	go notifyListening(bt.config, pub.client.Publish)
 
 	bt.mutex.Lock()
 	if bt.stopped {

--- a/beater/handlers.go
+++ b/beater/handlers.go
@@ -43,7 +43,7 @@ const (
 	supportedMethods = "POST, OPTIONS"
 )
 
-type ProcessorFactory func(conf.Config) processor.Processor
+type ProcessorFactory func() processor.Processor
 
 type ProcessorHandler func(ProcessorFactory, *Config, reporter) http.Handler
 
@@ -302,7 +302,7 @@ func processRequestHandler(pf ProcessorFactory, config conf.Config, report repor
 }
 
 func processRequest(r *http.Request, pf ProcessorFactory, config conf.Config, report reporter, decode decoder.Decoder) (int, error) {
-	processor := pf(config)
+	processor := pf()
 
 	if r.Method != "POST" {
 		return http.StatusMethodNotAllowed, errPOSTRequestOnly
@@ -317,12 +317,12 @@ func processRequest(r *http.Request, pf ProcessorFactory, config conf.Config, re
 		return http.StatusBadRequest, err
 	}
 
-	list, err := processor.Transform(data)
+	payload, err := processor.Decode(config, data)
 	if err != nil {
 		return http.StatusBadRequest, err
 	}
 
-	if err = report(list); err != nil {
+	if err = report(payload); err != nil {
 		return http.StatusServiceUnavailable, err
 	}
 

--- a/beater/handlers.go
+++ b/beater/handlers.go
@@ -317,12 +317,13 @@ func processRequest(r *http.Request, pf ProcessorFactory, config conf.Config, re
 		return http.StatusBadRequest, err
 	}
 
-	payload, err := processor.Decode(config, data)
+	payload, err := processor.Decode(data)
 	if err != nil {
 		return http.StatusBadRequest, err
 	}
 
-	if err = report(payload); err != nil {
+	event := event{payload: payload, config: config}
+	if err = report(event); err != nil {
 		return http.StatusServiceUnavailable, err
 	}
 

--- a/beater/handlers.go
+++ b/beater/handlers.go
@@ -322,8 +322,7 @@ func processRequest(r *http.Request, pf ProcessorFactory, config conf.Config, re
 		return http.StatusBadRequest, err
 	}
 
-	decodedRequest := decodedRequest{payload: payload, config: config}
-	if err = report(decodedRequest); err != nil {
+	if err = report(pendingReq{payload: payload, config: config}); err != nil {
 		return http.StatusServiceUnavailable, err
 	}
 

--- a/beater/handlers.go
+++ b/beater/handlers.go
@@ -322,8 +322,8 @@ func processRequest(r *http.Request, pf ProcessorFactory, config conf.Config, re
 		return http.StatusBadRequest, err
 	}
 
-	event := event{payload: payload, config: config}
-	if err = report(event); err != nil {
+	decodedRequest := decodedRequest{payload: payload, config: config}
+	if err = report(decodedRequest); err != nil {
 		return http.StatusServiceUnavailable, err
 	}
 

--- a/beater/onboarding.go
+++ b/beater/onboarding.go
@@ -8,7 +8,7 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 )
 
-func notifyListening(config *Config, reporter reporter) {
+func notifyListening(config *Config, pubFct func(beat.Event)) {
 
 	var isServerUp = func() bool {
 		secure := config.SSL.isEnabled()
@@ -22,7 +22,6 @@ func notifyListening(config *Config, reporter reporter) {
 			Timestamp: time.Now(),
 			Fields:    common.MapStr{"listening": config.Host},
 		}
-		events := []beat.Event{event}
-		reporter(events)
+		pubFct(event)
 	}
 }

--- a/beater/onboarding_test.go
+++ b/beater/onboarding_test.go
@@ -11,22 +11,20 @@ import (
 
 func TestNotifyUpServerDown(t *testing.T) {
 	config := defaultConfig("7.0.0")
-	var saved []beat.Event
-	var reporter = func(events []beat.Event) error {
-		saved = append(saved, events...)
-		return nil
-	}
+	var saved beat.Event
+	var publisher = func(e beat.Event) { saved = e }
 
 	lis, err := net.Listen("tcp", "localhost:0")
 	assert.NoError(t, err)
 	defer lis.Close()
 	config.Host = lis.Addr().String()
 
-	server := newServer(config, reporter)
+	server := newServer(config, nopReporter)
 	go run(server, lis, config)
 
-	notifyListening(config, reporter)
+	notifyListening(config, publisher)
 
-	listening := saved[0].Fields["listening"].(string)
+	listening := saved.Fields["listening"].(string)
 	assert.Equal(t, config.Host, listening)
+
 }

--- a/beater/pub.go
+++ b/beater/pub.go
@@ -10,24 +10,23 @@ import (
 	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/beats/libbeat/beat"
-	sysinfo "github.com/elastic/go-sysinfo"
 )
 
-// publisher forwards batches of events to libbeat. It uses GuaranteedSend
-// to enable infinite retry of events being processed.
+// publisher forwards batches of decodedRequests to libbeat. It uses GuaranteedSend
+// to enable infinite retry of decodedRequests being processed.
 // If the publisher's input channel is full, an error is returned immediately.
 // Number of concurrent requests waiting for processing do depend on the configured
 // queue size. As the publisher is not waiting for the outputs ACK, the total
-// number requests(events) active in the system can exceed the queue size. Only
+// number requests(decodedRequests) active in the system can exceed the queue size. Only
 // the number of concurrent HTTP requests trying to publish at the same time is limited.
 type publisher struct {
-	events  chan event
-	client  beat.Client
-	m       sync.RWMutex
-	stopped bool
+	decodedRequests chan decodedRequest
+	client          beat.Client
+	m               sync.RWMutex
+	stopped         bool
 }
 
-type event struct {
+type decodedRequest struct {
 	payload pr.Payload
 	config  config.Config
 }
@@ -39,7 +38,7 @@ var (
 )
 
 // newPublisher creates a new publisher instance.
-//MaxCPU new go-routines are started for forwarding events to libbeat.
+//MaxCPU new go-routines are started for forwarding decodedRequests to libbeat.
 //Stop must be called to close the beat.Client and free resources.
 func newPublisher(pipeline beat.Pipeline, N int, shutdownTimeout time.Duration) (*publisher, error) {
 	if N <= 0 {
@@ -62,42 +61,31 @@ func newPublisher(pipeline beat.Pipeline, N int, shutdownTimeout time.Duration) 
 
 		// Set channel size to N - 1. One request will be actively processed by the
 		// worker, while the other concurrent requests will be buffered in the queue.
-		events: make(chan event, N-1),
+		decodedRequests: make(chan decodedRequest, N-1),
 	}
 
-	for i := 0; i < numCPUToUse(); i++ {
+	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
 		go p.run()
 	}
 
 	return p, nil
 }
 
-func numCPUToUse() int {
-	maxCPU := sysinfo.Go().MaxProcs
-	numCPU := runtime.NumCPU()
-	//https://golang.org/pkg/runtime/#GOMAXPROCS
-	//If GOMAXPROCS < 1, it does not change the current setting.
-	if maxCPU < 1 || maxCPU > numCPU {
-		return numCPU
-	}
-	return maxCPU
-}
-
 // Stop closes all channels and waits for the the worker to stop.
-// The worker will drain the queue on shutdown, but no more events
+// The worker will drain the queue on shutdown, but no more decodedRequests
 // will be published.
 func (p *publisher) Stop() {
 	p.m.Lock()
 	p.stopped = true
 	p.m.Unlock()
-	close(p.events)
+	close(p.decodedRequests)
 	p.client.Close()
 }
 
-// Send tries to forward events to the publishers worker. If the queue is full,
+// Send tries to forward decodedRequests to the publishers worker. If the queue is full,
 // an error is returned.
 // Calling send after Stop will return an error.
-func (p *publisher) Send(event event) error {
+func (p *publisher) Send(decodedRequest decodedRequest) error {
 	p.m.RLock()
 	defer p.m.RUnlock()
 	if p.stopped {
@@ -105,7 +93,7 @@ func (p *publisher) Send(event event) error {
 	}
 
 	select {
-	case p.events <- event:
+	case p.decodedRequests <- decodedRequest:
 		return nil
 	case <-time.After(time.Second * 1): // this forces the go scheduler to try something else for a while
 		return errFull
@@ -113,7 +101,7 @@ func (p *publisher) Send(event event) error {
 }
 
 func (p *publisher) run() {
-	for event := range p.events {
-		p.client.PublishAll(event.payload.Transform(event.config))
+	for decodedRequest := range p.decodedRequests {
+		p.client.PublishAll(decodedRequest.payload.Transform(decodedRequest.config))
 	}
 }

--- a/beater/pub.go
+++ b/beater/pub.go
@@ -12,21 +12,21 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 )
 
-// publisher forwards batches of decodedRequests to libbeat. It uses GuaranteedSend
-// to enable infinite retry of decodedRequests being processed.
+// Publisher forwards batches of events to libbeat. It uses GuaranteedSend
+// to enable infinite retry of events being processed.
 // If the publisher's input channel is full, an error is returned immediately.
 // Number of concurrent requests waiting for processing do depend on the configured
 // queue size. As the publisher is not waiting for the outputs ACK, the total
-// number requests(decodedRequests) active in the system can exceed the queue size. Only
+// number requests(events) active in the system can exceed the queue size. Only
 // the number of concurrent HTTP requests trying to publish at the same time is limited.
 type publisher struct {
-	decodedRequests chan decodedRequest
+	pendingRequests chan pendingReq
 	client          beat.Client
 	m               sync.RWMutex
 	stopped         bool
 }
 
-type decodedRequest struct {
+type pendingReq struct {
 	payload pr.Payload
 	config  config.Config
 }
@@ -38,7 +38,7 @@ var (
 )
 
 // newPublisher creates a new publisher instance.
-//MaxCPU new go-routines are started for forwarding decodedRequests to libbeat.
+//MaxCPU new go-routines are started for forwarding events to libbeat.
 //Stop must be called to close the beat.Client and free resources.
 func newPublisher(pipeline beat.Pipeline, N int, shutdownTimeout time.Duration) (*publisher, error) {
 	if N <= 0 {
@@ -61,7 +61,7 @@ func newPublisher(pipeline beat.Pipeline, N int, shutdownTimeout time.Duration) 
 
 		// Set channel size to N - 1. One request will be actively processed by the
 		// worker, while the other concurrent requests will be buffered in the queue.
-		decodedRequests: make(chan decodedRequest, N-1),
+		pendingRequests: make(chan pendingReq, N-1),
 	}
 
 	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
@@ -72,20 +72,20 @@ func newPublisher(pipeline beat.Pipeline, N int, shutdownTimeout time.Duration) 
 }
 
 // Stop closes all channels and waits for the the worker to stop.
-// The worker will drain the queue on shutdown, but no more decodedRequests
+// The worker will drain the queue on shutdown, but no more pending requests
 // will be published.
 func (p *publisher) Stop() {
 	p.m.Lock()
 	p.stopped = true
 	p.m.Unlock()
-	close(p.decodedRequests)
+	close(p.pendingRequests)
 	p.client.Close()
 }
 
-// Send tries to forward decodedRequests to the publishers worker. If the queue is full,
+// Send tries to forward pendingReq to the publishers worker. If the queue is full,
 // an error is returned.
 // Calling send after Stop will return an error.
-func (p *publisher) Send(decodedRequest decodedRequest) error {
+func (p *publisher) Send(req pendingReq) error {
 	p.m.RLock()
 	defer p.m.RUnlock()
 	if p.stopped {
@@ -93,7 +93,7 @@ func (p *publisher) Send(decodedRequest decodedRequest) error {
 	}
 
 	select {
-	case p.decodedRequests <- decodedRequest:
+	case p.pendingRequests <- req:
 		return nil
 	case <-time.After(time.Second * 1): // this forces the go scheduler to try something else for a while
 		return errFull
@@ -101,7 +101,7 @@ func (p *publisher) Send(decodedRequest decodedRequest) error {
 }
 
 func (p *publisher) run() {
-	for decodedRequest := range p.decodedRequests {
-		p.client.PublishAll(decodedRequest.payload.Transform(decodedRequest.config))
+	for req := range p.pendingRequests {
+		p.client.PublishAll(req.payload.Transform(req.config))
 	}
 }

--- a/beater/pub_test.go
+++ b/beater/pub_test.go
@@ -11,19 +11,10 @@ import (
 )
 
 func TestNumberGoRoutines(t *testing.T) {
-	for _, test := range []struct {
-		goMaxProcs         int
-		expectedGoRoutines func() int
-	}{
-		{goMaxProcs: 0, expectedGoRoutines: func() int { return runtime.NumGoroutine() + runtime.NumCPU() }},
-		{goMaxProcs: 3, expectedGoRoutines: func() int { return runtime.NumGoroutine() + 3 }},
-	} {
-		expected := test.expectedGoRoutines()
-		runtime.GOMAXPROCS(test.goMaxProcs)
-		_, err := newPublisher(pip{}, 1, time.Duration(0))
-		assert.NoError(t, err)
-		assert.Equal(t, expected, runtime.NumGoroutine())
-	}
+	before := runtime.NumGoroutine()
+	_, err := newPublisher(pip{}, 1, time.Duration(0))
+	assert.NoError(t, err)
+	assert.Equal(t, before+runtime.GOMAXPROCS(0), runtime.NumGoroutine())
 }
 
 type pip struct{}

--- a/beater/pub_test.go
+++ b/beater/pub_test.go
@@ -16,8 +16,7 @@ func TestNumberGoRoutines(t *testing.T) {
 		expectedGoRoutines func() int
 	}{
 		{goMaxProcs: 0, expectedGoRoutines: func() int { return runtime.NumGoroutine() + runtime.NumCPU() }},
-		{goMaxProcs: 1, expectedGoRoutines: func() int { return runtime.NumGoroutine() + 1 }},
-		{goMaxProcs: 15, expectedGoRoutines: func() int { return runtime.NumGoroutine() + runtime.NumCPU() }},
+		{goMaxProcs: 3, expectedGoRoutines: func() int { return runtime.NumGoroutine() + 3 }},
 	} {
 		expected := test.expectedGoRoutines()
 		runtime.GOMAXPROCS(test.goMaxProcs)

--- a/beater/publisher_test.go
+++ b/beater/publisher_test.go
@@ -1,0 +1,40 @@
+package beater
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/beat"
+)
+
+func TestNumberGoRoutines(t *testing.T) {
+	for _, test := range []struct {
+		goMaxProcs         int
+		expectedGoRoutines func() int
+	}{
+		{goMaxProcs: 0, expectedGoRoutines: func() int { return runtime.NumGoroutine() + runtime.NumCPU() }},
+		{goMaxProcs: 1, expectedGoRoutines: func() int { return runtime.NumGoroutine() + 1 }},
+		{goMaxProcs: 15, expectedGoRoutines: func() int { return runtime.NumGoroutine() + runtime.NumCPU() }},
+	} {
+		expected := test.expectedGoRoutines()
+		runtime.GOMAXPROCS(test.goMaxProcs)
+		_, err := newPublisher(pip{}, 1, time.Duration(0))
+		assert.NoError(t, err)
+		assert.Equal(t, expected, runtime.NumGoroutine())
+	}
+}
+
+type pip struct{}
+
+func (p pip) Connect() (beat.Client, error) {
+	return nil, nil
+}
+func (p pip) ConnectWith(c beat.ClientConfig) (beat.Client, error) {
+	return nil, nil
+}
+func (p pip) SetACKHandler(ah beat.PipelineACKHandler) error {
+	return nil
+}

--- a/beater/server.go
+++ b/beater/server.go
@@ -7,12 +7,11 @@ import (
 
 	"golang.org/x/net/netutil"
 
-	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/version"
 )
 
-type reporter func(pr.Payload) error
+type reporter func(event) error
 
 func newServer(config *Config, report reporter) *http.Server {
 	mux := newMuxer(config, report)

--- a/beater/server.go
+++ b/beater/server.go
@@ -11,7 +11,7 @@ import (
 	"github.com/elastic/beats/libbeat/version"
 )
 
-type reporter func(event) error
+type reporter func(decodedRequest) error
 
 func newServer(config *Config, report reporter) *http.Server {
 	mux := newMuxer(config, report)

--- a/beater/server.go
+++ b/beater/server.go
@@ -11,7 +11,7 @@ import (
 	"github.com/elastic/beats/libbeat/version"
 )
 
-type reporter func(decodedRequest) error
+type reporter func(pendingReq) error
 
 func newServer(config *Config, report reporter) *http.Server {
 	mux := newMuxer(config, report)

--- a/beater/server.go
+++ b/beater/server.go
@@ -7,12 +7,12 @@ import (
 
 	"golang.org/x/net/netutil"
 
-	"github.com/elastic/beats/libbeat/beat"
+	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/version"
 )
 
-type reporter func([]beat.Event) error
+type reporter func(pr.Payload) error
 
 func newServer(config *Config, report reporter) *http.Server {
 	mux := newMuxer(config, report)

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -371,4 +371,4 @@ func waitForServer(url string, client *http.Client) {
 	panic("server run timeout (10 seconds)")
 }
 
-func nopReporter(e event) error { return nil }
+func nopReporter(e decodedRequest) error { return nil }

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/kabukky/httpscerts"
 	"github.com/stretchr/testify/assert"
 
+	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/apm-server/tests/loader"
-	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 )
 
@@ -372,4 +372,4 @@ func waitForServer(url string, client *http.Client) {
 	panic("server run timeout (10 seconds)")
 }
 
-func nopReporter(_ []beat.Event) error { return nil }
+func nopReporter(p pr.Payload) error { return nil }

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/kabukky/httpscerts"
 	"github.com/stretchr/testify/assert"
 
-	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/apm-server/tests/loader"
 	"github.com/elastic/beats/libbeat/common"
 )
@@ -372,4 +371,4 @@ func waitForServer(url string, client *http.Client) {
 	panic("server run timeout (10 seconds)")
 }
 
-func nopReporter(p pr.Payload) error { return nil }
+func nopReporter(e event) error { return nil }

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -371,4 +371,4 @@ func waitForServer(url string, client *http.Client) {
 	panic("server run timeout (10 seconds)")
 }
 
-func nopReporter(e decodedRequest) error { return nil }
+func nopReporter(_ pendingReq) error { return nil }

--- a/processor/error/benchmark_test.go
+++ b/processor/error/benchmark_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func BenchmarkEventWithFileLoading(b *testing.B) {
-	processor := NewProcessor(config.Config{})
+	processor := NewProcessor()
 	for i := 0; i < b.N; i++ {
 		data, _ := loader.LoadValidData("error")
 		err := processor.Validate(data)
@@ -16,12 +16,16 @@ func BenchmarkEventWithFileLoading(b *testing.B) {
 			panic(err)
 		}
 
-		processor.Transform(data)
+		payload, err := processor.Decode(config.Config{}, data)
+		if err != nil {
+			b.Fatalf("Error: %v", err)
+		}
+		payload.Transform()
 	}
 }
 
 func BenchmarkEventFileLoadingOnce(b *testing.B) {
-	processor := NewProcessor(config.Config{})
+	processor := NewProcessor()
 	data, _ := loader.LoadValidData("error")
 	for i := 0; i < b.N; i++ {
 		err := processor.Validate(data)
@@ -29,6 +33,10 @@ func BenchmarkEventFileLoadingOnce(b *testing.B) {
 			panic(err)
 		}
 
-		processor.Transform(data)
+		payload, err := processor.Decode(config.Config{}, data)
+		if err != nil {
+			b.Fatalf("Error: %v", err)
+		}
+		payload.Transform()
 	}
 }

--- a/processor/error/benchmark_test.go
+++ b/processor/error/benchmark_test.go
@@ -16,11 +16,11 @@ func BenchmarkEventWithFileLoading(b *testing.B) {
 			panic(err)
 		}
 
-		payload, err := processor.Decode(config.Config{}, data)
+		payload, err := processor.Decode(data)
 		if err != nil {
 			b.Fatalf("Error: %v", err)
 		}
-		payload.Transform()
+		payload.Transform(config.Config{})
 	}
 }
 
@@ -33,10 +33,10 @@ func BenchmarkEventFileLoadingOnce(b *testing.B) {
 			panic(err)
 		}
 
-		payload, err := processor.Decode(config.Config{}, data)
+		payload, err := processor.Decode(data)
 		if err != nil {
 			b.Fatalf("Error: %v", err)
 		}
-		payload.Transform()
+		payload.Transform(config.Config{})
 	}
 }

--- a/processor/error/package_tests/json_schema_test.go
+++ b/processor/error/package_tests/json_schema_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/fatih/set"
 
-	"github.com/elastic/apm-server/config"
 	er "github.com/elastic/apm-server/processor/error"
 	"github.com/elastic/apm-server/tests"
 )
@@ -56,5 +55,5 @@ func TestErrorPayloadSchema(t *testing.T) {
 		{File: "data/invalid/error_payload/no_service.json", Error: "missing properties: \"service\""},
 		{File: "data/invalid/error_payload/no_errors.json", Error: "missing properties: \"errors\""},
 	}
-	tests.TestDataAgainstProcessor(t, er.NewProcessor(config.Config{}), testData)
+	tests.TestDataAgainstProcessor(t, er.NewProcessor(), testData)
 }

--- a/processor/error/package_tests/processor_test.go
+++ b/processor/error/package_tests/processor_test.go
@@ -29,7 +29,7 @@ func TestProcessorBackendOK(t *testing.T) {
 		{Name: "TestProcessErrorAugmentedIP", Path: "data/valid/error/augmented_payload_backend.json"},
 	}
 	conf := config.Config{ExcludeFromGrouping: nil}
-	tests.TestProcessRequests(t, er.NewProcessor, conf, requestInfo, map[string]string{})
+	tests.TestProcessRequests(t, er.NewProcessor(), conf, requestInfo, map[string]string{})
 }
 
 func TestProcessorFrontendOK(t *testing.T) {
@@ -45,14 +45,14 @@ func TestProcessorFrontendOK(t *testing.T) {
 		LibraryPattern:      regexp.MustCompile("^test/e2e|~"),
 		ExcludeFromGrouping: regexp.MustCompile("^\\s*$|^/webpack|^[/][^/]*$"),
 	}
-	tests.TestProcessRequests(t, er.NewProcessor, conf, requestInfo, map[string]string{})
+	tests.TestProcessRequests(t, er.NewProcessor(), conf, requestInfo, map[string]string{})
 }
 
 // ensure invalid documents fail the json schema validation already
 func TestProcessorFailedValidation(t *testing.T) {
 	data, err := loader.LoadInvalidData("error")
 	assert.Nil(t, err)
-	err = er.NewProcessor(config.Config{}).Validate(data)
+	err = er.NewProcessor().Validate(data)
 	assert.NotNil(t, err)
 }
 

--- a/processor/error/payload.go
+++ b/processor/error/payload.go
@@ -21,15 +21,13 @@ type Payload struct {
 	Process *m.Process
 	User    *m.User
 	Events  []*Event
-
-	config config.Config
 }
 
-func DecodePayload(config config.Config, raw map[string]interface{}) (*Payload, error) {
+func DecodePayload(raw map[string]interface{}) (*Payload, error) {
 	if raw == nil {
 		return nil, nil
 	}
-	pa := Payload{config: config}
+	pa := Payload{}
 
 	var err error
 	service, err := m.DecodeService(raw["service"], err)
@@ -53,7 +51,7 @@ func DecodePayload(config config.Config, raw map[string]interface{}) (*Payload, 
 	return &pa, err
 }
 
-func (pa *Payload) Transform() []beat.Event {
+func (pa *Payload) Transform(conf config.Config) []beat.Event {
 	logp.NewLogger("transform").Debugf("Transform error events: events=%d, service=%s, agent=%s:%s", len(pa.Events), pa.Service.Name, pa.Service.Agent.Name, pa.Service.Agent.Version)
 	errorCounter.Add(int64(len(pa.Events)))
 
@@ -66,7 +64,7 @@ func (pa *Payload) Transform() []beat.Event {
 		ev := beat.Event{
 			Fields: common.MapStr{
 				"processor":  processorEntry,
-				errorDocType: event.Transform(pa.config, pa.Service),
+				errorDocType: event.Transform(conf, pa.Service),
 				"context":    context,
 			},
 			Timestamp: event.Timestamp,

--- a/processor/error/payload_test.go
+++ b/processor/error/payload_test.go
@@ -82,7 +82,7 @@ func TestPayloadDecode(t *testing.T) {
 			},
 		},
 	} {
-		payload, err := DecodePayload(config.Config{}, test.input)
+		payload, err := DecodePayload(test.input)
 		assert.Equal(t, test.p, payload)
 		assert.Equal(t, test.err, err)
 	}
@@ -170,8 +170,8 @@ func TestPayloadTransform(t *testing.T) {
 	}
 
 	for idx, test := range tests {
-		test.Payload.config = config.Config{SmapMapper: &sourcemap.SmapMapper{}}
-		outputEvents := test.Payload.Transform()
+		conf := config.Config{SmapMapper: &sourcemap.SmapMapper{}}
+		outputEvents := test.Payload.Transform(conf)
 		for j, outputEvent := range outputEvents {
 			assert.Equal(t, test.Output[j], outputEvent.Fields, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 			assert.Equal(t, timestamp, outputEvent.Timestamp, fmt.Sprintf("Bad timestamp at idx %v; %s", idx, test.Msg))

--- a/processor/error/processor.go
+++ b/processor/error/processor.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
-	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/monitoring"
 )
 
@@ -23,8 +22,8 @@ const (
 
 var schema = pr.CreateSchema(errorSchema, processorName)
 
-func NewProcessor(config config.Config) pr.Processor {
-	return &processor{schema: schema, config: config}
+func NewProcessor() pr.Processor {
+	return &processor{schema: schema}
 }
 
 func (p *processor) Name() string {
@@ -33,7 +32,6 @@ func (p *processor) Name() string {
 
 type processor struct {
 	schema *jsonschema.Schema
-	config config.Config
 }
 
 func (p *processor) Validate(raw map[string]interface{}) error {
@@ -45,11 +43,11 @@ func (p *processor) Validate(raw map[string]interface{}) error {
 	return err
 }
 
-func (p *processor) Transform(raw map[string]interface{}) ([]beat.Event, error) {
+func (p *processor) Decode(config config.Config, raw map[string]interface{}) (pr.Payload, error) {
 	transformations.Inc()
-	pa, err := decodeError(raw)
+	pa, err := DecodePayload(config, raw)
 	if err != nil {
 		return nil, err
 	}
-	return pa.transform(p.config), nil
+	return pa, nil
 }

--- a/processor/error/processor.go
+++ b/processor/error/processor.go
@@ -3,7 +3,6 @@ package error
 import (
 	"github.com/santhosh-tekuri/jsonschema"
 
-	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/beats/libbeat/monitoring"
 )
@@ -43,9 +42,9 @@ func (p *processor) Validate(raw map[string]interface{}) error {
 	return err
 }
 
-func (p *processor) Decode(config config.Config, raw map[string]interface{}) (pr.Payload, error) {
+func (p *processor) Decode(raw map[string]interface{}) (pr.Payload, error) {
 	transformations.Inc()
-	pa, err := DecodePayload(config, raw)
+	pa, err := DecodePayload(raw)
 	if err != nil {
 		return nil, err
 	}

--- a/processor/error/processor_test.go
+++ b/processor/error/processor_test.go
@@ -5,12 +5,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
 )
 
 func TestImplementProcessorInterface(t *testing.T) {
-	p := NewProcessor(config.Config{})
+	p := NewProcessor()
 	assert.NotNil(t, p)
 	_, ok := p.(pr.Processor)
 	assert.True(t, ok)

--- a/processor/healthcheck/processor.go
+++ b/processor/healthcheck/processor.go
@@ -1,7 +1,6 @@
 package healthcheck
 
 import (
-	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
 )
 
@@ -19,7 +18,7 @@ func (p *processor) Validate(_ map[string]interface{}) error {
 	return nil
 }
 
-func (p *processor) Decode(_ config.Config, _ map[string]interface{}) (pr.Payload, error) {
+func (p *processor) Decode(_ map[string]interface{}) (pr.Payload, error) {
 	return nil, nil
 }
 

--- a/processor/healthcheck/processor.go
+++ b/processor/healthcheck/processor.go
@@ -3,14 +3,13 @@ package healthcheck
 import (
 	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
-	"github.com/elastic/beats/libbeat/beat"
 )
 
 const (
 	processorName = "healthcheck"
 )
 
-func NewProcessor(_ config.Config) pr.Processor {
+func NewProcessor() pr.Processor {
 	return &processor{}
 }
 
@@ -20,7 +19,7 @@ func (p *processor) Validate(_ map[string]interface{}) error {
 	return nil
 }
 
-func (p *processor) Transform(_ map[string]interface{}) ([]beat.Event, error) {
+func (p *processor) Decode(_ config.Config, _ map[string]interface{}) (pr.Payload, error) {
 	return nil, nil
 }
 

--- a/processor/healthcheck/processor_test.go
+++ b/processor/healthcheck/processor_test.go
@@ -5,12 +5,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
 )
 
 func TestImplementProcessorInterface(t *testing.T) {
-	p := NewProcessor(config.Config{})
+	p := NewProcessor()
 	assert.NotNil(t, p)
 	_, ok := p.(pr.Processor)
 	assert.True(t, ok)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -9,11 +9,11 @@ type NewProcessor func() Processor
 
 type Processor interface {
 	Validate(map[string]interface{}) error
-	Decode(config.Config, map[string]interface{}) (Payload, error)
+	Decode(map[string]interface{}) (Payload, error)
 	Name() string
 }
 type Payload interface {
-	Transform() []beat.Event
+	Transform(config.Config) []beat.Event
 }
 
 type Decoder interface {

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -5,10 +5,17 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 )
 
-type NewProcessor func(conf config.Config) Processor
+type NewProcessor func() Processor
 
 type Processor interface {
 	Validate(map[string]interface{}) error
-	Transform(map[string]interface{}) ([]beat.Event, error)
+	Decode(config.Config, map[string]interface{}) (Payload, error)
 	Name() string
+}
+type Payload interface {
+	Transform() []beat.Event
+}
+
+type Decoder interface {
+	DecodePayload(map[string]interface{}) (*Payload, error)
 }

--- a/processor/sourcemap/package_tests/json_schema_test.go
+++ b/processor/sourcemap/package_tests/json_schema_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/fatih/set"
 
-	"github.com/elastic/apm-server/config"
 	"github.com/elastic/apm-server/processor/sourcemap"
 	"github.com/elastic/apm-server/tests"
 )
@@ -27,5 +26,5 @@ func TestSourcemapPayloadSchema(t *testing.T) {
 		{File: "data/invalid/sourcemap/not_allowed_empty_values.json", Error: "length must be >= 1, but got 0"},
 		{File: "data/invalid/sourcemap/not_allowed_null_values.json", Error: "expected string, but got null"},
 	}
-	tests.TestDataAgainstProcessor(t, sourcemap.NewProcessor(config.Config{}), testData)
+	tests.TestDataAgainstProcessor(t, sourcemap.NewProcessor(), testData)
 }

--- a/processor/sourcemap/package_tests/processor_test.go
+++ b/processor/sourcemap/package_tests/processor_test.go
@@ -17,14 +17,14 @@ func TestSourcemapProcessorOK(t *testing.T) {
 		{Name: "TestProcessSourcemapFull", Path: "data/valid/sourcemap/payload.json"},
 		{Name: "TestProcessSourcemapMinimalPayload", Path: "data/valid/sourcemap/minimal_payload.json"},
 	}
-	tests.TestProcessRequests(t, sourcemap.NewProcessor, config.Config{}, requestInfo, map[string]string{"@timestamp": "***IGNORED***"})
+	tests.TestProcessRequests(t, sourcemap.NewProcessor(), config.Config{}, requestInfo, map[string]string{"@timestamp": "***IGNORED***"})
 }
 
 // ensure invalid documents fail the json schema validation already
 func TestSourcemapProcessorValidationFailed(t *testing.T) {
 	data, err := loader.LoadInvalidData("sourcemap")
 	assert.Nil(t, err)
-	p := sourcemap.NewProcessor(config.Config{})
+	p := sourcemap.NewProcessor()
 	err = p.Validate(data)
 	assert.NotNil(t, err)
 }

--- a/processor/sourcemap/payload.go
+++ b/processor/sourcemap/payload.go
@@ -21,20 +21,18 @@ type Payload struct {
 	ServiceVersion string
 	Sourcemap      string
 	BundleFilepath string
-
-	config config.Config
 }
 
-func (pa *Payload) Transform() []beat.Event {
+func (pa *Payload) Transform(conf config.Config) []beat.Event {
 	sourcemapCounter.Add(1)
 	if pa == nil {
 		return nil
 	}
 
-	if pa.config.SmapMapper == nil {
+	if conf.SmapMapper == nil {
 		logp.NewLogger("sourcemap").Error("Sourcemap Accessor is nil, cache cannot be invalidated.")
 	} else {
-		pa.config.SmapMapper.NewSourcemapAdded(smap.Id{
+		conf.SmapMapper.NewSourcemapAdded(smap.Id{
 			ServiceName:    pa.ServiceName,
 			ServiceVersion: pa.ServiceVersion,
 			Path:           pa.BundleFilepath,

--- a/processor/sourcemap/payload.go
+++ b/processor/sourcemap/payload.go
@@ -16,23 +16,25 @@ var (
 	processorEntry   = common.MapStr{"name": processorName, "event": smapDocType}
 )
 
-type payload struct {
+type Payload struct {
 	ServiceName    string
 	ServiceVersion string
 	Sourcemap      string
 	BundleFilepath string
+
+	config config.Config
 }
 
-func (pa *payload) transform(config config.Config) []beat.Event {
+func (pa *Payload) Transform() []beat.Event {
 	sourcemapCounter.Add(1)
 	if pa == nil {
 		return nil
 	}
 
-	if config.SmapMapper == nil {
+	if pa.config.SmapMapper == nil {
 		logp.NewLogger("sourcemap").Error("Sourcemap Accessor is nil, cache cannot be invalidated.")
 	} else {
-		config.SmapMapper.NewSourcemapAdded(smap.Id{
+		pa.config.SmapMapper.NewSourcemapAdded(smap.Id{
 			ServiceName:    pa.ServiceName,
 			ServiceVersion: pa.ServiceVersion,
 			Path:           pa.BundleFilepath,

--- a/processor/sourcemap/payload_test.go
+++ b/processor/sourcemap/payload_test.go
@@ -19,14 +19,14 @@ func getStr(data common.MapStr, key string) string {
 }
 
 func TestPayloadTransform(t *testing.T) {
-	p := payload{
+	p := Payload{
 		ServiceName:    "myService",
 		ServiceVersion: "1.0",
 		BundleFilepath: "/my/path",
 		Sourcemap:      "mysmap",
 	}
 
-	events := p.transform(config.Config{})
+	events := p.Transform()
 	assert.Len(t, events, 1)
 	event := events[0]
 
@@ -63,8 +63,16 @@ func TestInvalidateCache(t *testing.T) {
 	mapping, err := smapMapper.Apply(smapId, 0, 0)
 	assert.NotNil(t, mapping)
 
-	_, err = NewProcessor(config.Config{SmapMapper: &smapMapper}).Transform(data)
+	conf := config.Config{SmapMapper: &smapMapper}
+	p := NewProcessor()
+	payload, err := p.Decode(conf, data)
 	assert.NoError(t, err)
+	payload.Transform()
+
+	p = NewProcessor()
+	payload, err = p.Decode(conf, data)
+	assert.NoError(t, err)
+	payload.Transform()
 
 	mapping, err = smapMapper.Apply(smapId, 0, 0)
 	assert.Nil(t, mapping)

--- a/processor/sourcemap/payload_test.go
+++ b/processor/sourcemap/payload_test.go
@@ -26,7 +26,7 @@ func TestPayloadTransform(t *testing.T) {
 		Sourcemap:      "mysmap",
 	}
 
-	events := p.Transform()
+	events := p.Transform(config.Config{})
 	assert.Len(t, events, 1)
 	event := events[0]
 
@@ -65,14 +65,14 @@ func TestInvalidateCache(t *testing.T) {
 
 	conf := config.Config{SmapMapper: &smapMapper}
 	p := NewProcessor()
-	payload, err := p.Decode(conf, data)
+	payload, err := p.Decode(data)
 	assert.NoError(t, err)
-	payload.Transform()
+	payload.Transform(conf)
 
 	p = NewProcessor()
-	payload, err = p.Decode(conf, data)
+	payload, err = p.Decode(data)
 	assert.NoError(t, err)
-	payload.Transform()
+	payload.Transform(conf)
 
 	mapping, err = smapMapper.Apply(smapId, 0, 0)
 	assert.Nil(t, mapping)

--- a/processor/sourcemap/processor.go
+++ b/processor/sourcemap/processor.go
@@ -8,7 +8,6 @@ import (
 
 	parser "github.com/go-sourcemap/sourcemap"
 
-	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/beats/libbeat/monitoring"
@@ -60,7 +59,7 @@ func (p *processor) Validate(raw map[string]interface{}) error {
 	return err
 }
 
-func (p *processor) Decode(config config.Config, raw map[string]interface{}) (pr.Payload, error) {
+func (p *processor) Decode(raw map[string]interface{}) (pr.Payload, error) {
 	transformations.Inc()
 
 	decoder := utility.ManualDecoder{}
@@ -69,8 +68,6 @@ func (p *processor) Decode(config config.Config, raw map[string]interface{}) (pr
 		ServiceVersion: decoder.String(raw, "service_version"),
 		Sourcemap:      decoder.String(raw, "sourcemap"),
 		BundleFilepath: decoder.String(raw, "bundle_filepath"),
-
-		config: config,
 	}
 	if decoder.Err != nil {
 		return nil, decoder.Err

--- a/processor/sourcemap/processor_test.go
+++ b/processor/sourcemap/processor_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestImplementProcessorInterface(t *testing.T) {
-	p := NewProcessor(config.Config{})
+	p := NewProcessor()
 	assert.NotNil(t, p)
 	_, ok := p.(pr.Processor)
 	assert.True(t, ok)
@@ -23,7 +23,7 @@ func TestImplementProcessorInterface(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	p := NewProcessor(config.Config{})
+	p := NewProcessor()
 	data, err := loader.LoadValidData("sourcemap")
 
 	assert.NoError(t, err)
@@ -48,14 +48,12 @@ func TestTransform(t *testing.T) {
 	data, err := loader.LoadValidData("sourcemap")
 	assert.NoError(t, err)
 
-	p := NewProcessor(config.Config{})
-	rs, err := p.Transform(data)
+	payload, err := NewProcessor().Decode(config.Config{}, data)
 	assert.NoError(t, err)
+	rs := payload.Transform()
 	assert.Len(t, rs, 1)
 	event := rs[0]
-
 	assert.WithinDuration(t, time.Now(), event.Timestamp, time.Second)
-
 	output := event.Fields["sourcemap"].(common.MapStr)
 
 	assert.Equal(t, "js/bundle.js", getStr(output, "bundle_filepath"))
@@ -63,8 +61,6 @@ func TestTransform(t *testing.T) {
 	assert.Equal(t, "1", getStr(output, "service.version"))
 	assert.Equal(t, data["sourcemap"], getStr(output, "sourcemap"))
 
-	p = NewProcessor(config.Config{})
-	rs, err = p.Transform(nil)
+	payload, err = NewProcessor().Decode(config.Config{}, nil)
 	assert.Equal(t, errors.New("Error fetching field"), err)
-	assert.Nil(t, rs)
 }

--- a/processor/sourcemap/processor_test.go
+++ b/processor/sourcemap/processor_test.go
@@ -48,9 +48,9 @@ func TestTransform(t *testing.T) {
 	data, err := loader.LoadValidData("sourcemap")
 	assert.NoError(t, err)
 
-	payload, err := NewProcessor().Decode(config.Config{}, data)
+	payload, err := NewProcessor().Decode(data)
 	assert.NoError(t, err)
-	rs := payload.Transform()
+	rs := payload.Transform(config.Config{})
 	assert.Len(t, rs, 1)
 	event := rs[0]
 	assert.WithinDuration(t, time.Now(), event.Timestamp, time.Second)
@@ -61,6 +61,6 @@ func TestTransform(t *testing.T) {
 	assert.Equal(t, "1", getStr(output, "service.version"))
 	assert.Equal(t, data["sourcemap"], getStr(output, "sourcemap"))
 
-	payload, err = NewProcessor().Decode(config.Config{}, nil)
+	payload, err = NewProcessor().Decode(nil)
 	assert.Equal(t, errors.New("Error fetching field"), err)
 }

--- a/processor/transaction/benchmark_test.go
+++ b/processor/transaction/benchmark_test.go
@@ -8,25 +8,33 @@ import (
 )
 
 func BenchmarkWithFileLoading(b *testing.B) {
-	processor := NewProcessor(config.Config{})
+	processor := NewProcessor()
 	for i := 0; i < b.N; i++ {
 		data, _ := loader.LoadValidData("transaction")
 		err := processor.Validate(data)
 		if err != nil {
 			b.Fatalf("Error: %v", err)
 		}
-		processor.Transform(data)
+		payload, err := processor.Decode(config.Config{}, data)
+		if err != nil {
+			b.Fatalf("Error: %v", err)
+		}
+		payload.Transform()
 	}
 }
 
 func BenchmarkTransactionFileLoadingOnce(b *testing.B) {
-	processor := NewProcessor(config.Config{})
+	processor := NewProcessor()
 	data, _ := loader.LoadValidData("transaction")
 	for i := 0; i < b.N; i++ {
 		err := processor.Validate(data)
 		if err != nil {
 			b.Fatalf("Error: %v", err)
 		}
-		processor.Transform(data)
+		payload, err := processor.Decode(config.Config{}, data)
+		if err != nil {
+			b.Fatalf("Error: %v", err)
+		}
+		payload.Transform()
 	}
 }

--- a/processor/transaction/benchmark_test.go
+++ b/processor/transaction/benchmark_test.go
@@ -15,11 +15,11 @@ func BenchmarkWithFileLoading(b *testing.B) {
 		if err != nil {
 			b.Fatalf("Error: %v", err)
 		}
-		payload, err := processor.Decode(config.Config{}, data)
+		payload, err := processor.Decode(data)
 		if err != nil {
 			b.Fatalf("Error: %v", err)
 		}
-		payload.Transform()
+		payload.Transform(config.Config{})
 	}
 }
 
@@ -29,12 +29,12 @@ func BenchmarkTransactionFileLoadingOnce(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		err := processor.Validate(data)
 		if err != nil {
+			payload, err := processor.Decode(data)
+			if err != nil {
+				b.Fatalf("Error: %v", err)
+			}
+			payload.Transform(config.Config{})
 			b.Fatalf("Error: %v", err)
 		}
-		payload, err := processor.Decode(config.Config{}, data)
-		if err != nil {
-			b.Fatalf("Error: %v", err)
-		}
-		payload.Transform()
 	}
 }

--- a/processor/transaction/package_tests/json_schema_test.go
+++ b/processor/transaction/package_tests/json_schema_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/fatih/set"
 
-	"github.com/elastic/apm-server/config"
 	"github.com/elastic/apm-server/processor/transaction"
 	"github.com/elastic/apm-server/tests"
 )
@@ -57,5 +56,5 @@ func TestTransactionPayloadSchema(t *testing.T) {
 		{File: "data/invalid/transaction_payload/no_service.json", Error: "missing properties: \"service\""},
 		{File: "data/invalid/transaction_payload/no_transactions.json", Error: "minimum 1 items allowed"},
 	}
-	tests.TestDataAgainstProcessor(t, transaction.NewProcessor(config.Config{}), testData)
+	tests.TestDataAgainstProcessor(t, transaction.NewProcessor(), testData)
 }

--- a/processor/transaction/package_tests/processor_test.go
+++ b/processor/transaction/package_tests/processor_test.go
@@ -26,7 +26,7 @@ func TestTransactionProcessorOK(t *testing.T) {
 		{Name: "TestProcessTransactionEmpty", Path: "data/valid/transaction/transaction_empty_values.json"},
 		{Name: "TestProcessTransactionAugmentedIP", Path: "data/valid/transaction/augmented_payload_backend.json"},
 	}
-	tests.TestProcessRequests(t, transaction.NewProcessor, config.Config{}, requestInfo, map[string]string{})
+	tests.TestProcessRequests(t, transaction.NewProcessor(), config.Config{}, requestInfo, map[string]string{})
 }
 
 func TestProcessorFrontendOK(t *testing.T) {
@@ -39,14 +39,14 @@ func TestProcessorFrontendOK(t *testing.T) {
 		LibraryPattern:      regexp.MustCompile("/test/e2e|~"),
 		ExcludeFromGrouping: regexp.MustCompile("^~/test"),
 	}
-	tests.TestProcessRequests(t, transaction.NewProcessor, conf, requestInfo, map[string]string{})
+	tests.TestProcessRequests(t, transaction.NewProcessor(), conf, requestInfo, map[string]string{})
 }
 
 // ensure invalid documents fail the json schema validation already
 func TestTransactionProcessorValidationFailed(t *testing.T) {
 	data, err := loader.LoadInvalidData("transaction")
 	assert.Nil(t, err)
-	p := transaction.NewProcessor(config.Config{})
+	p := transaction.NewProcessor()
 	err = p.Validate(data)
 	assert.NotNil(t, err)
 }

--- a/processor/transaction/payload.go
+++ b/processor/transaction/payload.go
@@ -17,19 +17,22 @@ var (
 	processorSpanEntry  = common.MapStr{"name": processorName, "event": spanDocType}
 )
 
-type payload struct {
+type Payload struct {
 	Service m.Service
 	System  *m.System
 	Process *m.Process
 	User    *m.User
-	Events  []Event
+	Events  []*Event
+
+	config config.Config
 }
 
-func decodeTransaction(raw map[string]interface{}) (*payload, error) {
+func DecodePayload(config config.Config, raw map[string]interface{}) (*Payload, error) {
 	if raw == nil {
 		return nil, nil
 	}
-	pa := &payload{}
+	pa := &Payload{config: config}
+
 	var err error
 	service, err := m.DecodeService(raw["service"], err)
 	if service != nil {
@@ -45,18 +48,14 @@ func decodeTransaction(raw map[string]interface{}) (*payload, error) {
 	decoder := utility.ManualDecoder{}
 	txs := decoder.InterfaceArr(raw, "transactions")
 	err = decoder.Err
-	pa.Events = make([]Event, len(txs))
-	var event *Event
+	pa.Events = make([]*Event, len(txs))
 	for idx, tx := range txs {
-		event, err = DecodeEvent(tx, err)
-		if event != nil {
-			pa.Events[idx] = *event
-		}
+		pa.Events[idx], err = DecodeEvent(tx, err)
 	}
 	return pa, err
 }
 
-func (pa *payload) transform(config config.Config) []beat.Event {
+func (pa *Payload) Transform() []beat.Event {
 	logp.NewLogger("transaction").Debugf("Transform transaction events: events=%d, service=%s, agent=%s:%s", len(pa.Events), pa.Service.Name, pa.Service.Agent.Name, pa.Service.Agent.Version)
 	transactionCounter.Add(int64(len(pa.Events)))
 
@@ -64,7 +63,8 @@ func (pa *payload) transform(config config.Config) []beat.Event {
 	spanContext := NewSpanContext(&pa.Service)
 
 	var events []beat.Event
-	for _, event := range pa.Events {
+	for idx := 0; idx < len(pa.Events); idx++ {
+		event := pa.Events[idx]
 		ev := beat.Event{
 			Fields: common.MapStr{
 				"processor":        processorTransEntry,
@@ -77,18 +77,21 @@ func (pa *payload) transform(config config.Config) []beat.Event {
 
 		trId := common.MapStr{"id": event.Id}
 		spanCounter.Add(int64(len(event.Spans)))
-		for _, sp := range event.Spans {
+		for spIdx := 0; spIdx < len(event.Spans); spIdx++ {
+			sp := event.Spans[spIdx]
 			ev := beat.Event{
 				Fields: common.MapStr{
 					"processor":   processorSpanEntry,
-					spanDocType:   sp.Transform(config, pa.Service),
+					spanDocType:   sp.Transform(pa.config, pa.Service),
 					"transaction": trId,
 					"context":     spanContext.Transform(sp.Context),
 				},
 				Timestamp: event.Timestamp,
 			}
 			events = append(events, ev)
+			event.Spans[spIdx] = nil
 		}
+		pa.Events[idx] = nil
 	}
 
 	return events

--- a/processor/transaction/payload_test.go
+++ b/processor/transaction/payload_test.go
@@ -84,7 +84,7 @@ func TestPayloadDecode(t *testing.T) {
 			},
 		},
 	} {
-		Payload, err := DecodePayload(config.Config{}, test.input)
+		Payload, err := DecodePayload(test.input)
 		assert.Equal(t, test.p, Payload)
 		assert.Equal(t, test.err, err)
 	}
@@ -232,7 +232,7 @@ func TestPayloadTransform(t *testing.T) {
 	}
 
 	for idx, test := range tests {
-		outputEvents := test.Payload.Transform()
+		outputEvents := test.Payload.Transform(config.Config{})
 		for j, outputEvent := range outputEvents {
 			assert.Equal(t, test.Output[j], outputEvent.Fields, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 			assert.Equal(t, timestamp, outputEvent.Timestamp)

--- a/processor/transaction/processor.go
+++ b/processor/transaction/processor.go
@@ -1,7 +1,6 @@
 package transaction
 
 import (
-	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/beats/libbeat/monitoring"
 
@@ -45,9 +44,9 @@ func (p *processor) Validate(raw map[string]interface{}) error {
 	return err
 }
 
-func (p *processor) Decode(config config.Config, raw map[string]interface{}) (pr.Payload, error) {
+func (p *processor) Decode(raw map[string]interface{}) (pr.Payload, error) {
 	transformations.Inc()
-	pa, err := DecodePayload(config, raw)
+	pa, err := DecodePayload(raw)
 	if err != nil {
 		return nil, err
 	}

--- a/processor/transaction/processor.go
+++ b/processor/transaction/processor.go
@@ -3,7 +3,6 @@ package transaction
 import (
 	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
-	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/monitoring"
 
 	"github.com/santhosh-tekuri/jsonschema"
@@ -25,13 +24,12 @@ const (
 
 var schema = pr.CreateSchema(transactionSchema, processorName)
 
-func NewProcessor(config config.Config) pr.Processor {
-	return &processor{schema: schema, config: config}
+func NewProcessor() pr.Processor {
+	return &processor{schema: schema}
 }
 
 type processor struct {
 	schema *jsonschema.Schema
-	config config.Config
 }
 
 func (p *processor) Name() string {
@@ -47,11 +45,11 @@ func (p *processor) Validate(raw map[string]interface{}) error {
 	return err
 }
 
-func (p *processor) Transform(raw map[string]interface{}) ([]beat.Event, error) {
+func (p *processor) Decode(config config.Config, raw map[string]interface{}) (pr.Payload, error) {
 	transformations.Inc()
-	pa, err := decodeTransaction(raw)
+	pa, err := DecodePayload(config, raw)
 	if err != nil {
 		return nil, err
 	}
-	return pa.transform(p.config), nil
+	return pa, nil
 }

--- a/processor/transaction/processor_test.go
+++ b/processor/transaction/processor_test.go
@@ -5,12 +5,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
 )
 
 func TestImplementProcessorInterface(t *testing.T) {
-	p := NewProcessor(config.Config{})
+	p := NewProcessor()
 	assert.NotNil(t, p)
 	_, ok := p.(pr.Processor)
 	assert.True(t, ok)

--- a/script/output_data/output_data.go
+++ b/script/output_data/output_data.go
@@ -34,7 +34,7 @@ func generate() error {
 			continue
 		}
 
-		p := mapping.ProcessorFactory(config.Config{})
+		p := mapping.ProcessorFactory()
 
 		data, err := loader.LoadData(filepath.Join(basePath, p.Name(), filename))
 		if err != nil {
@@ -46,11 +46,12 @@ func generate() error {
 			return err
 		}
 
-		events, err := p.Transform(data)
-
+		payload, err := p.Decode(config.Config{}, data)
 		if err != nil {
 			return err
 		}
+
+		events := payload.Transform()
 
 		for _, d := range events {
 			n, err := d.GetValue("processor.name")

--- a/script/output_data/output_data.go
+++ b/script/output_data/output_data.go
@@ -46,12 +46,12 @@ func generate() error {
 			return err
 		}
 
-		payload, err := p.Decode(config.Config{}, data)
+		payload, err := p.Decode(data)
 		if err != nil {
 			return err
 		}
 
-		events := payload.Transform()
+		events := payload.Transform(config.Config{})
 
 		for _, d := range events {
 			n, err := d.GetValue("processor.name")

--- a/tests/approvals.go
+++ b/tests/approvals.go
@@ -103,10 +103,10 @@ func TestProcessRequests(t *testing.T, p processor.Processor, config config.Conf
 		err = p.Validate(data)
 		assert.NoError(err)
 
-		payload, err := p.Decode(config, data)
+		payload, err := p.Decode(data)
 		assert.NoError(err)
 
-		events := payload.Transform()
+		events := payload.Transform(config)
 
 		// extract Fields and write to received.json
 		eventFields := make([]common.MapStr, len(events))

--- a/tests/approvals.go
+++ b/tests/approvals.go
@@ -13,7 +13,7 @@ import (
 	"github.com/yudai/gojsondiff"
 
 	"github.com/elastic/apm-server/config"
-	pr "github.com/elastic/apm-server/processor"
+	"github.com/elastic/apm-server/processor"
 	"github.com/elastic/apm-server/tests/loader"
 	"github.com/elastic/beats/libbeat/common"
 )
@@ -94,18 +94,19 @@ type RequestInfo struct {
 	Path string
 }
 
-func TestProcessRequests(t *testing.T, pf func(config.Config) pr.Processor, config config.Config, requestInfo []RequestInfo, ignored map[string]string) {
+func TestProcessRequests(t *testing.T, p processor.Processor, config config.Config, requestInfo []RequestInfo, ignored map[string]string) {
 	assert := assert.New(t)
 	for _, info := range requestInfo {
 		data, err := loader.LoadData(info.Path)
 		assert.Nil(err)
 
-		p := pf(config)
 		err = p.Validate(data)
 		assert.NoError(err)
 
-		events, err := p.Transform(data)
+		payload, err := p.Decode(config, data)
 		assert.NoError(err)
+
+		events := payload.Transform()
 
 		// extract Fields and write to received.json
 		eventFields := make([]common.MapStr, len(events))

--- a/tests/fields.go
+++ b/tests/fields.go
@@ -81,11 +81,11 @@ func fetchEventNames(fn processor.NewProcessor, blacklisted *set.Set) (*set.Set,
 		return nil, err
 	}
 
-	payl, err := p.Decode(config.Config{}, data)
+	payl, err := p.Decode(data)
 	if err != nil {
 		return nil, err
 	}
-	events := payl.Transform()
+	events := payl.Transform(config.Config{})
 
 	eventNames := set.New()
 	for _, event := range events {

--- a/tests/fields.go
+++ b/tests/fields.go
@@ -71,7 +71,7 @@ func TestDocumentedFieldsInEvent(t *testing.T, fieldPaths []string, fn processor
 }
 
 func fetchEventNames(fn processor.NewProcessor, blacklisted *set.Set) (*set.Set, error) {
-	p := fn(config.Config{})
+	p := fn()
 	data, err := loader.LoadValidData(p.Name())
 	if err != nil {
 		return nil, err
@@ -81,10 +81,11 @@ func fetchEventNames(fn processor.NewProcessor, blacklisted *set.Set) (*set.Set,
 		return nil, err
 	}
 
-	events, err := p.Transform(data)
+	payl, err := p.Decode(config.Config{}, data)
 	if err != nil {
 		return nil, err
 	}
+	events := payl.Transform()
 
 	eventNames := set.New()
 	for _, event := range events {


### PR DESCRIPTION
* Return payload from decoding
* Add payload to channel and run transformation on payload.
* Free up resources as early as possible

implements #715

With these changes we do return earlier to the caller, which helps freeing up resources in the agents. 
This also means that less processing happens before putting the data into the channel and after fetching data from the channel processing is heavier. This can lead to more `503` as the blocking part for moving data out of the channel gets slower. 