### PR TITLE
[Intake] require `message` or `type` for error.exception

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -7,6 +7,11 @@
 :issue: https://github.com/elastic/apm-server/issues/
 :pull: https://github.com/elastic/apm-server/pull/
 
+include::./changelogs/head.asciidoc[]
+include::./changelogs/6.4.asciidoc[]
+include::./changelogs/6.3.asciidoc[]
+include::./changelogs/6.2.asciidoc[]
+include::./changelogs/6.1.asciidoc[]
 https://github.com/elastic/apm-server/compare/6.4\...master[View commits]
 
 [float]
@@ -20,6 +25,7 @@ https://github.com/elastic/apm-server/compare/6.4\...master[View commits]
 - Make JSON schema spec distributed tracing compliant {pull}1303[1303]
 - Add required `transaction.span_count.started` to Intake v2 {pull}1351[1351]
 - Rename `transaction.span_count.dropped.total` to `transaction.span_count.dropped` on Intake API v2 {pull}1351[1351]
+- Require either `message` or `type` for `error.exception` {pull}1354[1354].
 
 [[release-notes-6.4]]
 == APM Server version 6.4

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -7,11 +7,6 @@
 :issue: https://github.com/elastic/apm-server/issues/
 :pull: https://github.com/elastic/apm-server/pull/
 
-include::./changelogs/head.asciidoc[]
-include::./changelogs/6.4.asciidoc[]
-include::./changelogs/6.3.asciidoc[]
-include::./changelogs/6.2.asciidoc[]
-include::./changelogs/6.1.asciidoc[]
 https://github.com/elastic/apm-server/compare/6.4\...master[View commits]
 
 [float]

--- a/docs/data/intake-api/generated/error/payload.json
+++ b/docs/data/intake-api/generated/error/payload.json
@@ -239,7 +239,7 @@
             "id": "7f0e9d68-c185-4d21-a6f4-4673ed561ec8",
             "timestamp": "2017-05-09T15:04:05Z",
             "exception": {
-                "message": "foo.bar is not a function"
+                "type": "connection error"
             }
         },
         {

--- a/docs/spec/errors/common_error.json
+++ b/docs/spec/errors/common_error.json
@@ -21,7 +21,7 @@
                 },
                 "message": {
                    "description": "The original error message.",
-                   "type": "string"
+                   "type": ["string", "null"]
                 },
                 "module": {
                     "description": "Describes the exception type's module namespace.",
@@ -47,7 +47,9 @@
                     "description": "Indicator whether the error was caught somewhere in the code or not."
                 }
             },
