### PR TITLE
[6.x] Add metrics for stacktrace. (#870)

### DIFF
--- a/processor/transaction/payload.go
+++ b/processor/transaction/payload.go
@@ -11,9 +11,12 @@ import (
 )
 
 var (
-	transformations     = monitoring.NewInt(transactionMetrics, "transformations")
-	transactionCounter  = monitoring.NewInt(transactionMetrics, "counter")
-	spanCounter         = monitoring.NewInt(transactionMetrics, "spans")
+	transformations    = monitoring.NewInt(transactionMetrics, "transformations")
+	transactionCounter = monitoring.NewInt(transactionMetrics, "transactions")
+	spanCounter        = monitoring.NewInt(transactionMetrics, "spans")
+	stacktraceCounter  = monitoring.NewInt(transactionMetrics, "stacktraces")
+	frameCounter       = monitoring.NewInt(transactionMetrics, "frames")
+
 	processorTransEntry = common.MapStr{"name": processorName, "event": transactionDocType}
 	processorSpanEntry  = common.MapStr{"name": processorName, "event": spanDocType}
 )
@@ -56,8 +59,8 @@ func DecodePayload(raw map[string]interface{}) (*Payload, error) {
 
 func (pa *Payload) Transform(conf config.Config) []beat.Event {
 	transformations.Inc()
-	logp.NewLogger("transaction").Debugf("Transform transaction events: events=%d, service=%s, agent=%s:%s", len(pa.Events), pa.Service.Name, pa.Service.Agent.Name, pa.Service.Agent.Version)
 	transactionCounter.Add(int64(len(pa.Events)))
+	logp.NewLogger("transaction").Debugf("Transform transaction events: events=%d, service=%s, agent=%s:%s", len(pa.Events), pa.Service.Name, pa.Service.Agent.Name, pa.Service.Agent.Version)
 
 	context := m.NewContext(&pa.Service, pa.Process, pa.System, pa.User)
 	spanContext := NewSpanContext(&pa.Service)
@@ -79,6 +82,10 @@ func (pa *Payload) Transform(conf config.Config) []beat.Event {
 		spanCounter.Add(int64(len(event.Spans)))
 		for spIdx := 0; spIdx < len(event.Spans); spIdx++ {
 			sp := event.Spans[spIdx]
+			if frames := len(sp.Stacktrace); frames > 0 {
+				stacktraceCounter.Inc()
+				frameCounter.Add(int64(frames))
+			}
 			ev := beat.Event{
 				Fields: common.MapStr{
 					"processor":   processorSpanEntry,


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Add metrics for stacktrace.  (#870)