### PR TITLE
[6.x] use libbeat version (#659)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ PREFIX?=.
 BEATS_VERSION?=6.x
 NOTICE_FILE=NOTICE.txt
 LICENSE_FILE=LICENSE.txt
+NOW=$(shell date -u '+%Y-%m-%dT%H:%M:%S')
+GOBUILD_FLAGS=-i -ldflags "-s -X $(BEAT_PATH)/vendor/github.com/elastic/beats/libbeat/version.buildTime=$(NOW) -X $(BEAT_PATH)/vendor/github.com/elastic/beats/libbeat/version.commit=$(COMMIT_ID)"
 TESTIFY_TOOL_REPO?=github.com/elastic/beats/vendor/github.com/stretchr/testify/assert
 
 # Path to the libbeat Makefile

--- a/beater/server.go
+++ b/beater/server.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/version"
 )
 
 type reporter func([]beat.Event) error
@@ -25,7 +26,7 @@ func newServer(config *Config, report reporter) *http.Server {
 
 func run(server *http.Server, lis net.Listener, config *Config) error {
 	logger := logp.NewLogger("server")
-	logger.Infof("Starting apm-server. Hit CTRL-C to stop it.")
+	logger.Infof("Starting apm-server [%s built %s]. Hit CTRL-C to stop it.", version.Commit(), version.BuildTime())
 	logger.Infof("Listening on: %s", server.Addr)
 	switch config.Frontend.isEnabled() {
 	case true:


### PR DESCRIPTION
Backports the following commits to 6.x:
 - use libbeat version  (#659)