### PR TITLE
Docs deprecate setup dashboards

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,7 @@ https://github.com/elastic/apm-server/compare/6.3\...master[View commits]
 - Add source_mapping.elasticsearch configuration option {pull}1114[1114].
 - Add /v1/metrics endpoint {pull}1000[1000] {pull}1121[1121].
 - Push onboarding doc to separate ES index {pull}1159[1159].
+- Deprecate usage of `apm-server setup` {pull}1142[1142].
 
 
 [[release-notes-6.3]]

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1694,6 +1694,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/spf13/pflag
+Version: v1.0.1
 Revision: e57e3eeb33f795204c1ca35f56c44f83227c6e66
 License type (autodetected): BSD-3-Clause
 ./vendor/github.com/spf13/pflag/LICENSE:

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -155,48 +155,6 @@ setup.template.settings:
     #number_of_routing_shards: 30
 
 
-#============================== Dashboards =====================================
-#
-# These settings control loading the sample dashboards to the Kibana index. Loading
-# the dashboards are disabled by default and can be enabled either by setting the
-# options here, or by using the `-setup` CLI flag or the `setup` command.
-#setup.dashboards.enabled: false
-
-# The directory from where to read the dashboards. The default is the `kibana`
-# folder in the home path.
-#setup.dashboards.directory: ${path.home}/kibana
-
-# The URL from where to download the dashboards archive. It is used instead of
-# the directory if it has a value.
-#setup.dashboards.url:
-
-# The file archive (zip file) from where to read the dashboards. It is used instead
-# of the directory when it has a value.
-#setup.dashboards.file:
-
-# The name of the Kibana index to use for setting the configuration. Default is ".kibana"
-#setup.dashboards.kibana_index: .kibana
-
-# The Elasticsearch index name. This overwrites the index name defined in the
-# dashboards and index pattern. Example: testbeat-*
-# The dashboards.index needs to be changed in case the elasticsearch index pattern is modified.
-#setup.dashboards.index:
-
-# Always use the Kibana API for loading the dashboards instead of autodetecting
-# how to install the dashboards by first querying Elasticsearch.
-#setup.dashboards.always_kibana: false
-
-# If true and Kibana is not reachable at the time when dashboards are loaded,
-# it will retry to reconnect to Kibana instead of exiting with an error.
-#setup.dashboards.retry.enabled: false
-
-# Duration interval between Kibana connection retries.
-#setup.dashboards.retry.interval: 1s
-
-# Maximum number of retries before exiting with an error, 0 for unlimited retrying.
-#setup.dashboards.retry.maximum: 0
-
-
 #============================== Template =====================================
 
 # A template is used to set the mapping in Elasticsearch
@@ -238,10 +196,59 @@ setup.template.settings:
     #enabled: false
 
 
-#============================== Kibana =====================================
+#============================== Deprecated: Dashboards =====================================
+#
+# Deprecated: Loading dashboards from the APM Server into Kibana is deprecated from 6.4 on.
+#             We suggest to use the Kibana UI to load APM Server dashboards and index pattern instead.
+#
+# These settings control loading the sample dashboards to the Kibana index. Loading
+# the dashboards are disabled by default and can be enabled either by setting the
+# options here, or by using the `-setup` CLI flag or the `setup` command.
+#setup.dashboards.enabled: false
 
-# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.
-# This requires a Kibana endpoint configuration.
+# The directory from where to read the dashboards. The default is the `kibana`
+# folder in the home path.
+#setup.dashboards.directory: ${path.home}/kibana
+
+# The URL from where to download the dashboards archive. It is used instead of
+# the directory if it has a value.
+#setup.dashboards.url:
+
+# The file archive (zip file) from where to read the dashboards. It is used instead
+# of the directory when it has a value.
+#setup.dashboards.file:
+
+# The name of the Kibana index to use for setting the configuration. Default is ".kibana"
+#setup.dashboards.kibana_index: .kibana
+
+# The Elasticsearch index name. This overwrites the index name defined in the
+# dashboards and index pattern. Example: testbeat-*
+# The dashboards.index needs to be changed in case the elasticsearch index pattern is modified.
+#setup.dashboards.index:
+
+# Always use the Kibana API for loading the dashboards instead of autodetecting
+# how to install the dashboards by first querying Elasticsearch.
+#setup.dashboards.always_kibana: false
+
+# If true and Kibana is not reachable at the time when dashboards are loaded,
+# it will retry to reconnect to Kibana instead of exiting with an error.
+#setup.dashboards.retry.enabled: false
+
+# Duration interval between Kibana connection retries.
+#setup.dashboards.retry.interval: 1s
+
+# Maximum number of retries before exiting with an error, 0 for unlimited retrying.
+#setup.dashboards.retry.maximum: 0
+
+
+#============================== Deprecated: Kibana =====================================
+
+# Deprecated: Starting with APM Server version 6.4, loading dashboards and index pattern 
+#             from the APM Server into Kibana is deprecated.
+#             We suggest to use the Kibana UI to load APM Server dashboards and index pattern instead.
+#
+#             Setting up a Kibana endpoint is not necessary when loading the index pattern and dashboards via the UI.
+
 #setup.kibana:
 
   # Kibana Host

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -155,48 +155,6 @@ setup.template.settings:
     #number_of_routing_shards: 30
 
 
-#============================== Dashboards =====================================
-#
-# These settings control loading the sample dashboards to the Kibana index. Loading
-# the dashboards are disabled by default and can be enabled either by setting the
-# options here, or by using the `-setup` CLI flag or the `setup` command.
-#setup.dashboards.enabled: false
-
-# The directory from where to read the dashboards. The default is the `kibana`
-# folder in the home path.
-#setup.dashboards.directory: ${path.home}/kibana
-
-# The URL from where to download the dashboards archive. It is used instead of
-# the directory if it has a value.
-#setup.dashboards.url:
-
-# The file archive (zip file) from where to read the dashboards. It is used instead
-# of the directory when it has a value.
-#setup.dashboards.file:
-
-# The name of the Kibana index to use for setting the configuration. Default is ".kibana"
-#setup.dashboards.kibana_index: .kibana
-
-# The Elasticsearch index name. This overwrites the index name defined in the
-# dashboards and index pattern. Example: testbeat-*
-# The dashboards.index needs to be changed in case the elasticsearch index pattern is modified.
-#setup.dashboards.index:
-
-# Always use the Kibana API for loading the dashboards instead of autodetecting
-# how to install the dashboards by first querying Elasticsearch.
-#setup.dashboards.always_kibana: false
-
-# If true and Kibana is not reachable at the time when dashboards are loaded,
-# it will retry to reconnect to Kibana instead of exiting with an error.
-#setup.dashboards.retry.enabled: false
-
-# Duration interval between Kibana connection retries.
-#setup.dashboards.retry.interval: 1s
-
-# Maximum number of retries before exiting with an error, 0 for unlimited retrying.
-#setup.dashboards.retry.maximum: 0
-
-
 #============================== Template =====================================
 
 # A template is used to set the mapping in Elasticsearch
@@ -238,10 +196,59 @@ setup.template.settings:
     #enabled: false
 
 
