### PR TITLE
Add release notes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,7 +1,7 @@
-
 [[release-notes-head]]
 == APM Server version HEAD
 
+// These have to be under a == headline unfortunately:
 // Use these for links to issue and pulls. Note issues and pulls redirect one to
 // each other on Github, so don't worry too much on using the right prefix.
 :issue: https://github.com/elastic/apm-server/issues/
@@ -12,9 +12,9 @@ https://github.com/elastic/apm-server/compare/9e0a1e281e56044745f1a4f18dcbf00a7f
 
 === Added
 
-- Listen on default port 8200 if unspecified {pull}[886]886.
+- Listen on default port 8200 if unspecified {pull}886[886].
 - Update Go to 1.10.1 {pull}894[894].
-- Combine `apm-server.yml` and `apm-server.reference.yml` into one file {pull}[958]958.
+- Combine `apm-server.yml` and `apm-server.reference.yml` into one file {pull}958[958].
 - Add optional tracing for the server's API and event publisher {pull}816[816].
 
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,37 +1,28 @@
+
+[[release-notes-head]]
+== APM Server version HEAD
+
 // Use these for links to issue and pulls. Note issues and pulls redirect one to
 // each other on Github, so don't worry too much on using the right prefix.
 :issue: https://github.com/elastic/apm-server/issues/
 :pull: https://github.com/elastic/apm-server/pull/
 
 
-=== APM Server version HEAD
 https://github.com/elastic/apm-server/compare/9e0a1e281e56044745f1a4f18dcbf00a7fa03683\...master[View commits]
 
-==== Breaking changes
-
-==== Bug fixes
-
-==== Added
+=== Added
 
 - Listen on default port 8200 if unspecified {pull}[886]886.
 - Update Go to 1.10.1 {pull}894[894].
 - Combine `apm-server.yml` and `apm-server.reference.yml` into one file {pull}[958]958.
 - Add optional tracing for the server's API and event publisher {pull}816[816].
 
-==== Deprecated
 
-==== Known Issues
-
-
-
-
-
-=== APM Server version 6.3
+[[release-notes-6.3]]
+== APM Server version 6.3
 https://github.com/elastic/apm-server/compare/6.2\...6.3[View commits]
 
-==== Breaking changes
-
-==== Bug fixes
+=== Bug fixes
 
 - Accept charset in request's content type {pull}677[677].
 - Use type integer instead of number in JSON schemas where applicable {pull}641[641].
@@ -41,7 +32,7 @@ https://github.com/elastic/apm-server/compare/6.2\...6.3[View commits]
 - Return proper response code for request entity too large {pull}862[862].
 - Make APM Server docker image listen on all interfaces by default https://github.com/elastic/apm-server-docker/pull/16[apm-server-dockers#16]
 
-==== Added
+=== Added
 
 - Enriched data with IP and UserAgent {pull}393[393], {pull}701[701], {pull}730[730], {pull}923[923].
 - Push errors and transactions to different ES indices {pull}706[706].
@@ -56,17 +47,11 @@ https://github.com/elastic/apm-server/compare/6.2\...6.3[View commits]
 - Make timestamp optional in the intake api {pull}819[819].
 
 
-==== Deprecated
-
-==== Known Issues
-
-
-
-
-=== APM Server version 6.2
+[[release-notes-6.2]]
+== APM Server version 6.2
 https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828e0761d\...4daa36bd5c144cf9182afc62dc8042af663756c6[View commits]
 
-==== Breaking changes
+=== Breaking changes
 - Renaming and reverse boolean `in_app` to `library_frame` {pull}385[385].
 - Renaming `app` to `service` {pull}377[377]
 - Move `trace.transaction_id` to `transaction.id` {pull}345[345], {pull}347[347], {pull}371[371]
@@ -76,13 +61,13 @@ https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828
 - Rename Kibana directories according to changed structure in beats framework. {pull}454[454]
 - Change config option `max_header_bytes` to `max_header_size` {pull}492[492].
 
-==== Bug fixes
+=== Bug fixes
 - Updated systemd doc url {pull}354[354]
 - Updated readme doc urls {pull}356[356]
 - Use updated stack trace frame values for calculating error `grouping_keys` {pull}485[485]
 - Fix panic when a signal is delivered before the server is instantiated {pull}580[580]
 
-==== Added
+=== Added
 - Include build time and revision in version information {pull}396[396]
 - service.environment {pull}366[366]
 - Consider exception or log message for grouping key when nothing else is available {pull}435[435]
@@ -107,21 +92,17 @@ https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828
 - Use seperate index for uploaded `source maps` {pull}582[582].
 - Store original values when applying source mapping or changing `library_frame` value {pull}647[647]
 
-==== Deprecated
 
