### PR TITLE
[6.x] Add valid error message for bad schema config (#1206)

### DIFF
--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -330,7 +330,10 @@ func TestServerSSL(t *testing.T) {
 			},
 		},
 		{
-			label: "bad schema", domain: "localhost", expectedMsgs: []string{"malformed HTTP response"}, overrideProtocol: true,
+			label: "bad schema", domain: "localhost", expectedMsgs: []string{
+				"malformed HTTP response",
+				"transport connection broken"},
+			overrideProtocol: true,
 		},
 		{
 			label: "with passphrase", domain: "localhost", statusCode: http.StatusAccepted, insecure: true, passphrase: "foobar",


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Add valid error message for bad schema config  (#1206)