-#============================== Kibana =====================================
+#============================== Deprecated: Dashboards =====================================
+#
+# Deprecated: Loading dashboards from the APM Server into Kibana is deprecated from 6.4 on.
+#             We suggest to use the Kibana UI to load APM Server dashboards and index pattern instead.
+#
+# These settings control loading the sample dashboards to the Kibana index. Loading
+# the dashboards are disabled by default and can be enabled either by setting the
+# options here, or by using the `-setup` CLI flag or the `setup` command.
+#setup.dashboards.enabled: false
 
-# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.
-# This requires a Kibana endpoint configuration.
+# The directory from where to read the dashboards. The default is the `kibana`
+# folder in the home path.
+#setup.dashboards.directory: ${path.home}/kibana
+
+# The URL from where to download the dashboards archive. It is used instead of
+# the directory if it has a value.
+#setup.dashboards.url:
+
+# The file archive (zip file) from where to read the dashboards. It is used instead
+# of the directory when it has a value.
+#setup.dashboards.file:
+
+# The name of the Kibana index to use for setting the configuration. Default is ".kibana"
+#setup.dashboards.kibana_index: .kibana
+
+# The Elasticsearch index name. This overwrites the index name defined in the
+# dashboards and index pattern. Example: testbeat-*
+# The dashboards.index needs to be changed in case the elasticsearch index pattern is modified.
+#setup.dashboards.index:
+
+# Always use the Kibana API for loading the dashboards instead of autodetecting
+# how to install the dashboards by first querying Elasticsearch.
+#setup.dashboards.always_kibana: false
+
+# If true and Kibana is not reachable at the time when dashboards are loaded,
+# it will retry to reconnect to Kibana instead of exiting with an error.
+#setup.dashboards.retry.enabled: false
+
+# Duration interval between Kibana connection retries.
+#setup.dashboards.retry.interval: 1s
+
+# Maximum number of retries before exiting with an error, 0 for unlimited retrying.
+#setup.dashboards.retry.maximum: 0
+
+
+#============================== Deprecated: Kibana =====================================
+
+# Deprecated: Starting with APM Server version 6.4, loading dashboards and index pattern 
+#             from the APM Server into Kibana is deprecated.
+#             We suggest to use the Kibana UI to load APM Server dashboards and index pattern instead.
+#
+#             Setting up a Kibana endpoint is not necessary when loading the index pattern and dashboards via the UI.
+
 #setup.kibana:
 
   # Kibana Host

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,4 +37,6 @@ var RootCmd *cmd.BeatsRootCmd
 func init() {
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
 	RootCmd = cmd.GenRootCmdWithIndexPrefixWithRunFlags(Name, IdxPattern, "", beater.New, runFlags)
+	RootCmd.RunCmd.Flags().MarkDeprecated("setup", "use Kibana UI for initial setup.")
+	RootCmd.SetupCmd.Deprecated = "use Kibana UI for initial setup."
 }

--- a/docs/configuring.asciidoc
+++ b/docs/configuring.asciidoc
@@ -12,8 +12,8 @@ The following topics describe how to configure APM Server:
 * <<configuration-ssl>>
 * <<configuration-template>>
 * <<configuration-logging>>
-* <<setup-kibana-endpoint, Set up the Kibana endpoint (deprecated)>>
-* <<configuration-dashboards, Load the Kibana dashboards (deprecated)>>
+* <<setup-kibana-endpoint>>
+* <<configuration-dashboards>>
 * <<configuration-rum>>
 * <<using-environ-vars>>
 * <<configuration-path>>

--- a/docs/configuring.asciidoc
+++ b/docs/configuring.asciidoc
@@ -12,8 +12,8 @@ The following topics describe how to configure APM Server:
 * <<configuration-ssl>>
 * <<configuration-template>>
 * <<configuration-logging>>
-* <<setup-kibana-endpoint>>
-* <<configuration-dashboards>>
+* <<setup-kibana-endpoint, Set up the Kibana endpoint (deprecated)>>
+* <<configuration-dashboards, Load the Kibana dashboards (deprecated)>>
 * <<configuration-rum>>
 * <<using-environ-vars>>
 * <<configuration-path>>

--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -20,7 +20,7 @@
 :modules-command-short-desc: Manages configured modules
 :run-command-short-desc: Runs {beatname_uc}. This command is used by default if you start {beatname_uc} without specifying a command
 
-ifndef::deprecate_dashboard_loading[] 
+ifndef::deprecate_dashboard_loading[]
 
 ifdef::has_ml_jobs[]
 :setup-command-short-desc: Sets up the initial environment, including the index template, Kibana dashboards (when available), and machine learning jobs (when available)
@@ -32,9 +32,9 @@ endif::[]
 
 endif::[]
 
-ifdef::deprecate_dashboard_loading[] 
+ifdef::deprecate_dashboard_loading[]
 
-:setup-command-short-desc: Sets up the initial environment, 
+:setup-command-short-desc: Sets up the initial environment,
 including the ES index template and Kibana dashboards (deprecated).
 
 endif::[]
@@ -50,12 +50,12 @@ endif::[]
 <titleabbrev>Command reference</titleabbrev>
 ++++
 
-ifndef::deprecate_dashboard_loading[] 
+ifndef::deprecate_dashboard_loading[]
 {beatname_uc} provides a command-line interface for starting {beatname_uc} and
-performing common tasks, like testing configuration files and loading dashboards. 
+performing common tasks, like testing configuration files and loading dashboards.
 endif::[]
 
-ifdef::deprecate_dashboard_loading[] 
+ifdef::deprecate_dashboard_loading[]
 {beatname_uc} provides a command-line interface for starting {beatname_uc} and
 performing common tasks, like testing configuration files and loading dashboards (deprecated).
 endif::[]
@@ -409,16 +409,16 @@ the end of the file is reached. By default harvesters are closed after
 
 endif::[]
 
-ifndef::deprecate_dashboard_loading[] 
-*`--setup`*:: 
+ifndef::deprecate_dashboard_loading[]
+*`--setup`*::
 endif::[]
 
-ifdef::deprecate_dashboard_loading[] 
-*`--setup (deprecated)`*:: 
+ifdef::deprecate_dashboard_loading[]
+*`--setup (deprecated)`*::
 endif::[]
 
 ifdef::has_ml_jobs[]
-Loads the initial setup, including Elasticsearch template, Kibana index pattern, 
+Loads the initial setup, including Elasticsearch template, Kibana index pattern,
 Kibana dashboards and Machine learning jobs.
 endif::[]
 
@@ -471,7 +471,7 @@ Or:
 
 * The Kibana dashboards make it easier for you to visualize {beatname_uc} data
 in Kibana.
-ifdef::deprecate_dashboard_loading[] 
+ifdef::deprecate_dashboard_loading[]
 (deprecated)
 endif::[]
 
@@ -493,7 +493,7 @@ environment without actually running {beatname_uc} and ingesting data.
 
 *FLAGS*
 
-ifndef::deprecate_dashboard_loading[] 
+ifndef::deprecate_dashboard_loading[]
 *`--dashboards`*::
 Sets up the Kibana dashboards only. This option loads the dashboards from the
 {beatname_uc} package. For more options, such as loading customized dashboards,
