### PR TITLE
[6.x] Use config.Config over processor.Config. (#745)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"regexp"
+
+	"github.com/elastic/apm-server/sourcemap"
+)
+
+type Config struct {
+	LibraryPattern      *regexp.Regexp
+	ExcludeFromGrouping *regexp.Regexp
+	SmapMapper          sourcemap.Mapper
+}

--- a/model/stacktrace.go
+++ b/model/stacktrace.go
@@ -3,7 +3,7 @@ package model
 import (
 	"errors"
 
-	pr "github.com/elastic/apm-server/processor"
+	"github.com/elastic/apm-server/config"
 	"github.com/elastic/beats/libbeat/common"
 )
 
@@ -24,7 +24,7 @@ func DecodeStacktrace(input interface{}, err error) (*Stacktrace, error) {
 	return &st, err
 }
 
-func (st *Stacktrace) Transform(config *pr.Config, service Service) []common.MapStr {
+func (st *Stacktrace) Transform(config config.Config, service Service) []common.MapStr {
 	if st == nil {
 		return nil
 	}
@@ -55,7 +55,7 @@ func (st *Stacktrace) Transform(config *pr.Config, service Service) []common.Map
 	fct := "<anonymous>"
 	for idx := frameCount - 1; idx >= 0; idx-- {
 		fr = (*st)[idx]
-		if config != nil && config.SmapMapper != nil {
+		if config.SmapMapper != nil {
 			fct = fr.applySourcemap(config.SmapMapper, service, fct)
 		}
 		frames[idx] = fr.Transform(config)

--- a/model/stacktrace_frame.go
+++ b/model/stacktrace_frame.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"regexp"
 
-	pr "github.com/elastic/apm-server/processor"
+	"github.com/elastic/apm-server/config"
 	"github.com/elastic/apm-server/sourcemap"
 	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/beats/libbeat/common"
@@ -71,19 +71,19 @@ func DecodeStacktraceFrame(input interface{}, err error) (*StacktraceFrame, erro
 	return &frame, decoder.Err
 }
 
-func (s *StacktraceFrame) Transform(config *pr.Config) common.MapStr {
+func (s *StacktraceFrame) Transform(config config.Config) common.MapStr {
 	m := common.MapStr{}
 	utility.Add(m, "filename", s.Filename)
 	utility.Add(m, "abs_path", s.AbsPath)
 	utility.Add(m, "module", s.Module)
 	utility.Add(m, "function", s.Function)
 	utility.Add(m, "vars", s.Vars)
-	if config != nil && config.LibraryPattern != nil {
+	if config.LibraryPattern != nil {
 		s.setLibraryFrame(config.LibraryPattern)
 	}
 	utility.Add(m, "library_frame", s.LibraryFrame)
 
-	if config != nil && config.ExcludeFromGrouping != nil {
+	if config.ExcludeFromGrouping != nil {
 		s.setExcludeFromGrouping(config.ExcludeFromGrouping)
 	}
 	utility.Add(m, "exclude_from_grouping", s.ExcludeFromGrouping)

--- a/model/stacktrace_frame_test.go
+++ b/model/stacktrace_frame_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	pr "github.com/elastic/apm-server/processor"
+	"github.com/elastic/apm-server/config"
 	"github.com/elastic/apm-server/sourcemap"
 	"github.com/elastic/beats/libbeat/common"
 )
@@ -131,7 +131,7 @@ func TestStacktraceFrameTransform(t *testing.T) {
 	}
 
 	for idx, test := range tests {
-		output := (&test.StFrame).Transform(&pr.Config{})
+		output := (&test.StFrame).Transform(config.Config{})
 		assert.Equal(t, test.Output, output, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 	}
 }
@@ -383,7 +383,7 @@ func TestExcludeFromGroupingKey(t *testing.T) {
 		if test.pattern != "" {
 			excludePattern = regexp.MustCompile(test.pattern)
 		}
-		out := test.fr.Transform(&pr.Config{ExcludeFromGrouping: excludePattern})
+		out := test.fr.Transform(config.Config{ExcludeFromGrouping: excludePattern})
 		exclude := out["exclude_from_grouping"]
 		assert.Equal(t, test.exclude, exclude,
 			fmt.Sprintf("(%v): Pattern: %v, Filename: %v, expected to be excluded: %v", idx, test.pattern, test.fr.Filename, test.exclude))
@@ -396,68 +396,68 @@ func TestLibraryFrame(t *testing.T) {
 	path := "/~/a/b"
 	tests := []struct {
 		fr               StacktraceFrame
-		conf             *pr.Config
+		conf             config.Config
 		libraryFrame     *bool
 		origLibraryFrame *bool
 		msg              string
 	}{
 		{fr: StacktraceFrame{},
-			conf:             &pr.Config{},
+			conf:             config.Config{},
 			libraryFrame:     nil,
 			origLibraryFrame: nil,
 			msg:              "Empty StacktraceFrame, empty config"},
 		{fr: StacktraceFrame{AbsPath: &path},
-			conf:             &pr.Config{LibraryPattern: nil},
+			conf:             config.Config{LibraryPattern: nil},
 			libraryFrame:     nil,
 			origLibraryFrame: nil,
 			msg:              "No pattern"},
 		{fr: StacktraceFrame{AbsPath: &path},
-			conf:             &pr.Config{LibraryPattern: regexp.MustCompile("")},
+			conf:             config.Config{LibraryPattern: regexp.MustCompile("")},
 			libraryFrame:     &truthy,
 			origLibraryFrame: nil,
 			msg:              "Empty pattern"},
 		{fr: StacktraceFrame{LibraryFrame: &falsy},
-			conf:             &pr.Config{LibraryPattern: regexp.MustCompile("~")},
+			conf:             config.Config{LibraryPattern: regexp.MustCompile("~")},
 			libraryFrame:     &falsy,
 			origLibraryFrame: &falsy,
 			msg:              "Empty StacktraceFrame"},
 		{fr: StacktraceFrame{AbsPath: &path, LibraryFrame: &truthy},
-			conf:             &pr.Config{LibraryPattern: regexp.MustCompile("^~/")},
+			conf:             config.Config{LibraryPattern: regexp.MustCompile("^~/")},
 			libraryFrame:     &falsy,
 			origLibraryFrame: &truthy,
 			msg:              "AbsPath given, no Match"},
 		{fr: StacktraceFrame{Filename: "myFile.js", LibraryFrame: &truthy},
-			conf:             &pr.Config{LibraryPattern: regexp.MustCompile("^~/")},
+			conf:             config.Config{LibraryPattern: regexp.MustCompile("^~/")},
 			libraryFrame:     &falsy,
 			origLibraryFrame: &truthy,
 			msg:              "Filename given, no Match"},
 		{fr: StacktraceFrame{AbsPath: &path, Filename: "myFile.js"},
-			conf:             &pr.Config{LibraryPattern: regexp.MustCompile("^~/")},
+			conf:             config.Config{LibraryPattern: regexp.MustCompile("^~/")},
 			libraryFrame:     &falsy,
 			origLibraryFrame: nil,
 			msg:              "AbsPath and Filename given, no Match"},
 		{fr: StacktraceFrame{Filename: "/tmp"},
-			conf:             &pr.Config{LibraryPattern: regexp.MustCompile("/tmp")},
+			conf:             config.Config{LibraryPattern: regexp.MustCompile("/tmp")},
 			libraryFrame:     &truthy,
 			origLibraryFrame: nil,
 			msg:              "Filename matching"},
 		{fr: StacktraceFrame{AbsPath: &path, LibraryFrame: &falsy},
-			conf:             &pr.Config{LibraryPattern: regexp.MustCompile("~/")},
+			conf:             config.Config{LibraryPattern: regexp.MustCompile("~/")},
 			libraryFrame:     &truthy,
 			origLibraryFrame: &falsy,
 			msg:              "AbsPath matching"},
 		{fr: StacktraceFrame{AbsPath: &path, Filename: "/a/b/c"},
-			conf:             &pr.Config{LibraryPattern: regexp.MustCompile("~/")},
+			conf:             config.Config{LibraryPattern: regexp.MustCompile("~/")},
 			libraryFrame:     &truthy,
 			origLibraryFrame: nil,
 			msg:              "AbsPath matching, Filename not matching"},
 		{fr: StacktraceFrame{AbsPath: &path, Filename: "/a/b/c"},
-			conf:             &pr.Config{LibraryPattern: regexp.MustCompile("/a/b/c")},
+			conf:             config.Config{LibraryPattern: regexp.MustCompile("/a/b/c")},
 			libraryFrame:     &truthy,
 			origLibraryFrame: nil,
 			msg:              "AbsPath not matching, Filename matching"},
 		{fr: StacktraceFrame{AbsPath: &path, Filename: "~/a/b/c"},
-			conf:             &pr.Config{LibraryPattern: regexp.MustCompile("~/")},
+			conf:             config.Config{LibraryPattern: regexp.MustCompile("~/")},
 			libraryFrame:     &truthy,
 			origLibraryFrame: nil,
 			msg:              "AbsPath and Filename matching"},

--- a/model/stacktrace_test.go
+++ b/model/stacktrace_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	pr "github.com/elastic/apm-server/processor"
+	"github.com/elastic/apm-server/config"
 	"github.com/elastic/beats/libbeat/common"
 )
 
@@ -125,7 +125,7 @@ func TestStacktraceTransform(t *testing.T) {
 	}
 
 	for idx, test := range tests {
-		output := test.Stacktrace.Transform(&pr.Config{}, service)
+		output := test.Stacktrace.Transform(config.Config{}, service)
 		assert.Equal(t, test.Output, output, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 	}
 }
@@ -242,8 +242,8 @@ func TestStacktraceTransformWithSourcemapping(t *testing.T) {
 
 	for idx, test := range tests {
 		// run `Stacktrace.Transform` twice to ensure method is idempotent
-		test.Stacktrace.Transform(&pr.Config{SmapMapper: &FakeMapper{}}, service)
-		output := test.Stacktrace.Transform(&pr.Config{SmapMapper: &FakeMapper{}}, service)
+		test.Stacktrace.Transform(config.Config{SmapMapper: &FakeMapper{}}, service)
+		output := test.Stacktrace.Transform(config.Config{SmapMapper: &FakeMapper{}}, service)
 		assert.Equal(t, test.Output, output, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 	}
 }

--- a/processor/error/benchmark_test.go
+++ b/processor/error/benchmark_test.go
@@ -3,11 +3,12 @@ package error
 import (
 	"testing"
 
+	"github.com/elastic/apm-server/config"
 	"github.com/elastic/apm-server/tests/loader"
 )
 
 func BenchmarkEventWithFileLoading(b *testing.B) {
-	processor := NewProcessor(nil)
+	processor := NewProcessor(config.Config{})
 	for i := 0; i < b.N; i++ {
 		data, _ := loader.LoadValidData("error")
 		err := processor.Validate(data)
@@ -20,7 +21,7 @@ func BenchmarkEventWithFileLoading(b *testing.B) {
 }
 
 func BenchmarkEventFileLoadingOnce(b *testing.B) {
-	processor := NewProcessor(nil)
+	processor := NewProcessor(config.Config{})
 	data, _ := loader.LoadValidData("error")
 	for i := 0; i < b.N; i++ {
 		err := processor.Validate(data)

--- a/processor/error/event.go
+++ b/processor/error/event.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/elastic/apm-server/config"
 	m "github.com/elastic/apm-server/model"
-	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/beats/libbeat/common"
 )
@@ -109,7 +109,7 @@ func DecodeEvent(input interface{}, err error) (*Event, error) {
 	return &e, err
 }
 
-func (e *Event) Transform(config *pr.Config, service m.Service) common.MapStr {
+func (e *Event) Transform(config config.Config, service m.Service) common.MapStr {
 	e.data = common.MapStr{}
 	e.add("id", e.Id)
 
@@ -124,8 +124,8 @@ func (e *Event) Transform(config *pr.Config, service m.Service) common.MapStr {
 	return e.data
 }
 
-func (e *Event) updateCulprit(config *pr.Config) {
-	if config == nil || config.SmapMapper == nil {
+func (e *Event) updateCulprit(config config.Config) {
+	if config.SmapMapper == nil {
 		return
 	}
 	var fr *m.StacktraceFrame
@@ -154,7 +154,7 @@ func findSmappedNonLibraryFrame(frames []*m.StacktraceFrame) *m.StacktraceFrame 
 	return nil
 }
 
-func (e *Event) addException(config *pr.Config, service m.Service) {
+func (e *Event) addException(config config.Config, service m.Service) {
 	if e.Exception == nil {
 		return
 	}
@@ -180,7 +180,7 @@ func (e *Event) addException(config *pr.Config, service m.Service) {
 	e.add("exception", ex)
 }
 
-func (e *Event) addLog(config *pr.Config, service m.Service) {
+func (e *Event) addLog(config config.Config, service m.Service) {
 	if e.Log == nil {
 		return
 	}

--- a/processor/error/event_test.go
+++ b/processor/error/event_test.go
@@ -17,8 +17,8 @@ import (
 
 	s "github.com/go-sourcemap/sourcemap"
 
+	"github.com/elastic/apm-server/config"
 	m "github.com/elastic/apm-server/model"
-	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/apm-server/sourcemap"
 	"github.com/elastic/beats/libbeat/common"
 )
@@ -332,7 +332,7 @@ func TestEventTransform(t *testing.T) {
 	}
 
 	for idx, test := range tests {
-		output := test.Event.Transform(&pr.Config{SmapMapper: &sourcemap.SmapMapper{}}, service)
+		output := test.Event.Transform(config.Config{SmapMapper: &sourcemap.SmapMapper{}}, service)
 		assert.Equal(t, test.Output, output, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 	}
 }
@@ -353,25 +353,25 @@ func TestCulprit(t *testing.T) {
 	mapper := sourcemap.SmapMapper{}
 	tests := []struct {
 		event   Event
-		config  pr.Config
+		config  config.Config
 		culprit string
 		msg     string
 	}{
 		{
 			event:   Event{Culprit: &c},
-			config:  pr.Config{},
+			config:  config.Config{},
 			culprit: "foo",
 			msg:     "No Sourcemap in config",
 		},
 		{
 			event:   Event{Culprit: &c},
-			config:  pr.Config{SmapMapper: &mapper},
+			config:  config.Config{SmapMapper: &mapper},
 			culprit: "foo",
 			msg:     "No Stacktrace Frame given.",
 		},
 		{
 			event:   Event{Culprit: &c, Log: &Log{Stacktrace: st}},
-			config:  pr.Config{SmapMapper: &mapper},
+			config:  config.Config{SmapMapper: &mapper},
 			culprit: "foo",
 			msg:     "Log.StacktraceFrame has no updated frame",
 		},
@@ -387,7 +387,7 @@ func TestCulprit(t *testing.T) {
 					},
 				},
 			},
-			config:  pr.Config{SmapMapper: &mapper},
+			config:  config.Config{SmapMapper: &mapper},
 			culprit: "f",
 			msg:     "Adapt culprit to first valid Log.StacktraceFrame information.",
 		},
@@ -396,7 +396,7 @@ func TestCulprit(t *testing.T) {
 				Culprit:   &c,
 				Exception: &Exception{Stacktrace: stUpdate},
 			},
-			config:  pr.Config{SmapMapper: &mapper},
+			config:  config.Config{SmapMapper: &mapper},
 			culprit: "f in fct",
 			msg:     "Adapt culprit to first valid Exception.StacktraceFrame information.",
 		},
@@ -406,7 +406,7 @@ func TestCulprit(t *testing.T) {
 				Log:       &Log{Stacktrace: st},
 				Exception: &Exception{Stacktrace: stUpdate},
 			},
-			config:  pr.Config{SmapMapper: &mapper},
+			config:  config.Config{SmapMapper: &mapper},
 			culprit: "f in fct",
 			msg:     "Log and Exception StacktraceFrame given, only one changes culprit.",
 		},
@@ -424,13 +424,13 @@ func TestCulprit(t *testing.T) {
 				},
 				Exception: &Exception{Stacktrace: stUpdate},
 			},
-			config:  pr.Config{SmapMapper: &mapper},
+			config:  config.Config{SmapMapper: &mapper},
 			culprit: "a in fct",
 			msg:     "Log Stacktrace is prioritized over Exception StacktraceFrame",
 		},
 	}
 	for idx, test := range tests {
-		test.event.updateCulprit(&test.config)
+		test.event.updateCulprit(test.config)
 		assert.Equal(t, test.culprit, *test.event.Culprit,
 			fmt.Sprintf("(%v) expected <%v>, received <%v>", idx, test.culprit, *test.event.Culprit))
 	}
@@ -656,7 +656,7 @@ func TestSourcemapping(t *testing.T) {
 			&m.StacktraceFrame{Filename: "/a/b/c", Lineno: 1, Colno: &c1},
 		},
 	}}
-	trNoSmap := event.Transform(&pr.Config{SmapMapper: nil}, m.Service{})
+	trNoSmap := event.Transform(config.Config{SmapMapper: nil}, m.Service{})
 
 	event2 := Event{Exception: &Exception{
 		Message: "exception message",
@@ -665,7 +665,7 @@ func TestSourcemapping(t *testing.T) {
 		},
 	}}
 	mapper := sourcemap.SmapMapper{Accessor: &fakeAcc{}}
-	trWithSmap := event2.Transform(&pr.Config{SmapMapper: &mapper}, m.Service{})
+	trWithSmap := event2.Transform(config.Config{SmapMapper: &mapper}, m.Service{})
 
 	assert.Equal(t, 1, event.Exception.Stacktrace[0].Lineno)
 	assert.Equal(t, 5, event2.Exception.Stacktrace[0].Lineno)

--- a/processor/error/package_tests/json_schema_test.go
+++ b/processor/error/package_tests/json_schema_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fatih/set"
 
+	"github.com/elastic/apm-server/config"
 	er "github.com/elastic/apm-server/processor/error"
 	"github.com/elastic/apm-server/tests"
 )
@@ -55,5 +56,5 @@ func TestErrorPayloadSchema(t *testing.T) {
 		{File: "data/invalid/error_payload/no_service.json", Error: "missing properties: \"service\""},
 		{File: "data/invalid/error_payload/no_errors.json", Error: "missing properties: \"errors\""},
 	}
-	tests.TestDataAgainstProcessor(t, er.NewProcessor(nil), testData)
+	tests.TestDataAgainstProcessor(t, er.NewProcessor(config.Config{}), testData)
 }

--- a/processor/error/package_tests/processor_test.go
+++ b/processor/error/package_tests/processor_test.go
@@ -10,7 +10,7 @@ import (
 	s "github.com/go-sourcemap/sourcemap"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/elastic/apm-server/processor"
+	"github.com/elastic/apm-server/config"
 	er "github.com/elastic/apm-server/processor/error"
 	"github.com/elastic/apm-server/sourcemap"
 	"github.com/elastic/apm-server/tests"
@@ -28,8 +28,8 @@ func TestProcessorBackendOK(t *testing.T) {
 		{Name: "TestProcessErrorNullValues", Path: "data/valid/error/null_values.json"},
 		{Name: "TestProcessErrorAugmentedIP", Path: "data/valid/error/augmented_payload_backend.json"},
 	}
-	conf := processor.Config{ExcludeFromGrouping: nil}
-	tests.TestProcessRequests(t, er.NewProcessor(&conf), requestInfo, map[string]string{})
+	conf := config.Config{ExcludeFromGrouping: nil}
+	tests.TestProcessRequests(t, er.NewProcessor, conf, requestInfo, map[string]string{})
 }
 
 func TestProcessorFrontendOK(t *testing.T) {
@@ -40,19 +40,19 @@ func TestProcessorFrontendOK(t *testing.T) {
 		{Name: "TestProcessErrorAugmentedUserAgentAndIP", Path: "data/valid/error/augmented_payload_frontend.json"},
 	}
 	mapper := sourcemap.SmapMapper{Accessor: &fakeAcc{}}
-	conf := processor.Config{
+	conf := config.Config{
 		SmapMapper:          &mapper,
 		LibraryPattern:      regexp.MustCompile("^test/e2e|~"),
 		ExcludeFromGrouping: regexp.MustCompile("^\\s*$|^/webpack|^[/][^/]*$"),
 	}
-	tests.TestProcessRequests(t, er.NewProcessor(&conf), requestInfo, map[string]string{})
+	tests.TestProcessRequests(t, er.NewProcessor, conf, requestInfo, map[string]string{})
 }
 
 // ensure invalid documents fail the json schema validation already
 func TestProcessorFailedValidation(t *testing.T) {
 	data, err := loader.LoadInvalidData("error")
 	assert.Nil(t, err)
-	err = er.NewProcessor(nil).Validate(data)
+	err = er.NewProcessor(config.Config{}).Validate(data)
 	assert.NotNil(t, err)
 }
 

--- a/processor/error/payload.go
+++ b/processor/error/payload.go
@@ -1,8 +1,8 @@
 package error
 
 import (
+	"github.com/elastic/apm-server/config"
 	m "github.com/elastic/apm-server/model"
-	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
@@ -20,8 +20,7 @@ type payload struct {
 	System  *m.System
 	Process *m.Process
 	User    *m.User
-
-	Events []Event
+	Events  []Event
 }
 
 func decodeError(raw map[string]interface{}) (*payload, error) {
@@ -55,13 +54,13 @@ func decodeError(raw map[string]interface{}) (*payload, error) {
 	return pa, err
 }
 
-func (pa *payload) transform(config *pr.Config) []beat.Event {
-	var events []beat.Event
+func (pa *payload) transform(config config.Config) []beat.Event {
+	logp.NewLogger("transform").Debugf("Transform error events: events=%d, service=%s, agent=%s:%s", len(pa.Events), pa.Service.Name, pa.Service.Agent.Name, pa.Service.Agent.Version)
+	errorCounter.Add(int64(len(pa.Events)))
+
 	context := m.NewContext(&pa.Service, pa.Process, pa.System, pa.User)
 
-	logp.NewLogger("transform").Debugf("Transform error events: events=%d, service=%s, agent=%s:%s", len(pa.Events), pa.Service.Name, pa.Service.Agent.Name, pa.Service.Agent.Version)
-
-	errorCounter.Add(int64(len(pa.Events)))
+	var events []beat.Event
 	for _, event := range pa.Events {
 		context := context.Transform(event.Context)
 		ev := beat.Event{

--- a/processor/error/payload_test.go
+++ b/processor/error/payload_test.go
@@ -9,8 +9,8 @@ import (
 
 	"time"
 
+	"github.com/elastic/apm-server/config"
 	m "github.com/elastic/apm-server/model"
-	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/apm-server/sourcemap"
 	"github.com/elastic/beats/libbeat/common"
 )
@@ -76,7 +76,7 @@ func TestPayloadDecode(t *testing.T) {
 				Process: &m.Process{Pid: pid},
 				User:    &m.User{IP: &ip},
 				Events: []Event{
-					{Timestamp: timestampParsed,
+					Event{Timestamp: timestampParsed,
 						Exception: &Exception{Message: "Exception Msg", Stacktrace: m.Stacktrace{}}},
 				},
 			},
@@ -168,7 +168,7 @@ func TestPayloadTransform(t *testing.T) {
 	}
 
 	for idx, test := range tests {
-		outputEvents := test.Payload.transform(&pr.Config{SmapMapper: &sourcemap.SmapMapper{}})
+		outputEvents := test.Payload.transform(config.Config{SmapMapper: &sourcemap.SmapMapper{}})
 		for j, outputEvent := range outputEvents {
 			assert.Equal(t, test.Output[j], outputEvent.Fields, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 			assert.Equal(t, timestamp, outputEvent.Timestamp, fmt.Sprintf("Bad timestamp at idx %v; %s", idx, test.Msg))

--- a/processor/error/processor.go
+++ b/processor/error/processor.go
@@ -3,6 +3,7 @@ package error
 import (
 	"github.com/santhosh-tekuri/jsonschema"
 
+	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/monitoring"
@@ -22,7 +23,7 @@ const (
 
 var schema = pr.CreateSchema(errorSchema, processorName)
 
-func NewProcessor(config *pr.Config) pr.Processor {
+func NewProcessor(config config.Config) pr.Processor {
 	return &processor{schema: schema, config: config}
 }
 
@@ -32,7 +33,7 @@ func (p *processor) Name() string {
 
 type processor struct {
 	schema *jsonschema.Schema
-	config *pr.Config
+	config config.Config
 }
 
 func (p *processor) Validate(raw map[string]interface{}) error {
@@ -46,7 +47,6 @@ func (p *processor) Validate(raw map[string]interface{}) error {
 
 func (p *processor) Transform(raw map[string]interface{}) ([]beat.Event, error) {
 	transformations.Inc()
-
 	pa, err := decodeError(raw)
 	if err != nil {
 		return nil, err

--- a/processor/error/processor_test.go
+++ b/processor/error/processor_test.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
 )
 
 func TestImplementProcessorInterface(t *testing.T) {
-	p := NewProcessor(nil)
+	p := NewProcessor(config.Config{})
 	assert.NotNil(t, p)
 	_, ok := p.(pr.Processor)
 	assert.True(t, ok)

--- a/processor/healthcheck/processor.go
+++ b/processor/healthcheck/processor.go
@@ -1,6 +1,7 @@
 package healthcheck
 
 import (
+	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/beats/libbeat/beat"
 )
@@ -9,7 +10,7 @@ const (
 	processorName = "healthcheck"
 )
 
-func NewProcessor(_ *pr.Config) pr.Processor {
+func NewProcessor(_ config.Config) pr.Processor {
 	return &processor{}
 }
 

--- a/processor/healthcheck/processor_test.go
+++ b/processor/healthcheck/processor_test.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
 )
 
 func TestImplementProcessorInterface(t *testing.T) {
-	p := NewProcessor(nil)
+	p := NewProcessor(config.Config{})
 	assert.NotNil(t, p)
 	_, ok := p.(pr.Processor)
 	assert.True(t, ok)

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1,22 +1,14 @@
 package processor
 
 import (
-	"regexp"
-
-	"github.com/elastic/apm-server/sourcemap"
+	"github.com/elastic/apm-server/config"
 	"github.com/elastic/beats/libbeat/beat"
 )
 
-type NewProcessor func(conf *Config) Processor
+type NewProcessor func(conf config.Config) Processor
 
 type Processor interface {
 	Validate(map[string]interface{}) error
 	Transform(map[string]interface{}) ([]beat.Event, error)
 	Name() string
-}
-
-type Config struct {
-	SmapMapper          sourcemap.Mapper
-	LibraryPattern      *regexp.Regexp
-	ExcludeFromGrouping *regexp.Regexp
 }

--- a/processor/sourcemap/package_tests/json_schema_test.go
+++ b/processor/sourcemap/package_tests/json_schema_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fatih/set"
 
+	"github.com/elastic/apm-server/config"
 	"github.com/elastic/apm-server/processor/sourcemap"
 	"github.com/elastic/apm-server/tests"
 )
@@ -26,5 +27,5 @@ func TestSourcemapPayloadSchema(t *testing.T) {
 		{File: "data/invalid/sourcemap/not_allowed_empty_values.json", Error: "length must be >= 1, but got 0"},
 		{File: "data/invalid/sourcemap/not_allowed_null_values.json", Error: "expected string, but got null"},
 	}
-	tests.TestDataAgainstProcessor(t, sourcemap.NewProcessor(nil), testData)
+	tests.TestDataAgainstProcessor(t, sourcemap.NewProcessor(config.Config{}), testData)
 }

--- a/processor/sourcemap/package_tests/processor_test.go
+++ b/processor/sourcemap/package_tests/processor_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/apm-server/config"
 	"github.com/elastic/apm-server/processor/sourcemap"
 	"github.com/elastic/apm-server/tests"
 	"github.com/elastic/apm-server/tests/loader"
@@ -16,14 +17,14 @@ func TestSourcemapProcessorOK(t *testing.T) {
 		{Name: "TestProcessSourcemapFull", Path: "data/valid/sourcemap/payload.json"},
 		{Name: "TestProcessSourcemapMinimalPayload", Path: "data/valid/sourcemap/minimal_payload.json"},
 	}
-	tests.TestProcessRequests(t, sourcemap.NewProcessor(nil), requestInfo, map[string]string{"@timestamp": "***IGNORED***"})
+	tests.TestProcessRequests(t, sourcemap.NewProcessor, config.Config{}, requestInfo, map[string]string{"@timestamp": "***IGNORED***"})
 }
 
 // ensure invalid documents fail the json schema validation already
 func TestSourcemapProcessorValidationFailed(t *testing.T) {
 	data, err := loader.LoadInvalidData("sourcemap")
 	assert.Nil(t, err)
-	p := sourcemap.NewProcessor(nil)
+	p := sourcemap.NewProcessor(config.Config{})
 	err = p.Validate(data)
 	assert.NotNil(t, err)
 }

--- a/processor/sourcemap/payload.go
+++ b/processor/sourcemap/payload.go
@@ -3,7 +3,7 @@ package sourcemap
 import (
 	"time"
 
-	pr "github.com/elastic/apm-server/processor"
+	"github.com/elastic/apm-server/config"
 	smap "github.com/elastic/apm-server/sourcemap"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
@@ -23,10 +23,13 @@ type payload struct {
 	BundleFilepath string
 }
 
-func (pa *payload) transform(config *pr.Config) []beat.Event {
+func (pa *payload) transform(config config.Config) []beat.Event {
 	sourcemapCounter.Add(1)
+	if pa == nil {
+		return nil
+	}
 
-	if config == nil || config.SmapMapper == nil {
+	if config.SmapMapper == nil {
 		logp.NewLogger("sourcemap").Error("Sourcemap Accessor is nil, cache cannot be invalidated.")
 	} else {
 		config.SmapMapper.NewSourcemapAdded(smap.Id{

--- a/processor/sourcemap/payload_test.go
+++ b/processor/sourcemap/payload_test.go
@@ -7,7 +7,7 @@ import (
 	s "github.com/go-sourcemap/sourcemap"
 	"github.com/stretchr/testify/assert"
 
-	pr "github.com/elastic/apm-server/processor"
+	"github.com/elastic/apm-server/config"
 	"github.com/elastic/apm-server/sourcemap"
 	"github.com/elastic/apm-server/tests/loader"
 	"github.com/elastic/beats/libbeat/common"
@@ -26,7 +26,7 @@ func TestPayloadTransform(t *testing.T) {
 		Sourcemap:      "mysmap",
 	}
 
-	events := p.transform(nil)
+	events := p.transform(config.Config{})
 	assert.Len(t, events, 1)
 	event := events[0]
 
@@ -63,7 +63,7 @@ func TestInvalidateCache(t *testing.T) {
 	mapping, err := smapMapper.Apply(smapId, 0, 0)
 	assert.NotNil(t, mapping)
 
-	_, err = NewProcessor(&pr.Config{SmapMapper: &smapMapper}).Transform(data)
+	_, err = NewProcessor(config.Config{SmapMapper: &smapMapper}).Transform(data)
 	assert.NoError(t, err)
 
 	mapping, err = smapMapper.Apply(smapId, 0, 0)

--- a/processor/sourcemap/processor.go
+++ b/processor/sourcemap/processor.go
@@ -8,6 +8,7 @@ import (
 
 	parser "github.com/go-sourcemap/sourcemap"
 
+	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/beats/libbeat/beat"
@@ -28,7 +29,7 @@ var (
 
 var schema = pr.CreateSchema(sourcemapSchema, processorName)
 
-func NewProcessor(config *pr.Config) pr.Processor {
+func NewProcessor(config config.Config) pr.Processor {
 	return &processor{schema: schema, config: config}
 }
 
@@ -38,7 +39,7 @@ func (p *processor) Name() string {
 
 type processor struct {
 	schema *jsonschema.Schema
-	config *pr.Config
+	config config.Config
 }
 
 func (p *processor) Validate(raw map[string]interface{}) error {
@@ -62,6 +63,7 @@ func (p *processor) Validate(raw map[string]interface{}) error {
 }
 
 func (p *processor) Transform(raw map[string]interface{}) ([]beat.Event, error) {
+
 	transformations.Inc()
 
 	decoder := utility.ManualDecoder{}
@@ -75,6 +77,5 @@ func (p *processor) Transform(raw map[string]interface{}) ([]beat.Event, error) 
 	if decoder.Err != nil {
 		return nil, decoder.Err
 	}
-
 	return pa.transform(p.config), nil
 }

--- a/processor/sourcemap/processor_test.go
+++ b/processor/sourcemap/processor_test.go
@@ -8,13 +8,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/apm-server/tests/loader"
 	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestImplementProcessorInterface(t *testing.T) {
-	p := NewProcessor(nil)
+	p := NewProcessor(config.Config{})
 	assert.NotNil(t, p)
 	_, ok := p.(pr.Processor)
 	assert.True(t, ok)
@@ -22,7 +23,7 @@ func TestImplementProcessorInterface(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-	p := NewProcessor(nil)
+	p := NewProcessor(config.Config{})
 	data, err := loader.LoadValidData("sourcemap")
 
 	assert.NoError(t, err)
@@ -47,9 +48,9 @@ func TestTransform(t *testing.T) {
 	data, err := loader.LoadValidData("sourcemap")
 	assert.NoError(t, err)
 
-	rs, err := NewProcessor(nil).Transform(data)
+	p := NewProcessor(config.Config{})
+	rs, err := p.Transform(data)
 	assert.NoError(t, err)
-
 	assert.Len(t, rs, 1)
 	event := rs[0]
 
@@ -62,7 +63,8 @@ func TestTransform(t *testing.T) {
 	assert.Equal(t, "1", getStr(output, "service.version"))
 	assert.Equal(t, data["sourcemap"], getStr(output, "sourcemap"))
 
-	rs, err = NewProcessor(nil).Transform(nil)
-	assert.Nil(t, rs)
+	p = NewProcessor(config.Config{})
+	rs, err = p.Transform(nil)
 	assert.Equal(t, errors.New("Error fetching field"), err)
+	assert.Nil(t, rs)
 }

--- a/processor/transaction/benchmark_test.go
+++ b/processor/transaction/benchmark_test.go
@@ -3,11 +3,12 @@ package transaction
 import (
 	"testing"
 
+	"github.com/elastic/apm-server/config"
 	"github.com/elastic/apm-server/tests/loader"
 )
 
 func BenchmarkWithFileLoading(b *testing.B) {
-	processor := NewProcessor(nil)
+	processor := NewProcessor(config.Config{})
 	for i := 0; i < b.N; i++ {
 		data, _ := loader.LoadValidData("transaction")
 		err := processor.Validate(data)
@@ -19,7 +20,7 @@ func BenchmarkWithFileLoading(b *testing.B) {
 }
 
 func BenchmarkTransactionFileLoadingOnce(b *testing.B) {
-	processor := NewProcessor(nil)
+	processor := NewProcessor(config.Config{})
 	data, _ := loader.LoadValidData("transaction")
 	for i := 0; i < b.N; i++ {
 		err := processor.Validate(data)

--- a/processor/transaction/package_tests/json_schema_test.go
+++ b/processor/transaction/package_tests/json_schema_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fatih/set"
 
+	"github.com/elastic/apm-server/config"
 	"github.com/elastic/apm-server/processor/transaction"
 	"github.com/elastic/apm-server/tests"
 )
@@ -56,5 +57,5 @@ func TestTransactionPayloadSchema(t *testing.T) {
 		{File: "data/invalid/transaction_payload/no_service.json", Error: "missing properties: \"service\""},
 		{File: "data/invalid/transaction_payload/no_transactions.json", Error: "minimum 1 items allowed"},
 	}
-	tests.TestDataAgainstProcessor(t, transaction.NewProcessor(nil), testData)
+	tests.TestDataAgainstProcessor(t, transaction.NewProcessor(config.Config{}), testData)
 }

--- a/processor/transaction/package_tests/processor_test.go
+++ b/processor/transaction/package_tests/processor_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/elastic/apm-server/processor"
+	"github.com/elastic/apm-server/config"
 	"github.com/elastic/apm-server/processor/transaction"
 	"github.com/elastic/apm-server/tests"
 	"github.com/elastic/apm-server/tests/loader"
@@ -26,7 +26,7 @@ func TestTransactionProcessorOK(t *testing.T) {
 		{Name: "TestProcessTransactionEmpty", Path: "data/valid/transaction/transaction_empty_values.json"},
 		{Name: "TestProcessTransactionAugmentedIP", Path: "data/valid/transaction/augmented_payload_backend.json"},
 	}
-	tests.TestProcessRequests(t, transaction.NewProcessor(nil), requestInfo, map[string]string{})
+	tests.TestProcessRequests(t, transaction.NewProcessor, config.Config{}, requestInfo, map[string]string{})
 }
 
 func TestProcessorFrontendOK(t *testing.T) {
@@ -35,18 +35,18 @@ func TestProcessorFrontendOK(t *testing.T) {
 		{Name: "TestProcessTransactionAugmentedMerge", Path: "data/valid/transaction/augmented_payload_frontend.json"},
 		{Name: "TestProcessTransactionAugmented", Path: "data/valid/transaction/augmented_payload_frontend_no_context.json"},
 	}
-	conf := processor.Config{
+	conf := config.Config{
 		LibraryPattern:      regexp.MustCompile("/test/e2e|~"),
 		ExcludeFromGrouping: regexp.MustCompile("^~/test"),
 	}
-	tests.TestProcessRequests(t, transaction.NewProcessor(&conf), requestInfo, map[string]string{})
+	tests.TestProcessRequests(t, transaction.NewProcessor, conf, requestInfo, map[string]string{})
 }
 
 // ensure invalid documents fail the json schema validation already
 func TestTransactionProcessorValidationFailed(t *testing.T) {
 	data, err := loader.LoadInvalidData("transaction")
 	assert.Nil(t, err)
-	p := transaction.NewProcessor(nil)
+	p := transaction.NewProcessor(config.Config{})
 	err = p.Validate(data)
 	assert.NotNil(t, err)
 }

--- a/processor/transaction/payload_test.go
+++ b/processor/transaction/payload_test.go
@@ -9,8 +9,8 @@ import (
 
 	"time"
 
+	"github.com/elastic/apm-server/config"
 	m "github.com/elastic/apm-server/model"
-	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/beats/libbeat/common"
 )
 
@@ -232,7 +232,7 @@ func TestPayloadTransform(t *testing.T) {
 	}
 
 	for idx, test := range tests {
-		outputEvents := test.Payload.transform(&pr.Config{})
+		outputEvents := test.Payload.transform(config.Config{})
 		for j, outputEvent := range outputEvents {
 			assert.Equal(t, test.Output[j], outputEvent.Fields, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 			assert.Equal(t, timestamp, outputEvent.Timestamp)

--- a/processor/transaction/processor.go
+++ b/processor/transaction/processor.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/monitoring"
@@ -24,13 +25,13 @@ const (
 
 var schema = pr.CreateSchema(transactionSchema, processorName)
 
-func NewProcessor(config *pr.Config) pr.Processor {
+func NewProcessor(config config.Config) pr.Processor {
 	return &processor{schema: schema, config: config}
 }
 
 type processor struct {
 	schema *jsonschema.Schema
-	config *pr.Config
+	config config.Config
 }
 
 func (p *processor) Name() string {

--- a/processor/transaction/processor_test.go
+++ b/processor/transaction/processor_test.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
 )
 
 func TestImplementProcessorInterface(t *testing.T) {
-	p := NewProcessor(nil)
+	p := NewProcessor(config.Config{})
 	assert.NotNil(t, p)
 	_, ok := p.(pr.Processor)
 	assert.True(t, ok)

--- a/processor/transaction/span.go
+++ b/processor/transaction/span.go
@@ -3,8 +3,8 @@ package transaction
 import (
 	"errors"
 
+	"github.com/elastic/apm-server/config"
 	m "github.com/elastic/apm-server/model"
-	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/beats/libbeat/common"
 )
@@ -46,7 +46,7 @@ func DecodeSpan(input interface{}, err error) (*Span, error) {
 	return &sp, err
 }
 
-func (s *Span) Transform(config *pr.Config, service m.Service) common.MapStr {
+func (s *Span) Transform(config config.Config, service m.Service) common.MapStr {
 	if s == nil {
 		return nil
 	}

--- a/processor/transaction/span_test.go
+++ b/processor/transaction/span_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/apm-server/config"
 	m "github.com/elastic/apm-server/model"
-	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/apm-server/sourcemap"
 	"github.com/elastic/beats/libbeat/common"
 )
@@ -120,7 +120,7 @@ func TestSpanTransform(t *testing.T) {
 	}
 
 	for idx, test := range tests {
-		output := test.Span.Transform(&pr.Config{SmapMapper: &sourcemap.SmapMapper{}}, service)
+		output := test.Span.Transform(config.Config{SmapMapper: &sourcemap.SmapMapper{}}, service)
 		assert.Equal(t, test.Output, output, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 	}
 }

--- a/script/output_data/output_data.go
+++ b/script/output_data/output_data.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/elastic/apm-server/beater"
+	"github.com/elastic/apm-server/config"
 	"github.com/elastic/apm-server/tests/loader"
 )
 
@@ -33,7 +34,7 @@ func generate() error {
 			continue
 		}
 
-		p := mapping.ProcessorFactory(nil)
+		p := mapping.ProcessorFactory(config.Config{})
 
 		data, err := loader.LoadData(filepath.Join(basePath, p.Name(), filename))
 		if err != nil {

--- a/tests/approvals.go
+++ b/tests/approvals.go
@@ -12,7 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/yudai/gojsondiff"
 
-	"github.com/elastic/apm-server/processor"
+	"github.com/elastic/apm-server/config"
+	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/apm-server/tests/loader"
 	"github.com/elastic/beats/libbeat/common"
 )
@@ -93,12 +94,13 @@ type RequestInfo struct {
 	Path string
 }
 
-func TestProcessRequests(t *testing.T, p processor.Processor, requestInfo []RequestInfo, ignored map[string]string) {
+func TestProcessRequests(t *testing.T, pf func(config.Config) pr.Processor, config config.Config, requestInfo []RequestInfo, ignored map[string]string) {
 	assert := assert.New(t)
 	for _, info := range requestInfo {
 		data, err := loader.LoadData(info.Path)
 		assert.Nil(err)
 
+		p := pf(config)
 		err = p.Validate(data)
 		assert.NoError(err)
 

--- a/tests/fields.go
+++ b/tests/fields.go
@@ -9,6 +9,7 @@ import (
 	"github.com/fatih/set"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/apm-server/config"
 	"github.com/elastic/apm-server/processor"
 	"github.com/elastic/apm-server/tests/loader"
 	"github.com/elastic/beats/libbeat/common"
@@ -70,7 +71,7 @@ func TestDocumentedFieldsInEvent(t *testing.T, fieldPaths []string, fn processor
 }
 
 func fetchEventNames(fn processor.NewProcessor, blacklisted *set.Set) (*set.Set, error) {
-	p := fn(nil)
+	p := fn(config.Config{})
 	data, err := loader.LoadValidData(p.Name())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Use config.Config over processor.Config.  (#745)