### PR TITLE
[6.4] clarify that is possible to use a secret token when uploading sourcemaps (#1271)

### DIFF
--- a/docs/sourcemap-api.asciidoc
+++ b/docs/sourcemap-api.asciidoc
@@ -25,6 +25,8 @@ The request must include some fields needed to identify `source map` correctly l
 The source map must follow the
 https://docs.google.com/document/d/1U1RGAehQwRypUTovF1KRlpiOFze0b-_2gc6fAH0KY0k[Source map revision 3 proposal] spec and be attached as a `file upload`.
 
+You can configure a <<secret-token, secret token>> to upload sourcemaps.
+
 [[sourcemap-api-examples]]
 [float]
 ==== Example


### PR DESCRIPTION
Backports the following commits to 6.4:
 - clarify that is possible to use a secret token when uploading sourcemaps  (#1271)