### PR TITLE
[6.x] listen on default port 8200 if unspecified (#886)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -13,6 +13,8 @@ https://github.com/elastic/apm-server/compare/9e0a1e281e56044745f1a4f18dcbf00a7f
 
 ==== Added
 
+- Listen on default port 8200 if unspecified {pull}[886]886.
+
 ==== Deprecated
 
 ==== Known Issues

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -63,6 +63,13 @@ func parseListener(host string) (string, string) {
 // This should only be called once, from Run.
 func (bt *beater) listen() (net.Listener, error) {
 	network, path := parseListener(bt.config.Host)
+	if network == "tcp" {
+		if _, _, err := net.SplitHostPort(path); err != nil {
+			// tack on a port if SplitHostPort fails on what should be a tcp network address
+			// if there were already too many colons, one more won't hurt
+			path = net.JoinHostPort(path, defaultPort)
+		}
+	}
 	lis, err := net.Listen(network, path)
 	if err != nil {
 		return nil, err

--- a/beater/config.go
+++ b/beater/config.go
@@ -1,12 +1,15 @@
 package beater
 
 import (
+	"net"
 	"regexp"
 	"time"
 
 	"github.com/elastic/apm-server/sourcemap"
 	"github.com/elastic/beats/libbeat/common"
 )
+
+const defaultPort = "8200"
 
 type Config struct {
 	Host                string          `config:"host"`
@@ -109,7 +112,7 @@ func replaceVersion(pattern, version string) string {
 
 func defaultConfig(beatVersion string) *Config {
 	return &Config{
-		Host:                "localhost:8200",
+		Host:                net.JoinHostPort("localhost", defaultPort),
 		MaxUnzippedSize:     30 * 1024 * 1024, // 30mb
 		MaxHeaderSize:       1 * 1024 * 1024,  // 1mb
 		ConcurrentRequests:  5,


### PR DESCRIPTION
Backports the following commits to 6.x:
 - listen on default port 8200 if unspecified  (#886)