### PR TITLE
[6.x] load generated fields (#986)

a64eb29cce2e0c84074d169534083761f5d3795c introduced replacement of
fields.yml with generated fields.go.  Ensure this is loaded at
startup.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/elastic/apm-server/beater"
+	_ "github.com/elastic/apm-server/include"
 	"github.com/elastic/beats/libbeat/cmd"
 )
 


### PR DESCRIPTION
Backports the following commits to 6.x:
 - load generated fields 

a64eb29cce2e0c84074d169534083761f5d3795c introduced replacement of
fields.yml with generated fields.go.  Ensure this is loaded at
startup. (#986)