### PR TITLE
load generated fields

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/elastic/apm-server/beater"
+	_ "github.com/elastic/apm-server/include"
 	"github.com/elastic/beats/libbeat/cmd"
 )
 


### PR DESCRIPTION
a64eb29cce2e0c84074d169534083761f5d3795c introduced replacement of
fields.yml with generated fields.go.  Ensure this is a loaded at
startup.

fixes #985