### PR TITLE
[6.3] utility: add RemoteAddr, change ExtractIP sig (#927)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -4,21 +4,6 @@
 :pull: https://github.com/elastic/apm-server/pull/
 
 
-=== APM Server version HEAD
-https://github.com/elastic/apm-server/compare/9e0a1e281e56044745f1a4f18dcbf00a7fa03683\...master[View commits]
-
-==== Breaking changes
-
-==== Bug fixes
-
-- Don't augment payloads with invalid IPs {pull}923[923], {pull}927[927].
-
-==== Added
-
-- Listen on default port 8200 if unspecified {pull}[886]886.
-- Update Go to 1.10.1 {pull}894[894].
-
-==== Deprecated
 
 === APM Server version HEAD
 https://github.com/elastic/apm-server/compare/4daa36bd5c144cf9182afc62dc8042af663756c6\...master[View commits]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -4,6 +4,21 @@
 :pull: https://github.com/elastic/apm-server/pull/
 
 
+=== APM Server version HEAD
+https://github.com/elastic/apm-server/compare/9e0a1e281e56044745f1a4f18dcbf00a7fa03683\...master[View commits]
+
+==== Breaking changes
+
+==== Bug fixes
+
+- Don't augment payloads with invalid IPs {pull}923[923], {pull}927[927].
+
+==== Added
+
+- Listen on default port 8200 if unspecified {pull}[886]886.
+- Update Go to 1.10.1 {pull}894[894].
+
+==== Deprecated
 
 === APM Server version HEAD
 https://github.com/elastic/apm-server/compare/4daa36bd5c144cf9182afc62dc8042af663756c6\...master[View commits]

--- a/beater/handlers.go
+++ b/beater/handlers.go
@@ -224,7 +224,7 @@ func logHandler(h http.Handler) http.Handler {
 			"method", r.Method,
 			"URL", r.URL,
 			"content_length", r.ContentLength,
-			"remote_address", utility.ExtractIP(r),
+			"remote_address", utility.RemoteAddr(r),
 			"user-agent", r.Header.Get("User-Agent"))
 
 		lr := r.WithContext(
@@ -263,7 +263,7 @@ func ipRateLimitHandler(rateLimit int, h http.Handler) http.Handler {
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if deny(utility.ExtractIP(r)) {
+		if deny(utility.RemoteAddr(r)) {
 			sendStatus(w, r, rateLimitedResponse)
 			return
 		}

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"strings"
 
@@ -156,8 +155,8 @@ func DecodeUserData(decoder Decoder, enabled bool) Decoder {
 		m := map[string]interface{}{
 			"user-agent": req.Header.Get("User-Agent"),
 		}
-		if ip := utility.ExtractIP(req); net.ParseIP(ip) != nil {
-			m["ip"] = ip
+		if ip := utility.ExtractIP(req); ip != nil {
+			m["ip"] = ip.String()
 		}
 		return m
 	}
@@ -170,8 +169,8 @@ func DecodeSystemData(decoder Decoder, enabled bool) Decoder {
 	}
 
 	augment := func(req *http.Request) map[string]interface{} {
-		if ip := utility.ExtractIP(req); net.ParseIP(ip) != nil {
-			return map[string]interface{}{"ip": ip}
+		if ip := utility.ExtractIP(req); ip != nil {
+			return map[string]interface{}{"ip": ip.String()}
 		}
 		return nil
 	}

--- a/utility/forwarded.go
+++ b/utility/forwarded.go
@@ -1,0 +1,57 @@
+package utility
+
+import (
+	"strconv"
+	"strings"
+)
+
+// ForwardedHeader holds information extracted from a "Forwarded" HTTP header.
+type ForwardedHeader struct {
+	For   string
+	Host  string
+	Proto string
+}
+
+// ParseForwarded parses a "Forwarded" HTTP header.
+func ParseForwarded(f string) ForwardedHeader {
+	// We only consider the first value in the sequence,
+	// if there are multiple. Disregard everything after
+	// the first comma.
+	if comma := strings.IndexRune(f, ','); comma != -1 {
+		f = f[:comma]
+	}
+	var result ForwardedHeader
+	for f != "" {
+		field := f
+		if semi := strings.IndexRune(f, ';'); semi != -1 {
+			field = f[:semi]
+			f = f[semi+1:]
+		} else {
+			f = ""
+		}
+		eq := strings.IndexRune(field, '=')
+		if eq == -1 {
+			// Malformed field, ignore.
+			continue
+		}
+		key := strings.TrimSpace(field[:eq])
+		value := strings.TrimSpace(field[eq+1:])
+		if len(value) > 0 && value[0] == '"' {
+			var err error
+			value, err = strconv.Unquote(value)
+			if err != nil {
+				// Malformed, ignore
+				continue
+			}
+		}
+		switch strings.ToLower(key) {
+		case "for":
+			result.For = value
+		case "host":
+			result.Host = value
+		case "proto":
+			result.Proto = value
+		}
+	}
+	return result
+}

--- a/utility/forwarded_test.go
+++ b/utility/forwarded_test.go
@@ -1,0 +1,52 @@
+package utility_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-server/utility"
+)
+
+func TestParseForwarded(t *testing.T) {
+	type test struct {
+		name   string
+		header string
+		expect utility.ForwardedHeader
+	}
+
+	tests := []test{{
+		name:   "Forwarded",
+		header: "by=127.0.0.1; for=127.1.1.1; Host=\"forwarded.invalid:443\"; proto=HTTPS",
+		expect: utility.ForwardedHeader{
+			For:   "127.1.1.1",
+			Host:  "forwarded.invalid:443",
+			Proto: "HTTPS",
+		},
+	}, {
+		name:   "Forwarded-Multi",
+		header: "host=first.invalid, host=second.invalid",
+		expect: utility.ForwardedHeader{
+			Host: "first.invalid",
+		},
+	}, {
+		name:   "Forwarded-Malformed-Fields-Ignored",
+		header: "what; nonsense=\"; host=first.invalid",
+		expect: utility.ForwardedHeader{
+			Host: "first.invalid",
+		},
+	}, {
+		name:   "Forwarded-Trailing-Separators",
+		header: "host=first.invalid;,",
+		expect: utility.ForwardedHeader{
+			Host: "first.invalid",
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			parsed := utility.ParseForwarded(test.header)
+			assert.Equal(t, test.expect, parsed)
+		})
+	}
+}

--- a/utility/ip.go
+++ b/utility/ip.go
@@ -3,36 +3,11 @@ package utility
 import (
 	"net"
 	"net/http"
-	"strings"
 )
 
-// Obtains the IP of a request, looking up X-Forwarded-For and X-Real-IP headers.
-// X-Forwarded-For has a list of IPs, of which the first is the one of the original client.
-// This value however might not be necessarily trusted, as it can be forged by a malicious user.
-func ExtractIP(r *http.Request) string {
-	if realIP := r.Header.Get("X-Real-Ip"); realIP != "" {
-		return realIP
-	}
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		if sep := strings.IndexRune(xff, ','); sep > 0 {
-			xff = xff[:sep]
-		}
-		return strings.TrimSpace(xff)
-	}
-	remoteAddr, _ := splitHost(r.RemoteAddr)
-	return remoteAddr
-}
-
-func splitHost(in string) (host, port string) {
-	if strings.LastIndexByte(in, ':') == -1 {
-		// In the common (relative to other "errors") case that
-		// there is no colon, we can avoid allocations by not
-		// calling SplitHostPort.
-		return in, ""
-	}
-	host, port, err := net.SplitHostPort(in)
-	if err != nil {
-		return in, ""
-	}
-	return host, port
+// ExtractIP calls RemoteAddr(r), and passes the result into net.ParseIP
+// and returns that. If the request does not have a valid IP remote address,
+// this function will return nil.
+func ExtractIP(r *http.Request) net.IP {
+	return net.ParseIP(RemoteAddr(r))
 }

--- a/utility/ip_test.go
+++ b/utility/ip_test.go
@@ -54,7 +54,14 @@ func TestExtractIP(t *testing.T) {
 			nilOrString(tc.remote), nilOrString(tc.real), nilOrString(tc.forward))
 		req := testRequest(tc.remote, tc.real, tc.forward)
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.want, ExtractIP(req))
+			ip := ExtractIP(req)
+			if tc.want == empty {
+				assert.Nil(t, ip)
+			} else {
+				if assert.NotNil(t, ip) {
+					assert.Equal(t, tc.want, ip.String())
+				}
+			}
 		})
 	}
 }

