### PR TITLE
Move generated schemas into sub-folders

### DIFF
--- a/processor/error/generated/schema/payload.go
+++ b/processor/error/generated/schema/payload.go
@@ -1,10 +1,6 @@
-package error
+package schema
 
-func Schema() string {
-	return errorSchema
-}
-
-var errorSchema = `{
+const PayloadSchema = `{
     "$id": "docs/spec/errors/payload.json",
     "title": "Errors payload",
     "description": "List of errors wrapped in an object containing some other attributes normalized away from the errors themselves",

--- a/processor/error/package_tests/json_schema_test.go
+++ b/processor/error/package_tests/json_schema_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	er "github.com/elastic/apm-server/processor/error"
+	"github.com/elastic/apm-server/processor/error/generated/schema"
 	"github.com/elastic/apm-server/tests"
 )
 
@@ -148,5 +149,5 @@ func TestPayloadAttributesInSchema(t *testing.T) {
 		"errors.context.request.cookies.c2",
 		"errors.context.tags.organization_uuid",
 	)
-	tests.TestPayloadAttributesInSchema(t, "error", undocumented, er.Schema())
+	tests.TestPayloadAttributesInSchema(t, "error", undocumented, schema.PayloadSchema)
 }

--- a/processor/error/processor.go
+++ b/processor/error/processor.go
@@ -4,6 +4,7 @@ import (
 	"github.com/santhosh-tekuri/jsonschema"
 
 	pr "github.com/elastic/apm-server/processor"
+	"github.com/elastic/apm-server/processor/error/generated/schema"
 	"github.com/elastic/beats/libbeat/monitoring"
 )
 
@@ -20,10 +21,10 @@ const (
 	errorDocType  = "error"
 )
 
-var schema = pr.CreateSchema(errorSchema, processorName)
+var loadedSchema = pr.CreateSchema(schema.PayloadSchema, processorName)
 
 func NewProcessor() pr.Processor {
-	return &processor{schema: schema}
+	return &processor{schema: loadedSchema}
 }
 
 func (p *processor) Name() string {

--- a/processor/sourcemap/generated/schema/payload.go
+++ b/processor/sourcemap/generated/schema/payload.go
@@ -1,10 +1,6 @@
-package sourcemap
+package schema
 
-func Schema() string {
-	return sourcemapSchema
-}
-
-var sourcemapSchema = `{
+const PayloadSchema = `{
     "$id": "docs/spec/sourcemaps/sourcemap-metadata.json",
     "title": "Sourcemap Metadata",
     "description": "Sourcemap Metadata",

--- a/processor/sourcemap/package_tests/json_schema_test.go
+++ b/processor/sourcemap/package_tests/json_schema_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	sm "github.com/elastic/apm-server/processor/sourcemap"
+	"github.com/elastic/apm-server/processor/sourcemap/generated/schema"
 	"github.com/elastic/apm-server/tests"
 )
 
@@ -14,7 +15,7 @@ func TestPayloadAttributesInSchema(t *testing.T) {
 		"sourcemap",
 		tests.NewSet("sourcemap", "sourcemap.file", "sourcemap.names", "sourcemap.sources", "sourcemap.sourceRoot",
 			"sourcemap.mappings", "sourcemap.sourcesContent", "sourcemap.version"),
-		sm.Schema())
+		schema.PayloadSchema)
 }
 
 var (

--- a/processor/sourcemap/processor.go
+++ b/processor/sourcemap/processor.go
@@ -9,6 +9,7 @@ import (
 	parser "github.com/go-sourcemap/sourcemap"
 
 	pr "github.com/elastic/apm-server/processor"
+	"github.com/elastic/apm-server/processor/sourcemap/generated/schema"
 	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/beats/libbeat/monitoring"
 )
@@ -26,10 +27,10 @@ var (
 	decodingError          = monitoring.NewInt(sourcemapUploadMetrics, "decoding.errors")
 )
 
-var schema = pr.CreateSchema(sourcemapSchema, processorName)
+var loadedSchema = pr.CreateSchema(schema.PayloadSchema, processorName)
 
 func NewProcessor() pr.Processor {
-	return &processor{schema: schema}
+	return &processor{schema: loadedSchema}
 }
 
 func (p *processor) Name() string {

--- a/processor/transaction/generated/schema/payload.go
+++ b/processor/transaction/generated/schema/payload.go
@@ -1,10 +1,6 @@
-package transaction
+package schema
 
-func Schema() string {
-	return transactionSchema
-}
-
-var transactionSchema = `{
+const PayloadSchema = `{
     "$id": "docs/spec/transactions/payload.json",
     "title": "Transactions payload",
     "description": "List of transactions wrapped in an object containing some other attributes normalized away from the transactions themselves",

--- a/processor/transaction/package_tests/json_schema_test.go
+++ b/processor/transaction/package_tests/json_schema_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	tr "github.com/elastic/apm-server/processor/transaction"
+	"github.com/elastic/apm-server/processor/transaction/generated/schema"
 	"github.com/elastic/apm-server/tests"
 )
 
@@ -173,5 +174,5 @@ func TestPayloadAttributesInSchema(t *testing.T) {
 		"transactions.marks.navigationTiming.navigationStart",
 		"transactions.marks.performance",
 	)
-	tests.TestPayloadAttributesInSchema(t, "transaction", undocumented, tr.Schema())
+	tests.TestPayloadAttributesInSchema(t, "transaction", undocumented, schema.PayloadSchema)
 }

--- a/processor/transaction/processor.go
+++ b/processor/transaction/processor.go
@@ -2,6 +2,7 @@ package transaction
 
 import (
 	pr "github.com/elastic/apm-server/processor"
+	"github.com/elastic/apm-server/processor/transaction/generated/schema"
 	"github.com/elastic/beats/libbeat/monitoring"
 
 	"github.com/santhosh-tekuri/jsonschema"
@@ -21,10 +22,10 @@ const (
 	spanDocType        = "span"
 )
 
-var schema = pr.CreateSchema(transactionSchema, processorName)
+var loadedSchema = pr.CreateSchema(schema.PayloadSchema, processorName)
 
 func NewProcessor() pr.Processor {
-	return &processor{schema: schema}
+	return &processor{schema: loadedSchema}
 }
 
 type processor struct {


### PR DESCRIPTION
This moves generated schemas into their own sub-folders in their respective processors.

This is extracted from the work on [intake v2](https://github.com/elastic/apm-server/pull/930). 

Right now, I think it's nice to have auto-generated and human-generated source code separately. 

In the future for intake v2, we'll need to validate entities like errors and transactions separate from the payload, which means we'll need to have the schemas separate for the individual entities.

When we add the individual schemas (errors, transactions) in the future, we'd be putting even more auto-generated files in the same directories as the human-generated code, if we didn't have a sub-folder for it. 

I went ahead and gave the schema constants names (`const PayloadSchema`) instead of using the `Schema()` method, because we'll need to have more schemas in the package in the future.