### PR TITLE
[6.2] Update beats framework to 1122568

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ check-full: check
 .PHONY: notice
 notice: python-env
 	@echo "Generating NOTICE"
-	@$(PYTHON_ENV)/bin/python ${ES_BEATS}/dev-tools/generate_notice.py . -e '_beats' -s "./vendor/github.com/elastic/beats" -b "Apm Server" --beats-origin ./_beats/vendor/vendor.json
+	@$(PYTHON_ENV)/bin/python ${ES_BEATS}/dev-tools/generate_notice.py . -e '_beats' -s "./vendor/github.com/elastic/beats" -b "Apm Server" --beats-origin <($(PYTHON_ENV)/bin/python script/generate_notice_overrides.py)
 
 .PHONY: force-update-docs
 force-update-docs: clean docs

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BEAT_NAME=apm-server
+BEAT_DESCRIPTION=Elastic Application Performance Monitoring Server
 BEAT_INDEX_PREFIX=apm
 BEAT_PATH=github.com/elastic/apm-server
 BEAT_GOPATH=$(firstword $(subst :, ,${GOPATH}))

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ check-full: check
 .PHONY: notice
 notice: python-env
 	@echo "Generating NOTICE"
-	@$(PYTHON_ENV)/bin/python ${ES_BEATS}/dev-tools/generate_notice.py . -e '_beats' -s "./vendor/github.com/elastic/beats" -b "Apm Server"
+	@$(PYTHON_ENV)/bin/python ${ES_BEATS}/dev-tools/generate_notice.py . -e '_beats' -s "./vendor/github.com/elastic/beats" -b "Apm Server" --beats-origin ./_beats/vendor/vendor.json
 
 .PHONY: force-update-docs
 force-update-docs: clean docs

--- a/Makefile
+++ b/Makefile
@@ -79,3 +79,6 @@ check-full: check
 notice: python-env
 	@echo "Generating NOTICE"
 	@$(PYTHON_ENV)/bin/python ${ES_BEATS}/dev-tools/generate_notice.py . -e '_beats' -s "./vendor/github.com/elastic/beats" -b "Apm Server"
+
+.PHONY: force-update-docs
+force-update-docs: clean docs

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -78,7 +78,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/docker/go-units
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
 License type (autodetected): Apache-2.0
 ./vendor/github.com/docker/go-units/LICENSE:
 --------------------------------------------------------------------
@@ -87,7 +87,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/docker/libtrust
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: aabc10ec26b754e797f9028f4589c5b7bd90dc20
 License type (autodetected): Apache-2.0
 ./vendor/github.com/docker/libtrust/LICENSE:
 --------------------------------------------------------------------
@@ -125,7 +125,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/eapache/go-xerial-snappy
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: bb955e01b9346ac19dc29eb16586c90ded99a98c
 License type (autodetected): MIT
 ./vendor/github.com/eapache/go-xerial-snappy/LICENSE:
 --------------------------------------------------------------------
@@ -153,7 +153,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/eapache/queue
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 44cc805cf13205b55f69e14bcb69867d1ae92f98
 License type (autodetected): MIT
 ./vendor/github.com/eapache/queue/LICENSE:
 --------------------------------------------------------------------
@@ -199,7 +199,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-ucfg
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 0ba28e36add27704e6b49a7ed8557989a8f4a635
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-ucfg/LICENSE:
 --------------------------------------------------------------------
@@ -208,7 +208,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/gosigar
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 237dff72b4ba95da2cd985f96a9c0ede4aefc760
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/gosigar/LICENSE:
 --------------------------------------------------------------------
@@ -226,7 +226,7 @@ subcomponents is subject to the terms and conditions of the
 subcomponent's license, as noted in the LICENSE file.
 --------------------------------------------------------------------
 Dependency: github.com/ericchiang/k8s
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 5912993f00cb7c971aaa54529a06bd3eecd6c3d4
 License type (autodetected): Apache-2.0
 ./vendor/github.com/ericchiang/k8s/LICENSE:
 --------------------------------------------------------------------
@@ -235,7 +235,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/fatih/color
-Revision: 62e9147c64a1ed519147b62a56a14e83e2be02c1
+Revision: 570b54cabe6b8eb0bc2dfce68d964677d63b5260
 License type (autodetected): MIT
 ./vendor/github.com/fatih/color/LICENSE.md:
 --------------------------------------------------------------------
@@ -298,7 +298,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/ghodss/yaml
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 License type (autodetected): MIT
 ./vendor/github.com/ghodss/yaml/LICENSE:
 --------------------------------------------------------------------
@@ -425,7 +425,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/golang/snappy
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 553a641470496b2327abcac10b36396bd98e45c9
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/golang/snappy/LICENSE:
 --------------------------------------------------------------------
@@ -828,7 +828,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 
 --------------------------------------------------------------------
 Dependency: github.com/inconshreveable/mousetrap
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 License type (autodetected): Apache-2.0
 ./vendor/github.com/inconshreveable/mousetrap/LICENSE:
 --------------------------------------------------------------------
@@ -837,7 +837,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/joeshaw/multierror
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 69b34d4ec901851247ae7e77d33909caf9df99ed
 License type (autodetected): MIT
 ./vendor/github.com/joeshaw/multierror/LICENSE:
 --------------------------------------------------------------------
@@ -933,7 +933,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/klauspost/cpuid
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 09cded8978dc9e80714c4d85b0322337b0a1e5e0
 License type (autodetected): MIT
 ./vendor/github.com/klauspost/cpuid/LICENSE:
 --------------------------------------------------------------------
@@ -962,7 +962,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/klauspost/crc32
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 1bab8b35b6bb565f92cbc97939610af9369f942a
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/klauspost/crc32/LICENSE:
 --------------------------------------------------------------------
@@ -997,7 +997,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/mattn/go-colorable
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 941b50ebc6efddf4c41c8e4537a5f68a4e686b24
 License type (autodetected): MIT
 ./vendor/github.com/mattn/go-colorable/LICENSE:
 --------------------------------------------------------------------
@@ -1025,7 +1025,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/mattn/go-isatty
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: fc9e8d8ef48496124e79ae0df75490096eccf6fe
 License type (autodetected): MIT
 ./vendor/github.com/mattn/go-isatty/LICENSE:
 --------------------------------------------------------------------
@@ -1041,7 +1041,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 --------------------------------------------------------------------
 Dependency: github.com/Microsoft/go-winio
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: f533f7a102197536779ea3a8cb881d639e21ec5a
 License type (autodetected): MIT
 ./vendor/github.com/Microsoft/go-winio/LICENSE:
 --------------------------------------------------------------------
@@ -1070,7 +1070,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/mitchellh/hashstructure
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: ab25296c0f51f1022f01cd99dfb45f1775de8799
 License type (autodetected): MIT
 ./vendor/github.com/mitchellh/hashstructure/LICENSE:
 --------------------------------------------------------------------
@@ -1098,7 +1098,7 @@ THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/mitchellh/mapstructure
-Revision: 06020f85339e21b2478f756a78e295255ffa4d6a
+Revision: 740c764bc6149d3f1806231418adb9f52c11bcbf
 License type (autodetected): MIT
 ./vendor/github.com/mitchellh/mapstructure/LICENSE:
 --------------------------------------------------------------------
@@ -1126,867 +1126,12 @@ THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/opencontainers/go-digest
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
-License type (autodetected): CC-BY-SA-4.0
-./vendor/github.com/opencontainers/go-digest/LICENSE.docs:
+Revision: eaa60544f31ccf3b0653b1a118b76d33418ff41b
+License type (autodetected): Apache-2.0
+./vendor/github.com/opencontainers/go-digest/LICENSE.code:
 --------------------------------------------------------------------
-Attribution-ShareAlike 4.0 International
+Apache License 2.0
 
