### PR TITLE
Multiple queues in the publisher

### DIFF
--- a/beater/handlers.go
+++ b/beater/handlers.go
@@ -387,7 +387,7 @@ func processRequest(r *http.Request, pf ProcessorFactory, config conf.Config, re
 		return cannotDecodeResponse(err)
 	}
 
-	if err = report(pendingReq{payload: payload, config: config}); err != nil {
+	if err = report(pendingReq{payload: payload, config: config, processorName: processor.Name()}); err != nil {
 		if strings.Contains(err.Error(), "publisher is being stopped") {
 			return serverShuttingDownResponse(err)
 		}

--- a/beater/pub.go
+++ b/beater/pub.go
@@ -7,9 +7,15 @@ import (
 
 	"github.com/pkg/errors"
 
+	"math"
+
 	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
+	perr "github.com/elastic/apm-server/processor/error"
+	"github.com/elastic/apm-server/processor/sourcemap"
+	"github.com/elastic/apm-server/processor/transaction"
 	"github.com/elastic/beats/libbeat/beat"
+	"fmt"
 )
 
 // Publisher forwards batches of events to libbeat. It uses GuaranteedSend
@@ -20,15 +26,18 @@ import (
 // number requests(events) active in the system can exceed the queue size. Only
 // the number of concurrent HTTP requests trying to publish at the same time is limited.
 type publisher struct {
-	pendingRequests chan pendingReq
-	client          beat.Client
-	m               sync.RWMutex
-	stopped         bool
+	errorsC       chan pendingReq
+	transactionsC chan pendingReq
+	sourcemapsC   chan pendingReq
+	client        beat.Client
+	m             sync.RWMutex
+	stopped       bool
 }
 
 type pendingReq struct {
-	payload pr.Payload
-	config  config.Config
+	processorName string
+	payload       pr.Payload
+	config        config.Config
 }
 
 var (
@@ -55,13 +64,15 @@ func newPublisher(pipeline beat.Pipeline, N int, shutdownTimeout time.Duration) 
 	if err != nil {
 		return nil, err
 	}
-
+	transactionsCSize := N - 1
+	errorsCSize := int(math.Max(math.Trunc(float64(transactionsCSize) * 0.2), 1))
+	fmt.Println("transSize  ", transactionsCSize)
+	fmt.Println("errSize ", errorsCSize)
 	p := &publisher{
-		client: client,
-
-		// Set channel size to N - 1. One request will be actively processed by the
-		// worker, while the other concurrent requests will be buffered in the queue.
-		pendingRequests: make(chan pendingReq, N-1),
+		client:        client,
+		transactionsC: make(chan pendingReq, transactionsCSize),
+		errorsC:       make(chan pendingReq, errorsCSize),
+		sourcemapsC:   make(chan pendingReq, 1),
 	}
 
 	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
@@ -78,7 +89,9 @@ func (p *publisher) Stop() {
 	p.m.Lock()
 	p.stopped = true
 	p.m.Unlock()
-	close(p.pendingRequests)
+	close(p.transactionsC)
+	close(p.errorsC)
+	close(p.sourcemapsC)
 	p.client.Close()
 }
 
@@ -91,17 +104,47 @@ func (p *publisher) Send(req pendingReq) error {
 	if p.stopped {
 		return errChannelClosed
 	}
+	switch req.processorName {
+	case transaction.ProcessorName:
+		select {
+		case p.transactionsC <- req:
+			return nil
+		case <-time.After(time.Second * 1):
+			return errFull
+		}
 
-	select {
-	case p.pendingRequests <- req:
-		return nil
-	case <-time.After(time.Second * 1): // this forces the go scheduler to try something else for a while
-		return errFull
+	case perr.ProcessorName:
+		select {
+		case p.errorsC <- req:
+			return nil
+		case <-time.After(time.Second * 1):
+			return errFull
+		}
+
+	case sourcemap.ProcessorName:
+		p.sourcemapsC <- req
 	}
+	return nil
 }
 
 func (p *publisher) run() {
-	for req := range p.pendingRequests {
+	pendingRequests := make(chan pendingReq, math.MaxInt16)
+	go func() {
+		defer close(pendingRequests)
+		var ok = true
+		for ok {
+			var req pendingReq
+			select {
+			case req, ok = <- p.transactionsC:
+			case req, ok = <- p.errorsC:
+			case req, ok = <- p.sourcemapsC:
+			}
+			if ok {
+				pendingRequests <- req
+			}
+		}
+	}()
+	for req := range pendingRequests {
 		p.client.PublishAll(req.payload.Transform(req.config))
 	}
 }

--- a/beater/pub.go
+++ b/beater/pub.go
@@ -128,7 +128,7 @@ func (p *publisher) Send(req pendingReq) error {
 }
 
 func (p *publisher) run() {
-	pendingRequests := make(chan pendingReq, math.MaxInt16)
+	pendingRequests := make(chan pendingReq)
 	go func() {
 		defer close(pendingRequests)
 		var ok = true

--- a/beater/pub.go
+++ b/beater/pub.go
@@ -9,13 +9,14 @@ import (
 
 	"math"
 
+	"fmt"
+
 	"github.com/elastic/apm-server/config"
 	pr "github.com/elastic/apm-server/processor"
 	perr "github.com/elastic/apm-server/processor/error"
 	"github.com/elastic/apm-server/processor/sourcemap"
 	"github.com/elastic/apm-server/processor/transaction"
 	"github.com/elastic/beats/libbeat/beat"
-	"fmt"
 )
 
 // Publisher forwards batches of events to libbeat. It uses GuaranteedSend
@@ -65,7 +66,7 @@ func newPublisher(pipeline beat.Pipeline, N int, shutdownTimeout time.Duration) 
 		return nil, err
 	}
 	transactionsCSize := N - 1
-	errorsCSize := int(math.Max(math.Trunc(float64(transactionsCSize) * 0.2), 1))
+	errorsCSize := int(math.Max(math.Trunc(float64(transactionsCSize)*0.2), 1))
 	fmt.Println("transSize  ", transactionsCSize)
 	fmt.Println("errSize ", errorsCSize)
 	p := &publisher{
@@ -135,9 +136,9 @@ func (p *publisher) run() {
 		for ok {
 			var req pendingReq
 			select {
-			case req, ok = <- p.transactionsC:
-			case req, ok = <- p.errorsC:
-			case req, ok = <- p.sourcemapsC:
+			case req, ok = <-p.transactionsC:
+			case req, ok = <-p.errorsC:
+			case req, ok = <-p.sourcemapsC:
 			}
 			if ok {
 				pendingRequests <- req

--- a/processor/error/payload.go
+++ b/processor/error/payload.go
@@ -15,7 +15,7 @@ var (
 	errorCounter      = monitoring.NewInt(errorMetrics, "errors")
 	stacktraceCounter = monitoring.NewInt(errorMetrics, "stacktraces")
 	frameCounter      = monitoring.NewInt(errorMetrics, "frames")
-	processorEntry    = common.MapStr{"name": processorName, "event": errorDocType}
+	processorEntry    = common.MapStr{"name": ProcessorName, "event": errorDocType}
 )
 
 type Payload struct {

--- a/processor/error/processor.go
+++ b/processor/error/processor.go
@@ -16,18 +16,18 @@ var (
 )
 
 const (
-	processorName = "error"
+	ProcessorName = "error"
 	errorDocType  = "error"
 )
 
-var schema = pr.CreateSchema(errorSchema, processorName)
+var schema = pr.CreateSchema(errorSchema, ProcessorName)
 
 func NewProcessor() pr.Processor {
 	return &processor{schema: schema}
 }
 
 func (p *processor) Name() string {
-	return processorName
+	return ProcessorName
 }
 
 type processor struct {

--- a/processor/sourcemap/payload.go
+++ b/processor/sourcemap/payload.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	sourcemapCounter = monitoring.NewInt(sourcemapUploadMetrics, "counter")
-	processorEntry   = common.MapStr{"name": processorName, "event": smapDocType}
+	processorEntry   = common.MapStr{"name": ProcessorName, "event": smapDocType}
 )
 
 type Payload struct {

--- a/processor/sourcemap/processor.go
+++ b/processor/sourcemap/processor.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	processorName = "sourcemap"
+	ProcessorName = "sourcemap"
 	smapDocType   = "sourcemap"
 )
 
@@ -26,14 +26,14 @@ var (
 	decodingError          = monitoring.NewInt(sourcemapUploadMetrics, "decoding.errors")
 )
 
-var schema = pr.CreateSchema(sourcemapSchema, processorName)
+var schema = pr.CreateSchema(sourcemapSchema, ProcessorName)
 
 func NewProcessor() pr.Processor {
 	return &processor{schema: schema}
 }
 
 func (p *processor) Name() string {
-	return processorName
+	return ProcessorName
 }
 
 type processor struct {

--- a/processor/transaction/payload.go
+++ b/processor/transaction/payload.go
@@ -17,8 +17,8 @@ var (
 	stacktraceCounter  = monitoring.NewInt(transactionMetrics, "stacktraces")
 	frameCounter       = monitoring.NewInt(transactionMetrics, "frames")
 
-	processorTransEntry = common.MapStr{"name": processorName, "event": transactionDocType}
-	processorSpanEntry  = common.MapStr{"name": processorName, "event": spanDocType}
+	processorTransEntry = common.MapStr{"name": ProcessorName, "event": transactionDocType}
+	processorSpanEntry  = common.MapStr{"name": ProcessorName, "event": spanDocType}
 )
 
 type Payload struct {

--- a/processor/transaction/processor.go
+++ b/processor/transaction/processor.go
@@ -16,12 +16,12 @@ var (
 )
 
 const (
-	processorName      = "transaction"
+	ProcessorName      = "transaction"
 	transactionDocType = "transaction"
 	spanDocType        = "span"
 )
 
-var schema = pr.CreateSchema(transactionSchema, processorName)
+var schema = pr.CreateSchema(transactionSchema, ProcessorName)
 
 func NewProcessor() pr.Processor {
 	return &processor{schema: schema}
@@ -32,7 +32,7 @@ type processor struct {
 }
 
 func (p *processor) Name() string {
-	return processorName
+	return ProcessorName
 }
 
 func (p *processor) Validate(raw map[string]interface{}) error {


### PR DESCRIPTION
This attempts to explore https://github.com/elastic/apm-server/issues/947

Made some measurements in GCP, variance is quite high so take the results with a grain of salt. For the tables bellow I selected results falling in the middle.
This approach prioritizes transactions over errors, overall performance respect to master seems better with `concurrent_requests = 5` (default) but is not so clear with `concurrent_requests = 10`.

There are many more variables untested (other relevant settings like`mem.queue.events`, other values for `concurrent_requests`, other workload patterns, etc.). Given the variability of the results and the amount of knobs we have, exhaustive testing is not really doable.
This code is also more complex (and adds another knob to the mix) so I am reluctant to go with this. 
Happy to see alternative implementations.

Besides, I found that the best runs with `concurrent_requests=10` are much better than the best runs with the default, and with a similar memory usage. Did that has been observed/tested before?

______

- duration of each test = 1min
- transactions payload = ~900kb, 3 workers
- errors payload = ~200kb, 10 workers
- first table: `concurrent_requests=5`, second table: `concurrent_requests=10`
- for each table: first column is `master`, and second is this branch.
- for each table: first row is transactions only, and second row is transactions + errors.

- things to notice: latency and ratio of 503's between rows and columns - as expected ratio of 503's between errors and transactions is higher in this branch.

```
http://localhost:8200/v1/transactions
pushed 3.4Mb / sec , accepted 2.1Mb / sec        pushed 3.5Mb / sec , accepted 2.7Mb / sec
  [202] 139 responses (60.96%)                     [202] 182 responses (76.79%)
  [503] 89 responses (39.04%)                      [503] 55 responses (23.21%)
  total 228 responses (3.80 rps)                   total 237 responses (3.95 rps)
  431.66 ms / request                              329.67 ms / request
396.5Mb (max RSS)                                377.8Mb (max RSS)


http://localhost:8200/v1/transactions
pushed 3.3Mb / sec , accepted 1.9Mb / sec        pushed 3.6Mb / sec , accepted 2.7Mb / sec
  [202] 126 responses (56.00%)                     [202] 183 responses (75.31%)
  [503] 99 responses (44.00%)                      [503] 60 responses (24.69%)
  total 225 responses (3.75 rps)                   total 243 responses (4.05 rps)
  476.19 ms / request                              327.87 ms / request
http://localhost:8200/v1/errors
pushed 1.0Mb / sec , accepted 496.7kb / sec      pushed 1.0Mb / sec , accepted 485.6kb / sec
  [202]	134 responses (47.02%)                     [202] 131 responses (46.45%)
  [503]	151 responses (52.98%)                     [503] 151 responses (53.55%)
  total	285 responses (5.70 rps)                   total 282 responses (5.64 rps)
  373.14 ms / request                              381.68 ms / request
445.0Mb (max RSS)                                463.8Mb (max RSS)                        
```

```
http://localhost:8200/v1/transactions
pushed 3.4Mb / sec , accepted 2.1Mb / sec        pushed 3.4Mb / sec , accepted 2.3Mb / sec
  [202] 140 responses (61.40%)                     [202] 156 responses (67.24%) 
  [503] 88 responses (38.60%)                      [503] 76 responses (32.76%) 
  total 228 responses (3.80 rps)                   total 232 responses (3.87 rps) 
  428.57 ms / request                              384.62 ms / request
421.3Mb (max RSS)                                426.6Mb (max RSS)


http://localhost:8200/v1/transactions
pushed 3.3Mb / sec , accepted 1.8Mb / sec        pushed 3.4Mb / sec , accepted 1.9Mb / sec 
  [202] 119 responses (53.85%)                     [202] 128 responses (56.14%)
  [503] 102 responses (46.15%)                     [503] 100 responses (43.86%)
  total 221 responses (3.68 rps)                   total 228 responses (3.80 rps)
  504.24 ms / request                              468.75 ms / request
http://localhost:8200/v1/errors
pushed 1.9Mb / sec , accepted 630.1kb / sec      pushed 1.8Mb / sec , accepted 215.0kb / sec
  [202] 170 responses (32.88%)                     [202] 58 responses (11.72%)
  [503] 347 responses (67.12%)                     [503] 437 responses (88.28%) 
  total 517 responses (10.34 rps)                  total 495 responses (9.90 rps)
  294.14 ms / request                              862.09 ms / request
456.4Mb (max RSS)                                461.0Mb (max RSS)
```