@@ -501,7 +501,7 @@ see {beatsdevguide}/import-dashboards.html[Importing Existing Beat Dashboards]
 in the _Beats Developer Guide_.
 endif::[]
 
-ifdef::deprecate_dashboard_loading[] 
+ifdef::deprecate_dashboard_loading[]
 *`--dashboards` (deprecated)*::
 Sets up the Kibana dashboards only.
 endif::[]

--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -453,7 +453,10 @@ environment without actually running {beatname_uc} and ingesting data.
 *FLAGS*
 
 *`--dashboards`*::
-Sets up the Kibana dashboards only.
+Sets up the Kibana dashboards only. This option loads the dashboards from the
+{beatname_uc} package. For more options, such as loading customized dashboards,
+see {beatsdevguide}/import-dashboards.html[Importing Existing Beat Dashboards]
+in the _Beats Developer Guide_.
 
 *`-h, --help`*::
 Shows help for the `setup` command.
@@ -466,6 +469,9 @@ ifeval::["{beatname_lc}"=="filebeat"]
 *`--modules MODULE_LIST`*::
 Specifies a comma-separated list of modules. Use this flag to avoid errors when
 there are no modules defined in the +{beatname_lc}.yml+ file.
+
+*`--pipelines`*::
+Sets up ingest pipelines for configured filesets.
 
 endif::[]
 

--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -34,8 +34,7 @@ endif::[]
 
 ifdef::deprecate_dashboard_loading[]
 
-:setup-command-short-desc: Sets up the initial environment,
-including the ES index template and Kibana dashboards (deprecated).
+:setup-command-short-desc: Sets up the initial environment, including the ES index template and Kibana dashboards (deprecated).
 
 endif::[]
 
@@ -409,24 +408,20 @@ the end of the file is reached. By default harvesters are closed after
 
 endif::[]
 
-ifndef::deprecate_dashboard_loading[]
 *`--setup`*::
-endif::[]
-
 ifdef::deprecate_dashboard_loading[]
-*`--setup (deprecated)`*::
+deprecated[{deprecate_dashboard_loading}]
 endif::[]
-
++
 ifdef::has_ml_jobs[]
 Loads the initial setup, including Elasticsearch template, Kibana index pattern,
 Kibana dashboards and Machine learning jobs.
 endif::[]
-
 ifndef::has_ml_jobs[]
 Loads the initial setup, including Elasticsearch template, Kibana index pattern and Kibana dashboards.
 endif::[]
-
 If you want to use the command without running {beatname_uc}, use the <<setup-command,`setup`>> command instead.
+
 
 ifeval::["{beatname_lc}"=="metricbeat"]
 
@@ -465,15 +460,12 @@ Or:
 [[setup-command]]
 ==== `setup` command
 
-{setup-command-short-desc}.
+{setup-command-short-desc}
 
 * The index template ensures that fields are mapped correctly in Elasticsearch.
 
 * The Kibana dashboards make it easier for you to visualize {beatname_uc} data
 in Kibana.
-ifdef::deprecate_dashboard_loading[]
-(deprecated)
-endif::[]
 
 ifdef::has_ml_jobs[]
 * The machine learning jobs contain the configuration information and metadata
@@ -502,7 +494,10 @@ in the _Beats Developer Guide_.
 endif::[]
 
 ifdef::deprecate_dashboard_loading[]
-*`--dashboards` (deprecated)*::
+*`--dashboards`*::
+
+deprecated[{deprecate_dashboard_loading}]
++
 Sets up the Kibana dashboards only.
 endif::[]
 

--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -20,12 +20,23 @@
 :modules-command-short-desc: Manages configured modules
 :run-command-short-desc: Runs {beatname_uc}. This command is used by default if you start {beatname_uc} without specifying a command
 
+ifndef::deprecate_dashboard_loading[] 
+
 ifdef::has_ml_jobs[]
 :setup-command-short-desc: Sets up the initial environment, including the index template, Kibana dashboards (when available), and machine learning jobs (when available)
 endif::[]
 
 ifndef::has_ml_jobs[]
-:setup-command-short-desc: Sets up the initial environment, including the index template, Kibana dashboards (when available)
+:setup-command-short-desc: Sets up the initial environment, including the index template and Kibana dashboards (when available)
+endif::[]
+
+endif::[]
+
+ifdef::deprecate_dashboard_loading[] 
+
+:setup-command-short-desc: Sets up the initial environment, 
+including the ES index template and Kibana dashboards (deprecated).
+
 endif::[]
 
 :test-command-short-desc: Tests the configuration
@@ -39,9 +50,17 @@ endif::[]
 <titleabbrev>Command reference</titleabbrev>
 ++++
 
+ifndef::deprecate_dashboard_loading[] 
 {beatname_uc} provides a command-line interface for starting {beatname_uc} and
-performing common tasks, like testing configuration files and loading
-dashboards. The command-line also supports <<global-flags,global flags>>
+performing common tasks, like testing configuration files and loading dashboards. 
+endif::[]
+
+ifdef::deprecate_dashboard_loading[] 
+{beatname_uc} provides a command-line interface for starting {beatname_uc} and
+performing common tasks, like testing configuration files and loading dashboards (deprecated).
+endif::[]
+
+The command-line also supports <<global-flags,global flags>>
 for controlling global behaviors.
 
 ifeval::["{beatname_lc}"!="winlogbeat"]
@@ -390,9 +409,24 @@ the end of the file is reached. By default harvesters are closed after
 
 endif::[]
 
-*`--setup`*::
-Loads the sample Kibana dashboards. If you want to load the dashboards without
-running {beatname_uc}, use the <<setup-command,`setup`>> command instead.
+ifndef::deprecate_dashboard_loading[] 
+*`--setup`*:: 
+endif::[]
+
+ifdef::deprecate_dashboard_loading[] 
+*`--setup (deprecated)`*:: 
+endif::[]
+
+ifdef::has_ml_jobs[]
+Loads the initial setup, including Elasticsearch template, Kibana index pattern, 
+Kibana dashboards and Machine learning jobs.
+endif::[]
+
+ifndef::has_ml_jobs[]
+Loads the initial setup, including Elasticsearch template, Kibana index pattern and Kibana dashboards.
+endif::[]
+
+If you want to use the command without running {beatname_uc}, use the <<setup-command,`setup`>> command instead.
 
 ifeval::["{beatname_lc}"=="metricbeat"]
 
@@ -434,10 +468,17 @@ Or:
 {setup-command-short-desc}.
 
 * The index template ensures that fields are mapped correctly in Elasticsearch.
+
 * The Kibana dashboards make it easier for you to visualize {beatname_uc} data
 in Kibana.
+ifdef::deprecate_dashboard_loading[] 
+(deprecated)
+endif::[]
+
+ifdef::has_ml_jobs[]
 * The machine learning jobs contain the configuration information and metadata
 necessary to analyze data for anomalies.
+endif::[]
 
 Use this command instead of `run --setup` when you want to set up the
 environment without actually running {beatname_uc} and ingesting data.
@@ -452,17 +493,28 @@ environment without actually running {beatname_uc} and ingesting data.
 
 *FLAGS*
 
