### PR TITLE
Update apt repository without prerelease

### DIFF
--- a/docs/copied-from-beats/repositories.asciidoc
+++ b/docs/copied-from-beats/repositories.asciidoc
@@ -49,11 +49,11 @@ wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add
 sudo apt-get install apt-transport-https
 --------------------------------------------------
 
-. Save the repository definition to  +/etc/apt/sources.list.d/elastic-6.x-prerelease.list+:
+. Save the repository definition to  +/etc/apt/sources.list.d/elastic-6.x.list+:
 +
 ["source","sh",subs="attributes,callouts"]
 --------------------------------------------------
-echo "deb https://artifacts.elastic.co/packages/6.x-prerelease/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x-prerelease.list
+echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list
 --------------------------------------------------
 +
 [WARNING]


### PR DESCRIPTION
Elastic already announced APM as GA. And I'm using well with release apt repository well. So, I think the documentation should be updated.