### PR TITLE
Update docs copied from beats.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,3 +89,12 @@ notice: python-env
 
 .PHONY: force-update-docs
 force-update-docs: clean docs
+
+.PHONY: update-beats-docs
+update-beats-docs:
+	@python script/copy-docs.py
+
+	@sed -i '' 's/If you plan to monitor {beatname_uc} in Kibana, you must also//' docs/copied-from-beats/security/securing-beats.asciidoc
+	@sed -i '' 's/<<beats-system-user,configure the `beats_system` built-in user>>.//' docs/copied-from-beats/security/securing-beats.asciidoc
+	@sed -i '' 's/include::beats-system.asciidoc\[\]//' docs/copied-from-beats/security/securing-beats.asciidoc
+	@$(MAKE) docs 

--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,4 @@ force-update-docs: clean docs
 .PHONY: update-beats-docs
 update-beats-docs:
 	@python script/copy-docs.py
-
-	@sed -i '' 's/If you plan to monitor {beatname_uc} in Kibana, you must also//' docs/copied-from-beats/security/securing-beats.asciidoc
-	@sed -i '' 's/<<beats-system-user,configure the `beats_system` built-in user>>.//' docs/copied-from-beats/security/securing-beats.asciidoc
-	@sed -i '' 's/include::beats-system.asciidoc\[\]//' docs/copied-from-beats/security/securing-beats.asciidoc
 	@$(MAKE) docs 

--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -172,7 +172,7 @@ Specifies the name of the command to show help for.
 [[keystore-command]]
 ==== `keystore` command
 
-{keystore-command-short-desc}.
+{keystore-command-short-desc}. 
 
 *SYNOPSIS*
 
@@ -397,10 +397,10 @@ ifeval::["{beatname_lc}"=="filebeat"]
 
 *`--once`*::
 When the `--once` flag is used, {beatname_uc} starts all configured harvesters
-and prospectors, and runs each prospector until the harvesters are closed. If
-you set the `--once` flag, you should also set `close_eof` so the harvester is
-closed when the end of the file is reached. By default harvesters are closed
-after `close_inactive` is reached.
+and inputs, and runs each input until the harvesters are closed. If you set the
+`--once` flag, you should also set `close_eof` so the harvester is closed when
+the end of the file is reached. By default harvesters are closed after
+`close_inactive` is reached.
 
 endif::[]
 

--- a/docs/copied-from-beats/keystore.asciidoc
+++ b/docs/copied-from-beats/keystore.asciidoc
@@ -10,7 +10,11 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[keystore]]
-=== Secrets keystore
+=== Secrets keystore for secure settings
+
+++++
+<titleabbrev>Secrets keystore</titleabbrev>
+++++
 
 When you configure {beatname_uc}, you might need to specify sensitive settings,
 such as passwords. Rather than relying on file system permissions to protect

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -14,8 +14,8 @@
 == Configure the output
 
 ifdef::only-elasticsearch[]
-You configure {beatname_uc} to write to Elasticsearch by setting options in
-the `output.elasticsearch` of the +{beatname_lc}.yml+ config file.
+You configure {beatname_uc} to write to Elasticsearch by setting options 
+in the `output.elasticsearch` section of the +{beatname_lc}.yml+ config file
 endif::[]
 
 ifndef::only-elasticsearch[]
@@ -81,7 +81,9 @@ output.elasticsearch:
 
 ==== Compatibility
 
-This output works with all compatible versions of Elasticsearch. See "Supported Beats Versions" in the https://www.elastic.co/support/matrix#show_compatibility[Elastic Support Matrix].
+This output works with all compatible versions of Elasticsearch. See the
+https://www.elastic.co/support/matrix#matrix_compatibility[Elastic Support
+Matrix].
 
 ==== Configuration options
 
@@ -132,6 +134,8 @@ The default value is 0.
 The number of workers per configured host publishing events to Elasticsearch. This
 is best used with load balancing mode enabled. Example: If you have 2 hosts and
 3 workers, in total 6 workers are started (3 for each host).
+
+The default value is 1.
 
 ===== `username`
 
@@ -254,11 +258,13 @@ Example elasticsearch output with `pipelines`:
 
 ["source","yaml"]
 ------------------------------------------------------------------------------
-filebeat.prospectors:
-- paths: ["/var/log/app/normal/*.log"]
+filebeat.inputs:
+- type: log
+  paths: ["/var/log/app/normal/*.log"]
   fields:
     type: "normal"
