### PR TITLE
[6.x] update github.com/elastic/beats/libbeat/kibana vendoring (#897)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ TESTIFY_TOOL_REPO?=github.com/elastic/beats/vendor/github.com/stretchr/testify/a
 update-beats:
 	rm -rf vendor/github.com/elastic/beats
 	@govendor fetch github.com/elastic/beats/...@$(BEATS_VERSION)
-	@govendor fetch github.com/elastic/beats/libbeat/kibana/@$(BEATS_VERSION)
+	@govendor fetch github.com/elastic/beats/libbeat/kibana@$(BEATS_VERSION)
 	@BEATS_VERSION=$(BEATS_VERSION) script/update_beats.sh
 	@$(MAKE) update
 	@echo --- Use this commit message: Update beats framework to `cat vendor/vendor.json | python -c 'import sys, json; print([p["revision"] for p in json.load(sys.stdin)["package"] if p["path"] == "github.com/elastic/beats/libbeat/beat"][0][:7])'`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -534,14 +534,6 @@
 			"versionExact": "6.x"
 		},
 		{
-			"checksumSHA1": "z8VztKgyYSA7eyVuhNocdpav6zA=",
-			"path": "github.com/elastic/beats/libbeat/kibana/",
-			"revision": "0438ae89b76724cd3e7d2b3f69b3d3ec1ff46181",
-			"revisionTime": "2018-04-25T11:07:50Z",
-			"version": "6.x",
-			"versionExact": "6.x"
-		},
-		{
 			"checksumSHA1": "o43GjmYyneJqJaevwdy6tBX4vLA=",
 			"path": "github.com/elastic/beats/libbeat/logp",
 			"revision": "0438ae89b76724cd3e7d2b3f69b3d3ec1ff46181",


### PR DESCRIPTION
Backports the following commits to 6.x:
 - update github.com/elastic/beats/libbeat/kibana vendoring  (#897)