### PR TITLE
[6.x] handle large integers in json (#783)

### DIFF
--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -1,33 +1,32 @@
-package decoder
+package decoder_test
 
 import (
 	"bytes"
 	"compress/gzip"
-	"encoding/json"
 	"io"
+	"io/ioutil"
+	"mime/multipart"
 	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"mime/multipart"
-
+	"github.com/elastic/apm-server/decoder"
 	"github.com/elastic/apm-server/tests/loader"
 )
 
 func TestDecode(t *testing.T) {
 	transactionBytes, err := loader.LoadValidDataAsBytes("transaction")
 	assert.Nil(t, err)
-	buffer := bytes.NewReader(transactionBytes)
-	var data map[string]interface{}
-	json.Unmarshal(transactionBytes, &data)
+	data, err := decoder.DecodeJSONData(ioutil.NopCloser(bytes.NewReader(transactionBytes)))
+	assert.Nil(t, err)
 
-	req, err := http.NewRequest("POST", "_", buffer)
+	req, err := http.NewRequest("POST", "_", bytes.NewReader(transactionBytes))
 	req.Header.Add("Content-Type", "application/json")
 	assert.Nil(t, err)
 
-	body, err := DecodeLimitJSONData(1024 * 1024)(req)
+	body, err := decoder.DecodeLimitJSONData(1024 * 1024)(req)
 	assert.Nil(t, err)
 	assert.Equal(t, data, body)
 }
@@ -35,15 +34,14 @@ func TestDecode(t *testing.T) {
 func TestDecodeContentType(t *testing.T) {
 	transactionBytes, err := loader.LoadValidDataAsBytes("transaction")
 	assert.Nil(t, err)
-	buffer := bytes.NewReader(transactionBytes)
-	var data map[string]interface{}
-	json.Unmarshal(transactionBytes, &data)
+	data, err := decoder.DecodeJSONData(ioutil.NopCloser(bytes.NewReader(transactionBytes)))
+	assert.Nil(t, err)
 
-	req, err := http.NewRequest("POST", "_", buffer)
+	req, err := http.NewRequest("POST", "_", bytes.NewReader(transactionBytes))
 	req.Header.Add("Content-Type", "application/json; charset=UTF-8")
 	assert.Nil(t, err)
 
-	body, err := DecodeLimitJSONData(1024 * 1024)(req)
+	body, err := decoder.DecodeLimitJSONData(1024 * 1024)(req)
 	assert.Nil(t, err)
 	assert.Equal(t, data, body)
 }
@@ -57,11 +55,11 @@ func TestDecodeSizeLimit(t *testing.T) {
 	}
 
 	// just fits
-	_, err := DecodeLimitJSONData(2)(minimalValid())
+	_, err := decoder.DecodeLimitJSONData(2)(minimalValid())
 	assert.Nil(t, err)
 
 	// too large, should not be EOF
-	_, err = DecodeLimitJSONData(1)(minimalValid())
+	_, err = decoder.DecodeLimitJSONData(1)(minimalValid())
 	assert.NotNil(t, err)
 	assert.NotEqual(t, err, io.EOF)
 }
@@ -91,10 +89,10 @@ func TestDecodeSizeLimitGzip(t *testing.T) {
 		t.Fatal("compressed data unexpectedly big")
 	}
 	/// uncompressed just fits
-	_, err := DecodeLimitJSONData(40)(gzipRequest(bigDataGz))
+	_, err := decoder.DecodeLimitJSONData(40)(gzipRequest(bigDataGz))
 	assert.Nil(t, err)
 	/// uncompressed too big
-	_, err = DecodeLimitJSONData(1)(gzipRequest(bigDataGz))
+	_, err = decoder.DecodeLimitJSONData(1)(gzipRequest(bigDataGz))
 	assert.NotNil(t, err)
 	assert.NotEqual(t, err, io.EOF)
 
@@ -105,10 +103,10 @@ func TestDecodeSizeLimitGzip(t *testing.T) {
 		t.Fatal("compressed data unexpectedly small")
 	}
 	/// uncompressed just fits
-	_, err = DecodeLimitJSONData(2)(gzipRequest(tinyDataGz))
+	_, err = decoder.DecodeLimitJSONData(2)(gzipRequest(tinyDataGz))
 	assert.Nil(t, err)
 	/// uncompressed too big
-	_, err = DecodeLimitJSONData(1)(gzipRequest(tinyDataGz))
+	_, err = decoder.DecodeLimitJSONData(1)(gzipRequest(tinyDataGz))
 	assert.NotNil(t, err)
 	assert.NotEqual(t, err, io.EOF)
 }
