### PR TITLE
utility.Add should not modify source value

### DIFF
--- a/utility/map_str_enhancer.go
+++ b/utility/map_str_enhancer.go
@@ -54,11 +54,12 @@ func Add(m common.MapStr, key string, val interface{}) {
 		}
 	case common.MapStr:
 		if valMap := val.(common.MapStr); len(valMap) > 0 {
+			newValMap := common.MapStr{}
 			for k, v := range valMap {
-				Add(valMap, k, v)
+				Add(newValMap, k, v)
 			}
-			if len(valMap) > 0 {
-				m[key] = valMap
+			if len(newValMap) > 0 {
+				m[key] = newValMap
 			} else {
 				delete(m, key)
 			}
@@ -67,11 +68,12 @@ func Add(m common.MapStr, key string, val interface{}) {
 		}
 	case map[string]interface{}:
 		if valMap := val.(map[string]interface{}); len(valMap) > 0 {
+			newValMap := map[string]interface{}{}
 			for k, v := range valMap {
-				Add(valMap, k, v)
+				Add(newValMap, k, v)
 			}
-			if len(valMap) > 0 {
-				m[key] = valMap
+			if len(newValMap) > 0 {
+				m[key] = newValMap
 			} else {
 				delete(m, key)
 			}

--- a/utility/map_str_enhancer_test.go
+++ b/utility/map_str_enhancer_test.go
@@ -19,6 +19,7 @@ package utility
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 	"unsafe"
 
@@ -190,6 +191,28 @@ func TestAdd(t *testing.T) {
 		expected = common.MapStr{}
 		assert.Equal(t, expected, m,
 			fmt.Sprintf("<%v>: Remove empty value - Expected: %v, Actual: %v", idx, expected, m))
+	}
+}
+
+func TestAddEnsureCopy(t *testing.T) {
+	for _, test := range []struct {
+		v interface{}
+	}{
+		{
+			common.MapStr{"b": "bar"},
+		},
+		{
+			map[string]interface{}{"b": "bar"},
+		},
+	} {
+		dest := common.MapStr{}
+		Add(dest, "key", test.v)
+
+		// modify the original value and ensure if doesn't modify the "add"ed value
+		reflect.ValueOf(test.v).SetMapIndex(reflect.ValueOf("f"), reflect.ValueOf("foo"))
+		actual := dest["key"]
+
+		assert.NotEqual(t, actual, test.v)
 	}
 }
 


### PR DESCRIPTION
`utility.Add` adds a `val` to a MapStr `m`. However, it can sometimes modify the value given as a `val`. 

If you use `utility.Add` concurrently, to add the same value `val` to two different `m`s, you'll get can risk getting the following error:
```
fatal error: concurrent map iteration and map write
```