### PR TITLE
[DOCS] Fix broken links by updating branch

### DIFF
--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,5 +1,5 @@
 :stack-version: 6.4.0
-:doc-branch: 6.x
+:doc-branch: 6.4
 :branch: {doc-branch}
 :go-version: 1.10.3
 :release-state: unreleased


### PR DESCRIPTION
When we started building the 6.4 documentation, we received the following errors:

Bad cross-document links:
  html/en/apm/get-started/6.4/install-and-run.html:
   - en/apm/server/6.x/index.html
   - en/apm/server/6.x/securing-apm-server.html
  html/en/apm/get-started/6.4/overview.html:
   - en/apm/server/6.x/index.html

This PR fixes the links by updating the branch info.