### PR TITLE
[6.x] Move onboarding document to dedicated index. (#1159)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,8 @@ https://github.com/elastic/apm-server/compare/6.3\...master[View commits]
 - Remove regexProperties validation rules {pull}1148[1148], {pull}1150[1150].
 - Add source_mapping.elasticsearch configuration option {pull}1114[1114].
 
+- Add /v1/metrics endpoint {pull}1000[1000] {pull}1121[1121].
+- Push onboarding doc to separate ES index {pull}1159[1159].
 
 
 [[release-notes-6.3]]

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -363,6 +363,10 @@ output.elasticsearch:
       when.contains:
         processor.event: "metric"
 
+    - index: "apm-%{[beat.version]}-onboarding-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "onboarding"
+
   # Optional ingest node pipeline. By default no pipeline will be used.
   #pipeline: ""
 

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -363,6 +363,10 @@ output.elasticsearch:
       when.contains:
         processor.event: "metric"
 
+    - index: "apm-%{[beat.version]}-onboarding-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "onboarding"
+
   # Optional ingest node pipeline. By default no pipeline will be used.
   #pipeline: ""
 

--- a/beater/onboarding.go
+++ b/beater/onboarding.go
@@ -37,7 +37,10 @@ func notifyListening(config *Config, pubFct func(beat.Event)) {
 
 		event := beat.Event{
 			Timestamp: time.Now(),
-			Fields:    common.MapStr{"listening": config.Host},
+			Fields: common.MapStr{
+				"processor": common.MapStr{"name": "onboarding", "event": "onboarding"},
+				"listening": config.Host,
+			},
 		}
 		pubFct(event)
 	}

--- a/beater/onboarding_test.go
+++ b/beater/onboarding_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/elastic/apm-agent-go"
 	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestNotifyUpServerDown(t *testing.T) {
@@ -44,5 +45,9 @@ func TestNotifyUpServerDown(t *testing.T) {
 
 	listening := saved.Fields["listening"].(string)
 	assert.Equal(t, config.Host, listening)
+
+	processor := saved.Fields["processor"].(common.MapStr)
+	assert.Equal(t, "onboarding", processor["name"])
+	assert.Equal(t, "onboarding", processor["event"])
 
 }


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Move onboarding document to dedicated index.  (#1159)