### PR TITLE
Own make target to build APM docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,5 @@
 /fields.yml
 /apm-server.template-es.json
 /vendor/github.com/elastic/beats/libbeat/fields.yml
-
+/docs/elastic/
 html_docs

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,11 @@ notice: python-env
 	@echo "Generating NOTICE"
 	@$(PYTHON_ENV)/bin/python ${ES_BEATS}/dev-tools/generate_notice.py . -e '_beats' -s "./vendor/github.com/elastic/beats" -b "Apm Server" --beats-origin <($(PYTHON_ENV)/bin/python script/generate_notice_overrides.py)
 
-.PHONY: force-update-docs
-force-update-docs: clean docs
+.PHONY: apm-docs
+apm-docs:  ## @build Builds the APM documents
+	@rm -rf build/html_docs
+	sh script/build_apm_docs.sh ${BEAT_NAME} ${BEAT_PATH}/docs ${BUILD_DIR}
+
 
 .PHONY: update-beats-docs
 update-beats-docs:

--- a/script/build_apm_docs.sh
+++ b/script/build_apm_docs.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+name=$1
+path=$2
+build_dir=$3
+
+docs_dir=docs/elastic
+html_dir=$build_dir/html_docs
+
+# Checks if docs clone already exists
+if [ ! -d $docs_dir ]; then
+    # Only head is cloned
+    git clone --depth=1 https://github.com/elastic/docs.git $docs_dir
+else
+    git -C $docs_dir pull https://github.com/elastic/docs.git
+fi
+
+index_list="$(find ${GOPATH%%:*}/src/$path -name 'index.asciidoc')"
+for index in $index_list
+do
+  echo "Building docs for ${name}..."
+  echo "Index document: ${index}"
+  index_path=$(basename $(dirname $index))
+  echo "Index path: $index_path"
+
+  dest_dir="$html_dir/${name}/${index_path}"
+  mkdir -p "$dest_dir"
+  params="--chunk=1"
+  $docs_dir/build_docs.pl $params --doc "$index" -out "$dest_dir"
+done


### PR DESCRIPTION
- Pulls elastic/docs instead of remove & clone each time
- Drops maxdepth = 1 so to build guide/index too

_____

not sure if this is the right thing to do, just an attempt to make build docs better for us