### PR TITLE
[6.x] listen on unix domain socket (#768)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,8 @@ https://github.com/elastic/apm-server/compare/4daa36bd5c144cf9182afc62dc8042af66
 - Limit number of new connections to accept simultaneously {pull}751[751].
 - Push spans to separate ES index {pull}774[774].
 - Update Go to 1.9.4 {pull}786[786].
+- Adjust in-memory queue defaults {pull}791[791].
+- Listen on unix domain socket with `host=unix:/path` {pull}768[768].
 
 
 ==== Deprecated

--- a/_meta/beat.reference.yml
+++ b/_meta/beat.reference.yml
@@ -3,7 +3,7 @@
 ############################# APM Server ######################################
 
 apm-server:
-  # Defines the host and port the server is listening on
+  # Defines the host and port the server is listening on.  use "unix:/path/to.sock" to listen on a unix domain socket.
   #host: "localhost:8200"
 
   # Maximum permitted size in bytes of an unzipped request accepted by the server to be processed.

--- a/apm-server.reference.yml
+++ b/apm-server.reference.yml
@@ -3,7 +3,7 @@
 ############################# APM Server ######################################
 
 apm-server:
-  # Defines the host and port the server is listening on
+  # Defines the host and port the server is listening on.  use "unix:/path/to.sock" to listen on a unix domain socket.
   #host: "localhost:8200"
 
   # Maximum permitted size in bytes of an unzipped request accepted by the server to be processed.

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -147,6 +147,7 @@ output.elasticsearch:
 The HTTP API exposed by APM Server listens on `localhost` and port 8200 by default.
 If you change the listen address from `localhost` to something that is accessible from outside of the machine,
 we recommend setting up firewall rules to ensure that only your own systems can access the API.
+Use path of the form `"unix:/path/to.sock"` to listen on unix domain socket.
 Alternatively,
 you can use the {apm-server-ref}/security.html[secret token and TLS] to secure access to APM Server API.
 

--- a/model/system.go
+++ b/model/system.go
@@ -40,6 +40,8 @@ func (s *System) Transform() common.MapStr {
 	utility.Add(system, "hostname", s.Hostname)
 	utility.Add(system, "architecture", s.Architecture)
 	utility.Add(system, "platform", s.Platform)
-	utility.Add(system, "ip", s.IP)
+	if s.IP != nil && *s.IP != "" {
+		utility.Add(system, "ip", s.IP)
+	}
 	return system
 }

--- a/model/system_test.go
+++ b/model/system_test.go
@@ -15,6 +15,7 @@ func TestSystemTransform(t *testing.T) {
 	hostname := "a.b.com"
 	platform := "darwin"
 	ip := "127.0.0.1"
+	empty := ""
 
 	tests := []struct {
 		System System
@@ -22,6 +23,12 @@ func TestSystemTransform(t *testing.T) {
 	}{
 		{
 			System: System{},
+			Output: common.MapStr{},
+		},
+		{
+			System: System{
+				IP: &empty,
+			},
 			Output: common.MapStr{},
 		},
 		{


### PR DESCRIPTION
Backports the following commits to 6.x:
 - listen on unix domain socket  (#768)