### PR TITLE
[6.x] Remove experimental note for frontend agent. (#1041)

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -40,9 +40,8 @@ apm-server:
   #ssl.certificate : "path/to/cert"
   #ssl.key : "path/to/private_key"
 
-  # Please be aware that frontend support is an experimental feature at the moment!
   frontend:
-    # To enable experimental frontend support set this to true.
+    # To enable frontend support set this to true.
     enabled: false
 
     # Rate limit per second and IP address for requests sent to the frontend endpoint.
@@ -305,7 +304,7 @@ output.elasticsearch:
   # - error
   # - transaction
   # - span
-  # - sourcemap (experimental feature)
+  # - sourcemap
   #
   # The indices are all prefixed with `apm-%{[beat.version]}`.
   # To allow managing indices based on their age, all indices (except for sourcemaps) 

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -40,9 +40,8 @@ apm-server:
   #ssl.certificate : "path/to/cert"
   #ssl.key : "path/to/private_key"
 
-  # Please be aware that frontend support is an experimental feature at the moment!
   frontend:
-    # To enable experimental frontend support set this to true.
+    # To enable frontend support set this to true.
     enabled: false
 
     # Rate limit per second and IP address for requests sent to the frontend endpoint.
@@ -305,7 +304,7 @@ output.elasticsearch:
   # - error
   # - transaction
   # - span
-  # - sourcemap (experimental feature)
+  # - sourcemap
   #
   # The indices are all prefixed with `apm-%{[beat.version]}`.
   # To allow managing indices based on their age, all indices (except for sourcemaps) 

--- a/docs/error-api.asciidoc
+++ b/docs/error-api.asciidoc
@@ -20,7 +20,7 @@ To send an error record you need to send a `HTTP POST` request to the APM Server
 http(s)://{hostname}:{port}/v1/errors
 ------------------------------------------------------------
 
-To send a record for a frontend error (see <<frontend,experimental frontend support>>), 
+To send a record for a frontend error (see <<frontend,frontend support>>), 
 you need to send a `HTTP POST` request to the APM Server `frontend errors` endpoint:
 
 [source,bash]

--- a/docs/frontend.asciidoc
+++ b/docs/frontend.asciidoc
@@ -1,15 +1,13 @@
 [[frontend]]
 == Frontend support
 
-NOTE: Frontend support is an experimental feature not intended for production usage at the moment. 
-
 This section describes features specifically designed to support frontend application monitoring
-and a guide on how to enable experimental frontend support. 
+and a guide on how to enable frontend support. 
 
 [[frontend-enable]]
 [float]
 === Enable Frontend Support
-To try out experimental frontend support, set the `apm-server.frontend.enabled` to `true`.
+To try out frontend support, set the `apm-server.frontend.enabled` to `true`.
 See https://github.com/elastic/apm-server/blob/{doc-branch}/apm-server.yml[`apm-server.yml`] for configuration options.
 
 Read more about frontend specific features:

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -20,7 +20,7 @@ To send a transaction record you need to send a `HTTP POST` request to the APM S
 http(s)://{hostname}:{port}/v1/transactions
 ------------------------------------------------------------
 
-To send a record for a frontend transaction (see <<frontend,experimental frontend support>>), 
+To send a record for a frontend transaction (see <<frontend,frontend support>>), 
 you need to send a `HTTP POST` request to the APM Server `frontend transactions` endpoint:
 
 [source,bash]


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Remove experimental note for frontend agent.  (#1041)