### PR TITLE
Update beats framework to 88911e7

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -211,7 +211,7 @@ SOFTWARE.
 --------------------------------------------------------------------
 Dependency: github.com/elastic/beats
 Version: master
-Revision: 4960293df6759a499221c132a453dcf9a64fe172
+Revision: 88911e75a197f7eeeb5c24b6196569469ed866cb
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/beats/LICENSE.txt:
 --------------------------------------------------------------------

--- a/_beats/libbeat/scripts/Makefile
+++ b/_beats/libbeat/scripts/Makefile
@@ -48,6 +48,7 @@ REVIEWDOG_OPTIONS?=-diff "git diff master"
 REVIEWDOG_REPO?=github.com/haya14busa/reviewdog/cmd/reviewdog
 PROCESSES?= 4
 TIMEOUT?= 90
+PYTHON_TEST_FILES?=$(shell find . -type f -name 'test_*.py' -not -path "*/build/*" -not -path "*/vendor/*")
 NOSETESTS_OPTIONS?=--process-timeout=$(TIMEOUT) --with-timer -v --with-xunit --xunit-file=${BUILD_DIR}/TEST-system.xml ## @testing the options to pass when calling nosetests
 TEST_ENVIRONMENT?=false ## @testing if true, "make testsuite" runs integration tests and system tests in a dockerized test environment
 SYSTEM_TESTS?=false ## @testing if true, "make test" and "make testsuite" run unit tests and system tests
@@ -187,7 +188,7 @@ integration-tests-environment: prepare-tests build-image
 .PHONY: system-tests
 system-tests: ## @testing Runs the system tests
 system-tests: prepare-tests ${BEAT_NAME}.test python-env ${ES_BEATS}/dev-tools/cmd/dashboards/export_dashboards
-	. ${PYTHON_ENV}/bin/activate; INTEGRATION_TESTS=${INTEGRATION_TESTS} TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} nosetests -w tests/system ${NOSETESTS_OPTIONS}
+	. ${PYTHON_ENV}/bin/activate; INTEGRATION_TESTS=${INTEGRATION_TESTS} TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} DOCKER_COMPOSE_PROJECT_NAME=${DOCKER_COMPOSE_PROJECT_NAME} nosetests ${PYTHON_TEST_FILES} ${NOSETESTS_OPTIONS}
 	python ${ES_BEATS}/dev-tools/aggregate_coverage.py -o ${COVERAGE_DIR}/system.cov ./build/system-tests/run
 
 # Runs the system tests
@@ -200,7 +201,7 @@ system-tests-environment: prepare-tests build-image
 .PHONY: fast-system-tests
 fast-system-tests: ## @testing Runs system tests without coverage reports and in parallel
 fast-system-tests: ${BEAT_NAME}.test python-env
-	. ${PYTHON_ENV}/bin/activate; nosetests -w tests/system ${NOSETESTS_OPTIONS}
+	. ${PYTHON_ENV}/bin/activate; nosetests ${PYTHON_TEST_FILES} ${NOSETESTS_OPTIONS}
 
 # Runs the go based stress tests
 .PHONY: stress-tests
@@ -219,7 +220,7 @@ benchmark-tests: ## @testing Runs benchmarks (NOT YET IMPLEMENTED)
 # Run load tests
 .PHONY: load-tests
 load-tests: ## @testing Runs load tests
-	. ${PYTHON_ENV}/bin/activate; LOAD_TESTS=1  nosetests -w tests/system --processes=$(PROCESSES) --process-timeout=$(TIMEOUT) -a 'load'
+	. ${PYTHON_ENV}/bin/activate; LOAD_TESTS=1  nosetests ${PYTHON_TEST_FILES} --processes=$(PROCESSES) --process-timeout=$(TIMEOUT) -a 'load'
 
 # Sets up the virtual python environment
 .PHONY: python-env
@@ -231,8 +232,8 @@ python-env: ${ES_BEATS}/libbeat/tests/system/requirements.txt
 	else \
 		. ${PYTHON_ENV}/bin/activate && pip install ${PIP_INSTALL_PARAMS} -qUr ${ES_BEATS}/libbeat/tests/system/requirements.txt ; \
 	fi
-	# Work around pip bug. See: https://github.com/pypa/pip/issues/4464
-	find ${PYTHON_ENV} -type d -name 'dist-packages' -exec sh -c "echo dist-packages > {}.pth" ';'
+	@# Work around pip bug. See: https://github.com/pypa/pip/issues/4464
+	@find ${PYTHON_ENV} -type d -name 'dist-packages' -exec sh -c "echo dist-packages > {}.pth" ';'
 
 .PHONY: test
 test: ## @testing Runs unit and system tests without coverage reports

--- a/_beats/libbeat/scripts/generate_fields_docs.py
+++ b/_beats/libbeat/scripts/generate_fields_docs.py
@@ -44,7 +44,7 @@ def document_field(output, field, path):
     if "path" not in field:
         field["path"] = path
 
-    output.write("[float]\n=== `{}`\n\n".format(field["path"]))
+    output.write("*`{}`*::\n+\n--\n".format(field["path"]))
 
     if "type" in field:
         output.write("type: {}\n\n".format(field["type"]))
@@ -69,6 +69,7 @@ def document_field(output, field, path):
     if "multi_fields" in field:
         for subfield in field["multi_fields"]:
             document_field(output, subfield, path + "." + subfield["name"])
+    output.write("--\n\n")
 
 
 def fields_to_asciidoc(input, output, beat):

--- a/_beats/libbeat/tests/system/beat/beat.py
+++ b/_beats/libbeat/tests/system/beat/beat.py
@@ -9,6 +9,7 @@ import signal
 import sys
 import time
 import yaml
+import hashlib
 from datetime import datetime, timedelta
 
 from .compose import ComposeMixin
@@ -18,6 +19,8 @@ BEAT_REQUIRED_FIELDS = ["@timestamp",
                         "beat.name", "beat.hostname", "beat.version"]
 
 INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
+
+yaml_cache = {}
 
 
 class TimeoutError(Exception):
@@ -487,6 +490,8 @@ class TestCase(unittest.TestCase, ComposeMixin):
         if not os.path.isfile(fields_doc):
             fields_doc = self.beat_path + "/_meta/fields.yml"
 
+        global yaml_cache
+
         # TODO: Make fields_doc path more generic to work with beat-generator
         with open(fields_doc, "r") as f:
             path = os.path.abspath(os.path.dirname(__file__) + "../../../../_meta/fields.generated.yml")
@@ -495,9 +500,15 @@ class TestCase(unittest.TestCase, ComposeMixin):
             with open(path) as f2:
                 content = f2.read()
 
-            #content = "fields:\n"
             content += f.read()
-            doc = yaml.load(content)
+
+            hash = hashlib.md5(content).hexdigest()
+            doc = ""
+            if hash in yaml_cache:
+                doc = yaml_cache[hash]
+            else:
+                doc = yaml.safe_load(content)
+                yaml_cache[hash] = doc
 
             fields = []
             dictfields = []
@@ -519,7 +530,9 @@ class TestCase(unittest.TestCase, ComposeMixin):
                 result[prefix + key] = value
         return result
 
-    def copy_files(self, files, source_dir="files/", target_dir=""):
+    def copy_files(self, files, source_dir="", target_dir=""):
+        if not source_dir:
+            source_dir = self.beat_path + "/tests/files/"
         if target_dir:
             target_dir = os.path.join(self.working_dir, target_dir)
         else:

--- a/_beats/libbeat/tests/system/beat/compose.py
+++ b/_beats/libbeat/tests/system/beat/compose.py
@@ -30,27 +30,54 @@ class ComposeMixin(object):
         """
         Ensure *only* the services defined under `COMPOSE_SERVICES` are running and healthy
         """
-        if INTEGRATION_TESTS and cls.COMPOSE_SERVICES:
-            cls.compose_project().up(
+        if not INTEGRATION_TESTS or not cls.COMPOSE_SERVICES:
+            return
+
+        def print_logs(container):
+            print("---- " + container.name_without_project)
+            print(container.logs())
+            print("----")
+
+        def is_healthy(container):
+            return container.inspect()['State']['Health']['Status'] == 'healthy'
+
+        project = cls.compose_project()
+        project.up(
+            service_names=cls.COMPOSE_SERVICES,
+            do_build=BuildAction.force,
+            timeout=30)
+
+        # Wait for them to be healthy
+        start = time.time()
+        while True:
+            containers = project.containers(
                 service_names=cls.COMPOSE_SERVICES,
-                do_build=BuildAction.force,
-                timeout=30)
+                stopped=True)
 
