### PR TITLE
catch errors when starting the beater

### DIFF
--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/kabukky/httpscerts"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/apm-server/tests/loader"
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
@@ -46,7 +48,7 @@ func TestMain(m *testing.M) {
 
 func TestServerOk(t *testing.T) {
 	apm, teardown, err := setupServer(t, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer teardown()
 
 	baseUrl, client := apm.client(false)
@@ -77,7 +79,7 @@ func TestServerTcpNoPort(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	btr, teardown, err := setupServer(t, ucfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer teardown()
 
 	baseUrl, client := btr.client(false)
@@ -104,7 +106,7 @@ func TestServerOkUnix(t *testing.T) {
 	ucfg, err := common.NewConfigFrom(m{"host": "unix:" + addr})
 	assert.NoError(t, err)
 	btr, stop, err := setupServer(t, ucfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer stop()
 
 	baseUrl, client := btr.client(false)
@@ -115,7 +117,7 @@ func TestServerOkUnix(t *testing.T) {
 
 func TestServerHealth(t *testing.T) {
 	apm, teardown, err := setupServer(t, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer teardown()
 
 	baseUrl, client := apm.client(false)
@@ -129,7 +131,7 @@ func TestServerFrontendSwitch(t *testing.T) {
 	ucfg, err := common.NewConfigFrom(m{"frontend": m{"enabled": true, "allow_origins": []string{"*"}}})
 	assert.NoError(t, err)
 	apm, teardown, err := setupServer(t, ucfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer teardown()
 
 	baseUrl, client := apm.client(false)
@@ -185,7 +187,7 @@ func TestServerCORS(t *testing.T) {
 		assert.NoError(t, err)
 		var apm *beater
 		apm, teardown, err = setupServer(t, ucfg)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		baseUrl, client := apm.client(false)
 		req, err := http.NewRequest("POST", baseUrl+FrontendTransactionsURL, bytes.NewReader(testData))
 		req.Header.Set("Origin", test.origin)
@@ -199,7 +201,7 @@ func TestServerCORS(t *testing.T) {
 
 func TestServerNoContentType(t *testing.T) {
 	apm, teardown, err := setupServer(t, nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer teardown()
 
 	baseUrl, client := apm.client(false)
@@ -248,7 +250,7 @@ func TestServerSSL(t *testing.T) {
 		var apm *beater
 		var err error
 		apm, teardown, err = setupServer(t, withSSL(t, test.domain))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		baseUrl, client := apm.client(test.insecure)
 		if test.overrideProtocol {
 			baseUrl = strings.Replace(baseUrl, "https", "http", 1)
@@ -289,7 +291,7 @@ func TestServerTcpConnLimit(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	apm, teardown, err := setupServer(t, ucfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer teardown()
 
 	conns := make([]net.Conn, backlog+maxConns)
@@ -409,7 +411,7 @@ func setupTestServerTracing(t *testing.T, enabled bool) (chan beat.Event, func()
 	})
 	assert.NoError(t, err)
 	beater, teardown, err := setupBeater(t, pub, cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// onboarding event
 	e := <-events

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -45,7 +45,8 @@ func TestMain(m *testing.M) {
 }
 
 func TestServerOk(t *testing.T) {
-	apm, teardown := setupServer(t, nil)
+	apm, teardown, err := setupServer(t, nil)
+	assert.NoError(t, err)
 	defer teardown()
 
 	baseUrl, client := apm.client(false)
@@ -75,7 +76,8 @@ func TestServerTcpNoPort(t *testing.T) {
 		"host": "localhost",
 	})
 	assert.NoError(t, err)
-	btr, teardown := setupServer(t, ucfg)
+	btr, teardown, err := setupServer(t, ucfg)
+	assert.NoError(t, err)
 	defer teardown()
 
 	baseUrl, client := btr.client(false)
@@ -101,7 +103,8 @@ func TestServerOkUnix(t *testing.T) {
 	addr := tmpTestUnix(t)
 	ucfg, err := common.NewConfigFrom(m{"host": "unix:" + addr})
 	assert.NoError(t, err)
-	btr, stop := setupServer(t, ucfg)
+	btr, stop, err := setupServer(t, ucfg)
+	assert.NoError(t, err)
 	defer stop()
 
 	baseUrl, client := btr.client(false)
@@ -111,7 +114,8 @@ func TestServerOkUnix(t *testing.T) {
 }
 
 func TestServerHealth(t *testing.T) {
-	apm, teardown := setupServer(t, nil)
+	apm, teardown, err := setupServer(t, nil)
+	assert.NoError(t, err)
 	defer teardown()
 
 	baseUrl, client := apm.client(false)
@@ -124,7 +128,8 @@ func TestServerHealth(t *testing.T) {
 func TestServerFrontendSwitch(t *testing.T) {
 	ucfg, err := common.NewConfigFrom(m{"frontend": m{"enabled": true, "allow_origins": []string{"*"}}})
 	assert.NoError(t, err)
-	apm, teardown := setupServer(t, ucfg)
+	apm, teardown, err := setupServer(t, ucfg)
+	assert.NoError(t, err)
 	defer teardown()
 
 	baseUrl, client := apm.client(false)
@@ -179,7 +184,8 @@ func TestServerCORS(t *testing.T) {
 		ucfg, err := common.NewConfigFrom(m{"frontend": m{"enabled": true, "allow_origins": test.allowedOrigins}})
 		assert.NoError(t, err)
 		var apm *beater
-		apm, teardown = setupServer(t, ucfg)
+		apm, teardown, err = setupServer(t, ucfg)
+		assert.NoError(t, err)
 		baseUrl, client := apm.client(false)
 		req, err := http.NewRequest("POST", baseUrl+FrontendTransactionsURL, bytes.NewReader(testData))
 		req.Header.Set("Origin", test.origin)
@@ -192,7 +198,8 @@ func TestServerCORS(t *testing.T) {
 }
 
 func TestServerNoContentType(t *testing.T) {
-	apm, teardown := setupServer(t, nil)
+	apm, teardown, err := setupServer(t, nil)
+	assert.NoError(t, err)
 	defer teardown()
 
 	baseUrl, client := apm.client(false)
@@ -239,7 +246,9 @@ func TestServerSSL(t *testing.T) {
 	defer teardown() // in case test crashes. calling teardown twice is ok
 	for idx, test := range tests {
 		var apm *beater
-		apm, teardown = setupServer(t, withSSL(t, test.domain))
+		var err error
+		apm, teardown, err = setupServer(t, withSSL(t, test.domain))
+		assert.NoError(t, err)
 		baseUrl, client := apm.client(test.insecure)
 		if test.overrideProtocol {
 			baseUrl = strings.Replace(baseUrl, "https", "http", 1)
@@ -279,7 +288,8 @@ func TestServerTcpConnLimit(t *testing.T) {
 		"max_connections": maxConns,
 	})
 	assert.NoError(t, err)
-	apm, teardown := setupServer(t, ucfg)
+	apm, teardown, err := setupServer(t, ucfg)
+	assert.NoError(t, err)
 	defer teardown()
 
 	conns := make([]net.Conn, backlog+maxConns)
@@ -398,7 +408,8 @@ func setupTestServerTracing(t *testing.T, enabled bool) (chan beat.Event, func()
 		"host":    "localhost:0",
 	})
 	assert.NoError(t, err)
-	beater, teardown := setupBeater(t, pub, cfg)
+	beater, teardown, err := setupBeater(t, pub, cfg)
+	assert.NoError(t, err)
 
 	// onboarding event
 	e := <-events
@@ -415,7 +426,7 @@ func setupTestServerTracing(t *testing.T, enabled bool) (chan beat.Event, func()
 	return events, teardown
 }
 
-func setupServer(t *testing.T, cfg *common.Config) (*beater, func()) {
+func setupServer(t *testing.T, cfg *common.Config) (*beater, func(), error) {
 	if testing.Short() {
 		t.Skip("skipping server test")
 	}
@@ -428,10 +439,11 @@ func setupServer(t *testing.T, cfg *common.Config) (*beater, func()) {
 		err = cfg.Unpack(baseConfig)
 	}
 	assert.NoError(t, err)
-	btr, stop := setupBeater(t, DummyPipeline(), baseConfig)
-
-	assert.NotEqual(t, btr.config.Host, "localhost:0", "config.Host unmodified")
-	return btr, stop
+	btr, stop, err := setupBeater(t, DummyPipeline(), baseConfig)
+	if err == nil {
+		assert.NotEqual(t, btr.config.Host, "localhost:0", "config.Host unmodified")
+	}
+	return btr, stop, err
 }
 
 var testData = func() []byte {
@@ -467,7 +479,7 @@ func makeTransactionRequest(t *testing.T, baseUrl string) *http.Request {
 	return req
 }
 
-func waitForServer(url string, client *http.Client) {
+func waitForServer(url string, client *http.Client, c chan error) {
 	var check = func() int {
 		var res *http.Response
 		var err error
@@ -478,13 +490,12 @@ func waitForServer(url string, client *http.Client) {
 		return res.StatusCode
 	}
 
-	for i := 0; i <= 1000; i++ {
+	for {
 		time.Sleep(time.Second / 50)
 		if check() == http.StatusOK {
-			return
+			c <- nil
 		}
 	}
-	panic("server run timeout (10 seconds)")
 }
 
 func body(t *testing.T, response *http.Response) string {


### PR DESCRIPTION
... and return immediately instead of timing out

(in support for https://github.com/elastic/apm-server/pull/1010, ie: passing a wrong passphrase will cause the beater to fail, and test should fail right away with a descriptive reason)
