### PR TITLE
don't build unused DMGs

### DIFF
--- a/_beats/dev-tools/packaging/packages.yml
+++ b/_beats/dev-tools/packaging/packages.yml
@@ -248,13 +248,6 @@ specs:
         <<: *apache_license_for_binaries
         name: '{{.BeatName}}-oss'
 
-    - os: darwin
-      types: [dmg]
-      spec:
-        <<: *macos_beat_pkg_spec
-        <<: *apache_license_for_macos_pkg
-        name: '{{.BeatName}}-oss'
-
     - os: linux
       types: [tgz]
       spec:
@@ -283,12 +276,6 @@ specs:
       spec:
         <<: *binary_spec
         <<: *elastic_license_for_binaries
-
-    - os: darwin
-      types: [dmg]
-      spec:
-        <<: *macos_beat_pkg_spec
-        <<: *elastic_license_for_macos_pkg
 
     - os: linux
       types: [tgz]

--- a/script/update_beats.sh
+++ b/script/update_beats.sh
@@ -24,6 +24,7 @@ git clone https://github.com/elastic/beats.git ${GIT_CLONE}
 rsync -crpv --delete \
     --exclude=dev-tools/packer/readme.md.j2 \
     --exclude="dev-tools/packer/platforms/darwin/preference-pane/***" \
+    --exclude="dev-tools/packaging/packages.yml" \
     --include="dev-tools/***" \
     --include="script/***" \
     --include="testing/***" \


### PR DESCRIPTION
Up for discussion - build time is insignificant but the dependencies (xcode) are not.