-            "required": ["message"]
+            "anyOf": [
+                {"required": ["message"]},{"required": ["type"]}
+            ]
         },
         "log": {
             "type": ["object", "null"],

--- a/model/error/event.go
+++ b/model/error/event.go
@@ -83,7 +83,7 @@ type Transaction struct {
 }
 
 type Exception struct {
-	Message    string
+	Message    *string
 	Module     *string
 	Code       interface{}
 	Attributes interface{}
@@ -151,13 +151,14 @@ func decodeEvent(input interface{}, err error) (*Event, map[string]interface{}, 
 	err = decoder.Err
 	ex := decoder.MapStr(raw, "exception")
 	exMsg := decoder.StringPtr(ex, "message")
-	if exMsg != nil {
+	exType := decoder.StringPtr(ex, "type")
+	if exMsg != nil || exType != nil {
 		e.Exception = &Exception{
-			Message:    *exMsg,
+			Message:    exMsg,
+			Type:       exType,
 			Code:       decoder.Interface(ex, "code"),
 			Module:     decoder.StringPtr(ex, "module"),
 			Attributes: decoder.Interface(ex, "attributes"),
-			Type:       decoder.StringPtr(ex, "type"),
 			Handled:    decoder.BoolPtr(ex, "handled"),
 			Stacktrace: m.Stacktrace{},
 		}
@@ -364,7 +365,7 @@ func (e *Event) calcGroupingKey() string {
 	}
 	if k.empty {
 		if e.Exception != nil {
-			k.add(&e.Exception.Message)
+			k.add(e.Exception.Message)
 		} else if e.Log != nil {
 			k.add(&e.Log.Message)
 		}

--- a/model/error/event_test.go
+++ b/model/error/event_test.go
@@ -44,7 +44,8 @@ import (
 )
 
 func baseException() *Exception {
-	return &Exception{Message: "exception message"}
+	msg := "exception message"
+	return &Exception{Message: &msg}
 }
 
 func (e *Exception) withCode(code interface{}) *Exception {
@@ -82,7 +83,7 @@ func TestErrorEventDecode(t *testing.T) {
 	timestamp := "2017-05-30T18:53:27.154Z"
 	timestampParsed, _ := time.Parse(time.RFC3339, timestamp)
 	code, module, attrs, exType, handled := "200", "a", "attr", "errorEx", false
-	paramMsg, level, logger := "log pm", "error", "mylogger"
+	exMsg, paramMsg, level, logger := "Exception Msg", "log pm", "error", "mylogger"
 	for _, test := range []struct {
 		input       interface{}
 		err, inpErr error
@@ -166,7 +167,7 @@ func TestErrorEventDecode(t *testing.T) {
 			e: &Event{
 				Timestamp: timestampParsed,
 				Exception: &Exception{
-					Message:    "Exception Msg",
+					Message:    &exMsg,
 					Code:       code,
 					Type:       &exType,
 					Module:     &module,
@@ -188,17 +189,18 @@ func TestErrorEventDecode(t *testing.T) {
 			},
 		},
 	} {
-		for _, decodeFct := range []func(interface{}, error) (transform.Transformable, error){V1DecodeEvent, V2DecodeEvent} {
+		for idx, decodeFct := range []func(interface{}, error) (transform.Transformable, error){V1DecodeEvent, V2DecodeEvent} {
 			transformable, err := decodeFct(test.input, test.inpErr)
 
 			if test.e != nil {
+				fmt.Println(idx)
 				event := transformable.(*Event)
-				assert.Equal(t, test.e, event)
+				assert.Equal(t, test.e, event, idx)
 			} else {
-				assert.Nil(t, transformable)
+				assert.Nil(t, transformable, idx)
 			}
 
-			assert.Equal(t, test.err, err)
+			assert.Equal(t, test.err, err, idx)
 		}
 	}
 }
@@ -247,7 +249,7 @@ func TestEventFields(t *testing.T) {
 	exception := Exception{
 		Type:       &errorType,
 		Code:       codeFloat,
-		Message:    exMsg,
+		Message:    &exMsg,
 		Module:     &module,
 		Handled:    &handled,
 		Attributes: attributes,
@@ -268,7 +270,7 @@ func TestEventFields(t *testing.T) {
 	context := common.MapStr{"user": common.MapStr{"id": "888"}, "c1": "val"}
 
 	baseExceptionHash := md5.New()
-	io.WriteString(baseExceptionHash, baseException().Message)
+	io.WriteString(baseExceptionHash, *baseException().Message)
 	// 706a38d554b47b8f82c6b542725c05dc
 	baseExceptionGroupingKey := hex.EncodeToString(baseExceptionHash.Sum(nil))
 
@@ -399,6 +401,7 @@ func TestEvents(t *testing.T) {
 	service := metadata.Service{
 		Name: "myservice",
 	}
+	exMsg := "exception message"
 
 	tests := []struct {
 		Tranformable transform.Transformable
@@ -427,7 +430,7 @@ func TestEvents(t *testing.T) {
 				Context:   common.MapStr{"foo": "bar", "user": common.MapStr{"email": "m@m.com"}},
 				Log:       baseLog(),
 				Exception: &Exception{
-					Message:    "exception message",
+					Message:    &exMsg,
 					Stacktrace: m.Stacktrace{&m.StacktraceFrame{Filename: "myFile"}},
 				},
 				Transaction: &Transaction{Id: "945254c5-67a5-417e-8a4e-aa29efcbfb79"},
@@ -621,8 +624,9 @@ func TestFramesUsableForGroupingKey(t *testing.T) {
 		&m.StacktraceFrame{Filename: "webpack", Lineno: 77, ExcludeFromGrouping: false},
 		&m.StacktraceFrame{Filename: "~/tmp", Lineno: 45, ExcludeFromGrouping: false},
 	}
-	e1 := Event{Exception: &Exception{Message: "base exception", Stacktrace: st1}}
-	e2 := Event{Exception: &Exception{Message: "base exception", Stacktrace: st2}}
+	exMsg := "base exception"
+	e1 := Event{Exception: &Exception{Message: &exMsg, Stacktrace: st1}}
+	e2 := Event{Exception: &Exception{Message: &exMsg, Stacktrace: st2}}
 	key1 := e1.calcGroupingKey()
 	key2 := e2.calcGroupingKey()
 	assert.NotEqual(t, key1, key2)
@@ -798,8 +802,9 @@ func md5With(args ...string) []byte {
 
 func TestSourcemapping(t *testing.T) {
 	c1 := 18
+	exMsg := "exception message"
 	event := Event{Exception: &Exception{
-		Message: "exception message",
+		Message: &exMsg,
 		Stacktrace: m.Stacktrace{
 			&m.StacktraceFrame{Filename: "/a/b/c", Lineno: 1, Colno: &c1},
 		},
@@ -813,7 +818,7 @@ func TestSourcemapping(t *testing.T) {
 	trNoSmap := event.fields(tctx)
 
 	event2 := Event{Exception: &Exception{
-		Message: "exception message",
+		Message: &exMsg,
 		Stacktrace: m.Stacktrace{
 			&m.StacktraceFrame{Filename: "/a/b/c", Lineno: 1, Colno: &c1},
 		},

--- a/model/error/generated/schema/error.go
+++ b/model/error/generated/schema/error.go
@@ -225,7 +225,7 @@ const ModelSchema = `{
                 },
                 "message": {
                    "description": "The original error message.",
-                   "type": "string"
+                   "type": ["string", "null"]
                 },
                 "module": {
                     "description": "Describes the exception type's module namespace.",
@@ -310,7 +310,9 @@ const ModelSchema = `{
                     "description": "Indicator whether the error was caught somewhere in the code or not."
                 }
             },
-            "required": ["message"]
+            "anyOf": [
+                {"required": ["message"]},{"required": ["type"]}
+            ]
         },
         "log": {
             "type": ["object", "null"],

--- a/model/error/generated/schema/payload.go
+++ b/model/error/generated/schema/payload.go
@@ -346,7 +346,7 @@ const PayloadSchema = `{
                 },
                 "message": {
                    "description": "The original error message.",
-                   "type": "string"
+                   "type": ["string", "null"]
                 },
                 "module": {
                     "description": "Describes the exception type's module namespace.",
@@ -431,7 +431,9 @@ const PayloadSchema = `{
                     "description": "Indicator whether the error was caught somewhere in the code or not."
                 }
             },
-            "required": ["message"]
+            "anyOf": [
+                {"required": ["message"]},{"required": ["type"]}
+            ]
         },
         "log": {
             "type": ["object", "null"],

--- a/processor/error/package_tests/TestProcessErrorFull.approved.json
+++ b/processor/error/package_tests/TestProcessErrorFull.approved.json
@@ -347,9 +347,9 @@
             },
             "error": {
                 "exception": {
-                    "message": "foo.bar is not a function"
+                    "type": "connection error"
                 },
-                "grouping_key": "5be374e988ceb5382d62c7ab53764663",
+                "grouping_key": "18f82051862e494727fa20e0adc15711",
                 "id": "7f0e9d68-c185-4d21-a6f4-4673ed561ec8"
             },
             "processor": {

--- a/processor/error/package_tests/attrs_common.go
+++ b/processor/error/package_tests/attrs_common.go
@@ -68,7 +68,6 @@ func payloadAttrsNotInJsonSchema(s *tests.Set) *tests.Set {
 func requiredKeys(s *tests.Set) *tests.Set {
 	return tests.Union(s, tests.NewSet(
 		"errors",
-		"errors.exception.message",
 		"errors.log.message",
 		"errors.exception.stacktrace.filename",
 		"errors.exception.stacktrace.lineno",
@@ -81,8 +80,10 @@ func requiredKeys(s *tests.Set) *tests.Set {
 
 func condRequiredKeys(c map[string]tests.Condition) map[string]tests.Condition {
 	base := map[string]tests.Condition{
-		"errors.exception": tests.Condition{Absence: []string{"errors.log"}},
-		"errors.log":       tests.Condition{Absence: []string{"errors.exception"}},
+		"errors.exception":         tests.Condition{Absence: []string{"errors.log"}},
+		"errors.exception.message": tests.Condition{Absence: []string{"errors.exception.type"}},
+		"errors.exception.type":    tests.Condition{Absence: []string{"errors.exception.message"}},
+		"errors.log":               tests.Condition{Absence: []string{"errors.exception"}},
 	}
 	for k, v := range c {
 		base[k] = v

--- a/testdata/error/payload.json
+++ b/testdata/error/payload.json
@@ -239,7 +239,7 @@
             "id": "7f0e9d68-c185-4d21-a6f4-4673ed561ec8",
             "timestamp": "2017-05-09T15:04:05Z",
             "exception": {
-                "message": "foo.bar is not a function"
+                "type": "connection error"
             }
         },
         {

--- a/tests/system/error.approved.json
+++ b/tests/system/error.approved.json
@@ -54,9 +54,9 @@
             },
             "error": {
                 "exception": {
-                    "message": "foo.bar is not a function"
+                    "type": "connection error"
                 },
-                "grouping_key": "5be374e988ceb5382d62c7ab53764663",
+                "grouping_key": "18f82051862e494727fa20e0adc15711",
                 "id": "7f0e9d68-c185-4d21-a6f4-4673ed561ec8"
             }
         },


### PR DESCRIPTION
Make either `message` or `type` required for `error.exception`,
without changing the logic for grouping_key.

implements #1297