### PR TITLE
[6.x] Backport/6.x/pr 1142

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ https://github.com/elastic/apm-server/compare/6.3\...master[View commits]
 
 - Add /v1/metrics endpoint {pull}1000[1000] {pull}1121[1121].
 - Push onboarding doc to separate ES index {pull}1159[1159].
+- Deprecate usage of `apm-server setup` {pull}1142[1142].
 
 
 [[release-notes-6.3]]

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -155,48 +155,6 @@ setup.template.settings:
     #number_of_routing_shards: 30
 
 
-#============================== Dashboards =====================================
-#
-# These settings control loading the sample dashboards to the Kibana index. Loading
-# the dashboards are disabled by default and can be enabled either by setting the
-# options here, or by using the `-setup` CLI flag or the `setup` command.
-#setup.dashboards.enabled: false
-
-# The directory from where to read the dashboards. The default is the `kibana`
-# folder in the home path.
-#setup.dashboards.directory: ${path.home}/kibana
-
-# The URL from where to download the dashboards archive. It is used instead of
-# the directory if it has a value.
-#setup.dashboards.url:
-
-# The file archive (zip file) from where to read the dashboards. It is used instead
-# of the directory when it has a value.
-#setup.dashboards.file:
-
-# The name of the Kibana index to use for setting the configuration. Default is ".kibana"
-#setup.dashboards.kibana_index: .kibana
-
-# The Elasticsearch index name. This overwrites the index name defined in the
-# dashboards and index pattern. Example: testbeat-*
-# The dashboards.index needs to be changed in case the elasticsearch index pattern is modified.
-#setup.dashboards.index:
-
-# Always use the Kibana API for loading the dashboards instead of autodetecting
-# how to install the dashboards by first querying Elasticsearch.
-#setup.dashboards.always_kibana: false
-
-# If true and Kibana is not reachable at the time when dashboards are loaded,
-# it will retry to reconnect to Kibana instead of exiting with an error.
-#setup.dashboards.retry.enabled: false
-
-# Duration interval between Kibana connection retries.
-#setup.dashboards.retry.interval: 1s
-
-# Maximum number of retries before exiting with an error, 0 for unlimited retrying.
-#setup.dashboards.retry.maximum: 0
-
-
 #============================== Template =====================================
 
 # A template is used to set the mapping in Elasticsearch
@@ -238,10 +196,59 @@ setup.template.settings:
     #enabled: false
 
 
-#============================== Kibana =====================================
+#============================== Deprecated: Dashboards =====================================
+#
+# Deprecated: Loading dashboards from the APM Server into Kibana is deprecated from 6.4 on.
+#             We suggest to use the Kibana UI to load APM Server dashboards and index pattern instead.
+#
+# These settings control loading the sample dashboards to the Kibana index. Loading
+# the dashboards are disabled by default and can be enabled either by setting the
+# options here, or by using the `-setup` CLI flag or the `setup` command.
+#setup.dashboards.enabled: false
 
-# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.
-# This requires a Kibana endpoint configuration.
+# The directory from where to read the dashboards. The default is the `kibana`
+# folder in the home path.
+#setup.dashboards.directory: ${path.home}/kibana
+
+# The URL from where to download the dashboards archive. It is used instead of
+# the directory if it has a value.
+#setup.dashboards.url:
+
+# The file archive (zip file) from where to read the dashboards. It is used instead
+# of the directory when it has a value.
+#setup.dashboards.file:
+
+# The name of the Kibana index to use for setting the configuration. Default is ".kibana"
+#setup.dashboards.kibana_index: .kibana
+
+# The Elasticsearch index name. This overwrites the index name defined in the
+# dashboards and index pattern. Example: testbeat-*
+# The dashboards.index needs to be changed in case the elasticsearch index pattern is modified.
+#setup.dashboards.index:
+
+# Always use the Kibana API for loading the dashboards instead of autodetecting
+# how to install the dashboards by first querying Elasticsearch.
+#setup.dashboards.always_kibana: false
+
+# If true and Kibana is not reachable at the time when dashboards are loaded,
+# it will retry to reconnect to Kibana instead of exiting with an error.
+#setup.dashboards.retry.enabled: false
+
+# Duration interval between Kibana connection retries.
+#setup.dashboards.retry.interval: 1s
+
+# Maximum number of retries before exiting with an error, 0 for unlimited retrying.
+#setup.dashboards.retry.maximum: 0
+
+
+#============================== Deprecated: Kibana =====================================
+
+# Deprecated: Starting with APM Server version 6.4, loading dashboards and index pattern 
+#             from the APM Server into Kibana is deprecated.
+#             We suggest to use the Kibana UI to load APM Server dashboards and index pattern instead.
+#
+#             Setting up a Kibana endpoint is not necessary when loading the index pattern and dashboards via the UI.
+
 #setup.kibana:
 
   # Kibana Host

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -155,48 +155,6 @@ setup.template.settings:
     #number_of_routing_shards: 30
 
 
