### PR TITLE
[v2] Deny nil values for conditional requirements in Intake API.

### DIFF
--- a/docs/spec/errors/common_error.json
+++ b/docs/spec/errors/common_error.json
@@ -48,7 +48,8 @@
                 }
             },
             "anyOf": [
-                {"required": ["message"]},{"required": ["type"]}
+                {"required": ["message"], "properties": {"message": {"type": "string"}}},
+                {"required": ["type"], "properties": {"type": {"type": "string"}}}
             ]
         },
         "log": {
@@ -94,11 +95,7 @@
         }
     },
     "anyOf": [
-        {
-            "required": ["exception"]
-        },
-        {
-            "required": ["log"]
-        }
+        { "required": ["exception"], "properties": {"exception": { "type": "object" }} },
+        { "required": ["log"], "properties": {"log": { "type": "object" }} }
     ]
 }

--- a/model/error/generated/schema/error.go
+++ b/model/error/generated/schema/error.go
@@ -311,7 +311,8 @@ const ModelSchema = `{
                 }
             },
             "anyOf": [
-                {"required": ["message"]},{"required": ["type"]}
+                {"required": ["message"], "properties": {"message": {"type": "string"}}},
+                {"required": ["type"], "properties": {"type": {"type": "string"}}}
             ]
         },
         "log": {
@@ -416,12 +417,8 @@ const ModelSchema = `{
         }
     },
     "anyOf": [
-        {
-            "required": ["exception"]
-        },
-        {
-            "required": ["log"]
-        }
+        { "required": ["exception"], "properties": {"exception": { "type": "object" }} },
+        { "required": ["log"], "properties": {"log": { "type": "object" }} }
     ]  }, 
         {  
             "properties": {

--- a/model/error/generated/schema/payload.go
+++ b/model/error/generated/schema/payload.go
@@ -432,7 +432,8 @@ const PayloadSchema = `{
                 }
             },
             "anyOf": [
-                {"required": ["message"]},{"required": ["type"]}
+                {"required": ["message"], "properties": {"message": {"type": "string"}}},
+                {"required": ["type"], "properties": {"type": {"type": "string"}}}
             ]
         },
         "log": {
@@ -537,12 +538,8 @@ const PayloadSchema = `{
         }
     },
     "anyOf": [
-        {
-            "required": ["exception"]
-        },
-        {
-            "required": ["log"]
-        }
+        { "required": ["exception"], "properties": {"exception": { "type": "object" }} },
+        { "required": ["log"], "properties": {"log": { "type": "object" }} }
     ]  }, 
                     {  
                         "properties": {

--- a/processor/error/package_tests/TestProcessErrorNullValues.approved.json
+++ b/processor/error/package_tests/TestProcessErrorNullValues.approved.json
@@ -112,10 +112,10 @@
                 }
             },
             "error": {
-                "grouping_key": "d6b3f958dfea98dc9ed2b57d5f0c48bb",
-                "log": {
-                    "message": "Cannot read property 'baz' of undefined"
-                }
+                "exception": {
+                    "type": "Read error"
+                },
+                "grouping_key": "a09e05b29fda7fec0b5dca5df084f336"
             },
             "processor": {
                 "event": "error",

--- a/processor/error/package_tests/attrs_common.go
+++ b/processor/error/package_tests/attrs_common.go
@@ -68,7 +68,11 @@ func payloadAttrsNotInJsonSchema(s *tests.Set) *tests.Set {
 func requiredKeys(s *tests.Set) *tests.Set {
 	return tests.Union(s, tests.NewSet(
 		"errors",
+		"errors.log",
+		"errors.exception",
 		"errors.log.message",
+		"errors.exception.message",
+		"errors.exception.type",
 		"errors.exception.stacktrace.filename",
 		"errors.exception.stacktrace.lineno",
 		"errors.log.stacktrace.filename",

--- a/testdata/error/null_values.json
+++ b/testdata/error/null_values.json
@@ -47,7 +47,8 @@
         {
             "timestamp": "2017-05-09T15:04:05.1Z",
             "exception": {
-                "message": "foo is not defined"
+                "message": "foo is not defined",
+                "type": null
             },
             "log": null,
             "context": {
@@ -128,8 +129,9 @@
         },
         {
             "timestamp": "2017-05-09T15:04:05.999Z",
-            "log": {
-                "message": "Cannot read property 'baz' of undefined"
+            "exception": {
+                "message": null,
+                "type": "Read error"
             },
             "context": {
                 "request": null,


### PR DESCRIPTION
fixing https://github.com/elastic/apm-server/pull/1354#issuecomment-420566931

This includes a bugfix for `error.exception` or `error.log` not only be required but also need to be not nil.

@roncohen I don't think we should enforce required strings to have a min length, without discussing this. So far we do not specify what the value looks like when a field is required, we just enforce the key needs to be set and the value must be of the specified type and not nil. 