### PR TITLE
[6.x] target for clean and docs together (make docs without removing '/build' first behaves in a unexpected way) (#624)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,3 +86,6 @@ check-full: check
 notice: python-env
 	@echo "Generating NOTICE"
 	@$(PYTHON_ENV)/bin/python ${ES_BEATS}/dev-tools/generate_notice.py . -e '_beats' -s "./vendor/github.com/elastic/beats" -b "Apm Server"
+
+.PHONY: force-update-docs
+force-update-docs: clean docs


### PR DESCRIPTION
Backports the following commits to 6.x:
 - target for clean and docs together (make docs without removing '/build' first behaves in a unexpected way)  (#624)