### PR TITLE
[6.x] add source_mapping.elasticsearch configuration option (#1114)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,7 @@ https://github.com/elastic/apm-server/compare/6.3\...master[View commits]
 - Read sourcemap content and fill context lines {pull}972[972].
 - Add /v1/metrics endpoint {pull}1000[1000].
 - Remove regexProperties validation rules {pull}1148[1148], {pull}1150[1150].
+- Add source_mapping.elasticsearch configuration option {pull}1114[1114].
 
 
 

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -72,7 +72,21 @@ apm-server:
     # to all error and transaction documents sent to the frontend endpoint.
     #source_mapping:
 
-      # Source maps are are fetched from Elasticsearch and then kept in an in-memory cache for a certain time.
+      # Source maps are always fetched from Elasticsearch, by default using the output.elasticsearch configuration.
+      # A different instance must be configured when using any other output.
+      # This setting only affects sourcemap reads - the output determines where sourcemaps are written.
+      #elasticsearch:
+        # Array of hosts to connect to.
+        # Scheme and port can be left out and will be set to the default (http and 9200)
+        # In case you specify and additional path, the scheme is required: http://localhost:9200/path
+        # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+        # hosts: ["localhost:9200"]
+
+        # Optional protocol and basic auth credentials.
+        #protocol: "https"
+        #username: "elastic"
+        #password: "changeme"
+
       # The `cache.expiration` determines how long a source map should be cached before fetching it again from Elasticsearch.
       # Note that values configured without a time unit will be interpreted as seconds.
       #cache:

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -72,7 +72,21 @@ apm-server:
     # to all error and transaction documents sent to the frontend endpoint.
     #source_mapping:
 
-      # Source maps are are fetched from Elasticsearch and then kept in an in-memory cache for a certain time.
+      # Source maps are always fetched from Elasticsearch, by default using the output.elasticsearch configuration.
+      # A different instance must be configured when using any other output.
+      # This setting only affects sourcemap reads - the output determines where sourcemaps are written.
+      #elasticsearch:
+        # Array of hosts to connect to.
+        # Scheme and port can be left out and will be set to the default (http and 9200)
+        # In case you specify and additional path, the scheme is required: http://localhost:9200/path
+        # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+        # hosts: ["localhost:9200"]
+
+        # Optional protocol and basic auth credentials.
+        #protocol: "https"
+        #username: "elastic"
+        #password: "changeme"
+
       # The `cache.expiration` determines how long a source map should be cached before fetching it again from Elasticsearch.
       # Note that values configured without a time unit will be interpreted as seconds.
       #cache:

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -48,6 +48,7 @@ type beater struct {
 
 // Creates beater
 func New(b *beat.Beat, ucfg *common.Config) (beat.Beater, error) {
+	logger := logp.NewLogger("beater")
 	beaterConfig := defaultConfig(b.Info.Version)
 	if err := ucfg.Unpack(beaterConfig); err != nil {
 		return nil, errors.Wrap(err, "Error processing configuration")
@@ -59,15 +60,21 @@ func New(b *beat.Beat, ucfg *common.Config) (beat.Beater, error) {
 		if _, err := regexp.Compile(beaterConfig.Frontend.ExcludeFromGrouping); err != nil {
 			return nil, errors.New(fmt.Sprintf("Invalid regex for `exclude_from_grouping`: %v", err.Error()))
 		}
-		if b.Config != nil && b.Config.Output.Name() == "elasticsearch" {
-			beaterConfig.setElasticsearch(b.Config.Output.Config())
+		if b.Config != nil && beaterConfig.Frontend.SourceMapping.EsConfig == nil {
+			// fall back to elasticsearch output configuration for sourcemap storage if possible
+			if b.Config.Output.Name() == "elasticsearch" {
+				logger.Info("Falling back to elasticsearch output for sourcemap storage")
+				beaterConfig.setSmapElasticsearch(b.Config.Output.Config())
+			} else {
+				logger.Info("Unable to determine sourcemap storage, sourcemaps will not be applied")
+			}
 		}
 	}
 
 	bt := &beater{
 		config:  beaterConfig,
 		stopped: false,
-		logger:  logp.NewLogger("beater"),
+		logger:  logger,
 	}
 	return bt, nil
 }

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -310,7 +310,20 @@ func (bt *beater) wait() error {
 	}
 }
 
-func setupBeater(t *testing.T, publisher beat.Pipeline, ucfg *common.Config) (*beater, func(), error) {
+func (bt *beater) smapElasticsearchHosts() []string {
+	var content map[string]interface{}
+	if err := bt.config.Frontend.SourceMapping.EsConfig.Unpack(&content); err != nil {
+		return nil
+	}
+	hostsContent := content["hosts"].([]interface{})
+	hosts := make([]string, len(hostsContent))
+	for i := range hostsContent {
+		hosts[i] = hostsContent[i].(string)
+	}
+	return hosts
+}
+
+func setupBeater(t *testing.T, publisher beat.Pipeline, ucfg *common.Config, beatConfig *beat.BeatConfig) (*beater, func(), error) {
 	// create a beat
 	apmBeat := &beat.Beat{
 		Publisher: publisher,
@@ -320,6 +333,7 @@ func setupBeater(t *testing.T, publisher beat.Pipeline, ucfg *common.Config) (*b
 			Version:     version.GetDefaultVersion(),
 			UUID:        uuid.NewV4(),
 		},
+		Config: beatConfig,
 	}
 
 	// create our beater

--- a/beater/config.go
+++ b/beater/config.go
@@ -72,7 +72,7 @@ type SourceMapping struct {
 	Cache        *Cache `config:"cache"`
 	IndexPattern string `config:"index_pattern"`
 
-	esConfig *common.Config
+	EsConfig *common.Config `config:"elasticsearch"`
 	mapper   sourcemap.Mapper
 }
 
@@ -90,9 +90,9 @@ type InstrumentationConfig struct {
 	Environment *string `config:"environment"`
 }
 
-func (c *Config) setElasticsearch(esConfig *common.Config) {
+func (c *Config) setSmapElasticsearch(esConfig *common.Config) {
 	if c != nil && c.Frontend.isEnabled() && c.Frontend.SourceMapping != nil {
-		c.Frontend.SourceMapping.esConfig = esConfig
+		c.Frontend.SourceMapping.EsConfig = esConfig
 	}
 }
 
@@ -113,7 +113,7 @@ func (c *metricsConfig) isEnabled() bool {
 }
 
 func (s *SourceMapping) isSetup() bool {
-	return s != nil && (s.esConfig != nil)
+	return s != nil && (s.EsConfig != nil)
 }
 
 func (c *FrontendConfig) memoizedSmapMapper() (sourcemap.Mapper, error) {
@@ -126,7 +126,7 @@ func (c *FrontendConfig) memoizedSmapMapper() (sourcemap.Mapper, error) {
 	}
 	smapConfig := sourcemap.Config{
 		CacheExpiration:     smap.Cache.Expiration,
-		ElasticsearchConfig: smap.esConfig,
+		ElasticsearchConfig: smap.EsConfig,
 		Index:               replaceVersion(c.SourceMapping.IndexPattern, c.beatVersion),
 	}
 	smapMapper, err := sourcemap.NewSmapMapper(smapConfig)

--- a/docs/configuration-frontend.asciidoc
+++ b/docs/configuration-frontend.asciidoc
@@ -64,6 +64,13 @@ Source maps are fetched from Elasticsearch and then kept in an in-memory cache f
 Values configured without a time unit are treated as seconds.
 Default value is 5 minutes.
 
+[[config-sourcemapping-elasticsearch]]
+[float]
+==== `source_mapping.elasticsearch`
+Configure the Elasticsearch source map retrieval location, taking the same options as <<elasticsearch-output,output.elasticsearch>>.
+If unset, sourcemaps are fetched from `output.elasticsearch` when that output is enabled.
+This must be set when using an output other than Elasticsearch for source maps to be applied.
+
 [float]
 ==== `source_mapping.index_pattern`
 Source maps are stored in a seperate index `apm-%{[beat.version]}-sourcemap` by default. 

--- a/docs/configuring-output-after.asciidoc
+++ b/docs/configuring-output-after.asciidoc
@@ -3,7 +3,10 @@
 [float]
 === Sourcemaps
 
-Sourcemaps can be uploaded through various outputs but can currently only be applied when Elasticsearch is the output.
+Sourcemaps can be uploaded through all outputs but must eventually be stored in Elasticsearch.
+When using outputs other than Elasticsearch, `source_mapping.elasticsearch` must be set for source maps to be applied.
+Be sure to update `source_mapping.index_pattern` if sourcemaps are stored in the non-default location.
+See <<config-sourcemapping-elasticsearch>> for more details.
 
 [[libbeat-configuration-fields]]
 [float]

--- a/sourcemap/accessor.go
+++ b/sourcemap/accessor.go
@@ -19,7 +19,6 @@ package sourcemap
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/go-sourcemap/sourcemap"
 
@@ -37,7 +36,7 @@ type SmapAccessor struct {
 }
 
 func NewSmapAccessor(config Config) (*SmapAccessor, error) {
-	logp.NewLogger("sourcemap").Debugf("NewSmapAccessor created at Time.now %v for index", time.Now().Unix(), config.Index)
+	logp.NewLogger("sourcemap").Debugf("creating NewSmapAccessor for index: %s", config.Index)
 
 	es, err := NewElasticsearch(config.ElasticsearchConfig, config.Index)
 	if err != nil {


### PR DESCRIPTION
Backports the following commits to 6.x:
 - add source_mapping.elasticsearch configuration option  (#1114)