### PR TITLE
[6.x] Update changelog to include the updated docker image. (#924)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,7 +24,7 @@ https://github.com/elastic/apm-server/compare/9e0a1e281e56044745f1a4f18dcbf00a7f
 
 
 === APM Server version 6.3
-https://github.com/elastic/apm-server/compare/4daa36bd5c144cf9182afc62dc8042af663756c6\...9e0a1e281e56044745f1a4f18dcbf00a7fa03683[View commits]
+https://github.com/elastic/apm-server/compare/6.2\...6.3[View commits]
 
 ==== Breaking changes
 
@@ -36,6 +36,7 @@ https://github.com/elastic/apm-server/compare/4daa36bd5c144cf9182afc62dc8042af66
 - Fix issue preventing server from being stopped {pull}704[704].
 - Limit the amount of concurrent requests being processed {pull}731[731].
 - Return proper response code for request entity too large {pull}862[862].
+- Make APM Server docker image listen on all interfaces by default https://github.com/elastic/apm-server-docker/pull/16[apm-server-dockers#16]
 
 ==== Added
 


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Update changelog to include the updated docker image.  (#924)