### PR TITLE
[6.x] spec: clarify HTTP result format (#904)

### DIFF
--- a/docs/spec/transactions/transaction.json
+++ b/docs/spec/transactions/transaction.json
@@ -22,8 +22,8 @@
             "maxLength": 1024
         },
         "result": {
-          	"type": "string",
-          	"description": "The result of the transaction. HTTP status code for HTTP-related transactions.",
+            "type": "string",
+            "description": "The result of the transaction. For HTTP-related transactions, this should be the status code formatted like 'HTTP 2xx'.",
             "maxLength": 1024
         },
         "timestamp": {

--- a/processor/transaction/schema.go
+++ b/processor/transaction/schema.go
@@ -359,8 +359,8 @@ var transactionSchema = `{
             "maxLength": 1024
         },
         "result": {
-          	"type": "string",
-          	"description": "The result of the transaction. HTTP status code for HTTP-related transactions.",
+            "type": "string",
+            "description": "The result of the transaction. For HTTP-related transactions, this should be the status code formatted like 'HTTP 2xx'.",
             "maxLength": 1024
         },
         "timestamp": {


### PR DESCRIPTION
Backports the following commits to 6.x:
 - spec: clarify HTTP result format  (#904)