### PR TITLE
Attempt at making sure "Added", "Bug fixes" etc. stay on the same page.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -10,6 +10,7 @@
 
 https://github.com/elastic/apm-server/compare/6.3\...master[View commits]
 
+[float]
 === Added
 
 - Listen on default port 8200 if unspecified {pull}886[886].
@@ -24,6 +25,7 @@ https://github.com/elastic/apm-server/compare/6.3\...master[View commits]
 == APM Server version 6.3
 https://github.com/elastic/apm-server/compare/6.2\...6.3[View commits]
 
+[float]
 === Bug fixes
 
 - Accept charset in request's content type {pull}677[677].
@@ -34,6 +36,7 @@ https://github.com/elastic/apm-server/compare/6.2\...6.3[View commits]
 - Return proper response code for request entity too large {pull}862[862].
 - Make APM Server docker image listen on all interfaces by default https://github.com/elastic/apm-server-docker/pull/16[apm-server-dockers#16]
 
+[float]
 === Added
 
 - Enriched data with IP and UserAgent {pull}393[393], {pull}701[701], {pull}730[730], {pull}923[923].
@@ -53,6 +56,7 @@ https://github.com/elastic/apm-server/compare/6.2\...6.3[View commits]
 == APM Server version 6.2
 https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828e0761d\...4daa36bd5c144cf9182afc62dc8042af663756c6[View commits]
 
+[float]
 === Breaking changes
 - Renaming and reverse boolean `in_app` to `library_frame` {pull}385[385].
 - Renaming `app` to `service` {pull}377[377]
@@ -63,12 +67,14 @@ https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828
 - Rename Kibana directories according to changed structure in beats framework. {pull}454[454]
 - Change config option `max_header_bytes` to `max_header_size` {pull}492[492].
 
+[float]
 === Bug fixes
 - Updated systemd doc url {pull}354[354]
 - Updated readme doc urls {pull}356[356]
 - Use updated stack trace frame values for calculating error `grouping_keys` {pull}485[485]
 - Fix panic when a signal is delivered before the server is instantiated {pull}580[580]
 
+[float]
 === Added
 - Include build time and revision in version information {pull}396[396]
 - service.environment {pull}366[366]
@@ -99,11 +105,13 @@ https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828
 == APM Server version 6.1
 https://github.com/elastic/apm-server/compare/f9a2086ceed0b918e1a0b3d8ddc140fc21af0e74\...421db9d1e10935e7b9aec00b64cf66ad2d50d797[View commits]
 
+[float]
 === Breaking changes
 - Allow ES template index prefix to be `apm` {pull}152[152].
 - Remove `git_ref` from Intake API and Elasticsearch output {pull}158[158].
 - Switch to Go 1.9.2
 
+[float]
 === Bug fixes
 - Fix dashboard loading for Kibana 5x {pull}221[221].
 - Fix command for loading dashboards in docs {pull}205[205].
@@ -115,6 +123,7 @@ https://github.com/elastic/apm-server/compare/f9a2086ceed0b918e1a0b3d8ddc140fc21
 - Update dashboard with fix for rpm graphs {pull}315[315].
 - Dashboards: Remove time from url_templates {pull}321[321].
 
+[float]
 === Added
 - Added wildcard matching for allowed origins for frontend {pull}287[287].
 - Added rate limit per IP for frontend {pull}257[257].
@@ -131,6 +140,7 @@ https://github.com/elastic/apm-server/compare/f9a2086ceed0b918e1a0b3d8ddc140fc21
 == APM Server version 0.2.0
 https://github.com/elastic/apm-server/compare/3ad33b3129c0be3b0e4057efc53948c381a2af79\...f9a2086ceed0b918e1a0b3d8ddc140fc21af0e74[View commits]
 
+[float]
 === Breaking changes
 - Changed response status code in the API from 201 to 202 {pull}34[34]
 - Set dynamic mapping to false, enable only for `context.tags`. Fix issues with indexing. Removed from index: `request.headers_sent`, `app.argv`. Changes take place with {pull}43[43], after updating beats framework.
@@ -141,6 +151,7 @@ https://github.com/elastic/apm-server/compare/3ad33b3129c0be3b0e4057efc53948c381
 - Changed default APM Server listen port from 8080 to 8200 {pull}91[91].
 - Removed `debug` unneeded handler. {pull}85[85].
 
+[float]
 === Bug fixes
 - changed `context.system.title` to `context.system.process_title`, removed `transaction.context`, `trace.context` (already available on top level). {pull}10[10]
 - changed type of `context.request.body` from `object` to `text`. {pull}27[27]
@@ -148,8 +159,8 @@ https://github.com/elastic/apm-server/compare/3ad33b3129c0be3b0e4057efc53948c381
 - forced apm-server to stop if/when the underlying http server is not running. Exit code is 0 for SIGINT / SIGTERM, 1 otherwise. {pull}94[94]
 - close http server immediately if it doesn't shutdown gracefully after a configurable timeout. {pull}107[107]
 
+[float]
 === Added
-
 - apm-server now returns JSON error responses when the Accept header allows for it.
 - Added `context.request.http_version` property {pull}52[52]
 - Added `shutdown_timeout` config attribute {pull}107[107]


### PR DESCRIPTION
This should put the individual sections "Added", "Bug fixes" on the same page as the headline:
![image](https://user-images.githubusercontent.com/744/42082832-52b56d82-7b89-11e8-9e51-5b592de08bea.png)


Instead of the current situation:

![image](https://user-images.githubusercontent.com/744/42082843-5ec2d06a-7b89-11e8-9187-c99e5d271b9b.png)