+ifndef::deprecate_dashboard_loading[] 
 *`--dashboards`*::
 Sets up the Kibana dashboards only. This option loads the dashboards from the
 {beatname_uc} package. For more options, such as loading customized dashboards,
 see {beatsdevguide}/import-dashboards.html[Importing Existing Beat Dashboards]
 in the _Beats Developer Guide_.
+endif::[]
+
+ifdef::deprecate_dashboard_loading[] 
+*`--dashboards` (deprecated)*::
+Sets up the Kibana dashboards only.
+endif::[]
 
 *`-h, --help`*::
 Shows help for the `setup` command.
 
+ifdef::has_ml_jobs[]
+
 *`--machine-learning`*::
 Sets up machine learning job configurations only.
+
+endif::[]
 
 ifeval::["{beatname_lc}"=="filebeat"]
 

--- a/docs/copied-from-beats/dashboards.asciidoc
+++ b/docs/copied-from-beats/dashboards.asciidoc
@@ -18,14 +18,17 @@ command (as described here) or
 +{beatname_lc}.yml+ config file.
 
 This requires a Kibana endpoint configuration. If you didn't already configure
-a Kibana endpoint, see <<{beatname_lc}-configuration,configure {beatname_uc}>>.
+a Kibana endpoint, see <<{beatname_lc}-configuration,configure {beatname_uc}>>. 
 
 Make sure Kibana is running before you perform this step. If you are accessing a
 secured Kibana instance, make sure you've configured credentials as described in
 <<{beatname_lc}-configuration>>.
 
 To set up the Kibana dashboards for {beatname_uc}, use the appropriate command
-for your system.
+for your system. The command shown here loads the dashboards from the {beatname_uc}
+package. For more options, such as loading customized dashboards, see
+{beatsdevguide}/import-dashboards.html[Importing Existing Beat Dashboards] in
+the _Beats Developer Guide_.
 ifndef::only-elasticsearch[]
 If you've configured the Logstash output, see
 <<load-dashboards-logstash>>.

--- a/docs/copied-from-beats/dashboardsconfig.asciidoc
+++ b/docs/copied-from-beats/dashboardsconfig.asciidoc
@@ -10,12 +10,11 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[configuration-dashboards]]
-ifndef::deprecate_dashboard_loading[]
 == Load the Kibana dashboards
-endif::[]
-
 ifdef::deprecate_dashboard_loading[]
-== Load the Kibana dashboards (deprecated)
+
+deprecated[{deprecate_dashboard_loading}]
+
 endif::[]
 
 {beatname_uc} comes packaged with example Kibana dashboards, visualizations,

--- a/docs/copied-from-beats/dashboardsconfig.asciidoc
+++ b/docs/copied-from-beats/dashboardsconfig.asciidoc
@@ -10,7 +10,13 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[configuration-dashboards]]
+ifndef::deprecate_dashboard_loading[]
+== Load the Kibana dashboards
+endif::[]
+
+ifdef::deprecate_dashboard_loading[]
 == Load the Kibana dashboards (deprecated)
+endif::[]
 
 {beatname_uc} comes packaged with example Kibana dashboards, visualizations,
 and searches for visualizing {beatname_uc} data in Kibana.

--- a/docs/copied-from-beats/dashboardsconfig.asciidoc
+++ b/docs/copied-from-beats/dashboardsconfig.asciidoc
@@ -10,7 +10,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[configuration-dashboards]]
-== Load the Kibana dashboards
+== Load the Kibana dashboards (deprecated)
 
 {beatname_uc} comes packaged with example Kibana dashboards, visualizations,
 and searches for visualizing {beatname_uc} data in Kibana.

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -216,10 +216,21 @@ The index name to write events to. The default is
 +"{beatname_lc}-%\{[beat.version]\}-%\{+yyyy.MM.dd\}"+ (for example,
 +"{beatname_lc}-{version}-2017.04.26"+). If you change this setting, you also
 need to configure the `setup.template.name` and `setup.template.pattern` options
-(see <<configuration-template>>). If you are using the pre-built Kibana
-dashboards, you also need to set the `setup.dashboards.index` option (see
-<<configuration-dashboards>>).
+(see <<configuration-template>>). 
 
+ifndef::deprecate_dashboard_loading[] 
+
+If you are using the pre-built Kibana dashboards, 
+you also need to set the `setup.dashboards.index` option (see <<configuration-dashboards>>).
+
+endif::[]
+
+ifdef::deprecate_dashboard_loading[] 
+
+If you are using the pre-built Kibana dashboards, 
+you also need to set the index pattern properly when loading the dashboards via the Kibana UI.
+
+endif::[]
 
 ===== `indices`
 

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -218,17 +218,12 @@ The index name to write events to. The default is
 need to configure the `setup.template.name` and `setup.template.pattern` options
 (see <<configuration-template>>).
 
-ifndef::deprecate_dashboard_loading[]
-
 If you are using the pre-built Kibana dashboards,
 you also need to set the `setup.dashboards.index` option (see <<configuration-dashboards>>).
 
-endif::[]
-
 ifdef::deprecate_dashboard_loading[]
 
-If you are using the pre-built Kibana dashboards,
-you also need to set the index pattern properly when loading the dashboards via the Kibana UI.
+deprecated[{deprecate_dashboard_loading}]
 
 endif::[]
 

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -216,18 +216,18 @@ The index name to write events to. The default is
 +"{beatname_lc}-%\{[beat.version]\}-%\{+yyyy.MM.dd\}"+ (for example,
 +"{beatname_lc}-{version}-2017.04.26"+). If you change this setting, you also
 need to configure the `setup.template.name` and `setup.template.pattern` options
-(see <<configuration-template>>). 
+(see <<configuration-template>>).
 
-ifndef::deprecate_dashboard_loading[] 
+ifndef::deprecate_dashboard_loading[]
 
-If you are using the pre-built Kibana dashboards, 
+If you are using the pre-built Kibana dashboards,
 you also need to set the `setup.dashboards.index` option (see <<configuration-dashboards>>).
 
 endif::[]
 
-ifdef::deprecate_dashboard_loading[] 
+ifdef::deprecate_dashboard_loading[]
 
-If you are using the pre-built Kibana dashboards, 
+If you are using the pre-built Kibana dashboards,
 you also need to set the index pattern properly when loading the dashboards via the Kibana UI.
 
 endif::[]

--- a/docs/copied-from-beats/shared-docker.asciidoc
+++ b/docs/copied-from-beats/shared-docker.asciidoc
@@ -2,7 +2,23 @@
 === Running {beatname_uc} on Docker
 
 Docker images for {beatname_uc} are available from the Elastic Docker
-registry. You can retrieve an image with a `docker pull` command.
+registry. The base image is https://hub.docker.com/_/centos/[centos:7].
+
+A list of all published Docker images and tags is available at
+https://www.docker.elastic.co[www.docker.elastic.co]. The source code is in
+{dockergithub}[GitHub].
+
+These images are free to use under the Elastic license. They contain open source 
+and free commercial features and access to paid commercial features.  
+{xpack-ref}/license-management.html[Start a 30-day trial] to try out all of the 
+paid commercial features. See the 
+https://www.elastic.co/subscriptions[Subscriptions] page for information about 
+Elastic license levels.
+
+==== Pulling the image
+
+Obtaining Beats for Docker is as simple as issuing a +docker pull+ command
+against the Elastic Docker registry.
 
 ifeval::["{release-state}"=="unreleased"]
 