-- paths: ["/var/log/app/critical/*.log"]
+- type: log
+  paths: ["/var/log/app/critical/*.log"]
   fields:
     type: "critical"
 
@@ -283,6 +289,7 @@ After the specified number of retries, the events are typically dropped.
 ifeval::["{beatname_lc}" == "filebeat"]
 Filebeat will ignore the `max_retries` setting and retry until all
 events are published.
+endif::[]
 ifeval::["{beatname_lc}" != "filebeat"]
 Set `max_retries` to a value less than 0 to retry until all events are published.
 endif::[]
@@ -396,7 +403,9 @@ will be similar to events directly indexed by Beats into Elasticsearch.
 
 ==== Compatibility
 
-This output works with all compatible versions of Logstash. See "Supported Beats Versions" in the https://www.elastic.co/support/matrix#show_compatibility[Elastic Support Matrix].
+This output works with all compatible versions of Logstash. See the
+https://www.elastic.co/support/matrix#matrix_compatibility[Elastic Support
+Matrix].
 
 ==== Configuration options
 
@@ -443,6 +452,14 @@ load balances published events onto all Logstash hosts. If set to false,
 the output plugin sends all events to only one host (determined at random) and
 will switch to another host if the selected one becomes unresponsive. The default value is false.
 
+["source","yaml",subs="attributes"]
+------------------------------------------------------------------------------
+output.logstash:
+  hosts: ["localhost:5044", "localhost:5045"]
+  loadbalance: true
+  index: {beatname_lc}
+------------------------------------------------------------------------------
+
 ===== `ttl`
 
 Time to live for a connection to Logstash after which the connection will be re-established.
@@ -455,20 +472,12 @@ The default value is 0.
 
 NOTE: The "ttl" option is not yet supported on an async Logstash client (one with the "pipelining" option set).
 
-["source","yaml",subs="attributes"]
-------------------------------------------------------------------------------
-output.logstash:
-  hosts: ["localhost:5044", "localhost:5045"]
-  loadbalance: true
-  index: {beatname_lc}
-------------------------------------------------------------------------------
-
 ===== `pipelining`
 
 Configures number of batches to be sent asynchronously to logstash while waiting
 for ACK from logstash. Output only becomes blocking once number of `pipelining`
 batches have been written. Pipelining is disabled if a values of 0 is
-configured. The default value is 5.
+configured. The default value is 2.
 
 [[port]]
 ===== `port`
@@ -530,6 +539,7 @@ After the specified number of retries, the events are typically dropped.
 ifeval::["{beatname_lc}" == "filebeat"]
 Filebeat will ignore the `max_retries` setting and retry until all
 events are published.
+endif::[]
 ifeval::["{beatname_lc}" != "filebeat"]
 Set `max_retries` to a value less than 0 to retry until all events are published.
 endif::[]
@@ -724,6 +734,8 @@ After the specified number of retries, the events are typically dropped.
 ifeval::["{beatname_lc}" == "filebeat"]
 Filebeat will ignore the `max_retries` setting and retry until all
 events are published.
+endif::[]
+
 ifeval::["{beatname_lc}" != "filebeat"]
 Set `max_retries` to a value less than 0 to retry until all events are published.
 endif::[]
@@ -949,6 +961,7 @@ After the specified number of retries, the events are typically dropped.
 ifeval::["{beatname_lc}" == "filebeat"]
 Filebeat will ignore the `max_retries` setting and retry until all
 events are published.
+endif::[]
 ifeval::["{beatname_lc}" != "filebeat"]
 Set `max_retries` to a value less than 0 to retry until all events are published.
 endif::[]

--- a/docs/copied-from-beats/repositories.asciidoc
+++ b/docs/copied-from-beats/repositories.asciidoc
@@ -49,12 +49,22 @@ wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo apt-key add
 sudo apt-get install apt-transport-https
 --------------------------------------------------
 
+ifeval::["{release-state}"=="prerelease"]
 . Save the repository definition to  +/etc/apt/sources.list.d/elastic-6.x-prerelease.list+:
 +
-["source","sh",subs="attributes,callouts"]
+["source","sh",subs="attributes"]
 --------------------------------------------------
 echo "deb https://artifacts.elastic.co/packages/6.x-prerelease/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x-prerelease.list
 --------------------------------------------------
+endif::[]
+ifeval::["{release-state}"=="released"]
+. Save the repository definition to  +/etc/apt/sources.list.d/elastic-6.x.list+:
++
+["source","sh",subs="attributes"]
+--------------------------------------------------
+echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list
+--------------------------------------------------
+endif::[]
 +
 [WARNING]
 ==================================================
