### PR TITLE
[6.x] Fix link to beats platform reference (#614)

### DIFF
--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -34,7 +34,7 @@ There's also a full example configuration file at
 +/etc/{beatname_lc}/{beatname_lc}.reference.yml+ that shows all non-deprecated
 options. For mac and win, look in the archive that you extracted.
 
-See the _Beats Platform Reference_ for more about the structure of the config file.
+See {libbeat}/config-file-format.html[Config File Format] in _Beats Platform Reference_ for more about the structure of the config file.
 
 [source,yaml]
 ----------------------------------


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Fix link to beats platform reference  (#614)