-            # Wait for them to be healthy
-            healthy = False
-            seconds = cls.COMPOSE_TIMEOUT
-            while not healthy and seconds > 0:
-                print("Seconds: %d".format(seconds))
-                seconds -= 1
-                time.sleep(1)
-                healthy = True
-                for container in cls.compose_project().containers(service_names=cls.COMPOSE_SERVICES):
-                    if container.inspect()['State']['Health']['Status'] != 'healthy':
-                        healthy = False
-                        break
+            healthy = True
+            for container in containers:
+                if not container.is_running:
+                    print_logs(container)
+                    raise Exception(
+                        "Container %s unexpectedly finished on startup" %
+                        container.name_without_project)
+                if not is_healthy(container):
+                    healthy = False
+                    break
 
-            if not healthy:
-                raise Exception('Timeout while waiting for healthy docker-compose services')
+            if healthy:
+                break
+
+            time.sleep(1)
+            timeout = time.time() - start > cls.COMPOSE_TIMEOUT
+            if timeout:
+                for container in containers:
+                    if not is_healthy(container):
+                        print_logs(container)
+                raise Exception(
+                    "Timeout while waiting for healthy "
+                    "docker-compose services: %s" %
+                    ','.join(cls.COMPOSE_SERVICES))
 
     @classmethod
     def compose_down(cls):

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -30,27 +30,33 @@ grouped in the following categories:
 None
 
 
-[float]
-=== `listening`
-
+*`listening`*::
++
+--
 type: keyword
 
 Address the server is listening on.
 
 
-[float]
-=== `processor.name`
+--
 
+*`processor.name`*::
++
+--
 type: keyword
 
 Processor name.
 
-[float]
-=== `processor.event`
+--
 
+*`processor.event`*::
++
+--
 type: keyword
 
 Processor event.
+
+--
 
 [float]
 == context fields
@@ -59,54 +65,66 @@ Any arbitrary contextual information regarding the event, captured by the agent,
 
 
 
-[float]
-=== `context.tags`
-
+*`context.tags`*::
++
+--
 type: object
 
 A flat mapping of user-defined tags with string values.
 
 
+--
 
-[float]
-=== `context.user.username`
 
+*`context.user.username`*::
++
+--
 type: keyword
 
 The username of the logged in user.
 
 
-[float]
-=== `context.user.id`
+--
 
+*`context.user.id`*::
++
+--
 type: keyword
 
 Identifier of the logged in user.
 
 
-[float]
-=== `context.user.email`
+--
 
+*`context.user.email`*::
++
+--
 type: keyword
 
 Email of the logged in user.
 
 
-[float]
-=== `context.user.ip`
+--
 
+*`context.user.ip`*::
++
+--
 type: ip
 
 IP of the user where the event is recorded, typically a web browser. This is obtained from the X-Forwarded-For header, of which the first entry is the IP of the original client. This value however might not be necessarily trusted, as it can be forged by a malicious user.
 
 
-[float]
-=== `context.user.user-agent`
+--
 
+*`context.user.user-agent`*::
++
+--
 type: text
 
 Software agent acting in behalf of a user, eg. a web browser / OS combination.
 
+
+--
 
 
 [float]
@@ -116,102 +134,126 @@ A complete Url, with scheme, host and path.
 
 
 
-[float]
-=== `context.request.url.raw`
-
+*`context.request.url.raw`*::
++
+--
 type: keyword
 
 The raw, unparsed URL of the request, e.g https://example.com:443/search?q=elasticsearch#top.
 
 
-[float]
-=== `context.request.url.protocol`
+--
 
+*`context.request.url.protocol`*::
++
+--
 type: keyword
 
 The protocol of the request, e.g. "https:".
 
 
-[float]
-=== `context.request.url.full`
+--
 
+*`context.request.url.full`*::
++
+--
 type: keyword
 
 The full, possibly agent-assembled URL of the request, e.g https://example.com:443/search?q=elasticsearch#top.
 
 
-[float]
-=== `context.request.url.hostname`
+--
 
+*`context.request.url.hostname`*::
++
+--
 type: keyword
 
 The hostname of the request, e.g. "example.com".
 
 
-[float]
-=== `context.request.url.port`
+--
 
+*`context.request.url.port`*::
++
+--
 type: keyword
 
 The port of the request, e.g. 443.
 
 
-[float]
-=== `context.request.url.pathname`
+--
 
+*`context.request.url.pathname`*::
++
+--
 type: keyword
 
 The path of the request, e.g. "/search".
 
 
-[float]
-=== `context.request.url.search`
+--
 
+*`context.request.url.search`*::
++
+--
 type: keyword
 
 The search describes the query string of the request, e.g. "q=elasticsearch".
 
 
-[float]
-=== `context.request.url.hash`
+--
 
+*`context.request.url.hash`*::
++
+--
 type: keyword
 
 The hash of the request URL, e.g. "top".
 
 
-[float]
-=== `context.request.http_version`
+--
 
+*`context.request.http_version`*::
++
+--
 type: keyword
 
 The http version of the request leading to this event.
 
 
-[float]
-=== `context.request.method`
+--
 
+*`context.request.method`*::
++
+--
 type: keyword
 
 The http method of the request leading to this event.
 
 
+--
 
-[float]
-=== `context.response.status_code`
 
+*`context.response.status_code`*::
++
+--
 type: long
 
 The http status code of the response, eg. '200'.
 
 
-[float]
-=== `context.response.finished`
+--
 
+*`context.response.finished`*::
++
+--
 type: boolean
 
 A boolean indicating whether the response was finished or not.
 
+
+--
 
 [float]
 == system fields
@@ -220,37 +262,45 @@ Optional system fields.
 
 
 
-[float]
-=== `context.system.hostname`
-
+*`context.system.hostname`*::
++
+--
 type: keyword
 
 The hostname of the system the event was recorded on.
 
 
-[float]
-=== `context.system.architecture`
+--
 
+*`context.system.architecture`*::
++
+--
 type: keyword
 
 The architecture of the system the event was recorded on.
 
 
-[float]
-=== `context.system.platform`
+--
 
+*`context.system.platform`*::
++
+--
 type: keyword
 
 The platform of the system the event was recorded on.
 
 
-[float]
-=== `context.system.ip`
+--
 
+*`context.system.ip`*::
++
+--
 type: ip
 
 IP of the host that records the event.
 
+
+--
 
 [float]
 == process fields
@@ -259,29 +309,35 @@ Information pertaining to the running process where the data was collected
 
 
 
-[float]
-=== `context.process.pid`
-
+*`context.process.pid`*::
++
+--
 type: long
 
 Numeric process ID of the service process.
 
 
-[float]
-=== `context.process.ppid`
+--
 
+*`context.process.ppid`*::
++
+--
 type: long
 
 Numeric ID of the service's parent process.
 
 
-[float]
-=== `context.process.title`
+--
 
+*`context.process.title`*::
++
+--
 type: keyword
 
 Service process title.
 
+
+--
 
 [float]
 == service fields
@@ -290,9 +346,9 @@ Service fields.
 
 
 
-[float]
-=== `context.service.name`
-
+*`context.service.name`*::
++
+--
 type: keyword
 
 format: url
@@ -300,94 +356,116 @@ format: url
 Immutable unique name of the service emitting this event.
 
 
-[float]
-=== `context.service.version`
+--
 
+*`context.service.version`*::
++
+--
 type: keyword
 
 Version of the service emitting this event.
 
 
-[float]
-=== `context.service.environment`
+--
 
+*`context.service.environment`*::
++
+--
 type: keyword
 
 Service environment.
 
 
+--
 
-[float]
-=== `context.service.language.name`
 
+*`context.service.language.name`*::
++
+--
 type: keyword
 
 Name of the programming language used.
 
 
-[float]
-=== `context.service.language.version`
+--
 
+*`context.service.language.version`*::
++
+--
 type: keyword
 
 Version of the programming language used.
 
 
+--
 
-[float]
-=== `context.service.runtime.name`
 
+*`context.service.runtime.name`*::
++
+--
 type: keyword
 
 Name of the runtime used.
 
 
-[float]
-=== `context.service.runtime.version`
+--
 
+*`context.service.runtime.version`*::
++
+--
 type: keyword
 
 Version of the runtime used.
 
 
+--
 
-[float]
-=== `context.service.framework.name`
 
+*`context.service.framework.name`*::
++
+--
 type: keyword
 
 Name of the framework used.
 
 
-[float]
-=== `context.service.framework.version`
+--
 
+*`context.service.framework.version`*::
++
+--
 type: keyword
 
 Version of the framework used.
 
 
+--
 
-[float]
-=== `context.service.agent.name`
 
+*`context.service.agent.name`*::
++
+--
 type: keyword
 
 Name of the agent used.
 
 
-[float]
-=== `context.service.agent.version`
+--
 
+*`context.service.agent.version`*::
++
+--
 type: keyword
 
 Version of the agent used.
 
 
+--
 
-[float]
-=== `transaction.id`
 
+*`transaction.id`*::
++
+--
 type: keyword
 
 format: url
@@ -395,25 +473,31 @@ format: url
 A UUID4 transaction ID.
 
 
+--
+
 [[exported-fields-apm-error]]
 == APM Error fields
 
 Error-specific data for APM
 
 
