### PR TITLE
[6.3] update github.com/elastic/beats/libbeat/kibana vendoring (#897)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ TESTIFY_TOOL_REPO?=github.com/elastic/beats/vendor/github.com/stretchr/testify/a
 update-beats:
 	rm -rf vendor/github.com/elastic/beats
 	@govendor fetch github.com/elastic/beats/...@$(BEATS_VERSION)
-	@govendor fetch github.com/elastic/beats/libbeat/kibana/@$(BEATS_VERSION)
+	@govendor fetch github.com/elastic/beats/libbeat/kibana@$(BEATS_VERSION)
 	@BEATS_VERSION=$(BEATS_VERSION) script/update_beats.sh
 	@$(MAKE) update
 	@echo --- Use this commit message: Update beats framework to `cat vendor/vendor.json | python -c 'import sys, json; print([p["revision"] for p in json.load(sys.stdin)["package"] if p["path"] == "github.com/elastic/beats/libbeat/beat"][0][:7])'`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -528,14 +528,6 @@
 		{
 			"checksumSHA1": "z8VztKgyYSA7eyVuhNocdpav6zA=",
 			"path": "github.com/elastic/beats/libbeat/kibana",
-			"revision": "52b95427ecbf6530773d19d43d9c379e9b2426f7",
-			"revisionTime": "2018-04-19T21:07:42Z",
-			"version": "6.x",
-			"versionExact": "6.x"
-		},
-		{
-			"checksumSHA1": "z8VztKgyYSA7eyVuhNocdpav6zA=",
-			"path": "github.com/elastic/beats/libbeat/kibana/",
 			"revision": "237acd2ce4e8990009a556b154e7e459eb182e78",
 			"revisionTime": "2018-04-24T22:21:19Z",
 			"version": "6.3",


### PR DESCRIPTION
Backports the following commits to 6.3:
 - update github.com/elastic/beats/libbeat/kibana vendoring  (#897)