### PR TITLE
Add and align monitoring metrics for APM.

### DIFF
--- a/beater/handlers.go
+++ b/beater/handlers.go
@@ -96,21 +96,21 @@ var (
 		}
 	}
 	rateLimitedResponse = serverResponse{
-		errors.New("too many requests"), http.StatusTooManyRequests, counter("response.error.ratelimit"),
+		errors.New("too many requests"), http.StatusTooManyRequests, counter("response.errors.ratelimit"),
 	}
 	methodNotAllowedResponse = serverResponse{
-		errors.New("only POST requests are supported"), http.StatusMethodNotAllowed, counter("response.error.method"),
+		errors.New("only POST requests are supported"), http.StatusMethodNotAllowed, counter("response.errors.method"),
 	}
 	tooManyConcurrentRequestsResponse = serverResponse{
-		errors.New("timeout waiting to be processed"), http.StatusServiceUnavailable, counter("response.error.concurrency"),
+		errors.New("timeout waiting to be processed"), http.StatusServiceUnavailable, counter("response.errors.concurrency"),
 	}
-	fullQueueCounter  = counter("response.error.queue")
+	fullQueueCounter  = counter("response.errors.queue")
 	fullQueueResponse = func(err error) serverResponse {
 		return serverResponse{
 			errors.New("queue is full"), http.StatusServiceUnavailable, fullQueueCounter,
 		}
 	}
-	serverShuttingDownCounter  = counter("response.error.closed")
+	serverShuttingDownCounter  = counter("response.errors.closed")
 	serverShuttingDownResponse = func(err error) serverResponse {
 		return serverResponse{
 			errors.New("server is shutting down"), http.StatusServiceUnavailable, serverShuttingDownCounter,

--- a/processor/error/processor.go
+++ b/processor/error/processor.go
@@ -13,7 +13,6 @@ var (
 	validationError = monitoring.NewInt(errorMetrics, "validation.errors")
 	decodingCount   = monitoring.NewInt(errorMetrics, "decoding.count")
 	decodingError   = monitoring.NewInt(errorMetrics, "decoding.errors")
-	agent           = monitoring.NewString(errorMetrics, "agent")
 )
 
 const (
@@ -51,6 +50,5 @@ func (p *processor) Decode(raw map[string]interface{}) (pr.Payload, error) {
 		decodingError.Inc()
 		return nil, err
 	}
-	agent.Set(pa.Service.Agent.Name)
 	return pa, nil
 }

--- a/processor/transaction/processor.go
+++ b/processor/transaction/processor.go
@@ -13,7 +13,6 @@ var (
 	decodingError      = monitoring.NewInt(transactionMetrics, "decoding.errors")
 	validationCount    = monitoring.NewInt(transactionMetrics, "validation.count")
 	validationError    = monitoring.NewInt(transactionMetrics, "validation.errors")
-	agent              = monitoring.NewString(transactionMetrics, "agent")
 )
 
 const (
@@ -52,6 +51,5 @@ func (p *processor) Decode(raw map[string]interface{}) (pr.Payload, error) {
 		decodingError.Inc()
 		return nil, err
 	}
-	agent.Set(pa.Service.Agent.Name)
 	return pa, nil
 }


### PR DESCRIPTION
Align naming for request errors,
add counters for payload measurements
and remove agent information as it is always set to the latest agent information. 