### PR TITLE
Docs: Add server upgrade instructions.

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -30,6 +30,8 @@ include::./overview.asciidoc[]
 
 include::./installing.asciidoc[]
 
+include::./upgrading.asciidoc[]
+
 include::./setting-up-and-running.asciidoc[]
 
 include::./configuring.asciidoc[]

--- a/docs/installing.asciidoc
+++ b/docs/installing.asciidoc
@@ -12,4 +12,7 @@ You can also install APM Server from our repositories or install as a service on
 To run APM Server in Docker, please see <<running-on-docker>>.
 
 include::./copied-from-beats/repositories.asciidoc[]
+
 include::./installing-on-windows.asciidoc[]
+
+include::./upgrading.asciidoc[]

--- a/docs/installing.asciidoc
+++ b/docs/installing.asciidoc
@@ -14,5 +14,3 @@ To run APM Server in Docker, please see <<running-on-docker>>.
 include::./copied-from-beats/repositories.asciidoc[]
 
 include::./installing-on-windows.asciidoc[]
-
-include::./upgrading.asciidoc[]

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -1,16 +1,16 @@
 [[upgrading]]
-=== Upgrading APM Server
+== Upgrading APM Server
 
 We do our best to keep APM Server backwards compatible between minor releases.
-However, check out the <<breaking-changes, breaking changes>> section before upgrading.
+However, check out the <<breaking-changes, breaking changes>> section for exceptions.
 
-Before upgrading we recommend to:
+Before upgrading:
 
-* Review changes between your currently used version and the one you want to upgrade to,
-by checking the <<release-notes,release notes>>.
+* Review the <<release-notes,release notes>> and the <<breaking-changes, breaking changes>> 
+for changes between your current version and the one you are upgrading to.
 * Check the {stack-ref}/index.html[Elastic Stack Installation and Upgrade Guide] for guidance on how to upgrade your 
- Elastic Stack used in combination with APM. 
- For a more tailored upgrade guide you can also try out the {upgrade_guide}[Interactive Upgrade Guide].
+ Elastic Stack. 
+ For a more tailored upgrade guide, try out the {upgrade_guide}[Interactive Upgrade Guide].
 
 When ready to actually upgrade your APM Server between minor versions, 
 simply install the new release.
@@ -20,30 +20,31 @@ Be aware of newly added configuration options and their default settings.
 Also check out the documentation for <<configuring-howto-apm-server, configuration>>
 to read more about available configuration options.
 
-In case you had set up index patterns and dashboards manually by running `./apm-server setup`, 
-rerun the command to update the index pattern and the dashboards.
+If you set up index patterns and dashboards manually by running `./apm-server setup`, rerun
+the command to update the index pattern and the dashboards.
 
-When you have ensured everything is properly configured and updated,
-start the APM Server again.
+When everything is properly configured and updated, start the APM server.
 
-By default index names and the mapping templates are versioned. 
-When starting the new installation of APM Server new indices with the current version are created, 
-and the correct template for this version is applied automatically. 
+When you start the APM server after upgrading, it creates new indices that use the current version,
+and applies the correct template automatically.
 
 [[breaking-changes]]
-[float]
-==== Breaking Changes
+=== Breaking Changes
 APM Server is built on top of {beats-ref}/index.html[libbeat].
 As such any breaking change in libbeat is also considered to be a breaking change in APM Server.
 
 [float]
-===== HEAD 
-https://www.elastic.co/guide/en/beats/libbeat/master/breaking-changes.html
+==== HEAD 
+no breaking changes in APM Server
+
+https://www.elastic.co/guide/en/beats/libbeat/master/breaking-changes.html[breaking changes in libbeat]
 
 [float]
-===== 6.3
-https://www.elastic.co/guide/en/beats/libbeat/current/breaking-changes-6.3.html
+==== 6.3
+no breaking changes in APM Server
+
+https://www.elastic.co/guide/en/beats/libbeat/current/breaking-changes-6.3.html[breaking changes in libbeat]
 
 [float]
-===== 6.2
+==== 6.2
 First stable version.

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -1,0 +1,47 @@
+[[upgrading]]
+=== Upgrading APM Server
+
+We do our best to keep APM Server backwards compatible between minor releases.
+However, check out the <<breaking-changes, breaking changes>> section before upgrading.
+
+Before upgrading we recommend to:
+
+* Review changes between your currently used version and the one you want to upgrade to,
+by checking the <<release-notes,release notes>>.
+* Check the {stack-ref}/index.html[Elastic Stack Installation and Upgrade Guide] for guidance on how to upgrade your 
+ Elastic Stack used in combination with APM. 
+ For a more tailored upgrade guide you can also try out the {upgrade_guide}[Interactive Upgrade Guide].
+
+When ready to actually upgrade your APM Server between minor versions, 
+simply install the new release.
+
+Ensure the configuration file `apm-server.yml` is configured properly again according to your needs.
+Be aware of newly added configuration options and their default settings.
+Also check out the documentation for <<configuring-howto-apm-server, configuration>>
+to read more about available configuration options.
+
+In case you had set up index patterns and dashboards manually by running `./apm-server setup`, 
+rerun the command to update the index pattern and the dashboards.
+
+When you have ensured everything is properly configured and updated,
+start the APM Server again.
+
+By default index names and the mapping templates are versioned. 
+When starting the new installation of APM Server new indices with the current version are created, 
+and the correct template for this version is applied automatically. 
+
+[[breaking-changes]]
+[float]
+==== Breaking Changes
+
+[float]
+===== master 
+No breaking changes
+
+[float]
+===== 6.3
+No breaking changes
+
+[float]
+===== 6.2
+First stable version.

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -33,14 +33,16 @@ and the correct template for this version is applied automatically.
 [[breaking-changes]]
 [float]
 ==== Breaking Changes
+APM Server is built on top of {beats-ref}/index.html[libbeat].
+As such any breaking change in libbeat is also considered to be a breaking change in APM Server.
 
 [float]
-===== master 
-No breaking changes
+===== HEAD 
+https://www.elastic.co/guide/en/beats/libbeat/master/breaking-changes.html
 
 [float]
 ===== 6.3
-No breaking changes
+https://www.elastic.co/guide/en/beats/libbeat/current/breaking-changes-6.3.html
 
 [float]
 ===== 6.2

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -47,4 +47,4 @@ https://www.elastic.co/guide/en/beats/libbeat/current/breaking-changes-6.3.html[
 
 [float]
 ==== 6.2
-First stable version.
+APM Server GA


### PR DESCRIPTION
implements elastic/apm-server#1008

related to https://github.com/elastic/stack-docs/pull/81

@dedemorton how can I add APM Server to https://www.elastic.co/products/upgrade_guide?

update:
![screen shot 2018-07-17 at 16 36 49](https://user-images.githubusercontent.com/5555349/42824231-adfa1116-89df-11e8-82e4-0bddc4fc0ae6.png)