@@ -18,30 +34,30 @@ ifeval::["{release-state}"!="unreleased"]
 docker pull {dockerimage}
 ------------------------------------------------
 
-endif::[]
+Alternatively, you can download other Docker images that contain only features
+available under the Apache 2.0 license. To download the images, go to 
+https://www.docker.elastic.co[www.docker.elastic.co]. 
 
-The base image is https://hub.docker.com/_/centos/[centos:7] and the source
-code can be found on
-{dockergithub}[GitHub].
+endif::[]
 
 [float]
 ==== Configure {beatname_uc} on Docker
 
 The Docker image provides several methods for configuring {beatname_uc}. The
-conventional approach is to provide a configuration file via a bind-mounted
-volume, but it's also possible to create a custom image with your
+conventional approach is to provide a configuration file via a bind mount, but 
+it's also possible to create a custom image with your
 configuration included.
 
 [float]
 ===== Bind-mounted configuration
 
-One way to configure {beatname_uc} on Docker is to provide +{beatname_lc}.yml+ via bind-mounting.
-With +docker run+, the bind-mount can be specified like this:
+One way to configure {beatname_uc} on Docker is to provide +{beatname_lc}.yml+ via a bind mount.
+With +docker run+, the bind mount can be specified like this:
 
 ["source", "sh", subs="attributes"]
 --------------------------------------------
 docker run \
-  -v ~/{beatname_lc}.yml:/usr/share/{beatname_lc}/{beatname_lc}.yml \
+  --mount type=bind,source="$(pwd)"/{beatname_lc}.yml,target=/usr/share/{beatname_lc}/{beatname_lc}.yml \
   {dockerimage}
 --------------------------------------------
 

--- a/docs/copied-from-beats/shared-kibana-config.asciidoc
+++ b/docs/copied-from-beats/shared-kibana-config.asciidoc
@@ -10,7 +10,13 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[setup-kibana-endpoint]]
+ifndef::deprecate_dashboard_loading[]
+== Set up the Kibana endpoint
+endif::[]
+ifdef::deprecate_dashboard_loading[]
 == Set up the Kibana endpoint (deprecated)
+endif::[]
+
 
 ifeval::["{beatname_lc}" == "apm-server"]
 The Kibana dashboards are loaded into Kibana via the Kibana API.

--- a/docs/copied-from-beats/shared-kibana-config.asciidoc
+++ b/docs/copied-from-beats/shared-kibana-config.asciidoc
@@ -10,13 +10,12 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[setup-kibana-endpoint]]
-ifndef::deprecate_dashboard_loading[]
 == Set up the Kibana endpoint
-endif::[]
 ifdef::deprecate_dashboard_loading[]
-== Set up the Kibana endpoint (deprecated)
-endif::[]
 
+deprecated[{deprecate_dashboard_loading}]
+
+endif::[]
 
 ifeval::["{beatname_lc}" == "apm-server"]
 The Kibana dashboards are loaded into Kibana via the Kibana API.

--- a/docs/copied-from-beats/shared-kibana-config.asciidoc
+++ b/docs/copied-from-beats/shared-kibana-config.asciidoc
@@ -10,7 +10,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[setup-kibana-endpoint]]
-== Set up the Kibana endpoint
+== Set up the Kibana endpoint (deprecated)
 
 ifeval::["{beatname_lc}" == "apm-server"]
 The Kibana dashboards are loaded into Kibana via the Kibana API.

--- a/docs/copied-from-beats/shared-ssl-config.asciidoc
+++ b/docs/copied-from-beats/shared-ssl-config.asciidoc
@@ -5,7 +5,6 @@ You can specify SSL options when you configure:
 
 * <<configuring-output,outputs>> that support SSL
 * the <<setup-kibana-endpoint,Kibana endpoint>>
-
 ifeval::["{beatname_lc}"=="heartbeat"]
 * <<configuration-heartbeat-options,{beatname_uc} monitors>> that support SSL
 endif::[]
@@ -23,7 +22,6 @@ output.elasticsearch.ssl.key: "/etc/pki/client/cert.key"
 ifndef::only-elasticsearch[]
 Also see <<configuring-ssl-logstash>>.
 endif::[]
-
 
 Example Kibana endpoint config with SSL enabled:
 

--- a/docs/copied-from-beats/shared-ssl-config.asciidoc
+++ b/docs/copied-from-beats/shared-ssl-config.asciidoc
@@ -5,6 +5,7 @@ You can specify SSL options when you configure:
 
 * <<configuring-output,outputs>> that support SSL
 * the <<setup-kibana-endpoint,Kibana endpoint>>
+
 ifeval::["{beatname_lc}"=="heartbeat"]
 * <<configuration-heartbeat-options,{beatname_uc} monitors>> that support SSL
 endif::[]
@@ -22,6 +23,7 @@ output.elasticsearch.ssl.key: "/etc/pki/client/cert.key"
 ifndef::only-elasticsearch[]
 Also see <<configuring-ssl-logstash>>.
 endif::[]
+
 
 Example Kibana endpoint config with SSL enabled:
 

--- a/docs/copied-from-beats/shared-template-load.asciidoc
+++ b/docs/copied-from-beats/shared-template-load.asciidoc
@@ -94,7 +94,7 @@ that you specify should include the root name of the index plus version and
 date information. You also need to configure the `setup.template.name` and
 `setup.template.pattern` options to match the new name. For example:
 +
-ifndef::deprecate_dashboard_loading[] 
+ifndef::deprecate_dashboard_loading[]
 
 ["source","sh",subs="attributes,callouts"]
 -----
@@ -111,7 +111,7 @@ pattern.
 
 endif::[]
 
-ifdef::deprecate_dashboard_loading[] 
+ifdef::deprecate_dashboard_loading[]
 
 ["source","sh",subs="attributes,callouts"]
 -----

--- a/docs/copied-from-beats/shared-template-load.asciidoc
+++ b/docs/copied-from-beats/shared-template-load.asciidoc
@@ -94,6 +94,8 @@ that you specify should include the root name of the index plus version and
 date information. You also need to configure the `setup.template.name` and
 `setup.template.pattern` options to match the new name. For example:
 +
+ifndef::deprecate_dashboard_loading[] 
+
 ["source","sh",subs="attributes,callouts"]
 -----
 output.elasticsearch.index: "customname-%{[beat.version]}-%{+yyyy.MM.dd}"
@@ -101,10 +103,27 @@ setup.template.name: "customname"
 setup.template.pattern: "customname-*"
 setup.dashboards.index: "customname-*" <1>
 -----
+
 <1> If you plan to
 <<load-kibana-dashboards, set up the Kibana dashboards>>, also set
 this option to overwrite the index name defined in the dashboards and index
 pattern.
+
+endif::[]
+
+ifdef::deprecate_dashboard_loading[] 
+
+["source","sh",subs="attributes,callouts"]
+-----
+output.elasticsearch.index: "customname-%{[beat.version]}-%{+yyyy.MM.dd}"
+setup.template.name: "customname"
+setup.template.pattern: "customname-*"
+-----
++
+Also ensure to change the index name accordingly in the Kibana dashboards,
+when loading via the Kibana UI.
+
+endif::[]
 
 See <<configuration-template>> for the full list of configuration options.
 

