### PR TITLE
[6.x] Split indices by `processor.event` instead of `name`. (#774)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,8 @@ https://github.com/elastic/apm-server/compare/4daa36bd5c144cf9182afc62dc8042af66
 - Change `concurrent_request` default from 40 to 5 {pull}731[731].
 - Change `max_unzipped_size` default from 50mb to 30mb {pull}731[731].
 - Change `read_timeout` and `write_timeout` defaults from 2s to 30s {pull}748[748], {pull}752[752].
+- Limit number of new connections to accept simultaneously {pull}751[751].
+- Push spans to separate ES index {pull}774[774].
 
 
 ==== Deprecated

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -66,9 +66,10 @@ output.elasticsearch:
   hosts: ["localhost:9200"]
 
   # By using the configuration below, apm documents are stored to separate indices, 
-  # depending on their `processor.name` or `processor.event`:
+  # depending on their `processor.event`:
   # - error
   # - transaction
+  # - span
   # - sourcemap (experimental feature)
   #
   # The indices are all prefixed with `apm-%{[beat.version]}`.
@@ -89,11 +90,15 @@ output.elasticsearch:
 
     - index: "apm-%{[beat.version]}-error-%{+yyyy.MM.dd}"
       when.contains:
-        processor.name: "error"
+        processor.event: "error"
 
     - index: "apm-%{[beat.version]}-transaction-%{+yyyy.MM.dd}"
       when.contains:
-        processor.name: "transaction"
+        processor.event: "transaction"
+
+    - index: "apm-%{[beat.version]}-span-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "span"
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -66,9 +66,10 @@ output.elasticsearch:
   hosts: ["localhost:9200"]
 
   # By using the configuration below, apm documents are stored to separate indices, 
-  # depending on their `processor.name` or `processor.event`:
+  # depending on their `processor.event`:
   # - error
   # - transaction
+  # - span
   # - sourcemap (experimental feature)
   #
   # The indices are all prefixed with `apm-%{[beat.version]}`.
@@ -89,11 +90,15 @@ output.elasticsearch:
 
     - index: "apm-%{[beat.version]}-error-%{+yyyy.MM.dd}"
       when.contains:
-        processor.name: "error"
+        processor.event: "error"
 
     - index: "apm-%{[beat.version]}-transaction-%{+yyyy.MM.dd}"
       when.contains:
-        processor.name: "transaction"
+        processor.event: "transaction"
+
+    - index: "apm-%{[beat.version]}-span-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "span"
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -142,11 +142,11 @@ class ElasticTest(ServerBaseTest):
         self.es = Elasticsearch([self.get_elasticsearch_url()])
 
         # Cleanup index and template first
-        self.es.indices.delete(index=self.index_name, ignore=[400, 404])
+        self.es.indices.delete(index="*", ignore=[400, 404])
         self.wait_until(lambda: not self.es.indices.exists(self.index_name))
 
         self.es.indices.delete_template(
-            name=self.index_name, ignore=[400, 404])
+            name="*", ignore=[400, 404])
         self.wait_until(
             lambda: not self.es.indices.exists_template(self.index_name))
 
@@ -305,13 +305,14 @@ class SplitIndicesTest(ElasticTest):
     @classmethod
     def setUpClass(cls):
         super(SplitIndicesTest, cls).setUpClass()
-
         cls.index_name_transaction = "test-apm-transaction-12-12-2017"
+        cls.index_name_span = "test-apm-span-12-12-2017"
         cls.index_name_error = "test-apm-error-12-12-2017"
 
     def config(self):
         cfg = super(SplitIndicesTest, self).config()
         cfg.update({"index_name_transaction": self.index_name_transaction,
+                    "index_name_span": self.index_name_span,
                     "index_name_error": self.index_name_error})
         return cfg
 

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -61,21 +61,32 @@ output.elasticsearch:
   hosts: ["{{ elasticsearch_host }}"]
 
   index: {{ index_name }}
-  {% if smap_index %}
+  {% if smap_index or index_name_transaction or index_name_span or index_name_error %}
   indices:
+  {% endif %}
+
+  {% if smap_index %}
     - index: {{ smap_index }}
       when.contains:
         processor.event: "sourcemap"
   {% endif %}
 
-  {% if index_name_transaction and index_name_error %}
-  indices:
+  {% if index_name_transaction %}
     - index: {{ index_name_transaction }}
       when.contains:
-        processor.name: "transaction"
+        processor.event: "transaction"
+  {% endif %}
+
+  {% if index_name_span %}
+    - index: {{ index_name_span }}
+      when.contains:
+        processor.event: "span"
+  {% endif %}
+
+  {% if index_name_error %}
     - index: {{ index_name_error }}
       when.contains:
-        processor.name: "error"
+        processor.event: "error"
   {% endif %}
 
 {% endif %}


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Split indices by `processor.event` instead of `name`.  (#774)