### PR TITLE
add Elastic Cloud config

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -325,6 +325,19 @@ setup.template.settings:
   #ssl.curve_types: []
 
 
+#============================= Elastic Cloud ==================================
+
+# These settings simplify using APM Server with the Elastic Cloud (https://cloud.elastic.co/).
+
+# The cloud.id setting overwrites the `output.elasticsearch.hosts` and
+# [deprecated] `setup.kibana.host` options.
+# You can find the `cloud.id` in the Elastic Cloud web UI.
+#cloud.id:
+
+# The cloud.auth setting overwrites the `output.elasticsearch.username` and
+# `output.elasticsearch.password` settings. The format is `<user>:<pass>`.
+#cloud.auth:
+
 #================================ Outputs =====================================
 
 # Configure what output to use when sending the data collected by the beat.

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -325,6 +325,19 @@ setup.template.settings:
   #ssl.curve_types: []
 
 
+#============================= Elastic Cloud ==================================
+
+# These settings simplify using APM Server with the Elastic Cloud (https://cloud.elastic.co/).
+
+# The cloud.id setting overwrites the `output.elasticsearch.hosts` and
+# [deprecated] `setup.kibana.host` options.
+# You can find the `cloud.id` in the Elastic Cloud web UI.
+#cloud.id:
+
+# The cloud.auth setting overwrites the `output.elasticsearch.username` and
+# `output.elasticsearch.password` settings. The format is `<user>:<pass>`.
+#cloud.auth:
+
 #================================ Outputs =====================================
 
 # Configure what output to use when sending the data collected by the beat.


### PR DESCRIPTION
This is already documented, eg https://www.elastic.co/guide/en/apm/server/6.4/configure-cloud-id.html.  This change adds commented out defaults to the bundled configuration.

closes elastic/apm-server#1428 