### PR TITLE
[6.x] update/sync configuration defaults (#748)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ https://github.com/elastic/apm-server/compare/4daa36bd5c144cf9182afc62dc8042af66
 - Allow custom `error.log.level` {pull}712[712].
 - Change `concurrent_request` default from 40 to 5 {pull}731[731].
 - Change `max_unzipped_size` default from 50mb to 30mb {pull}731[731].
+- Change `read_timeout` and `write_timeout` defaults from 2s to 30s {pull}748[748].
 
 
 ==== Deprecated

--- a/_meta/beat.reference.yml
+++ b/_meta/beat.reference.yml
@@ -7,20 +7,22 @@ apm-server:
   #host: "localhost:8200"
 
   # Maximum permitted size in bytes of an unzipped request accepted by the server to be processed.
-  #max_unzipped_size: 52428800
+  #max_unzipped_size: 31457280
   # Maximum permitted size in bytes of a request's header accepted by the server to be processed.
   #max_header_size: 1048576
 
-  # Maximum permitted duration in seconds for reading an entire request.
-  #read_timeout: 2s
-  # Maximum permitted duration in seconds for writing a response.
-  #write_timeout: 2s
+  # Maximum duration request will be queued before being read.
+  #max_request_queue_time: 2s
+  # Maximum permitted duration for reading an entire request.
+  #read_timeout: 30s
+  # Maximum permitted duration for writing a response.
+  #write_timeout: 30s
 
   # Maximum duration in seconds before releasing resources when shutting down the server.
   #shutdown_timeout: 5s
 
   # Maximum number of requests permitted to be sent to the server concurrently.
-  #concurrent_requests: 40
+  #concurrent_requests: 5
 
   # Authorization token to be checked. If a token is set here the agents must
   # send their token in the following format: Authorization: Bearer <secret-token>.

--- a/apm-server.reference.yml
+++ b/apm-server.reference.yml
@@ -7,20 +7,22 @@ apm-server:
   #host: "localhost:8200"
 
   # Maximum permitted size in bytes of an unzipped request accepted by the server to be processed.
-  #max_unzipped_size: 52428800
+  #max_unzipped_size: 31457280
   # Maximum permitted size in bytes of a request's header accepted by the server to be processed.
   #max_header_size: 1048576
 
-  # Maximum permitted duration in seconds for reading an entire request.
-  #read_timeout: 2s
-  # Maximum permitted duration in seconds for writing a response.
-  #write_timeout: 2s
+  # Maximum duration request will be queued before being read.
+  #max_request_queue_time: 2s
+  # Maximum permitted duration for reading an entire request.
+  #read_timeout: 30s
+  # Maximum permitted duration for writing a response.
+  #write_timeout: 30s
 
   # Maximum duration in seconds before releasing resources when shutting down the server.
   #shutdown_timeout: 5s
 
   # Maximum number of requests permitted to be sent to the server concurrently.
-  #concurrent_requests: 40
+  #concurrent_requests: 5
 
   # Authorization token to be checked. If a token is set here the agents must
   # send their token in the following format: Authorization: Bearer <secret-token>.

--- a/beater/config.go
+++ b/beater/config.go
@@ -113,8 +113,8 @@ func defaultConfig(beatVersion string) *Config {
 		MaxHeaderSize:       1 * 1024 * 1024,  // 1mb
 		ConcurrentRequests:  5,
 		MaxRequestQueueTime: 2 * time.Second,
-		ReadTimeout:         2 * time.Second,
-		WriteTimeout:        2 * time.Second,
+		ReadTimeout:         30 * time.Second,
+		WriteTimeout:        30 * time.Second,
 		ShutdownTimeout:     5 * time.Second,
 		SecretToken:         "",
 		AugmentEnabled:      true,


### PR DESCRIPTION
Backports the following commits to 6.x:
 - update/sync configuration defaults  (#748)