### PR TITLE
[6.4] streamline docs a bit, and remove redundant info (#1169)

### DIFF
--- a/docs/common-problems.asciidoc
+++ b/docs/common-problems.asciidoc
@@ -10,28 +10,25 @@ This section describes common problems you might encounter with APM Server.
 [float]
 === HTTP 503: Queue is full
 
-APM Server has an internal queue that buffers documents until they can be delivered to Elasticsearch.
-The internal queue helps to:
+APM Server has an internal queue that helps to:
 
-* alleviate problems that might occur if Elasticsearch is intermittently unavailable
-* handle large spikes of data arriving at the APM Server at the same time
+* buffer data temporarily if Elasticsearch is intermittently unavailable
+* handle sudden large spikes of data
 * send documents to Elasticsearch in bulk, instead of individually
 
-When the internal queue has reached the maximum buffer size, 
+When the queue has reached the maximum size,
 APM Server returns an HTTP 503 status with the message "Queue is full".
 
-A full queue generally means that the agents collect more data than APM server is able to deliver to Elasticsearch.
+A full queue generally means that the agents collect more data than APM server is able to process.
 This might happen when APM Server is not configured properly for the size of your Elasticsearch cluster,
 or because your Elasticsearch cluster is underpowered or not configured properly for the given workload.
 
-The queue can also fill up if Elasticsearch is unavailable for a prolonged period,
-it runs out of disk space,
-or a sudden spike of data arrives at the APM Server.
+The queue can also fill up if Elasticsearch runs out of disk space.
 
-If the APM Server only returns 503 responses, it might indicate that an Elasticsearch disk is full.
-If the APM Server returns interleaved 503 and 202 responses, it might indicate that the APM Server can't process that much data.
+If the APM Server only returns 503 responses, it indicates that an Elasticsearch disk might be full.
+If the APM Server returns interleaved 503 and 202 responses, it indicates that the APM Server can't process that much data.
 
-You have a few options to solve this problem: 
+You have a few options to solve this problem:
 
 * <<reduce-storage, Reduce storage>>
 * <<tune-output-config>>
@@ -42,8 +39,7 @@ You have a few options to solve this problem:
 [float]
 === HTTP 503: Request timed out waiting to be processed
 
-There is a limit to the number of requests that the APM Server can process concurrently.
-The APM Server returns an HTTP 503 status with the message "Request timed out waiting to be processed" when the limit is reached and the request from an agent is blocked.
+This happens when APM Server exceeds the maximum number of requests that it can process concurrently.
 This limit is determined by the `apm-server.concurrent_requests` configuration parameter.
 
 To alleviate this problem,
@@ -53,7 +49,7 @@ you can try to:
 * <<reduce-stacktrace>>
 * <<reduce-payload-size>>
 * <<adjust-concurrent-requests>>
-* <<add-apm-server-nodes>>
+* <<add-apm-server-instances>>
 
 [float]
 [[ssl-client-fails]]

--- a/docs/configuration-process.asciidoc
+++ b/docs/configuration-process.asciidoc
@@ -1,28 +1,17 @@
 [[configuration-process]]
 == General configuration options
 
-Example config showing some basic configuration options for APM Server:
+Example config file:
 
 ["source","yaml"]
 ----
-apm-server.host: "localhost:8200"
-apm-server.max_unzipped_size: 31457280
-apm-server.max_header_size: 1048576
-apm-server.max_request_queue_time: 2s
-apm-server.read_timeout: 30s
-apm-server.write_timeout: 30s
-apm-server.shutdown_timeout: 5s
-apm-server.concurrent_requests: 5
-apm-server.max_connections: 0
-apm-server.instrumentation.enabled: false
-apm-server.capture_personal_data: true
-apm-server.expvar.enabled: false
-apm-server.expvar.url:"/debug/vars"
-apm-server.metrics.enabled: true
+apm-server:
+  host: "localhost:8200"
+  concurrent_requests: 5
+  rum:
+    enabled: true
 
 queue.mem.events: 4096
-queue.mem.flush.min_events: 0
-queue.mem.flush.timeout: 1s
 
 max_procs: 4
 ----
@@ -76,15 +65,15 @@ Defaults to 5 seconds.
 [[concurrent_requests]]
 [float]
 ==== `concurrent_request`
-Maximum number of requests a server is allowed to process concurrently.
+Maximum number of requests the server can process concurrently.
 Read more about how to tune data ingestion by <<adjust-concurrent-requests, adjusting concurrent_requests>>.
-Default value is set to 5.
+Default value is 5.
 
 [[max_connections]]
 [float]
 ==== `max_connections`
-Maximum number of new connections to accept simultaneously..
-Default value is set to 0, which means _unlimited_.
+Maximum number of TCP connections to accept simultaneously.
+Default value is 0, which means _unlimited_.
 
 [[instrumentation.enabled]]
 [float]
@@ -96,20 +85,19 @@ Disabled by default.
 [float]
 ==== `secret_token`
 Authorization token for sending data to the APM server.
-If a token is set the agents must send the token in the following format:
+If a token is set, the agents must send it in the following format:
 Authorization: Bearer <secret-token>.
-By default no authorization token is set.
+The token is not used for RUM endpoints. By default no authorization token is set.
 
-It is recommended though to use an authorization token in combination with SSL enabled.
+It is recommended to use an authorization token in combination with SSL enabled.
 Read more about <<securing-apm-server, Securing APM Server>> and the <<secret-token, secret token>>.
 
 [[capture_personal_data]]
 [float]
 ==== `capture_personal_data`
-If set to true,
-APM Server augments data received by the agent with the original IP of either the backend server,
-or the IP and User Agent of the real user (only for real user monitoring).
-It defaults to true.
+If true,
+APM Server captures the IP of the instrumented service and its User Agent if any.
+Enabled by default.
 
 [[expvar.enabled]]
 [float]
@@ -126,22 +114,20 @@ Defaults to `debug/vars`.
 [[metrics.enabled]]
 [float]
 ==== `metrics`
-Experimental Metrics endpoint allowing to collect and upload metrics related to APM.
-The experimental endpoint is enabled by default.
+Experimental Metrics endpoint for collecting application metrics.
+Enabled by default.
 
 [float]
 === Configuration options `queue.mem.*`
-All event data are buffered in a memory queue before they get published to the configured output.
-How manya data events are buffered and for how long
-is directly influenced by the `queue.mem.*` settings.
+Data is buffered in a memory queue before it is published to the configured output.
+`queue.mem.*` settings modify the queue behaviour.
 
 [[mem.events]]
 [float]
 ==== `events`
 Maximum number of events the memory queue can buffer.
-Read more about how this setting can be used for <<tune-data-ingestion, tuning data ingestion>> and how it plays
-together with other config options.
-Defaults to 4096.
+Read more about how this setting can be used for <<tune-data-ingestion, tuning data ingestion>>.
+Default value is 4096.
 
 [[mem.flush.min_events]]
 [float]

--- a/docs/configuration-rum.asciidoc
+++ b/docs/configuration-rum.asciidoc
@@ -1,20 +1,19 @@
 [[configuration-rum]]
 == Set up Real User Monitoring (RUM) support
 
-At the moment the {apm-rum-ref}/index.html[JavaScript RUM Agent] 
-offers <<rum, real user monitoring (RUM)>> support.
+The {apm-rum-ref}/index.html[JavaScript RUM Agent] offers <<rum, real user monitoring (RUM)>> support.
 
 Example config with RUM enabled:
 
 ["source","yaml"]
 ----
-apm-server.rum.enabled: true 
-apm-server.rum.rate_limit: 10 
-apm-server.rum.allow_origins: ['*'] 
-apm-server.rum.library_pattern: "node_modules|bower_components|~" 
-apm-server.rum.exclude_from_grouping: "^/webpack" 
-apm-server.rum.source_mapping.cache.expiration: 5m 
-apm-server.rum.source_mapping.index_pattern: "apm-*-sourcemap*" 
+apm-server.rum.enabled: true
+apm-server.rum.rate_limit: 10
+apm-server.rum.allow_origins: ['*']
+apm-server.rum.library_pattern: "node_modules|bower_components|~"
+apm-server.rum.exclude_from_grouping: "^/webpack"
+apm-server.rum.source_mapping.cache.expiration: 5m
+apm-server.rum.source_mapping.index_pattern: "apm-*-sourcemap*"
 ----
 
 [float]
@@ -22,43 +21,44 @@ apm-server.rum.source_mapping.index_pattern: "apm-*-sourcemap*"
 
 [[rum-enable]]
 [float]
-==== `enabled` 
+==== `enabled`
 For enabling RUM support, set the `apm-server.rum.enabled` to `true`.
 By default this is disabled.
 
 [float]
 ==== `rate_limit`
 Rate limit per second and IP address for requests sent to the RUM endpoint.
-If the rate limit is hit the APM Server will return an HTTP status code `429`. 
+If the rate limit is hit, the APM Server will return an HTTP status code `429`.
 The rate limit cannot be disabled. Ensure to have it set to a number suiting your requirements.
 Default value is set to 10.
 
 [float]
 ==== `allow_origins`
-Comma separated list of permitted origins for RUM supprt. 
-User-agents send an origin header that will be validated against this list.
-This is done by default by modern browsers as part of the https://www.w3.org/TR/cors/[CORS specification].
+Comma separated list of permitted origins for RUM supprt.
+User-agents send an Origin header that will be validated against this list.
+This is done automatically by modern browsers as part of the https://www.w3.org/TR/cors/[CORS specification].
 An origin is made of a protocol scheme, host and port, without the url path.
 Default value is set to `['*']`, which allows everything.
 
 [float]
 ==== `library_pattern`
-Configure a regexp to be matched against a stacktrace frame's `file_name` and `abs_path` attributes.
+Regexp to be matched against a stacktrace frame's `file_name` and `abs_path` attributes.
 If the regexp matches, the stacktrace frame is considered to be a library frame.
-When source mapping is applied the `error.culprit` is set to reflect the _function_ and the _filename_ 
-of the first stacktrace frame not considered to be a library frame. 
-This aims to provide an entry point for identifying issues. 
+When source mapping is applied the `error.culprit` is set to reflect the _function_ and the _filename_
+of the first not library frame.
+This aims to provide an entry point for identifying issues.
 Default value is `"node_modules|bower_components|~"`.
 
 [float]
 ==== `exclude_from_grouping`
-Configure a regexp to be matched against a stacktrace frame's `file_name`.
+Regexp to be matched against a stacktrace frame's `file_name`.
 If the regexp matches, the stacktrace frame is excluded from being used for calculating error groups.
 The default pattern excludes stacktrace frames that have a filename starting with `/webpack`.
 
+[[rum-sourcemap-cache]]
 [float]
 ==== `source_mapping.cache.expiration`
-If a source map has been uploaded to the APM Server, 
+If a source map has been uploaded to the APM Server,
 <<sourcemaps,source mapping>> is automatically applied to documents sent to the RUM endpoint.
 Source maps are fetched from Elasticsearch and then kept in an in-memory cache for the configured time.
 Values configured without a time unit are treated as seconds.
@@ -68,12 +68,11 @@ Default value is 5 minutes.
 [float]
 ==== `source_mapping.elasticsearch`
 Configure the Elasticsearch source map retrieval location, taking the same options as <<elasticsearch-output,output.elasticsearch>>.
-If unset, sourcemaps are fetched from `output.elasticsearch` when that output is enabled.
-This must be set when using an output other than Elasticsearch for source maps to be applied.
+This must be set when using an output other than Elasticsearch, and that output is writing to Elasticsearch.
+Othewise leave this section empty.
 
 [float]
 ==== `source_mapping.index_pattern`
-Source maps are stored in a seperate index `apm-%{[beat.version]}-sourcemap` by default. 
-If this default is changed, 
-a matching index pattern needs to be specified here.
-Default value is `apm-*-sourcemap*`
+Source maps are stored in a seperate index `apm-%{[beat.version]}-sourcemap` by default.
+If changed, a matching index pattern needs to be specified here.
+

--- a/docs/configuring.asciidoc
+++ b/docs/configuring.asciidoc
@@ -5,8 +5,6 @@
 --
 include::./copied-from-beats/shared-configuring.asciidoc[]
 
-The following topics describe how to configure APM Server:
-
 * <<configuration-process>>
 * <<configuring-output>>
 * <<configuration-ssl>>

--- a/docs/context.asciidoc
+++ b/docs/context.asciidoc
@@ -1,12 +1,10 @@
-An event's context bundles information regarding the environment in which it is recorded.
-It describes the `service` in which the event is captured, 
-the `system` in which the monitored service is running and the event's `process` information.
+The contextual data describes the environment in which an event is recorded.
+It includes the `service`, the `system` where the service runs, and the `process`.
 
-It can also contain information about the authenticated `user`. 
+It can also contain information about the authenticated `user`.
 
-An event's context can also include information about the request leading to the event and the response of processing the event. 
-In case a http request is captured, it contains information about the `url`, `cookies`, `body`, `headers`, etc.
+An event's context can also include information about an authenticated `user`, a request leading to it, or a response.
+For instance, HTTP requests context have `url`, `cookies`, `body`, `headers`, etc.
 
-The agents provide some configuration options with which the users can also capture customized information.
-The non-indexed information is captured within a `custom` object,
-while the searchable information is stored within `tags`.
+The agents provide some settings for users to capture customized information. This data is stored as not-indexed in a `custom` object.
+Searchable information is stored as `tags` instead.

--- a/docs/data-ingestion.asciidoc
+++ b/docs/data-ingestion.asciidoc
@@ -3,10 +3,7 @@
 
 [partintro]
 --
-APM Server offers a set of <<configuring-howto-apm-server, configuration options>>,
-helping you to adapt Elastic APM according to your needs.
-
-For optimizing your Elastic APM setup read more about how to:
+This section explains how to adapt data ingestion according to your needs.
 
 * <<tune-apm-server>>
 * <<tune-es>>
@@ -15,83 +12,76 @@ For optimizing your Elastic APM setup read more about how to:
 
 [[tune-apm-server]]
 == Tune APM Server
-You can fine tune your setup considering following options:
+
 
 * <<tune-output-config>>
 * <<adjust-queue-size>>
 * <<adjust-concurrent-requests>>
-* <<add-apm-server-nodes>>
+* <<add-apm-server-instances>>
 * <<reduce-payload-size>>
 
 [[tune-output-config]]
 [float]
 === Tune APM Server output parameters for your Elasticsearch cluster
 
-If your Elasticsearch cluster is sized properly,
-but not ingesting the amount of data you expect,
-you can tweak APM Server options to make better use of the cluster:
+If your Elasticsearch cluster is not ingesting the amount of data you expect,
+you can tweak a few APM Server settings:
 
-* Adjust `output.elasticsearch.workers` to a number that suits your setup.
+* Adjust `output.elasticsearch.workers`.
 See {ref}/tune-for-indexing-speed.html[tune for indexing speed] for an overview.
 * Ensure `output.elasticsearch.bulk_max_size` is set to a high value, for example 5120.
   The default of 50 is very conservative.
 * Ensure that `queue.mem.events` is set to a reasonable value compared to your other settings.
 A good rule of thumb is that `queue.mem.events` should equal `output.elasticsearch.worker` multiplied by `output.elasticsearch.bulk_max_size`.
 
-Get detailed information on available <<configuring-output,output configuration options>> and their default values.
+The <<configuring-output,output configuration>> section shows more details.
 
 [[adjust-queue-size]]
 [float]
 === Adjust internal queue size
 
-APM Server uses an internal queue to allow buffering incoming requests until they can be delievered to Elasticsearch. 
-A larger internal queue allows Elasticsearch to be unavailable for longer periods,
-and it alleviates problems that might result from sudden spikes of data.
+APM Server uses an internal queue to buffer incoming events.
+A larger queue can retain more data if Elasticsearch is unavailable for longer periods,
+and it alleviates problems that might result from sudden spikes of traffic.
 You can adjust the queue size by overriding `queue.mem.events`.
-Be aware that increasing `queue.mem.events` can significantly affect APM Server memory usage.
+Increasing `queue.mem.events` can significantly affect APM Server memory usage.
 
 [[adjust-concurrent-requests]]
 [float]
 === Adjust concurrent requests
-To avoid overflowing the APM Server,
-it has an upper limit to how many requests are accepted concurrently.
-This limit is determined by the `apm-server.concurrent_requests` configuration parameter.
-As this limit is set to a rather conservative default you might want to set it to some higher value.
-Be aware though, that increasing the limit can significantly affect APM Server memory usage.
+APM Server has a limit to how many requests can be processed concurrently.
+This limit is determined by the `apm-server.concurrent_requests` setting.
+Increasing this value will improve throughput, but it can significantly affect APM Server memory usage.
 
-[[add-apm-server-nodes]]
+[[add-apm-server-instances]]
 [float]
-=== Add APM Server nodes
+=== Add APM Server instances
 
-In case the APM Server cannot process incoming requests quickly enough,
-you will see a server timeout.
+If the APM Server cannot process data quickly enough,
+you will see request timeouts.
 
-One way to avoid this problem is to add more processing power to your APM Server cluster.
-This can be easily done by either migrating your APM Server processes to more powerful machines 
-or adding more APM Server nodes.
-Please refer to the <<high-availability, high availability>> section for general information on how to set up multiple APM Server.
+One way to solve this problem is to increase processing power.
+This can be done by either migrating your APM Server to a more powerful machine
+or adding more APM Server instances.
+Having several instances will also increase <<high-availability, availability>>.
 
 [[reduce-payload-size]]
 [float]
 === Reduce the payload size
 
-Large payloads coming from agents may result in a server timeout.
-You can reduce the payload size by decreasing the `max_queue_size` in the agents.
-This will result in agents sending smaller payloads to the APM Server,
-but the requests will be more frequent.
-See the documentation for the {apm-py-ref}/configuration.html#config-max-queue-size[Python] and {apm-node-ref}/agent-api.html#max-queue-size[Node.js] agents for more information.
+Large payloads may result in request timeouts.
+You can reduce the payload size by decreasing the flush interval in the agents.
+This will cause agents to send smaller and more frequent requests.
 
-Optionally you can also <<reduce-sample-rate, reduce the sample rate>> or <<reduce-stacktrace, reduce the amount of stacktraces 
-collected>>,
-both leading to collect less data and decreasing the payload size. 
+Optionally you can also <<reduce-sample-rate, reduce the sample rate>> or <<reduce-stacktrace, reduce the amount of stacktraces>>.
 
-Read more about configuration options directly in the {apm-agents-ref}/index.html[agent documentation].
+Read more in the {apm-agents-ref}/index.html[agents documentation].
 
 [[tune-es]]
 == Tune Elasticsearch
 
-Get insights about tuning the Elasticsearch ingestion rate, 
-especially with regards to 
+Get insights about tuning the Elasticsearch ingestion rate,
+especially with regards to
 
 * refresh interval
 * disable swapping

--- a/docs/error-api.asciidoc
+++ b/docs/error-api.asciidoc
@@ -1,9 +1,6 @@
 [[error-api]]
 == Error API
 
-The APM Server exposes an API Endpoint to send error records.
-Unless you are implementing an agent, you don't need to know about the specifics of this API.
-
 The following section contains information about:
 
 * <<error-endpoint>>
@@ -14,30 +11,24 @@ The following section contains information about:
 [float]
 === Endpoint
 
-To send an error record you need to send a `HTTP POST` request to the APM Server `errors` endpoint:
+Send a `HTTP POST` request to the APM Server `errors` endpoint:
 [source,bash]
 ------------------------------------------------------------
 http(s)://{hostname}:{port}/v1/errors
 ------------------------------------------------------------
 
-To send a record for an error monitored by the
-{apm-rum-ref}/index.html[JavaScript RUM Agent]
-you need to send a `HTTP POST` request to the APM Server `rum errors` endpoint:
+For <<rum, RUM>> send a `HTTP POST` request to the `rum errors` endpoint instead:
 
 [source,bash]
 ------------------------------------------------------------
 http(s)://{hostname}:{port}/v1/rum/errors
 ------------------------------------------------------------
 
-Information pertaining to the error record must be sent as a JSON object to the endpoint.
-
 [[error-schema-definition]]
 [float]
 === Schema Definition
 
-The APM Server uses a JSON Schema for validating the transaction requests.
-Find details on how the schema is defined:
-
+The APM Server uses JSON Schema for validating requests. The specification for errors is defined bellow:
 * <<error-payload-schema>>
 * <<error-error-schema>>
 * <<error-service-schema>>
@@ -124,7 +115,7 @@ include::./spec/user.json[]
 [float]
 === Examples
 
-Send an example request to the APM Server:
+Request example:
 
 ["source","sh",subs="attributes"]
 ------------------------------------------------------------
@@ -133,7 +124,7 @@ curl http://localhost:8200/v1/errors \
   --data @docs/data/intake-api/generated/error/payload.json
 ------------------------------------------------------------
 
-See examples on how an error request to the APM Server can look like:
+Example error requests:
 
 * <<payload-with-error>>
 * <<payload-with-minimal-exception>>

--- a/docs/error-indices.asciidoc
+++ b/docs/error-indices.asciidoc
@@ -2,14 +2,12 @@
 == Error Indices
 
 Errors are stored in separate indices of the format `apm-[version]-error-[date]`.
-Read more about the general purpose of <<errors, error>> documents.
-
 
 [[error-example]]
 [float]
 === Example document
 
-Example of an error document indexed in Elasticsearch:
+See an example error indexed in Elasticsearch:
 
 [source,json]
 ----

--- a/docs/errors.asciidoc
+++ b/docs/errors.asciidoc
@@ -1,21 +1,21 @@
 [[errors]]
 == Errors
 
-An error record represents one error event, 
-captured by Elastic APM agents within one service. 
-It is identified by a unique ID.
+Errors are identified by a unique ID.
 An error event contains at least
-information about the original `exception` that occured 
-or information about a `log` that was created when the exception occured. 
+information about the original `exception` that occured
+or about a `log` created when the exception occured.
 
-Both the captured `exception` and the captured `log` of an error can contain `stack trace` information,
-helpful for debugging an error. 
+Both the captured `exception` and the captured `log` of an error can contain a `stack trace`,
+helpful for debugging.
 
-The `culprit` of an error gives some information about the origin of the error. 
+The `culprit` of an error indicates where is originated.
 
-An error can be mapped to the <<transactions,transaction>> during which it happened, 
+An error might relate to the <<transactions,transaction>> during which it happened,
 via the `transaction.id`.
+
+Errors also have some contextual data.
 
 include::./context.asciidoc[]
 
-Read more about how an <<error-indices, error document>> is indexed in Elasticsearch.
+Errors are stored in <<error-indices, error indices>>.

--- a/docs/event-types.asciidoc
+++ b/docs/event-types.asciidoc
@@ -3,8 +3,7 @@
 
 [partintro]
 --
-Elastic APM agents capture information about `transaction` and `error` events and send the information to the APM Server.
-The actual available information might be optimized per agent. 
+Agents capture different types of information, namely `transactions` and `errors`.
 
 * <<transactions,Transactions>>
 * <<errors,Errors>>

--- a/docs/exploring-es-data.asciidoc
+++ b/docs/exploring-es-data.asciidoc
@@ -3,11 +3,12 @@
 
 [partintro]
 --
-By default Elastic APM data are stored in different indices, 
-in the format of 
-`apm-%{[beat.version]}-{type}-%{+yyyy.MM.dd}`.
+By default Elastic APM data is stored in separated indices following the format:
+`apm-%{[version]}-{type}-%{+yyyy.MM.dd}`.
 
-For getting an overview of existing indices you can run:
+Data types are described <<event-types, here>>.
+
+To get an overview of existing indices you can run:
 ["source","sh"]
 ------------------------------------------------------------
 GET _cat/indices/apm*
@@ -21,33 +22,24 @@ Default APM `template` and `indices`:
 * <<span-indices>>
 * <<error-indices>>
 * <<sourcemap-indices>>
-* <<healthcheck-indices>>
 
 
-For querying all APM data:
-["source","sh"]
-------------------------------------------------------------
-GET apm*/_search
-------------------------------------------------------------
-// CONSOLE
-
-Querying documents that have been collected with a specific APM Server version:
+To query all documents collected with a specific APM Server version:
 ["source","sh",subs="attributes"]
 ------------------------------------------------------------
 GET apm-{version}-*/_search
 ------------------------------------------------------------
 // CONSOLE
 
-If you are only interested in specific document types, e.g. error documents you can use the type in your query:
+To query a specific type, for example transactions:
 ["source","sh",subs="attributes"]
 ------------------------------------------------------------
-GET apm-*error-*/_search
+GET apm-*transactions-*/_search
 ------------------------------------------------------------
 // CONSOLE
 
-If you are interested in the _settings_ and _mappings_ applied to the Elastic APM indices,
-you can fetch the index templates.
-First run a query for figuring out which templates exist:
+If you are interested in the _settings_ and _mappings_ of the Elastic APM indices,
+first run a query to find template names:
 
 ["source","sh"]
 ------------------------------------------------------------
@@ -55,17 +47,17 @@ GET _cat/templates/apm*
 ------------------------------------------------------------
 // CONSOLE
 
-Then you can retrieve the specific template you are interested in by sending:
+Then you can retrieve the specific template you are interested in:
 ["source","sh"]
 ------------------------------------------------------------
 GET  /_template/your-template-name
 ------------------------------------------------------------
 // CONSOLE
 
-You can read more about {ref}/indices-templates.html[Index Templates] and how they are used.
+Read more about {ref}/indices-templates.html[Index Templates] and how they are used.
 
-Another option is to use the {kibana-ref}/managing-indices.html[Kibana Index Management UI]. 
-When clicking on a specific index you can view the _settings_ and _mapping_ for it. 
+Alternatively, use the {kibana-ref}/managing-indices.html[Kibana Index Management UI].
+When clicking on a specific index you can view the _settings_ and _mapping_ for it.
 
 --
 
@@ -74,4 +66,3 @@ include::./transaction-indices.asciidoc[]
 include::./span-indices.asciidoc[]
 include::./error-indices.asciidoc[]
 include::./sourcemap-indices.asciidoc[]
-include::./healthcheck-indices.asciidoc[]

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -7,22 +7,20 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 [[overview]]
 == Overview
 
-APM is an application performance monitoring system built on the Elastic Stack.
-It uses Elasticsearch as its data store and allows you to monitor software services and applications in real time.
-Regardless of whether your code is best described as a service or as an application,
-this guide will indiscriminately use the word service.
-
-With APM you can automatically collect detailed performance information from inside your service with only minor changes to your code.
-For example APM agents can measure the response time for incoming requests,
-time spent in database queries,
+Elastic APM is an application performance monitoring system built on the Elastic Stack.
+It allows you to monitor software services and applications in real time,
+collecting detailed performance information on response time for incoming requests,
+database queries,
 calls to caches,
 external HTTP requests,
 etc.
 This makes it easier to pinpoint and fix performance problems quickly.
 
-APM also automatically collects errors and exceptions that are not handled by your service.
-Collected errors automatically get assigned a checksum based primarily on the stacktrace.
-This enables you to spot new errors as they appear and keep an eye on how many times specific errors happen.
+Elastic APM also collects automatically unhandled errors and exceptions.
+Errors are grouped based primarily on the stacktrace,
+so you can identify new errors as they appear and keep an eye on how many times specific errors happen.
+
+NOTE: this guide will indiscriminately use the word service for both services and applications.
 
 [[components]]
 [float]
@@ -39,29 +37,24 @@ image::apm-architecture.png[Architecture of Elastic APM]
 
 *APM agents* are open source libraries written in the same language as your service.
 You install them into your service as you would install any other library.
-The agents hook into your service and start collecting performance metrics and errors once it starts.
-All data collected by agents is buffered for a short period and sent on to APM Server.
-This happens once per minute,
-by default.
+They instrument your code and collect performance data and errors at runtime.
+This data is buffered for a short period and sent on to APM Server.
 
 Out of the box,
-APM automatically instruments most popular web frameworks,
+APM automatically instruments web frameworks,
 database drivers,
 calls to caching servers,
 and HTTP libraries for requests to external services.
 Additionally,
-agents provide an API that you can use to manually instrument anything else you find interesting.
+agents provide an API to manually instrument anything else you find interesting.
 
 *APM Server* is an open source application written in Go which typically runs on dedicated servers.
-It listens on port 8200 by default and receives data from agents periodically through a JSON API.
-APM Server creates documents from the data received from agents and stores them in an Elasticsearch cluster.
+It listens on port 8200 by default and receives data from agents through a JSON HTTP API.
+Then it creates documents from that data and stores them in Elasticsearch.
 
 To visualize the data after it's sent to Elasticsearch,
 you can use the the dedicated APM UI bundled in X-Pack,
 or the pre-built open source Kibana dashboards that can be loaded directly in the Kibana UI.
-
-We designed Elastic APM to run on anything from a regular laptop to thousands of machines,
-and it's easy to get started.
 
 [[install-and-run]]
 == Install and run Elastic APM
@@ -76,7 +69,6 @@ you need to have:
 
 For information about setting up an Elasticsearch cluster,
 see the Elasticsearch {ref}/getting-started.html[Getting Started].
-To view the collected data you need Kibana.
 
 The following sections show how to get started quickly with Elastic APM on a local machine.
 
@@ -86,31 +78,28 @@ The following sections show how to get started quickly with Elastic APM on a loc
 
 First, https://www.elastic.co/downloads/apm/apm-server[download APM Server] for your operating system and extract the package.
 
-In a production environment,
-you would put APM Server on it's own machines,
+In a production environment you would put APM Server on its own machines,
 similar to how you run Elasticsearch.
 You _can_ run it on the same machines as Elasticsearch,
 but this is not recommended,
 as the processes will be competing for resources.
 
-To start APM Server,
-run:
+To start APM Server, run:
 
 [source,bash]
 ----------------------------------
 ./apm-server -e
 ----------------------------------
 
-You should see APM Server start up.
 It will try to connect to Elasticsearch on localhost port 9200 and expose an API to agents on port 8200.
-You can change the defaults by supplying a different addresses on the command line:
+You can change the defaults by supplying different addresses on the command line:
 
 [source,bash]
 ----------------------------------
 ./apm-server -e -E output.elasticsearch.hosts=ElasticsearchAddress:9200 -E apm-server.host=localhost:8200
 ----------------------------------
 
-Or you can update the `apm-server.yml` configuration file to change the defaults.
+Or you can update the `apm-server.yml` configuration file:
 
 [source,yaml]
 ----------------------------------
@@ -123,8 +112,7 @@ output:
 ----------------------------------
 
 NOTE: If you are using an X-Pack secured version of Elastic Stack,
-you need to specify credentials in the config file before you run the commands that set up and start APM Server.
-For example:
+you need to specify credentials in the config file:
 
 [source,yaml]
 ----
@@ -139,12 +127,13 @@ output.elasticsearch:
 [[secure-api-access]]
 [float]
 ==== Secure access to the API
-The HTTP API exposed by APM Server listens on `localhost` and port 8200 by default.
 If you change the listen address from `localhost` to something that is accessible from outside of the machine,
 we recommend setting up firewall rules to ensure that only your own systems can access the API.
 Alternatively,
-you can use the {apm-server-ref}/securing-apm-server.html[secret token and TLS] to secure access to APM Server API.
-You can also configure APM Server to listen on a Unix domain socket.
+you can use a {apm-server-ref}/securing-apm-server.html[secret token and TLS].
+
+If you have APM Server running on the same host as your service, you can configure it to listen on a Unix domain socket.
+
 [[kibana-dashboards]]
 [float]
 ==== Install the Kibana dashboards
@@ -172,20 +161,17 @@ you need to install an agent in your service.
 Agents are written in the same language as your service.
 Currently Elastic APM has agents for Node.js, Python, Ruby, and JavaScript.
 
-Setting up a new service to be monitored requires installing the agent in the service,
-coming up with a good name for the service,
-and then configuring the agents so they know the address of your APM Server and the service name.
+Setting up a new service to be monitored requires installing the agent,
+and configuring it with the address of your APM Server and the service name.
 
 [[choose-service-name]]
 [float]
 ==== Choose a service name
 
-The service name is used by Elastic APM to differentiate between data coming from different services and to group data coming from the same services.
-When configuring an agent,
-you need to supply a service name.
+The service name is used by Elastic APM to differentiate between data coming from different services.
 
 Elastic APM includes the service name field on every document that it saves in Elasticsearch.
-This has the implication that if you change the service name after using Elastic APM for some time,
+If you change the service name after using Elastic APM,
 you will see the old service name and the new service name as two separate services.
 Make sure you choose a good service name before you get started.
 
@@ -198,15 +184,14 @@ and dashes (must match `^[a-zA-Z0-9 _-]+$`).
 [float]
 ==== Install the Node.js agent
 
-To install the Node.js agent,
-simply install the elastic-apm-node module from npm in your service:
+Install the elastic-apm-node module from npm in your service:
 
 [source,bash]
 ----------------------------------
 npm install elastic-apm-node --save
 ----------------------------------
 
-Then configure the elastic-apm-node module inside your service by adding the following lines to the very top of your code:
+Then configure the elastic-apm-node module by adding the following lines to the top of your code:
 
 [source,javascript]
 ----------------------------------
@@ -223,7 +208,7 @@ var apm = require('elastic-apm-node').start({
 })
 ----------------------------------
 
-The Node.js agent supports Express,
+The Node.js agent automatically instruments Express,
 hapi,
 and Koa out of the box.
 See the {apm-node-ref}/index.html[APM Node.js Agent documentation] for more details.
@@ -232,15 +217,14 @@ See the {apm-node-ref}/index.html[APM Node.js Agent documentation] for more deta
 [float]
 ==== Install the Python agent
 
-To install the Python agent,
-install the Elastic APM module from pypi:
+Install the Elastic APM module from pypi:
 
 [source,bash]
 ----------------------------------
 pip install elastic-apm
 ----------------------------------
 
-The Python agent supports Django and Flask out of the box.
+The Python agent automatically instruments Django and Flask out of the box.
 See the {apm-py-ref}/index.html[APM Python Agent documentation] for more details.
 
 [[ruby-agent]]

--- a/docs/healthcheck-indices.asciidoc
+++ b/docs/healthcheck-indices.asciidoc
@@ -1,6 +1,0 @@
-[[healthcheck-indices]]
-== Healthcheck Indices 
-
-Healthcheck indices by default are in the format of `apm-version-date`.
-When starting an APM Server a healtcheck document is sent to Elasticsearch, 
-ensuring the configuration is set up properly.

--- a/docs/high-availability.asciidoc
+++ b/docs/high-availability.asciidoc
@@ -1,25 +1,16 @@
 [[high-availability]]
 === High Availability
 
-The API exposed by APM Server is a regular HTTP JSON API. 
-To achieve high availability, 
+To achieve high availability
 you can place multiple instances of APM Server behind a regular HTTP load balancer,
 for example HAProxy or nginx.
 
-If an instance of APM Server should fail, 
-the load balancer will remove it from the load balancing rotation after a short period of time.
+The endpoint `/healthcheck` always returns a `HTTP 200`.
+You can configure your load balancer to send HTTP requests to this endpoint
+to determine if an APM Server is running.
 
-APM Server endpoint `/healthcheck` always returns a `HTTP 200`.
-You can configure your load balancer to send HTTP requests to this endpoint 
-to determine if a given APM Server is up and running.
+In case of temporal issues, like unavailable Elasticsearch or a sudden high workload,
+the data is buffered in an internal memory queue and ingestion retried.
 
-APM Server maintains a small buffer internally. 
-Data coming from agents is kept here until it can be delivered to Elasticsearch.
-Under normal circumstance, data is forwarded to Elasticsearch immediately.
-In situations in which Elasticsearch is down briefly 
-or in situations where there is a sudden influx of data and Elasticsearch cannot ingest it all at once, 
-the buffer acts as a temporary storage until the data can be ingested by Elasticsearch.
-
-This also means that if a given APM Server process fails, 
-for example because the machine its running on experiences an issue, 
+If a given APM Server process fails,
 the data that has not yet been forwarded to Elasticsearch is lost.

--- a/docs/installing.asciidoc
+++ b/docs/installing.asciidoc
@@ -9,7 +9,7 @@ You can also install APM Server from our repositories or install as a service on
 * <<setup-repositories>>
 * <<installing-on-windows>>
 
-To run APM Server in Docker, please see <<running-on-docker>>.
+To run APM Server in Docker, see <<running-on-docker>>.
 
 include::./copied-from-beats/repositories.asciidoc[]
 

--- a/docs/intake-api.asciidoc
+++ b/docs/intake-api.asciidoc
@@ -2,11 +2,14 @@
 = Intake API
 [partintro]
 --
-The APM Server exposes API Endpoints for 
+The Intake API is HTTP JSON based. The APM Server exposes endpoints for
 
-* <<transaction-api,Transaction API>>
-* <<error-api,Error API>>
-* <<sourcemap-api,Source Map API>>
+* <<transaction-api,Transactions>>
+* <<error-api,Errors>>
+* <<sourcemap-api,Source Map Upload>>
+
+Unless you are implementing an agent, you don't need to know about the specifics of this API.
+
 --
 include::./transaction-api.asciidoc[]
 include::./error-api.asciidoc[]

--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -1,30 +1,15 @@
 [[overview]]
 == Overview
 
-Welcome to APM Server Docs.
+The APM Server receives data from APM agents and transforms them into Elasticsearch documents.
 
-NOTE: The documentation pages are still work in progress.
-For more details also check APM Server https://github.com/elastic/apm-server[Github repository].
+It works by exposing an HTTP server to which agents post the APM data they collect.
 
-APM Server is a central component in the Elastic APM system.
-It receives data from APM agents and transforms them into Elasticsearch documents.
-
-A single APM server can handle data from multiple services.
-APM Server works by exposing an HTTP server to which agents post the APM data they collect.
-This includes performance information about the services,
-as well as errors that occur in them.
-
-APM Server is an application built in Go using the beats framework
-and as such it shares many of the same configuration options as beats.
-
-In the following you can read more about the APM Server
-
-* <<installing>>
-* <<setting-up-and-running>>
-* <<configuring-howto-apm-server>>
+APM Server is built with the Beats framework,
+and as such it levarages its functionality.
 
 To get an overview of the whole Elastic APM system,
-please also have a look at the documentation for
+ also have a look at:
 
 * {apm-node-ref}/index.html[APM Node.js Agent]
 * {apm-py-ref}/index.html[APM Python Agent]
@@ -32,20 +17,18 @@ please also have a look at the documentation for
 * {apm-rum-ref}/index.html[APM RUM JavaScript Agent]
 * {ref}/index.html[Elasticsearch]
 
-See how to {apm-get-started}/index.html[Get Started] with the Elastic APM system.
 
 [[why-separate-component]]
 === Why is APM Server a separate component?
 
-The APM Server is kept as a separate component for the following reasons:
+The APM Server is a separate component for the following reasons:
 
-* It helps keep the agents as light as possible and since the APM Server is a stateless separate component,
+* It helps to keep the agents as light as possible and since the APM Server is a stateless separate component,
 it can be scaled independently.
-* For real-user-monitoring (beta),
-data is being collected in agents running in browsers.
+* For Real User monitoring data is collected in browsers.
   APM Server prevents browsers from interacting directly with Elasticsearch (which poses a security risk),
   and controls the amount of data flowing into Elasticsearch.
 * In cases where Elasticsearch becomes unresponsive,
-APM Server can buffer data temporarily (configurable) without adding overhead to the agents.
-* APM Server serves as a middleware for source mapping for javascript in the browser.
-* The APM Server provides a JSON API for agents to use thereby improving compatibility across different versions of agents and the Elastic Stack.
+APM Server can buffer data temporarily without adding overhead to the agents.
+* Acts as a middleware for source mapping for javascript in the browser.
+* Provides a JSON API for agents to use thereby improving compatibility across different versions of agents and the Elastic Stack.

--- a/docs/rum.asciidoc
+++ b/docs/rum.asciidoc
@@ -2,51 +2,43 @@
 = Real User Monitoring (RUM)
 [partintro]
 --
-The {apm-rum-ref}/index.html[JavaScript RUM Agent] is supporting Real User Monitoring.
-You can make use of <<sourcemaps, source maps>> when using Elastic RUM. 
+Real User Monitoring captures user interaction with clients such as web browsers.
+The {apm-rum-ref}/index.html[JavaScript Agent] is Elastic's RUM Agent.
+To use it you need to <<rum-enable,enable RUM support>> in the APM Server.
 --
 
 [[sourcemaps]]
 == Source Maps
-It is common practice to minify JavaScript code for several reasons, e.g. performance gain. 
-This can make debugging very difficult, as it is hard to read the minified files.
-Source mapping can help for debugging minfied JavaScript files, 
-by mapping code from the minified files to the original source code. 
+It is common practice to minify JavaScript code, for example to reduce network latency.
+While improving performance, minified code is also hard to debug.
+A source map library helps by mapping the minified files back the the original source code.
 
-APM Server provides a <<sourcemap-api,Source Map API>> 
-which accepts source maps complying to the 
-https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k[Source map revision 3 proposal].
+APM Server provides a <<sourcemap-api,Source Map API>> for uploading source maps.
 
-Uploaded source maps are used to map _stack trace_ information from recorded transaction and error documents 
-to the original source code files for easier debugging.  
+Source maps are then automatically applied to all incoming transactions and errors.
+
+Source maps are cached in memory for as long as the <<rum-sourcemap-cache,cache expiration>> setting indicates.
 
 [[sourcemap-apply]]
 [float]
 === How source maps are applied
 
-When source maps have been <<sourcemap-endpoint,uploaded>> and <<rum-enable,RUM support>> is enabled, 
-source mapping is automatically applied to the _stack trace frames_ of all errors and transactions 
-recorded with the
-{apm-rum-ref}/index.html[JavaScript RUM Agent].
+APM Server needs to find the correct source map for every `stack trace frame` in an event.
+To do so, it tries the following:
 
-The server tries to find an uploaded source map for every `stack trace frame` of the record.
-The following information is used to find the previously uploaded source map entry:
+* compare the event's `service.name` with the source map's `service_name`
+* compare the event's `service.version` with the source map's `service_version`
+* compare the stack trace frame's `abs_path` with the source map's `bundle_filepath`
 
-* the record's `service.name` is matched against the source map's `service_name`
-* the record's `service.version` is matched against the source map's `service_version`
-* the stack trace frame's `abs_path` is matched against the source map's `bundle_filepath`
-
-If multiple source maps with the same meta information are found, 
-the source map with the latest upload timestamp is used. 
-
-In case a matching source map is found and the source map can be applied to the `stack trace frame`, 
-the frame's information is updated with the mapped information before the record is indexed.
-The following information is changed to reflect the original source code file, when source mapping is applied:
+If a source map is found, the following attributes in the `stack trace frames` are overwritten:
 
 * `filename`
 * `function`
 * `line number`
 * `column number`
-* `abs path`: is https://golang.org/pkg/path/#Clean[cleaned] to be the shortest path name equivalent to the given path name 
+* `abs path`: is https://golang.org/pkg/path/#Clean[cleaned] to be the shortest path name equivalent to the given path name
+
+If multiple source maps are found,
+the one with the latest upload timestamp is used.
 
 See how an <<sourcemap-example, example source map>> looks like in Elasticsearch.

--- a/docs/security.asciidoc
+++ b/docs/security.asciidoc
@@ -2,21 +2,20 @@
 [float]
 === Security Overview
 
-APM Server exposes a HTTP endpoint and as with anything that opens ports on your servers,
+APM Server exposes an HTTP endpoint and as with anything that opens ports on your servers,
 you should be careful about who can connect to it.
-We recommend using firewall rules to ensure only authorized systems can connect.
-
-There is also the option of setting up SSL to ensure data sent to the APM Server is encrypted.
+Firewall rules are recommended to ensure only authorized systems can connect.
 
 [[secret-token]]
 [float]
 ==== Secret token
 
-You can configure a secret token which is sent with every request from the APM agents to the server.
-This string is used to ensure that only your agents can send data to your APM servers.
+You can configure a secret token to authorize requests to the APM Server,
+and ensure that only your agents can send data to your APM servers.
 Both the agents and the APM servers have to be configured with the same secret token.
 
-NOTE: The usage of a secret token only provides any security when used in combination with having SSL/TLS configured.
+NOTE: Secret tokens provide security only when used in combination with SSL/TLS.
+Secret tokens are not applicable for RUM, as they would be publicly exposed.
 
 [[ssl-setup]]
 [float]

--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -44,6 +44,7 @@ output:
     hosts: ElasticsearchAddress:9200
 ----------------------------------
 
+The output section, like in other Beats, contains settings describing how and where to store the data.
 
 NOTE: If you are using an X-Pack secured version of Elastic Stack,
 you need to specify credentials in the config file before you run the commands that set up and start APM Server.

--- a/docs/sourcemap-api.asciidoc
+++ b/docs/sourcemap-api.asciidoc
@@ -1,14 +1,12 @@
 [[sourcemap-api]]
 == Sourcemap Upload API
 
-The APM Server exposes an API Endpoint to upload source maps,
-helpful if you are using <<rum, real user monitoring (RUM)>>.
+The APM Server exposes an API endpoint to upload source maps for <<rum, real user monitoring (RUM)>>.
 
 [[sourcemap-endpoint]]
 [float]
-=== Upload Endpoint 
-To upload a source map you need to send a `HTTP POST` request
-with `Content-Type` set to `multipart/form-data` to the APM Server source maps endpoint:
+=== Upload endpoint
+Send a `HTTP POST` request with the `Content-Type` header set to `multipart/form-data` to the source map endpoint:
 
 [source,bash]
 ------------------------------------------------------------
@@ -18,25 +16,20 @@ http(s)://{hostname}:{port}/v1/rum/sourcemaps
 [[sourcemap-request-fields]]
 [float]
 ==== Request Fields
-The request consists of some meta information and the actual source map.
-The meta information must contain the following fields:
+The request must include some fields needed to identify `source map` correctly later on:
 
 * `service_name`
 * `service_version`
 * `bundle_filepath`: needs to be the absolute path of the final bundle as it is used in the web application
 
-The meta information is used to identify a `source map` when source mapping is applied.
-
-The actual source map must be attached to the request as a `file upload`
-and it must match the specification for 
-https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k[Source map revision 3 proposal].
-
+The source map must follow the
+https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k[Source map revision 3 proposal] spec and be attached as a `file upload`.
 
 [[sourcemap-api-examples]]
 [float]
 ==== Example
 
-Send an example source map to the APM Server:
+Example source map request
 
 ["source","sh",subs="attributes"]
 ---------------------------------------------------------------------------

--- a/docs/sourcemap-indices.asciidoc
+++ b/docs/sourcemap-indices.asciidoc
@@ -1,14 +1,13 @@
 [[sourcemap-indices]]
 == Source Map Indices
-Source maps are also stored in a separate index, 
-defined by the Elastic APM Server version and the date. 
 
+Source maps are stored in separate indices of the format `apm-[version]-sourcemap`.
 
 [[sourcemap-example]]
 [float]
 ==== Example document
 
-Example of an acceptable source map file:
+Example of a source map file:
 
 [source,json]
 ----

--- a/docs/span-indices.asciidoc
+++ b/docs/span-indices.asciidoc
@@ -1,9 +1,8 @@
 [[span-indices]]
 == Span Indices
 
-Spans are monitored as parts of <<transactions, transactions>>. 
-They are stored in their separate indices `apm-[version]-span-[date]` though.
-
+Spans are stored in separate indices of the format `apm-[version]-span-[date]`.
+Conceptually, spans are part of transactions.
 
 [[span-example]]
 [float]

--- a/docs/storage-management.asciidoc
+++ b/docs/storage-management.asciidoc
@@ -3,73 +3,65 @@
 
 [partintro]
 --
-In the following we focus on how you can 
+In the following section you can learn how to
 
 * <<manage-indices-kibana, manage APM indices via Kibana>>
-* <<reduce-storage, reduce storage>> by deleting data 
-or trimming data collection already during ingestion time 
-* <<update-existing-data, update data>> once they are stored 
+* <<reduce-storage, reduce storage usage>>
+* <<update-existing-data, update existing data>>
 --
 
 [[manage-indices-kibana]]
 == Manage Indices via Kibana
-The Kinana UI for managing indices allows you to 
-view your indices, index settings, mappings, docs count, used storage per index and much more. 
-You can perform management operations, 
-e.g. deleting indices directly via the Kibana UI.
-The UI also supports applying bulk operations on several indices at once. 
-Check out the {kibana-ref}/managing-indices.html[Kibana Managing Indices] docs for how to use the index management UI.
+The Kibana UI for managing indices allows you to
+view indices, index settings, mappings, docs count, used storage per index and much more.
+You can perform management operations,
+for example deleting indices directly via the Kibana UI.
+The UI also supports applying bulk operations on several indices at once.
+Check out the {kibana-ref}/managing-indices.html[Kibana Managing Indices] documentation for more details.
 
 [[reduce-storage]]
 == Reduce storage
-The amount of storage for APM data depends on several factors. 
-Depending on how many services you are instrumenting and how much traffic the services see, 
-the number of recorded transactions varies.
-You can influence the detail level of the information collected 
-by reducing the sample rate or reducing collected stacktrace information.
-Another factor is for how long you want to keep monitoring data around.
+The amount of storage for APM data depends on several factors:
+how many services you are instrumenting, how much traffic the services see, agent and server settings,
+and for how long you keep monitoring data.
 
 [[reduce-sample-rate]]
 [float]
 === Reduce the sample rate
-In case you are monitoring high traffic services you might want to decrease the number of transactions that are sampled. 
-The transaction sample rate directly influences the number of documents to be indexed
-and therefore is the most obvious way to reduce storage. 
 
-The transaction sample rate is controlled in the configuration of agents (for example for {apm-py-ref}/configuration.html#config-transaction-sample-rate[Python] and {apm-node-ref}/agent-api.html#transaction-sample-rate[Node.js]).
+The transaction sample rate directly influences the number of documents (more precisely, spans) to be indexed
+and therefore is the most obvious way to reduce storage.
 
-Reducing the transaction sample rate does not affect the collection of metrics such as _Transactions Per Second_.
+The transaction sample rate is a configuration setting of the agents.
+
+Reducing it does not affect the collection of metrics such as _Transactions Per Second_.
 
 [[reduce-stacktrace]]
 [float]
 === Reduce collected stacktrace information
-Elastic APM agents automatically collect information regarding stacktraces under certain circumstances. 
+Elastic APM agents collect `stacktrace` information under certain circumstances.
 This can be very helpful by identifying issues in your code,
-but it also comes with an overhead at collection time 
-and increaeses the storage usage. 
-If you want to decrease collected stacktrace information you have to configure this directly in the agents. 
-Please refer to our {apm-agents-ref}/index.html[agent documentation] to read more about the options in the single 
-agents. 
+but it also comes with an overhead at collection time and increases the storage usage.
+Stacktrace collection settings are managed in the agents.
 
 [[delete-data]]
 [float]
 === Delete data
-You might want to delete data for several reasons.
-A common use case is to keep data only for a defined time period and delete older documents. 
-You might also want to delete data collected for specific services or customers, 
-or delete specific indices. 
-Depending on your use case, 
-you can either delete data periodically with a tool like {curator-ref-current}[Curator] 
-or by using the {ref}/docs-delete-by-query.html[Delete By Query API]
-or by using the {kibana-ref}/managing-indices.html[Kibana Index Management UI]. 
+
+You might want to keep data only for a defined time period and delete old documents periodically,
+or you might also want to delete data collected for specific services or customers,
+or delete specific indices.
+Depending on your use case,
+you can either delete data periodically with {curator-ref-current}[Curator],
+by using the {ref}/docs-delete-by-query.html[Delete By Query API],
+or by using the {kibana-ref}/managing-indices.html[Kibana Index Management UI].
 
 
 [[delete-data-periodically]]
 [float]
 ==== Delete data periodically
 
-It might make sense to delete old APM indices on a periodic basis to make room for new data. 
-To do this you can use a tool like {curator-ref-current}[Curator] and set up a cron job to run it periodically.
+To delete data periodically you can use {curator-ref-current}[Curator] and set up a cron job to run it.
 
 By default APM indices have the pattern `apm-%{[beat.version]}-{type}-%{+yyyy.MM.dd}`.
 With the curator command line interface you can, for instance, see all your existing indices:
@@ -107,8 +99,10 @@ INFO      "delete_indices" action completed.
 [float]
 ==== Delete data matching a query
 
-In case you want to delete documents matching a specific query, e.g. all documents with a given `context.service.name`,
-you can do this by sending the following request:
+To delete documents matching a specific query, for example, all documents with a given context.service.name,
+use the following request:
+
+
 
 ["source","sh"]
 ------------------------------------------------------------
@@ -136,25 +130,23 @@ See {ref}/docs-delete-by-query.html[delete by query] for further information on 
 [[delete-data-kibana]]
 [float]
 ==== Delete data via Kibana Index Management UI
-Follow the {kibana-ref}/managing-indices.html[Kibana Index Management] docs 
-for how to get started with the index management UI.
-Select the indices you want to delete, then click the _Manage indices_ button to see supported options.
-Choose _delete indices_ and your indices will be deleted. 
+Select the indices you want to delete, and click the _Manage indices_ button to see the available actions.
+Then click _delete indices_.
+Follow the {kibana-ref}/managing-indices.html[Kibana Index Management] documentation
+ to get started with the index management UI.
 
 [[update-existing-data]]
 == Update existing data
-You might want to update documents already ingested to Elasticsearch, 
-e.g. if you your service name was set incorrectly, 
-or you need to update a tag you have set.
+You might want to update documents already indexed,
+for example if you your service name was set incorrectly.
 
-You can update existing data by using the {ref}/docs-update-by-query.html[Update By Query API].
+For this you can use the {ref}/docs-update-by-query.html[Update By Query API].
 
 [[update-data-rename-a-service]]
 [float]
 === Rename a service
-For exampe, 
-if you want to change the service name reported for your monitored data,
-you can do that by sending the following request:
+
+To rename a service send the following request:
 
 ["source","sh"]
 ------------------------------------------------------------
@@ -175,4 +167,4 @@ POST /apm-*/_update_by_query
 ------------------------------------------------------------
 // CONSOLE
 
-Also check out how to change the service name for newly collected documents in the {apm-agents-ref}/index.html[APM agent configuration] accordingly.
+Remember to also change the service name in the {apm-agents-ref}/index.html[APM agent configuration] accordingly.

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -1,9 +1,6 @@
 [[transaction-api]]
 == Transaction API
 
-The APM Server exposes an API Endpoint to send <<transactions,transaction records>>.
-Unless you are implementing an agent, you don't need to know about the specifics of this API.
-
 The following section contains information about:
 
 * <<transaction-endpoint>>
@@ -13,30 +10,25 @@ The following section contains information about:
 [[transaction-endpoint]]
 [float]
 === Endpoint
-To send a transaction record you need to send a `HTTP POST` request to the APM Server `transactions` endpoint:
+Send a `HTTP POST` request to the APM Server `transactions` endpoint:
 
 [source,bash]
 ------------------------------------------------------------
 http(s)://{hostname}:{port}/v1/transactions
 ------------------------------------------------------------
 
-To send a record for a transaction monitored by the 
-{apm-rum-ref}/index.html[JavaScript RUM Agent]
-you need to send a `HTTP POST` request to the APM Server `rum transactions` endpoint:
+For <<rum, RUM>> send a `HTTP POST` request to the APM Server `rum transactions` endpoint instead:
 
 [source,bash]
 ------------------------------------------------------------
 http(s)://{hostname}:{port}/v1/rum/transactions
 ------------------------------------------------------------
 
-Information pertaining to the record must be sent as a JSON object.
-
 [[transaction-schema-definition]]
 [float]
 === Schema Definition
 
-The APM Server uses a JSON Schema for validating the transaction requests.
-Find details on how the schema is defined:
+The APM Server uses JSON Schema for validating requests. The specification for transactions is defined bellow:
 
 * <<transaction-payload-schema>>
 * <<transaction-transaction-schema>>
@@ -133,7 +125,7 @@ include::./spec/user.json[]
 [float]
 === Examples
 
-Send an example request to the APM Server:
+Request example:
 
 ["source","sh",subs="attributes"]
 ------------------------------------------------------------
@@ -142,7 +134,7 @@ curl http://localhost:8200/v1/transactions \
   --data @docs/data/intake-api/generated/transaction/payload.json
 ------------------------------------------------------------
 
-See examples on how a transaction request to the APM Server can look like:
+Example transaction requests:
 
 * <<payload-with-transactions>>
 * <<payload-with-minimal-transaction>>

--- a/docs/transaction-indices.asciidoc
+++ b/docs/transaction-indices.asciidoc
@@ -2,12 +2,11 @@
 == Transaction Indices
 
 Transactions are by default stored to indices of the format `apm-[version]-transaction-[date]`.
-Read more about the general purpose of a <<transactions, transaction>>.
 
 [[transaction-example]]
 [float]
 === Example Document
-See an example document of an indexed transaction:
+See an example transaction indexed in Elasticsearch:
 [source,json]
 ----
 include::./data/elasticsearch/transaction.json[]

--- a/docs/transactions.asciidoc
+++ b/docs/transactions.asciidoc
@@ -1,48 +1,40 @@
 [[transactions]]
 == Transactions
 
-A transaction represents one event, captured by an Elastic APM agent within one service. 
-A transaction can for example be a single HTTP request or an asynchrounous background job within one service.
+A transaction describes an event captured by an Elastic APM agent instrumeting a service.
+A transaction can for example be an HTTP request or an asynchrounous background job.
 
-The transaction shows the duration of the event, 
-a unique id, the type and an automatically retrieved name,
-as well as an indication whether or not the transaction was handled successfully. 
-
-
-If a transaction was sampled, 
-the <<transaction-spans,spans>> of the transaction were captured and are available as seperate documents.
-There is a configuration option on how many spans should be captured per transaction.
-
-A transaction can also contain information regarding `marks`. 
-Marks capture the timing in milliseconds of a significant event during the lifetime of a transaction, 
-set by the user or the agent
+It contains the timestamp and duration of the event,
+a unique id, type, name,
+a result (for example a response code), some contextual data, and other relevant information depending on the agent.
+For instance, the JavaScript RUM captures transaction marks,
+which are points in time relative to the start of the transaction with some label.
 
 [[transactions-context]]
 include::./context.asciidoc[]
 
+Agents decide whether to sample transactions or not, and provide settings to control sampling behaviour.
+If sampled,
+the <<transaction-spans,spans>> of a transaction are sent and stored seperate documents.
+
+Transactions are stored in <<transaction-indices, transaction indices>>.
+
 [[transaction-spans]]
 [float]
 === Spans
-Several spans can be related to a transaction. 
-The relationship is indicated by a `transaction.id`.
+Spans can have 0, 1, or many spans. Spans have a `transaction.id` attribute that refer to their transaction.
 
-A span contains information about a specific code path, 
-executed as part of a transaction. 
-Elastic APM agents automatically instrument a variety of libraries, 
-but also support custom instrumentation for code paths.
-Every code path that is captured by an agent creates a span.
+A span contains information about a specific code path,
+executed as part of a transaction. Such information includes start time, duration, name, type, and optionally a `stack trace`.
 
-Every span is identified by an unique ID per transaction.
-Spans at least collect information about when the code path execution started, 
-the duration, and the type of the code path execution.
-
-This means, if for example a database query happens within a recorded transaction,
-a span representing this database query will be created.
+If for example a database query happens within a sampled transaction,
+a span describing the database query will be created.
 In such a case the name of the span will contain information about the query itself,
-and the type will hold information about the database type. 
+and the type about the database.
 
-A span can also contain `stack trace` information.
+Typically, agents instrument automatically a variety of libraries,
+but also provide an API for ad hoc instrumentation of specific code paths.
 
-Transactions and spans are stored in separated indices by default. 
-Read more about their representation in Elasticsearch in <<transaction-indices, transaction indices>> and 
-<<span-indices, span indices>>.
+Transactions are stored in <<transaction-indices, transaction indices>> and spans are stored in separated indices by default.
+
+Spans are stored in <<span-indices, span indices>>.


### PR DESCRIPTION
Backports the following commits to 6.4:
 - streamline docs a bit, and remove redundant info  (#1169)