### PR TITLE
[6.x] Clarify semantics of request.url.raw (#785)

### DIFF
--- a/docs/spec/request.json
+++ b/docs/spec/request.json
@@ -58,7 +58,7 @@
             "properties": {
                 "raw": {
                     "type": ["string", "null"],
-                    "description": "The raw, unparsed URL of the request, e.g https://example.com:443/search?q=elasticsearch#top.",
+                    "description": "The raw, unparsed URL of the HTTP request line, e.g https://example.com:443/search?q=elasticsearch. This URL may be absolute or relative. For more details, see https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.2.",
                     "maxLength": 1024
                 },
                 "protocol": {

--- a/processor/error/schema.go
+++ b/processor/error/schema.go
@@ -236,7 +236,7 @@ var errorSchema = `{
             "properties": {
                 "raw": {
                     "type": ["string", "null"],
-                    "description": "The raw, unparsed URL of the request, e.g https://example.com:443/search?q=elasticsearch#top.",
+                    "description": "The raw, unparsed URL of the HTTP request line, e.g https://example.com:443/search?q=elasticsearch. This URL may be absolute or relative. For more details, see https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.2.",
                     "maxLength": 1024
                 },
                 "protocol": {

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -259,7 +259,7 @@ var transactionSchema = `{
             "properties": {
                 "raw": {
                     "type": ["string", "null"],
-                    "description": "The raw, unparsed URL of the request, e.g https://example.com:443/search?q=elasticsearch#top.",
+                    "description": "The raw, unparsed URL of the HTTP request line, e.g https://example.com:443/search?q=elasticsearch. This URL may be absolute or relative. For more details, see https://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.2.",
                     "maxLength": 1024
                 },
                 "protocol": {


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Clarify semantics of request.url.raw  (#785)