--- a/utility/remoteaddr.go
+++ b/utility/remoteaddr.go
@@ -1,0 +1,56 @@
+package utility
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// RemoteAddr returns the remote address for the HTTP request.
+//
+// In order:
+//  - if the Forwarded header is set, then the first item in the
+//    list's "for" field is used, if it exists. The "for" value
+//    is returned even if it is an obfuscated identifier.
+//  - if the X-Real-Ip header is set, then its value is returned.
+//  - if the X-Forwarded-For header is set, then the first value
+//    in the comma-separated list is returned.
+//  - otherwise, the host portion of req.RemoteAddr is returned.
+//
+// Because the client can control the headers, they can control
+// the result of this function. The result should therefore not
+// necessarily be trusted to be correct.
+func RemoteAddr(req *http.Request) string {
+	if fwd := req.Header.Get("Forwarded"); fwd != "" {
+		forwarded := ParseForwarded(fwd)
+		if forwarded.For != "" {
+			host, _ := splitHost(forwarded.For)
+			return host
+		}
+	}
+	if realIP := req.Header.Get("X-Real-Ip"); realIP != "" {
+		return realIP
+	}
+	if xff := req.Header.Get("X-Forwarded-For"); xff != "" {
+		if sep := strings.IndexRune(xff, ','); sep > 0 {
+			xff = xff[:sep]
+		}
+		return strings.TrimSpace(xff)
+	}
+	host, _ := splitHost(req.RemoteAddr)
+	return host
+}
+
+func splitHost(in string) (host, port string) {
+	if strings.LastIndexByte(in, ':') == -1 {
+		// In the common (relative to other "errors") case that
+		// there is no colon, we can avoid allocations by not
+		// calling SplitHostPort.
+		return in, ""
+	}
+	host, port, err := net.SplitHostPort(in)
+	if err != nil {
+		return in, ""
+	}
+	return host, port
+}