--- a/docs/copied-from-beats/template-config.asciidoc
+++ b/docs/copied-from-beats/template-config.asciidoc
@@ -87,4 +87,16 @@ ifeval::["{beatname_lc}"!="apm-server"]
 
 NOTE: With append_fields only new fields can be added an no existing one overwritten or changed. This is especially useful if data is collected through the http/json metricset where the data structure is not known in advance. Changing the config of append_fields means the template has to be overwritten and only applies to new indices. If there are 2 Beats with different append_fields configs the last one writing the template will win. Any changes will also have an affect on the Kibana Index pattern.
 
+*`setup.template.json.enabled`*:: Set to true to load a json based template file. Specify the path to your Elasticsearch
+index template file and set the name of the template. experimental[]
+
+["source","yaml",subs="attributes"]
+----------------------------------------------------------------------
+setup.template.json.enabled: true
+setup.template.json.path: "template.json"
+setup.template.json.name: "template-name
+----------------------------------------------------------------------
+
+NOTE: If the JSON template is used, the fields.yml is skipped for the template generation.
+
 endif::[]

--- a/docs/dashboards.asciidoc
+++ b/docs/dashboards.asciidoc
@@ -3,10 +3,10 @@
 
 From APM Server and Kibana 6.4 on you can load dashboards directly via the Kibana UI.
 
-NOTE: Loading index pattern and dashboards through the APM Server is deprecated.
-      It is recommended to use the Kibana UI instead.
+==== Setup via APM Server
 
-==== Setup via APM Server (deprecated)
+deprecated[{deprecate_dashboard_loading}]
+
 Loading via APM Server requires a <<setup-kibana-endpoint,Kibana endpoint configuration>>. 
 If you are accessing a secured Kibana instance, make sure you've configured credentials.
 

--- a/docs/dashboards.asciidoc
+++ b/docs/dashboards.asciidoc
@@ -1,5 +1,53 @@
 [[load-kibana-dashboards]]
 === Dashboards
 
+From APM Server and Kibana 6.4 on you can load dashboards directly via the Kibana UI.
 
-include::./copied-from-beats/dashboards.asciidoc[]
+NOTE: Loading index pattern and dashboards through the APM Server is deprecated.
+      It is recommended to use the Kibana UI instead.
+
+==== Setup via APM Server (deprecated)
+Loading via APM Server requires a <<setup-kibana-endpoint,Kibana endpoint configuration>>. 
+If you are accessing a secured Kibana instance, make sure you've configured credentials.
+
+You have to either <<configuration-dashboards,configure dashboard loading>> in the
++{beatname_lc}.yml+ config file,
+or run the appropriate `setup` command for your system:
+
+*deb and rpm:*
+
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+{beatname_lc} setup --dashboards
+----------------------------------------------------------------------
+
+
+*mac:*
+
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+./{beatname_lc} setup --dashboards
+----------------------------------------------------------------------
+
+
+*docker:*
+
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+docker run {dockerimage} setup --dashboards
+----------------------------------------------------------------------
+
+*win:*
+
+endif::allplatforms[]
+
+Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
+and select *Run As Administrator*).
+
+From the PowerShell prompt, change to the directory where you installed {beatname_uc},
+and run:
+
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+PS > .{backslash}{beatname_lc}.exe setup --dashboards
+----------------------------------------------------------------------

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -58,7 +58,7 @@ APM Server creates documents from the data received from agents and stores them 
 
 To visualize the data after it's sent to Elasticsearch,
 you can use the the dedicated APM UI bundled in X-Pack,
-or the pre-built open source Kibana dashboards that come with APM Server.
+or the pre-built open source Kibana dashboards that can be loaded directly in the Kibana UI.
 
 We designed Elastic APM to run on anything from a regular laptop to thousands of machines,
 and it's easy to get started.
@@ -148,16 +148,8 @@ You can also configure APM Server to listen on a Unix domain socket.
 [[kibana-dashboards]]
 [float]
 ==== Install the Kibana dashboards
-APM Server comes with predefined Kibana dashboards and index templates for APM data.
-To install those run the following command:
 
-[source,bash]
-----------------------------------
-./apm-server setup
-----------------------------------
-
-NOTE: Due to a bug in Kibana 6.0.0.-rc2 the dashboards don't work in Kibana 6.0.0-rc2.
-
+From APM Server and Kibana 6.4 on you can load dashboards directly via the Kibana UI.
 
 See an example screenshot of a Kibana dashboard:
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -17,6 +17,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
 :securitydoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
+:deprecate_dashboard_loading: true 
 
 ifdef::env-github[]
 NOTE: For the best reading experience,

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -17,7 +17,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
 :securitydoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
-:deprecate_dashboard_loading: true 
+:deprecate_dashboard_loading: 6.4.0 
 
 ifdef::env-github[]
 NOTE: For the best reading experience,

--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -57,24 +57,6 @@ output.elasticsearch:
   password: "elastic"
 ----
 
-If you plan to use the sample Kibana dashboards provided with {beatname_uc},
-configure the Kibana endpoint:
-
-[source,yaml]
-----------------------------------------------------------------------
-setup.kibana:
-  host: "localhost:5601"
-----------------------------------------------------------------------
-
---
-Where `host` is the hostname and port of the machine where Kibana is running,
-for example, `localhost:5601`.
-
-NOTE: If you specify a path after the port number, you need to include
-the scheme and port: `http://localhost:5601/path`.
-
---
-
 See <<configuring-howto-apm-server>> for more configuration options.
 
 

--- a/vendor/github.com/elastic/beats/libbeat/cmd/setup.go
+++ b/vendor/github.com/elastic/beats/libbeat/cmd/setup.go
@@ -34,7 +34,7 @@ func genSetupCmd(name, idxPrefix, version string, beatCreator beat.Creator) *cob
 		Long: `This command does initial setup of the environment:
 
  * Index mapping template in Elasticsearch to ensure fields are mapped.
- * Kibana dashboards (where available).
+ * Kibana dashboards and index patterns (where available).
  * ML jobs (where available).
  * Ingest pipelines (where available).
 `,