-#============================== Dashboards =====================================
-#
-# These settings control loading the sample dashboards to the Kibana index. Loading
-# the dashboards are disabled by default and can be enabled either by setting the
-# options here, or by using the `-setup` CLI flag or the `setup` command.
-#setup.dashboards.enabled: false
-
-# The directory from where to read the dashboards. The default is the `kibana`
-# folder in the home path.
-#setup.dashboards.directory: ${path.home}/kibana
-
-# The URL from where to download the dashboards archive. It is used instead of
-# the directory if it has a value.
-#setup.dashboards.url:
-
-# The file archive (zip file) from where to read the dashboards. It is used instead
-# of the directory when it has a value.
-#setup.dashboards.file:
-
-# The name of the Kibana index to use for setting the configuration. Default is ".kibana"
-#setup.dashboards.kibana_index: .kibana
-
-# The Elasticsearch index name. This overwrites the index name defined in the
-# dashboards and index pattern. Example: testbeat-*
-# The dashboards.index needs to be changed in case the elasticsearch index pattern is modified.
-#setup.dashboards.index:
-
-# Always use the Kibana API for loading the dashboards instead of autodetecting
-# how to install the dashboards by first querying Elasticsearch.
-#setup.dashboards.always_kibana: false
-
-# If true and Kibana is not reachable at the time when dashboards are loaded,
-# it will retry to reconnect to Kibana instead of exiting with an error.
-#setup.dashboards.retry.enabled: false
-
-# Duration interval between Kibana connection retries.
-#setup.dashboards.retry.interval: 1s
-
-# Maximum number of retries before exiting with an error, 0 for unlimited retrying.
-#setup.dashboards.retry.maximum: 0
-
-
 #============================== Template =====================================
 
 # A template is used to set the mapping in Elasticsearch
@@ -238,10 +196,59 @@ setup.template.settings:
     #enabled: false
 
 
-#============================== Kibana =====================================
+#============================== Deprecated: Dashboards =====================================
+#
+# Deprecated: Loading dashboards from the APM Server into Kibana is deprecated from 6.4 on.
+#             We suggest to use the Kibana UI to load APM Server dashboards and index pattern instead.
+#
+# These settings control loading the sample dashboards to the Kibana index. Loading
+# the dashboards are disabled by default and can be enabled either by setting the
+# options here, or by using the `-setup` CLI flag or the `setup` command.
+#setup.dashboards.enabled: false
 
-# Starting with Beats version 6.0.0, the dashboards are loaded via the Kibana API.
-# This requires a Kibana endpoint configuration.
+# The directory from where to read the dashboards. The default is the `kibana`
+# folder in the home path.
+#setup.dashboards.directory: ${path.home}/kibana
+
+# The URL from where to download the dashboards archive. It is used instead of
+# the directory if it has a value.
+#setup.dashboards.url:
+
+# The file archive (zip file) from where to read the dashboards. It is used instead
+# of the directory when it has a value.
+#setup.dashboards.file:
+
+# The name of the Kibana index to use for setting the configuration. Default is ".kibana"
+#setup.dashboards.kibana_index: .kibana
+
+# The Elasticsearch index name. This overwrites the index name defined in the
+# dashboards and index pattern. Example: testbeat-*
+# The dashboards.index needs to be changed in case the elasticsearch index pattern is modified.
+#setup.dashboards.index:
+
+# Always use the Kibana API for loading the dashboards instead of autodetecting
+# how to install the dashboards by first querying Elasticsearch.
+#setup.dashboards.always_kibana: false
+
+# If true and Kibana is not reachable at the time when dashboards are loaded,
+# it will retry to reconnect to Kibana instead of exiting with an error.
+#setup.dashboards.retry.enabled: false
+
+# Duration interval between Kibana connection retries.
+#setup.dashboards.retry.interval: 1s
+
+# Maximum number of retries before exiting with an error, 0 for unlimited retrying.
+#setup.dashboards.retry.maximum: 0
+
+
+#============================== Deprecated: Kibana =====================================
+
+# Deprecated: Starting with APM Server version 6.4, loading dashboards and index pattern 
+#             from the APM Server into Kibana is deprecated.
+#             We suggest to use the Kibana UI to load APM Server dashboards and index pattern instead.
+#
+#             Setting up a Kibana endpoint is not necessary when loading the index pattern and dashboards via the UI.
+
 #setup.kibana:
 
   # Kibana Host

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,4 +37,6 @@ var RootCmd *cmd.BeatsRootCmd
 func init() {
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
 	RootCmd = cmd.GenRootCmdWithIndexPrefixWithRunFlags(Name, IdxPattern, "", beater.New, runFlags)
+	RootCmd.RunCmd.Flags().MarkDeprecated("setup", "use Kibana UI for initial setup.")
+	RootCmd.SetupCmd.Deprecated = "use Kibana UI for initial setup."
 }

