### PR TITLE
remove regexProperties validation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -52,6 +52,7 @@ https://github.com/elastic/apm-server/compare/v6.2.4\...v6.3.0[View commits]
 - Limit the amount of concurrent requests being processed {pull}731[731].
 - Return proper response code for request entity too large {pull}862[862].
 - Make APM Server docker image listen on all interfaces by default https://github.com/elastic/apm-server-docker/pull/16[apm-server-dockers#16]
+- Remove regexProperties validation rules {pull}1148[1148].
 
 [float]
 ==== Added

--- a/docs/data/elasticsearch/transaction.json
+++ b/docs/data/elasticsearch/transaction.json
@@ -1,6 +1,7 @@
 {
     "context": {
         "custom": {
+            "(": "not a valid regex and that is fine",
             "and_objects": {
                 "foo": [
                     "bar",

--- a/docs/data/intake-api/generated/transaction/payload.json
+++ b/docs/data/intake-api/generated/transaction/payload.json
@@ -118,7 +118,8 @@
                             "bar",
                             "baz"
                         ]
-                    }
+                    },
+                    "(": "not a valid regex and that is fine"
                 }
             },
             "spans": [

--- a/docs/spec/context.json
+++ b/docs/spec/context.json
@@ -7,7 +7,6 @@
         "custom": {
             "description": "An arbitrary mapping of additional metadata to store with the event.",
             "type": ["object", "null"],
-            "regexProperties": true,
             "patternProperties": {
                 "^[^.*\"]*$": {}
             },
@@ -44,7 +43,6 @@
         "tags": {
             "type": ["object", "null"],
             "description": "A flat mapping of user-defined tags with string values.",
-            "regexProperties": true,
             "patternProperties": {
                 "^[^.*\"]*$": {
                     "type": ["string", "null"],

--- a/docs/spec/metrics/metric.json
+++ b/docs/spec/metrics/metric.json
@@ -7,7 +7,6 @@
         "samples": {
             "type": ["object"],
             "description": "Sampled application metrics collected from the agent",
-            "regexProperties": true,
             "patternProperties": {
                 "^[^*\"]*$": {
                     "$ref": "sample.json"
@@ -18,7 +17,6 @@
         "tags": {
             "type": ["object", "null"],
             "description": "A flat mapping of user-defined tags with string values",
-            "regexProperties": true,
             "patternProperties": {
                 "^[^*\"]*$": {
                     "type": ["string", "null"],

--- a/docs/spec/transactions/mark.json
+++ b/docs/spec/transactions/mark.json
@@ -2,7 +2,6 @@
     "$id": "docs/spec/transactions/mark.json",
     "type": ["object", "null"],
     "description": "A mark captures the timing in milliseconds of a significant event during the lifetime of a transaction. Every mark is a simple key value pair, where the value has to be a number, and can be set by the user or the agent.",
-    "regexProperties": true,
     "patternProperties": {
         "^[^.*\"]*$": {
             "type": ["number", "null"]

--- a/docs/spec/transactions/transaction.json
+++ b/docs/spec/transactions/transaction.json
@@ -46,7 +46,6 @@
         "marks": {
             "type": ["object", "null"],
             "description": "A mark captures the timing of a significant event during the lifetime of a transaction. Marks are organized into groups and can be set by the user or the agent.",
-            "regexProperties": true,
             "patternProperties": {
                 "^[^.*\"]*$": {
                     "$ref": "mark.json"

--- a/processor/error/generated/schema/payload.go
+++ b/processor/error/generated/schema/payload.go
@@ -153,7 +153,6 @@ const PayloadSchema = `{
         "custom": {
             "description": "An arbitrary mapping of additional metadata to store with the event.",
             "type": ["object", "null"],
-            "regexProperties": true,
             "patternProperties": {
                 "^[^.*\"]*$": {}
             },
@@ -293,7 +292,6 @@ const PayloadSchema = `{
         "tags": {
             "type": ["object", "null"],
             "description": "A flat mapping of user-defined tags with string values.",
-            "regexProperties": true,
             "patternProperties": {
                 "^[^.*\"]*$": {
                     "type": ["string", "null"],

--- a/processor/metric/generated/schema/payload.go
+++ b/processor/metric/generated/schema/payload.go
@@ -35,7 +35,6 @@ const PayloadSchema = `{
         "samples": {
             "type": ["object"],
             "description": "Sampled application metrics collected from the agent",
-            "regexProperties": true,
             "patternProperties": {
                 "^[^*\"]*$": {
                         "$schema": "http://json-schema.org/draft-04/schema#",
@@ -116,7 +115,6 @@ const PayloadSchema = `{
         "tags": {
             "type": ["object", "null"],
             "description": "A flat mapping of user-defined tags with string values",
-            "regexProperties": true,
             "patternProperties": {
                 "^[^*\"]*$": {
                     "type": ["string", "null"],

--- a/processor/transaction/generated/schema/payload.go
+++ b/processor/transaction/generated/schema/payload.go
@@ -175,7 +175,6 @@ const PayloadSchema = `{
         "custom": {
             "description": "An arbitrary mapping of additional metadata to store with the event.",
             "type": ["object", "null"],
-            "regexProperties": true,
             "patternProperties": {
                 "^[^.*\"]*$": {}
             },
@@ -315,7 +314,6 @@ const PayloadSchema = `{
         "tags": {
             "type": ["object", "null"],
             "description": "A flat mapping of user-defined tags with string values.",
-            "regexProperties": true,
             "patternProperties": {
                 "^[^.*\"]*$": {
                     "type": ["string", "null"],
@@ -529,13 +527,11 @@ const PayloadSchema = `{
         "marks": {
             "type": ["object", "null"],
             "description": "A mark captures the timing of a significant event during the lifetime of a transaction. Marks are organized into groups and can be set by the user or the agent.",
-            "regexProperties": true,
             "patternProperties": {
                 "^[^.*\"]*$": {
                         "$id": "docs/spec/transactions/mark.json",
     "type": ["object", "null"],
     "description": "A mark captures the timing in milliseconds of a significant event during the lifetime of a transaction. Every mark is a simple key value pair, where the value has to be a number, and can be set by the user or the agent.",
-    "regexProperties": true,
     "patternProperties": {
         "^[^.*\"]*$": {
             "type": ["number", "null"]

--- a/processor/transaction/package_tests/TestProcessTransactionFull.approved.json
+++ b/processor/transaction/package_tests/TestProcessTransactionFull.approved.json
@@ -4,6 +4,7 @@
             "@timestamp": "2017-05-30T18:53:27.154Z",
             "context": {
                 "custom": {
+                    "(": "not a valid regex and that is fine",
                     "and_objects": {
                         "foo": [
                             "bar",

--- a/testdata/transaction/payload.json
+++ b/testdata/transaction/payload.json
@@ -118,7 +118,8 @@
                             "bar",
                             "baz"
                         ]
-                    }
+                    },
+                    "(": "not a valid regex and that is fine"
                 }
             },
             "spans": [


### PR DESCRIPTION
Removes requirement that certain fields are valid regexes, as reported in #909.

I introduced at least one of these rules but misunderstood this directive's actual purpose: https://github.com/santhosh-tekuri/jsonschema/blob/v1.2.2/schema.go#L319-L325

closes elastic/apm-server#909 