--- a/vendor/github.com/spf13/pflag/bytes.go
+++ b/vendor/github.com/spf13/pflag/bytes.go
@@ -1,0 +1,105 @@
+package pflag
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// BytesHex adapts []byte for use as a flag. Value of flag is HEX encoded
+type bytesHexValue []byte
+
+func (bytesHex bytesHexValue) String() string {
+	return fmt.Sprintf("%X", []byte(bytesHex))
+}
+
+func (bytesHex *bytesHexValue) Set(value string) error {
+	bin, err := hex.DecodeString(strings.TrimSpace(value))
+
+	if err != nil {
+		return err
+	}
+
+	*bytesHex = bin
+
+	return nil
+}
+
+func (*bytesHexValue) Type() string {
+	return "bytesHex"
+}
+
+func newBytesHexValue(val []byte, p *[]byte) *bytesHexValue {
+	*p = val
+	return (*bytesHexValue)(p)
+}
+
+func bytesHexConv(sval string) (interface{}, error) {
+
+	bin, err := hex.DecodeString(sval)
+
+	if err == nil {
+		return bin, nil
+	}
+
+	return nil, fmt.Errorf("invalid string being converted to Bytes: %s %s", sval, err)
+}
+
+// GetBytesHex return the []byte value of a flag with the given name
+func (f *FlagSet) GetBytesHex(name string) ([]byte, error) {
+	val, err := f.getFlagType(name, "bytesHex", bytesHexConv)
+
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return val.([]byte), nil
+}
+
+// BytesHexVar defines an []byte flag with specified name, default value, and usage string.
+// The argument p points to an []byte variable in which to store the value of the flag.
+func (f *FlagSet) BytesHexVar(p *[]byte, name string, value []byte, usage string) {
+	f.VarP(newBytesHexValue(value, p), name, "", usage)
+}
+
+// BytesHexVarP is like BytesHexVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string) {
+	f.VarP(newBytesHexValue(value, p), name, shorthand, usage)
+}
+
+// BytesHexVar defines an []byte flag with specified name, default value, and usage string.
+// The argument p points to an []byte variable in which to store the value of the flag.
+func BytesHexVar(p *[]byte, name string, value []byte, usage string) {
+	CommandLine.VarP(newBytesHexValue(value, p), name, "", usage)
+}
+
+// BytesHexVarP is like BytesHexVar, but accepts a shorthand letter that can be used after a single dash.
+func BytesHexVarP(p *[]byte, name, shorthand string, value []byte, usage string) {
+	CommandLine.VarP(newBytesHexValue(value, p), name, shorthand, usage)
+}
+
+// BytesHex defines an []byte flag with specified name, default value, and usage string.
+// The return value is the address of an []byte variable that stores the value of the flag.
+func (f *FlagSet) BytesHex(name string, value []byte, usage string) *[]byte {
+	p := new([]byte)
+	f.BytesHexVarP(p, name, "", value, usage)
+	return p
+}
+
+// BytesHexP is like BytesHex, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) BytesHexP(name, shorthand string, value []byte, usage string) *[]byte {
+	p := new([]byte)
+	f.BytesHexVarP(p, name, shorthand, value, usage)
+	return p
+}
+
+// BytesHex defines an []byte flag with specified name, default value, and usage string.
+// The return value is the address of an []byte variable that stores the value of the flag.
+func BytesHex(name string, value []byte, usage string) *[]byte {
+	return CommandLine.BytesHexP(name, "", value, usage)
+}
+
+// BytesHexP is like BytesHex, but accepts a shorthand letter that can be used after a single dash.
+func BytesHexP(name, shorthand string, value []byte, usage string) *[]byte {
+	return CommandLine.BytesHexP(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/duration_slice.go
+++ b/vendor/github.com/spf13/pflag/duration_slice.go
@@ -1,0 +1,128 @@
+package pflag
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// -- durationSlice Value
+type durationSliceValue struct {
+	value   *[]time.Duration
+	changed bool
+}
+
+func newDurationSliceValue(val []time.Duration, p *[]time.Duration) *durationSliceValue {
+	dsv := new(durationSliceValue)
+	dsv.value = p
+	*dsv.value = val
+	return dsv
+}
+
+func (s *durationSliceValue) Set(val string) error {
+	ss := strings.Split(val, ",")
+	out := make([]time.Duration, len(ss))
+	for i, d := range ss {
+		var err error
+		out[i], err = time.ParseDuration(d)
+		if err != nil {
+			return err
+		}
+
+	}
+	if !s.changed {
+		*s.value = out
+	} else {
+		*s.value = append(*s.value, out...)
+	}
+	s.changed = true
+	return nil
+}
+
+func (s *durationSliceValue) Type() string {
+	return "durationSlice"
+}
+
+func (s *durationSliceValue) String() string {
+	out := make([]string, len(*s.value))
+	for i, d := range *s.value {
+		out[i] = fmt.Sprintf("%s", d)
+	}
+	return "[" + strings.Join(out, ",") + "]"
+}
+
+func durationSliceConv(val string) (interface{}, error) {
+	val = strings.Trim(val, "[]")
+	// Empty string would cause a slice with one (empty) entry
+	if len(val) == 0 {
+		return []time.Duration{}, nil
+	}
+	ss := strings.Split(val, ",")
+	out := make([]time.Duration, len(ss))
+	for i, d := range ss {
+		var err error
+		out[i], err = time.ParseDuration(d)
+		if err != nil {
+			return nil, err
+		}
+
+	}
+	return out, nil
+}
+
+// GetDurationSlice returns the []time.Duration value of a flag with the given name
+func (f *FlagSet) GetDurationSlice(name string) ([]time.Duration, error) {
+	val, err := f.getFlagType(name, "durationSlice", durationSliceConv)
+	if err != nil {
+		return []time.Duration{}, err
+	}
+	return val.([]time.Duration), nil
+}
+
+// DurationSliceVar defines a durationSlice flag with specified name, default value, and usage string.
+// The argument p points to a []time.Duration variable in which to store the value of the flag.
+func (f *FlagSet) DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string) {
+	f.VarP(newDurationSliceValue(value, p), name, "", usage)
+}
+
+// DurationSliceVarP is like DurationSliceVar, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string) {
+	f.VarP(newDurationSliceValue(value, p), name, shorthand, usage)
+}
+
+// DurationSliceVar defines a duration[] flag with specified name, default value, and usage string.
+// The argument p points to a duration[] variable in which to store the value of the flag.
+func DurationSliceVar(p *[]time.Duration, name string, value []time.Duration, usage string) {
+	CommandLine.VarP(newDurationSliceValue(value, p), name, "", usage)
+}
+
+// DurationSliceVarP is like DurationSliceVar, but accepts a shorthand letter that can be used after a single dash.
+func DurationSliceVarP(p *[]time.Duration, name, shorthand string, value []time.Duration, usage string) {
+	CommandLine.VarP(newDurationSliceValue(value, p), name, shorthand, usage)
+}
+
+// DurationSlice defines a []time.Duration flag with specified name, default value, and usage string.
+// The return value is the address of a []time.Duration variable that stores the value of the flag.
+func (f *FlagSet) DurationSlice(name string, value []time.Duration, usage string) *[]time.Duration {
+	p := []time.Duration{}
+	f.DurationSliceVarP(&p, name, "", value, usage)
+	return &p
+}
+
+// DurationSliceP is like DurationSlice, but accepts a shorthand letter that can be used after a single dash.
+func (f *FlagSet) DurationSliceP(name, shorthand string, value []time.Duration, usage string) *[]time.Duration {
+	p := []time.Duration{}
+	f.DurationSliceVarP(&p, name, shorthand, value, usage)
+	return &p
+}
+
+// DurationSlice defines a []time.Duration flag with specified name, default value, and usage string.
+// The return value is the address of a []time.Duration variable that stores the value of the flag.
+func DurationSlice(name string, value []time.Duration, usage string) *[]time.Duration {
+	return CommandLine.DurationSliceP(name, "", value, usage)
+}
+
+// DurationSliceP is like DurationSlice, but accepts a shorthand letter that can be used after a single dash.
+func DurationSliceP(name, shorthand string, value []time.Duration, usage string) *[]time.Duration {
+	return CommandLine.DurationSliceP(name, shorthand, value, usage)
+}

