### PR TITLE
docs/guide: Added docs

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -68,6 +68,22 @@ open source Kibana dashboards that come with APM Server.
 We designed Elastic APM to run on anything from a regular laptop to thousands of machines,
 and it's easy to get started.
 
+[[separate-component]]
+== Why is APM Server a separate component?
+
+The APM Server is kept as a separate component for the following reasons:
+
+* Agents can offload their heavy lifting tasks to the APM Server thereby reducing the load on your app.
+  It helps keep the agents as light as possible and since the APM Server is a separate component,
+  it can be scaled independently.
+* For real-user-monitoring, data is being collected in agents running in browsers.
+  Browsers communicate with the APM Server which acts as a central point to control the amount of data flowing into Elasticsearch and also control the pace of ingesting data.
+  This also prevents the browser from directly interacting with Elasticsearch which is not recommended.
+* In cases where Elasticsearch is temporarily down, APM Server can buffer up the data until Elasticsearch becomes available again.
+  We can't rely on the agents to buffer up the data since that increases the memory footprint of the application and we can't rely on disk access being available to the agents
+* APM Server serves as a middleware for source mapping for javascript in the browser.
+* The APM Server provides a JSON API for agents to use thereby improving compatibility across different versions of agents and Elasticsearch.
+
 [[install-and-run]]
 == Install and run Elastic APM
 


### PR DESCRIPTION
Adds a new section to docs/guide/index.asciidoc
explaining the various reasons for the APM server
being a separate component

Closes: https://github.com/elastic/apm-server/issues/602

cc @roncohen