--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -20,12 +20,22 @@
 :modules-command-short-desc: Manages configured modules
 :run-command-short-desc: Runs {beatname_uc}. This command is used by default if you start {beatname_uc} without specifying a command
 
+ifndef::deprecate_dashboard_loading[]
+
 ifdef::has_ml_jobs[]
 :setup-command-short-desc: Sets up the initial environment, including the index template, Kibana dashboards (when available), and machine learning jobs (when available)
 endif::[]
 
 ifndef::has_ml_jobs[]
-:setup-command-short-desc: Sets up the initial environment, including the index template, Kibana dashboards (when available)
+:setup-command-short-desc: Sets up the initial environment, including the index template and Kibana dashboards (when available)
+endif::[]
+
+endif::[]
+
+ifdef::deprecate_dashboard_loading[]
+
+:setup-command-short-desc: Sets up the initial environment, including the ES index template and Kibana dashboards (deprecated).
+
 endif::[]
 
 :test-command-short-desc: Tests the configuration
@@ -39,9 +49,17 @@ endif::[]
 <titleabbrev>Command reference</titleabbrev>
 ++++
 
+ifndef::deprecate_dashboard_loading[]
 {beatname_uc} provides a command-line interface for starting {beatname_uc} and
-performing common tasks, like testing configuration files and loading
-dashboards. The command-line also supports <<global-flags,global flags>>
+performing common tasks, like testing configuration files and loading dashboards.
+endif::[]
+
+ifdef::deprecate_dashboard_loading[]
+{beatname_uc} provides a command-line interface for starting {beatname_uc} and
+performing common tasks, like testing configuration files and loading dashboards (deprecated).
+endif::[]
+
+The command-line also supports <<global-flags,global flags>>
 for controlling global behaviors.
 
 ifeval::["{beatname_lc}"!="winlogbeat"]
@@ -391,8 +409,19 @@ the end of the file is reached. By default harvesters are closed after
 endif::[]
 
 *`--setup`*::
-Loads the sample Kibana dashboards. If you want to load the dashboards without
-running {beatname_uc}, use the <<setup-command,`setup`>> command instead.
+ifdef::deprecate_dashboard_loading[]
+deprecated[{deprecate_dashboard_loading}]
+endif::[]
++
+ifdef::has_ml_jobs[]
+Loads the initial setup, including Elasticsearch template, Kibana index pattern,
+Kibana dashboards and Machine learning jobs.
+endif::[]
+ifndef::has_ml_jobs[]
+Loads the initial setup, including Elasticsearch template, Kibana index pattern and Kibana dashboards.
+endif::[]
+If you want to use the command without running {beatname_uc}, use the <<setup-command,`setup`>> command instead.
+
 
 ifeval::["{beatname_lc}"=="metricbeat"]
 
@@ -431,13 +460,17 @@ Or:
 [[setup-command]]
 ==== `setup` command
 
-{setup-command-short-desc}.
+{setup-command-short-desc}
 
 * The index template ensures that fields are mapped correctly in Elasticsearch.
+
 * The Kibana dashboards make it easier for you to visualize {beatname_uc} data
 in Kibana.
+
+ifdef::has_ml_jobs[]
 * The machine learning jobs contain the configuration information and metadata
 necessary to analyze data for anomalies.
+endif::[]
 
 Use this command instead of `run --setup` when you want to set up the
 environment without actually running {beatname_uc} and ingesting data.
@@ -452,20 +485,40 @@ environment without actually running {beatname_uc} and ingesting data.
 
 *FLAGS*
 
+ifndef::deprecate_dashboard_loading[]
 *`--dashboards`*::