-[float]
-=== `view errors`
-
+*`view errors`*::
++
+--
 type: keyword
 
 format: url
 
-[float]
-=== `error id icon`
+--
 
+*`error id icon`*::
++
+--
 type: keyword
 
 format: url
+
+--
 
 [float]
 == error fields
@@ -422,30 +506,36 @@ Data captured by an agent representing an event occurring in a monitored service
 
 
 
-[float]
-=== `error.id`
-
+*`error.id`*::
++
+--
 type: keyword
 
 A UUID for the error.
 
 
-[float]
-=== `error.culprit`
+--
 
+*`error.culprit`*::
++
+--
 type: text
 
 Function call which was the primary perpetrator of this event.
 
-[float]
-=== `error.grouping_key`
+--
 
+*`error.grouping_key`*::
++
+--
 type: keyword
 
 format: url
 
 GroupingKey of the logged error for use in grouping.
 
+
+--
 
 [float]
 == exception fields
@@ -454,38 +544,48 @@ Information about the originally thrown error.
 
 
 
-[float]
-=== `error.exception.code`
-
+*`error.exception.code`*::
++
+--
 type: keyword
 
 The error code set when the error happened, e.g. database error code.
 
-[float]
-=== `error.exception.message`
+--
 
+*`error.exception.message`*::
++
+--
 type: text
 
 The original error message.
 
-[float]
-=== `error.exception.module`
+--
 
+*`error.exception.module`*::
++
+--
 type: keyword
 
 The module namespace of the original error.
 
-[float]
-=== `error.exception.type`
+--
 
+*`error.exception.type`*::
++
+--
 type: keyword
 
-[float]
-=== `error.exception.handled`
+--
 
+*`error.exception.handled`*::
++
+--
 type: boolean
 
 Indicator whether the error was caught somewhere in the code or not.
+
+--
 
 [float]
 == log fields
@@ -494,34 +594,42 @@ Additional information added by logging the error.
 
 
 
-[float]
-=== `error.log.level`
-
+*`error.log.level`*::
++
+--
 type: keyword
 
 The severity of the record.
 
-[float]
-=== `error.log.logger_name`
+--
 
+*`error.log.logger_name`*::
++
+--
 type: keyword
 
 The name of the logger instance used.
 
-[float]
-=== `error.log.message`
+--
 
+*`error.log.message`*::
++
+--
 type: text
 
 The additionally logged error message.
 
-[float]
-=== `error.log.param_message`
+--
 
+*`error.log.param_message`*::
++
+--
 type: keyword
 
 A parametrized message. E.g. 'Could not connect to %s'. The property message is still required, and should be equal to the param_message, but with placeholders replaced. In some situations the param_message is used to group errors together.
 
+
+--
 
 [[exported-fields-apm-sourcemap]]
 == APM Sourcemap fields
@@ -537,29 +645,35 @@ Service fields.
 
 
 
-[float]
-=== `sourcemap.service.name`
-
+*`sourcemap.service.name`*::
++
+--
 type: keyword
 
 The name of the service this sourcemap belongs to.
 
 
-[float]
-=== `sourcemap.service.version`
+--
 
+*`sourcemap.service.version`*::
++
+--
 type: keyword
 
 Service version.
 
 
-[float]
-=== `sourcemap.bundle_filepath`
+--
 
+*`sourcemap.bundle_filepath`*::
++
+--
 type: keyword
 
 Location of the sourcemap relative to the file requesting it.
 
+
+--
 
 [[exported-fields-apm-span]]
 == APM Span fields
@@ -567,35 +681,43 @@ Location of the sourcemap relative to the file requesting it.
 Span-specific data for APM.
 
 
-[float]
-=== `view spans`
-
+*`view spans`*::
++
+--
 format: url
 
+--
 
-[float]
-=== `span.id`
 
+*`span.id`*::
++
+--
 type: long
 
 A locally unique ID of the span.
 
 
-[float]
-=== `span.name`
+--
 
+*`span.name`*::
++
+--
 type: keyword
 
 Generic designation of a span in the scope of a transaction.
 
 
-[float]
-=== `span.type`
+--
 
+*`span.type`*::
++
+--
 type: keyword
 
 Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', 'cache', etc).
 
+
+--
 
 [float]
 == start fields
@@ -603,13 +725,15 @@ Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query'
 None
 
 
-[float]
-=== `span.start.us`
-
+*`span.start.us`*::
++
+--
 type: long
 
 Offset relative to the transaction's timestamp identifying the start of the span, in microseconds.
 
+
+--
 
 [float]
 == duration fields
@@ -617,9 +741,9 @@ Offset relative to the transaction's timestamp identifying the start of the span
 None
 
 
-[float]
-=== `span.duration.us`
-
+*`span.duration.us`*::
++
+--
 type: long
 
 format: duration
@@ -627,13 +751,17 @@ format: duration
 Duration of the span, in microseconds.
 
 
-[float]
-=== `span.parent`
+--
 
+*`span.parent`*::
++
+--
 type: long
 
 The locally unique ID of the parent of the span.
 
+
+--
 
 [[exported-fields-apm-transaction]]
 == APM Transaction fields
@@ -642,26 +770,32 @@ Transaction-specific data for APM
 
 
 
-[float]
-=== `transaction.name`
-
+*`transaction.name`*::
++
+--
 type: text
 
 Generic designation of a transaction in the scope of a single service (eg. 'GET /users/:id').
 
 
-[float]
-=== `transaction.name.keyword`
-
+*`transaction.name.keyword`*::
++
+--
 type: keyword
 
-[float]
-=== `transaction.type`
+--
 
+--
+
+*`transaction.type`*::
++
+--
 type: keyword
 
 Keyword of specific relevance in the service's domain (eg. 'request', 'backgroundjob', etc)
 
+
+--
 
 [float]
 == duration fields
@@ -669,9 +803,9 @@ Keyword of specific relevance in the service's domain (eg. 'request', 'backgroun
 None
 
 
-[float]
-=== `transaction.duration.us`
-
+*`transaction.duration.us`*::
++
+--
 type: long
 
 format: duration
@@ -679,38 +813,48 @@ format: duration
 Total duration of this transaction, in microseconds.
 
 
-[float]
-=== `transaction.result`
+--
 
+*`transaction.result`*::
++
+--
 type: keyword
 
 The result of the transaction. HTTP status code for HTTP-related transactions.
 
 
-[float]
-=== `transaction.marks`
+--
 
+*`transaction.marks`*::
++
+--
 type: object
 
 A user-defined mapping of groups of marks in milliseconds.
 
 
-[float]
-=== `transaction.sampled`
+--
 
+*`transaction.sampled`*::
++
+--
 type: boolean
 
 Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have spans or context. Defaults to true.
 
 
+--
 
 
-[float]
-=== `transaction.span_count.dropped.total`
 
+*`transaction.span_count.dropped.total`*::
++
+--
 type: long
 
 The total amount of dropped spans for this transaction.
+
+--
 
 [[exported-fields-beat]]
 == Beat fields
@@ -719,33 +863,41 @@ Contains common beat fields available in all event types.
 
 
 
-[float]
-=== `beat.name`
-
+*`beat.name`*::
++
+--
 The name of the Beat sending the log messages. If the Beat name is set in the configuration file, then that value is used. If it is not set, the hostname is used. To set the Beat name, use the `name` option in the configuration file.
 
 
-[float]
-=== `beat.hostname`
+--
 
+*`beat.hostname`*::
++
+--
 The hostname as returned by the operating system on which the Beat is running.
 
 
-[float]
-=== `beat.timezone`
+--
 
+*`beat.timezone`*::
++
+--
 The timezone as returned by the operating system on which the Beat is running.
 
 
-[float]
-=== `beat.version`
+--
 
+*`beat.version`*::
++
+--
 The version of the beat that generated this event.
 
 
-[float]
-=== `@timestamp`
+--
 
+*`@timestamp`*::
++
+--
 type: date
 
 example: August 26th 2016, 12:35:53.332
@@ -757,19 +909,25 @@ required: True
 The timestamp when the event log record was generated.
 
 
-[float]
-=== `tags`
+--
 
+*`tags`*::
++
+--
 Arbitrary tags that can be set per Beat and per transaction type.
 
 
-[float]
-=== `fields`
+--
 
+*`fields`*::
++
+--
 type: object
 
 Contains user configurable fields.
 
+
+--
 
 [float]
 == error fields
@@ -778,29 +936,35 @@ Error fields containing additional info in case of errors.
 
 
 
-[float]
-=== `error.message`
-
+*`error.message`*::
++
+--
 type: text
 
 Error message.
 
 
-[float]
-=== `error.code`
+--
 
+*`error.code`*::
++
+--
 type: long
 
 Error code.
 
 
-[float]
-=== `error.type`
+--
 
+*`error.type`*::
++
+--
 type: keyword
 
 Error type.
 
+
+--
 
 [[exported-fields-cloud]]
 == Cloud provider metadata fields
