### PR TITLE
[6.x] incorporate TLS key passphrase support from beats. (#1010)

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -39,6 +39,8 @@ apm-server:
   #ssl.enabled: false
   #ssl.certificate : "path/to/cert"
   #ssl.key : "path/to/private_key"
+  # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
+  #ssl.key_passphrase: ""
 
   frontend:
     # To enable frontend support set this to true.

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -39,6 +39,8 @@ apm-server:
   #ssl.enabled: false
   #ssl.certificate : "path/to/cert"
   #ssl.key : "path/to/private_key"
+  # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
+  #ssl.key_passphrase: ""
 
   frontend:
     # To enable frontend support set this to true.

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -103,7 +103,7 @@ func TestBeatConfig(t *testing.T) {
 				WriteTimeout:        4000000000,
 				ShutdownTimeout:     9000000000,
 				SecretToken:         "1234random",
-				SSL:                 &SSLConfig{Enabled: &truthy, PrivateKey: "1234key", Cert: "1234cert"},
+				SSL:                 &SSLConfig{Enabled: &truthy, Certificate: outputs.CertificateConfig{Certificate: "1234cert", Key: "1234key"}},
 				AugmentEnabled:      true,
 				Expvar: &ExpvarConfig{
 					Enabled: &truthy,
@@ -155,7 +155,7 @@ func TestBeatConfig(t *testing.T) {
 				WriteTimeout:        30000000000,
 				ShutdownTimeout:     5000000000,
 				SecretToken:         "1234random",
-				SSL:                 &SSLConfig{Enabled: &truthy, PrivateKey: "", Cert: ""},
+				SSL:                 &SSLConfig{Enabled: &truthy, Certificate: outputs.CertificateConfig{Certificate: "", Key: ""}},
 				AugmentEnabled:      true,
 				Expvar: &ExpvarConfig{
 					Enabled: &truthy,

--- a/beater/config.go
+++ b/beater/config.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/elastic/apm-server/sourcemap"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/outputs"
 )
 
 const defaultPort = "8200"
@@ -75,9 +76,8 @@ type Cache struct {
 }
 
 type SSLConfig struct {
-	Enabled    *bool  `config:"enabled"`
-	PrivateKey string `config:"key"`
-	Cert       string `config:"certificate"`
+	Enabled     *bool                     `config:"enabled"`
+	Certificate outputs.CertificateConfig `config:",inline"`
 }
 
 type TraceConfig struct {

--- a/beater/config_test.go
+++ b/beater/config_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/go-ucfg/yaml"
 )
 
@@ -70,7 +71,7 @@ func TestConfig(t *testing.T) {
 				WriteTimeout:    4000000000,
 				ShutdownTimeout: 9000000000,
 				SecretToken:     "1234random",
-				SSL:             &SSLConfig{Enabled: &truthy, PrivateKey: "1234key", Cert: "1234cert"},
+				SSL:             &SSLConfig{Enabled: &truthy, Certificate: outputs.CertificateConfig{Certificate: "1234cert", Key: "1234key"}},
 				Frontend: &FrontendConfig{
 					Enabled:      &truthy,
 					RateLimit:    1000,
@@ -109,7 +110,7 @@ func TestConfig(t *testing.T) {
 				WriteTimeout:       2000000000,
 				ShutdownTimeout:    5000000000,
 				SecretToken:        "1234random",
-				SSL:                &SSLConfig{Enabled: nil, PrivateKey: "", Cert: ""},
+				SSL:                &SSLConfig{Enabled: nil, Certificate: outputs.CertificateConfig{Certificate: "", Key: ""}},
 				ConcurrentRequests: 20,
 				Frontend: &FrontendConfig{
 					Enabled:      nil,
@@ -158,9 +159,9 @@ func TestIsEnabled(t *testing.T) {
 	}{
 		{config: nil, expected: false},
 		{config: &SSLConfig{Enabled: nil}, expected: true},
-		{config: &SSLConfig{Cert: "Cert"}, expected: true},
-		{config: &SSLConfig{Cert: "Cert", PrivateKey: "key"}, expected: true},
-		{config: &SSLConfig{Cert: "Cert", PrivateKey: "key", Enabled: &falsy}, expected: false},
+		{config: &SSLConfig{Certificate: outputs.CertificateConfig{Certificate: "Cert"}}, expected: true},
+		{config: &SSLConfig{Certificate: outputs.CertificateConfig{Certificate: "Cert", Key: "key"}}, expected: true},
+		{config: &SSLConfig{Certificate: outputs.CertificateConfig{Certificate: "Cert", Key: "key"}, Enabled: &falsy}, expected: false},
 		{config: &SSLConfig{Enabled: &truthy}, expected: true},
 		{config: &SSLConfig{Enabled: &falsy}, expected: false},
 	}


### PR DESCRIPTION
Backports the following commits to 6.x:
 - incorporate TLS key passphrase support from beats.  (#1010)