-==== Known Issues
-
-
-
-=== APM Server version 6.1
+[[release-notes-6.1]]
+== APM Server version 6.1
 https://github.com/elastic/apm-server/compare/f9a2086ceed0b918e1a0b3d8ddc140fc21af0e74\...421db9d1e10935e7b9aec00b64cf66ad2d50d797[View commits]
 
-==== Breaking changes
+=== Breaking changes
 - Allow ES template index prefix to be `apm` {pull}152[152].
 - Remove `git_ref` from Intake API and Elasticsearch output {pull}158[158].
 - Switch to Go 1.9.2
 
-==== Bug fixes
+=== Bug fixes
 - Fix dashboard loading for Kibana 5x {pull}221[221].
 - Fix command for loading dashboards in docs {pull}205[205].
 - Log a warning message if secret token is set but ssl is not {pull}204[204].
@@ -132,7 +113,7 @@ https://github.com/elastic/apm-server/compare/f9a2086ceed0b918e1a0b3d8ddc140fc21
 - Update dashboard with fix for rpm graphs {pull}315[315].
 - Dashboards: Remove time from url_templates {pull}321[321].
 
-==== Added
+=== Added
 - Added wildcard matching for allowed origins for frontend {pull}287[287].
 - Added rate limit per IP for frontend {pull}257[257].
 - Allow null for all optional fields {pull}253[253].
@@ -144,15 +125,11 @@ https://github.com/elastic/apm-server/compare/f9a2086ceed0b918e1a0b3d8ddc140fc21
 - Send document to output on start of server {pull}117[117].
 - Log frontend status at startup  {pull}284[284].
 
-==== Deprecated
-
-==== Known Issues
-
-
-=== APM Server version 0.2.0
+[[release-notes-0.2]]
+== APM Server version 0.2.0
 https://github.com/elastic/apm-server/compare/3ad33b3129c0be3b0e4057efc53948c381a2af79\...f9a2086ceed0b918e1a0b3d8ddc140fc21af0e74[View commits]
 
-==== Breaking changes
+=== Breaking changes
 - Changed response status code in the API from 201 to 202 {pull}34[34]
 - Set dynamic mapping to false, enable only for `context.tags`. Fix issues with indexing. Removed from index: `request.headers_sent`, `app.argv`. Changes take place with {pull}43[43], after updating beats framework.
 - Remove `context.db.sql` and add `context.db.instance`, `context.db.statement`, `context.db.type` and `context.db.user` instead {pull}38[38].
@@ -162,14 +139,14 @@ https://github.com/elastic/apm-server/compare/3ad33b3129c0be3b0e4057efc53948c381
 - Changed default APM Server listen port from 8080 to 8200 {pull}91[91].
 - Removed `debug` unneeded handler. {pull}85[85].
 
-==== Bug fixes
+=== Bug fixes
 - changed `context.system.title` to `context.system.process_title`, removed `transaction.context`, `trace.context` (already available on top level). {pull}10[10]
 - changed type of `context.request.body` from `object` to `text`. {pull}27[27]
 - incoming transactions and errors could reuse data from previous POSTs due to payload state being kept in processors {pull}98[98].
 - forced apm-server to stop if/when the underlying http server is not running. Exit code is 0 for SIGINT / SIGTERM, 1 otherwise. {pull}94[94]
 - close http server immediately if it doesn't shutdown gracefully after a configurable timeout. {pull}107[107]
 
-==== Added
+=== Added
 
 - apm-server now returns JSON error responses when the Accept header allows for it.
 - Added `context.request.http_version` property {pull}52[52]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,7 +8,7 @@
 :pull: https://github.com/elastic/apm-server/pull/
 
 
-https://github.com/elastic/apm-server/compare/9e0a1e281e56044745f1a4f18dcbf00a7fa03683\...master[View commits]
+https://github.com/elastic/apm-server/compare/6.3\...master[View commits]
 
 === Added
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -41,3 +41,5 @@ include::./intake-api.asciidoc[]
 include::./fields.asciidoc[]
 
 include::./troubleshooting.asciidoc[]
+
+include::./release-notes.asciidoc[]

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -1,0 +1,20 @@
+:root-dir: ../
+
+[[release-notes]]
+= Release notes
+
+[partintro]
+
+--
+This following section summarizes the changes in each release.
+
+
+* <<release-notes-head>>
+* <<release-notes-6.3>>
+* <<release-notes-6.2>>
+* <<release-notes-6.1>>
+
+
+--
+
+include::{root-dir}/CHANGELOG.asciidoc[]


### PR DESCRIPTION
Adds the CHANGELOG.asciidoc (that we're already maintaining) to the docs they will get rendered nicely and so we can link to them from download pages.

![image](https://user-images.githubusercontent.com/744/41841048-96388faa-7867-11e8-96e3-2257cc9276b5.png)

![image](https://user-images.githubusercontent.com/744/41841078-a7289198-7867-11e8-9a7f-c2aa2a5f4202.png)
