### PR TITLE
enable sending instrumentation to another apm-server

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -27,13 +27,6 @@ apm-server:
   # Maximum number of new connections to accept simultaneously (0 means unlimited)
   # max_connections: 0
 
-  # Instrumentation support for the server's HTTP endpoints and event publisher.
-  #instrumentation:
-    # Set to true to enable instrumentation of the APM server itself.
-    #enabled: false
-    # Environment in which the APM Server is running on (eg: staging, production, etc.)
-    #environment: ""
-
   # Authorization token to be checked. If a token is set here the agents must
   # send their token in the following format: Authorization: Bearer <secret-token>.
   # It is recommended to use an authorization token in combination with SSL enabled,
@@ -108,6 +101,19 @@ apm-server:
 
     # Url to expose expvar
     #url: "/debug/vars"
+
+  # Instrumentation support for the server's HTTP endpoints and event publisher.
+  #instrumentation:
+    # Set to true to enable instrumentation of the APM server itself.
+    #enabled: false
+    # Environment in which the APM Server is running on (eg: staging, production, etc.)
+    #environment: ""
+    # Remote host to report instrumentation results to. Single entry permitted until
+    # https://github.com/elastic/apm-agent-go/issues/200 is resolved.
+    #hosts:
+    #  - http://remote-apm-server:8200
+    # Remote apm-servers' secret_token
+    #secret_token:
 
   # Experimental Metrics endpoint
   #metrics:

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -27,13 +27,6 @@ apm-server:
   # Maximum number of new connections to accept simultaneously (0 means unlimited)
   # max_connections: 0
 
-  # Instrumentation support for the server's HTTP endpoints and event publisher.
-  #instrumentation:
-    # Set to true to enable instrumentation of the APM server itself.
-    #enabled: false
-    # Environment in which the APM Server is running on (eg: staging, production, etc.)
-    #environment: ""
-
   # Authorization token to be checked. If a token is set here the agents must
   # send their token in the following format: Authorization: Bearer <secret-token>.
   # It is recommended to use an authorization token in combination with SSL enabled,
@@ -108,6 +101,19 @@ apm-server:
 
     # Url to expose expvar
     #url: "/debug/vars"
