### PR TITLE
[6.3] clarify root cause for 403 errors, fixes #973 (#974)

### DIFF
--- a/beater/handlers_test.go
+++ b/beater/handlers_test.go
@@ -19,7 +19,7 @@ func TestIncCounter(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	for i := 1; i <= 5; i++ {
-		for _, res := range []serverResponse{acceptedResponse, okResponse, forbiddenResponse, unauthorizedResponse,
+		for _, res := range []serverResponse{acceptedResponse, okResponse, forbiddenResponse(errors.New("")), unauthorizedResponse,
 			requestTooLargeResponse, rateLimitedResponse, methodNotAllowedResponse, tooManyConcurrentRequestsResponse,
 			cannotValidateResponse(errors.New("")), cannotDecodeResponse(errors.New("")),
 			fullQueueResponse(errors.New("")), serverShuttingDownResponse(errors.New(""))} {


### PR DESCRIPTION
Backports the following commits to 6.3:
 - clarify root cause for 403 errors, fixes elastic/apm-server#973  (#974)