@@ -809,55 +973,69 @@ Metadata from cloud providers added by the add_cloud_metadata processor.
 
 
 
-[float]
-=== `meta.cloud.provider`
-
+*`meta.cloud.provider`*::
++
+--
 example: ec2
 
 Name of the cloud provider. Possible values are ec2, gce, or digitalocean.
 
 
-[float]
-=== `meta.cloud.instance_id`
+--
 
+*`meta.cloud.instance_id`*::
++
+--
 Instance ID of the host machine.
 
 
-[float]
-=== `meta.cloud.instance_name`
+--
 
+*`meta.cloud.instance_name`*::
++
+--
 Instance name of the host machine.
 
 
-[float]
-=== `meta.cloud.machine_type`
+--
 
+*`meta.cloud.machine_type`*::
++
+--
 example: t2.medium
 
 Machine type of the host machine.
 
 
-[float]
-=== `meta.cloud.availability_zone`
+--
 
+*`meta.cloud.availability_zone`*::
++
+--
 example: us-east-1c
 
 Availability zone in which this host is running.
 
 
-[float]
-=== `meta.cloud.project_id`
+--
 
+*`meta.cloud.project_id`*::
++
+--
 example: project-x
 
 Name of the project in Google Cloud.
 
 
-[float]
-=== `meta.cloud.region`
+--
 
+*`meta.cloud.region`*::
++
+--
 Region in which this host is running.
 
+
+--
 
 [[exported-fields-docker-processor]]
 == Docker fields
@@ -867,37 +1045,45 @@ Docker stats collected from Docker.
 
 
 
-[float]
-=== `docker.container.id`
-
+*`docker.container.id`*::
++
+--
 type: keyword
 
 Unique container id.
 
 
-[float]
-=== `docker.container.image`
+--
 
+*`docker.container.image`*::
++
+--
 type: keyword
 
 Name of the image the container was built on.
 
 
-[float]
-=== `docker.container.name`
+--
 
+*`docker.container.name`*::
++
+--
 type: keyword
 
 Container name.
 
 
-[float]
-=== `docker.container.labels`
+--
 
+*`docker.container.labels`*::
++
+--
 type: object
 
 Image labels.
 
+
+--
 
 [[exported-fields-host-processor]]
 == Host fields
@@ -907,53 +1093,65 @@ Info collected for the host machine.
 
 
 
-[float]
-=== `host.name`
-
+*`host.name`*::
++
+--
 type: keyword
 
 Hostname.
 
 
-[float]
-=== `host.id`
+--
 
+*`host.id`*::
++
+--
 type: keyword
 
 Unique host id.
 
 
-[float]
-=== `host.architecture`
+--
 
+*`host.architecture`*::
++
+--
 type: keyword
 
 Host architecture (e.g. x86_64, arm, ppc, mips).
 
 
-[float]
-=== `host.os.platform`
+--
 
+*`host.os.platform`*::
++
+--
 type: keyword
 
 OS platform (e.g. centos, ubuntu, windows).
 
 
-[float]
-=== `host.os.version`
+--
 
+*`host.os.version`*::
++
+--
 type: keyword
 
 OS version.
 
 
-[float]
-=== `host.os.family`
+--
 
+*`host.os.family`*::
++
+--
 type: keyword
 
 OS family (e.g. redhat, debian, freebsd, windows).
 
+
+--
 
 [[exported-fields-kubernetes-processor]]
 == Kubernetes fields
@@ -963,59 +1161,73 @@ Kubernetes metadata added by the kubernetes processor
 
 
 
-[float]
-=== `kubernetes.pod.name`
-
+*`kubernetes.pod.name`*::
++
+--
 type: keyword
 
 Kubernetes pod name
 
 
-[float]
-=== `kubernetes.namespace`
+--
 
+*`kubernetes.namespace`*::
++
+--
 type: keyword
 
 Kubernetes namespace
 
 
-[float]
-=== `kubernetes.node.name`
+--
 
+*`kubernetes.node.name`*::
++
+--
 type: keyword
 
 Kubernetes node name
 
 
-[float]
-=== `kubernetes.labels`
+--
 
+*`kubernetes.labels`*::
++
+--
 type: object
 
 Kubernetes labels map
 
 
-[float]
-=== `kubernetes.annotations`
+--
 
+*`kubernetes.annotations`*::
++
+--
 type: object
 
 Kubernetes annotations map
 
 
-[float]
-=== `kubernetes.container.name`
+--
 
+*`kubernetes.container.name`*::
++
+--
 type: keyword
 
 Kubernetes container name
 
 
-[float]
-=== `kubernetes.container.image`
+--
 
+*`kubernetes.container.image`*::
++
+--
 type: keyword
 
 Kubernetes container image
 
+
+--
 

--- a/vendor/github.com/elastic/beats/libbeat/common/mapstr.go
+++ b/vendor/github.com/elastic/beats/libbeat/common/mapstr.go
@@ -80,20 +80,28 @@ func deepUpdateValue(old interface{}, val MapStr) interface{} {
 
 // Delete deletes the given key from the map.
 func (m MapStr) Delete(key string) error {
-	_, err := walkMap(key, m, opDelete)
-	return err
+	k, d, _, found, err := mapFind(key, m, false)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return ErrKeyNotFound
+	}
+
+	delete(d, k)
+	return nil
 }
 
 // CopyFieldsTo copies the field specified by key to the given map. It will
 // overwrite the key if it exists. An error is returned if the key does not
 // exist in the source map.
 func (m MapStr) CopyFieldsTo(to MapStr, key string) error {
-	v, err := walkMap(key, m, opGet)
+	v, err := m.GetValue(key)
 	if err != nil {
 		return err
 	}
 
-	_, err = walkMap(key, to, mapStrOperation{putOperation{v}, true})
+	_, err = to.Put(key, v)
 	return err
 }
 
@@ -115,18 +123,21 @@ func (m MapStr) Clone() MapStr {
 // HasKey returns true if the key exist. If an error occurs then false is
 // returned with a non-nil error.
 func (m MapStr) HasKey(key string) (bool, error) {
-	hasKey, err := walkMap(key, m, opHasKey)
-	if err != nil {
-		return false, err
-	}
-
-	return hasKey.(bool), nil
+	_, _, _, hasKey, err := mapFind(key, m, false)
+	return hasKey, err
 }
 
 // GetValue gets a value from the map. If the key does not exist then an error
 // is returned.
 func (m MapStr) GetValue(key string) (interface{}, error) {
-	return walkMap(key, m, opGet)
+	_, _, v, found, err := mapFind(key, m, false)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, ErrKeyNotFound
+	}
+	return v, nil
 }
 
 // Put associates the specified value with the specified key. If the map
@@ -138,7 +149,13 @@ func (m MapStr) GetValue(key string) (interface{}, error) {
 // to insert values (e.g. m[key] = value).
 func (m MapStr) Put(key string, value interface{}) (interface{}, error) {
 	// XXX `safemapstr.Put` mimics this implementation, both should be updated to have similar behavior
-	return walkMap(key, m, mapStrOperation{putOperation{value}, true})
+	k, d, old, _, err := mapFind(key, m, true)
+	if err != nil {
+		return nil, err
+	}
+
+	d[k] = value
+	return old, nil
 }
 
 // StringToPrint returns the MapStr as pretty JSON.
@@ -316,110 +333,50 @@ func tryToMapStr(v interface{}) (MapStr, bool) {
 	}
 }
 