--- a/vendor/github.com/spf13/pflag/golangflag.go
+++ b/vendor/github.com/spf13/pflag/golangflag.go
@@ -98,4 +98,8 @@ func (f *FlagSet) AddGoFlagSet(newSet *goflag.FlagSet) {
 	newSet.VisitAll(func(goflag *goflag.Flag) {
 		f.AddGoFlag(goflag)
 	})
+	if f.addedGoFlagSets == nil {
+		f.addedGoFlagSets = make([]*goflag.FlagSet, 0)
+	}
+	f.addedGoFlagSets = append(f.addedGoFlagSets, newSet)
 }

--- a/vendor/github.com/spf13/pflag/string_array.go
+++ b/vendor/github.com/spf13/pflag/string_array.go
@@ -52,7 +52,7 @@ func (f *FlagSet) GetStringArray(name string) ([]string, error) {
 
 // StringArrayVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the values of the multiple flags.
-// The value of each argument will not try to be separated by comma
+// The value of each argument will not try to be separated by comma. Use a StringSlice for that.
 func (f *FlagSet) StringArrayVar(p *[]string, name string, value []string, usage string) {
 	f.VarP(newStringArrayValue(value, p), name, "", usage)
 }
@@ -64,7 +64,7 @@ func (f *FlagSet) StringArrayVarP(p *[]string, name, shorthand string, value []s
 
 // StringArrayVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the value of the flag.
-// The value of each argument will not try to be separated by comma
+// The value of each argument will not try to be separated by comma. Use a StringSlice for that.
 func StringArrayVar(p *[]string, name string, value []string, usage string) {
 	CommandLine.VarP(newStringArrayValue(value, p), name, "", usage)
 }
@@ -76,7 +76,7 @@ func StringArrayVarP(p *[]string, name, shorthand string, value []string, usage 
 
 // StringArray defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a []string variable that stores the value of the flag.
-// The value of each argument will not try to be separated by comma
+// The value of each argument will not try to be separated by comma. Use a StringSlice for that.
 func (f *FlagSet) StringArray(name string, value []string, usage string) *[]string {
 	p := []string{}
 	f.StringArrayVarP(&p, name, "", value, usage)
@@ -92,7 +92,7 @@ func (f *FlagSet) StringArrayP(name, shorthand string, value []string, usage str
 
 // StringArray defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a []string variable that stores the value of the flag.
-// The value of each argument will not try to be separated by comma
+// The value of each argument will not try to be separated by comma. Use a StringSlice for that.
 func StringArray(name string, value []string, usage string) *[]string {
 	return CommandLine.StringArrayP(name, "", value, usage)
 }

--- a/vendor/github.com/spf13/pflag/string_slice.go
+++ b/vendor/github.com/spf13/pflag/string_slice.go
@@ -82,6 +82,11 @@ func (f *FlagSet) GetStringSlice(name string) ([]string, error) {
 
 // StringSliceVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the value of the flag.
+// Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
+// For example:
+//   --ss="v1,v2" -ss="v3"
+// will result in
+//   []string{"v1", "v2", "v3"}
 func (f *FlagSet) StringSliceVar(p *[]string, name string, value []string, usage string) {
 	f.VarP(newStringSliceValue(value, p), name, "", usage)
 }
@@ -93,6 +98,11 @@ func (f *FlagSet) StringSliceVarP(p *[]string, name, shorthand string, value []s
 
 // StringSliceVar defines a string flag with specified name, default value, and usage string.
 // The argument p points to a []string variable in which to store the value of the flag.
+// Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
+// For example:
+//   --ss="v1,v2" -ss="v3"
+// will result in
+//   []string{"v1", "v2", "v3"}
 func StringSliceVar(p *[]string, name string, value []string, usage string) {
 	CommandLine.VarP(newStringSliceValue(value, p), name, "", usage)
 }
@@ -104,6 +114,11 @@ func StringSliceVarP(p *[]string, name, shorthand string, value []string, usage 
 
 // StringSlice defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a []string variable that stores the value of the flag.
+// Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
+// For example:
+//   --ss="v1,v2" -ss="v3"
+// will result in
+//   []string{"v1", "v2", "v3"}
 func (f *FlagSet) StringSlice(name string, value []string, usage string) *[]string {
 	p := []string{}
 	f.StringSliceVarP(&p, name, "", value, usage)
@@ -119,6 +134,11 @@ func (f *FlagSet) StringSliceP(name, shorthand string, value []string, usage str
 
 // StringSlice defines a string flag with specified name, default value, and usage string.
 // The return value is the address of a []string variable that stores the value of the flag.
+// Compared to StringArray flags, StringSlice flags take comma-separated value as arguments and split them accordingly.
+// For example:
+//   --ss="v1,v2" -ss="v3"
+// will result in
+//   []string{"v1", "v2", "v3"}
 func StringSlice(name string, value []string, usage string) *[]string {
 	return CommandLine.StringSliceP(name, "", value, usage)
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1835,10 +1835,12 @@
 			"revisionTime": "2017-11-23T00:13:03Z"
 		},
 		{
-			"checksumSHA1": "fKq6NiaqP3DFxnCRF5mmpJWTSUA=",
+			"checksumSHA1": "k5TsfhX2vvfffYbZQ4fMKtL5+cA=",
 			"path": "github.com/spf13/pflag",
-			"revision": "4c012f6dcd9546820e378d0bdda4d8fc772cdfea",
-			"revisionTime": "2017-11-06T14:28:49Z"
+			"revision": "583c0c0531f06d5278b7d917446061adc344b5cd",
+			"revisionTime": "2018-04-12T12:09:13Z",
+			"version": "v1.0.1",
+			"versionExact": "v1.0.1"
 		},
 		{
 			"checksumSHA1": "Le1psgZO0t6mRg6oY5dmnjH13hk=",
@@ -2105,6 +2107,11 @@
 			"path": "howett.net/plist",
 			"revision": "84d08b7bddb35583bb3153b811c6cc52bb306f52",
 			"revisionTime": "2018-02-14T08:12:42Z"
+		},
+		{
+			"path": "https://github.com/spf13/pflag",
+			"revision": "v1.0.1",
+			"version": "v1.0.1"
 		}
 	],
 	"rootPath": "github.com/elastic/apm-server"


### PR DESCRIPTION
From 6.4 on loading the dashboards and Kibana index pattern via the APM Server will be deprecated, in favour of loading them via the Kibana UI. 
The reason behind this is that some features will require an existing APM Kibana Index Pattern. If a missing index pattern is detected the customer can load the Index Pattern directly via Kibana, instead of having to load it via the Server. 

This PR aims to 
* print a deprecated message when the dashboards and index patterns are loaded via the server.
* mark Kibana and dashboard sections as deprecated in `apm-server.yml`.
* mark configuring Kibana endpoint and dashboard settings as deprecated in official docs.

implements elastic/apm-server#1135 

update:
forgot to mention, that once we align on the deprecation docs I'll open a PR in beats to update the copied docs properly.