### PR TITLE
Move onboarding document to dedicated index.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -14,6 +14,7 @@ https://github.com/elastic/apm-server/compare/6.3\...master[View commits]
 
 - Change `frontend` to `rum` in config file, but still support `frontend` for backwards compatibility {pull}1155[1155].
 - Support `rum` and `client-side` endpoint for RUM for backwards compatibility {pull}1155[1155].
+- Push onboarding doc to separate ES index {pull}1159[1159].
 - Listen on default port 8200 if unspecified {pull}886[886].
 - Update Go to 1.10.3 {pull}1054[1054].
 - Combine `apm-server.yml` and `apm-server.reference.yml` into one file {pull}958[958].

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -14,7 +14,6 @@ https://github.com/elastic/apm-server/compare/6.3\...master[View commits]
 
 - Change `frontend` to `rum` in config file, but still support `frontend` for backwards compatibility {pull}1155[1155].
 - Support `rum` and `client-side` endpoint for RUM for backwards compatibility {pull}1155[1155].
-- Push onboarding doc to separate ES index {pull}1159[1159].
 - Listen on default port 8200 if unspecified {pull}886[886].
 - Update Go to 1.10.3 {pull}1054[1054].
 - Combine `apm-server.yml` and `apm-server.reference.yml` into one file {pull}958[958].
@@ -24,6 +23,7 @@ https://github.com/elastic/apm-server/compare/6.3\...master[View commits]
 - Remove regexProperties validation rules {pull}1148[1148], {pull}1150[1150].
 - Add source_mapping.elasticsearch configuration option {pull}1114[1114].
 - Add /v1/metrics endpoint {pull}1000[1000] {pull}1121[1121].
+- Push onboarding doc to separate ES index {pull}1159[1159].
 
 
 [[release-notes-6.3]]

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -363,6 +363,10 @@ output.elasticsearch:
       when.contains:
         processor.event: "metric"
 
+    - index: "apm-%{[beat.version]}-onboarding-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "onboarding"
+
   # Optional ingest node pipeline. By default no pipeline will be used.
   #pipeline: ""
 

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -363,6 +363,10 @@ output.elasticsearch:
       when.contains:
         processor.event: "metric"
 
+    - index: "apm-%{[beat.version]}-onboarding-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "onboarding"
+
   # Optional ingest node pipeline. By default no pipeline will be used.
   #pipeline: ""
 

--- a/beater/onboarding.go
+++ b/beater/onboarding.go
@@ -37,7 +37,10 @@ func notifyListening(config *Config, pubFct func(beat.Event)) {
 
 		event := beat.Event{
 			Timestamp: time.Now(),
-			Fields:    common.MapStr{"listening": config.Host},
+			Fields: common.MapStr{
+				"processor": common.MapStr{"name": "onboarding", "event": "onboarding"},
+				"listening": config.Host,
+			},
 		}
 		pubFct(event)
 	}

--- a/beater/onboarding_test.go
+++ b/beater/onboarding_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/elastic/apm-agent-go"
 	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestNotifyUpServerDown(t *testing.T) {
@@ -44,5 +45,9 @@ func TestNotifyUpServerDown(t *testing.T) {
 
 	listening := saved.Fields["listening"].(string)
 	assert.Equal(t, config.Host, listening)
+
+	processor := saved.Fields["processor"].(common.MapStr)
+	assert.Equal(t, "onboarding", processor["name"])
+	assert.Equal(t, "onboarding", processor["event"])
 
 }


### PR DESCRIPTION
Add processor information to onboarding doc and use this to move to its
own index.

implements elastic/apm-server#1158

@graphaelli I wasn't sure if you were going to touch the onboarding docs in any way when working on elastic/apm-server#957 so please let me know if this interferes with your plans. 

@jalvz also brought up that it might make sense to call it `healthcheck` instead of `onboarding`. I am tempted to stick with `onboarding` as it is unrelated to the actual healthcheck endpoint. 