### PR TITLE
[6.x] Add monitoring for agents and all response codes and reasons (#862)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -16,7 +16,8 @@ https://github.com/elastic/apm-server/compare/4daa36bd5c144cf9182afc62dc8042af66
 - Use type integer instead of number in JSON schemas where applicable {pull}641[641].
 - Set array item types to string in JSON schemas {pull}651[651].
 - Fix issue preventing server from being stopped {pull}704[704].
-- Limit the amount of concurrent requests being processed{pull}731[731].
+- Limit the amount of concurrent requests being processed {pull}731[731].
+- Return proper response code for request entity too large {pull}862[862].
 
 ==== Added
 

--- a/beater/handlers_test.go
+++ b/beater/handlers_test.go
@@ -7,69 +7,52 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"fmt"
+
 	"github.com/stretchr/testify/assert"
 )
 
-func TestJSONFailureResponse(t *testing.T) {
+func TestIncCounter(t *testing.T) {
 	req, err := http.NewRequest("POST", "_", nil)
 	assert.Nil(t, err)
-
 	req.Header.Set("Accept", "application/json")
 	w := httptest.NewRecorder()
 
-	sendStatus(w, req, 400, errors.New("Cannot compare apples to oranges"))
-
-	resp := w.Result()
-	body, _ := ioutil.ReadAll(resp.Body)
-	assert.Equal(t, 400, w.Code)
-	assert.Equal(t, body, []byte(`{"error":"Cannot compare apples to oranges"}`))
-	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+	for i := 1; i <= 5; i++ {
+		for _, res := range []serverResponse{acceptedResponse, okResponse, forbiddenResponse, unauthorizedResponse,
+			requestTooLargeResponse, rateLimitedResponse, methodNotAllowedResponse, tooManyConcurrentRequestsResponse,
+			cannotValidateResponse(errors.New("")), cannotDecodeResponse(errors.New("")),
+			fullQueueResponse(errors.New("")), serverShuttingDownResponse(errors.New(""))} {
+			sendStatus(w, req, res)
+			assert.Equal(t, int64(i), res.counter.Get())
+		}
+	}
+	assert.Equal(t, int64(60), responseCounter.Get())
+	assert.Equal(t, int64(50), responseErrors.Get())
 }
 
-func TestJSONFailureResponseWhenAcceptingAnything(t *testing.T) {
-	req, err := http.NewRequest("POST", "_", nil)
-	assert.Nil(t, err)
-	req.Header.Set("Accept", "*/*")
-	w := httptest.NewRecorder()
-
-	sendStatus(w, req, 400, errors.New("Cannot compare apples to oranges"))
-
-	resp := w.Result()
-	body, _ := ioutil.ReadAll(resp.Body)
-	assert.Equal(t, 400, w.Code)
-	assert.Equal(t, body, []byte(`{"error":"Cannot compare apples to oranges"}`))
-	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
-}
-
-func TestHTMLFailureResponse(t *testing.T) {
-	req, err := http.NewRequest("POST", "_", nil)
-	assert.Nil(t, err)
-	req.Header.Set("Accept", "text/html")
-	w := httptest.NewRecorder()
-
-	sendStatus(w, req, 400, errors.New("Cannot compare apples to oranges"))
-
-	resp := w.Result()
-	body, _ := ioutil.ReadAll(resp.Body)
-	assert.Equal(t, 400, w.Code)
-	assert.Equal(t, body, []byte(`Cannot compare apples to oranges`))
-	assert.Equal(t, "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
-}
-
-func TestFailureResponseNoAcceptHeader(t *testing.T) {
-	req, err := http.NewRequest("POST", "_", nil)
-	assert.Nil(t, err)
-
-	req.Header.Del("Accept")
-
-	w := httptest.NewRecorder()
-	sendStatus(w, req, 400, errors.New("Cannot compare apples to oranges"))
-
-	resp := w.Result()
-	body, _ := ioutil.ReadAll(resp.Body)
-	assert.Equal(t, 400, w.Code)
-	assert.Equal(t, body, []byte(`Cannot compare apples to oranges`))
-	assert.Equal(t, "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
+func TestAccept(t *testing.T) {
+	for idx, test := range []struct{ accept, expectedError, expectedContentType string }{
+		{"application/json", "{\"error\":\"data validation error: error message\"}", "application/json"},
+		{"*/*", "{\"error\":\"data validation error: error message\"}", "application/json"},
+		{"text/html", "data validation error: error message", "text/plain; charset=utf-8"},
+		{"", "data validation error: error message", "text/plain; charset=utf-8"},
+	} {
+		req, err := http.NewRequest("POST", "_", nil)
+		assert.Nil(t, err)
+		if test.accept != "" {
+			req.Header.Set("Accept", test.accept)
+		} else {
+			delete(req.Header, "Accept")
+		}
+		w := httptest.NewRecorder()
+		sendStatus(w, req, cannotValidateResponse(errors.New("error message")))
+		resp := w.Result()
+		body, _ := ioutil.ReadAll(resp.Body)
+		assert.Equal(t, 400, w.Code)
+		assert.Equal(t, test.expectedError, string(body), fmt.Sprintf("at index %d", idx))
+		assert.Equal(t, test.expectedContentType, resp.Header.Get("Content-Type"), fmt.Sprintf("at index %d", idx))
+	}
 }
 
 func TestIsAuthorized(t *testing.T) {

--- a/processor/error/processor.go
+++ b/processor/error/processor.go
@@ -13,6 +13,7 @@ var (
 	validationError = monitoring.NewInt(errorMetrics, "validation.errors")
 	decodingCount   = monitoring.NewInt(errorMetrics, "decoding.count")
 	decodingError   = monitoring.NewInt(errorMetrics, "decoding.errors")
+	agent           = monitoring.NewString(errorMetrics, "agent")
 )
 
 const (
@@ -50,5 +51,6 @@ func (p *processor) Decode(raw map[string]interface{}) (pr.Payload, error) {
 		decodingError.Inc()
 		return nil, err
 	}
+	agent.Set(pa.Service.Agent.Name)
 	return pa, nil
 }

--- a/processor/transaction/processor.go
+++ b/processor/transaction/processor.go
@@ -13,10 +13,10 @@ var (
 	decodingError      = monitoring.NewInt(transactionMetrics, "decoding.errors")
 	validationCount    = monitoring.NewInt(transactionMetrics, "validation.count")
 	validationError    = monitoring.NewInt(transactionMetrics, "validation.errors")
+	agent              = monitoring.NewString(transactionMetrics, "agent")
 )
 
 const (
-	eventName          = "processor"
 	processorName      = "transaction"
 	transactionDocType = "transaction"
 	spanDocType        = "span"
@@ -52,5 +52,6 @@ func (p *processor) Decode(raw map[string]interface{}) (pr.Payload, error) {
 		decodingError.Inc()
 		return nil, err
 	}
+	agent.Set(pa.Service.Agent.Name)
 	return pa, nil
 }


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Add monitoring for agents and all response codes and reasons  (#862)