@@ -78,7 +88,7 @@ install {beatname_uc} by running:
 sudo apt-get update && sudo apt-get install {beatname_pkg}
 --------------------------------------------------
 
-. To configure the Beat to start automatically during boot, run:
+. To configure {beatname_uc} to start automatically during boot, run:
 +
 ["source","sh",subs="attributes"]
 --------------------------------------------------
@@ -110,7 +120,8 @@ sudo rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch
 . Create a file with a `.repo` extension (for example, `elastic.repo`) in
 your `/etc/yum.repos.d/` directory and add the following lines:
 +
-["source","sh",subs="attributes,callouts"]
+ifeval::["{release-state}"=="prerelease"]
+["source","sh",subs="attributes"]
 --------------------------------------------------
 [elastic-6.x-prerelease]
 name=Elastic repository for 6.x prerelease packages
@@ -121,6 +132,20 @@ enabled=1
 autorefresh=1
 type=rpm-md
 --------------------------------------------------
+endif::[]
+ifeval::["{release-state}"=="released"]
+["source","sh",subs="attributes"]
+--------------------------------------------------
+[elastic-6.x]
+name=Elastic repository for 6.x packages
+baseurl=https://artifacts.elastic.co/packages/6.x/yum
+gpgcheck=1
+gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+enabled=1
+autorefresh=1
+type=rpm-md
+--------------------------------------------------
+endif::[]
 +
 Your repository is ready to use. For example, you can install {beatname_uc} by
 running:
@@ -138,3 +163,4 @@ sudo chkconfig --add {beatname_pkg}
 --------------------------------------------------
 
 endif::[]
+

--- a/docs/copied-from-beats/security/basic-auth.asciidoc
+++ b/docs/copied-from-beats/security/basic-auth.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[beats-basic-auth]]
-=== Configuring Authentication Credentials for {beatname_uc}
+=== Configuring authentication credentials for {beatname_uc}
 
 When sending data to a secured cluster through the `elasticsearch`
 output, {beatname_uc} must either provide basic authentication credentials

--- a/docs/copied-from-beats/security/securing-beats.asciidoc
+++ b/docs/copied-from-beats/security/securing-beats.asciidoc
@@ -17,9 +17,13 @@ In addition to configuring authentication credentials for the {beatname_uc}
 itself, you need to grant authorized users permission to access the indices it
 creates. See <<beats-user-access>>.
 
+ 
+
+
 For more information about {security}, see
 {xpack-ref}/xpack-security.html[Securing {es} and {kib}].
 
 include::basic-auth.asciidoc[]
 include::user-access.asciidoc[]
 include::tls.asciidoc[]
+

--- a/docs/copied-from-beats/security/securing-beats.asciidoc
+++ b/docs/copied-from-beats/security/securing-beats.asciidoc
@@ -17,8 +17,10 @@ In addition to configuring authentication credentials for the {beatname_uc}
 itself, you need to grant authorized users permission to access the indices it
 creates. See <<beats-user-access>>.
 
- 
-
+ifeval::["{beatname_lc}"!="apm-server"]
+If you plan to monitor {beatname_uc} in Kibana, you must also 
+<<beats-system-user,configure the `beats_system` built-in user>>.
+endif::[]
 
 For more information about {security}, see
 {xpack-ref}/xpack-security.html[Securing {es} and {kib}].
@@ -26,4 +28,6 @@ For more information about {security}, see
 include::basic-auth.asciidoc[]
 include::user-access.asciidoc[]
 include::tls.asciidoc[]
-
+ifeval::["{beatname_lc}"!="apm-server"]
+include::beats-system.asciidoc[]
+endif::[]

--- a/docs/copied-from-beats/security/tls.asciidoc
+++ b/docs/copied-from-beats/security/tls.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[beats-tls]]
-=== Configuring {beatname_uc} to use Encrypted Connections
+=== Configuring {beatname_uc} to use encrypted connections
 
 If encryption is enabled on the {es} cluster, you need to connect to {es} via
 HTTPS. If the certificate authority (CA) that signed your node certificates

--- a/docs/copied-from-beats/security/user-access.asciidoc
+++ b/docs/copied-from-beats/security/user-access.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[beats-user-access]]
-=== Granting Users Access to {beatname_uc} Indices
+=== Granting users access to {beatname_uc} indices
 
 To enable users to access the indices a {beatname_uc} creates, grant them `read`
 and `view_index_metadata` privileges on the {beatname_uc} indices:

