### PR TITLE
[v2] create span per reporting session

### DIFF
--- a/beater/common_handlers.go
+++ b/beater/common_handlers.go
@@ -431,10 +431,8 @@ func processRequest(r *http.Request, p processor.Processor, config transform.Con
 	req := publish.PendingReq{Transformables: transformables, Tcontext: tctx}
 	ctx := r.Context()
 	span, ctx := elasticapm.StartSpan(ctx, "Send", "Reporter")
-	if span != nil {
-		defer span.End()
-		req.Trace = !span.Dropped()
-	}
+	defer span.End()
+	req.Trace = !span.Dropped()
 
 	if err = report(ctx, req); err != nil {
 		if err == publish.ErrChannelClosed {

--- a/processor/stream/stream_processor.go
+++ b/processor/stream/stream_processor.go
@@ -263,9 +263,7 @@ func (s *StreamProcessor) HandleStream(ctx context.Context, meta map[string]inte
 	rl := rateLimiterFromContext(ctx)
 
 	sp, ctx := elasticapm.StartSpan(ctx, "Stream", "Reporter")
-	if sp != nil {
-		defer sp.End()
-	}
+	defer sp.End()
 
 	for {
 

--- a/publish/pub.go
+++ b/publish/pub.go
@@ -50,7 +50,7 @@ type publisher struct {
 type PendingReq struct {
 	Transformables []transform.Transformable
 	Tcontext       *transform.Context
-	trace          bool
+	Trace          bool
 }
 
 var (
@@ -119,12 +119,6 @@ func (p *publisher) Send(ctx context.Context, req PendingReq) error {
 		return ErrChannelClosed
 	}
 
-	span, ctx := elasticapm.StartSpan(ctx, "Send", "Publisher")
-	if span != nil {
-		defer span.End()
-		req.trace = !span.Dropped()
-	}
-
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -143,7 +137,7 @@ func (p *publisher) run() {
 
 func (p *publisher) processPendingReq(req PendingReq) {
 	var tx *elasticapm.Transaction
-	if req.trace {
+	if req.Trace {
 		tx = p.tracer.StartTransaction("ProcessPending", "Publisher")
 		defer tx.End()
 	}


### PR DESCRIPTION
This effectively makes no change for tracing in the v1 api and reduces span count to 1 per request in the v2 api.

for #1385