### PR TITLE
Split indices by `processor.event` instead of `name`.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ https://github.com/elastic/apm-server/compare/4daa36bd5c144cf9182afc62dc8042af66
 - Change `max_unzipped_size` default from 50mb to 30mb {pull}731[731].
 - Change `read_timeout` and `write_timeout` defaults from 2s to 30s {pull}748[748], {pull}752[752].
 - Limit number of new connections to accept simultaneously {pull}751[751].
+- Push spans to separate ES index {pull}774[774].
 
 
 ==== Deprecated

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -62,9 +62,10 @@ output.elasticsearch:
   hosts: ["localhost:9200"]
 
   # By using the configuration below, apm documents are stored to separate indices, 
-  # depending on their `processor.name` or `processor.event`:
+  # depending on their `processor.event`:
   # - error
   # - transaction
+  # - span
   # - sourcemap (experimental feature)
   #
   # The indices are all prefixed with `apm-%{[beat.version]}`.
@@ -85,11 +86,15 @@ output.elasticsearch:
 
     - index: "apm-%{[beat.version]}-error-%{+yyyy.MM.dd}"
       when.contains:
-        processor.name: "error"
+        processor.event: "error"
 
     - index: "apm-%{[beat.version]}-transaction-%{+yyyy.MM.dd}"
       when.contains:
-        processor.name: "transaction"
+        processor.event: "transaction"
+
+    - index: "apm-%{[beat.version]}-span-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "span"
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -62,9 +62,10 @@ output.elasticsearch:
   hosts: ["localhost:9200"]
 
   # By using the configuration below, apm documents are stored to separate indices, 
-  # depending on their `processor.name` or `processor.event`:
+  # depending on their `processor.event`:
   # - error
   # - transaction
+  # - span
   # - sourcemap (experimental feature)
   #
   # The indices are all prefixed with `apm-%{[beat.version]}`.
@@ -85,11 +86,15 @@ output.elasticsearch:
 
     - index: "apm-%{[beat.version]}-error-%{+yyyy.MM.dd}"
       when.contains:
-        processor.name: "error"
+        processor.event: "error"
 
     - index: "apm-%{[beat.version]}-transaction-%{+yyyy.MM.dd}"
       when.contains:
-        processor.name: "transaction"
+        processor.event: "transaction"
+
+    - index: "apm-%{[beat.version]}-span-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "span"
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -142,11 +142,11 @@ class ElasticTest(ServerBaseTest):
         self.es = Elasticsearch([self.get_elasticsearch_url()])
 
         # Cleanup index and template first
-        self.es.indices.delete(index=self.index_name, ignore=[400, 404])
+        self.es.indices.delete(index="*", ignore=[400, 404])
         self.wait_until(lambda: not self.es.indices.exists(self.index_name))
 
         self.es.indices.delete_template(
-            name=self.index_name, ignore=[400, 404])
+            name="*", ignore=[400, 404])
         self.wait_until(
             lambda: not self.es.indices.exists_template(self.index_name))
 
@@ -305,13 +305,14 @@ class SplitIndicesTest(ElasticTest):
     @classmethod
     def setUpClass(cls):
         super(SplitIndicesTest, cls).setUpClass()
-
         cls.index_name_transaction = "test-apm-transaction-12-12-2017"
+        cls.index_name_span = "test-apm-span-12-12-2017"
         cls.index_name_error = "test-apm-error-12-12-2017"
 
     def config(self):
         cfg = super(SplitIndicesTest, self).config()
         cfg.update({"index_name_transaction": self.index_name_transaction,
+                    "index_name_span": self.index_name_span,
                     "index_name_error": self.index_name_error})
         return cfg
 

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -61,21 +61,32 @@ output.elasticsearch:
   hosts: ["{{ elasticsearch_host }}"]
 
   index: {{ index_name }}
-  {% if smap_index %}
+  {% if smap_index or index_name_transaction or index_name_span or index_name_error %}
   indices:
+  {% endif %}
+
+  {% if smap_index %}
     - index: {{ smap_index }}
       when.contains:
         processor.event: "sourcemap"
   {% endif %}
 
-  {% if index_name_transaction and index_name_error %}
-  indices:
+  {% if index_name_transaction %}
     - index: {{ index_name_transaction }}
       when.contains:
-        processor.name: "transaction"
+        processor.event: "transaction"
+  {% endif %}
+
+  {% if index_name_span %}
+    - index: {{ index_name_span }}
+      when.contains:
+        processor.event: "span"
+  {% endif %}
+
+  {% if index_name_error %}
     - index: {{ index_name_error }}
       when.contains:
-        processor.name: "error"
+        processor.event: "error"
   {% endif %}
 
 {% endif %}

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -222,8 +222,16 @@ class SplitIndicesIntegrationTest(SplitIndicesTest):
         self.load_docs_with_template(self.get_transaction_payload_path(name="payload.json"),
                                      'http://localhost:8200/v1/transactions',
                                      'transaction',
-                                     9,
+                                     4,
                                      query_index="test-apm-transaction-12-12-2017")
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_span_index(self):
+        self.load_docs_with_template(self.get_transaction_payload_path(name="payload.json"),
+                                     'http://localhost:8200/v1/transactions',
+                                     'transaction',
+                                     5,
+                                     query_index="test-apm-span-12-12-2017")
 
 
 class SourcemappingIntegrationTest(ClientSideBaseTest):

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -2,7 +2,8 @@ import os
 import unittest
 
 from apmserver import ElasticTest, ExpvarBaseTest
-from apmserver import ClientSideBaseTest, SmapIndexBaseTest, SmapCacheBaseTest, SplitIndicesTest
+from apmserver import ClientSideBaseTest, SmapIndexBaseTest, SmapCacheBaseTest
+from apmserver import SplitIndicesTest
 from beat.beat import INTEGRATION_TESTS
 import json
 
@@ -28,16 +29,11 @@ class Test(ElasticTest):
     def test_load_docs_with_template_and_add_transaction(self):
         """
         This test starts the beat with a loaded template and sends transaction data to elasticsearch.
-        It verifies that all data make it into ES means data is compatible with the template.
+        It verifies that all data make it into ES, means data is compatible with the template
+        and data are in expected format.
         """
-        f = os.path.abspath(os.path.join(self.beat_path,
-                                         'tests',
-                                         'data',
-                                         'valid',
-                                         'transaction',
-                                         'payload.json'))
-        self.load_docs_with_template(
-            f, self.transactions_url, 'transaction', 9)
+        self.load_docs_with_template(self.get_transaction_payload_path(),
+                                     self.transactions_url, 'transaction', 9)
         self.assert_no_logged_warnings()
 
         # compare existing ES documents for transactions with new ones
@@ -62,13 +58,8 @@ class Test(ElasticTest):
         This test starts the beat with a loaded template and sends error data to elasticsearch.
         It verifies that all data make it into ES means data is compatible with the template.
         """
-        f = os.path.abspath(os.path.join(self.beat_path,
-                                         'tests',
-                                         'data',
-                                         'valid',
-                                         'error',
-                                         'payload.json'))
-        self.load_docs_with_template(f, self.errors_url, 'error', 4)
+        self.load_docs_with_template(self.get_error_payload_path(),
+                                     self.errors_url, 'error', 4)
         self.assert_no_logged_warnings()
 
         # compare existing ES documents for errors with new ones
@@ -210,28 +201,40 @@ class FrontendEnabledIntegrationTest(ClientSideBaseTest):
 
 class SplitIndicesIntegrationTest(SplitIndicesTest):
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    def test_error_index(self):
-        self.load_docs_with_template(self.get_error_payload_path(name="payload.json"),
-                                     'http://localhost:8200/v1/errors',
+    def test_split_docs_into_separate_indices(self):
+        # load error and transaction document to ES
+        self.load_docs_with_template(self.get_error_payload_path(),
+                                     self.errors_url,
                                      'error',
                                      4,
-                                     query_index="test-apm-error-12-12-2017")
-
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    def test_transaction_index(self):
-        self.load_docs_with_template(self.get_transaction_payload_path(name="payload.json"),
-                                     'http://localhost:8200/v1/transactions',
+                                     query_index="test-apm*")
+        self.load_docs_with_template(self.get_transaction_payload_path(),
+                                     self.transactions_url,
                                      'transaction',
-                                     4,
-                                     query_index="test-apm-transaction-12-12-2017")
+                                     9,
+                                     query_index="test-apm*")
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    def test_span_index(self):
-        self.load_docs_with_template(self.get_transaction_payload_path(name="payload.json"),
-                                     'http://localhost:8200/v1/transactions',
-                                     'transaction',
-                                     5,
-                                     query_index="test-apm-span-12-12-2017")
+        # check that every document is indexed once (incl.1 onboarding doc)
+        assert 14 == self.es.count(index="test-apm*")['count']
+
+        # check that documents are split into separate indices
+        ct = self.es.count(
+            index="test-apm-error-12-12-2017",
+            body={"query": {"term": {"processor.event": "error"}}}
+        )['count']
+        assert 4 == ct
+
+        ct = self.es.count(
+            index="test-apm-transaction-12-12-2017",
+            body={"query": {"term": {"processor.event": "transaction"}}}
+        )['count']
+        assert 4 == ct
+
+        ct = self.es.count(
+            index="test-apm-span-12-12-2017",
+            body={"query": {"term": {"processor.event": "span"}}}
+        )['count']
+        assert 5 == ct
 
 
 class SourcemappingIntegrationTest(ClientSideBaseTest):


### PR DESCRIPTION
This creates a seperate index for `spans`
rather than storing them in the same index as transactions.

closes #734