### PR TITLE
make changelogs more portable between branches

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,12 +1,3 @@
-[[release-notes-head]]
-== APM Server version HEAD
-
-// These have to be under a == headline unfortunately:
-// Use these for links to issue and pulls. Note issues and pulls redirect one to
-// each other on Github, so don't worry too much on using the right prefix.
-:issue: https://github.com/elastic/apm-server/issues/
-:pull: https://github.com/elastic/apm-server/pull/
-
 include::./changelogs/head.asciidoc[]
 include::./changelogs/6.4.asciidoc[]
 include::./changelogs/6.3.asciidoc[]

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -1,3 +1,6 @@
+[[release-notes-head]]
+== APM Server version HEAD
+
 https://github.com/elastic/apm-server/compare/6.4\...master[View commits]
 
 [float]

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -2,6 +2,8 @@
 
 [[release-notes]]
 = Release notes
+:issue: https://github.com/elastic/apm-server/issues/
+:pull: https://github.com/elastic/apm-server/pull/
 
 [partintro]
 


### PR DESCRIPTION
Considered removing `CHANGELOG.asciidoc` altogether and doing everything in `docs/release-notes.asciidoc` but I think it's worth it keep around a top-level file for a changelog, even if it just points at other files.

follows on from #1342 and #1361