### PR TITLE
[6.x] Add note to docs for dashboard loading. (#648)

Describe that `setup.dashboards.index`
only works for >= 6.0
closes #519

### DIFF
--- a/docs/copied-from-beats/dashboardsconfig.asciidoc
+++ b/docs/copied-from-beats/dashboardsconfig.asciidoc
@@ -92,6 +92,8 @@ is `".kibana"`
 The Elasticsearch index name. This setting overwrites the index name defined
 in the dashboards and index pattern. Example: `"testbeat-*"`
 
+NOTE: This setting only works for Kibana 6.0 and newer.
+
 [float]
 ==== `setup.dashboards.always_kibana`
 


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Add note to docs for dashboard loading. 

Describe that `setup.dashboards.index`
only works for >= 6.0
closes #519 (#648)