@@ -137,7 +135,7 @@ func TestDecodeSourcemapFormData(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.NoError(t, err)
-	data, err := DecodeSourcemapFormData(req)
+	data, err := decoder.DecodeSourcemapFormData(req)
 	assert.NoError(t, err)
 
 	assert.Len(t, data, 4)
@@ -160,7 +158,7 @@ func TestDecodeSystemData(t *testing.T) {
 		req.Header.Add("Content-Type", "application/json")
 		assert.Nil(t, err)
 
-		body, err := DecodeSystemData(DecodeLimitJSONData(1024*1024), enabled)(req)
+		body, err := decoder.DecodeSystemData(decoder.DecodeLimitJSONData(1024*1024), enabled)(req)
 		assert.Nil(t, err)
 
 		system, hasSystem := body["system"].(map[string]interface{})
@@ -182,7 +180,7 @@ func TestDecodeUserData(t *testing.T) {
 		req.Header.Add("Content-Type", "application/json")
 		assert.Nil(t, err)
 
-		body, err := DecodeUserData(DecodeLimitJSONData(1024*1024), enabled)(req)
+		body, err := decoder.DecodeUserData(decoder.DecodeLimitJSONData(1024*1024), enabled)(req)
 		assert.Nil(t, err)
 		user, hasUser := body["user"].(map[string]interface{})
 		assert.Equal(t, enabled, hasUser)

--- a/docs/data/intake-api/generated/transaction/minimal_span.json
+++ b/docs/data/intake-api/generated/transaction/minimal_span.json
@@ -14,6 +14,7 @@
             "timestamp": "2017-05-30T18:53:27.154Z",
             "spans": [
                 {
+                    "id": 100000000000,
                     "name": "GET /api/types",
                     "type": "request",
                     "start": 0,

--- a/processor/error/event.go
+++ b/processor/error/event.go
@@ -3,6 +3,7 @@ package error
 import (
 	"crypto/md5"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash"
@@ -165,13 +166,15 @@ func (e *Event) addException(config config.Config, service m.Service) {
 	utility.Add(ex, "type", e.Exception.Type)
 	utility.Add(ex, "handled", e.Exception.Handled)
 
-	switch e.Exception.Code.(type) {
+	switch code := e.Exception.Code.(type) {
 	case int:
-		utility.Add(ex, "code", strconv.Itoa(e.Exception.Code.(int)))
+		utility.Add(ex, "code", strconv.Itoa(code))
 	case float64:
-		utility.Add(ex, "code", fmt.Sprintf("%.0f", e.Exception.Code))
+		utility.Add(ex, "code", fmt.Sprintf("%.0f", code))
 	case string:
-		utility.Add(ex, "code", e.Exception.Code.(string))
+		utility.Add(ex, "code", code)
+	case json.Number:
+		utility.Add(ex, "code", code.String())
 	}
 
 	st := e.Exception.Stacktrace.Transform(config, service)

--- a/processor/transaction/package_tests/TestProcessTransactionMinimalSpan.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionMinimalSpan.approved.json
@@ -43,6 +43,7 @@
                 "duration": {
                     "us": 32592
                 },
+                "id": 100000000000,
                 "name": "GET /api/types",
                 "start": {
                     "us": 0

--- a/tests/data/valid/transaction/minimal_span.json
+++ b/tests/data/valid/transaction/minimal_span.json
@@ -14,6 +14,7 @@
             "timestamp": "2017-05-30T18:53:27.154Z",
             "spans": [
                 {
+                    "id": 100000000000,
                     "name": "GET /api/types",
                     "type": "request",
                     "start": 0,

--- a/utility/data_fetcher.go
+++ b/utility/data_fetcher.go
@@ -1,6 +1,7 @@
 package utility
 
 import (
+	"encoding/json"
 	"errors"
 	"time"
 
@@ -19,7 +20,14 @@ func (d *ManualDecoder) Float64(base map[string]interface{}, key string, keys ..
 	val := getDeep(base, keys...)[key]
 	if valFloat, ok := val.(float64); ok {
 		return valFloat
+	} else if valNumber, ok := val.(json.Number); ok {
+		if valFloat, err := valNumber.Float64(); err != nil {
+			d.Err = err
+		} else {
+			return valFloat
+		}
 	}
+
 	d.Err = fetchErr
 	return 0.0
 }
@@ -28,6 +36,13 @@ func (d *ManualDecoder) IntPtr(base map[string]interface{}, key string, keys ...
 	val := getDeep(base, keys...)[key]
 	if val == nil {
 		return nil
+	} else if valNumber, ok := val.(json.Number); ok {
+		if valInt, err := valNumber.Int64(); err != nil {
+			d.Err = err
+		} else {
+			i := int(valInt)
+			return &i
+		}
 	} else if valFloat, ok := val.(float64); ok {
 		valInt := int(valFloat)
 		if valFloat == float64(valInt) {

--- a/utility/map_str_enhancer.go
+++ b/utility/map_str_enhancer.go
@@ -1,6 +1,7 @@
 package utility
 
 import (
+	"encoding/json"
 	"reflect"
 
 	"github.com/elastic/beats/libbeat/common"
@@ -15,7 +16,7 @@ func Add(m common.MapStr, key string, val interface{}) {
 		return
 	}
 
-	switch val.(type) {
+	switch value := val.(type) {
 	case *bool:
 		if newVal := val.(*bool); newVal != nil {
 			m[key] = *newVal
@@ -59,6 +60,12 @@ func Add(m common.MapStr, key string, val interface{}) {
 			}
 		} else {
 			delete(m, key)
+		}
+	case json.Number:
+		if floatVal, err := value.Float64(); err != nil {
+			Add(m, key, value.String())
+		} else {
+			Add(m, key, floatVal)
 		}
 	case float64:
 		floatVal := val.(float64)


### PR DESCRIPTION
Backports the following commits to 6.x:
 - handle large integers in json  (#783)