### PR TITLE
[6.x] Allow system tests to be run from any directory (#835) | Allow other tests to be run from any directory (#837)

### DIFF
--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -2,14 +2,14 @@ import json
 import os
 import re
 import shutil
-import sys
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '../../_beats/libbeat/tests/system'))
-
-from beat.beat import TestCase
-from elasticsearch import Elasticsearch
 import requests
+import sys
 import time
+from elasticsearch import Elasticsearch
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', '_beats', 'libbeat', 'tests', 'system'))
+from beat.beat import TestCase
 
 
 class BaseTest(TestCase):
@@ -17,30 +17,34 @@ class BaseTest(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.beat_name = "apm-server"
-        cls.build_path = "../../build/system-tests/"
-        cls.beat_path = os.path.join(os.path.dirname(__file__), "../../")
+        cls.beat_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+        cls.build_path = cls._beat_path_join("build", "system-tests")
         cls.index_name = "test-apm-12-12-2017"
         super(BaseTest, cls).setUpClass()
 
+    @classmethod
+    def _beat_path_join(cls, *paths):
+        return os.path.abspath(os.path.join(cls.beat_path, *paths))
+
     def get_transaction_payload_path(self, name="payload.json"):
-        return os.path.abspath(os.path.join(self.beat_path,
-                                            'tests',
-                                            'data',
-                                            'valid',
-                                            'transaction',
-                                            name))
+        return self._beat_path_join(
+            'tests',
+            'data',
+            'valid',
+            'transaction',
+            name)
 
     def get_transaction_payload(self):
         path = self.get_transaction_payload_path()
         return json.loads(open(path).read())
 
     def get_error_payload_path(self, name="payload.json"):
-        return os.path.abspath(os.path.join(self.beat_path,
-                                            'tests',
-                                            'data',
-                                            'valid',
-                                            'error',
-                                            name))
+        return self._beat_path_join(
+            'tests',
+            'data',
+            'valid',
+            'error',
+            name)
 
     def get_error_payload(self):
         path = self.get_error_payload_path()
@@ -58,7 +62,7 @@ class ServerSetUpBaseTest(BaseTest):
 
     def setUp(self):
         super(ServerSetUpBaseTest, self).setUp()
-        shutil.copy(self.beat_path + "/fields.yml", self.working_dir)
+        shutil.copy(self._beat_path_join("fields.yml"), self.working_dir)
 
         self.render_config_template(**self.config())
         self.apmserver_proc = self.start_beat()
@@ -110,8 +114,8 @@ class SecureServerBaseTest(ServerSetUpBaseTest):
         cfg = super(SecureServerBaseTest, self).config()
         cfg.update({
             "ssl_enabled": "true",
-            "ssl_cert": "config/certs/cert.pem",
-            "ssl_key": "config/certs/key.pem",
+            "ssl_cert": self._beat_path_join("tests", "system", "config", "certs", "cert.pem"),
+            "ssl_key": self._beat_path_join("tests", "system", "config", "certs", "key.pem"),
         })
         return cfg
 
@@ -245,12 +249,12 @@ class ClientSideBaseTest(ElasticTest):
                          service_version='1.0.1',
                          bundle_filepath='bundle_no_mapping.js.map',
                          expected_ct=1):
-        path = os.path.abspath(os.path.join(self.beat_path,
-                                            'tests',
-                                            'data',
-                                            'valid',
-                                            'sourcemap',
-                                            file_name))
+        path = self._beat_path_join(
+            'tests',
+            'data',
+            'valid',
+            'sourcemap',
+            file_name)
         f = open(path)
         r = requests.post(self.sourcemap_url,
                           files={'sourcemap': f},

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -4,7 +4,8 @@ import re
 import shutil
 import sys
 
-sys.path.append('../../_beats/libbeat/tests/system')
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../_beats/libbeat/tests/system'))
+
 from beat.beat import TestCase
 from elasticsearch import Elasticsearch
 import requests
@@ -17,7 +18,7 @@ class BaseTest(TestCase):
     def setUpClass(cls):
         cls.beat_name = "apm-server"
         cls.build_path = "../../build/system-tests/"
-        cls.beat_path = "../../"
+        cls.beat_path = os.path.join(os.path.dirname(__file__), "../../")
         cls.index_name = "test-apm-12-12-2017"
         super(BaseTest, cls).setUpClass()
 

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -40,14 +40,16 @@ class Test(ElasticTest):
         rs = self.es.search(index=self.index_name, body={
             "query": {"term": {"processor.event": "transaction"}}})
         assert rs['hits']['total'] == 4, "found {} documents".format(rs['count'])
-        approved = json.load(open('transaction.approved.json'))
+        with open(self._beat_path_join(os.path.dirname(__file__), 'transaction.approved.json')) as f:
+            approved = json.load(f)
         self.check_docs(approved, rs['hits']['hits'], 'transaction')
 
         # compare existing ES documents for spans with new ones
         rs = self.es.search(index=self.index_name, body={
             "query": {"term": {"processor.event": "span"}}})
         assert rs['hits']['total'] == 5, "found {} documents".format(rs['count'])
-        approved = json.load(open('spans.approved.json'))
+        with open(self._beat_path_join(os.path.dirname(__file__), 'spans.approved.json')) as f:
+            approved = json.load(f)
         self.check_docs(approved, rs['hits']['hits'], 'span')
 
         self.check_backend_transaction_sourcemap(count=5)
@@ -66,7 +68,8 @@ class Test(ElasticTest):
         rs = self.es.search(index=self.index_name, body={
             "query": {"term": {"processor.event": "error"}}})
         assert rs['hits']['total'] == 4, "found {} documents".format(rs['count'])
-        approved = json.load(open('error.approved.json'))
+        with open(self._beat_path_join(os.path.dirname(__file__), 'error.approved.json')) as f:
+            approved = json.load(f)
         self.check_docs(approved, rs['hits']['hits'], 'error')
 
         self.check_backend_error_sourcemap(count=4)

--- a/tests/system/test_requests.py
+++ b/tests/system/test_requests.py
@@ -1,20 +1,21 @@
+from collections import defaultdict
+import gzip
+import json
+import requests
+import threading
+import time
+import zlib
+
 from nose.tools import raises
+from requests.exceptions import SSLError
 
 from apmserver import ServerBaseTest, SecureServerBaseTest, ClientSideBaseTest, CorsBaseTest
-from requests.exceptions import SSLError
-import requests
-import json
-import zlib
-import gzip
-import time
-from datetime import datetime
-from collections import defaultdict
-import threading
+
 
 try:
     from StringIO import StringIO
 except ImportError:
-    import io
+    from io import StringIO
 
 
 class Test(ServerBaseTest):
@@ -150,13 +151,12 @@ class ClientSideTest(ClientSideBaseTest):
         assert r.status_code == 202, r.status_code
 
     def test_sourcemap_upload_fail(self):
-        import os
-        path = os.path.abspath(os.path.join(self.beat_path,
-                                            'tests',
-                                            'data',
-                                            'valid',
-                                            'sourcemap',
-                                            'bundle.js.map'))
+        path = self._beat_path_join(
+            'tests',
+            'data',
+            'valid',
+            'sourcemap',
+            'bundle.js.map')
         file = open(path)
         r = requests.post(self.sourcemap_url,
                           files={'sourcemap': file})


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Allow system tests to be run from any directory  (#835)
 - Allow other tests to be run from any directory  (#837)