### PR TITLE
Fix links to Javascript agent.

### DIFF
--- a/docs/configuration-rum.asciidoc
+++ b/docs/configuration-rum.asciidoc
@@ -12,5 +12,5 @@ To try out experimental real user monitoring, set the `apm-server.frontend.enabl
 See https://github.com/elastic/apm-server/blob/{doc-branch}/apm-server.yml[`apm-server.yml`] for configuration options.
 
 Read more about specific features related to experimental <<rum, real user monitoring>>
-and how to set up the
-{apm-rum-ref}/index.html[JavaScript RUM Agent].
+and how to set up the 
+https://github.com/elastic/apm-agent-js-base[JavaScript Frontend Agent].

--- a/docs/error-api.asciidoc
+++ b/docs/error-api.asciidoc
@@ -21,7 +21,7 @@ http(s)://{hostname}:{port}/v1/errors
 ------------------------------------------------------------
 
 To send a record for an error monitored by the
-{apm-rum-ref}/index.html[JavaScript RUM Agent]
+https://github.com/elastic/apm-agent-js-base[JavaScript Frontend Agent]
 you need to send a `HTTP POST` request to the experimental APM Server `client-side errors` endpoint:
 
 [source,bash]

--- a/docs/rum.asciidoc
+++ b/docs/rum.asciidoc
@@ -7,7 +7,8 @@ NOTE: Real user monitoring is an experimental feature not intended for productio
 
 By supporting real user monitoring (RUM).
 Elastic APM allows to collect performance data about your frontend JavaScript applications 
-by setting up the {apm-rum-ref}/index.html[JavaScript RUM Agent].
+by setting up the 
+https://github.com/elastic/apm-agent-js-base[JavaScript Frontend Agent].
 
 You can make use of <<sourcemaps, source maps>> when using Elastic RUM. 
 --

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -21,7 +21,7 @@ http(s)://{hostname}:{port}/v1/transactions
 ------------------------------------------------------------
 
 To send a record for a transaction monitored by the 
-{apm-rum-ref}/index.html[JavaScript RUM Agent]
+https://github.com/elastic/apm-agent-js-base[JavaScript Frontend Agent]
 you need to send a `HTTP POST` request to the experimental APM Server `client-side transactions` endpoint:
 
 [source,bash]


### PR DESCRIPTION
The usage of `apm-rum-ref` broke the docs build, so changing back to pointing to the github project for the `6.3` branch for the moment.