### PR TITLE
[6.x] run benchmarks from top directory instead of only /processor, we were missing eg. `BenchmarkServer` (#1243)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ release-manager-release:
 
 .PHONY: bench
 bench:
-	@go test -benchmem -run=XXX -benchtime=100ms -bench='.*' ./processor/...
+	@go test -benchmem -run=XXX -benchtime=100ms -bench='.*' ./...
 
 .PHONY: are-kibana-objects-updated
 are-kibana-objects-updated: python-env


### PR DESCRIPTION
Backports the following commits to 6.x:
 - run benchmarks from top directory instead of only /processor, we were missing eg. `BenchmarkServer`  (#1243)