### PR TITLE
Server information

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -12,6 +12,8 @@ https://github.com/elastic/apm-server/compare/6.4\...master[View commits]
 [float]
 === Added
 
+- Provide basic server information at `/` {pull}1197[1197]
+
 [[release-notes-6.4]]
 == APM Server version 6.4
 

--- a/beater/handlers_test.go
+++ b/beater/handlers_test.go
@@ -75,6 +75,37 @@ func TestConcurrency(t *testing.T) {
 	assert.True(t, concurrentWait.Get() > 20, strconv.FormatInt(concurrentWait.Get(), 10))
 }
 
+func TestOkBody(t *testing.T) {
+	req, err := http.NewRequest("POST", "_", nil)
+	assert.Nil(t, err)
+	w := httptest.NewRecorder()
+	sendStatus(w, req, serverResponse{
+		code:    http.StatusNonAuthoritativeInfo,
+		counter: requestCounter,
+		body:    "some body",
+	})
+	resp := w.Result()
+	got, _ := ioutil.ReadAll(resp.Body)
+	assert.Equal(t, "some body", string(got))
+	assert.Equal(t, "text/plain; charset=utf-8", resp.Header.Get("Content-Type"))
+}
+
+func TestOkBodyJson(t *testing.T) {
+	req, err := http.NewRequest("POST", "_", nil)
+	req.Header.Set("Accept", "application/json")
+	assert.Nil(t, err)
+	w := httptest.NewRecorder()
+	sendStatus(w, req, serverResponse{
+		code:    http.StatusNonAuthoritativeInfo,
+		counter: requestCounter,
+		body:    "some body",
+	})
+	resp := w.Result()
+	got, _ := ioutil.ReadAll(resp.Body)
+	assert.Equal(t, "{\"ok\":\"some body\"}", string(got))
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+}
+
 func TestAccept(t *testing.T) {
 	for idx, test := range []struct{ accept, expectedError, expectedContentType string }{
 		{"application/json", "{\"error\":\"data validation error: error message\"}", "application/json"},

--- a/docs/high-availability.asciidoc
+++ b/docs/high-availability.asciidoc
@@ -5,9 +5,10 @@ To achieve high availability
 you can place multiple instances of APM Server behind a regular HTTP load balancer,
 for example HAProxy or nginx.
 
-The endpoint `/healthcheck` always returns a `HTTP 200`.
+The endpoint `/` always returns an `HTTP 200`.
 You can configure your load balancer to send HTTP requests to this endpoint
 to determine if an APM Server is running.
+See <<server-info>> for more information on that endpoint.
 
 In case of temporal issues, like unavailable Elasticsearch or a sudden high workload,
 the data is buffered in an internal memory queue and ingestion retried.

--- a/docs/intake-api.asciidoc
+++ b/docs/intake-api.asciidoc
@@ -7,6 +7,7 @@ The Intake API is HTTP JSON based. The APM Server exposes endpoints for
 * <<transaction-api,Transactions>>
 * <<error-api,Errors>>
 * <<sourcemap-api,Source Map Upload>>
+* <<server-info,Server Information>>
 
 Unless you are implementing an agent, you don't need to know about the specifics of this API.
 
@@ -14,3 +15,4 @@ Unless you are implementing an agent, you don't need to know about the specifics
 include::./transaction-api.asciidoc[]
 include::./error-api.asciidoc[]
 include::./sourcemap-api.asciidoc[]
+include::./server-info.asciidoc[]

--- a/docs/server-info.asciidoc
+++ b/docs/server-info.asciidoc
@@ -3,6 +3,8 @@
 
 The APM Server exposes an API endpoint to query some server information.
 
+This lightweight endpoint is useful as a server up/down healthcheck.
+
 [[server-info-endpoint]]
 [float]
 === Server Information endpoint
@@ -17,7 +19,7 @@ This endpoint always returns an HTTP 200.
 
 If a <<secret-token, secret token>> is set, only requests including <<config-secret-token, authentication>> will include server details.
 
-Set the `Content-Type` header set to `text/plain` to move the server information to the root level of the response, removing `ok`.
+Set the `Accept` header set to `text/plain` to move the server information to the root level of the response, removing `ok`.
 
 [[server-info-examples]]
 [float]

--- a/docs/server-info.asciidoc
+++ b/docs/server-info.asciidoc
@@ -1,0 +1,39 @@
+[[server-info]]
+== Server Information
+
+The APM Server exposes an API endpoint to query some server information.
+
+[[server-info-endpoint]]
+[float]
+=== Server Information endpoint
+Send an `HTTP GET` request to the server information endpoint:
+
+[source,bash]
+------------------------------------------------------------
+http(s)://{hostname}:{port}/
+------------------------------------------------------------
+
+This endpoint always returns an HTTP 200.
+
+If a <<secret-token, secret token>> is set, only requests including <<config-secret-token, authentication>> will include server details.
+
+Set the `Content-Type` header set to `text/plain` to move the server information to the root level of the response, removing `ok`.
+
+[[server-info-examples]]
+[float]
+==== Example
+
+Example server information request:
+
+["source","sh",subs="attributes"]
+---------------------------------------------------------------------------
+curl http://127.0.0.1:8200/
+
+{
+  "ok": {
+    "build_date": "2018-07-27T18:49:58Z",
+    "build_sha": "bc4d9a286a65b4283c2462404add86a26be61dca",
+    "version": "7.0.0-alpha1"
+  }
+}
+---------------------------------------------------------------------------


### PR DESCRIPTION
provide basic server information at /
* if no secret token is set
* if secret token is set and request is authorized

```
{
    "build_date": "2018-07-27T18:49:58Z",
    "build_sha": "bc4d9a286a65b4283c2462404add86a26be61dca",
    "version": "7.0.0-alpha1"
}
```

returns 200 OK in any case, to replace /healthcheck eventually

closes #957