### PR TITLE
[6.x] Revert deprecating setup cmd. (#1261)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,8 @@ https://github.com/elastic/apm-server/compare/v6.3.2\...v6.4.0[View commits]
 - Add /v1/metrics endpoint {pull}1000[1000] {pull}1121[1121].
 - Push onboarding doc to separate ES index {pull}1159[1159].
 - Deprecate usage of `apm-server setup` {pull}1142[1142].
+- Deprecate usage of `apm-server setup` {pull}1142[1142],{pull}1261[1261].
+- Disable metrics logging by default {pull}1127[1127].
 
 
 [[release-notes-6.3]]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,4 @@ var RootCmd *cmd.BeatsRootCmd
 func init() {
 	var runFlags = pflag.NewFlagSet(Name, pflag.ExitOnError)
 	RootCmd = cmd.GenRootCmdWithIndexPrefixWithRunFlags(Name, IdxPattern, "", beater.New, runFlags)
-	RootCmd.RunCmd.Flags().MarkDeprecated("setup", "use Kibana UI for initial setup.")
-	RootCmd.SetupCmd.Deprecated = "use Kibana UI for initial setup."
 }


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Revert deprecating setup cmd.  (#1261)