### PR TITLE
[6.x] rotate changelog to 6.4 (#1202)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -8,13 +8,24 @@
 :pull: https://github.com/elastic/apm-server/pull/
 
 
-https://github.com/elastic/apm-server/compare/6.3\...6.x[View commits]
-https://github.com/elastic/apm-server/compare/6.3\...master[View commits]
+https://github.com/elastic/apm-server/compare/6.4\...master[View commits]
 
 [float]
 === Added
 
 - Listen on default port 8200 if unspecified {pull}[886]886.
+[[release-notes-6.4]]
+== APM Server version 6.4
+
+https://github.com/elastic/apm-server/compare/6.3\...6.4[View commits]
+
+* <<release-notes-6.4.0>>
+
+[[release-notes-6.4.0]]
+=== APM Server version 6.4.0
+
+https://github.com/elastic/apm-server/compare/v6.3.2\...v6.4.0[View commits]
+
 - Change `frontend` to `rum` in config file, but still support `frontend` for backwards compatibility {pull}1155[1155].
 - Support `rum` and `client-side` endpoint for RUM for backwards compatibility {pull}1155[1155].
 - Listen on default port 8200 if unspecified {pull}886[886].
@@ -24,7 +35,6 @@ https://github.com/elastic/apm-server/compare/6.3\...master[View commits]
 - Combine `apm-server.yml` and `apm-server.reference.yml` into one file {pull}[958]958.
 - Add optional tracing for the server's API and event publisher {pull}816[816].
 - Read sourcemap content and fill context lines {pull}972[972].
-- Add /v1/metrics endpoint {pull}1000[1000].
 - Remove regexProperties validation rules {pull}1148[1148], {pull}1150[1150].
 - Add source_mapping.elasticsearch configuration option {pull}1114[1114].
 - Add /v1/metrics endpoint {pull}1000[1000] {pull}1121[1121].

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -10,6 +10,7 @@ This following section summarizes the changes in each release.
 
 
 * <<release-notes-head>>
+* <<release-notes-6.4>>
 * <<release-notes-6.3>>
 * <<release-notes-6.2>>
 * <<release-notes-6.1>>


### PR DESCRIPTION
Backports the following commits to 6.x:
 - rotate changelog to 6.4  (#1202)