+Sets up the Kibana dashboards only. This option loads the dashboards from the
+{beatname_uc} package. For more options, such as loading customized dashboards,
+see {beatsdevguide}/import-dashboards.html[Importing Existing Beat Dashboards]
+in the _Beats Developer Guide_.
+endif::[]
+
+ifdef::deprecate_dashboard_loading[]
+*`--dashboards`*::
+
+deprecated[{deprecate_dashboard_loading}]
++
 Sets up the Kibana dashboards only.
+endif::[]
 
 *`-h, --help`*::
 Shows help for the `setup` command.
 
+ifdef::has_ml_jobs[]
+
 *`--machine-learning`*::
 Sets up machine learning job configurations only.
+
+endif::[]
 
 ifeval::["{beatname_lc}"=="filebeat"]
 
 *`--modules MODULE_LIST`*::
 Specifies a comma-separated list of modules. Use this flag to avoid errors when
 there are no modules defined in the +{beatname_lc}.yml+ file.
+
+*`--pipelines`*::
+Sets up ingest pipelines for configured filesets.
 
 endif::[]
 

--- a/docs/copied-from-beats/dashboards.asciidoc
+++ b/docs/copied-from-beats/dashboards.asciidoc
@@ -18,14 +18,17 @@ command (as described here) or
 +{beatname_lc}.yml+ config file.
 
 This requires a Kibana endpoint configuration. If you didn't already configure
-a Kibana endpoint, see <<{beatname_lc}-configuration,configure {beatname_uc}>>.
+a Kibana endpoint, see <<{beatname_lc}-configuration,configure {beatname_uc}>>. 
 
 Make sure Kibana is running before you perform this step. If you are accessing a
 secured Kibana instance, make sure you've configured credentials as described in
 <<{beatname_lc}-configuration>>.
 
 To set up the Kibana dashboards for {beatname_uc}, use the appropriate command
-for your system.
+for your system. The command shown here loads the dashboards from the {beatname_uc}
+package. For more options, such as loading customized dashboards, see
+{beatsdevguide}/import-dashboards.html[Importing Existing Beat Dashboards] in
+the _Beats Developer Guide_.
 ifndef::only-elasticsearch[]
 If you've configured the Logstash output, see
 <<load-dashboards-logstash>>.

--- a/docs/copied-from-beats/dashboardsconfig.asciidoc
+++ b/docs/copied-from-beats/dashboardsconfig.asciidoc
@@ -11,6 +11,11 @@
 
 [[configuration-dashboards]]
 == Load the Kibana dashboards
+ifdef::deprecate_dashboard_loading[]
+
+deprecated[{deprecate_dashboard_loading}]
+
+endif::[]
 
 {beatname_uc} comes packaged with example Kibana dashboards, visualizations,
 and searches for visualizing {beatname_uc} data in Kibana.

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -216,10 +216,16 @@ The index name to write events to. The default is
 +"{beatname_lc}-%\{[beat.version]\}-%\{+yyyy.MM.dd\}"+ (for example,
 +"{beatname_lc}-{version}-2017.04.26"+). If you change this setting, you also
 need to configure the `setup.template.name` and `setup.template.pattern` options
-(see <<configuration-template>>). If you are using the pre-built Kibana
-dashboards, you also need to set the `setup.dashboards.index` option (see
-<<configuration-dashboards>>).
+(see <<configuration-template>>).
 
+If you are using the pre-built Kibana dashboards,
+you also need to set the `setup.dashboards.index` option (see <<configuration-dashboards>>).
+
+ifdef::deprecate_dashboard_loading[]
+
+deprecated[{deprecate_dashboard_loading}]
+
+endif::[]
 
 ===== `indices`
 

--- a/docs/copied-from-beats/shared-docker.asciidoc
+++ b/docs/copied-from-beats/shared-docker.asciidoc
@@ -2,7 +2,23 @@
 === Running {beatname_uc} on Docker
 
 Docker images for {beatname_uc} are available from the Elastic Docker
-registry. You can retrieve an image with a `docker pull` command.
+registry. The base image is https://hub.docker.com/_/centos/[centos:7].
+
+A list of all published Docker images and tags is available at
+https://www.docker.elastic.co[www.docker.elastic.co]. The source code is in
+{dockergithub}[GitHub].
+
+These images are free to use under the Elastic license. They contain open source 
+and free commercial features and access to paid commercial features.  
+{xpack-ref}/license-management.html[Start a 30-day trial] to try out all of the 
+paid commercial features. See the 
+https://www.elastic.co/subscriptions[Subscriptions] page for information about 
+Elastic license levels.
+
+==== Pulling the image
+
+Obtaining Beats for Docker is as simple as issuing a +docker pull+ command
+against the Elastic Docker registry.
 
 ifeval::["{release-state}"=="unreleased"]
 