-=======================================================================
-
-Creative Commons Corporation ("Creative Commons") is not a law firm and
-does not provide legal services or legal advice. Distribution of
-Creative Commons public licenses does not create a lawyer-client or
-other relationship. Creative Commons makes its licenses and related
-information available on an "as-is" basis. Creative Commons gives no
-warranties regarding its licenses, any material licensed under their
-terms and conditions, or any related information. Creative Commons
-disclaims all liability for damages resulting from their use to the
-fullest extent possible.
-
-Using Creative Commons Public Licenses
-
-Creative Commons public licenses provide a standard set of terms and
-conditions that creators and other rights holders may use to share
-original works of authorship and other material subject to copyright
-and certain other rights specified in the public license below. The
-following considerations are for informational purposes only, are not
-exhaustive, and do not form part of our licenses.
-
-     Considerations for licensors: Our public licenses are
-     intended for use by those authorized to give the public
-     permission to use material in ways otherwise restricted by
-     copyright and certain other rights. Our licenses are
-     irrevocable. Licensors should read and understand the terms
-     and conditions of the license they choose before applying it.
-     Licensors should also secure all rights necessary before
-     applying our licenses so that the public can reuse the
-     material as expected. Licensors should clearly mark any
-     material not subject to the license. This includes other CC-
-     licensed material, or material used under an exception or
-     limitation to copyright. More considerations for licensors:
-	wiki.creativecommons.org/Considerations_for_licensors
-
-     Considerations for the public: By using one of our public
-     licenses, a licensor grants the public permission to use the
-     licensed material under specified terms and conditions. If
-     the licensor's permission is not necessary for any reason--for
-     example, because of any applicable exception or limitation to
-     copyright--then that use is not regulated by the license. Our
-     licenses grant only permissions under copyright and certain
-     other rights that a licensor has authority to grant. Use of
-     the licensed material may still be restricted for other
-     reasons, including because others have copyright or other
-     rights in the material. A licensor may make special requests,
-     such as asking that all changes be marked or described.
-     Although not required by our licenses, you are encouraged to
-     respect those requests where reasonable. More_considerations
-     for the public:
-	wiki.creativecommons.org/Considerations_for_licensees
-
-=======================================================================
-
-Creative Commons Attribution-ShareAlike 4.0 International Public
-License
-
-By exercising the Licensed Rights (defined below), You accept and agree
-to be bound by the terms and conditions of this Creative Commons
-Attribution-ShareAlike 4.0 International Public License ("Public
-License"). To the extent this Public License may be interpreted as a
-contract, You are granted the Licensed Rights in consideration of Your
-acceptance of these terms and conditions, and the Licensor grants You
-such rights in consideration of benefits the Licensor receives from
-making the Licensed Material available under these terms and
-conditions.
-
-
-Section 1 -- Definitions.
-
-  a. Adapted Material means material subject to Copyright and Similar
-     Rights that is derived from or based upon the Licensed Material
-     and in which the Licensed Material is translated, altered,
-     arranged, transformed, or otherwise modified in a manner requiring
-     permission under the Copyright and Similar Rights held by the
-     Licensor. For purposes of this Public License, where the Licensed
-     Material is a musical work, performance, or sound recording,
-     Adapted Material is always produced where the Licensed Material is
-     synched in timed relation with a moving image.
-
-  b. Adapter's License means the license You apply to Your Copyright
-     and Similar Rights in Your contributions to Adapted Material in
-     accordance with the terms and conditions of this Public License.
-
-  c. BY-SA Compatible License means a license listed at
-     creativecommons.org/compatiblelicenses, approved by Creative
-     Commons as essentially the equivalent of this Public License.
-
-  d. Copyright and Similar Rights means copyright and/or similar rights
-     closely related to copyright including, without limitation,
-     performance, broadcast, sound recording, and Sui Generis Database
-     Rights, without regard to how the rights are labeled or
-     categorized. For purposes of this Public License, the rights
-     specified in Section 2(b)(1)-(2) are not Copyright and Similar
-     Rights.
-
-  e. Effective Technological Measures means those measures that, in the
-     absence of proper authority, may not be circumvented under laws
-     fulfilling obligations under Article 11 of the WIPO Copyright
-     Treaty adopted on December 20, 1996, and/or similar international
-     agreements.
-
-  f. Exceptions and Limitations means fair use, fair dealing, and/or
-     any other exception or limitation to Copyright and Similar Rights
-     that applies to Your use of the Licensed Material.
-
-  g. License Elements means the license attributes listed in the name
-     of a Creative Commons Public License. The License Elements of this
-     Public License are Attribution and ShareAlike.
-
-  h. Licensed Material means the artistic or literary work, database,
-     or other material to which the Licensor applied this Public
-     License.
-
-  i. Licensed Rights means the rights granted to You subject to the
-     terms and conditions of this Public License, which are limited to
-     all Copyright and Similar Rights that apply to Your use of the
-     Licensed Material and that the Licensor has authority to license.
-
-  j. Licensor means the individual(s) or entity(ies) granting rights
-     under this Public License.
-
-  k. Share means to provide material to the public by any means or
-     process that requires permission under the Licensed Rights, such
-     as reproduction, public display, public performance, distribution,
-     dissemination, communication, or importation, and to make material
-     available to the public including in ways that members of the
-     public may access the material from a place and at a time
-     individually chosen by them.
-
-  l. Sui Generis Database Rights means rights other than copyright
-     resulting from Directive 96/9/EC of the European Parliament and of
-     the Council of 11 March 1996 on the legal protection of databases,
-     as amended and/or succeeded, as well as other essentially
-     equivalent rights anywhere in the world.
-
-  m. You means the individual or entity exercising the Licensed Rights
-     under this Public License. Your has a corresponding meaning.
-
-
-Section 2 -- Scope.
-
-  a. License grant.
-
-       1. Subject to the terms and conditions of this Public License,
-          the Licensor hereby grants You a worldwide, royalty-free,
-          non-sublicensable, non-exclusive, irrevocable license to
-          exercise the Licensed Rights in the Licensed Material to:
-
-            a. reproduce and Share the Licensed Material, in whole or
-               in part; and
-
-            b. produce, reproduce, and Share Adapted Material.
-
-       2. Exceptions and Limitations. For the avoidance of doubt, where
-          Exceptions and Limitations apply to Your use, this Public
-          License does not apply, and You do not need to comply with
-          its terms and conditions.
-
-       3. Term. The term of this Public License is specified in Section
-          6(a).
-
-       4. Media and formats; technical modifications allowed. The
-          Licensor authorizes You to exercise the Licensed Rights in
-          all media and formats whether now known or hereafter created,
-          and to make technical modifications necessary to do so. The
-          Licensor waives and/or agrees not to assert any right or
-          authority to forbid You from making technical modifications
-          necessary to exercise the Licensed Rights, including
-          technical modifications necessary to circumvent Effective
-          Technological Measures. For purposes of this Public License,
-          simply making modifications authorized by this Section 2(a)
-          (4) never produces Adapted Material.
-
-       5. Downstream recipients.
-
-            a. Offer from the Licensor -- Licensed Material. Every
-               recipient of the Licensed Material automatically
-               receives an offer from the Licensor to exercise the
-               Licensed Rights under the terms and conditions of this
-               Public License.
-
-            b. Additional offer from the Licensor -- Adapted Material.
-               Every recipient of Adapted Material from You
-               automatically receives an offer from the Licensor to
-               exercise the Licensed Rights in the Adapted Material
-               under the conditions of the Adapter's License You apply.
-
-            c. No downstream restrictions. You may not offer or impose
-               any additional or different terms or conditions on, or
-               apply any Effective Technological Measures to, the
-               Licensed Material if doing so restricts exercise of the
-               Licensed Rights by any recipient of the Licensed
-               Material.
-
-       6. No endorsement. Nothing in this Public License constitutes or
-          may be construed as permission to assert or imply that You
-          are, or that Your use of the Licensed Material is, connected
-          with, or sponsored, endorsed, or granted official status by,
-          the Licensor or others designated to receive attribution as
-          provided in Section 3(a)(1)(A)(i).
-
-  b. Other rights.
-
-       1. Moral rights, such as the right of integrity, are not
-          licensed under this Public License, nor are publicity,
-          privacy, and/or other similar personality rights; however, to
-          the extent possible, the Licensor waives and/or agrees not to
-          assert any such rights held by the Licensor to the limited
-          extent necessary to allow You to exercise the Licensed
-          Rights, but not otherwise.
-
-       2. Patent and trademark rights are not licensed under this
-          Public License.
-
-       3. To the extent possible, the Licensor waives any right to
-          collect royalties from You for the exercise of the Licensed
-          Rights, whether directly or through a collecting society
-          under any voluntary or waivable statutory or compulsory
-          licensing scheme. In all other cases the Licensor expressly
-          reserves any right to collect such royalties.
-
-
-Section 3 -- License Conditions.
-
-Your exercise of the Licensed Rights is expressly made subject to the
-following conditions.
-
-  a. Attribution.
-
-       1. If You Share the Licensed Material (including in modified
-          form), You must:
-
-            a. retain the following if it is supplied by the Licensor
-               with the Licensed Material:
-
-                 i. identification of the creator(s) of the Licensed
-                    Material and any others designated to receive
-                    attribution, in any reasonable manner requested by
-                    the Licensor (including by pseudonym if
-                    designated);
-
-                ii. a copyright notice;
-
-               iii. a notice that refers to this Public License;
-
-                iv. a notice that refers to the disclaimer of
-                    warranties;
-
-                 v. a URI or hyperlink to the Licensed Material to the
-                    extent reasonably practicable;
-
-            b. indicate if You modified the Licensed Material and
-               retain an indication of any previous modifications; and
-
-            c. indicate the Licensed Material is licensed under this
-               Public License, and include the text of, or the URI or
-               hyperlink to, this Public License.
-
-       2. You may satisfy the conditions in Section 3(a)(1) in any
-          reasonable manner based on the medium, means, and context in
-          which You Share the Licensed Material. For example, it may be
-          reasonable to satisfy the conditions by providing a URI or
-          hyperlink to a resource that includes the required
-          information.
-
-       3. If requested by the Licensor, You must remove any of the
-          information required by Section 3(a)(1)(A) to the extent
-          reasonably practicable.
-
-  b. ShareAlike.
-
-     In addition to the conditions in Section 3(a), if You Share
-     Adapted Material You produce, the following conditions also apply.
-
-       1. The Adapter's License You apply must be a Creative Commons
-          license with the same License Elements, this version or
-          later, or a BY-SA Compatible License.
-
-       2. You must include the text of, or the URI or hyperlink to, the
-          Adapter's License You apply. You may satisfy this condition
-          in any reasonable manner based on the medium, means, and
-          context in which You Share Adapted Material.
-
-       3. You may not offer or impose any additional or different terms
-          or conditions on, or apply any Effective Technological
-          Measures to, Adapted Material that restrict exercise of the
-          rights granted under the Adapter's License You apply.
-
-
-Section 4 -- Sui Generis Database Rights.
-
-Where the Licensed Rights include Sui Generis Database Rights that
-apply to Your use of the Licensed Material:
-
-  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
-     to extract, reuse, reproduce, and Share all or a substantial
-     portion of the contents of the database;
-
-  b. if You include all or a substantial portion of the database
-     contents in a database in which You have Sui Generis Database
-     Rights, then the database in which You have Sui Generis Database
-     Rights (but not its individual contents) is Adapted Material,
-
-     including for purposes of Section 3(b); and
-  c. You must comply with the conditions in Section 3(a) if You Share
-     all or a substantial portion of the contents of the database.
-
-For the avoidance of doubt, this Section 4 supplements and does not
-replace Your obligations under this Public License where the Licensed
-Rights include other Copyright and Similar Rights.
-
-
-Section 5 -- Disclaimer of Warranties and Limitation of Liability.
-
-  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
-     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
-     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
-     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
-     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
-     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
-     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
-     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
-     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
-     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
-
-  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
-     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
-     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
-     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
-     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
-     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
-     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
-     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
-     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
-
-  c. The disclaimer of warranties and limitation of liability provided
-     above shall be interpreted in a manner that, to the extent
-     possible, most closely approximates an absolute disclaimer and
-     waiver of all liability.
-
-
-Section 6 -- Term and Termination.
-
-  a. This Public License applies for the term of the Copyright and
-     Similar Rights licensed here. However, if You fail to comply with
-     this Public License, then Your rights under this Public License
-     terminate automatically.
-
-  b. Where Your right to use the Licensed Material has terminated under
-     Section 6(a), it reinstates:
-
-       1. automatically as of the date the violation is cured, provided
-          it is cured within 30 days of Your discovery of the
-          violation; or
-
-       2. upon express reinstatement by the Licensor.
-
-     For the avoidance of doubt, this Section 6(b) does not affect any
-     right the Licensor may have to seek remedies for Your violations
-     of this Public License.
-
-  c. For the avoidance of doubt, the Licensor may also offer the
-     Licensed Material under separate terms or conditions or stop
-     distributing the Licensed Material at any time; however, doing so
-     will not terminate this Public License.
-
-  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
-     License.
-
-
-Section 7 -- Other Terms and Conditions.
-
-  a. The Licensor shall not be bound by any additional or different
-     terms or conditions communicated by You unless expressly agreed.
-
-  b. Any arrangements, understandings, or agreements regarding the
-     Licensed Material not stated herein are separate from and
-     independent of the terms and conditions of this Public License.
-
-
-Section 8 -- Interpretation.
-
-  a. For the avoidance of doubt, this Public License does not, and
-     shall not be interpreted to, reduce, limit, restrict, or impose
-     conditions on any use of the Licensed Material that could lawfully
-     be made without permission under this Public License.
-
-  b. To the extent possible, if any provision of this Public License is
-     deemed unenforceable, it shall be automatically reformed to the
-     minimum extent necessary to make it enforceable. If the provision
-     cannot be reformed, it shall be severed from this Public License
-     without affecting the enforceability of the remaining terms and
-     conditions.
-
-  c. No term or condition of this Public License will be waived and no
-     failure to comply consented to unless expressly agreed to by the
-     Licensor.
-
-  d. Nothing in this Public License constitutes or may be interpreted
-     as a limitation upon, or waiver of, any privileges and immunities
-     that apply to the Licensor or You, including from the legal
-     processes of any jurisdiction or authority.
-
-
-=======================================================================
-
-Creative Commons is not a party to its public licenses.
-Notwithstanding, Creative Commons may elect to apply one of its public
-licenses to material it publishes and in those instances will be
-considered the "Licensor." Except for the limited purpose of indicating
-that material is shared under a Creative Commons public license or as
-otherwise permitted by the Creative Commons policies published at
-creativecommons.org/policies, Creative Commons does not authorize the
-use of the trademark "Creative Commons" or any other trademark or logo
-of Creative Commons without its prior written consent including,
-without limitation, in connection with any unauthorized modifications
-to any of its public licenses or any other arrangements,
-understandings, or agreements concerning use of licensed material. For
-the avoidance of doubt, this paragraph does not form part of the public
-licenses.
-
-Creative Commons may be contacted at creativecommons.org.
-
---------------------------------------------------------------------
-Dependency: github.com/opencontainers/go-digest
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
-License type (autodetected): CC-BY-SA-4.0
-./vendor/github.com/opencontainers/go-digest/LICENSE.docs:
---------------------------------------------------------------------
-Attribution-ShareAlike 4.0 International
-
-=======================================================================
-
-Creative Commons Corporation ("Creative Commons") is not a law firm and
-does not provide legal services or legal advice. Distribution of
-Creative Commons public licenses does not create a lawyer-client or
-other relationship. Creative Commons makes its licenses and related
-information available on an "as-is" basis. Creative Commons gives no
-warranties regarding its licenses, any material licensed under their
-terms and conditions, or any related information. Creative Commons
-disclaims all liability for damages resulting from their use to the
-fullest extent possible.
-
-Using Creative Commons Public Licenses
-
-Creative Commons public licenses provide a standard set of terms and
-conditions that creators and other rights holders may use to share
-original works of authorship and other material subject to copyright
-and certain other rights specified in the public license below. The
-following considerations are for informational purposes only, are not
-exhaustive, and do not form part of our licenses.
-
-     Considerations for licensors: Our public licenses are
-     intended for use by those authorized to give the public
-     permission to use material in ways otherwise restricted by
-     copyright and certain other rights. Our licenses are
-     irrevocable. Licensors should read and understand the terms
-     and conditions of the license they choose before applying it.
-     Licensors should also secure all rights necessary before
-     applying our licenses so that the public can reuse the
-     material as expected. Licensors should clearly mark any
-     material not subject to the license. This includes other CC-
-     licensed material, or material used under an exception or
-     limitation to copyright. More considerations for licensors:
-	wiki.creativecommons.org/Considerations_for_licensors
-
-     Considerations for the public: By using one of our public
-     licenses, a licensor grants the public permission to use the
-     licensed material under specified terms and conditions. If
-     the licensor's permission is not necessary for any reason--for
-     example, because of any applicable exception or limitation to
-     copyright--then that use is not regulated by the license. Our
-     licenses grant only permissions under copyright and certain
-     other rights that a licensor has authority to grant. Use of
-     the licensed material may still be restricted for other
-     reasons, including because others have copyright or other
-     rights in the material. A licensor may make special requests,
-     such as asking that all changes be marked or described.
-     Although not required by our licenses, you are encouraged to
-     respect those requests where reasonable. More_considerations
-     for the public:
-	wiki.creativecommons.org/Considerations_for_licensees
-
-=======================================================================
-
-Creative Commons Attribution-ShareAlike 4.0 International Public
-License
-
-By exercising the Licensed Rights (defined below), You accept and agree
-to be bound by the terms and conditions of this Creative Commons
-Attribution-ShareAlike 4.0 International Public License ("Public
-License"). To the extent this Public License may be interpreted as a
-contract, You are granted the Licensed Rights in consideration of Your
-acceptance of these terms and conditions, and the Licensor grants You
-such rights in consideration of benefits the Licensor receives from
-making the Licensed Material available under these terms and
-conditions.
-
-
-Section 1 -- Definitions.
-
-  a. Adapted Material means material subject to Copyright and Similar
-     Rights that is derived from or based upon the Licensed Material
-     and in which the Licensed Material is translated, altered,
-     arranged, transformed, or otherwise modified in a manner requiring
-     permission under the Copyright and Similar Rights held by the
-     Licensor. For purposes of this Public License, where the Licensed
-     Material is a musical work, performance, or sound recording,
-     Adapted Material is always produced where the Licensed Material is
-     synched in timed relation with a moving image.
-
-  b. Adapter's License means the license You apply to Your Copyright
-     and Similar Rights in Your contributions to Adapted Material in
-     accordance with the terms and conditions of this Public License.
-
-  c. BY-SA Compatible License means a license listed at
-     creativecommons.org/compatiblelicenses, approved by Creative
-     Commons as essentially the equivalent of this Public License.
-
-  d. Copyright and Similar Rights means copyright and/or similar rights
-     closely related to copyright including, without limitation,
-     performance, broadcast, sound recording, and Sui Generis Database
-     Rights, without regard to how the rights are labeled or
-     categorized. For purposes of this Public License, the rights
-     specified in Section 2(b)(1)-(2) are not Copyright and Similar
-     Rights.
-
-  e. Effective Technological Measures means those measures that, in the
-     absence of proper authority, may not be circumvented under laws
-     fulfilling obligations under Article 11 of the WIPO Copyright
-     Treaty adopted on December 20, 1996, and/or similar international
-     agreements.
-
-  f. Exceptions and Limitations means fair use, fair dealing, and/or
-     any other exception or limitation to Copyright and Similar Rights
-     that applies to Your use of the Licensed Material.
-
-  g. License Elements means the license attributes listed in the name
-     of a Creative Commons Public License. The License Elements of this
-     Public License are Attribution and ShareAlike.
-
-  h. Licensed Material means the artistic or literary work, database,
-     or other material to which the Licensor applied this Public
-     License.
-
-  i. Licensed Rights means the rights granted to You subject to the
-     terms and conditions of this Public License, which are limited to
-     all Copyright and Similar Rights that apply to Your use of the
-     Licensed Material and that the Licensor has authority to license.
-
-  j. Licensor means the individual(s) or entity(ies) granting rights
-     under this Public License.
-
-  k. Share means to provide material to the public by any means or
-     process that requires permission under the Licensed Rights, such
-     as reproduction, public display, public performance, distribution,
-     dissemination, communication, or importation, and to make material
-     available to the public including in ways that members of the
-     public may access the material from a place and at a time
-     individually chosen by them.
-
-  l. Sui Generis Database Rights means rights other than copyright
-     resulting from Directive 96/9/EC of the European Parliament and of
-     the Council of 11 March 1996 on the legal protection of databases,
-     as amended and/or succeeded, as well as other essentially
-     equivalent rights anywhere in the world.
-
-  m. You means the individual or entity exercising the Licensed Rights
-     under this Public License. Your has a corresponding meaning.
-
-
-Section 2 -- Scope.
-
-  a. License grant.
-
-       1. Subject to the terms and conditions of this Public License,
-          the Licensor hereby grants You a worldwide, royalty-free,
-          non-sublicensable, non-exclusive, irrevocable license to
-          exercise the Licensed Rights in the Licensed Material to:
-
-            a. reproduce and Share the Licensed Material, in whole or
-               in part; and
-
-            b. produce, reproduce, and Share Adapted Material.
-
-       2. Exceptions and Limitations. For the avoidance of doubt, where
-          Exceptions and Limitations apply to Your use, this Public
-          License does not apply, and You do not need to comply with
-          its terms and conditions.
-
-       3. Term. The term of this Public License is specified in Section
-          6(a).
-
-       4. Media and formats; technical modifications allowed. The
-          Licensor authorizes You to exercise the Licensed Rights in
-          all media and formats whether now known or hereafter created,
-          and to make technical modifications necessary to do so. The
-          Licensor waives and/or agrees not to assert any right or
-          authority to forbid You from making technical modifications
-          necessary to exercise the Licensed Rights, including
-          technical modifications necessary to circumvent Effective
-          Technological Measures. For purposes of this Public License,
-          simply making modifications authorized by this Section 2(a)
-          (4) never produces Adapted Material.
-
-       5. Downstream recipients.
-
-            a. Offer from the Licensor -- Licensed Material. Every
-               recipient of the Licensed Material automatically
-               receives an offer from the Licensor to exercise the
-               Licensed Rights under the terms and conditions of this
-               Public License.
-
-            b. Additional offer from the Licensor -- Adapted Material.
-               Every recipient of Adapted Material from You
-               automatically receives an offer from the Licensor to
-               exercise the Licensed Rights in the Adapted Material
-               under the conditions of the Adapter's License You apply.
-
-            c. No downstream restrictions. You may not offer or impose
-               any additional or different terms or conditions on, or
-               apply any Effective Technological Measures to, the
-               Licensed Material if doing so restricts exercise of the
-               Licensed Rights by any recipient of the Licensed
-               Material.
-
-       6. No endorsement. Nothing in this Public License constitutes or
-          may be construed as permission to assert or imply that You
-          are, or that Your use of the Licensed Material is, connected
-          with, or sponsored, endorsed, or granted official status by,
-          the Licensor or others designated to receive attribution as
-          provided in Section 3(a)(1)(A)(i).
-
-  b. Other rights.
-
-       1. Moral rights, such as the right of integrity, are not
-          licensed under this Public License, nor are publicity,
-          privacy, and/or other similar personality rights; however, to
-          the extent possible, the Licensor waives and/or agrees not to
-          assert any such rights held by the Licensor to the limited
-          extent necessary to allow You to exercise the Licensed
-          Rights, but not otherwise.
-
-       2. Patent and trademark rights are not licensed under this
-          Public License.
-
-       3. To the extent possible, the Licensor waives any right to
-          collect royalties from You for the exercise of the Licensed
-          Rights, whether directly or through a collecting society
-          under any voluntary or waivable statutory or compulsory
-          licensing scheme. In all other cases the Licensor expressly
-          reserves any right to collect such royalties.
-
-
-Section 3 -- License Conditions.
-
-Your exercise of the Licensed Rights is expressly made subject to the
-following conditions.
-
-  a. Attribution.
-
-       1. If You Share the Licensed Material (including in modified
-          form), You must:
-
-            a. retain the following if it is supplied by the Licensor
-               with the Licensed Material:
-
-                 i. identification of the creator(s) of the Licensed
-                    Material and any others designated to receive
-                    attribution, in any reasonable manner requested by
-                    the Licensor (including by pseudonym if
-                    designated);
-
-                ii. a copyright notice;
-
-               iii. a notice that refers to this Public License;
-
-                iv. a notice that refers to the disclaimer of
-                    warranties;
-
-                 v. a URI or hyperlink to the Licensed Material to the
-                    extent reasonably practicable;
-
-            b. indicate if You modified the Licensed Material and
-               retain an indication of any previous modifications; and
-
-            c. indicate the Licensed Material is licensed under this
-               Public License, and include the text of, or the URI or
-               hyperlink to, this Public License.
-
-       2. You may satisfy the conditions in Section 3(a)(1) in any
-          reasonable manner based on the medium, means, and context in
-          which You Share the Licensed Material. For example, it may be
-          reasonable to satisfy the conditions by providing a URI or
-          hyperlink to a resource that includes the required
-          information.
-
-       3. If requested by the Licensor, You must remove any of the
-          information required by Section 3(a)(1)(A) to the extent
-          reasonably practicable.
-
-  b. ShareAlike.
-
-     In addition to the conditions in Section 3(a), if You Share
-     Adapted Material You produce, the following conditions also apply.
-
-       1. The Adapter's License You apply must be a Creative Commons
-          license with the same License Elements, this version or
-          later, or a BY-SA Compatible License.
-
-       2. You must include the text of, or the URI or hyperlink to, the
-          Adapter's License You apply. You may satisfy this condition
-          in any reasonable manner based on the medium, means, and
-          context in which You Share Adapted Material.
-
-       3. You may not offer or impose any additional or different terms
-          or conditions on, or apply any Effective Technological
-          Measures to, Adapted Material that restrict exercise of the
-          rights granted under the Adapter's License You apply.
-
-
-Section 4 -- Sui Generis Database Rights.
-
-Where the Licensed Rights include Sui Generis Database Rights that
-apply to Your use of the Licensed Material:
-
-  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
-     to extract, reuse, reproduce, and Share all or a substantial
-     portion of the contents of the database;
-
-  b. if You include all or a substantial portion of the database
-     contents in a database in which You have Sui Generis Database
-     Rights, then the database in which You have Sui Generis Database
-     Rights (but not its individual contents) is Adapted Material,
-
-     including for purposes of Section 3(b); and
-  c. You must comply with the conditions in Section 3(a) if You Share
-     all or a substantial portion of the contents of the database.
-
-For the avoidance of doubt, this Section 4 supplements and does not
-replace Your obligations under this Public License where the Licensed
-Rights include other Copyright and Similar Rights.
-
-
-Section 5 -- Disclaimer of Warranties and Limitation of Liability.
-
-  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
-     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
-     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
-     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
-     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
-     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
-     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
-     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
-     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
-     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
-
-  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
-     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
-     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
-     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
-     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
-     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
-     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
-     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
-     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
-
-  c. The disclaimer of warranties and limitation of liability provided
-     above shall be interpreted in a manner that, to the extent
-     possible, most closely approximates an absolute disclaimer and
-     waiver of all liability.
-
-
-Section 6 -- Term and Termination.
-
-  a. This Public License applies for the term of the Copyright and
-     Similar Rights licensed here. However, if You fail to comply with
-     this Public License, then Your rights under this Public License
-     terminate automatically.
-
-  b. Where Your right to use the Licensed Material has terminated under
-     Section 6(a), it reinstates:
-
-       1. automatically as of the date the violation is cured, provided
-          it is cured within 30 days of Your discovery of the
-          violation; or
-
-       2. upon express reinstatement by the Licensor.
-
-     For the avoidance of doubt, this Section 6(b) does not affect any
-     right the Licensor may have to seek remedies for Your violations
-     of this Public License.
-
-  c. For the avoidance of doubt, the Licensor may also offer the
-     Licensed Material under separate terms or conditions or stop
-     distributing the Licensed Material at any time; however, doing so
-     will not terminate this Public License.
-
-  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
-     License.
-
-
-Section 7 -- Other Terms and Conditions.
-
-  a. The Licensor shall not be bound by any additional or different
-     terms or conditions communicated by You unless expressly agreed.
-
-  b. Any arrangements, understandings, or agreements regarding the
-     Licensed Material not stated herein are separate from and
-     independent of the terms and conditions of this Public License.
-
-
-Section 8 -- Interpretation.
-
-  a. For the avoidance of doubt, this Public License does not, and
-     shall not be interpreted to, reduce, limit, restrict, or impose
-     conditions on any use of the Licensed Material that could lawfully
-     be made without permission under this Public License.
-
-  b. To the extent possible, if any provision of this Public License is
-     deemed unenforceable, it shall be automatically reformed to the
-     minimum extent necessary to make it enforceable. If the provision
-     cannot be reformed, it shall be severed from this Public License
-     without affecting the enforceability of the remaining terms and
-     conditions.
-
-  c. No term or condition of this Public License will be waived and no
-     failure to comply consented to unless expressly agreed to by the
-     Licensor.
-
-  d. Nothing in this Public License constitutes or may be interpreted
-     as a limitation upon, or waiver of, any privileges and immunities
-     that apply to the Licensor or You, including from the legal
-     processes of any jurisdiction or authority.
-
-
-=======================================================================
-
-Creative Commons is not a party to its public licenses.
-Notwithstanding, Creative Commons may elect to apply one of its public
-licenses to material it publishes and in those instances will be
-considered the "Licensor." Except for the limited purpose of indicating
-that material is shared under a Creative Commons public license or as
-otherwise permitted by the Creative Commons policies published at
-creativecommons.org/policies, Creative Commons does not authorize the
-use of the trademark "Creative Commons" or any other trademark or logo
-of Creative Commons without its prior written consent including,
-without limitation, in connection with any unauthorized modifications
-to any of its public licenses or any other arrangements,
-understandings, or agreements concerning use of licensed material. For
-the avoidance of doubt, this paragraph does not form part of the public
-licenses.
-
-Creative Commons may be contacted at creativecommons.org.
 
 --------------------------------------------------------------------
 Dependency: github.com/opencontainers/image-spec
@@ -2025,7 +1170,7 @@ THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/pierrec/lz4
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 90290f74b1b4d9c097f0a3b3c7eba2ef3875c699
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/pierrec/lz4/LICENSE:
 --------------------------------------------------------------------
@@ -2095,7 +1240,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/pkg/errors
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: ff09b135c25aae272398c51a07235b90a75aa4f0
 License type (autodetected): BSD-2-Clause
 ./vendor/github.com/pkg/errors/LICENSE:
 --------------------------------------------------------------------
@@ -2159,7 +1304,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/rcrowley/go-metrics
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 1f30fe9094a513ce4c700b9a54458bbb0c96996c
 License type (autodetected): BSD-2-Clause
 ./vendor/github.com/rcrowley/go-metrics/LICENSE:
 --------------------------------------------------------------------
@@ -2256,7 +1401,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------------------------------
 Dependency: github.com/satori/go.uuid
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 License type (autodetected): MIT
 ./vendor/github.com/satori/go.uuid/LICENSE:
 --------------------------------------------------------------------
@@ -2310,7 +1455,7 @@ DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/Shopify/sarama
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: c292021939f5aba53b3ffc2cb09c7aadb32a42df
 License type (autodetected): MIT
 ./vendor/github.com/Shopify/sarama/LICENSE:
 --------------------------------------------------------------------
@@ -2337,7 +1482,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/Sirupsen/logrus
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 5e5dc898656f695e2a086b8e12559febbfc01562
 License type (autodetected): MIT
 ./vendor/github.com/Sirupsen/logrus/LICENSE:
 --------------------------------------------------------------------
@@ -2365,7 +1510,7 @@ THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/spf13/cobra
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 1be1d2841c773c01bee8289f55f7463b6e2c2539
 License type (autodetected): Apache-2.0
 ./vendor/github.com/spf13/cobra/LICENSE.txt:
 --------------------------------------------------------------------
@@ -2374,7 +1519,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/spf13/pflag
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: e57e3eeb33f795204c1ca35f56c44f83227c6e66
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/spf13/pflag/LICENSE:
 --------------------------------------------------------------------
@@ -2409,7 +1554,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/StackExchange/wmi
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 9f32b5905fd6ce7384093f9d048437e79f7b4d85
 License type (autodetected): MIT
 ./vendor/github.com/StackExchange/wmi/LICENSE:
 --------------------------------------------------------------------
@@ -2706,7 +1851,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 --------------------------------------------------------------------
 Dependency: go.uber.org/atomic
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
 License type (autodetected): MIT
 ./vendor/go.uber.org/atomic/LICENSE.txt:
 --------------------------------------------------------------------
@@ -2732,7 +1877,7 @@ THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: go.uber.org/multierr
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: fb7d312c2c04c34f0ad621048bbb953b168f9ff6
 License type (autodetected): MIT
 ./vendor/go.uber.org/multierr/LICENSE.txt:
 --------------------------------------------------------------------
@@ -2758,7 +1903,7 @@ THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: go.uber.org/zap
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 35aad584952c3e7020db7b839f6b102de6271f89
 License type (autodetected): MIT
 ./vendor/go.uber.org/zap/LICENSE.txt:
 --------------------------------------------------------------------
@@ -2920,7 +2065,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: gopkg.in/yaml.v2
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
 License type (autodetected): MIT
 ./vendor/gopkg.in/yaml.v2/LICENSE.libyaml:
 --------------------------------------------------------------------
@@ -2958,7 +2103,7 @@ SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: gopkg.in/yaml.v2
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
 License type (autodetected): MIT
 ./vendor/gopkg.in/yaml.v2/LICENSE.libyaml:
 --------------------------------------------------------------------

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -11,7 +11,7 @@ Third party libraries used by the Apm Server project:
 
 --------------------------------------------------------------------
 Dependency: github.com/davecgh/go-spew
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 346938d642f2ec3594ed81d874461961cd0faa76
 License type (autodetected): MIT
 ./vendor/github.com/davecgh/go-spew/LICENSE:
 --------------------------------------------------------------------
@@ -31,7 +31,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/docker/distribution
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 1e2f10eb65743fed02f573d31a4587de09afb20e
 License type (autodetected): Apache-2.0
 ./vendor/github.com/docker/distribution/LICENSE:
 --------------------------------------------------------------------
@@ -40,7 +40,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/docker/docker
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: d192db0d9350222d2b8bb6eba8525b04c3be7d61
 License type (autodetected): Apache-2.0
 ./vendor/github.com/docker/docker/LICENSE:
 --------------------------------------------------------------------
@@ -69,7 +69,7 @@ See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.
 
 --------------------------------------------------------------------
 Dependency: github.com/docker/go-connections
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: e15c02316c12de00874640cd76311849de2aeed5
 License type (autodetected): Apache-2.0
 ./vendor/github.com/docker/go-connections/LICENSE:
 --------------------------------------------------------------------
@@ -96,7 +96,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/eapache/go-resiliency
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: b86b1ec0dd4209a588dc1285cdd471e73525c0b3
 License type (autodetected): MIT
 ./vendor/github.com/eapache/go-resiliency/LICENSE:
 --------------------------------------------------------------------
@@ -190,7 +190,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-lumber
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 616041e345fc33c97bc0eb0fa6b388aa07bca3e1
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-lumber/LICENSE:
 --------------------------------------------------------------------
@@ -199,7 +199,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-ucfg
-Revision: 0ba28e36add27704e6b49a7ed8557989a8f4a635
+Revision: ec8488a52542c0c51e42e8ea204dcaff400bc644
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-ucfg/LICENSE:
 --------------------------------------------------------------------
@@ -289,7 +289,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/garyburd/redigo
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: b8dc90050f24c1a73a52f107f3f575be67b21b7c
 License type (autodetected): Apache-2.0
 ./vendor/github.com/garyburd/redigo/LICENSE:
 --------------------------------------------------------------------
@@ -387,7 +387,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/golang/protobuf
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 2bba0603135d7d7f5cb73b2125beeda19c09f4ef
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/golang/protobuf/LICENSE:
 --------------------------------------------------------------------
@@ -899,7 +899,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/klauspost/compress
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 14c9a76e3c95e47f8ccce949bba2c1101a8b85e6
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/klauspost/compress/LICENSE:
 --------------------------------------------------------------------
@@ -1135,7 +1135,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/opencontainers/image-spec
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 4038d4391fe912af1031db5a1f511cf07c07cbc8
 License type (autodetected): Apache-2.0
 ./vendor/github.com/opencontainers/image-spec/LICENSE:
 --------------------------------------------------------------------
@@ -1205,7 +1205,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: github.com/pierrec/xxHash
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 5a004441f897722c627870a981d02b29924215fa
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/pierrec/xxHash/LICENSE:
 --------------------------------------------------------------------
@@ -1582,7 +1582,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 --------------------------------------------------------------------
 Dependency: github.com/stretchr/testify
 Version: v1.1.4
-Revision: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+Revision: b91bfb9ebec76498946beb6af7c0230c7cc7ba6c
 License type (autodetected): MIT
 ./vendor/github.com/stretchr/testify/LICENSE:
 --------------------------------------------------------------------
@@ -1929,7 +1929,7 @@ THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: golang.org/x/crypto
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 5119cf507ed5294cc409c092980c7497ee5d6fd2
 License type (autodetected): BSD-3-Clause
 ./vendor/golang.org/x/crypto/LICENSE:
 --------------------------------------------------------------------
@@ -1963,7 +1963,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: golang.org/x/net
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3
 License type (autodetected): BSD-3-Clause
 ./vendor/golang.org/x/net/LICENSE:
 --------------------------------------------------------------------
@@ -1997,7 +1997,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: golang.org/x/sys
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 37707fdb30a5b38865cfb95e5aab41707daec7fd
 License type (autodetected): BSD-3-Clause
 ./vendor/golang.org/x/sys/LICENSE:
 --------------------------------------------------------------------

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -11,7 +11,7 @@ Third party libraries used by the Apm Server project:
 
 --------------------------------------------------------------------
 Dependency: github.com/davecgh/go-spew
-Revision: 346938d642f2ec3594ed81d874461961cd0faa76
+Revision: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
 License type (autodetected): MIT
 ./vendor/github.com/davecgh/go-spew/LICENSE:
 --------------------------------------------------------------------
@@ -181,7 +181,7 @@ SOFTWARE.
 --------------------------------------------------------------------
 Dependency: github.com/elastic/beats
 Version: 6.2
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 1122568edf4ad039734b5224aece9a6259c72684
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/beats/LICENSE.txt:
 --------------------------------------------------------------------
@@ -208,7 +208,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/gosigar
-Revision: 237dff72b4ba95da2cd985f96a9c0ede4aefc760
+Revision: cdcbd8c3b8bf28ef6d8639ec1e45bf31d2745f2d
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/gosigar/LICENSE:
 --------------------------------------------------------------------
@@ -226,7 +226,7 @@ subcomponents is subject to the terms and conditions of the
 subcomponent's license, as noted in the LICENSE file.
 --------------------------------------------------------------------
 Dependency: github.com/ericchiang/k8s
-Revision: 5912993f00cb7c971aaa54529a06bd3eecd6c3d4
+Revision: 5803ed75e31fc1998b5f781ac08e22ff985c3f8f
 License type (autodetected): Apache-2.0
 ./vendor/github.com/ericchiang/k8s/LICENSE:
 --------------------------------------------------------------------
@@ -1582,7 +1582,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 --------------------------------------------------------------------
 Dependency: github.com/stretchr/testify
 Version: v1.1.4
-Revision: b91bfb9ebec76498946beb6af7c0230c7cc7ba6c
+Revision: f390dcf405f7b83c997eac1b06768bb9f44dec18
 License type (autodetected): MIT
 ./vendor/github.com/stretchr/testify/LICENSE:
 --------------------------------------------------------------------
@@ -1611,7 +1611,7 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/urso/go-structform
-Revision: 50372ae92c0b6f54b780751068f82ea0c5844954
+Revision: 844d7d44009e9e8c0f08016fc4dab64e136ca040
 License type (autodetected): Apache-2.0
 ./vendor/github.com/urso/go-structform/LICENSE:
 --------------------------------------------------------------------
@@ -1929,7 +1929,7 @@ THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: golang.org/x/crypto
-Revision: 5119cf507ed5294cc409c092980c7497ee5d6fd2
+Revision: e8f229864d71a49e5fdc4a9a134c5f85c4c33d64
 License type (autodetected): BSD-3-Clause
 ./vendor/golang.org/x/crypto/LICENSE:
 --------------------------------------------------------------------
@@ -1963,7 +1963,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: golang.org/x/net
-Revision: 44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3
+Revision: e90d6d0afc4c315a0d87a568ae68577cc15149a0
 License type (autodetected): BSD-3-Clause
 ./vendor/golang.org/x/net/LICENSE:
 --------------------------------------------------------------------
@@ -1997,7 +1997,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: golang.org/x/sys
-Revision: 37707fdb30a5b38865cfb95e5aab41707daec7fd
+Revision: 571f7bbbe08da2a8955aed9d4db316e78630e9a3
 License type (autodetected): BSD-3-Clause
 ./vendor/golang.org/x/sys/LICENSE:
 --------------------------------------------------------------------
@@ -2031,7 +2031,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------
 Dependency: golang.org/x/time
-Revision: 8be79e1e0910c292df4e79c241bb7e8f7e725959
+Revision: 26559e0f760e39c24d730d3224364aef164ee23f
 License type (autodetected): BSD-3-Clause
 ./vendor/golang.org/x/time/LICENSE:
 --------------------------------------------------------------------

--- a/_beats/dev-tools/generate_notice.py
+++ b/_beats/dev-tools/generate_notice.py
@@ -215,6 +215,8 @@ MPL_LICENSE_TITLES = [
 def detect_license_summary(content):
     # replace all white spaces with a single space
     content = re.sub(r"\s+", ' ', content)
+    # replace smart quotes with less intelligent ones
+    content = content.replace(b'\xe2\x80\x9c', '"').replace(b'\xe2\x80\x9d', '"')
     if any(sentence in content[0:1000] for sentence in APACHE2_LICENSE_TITLES):
         return "Apache-2.0"
     if any(sentence in content[0:1000] for sentence in MIT_LICENSES):

--- a/_beats/dev-tools/generate_notice.py
+++ b/_beats/dev-tools/generate_notice.py
@@ -44,7 +44,7 @@ def read_versions(vendor):
     return libs
 
 
-def gather_dependencies(vendor_dirs):
+def gather_dependencies(vendor_dirs, overrides=None):
     dependencies = {}   # lib_path -> [array of lib]
     for vendor in vendor_dirs:
         libs = read_versions(vendor)
@@ -52,7 +52,7 @@ def gather_dependencies(vendor_dirs):
         # walk looking for LICENSE files
         for root, dirs, filenames in os.walk(vendor):
             for filename in sorted(filenames):
-                if filename.startswith("LICENSE"):
+                if filename.startswith("LICENSE") and "docs" not in filename:
                     lib_path = get_library_path(root)
                     lib_search = [l for l in libs if l["path"].startswith(lib_path)]
                     if len(lib_search) == 0:
@@ -66,7 +66,9 @@ def gather_dependencies(vendor_dirs):
                     lib["license_summary"] = detect_license_summary(lib["license_contents"])
                     if lib["license_summary"] == "UNKNOWN":
                         print("WARNING: Unknown license for: {}".format(lib_path))
-
+                    revision = overrides.get(lib_path, {}).get("revision")
+                    if revision:
+                        lib["revision"] = revision
                     if lib_path not in dependencies:
                         dependencies[lib_path] = [lib]
                     else:
@@ -137,8 +139,8 @@ def get_url(repo):
     return "https://github.com/{}/{}".format(words[1], words[2])
 
 
-def create_notice(filename, beat, copyright, vendor_dirs, csvfile):
-    dependencies = gather_dependencies(vendor_dirs)
+def create_notice(filename, beat, copyright, vendor_dirs, csvfile, overrides=None):
+    dependencies = gather_dependencies(vendor_dirs, overrides=overrides)
     if not csvfile:
         with open(filename, "w+") as f:
             write_notice_file(f, beat, copyright, dependencies)
@@ -150,7 +152,11 @@ def create_notice(filename, beat, copyright, vendor_dirs, csvfile):
 
 APACHE2_LICENSE_TITLES = [
     "Apache License Version 2.0",
-    "Apache License, Version 2.0"
+    "Apache License, Version 2.0",
+    re.sub(r"\s+", " ", """Apache License
+    ==============
+
+    _Version 2.0, January 2004_"""),
 ]
 
 MIT_LICENSES = [
@@ -246,6 +252,9 @@ if __name__ == "__main__":
                         help="Output to a csv file")
     parser.add_argument("-e", "--excludes", default=["dev-tools", "build"],
                         help="List of top directories to exclude")
+    # no need to be generic for now, no other transitive dependency information available
+    parser.add_argument("--beats-origin", type=argparse.FileType('r'),
+                        help="path to beats vendor.json")
     parser.add_argument("-s", "--skip-notice", default=[],
                         help="List of NOTICE files to skip")
     args = parser.parse_args()
@@ -273,7 +282,12 @@ if __name__ == "__main__":
             if exclude in dirs:
                 dirs.remove(exclude)
 
+    overrides = {}  # revision overrides only for now
+    if args.beats_origin:
+        govendor = json.load(args.beats_origin)
+        overrides = {package['path']: package for package in govendor["package"]}
+
     print("Get the licenses available from {}".format(vendor_dirs))
-    create_notice(notice, args.beat, args.copyright, vendor_dirs, args.csvfile)
+    create_notice(notice, args.beat, args.copyright, vendor_dirs, args.csvfile, overrides=overrides)
 
     print("Available at {}".format(notice))

--- a/_beats/dev-tools/set_docs_version
+++ b/_beats/dev-tools/set_docs_version
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+import argparse
+from subprocess import check_call
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Used to set the current docs version. Doesn't commit changes.")
+    parser.add_argument("version",
+                        help="The new docs version")
+    args = parser.parse_args()
+    version = args.version
+
+    # make sure we have no dirty files in this branch (might throw off `make update`)
+    check_call("git clean -dfx", shell=True)
+
+    # edit the file
+    with open("libbeat/docs/version.asciidoc", "r") as f:
+        lines = f.readlines()
+    for i, line in enumerate(lines):
+        if line.startswith(":stack-version:"):
+            lines[i] = ":stack-version: {}\n".format(version)
+    with open("libbeat/docs/version.asciidoc", "w") as f:
+        f.writelines(lines)
+
+    check_call("make update", shell=True)
+
+if __name__ == "__main__":
+    main()

--- a/_beats/vendor/vendor.json
+++ b/_beats/vendor/vendor.json
@@ -1,0 +1,1684 @@
+{
+	"comment": "",
+	"ignore": "test",
+	"package": [
+		{
+			"checksumSHA1": "AzjRkOQtVBTwIw4RJLTygFhJs3s=",
+			"path": "github.com/Microsoft/go-winio",
+			"revision": "f533f7a102197536779ea3a8cb881d639e21ec5a",
+			"revisionTime": "2017-05-24T00:36:31Z"
+		},
+		{
+			"checksumSHA1": "GCpYz281OE/XkAQK23BLr+nK6O0=",
+			"origin": "github.com/urso/sarama",
+			"path": "github.com/Shopify/sarama",
+			"revision": "c292021939f5aba53b3ffc2cb09c7aadb32a42df",
+			"revisionTime": "2016-11-23T00:27:23Z",
+			"tree": true,
+			"version": "v1.12/enh/offset-replica-id",
+			"versionExact": "v1.12/enh/offset-replica-id"
+		},
+		{
+			"checksumSHA1": "DYv6Q1+VfnUVxMwvk5IshAClLvw=",
+			"path": "github.com/Sirupsen/logrus",
+			"revision": "5e5dc898656f695e2a086b8e12559febbfc01562",
+			"revisionTime": "2017-05-15T10:45:16Z"
+		},
+		{
+			"checksumSHA1": "Te1xRugxHQMAg7EvbIUuPWm8fvU=",
+			"path": "github.com/StackExchange/wmi",
+			"revision": "9f32b5905fd6ce7384093f9d048437e79f7b4d85",
+			"revisionTime": "2017-02-20T21:12:21Z"
+		},
+		{
+			"checksumSHA1": "fOaPbtxEyjvnQt1WjYV+qBBUa6w=",
+			"path": "github.com/aerospike/aerospike-client-go",
+			"revision": "0f3b54da6bdc2c31c505f9afbc5f434dd2089658",
+			"revisionTime": "2017-06-12T17:41:08Z"
+		},
+		{
+			"checksumSHA1": "VPNsoCYh+XZL2JGX5LQh3JYKCKA=",
+			"path": "github.com/aerospike/aerospike-client-go/internal/lua",
+			"revision": "0f3b54da6bdc2c31c505f9afbc5f434dd2089658",
+			"revisionTime": "2017-06-12T17:41:08Z"
+		},
+		{
+			"checksumSHA1": "XbQ7dIXjGH+/wl5UyVWosqpuoys=",
+			"path": "github.com/aerospike/aerospike-client-go/internal/lua/resources",
+			"revision": "0f3b54da6bdc2c31c505f9afbc5f434dd2089658",
+			"revisionTime": "2017-06-12T17:41:08Z"
+		},
+		{
+			"checksumSHA1": "wGou8ehkc2gw/zWdteA/aq1/fOA=",
+			"path": "github.com/aerospike/aerospike-client-go/logger",
+			"revision": "0f3b54da6bdc2c31c505f9afbc5f434dd2089658",
+			"revisionTime": "2017-06-12T17:41:08Z"
+		},
+		{
+			"checksumSHA1": "W19k/UVPrMdsV1KM0VgDRLv1EvU=",
+			"path": "github.com/aerospike/aerospike-client-go/pkg/bcrypt",
+			"revision": "0f3b54da6bdc2c31c505f9afbc5f434dd2089658",
+			"revisionTime": "2017-06-12T17:41:08Z"
+		},
+		{
+			"checksumSHA1": "OIxaM040XKFig4zE9PZTTlI+s4M=",
+			"path": "github.com/aerospike/aerospike-client-go/pkg/ripemd160",
+			"revision": "0f3b54da6bdc2c31c505f9afbc5f434dd2089658",
+			"revisionTime": "2017-06-12T17:41:08Z"
+		},
+		{
+			"checksumSHA1": "hn2G2IARUZneHSbwIr7cJlHIJrM=",
+			"path": "github.com/aerospike/aerospike-client-go/types",
+			"revision": "0f3b54da6bdc2c31c505f9afbc5f434dd2089658",
+			"revisionTime": "2017-06-12T17:41:08Z"
+		},
+		{
+			"checksumSHA1": "Mja2OgcnYsZ3uUv02nixVHU4SbU=",
+			"path": "github.com/aerospike/aerospike-client-go/types/atomic",
+			"revision": "0f3b54da6bdc2c31c505f9afbc5f434dd2089658",
+			"revisionTime": "2017-06-12T17:41:08Z"
+		},
+		{
+			"checksumSHA1": "1xmzaXT3uA8K5FL92TNw/PfG0TU=",
+			"path": "github.com/aerospike/aerospike-client-go/types/particle_type",
+			"revision": "0f3b54da6bdc2c31c505f9afbc5f434dd2089658",
+			"revisionTime": "2017-06-12T17:41:08Z"
+		},
+		{
+			"checksumSHA1": "cXow2vGzsUtayrJuhz57vCDb2w0=",
+			"path": "github.com/aerospike/aerospike-client-go/types/rand",
+			"revision": "0f3b54da6bdc2c31c505f9afbc5f434dd2089658",
+			"revisionTime": "2017-06-12T17:41:08Z"
+		},
+		{
+			"checksumSHA1": "BdxmIb2XgZufRGpQSlE8R9UEqWc=",
+			"path": "github.com/aerospike/aerospike-client-go/utils/buffer",
+			"revision": "0f3b54da6bdc2c31c505f9afbc5f434dd2089658",
+			"revisionTime": "2017-06-12T17:41:08Z"
+		},
+		{
+			"checksumSHA1": "QZeGe47LzTo4drKys2X2DNGtPFA=",
+			"path": "github.com/andrewkroh/sys/windows/svc/eventlog",
+			"revision": "287798fe3e430efeb9318b95ff52353aaa2b59b1",
+			"revisionTime": "2015-11-28T19:19:22Z"
+		},
+		{
+			"checksumSHA1": "UlWLJjLRCRtXOzP6nLHb5YTWK+c=",
+			"path": "github.com/armon/go-socks5",
+			"revision": "e75332964ef517daa070d7c38a9466a0d687e0a5",
+			"revisionTime": "2016-09-02T18:42:37Z"
+		},
+		{
+			"checksumSHA1": "R1Q34Pfnt197F/nCOO9kG8c+Z90=",
+			"path": "github.com/boltdb/bolt",
+			"revision": "2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8",
+			"revisionTime": "2017-07-17T17:11:48Z",
+			"version": "v1.3.1",
+			"versionExact": "v1.3.1"
+		},
+		{
+			"checksumSHA1": "dvabztWVQX8f6oMLRyv4dLH+TGY=",
+			"path": "github.com/davecgh/go-spew/spew",
+			"revision": "346938d642f2ec3594ed81d874461961cd0faa76",
+			"revisionTime": "2016-10-29T20:57:26Z",
+			"version": "v1.1.0",
+			"versionExact": "v1.1.0"
+		},
+		{
+			"checksumSHA1": "Gj+xR1VgFKKmFXYOJMnAczC3Znk=",
+			"path": "github.com/docker/distribution/digestset",
+			"revision": "1e2f10eb65743fed02f573d31a4587de09afb20e",
+			"revisionTime": "2017-05-24T20:58:24Z"
+		},
+		{
+			"checksumSHA1": "2Fe4D6PGaVE2he4fUeenLmhC1lE=",
+			"path": "github.com/docker/distribution/reference",
+			"revision": "1e2f10eb65743fed02f573d31a4587de09afb20e",
+			"revisionTime": "2017-05-24T20:58:24Z"
+		},
+		{
+			"checksumSHA1": "UL2NF1EGiSsQoEfvycnuZIcUbZY=",
+			"path": "github.com/docker/docker/api",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "KMFpbV3mlrbc41d2DYnq05QYpSc=",
+			"path": "github.com/docker/docker/api/types",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "jVJDbe0IcyjoKc2xbohwzQr+FF0=",
+			"path": "github.com/docker/docker/api/types/blkiodev",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "AeSC0BOu1uapkGqfSXtfVSpwJzs=",
+			"path": "github.com/docker/docker/api/types/container",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "4XuWn5+wgYwUsw604jvYMklq4Hc=",
+			"path": "github.com/docker/docker/api/types/events",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "J2OKngfI3vgswudr9PZVUFcRRu0=",
+			"path": "github.com/docker/docker/api/types/filters",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "yeB781yxPhnN6OXQ9/qSsyih3ek=",
+			"path": "github.com/docker/docker/api/types/image",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "UK+VdM648oWzyqE4OqttgmPqjoA=",
+			"path": "github.com/docker/docker/api/types/mount",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "Gskp+nvbVe8Gk1xPLHylZvNmqTg=",
+			"path": "github.com/docker/docker/api/types/network",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "r2vWq7Uc3ExKzMqYgH0b4AKjLKY=",
+			"path": "github.com/docker/docker/api/types/registry",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "VTxWyFud/RedrpllGdQonVtGM/A=",
+			"path": "github.com/docker/docker/api/types/strslice",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "ZaizCpJ3eBcfR9ywpLaJd4AhM9k=",
+			"path": "github.com/docker/docker/api/types/swarm",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "B7ZwKzrv3t3Vlox6/bYMHhMjsM8=",
+			"path": "github.com/docker/docker/api/types/time",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "uDPQ3nHsrvGQc9tg/J9OSC4N5dQ=",
+			"path": "github.com/docker/docker/api/types/versions",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "IBJy2zPEnYmcFJ3lM1eiRWnCxTA=",
+			"path": "github.com/docker/docker/api/types/volume",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "c6OyeEvpQDvVLhrJSxgjEZv1tF8=",
+			"origin": "github.com/exekias/moby/client",
+			"path": "github.com/docker/docker/client",
+			"revision": "83d94aa2b98f10c4534d77077645d5e328533ce4",
+			"revisionTime": "2017-05-29T14:39:59Z",
+			"version": "master",
+			"versionExact": "master"
+		},
+		{
+			"checksumSHA1": "kK/ZpRsTmbHTYGkV7NixaG2rork=",
+			"path": "github.com/docker/docker/opts",
+			"revision": "89658bed64c2a8fe05a978e5b87dbec409d57a0f",
+			"revisionTime": "2017-05-04T20:25:03Z",
+			"version": "v17.05.0-ce",
+			"versionExact": "v17.05.0-ce"
+		},
+		{
+			"checksumSHA1": "NC4Tz59SrBVdPxt12GjYCxX60eU=",
+			"path": "github.com/docker/docker/pkg/fileutils",
+			"revision": "89658bed64c2a8fe05a978e5b87dbec409d57a0f",
+			"revisionTime": "2017-05-04T20:25:03Z",
+			"version": "v17.05.0-ce",
+			"versionExact": "v17.05.0-ce"
+		},
+		{
+			"checksumSHA1": "W7Rnb5YoC9u0vT9eLKoezV3N4E8=",
+			"path": "github.com/docker/docker/pkg/homedir",
+			"revision": "89658bed64c2a8fe05a978e5b87dbec409d57a0f",
+			"revisionTime": "2017-05-04T20:25:03Z",
+			"version": "v17.05.0-ce",
+			"versionExact": "v17.05.0-ce"
+		},
+		{
+			"checksumSHA1": "bfvwzIbEFwclBKJSNa6oaA27DgE=",
+			"path": "github.com/docker/docker/pkg/idtools",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "jmo/t2zXAxirEPoFucNPXA/1SEc=",
+			"path": "github.com/docker/docker/pkg/ioutils",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "kp20bhjkvJ06uW6DRfVIZbCj8SY=",
+			"path": "github.com/docker/docker/pkg/jsonlog",
+			"revision": "89658bed64c2a8fe05a978e5b87dbec409d57a0f",
+			"revisionTime": "2017-05-04T20:25:03Z",
+			"version": "v17.05.0-ce",
+			"versionExact": "v17.05.0-ce"
+		},
+		{
+			"checksumSHA1": "ndnAFCfsGC3upNQ6jAEwzxcurww=",
+			"path": "github.com/docker/docker/pkg/longpath",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "3u2xJnbqYSxOP3kOORetQD7P1Co=",
+			"path": "github.com/docker/docker/pkg/mount",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "H1rrbVmeE1z2TnkF7tSrfh+qUOY=",
+			"path": "github.com/docker/docker/pkg/stdcopy",
+			"revision": "89658bed64c2a8fe05a978e5b87dbec409d57a0f",
+			"revisionTime": "2017-05-04T20:25:03Z",
+			"version": "v17.05.0-ce",
+			"versionExact": "v17.05.0-ce"
+		},
+		{
+			"checksumSHA1": "kr46EAa+FsUcWxOq6edyX6BUzE4=",
+			"origin": "github.com/exekias/moby/pkg/system",
+			"path": "github.com/docker/docker/pkg/system",
+			"revision": "83d94aa2b98f10c4534d77077645d5e328533ce4",
+			"revisionTime": "2017-05-29T14:39:59Z",
+			"version": "master",
+			"versionExact": "master"
+		},
+		{
+			"checksumSHA1": "8I0Ez+aUYGpsDEVZ8wN/Ztf6Zqs=",
+			"path": "github.com/docker/docker/pkg/tlsconfig",
+			"revision": "d192db0d9350222d2b8bb6eba8525b04c3be7d61",
+			"revisionTime": "2017-05-29T13:58:50Z"
+		},
+		{
+			"checksumSHA1": "JbiWTzH699Sqz25XmDlsARpMN9w=",
+			"path": "github.com/docker/go-connections/nat",
+			"revision": "e15c02316c12de00874640cd76311849de2aeed5",
+			"revisionTime": "2017-03-31T14:51:22Z"
+		},
+		{
+			"checksumSHA1": "jUfDG3VQsA2UZHvvIXncgiddpYA=",
+			"path": "github.com/docker/go-connections/sockets",
+			"revision": "e15c02316c12de00874640cd76311849de2aeed5",
+			"revisionTime": "2017-03-31T14:51:22Z"
+		},
+		{
+			"checksumSHA1": "tuSzlS1UQ03+5Fvtqr5hI5sLLhA=",
+			"path": "github.com/docker/go-connections/tlsconfig",
+			"revision": "e15c02316c12de00874640cd76311849de2aeed5",
+			"revisionTime": "2017-03-31T14:51:22Z"
+		},
+		{
+			"checksumSHA1": "UmXGieuTJQOzJPspPJTVKKKMiUA=",
+			"path": "github.com/docker/go-units",
+			"revision": "0dadbb0345b35ec7ef35e228dabb8de89a65bf52",
+			"revisionTime": "2017-01-27T09:51:30Z"
+		},
+		{
+			"checksumSHA1": "sNAU9ojYVUhO6dVXey6T3JhRQpw=",
+			"path": "github.com/docker/libtrust",
+			"revision": "aabc10ec26b754e797f9028f4589c5b7bd90dc20",
+			"revisionTime": "2016-07-08T17:25:13Z"
+		},
+		{
+			"checksumSHA1": "rhLUtXvcmouYuBwOq9X/nYKzvNg=",
+			"path": "github.com/dustin/go-humanize",
+			"revision": "259d2a102b871d17f30e3cd9881a642961a1e486",
+			"revisionTime": "2017-02-28T07:34:54Z"
+		},
+		{
+			"checksumSHA1": "y2Kh4iPlgCPXSGTCcFpzePYdzzg=",
+			"path": "github.com/eapache/go-resiliency/breaker",
+			"revision": "b86b1ec0dd4209a588dc1285cdd471e73525c0b3",
+			"revisionTime": "2016-01-04T19:15:39Z"
+		},
+		{
+			"checksumSHA1": "WHl96RVZlOOdF4Lb1OOadMpw8ls=",
+			"path": "github.com/eapache/go-xerial-snappy",
+			"revision": "bb955e01b9346ac19dc29eb16586c90ded99a98c",
+			"revisionTime": "2016-06-09T14:24:08Z"
+		},
+		{
+			"checksumSHA1": "oCCs6kDanizatplM5e/hX76busE=",
+			"path": "github.com/eapache/queue",
+			"revision": "44cc805cf13205b55f69e14bcb69867d1ae92f98",
+			"revisionTime": "2016-08-05T00:47:13Z"
+		},
+		{
+			"checksumSHA1": "yxowcZEI5Qx1xwu9TI+L5NS87Sw=",
+			"path": "github.com/elastic/go-libaudit",
+			"revision": "c139147102117edd4175a74ce071e4cc7982259a",
+			"revisionTime": "2018-01-18T05:11:38Z",
+			"version": "v0.0.7",
+			"versionExact": "v0.0.7"
+		},
+		{
+			"checksumSHA1": "n8bRlhOdmfREBoCgStzHWGWiwSY=",
+			"path": "github.com/elastic/go-libaudit/aucoalesce",
+			"revision": "df0d4981f3fce65ffd3d7411dfec3e03231b491c",
+			"revisionTime": "2017-09-07T20:19:58Z",
+			"version": "v0.0.6",
+			"versionExact": "v0.0.6"
+		},
+		{
+			"checksumSHA1": "eUIiDm0pSFKNKjWme5s3PtWEoSU=",
+			"path": "github.com/elastic/go-libaudit/auparse",
+			"revision": "df0d4981f3fce65ffd3d7411dfec3e03231b491c",
+			"revisionTime": "2017-09-07T20:19:58Z",
+			"version": "v0.0.6",
+			"versionExact": "v0.0.6"
+		},
+		{
+			"checksumSHA1": "H0rnscnKHbkjmXc4whC3gtIPR0c=",
+			"path": "github.com/elastic/go-libaudit/rule",
+			"revision": "df0d4981f3fce65ffd3d7411dfec3e03231b491c",
+			"revisionTime": "2017-09-07T20:19:58Z",
+			"version": "v0.0.6",
+			"versionExact": "v0.0.6"
+		},
+		{
+			"checksumSHA1": "36UaYid29Kyhrsa5D8N6BoM8dVw=",
+			"path": "github.com/elastic/go-libaudit/rule/flags",
+			"revision": "df0d4981f3fce65ffd3d7411dfec3e03231b491c",
+			"revisionTime": "2017-09-07T20:19:58Z",
+			"version": "v0.0.6",
+			"versionExact": "v0.0.6"
+		},
+		{
+			"checksumSHA1": "3jizmlZPCyo6FAZY8Trk9jA8NH4=",
+			"path": "github.com/elastic/go-lumber/client/v2",
+			"revision": "616041e345fc33c97bc0eb0fa6b388aa07bca3e1",
+			"revisionTime": "2016-06-17T14:03:01Z"
+		},
+		{
+			"checksumSHA1": "ZIgOGAYrMnc+qAVcBN/qht3WUr0=",
+			"path": "github.com/elastic/go-lumber/lj",
+			"revision": "616041e345fc33c97bc0eb0fa6b388aa07bca3e1",
+			"revisionTime": "2016-06-17T14:03:01Z"
+		},
+		{
+			"checksumSHA1": "ZYW2Gn5En04g39XG/uEpDwqwGj8=",
+			"path": "github.com/elastic/go-lumber/log",
+			"revision": "616041e345fc33c97bc0eb0fa6b388aa07bca3e1",
+			"revisionTime": "2016-06-17T14:03:01Z"
+		},
+		{
+			"checksumSHA1": "m6HLKpDAZlkTTQMqabf3aT6TQ/s=",
+			"path": "github.com/elastic/go-lumber/protocol/v2",
+			"revision": "616041e345fc33c97bc0eb0fa6b388aa07bca3e1",
+			"revisionTime": "2016-06-17T14:03:01Z"
+		},
+		{
+			"checksumSHA1": "H5Fwve/3E9K8CTN/u7XdpOn58Zk=",
+			"path": "github.com/elastic/go-lumber/server/internal",
+			"revision": "616041e345fc33c97bc0eb0fa6b388aa07bca3e1",
+			"revisionTime": "2016-06-17T14:03:01Z"
+		},
+		{
+			"checksumSHA1": "3vfLXdvjt0w8+zrEqaH/01eZ5n0=",
+			"path": "github.com/elastic/go-lumber/server/v2",
+			"revision": "616041e345fc33c97bc0eb0fa6b388aa07bca3e1",
+			"revisionTime": "2016-06-17T14:03:01Z"
+		},
+		{
+			"checksumSHA1": "AaEPt+KMknLXze11YOnBGKzP3aA=",
+			"path": "github.com/elastic/go-structform",
+			"revision": "0a66add879601f69f55663f4c913c72988218982",
+			"revisionTime": "2018-03-09T00:36:09Z",
+			"version": "v0.0.3",
+			"versionExact": "v0.0.3"
+		},
+		{
+			"checksumSHA1": "SXsT/tWnjLqR8dBiJGZqxCyuNaY=",
+			"path": "github.com/elastic/go-structform/cborl",
+			"revision": "0a66add879601f69f55663f4c913c72988218982",
+			"revisionTime": "2018-03-09T00:36:09Z",
+			"version": "v0.0.3",
+			"versionExact": "v0.0.3"
+		},
+		{
+			"checksumSHA1": "LUbWdzbpzhBh+5TizsScD8gTm4M=",
+			"path": "github.com/elastic/go-structform/gotype",
+			"revision": "0a66add879601f69f55663f4c913c72988218982",
+			"revisionTime": "2018-03-09T00:36:09Z",
+			"version": "v0.0.3",
+			"versionExact": "v0.0.3"
+		},
+		{
+			"checksumSHA1": "s7k0vEuuqkoPXU0FtrD6Y0jxd7U=",
+			"path": "github.com/elastic/go-structform/internal/unsafe",
+			"revision": "0a66add879601f69f55663f4c913c72988218982",
+			"revisionTime": "2018-03-09T00:36:09Z",
+			"version": "v0.0.3",
+			"versionExact": "v0.0.3"
+		},
+		{
+			"checksumSHA1": "s5nSu8O8TOv4DZhdbU7OC5x0C50=",
+			"path": "github.com/elastic/go-structform/json",
+			"revision": "0a66add879601f69f55663f4c913c72988218982",
+			"revisionTime": "2018-03-09T00:36:09Z",
+			"version": "v0.0.3",
+			"versionExact": "v0.0.3"
+		},
+		{
+			"checksumSHA1": "PDqC4Sh2H2EIxVhWZHdsusBMPB8=",
+			"path": "github.com/elastic/go-structform/ubjson",
+			"revision": "0a66add879601f69f55663f4c913c72988218982",
+			"revisionTime": "2018-03-09T00:36:09Z",
+			"version": "v0.0.3",
+			"versionExact": "v0.0.3"
+		},
+		{
+			"checksumSHA1": "493PQcWaAgD4s0nEb5dpeTb2Ky0=",
+			"path": "github.com/elastic/go-structform/visitors",
+			"revision": "0a66add879601f69f55663f4c913c72988218982",
+			"revisionTime": "2018-03-09T00:36:09Z",
+			"version": "v0.0.3",
+			"versionExact": "v0.0.3"
+		},
+		{
+			"checksumSHA1": "IdhOS26Kl7cvP0wWAglYOlRlTok=",
+			"path": "github.com/elastic/go-sysinfo",
+			"revision": "9c842019df6fc236a6f1ef5537109ac36357dd63",
+			"revisionTime": "2018-03-16T07:12:44Z"
+		},
+		{
+			"checksumSHA1": "jTbNB3zTWutaSKScd7UyLWt+jn0=",
+			"path": "github.com/elastic/go-sysinfo/internal/registry",
+			"revision": "9c842019df6fc236a6f1ef5537109ac36357dd63",
+			"revisionTime": "2018-03-16T07:12:44Z"
+		},
+		{
+			"checksumSHA1": "/4zxHe2iBgWg5L9x+LOpRo0c3i0=",
+			"path": "github.com/elastic/go-sysinfo/providers/darwin",
+			"revision": "9c842019df6fc236a6f1ef5537109ac36357dd63",
+			"revisionTime": "2018-03-16T07:12:44Z"
+		},
+		{
+			"checksumSHA1": "DZtaJU4DTt14eiDx5WXUHrmN6Kg=",
+			"path": "github.com/elastic/go-sysinfo/providers/linux",
+			"revision": "9c842019df6fc236a6f1ef5537109ac36357dd63",
+			"revisionTime": "2018-03-16T07:12:44Z"
+		},
+		{
+			"checksumSHA1": "oX0/bPid3LuReipgLLFy5Pc7gRc=",
+			"path": "github.com/elastic/go-sysinfo/providers/shared",
+			"revision": "9c842019df6fc236a6f1ef5537109ac36357dd63",
+			"revisionTime": "2018-03-16T07:12:44Z"
+		},
+		{
+			"checksumSHA1": "e+78LkI5GTavAzV9ySjdME4KgWk=",
+			"path": "github.com/elastic/go-sysinfo/providers/windows",
+			"revision": "9c842019df6fc236a6f1ef5537109ac36357dd63",
+			"revisionTime": "2018-03-16T07:12:44Z"
+		},
+		{
+			"checksumSHA1": "zqbmoQ1OSDWiV/XTXzPLc/Vxcxo=",
+			"path": "github.com/elastic/go-sysinfo/types",
+			"revision": "9c842019df6fc236a6f1ef5537109ac36357dd63",
+			"revisionTime": "2018-03-16T07:12:44Z"
+		},
+		{
+			"checksumSHA1": "61XUpyQ3zWnJ7Tlj0xLsHtnzwJY=",
+			"path": "github.com/elastic/go-ucfg",
+			"revision": "0ba28e36add27704e6b49a7ed8557989a8f4a635",
+			"revisionTime": "2018-01-30T20:43:55Z",
+			"version": "v0.5.1",
+			"versionExact": "v0.5.1"
+		},
+		{
+			"checksumSHA1": "8cr5YhslUMgpvF2JebYvKC+Ezr4=",
+			"path": "github.com/elastic/go-ucfg/cfgutil",
+			"revision": "ec8488a52542c0c51e42e8ea204dcaff400bc644",
+			"revisionTime": "2017-02-07T06:38:51Z"
+		},
+		{
+			"checksumSHA1": "Q2qrc/nI9d1tNzWTmfrkWvBNqsc=",
+			"path": "github.com/elastic/go-ucfg/flag",
+			"revision": "ec8488a52542c0c51e42e8ea204dcaff400bc644",
+			"revisionTime": "2017-02-07T06:38:51Z"
+		},
+		{
+			"checksumSHA1": "uOrhvj7stlb0foxGZ5vbC1XJeto=",
+			"path": "github.com/elastic/go-ucfg/internal/parse",
+			"revision": "ec8488a52542c0c51e42e8ea204dcaff400bc644",
+			"revisionTime": "2017-02-07T06:38:51Z"
+		},
+		{
+			"checksumSHA1": "sMBM95+VYBPhwtNVHqqN1yrvk1o=",
+			"path": "github.com/elastic/go-ucfg/json",
+			"revision": "ec8488a52542c0c51e42e8ea204dcaff400bc644",
+			"revisionTime": "2017-02-07T06:38:51Z"
+		},
+		{
+			"checksumSHA1": "qvzj0KzxrWvYhHIbo+FwBxUNDFw=",
+			"path": "github.com/elastic/go-ucfg/yaml",
+			"revision": "ec8488a52542c0c51e42e8ea204dcaff400bc644",
+			"revisionTime": "2017-02-07T06:38:51Z"
+		},
+		{
+			"checksumSHA1": "DRu6+HSK/RVvCx0j2LdlL6vQjcA=",
+			"path": "github.com/elastic/go-windows",
+			"revision": "a8f9f07dec5f30c1e17afc9f360c0aed39225222",
+			"revisionTime": "2018-02-07T18:09:04Z"
+		},
+		{
+			"checksumSHA1": "RPOLNUpw00QUUaA/U4YbPVf6WlA=",
+			"path": "github.com/elastic/gosigar",
+			"revision": "237dff72b4ba95da2cd985f96a9c0ede4aefc760",
+			"revisionTime": "2018-03-16T16:52:25Z",
+			"version": "v0.9.0",
+			"versionExact": "v0.9.0"
+		},
+		{
+			"checksumSHA1": "TX9y4oPL5YmT4Gb/OU4GIPTdQB4=",
+			"path": "github.com/elastic/gosigar/cgroup",
+			"revision": "237dff72b4ba95da2cd985f96a9c0ede4aefc760",
+			"revisionTime": "2018-03-16T16:52:25Z",
+			"version": "v0.9.0",
+			"versionExact": "v0.9.0"
+		},
+		{
+			"checksumSHA1": "hPqGM3DENaGfipEODoyZ4mKogTQ=",
+			"path": "github.com/elastic/gosigar/sys",
+			"revision": "237dff72b4ba95da2cd985f96a9c0ede4aefc760",
+			"revisionTime": "2018-03-16T16:52:25Z",
+			"version": "v0.9.0",
+			"versionExact": "v0.9.0"
+		},
+		{
+			"checksumSHA1": "mLq5lOyD0ZU39ysXuf1ETOLJ+f0=",
+			"path": "github.com/elastic/gosigar/sys/linux",
+			"revision": "237dff72b4ba95da2cd985f96a9c0ede4aefc760",
+			"revisionTime": "2018-03-16T16:52:25Z",
+			"version": "v0.9.0",
+			"versionExact": "v0.9.0"
+		},
+		{
+			"checksumSHA1": "qDsgp2kAeI9nhj565HUScaUyjU4=",
+			"path": "github.com/elastic/gosigar/sys/windows",
+			"revision": "237dff72b4ba95da2cd985f96a9c0ede4aefc760",
+			"revisionTime": "2018-03-16T16:52:25Z",
+			"version": "v0.9.0",
+			"versionExact": "v0.9.0"
+		},
+		{
+			"checksumSHA1": "hTxFrbA619JCHysWjXHa9U6bfto=",
+			"path": "github.com/ericchiang/k8s",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "uQuMoUlS7hAWsB+Mwr/1B7+35BU=",
+			"path": "github.com/ericchiang/k8s/api/resource",
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "XN1tbPrI03O0ishnZyfkWtTnrcQ=",
+			"path": "github.com/ericchiang/k8s/api/unversioned",
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "yfTg3/Qn7KiizNJ39JmPBFi9YDQ=",
+			"path": "github.com/ericchiang/k8s/api/v1",
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "y8fNiBLSoGojnUsGDsdLlsJYyqQ=",
+			"path": "github.com/ericchiang/k8s/apis/apiextensions/v1beta1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "uw/3eB6WiVCSrQZS9ZZs/1kyu1I=",
+			"path": "github.com/ericchiang/k8s/apis/apps/v1alpha1",
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "JxQ/zEWQSrncYNKifCuMctq+Tsw=",
+			"path": "github.com/ericchiang/k8s/apis/apps/v1beta1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "bjklGt/pc6kWOZewAw87Hchw5oY=",
+			"path": "github.com/ericchiang/k8s/apis/authentication/v1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "LExhnM9Vn0LQoLQWszQ7aIxDxb4=",
+			"path": "github.com/ericchiang/k8s/apis/authentication/v1beta1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "GM+PzOiBoq3cxx4h5RKVUb3UH60=",
+			"path": "github.com/ericchiang/k8s/apis/authorization/v1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "zfr5oUVjbWRfvXi2LJiGMfFeDQY=",
+			"path": "github.com/ericchiang/k8s/apis/authorization/v1beta1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "izkXNDp5a5WP45jU0hSfTrwyfvM=",
+			"path": "github.com/ericchiang/k8s/apis/autoscaling/v1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "kUXiQQA99K7zquvG9es3yauVjYw=",
+			"path": "github.com/ericchiang/k8s/apis/autoscaling/v2alpha1",
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "FryZuAxWn4Ig8zc913w9BdfYzvs=",
+			"path": "github.com/ericchiang/k8s/apis/batch/v1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "ylo7Z8wyJD+tmICB7wsOVIBpO+U=",
+			"path": "github.com/ericchiang/k8s/apis/batch/v2alpha1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "9GRVPI+Tf4RrlX2aveUGEUHKIrM=",
+			"path": "github.com/ericchiang/k8s/apis/certificates/v1alpha1",
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "+d8+mSdkdcPWQIpczXDZZW0lrjg=",
+			"path": "github.com/ericchiang/k8s/apis/certificates/v1beta1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "S7AvxmCe/+WoFP/v9lZr0Mv66qg=",
+			"path": "github.com/ericchiang/k8s/apis/core/v1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "cWPoP6XZN7WMnEVMPcgPgg3Aw9Q=",
+			"path": "github.com/ericchiang/k8s/apis/extensions/v1beta1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "vaNrBPcGWeDd1rXl8+uN08uxWhE=",
+			"path": "github.com/ericchiang/k8s/apis/imagepolicy/v1alpha1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "UNTTH+Ppu4vImnF+bPkG3/NR3gg=",
+			"path": "github.com/ericchiang/k8s/apis/meta/v1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "wYSNb+W2L5gJlGO8n6mGOGft8R8=",
+			"path": "github.com/ericchiang/k8s/apis/policy/v1alpha1",
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "Mmyg9Wh+FCVR6fV8MGEKRxvqZ2k=",
+			"path": "github.com/ericchiang/k8s/apis/policy/v1beta1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "bvwYS/wrBkyAfvCjzMbi/vKamrQ=",
+			"path": "github.com/ericchiang/k8s/apis/rbac/v1alpha1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "m1Tde18NwewnvJoOYL3uykNcBuM=",
+			"path": "github.com/ericchiang/k8s/apis/rbac/v1beta1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "JirJkoeIkWJRNrbprsQvqwisxds=",
+			"path": "github.com/ericchiang/k8s/apis/resource",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "rQZ69PjEClQQ+PGEHRKzkGVVQyw=",
+			"path": "github.com/ericchiang/k8s/apis/settings/v1alpha1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "pp0AetmPoKy7Rz0zNhBwUpExkbc=",
+			"path": "github.com/ericchiang/k8s/apis/storage/v1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "WeACcIrS4EkeBm8TTftwuVniaWk=",
+			"path": "github.com/ericchiang/k8s/apis/storage/v1beta1",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "Su6wSR8V8HL2QZsF8icJ0R9AFq8=",
+			"path": "github.com/ericchiang/k8s/runtime",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "8ETrRvIaXPfD21N7fa8kdbumL00=",
+			"path": "github.com/ericchiang/k8s/runtime/schema",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "cMk3HE8/81ExHuEs0F5sZCclOFs=",
+			"path": "github.com/ericchiang/k8s/util/intstr",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "fobEKiMk5D7IGvCSwh4HdG1o98c=",
+			"path": "github.com/ericchiang/k8s/watch/versioned",
+			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
+			"revisionTime": "2018-01-20T20:28:12Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "AANTVr9CVVyzsgviODY6Wi2thuM=",
+			"path": "github.com/fatih/color",
+			"revision": "570b54cabe6b8eb0bc2dfce68d964677d63b5260",
+			"revisionTime": "2017-05-23T13:53:55Z",
+			"version": "v1.5.0",
+			"versionExact": "v1.5.0"
+		},
+		{
+			"checksumSHA1": "dgmdG37hn1qma1kdpCaUJ6JltXk=",
+			"origin": "github.com/elastic/fsevents",
+			"path": "github.com/fsnotify/fsevents",
+			"revision": "690cb784149d5facd7fe613c52757445c43afcde",
+			"revisionTime": "2017-12-04T13:54:51Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "x2Km0Qy3WgJJnV19Zv25VwTJcBM=",
+			"path": "github.com/fsnotify/fsnotify",
+			"revision": "4da3e2cfbabc9f751898f250b49f2439785783a1",
+			"revisionTime": "2017-03-29T04:21:07Z"
+		},
+		{
+			"checksumSHA1": "2UmMbNHc8FBr98mJFN1k8ISOIHk=",
+			"path": "github.com/garyburd/redigo/internal",
+			"revision": "b8dc90050f24c1a73a52f107f3f575be67b21b7c",
+			"revisionTime": "2016-05-25T16:57:06Z"
+		},
+		{
+			"checksumSHA1": "507OiSqTxfGCje7xDT5eq9CCaNQ=",
+			"path": "github.com/garyburd/redigo/redis",
+			"revision": "b8dc90050f24c1a73a52f107f3f575be67b21b7c",
+			"revisionTime": "2016-05-25T16:57:06Z"
+		},
+		{
+			"checksumSHA1": "ImX1uv6O09ggFeBPUJJ2nu7MPSA=",
+			"path": "github.com/ghodss/yaml",
+			"revision": "0ca9ea5df5451ffdf184b4428c902747c2c11cd7",
+			"revisionTime": "2017-03-27T23:54:44Z"
+		},
+		{
+			"checksumSHA1": "wDZdTaY9JiqqqnF4c3pHP71nWmk=",
+			"path": "github.com/go-ole/go-ole",
+			"revision": "de8695c8edbf8236f30d6e1376e20b198a028d42",
+			"revisionTime": "2017-02-09T15:13:32Z"
+		},
+		{
+			"checksumSHA1": "Q0ZOcJW0fqOefDzEdn+PJHOeSgI=",
+			"path": "github.com/go-ole/go-ole/oleutil",
+			"revision": "de8695c8edbf8236f30d6e1376e20b198a028d42",
+			"revisionTime": "2017-02-09T15:13:32Z"
+		},
+		{
+			"checksumSHA1": "VkwT/BxZIqv+rCFwz3jjQ08IRis=",
+			"path": "github.com/gocarina/gocsv",
+			"revision": "ffef3ffc77bec026fefa6f76bd53d158cfa0e669",
+			"revisionTime": "2017-03-24T09:53:51Z"
+		},
+		{
+			"checksumSHA1": "kBeNcaKk56FguvPSUCEaH6AxpRc=",
+			"path": "github.com/golang/protobuf/proto",
+			"revision": "2bba0603135d7d7f5cb73b2125beeda19c09f4ef",
+			"revisionTime": "2017-03-31T03:19:02Z"
+		},
+		{
+			"checksumSHA1": "p/8vSviYF91gFflhrt5vkyksroo=",
+			"path": "github.com/golang/snappy",
+			"revision": "553a641470496b2327abcac10b36396bd98e45c9",
+			"revisionTime": "2017-02-15T23:32:05Z"
+		},
+		{
+			"checksumSHA1": "upYudcnxqDBx2/71UDwwxHn/KyY=",
+			"path": "github.com/google/flatbuffers/go",
+			"revision": "7a6b2bf521e95097a92ec848001531b2dcf0f3fa",
+			"revisionTime": "2017-09-25T18:44:58Z"
+		},
+		{
+			"checksumSHA1": "5DBIm/bJOKLR3CbQH6wIELQDLlQ=",
+			"path": "github.com/gorhill/cronexpr",
+			"revision": "d520615e531a6bf3fb69406b9eba718261285ec8",
+			"revisionTime": "2016-12-05T14:13:22Z"
+		},
+		{
+			"checksumSHA1": "40vJyUB4ezQSn/NSadsKEOrudMc=",
+			"path": "github.com/inconshreveable/mousetrap",
+			"revision": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75",
+			"revisionTime": "2014-10-17T20:07:13Z"
+		},
+		{
+			"checksumSHA1": "l9wW52CYGbmO/NGwYZ/Op2QTmaA=",
+			"path": "github.com/joeshaw/multierror",
+			"revision": "69b34d4ec901851247ae7e77d33909caf9df99ed",
+			"revisionTime": "2014-01-24T17:37:10Z"
+		},
+		{
+			"checksumSHA1": "a8Ge6pE7oxux9ZMZVAlyEeGzCng=",
+			"path": "github.com/juju/ratelimit",
+			"revision": "5b9ff866471762aa2ab2dced63c9fb6f53921342",
+			"revisionTime": "2017-05-23T01:21:41Z"
+		},
+		{
+			"checksumSHA1": "+CqJGh7NIDMnHgScq9sl9tPrnVM=",
+			"path": "github.com/klauspost/compress/flate",
+			"revision": "14c9a76e3c95e47f8ccce949bba2c1101a8b85e6",
+			"revisionTime": "2017-02-18T08:16:04Z"
+		},
+		{
+			"checksumSHA1": "+azPXaZpPF14YHRghNAer13ThQU=",
+			"path": "github.com/klauspost/compress/zlib",
+			"revision": "14c9a76e3c95e47f8ccce949bba2c1101a8b85e6",
+			"revisionTime": "2017-02-18T08:16:04Z"
+		},
+		{
+			"checksumSHA1": "iKPMvbAueGfdyHcWCgzwKzm8WVo=",
+			"path": "github.com/klauspost/cpuid",
+			"revision": "09cded8978dc9e80714c4d85b0322337b0a1e5e0",
+			"revisionTime": "2016-03-02T07:53:16Z"
+		},
+		{
+			"checksumSHA1": "BM6ZlNJmtKy3GBoWwg2X55gnZ4A=",
+			"path": "github.com/klauspost/crc32",
+			"revision": "1bab8b35b6bb565f92cbc97939610af9369f942a",
+			"revisionTime": "2017-02-10T14:05:23Z"
+		},
+		{
+			"checksumSHA1": "qNkx9+OTwZI6aFv7K9zuFCGODUw=",
+			"path": "github.com/mattn/go-colorable",
+			"revision": "941b50ebc6efddf4c41c8e4537a5f68a4e686b24",
+			"revisionTime": "2017-06-15T03:49:14Z"
+		},
+		{
+			"checksumSHA1": "U6lX43KDDlNOn+Z0Yyww+ZzHfFo=",
+			"path": "github.com/mattn/go-isatty",
+			"revision": "fc9e8d8ef48496124e79ae0df75490096eccf6fe",
+			"revisionTime": "2017-03-22T23:44:13Z"
+		},
+		{
+			"checksumSHA1": "Y89CHl2URaBbobeyCOr4kzbLwYE=",
+			"path": "github.com/miekg/dns",
+			"revision": "5d001d020961ae1c184f9f8152fdc73810481677",
+			"revisionTime": "2016-06-14T16:21:01Z"
+		},
+		{
+			"checksumSHA1": "sWdAYPKyaT4SW8hNQNpRS0sU4lU=",
+			"path": "github.com/mitchellh/hashstructure",
+			"revision": "ab25296c0f51f1022f01cd99dfb45f1775de8799",
+			"revisionTime": "2017-01-16T05:20:23Z"
+		},
+		{
+			"checksumSHA1": "+OwSloMUOgkUXkJmGr7pQyNsh4Q=",
+			"path": "github.com/mitchellh/mapstructure",
+			"revision": "740c764bc6149d3f1806231418adb9f52c11bcbf",
+			"revisionTime": "2014-07-21T15:06:20Z"
+		},
+		{
+			"checksumSHA1": "2AyUkWjutec6p+470tgio8mYOxI=",
+			"path": "github.com/opencontainers/go-digest",
+			"revision": "eaa60544f31ccf3b0653b1a118b76d33418ff41b",
+			"revisionTime": "2017-05-10T16:33:54Z"
+		},
+		{
+			"checksumSHA1": "eOMCORUm8KxiGSy0hBuQsMsxauo=",
+			"path": "github.com/opencontainers/image-spec/specs-go",
+			"revision": "4038d4391fe912af1031db5a1f511cf07c07cbc8",
+			"revisionTime": "2017-05-25T20:40:40Z"
+		},
+		{
+			"checksumSHA1": "9YujSsJjiLGkQMzwWycsjqR340k=",
+			"path": "github.com/opencontainers/image-spec/specs-go/v1",
+			"revision": "4038d4391fe912af1031db5a1f511cf07c07cbc8",
+			"revisionTime": "2017-05-25T20:40:40Z"
+		},
+		{
+			"checksumSHA1": "MA07KaAp1aPVheuopyrFr7pxANs=",
+			"path": "github.com/opencontainers/runc/libcontainer/user",
+			"revision": "653207bc29a6d2d62b5d4f55b596467cb715a128",
+			"revisionTime": "2017-03-27T18:58:03Z"
+		},
+		{
+			"checksumSHA1": "WmrPO1ovmQ7t7hs9yZGbr2SAoM4=",
+			"path": "github.com/pierrec/lz4",
+			"revision": "90290f74b1b4d9c097f0a3b3c7eba2ef3875c699",
+			"revisionTime": "2017-02-26T14:26:21Z"
+		},
+		{
+			"checksumSHA1": "IT4sX58d+e8osXHV5U6YCSdB/uE=",
+			"path": "github.com/pierrec/xxHash/xxHash32",
+			"revision": "5a004441f897722c627870a981d02b29924215fa",
+			"revisionTime": "2016-01-12T16:53:51Z"
+		},
+		{
+			"checksumSHA1": "jFvSgd78ZfuFULvWd6uFD5mi+94=",
+			"path": "github.com/pierrre/gotestcover",
+			"revision": "7b94f124d338b6ae06df22bc2ee7909af27aae85",
+			"revisionTime": "2016-01-13T21:25:33Z",
+			"tree": true
+		},
+		{
+			"checksumSHA1": "ynJSWoF6v+3zMnh9R0QmmG6iGV8=",
+			"path": "github.com/pkg/errors",
+			"revision": "ff09b135c25aae272398c51a07235b90a75aa4f0",
+			"revisionTime": "2017-03-16T20:15:38Z"
+		},
+		{
+			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
+			"path": "github.com/pmezard/go-difflib/difflib",
+			"revision": "792786c7400a136282c1664665ae0a8db921c6c2",
+			"revisionTime": "2016-01-10T10:55:54Z",
+			"version": "v1.0.0",
+			"versionExact": "v1.0.0"
+		},
+		{
+			"checksumSHA1": "Etvt6mgzvD7ARf4Ux03LHfgSlzU=",
+			"path": "github.com/prometheus/procfs",
+			"revision": "54d17b57dd7d4a3aa092476596b3f8a933bde349",
+			"revisionTime": "2018-03-10T14:15:09Z"
+		},
+		{
+			"checksumSHA1": "lv9rIcjbVEGo8AT1UCUZXhXrfQc=",
+			"path": "github.com/prometheus/procfs/internal/util",
+			"revision": "54d17b57dd7d4a3aa092476596b3f8a933bde349",
+			"revisionTime": "2018-03-10T14:15:09Z"
+		},
+		{
+			"checksumSHA1": "EekY1iRG9JY74mDD0jsbFCWbAFs=",
+			"path": "github.com/prometheus/procfs/nfs",
+			"revision": "54d17b57dd7d4a3aa092476596b3f8a933bde349",
+			"revisionTime": "2018-03-10T14:15:09Z"
+		},
+		{
+			"checksumSHA1": "yItvTQLUVqm/ArLEbvEhqG0T5a0=",
+			"path": "github.com/prometheus/procfs/xfs",
+			"revision": "54d17b57dd7d4a3aa092476596b3f8a933bde349",
+			"revisionTime": "2018-03-10T14:15:09Z"
+		},
+		{
+			"checksumSHA1": "KAzbLjI9MzW2tjfcAsK75lVRp6I=",
+			"path": "github.com/rcrowley/go-metrics",
+			"revision": "1f30fe9094a513ce4c700b9a54458bbb0c96996c",
+			"revisionTime": "2016-11-28T21:05:44Z"
+		},
+		{
+			"checksumSHA1": "q/d9nXRQYKEJ/EWn+5y6jL8rPGs=",
+			"path": "github.com/rcrowley/go-metrics/exp",
+			"revision": "1f30fe9094a513ce4c700b9a54458bbb0c96996c",
+			"revisionTime": "2016-11-28T21:05:44Z"
+		},
+		{
+			"checksumSHA1": "nP4adVqIbQB1KW4VHYTjZ4BGwDQ=",
+			"path": "github.com/samuel/go-parser/parser",
+			"revision": "ca8abbf65d0e61dedf061f98bd3850f250e27539",
+			"revisionTime": "2013-07-31T16:04:55Z"
+		},
+		{
+			"checksumSHA1": "Kr4KcNMd1VR66oHRkoGDEnspIFU=",
+			"path": "github.com/samuel/go-thrift/parser",
+			"revision": "2187045faa54fce7f5028706ffeb2f2fc342aa7e",
+			"revisionTime": "2014-05-22T04:34:39Z"
+		},
+		{
+			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",
+			"path": "github.com/satori/go.uuid",
+			"revision": "5bf94b69c6b68ee1b541973bb8e1144db23a194b",
+			"revisionTime": "2017-03-21T23:07:31Z"
+		},
+		{
+			"checksumSHA1": "lZRqG0Rl5w+mkaTUOuEjcKvNU6c=",
+			"path": "github.com/shirou/gopsutil/disk",
+			"revision": "c432be29ccce470088d07eea25b3ea7e68a8afbb",
+			"revisionTime": "2018-01-30T01:13:38Z",
+			"version": "v2.18.01",
+			"versionExact": "v2.18.01"
+		},
+		{
+			"checksumSHA1": "jWpwWWcywJPNhKTYxi4RXds+amQ=",
+			"path": "github.com/shirou/gopsutil/internal/common",
+			"revision": "c432be29ccce470088d07eea25b3ea7e68a8afbb",
+			"revisionTime": "2018-01-30T01:13:38Z",
+			"version": "v2.18.01",
+			"versionExact": "v2.18.01"
+		},
+		{
+			"checksumSHA1": "Z7FjZvR5J5xh6Ne572gD7tRUsc8=",
+			"path": "github.com/shirou/gopsutil/net",
+			"revision": "c432be29ccce470088d07eea25b3ea7e68a8afbb",
+			"revisionTime": "2018-01-30T01:13:38Z",
+			"version": "v2.18.01",
+			"versionExact": "v2.18.01"
+		},
+		{
+			"checksumSHA1": "e7mAb9jMke2ASQGZepFgOmfBFzM=",
+			"path": "github.com/spf13/cobra",
+			"revision": "1be1d2841c773c01bee8289f55f7463b6e2c2539",
+			"revisionTime": "2017-11-23T00:13:03Z"
+		},
+		{
+			"checksumSHA1": "STxYqRb4gnlSr3mRpT+Igfdz/kM=",
+			"path": "github.com/spf13/pflag",
+			"revision": "e57e3eeb33f795204c1ca35f56c44f83227c6e66",
+			"revisionTime": "2017-05-08T18:43:26Z"
+		},
+		{
+			"checksumSHA1": "Le1psgZO0t6mRg6oY5dmnjH13hk=",
+			"path": "github.com/stretchr/testify/assert",
+			"revision": "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c",
+			"revisionTime": "2017-12-30T17:54:59Z",
+			"version": "v1.2.0",
+			"versionExact": "v1.2.0"
+		},
+		{
+			"checksumSHA1": "M0S9278lG9Fztu+ZUsLUi40GDJU=",
+			"path": "github.com/tsg/gopacket",
+			"revision": "f289b3ea3e41a01b2822be9caf5f40c01fdda05c",
+			"revisionTime": "2018-03-16T21:03:30Z"
+		},
+		{
+			"checksumSHA1": "STY8i3sZLdZfFcKiyOdpV852nls=",
+			"path": "github.com/tsg/gopacket/afpacket",
+			"revision": "8e703b9968693c15f25cabb6ba8be4370cf431d0",
+			"revisionTime": "2016-08-17T18:24:57Z"
+		},
+		{
+			"checksumSHA1": "+NwKULkolGgMn67wFYf+n0wz+a8=",
+			"path": "github.com/tsg/gopacket/layers",
+			"revision": "8e703b9968693c15f25cabb6ba8be4370cf431d0",
+			"revisionTime": "2016-08-17T18:24:57Z"
+		},
+		{
+			"checksumSHA1": "pDfiWUxZQdXap4CR6ASDvblChLU=",
+			"path": "github.com/tsg/gopacket/pcap",
+			"revision": "8e703b9968693c15f25cabb6ba8be4370cf431d0",
+			"revisionTime": "2016-08-17T18:24:57Z"
+		},
+		{
+			"checksumSHA1": "nGCIgH3ohqLru6ivQSSiY6YWEow=",
+			"path": "github.com/tsg/gopacket/pfring",
+			"revision": "8e703b9968693c15f25cabb6ba8be4370cf431d0",
+			"revisionTime": "2016-08-17T18:24:57Z"
+		},
+		{
+			"checksumSHA1": "Und+nhgN1YsNWvd0aDYO+0cMcAo=",
+			"path": "github.com/yuin/gopher-lua",
+			"revision": "b402f3114ec730d8bddb074a6c137309f561aa78",
+			"revisionTime": "2017-04-03T16:00:31Z"
+		},
+		{
+			"checksumSHA1": "yNGEI9BMDbGwabUnaHvV9ZZm/a0=",
+			"path": "github.com/yuin/gopher-lua/ast",
+			"revision": "b402f3114ec730d8bddb074a6c137309f561aa78",
+			"revisionTime": "2017-04-03T16:00:31Z"
+		},
+		{
+			"checksumSHA1": "RzAFlqrwEE/ybIrUhDQeIE8+7pM=",
+			"path": "github.com/yuin/gopher-lua/parse",
+			"revision": "b402f3114ec730d8bddb074a6c137309f561aa78",
+			"revisionTime": "2017-04-03T16:00:31Z"
+		},
+		{
+			"checksumSHA1": "pOY+AESgLoqczVCXNCvmPtJyUXE=",
+			"path": "github.com/yuin/gopher-lua/pm",
+			"revision": "b402f3114ec730d8bddb074a6c137309f561aa78",
+			"revisionTime": "2017-04-03T16:00:31Z"
+		},
+		{
+			"checksumSHA1": "HedK9m8E8iyib4bIBtIX7xprOgo=",
+			"path": "go.uber.org/atomic",
+			"revision": "8474b86a5a6f79c443ce4b2992817ff32cf208b8",
+			"revisionTime": "2017-11-14T20:44:01Z"
+		},
+		{
+			"checksumSHA1": "JDGx7hehaQunZySwPs7yvdUs2m8=",
+			"path": "go.uber.org/multierr",
+			"revision": "fb7d312c2c04c34f0ad621048bbb953b168f9ff6",
+			"revisionTime": "2017-08-29T22:43:07Z"
+		},
+		{
+			"checksumSHA1": "5BYbiKEkYykvfjSaNYDuQpBqglo=",
+			"path": "go.uber.org/zap",
+			"revision": "35aad584952c3e7020db7b839f6b102de6271f89",
+			"revisionTime": "2017-09-25T19:53:02Z",
+			"version": "v1.7.1",
+			"versionExact": "v1.7.1"
+		},
+		{
+			"checksumSHA1": "HYo/9nwrY08NQA+2ItPOAH8IFW8=",
+			"path": "go.uber.org/zap/buffer",
+			"revision": "35aad584952c3e7020db7b839f6b102de6271f89",
+			"revisionTime": "2017-09-25T19:53:02Z",
+			"version": "v1.7.1",
+			"versionExact": "v1.7.1"
+		},
+		{
+			"checksumSHA1": "MuxOAtZEsJitlWBzhmpm2vGiHok=",
+			"path": "go.uber.org/zap/internal/bufferpool",
+			"revision": "35aad584952c3e7020db7b839f6b102de6271f89",
+			"revisionTime": "2017-09-25T19:53:02Z",
+			"version": "v1.7.1",
+			"versionExact": "v1.7.1"
+		},
+		{
+			"checksumSHA1": "uC0L9eCSAYcCWNC8udJk/t1vvIU=",
+			"path": "go.uber.org/zap/internal/color",
+			"revision": "35aad584952c3e7020db7b839f6b102de6271f89",
+			"revisionTime": "2017-09-25T19:53:02Z",
+			"version": "v1.7.1",
+			"versionExact": "v1.7.1"
+		},
+		{
+			"checksumSHA1": "b80CJExrVpXu3SA1iCQ6uLqTn2c=",
+			"path": "go.uber.org/zap/internal/exit",
+			"revision": "35aad584952c3e7020db7b839f6b102de6271f89",
+			"revisionTime": "2017-09-25T19:53:02Z",
+			"version": "v1.7.1",
+			"versionExact": "v1.7.1"
+		},
+		{
+			"checksumSHA1": "mRD6lujPvXPkbC3+byNwO/bNVu8=",
+			"path": "go.uber.org/zap/zapcore",
+			"revision": "35aad584952c3e7020db7b839f6b102de6271f89",
+			"revisionTime": "2017-09-25T19:53:02Z",
+			"version": "v1.7.1",
+			"versionExact": "v1.7.1"
+		},
+		{
+			"checksumSHA1": "gyBmIfDZslmQGKnqisJ/p7oHbQc=",
+			"path": "go.uber.org/zap/zaptest/observer",
+			"revision": "35aad584952c3e7020db7b839f6b102de6271f89",
+			"revisionTime": "2017-09-25T19:53:02Z",
+			"version": "v1.7.1",
+			"versionExact": "v1.7.1"
+		},
+		{
+			"checksumSHA1": "ppPg0bIlBAVJy0Pn13BfBnkp9V4=",
+			"path": "golang.org/x/crypto/blake2b",
+			"revision": "5119cf507ed5294cc409c092980c7497ee5d6fd2",
+			"revisionTime": "2018-01-22T10:39:14Z"
+		},
+		{
+			"checksumSHA1": "1MGpGDQqnUoRpv7VEcQrXOBydXE=",
+			"path": "golang.org/x/crypto/pbkdf2",
+			"revision": "5119cf507ed5294cc409c092980c7497ee5d6fd2",
+			"revisionTime": "2018-01-22T10:39:14Z"
+		},
+		{
+			"checksumSHA1": "iNE2KX9BQzCptlQC2DdQEVmn4R4=",
+			"path": "golang.org/x/crypto/sha3",
+			"revision": "5119cf507ed5294cc409c092980c7497ee5d6fd2",
+			"revisionTime": "2018-01-22T10:39:14Z"
+		},
+		{
+			"checksumSHA1": "6U7dCaxxIMjf5V02iWgyAwppczw=",
+			"path": "golang.org/x/crypto/ssh/terminal",
+			"revision": "5119cf507ed5294cc409c092980c7497ee5d6fd2",
+			"revisionTime": "2018-01-22T10:39:14Z"
+		},
+		{
+			"checksumSHA1": "uX2McdP4VcQ6zkAF0Q4oyd0rFtU=",
+			"path": "golang.org/x/net/bpf",
+			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
+			"revisionTime": "2017-10-22T17:59:00Z",
+			"version": "release-branch.go1.9",
+			"versionExact": "release-branch.go1.9"
+		},
+		{
+			"checksumSHA1": "dr5+PfIRzXeN+l1VG+s0lea9qz8=",
+			"path": "golang.org/x/net/context",
+			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
+			"revisionTime": "2017-10-22T17:59:00Z",
+			"version": "release-branch.go1.9",
+			"versionExact": "release-branch.go1.9"
+		},
+		{
+			"checksumSHA1": "WHc3uByvGaMcnSoI21fhzYgbOgg=",
+			"path": "golang.org/x/net/context/ctxhttp",
+			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
+			"revisionTime": "2017-10-22T17:59:00Z",
+			"version": "release-branch.go1.9",
+			"versionExact": "release-branch.go1.9"
+		},
+		{
+			"checksumSHA1": "TWcqN2+KUWtdqnu18rruwn14UEQ=",
+			"path": "golang.org/x/net/http2",
+			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
+			"revisionTime": "2017-10-22T17:59:00Z",
+			"version": "release-branch.go1.9",
+			"versionExact": "release-branch.go1.9"
+		},
+		{
+			"checksumSHA1": "ezWhc7n/FtqkLDQKeU2JbW+80tE=",
+			"path": "golang.org/x/net/http2/hpack",
+			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
+			"revisionTime": "2017-10-22T17:59:00Z",
+			"version": "release-branch.go1.9",
+			"versionExact": "release-branch.go1.9"
+		},
+		{
+			"checksumSHA1": "DqdFGWbLLyVFeDvzvXyf1Y678uA=",
+			"path": "golang.org/x/net/icmp",
+			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
+			"revisionTime": "2017-10-22T17:59:00Z",
+			"version": "release-branch.go1.9",
+			"versionExact": "release-branch.go1.9"
+		},
+		{
+			"checksumSHA1": "RcrB7tgYS/GMW4QrwVdMOTNqIU8=",
+			"path": "golang.org/x/net/idna",
+			"revision": "f5dfe339be1d06f81b22525fe34671ee7d2c8904",
+			"revisionTime": "2018-02-04T03:50:36Z"
+		},
+		{
+			"checksumSHA1": "5JWn/wMC+EWNDKI/AYE4JifQF54=",
+			"path": "golang.org/x/net/internal/iana",
+			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
+			"revisionTime": "2017-10-22T17:59:00Z",
+			"version": "release-branch.go1.9",
+			"versionExact": "release-branch.go1.9"
+		},
+		{
+			"checksumSHA1": "WnI4058Oj6W4YSvyXAnK3qCKqvo=",
+			"path": "golang.org/x/net/internal/socket",
+			"revision": "f5dfe339be1d06f81b22525fe34671ee7d2c8904",
+			"revisionTime": "2018-02-04T03:50:36Z"
+		},
+		{
+			"checksumSHA1": "zPTKyZ1C55w1fk1W+/qGE15jaek=",
+			"path": "golang.org/x/net/ipv4",
+			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
+			"revisionTime": "2017-10-22T17:59:00Z",
+			"version": "release-branch.go1.9",
+			"versionExact": "release-branch.go1.9"
+		},
+		{
+			"checksumSHA1": "3L3n7qKMO9X8E1ibA5mExKvwbmI=",
+			"path": "golang.org/x/net/ipv6",
+			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
+			"revisionTime": "2017-10-22T17:59:00Z",
+			"version": "release-branch.go1.9",
+			"versionExact": "release-branch.go1.9"
+		},
+		{
+			"checksumSHA1": "3xyuaSNmClqG4YWC7g0isQIbUTc=",
+			"path": "golang.org/x/net/lex/httplex",
+			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
+			"revisionTime": "2017-10-22T17:59:00Z",
+			"version": "release-branch.go1.9",
+			"versionExact": "release-branch.go1.9"
+		},
+		{
+			"checksumSHA1": "QEm/dePZ0lOnyOs+m22KjXfJ/IU=",
+			"path": "golang.org/x/net/proxy",
+			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
+			"revisionTime": "2017-10-22T17:59:00Z",
+			"version": "release-branch.go1.9",
+			"versionExact": "release-branch.go1.9"
+		},
+		{
+			"checksumSHA1": "+7gSOeJWKSUhXho9cQPtyzJL+ok=",
+			"path": "golang.org/x/net/publicsuffix",
+			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
+			"revisionTime": "2017-10-22T17:59:00Z",
+			"version": "release-branch.go1.9",
+			"versionExact": "release-branch.go1.9"
+		},
+		{
+			"checksumSHA1": "CNHEeGnucEUlTHJrLS2kHtfNbws=",
+			"path": "golang.org/x/sys/unix",
+			"revision": "37707fdb30a5b38865cfb95e5aab41707daec7fd",
+			"revisionTime": "2018-02-02T13:35:31Z"
+		},
+		{
+			"checksumSHA1": "eQq+ZoTWPjyizS9XalhZwfGjQao=",
+			"path": "golang.org/x/sys/windows",
+			"revision": "37707fdb30a5b38865cfb95e5aab41707daec7fd",
+			"revisionTime": "2018-02-02T13:35:31Z"
+		},
+		{
+			"checksumSHA1": "ZdFZFaXmCgEEaEhVPkyXrnhKhsg=",
+			"path": "golang.org/x/sys/windows/registry",
+			"revision": "37707fdb30a5b38865cfb95e5aab41707daec7fd",
+			"revisionTime": "2018-02-02T13:35:31Z"
+		},
+		{
+			"checksumSHA1": "VNlkHemg81Ba7ElHfKKUU1h+U1U=",
+			"path": "golang.org/x/sys/windows/svc",
+			"revision": "37707fdb30a5b38865cfb95e5aab41707daec7fd",
+			"revisionTime": "2018-02-02T13:35:31Z"
+		},
+		{
+			"checksumSHA1": "lZi+t2ilFyYSpqL1ThwNf8ot3WQ=",
+			"path": "golang.org/x/sys/windows/svc/debug",
+			"revision": "37707fdb30a5b38865cfb95e5aab41707daec7fd",
+			"revisionTime": "2018-02-02T13:35:31Z"
+		},
+		{
+			"checksumSHA1": "uVlUSSKplihZG7N+QJ6fzDZ4Kh8=",
+			"path": "golang.org/x/sys/windows/svc/eventlog",
+			"revision": "37707fdb30a5b38865cfb95e5aab41707daec7fd",
+			"revisionTime": "2018-02-02T13:35:31Z"
+		},
+		{
+			"checksumSHA1": "rEd9Z4B9rbkOzxpwWSu0SN1PtDg=",
+			"path": "golang.org/x/text",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "Mr4ur60bgQJnQFfJY0dGtwWwMPE=",
+			"path": "golang.org/x/text/encoding",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "DSdlK4MKI/a3U8Zaee2XKBe01Fo=",
+			"path": "golang.org/x/text/encoding/charmap",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "tLQQZEU7qS/eYyCvd76Wqfz1oR8=",
+			"path": "golang.org/x/text/encoding/htmlindex",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "zeHyHebIZl1tGuwGllIhjfci+wI=",
+			"path": "golang.org/x/text/encoding/internal",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "7kYqxy64WhMjFIFZgN7tJ3lbKxM=",
+			"path": "golang.org/x/text/encoding/internal/identifier",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "2YqVpmvjWGEBATyUphTP1MS34JE=",
+			"path": "golang.org/x/text/encoding/japanese",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "+ErWCAdaMwO4PLtrk9D/Hh+7oQM=",
+			"path": "golang.org/x/text/encoding/korean",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "mTuZi5urYwgDIO8+Gfql2pv8Vwg=",
+			"path": "golang.org/x/text/encoding/simplifiedchinese",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "D+VI4j0Wjzr8SeupWdOB5KBdFOw=",
+			"path": "golang.org/x/text/encoding/traditionalchinese",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "G9LfJI9gySazd+MyyC6QbTHx4to=",
+			"path": "golang.org/x/text/encoding/unicode",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "hyNCcTwMQnV6/MK8uUW9E5H0J0M=",
+			"path": "golang.org/x/text/internal/tag",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "Qk7dljcrEK1BJkAEZguxAbG9dSo=",
+			"path": "golang.org/x/text/internal/utf8internal",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "/N4Gt0BoQcasJJ28JOlzLO5v/ug=",
+			"path": "golang.org/x/text/language",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "IV4MN7KGBSocu/5NR3le3sxup4Y=",
+			"path": "golang.org/x/text/runes",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "CbpjEkkOeh0fdM/V8xKDdI0AA88=",
+			"path": "golang.org/x/text/secure/bidirule",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "ziMb9+ANGRJSSIuxYdRbA+cDRBQ=",
+			"path": "golang.org/x/text/transform",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "w8kDfZ1Ug+qAcVU0v8obbu3aDOY=",
+			"path": "golang.org/x/text/unicode/bidi",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "BCNYmf4Ek93G4lk5x3ucNi/lTwA=",
+			"path": "golang.org/x/text/unicode/norm",
+			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
+			"revisionTime": "2018-02-04T03:07:25Z"
+		},
+		{
+			"checksumSHA1": "p3gWsy4fQOSXGRMUHr3TnmVFias=",
+			"path": "golang.org/x/tools/go/ast/astutil",
+			"revision": "5d2fd3ccab986d52112bf301d47a819783339d0e",
+			"revisionTime": "2017-08-07T23:04:23Z",
+			"version": "release-branch.go1.9",
+			"versionExact": "release-branch.go1.9"
+		},
+		{
+			"checksumSHA1": "AnXFEvmaJ7w2Q7hWPcLUmCbPgq0=",
+			"path": "golang.org/x/tools/go/buildutil",
+			"revision": "5d2fd3ccab986d52112bf301d47a819783339d0e",
+			"revisionTime": "2017-08-07T23:04:23Z",
+			"version": "release-branch.go1.9",
+			"versionExact": "release-branch.go1.9"
+		},
+		{
+			"checksumSHA1": "ZpAR2KupZto/mWf9zu5e6IKDWt0=",
+			"path": "golang.org/x/tools/go/loader",
+			"revision": "5d2fd3ccab986d52112bf301d47a819783339d0e",
+			"revisionTime": "2017-08-07T23:04:23Z",
+			"version": "release-branch.go1.9",
+			"versionExact": "release-branch.go1.9"
+		},
+		{
+			"checksumSHA1": "6f8MEU31llHM1sLM/GGH4/Qxu0A=",
+			"path": "gopkg.in/inf.v0",
+			"revision": "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4",
+			"revisionTime": "2015-09-11T12:57:57Z"
+		},
+		{
+			"checksumSHA1": "1D8GzeoFGUs5FZOoyC2DpQg8c5Y=",
+			"path": "gopkg.in/mgo.v2",
+			"revision": "3f83fa5005286a7fe593b055f0d7771a7dce4655",
+			"revisionTime": "2016-08-18T02:01:20Z"
+		},
+		{
+			"checksumSHA1": "YsB2DChSV9HxdzHaKATllAUKWSI=",
+			"path": "gopkg.in/mgo.v2/bson",
+			"revision": "3f83fa5005286a7fe593b055f0d7771a7dce4655",
+			"revisionTime": "2016-08-18T02:01:20Z"
+		},
+		{
+			"checksumSHA1": "XQsrqoNT1U0KzLxOFcAZVvqhLfk=",
+			"path": "gopkg.in/mgo.v2/internal/json",
+			"revision": "3f83fa5005286a7fe593b055f0d7771a7dce4655",
+			"revisionTime": "2016-08-18T02:01:20Z"
+		},
+		{
+			"checksumSHA1": "LEvMCnprte47qdAxWvQ/zRxVF1U=",
+			"path": "gopkg.in/mgo.v2/internal/sasl",
+			"revision": "3f83fa5005286a7fe593b055f0d7771a7dce4655",
+			"revisionTime": "2016-08-18T02:01:20Z"
+		},
+		{
+			"checksumSHA1": "+1WDRPaOphSCmRMxVPIPBV4aubc=",
+			"path": "gopkg.in/mgo.v2/internal/scram",
+			"revision": "3f83fa5005286a7fe593b055f0d7771a7dce4655",
+			"revisionTime": "2016-08-18T02:01:20Z"
+		},
+		{
+			"checksumSHA1": "fALlQNY1fM99NesfLJ50KguWsio=",
+			"path": "gopkg.in/yaml.v2",
+			"revision": "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b",
+			"revisionTime": "2017-04-07T17:21:22Z"
+		},
+		{
+			"checksumSHA1": "ZDOewomjpADMDyjKRW5rP15519M=",
+			"path": "howett.net/plist",
+			"revision": "233df3c4f07b0c562da0e8a6fb850681ac49bb90",
+			"revisionTime": "2017-11-05T00:43:39Z"
+		},
+		{
+			"path": "plugin",
+			"revision": ""
+		}
+	],
+	"rootPath": "github.com/elastic/beats"
+}

--- a/_beats/vendor/vendor.json
+++ b/_beats/vendor/vendor.json
@@ -117,12 +117,10 @@
 			"versionExact": "v1.3.1"
 		},
 		{
-			"checksumSHA1": "dvabztWVQX8f6oMLRyv4dLH+TGY=",
+			"checksumSHA1": "5rPfda8jFccr3A6heL+JAmi9K9g=",
 			"path": "github.com/davecgh/go-spew/spew",
-			"revision": "346938d642f2ec3594ed81d874461961cd0faa76",
-			"revisionTime": "2016-10-29T20:57:26Z",
-			"version": "v1.1.0",
-			"versionExact": "v1.1.0"
+			"revision": "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d",
+			"revisionTime": "2015-11-05T21:09:06Z"
 		},
 		{
 			"checksumSHA1": "Gj+xR1VgFKKmFXYOJMnAczC3Znk=",
@@ -369,44 +367,44 @@
 			"revisionTime": "2016-08-05T00:47:13Z"
 		},
 		{
-			"checksumSHA1": "yxowcZEI5Qx1xwu9TI+L5NS87Sw=",
+			"checksumSHA1": "FmPMalgdsaNNmghFB2DWm8fJjVA=",
 			"path": "github.com/elastic/go-libaudit",
-			"revision": "c139147102117edd4175a74ce071e4cc7982259a",
-			"revisionTime": "2018-01-18T05:11:38Z",
-			"version": "v0.0.7",
-			"versionExact": "v0.0.7"
+			"revision": "4a806edf821706e315ef7d4f3b5d0cac6d638b34",
+			"revisionTime": "2018-03-28T14:46:34Z",
+			"version": "v0.1.0",
+			"versionExact": "v0.1.0"
 		},
 		{
-			"checksumSHA1": "n8bRlhOdmfREBoCgStzHWGWiwSY=",
+			"checksumSHA1": "uu4544BCRlonueK+mB7549opucs=",
 			"path": "github.com/elastic/go-libaudit/aucoalesce",
-			"revision": "df0d4981f3fce65ffd3d7411dfec3e03231b491c",
-			"revisionTime": "2017-09-07T20:19:58Z",
-			"version": "v0.0.6",
-			"versionExact": "v0.0.6"
+			"revision": "4a806edf821706e315ef7d4f3b5d0cac6d638b34",
+			"revisionTime": "2018-03-28T14:46:34Z",
+			"version": "v0.1.0",
+			"versionExact": "v0.1.0"
 		},
 		{
-			"checksumSHA1": "eUIiDm0pSFKNKjWme5s3PtWEoSU=",
+			"checksumSHA1": "+L/ZGneCw2zrkK5Vlto9UB3LaEk=",
 			"path": "github.com/elastic/go-libaudit/auparse",
-			"revision": "df0d4981f3fce65ffd3d7411dfec3e03231b491c",
-			"revisionTime": "2017-09-07T20:19:58Z",
-			"version": "v0.0.6",
-			"versionExact": "v0.0.6"
+			"revision": "4a806edf821706e315ef7d4f3b5d0cac6d638b34",
+			"revisionTime": "2018-03-28T14:46:34Z",
+			"version": "v0.1.0",
+			"versionExact": "v0.1.0"
 		},
 		{
 			"checksumSHA1": "H0rnscnKHbkjmXc4whC3gtIPR0c=",
 			"path": "github.com/elastic/go-libaudit/rule",
-			"revision": "df0d4981f3fce65ffd3d7411dfec3e03231b491c",
-			"revisionTime": "2017-09-07T20:19:58Z",
-			"version": "v0.0.6",
-			"versionExact": "v0.0.6"
+			"revision": "4a806edf821706e315ef7d4f3b5d0cac6d638b34",
+			"revisionTime": "2018-03-28T14:46:34Z",
+			"version": "v0.1.0",
+			"versionExact": "v0.1.0"
 		},
 		{
 			"checksumSHA1": "36UaYid29Kyhrsa5D8N6BoM8dVw=",
 			"path": "github.com/elastic/go-libaudit/rule/flags",
-			"revision": "df0d4981f3fce65ffd3d7411dfec3e03231b491c",
-			"revisionTime": "2017-09-07T20:19:58Z",
-			"version": "v0.0.6",
-			"versionExact": "v0.0.6"
+			"revision": "4a806edf821706e315ef7d4f3b5d0cac6d638b34",
+			"revisionTime": "2018-03-28T14:46:34Z",
+			"version": "v0.1.0",
+			"versionExact": "v0.1.0"
 		},
 		{
 			"checksumSHA1": "3jizmlZPCyo6FAZY8Trk9jA8NH4=",
@@ -443,104 +441,6 @@
 			"path": "github.com/elastic/go-lumber/server/v2",
 			"revision": "616041e345fc33c97bc0eb0fa6b388aa07bca3e1",
 			"revisionTime": "2016-06-17T14:03:01Z"
-		},
-		{
-			"checksumSHA1": "AaEPt+KMknLXze11YOnBGKzP3aA=",
-			"path": "github.com/elastic/go-structform",
-			"revision": "0a66add879601f69f55663f4c913c72988218982",
-			"revisionTime": "2018-03-09T00:36:09Z",
-			"version": "v0.0.3",
-			"versionExact": "v0.0.3"
-		},
-		{
-			"checksumSHA1": "SXsT/tWnjLqR8dBiJGZqxCyuNaY=",
-			"path": "github.com/elastic/go-structform/cborl",
-			"revision": "0a66add879601f69f55663f4c913c72988218982",
-			"revisionTime": "2018-03-09T00:36:09Z",
-			"version": "v0.0.3",
-			"versionExact": "v0.0.3"
-		},
-		{
-			"checksumSHA1": "LUbWdzbpzhBh+5TizsScD8gTm4M=",
-			"path": "github.com/elastic/go-structform/gotype",
-			"revision": "0a66add879601f69f55663f4c913c72988218982",
-			"revisionTime": "2018-03-09T00:36:09Z",
-			"version": "v0.0.3",
-			"versionExact": "v0.0.3"
-		},
-		{
-			"checksumSHA1": "s7k0vEuuqkoPXU0FtrD6Y0jxd7U=",
-			"path": "github.com/elastic/go-structform/internal/unsafe",
-			"revision": "0a66add879601f69f55663f4c913c72988218982",
-			"revisionTime": "2018-03-09T00:36:09Z",
-			"version": "v0.0.3",
-			"versionExact": "v0.0.3"
-		},
-		{
-			"checksumSHA1": "s5nSu8O8TOv4DZhdbU7OC5x0C50=",
-			"path": "github.com/elastic/go-structform/json",
-			"revision": "0a66add879601f69f55663f4c913c72988218982",
-			"revisionTime": "2018-03-09T00:36:09Z",
-			"version": "v0.0.3",
-			"versionExact": "v0.0.3"
-		},
-		{
-			"checksumSHA1": "PDqC4Sh2H2EIxVhWZHdsusBMPB8=",
-			"path": "github.com/elastic/go-structform/ubjson",
-			"revision": "0a66add879601f69f55663f4c913c72988218982",
-			"revisionTime": "2018-03-09T00:36:09Z",
-			"version": "v0.0.3",
-			"versionExact": "v0.0.3"
-		},
-		{
-			"checksumSHA1": "493PQcWaAgD4s0nEb5dpeTb2Ky0=",
-			"path": "github.com/elastic/go-structform/visitors",
-			"revision": "0a66add879601f69f55663f4c913c72988218982",
-			"revisionTime": "2018-03-09T00:36:09Z",
-			"version": "v0.0.3",
-			"versionExact": "v0.0.3"
-		},
-		{
-			"checksumSHA1": "IdhOS26Kl7cvP0wWAglYOlRlTok=",
-			"path": "github.com/elastic/go-sysinfo",
-			"revision": "9c842019df6fc236a6f1ef5537109ac36357dd63",
-			"revisionTime": "2018-03-16T07:12:44Z"
-		},
-		{
-			"checksumSHA1": "jTbNB3zTWutaSKScd7UyLWt+jn0=",
-			"path": "github.com/elastic/go-sysinfo/internal/registry",
-			"revision": "9c842019df6fc236a6f1ef5537109ac36357dd63",
-			"revisionTime": "2018-03-16T07:12:44Z"
-		},
-		{
-			"checksumSHA1": "/4zxHe2iBgWg5L9x+LOpRo0c3i0=",
-			"path": "github.com/elastic/go-sysinfo/providers/darwin",
-			"revision": "9c842019df6fc236a6f1ef5537109ac36357dd63",
-			"revisionTime": "2018-03-16T07:12:44Z"
-		},
-		{
-			"checksumSHA1": "DZtaJU4DTt14eiDx5WXUHrmN6Kg=",
-			"path": "github.com/elastic/go-sysinfo/providers/linux",
-			"revision": "9c842019df6fc236a6f1ef5537109ac36357dd63",
-			"revisionTime": "2018-03-16T07:12:44Z"
-		},
-		{
-			"checksumSHA1": "oX0/bPid3LuReipgLLFy5Pc7gRc=",
-			"path": "github.com/elastic/go-sysinfo/providers/shared",
-			"revision": "9c842019df6fc236a6f1ef5537109ac36357dd63",
-			"revisionTime": "2018-03-16T07:12:44Z"
-		},
-		{
-			"checksumSHA1": "e+78LkI5GTavAzV9ySjdME4KgWk=",
-			"path": "github.com/elastic/go-sysinfo/providers/windows",
-			"revision": "9c842019df6fc236a6f1ef5537109ac36357dd63",
-			"revisionTime": "2018-03-16T07:12:44Z"
-		},
-		{
-			"checksumSHA1": "zqbmoQ1OSDWiV/XTXzPLc/Vxcxo=",
-			"path": "github.com/elastic/go-sysinfo/types",
-			"revision": "9c842019df6fc236a6f1ef5537109ac36357dd63",
-			"revisionTime": "2018-03-16T07:12:44Z"
 		},
 		{
 			"checksumSHA1": "61XUpyQ3zWnJ7Tlj0xLsHtnzwJY=",
@@ -581,314 +481,222 @@
 			"revisionTime": "2017-02-07T06:38:51Z"
 		},
 		{
-			"checksumSHA1": "DRu6+HSK/RVvCx0j2LdlL6vQjcA=",
-			"path": "github.com/elastic/go-windows",
-			"revision": "a8f9f07dec5f30c1e17afc9f360c0aed39225222",
-			"revisionTime": "2018-02-07T18:09:04Z"
-		},
-		{
-			"checksumSHA1": "RPOLNUpw00QUUaA/U4YbPVf6WlA=",
+			"checksumSHA1": "386qAesaBQFadNHu7di78fZT7xk=",
 			"path": "github.com/elastic/gosigar",
-			"revision": "237dff72b4ba95da2cd985f96a9c0ede4aefc760",
-			"revisionTime": "2018-03-16T16:52:25Z",
-			"version": "v0.9.0",
-			"versionExact": "v0.9.0"
+			"revision": "16df19fe5efee4ea2938bde5f56c02d9929dc054",
+			"revisionTime": "2018-01-22T22:24:54Z",
+			"version": "v0.8.0",
+			"versionExact": "v0.8.0"
 		},
 		{
 			"checksumSHA1": "TX9y4oPL5YmT4Gb/OU4GIPTdQB4=",
 			"path": "github.com/elastic/gosigar/cgroup",
-			"revision": "237dff72b4ba95da2cd985f96a9c0ede4aefc760",
-			"revisionTime": "2018-03-16T16:52:25Z",
-			"version": "v0.9.0",
-			"versionExact": "v0.9.0"
+			"revision": "cdcbd8c3b8bf28ef6d8639ec1e45bf31d2745f2d",
+			"revisionTime": "2018-01-17T18:54:32Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
-			"checksumSHA1": "hPqGM3DENaGfipEODoyZ4mKogTQ=",
-			"path": "github.com/elastic/gosigar/sys",
-			"revision": "237dff72b4ba95da2cd985f96a9c0ede4aefc760",
-			"revisionTime": "2018-03-16T16:52:25Z",
-			"version": "v0.9.0",
-			"versionExact": "v0.9.0"
-		},
-		{
-			"checksumSHA1": "mLq5lOyD0ZU39ysXuf1ETOLJ+f0=",
+			"checksumSHA1": "2VhOsaR4sv3S79HO6X+6dEphNKU=",
 			"path": "github.com/elastic/gosigar/sys/linux",
-			"revision": "237dff72b4ba95da2cd985f96a9c0ede4aefc760",
-			"revisionTime": "2018-03-16T16:52:25Z",
-			"version": "v0.9.0",
-			"versionExact": "v0.9.0"
+			"revision": "cdcbd8c3b8bf28ef6d8639ec1e45bf31d2745f2d",
+			"revisionTime": "2018-01-17T18:54:32Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
 			"checksumSHA1": "qDsgp2kAeI9nhj565HUScaUyjU4=",
 			"path": "github.com/elastic/gosigar/sys/windows",
-			"revision": "237dff72b4ba95da2cd985f96a9c0ede4aefc760",
-			"revisionTime": "2018-03-16T16:52:25Z",
-			"version": "v0.9.0",
-			"versionExact": "v0.9.0"
+			"revision": "cdcbd8c3b8bf28ef6d8639ec1e45bf31d2745f2d",
+			"revisionTime": "2018-01-17T18:54:32Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
-			"checksumSHA1": "hTxFrbA619JCHysWjXHa9U6bfto=",
+			"checksumSHA1": "P0CvGmmAM8uYPSE2ix4th/L9c/8=",
+			"path": "github.com/elastic/procfs",
+			"revision": "664e6bc79eb43c956507b6e20a867140516ad15a",
+			"revisionTime": "2016-09-16T08:04:11Z"
+		},
+		{
+			"checksumSHA1": "yKbtGvockvU0/yhbc5W+qm4O0iI=",
 			"path": "github.com/ericchiang/k8s",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
 			"checksumSHA1": "uQuMoUlS7hAWsB+Mwr/1B7+35BU=",
 			"path": "github.com/ericchiang/k8s/api/resource",
 			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
-			"revisionTime": "2017-06-29T16:56:01Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
 			"checksumSHA1": "XN1tbPrI03O0ishnZyfkWtTnrcQ=",
 			"path": "github.com/ericchiang/k8s/api/unversioned",
 			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
-			"revisionTime": "2017-06-29T16:56:01Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
 			"checksumSHA1": "yfTg3/Qn7KiizNJ39JmPBFi9YDQ=",
 			"path": "github.com/ericchiang/k8s/api/v1",
 			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
-			"revisionTime": "2017-06-29T16:56:01Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
-		},
-		{
-			"checksumSHA1": "y8fNiBLSoGojnUsGDsdLlsJYyqQ=",
-			"path": "github.com/ericchiang/k8s/apis/apiextensions/v1beta1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
 			"checksumSHA1": "uw/3eB6WiVCSrQZS9ZZs/1kyu1I=",
 			"path": "github.com/ericchiang/k8s/apis/apps/v1alpha1",
 			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
-			"revisionTime": "2017-06-29T16:56:01Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "JxQ/zEWQSrncYNKifCuMctq+Tsw=",
+			"checksumSHA1": "GPnvYx9Uxhpwmv01iygWR6+naTI=",
 			"path": "github.com/ericchiang/k8s/apis/apps/v1beta1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "bjklGt/pc6kWOZewAw87Hchw5oY=",
+			"checksumSHA1": "Jjw5tBYv4k+Es+qPp03rnzyzRWA=",
 			"path": "github.com/ericchiang/k8s/apis/authentication/v1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "LExhnM9Vn0LQoLQWszQ7aIxDxb4=",
+			"checksumSHA1": "uR4S43Wc80fhS0vMDE3Z3hFg7J8=",
 			"path": "github.com/ericchiang/k8s/apis/authentication/v1beta1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "GM+PzOiBoq3cxx4h5RKVUb3UH60=",
+			"checksumSHA1": "aM2KSDZbHn8jJomPPeG6LKpMwhs=",
 			"path": "github.com/ericchiang/k8s/apis/authorization/v1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "zfr5oUVjbWRfvXi2LJiGMfFeDQY=",
+			"checksumSHA1": "4yWZvduAw2JNdHd1cXjTJBUy0lw=",
 			"path": "github.com/ericchiang/k8s/apis/authorization/v1beta1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "izkXNDp5a5WP45jU0hSfTrwyfvM=",
+			"checksumSHA1": "1nMeCVQImIo1CpRRyOYMIqLoPBc=",
 			"path": "github.com/ericchiang/k8s/apis/autoscaling/v1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
 			"checksumSHA1": "kUXiQQA99K7zquvG9es3yauVjYw=",
 			"path": "github.com/ericchiang/k8s/apis/autoscaling/v2alpha1",
 			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
-			"revisionTime": "2017-06-29T16:56:01Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "FryZuAxWn4Ig8zc913w9BdfYzvs=",
+			"checksumSHA1": "vMWsdmHlmaAQZIT0c26dwxe9pDw=",
 			"path": "github.com/ericchiang/k8s/apis/batch/v1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "ylo7Z8wyJD+tmICB7wsOVIBpO+U=",
+			"checksumSHA1": "bqaX0T9jycmp9ao1Ov41dfPn0Ng=",
 			"path": "github.com/ericchiang/k8s/apis/batch/v2alpha1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
 			"checksumSHA1": "9GRVPI+Tf4RrlX2aveUGEUHKIrM=",
 			"path": "github.com/ericchiang/k8s/apis/certificates/v1alpha1",
 			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
-			"revisionTime": "2017-06-29T16:56:01Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "+d8+mSdkdcPWQIpczXDZZW0lrjg=",
+			"checksumSHA1": "k1dF56GRoEg6rooFKO7UvEJvBcE=",
 			"path": "github.com/ericchiang/k8s/apis/certificates/v1beta1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "S7AvxmCe/+WoFP/v9lZr0Mv66qg=",
-			"path": "github.com/ericchiang/k8s/apis/core/v1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
-		},
-		{
-			"checksumSHA1": "cWPoP6XZN7WMnEVMPcgPgg3Aw9Q=",
+			"checksumSHA1": "4pDHINIk6BdPBYWGF20IwHNCg2Q=",
 			"path": "github.com/ericchiang/k8s/apis/extensions/v1beta1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "vaNrBPcGWeDd1rXl8+uN08uxWhE=",
+			"checksumSHA1": "NAL7OeKSEzTOoXHBFnC1B1VmBVs=",
 			"path": "github.com/ericchiang/k8s/apis/imagepolicy/v1alpha1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "UNTTH+Ppu4vImnF+bPkG3/NR3gg=",
+			"checksumSHA1": "Vg1/xjzLJHZlvuheWC4abghACwQ=",
 			"path": "github.com/ericchiang/k8s/apis/meta/v1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
 			"checksumSHA1": "wYSNb+W2L5gJlGO8n6mGOGft8R8=",
 			"path": "github.com/ericchiang/k8s/apis/policy/v1alpha1",
 			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
-			"revisionTime": "2017-06-29T16:56:01Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "Mmyg9Wh+FCVR6fV8MGEKRxvqZ2k=",
+			"checksumSHA1": "ioJ28pdUN6fDkOp8dT+Tg3HSqmk=",
 			"path": "github.com/ericchiang/k8s/apis/policy/v1beta1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "bvwYS/wrBkyAfvCjzMbi/vKamrQ=",
+			"checksumSHA1": "UErnBsjjtmg3oYjLYU1S80oi3sk=",
 			"path": "github.com/ericchiang/k8s/apis/rbac/v1alpha1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "m1Tde18NwewnvJoOYL3uykNcBuM=",
+			"checksumSHA1": "Xl+Tm8ZOz0cMOrfLaQvu/lsWObU=",
 			"path": "github.com/ericchiang/k8s/apis/rbac/v1beta1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "JirJkoeIkWJRNrbprsQvqwisxds=",
-			"path": "github.com/ericchiang/k8s/apis/resource",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
-		},
-		{
-			"checksumSHA1": "rQZ69PjEClQQ+PGEHRKzkGVVQyw=",
+			"checksumSHA1": "YyZyaF0k2NAQAZvsCOVdhAkfVU0=",
 			"path": "github.com/ericchiang/k8s/apis/settings/v1alpha1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "pp0AetmPoKy7Rz0zNhBwUpExkbc=",
+			"checksumSHA1": "vUc3mf0rE7CQ3B52wfrMDyspLgA=",
 			"path": "github.com/ericchiang/k8s/apis/storage/v1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "WeACcIrS4EkeBm8TTftwuVniaWk=",
+			"checksumSHA1": "7/oj1z0vG1pvRza+UuKQ6txdleI=",
 			"path": "github.com/ericchiang/k8s/apis/storage/v1beta1",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "Su6wSR8V8HL2QZsF8icJ0R9AFq8=",
+			"checksumSHA1": "mm5iTFmLQ6h98DKgiUuTCpHP9H4=",
 			"path": "github.com/ericchiang/k8s/runtime",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "8ETrRvIaXPfD21N7fa8kdbumL00=",
+			"checksumSHA1": "Kk1UDqUx2Pr1LyvIIgcJBApTlCk=",
 			"path": "github.com/ericchiang/k8s/runtime/schema",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
-			"checksumSHA1": "cMk3HE8/81ExHuEs0F5sZCclOFs=",
+			"checksumSHA1": "LoxBND74egHIasOX6z98FeeW0zI=",
 			"path": "github.com/ericchiang/k8s/util/intstr",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
 			"checksumSHA1": "fobEKiMk5D7IGvCSwh4HdG1o98c=",
 			"path": "github.com/ericchiang/k8s/watch/versioned",
-			"revision": "5912993f00cb7c971aaa54529a06bd3eecd6c3d4",
-			"revisionTime": "2018-01-20T20:28:12Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
+			"revision": "5803ed75e31fc1998b5f781ac08e22ff985c3f8f",
+			"revisionTime": "2017-06-29T16:56:01Z"
 		},
 		{
 			"checksumSHA1": "AANTVr9CVVyzsgviODY6Wi2thuM=",
@@ -983,12 +791,6 @@
 			"path": "github.com/joeshaw/multierror",
 			"revision": "69b34d4ec901851247ae7e77d33909caf9df99ed",
 			"revisionTime": "2014-01-24T17:37:10Z"
-		},
-		{
-			"checksumSHA1": "a8Ge6pE7oxux9ZMZVAlyEeGzCng=",
-			"path": "github.com/juju/ratelimit",
-			"revision": "5b9ff866471762aa2ab2dced63c9fb6f53921342",
-			"revisionTime": "2017-05-23T01:21:41Z"
 		},
 		{
 			"checksumSHA1": "+CqJGh7NIDMnHgScq9sl9tPrnVM=",
@@ -1094,38 +896,6 @@
 			"revisionTime": "2017-03-16T20:15:38Z"
 		},
 		{
-			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
-			"path": "github.com/pmezard/go-difflib/difflib",
-			"revision": "792786c7400a136282c1664665ae0a8db921c6c2",
-			"revisionTime": "2016-01-10T10:55:54Z",
-			"version": "v1.0.0",
-			"versionExact": "v1.0.0"
-		},
-		{
-			"checksumSHA1": "Etvt6mgzvD7ARf4Ux03LHfgSlzU=",
-			"path": "github.com/prometheus/procfs",
-			"revision": "54d17b57dd7d4a3aa092476596b3f8a933bde349",
-			"revisionTime": "2018-03-10T14:15:09Z"
-		},
-		{
-			"checksumSHA1": "lv9rIcjbVEGo8AT1UCUZXhXrfQc=",
-			"path": "github.com/prometheus/procfs/internal/util",
-			"revision": "54d17b57dd7d4a3aa092476596b3f8a933bde349",
-			"revisionTime": "2018-03-10T14:15:09Z"
-		},
-		{
-			"checksumSHA1": "EekY1iRG9JY74mDD0jsbFCWbAFs=",
-			"path": "github.com/prometheus/procfs/nfs",
-			"revision": "54d17b57dd7d4a3aa092476596b3f8a933bde349",
-			"revisionTime": "2018-03-10T14:15:09Z"
-		},
-		{
-			"checksumSHA1": "yItvTQLUVqm/ArLEbvEhqG0T5a0=",
-			"path": "github.com/prometheus/procfs/xfs",
-			"revision": "54d17b57dd7d4a3aa092476596b3f8a933bde349",
-			"revisionTime": "2018-03-10T14:15:09Z"
-		},
-		{
 			"checksumSHA1": "KAzbLjI9MzW2tjfcAsK75lVRp6I=",
 			"path": "github.com/rcrowley/go-metrics",
 			"revision": "1f30fe9094a513ce4c700b9a54458bbb0c96996c",
@@ -1156,28 +926,28 @@
 			"revisionTime": "2017-03-21T23:07:31Z"
 		},
 		{
-			"checksumSHA1": "lZRqG0Rl5w+mkaTUOuEjcKvNU6c=",
+			"checksumSHA1": "9ev6lHyQOxl1/VndOHAnMfbLmvs=",
 			"path": "github.com/shirou/gopsutil/disk",
-			"revision": "c432be29ccce470088d07eea25b3ea7e68a8afbb",
-			"revisionTime": "2018-01-30T01:13:38Z",
-			"version": "v2.18.01",
-			"versionExact": "v2.18.01"
+			"revision": "9af92986dda65a8c367157a82b484553e1ec1c55",
+			"revisionTime": "2017-04-30T14:39:46Z",
+			"version": "v2.17.04",
+			"versionExact": "v2.17.04"
 		},
 		{
-			"checksumSHA1": "jWpwWWcywJPNhKTYxi4RXds+amQ=",
+			"checksumSHA1": "hKDsT0KAOtA7UqiXYdO0RahnQZ8=",
 			"path": "github.com/shirou/gopsutil/internal/common",
-			"revision": "c432be29ccce470088d07eea25b3ea7e68a8afbb",
-			"revisionTime": "2018-01-30T01:13:38Z",
-			"version": "v2.18.01",
-			"versionExact": "v2.18.01"
+			"revision": "9af92986dda65a8c367157a82b484553e1ec1c55",
+			"revisionTime": "2017-04-30T14:39:46Z",
+			"version": "v2.17.04",
+			"versionExact": "v2.17.04"
 		},
 		{
-			"checksumSHA1": "Z7FjZvR5J5xh6Ne572gD7tRUsc8=",
+			"checksumSHA1": "/MH6TIdlj16nThxkU9Bu+/WBm2w=",
 			"path": "github.com/shirou/gopsutil/net",
-			"revision": "c432be29ccce470088d07eea25b3ea7e68a8afbb",
-			"revisionTime": "2018-01-30T01:13:38Z",
-			"version": "v2.18.01",
-			"versionExact": "v2.18.01"
+			"revision": "9af92986dda65a8c367157a82b484553e1ec1c55",
+			"revisionTime": "2017-04-30T14:39:46Z",
+			"version": "v2.17.04",
+			"versionExact": "v2.17.04"
 		},
 		{
 			"checksumSHA1": "e7mAb9jMke2ASQGZepFgOmfBFzM=",
@@ -1192,12 +962,11 @@
 			"revisionTime": "2017-05-08T18:43:26Z"
 		},
 		{
-			"checksumSHA1": "Le1psgZO0t6mRg6oY5dmnjH13hk=",
-			"path": "github.com/stretchr/testify/assert",
-			"revision": "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c",
-			"revisionTime": "2017-12-30T17:54:59Z",
-			"version": "v1.2.0",
-			"versionExact": "v1.2.0"
+			"checksumSHA1": "Z7NuzgpfDQhKRvVq4qsbD/v9cIY=",
+			"path": "github.com/stretchr/testify",
+			"revision": "f390dcf405f7b83c997eac1b06768bb9f44dec18",
+			"revisionTime": "2016-01-09T20:38:47Z",
+			"tree": true
 		},
 		{
 			"checksumSHA1": "M0S9278lG9Fztu+ZUsLUi40GDJU=",
@@ -1228,6 +997,78 @@
 			"path": "github.com/tsg/gopacket/pfring",
 			"revision": "8e703b9968693c15f25cabb6ba8be4370cf431d0",
 			"revisionTime": "2016-08-17T18:24:57Z"
+		},
+		{
+			"checksumSHA1": "ci7skUhpD1VwkoR0tKVdggTkYrE=",
+			"path": "github.com/urso/go-structform",
+			"revision": "844d7d44009e9e8c0f08016fc4dab64e136ca040",
+			"revisionTime": "2017-12-05T17:32:58Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
+		},
+		{
+			"checksumSHA1": "da75fv5z2n4AHmTzUWLBs7pNkog=",
+			"path": "github.com/urso/go-structform/cborl",
+			"revision": "844d7d44009e9e8c0f08016fc4dab64e136ca040",
+			"revisionTime": "2017-12-05T17:32:58Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
+		},
+		{
+			"checksumSHA1": "AkYoBxV+Imq2EBwNcb53hEGh7sQ=",
+			"path": "github.com/urso/go-structform/gotype",
+			"revision": "844d7d44009e9e8c0f08016fc4dab64e136ca040",
+			"revisionTime": "2017-12-05T17:32:58Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
+		},
+		{
+			"checksumSHA1": "25sJtDsLVmS+aCILjB8zm/JBgPs=",
+			"path": "github.com/urso/go-structform/internal/gen",
+			"revision": "844d7d44009e9e8c0f08016fc4dab64e136ca040",
+			"revisionTime": "2017-12-05T17:32:58Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
+		},
+		{
+			"checksumSHA1": "m9H8/w6okS+8ixvkq+eYLd/Kk3g=",
+			"path": "github.com/urso/go-structform/internal/unsafe",
+			"revision": "844d7d44009e9e8c0f08016fc4dab64e136ca040",
+			"revisionTime": "2017-12-05T17:32:58Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
+		},
+		{
+			"checksumSHA1": "UXf4TzYK1UB8xAa6Phy9CvkvWL0=",
+			"path": "github.com/urso/go-structform/json",
+			"revision": "844d7d44009e9e8c0f08016fc4dab64e136ca040",
+			"revisionTime": "2017-12-05T17:32:58Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
+		},
+		{
+			"checksumSHA1": "SVGAVpMy8NbNCI7GVBLCKuJ7JNQ=",
+			"path": "github.com/urso/go-structform/sftest",
+			"revision": "844d7d44009e9e8c0f08016fc4dab64e136ca040",
+			"revisionTime": "2017-12-05T17:32:58Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
+		},
+		{
+			"checksumSHA1": "ttk3rguPusHM0+Pkp5diTbps/18=",
+			"path": "github.com/urso/go-structform/ubjson",
+			"revision": "844d7d44009e9e8c0f08016fc4dab64e136ca040",
+			"revisionTime": "2017-12-05T17:32:58Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
+		},
+		{
+			"checksumSHA1": "MytQct/960akBAZm7xmbpi2BKGs=",
+			"path": "github.com/urso/go-structform/visitors",
+			"revision": "844d7d44009e9e8c0f08016fc4dab64e136ca040",
+			"revisionTime": "2017-12-05T17:32:58Z",
+			"version": "v0.0.2",
+			"versionExact": "v0.0.2"
 		},
 		{
 			"checksumSHA1": "Und+nhgN1YsNWvd0aDYO+0cMcAo=",
@@ -1324,308 +1165,248 @@
 		{
 			"checksumSHA1": "ppPg0bIlBAVJy0Pn13BfBnkp9V4=",
 			"path": "golang.org/x/crypto/blake2b",
-			"revision": "5119cf507ed5294cc409c092980c7497ee5d6fd2",
-			"revisionTime": "2018-01-22T10:39:14Z"
+			"revision": "d585fd2cc9195196078f516b69daff6744ef5e84",
+			"revisionTime": "2017-12-16T04:08:15Z"
 		},
 		{
 			"checksumSHA1": "1MGpGDQqnUoRpv7VEcQrXOBydXE=",
 			"path": "golang.org/x/crypto/pbkdf2",
-			"revision": "5119cf507ed5294cc409c092980c7497ee5d6fd2",
-			"revisionTime": "2018-01-22T10:39:14Z"
+			"revision": "e8f229864d71a49e5fdc4a9a134c5f85c4c33d64",
+			"revisionTime": "2017-11-28T04:39:32Z"
 		},
 		{
 			"checksumSHA1": "iNE2KX9BQzCptlQC2DdQEVmn4R4=",
 			"path": "golang.org/x/crypto/sha3",
-			"revision": "5119cf507ed5294cc409c092980c7497ee5d6fd2",
-			"revisionTime": "2018-01-22T10:39:14Z"
+			"revision": "9419663f5a44be8b34ca85f08abc5fe1be11f8a3",
+			"revisionTime": "2017-09-30T17:45:11Z"
 		},
 		{
-			"checksumSHA1": "6U7dCaxxIMjf5V02iWgyAwppczw=",
+			"checksumSHA1": "X1NTlfcau2XcV6WtAHF6b/DECOA=",
 			"path": "golang.org/x/crypto/ssh/terminal",
-			"revision": "5119cf507ed5294cc409c092980c7497ee5d6fd2",
-			"revisionTime": "2018-01-22T10:39:14Z"
+			"revision": "e8f229864d71a49e5fdc4a9a134c5f85c4c33d64",
+			"revisionTime": "2017-11-28T04:39:32Z"
 		},
 		{
-			"checksumSHA1": "uX2McdP4VcQ6zkAF0Q4oyd0rFtU=",
+			"checksumSHA1": "tK8eFmQ0JeKpR3P0TjiGobzlIh0=",
 			"path": "golang.org/x/net/bpf",
-			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
-			"revisionTime": "2017-10-22T17:59:00Z",
-			"version": "release-branch.go1.9",
-			"versionExact": "release-branch.go1.9"
+			"revision": "e90d6d0afc4c315a0d87a568ae68577cc15149a0",
+			"revisionTime": "2016-07-15T16:59:30Z"
 		},
 		{
-			"checksumSHA1": "dr5+PfIRzXeN+l1VG+s0lea9qz8=",
+			"checksumSHA1": "Y+HGqEkYM15ir+J93MEaHdyFy0c=",
 			"path": "golang.org/x/net/context",
-			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
-			"revisionTime": "2017-10-22T17:59:00Z",
-			"version": "release-branch.go1.9",
-			"versionExact": "release-branch.go1.9"
+			"revision": "ffcf1bedda3b04ebb15a168a59800a73d6dc0f4d",
+			"revisionTime": "2017-03-29T01:43:45Z"
 		},
 		{
 			"checksumSHA1": "WHc3uByvGaMcnSoI21fhzYgbOgg=",
 			"path": "golang.org/x/net/context/ctxhttp",
-			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
-			"revisionTime": "2017-10-22T17:59:00Z",
-			"version": "release-branch.go1.9",
-			"versionExact": "release-branch.go1.9"
+			"revision": "48359f4f600b3a2d5cf657458e3f940021631a56",
+			"revisionTime": "2017-03-18T09:30:21Z"
 		},
 		{
-			"checksumSHA1": "TWcqN2+KUWtdqnu18rruwn14UEQ=",
+			"checksumSHA1": "SPYGC6DQrH9jICccUsOfbvvhB4g=",
 			"path": "golang.org/x/net/http2",
-			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
-			"revisionTime": "2017-10-22T17:59:00Z",
-			"version": "release-branch.go1.9",
-			"versionExact": "release-branch.go1.9"
+			"revision": "e90d6d0afc4c315a0d87a568ae68577cc15149a0",
+			"revisionTime": "2017-04-13T17:15:43Z"
 		},
 		{
-			"checksumSHA1": "ezWhc7n/FtqkLDQKeU2JbW+80tE=",
+			"checksumSHA1": "EYNaHp7XdLWRydUCE0amEkKAtgk=",
 			"path": "golang.org/x/net/http2/hpack",
-			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
-			"revisionTime": "2017-10-22T17:59:00Z",
-			"version": "release-branch.go1.9",
-			"versionExact": "release-branch.go1.9"
+			"revision": "e90d6d0afc4c315a0d87a568ae68577cc15149a0",
+			"revisionTime": "2017-04-13T17:15:43Z"
 		},
 		{
-			"checksumSHA1": "DqdFGWbLLyVFeDvzvXyf1Y678uA=",
+			"checksumSHA1": "vU7M5xs/uYYjyKv+P8ZqQCT3LeI=",
 			"path": "golang.org/x/net/icmp",
-			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
-			"revisionTime": "2017-10-22T17:59:00Z",
-			"version": "release-branch.go1.9",
-			"versionExact": "release-branch.go1.9"
+			"revision": "e90d6d0afc4c315a0d87a568ae68577cc15149a0",
+			"revisionTime": "2016-07-15T16:59:30Z"
 		},
 		{
-			"checksumSHA1": "RcrB7tgYS/GMW4QrwVdMOTNqIU8=",
-			"path": "golang.org/x/net/idna",
-			"revision": "f5dfe339be1d06f81b22525fe34671ee7d2c8904",
-			"revisionTime": "2018-02-04T03:50:36Z"
-		},
-		{
-			"checksumSHA1": "5JWn/wMC+EWNDKI/AYE4JifQF54=",
+			"checksumSHA1": "yRuyntx9a59ugMi5NlN4ST0XRcI=",
 			"path": "golang.org/x/net/internal/iana",
-			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
-			"revisionTime": "2017-10-22T17:59:00Z",
-			"version": "release-branch.go1.9",
-			"versionExact": "release-branch.go1.9"
+			"revision": "e90d6d0afc4c315a0d87a568ae68577cc15149a0",
+			"revisionTime": "2016-07-15T16:59:30Z"
 		},
 		{
-			"checksumSHA1": "WnI4058Oj6W4YSvyXAnK3qCKqvo=",
-			"path": "golang.org/x/net/internal/socket",
-			"revision": "f5dfe339be1d06f81b22525fe34671ee7d2c8904",
-			"revisionTime": "2018-02-04T03:50:36Z"
-		},
-		{
-			"checksumSHA1": "zPTKyZ1C55w1fk1W+/qGE15jaek=",
+			"checksumSHA1": "BJrlL/vetMJZLv8XPuzvw3ZITaU=",
 			"path": "golang.org/x/net/ipv4",
-			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
-			"revisionTime": "2017-10-22T17:59:00Z",
-			"version": "release-branch.go1.9",
-			"versionExact": "release-branch.go1.9"
+			"revision": "e90d6d0afc4c315a0d87a568ae68577cc15149a0",
+			"revisionTime": "2016-07-15T16:59:30Z"
 		},
 		{
-			"checksumSHA1": "3L3n7qKMO9X8E1ibA5mExKvwbmI=",
+			"checksumSHA1": "oHDMN5yvCAux6ghrbdDYEyaOydo=",
 			"path": "golang.org/x/net/ipv6",
-			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
-			"revisionTime": "2017-10-22T17:59:00Z",
-			"version": "release-branch.go1.9",
-			"versionExact": "release-branch.go1.9"
+			"revision": "e90d6d0afc4c315a0d87a568ae68577cc15149a0",
+			"revisionTime": "2016-07-15T16:59:30Z"
 		},
 		{
-			"checksumSHA1": "3xyuaSNmClqG4YWC7g0isQIbUTc=",
+			"checksumSHA1": "yhndhWXMs/VSEDLks4dNyFMQStA=",
 			"path": "golang.org/x/net/lex/httplex",
-			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
-			"revisionTime": "2017-10-22T17:59:00Z",
-			"version": "release-branch.go1.9",
-			"versionExact": "release-branch.go1.9"
+			"revision": "e90d6d0afc4c315a0d87a568ae68577cc15149a0",
+			"revisionTime": "2017-04-13T17:15:43Z"
 		},
 		{
-			"checksumSHA1": "QEm/dePZ0lOnyOs+m22KjXfJ/IU=",
+			"checksumSHA1": "LvdVRE0FqdR68SvVpRkHs1rxhcA=",
 			"path": "golang.org/x/net/proxy",
-			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
-			"revisionTime": "2017-10-22T17:59:00Z",
-			"version": "release-branch.go1.9",
-			"versionExact": "release-branch.go1.9"
+			"revision": "e90d6d0afc4c315a0d87a568ae68577cc15149a0",
+			"revisionTime": "2016-07-15T16:59:30Z"
 		},
 		{
-			"checksumSHA1": "+7gSOeJWKSUhXho9cQPtyzJL+ok=",
+			"checksumSHA1": "2uRCLUe0L2smIdTGnSaVDqNECOg=",
 			"path": "golang.org/x/net/publicsuffix",
-			"revision": "44b7c21cbf19450f38b337eb6b6fe4f6496fb5b3",
-			"revisionTime": "2017-10-22T17:59:00Z",
-			"version": "release-branch.go1.9",
-			"versionExact": "release-branch.go1.9"
+			"revision": "e90d6d0afc4c315a0d87a568ae68577cc15149a0",
+			"revisionTime": "2016-07-15T16:59:30Z"
 		},
 		{
-			"checksumSHA1": "CNHEeGnucEUlTHJrLS2kHtfNbws=",
+			"checksumSHA1": "l/AvVB/e1LjZ28XXItkdOW9tKMQ=",
 			"path": "golang.org/x/sys/unix",
-			"revision": "37707fdb30a5b38865cfb95e5aab41707daec7fd",
-			"revisionTime": "2018-02-02T13:35:31Z"
+			"revision": "b76f9891dc1d975623261def70f9b89661f5baab",
+			"revisionTime": "2017-11-28T14:20:51Z"
 		},
 		{
-			"checksumSHA1": "eQq+ZoTWPjyizS9XalhZwfGjQao=",
+			"checksumSHA1": "cQoW6a5F9mbu10APPXM39YJtv48=",
 			"path": "golang.org/x/sys/windows",
-			"revision": "37707fdb30a5b38865cfb95e5aab41707daec7fd",
-			"revisionTime": "2018-02-02T13:35:31Z"
+			"revision": "b76f9891dc1d975623261def70f9b89661f5baab",
+			"revisionTime": "2017-11-28T14:20:51Z"
 		},
 		{
-			"checksumSHA1": "ZdFZFaXmCgEEaEhVPkyXrnhKhsg=",
+			"checksumSHA1": "Qvq4DjtYrcpGgBT0O1s8nTTeFWQ=",
 			"path": "golang.org/x/sys/windows/registry",
-			"revision": "37707fdb30a5b38865cfb95e5aab41707daec7fd",
-			"revisionTime": "2018-02-02T13:35:31Z"
+			"revision": "62bee037599929a6e9146f29d10dd5208c43507d",
+			"revisionTime": "2016-06-14T22:52:37Z"
 		},
 		{
-			"checksumSHA1": "VNlkHemg81Ba7ElHfKKUU1h+U1U=",
+			"checksumSHA1": "IRqLaXM/VQRzkbXPuiqOxTb2W0Y=",
 			"path": "golang.org/x/sys/windows/svc",
-			"revision": "37707fdb30a5b38865cfb95e5aab41707daec7fd",
-			"revisionTime": "2018-02-02T13:35:31Z"
+			"revision": "62bee037599929a6e9146f29d10dd5208c43507d",
+			"revisionTime": "2016-06-14T22:52:37Z"
 		},
 		{
-			"checksumSHA1": "lZi+t2ilFyYSpqL1ThwNf8ot3WQ=",
+			"checksumSHA1": "1ouiyoHRaaMDNeq/nap9B0UuQw4=",
 			"path": "golang.org/x/sys/windows/svc/debug",
-			"revision": "37707fdb30a5b38865cfb95e5aab41707daec7fd",
-			"revisionTime": "2018-02-02T13:35:31Z"
+			"revision": "62bee037599929a6e9146f29d10dd5208c43507d",
+			"revisionTime": "2016-06-14T22:52:37Z"
 		},
 		{
 			"checksumSHA1": "uVlUSSKplihZG7N+QJ6fzDZ4Kh8=",
 			"path": "golang.org/x/sys/windows/svc/eventlog",
-			"revision": "37707fdb30a5b38865cfb95e5aab41707daec7fd",
-			"revisionTime": "2018-02-02T13:35:31Z"
+			"revision": "571f7bbbe08da2a8955aed9d4db316e78630e9a3",
+			"revisionTime": "2017-12-16T14:55:03Z"
 		},
 		{
-			"checksumSHA1": "rEd9Z4B9rbkOzxpwWSu0SN1PtDg=",
-			"path": "golang.org/x/text",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
-		},
-		{
-			"checksumSHA1": "Mr4ur60bgQJnQFfJY0dGtwWwMPE=",
+			"checksumSHA1": "oaglBTpGgEUgk7m92i6nuZbpicE=",
 			"path": "golang.org/x/text/encoding",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
+			"revision": "2910a502d2bf9e43193af9d68ca516529614eed3",
+			"revisionTime": "2016-07-21T22:28:28Z"
 		},
 		{
-			"checksumSHA1": "DSdlK4MKI/a3U8Zaee2XKBe01Fo=",
+			"checksumSHA1": "ETIWndVBXuAJ7N6GOfQz1rnZnFo=",
 			"path": "golang.org/x/text/encoding/charmap",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
+			"revision": "2910a502d2bf9e43193af9d68ca516529614eed3",
+			"revisionTime": "2016-07-21T22:28:28Z"
 		},
 		{
-			"checksumSHA1": "tLQQZEU7qS/eYyCvd76Wqfz1oR8=",
+			"checksumSHA1": "mI8YM2LehMxYDcauq5loMZr1pP8=",
 			"path": "golang.org/x/text/encoding/htmlindex",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
+			"revision": "2910a502d2bf9e43193af9d68ca516529614eed3",
+			"revisionTime": "2016-07-21T22:28:28Z"
 		},
 		{
 			"checksumSHA1": "zeHyHebIZl1tGuwGllIhjfci+wI=",
 			"path": "golang.org/x/text/encoding/internal",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
+			"revision": "2910a502d2bf9e43193af9d68ca516529614eed3",
+			"revisionTime": "2016-07-21T22:28:28Z"
 		},
 		{
-			"checksumSHA1": "7kYqxy64WhMjFIFZgN7tJ3lbKxM=",
+			"checksumSHA1": "TF4hoIqHVEAvOq67rfnSLSkcZ1Y=",
 			"path": "golang.org/x/text/encoding/internal/identifier",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
+			"revision": "2910a502d2bf9e43193af9d68ca516529614eed3",
+			"revisionTime": "2016-07-21T22:28:28Z"
 		},
 		{
-			"checksumSHA1": "2YqVpmvjWGEBATyUphTP1MS34JE=",
+			"checksumSHA1": "HeZV82ktrmgyAaYLtNFS0qYgspI=",
 			"path": "golang.org/x/text/encoding/japanese",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
+			"revision": "2910a502d2bf9e43193af9d68ca516529614eed3",
+			"revisionTime": "2016-07-21T22:28:28Z"
 		},
 		{
-			"checksumSHA1": "+ErWCAdaMwO4PLtrk9D/Hh+7oQM=",
+			"checksumSHA1": "8y87WJz3OkDWtPCIXxJcYpo+OY8=",
 			"path": "golang.org/x/text/encoding/korean",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
+			"revision": "2910a502d2bf9e43193af9d68ca516529614eed3",
+			"revisionTime": "2016-07-21T22:28:28Z"
 		},
 		{
-			"checksumSHA1": "mTuZi5urYwgDIO8+Gfql2pv8Vwg=",
+			"checksumSHA1": "WYfmebIyX5Zae8NUfu9PsQjQff0=",
 			"path": "golang.org/x/text/encoding/simplifiedchinese",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
+			"revision": "2910a502d2bf9e43193af9d68ca516529614eed3",
+			"revisionTime": "2016-07-21T22:28:28Z"
 		},
 		{
-			"checksumSHA1": "D+VI4j0Wjzr8SeupWdOB5KBdFOw=",
+			"checksumSHA1": "KKqYmi6fxt3r3uo4lExss2yTMbs=",
 			"path": "golang.org/x/text/encoding/traditionalchinese",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
+			"revision": "2910a502d2bf9e43193af9d68ca516529614eed3",
+			"revisionTime": "2016-07-21T22:28:28Z"
 		},
 		{
 			"checksumSHA1": "G9LfJI9gySazd+MyyC6QbTHx4to=",
 			"path": "golang.org/x/text/encoding/unicode",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
+			"revision": "2910a502d2bf9e43193af9d68ca516529614eed3",
+			"revisionTime": "2016-07-21T22:28:28Z"
 		},
 		{
 			"checksumSHA1": "hyNCcTwMQnV6/MK8uUW9E5H0J0M=",
 			"path": "golang.org/x/text/internal/tag",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
+			"revision": "2910a502d2bf9e43193af9d68ca516529614eed3",
+			"revisionTime": "2016-07-21T22:28:28Z"
 		},
 		{
 			"checksumSHA1": "Qk7dljcrEK1BJkAEZguxAbG9dSo=",
 			"path": "golang.org/x/text/internal/utf8internal",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
+			"revision": "2910a502d2bf9e43193af9d68ca516529614eed3",
+			"revisionTime": "2016-07-21T22:28:28Z"
 		},
 		{
-			"checksumSHA1": "/N4Gt0BoQcasJJ28JOlzLO5v/ug=",
+			"checksumSHA1": "vbYsvMa+yYFTrmD0bIVhA36DpgQ=",
 			"path": "golang.org/x/text/language",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
+			"revision": "2910a502d2bf9e43193af9d68ca516529614eed3",
+			"revisionTime": "2016-07-21T22:28:28Z"
 		},
 		{
-			"checksumSHA1": "IV4MN7KGBSocu/5NR3le3sxup4Y=",
+			"checksumSHA1": "cQ4+8mXpYioml5/hO7ZyeECoFJc=",
 			"path": "golang.org/x/text/runes",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
+			"revision": "2910a502d2bf9e43193af9d68ca516529614eed3",
+			"revisionTime": "2016-07-21T22:28:28Z"
 		},
 		{
-			"checksumSHA1": "CbpjEkkOeh0fdM/V8xKDdI0AA88=",
-			"path": "golang.org/x/text/secure/bidirule",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
-		},
-		{
-			"checksumSHA1": "ziMb9+ANGRJSSIuxYdRbA+cDRBQ=",
+			"checksumSHA1": "TZDHZj3zWDc5LKqpoLamOKt6Nmo=",
 			"path": "golang.org/x/text/transform",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
+			"revision": "2910a502d2bf9e43193af9d68ca516529614eed3",
+			"revisionTime": "2016-07-21T22:28:28Z"
 		},
 		{
-			"checksumSHA1": "w8kDfZ1Ug+qAcVU0v8obbu3aDOY=",
-			"path": "golang.org/x/text/unicode/bidi",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
-		},
-		{
-			"checksumSHA1": "BCNYmf4Ek93G4lk5x3ucNi/lTwA=",
-			"path": "golang.org/x/text/unicode/norm",
-			"revision": "4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1",
-			"revisionTime": "2018-02-04T03:07:25Z"
+			"checksumSHA1": "vGfePfr0+weQUeTM/71mu+LCFuE=",
+			"path": "golang.org/x/time/rate",
+			"revision": "26559e0f760e39c24d730d3224364aef164ee23f",
+			"revisionTime": "2018-03-14T17:21:34Z"
 		},
 		{
 			"checksumSHA1": "p3gWsy4fQOSXGRMUHr3TnmVFias=",
 			"path": "golang.org/x/tools/go/ast/astutil",
-			"revision": "5d2fd3ccab986d52112bf301d47a819783339d0e",
-			"revisionTime": "2017-08-07T23:04:23Z",
-			"version": "release-branch.go1.9",
-			"versionExact": "release-branch.go1.9"
+			"revision": "9be3b7cbc7ccd19baaa3b7704c22f57db5ebbdf2",
+			"revisionTime": "2017-06-28T06:26:50Z"
 		},
 		{
 			"checksumSHA1": "AnXFEvmaJ7w2Q7hWPcLUmCbPgq0=",
 			"path": "golang.org/x/tools/go/buildutil",
-			"revision": "5d2fd3ccab986d52112bf301d47a819783339d0e",
-			"revisionTime": "2017-08-07T23:04:23Z",
-			"version": "release-branch.go1.9",
-			"versionExact": "release-branch.go1.9"
+			"revision": "9be3b7cbc7ccd19baaa3b7704c22f57db5ebbdf2",
+			"revisionTime": "2017-06-28T06:26:50Z"
 		},
 		{
-			"checksumSHA1": "ZpAR2KupZto/mWf9zu5e6IKDWt0=",
+			"checksumSHA1": "aXtllsj+ZEheKoMt22s6hPTHdTM=",
 			"path": "golang.org/x/tools/go/loader",
-			"revision": "5d2fd3ccab986d52112bf301d47a819783339d0e",
-			"revisionTime": "2017-08-07T23:04:23Z",
-			"version": "release-branch.go1.9",
-			"versionExact": "release-branch.go1.9"
+			"revision": "9be3b7cbc7ccd19baaa3b7704c22f57db5ebbdf2",
+			"revisionTime": "2017-06-28T06:26:50Z"
 		},
 		{
 			"checksumSHA1": "6f8MEU31llHM1sLM/GGH4/Qxu0A=",

--- a/script/generate_notice_overrides.py
+++ b/script/generate_notice_overrides.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+"""
+Generate data used to put the correct revision information in NOTICE.TXT.
+"""
+import argparse
+import json
+import logging
+import sys
+
+
+def gather(vendor):
+    overrides = {}
+    for package in vendor['package']:
+        path = package['path']
+        sub_path = []
+        for p in path.split('/'):
+            sub_path.append(p)
+            sub_path_str = '/'.join(sub_path)
+            if sub_path_str in overrides and overrides[sub_path_str]['revision'] != package['revision'] and len(sub_path) > 1:
+                logging.debug("warning: %s changed by: %s was: %s is: %s", sub_path_str,
+                              path, overrides[sub_path_str]['revision'], package['revision'])
+            overrides[sub_path_str] = package
+    return overrides
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-i', '--vendor_input', type=argparse.FileType('r'), default='_beats/vendor/vendor.json')
+    parser.add_argument('-o', '--overrides', type=argparse.FileType('w'), default=sys.stdout)
+    parser.add_argument('-D', '--debug', action='store_true')
+    args = parser.parse_args()
+
+    level = logging.DEBUG if args.debug else logging.ERROR
+    logging.basicConfig(level=level)
+
+    vendor = json.load(args.vendor_input)
+    overrides = gather(vendor)
+    for path_override, package in sorted(overrides.items()):
+        vendor['package'].append({
+            "path": path_override,
+            "revision": package["revision"]
+        })
+    json.dump(vendor, args.overrides)
+
+
+if __name__ == '__main__':
+    main()

--- a/script/update_beats.sh
+++ b/script/update_beats.sh
@@ -21,8 +21,10 @@ git clone https://github.com/elastic/beats.git ${GIT_CLONE}
 )
 
 # sync
+# exclude generate_notice.py on this branch since updates have not been backported in beats
 rsync -crpv --delete \
     --exclude=dev-tools/packer/readme.md.j2 \
+    --exclude=dev-tools/generate_notice.py \
     --include="dev-tools/***" \
     --include="script/***" \
     --include="testing/***" \

--- a/script/update_beats.sh
+++ b/script/update_beats.sh
@@ -43,6 +43,9 @@ rsync -crpv --delete \
     --include="libbeat/tests/system/beat/***" \
     --exclude="libbeat/*" \
     --include=.go-version \
+    --include="vendor/" \
+    --include="vendor/vendor.json" \
+    --exclude="vendor/*" \
     --exclude="*" \
     ${GIT_CLONE}/ .
 

--- a/vendor/github.com/elastic/beats/NOTICE.txt
+++ b/vendor/github.com/elastic/beats/NOTICE.txt
@@ -342,8 +342,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-libaudit
-Version: v0.0.7
-Revision: c139147102117edd4175a74ce071e4cc7982259a
+Version: v0.1.0
+Revision: 4a806edf821706e315ef7d4f3b5d0cac6d638b34
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-libaudit/LICENSE:
 --------------------------------------------------------------------
@@ -1573,204 +1573,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
---------------------------------------------------------------------
-Dependency: github.com/juju/ratelimit
-Revision: 5b9ff866471762aa2ab2dced63c9fb6f53921342
-License type (autodetected): LGPL-3.0
-./vendor/github.com/juju/ratelimit/LICENSE:
---------------------------------------------------------------------
-All files in this repository are licensed as follows. If you contribute
-to this repository, it is assumed that you license your contribution
-under the same license unless you state otherwise.
-
-All files Copyright (C) 2015 Canonical Ltd. unless otherwise specified in the file.
-
-This software is licensed under the LGPLv3, included below.
-
-As a special exception to the GNU Lesser General Public License version 3
-("LGPL3"), the copyright holders of this Library give you permission to
-convey to a third party a Combined Work that links statically or dynamically
-to this Library without providing any Minimal Corresponding Source or
-Minimal Application Code as set out in 4d or providing the installation
-information set out in section 4e, provided that you comply with the other
-provisions of LGPL3 and provided that you meet, for the Application the
-terms and conditions of the license(s) which apply to the Application.
-
-Except as stated in this special exception, the provisions of LGPL3 will
-continue to comply in full to this Library. If you modify this Library, you
-may apply this exception to your version of this Library, but you are not
-obliged to do so. If you do not wish to do so, delete this exception
-statement from your version. This exception does not (and cannot) modify any
-license terms which apply to the Application, with which you must still
-comply.
-
-
-                   GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
-
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
-
-
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
-
-  0. Additional Definitions.
-
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
-
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
-
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
-
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
-
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
-
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
-
-  1. Exception to Section 3 of the GNU GPL.
-
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
-
-  2. Conveying Modified Versions.
-
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
-
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
-
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
-
-  3. Object Code Incorporating Material from Library Header Files.
-
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
-
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
-
-  4. Combined Works.
-
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
-
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
-
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
-
-   d) Do one of the following:
-
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
-
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
-
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
-
-  5. Combined Libraries.
-
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
-
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
-
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
-
-  6. Revised Versions of the GNU Lesser General Public License.
-
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
-
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
-
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
 
 --------------------------------------------------------------------
 Dependency: github.com/klauspost/compress
@@ -3457,7 +3259,7 @@ OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/tsg/gopacket
-Revision: 8e703b9968693c15f25cabb6ba8be4370cf431d0
+Revision: f289b3ea3e41a01b2822be9caf5f40c01fdda05c
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/tsg/gopacket/LICENSE:
 --------------------------------------------------------------------
@@ -3757,6 +3559,40 @@ Dependency: golang.org/x/text
 Revision: 2910a502d2bf9e43193af9d68ca516529614eed3
 License type (autodetected): BSD-3-Clause
 ./vendor/golang.org/x/text/LICENSE:
+--------------------------------------------------------------------
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------
+Dependency: golang.org/x/time
+Revision: 26559e0f760e39c24d730d3224364aef164ee23f
+License type (autodetected): BSD-3-Clause
+./vendor/golang.org/x/time/LICENSE:
 --------------------------------------------------------------------
 Copyright (c) 2009 The Go Authors. All rights reserved.
 

--- a/vendor/github.com/elastic/beats/libbeat/cmd/instance/metrics.go
+++ b/vendor/github.com/elastic/beats/libbeat/cmd/instance/metrics.go
@@ -1,5 +1,4 @@
-// +build darwin linux windows
-// +build cgo
+// +build darwin,cgo freebsd,cgo linux windows
 
 package instance
 
@@ -7,38 +6,31 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"time"
-
-	"github.com/satori/go.uuid"
 
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/metric/system/cpu"
 	"github.com/elastic/beats/libbeat/metric/system/process"
 	"github.com/elastic/beats/libbeat/monitoring"
-	"github.com/elastic/beats/libbeat/monitoring/report/log"
 )
 
 var (
 	beatProcessStats *process.Stats
-	ephemeralID      uuid.UUID
+	systemMetrics    *monitoring.Registry
 )
 
 func init() {
-	beatMetrics := monitoring.Default.NewRegistry("beat")
+	systemMetrics = monitoring.Default.NewRegistry("system")
+}
+
+func setupMetrics(name string) error {
 	monitoring.NewFunc(beatMetrics, "memstats", reportMemStats, monitoring.Report)
 	monitoring.NewFunc(beatMetrics, "cpu", reportBeatCPU, monitoring.Report)
-	monitoring.NewFunc(beatMetrics, "info", reportInfo, monitoring.Report)
 
-	systemMetrics := monitoring.Default.NewRegistry("system")
 	monitoring.NewFunc(systemMetrics, "cpu", reportSystemCPUUsage, monitoring.Report)
 	if runtime.GOOS != "windows" {
 		monitoring.NewFunc(systemMetrics, "load", reportSystemLoadAverage, monitoring.Report)
 	}
 
-	ephemeralID = uuid.NewV4()
-}
-
-func setupMetrics(name string) error {
 	beatProcessStats = &process.Stats{
 		Procs:        []string{name},
 		EnvWhitelist: nil,
@@ -89,19 +81,6 @@ func getRSSSize() (uint64, error) {
 		return 0, fmt.Errorf("error converting Resident Set Size to uint64: %v", iRss)
 	}
 	return rss, nil
-}
-
-func reportInfo(_ monitoring.Mode, V monitoring.Visitor) {
-	V.OnRegistryStart()
-	defer V.OnRegistryFinished()
-
-	delta := time.Since(log.StartTime)
-	uptime := int64(delta / time.Millisecond)
-	monitoring.ReportNamespace(V, "uptime", func() {
-		monitoring.ReportInt(V, "ms", uptime)
-	})
-
-	monitoring.ReportString(V, "ephemeral_id", ephemeralID.String())
 }
 
 func reportBeatCPU(_ monitoring.Mode, V monitoring.Visitor) {

--- a/vendor/github.com/elastic/beats/libbeat/cmd/instance/metrics_common.go
+++ b/vendor/github.com/elastic/beats/libbeat/cmd/instance/metrics_common.go
@@ -1,0 +1,35 @@
+package instance
+
+import (
+	"time"
+
+	"github.com/satori/go.uuid"
+
+	"github.com/elastic/beats/libbeat/monitoring"
+	"github.com/elastic/beats/libbeat/monitoring/report/log"
+)
+
+var (
+	ephemeralID uuid.UUID
+	beatMetrics *monitoring.Registry
+)
+
+func init() {
+	beatMetrics = monitoring.Default.NewRegistry("beat")
+	monitoring.NewFunc(beatMetrics, "info", reportInfo, monitoring.Report)
+
+	ephemeralID = uuid.NewV4()
+}
+
+func reportInfo(_ monitoring.Mode, V monitoring.Visitor) {
+	V.OnRegistryStart()
+	defer V.OnRegistryFinished()
+
+	delta := time.Since(log.StartTime)
+	uptime := int64(delta / time.Millisecond)
+	monitoring.ReportNamespace(V, "uptime", func() {
+		monitoring.ReportInt(V, "ms", uptime)
+	})
+
+	monitoring.ReportString(V, "ephemeral_id", ephemeralID.String())
+}

--- a/vendor/github.com/elastic/beats/libbeat/cmd/instance/metrics_other.go
+++ b/vendor/github.com/elastic/beats/libbeat/cmd/instance/metrics_other.go
@@ -1,8 +1,12 @@
-// +build !darwin,!linux,!windows darwin,!cgo linux,!cgo windows,!cgo
+// +build !darwin !cgo
+// +build !freebsd !cgo
+// +build !linux,!windows
 
 package instance
 
-import "github.com/elastic/beats/libbeat/logp"
+import (
+	"github.com/elastic/beats/libbeat/logp"
+)
 
 func setupMetrics(name string) error {
 	logp.Warn("Metrics not implemented for this OS.")

--- a/vendor/github.com/elastic/beats/libbeat/common/cli/cli.go
+++ b/vendor/github.com/elastic/beats/libbeat/common/cli/cli.go
@@ -3,15 +3,25 @@ package cli
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
+
+func exitOnPanic() {
+	if r := recover(); r != nil {
+		fmt.Fprintf(os.Stderr, "panic: %s\n", r)
+		debug.PrintStack()
+		os.Exit(1)
+	}
+}
 
 // RunWith wrap cli function with an error handler instead of having the code exit early.
 func RunWith(
 	fn func(cmd *cobra.Command, args []string) error,
 ) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
+		defer exitOnPanic()
 		if err := fn(cmd, args); err != nil {
 			fmt.Fprintln(os.Stderr, err.Error())
 			os.Exit(1)

--- a/vendor/github.com/elastic/beats/libbeat/common/file/file_other.go
+++ b/vendor/github.com/elastic/beats/libbeat/common/file/file_other.go
@@ -3,8 +3,8 @@
 package file
 
 import (
-	"fmt"
 	"os"
+	"strconv"
 	"syscall"
 )
 
@@ -32,7 +32,11 @@ func (fs StateOS) IsSame(state StateOS) bool {
 }
 
 func (fs StateOS) String() string {
-	return fmt.Sprintf("%d-%d", fs.Inode, fs.Device)
+	var buf [64]byte
+	current := strconv.AppendUint(buf[:0], fs.Inode, 10)
+	current = append(current, '-')
+	current = strconv.AppendUint(current, fs.Device, 10)
+	return string(current)
 }
 
 // ReadOpen opens a file for reading only

--- a/vendor/github.com/elastic/beats/libbeat/common/file/file_windows.go
+++ b/vendor/github.com/elastic/beats/libbeat/common/file/file_windows.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
 	"syscall"
 )
 
@@ -43,7 +44,13 @@ func (fs StateOS) IsSame(state StateOS) bool {
 }
 
 func (fs StateOS) String() string {
-	return fmt.Sprintf("%d-%d-%d", fs.IdxHi, fs.IdxLo, fs.Vol)
+	var buf [92]byte
+	current := strconv.AppendUint(buf[:0], fs.IdxHi, 10)
+	current = append(current, '-')
+	current = strconv.AppendUint(current, fs.IdxLo, 10)
+	current = append(current, '-')
+	current = strconv.AppendUint(current, fs.Vol, 10)
+	return string(current)
 }
 
 // ReadOpen opens a file for reading only

--- a/vendor/github.com/elastic/beats/libbeat/metric/system/process/process.go
+++ b/vendor/github.com/elastic/beats/libbeat/metric/system/process/process.go
@@ -76,7 +76,7 @@ func newProcess(pid int, cmdline string, env common.MapStr) (*Process, error) {
 	}
 
 	exe := sigar.ProcExe{}
-	if err := exe.Get(pid); err != nil && !sigar.IsNotImplemented(err) && !os.IsPermission(err) {
+	if err := exe.Get(pid); err != nil && !sigar.IsNotImplemented(err) && !os.IsPermission(err) && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("error getting process exe for pid=%d: %v", pid, err)
 	}
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1306,8 +1306,8 @@
 			"checksumSHA1": "40vJyUB4ezQSn/NSadsKEOrudMc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/inconshreveable/mousetrap",
 			"path": "github.com/inconshreveable/mousetrap",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75",
+			"revisionTime": "2014-10-17T20:07:13Z"
 		},
 		{
 			"checksumSHA1": "l9wW52CYGbmO/NGwYZ/Op2QTmaA=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -6,260 +6,260 @@
 			"checksumSHA1": "AzjRkOQtVBTwIw4RJLTygFhJs3s=",
 			"origin": "github.com/elastic/beats/vendor/github.com/Microsoft/go-winio",
 			"path": "github.com/Microsoft/go-winio",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "jVDEyP/iraz6r173/GzkXF24ijQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/Shopify/sarama",
 			"path": "github.com/Shopify/sarama",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "DYv6Q1+VfnUVxMwvk5IshAClLvw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/Sirupsen/logrus",
 			"path": "github.com/Sirupsen/logrus",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "Te1xRugxHQMAg7EvbIUuPWm8fvU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/StackExchange/wmi",
 			"path": "github.com/StackExchange/wmi",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "5rPfda8jFccr3A6heL+JAmi9K9g=",
 			"origin": "github.com/elastic/beats/vendor/github.com/davecgh/go-spew/spew",
 			"path": "github.com/davecgh/go-spew/spew",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "Gj+xR1VgFKKmFXYOJMnAczC3Znk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/distribution/digestset",
 			"path": "github.com/docker/distribution/digestset",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "2Fe4D6PGaVE2he4fUeenLmhC1lE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/distribution/reference",
 			"path": "github.com/docker/distribution/reference",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "UL2NF1EGiSsQoEfvycnuZIcUbZY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api",
 			"path": "github.com/docker/docker/api",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "KMFpbV3mlrbc41d2DYnq05QYpSc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types",
 			"path": "github.com/docker/docker/api/types",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "jVJDbe0IcyjoKc2xbohwzQr+FF0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/blkiodev",
 			"path": "github.com/docker/docker/api/types/blkiodev",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "AeSC0BOu1uapkGqfSXtfVSpwJzs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/container",
 			"path": "github.com/docker/docker/api/types/container",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "4XuWn5+wgYwUsw604jvYMklq4Hc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/events",
 			"path": "github.com/docker/docker/api/types/events",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "J2OKngfI3vgswudr9PZVUFcRRu0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/filters",
 			"path": "github.com/docker/docker/api/types/filters",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "yeB781yxPhnN6OXQ9/qSsyih3ek=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/image",
 			"path": "github.com/docker/docker/api/types/image",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "UK+VdM648oWzyqE4OqttgmPqjoA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/mount",
 			"path": "github.com/docker/docker/api/types/mount",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "Gskp+nvbVe8Gk1xPLHylZvNmqTg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/network",
 			"path": "github.com/docker/docker/api/types/network",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "r2vWq7Uc3ExKzMqYgH0b4AKjLKY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/registry",
 			"path": "github.com/docker/docker/api/types/registry",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "VTxWyFud/RedrpllGdQonVtGM/A=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/strslice",
 			"path": "github.com/docker/docker/api/types/strslice",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "ZaizCpJ3eBcfR9ywpLaJd4AhM9k=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/swarm",
 			"path": "github.com/docker/docker/api/types/swarm",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "B7ZwKzrv3t3Vlox6/bYMHhMjsM8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/time",
 			"path": "github.com/docker/docker/api/types/time",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "uDPQ3nHsrvGQc9tg/J9OSC4N5dQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/versions",
 			"path": "github.com/docker/docker/api/types/versions",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "IBJy2zPEnYmcFJ3lM1eiRWnCxTA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/volume",
 			"path": "github.com/docker/docker/api/types/volume",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "c6OyeEvpQDvVLhrJSxgjEZv1tF8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/client",
 			"path": "github.com/docker/docker/client",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "jmo/t2zXAxirEPoFucNPXA/1SEc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/ioutils",
 			"path": "github.com/docker/docker/pkg/ioutils",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "ndnAFCfsGC3upNQ6jAEwzxcurww=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/longpath",
 			"path": "github.com/docker/docker/pkg/longpath",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "kr46EAa+FsUcWxOq6edyX6BUzE4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/system",
 			"path": "github.com/docker/docker/pkg/system",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "8I0Ez+aUYGpsDEVZ8wN/Ztf6Zqs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/tlsconfig",
 			"path": "github.com/docker/docker/pkg/tlsconfig",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "JbiWTzH699Sqz25XmDlsARpMN9w=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-connections/nat",
 			"path": "github.com/docker/go-connections/nat",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "jUfDG3VQsA2UZHvvIXncgiddpYA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-connections/sockets",
 			"path": "github.com/docker/go-connections/sockets",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "tuSzlS1UQ03+5Fvtqr5hI5sLLhA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-connections/tlsconfig",
 			"path": "github.com/docker/go-connections/tlsconfig",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "ambe8F4AofPxChCJssXXwWphQQ8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-units",
 			"path": "github.com/docker/go-units",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "sNAU9ojYVUhO6dVXey6T3JhRQpw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/libtrust",
 			"path": "github.com/docker/libtrust",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "y2Kh4iPlgCPXSGTCcFpzePYdzzg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/eapache/go-resiliency/breaker",
 			"path": "github.com/eapache/go-resiliency/breaker",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "WHl96RVZlOOdF4Lb1OOadMpw8ls=",
 			"origin": "github.com/elastic/beats/vendor/github.com/eapache/go-xerial-snappy",
 			"path": "github.com/eapache/go-xerial-snappy",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "oCCs6kDanizatplM5e/hX76busE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/eapache/queue",
 			"path": "github.com/eapache/queue",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "jO3LUqx5sKP8SMh052PUpAKAnS0=",
 			"path": "github.com/elastic/beats/libbeat/api",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "i+uHzsLvmaC6TbE1ViYhJTK9XLE=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
@@ -272,184 +272,184 @@
 		{
 			"checksumSHA1": "mvMbWi8jMCS5ZDCiWv+GkUzsmEw=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/meta",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "dDQwsavFnJ+1/f/eoNGVHjWiGmA=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/providers/docker",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "ipLA00wNb2e2Y0JCCKTq6LRL3JM=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/providers/kubernetes",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "2sZQ2RjQpeYI5l615G+W3ODSVRk=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/template",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "0lO6JkylG++k5f4AWzEgQ67UHgo=",
 			"path": "github.com/elastic/beats/libbeat/beat",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "xk8rkIPmXFqMpKdow17KuNHsZbM=",
 			"path": "github.com/elastic/beats/libbeat/cfgfile",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "kcJBPeHVyLhstApfy7Smi6fcxrg=",
 			"path": "github.com/elastic/beats/libbeat/cloudid",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "TNVaV0NTAkAR3F9ydhTTubOQeNE=",
 			"path": "github.com/elastic/beats/libbeat/cmd",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "b1jzseq9b5NzIaMYk6D1W1xA5MU=",
 			"path": "github.com/elastic/beats/libbeat/cmd/export",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
-			"checksumSHA1": "cuLtUPnYZRVyCzHuI2859Xkkb1M=",
+			"checksumSHA1": "jdJLVkJm3UQ7dzmilWr0gudiAdI=",
 			"path": "github.com/elastic/beats/libbeat/cmd/instance",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "hnrALZ/owH5lcue6u3G9p0/K4ag=",
 			"path": "github.com/elastic/beats/libbeat/cmd/test",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "5cXiuNi2aNCWF5xaSOr1dwG4sCE=",
 			"path": "github.com/elastic/beats/libbeat/common",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "SS/yBENBeoNVCAu+TQcDylo4CPg=",
 			"path": "github.com/elastic/beats/libbeat/common/atomic",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "I5ABLC2bPeiBbL2fKqLsQNe4DSQ=",
 			"path": "github.com/elastic/beats/libbeat/common/bus",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "5Y5WqKnrBD4VBRXCRn2JgFDvMV8=",
 			"path": "github.com/elastic/beats/libbeat/common/cfgwarn",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
-			"checksumSHA1": "pcyIn2gzdvx6y3Icc8N9ij2FRAU=",
+			"checksumSHA1": "OSXtQFu0+JoGUcWYpcFkXuvhRO4=",
 			"path": "github.com/elastic/beats/libbeat/common/cli",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "gGB9FaK8K+1w4kD0HsF1OpnN9eM=",
 			"path": "github.com/elastic/beats/libbeat/common/docker",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "7bGcM14M5R8BuQLqKdWfbbQaKEM=",
 			"path": "github.com/elastic/beats/libbeat/common/dtfmt",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
-			"checksumSHA1": "jnjiRowimBwicqurgxbUIBEtaIU=",
+			"checksumSHA1": "RZhgeb5xg6OKtyGq5Dvilt601Rw=",
 			"path": "github.com/elastic/beats/libbeat/common/file",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "7WSOY58klc0crUF/5UZx/pLFIR0=",
 			"path": "github.com/elastic/beats/libbeat/common/fmtstr",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "pdFJ+DF0STunSGRopAMwn9n9ZlY=",
 			"path": "github.com/elastic/beats/libbeat/common/jsontransform",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "R3u/rgTwTO3nWWrnAgarvzHu2sg=",
 			"path": "github.com/elastic/beats/libbeat/common/kubernetes",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "43jcD3PFE0qBsP40iA4kb/g94MU=",
 			"path": "github.com/elastic/beats/libbeat/common/match",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
@@ -462,48 +462,48 @@
 		{
 			"checksumSHA1": "8exGjSEBI+fSKXMHdWI2e2lX5D0=",
 			"path": "github.com/elastic/beats/libbeat/common/schema",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "WmqoD6kF9VraYUmjXacgWSHd2v4=",
 			"path": "github.com/elastic/beats/libbeat/common/schema/mapstriface",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "zi4xMJ43/IzPCPNXs8iBc0WI2sE=",
 			"path": "github.com/elastic/beats/libbeat/common/streambuf",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "1k581NuOkCx0xoGSrGV0vD6i+PA=",
 			"path": "github.com/elastic/beats/libbeat/common/terminal",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "hS/BvyAfk6/DTuu7+XWrx/gCvak=",
 			"path": "github.com/elastic/beats/libbeat/dashboards",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "Ie2zbuch+Jx2IrpjstO1jJeiV8o=",
 			"path": "github.com/elastic/beats/libbeat/keystore",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
@@ -518,120 +518,120 @@
 		{
 			"checksumSHA1": "z8VztKgyYSA7eyVuhNocdpav6zA=",
 			"path": "github.com/elastic/beats/libbeat/kibana/",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "Ol8fiOfQ+qh0cvwEI7kRFjRaNHY=",
 			"path": "github.com/elastic/beats/libbeat/logp",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "/fSZH8iFO9jqRiSSxzM593zMS4Y=",
 			"path": "github.com/elastic/beats/libbeat/logp/configure",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "3rCxbiMynIdSdQe7h95cuTKEXbY=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/cpu",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "2zYwb3Ycma7Ep8yGNRfnm4hvODA=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/memory",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
-			"checksumSHA1": "r7Cyj6XP4JE23i47GpOKPeDi2Wk=",
+			"checksumSHA1": "vnjuaoa2eZJzq9/UhURJ7c5YWv0=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/process",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "kZBPfX0Pv2dLMP5Iho9Mx/hXz9o=",
 			"path": "github.com/elastic/beats/libbeat/monitoring",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "tRfILb+3nS9S5xf1GTqyGVbvGnU=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/adapter",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "9OgsegLCw7fQSbzm92h5SSLJSqo=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "unvMHHTCkeHv3h3Kr02WucKeck0=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report/elasticsearch",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "O0mqYi92UChneQIZItpvDf+egYM=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report/log",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "P72p6i7s+3eRkfSxD/oYFbATnxY=",
 			"path": "github.com/elastic/beats/libbeat/outputs",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "/g/IAXGizefK4Zw3Zw11f1Gw5Gw=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "vjVLDyWbKmCR6e2OayNshujneSI=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec/format",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "j57gNFrdsjPGmF7AHx3dHdvB7qE=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec/json",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
@@ -650,40 +650,40 @@
 		{
 			"checksumSHA1": "JGP5bMcL1KyJRJCR1kW11gZhPhk=",
 			"path": "github.com/elastic/beats/libbeat/outputs/console",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "FXyBV4GWd0zPalEN4AunM86+zss=",
 			"path": "github.com/elastic/beats/libbeat/outputs/elasticsearch",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "S1nJaQZExaATn2Xpin4eY7Oyr34=",
 			"path": "github.com/elastic/beats/libbeat/outputs/fileout",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "iI6dpKLMOnY+0KdVizQhgSlKq0M=",
 			"path": "github.com/elastic/beats/libbeat/outputs/kafka",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "Wpvv92+QT4zveD+nlAx91aKq5OE=",
 			"path": "github.com/elastic/beats/libbeat/outputs/logstash",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
@@ -714,72 +714,72 @@
 		{
 			"checksumSHA1": "UEGH5mAXdKBysIjODuTxHKlzqsY=",
 			"path": "github.com/elastic/beats/libbeat/outputs/outil",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "j11eTg831Fs7uxEz2dRA/DJmKoU=",
 			"path": "github.com/elastic/beats/libbeat/outputs/redis",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "N8FWsJ68uJ5Haxc5vp8eS2Cp8jw=",
 			"path": "github.com/elastic/beats/libbeat/outputs/transport",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "d5b9Ra0zcwznwemxEJmyW28FZJ0=",
 			"path": "github.com/elastic/beats/libbeat/paths",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "2ef0H1yIcmjczaj6LsUc17/ss6I=",
 			"path": "github.com/elastic/beats/libbeat/plugin",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "gGNyFGQLyg9NpEQnoy7Pyat76NA=",
 			"path": "github.com/elastic/beats/libbeat/processors",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "JBWiLNZylmEHFiAbNXJAYa9D8fw=",
 			"path": "github.com/elastic/beats/libbeat/processors/actions",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "rI+RcxALfhqftyApiHM1AgSjQ8U=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_cloud_metadata",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "Z0GJcCgthM2W9FligSojRZNJ+fQ=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_docker_metadata",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
@@ -792,16 +792,16 @@
 		{
 			"checksumSHA1": "2vzViF52FVCvHplQZxESIs0QPeg=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_kubernetes_metadata",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "UCfWJFoOVRzY1nQ+mAHT+mpGYv4=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_locale",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
@@ -814,8 +814,8 @@
 		{
 			"checksumSHA1": "3kyV9PwlSwcLnK9SWKX97Gh7c00=",
 			"path": "github.com/elastic/beats/libbeat/publisher",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
@@ -854,72 +854,78 @@
 		{
 			"checksumSHA1": "btf3XhwPROVy4JtECpH0eL3nGwg=",
 			"path": "github.com/elastic/beats/libbeat/publisher/includes",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "vSCFcYhsiCm0U4o1XyboWf9IL7M=",
 			"path": "github.com/elastic/beats/libbeat/publisher/pipeline",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "k/1pxNUislJBfsjb/yZVG7+YP28=",
 			"path": "github.com/elastic/beats/libbeat/publisher/queue",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "dRlFNTjIKtVHBmkyTOiOhWxCWws=",
 			"path": "github.com/elastic/beats/libbeat/publisher/queue/memqueue",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
+			"version": "6.2",
+			"versionExact": "6.2"
+		},
+		{
+			"path": "github.com/elastic/beats/libbeat/publisher/queue/spool",
+			"revision": "6.2",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "kT9MLdbYAKYJ0lWfjqX8fbrZTiY=",
 			"path": "github.com/elastic/beats/libbeat/service",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "semQzHqIR5CoJmXvPQmjtZnwwkA=",
 			"path": "github.com/elastic/beats/libbeat/setup/kibana",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "BVrLP+2Vd0A3dhTfKTMIEvdVg4Q=",
 			"path": "github.com/elastic/beats/libbeat/template",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "p+um0Jv/tT4q7+rCQS7dxq50Ws0=",
 			"path": "github.com/elastic/beats/libbeat/testing",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
 		{
 			"checksumSHA1": "rllfL2iTusZWwpfLyF/4L6tQ/Eo=",
 			"path": "github.com/elastic/beats/libbeat/version",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z",
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z",
 			"version": "6.2",
 			"versionExact": "6.2"
 		},
@@ -927,295 +933,295 @@
 			"checksumSHA1": "3jizmlZPCyo6FAZY8Trk9jA8NH4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-lumber/client/v2",
 			"path": "github.com/elastic/go-lumber/client/v2",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "m6HLKpDAZlkTTQMqabf3aT6TQ/s=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-lumber/protocol/v2",
 			"path": "github.com/elastic/go-lumber/protocol/v2",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "61XUpyQ3zWnJ7Tlj0xLsHtnzwJY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg",
 			"path": "github.com/elastic/go-ucfg",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "8cr5YhslUMgpvF2JebYvKC+Ezr4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/cfgutil",
 			"path": "github.com/elastic/go-ucfg/cfgutil",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "Q2qrc/nI9d1tNzWTmfrkWvBNqsc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/flag",
 			"path": "github.com/elastic/go-ucfg/flag",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "uOrhvj7stlb0foxGZ5vbC1XJeto=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/internal/parse",
 			"path": "github.com/elastic/go-ucfg/internal/parse",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "sMBM95+VYBPhwtNVHqqN1yrvk1o=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/json",
 			"path": "github.com/elastic/go-ucfg/json",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "qvzj0KzxrWvYhHIbo+FwBxUNDFw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/yaml",
 			"path": "github.com/elastic/go-ucfg/yaml",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "2F9EiHAqPu6y4I/uNQWTS27VeGw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar",
 			"path": "github.com/elastic/gosigar",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "TX9y4oPL5YmT4Gb/OU4GIPTdQB4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/cgroup",
 			"path": "github.com/elastic/gosigar/cgroup",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "2VhOsaR4sv3S79HO6X+6dEphNKU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/sys/linux",
 			"path": "github.com/elastic/gosigar/sys/linux",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "qDsgp2kAeI9nhj565HUScaUyjU4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/sys/windows",
 			"path": "github.com/elastic/gosigar/sys/windows",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "xS5tIena63lzjTziIsbJbdTeue0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s",
 			"path": "github.com/ericchiang/k8s",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "uQuMoUlS7hAWsB+Mwr/1B7+35BU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/api/resource",
 			"path": "github.com/ericchiang/k8s/api/resource",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "XN1tbPrI03O0ishnZyfkWtTnrcQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/api/unversioned",
 			"path": "github.com/ericchiang/k8s/api/unversioned",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "yfTg3/Qn7KiizNJ39JmPBFi9YDQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/api/v1",
 			"path": "github.com/ericchiang/k8s/api/v1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "uw/3eB6WiVCSrQZS9ZZs/1kyu1I=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/apps/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/apps/v1alpha1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "GPnvYx9Uxhpwmv01iygWR6+naTI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/apps/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/apps/v1beta1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "Jjw5tBYv4k+Es+qPp03rnzyzRWA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authentication/v1",
 			"path": "github.com/ericchiang/k8s/apis/authentication/v1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "uR4S43Wc80fhS0vMDE3Z3hFg7J8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authentication/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/authentication/v1beta1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "aM2KSDZbHn8jJomPPeG6LKpMwhs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authorization/v1",
 			"path": "github.com/ericchiang/k8s/apis/authorization/v1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "4yWZvduAw2JNdHd1cXjTJBUy0lw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authorization/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/authorization/v1beta1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "1nMeCVQImIo1CpRRyOYMIqLoPBc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/autoscaling/v1",
 			"path": "github.com/ericchiang/k8s/apis/autoscaling/v1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "kUXiQQA99K7zquvG9es3yauVjYw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/autoscaling/v2alpha1",
 			"path": "github.com/ericchiang/k8s/apis/autoscaling/v2alpha1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "vMWsdmHlmaAQZIT0c26dwxe9pDw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/batch/v1",
 			"path": "github.com/ericchiang/k8s/apis/batch/v1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "bqaX0T9jycmp9ao1Ov41dfPn0Ng=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/batch/v2alpha1",
 			"path": "github.com/ericchiang/k8s/apis/batch/v2alpha1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "9GRVPI+Tf4RrlX2aveUGEUHKIrM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/certificates/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/certificates/v1alpha1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "k1dF56GRoEg6rooFKO7UvEJvBcE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/certificates/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/certificates/v1beta1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "4pDHINIk6BdPBYWGF20IwHNCg2Q=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/extensions/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/extensions/v1beta1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "NAL7OeKSEzTOoXHBFnC1B1VmBVs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/imagepolicy/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/imagepolicy/v1alpha1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "Vg1/xjzLJHZlvuheWC4abghACwQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/meta/v1",
 			"path": "github.com/ericchiang/k8s/apis/meta/v1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "wYSNb+W2L5gJlGO8n6mGOGft8R8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/policy/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/policy/v1alpha1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "ioJ28pdUN6fDkOp8dT+Tg3HSqmk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/policy/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/policy/v1beta1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "UErnBsjjtmg3oYjLYU1S80oi3sk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/rbac/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/rbac/v1alpha1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "Xl+Tm8ZOz0cMOrfLaQvu/lsWObU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/rbac/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/rbac/v1beta1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "YyZyaF0k2NAQAZvsCOVdhAkfVU0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/settings/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/settings/v1alpha1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "vUc3mf0rE7CQ3B52wfrMDyspLgA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/storage/v1",
 			"path": "github.com/ericchiang/k8s/apis/storage/v1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "7/oj1z0vG1pvRza+UuKQ6txdleI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/storage/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/storage/v1beta1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "mm5iTFmLQ6h98DKgiUuTCpHP9H4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/runtime",
 			"path": "github.com/ericchiang/k8s/runtime",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "Kk1UDqUx2Pr1LyvIIgcJBApTlCk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/runtime/schema",
 			"path": "github.com/ericchiang/k8s/runtime/schema",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "LoxBND74egHIasOX6z98FeeW0zI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/util/intstr",
 			"path": "github.com/ericchiang/k8s/util/intstr",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "fobEKiMk5D7IGvCSwh4HdG1o98c=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/watch/versioned",
 			"path": "github.com/ericchiang/k8s/watch/versioned",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "AANTVr9CVVyzsgviODY6Wi2thuM=",
@@ -1233,36 +1239,36 @@
 			"checksumSHA1": "2UmMbNHc8FBr98mJFN1k8ISOIHk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/garyburd/redigo/internal",
 			"path": "github.com/garyburd/redigo/internal",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "507OiSqTxfGCje7xDT5eq9CCaNQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/garyburd/redigo/redis",
 			"path": "github.com/garyburd/redigo/redis",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "ImX1uv6O09ggFeBPUJJ2nu7MPSA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ghodss/yaml",
 			"path": "github.com/ghodss/yaml",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "lfNGgtGL2Yrw+mVUexmA25lBYhY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/go-ole/go-ole",
 			"path": "github.com/go-ole/go-ole",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "Q0ZOcJW0fqOefDzEdn+PJHOeSgI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/go-ole/go-ole/oleutil",
 			"path": "github.com/go-ole/go-ole/oleutil",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "zF83b/btagb1yQnrxoNwL2+mqpQ=",
@@ -1280,15 +1286,15 @@
 			"checksumSHA1": "kBeNcaKk56FguvPSUCEaH6AxpRc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/golang/protobuf/proto",
 			"path": "github.com/golang/protobuf/proto",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "p/8vSviYF91gFflhrt5vkyksroo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/golang/snappy",
 			"path": "github.com/golang/snappy",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "d9PxF1XQGLMJZRct2R8qVM/eYlE=",
@@ -1306,15 +1312,15 @@
 			"checksumSHA1": "40vJyUB4ezQSn/NSadsKEOrudMc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/inconshreveable/mousetrap",
 			"path": "github.com/inconshreveable/mousetrap",
-			"revision": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75",
-			"revisionTime": "2014-10-17T20:07:13Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "l9wW52CYGbmO/NGwYZ/Op2QTmaA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/joeshaw/multierror",
 			"path": "github.com/joeshaw/multierror",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "pa+ZwMzIv+u+BlL8Q2xgL9cQtJg=",
@@ -1326,50 +1332,50 @@
 			"checksumSHA1": "KKxbAKrKrfd33YPpkNsDmTN3S+M=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/compress/flate",
 			"path": "github.com/klauspost/compress/flate",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "+azPXaZpPF14YHRghNAer13ThQU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/compress/zlib",
 			"path": "github.com/klauspost/compress/zlib",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "R6zKqn31GjJH1G8W/api7fAW0RU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/cpuid",
 			"path": "github.com/klauspost/cpuid",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "BM6ZlNJmtKy3GBoWwg2X55gnZ4A=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/crc32",
 			"path": "github.com/klauspost/crc32",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "qNkx9+OTwZI6aFv7K9zuFCGODUw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/mattn/go-colorable",
 			"path": "github.com/mattn/go-colorable",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "U6lX43KDDlNOn+Z0Yyww+ZzHfFo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/mattn/go-isatty",
 			"path": "github.com/mattn/go-isatty",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "sWdAYPKyaT4SW8hNQNpRS0sU4lU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/mitchellh/hashstructure",
 			"path": "github.com/mitchellh/hashstructure",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "gILp4IL+xwXLH6tJtRLrnZ56F24=",
@@ -1381,22 +1387,22 @@
 			"checksumSHA1": "2AyUkWjutec6p+470tgio8mYOxI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/go-digest",
 			"path": "github.com/opencontainers/go-digest",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "eOMCORUm8KxiGSy0hBuQsMsxauo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/image-spec/specs-go",
 			"path": "github.com/opencontainers/image-spec/specs-go",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "9YujSsJjiLGkQMzwWycsjqR340k=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/image-spec/specs-go/v1",
 			"path": "github.com/opencontainers/image-spec/specs-go/v1",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "JVGDxPn66bpe6xEiexs1r+y6jF0=",
@@ -1408,22 +1414,22 @@
 			"checksumSHA1": "WmrPO1ovmQ7t7hs9yZGbr2SAoM4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pierrec/lz4",
 			"path": "github.com/pierrec/lz4",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "IT4sX58d+e8osXHV5U6YCSdB/uE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pierrec/xxHash/xxHash32",
 			"path": "github.com/pierrec/xxHash/xxHash32",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "PdQm3s8DoVJ17Vk8n7o5iPa7PK0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pkg/errors",
 			"path": "github.com/pkg/errors",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
@@ -1435,8 +1441,8 @@
 			"checksumSHA1": "KAzbLjI9MzW2tjfcAsK75lVRp6I=",
 			"origin": "github.com/elastic/beats/vendor/github.com/rcrowley/go-metrics",
 			"path": "github.com/rcrowley/go-metrics",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "6JP37UqrI0H80Gpk0Y2P+KXgn5M=",
@@ -1466,8 +1472,8 @@
 			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/satori/go.uuid",
 			"path": "github.com/satori/go.uuid",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "v7C+aJ1D/z3MEeCte6bxvpoGjM4=",
@@ -1479,15 +1485,15 @@
 			"checksumSHA1": "e7mAb9jMke2ASQGZepFgOmfBFzM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/spf13/cobra",
 			"path": "github.com/spf13/cobra",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "STxYqRb4gnlSr3mRpT+Igfdz/kM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/spf13/pflag",
 			"path": "github.com/spf13/pflag",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "q1qqfgDOGwfEuMlbHWNjYf09ACM=",
@@ -1501,36 +1507,36 @@
 			"checksumSHA1": "ci7skUhpD1VwkoR0tKVdggTkYrE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/urso/go-structform",
 			"path": "github.com/urso/go-structform",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "AkYoBxV+Imq2EBwNcb53hEGh7sQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/urso/go-structform/gotype",
 			"path": "github.com/urso/go-structform/gotype",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "m9H8/w6okS+8ixvkq+eYLd/Kk3g=",
 			"origin": "github.com/elastic/beats/vendor/github.com/urso/go-structform/internal/unsafe",
 			"path": "github.com/urso/go-structform/internal/unsafe",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "UXf4TzYK1UB8xAa6Phy9CvkvWL0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/urso/go-structform/json",
 			"path": "github.com/urso/go-structform/json",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "MytQct/960akBAZm7xmbpi2BKGs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/urso/go-structform/visitors",
 			"path": "github.com/urso/go-structform/visitors",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "8Kj0VH496b0exuyv4wAF4CXa7Y4=",
@@ -1555,162 +1561,162 @@
 			"checksumSHA1": "HedK9m8E8iyib4bIBtIX7xprOgo=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/atomic",
 			"path": "go.uber.org/atomic",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "JDGx7hehaQunZySwPs7yvdUs2m8=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/multierr",
 			"path": "go.uber.org/multierr",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "5BYbiKEkYykvfjSaNYDuQpBqglo=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap",
 			"path": "go.uber.org/zap",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "HYo/9nwrY08NQA+2ItPOAH8IFW8=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/buffer",
 			"path": "go.uber.org/zap/buffer",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "MuxOAtZEsJitlWBzhmpm2vGiHok=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/internal/bufferpool",
 			"path": "go.uber.org/zap/internal/bufferpool",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "uC0L9eCSAYcCWNC8udJk/t1vvIU=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/internal/color",
 			"path": "go.uber.org/zap/internal/color",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "b80CJExrVpXu3SA1iCQ6uLqTn2c=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/internal/exit",
 			"path": "go.uber.org/zap/internal/exit",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "mRD6lujPvXPkbC3+byNwO/bNVu8=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/zapcore",
 			"path": "go.uber.org/zap/zapcore",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "gyBmIfDZslmQGKnqisJ/p7oHbQc=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/zaptest/observer",
 			"path": "go.uber.org/zap/zaptest/observer",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "1MGpGDQqnUoRpv7VEcQrXOBydXE=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/crypto/pbkdf2",
 			"path": "golang.org/x/crypto/pbkdf2",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "X1NTlfcau2XcV6WtAHF6b/DECOA=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/crypto/ssh/terminal",
 			"path": "golang.org/x/crypto/ssh/terminal",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "Y+HGqEkYM15ir+J93MEaHdyFy0c=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/context",
 			"path": "golang.org/x/net/context",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "WHc3uByvGaMcnSoI21fhzYgbOgg=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/context/ctxhttp",
 			"path": "golang.org/x/net/context/ctxhttp",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "SPYGC6DQrH9jICccUsOfbvvhB4g=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/http2",
 			"path": "golang.org/x/net/http2",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "EYNaHp7XdLWRydUCE0amEkKAtgk=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/http2/hpack",
 			"path": "golang.org/x/net/http2/hpack",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "yhndhWXMs/VSEDLks4dNyFMQStA=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/lex/httplex",
 			"path": "golang.org/x/net/lex/httplex",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "LvdVRE0FqdR68SvVpRkHs1rxhcA=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/proxy",
 			"path": "golang.org/x/net/proxy",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "l/AvVB/e1LjZ28XXItkdOW9tKMQ=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/unix",
 			"path": "golang.org/x/sys/unix",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "cQoW6a5F9mbu10APPXM39YJtv48=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows",
 			"path": "golang.org/x/sys/windows",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "Qvq4DjtYrcpGgBT0O1s8nTTeFWQ=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/registry",
 			"path": "golang.org/x/sys/windows/registry",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "IRqLaXM/VQRzkbXPuiqOxTb2W0Y=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/svc",
 			"path": "golang.org/x/sys/windows/svc",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "1ouiyoHRaaMDNeq/nap9B0UuQw4=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/svc/debug",
 			"path": "golang.org/x/sys/windows/svc/debug",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "uVlUSSKplihZG7N+QJ6fzDZ4Kh8=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/svc/eventlog",
 			"path": "golang.org/x/sys/windows/svc/eventlog",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		},
 		{
 			"checksumSHA1": "vGfePfr0+weQUeTM/71mu+LCFuE=",
@@ -1722,8 +1728,8 @@
 			"checksumSHA1": "fALlQNY1fM99NesfLJ50KguWsio=",
 			"origin": "github.com/elastic/beats/vendor/gopkg.in/yaml.v2",
 			"path": "gopkg.in/yaml.v2",
-			"revision": "50372ae92c0b6f54b780751068f82ea0c5844954",
-			"revisionTime": "2018-03-20T20:42:46Z"
+			"revision": "1122568edf4ad039734b5224aece9a6259c72684",
+			"revisionTime": "2018-04-10T05:40:41Z"
 		}
 	],
 	"rootPath": "github.com/elastic/apm-server"


### PR DESCRIPTION
Backports the following commits to 6.2:

 - target for clean and docs together (#624)
 - use transitive dep versions in NOTICE (#790)
 - override revision for missed subpackages (#797)
 - update description used in packaging (#807)