### PR TITLE
docs(node): list support for Restify framework

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -212,7 +212,8 @@ var apm = require('elastic-apm-node').start({
 
 The Node.js agent automatically instruments Express,
 hapi,
-and Koa out of the box.
+Koa,
+and Restify out of the box.
 See the {apm-node-ref}/index.html[APM Node.js Agent documentation] for more details.
 
 [[python-agent]]


### PR DESCRIPTION
The upcoming version of the Node.js agent (v1.12.0) will have support for the Restify framework. It's going to be released now and will be compatible with all versions of the APM Server from v6.2+