### PR TITLE
[6.x] Split changelog per patch version and add links for better visualization in docs (#1087)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -9,6 +9,7 @@
 
 
 https://github.com/elastic/apm-server/compare/6.3\...6.x[View commits]
+https://github.com/elastic/apm-server/compare/6.3\...master[View commits]
 
 [float]
 === Added
@@ -26,10 +27,28 @@ https://github.com/elastic/apm-server/compare/6.3\...6.x[View commits]
 
 [[release-notes-6.3]]
 == APM Server version 6.3
+
 https://github.com/elastic/apm-server/compare/6.2\...6.3[View commits]
 
+* <<release-notes-6.3.1>>
+* <<release-notes-6.3.0>>
+
+
+[[release-notes-6.3.1]]
+=== APM Server version 6.3.1
+
+https://github.com/elastic/apm-server/compare/v6.3.0\...v6.3.1[View commits]
+
+No significant changes.
+
+
+[[release-notes-6.3.0]]
+=== APM Server version 6.3.0
+
+https://github.com/elastic/apm-server/compare/v6.2.4\...v6.3.0[View commits]
+
 [float]
-=== Bug fixes
+==== Bug fixes
 
 - Accept charset in request's content type {pull}677[677].
 - Use type integer instead of number in JSON schemas where applicable {pull}641[641].
@@ -40,7 +59,7 @@ https://github.com/elastic/apm-server/compare/6.2\...6.3[View commits]
 - Make APM Server docker image listen on all interfaces by default https://github.com/elastic/apm-server-docker/pull/16[apm-server-dockers#16]
 
 [float]
-=== Added
+==== Added
 
 - Enriched data with IP and UserAgent {pull}393[393], {pull}701[701], {pull}730[730], {pull}923[923].
 - Push errors and transactions to different ES indices {pull}706[706].
@@ -57,10 +76,51 @@ https://github.com/elastic/apm-server/compare/6.2\...6.3[View commits]
 
 [[release-notes-6.2]]
 == APM Server version 6.2
-https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828e0761d\...4daa36bd5c144cf9182afc62dc8042af663756c6[View commits]
+
+https://github.com/elastic/apm-server/compare/6.1...6.2[View commits]
+
+* <<release-notes-6.2.4>>
+* <<release-notes-6.2.3>>
+* <<release-notes-6.2.2>>
+* <<release-notes-6.2.1>>
+* <<release-notes-6.2.0>>
+
+
+[[release-notes-6.2.4]]
+=== APM Server version 6.2.4
+
+https://github.com/elastic/apm-server/compare/v6.2.3\...v6.2.4[View commits]
+
+No significant changes.
+
+[[release-notes-6.2.3]]
+=== APM Server version 6.2.3
+
+https://github.com/elastic/apm-server/compare/v6.2.2\...v6.2.3[View commits]
+
+No significant changes.
+
+[[release-notes-6.2.2]]
+=== APM Server version 6.2.2
+
+https://github.com/elastic/apm-server/compare/v6.2.1\...v6.2.2[View commits]
+
+No significant changes.
+
+[[release-notes-6.2.1]]
+=== APM Server version 6.2.1
+
+https://github.com/elastic/apm-server/compare/v6.2.0\...v6.2.1[View commits]
+
+No significant changes.
+
+[[release-notes-6.2.0]]
+=== APM Server version 6.2.0
+
+https://github.com/elastic/apm-server/compare/v6.1.4\...v6.2.0[View commits]
 
 [float]
-=== Breaking changes
+==== Breaking changes
 - Renaming and reverse boolean `in_app` to `library_frame` {pull}385[385].
 - Renaming `app` to `service` {pull}377[377]
 - Move `trace.transaction_id` to `transaction.id` {pull}345[345], {pull}347[347], {pull}371[371]
@@ -69,18 +129,18 @@ https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828
 - Move process related fields to their own namespace {pull}445[445].
 - Rename Kibana directories according to changed structure in beats framework. {pull}454[454]
 - Change config option `max_header_bytes` to `max_header_size` {pull}492[492].
+- Change config option `frontend.sourcemapping.index` to `frontend.source_mapping.index_pattern` and remove adding a '*' by default.{pull}492[492].
 - Remove untested config options from config yml files {pull}496[496]
 
 [float]
-=== Bug fixes
+==== Bug fixes
 - Updated systemd doc url {pull}354[354]
 - Updated readme doc urls {pull}356[356]
 - Use updated stack trace frame values for calculating error `grouping_keys` {pull}485[485]
 - Fix panic when a signal is delivered before the server is instantiated {pull}580[580]
 
 [float]
-=== Added
-- Include build time and revision in version information {pull}396[396]
+==== Added
 - service.environment {pull}366[366]
 - Consider exception or log message for grouping key when nothing else is available {pull}435[435]
 - Add context.request.url.full {pull}436[436]
@@ -94,7 +154,6 @@ https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828
 - Optional field `transaction.sampled` {pull}441[441]
 - Add Kibana sourcefilter for `sourcemap.sourcemap` {pull}454[454]
 - Increase default 'ConcurrentRequests' from 20 to 40 {pull}492[492]
-- Change config option `frontend.sourcemapping.index` to `frontend.source_mapping.index_pattern` and remove adding a '*' by default.{pull}492[492].
 - Add Config option for excluding stack trace frames from `grouping_key` calculation {pull}482[482]
 - Expose expvar {pull}509[509]
 - Add `process.ppid` as optional field {pull}564[564]
@@ -107,16 +166,61 @@ https://github.com/elastic/apm-server/compare/71df0d96445df35afe27f38bcf734a0828
 
 [[release-notes-6.1]]
 == APM Server version 6.1
-https://github.com/elastic/apm-server/compare/f9a2086ceed0b918e1a0b3d8ddc140fc21af0e74\...421db9d1e10935e7b9aec00b64cf66ad2d50d797[View commits]
+
+https://github.com/elastic/apm-server/compare/6.0\...6.1[View commits]
+
+* <<release-notes-6.1.4>>
+* <<release-notes-6.1.3>>
+* <<release-notes-6.1.2>>
+* <<release-notes-6.1.1>>
+* <<release-notes-6.1.0>>
+
+
+[[release-notes-6.1.4]]
+=== APM Server version 6.1.4
+
+https://github.com/elastic/apm-server/compare/v6.1.3\...v6.1.4[View commits]
+
+No significant changes.
+
+
+[[release-notes-6.1.3]]
+=== APM Server version 6.1.3
+
+https://github.com/elastic/apm-server/compare/v6.1.2\...v6.1.3[View commits]
+
+No significant changes.
+
+
+[[release-notes-6.1.2]]
+=== APM Server version 6.1.2
+
+https://github.com/elastic/apm-server/compare/v6.1.1\...v6.1.2[View commits]
+
+No significant changes.
+
+
+[[release-notes-6.1.1]]
+=== APM Server version 6.1.1
+
+https://github.com/elastic/apm-server/compare/v6.1.0\...v6.1.1[View commits]
+
+No significant changes.
+
+
+[[release-notes-6.1.0]]
+=== APM Server version 6.1.0
+
+https://github.com/elastic/apm-server/compare/v6.0.1\...v6.1.0[View commits]
 
 [float]
-=== Breaking changes
+==== Breaking changes
 - Allow ES template index prefix to be `apm` {pull}152[152].
 - Remove `git_ref` from Intake API and Elasticsearch output {pull}158[158].
 - Switch to Go 1.9.2
 
 [float]
-=== Bug fixes
+==== Bug fixes
 - Fix dashboard loading for Kibana 5x {pull}221[221].
 - Fix command for loading dashboards in docs {pull}205[205].
 - Log a warning message if secret token is set but ssl is not {pull}204[204].
@@ -126,9 +230,10 @@ https://github.com/elastic/apm-server/compare/f9a2086ceed0b918e1a0b3d8ddc140fc21
 - Updated systemd doc url {pull}354[354]
 - Update dashboard with fix for rpm graphs {pull}315[315].
 - Dashboards: Remove time from url_templates {pull}321[321].
+- Updated readme doc urls {pull}356[356]
 
 [float]
-=== Added
+==== Added
 - Added wildcard matching for allowed origins for frontend {pull}287[287].
 - Added rate limit per IP for frontend {pull}257[257].
 - Allow null for all optional fields {pull}253[253].
@@ -139,6 +244,7 @@ https://github.com/elastic/apm-server/compare/f9a2086ceed0b918e1a0b3d8ddc140fc21
 - Added Kibana 5.6 compatible dashboards {pull}208[208].
 - Send document to output on start of server {pull}117[117].
 - Log frontend status at startup  {pull}284[284].
+
 
 [[release-notes-0.2]]
 == APM Server version 0.2.0


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Split changelog per patch version and add links for better visualization in docs  (#1087)