### PR TITLE
Fix broken docs link.

### DIFF
--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -43,7 +43,6 @@ https://www.elastic.co/guide/en/beats/libbeat/master/breaking-changes.html[break
 ==== 6.4
 Indexing the `onboarding` document in it's own index by default.
 
-https://www.elastic.co/guide/en/beats/libbeat/current/breaking-changes-6.4.html[breaking changes in libbeat]
 
 [float]
 ==== 6.3


### PR DESCRIPTION
Remove link to beats breaking changes, as no breaking changes section exists for 6.4.