### PR TITLE
[6.x] Briefly explain benchmarking in README (#1147)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,12 @@ release-manager-snapshot:
 release-manager-release:
 	./_beats/dev-tools/run_with_go_ver $(MAKE) release
 
+.PHONY: bench
+bench:
+	@go test -benchmem -run=XXX -benchtime=100ms -bench='.*' ./processor/...
+
 .PHONY: are-kibana-objects-updated
 are-kibana-objects-updated: python-env
 	@$(MAKE) clean update
 	@$(PYTHON_ENV)/bin/python ./script/are_kibana_saved_objects_updated.py ${BEATS_VERSION}
+

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ make package
 
 This will fetch and create all images required for the build process. The whole process can take several minutes.
 
+
 ## Documentation
 The [Documentation](https://www.elastic.co/guide/en/apm/server/current/index.html) for the APM Server can be found in the `docs` folder.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -43,3 +43,23 @@ Alternatively you can send a `curl` request to the
 * Open `localhost:5601` in your browser
 * In Kibana go to the Dashboards to see APM Data
 * In Kibana go to the Discovery tab to query for APM Data
+
+
+## Benchmarking
+
+To run simple benchmark tests, run:
+
+```
+make bench
+```
+
+A good way to present your results is by using `benchcmp`.
+With your changes in the current working tree, do:
+
+```
+$ go get -u benchcmp
+$ make bench > new.txt
+$ git checkout master
+$ make bench > old.txt
+$ benchcmp old.txt new.txt
+```


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Briefly explain benchmarking in README  (#1147)