### PR TITLE
[6.x] Resolve attrs in docs example. (#661)

### DIFF
--- a/docs/copied-from-beats/loggingconfig.asciidoc
+++ b/docs/copied-from-beats/loggingconfig.asciidoc
@@ -18,7 +18,7 @@ for configuring the logging output. The logging system can write logs to
 the syslog or rotate log files. If logging is not explicitly configured the file
 output is used.
 
-[source,yaml]
+["source","yaml",subs="attributes"]
 --------------------------------------------------------------------------------
 logging.level: info
 logging.to_files: true


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Resolve attrs in docs example.  (#661)