### PR TITLE
new goimports, new rules

### DIFF
--- a/_beats/libbeat/scripts/cmd/stress_pipeline/main.go
+++ b/_beats/libbeat/scripts/cmd/stress_pipeline/main.go
@@ -28,19 +28,15 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	logpcfg "github.com/elastic/beats/libbeat/logp/configure"
-	"github.com/elastic/beats/libbeat/paths"
-	"github.com/elastic/beats/libbeat/publisher/pipeline/stress"
-	"github.com/elastic/beats/libbeat/service"
-
-	// import queue types
-	_ "github.com/elastic/beats/libbeat/publisher/queue/memqueue"
-	_ "github.com/elastic/beats/libbeat/publisher/queue/spool"
-
-	// import outputs
 	_ "github.com/elastic/beats/libbeat/outputs/console"
 	_ "github.com/elastic/beats/libbeat/outputs/elasticsearch"
 	_ "github.com/elastic/beats/libbeat/outputs/fileout"
 	_ "github.com/elastic/beats/libbeat/outputs/logstash"
+	"github.com/elastic/beats/libbeat/paths"
+	"github.com/elastic/beats/libbeat/publisher/pipeline/stress"
+	_ "github.com/elastic/beats/libbeat/publisher/queue/memqueue"
+	_ "github.com/elastic/beats/libbeat/publisher/queue/spool"
+	"github.com/elastic/beats/libbeat/service"
 )
 
 var (

--- a/_beats/libbeat/testing/mapvaltest/mapvaltest.go
+++ b/_beats/libbeat/testing/mapvaltest/mapvaltest.go
@@ -24,9 +24,8 @@ package mapvaltest
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/mapval"

--- a/beater/config.go
+++ b/beater/config.go
@@ -26,11 +26,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/elastic/go-ucfg"
-
 	"github.com/elastic/apm-server/sourcemap"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs"
+	"github.com/elastic/go-ucfg"
 )
 
 const defaultPort = "8200"

--- a/beater/handlers.go
+++ b/beater/handlers.go
@@ -41,7 +41,6 @@ import (
 	"github.com/elastic/apm-server/processor/sourcemap"
 	"github.com/elastic/apm-server/processor/transaction"
 	"github.com/elastic/apm-server/transform"
-
 	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"

--- a/beater/handlers_test.go
+++ b/beater/handlers_test.go
@@ -19,17 +19,14 @@ package beater
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"testing"
-
-	"fmt"
-
-	"sync"
-	"time"
-
 	"strconv"
+	"sync"
+	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/beater/server.go
+++ b/beater/server.go
@@ -19,16 +19,14 @@ package beater
 
 import (
 	"context"
+	"crypto/tls"
 	"net"
 	"net/http"
 
 	"golang.org/x/net/netutil"
 
-	"crypto/tls"
-
 	"github.com/elastic/apm-agent-go"
 	"github.com/elastic/apm-agent-go/module/apmhttp"
-
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/version"

--- a/model/error/event.go
+++ b/model/error/event.go
@@ -28,11 +28,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/elastic/beats/libbeat/beat"
-
 	m "github.com/elastic/apm-server/model"
 	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/apm-server/utility"
+	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/monitoring"
 )

--- a/model/error/event_test.go
+++ b/model/error/event_test.go
@@ -27,17 +27,14 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-
-	"github.com/elastic/apm-server/model/metadata"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"time"
 
 	s "github.com/go-sourcemap/sourcemap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	m "github.com/elastic/apm-server/model"
+	"github.com/elastic/apm-server/model/metadata"
 	"github.com/elastic/apm-server/sourcemap"
 	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/beats/libbeat/common"

--- a/model/metadata/metadata_test.go
+++ b/model/metadata/metadata_test.go
@@ -21,9 +21,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/common"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestDecodeMetadata(t *testing.T) {

--- a/model/metric/event_test.go
+++ b/model/metric/event_test.go
@@ -24,10 +24,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/apm-server/model/metadata"
-
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/apm-server/model/metadata"
 	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/beats/libbeat/common"
 )

