### PR TITLE
v2Handler: use 'application/json' content-type for error responses

### DIFF
--- a/beater/v2_handler.go
+++ b/beater/v2_handler.go
@@ -72,7 +72,7 @@ func (v *v2Handler) sendResponse(logger *logp.Logger, w http.ResponseWriter, sr 
 		// but also signals to http.Server that it should close it:
 		// https://golang.org/src/net/http/server.go#L1254
 		w.Header().Add("Connection", "Close")
-
+		w.Header().Add("Content-Type", "application/json")
 		buf, err := json.Marshal(sr)
 		if err != nil {
 			logger.Errorw("error sending response", "error", err)

--- a/beater/v2_handler_test.go
+++ b/beater/v2_handler_test.go
@@ -127,7 +127,10 @@ func TestRequestIntegration(t *testing.T) {
 			assert.Equal(t, test.code, w.Code, w.Body.String())
 			if test.code == http.StatusAccepted {
 				assert.Equal(t, 0, w.Body.Len())
+				assert.Equal(t, w.HeaderMap.Get("Content-Type"), "")
 			} else {
+				assert.Equal(t, w.HeaderMap.Get("Content-Type"), "application/json")
+
 				body := w.Body.Bytes()
 				tests.AssertApproveResult(t, "approved-stream-result/TestRequestIntegration"+test.name, body)
 			}


### PR DESCRIPTION
Error responses from intake v2 should have `Content-Type: application/json`.