### PR TITLE
[6.4] add release notes for 6.4 (#1277)

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -31,7 +31,7 @@ Elastic APM consists of four components:
 * {ref}/index.html[Elasticsearch]
 * {apm-agents-ref}/index.html[APM agents]
 * {apm-server-ref}/index.html[APM Server]
-* Kibana APM UI
+* {kibana-ref}/xpack-apm.html[Kibana APM UI]
 
 image::apm-architecture.png[Architecture of Elastic APM]
 
@@ -55,6 +55,49 @@ Then it creates documents from that data and stores them in Elasticsearch.
 To visualize the data after it's sent to Elasticsearch,
 you can use the the dedicated APM UI bundled in X-Pack,
 or the pre-built open source Kibana dashboards that can be loaded directly in the Kibana UI.
+
+[[apm-release-notes]]
+=== Release notes
+
+[float]
+==== APM version 6.4
+
+[float]
+===== Breaking changes
+
+We previously split APM data into separate indices (transaction, span, error, etc.).
+In 6.4 APM Kibana UI starts to leverage those separate indices for queries.
+In case you only update Kibana but run an older version of APM Server you will not be able to see any APM data by default.
+To fix this, use the Kibana APM configuration options to specify the location of the APM index.
+See {kibana-ref}/apm-settings-kb.html[Kibana APM settings] for details.
+
+When upgrading to Kibana 6.4, you might need to refresh your APM index pattern for certain APM UI features to work.
+
+[float]
+===== New features
+
+*APM Server*
+
+* Logstash output
+* Kafka output
+
+
+*APM UI*
+
+* Query bar
+* Machine Learning integration: Anomaly detection on service response times
+* Kibana objects (index pattern, dashboards, etc.) can now be imported via the Kibana setup instuctions
+
+
+*APM agents*
+
+* RUM is now GA
+* Ruby is now GA
+* Java is now Beta
+* Go is now Beta
+* Python added instrumentation for Cassandra, PyODBC and PyMSSQL
+* Node.js added instrumentation for Cassandra and broader MySQL support
+
 
 [[install-and-run]]
 == Install and run Elastic APM

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -17,7 +17,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
 :securitydoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
-:deprecate_dashboard_loading: 6.4.0 
+:deprecate_dashboard_loading: 6.4.0
 
 ifdef::env-github[]
 NOTE: For the best reading experience,

--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -6,7 +6,7 @@ The APM Server receives data from APM agents and transforms them into Elasticsea
 It works by exposing an HTTP server to which agents post the APM data they collect.
 
 APM Server is built with the Beats framework,
-and as such it levarages its functionality.
+and as such it leverages its functionality.
 
 To get an overview of the whole Elastic APM system,
  also have a look at:


### PR DESCRIPTION
Backports the following commits to 6.4:
 - add release notes for 6.4  (#1277)