### PR TITLE
[6.4] docs: fix grammar, overwrite -> override (#1357)

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -271,7 +271,7 @@ Then configure the elastic-apm-node module by adding the following lines to the 
 ----------------------------------
 // Add this to the VERY top of the first file loaded in your app
 var apm = require('elastic-apm-node').start({
-  // Overwrite service name from package.json
+  // Override service name from package.json
   // Allowed characters: a-z, A-Z, 0-9, -, _, and space
   serviceName: '',
 


### PR DESCRIPTION
Backports the following commits to 6.4:
 - docs: fix grammar, overwrite -> override  (#1357)