--- a/utility/remoteaddr_test.go
+++ b/utility/remoteaddr_test.go
@@ -1,0 +1,37 @@
+package utility_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-server/utility"
+)
+
+func TestRemoteAddr(t *testing.T) {
+	req := &http.Request{
+		RemoteAddr: "[::1]:1234",
+		Header:     make(http.Header),
+	}
+	assert.Equal(t, "::1", utility.RemoteAddr(req))
+
+	req.Header.Set("X-Forwarded-For", "client.invalid")
+	assert.Equal(t, "client.invalid", utility.RemoteAddr(req))
+
+	req.Header.Set("X-Forwarded-For", "client.invalid, proxy.invalid")
+	assert.Equal(t, "client.invalid", utility.RemoteAddr(req))
+
+	req.Header.Set("X-Real-IP", "127.1.2.3")
+	assert.Equal(t, "127.1.2.3", utility.RemoteAddr(req))
+
+	// "for" is missing from Forwarded, so fall back to the next thing
+	req.Header.Set("Forwarded", "")
+	assert.Equal(t, "127.1.2.3", utility.RemoteAddr(req))
+
+	req.Header.Set("Forwarded", "for=_secret")
+	assert.Equal(t, "_secret", utility.RemoteAddr(req))
+
+	req.Header.Set("Forwarded", "for=[2001:db8:cafe::17]:4711")
+	assert.Equal(t, "2001:db8:cafe::17", utility.RemoteAddr(req))
+}


### PR DESCRIPTION
Backports the following commits to 6.3:
 - utility: add RemoteAddr, change ExtractIP sig  (#927)