-// walkMapRecursive walks the data MapStr to arrive at the value specified by the key.
-// The key is expressed in dot-notation (eg. x.y.z). When the key is found then
-// the given mapStrOperation is invoked.
-func walkMapRecursive(key string, data MapStr, op mapStrOperation) (interface{}, error) {
+// mapFind iterates a MapStr based on a the given dotted key, finding the final
+// subMap and subKey to operate on.
+// An error is returned if some intermediate is no map or the key doesn't exist.
+// If createMissing is set to true, intermediate maps are created.
+// The final map and un-dotted key to run further operations on are returned in
+// subKey and subMap. The subMap already contains a value for subKey, the
+// present flag is set to true and the oldValue return will hold
+// the original value.
+func mapFind(
+	key string,
+	data MapStr,
+	createMissing bool,
+) (subKey string, subMap MapStr, oldValue interface{}, present bool, err error) {
+	// XXX `safemapstr.mapFind` mimics this implementation, both should be updated to have similar behavior
 
-	// Splits up the key in two parts: full key and first part before the dot
-	_, exists := data[key]
-	// If leave node or key exists directly
-	if exists {
-		// Execute the mapStrOperator on the leaf object.
-		return op.Do(key, data)
-	}
-
-	keyParts := strings.SplitN(key, ".", 2)
-	// If leave node or key exists directly
-	if len(keyParts) == 1 {
-		// Execute the mapStrOperator on the leaf object.
-		return op.Do(key, data)
-	}
-
-	// Checks if first part of the key exists
-	k := keyParts[0]
-	d, keyExist := data[k]
-	if !keyExist {
-		if op.CreateMissingKeys {
-			d = MapStr{}
-			data[k] = d
-		} else {
-			return nil, ErrKeyNotFound
+	for {
+		// Fast path, key is present as is.
+		if v, exists := data[key]; exists {
+			return key, data, v, true, nil
 		}
+
+		idx := strings.IndexRune(key, '.')
+		if idx < 0 {
+			return key, data, nil, false, nil
+		}
+
+		k := key[:idx]
+		d, exists := data[k]
+		if !exists {
+			if createMissing {
+				d = MapStr{}
+				data[k] = d
+			} else {
+				return "", nil, nil, false, ErrKeyNotFound
+			}
+		}
+
+		v, err := toMapStr(d)
+		if err != nil {
+			return "", nil, nil, false, err
+		}
+
+		// advance to sub-map
+		key = key[idx+1:]
+		data = v
 	}
-
-	v, err := toMapStr(d)
-	if err != nil {
-		return nil, err
-	}
-
-	return walkMapRecursive(keyParts[1], v, op)
-}
-
-func walkMap(key string, data MapStr, op mapStrOperation) (interface{}, error) {
-	v, err := walkMapRecursive(key, data, op)
-	if err != nil {
-		// Add key to error
-		err = errors.Wrapf(err, "key=%v", key)
-	}
-	return v, err
-}
-
-// mapStrOperation types
-
-// These are static mapStrOperation types that store no state and are reusable.
-var (
-	opDelete = mapStrOperation{deleteOperation{}, false}
-	opGet    = mapStrOperation{getOperation{}, false}
-	opHasKey = mapStrOperation{hasKeyOperation{}, false}
-)
-
-// mapStrOperation represents an operation that can be applied to map.
-type mapStrOperation struct {
-	mapStrOperator
-	CreateMissingKeys bool
-}
-
-// mapStrOperator is an interface with a single function that performs an
-// operation on a MapStr.
-type mapStrOperator interface {
-	Do(key string, data MapStr) (value interface{}, err error)
-}
-
-type deleteOperation struct{}
-
-func (op deleteOperation) Do(key string, data MapStr) (interface{}, error) {
-	value, found := data[key]
-	if !found {
-		return nil, ErrKeyNotFound
-	}
-	delete(data, key)
-	return value, nil
-}
-
-type getOperation struct{}
-
-func (op getOperation) Do(key string, data MapStr) (interface{}, error) {
-	value, found := data[key]
-	if !found {
-		return nil, ErrKeyNotFound
-	}
-	return value, nil
-}
-
-type hasKeyOperation struct{}
-
-func (op hasKeyOperation) Do(key string, data MapStr) (interface{}, error) {
-	_, found := data[key]
-	return found, nil
-}
-
-type putOperation struct {
-	Value interface{}
-}
-
-func (op putOperation) Do(key string, data MapStr) (interface{}, error) {
-	existingValue, _ := data[key]
-	data[key] = op.Value
-	return existingValue, nil
 }

--- a/vendor/github.com/elastic/beats/libbeat/common/safemapstr/safemapstr.go
+++ b/vendor/github.com/elastic/beats/libbeat/common/safemapstr/safemapstr.go
@@ -22,39 +22,66 @@ const alternativeKey = "value"
 // `.value`
 func Put(data common.MapStr, key string, value interface{}) error {
 	// XXX This implementation mimics `common.MapStr.Put`, both should be updated to have similar behavior
-	keyParts := strings.SplitN(key, ".", 2)
 
-	// If leaf node or key exists directly
-	if len(keyParts) == 1 {
-		oldValue, exists := data[key]
-		if exists {
-			oldMap, ok := tryToMapStr(oldValue)
-			if ok {
-				// This would replace a whole object, change its key to avoid that:
-				oldMap[alternativeKey] = value
-				return nil
+	d, k := mapFind(data, key, alternativeKey)
+	d[k] = value
+	return nil
+}
+
+// mapFind walk the map based on the given dotted key and returns the final map
+// and key to operate on. This function adds intermediate maps, if the key is
+// missing from the original map.
+
+// mapFind iterates a MapStr based on the given dotted key, finding the final
+// subMap and subKey to operate on.
+// If a key is already used, but the used value is no map, an intermediate map will be inserted and
+// the old value will be stored using the 'alternativeKey' in a new map.
+// If the old value found under key is already an dictionary, subMap will be
+// the old value and subKey will be set to alternativeKey.
+func mapFind(data common.MapStr, key, alternativeKey string) (subMap common.MapStr, subKey string) {
+	// XXX This implementation mimics `common.mapFind`, both should be updated to have similar behavior
+
+	for {
+		if oldValue, exists := data[key]; exists {
+			if oldMap, ok := tryToMapStr(oldValue); ok {
+				return oldMap, alternativeKey
 			}
+			return data, key
 		}
-		data[key] = value
-		return nil
-	}
 
-	// Checks if first part of the key exists
-	k := keyParts[0]
-	d, exists := data[k]
-	if !exists {
-		d = common.MapStr{}
-		data[k] = d
-	}
+		idx := strings.IndexRune(key, '.')
+		if idx < 0 {
+			// if old value exists and is a dictionary, return the old dictionary and
+			// make sure we store the new value using the 'alternativeKey'
+			if oldValue, exists := data[key]; exists {
+				if oldMap, ok := tryToMapStr(oldValue); ok {
+					return oldMap, alternativeKey
+				}
+			}
 
-	v, ok := tryToMapStr(d)
-	if !ok {
-		// This would replace a leaf with an object, change its key to avoid that:
-		v = common.MapStr{alternativeKey: d}
-		data[k] = v
-	}
+			return data, key
+		}
 
-	return Put(v, keyParts[1], value)
+		// Check if first sub-key exists. Create an intermediate map if not.
+		k := key[:idx]
+		d, exists := data[k]
+		if !exists {
+			d = common.MapStr{}
+			data[k] = d
+		}
+
+		// store old value under 'alternativeKey' if the old value is no map.
+		// Do not overwrite old value.
+		v, ok := tryToMapStr(d)
+		if !ok {
+			v = common.MapStr{alternativeKey: d}
+			data[k] = v
+		}
+
+		// advance into sub-map
+		key = key[idx+1:]
+		data = v
+	}
 }
 
 func tryToMapStr(v interface{}) (common.MapStr, bool) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -6,22 +6,22 @@
 			"checksumSHA1": "AzjRkOQtVBTwIw4RJLTygFhJs3s=",
 			"origin": "github.com/elastic/beats/vendor/github.com/Microsoft/go-winio",
 			"path": "github.com/Microsoft/go-winio",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "jVDEyP/iraz6r173/GzkXF24ijQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/Shopify/sarama",
 			"path": "github.com/Shopify/sarama",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "DYv6Q1+VfnUVxMwvk5IshAClLvw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/Sirupsen/logrus",
 			"path": "github.com/Sirupsen/logrus",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "qtjd74+bErubh+qyv3s+lWmn9wc=",
@@ -33,197 +33,197 @@
 			"checksumSHA1": "dvabztWVQX8f6oMLRyv4dLH+TGY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/davecgh/go-spew/spew",
 			"path": "github.com/davecgh/go-spew/spew",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "Gj+xR1VgFKKmFXYOJMnAczC3Znk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/distribution/digestset",
 			"path": "github.com/docker/distribution/digestset",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "2Fe4D6PGaVE2he4fUeenLmhC1lE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/distribution/reference",
 			"path": "github.com/docker/distribution/reference",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "UL2NF1EGiSsQoEfvycnuZIcUbZY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api",
 			"path": "github.com/docker/docker/api",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "KMFpbV3mlrbc41d2DYnq05QYpSc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types",
 			"path": "github.com/docker/docker/api/types",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "jVJDbe0IcyjoKc2xbohwzQr+FF0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/blkiodev",
 			"path": "github.com/docker/docker/api/types/blkiodev",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "AeSC0BOu1uapkGqfSXtfVSpwJzs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/container",
 			"path": "github.com/docker/docker/api/types/container",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "4XuWn5+wgYwUsw604jvYMklq4Hc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/events",
 			"path": "github.com/docker/docker/api/types/events",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "J2OKngfI3vgswudr9PZVUFcRRu0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/filters",
 			"path": "github.com/docker/docker/api/types/filters",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "yeB781yxPhnN6OXQ9/qSsyih3ek=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/image",
 			"path": "github.com/docker/docker/api/types/image",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "UK+VdM648oWzyqE4OqttgmPqjoA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/mount",
 			"path": "github.com/docker/docker/api/types/mount",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "Gskp+nvbVe8Gk1xPLHylZvNmqTg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/network",
 			"path": "github.com/docker/docker/api/types/network",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "r2vWq7Uc3ExKzMqYgH0b4AKjLKY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/registry",
 			"path": "github.com/docker/docker/api/types/registry",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "VTxWyFud/RedrpllGdQonVtGM/A=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/strslice",
 			"path": "github.com/docker/docker/api/types/strslice",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "ZaizCpJ3eBcfR9ywpLaJd4AhM9k=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/swarm",
 			"path": "github.com/docker/docker/api/types/swarm",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "B7ZwKzrv3t3Vlox6/bYMHhMjsM8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/time",
 			"path": "github.com/docker/docker/api/types/time",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "uDPQ3nHsrvGQc9tg/J9OSC4N5dQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/versions",
 			"path": "github.com/docker/docker/api/types/versions",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "IBJy2zPEnYmcFJ3lM1eiRWnCxTA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/volume",
 			"path": "github.com/docker/docker/api/types/volume",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "c6OyeEvpQDvVLhrJSxgjEZv1tF8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/client",
 			"path": "github.com/docker/docker/client",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "jmo/t2zXAxirEPoFucNPXA/1SEc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/ioutils",
 			"path": "github.com/docker/docker/pkg/ioutils",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "ndnAFCfsGC3upNQ6jAEwzxcurww=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/longpath",
 			"path": "github.com/docker/docker/pkg/longpath",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "kr46EAa+FsUcWxOq6edyX6BUzE4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/system",
 			"path": "github.com/docker/docker/pkg/system",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "8I0Ez+aUYGpsDEVZ8wN/Ztf6Zqs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/tlsconfig",
 			"path": "github.com/docker/docker/pkg/tlsconfig",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "JbiWTzH699Sqz25XmDlsARpMN9w=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-connections/nat",
 			"path": "github.com/docker/go-connections/nat",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "jUfDG3VQsA2UZHvvIXncgiddpYA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-connections/sockets",
 			"path": "github.com/docker/go-connections/sockets",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "tuSzlS1UQ03+5Fvtqr5hI5sLLhA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-connections/tlsconfig",
 			"path": "github.com/docker/go-connections/tlsconfig",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "ambe8F4AofPxChCJssXXwWphQQ8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-units",
 			"path": "github.com/docker/go-units",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "sNAU9ojYVUhO6dVXey6T3JhRQpw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/libtrust",
 			"path": "github.com/docker/libtrust",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "tJd2T/eyW6ejAev7WzGxTeUVOPQ=",
@@ -235,634 +235,626 @@
 			"checksumSHA1": "y2Kh4iPlgCPXSGTCcFpzePYdzzg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/eapache/go-resiliency/breaker",
 			"path": "github.com/eapache/go-resiliency/breaker",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "WHl96RVZlOOdF4Lb1OOadMpw8ls=",
 			"origin": "github.com/elastic/beats/vendor/github.com/eapache/go-xerial-snappy",
 			"path": "github.com/eapache/go-xerial-snappy",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "oCCs6kDanizatplM5e/hX76busE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/eapache/queue",
 			"path": "github.com/eapache/queue",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "jO3LUqx5sKP8SMh052PUpAKAnS0=",
 			"path": "github.com/elastic/beats/libbeat/api",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "hpA1zGquxZvOF9/V7x/f1EnQTY0=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "1kB/tsDeGhaOVKcmci2aAC6sN+w=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/builder",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "mvMbWi8jMCS5ZDCiWv+GkUzsmEw=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/meta",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "BSmIe4Vvu9/XKvfIUHUDEjmzRVY=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/providers/docker",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "CRL9ISlijM9ffSVSMRxSb7SxZwg=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/providers/kubernetes",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "1jESfeLQBUHMWV7Ue6+bKINWnhM=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/template",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "7+VltcGv9o0D4G84pOl6yieyYLY=",
 			"path": "github.com/elastic/beats/libbeat/beat",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "xk8rkIPmXFqMpKdow17KuNHsZbM=",
 			"path": "github.com/elastic/beats/libbeat/cfgfile",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "kcJBPeHVyLhstApfy7Smi6fcxrg=",
 			"path": "github.com/elastic/beats/libbeat/cloudid",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "C188tgHii0rC9jfvfNw/Njfs3c4=",
 			"path": "github.com/elastic/beats/libbeat/cmd",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "b1jzseq9b5NzIaMYk6D1W1xA5MU=",
 			"path": "github.com/elastic/beats/libbeat/cmd/export",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "lpUH8u8oCW9I6pDQMzSD3RyFUZg=",
 			"path": "github.com/elastic/beats/libbeat/cmd/instance",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "hnrALZ/owH5lcue6u3G9p0/K4ag=",
 			"path": "github.com/elastic/beats/libbeat/cmd/test",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "MU1vm/DxWe6uL1yAJy484q/AYpE=",
+			"checksumSHA1": "3wdKnenEWhJ2chGWy9ejd3qYSyI=",
 			"path": "github.com/elastic/beats/libbeat/common",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "/d9OH1zlHQck1QRHUyrl28xl2fM=",
 			"path": "github.com/elastic/beats/libbeat/common/atomic",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "I5ABLC2bPeiBbL2fKqLsQNe4DSQ=",
 			"path": "github.com/elastic/beats/libbeat/common/bus",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "5Y5WqKnrBD4VBRXCRn2JgFDvMV8=",
 			"path": "github.com/elastic/beats/libbeat/common/cfgwarn",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "OSXtQFu0+JoGUcWYpcFkXuvhRO4=",
 			"path": "github.com/elastic/beats/libbeat/common/cli",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "89XnmNzW2SzjHjvy7nKGqvC5izk=",
 			"path": "github.com/elastic/beats/libbeat/common/docker",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "7bGcM14M5R8BuQLqKdWfbbQaKEM=",
 			"path": "github.com/elastic/beats/libbeat/common/dtfmt",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "RZhgeb5xg6OKtyGq5Dvilt601Rw=",
 			"path": "github.com/elastic/beats/libbeat/common/file",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "7WSOY58klc0crUF/5UZx/pLFIR0=",
 			"path": "github.com/elastic/beats/libbeat/common/fmtstr",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "pdFJ+DF0STunSGRopAMwn9n9ZlY=",
 			"path": "github.com/elastic/beats/libbeat/common/jsontransform",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "4pSlshnQ5zOS4mYoXNE9EcETCpw=",
 			"path": "github.com/elastic/beats/libbeat/common/kubernetes",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "43jcD3PFE0qBsP40iA4kb/g94MU=",
 			"path": "github.com/elastic/beats/libbeat/common/match",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "ENPdWrt0ZXJCJa3qZoJu53//u40=",
+			"checksumSHA1": "ZVSXt7kvNZA3mVDwoGFv/8IDDys=",
 			"path": "github.com/elastic/beats/libbeat/common/safemapstr",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "8exGjSEBI+fSKXMHdWI2e2lX5D0=",
 			"path": "github.com/elastic/beats/libbeat/common/schema",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "WmqoD6kF9VraYUmjXacgWSHd2v4=",
 			"path": "github.com/elastic/beats/libbeat/common/schema/mapstriface",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "zi4xMJ43/IzPCPNXs8iBc0WI2sE=",
 			"path": "github.com/elastic/beats/libbeat/common/streambuf",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "1k581NuOkCx0xoGSrGV0vD6i+PA=",
 			"path": "github.com/elastic/beats/libbeat/common/terminal",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "utHGeuN9d0MI6NzFw4yTBMxFgx0=",
 			"path": "github.com/elastic/beats/libbeat/dashboards",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Ie2zbuch+Jx2IrpjstO1jJeiV8o=",
 			"path": "github.com/elastic/beats/libbeat/keystore",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "z8VztKgyYSA7eyVuhNocdpav6zA=",
 			"path": "github.com/elastic/beats/libbeat/kibana",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
-		},
-		{
-			"checksumSHA1": "z8VztKgyYSA7eyVuhNocdpav6zA=",
-			"path": "github.com/elastic/beats/libbeat/kibana/",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
-			"version": "master",
-			"versionExact": "master"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "o43GjmYyneJqJaevwdy6tBX4vLA=",
 			"path": "github.com/elastic/beats/libbeat/logp",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "/fSZH8iFO9jqRiSSxzM593zMS4Y=",
 			"path": "github.com/elastic/beats/libbeat/logp/configure",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "3rCxbiMynIdSdQe7h95cuTKEXbY=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/cpu",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "z7V8OR3yB8TYRVYkckzIl17wuYQ=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/memory",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "B0sjyYQEXlhHRQQ0/lqWBY4sKCQ=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/process",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "kZBPfX0Pv2dLMP5Iho9Mx/hXz9o=",
 			"path": "github.com/elastic/beats/libbeat/monitoring",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "tRfILb+3nS9S5xf1GTqyGVbvGnU=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/adapter",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "9OgsegLCw7fQSbzm92h5SSLJSqo=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "oXzJ+dK5IkLXphcT+DRKldFHQKc=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report/elasticsearch",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "O0mqYi92UChneQIZItpvDf+egYM=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report/log",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "P72p6i7s+3eRkfSxD/oYFbATnxY=",
 			"path": "github.com/elastic/beats/libbeat/outputs",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "lRSwiGVO2pp69QtoR2Fa8CP3O8I=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "vjVLDyWbKmCR6e2OayNshujneSI=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec/format",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Fsj11NCCIR55lFMYxRDbEbRfd3k=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec/json",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "JGP5bMcL1KyJRJCR1kW11gZhPhk=",
 			"path": "github.com/elastic/beats/libbeat/outputs/console",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Zza7ZIc1UYgxgEiNoLPB0jks/xo=",
 			"path": "github.com/elastic/beats/libbeat/outputs/elasticsearch",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "S1nJaQZExaATn2Xpin4eY7Oyr34=",
 			"path": "github.com/elastic/beats/libbeat/outputs/fileout",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "knOll4Vxl2/0KC84blo6Cpu+xbk=",
 			"path": "github.com/elastic/beats/libbeat/outputs/kafka",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Wpvv92+QT4zveD+nlAx91aKq5OE=",
 			"path": "github.com/elastic/beats/libbeat/outputs/logstash",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "UEGH5mAXdKBysIjODuTxHKlzqsY=",
 			"path": "github.com/elastic/beats/libbeat/outputs/outil",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "j11eTg831Fs7uxEz2dRA/DJmKoU=",
 			"path": "github.com/elastic/beats/libbeat/outputs/redis",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "N8FWsJ68uJ5Haxc5vp8eS2Cp8jw=",
 			"path": "github.com/elastic/beats/libbeat/outputs/transport",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "d5b9Ra0zcwznwemxEJmyW28FZJ0=",
 			"path": "github.com/elastic/beats/libbeat/paths",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "H+5T9ru9pqZxsXX739UwIH561nc=",
 			"path": "github.com/elastic/beats/libbeat/plugin",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "lVYS7/dQ1o0UzcIwPq5LcCTbm4k=",
 			"path": "github.com/elastic/beats/libbeat/processors",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "xZsQwtDUvf81CVLGkbdWbffF4wE=",
 			"path": "github.com/elastic/beats/libbeat/processors/actions",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "rI+RcxALfhqftyApiHM1AgSjQ8U=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_cloud_metadata",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "bJALxMP7ohe+6RcLkChwweME0jQ=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_docker_metadata",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "pZ9mlRsbTygzsuFXWxA7FoB/j/A=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_host_metadata",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "tFpY7dKia1F21qlStU3HSXD3Dsg=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_kubernetes_metadata",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "UCfWJFoOVRzY1nQ+mAHT+mpGYv4=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_locale",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "3kyV9PwlSwcLnK9SWKX97Gh7c00=",
 			"path": "github.com/elastic/beats/libbeat/publisher",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "1o8H8N6gEznJwpTwmtlgDu9o+/A=",
 			"path": "github.com/elastic/beats/libbeat/publisher/includes",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "qWblq75ZfGcjsPD+c6ebH9KttBk=",
 			"path": "github.com/elastic/beats/libbeat/publisher/pipeline",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "k/1pxNUislJBfsjb/yZVG7+YP28=",
 			"path": "github.com/elastic/beats/libbeat/publisher/queue",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "dWDK9p/Axnnr9A/kM4qhsh2arhQ=",
 			"path": "github.com/elastic/beats/libbeat/publisher/queue/memqueue",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "vRl5tYK/1Vu4vHbltLDEGxyun4k=",
 			"path": "github.com/elastic/beats/libbeat/publisher/queue/spool",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "AQpIjVClosTUbCL9bFO0onlxr9Y=",
 			"path": "github.com/elastic/beats/libbeat/service",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Eb4t/I1MO3YdcpPZvsFuRvi0tYQ=",
 			"path": "github.com/elastic/beats/libbeat/setup/kibana",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "73EogSbTF2NmyDe7Qt8pJTQRv/w=",
 			"path": "github.com/elastic/beats/libbeat/template",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "p+um0Jv/tT4q7+rCQS7dxq50Ws0=",
 			"path": "github.com/elastic/beats/libbeat/testing",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "70PCkIykADgatq8ExOSFudQ2U90=",
 			"path": "github.com/elastic/beats/libbeat/version",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z",
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z",
 			"version": "master",
 			"versionExact": "master"
 		},
@@ -870,15 +862,15 @@
 			"checksumSHA1": "3jizmlZPCyo6FAZY8Trk9jA8NH4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-lumber/client/v2",
 			"path": "github.com/elastic/go-lumber/client/v2",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "m6HLKpDAZlkTTQMqabf3aT6TQ/s=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-lumber/protocol/v2",
 			"path": "github.com/elastic/go-lumber/protocol/v2",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "AaEPt+KMknLXze11YOnBGKzP3aA=",
@@ -1004,43 +996,43 @@
 			"checksumSHA1": "61XUpyQ3zWnJ7Tlj0xLsHtnzwJY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg",
 			"path": "github.com/elastic/go-ucfg",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "8cr5YhslUMgpvF2JebYvKC+Ezr4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/cfgutil",
 			"path": "github.com/elastic/go-ucfg/cfgutil",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "Q2qrc/nI9d1tNzWTmfrkWvBNqsc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/flag",
 			"path": "github.com/elastic/go-ucfg/flag",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "uOrhvj7stlb0foxGZ5vbC1XJeto=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/internal/parse",
 			"path": "github.com/elastic/go-ucfg/internal/parse",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "sMBM95+VYBPhwtNVHqqN1yrvk1o=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/json",
 			"path": "github.com/elastic/go-ucfg/json",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "qvzj0KzxrWvYhHIbo+FwBxUNDFw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/yaml",
 			"path": "github.com/elastic/go-ucfg/yaml",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "yu/X+qHftvfQlAnjPdYLwrDn2nI=",
@@ -1052,43 +1044,43 @@
 			"checksumSHA1": "RPOLNUpw00QUUaA/U4YbPVf6WlA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar",
 			"path": "github.com/elastic/gosigar",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "TX9y4oPL5YmT4Gb/OU4GIPTdQB4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/cgroup",
 			"path": "github.com/elastic/gosigar/cgroup",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "hPqGM3DENaGfipEODoyZ4mKogTQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/sys",
 			"path": "github.com/elastic/gosigar/sys",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "mLq5lOyD0ZU39ysXuf1ETOLJ+f0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/sys/linux",
 			"path": "github.com/elastic/gosigar/sys/linux",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "qDsgp2kAeI9nhj565HUScaUyjU4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/sys/windows",
 			"path": "github.com/elastic/gosigar/sys/windows",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "hTxFrbA619JCHysWjXHa9U6bfto=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s",
 			"path": "github.com/ericchiang/k8s",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "uQuMoUlS7hAWsB+Mwr/1B7+35BU=",
@@ -1115,8 +1107,8 @@
 			"checksumSHA1": "y8fNiBLSoGojnUsGDsdLlsJYyqQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/apiextensions/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/apiextensions/v1beta1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "uw/3eB6WiVCSrQZS9ZZs/1kyu1I=",
@@ -1129,43 +1121,43 @@
 			"checksumSHA1": "JxQ/zEWQSrncYNKifCuMctq+Tsw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/apps/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/apps/v1beta1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "bjklGt/pc6kWOZewAw87Hchw5oY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authentication/v1",
 			"path": "github.com/ericchiang/k8s/apis/authentication/v1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "LExhnM9Vn0LQoLQWszQ7aIxDxb4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authentication/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/authentication/v1beta1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "GM+PzOiBoq3cxx4h5RKVUb3UH60=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authorization/v1",
 			"path": "github.com/ericchiang/k8s/apis/authorization/v1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "zfr5oUVjbWRfvXi2LJiGMfFeDQY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authorization/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/authorization/v1beta1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "izkXNDp5a5WP45jU0hSfTrwyfvM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/autoscaling/v1",
 			"path": "github.com/ericchiang/k8s/apis/autoscaling/v1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "kUXiQQA99K7zquvG9es3yauVjYw=",
@@ -1178,15 +1170,15 @@
 			"checksumSHA1": "FryZuAxWn4Ig8zc913w9BdfYzvs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/batch/v1",
 			"path": "github.com/ericchiang/k8s/apis/batch/v1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "ylo7Z8wyJD+tmICB7wsOVIBpO+U=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/batch/v2alpha1",
 			"path": "github.com/ericchiang/k8s/apis/batch/v2alpha1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "9GRVPI+Tf4RrlX2aveUGEUHKIrM=",
@@ -1199,36 +1191,36 @@
 			"checksumSHA1": "+d8+mSdkdcPWQIpczXDZZW0lrjg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/certificates/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/certificates/v1beta1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "S7AvxmCe/+WoFP/v9lZr0Mv66qg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/core/v1",
 			"path": "github.com/ericchiang/k8s/apis/core/v1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "cWPoP6XZN7WMnEVMPcgPgg3Aw9Q=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/extensions/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/extensions/v1beta1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "vaNrBPcGWeDd1rXl8+uN08uxWhE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/imagepolicy/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/imagepolicy/v1alpha1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "UNTTH+Ppu4vImnF+bPkG3/NR3gg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/meta/v1",
 			"path": "github.com/ericchiang/k8s/apis/meta/v1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "wYSNb+W2L5gJlGO8n6mGOGft8R8=",
@@ -1241,78 +1233,78 @@
 			"checksumSHA1": "Mmyg9Wh+FCVR6fV8MGEKRxvqZ2k=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/policy/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/policy/v1beta1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "bvwYS/wrBkyAfvCjzMbi/vKamrQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/rbac/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/rbac/v1alpha1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "m1Tde18NwewnvJoOYL3uykNcBuM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/rbac/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/rbac/v1beta1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "JirJkoeIkWJRNrbprsQvqwisxds=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/resource",
 			"path": "github.com/ericchiang/k8s/apis/resource",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "rQZ69PjEClQQ+PGEHRKzkGVVQyw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/settings/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/settings/v1alpha1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "pp0AetmPoKy7Rz0zNhBwUpExkbc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/storage/v1",
 			"path": "github.com/ericchiang/k8s/apis/storage/v1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "WeACcIrS4EkeBm8TTftwuVniaWk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/storage/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/storage/v1beta1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "Su6wSR8V8HL2QZsF8icJ0R9AFq8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/runtime",
 			"path": "github.com/ericchiang/k8s/runtime",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "8ETrRvIaXPfD21N7fa8kdbumL00=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/runtime/schema",
 			"path": "github.com/ericchiang/k8s/runtime/schema",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "cMk3HE8/81ExHuEs0F5sZCclOFs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/util/intstr",
 			"path": "github.com/ericchiang/k8s/util/intstr",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "fobEKiMk5D7IGvCSwh4HdG1o98c=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/watch/versioned",
 			"path": "github.com/ericchiang/k8s/watch/versioned",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "AANTVr9CVVyzsgviODY6Wi2thuM=",
@@ -1330,22 +1322,22 @@
 			"checksumSHA1": "2UmMbNHc8FBr98mJFN1k8ISOIHk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/garyburd/redigo/internal",
 			"path": "github.com/garyburd/redigo/internal",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "507OiSqTxfGCje7xDT5eq9CCaNQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/garyburd/redigo/redis",
 			"path": "github.com/garyburd/redigo/redis",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "ImX1uv6O09ggFeBPUJJ2nu7MPSA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ghodss/yaml",
 			"path": "github.com/ghodss/yaml",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "gxV/cPPLkByTdY8y172t7v4qcZA=",
@@ -1375,15 +1367,15 @@
 			"checksumSHA1": "kBeNcaKk56FguvPSUCEaH6AxpRc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/golang/protobuf/proto",
 			"path": "github.com/golang/protobuf/proto",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "p/8vSviYF91gFflhrt5vkyksroo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/golang/snappy",
 			"path": "github.com/golang/snappy",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "d9PxF1XQGLMJZRct2R8qVM/eYlE=",
@@ -1407,8 +1399,8 @@
 			"checksumSHA1": "l9wW52CYGbmO/NGwYZ/Op2QTmaA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/joeshaw/multierror",
 			"path": "github.com/joeshaw/multierror",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "pa+ZwMzIv+u+BlL8Q2xgL9cQtJg=",
@@ -1420,29 +1412,29 @@
 			"checksumSHA1": "KKxbAKrKrfd33YPpkNsDmTN3S+M=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/compress/flate",
 			"path": "github.com/klauspost/compress/flate",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "+azPXaZpPF14YHRghNAer13ThQU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/compress/zlib",
 			"path": "github.com/klauspost/compress/zlib",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "R6zKqn31GjJH1G8W/api7fAW0RU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/cpuid",
 			"path": "github.com/klauspost/cpuid",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "BM6ZlNJmtKy3GBoWwg2X55gnZ4A=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/crc32",
 			"path": "github.com/klauspost/crc32",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "bfGiF5iraNvFHCCK3KVvITsPCok=",
@@ -1460,29 +1452,29 @@
 			"checksumSHA1": "sWdAYPKyaT4SW8hNQNpRS0sU4lU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/mitchellh/hashstructure",
 			"path": "github.com/mitchellh/hashstructure",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "2AyUkWjutec6p+470tgio8mYOxI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/go-digest",
 			"path": "github.com/opencontainers/go-digest",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "eOMCORUm8KxiGSy0hBuQsMsxauo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/image-spec/specs-go",
 			"path": "github.com/opencontainers/image-spec/specs-go",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "9YujSsJjiLGkQMzwWycsjqR340k=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/image-spec/specs-go/v1",
 			"path": "github.com/opencontainers/image-spec/specs-go/v1",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "JVGDxPn66bpe6xEiexs1r+y6jF0=",
@@ -1494,22 +1486,22 @@
 			"checksumSHA1": "WmrPO1ovmQ7t7hs9yZGbr2SAoM4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pierrec/lz4",
 			"path": "github.com/pierrec/lz4",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "IT4sX58d+e8osXHV5U6YCSdB/uE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pierrec/xxHash/xxHash32",
 			"path": "github.com/pierrec/xxHash/xxHash32",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "PdQm3s8DoVJ17Vk8n7o5iPa7PK0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pkg/errors",
 			"path": "github.com/pkg/errors",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
@@ -1547,8 +1539,8 @@
 			"checksumSHA1": "KAzbLjI9MzW2tjfcAsK75lVRp6I=",
 			"origin": "github.com/elastic/beats/vendor/github.com/rcrowley/go-metrics",
 			"path": "github.com/rcrowley/go-metrics",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "6JP37UqrI0H80Gpk0Y2P+KXgn5M=",
@@ -1578,8 +1570,8 @@
 			"checksumSHA1": "zmC8/3V4ls53DJlNTKDZwPSC/dA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/satori/go.uuid",
 			"path": "github.com/satori/go.uuid",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "v7C+aJ1D/z3MEeCte6bxvpoGjM4=",
@@ -1708,29 +1700,29 @@
 			"checksumSHA1": "dr5+PfIRzXeN+l1VG+s0lea9qz8=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/context",
 			"path": "golang.org/x/net/context",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "WHc3uByvGaMcnSoI21fhzYgbOgg=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/context/ctxhttp",
 			"path": "golang.org/x/net/context/ctxhttp",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "TWcqN2+KUWtdqnu18rruwn14UEQ=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/http2",
 			"path": "golang.org/x/net/http2",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "ezWhc7n/FtqkLDQKeU2JbW+80tE=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/http2/hpack",
 			"path": "golang.org/x/net/http2/hpack",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "RcrB7tgYS/GMW4QrwVdMOTNqIU8=",
@@ -1742,8 +1734,8 @@
 			"checksumSHA1": "3xyuaSNmClqG4YWC7g0isQIbUTc=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/lex/httplex",
 			"path": "golang.org/x/net/lex/httplex",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "whCSspa9pYarl527EuhPz91cbUE=",
@@ -1755,22 +1747,22 @@
 			"checksumSHA1": "QEm/dePZ0lOnyOs+m22KjXfJ/IU=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/proxy",
 			"path": "golang.org/x/net/proxy",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "CNHEeGnucEUlTHJrLS2kHtfNbws=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/unix",
 			"path": "golang.org/x/sys/unix",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "eQq+ZoTWPjyizS9XalhZwfGjQao=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows",
 			"path": "golang.org/x/sys/windows",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "ZdFZFaXmCgEEaEhVPkyXrnhKhsg=",
@@ -1782,15 +1774,15 @@
 			"checksumSHA1": "VNlkHemg81Ba7ElHfKKUU1h+U1U=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/svc",
 			"path": "golang.org/x/sys/windows/svc",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "lZi+t2ilFyYSpqL1ThwNf8ot3WQ=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/svc/debug",
 			"path": "golang.org/x/sys/windows/svc/debug",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "uVlUSSKplihZG7N+QJ6fzDZ4Kh8=",
@@ -1832,8 +1824,8 @@
 			"checksumSHA1": "fALlQNY1fM99NesfLJ50KguWsio=",
 			"origin": "github.com/elastic/beats/vendor/gopkg.in/yaml.v2",
 			"path": "gopkg.in/yaml.v2",
-			"revision": "4960293df6759a499221c132a453dcf9a64fe172",
-			"revisionTime": "2018-04-12T14:53:20Z"
+			"revision": "88911e75a197f7eeeb5c24b6196569469ed866cb",
+			"revisionTime": "2018-04-16T15:49:05Z"
 		},
 		{
 			"checksumSHA1": "tFDvoOebIC12z/m4GKPqrE7BrUM=",


### PR DESCRIPTION
* removes `github.com/elastic/beats/libbeat/kibana/`, retaining `github.com/elastic/beats/libbeat/kibana` (no trailing slash)