### PR TITLE
[6.x] limit number of new connections to accept simultaneously (#751)

### DIFF
--- a/_meta/beat.reference.yml
+++ b/_meta/beat.reference.yml
@@ -24,6 +24,9 @@ apm-server:
   # Maximum number of requests permitted to be sent to the server concurrently.
   #concurrent_requests: 5
 
+  # Maximum number of new connections to accept simultaneously (0 means unlimited)
+  # max_connections: 0
+
   # Authorization token to be checked. If a token is set here the agents must
   # send their token in the following format: Authorization: Bearer <secret-token>.
   # It is recommended to use an authorization token in combination with SSL enabled.

--- a/apm-server.reference.yml
+++ b/apm-server.reference.yml
@@ -24,6 +24,9 @@ apm-server:
   # Maximum number of requests permitted to be sent to the server concurrently.
   #concurrent_requests: 5
 
+  # Maximum number of new connections to accept simultaneously (0 means unlimited)
+  # max_connections: 0
+
   # Authorization token to be checked. If a token is set here the agents must
   # send their token in the following format: Authorization: Bearer <secret-token>.
   # It is recommended to use an authorization token in combination with SSL enabled.

--- a/beater/config.go
+++ b/beater/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	SecretToken         string          `config:"secret_token"`
 	SSL                 *SSLConfig      `config:"ssl"`
 	ConcurrentRequests  int             `config:"concurrent_requests" validate:"min=1"`
+	MaxConnections      int             `config:"max_connections"`
 	MaxRequestQueueTime time.Duration   `config:"max_request_queue_time"`
 	Expvar              *ExpvarConfig   `config:"expvar"`
 	Frontend            *FrontendConfig `config:"frontend"`
@@ -112,6 +113,7 @@ func defaultConfig(beatVersion string) *Config {
 		MaxUnzippedSize:     30 * 1024 * 1024, // 30mb
 		MaxHeaderSize:       1 * 1024 * 1024,  // 1mb
 		ConcurrentRequests:  5,
+		MaxConnections:      0, // unlimited
 		MaxRequestQueueTime: 2 * time.Second,
 		ReadTimeout:         30 * time.Second,
 		WriteTimeout:        30 * time.Second,

--- a/beater/server.go
+++ b/beater/server.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"net/http"
 
+	"golang.org/x/net/netutil"
+
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/version"
@@ -33,6 +35,11 @@ func run(server *http.Server, lis net.Listener, config *Config) error {
 		logger.Info("Frontend endpoints enabled!")
 	case false:
 		logger.Info("Frontend endpoints disabled")
+	}
+
+	if config.MaxConnections > 0 {
+		lis = netutil.LimitListener(lis, config.MaxConnections)
+		logger.Infof("connections limit set to: %d", config.MaxConnections)
 	}
 
 	ssl := config.SSL

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -215,6 +215,8 @@ func TestServerBadProtocol(t *testing.T) {
 }
 
 func TestServerTcpConnLimit(t *testing.T) {
+	t.Skip("tcp conn limit test disabled")
+
 	if testing.Short() {
 		t.Skip("skipping tcp conn limit test")
 	}

--- a/vendor/golang.org/x/net/netutil/listen.go
+++ b/vendor/golang.org/x/net/netutil/listen.go
@@ -1,0 +1,48 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package netutil provides network utility functions, complementing the more
+// common ones in the net package.
+package netutil // import "golang.org/x/net/netutil"
+
+import (
+	"net"
+	"sync"
+)
+
+// LimitListener returns a Listener that accepts at most n simultaneous
+// connections from the provided Listener.
+func LimitListener(l net.Listener, n int) net.Listener {
+	return &limitListener{l, make(chan struct{}, n)}
+}
+
+type limitListener struct {
+	net.Listener
+	sem chan struct{}
+}
+
+func (l *limitListener) acquire() { l.sem <- struct{}{} }
+func (l *limitListener) release() { <-l.sem }
+
+func (l *limitListener) Accept() (net.Conn, error) {
+	l.acquire()
+	c, err := l.Listener.Accept()
+	if err != nil {
+		l.release()
+		return nil, err
+	}
+	return &limitListenerConn{Conn: c, release: l.release}, nil
+}
+
+type limitListenerConn struct {
+	net.Conn
+	releaseOnce sync.Once
+	release     func()
+}
+
+func (l *limitListenerConn) Close() error {
+	err := l.Conn.Close()
+	l.releaseOnce.Do(l.release)
+	return err
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1793,6 +1793,12 @@
 			"revisionTime": "2018-03-22T18:04:37Z"
 		},
 		{
+			"checksumSHA1": "whCSspa9pYarl527EuhPz91cbUE=",
+			"path": "golang.org/x/net/netutil",
+			"revision": "6078986fec03a1dcc236c34816c71b0e05018fda",
+			"revisionTime": "2017-09-09T04:35:08Z"
+		},
+		{
 			"checksumSHA1": "QEm/dePZ0lOnyOs+m22KjXfJ/IU=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/proxy",
 			"path": "golang.org/x/net/proxy",


### PR DESCRIPTION
Backports the following commits to 6.x:
 - limit number of new connections to accept simultaneously  (#751)
 - disable conn limit test (#781)