### PR TITLE
[v2] updated changelog

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -12,18 +12,10 @@ https://github.com/elastic/apm-server/compare/6.4\...master[View commits]
 [float]
 === Added
 
-- Provide basic server information at `/` {pull}1197[1197]
-- Add pipeline registration and pipeline usage {pull}1258[1258],{pull}1296[1296]
+- Provide basic server information at `/` {pull}1197[1197].
+- Add pipeline registration and pipeline usage {pull}1258[1258],{pull}1296[1296].
 - Allow sending `tags` for `spans`, that get indexed in ES {pull}1156[1156].
-- Add pipeline registration and pipeline usage {pull}1258[1258]
-- Update JSON schema spec for v2 {pull}1303[1303]
-- Make JSON schema spec distributed tracing compliant {pull}1303[1303]
-- Add required `transaction.span_count.started` to Intake v2 {pull}1351[1351]
-- Rename `transaction.span_count.dropped.total` to `transaction.span_count.dropped` on Intake API v2 {pull}1351[1351]
-- Require either `message` or `type` for `error.exception` {pull}1354[1354].
-- Require `span.parent_id`, forbid `null` for `span.trace_id`, `transaction.trace_id` {pull}1391[1391]
-- Require `error.id` and changed description to 128 random bits ID {pull}1384[1384]
-- Add rate limit handling per event {pull}1367[1367]
+- Added Intake Protocol v2 with distributed tracing support {pull}1237[1237], {pull}1390[1390].
 
 [[release-notes-6.4]]
 == APM Server version 6.4


### PR DESCRIPTION
Update change log in preparation for merging v2 into master.

v2 is a whole new API that we're introducing, so including the changes we've made to v2 separately from the introduction of v2 doesn't seem right to me. Users of the next version of APM Server will just see a new protocol added and shouldn't mind the fact that we've been doing it in iterations between the releases.

So I've gone ahead and removed the individual change log entries that we did for v2 and instead linked to the two meta issues: one for v2 and one for DT. This way, people can still see all the individual work that went into it, but as a change log entry it just shows up as the introduction of v2 with distributed tracing support.