### PR TITLE
[6.x] Rename tracing configuration to instrumentation (#1120)

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -27,10 +27,12 @@ apm-server:
   # Maximum number of new connections to accept simultaneously (0 means unlimited)
   # max_connections: 0
 
-  # Tracing support for the server's HTTP endpoints and event publisher.
-  #tracing:
-    # Set to true to enable tracing in the APM server itself.
+  # Instrumentation support for the server's HTTP endpoints and event publisher.
+  #instrumentation:
+    # Set to true to enable instrumentation of the APM server itself.
     #enabled: false
+    # Environment in which the APM Server is running on (eg: staging, production, etc.)
+    #environment: ""
 
   # Authorization token to be checked. If a token is set here the agents must
   # send their token in the following format: Authorization: Bearer <secret-token>.

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -27,10 +27,12 @@ apm-server:
   # Maximum number of new connections to accept simultaneously (0 means unlimited)
   # max_connections: 0
 
-  # Tracing support for the server's HTTP endpoints and event publisher.
-  #tracing:
-    # Set to true to enable tracing in the APM server itself.
+  # Instrumentation support for the server's HTTP endpoints and event publisher.
+  #instrumentation:
+    # Set to true to enable instrumentation of the APM server itself.
     #enabled: false
+    # Environment in which the APM Server is running on (eg: staging, production, etc.)
+    #environment: ""
 
   # Authorization token to be checked. If a token is set here the agents must
   # send their token in the following format: Authorization: Bearer <secret-token>.

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -144,7 +144,7 @@ func (bt *beater) Run(b *beat.Beat) error {
 	g.Go(func() error {
 		return run(bt.server, lis, bt.config)
 	})
-	if bt.config.Tracing.isEnabled() {
+	if bt.config.SelfInstrumentation.isEnabled() {
 		g.Go(func() error {
 			return bt.server.Serve(traceListener)
 		})
@@ -159,21 +159,21 @@ func (bt *beater) Run(b *beat.Beat) error {
 // initTracer configures and returns an elasticapm.Tracer for tracing
 // the APM server's own execution.
 func initTracer(info beat.Info, config *Config, logger *logp.Logger) (*elasticapm.Tracer, net.Listener, error) {
-	if !config.Tracing.isEnabled() {
+	if !config.SelfInstrumentation.isEnabled() {
 		os.Setenv("ELASTIC_APM_ACTIVE", "false")
-		logger.Infof("Tracing is disabled")
+		logger.Infof("self instrumentation is disabled")
 	} else {
 		os.Setenv("ELASTIC_APM_ACTIVE", "true")
-		logger.Infof("Tracing is enabled")
+		logger.Infof("self instrumentation is enabled")
 	}
 
 	tracer, err := elasticapm.NewTracer(info.Beat, info.Version)
 	if err != nil {
 		return nil, nil, err
 	}
-	if config.Tracing.isEnabled() {
-		if config.Tracing.Environment != nil {
-			tracer.Service.Environment = *config.Tracing.Environment
+	if config.SelfInstrumentation.isEnabled() {
+		if config.SelfInstrumentation.Environment != nil {
+			tracer.Service.Environment = *config.SelfInstrumentation.Environment
 		}
 		tracer.SetLogger(logp.NewLogger("tracing"))
 	}

--- a/beater/config.go
+++ b/beater/config.go
@@ -30,22 +30,22 @@ import (
 const defaultPort = "8200"
 
 type Config struct {
-	Host                string          `config:"host"`
-	MaxUnzippedSize     int64           `config:"max_unzipped_size"`
-	MaxHeaderSize       int             `config:"max_header_size"`
-	ReadTimeout         time.Duration   `config:"read_timeout"`
-	WriteTimeout        time.Duration   `config:"write_timeout"`
-	ShutdownTimeout     time.Duration   `config:"shutdown_timeout"`
-	SecretToken         string          `config:"secret_token"`
-	SSL                 *SSLConfig      `config:"ssl"`
-	ConcurrentRequests  int             `config:"concurrent_requests" validate:"min=1"`
-	MaxConnections      int             `config:"max_connections"`
-	MaxRequestQueueTime time.Duration   `config:"max_request_queue_time"`
-	Expvar              *ExpvarConfig   `config:"expvar"`
-	Frontend            *FrontendConfig `config:"frontend"`
-	Metrics             *metricsConfig  `config:"metrics"`
-	AugmentEnabled      bool            `config:"capture_personal_data"`
-	Tracing             *TraceConfig    `config:"tracing"`
+	Host                string                 `config:"host"`
+	MaxUnzippedSize     int64                  `config:"max_unzipped_size"`
+	MaxHeaderSize       int                    `config:"max_header_size"`
+	ReadTimeout         time.Duration          `config:"read_timeout"`
+	WriteTimeout        time.Duration          `config:"write_timeout"`
+	ShutdownTimeout     time.Duration          `config:"shutdown_timeout"`
+	SecretToken         string                 `config:"secret_token"`
+	SSL                 *SSLConfig             `config:"ssl"`
+	ConcurrentRequests  int                    `config:"concurrent_requests" validate:"min=1"`
+	MaxConnections      int                    `config:"max_connections"`
+	MaxRequestQueueTime time.Duration          `config:"max_request_queue_time"`
+	Expvar              *ExpvarConfig          `config:"expvar"`
+	Frontend            *FrontendConfig        `config:"frontend"`
+	Metrics             *metricsConfig         `config:"metrics"`
+	AugmentEnabled      bool                   `config:"capture_personal_data"`
+	SelfInstrumentation *InstrumentationConfig `config:"instrumentation"`
 }
 
 type ExpvarConfig struct {
@@ -85,7 +85,7 @@ type SSLConfig struct {
 	Certificate outputs.CertificateConfig `config:",inline"`
 }
 
-type TraceConfig struct {
+type InstrumentationConfig struct {
 	Enabled     *bool   `config:"enabled"`
 	Environment *string `config:"environment"`
 }
@@ -137,8 +137,8 @@ func (c *FrontendConfig) memoizedSmapMapper() (sourcemap.Mapper, error) {
 	return c.SourceMapping.mapper, nil
 }
 
-func (c *TraceConfig) isEnabled() bool {
-	// Tracing is disabled by default.
+func (c *InstrumentationConfig) isEnabled() bool {
+	// self instrumentation is disabled by default.
 	return c != nil && c.Enabled != nil && *c.Enabled
 }
 

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -365,7 +365,7 @@ func TestServerTcpConnLimit(t *testing.T) {
 }
 
 func TestServerTracingEnabled(t *testing.T) {
-	events, teardown := setupTestServerTracing(t, true)
+	events, teardown := setupTestServerInstrumentation(t, true)
 	defer teardown()
 
 	txEvents := transactionEvents(events)
@@ -397,7 +397,7 @@ func TestServerTracingEnabled(t *testing.T) {
 }
 
 func TestServerTracingDisabled(t *testing.T) {
-	events, teardown := setupTestServerTracing(t, false)
+	events, teardown := setupTestServerInstrumentation(t, false)
 	defer teardown()
 
 	txEvents := transactionEvents(events)
@@ -430,11 +430,11 @@ func transactionEvents(events <-chan beat.Event) <-chan beat.Event {
 	return out
 }
 
-// setupTestServerTracing sets up a beater with or without tracing enabled,
+// setupTestServerInstrumentation sets up a beater with or without instrumentation enabled,
 // and returns a channl to which events are published, and a function to be
 // called to teardown the beater. The initial onboarding event is consumed
 // and a transactions request is made before returning.
-func setupTestServerTracing(t *testing.T, enabled bool) (chan beat.Event, func()) {
+func setupTestServerInstrumentation(t *testing.T, enabled bool) (chan beat.Event, func()) {
 	if testing.Short() {
 		t.Skip("skipping server test")
 	}
@@ -447,8 +447,8 @@ func setupTestServerTracing(t *testing.T, enabled bool) (chan beat.Event, func()
 	pub := publishertesting.PublisherWithClient(pubClient)
 
 	cfg, err := common.NewConfigFrom(m{
-		"tracing": m{"enabled": enabled},
-		"host":    "localhost:0",
+		"instrumentation": m{"enabled": enabled},
+		"host":            "localhost:0",
 	})
 	assert.NoError(t, err)
 	beater, teardown, err := setupBeater(t, pub, cfg)

--- a/docs/configuration-process.asciidoc
+++ b/docs/configuration-process.asciidoc
@@ -5,23 +5,23 @@ Example config showing some basic configuration options for APM Server:
 
 ["source","yaml"]
 ----
-apm-server.host: "localhost:8200" 
-apm-server.max_unzipped_size: 31457280 
+apm-server.host: "localhost:8200"
+apm-server.max_unzipped_size: 31457280
 apm-server.max_header_size: 1048576
-apm-server.max_request_queue_time: 2s 
+apm-server.max_request_queue_time: 2s
 apm-server.read_timeout: 30s
 apm-server.write_timeout: 30s
 apm-server.shutdown_timeout: 5s
-apm-server.concurrent_requests: 5 
+apm-server.concurrent_requests: 5
 apm-server.max_connections: 0
-apm-server.tracing.enabled: false 
-apm-server.capture_personal_data: true 
-apm-server.expvar.enabled: false 
+apm-server.instrumentation.enabled: false
+apm-server.capture_personal_data: true
+apm-server.expvar.enabled: false
 apm-server.expvar.url:"/debug/vars"
-apm-server.metrics.enabled: true 
+apm-server.metrics.enabled: true
 
 queue.mem.events: 4096
-queue.mem.flush.min_events: 0 
+queue.mem.flush.min_events: 0
 queue.mem.flush.timeout: 1s
 
 max_procs: 4
@@ -33,72 +33,70 @@ max_procs: 4
 [[host]]
 [float]
 ==== `host`
-Defines the host and port the server is listening on.  
+Defines the host and port the server is listening on.
 Use "unix:/path/to.sock" to listen on a unix domain socket.
 Defaults to 'localhost:8200'.
 
 [[max_unzipped_size]]
 [float]
-==== `max_unzipped_size` 
+==== `max_unzipped_size`
 Maximum permitted size of an unzipped request accepted by the server to be processed (in Bytes).
 Defaults to 31457280 Bytes (30 MB).
 
 [[max_header_size]]
 [float]
-==== `max_header_size` 
+==== `max_header_size`
 Maximum permitted size of a request's header accepted by the server to be processed (in Bytes).
 Defaults to 1048576 Bytes (1 MB).
 
 [[max_request_queue_time]]
 [float]
-==== `max_request_queue_time` 
+==== `max_request_queue_time`
 Maximum duration a request will be queued before being read.
 Defaults to 2 seconds.
 
 [[read_timeout]]
 [float]
-==== `read_timeout` 
+==== `read_timeout`
 Maximum permitted duration for reading an entire request.
 Defaults to 30 seconds.
 
 [[write_timeout]]
 [float]
-==== `write_timeout` 
+==== `write_timeout`
 Maximum permitted duration for writing a response.
 Defaults to 30 seconds.
 
 [[shutdown_timeout]]
 [float]
-==== `shutdown_timeout` 
+==== `shutdown_timeout`
 Maximum duration in seconds before releasing resources when shutting down the server.
 Defaults to 5 seconds.
 
 [[concurrent_requests]]
 [float]
-==== `concurrent_request` 
+==== `concurrent_request`
 Maximum number of requests a server is allowed to process concurrently.
-Read more about how to tune data ingestion by <<adjust-concurrent-requests, adjusting concurrent_requests>>. 
-Default value is set to 5. 
+Read more about how to tune data ingestion by <<adjust-concurrent-requests, adjusting concurrent_requests>>.
+Default value is set to 5.
 
 [[max_connections]]
 [float]
-==== `max_connections` 
+==== `max_connections`
 Maximum number of new connections to accept simultaneously..
 Default value is set to 0, which means _unlimited_.
 
-[[tracing.enabled]]
+[[instrumentation.enabled]]
 [float]
-==== `tracing.enabled` 
-Tracing support for the server's HTTP endpoints and event publisher.
-When set to true,
-Elastic APM tracing will be enabled for the server itself. 
-Tracing is disabled by default.
+==== `instrumentation.enabled`
+Enables self instrumentation of the APM Server itself.
+Disabled by default.
 
 [[config-secret-token]]
 [float]
-==== `secret_token` 
-Authorization token for sending data to the APM server. 
-If a token is set the agents must send the token in the following format: 
+==== `secret_token`
+Authorization token for sending data to the APM server.
+If a token is set the agents must send the token in the following format:
 Authorization: Bearer <secret-token>.
 By default no authorization token is set.
 
@@ -107,29 +105,29 @@ Read more about <<securing-apm-server, Securing APM Server>> and the <<secret-to
 
 [[capture_personal_data]]
 [float]
-==== `capture_personal_data` 
-If set to true, 
+==== `capture_personal_data`
+If set to true,
 APM Server augments data received by the agent with the original IP of either the backend server,
-or the IP and User Agent of the real user (frontend requests). 
+or the IP and User Agent of the real user (frontend requests).
 It defaults to true.
 
 [[expvar.enabled]]
 [float]
-==== `expvar.enabled` 
+==== `expvar.enabled`
 When set to true APM Server exposes https://golang.org/pkg/expvar/[golang expvar].
 Disabled by default.
 
 [[expvar.url]]
 [float]
-==== `expvar.url` 
+==== `expvar.url`
 Configure the url to expose expvar.
 Defaults to `debug/vars`.
 
 [[metrics.enabled]]
 [float]
-==== `metrics` 
+==== `metrics`
 Experimental Metrics endpoint allowing to collect and upload metrics related to APM.
-The experimental endpoint is enabled by default. 
+The experimental endpoint is enabled by default.
 
 [float]
 === Configuration options `queue.mem.*`
@@ -141,7 +139,7 @@ is directly influenced by the `queue.mem.*` settings.
 [float]
 ==== `events`
 Maximum number of events the memory queue can buffer.
-Read more about how this setting can be used for <<tune-data-ingestion, tuning data ingestion>> and how it plays 
+Read more about how this setting can be used for <<tune-data-ingestion, tuning data ingestion>> and how it plays
 together with other config options.
 Defaults to 4096.
 
@@ -165,5 +163,5 @@ Default value is 1 second.
 [[max_procs]]
 [float]
 ==== `max_procs`
-Sets the maximum number of CPUs that can be executing simultaneously. 
+Sets the maximum number of CPUs that can be executing simultaneously.
 The default is the number of logical CPUs available in the system.


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Rename tracing configuration to instrumentation  (#1120)