### PR TITLE
Move "Why is APM Server a separate component?" under "Overview"."

### DIFF
--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -33,7 +33,7 @@ please also have a look at the documentation for
 See how to {apm-get-started}/index.html[Get Started] with the Elastic APM system.
 
 [[why-separate-component]]
-== Why is APM Server a separate component?
+=== Why is APM Server a separate component?
 
 The APM Server is kept as a separate component for the following reasons:
 


### PR DESCRIPTION
It's no longer a top level heading:

![image](https://user-images.githubusercontent.com/744/42033520-64e694b0-7add-11e8-8dca-30b95b0d3d4d.png)
