### PR TITLE
[6.2] add jenkins release wrapper

### DIFF
--- a/_beats/dev-tools/jenkins_release.sh
+++ b/_beats/dev-tools/jenkins_release.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+source ./_beats/dev-tools/common.bash && jenkins_setup
+
+cleanup() {
+  rm -rf $TEMP_PYTHON_ENV
+}
+trap cleanup EXIT
+
+# Run the deploy script with the appropriate version in the environment.
+cd ${WORKSPACE}/src/github.com/elastic/apm-server
+make SNAPSHOT=yes clean update package
+
+ln -s ${WORKSPACE}/src/github.com/elastic/apm-server/build/upload ${WORKSPACE}/src/github.com/elastic/apm-server/build/distributions

--- a/script/update_beats.sh
+++ b/script/update_beats.sh
@@ -25,6 +25,7 @@ git clone https://github.com/elastic/beats.git ${GIT_CLONE}
 rsync -crpv --delete \
     --exclude=dev-tools/packer/readme.md.j2 \
     --exclude=dev-tools/generate_notice.py \
+    --exclude=dev-tools/jenkins_release.sh \
     --include="dev-tools/***" \
     --include="script/***" \
     --include="testing/***" \


### PR DESCRIPTION
As of #1053, this path is used to trigger package tests on master. This change wraps the 6.2 version of package tests at the new path so a single jenkins configuration can be used for both versions.