--- a/docs/copied-from-beats/shared-directory-layout.asciidoc
+++ b/docs/copied-from-beats/shared-directory-layout.asciidoc
@@ -59,7 +59,7 @@ Otherwise the paths might be set incorrectly.
 | bin    | The location for the binary files. | /usr/share/{beatname_lc}
 | config | The location for configuration files. | /usr/share/{beatname_lc}
 | data   | The location for persistent data files. | /usr/share/{beatname_lc}/data
-| logs   | The location for the logs created by {beatname_uc}. | /usr/share//{beatname_lc}/logs
+| logs   | The location for the logs created by {beatname_uc}. | /usr/share/{beatname_lc}/logs
 |=======================================================================
 
 endif::[]

--- a/docs/copied-from-beats/shared-docker.asciidoc
+++ b/docs/copied-from-beats/shared-docker.asciidoc
@@ -51,6 +51,8 @@ docker run \
 It's possible to embed your {beatname_uc} configuration in a custom image.
 Here is an example Dockerfile to achieve this:
 
+ifeval::["{beatname_lc}"!="auditbeat"]
+
 ["source", "dockerfile", subs="attributes"]
 --------------------------------------------
 FROM {dockerimage}
@@ -59,3 +61,15 @@ USER root
 RUN chown {beatname_lc} /usr/share/{beatname_lc}/{beatname_lc}.yml
 USER {beatname_lc}
 --------------------------------------------
+
+endif::[]
+
+ifeval::["{beatname_lc}"=="auditbeat"]
+
+["source", "dockerfile", subs="attributes"]
+--------------------------------------------
+FROM {dockerimage}
+COPY {beatname_lc}.yml /usr/share/{beatname_lc}/{beatname_lc}.yml
+--------------------------------------------
+
+endif::[]

--- a/docs/copied-from-beats/shared-env-vars.asciidoc
+++ b/docs/copied-from-beats/shared-env-vars.asciidoc
@@ -49,7 +49,7 @@ If you need to use a literal `${` in your configuration file then you can write
 `$${` to escape the expansion.
 
 After changing the value of an environment variable, you need to restart
-the Beat to pick up the new value.
+{beatname_uc} to pick up the new value.
 
 [NOTE]
 ==================================
@@ -104,7 +104,7 @@ output.elasticsearch:
   hosts: '${ES_HOSTS}'
 -------------------------------------------------------------------------------
 
