### PR TITLE
[6.4] docs(node): list support for Restify framework (#1343)

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -284,7 +284,8 @@ var apm = require('elastic-apm-node').start({
 
 The Node.js agent automatically instruments Express,
 hapi,
-and Koa out of the box.
+Koa,
+and Restify out of the box.
 See the {apm-node-ref}/index.html[APM Node.js Agent documentation] for more details.
 
 [[python-agent]]


### PR DESCRIPTION
Backports the following commits to 6.4:
 - docs(node): list support for Restify framework  (#1343)