+
+  # Instrumentation support for the server's HTTP endpoints and event publisher.
+  #instrumentation:
+    # Set to true to enable instrumentation of the APM server itself.
+    #enabled: false
+    # Environment in which the APM Server is running on (eg: staging, production, etc.)
+    #environment: ""
+    # Remote host to report instrumentation results to. Single entry permitted until
+    # https://github.com/elastic/apm-agent-go/issues/200 is resolved.
+    #hosts:
+    #  - http://remote-apm-server:8200
+    # Remote apm-servers' secret_token
+    #secret_token:
 
   # Experimental Metrics endpoint
   #metrics:

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -209,6 +209,7 @@ func initTracer(info beat.Info, config *Config, logger *logp.Logger) (*elasticap
 	if config.SelfInstrumentation.Hosts != nil {
 		t, err := transport.NewHTTPTransport(config.SelfInstrumentation.Hosts[0], config.SelfInstrumentation.SecretToken)
 		if err != nil {
+			tracer.Close()
 			return nil, nil, err
 		}
 		tracer.Transport = t

--- a/beater/config.go
+++ b/beater/config.go
@@ -132,7 +132,7 @@ func init() {
 type InstrumentationConfig struct {
 	Enabled     *bool    `config:"enabled"`
 	Environment *string  `config:"environment"`
-	Hosts       []string `config:"hosts" validate:"maxlen=1"`
+	Hosts       []string `config:"hosts" validate:"nonzero,maxlen=1"`
 	SecretToken string   `config:"secret_token"`
 }
 

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs/transport/transptest"
-	publishertesting "github.com/elastic/beats/libbeat/publisher/testing"
 )
 
 var tmpCertPath string
@@ -473,111 +472,6 @@ func TestServerSecureBadPassphrase(t *testing.T) {
 		assert.True(t, b, err.Error())
 	}
 
-}
-
-func TestServerTracingEnabled(t *testing.T) {
-	events, teardown := setupTestServerInstrumentation(t, true)
-	defer teardown()
-
-	txEvents := transactionEvents(events)
-	var selfTransactions []string
-	for len(selfTransactions) < 2 {
-		select {
-		case e := <-txEvents:
-			name := eventTransactionName(e)
-			if name == "GET /api/types" {
-				continue
-			}
-			selfTransactions = append(selfTransactions, name)
-		case <-time.After(5 * time.Second):
-			assert.FailNow(t, "timed out waiting for transaction")
-		}
-	}
-	assert.Contains(t, selfTransactions, "POST "+BackendTransactionsURL)
-	assert.Contains(t, selfTransactions, "ProcessPending")
-
-	// We expect no more events, i.e. no recursive self-tracing.
-	for {
-		select {
-		case e := <-txEvents:
-			assert.FailNowf(t, "unexpected event", "%v", e)
-		case <-time.After(time.Second):
-			return
-		}
-	}
-}
-
-func TestServerTracingDisabled(t *testing.T) {
-	events, teardown := setupTestServerInstrumentation(t, false)
-	defer teardown()
-
-	txEvents := transactionEvents(events)
-	for {
-		select {
-		case e := <-txEvents:
-			assert.Equal(t, "GET /api/types", eventTransactionName(e))
-		case <-time.After(time.Second):
-			return
-		}
-	}
-}
-
-func eventTransactionName(event beat.Event) string {
-	transaction := event.Fields["transaction"].(common.MapStr)
-	return transaction["name"].(string)
-}
-
-func transactionEvents(events <-chan beat.Event) <-chan beat.Event {
-	out := make(chan beat.Event, 1)
-	go func() {
-		defer close(out)
-		for event := range events {
-			processor := event.Fields["processor"].(common.MapStr)
-			if processor["event"] == "transaction" {
-				out <- event
-			}
-		}
-	}()
-	return out
-}
-
-// setupTestServerInstrumentation sets up a beater with or without instrumentation enabled,
-// and returns a channl to which events are published, and a function to be
-// called to teardown the beater. The initial onboarding event is consumed
-// and a transactions request is made before returning.
-func setupTestServerInstrumentation(t *testing.T, enabled bool) (chan beat.Event, func()) {
-	if testing.Short() {
-		t.Skip("skipping server test")
-	}
-
-	os.Setenv("ELASTIC_APM_FLUSH_INTERVAL", "100ms")
-	defer os.Unsetenv("ELASTIC_APM_FLUSH_INTERVAL")
-
-	events := make(chan beat.Event, 10)
-	pubClient := publishertesting.NewChanClientWith(events)
-	pub := publishertesting.PublisherWithClient(pubClient)
-
-	cfg, err := common.NewConfigFrom(m{
-		"instrumentation": m{"enabled": enabled},
-		"host":            "localhost:0",
-	})
-	assert.NoError(t, err)
-	beater, teardown, err := setupBeater(t, pub, cfg, nil)
-	require.NoError(t, err)
-
-	// onboarding event
-	e := <-events
-	assert.Contains(t, e.Fields, "listening")
-
-	// Send a transaction request so we have something to trace.
-	baseUrl, client := beater.client(false)
-	req := makeTransactionRequest(t, baseUrl)
-	req.Header.Add("Content-Type", "application/json")
-	resp, err := client.Do(req)
-	assert.NoError(t, err)
-	resp.Body.Close()
-
-	return events, teardown
 }
 
 func setupServer(t *testing.T, cfg *common.Config, beatConfig *beat.BeatConfig) (*beater, func(), error) {

--- a/beater/tracing_test.go
+++ b/beater/tracing_test.go
@@ -1,0 +1,136 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	publishertesting "github.com/elastic/beats/libbeat/publisher/testing"
+)
+
+func TestServerTracingEnabled(t *testing.T) {
+	events, teardown := setupTestServerInstrumentation(t, true)
+	defer teardown()
+
+	txEvents := transactionEvents(events)
+	var selfTransactions []string
+	for len(selfTransactions) < 2 {
+		select {
+		case e := <-txEvents:
+			name := eventTransactionName(e)
+			if name == "GET /api/types" {
+				continue
+			}
+			selfTransactions = append(selfTransactions, name)
+		case <-time.After(5 * time.Second):
+			assert.FailNow(t, "timed out waiting for transaction")
+		}
+	}
+	assert.Contains(t, selfTransactions, "POST "+BackendTransactionsURL)
+	assert.Contains(t, selfTransactions, "ProcessPending")
+
+	// We expect no more events, i.e. no recursive self-tracing.
+	for {
+		select {
+		case e := <-txEvents:
+			assert.FailNowf(t, "unexpected event", "%v", e)
+		case <-time.After(time.Second):
+			return
+		}
+	}
+}
+
+func TestServerTracingDisabled(t *testing.T) {
+	events, teardown := setupTestServerInstrumentation(t, false)
+	defer teardown()
+
+	txEvents := transactionEvents(events)
+	for {
+		select {
+		case e := <-txEvents:
+			assert.Equal(t, "GET /api/types", eventTransactionName(e))
+		case <-time.After(time.Second):
+			return
+		}
+	}
+}
+
+func eventTransactionName(event beat.Event) string {
+	transaction := event.Fields["transaction"].(common.MapStr)
+	return transaction["name"].(string)
+}
+
+func transactionEvents(events <-chan beat.Event) <-chan beat.Event {
+	out := make(chan beat.Event, 1)
+	go func() {
+		defer close(out)
+		for event := range events {
+			processor := event.Fields["processor"].(common.MapStr)
+			if processor["event"] == "transaction" {
+				out <- event
+			}
+		}
+	}()
+	return out
+}
+
+// setupTestServerInstrumentation sets up a beater with or without instrumentation enabled,
+// and returns a channel to which events are published, and a function to be
+// called to teardown the beater. The initial onboarding event is consumed
+// and a transactions request is made before returning.
+func setupTestServerInstrumentation(t *testing.T, enabled bool) (chan beat.Event, func()) {
+	if testing.Short() {
+		t.Skip("skipping server test")
+	}
+
+	os.Setenv("ELASTIC_APM_FLUSH_INTERVAL", "100ms")
+	defer os.Unsetenv("ELASTIC_APM_FLUSH_INTERVAL")
+
+	events := make(chan beat.Event, 10)
+	pubClient := publishertesting.NewChanClientWith(events)
+	pub := publishertesting.PublisherWithClient(pubClient)
+
+	cfg, err := common.NewConfigFrom(m{
+		"instrumentation": m{"enabled": enabled},
+		"host":            "localhost:0",
+	})
+	assert.NoError(t, err)
+	beater, teardown, err := setupBeater(t, pub, cfg, nil)
+	require.NoError(t, err)
+
+	// onboarding event
+	e := <-events
+	assert.Contains(t, e.Fields, "listening")
+
+	// Send a transaction request so we have something to trace.
+	baseUrl, client := beater.client(false)
+	req := makeTransactionRequest(t, baseUrl)
+	req.Header.Add("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	assert.NoError(t, err)
+	resp.Body.Close()
+
+	return events, teardown
+}

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -10,3 +10,4 @@ https://github.com/elastic/apm-server/compare/6.4\...master[View commits]
 - Add pipeline registration and pipeline usage {pull}1258[1258],{pull}1296[1296]
 - Allow sending `tags` for `spans`, that get indexed in ES {pull}1156[1156].
 - Add apm-server monitoring {pull}1382[1382].
+- Enable sending instrumentation to a remote APM Server with `instrumentation.hosts` {pull}1389[1389].


### PR DESCRIPTION
Adds `apm-server.instrumentation` configuration directives: `hosts` and `secret_token`.  `hosts` can only contain 1 element at the moment but is an array in anticipation of this restriction being lifted following elastic/apm-agent-go#200.

TODO:
- [x] merge elastic/apm-server#1387
- [x] docs/config
- [x] tests

closes elastic/apm-server#1388