@@ -18,30 +34,30 @@ ifeval::["{release-state}"!="unreleased"]
 docker pull {dockerimage}
 ------------------------------------------------
 
-endif::[]
+Alternatively, you can download other Docker images that contain only features
+available under the Apache 2.0 license. To download the images, go to 
+https://www.docker.elastic.co[www.docker.elastic.co]. 
 
-The base image is https://hub.docker.com/_/centos/[centos:7] and the source
-code can be found on
-{dockergithub}[GitHub].
+endif::[]
 
 [float]
 ==== Configure {beatname_uc} on Docker
 
 The Docker image provides several methods for configuring {beatname_uc}. The
-conventional approach is to provide a configuration file via a bind-mounted
-volume, but it's also possible to create a custom image with your
+conventional approach is to provide a configuration file via a bind mount, but 
+it's also possible to create a custom image with your
 configuration included.
 
 [float]
 ===== Bind-mounted configuration
 
-One way to configure {beatname_uc} on Docker is to provide +{beatname_lc}.yml+ via bind-mounting.
-With +docker run+, the bind-mount can be specified like this:
+One way to configure {beatname_uc} on Docker is to provide +{beatname_lc}.yml+ via a bind mount.
+With +docker run+, the bind mount can be specified like this:
 
 ["source", "sh", subs="attributes"]
 --------------------------------------------
 docker run \
-  -v ~/{beatname_lc}.yml:/usr/share/{beatname_lc}/{beatname_lc}.yml \
+  --mount type=bind,source="$(pwd)"/{beatname_lc}.yml,target=/usr/share/{beatname_lc}/{beatname_lc}.yml \
   {dockerimage}
 --------------------------------------------
 

--- a/docs/copied-from-beats/shared-kibana-config.asciidoc
+++ b/docs/copied-from-beats/shared-kibana-config.asciidoc
@@ -11,6 +11,11 @@
 
 [[setup-kibana-endpoint]]
 == Set up the Kibana endpoint
+ifdef::deprecate_dashboard_loading[]
+
+deprecated[{deprecate_dashboard_loading}]
+
+endif::[]
 
 ifeval::["{beatname_lc}" == "apm-server"]
 The Kibana dashboards are loaded into Kibana via the Kibana API.

--- a/docs/copied-from-beats/shared-template-load.asciidoc
+++ b/docs/copied-from-beats/shared-template-load.asciidoc
@@ -94,6 +94,8 @@ that you specify should include the root name of the index plus version and
 date information. You also need to configure the `setup.template.name` and
 `setup.template.pattern` options to match the new name. For example:
 +
+ifndef::deprecate_dashboard_loading[]
+
 ["source","sh",subs="attributes,callouts"]
 -----
 output.elasticsearch.index: "customname-%{[beat.version]}-%{+yyyy.MM.dd}"
@@ -101,10 +103,27 @@ setup.template.name: "customname"
 setup.template.pattern: "customname-*"
 setup.dashboards.index: "customname-*" <1>
 -----
+
 <1> If you plan to
 <<load-kibana-dashboards, set up the Kibana dashboards>>, also set
 this option to overwrite the index name defined in the dashboards and index
 pattern.
+
+endif::[]
+
+ifdef::deprecate_dashboard_loading[]
+
+["source","sh",subs="attributes,callouts"]
+-----
+output.elasticsearch.index: "customname-%{[beat.version]}-%{+yyyy.MM.dd}"
+setup.template.name: "customname"
+setup.template.pattern: "customname-*"
+-----
++
+Also ensure to change the index name accordingly in the Kibana dashboards,
+when loading via the Kibana UI.
+
+endif::[]
 
 See <<configuration-template>> for the full list of configuration options.
 

--- a/docs/copied-from-beats/template-config.asciidoc
+++ b/docs/copied-from-beats/template-config.asciidoc
@@ -87,4 +87,16 @@ ifeval::["{beatname_lc}"!="apm-server"]
 
 NOTE: With append_fields only new fields can be added an no existing one overwritten or changed. This is especially useful if data is collected through the http/json metricset where the data structure is not known in advance. Changing the config of append_fields means the template has to be overwritten and only applies to new indices. If there are 2 Beats with different append_fields configs the last one writing the template will win. Any changes will also have an affect on the Kibana Index pattern.
 