--- a/model/span/span.go
+++ b/model/span/span.go
@@ -21,13 +21,12 @@ import (
 	"errors"
 	"time"
 
-	"github.com/elastic/beats/libbeat/beat"
-	"github.com/elastic/beats/libbeat/monitoring"
-
 	m "github.com/elastic/apm-server/model"
 	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/apm-server/utility"
+	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/monitoring"
 )
 
 var (

--- a/model/span/span_test.go
+++ b/model/span/span_test.go
@@ -22,11 +22,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/elastic/apm-server/model/metadata"
-
 	"github.com/stretchr/testify/assert"
 
 	m "github.com/elastic/apm-server/model"
+	"github.com/elastic/apm-server/model/metadata"
 	"github.com/elastic/apm-server/sourcemap"
 	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/beats/libbeat/common"

--- a/model/transaction/event.go
+++ b/model/transaction/event.go
@@ -21,13 +21,12 @@ import (
 	"errors"
 	"time"
 
-	"github.com/elastic/beats/libbeat/beat"
-	"github.com/elastic/beats/libbeat/monitoring"
-
 	"github.com/elastic/apm-server/model/span"
 	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/apm-server/utility"
+	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/monitoring"
 )
 
 const (

--- a/model/transaction/event_test.go
+++ b/model/transaction/event_test.go
@@ -21,15 +21,13 @@ import (
 	"errors"
 	"fmt"
 	"testing"
-
-	"github.com/elastic/apm-server/transform"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
-	"time"
-
 	"github.com/elastic/apm-server/model/metadata"
 	"github.com/elastic/apm-server/model/span"
+	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/beats/libbeat/common"
 )
 

--- a/processor/transaction/package_tests/processor_test.go
+++ b/processor/transaction/package_tests/processor_test.go
@@ -22,9 +22,8 @@ import (
 	"testing"
 
 	"github.com/elastic/apm-server/processor/transaction"
-	"github.com/elastic/apm-server/transform"
-
 	"github.com/elastic/apm-server/tests"
+	"github.com/elastic/apm-server/transform"
 )
 
 var (

--- a/script/output_data/output_data.go
+++ b/script/output_data/output_data.go
@@ -24,11 +24,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/elastic/beats/libbeat/beat"
-
 	"github.com/elastic/apm-server/beater"
 	"github.com/elastic/apm-server/tests/loader"
 	"github.com/elastic/apm-server/transform"
+	"github.com/elastic/beats/libbeat/beat"
 )
 
 func main() {

--- a/sourcemap/mapper.go
+++ b/sourcemap/mapper.go
@@ -19,9 +19,8 @@ package sourcemap
 
 import (
 	"fmt"
-	"time"
-
 	"strings"
+	"time"
 
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"

--- a/tests/approvals.go
+++ b/tests/approvals.go
@@ -26,8 +26,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/beat"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/yudai/gojsondiff"
@@ -35,6 +33,7 @@ import (
 	"github.com/elastic/apm-server/processor"
 	"github.com/elastic/apm-server/tests/loader"
 	"github.com/elastic/apm-server/transform"
+	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 )
 

--- a/tests/fields.go
+++ b/tests/fields.go
@@ -23,13 +23,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/elastic/beats/libbeat/beat"
-
 	"github.com/stretchr/testify/require"
 
 	pr "github.com/elastic/apm-server/processor"
 	"github.com/elastic/apm-server/tests/loader"
 	"github.com/elastic/apm-server/transform"
+	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 )
 

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -20,10 +20,9 @@ package transform
 import (
 	"regexp"
 
-	"github.com/elastic/beats/libbeat/beat"
-
 	"github.com/elastic/apm-server/model/metadata"
 	"github.com/elastic/apm-server/sourcemap"
+	"github.com/elastic/beats/libbeat/beat"
 )
 
 type Transformable interface {


### PR DESCRIPTION
simply updated goimports, ran `make fmt` and removed comments from `_beats/libbeat/scripts/cmd/stress_pipeline/main.go` that no longer made sense.