### PR TITLE
[6.x] Expose apm-server metrics via expvar (#861)

### DIFF
--- a/beater/handlers.go
+++ b/beater/handlers.go
@@ -53,7 +53,7 @@ type routeMapping struct {
 }
 
 var (
-	serverMetrics  = monitoring.Default.NewRegistry("apm-server.server")
+	serverMetrics  = monitoring.Default.NewRegistry("apm-server.server", monitoring.PublishExpvar)
 	requestCounter = monitoring.NewInt(serverMetrics, "requests.counter")
 	responseValid  = monitoring.NewInt(serverMetrics, "response.valid")
 	responseErrors = monitoring.NewInt(serverMetrics, "response.errors")

--- a/processor/error/processor.go
+++ b/processor/error/processor.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	errorMetrics    = monitoring.Default.NewRegistry("apm-server.processor.error")
+	errorMetrics    = monitoring.Default.NewRegistry("apm-server.processor.error", monitoring.PublishExpvar)
 	validationCount = monitoring.NewInt(errorMetrics, "validation.count")
 	validationError = monitoring.NewInt(errorMetrics, "validation.errors")
 	decodingCount   = monitoring.NewInt(errorMetrics, "decoding.count")

--- a/processor/sourcemap/processor.go
+++ b/processor/sourcemap/processor.go
@@ -19,7 +19,7 @@ const (
 )
 
 var (
-	sourcemapUploadMetrics = monitoring.Default.NewRegistry("apm-server.processor.sourcemap")
+	sourcemapUploadMetrics = monitoring.Default.NewRegistry("apm-server.processor.sourcemap", monitoring.PublishExpvar)
 	validationCount        = monitoring.NewInt(sourcemapUploadMetrics, "validation.count")
 	validationError        = monitoring.NewInt(sourcemapUploadMetrics, "validation.errors")
 	decodingCount          = monitoring.NewInt(sourcemapUploadMetrics, "decoding.count")

--- a/processor/transaction/processor.go
+++ b/processor/transaction/processor.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	transactionMetrics = monitoring.Default.NewRegistry("apm-server.processor.transaction")
+	transactionMetrics = monitoring.Default.NewRegistry("apm-server.processor.transaction", monitoring.PublishExpvar)
 	decodingCount      = monitoring.NewInt(transactionMetrics, "decoding.count")
 	decodingError      = monitoring.NewInt(transactionMetrics, "decoding.errors")
 	validationCount    = monitoring.NewInt(transactionMetrics, "validation.count")


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Expose apm-server metrics via expvar  (#861)