-When the Beat loads the config file, it resolves the environment variable and
+When {beatname_uc} loads the config file, it resolves the environment variable and
 replaces it with the specified list before reading the `hosts` setting.
 
 NOTE: Do not use double-quotes (`"`) to wrap regular expressions, or the backslash (`\`) will be interpreted as an escape character.

--- a/docs/copied-from-beats/shared-path-config.asciidoc
+++ b/docs/copied-from-beats/shared-path-config.asciidoc
@@ -14,10 +14,12 @@
 == Set up project paths
 
 The `path` section of the +{beatname_lc}.yml+ config file contains configuration
-options that define where the Beat looks for its files. For example, all Beats
-look for the Elasticsearch template file in the configuration path, Filebeat and
-Winlogbeat look for their registry files in the data path, and all Beats write
-their log files in the logs path.
+options that define where {beatname_lc} looks for its files. For example, {beatname_uc}
+looks for the Elasticsearch template file in the configuration path and writes
+log files in the logs path.
+ifeval::["{beatname_lc}"=="filebeat" or "{beatname_lc}"=="winlogbeat"]
+Filebeat and Winlogbeat look for their registry files in the data path.
+endif::[]
 
 Please see the <<directory-layout>> section for more details.
 
@@ -87,7 +89,7 @@ path.data: /var/lib/beats
 [float]
 ==== `logs`
 
-The logs path for a {beatname_uc} installation. This is the default location for the Beat's
+The logs path for a {beatname_uc} installation. This is the default location for {beatname_uc}'s
 log files. If not set by a CLI flag or in the configuration file, the default
 for the logs path is a `logs` subdirectory inside the home path.
 

--- a/docs/copied-from-beats/shared-ssl-config.asciidoc
+++ b/docs/copied-from-beats/shared-ssl-config.asciidoc
@@ -1,5 +1,5 @@
 [[configuration-ssl]]
-== SSL settings for outputs
+== Specify SSL settings
 
 You can specify SSL options for any <<configuring-output,output>> that supports
 SSL. You can also specify SSL options when you

--- a/docs/copied-from-beats/shared-template-load.asciidoc
+++ b/docs/copied-from-beats/shared-template-load.asciidoc
@@ -211,7 +211,7 @@ PS > Invoke-RestMethod -Method Delete "http://localhost:9200/{beatname_lc}-*"
 ----------------------------------------------------------------------
 
 
-This command deletes all indices that match the pattern +{beatname_lc}-*+.
+This command deletes all indices that match the pattern +{beat_default_index_prefix}-*+.
 Before running this command, make sure you want to delete all indices that match
 the pattern.
 

--- a/docs/copied-from-beats/template-config.asciidoc
+++ b/docs/copied-from-beats/template-config.asciidoc
@@ -23,7 +23,7 @@ existing one.
 you must <<load-template-manually,load the template manually>>.
 
 *`setup.template.name`*:: The name of the template. The default is
-+{beatname_lc}-*+. The {beatname_uc} version is always appended to the given
++{beatname_lc}+. The {beatname_uc} version is always appended to the given
 name, so the final name is +{beatname_lc}-%\{[beat.version]\}+.
 
 // Maintainers: a backslash character is required to escape curly braces and
@@ -82,3 +82,7 @@ setup.template.overwrite: false
 setup.template.settings:
   _source.enabled: false
 ----------------------------------------------------------------------
+
+*`setup.template.append_fields`*:: A list of of fields to be added to the template and Kibana index pattern. experimental[]
+
+NOTE: With append_fields only new fields can be added an no existing one overwritten or changed. This is especially useful if data is collected through the http/json metricset where the data structure is not known in advance. Changing the config of append_fields means the template has to be overwritten and only applies to new indices. If there are 2 Beats with different append_fields configs the last one writing the template will win. Any changes will also have an affect on the Kibana Index pattern.

--- a/docs/copied-from-beats/template-config.asciidoc
+++ b/docs/copied-from-beats/template-config.asciidoc
@@ -82,7 +82,8 @@ setup.template.overwrite: false
 setup.template.settings:
   _source.enabled: false
 ----------------------------------------------------------------------
-
+ifeval::["{beatname_lc}"!="apm-server"]
 *`setup.template.append_fields`*:: A list of of fields to be added to the template and Kibana index pattern. experimental[]
 
 NOTE: With append_fields only new fields can be added an no existing one overwritten or changed. This is especially useful if data is collected through the http/json metricset where the data structure is not known in advance. Changing the config of append_fields means the template has to be overwritten and only applies to new indices. If there are 2 Beats with different append_fields configs the last one writing the template will win. Any changes will also have an affect on the Kibana Index pattern.
+endif::[]

--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -92,4 +92,4 @@ include::./copied-from-beats/command-reference.asciidoc[]
 
 include::./copied-from-beats/shared-directory-layout.asciidoc[]
 
-include::./copied-from-beats/running-on-docker.asciidoc[]
+include::./copied-from-beats/shared-docker.asciidoc[]

--- a/script/copy-docs.py
+++ b/script/copy-docs.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import os
+import shutil
+import argparse
+
+def is_dir(d):
+    if os.path.isdir(d) and os.access(d, os.R_OK):
+        return d
+    raise Exception("Invalid directory")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-t', '--target_dir', type=is_dir, default='docs/copied-from-beats')
+    parser.add_argument('-s', '--source_dir', type=is_dir, default='../beats/libbeat/docs')
+    args = parser.parse_args()
+
+    start = len(args.target_dir.strip("/"))+1
+    for root, subdirs, files in os.walk(args.target_dir):
+        for fname in files:
+            target = os.path.join(root, fname)
+            source = os.path.join(args.source_dir, os.path.join(root[start::], fname))
+            try:
+                shutil.copyfile(source, target)
+            except:
+                print("File doesn't exist: {}".format(source))
+
+
+if __name__ == '__main__':
+    main()

--- a/script/copy-docs.py
+++ b/script/copy-docs.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import argparse
 
+
 def is_dir(d):
     if os.path.isdir(d) and os.access(d, os.R_OK):
         return d


### PR DESCRIPTION
Add script that
* copies all docs from a local beats folder that are currently listed in the `docs/copied-from-beats/`  folder
* (removed: temporary fixes inconsistencies between beats and apm-server documentation (e.g. removing the monitoring section).)
*  run `make docs` afterwards.

You can trigger the script by running `make update-beats-docs`. 

Please verify the generated documentation afterwards. In case new files are linked, the `make docs` command should fail and you need to manually resolve issues. 

(update info)