+*`setup.template.json.enabled`*:: Set to true to load a json based template file. Specify the path to your Elasticsearch
+index template file and set the name of the template. experimental[]
+
+["source","yaml",subs="attributes"]
+----------------------------------------------------------------------
+setup.template.json.enabled: true
+setup.template.json.path: "template.json"
+setup.template.json.name: "template-name
+----------------------------------------------------------------------
+
+NOTE: If the JSON template is used, the fields.yml is skipped for the template generation.
+
 endif::[]

--- a/docs/dashboards.asciidoc
+++ b/docs/dashboards.asciidoc
@@ -1,5 +1,53 @@
 [[load-kibana-dashboards]]
 === Dashboards
 
+From APM Server and Kibana 6.4 on you can load dashboards directly via the Kibana UI.
 
-include::./copied-from-beats/dashboards.asciidoc[]
+==== Setup via APM Server
+
+deprecated[{deprecate_dashboard_loading}]
+
+Loading via APM Server requires a <<setup-kibana-endpoint,Kibana endpoint configuration>>. 
+If you are accessing a secured Kibana instance, make sure you've configured credentials.
+
+You have to either <<configuration-dashboards,configure dashboard loading>> in the
++{beatname_lc}.yml+ config file,
+or run the appropriate `setup` command for your system:
+
+*deb and rpm:*
+
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+{beatname_lc} setup --dashboards
+----------------------------------------------------------------------
+
+
+*mac:*
+
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+./{beatname_lc} setup --dashboards
+----------------------------------------------------------------------
+
+
+*docker:*
+
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+docker run {dockerimage} setup --dashboards
+----------------------------------------------------------------------
+
+*win:*
+
+endif::allplatforms[]
+
+Open a PowerShell prompt as an Administrator (right-click the PowerShell icon
+and select *Run As Administrator*).
+
+From the PowerShell prompt, change to the directory where you installed {beatname_uc},
+and run:
+
+["source","sh",subs="attributes"]
+----------------------------------------------------------------------
+PS > .{backslash}{beatname_lc}.exe setup --dashboards
+----------------------------------------------------------------------

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -58,7 +58,7 @@ APM Server creates documents from the data received from agents and stores them 
 
 To visualize the data after it's sent to Elasticsearch,
 you can use the the dedicated APM UI bundled in X-Pack,
-or the pre-built open source Kibana dashboards that come with APM Server.
+or the pre-built open source Kibana dashboards that can be loaded directly in the Kibana UI.
 
 We designed Elastic APM to run on anything from a regular laptop to thousands of machines,
 and it's easy to get started.
@@ -148,16 +148,8 @@ You can also configure APM Server to listen on a Unix domain socket.
 [[kibana-dashboards]]
 [float]
 ==== Install the Kibana dashboards
-APM Server comes with predefined Kibana dashboards and index templates for APM data.
-To install those run the following command:
 
-[source,bash]
-----------------------------------
-./apm-server setup
-----------------------------------
-
-NOTE: Due to a bug in Kibana 6.0.0.-rc2 the dashboards don't work in Kibana 6.0.0-rc2.
-
+From APM Server and Kibana 6.4 on you can load dashboards directly via the Kibana UI.
 
 See an example screenshot of a Kibana dashboard:
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -17,6 +17,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
 :securitydoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
+:deprecate_dashboard_loading: 6.4.0 
 
 ifdef::env-github[]
 NOTE: For the best reading experience,

--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -57,24 +57,6 @@ output.elasticsearch:
   password: "elastic"
 ----
 
-If you plan to use the sample Kibana dashboards provided with {beatname_uc},
-configure the Kibana endpoint:
-
-[source,yaml]
-----------------------------------------------------------------------
-setup.kibana:
-  host: "localhost:5601"
-----------------------------------------------------------------------
-
---
-Where `host` is the hostname and port of the machine where Kibana is running,
-for example, `localhost:5601`.
-
-NOTE: If you specify a path after the port number, you need to include
-the scheme and port: `http://localhost:5601/path`.
-
---
-
 See <<configuring-howto-apm-server>> for more configuration options.
 
 


### PR DESCRIPTION
backporting PR #1142 

* Docs: deprecate loading dashboards and index pattern.

Add deprecation notes to apm-server.yml and docs
for loading dashboards and index patterns via Kibana.
Add deprecation note for setting up Kibana endpoint as it won't be
needed any more.

implements #1135