### PR TITLE
[6.2] update github.com/elastic/beats/libbeat/kibana vendoring (#897)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ TESTIFY_TOOL_REPO?=github.com/elastic/beats/vendor/github.com/stretchr/testify/a
 update-beats:
 	rm -rf vendor/github.com/elastic/beats
 	@govendor fetch github.com/elastic/beats/...@$(BEATS_VERSION)
-	@govendor fetch github.com/elastic/beats/libbeat/kibana/@$(BEATS_VERSION)
+	@govendor fetch github.com/elastic/beats/libbeat/kibana@$(BEATS_VERSION)
 	@BEATS_VERSION=$(BEATS_VERSION) script/update_beats.sh
 	@$(MAKE) update
 	@echo --- Use this commit message: Update beats framework to `cat vendor/vendor.json | python -c 'import sys, json; print([p["revision"] for p in json.load(sys.stdin)["package"] if p["path"] == "github.com/elastic/beats/libbeat/beat"][0][:7])'`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -514,16 +514,8 @@
 			"versionExact": "6.2"
 		},
 		{
-			"checksumSHA1": "qr5L7wYi9UcKO0ZPX7P6vxE1Vs0=",
-			"path": "github.com/elastic/beats/libbeat/kibana",
-			"revision": "3e2622dfaca8c4a3c28b0ec35622ea1d838d204d",
-			"revisionTime": "2017-11-27T03:18:09Z",
-			"version": "6.x",
-			"versionExact": "6.x"
-		},
-		{
 			"checksumSHA1": "z8VztKgyYSA7eyVuhNocdpav6zA=",
-			"path": "github.com/elastic/beats/libbeat/kibana/",
+			"path": "github.com/elastic/beats/libbeat/kibana",
 			"revision": "4460b29570f24d07ec5e5f410321fd6830065152",
 			"revisionTime": "2018-04-30T13:39:34Z",
 			"version": "6.2",


### PR DESCRIPTION
Backports the following commits to 6.2:
 - update github.com/elastic/beats/libbeat/kibana vendoring  (#897)