### PR TITLE
disable conn limit test

### DIFF
--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -215,6 +215,8 @@ func TestServerBadProtocol(t *testing.T) {
 }
 
 func TestServerTcpConnLimit(t *testing.T) {
+	t.Skip("tcp conn limit test disabled")
+
 	if testing.Short() {
 		t.Skip("skipping tcp conn limit test")
 	}


### PR DESCRIPTION
even with room for error, this has not been passing consistently across platforms.  Disabling for now.