### PR TITLE
Deduplicate sourcemap error logs 

### DIFF
--- a/model/stacktrace.go
+++ b/model/stacktrace.go
@@ -85,7 +85,7 @@ func (st *Stacktrace) Transform(tctx *transform.Context) []common.MapStr {
 	logger := logp.NewLogger("stacktrace")
 	for errMsg, _ := range sourcemapErrorSet {
 		if errMsg != "" {
-			logger.Error(errMsg)
+			logger.Warn(errMsg)
 		}
 	}
 

--- a/model/stacktrace.go
+++ b/model/stacktrace.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 type Stacktrace []*StacktraceFrame
@@ -70,12 +71,23 @@ func (st *Stacktrace) Transform(tctx *transform.Context) []common.MapStr {
 	frames = make([]common.MapStr, frameCount)
 
 	fct := "<anonymous>"
+	var sourcemapErrorSet = make(map[string]struct{})
+
 	for idx := frameCount - 1; idx >= 0; idx-- {
 		fr = (*st)[idx]
 		if tctx.Config.SmapMapper != nil && tctx.Metadata.Service != nil {
-			fct = fr.applySourcemap(tctx.Config.SmapMapper, tctx.Metadata.Service, fct)
+			var errMsg string
+			fct, errMsg = fr.applySourcemap(tctx.Config.SmapMapper, tctx.Metadata.Service, fct)
+			sourcemapErrorSet[errMsg] = struct{}{}
 		}
 		frames[idx] = fr.Transform(tctx)
 	}
+	logger := logp.NewLogger("stacktrace")
+	for errMsg, _ := range sourcemapErrorSet {
+		if errMsg != "" {
+			logger.Error(errMsg)
+		}
+	}
+
 	return frames
 }

--- a/model/stacktrace_frame_test.go
+++ b/model/stacktrace_frame_test.go
@@ -307,8 +307,9 @@ func TestApplySourcemap(t *testing.T) {
 			}
 		}
 
-		// check that source mapping is applied as excpected
-		output := (&test.fr).applySourcemap(&FakeMapper{}, service, test.fct)
+		// check that source mapping is applied as expected
+		output, errMsg := (&test.fr).applySourcemap(&FakeMapper{}, service, test.fct)
+		assert.Equal(t, test.smapError, errMsg)
 		assert.Equal(t, test.outFct, output)
 		assert.Equal(t, test.lineno, test.fr.Lineno, fmt.Sprintf("Failed at idx %v; %s", idx, test.msg))
 		assert.Equal(t, test.filename, test.fr.Filename, fmt.Sprintf("Failed at idx %v; %s", idx, test.msg))


### PR DESCRIPTION
Also write them once per span instead of once per stackframe.

Something like eg:

```
2018-10-16T14:29:18.106+0200	ERROR	[stacktrace]	model/stacktrace_frame.go:168	failed to apply sourcemap No Sourcemap available for Service Name: 'client', Service Version: '1.0.0' and Path: 'http://localhost:3000/static/js/main.e0dea103.js'.
2018-10-16T14:29:18.106+0200	ERROR	[stacktrace]	model/stacktrace_frame.go:220	No Sourcemap available for Service Name: 'client', Service Version: '1.0.0' and Path: 'http://localhost:3000/static/js/main.e0dea103.js'.
2018-10-16T14:29:18.106+0200	ERROR	[stacktrace]	model/stacktrace_frame.go:168	failed to apply sourcemap No Sourcemap available for Service Name: 'client', Service Version: '1.0.0' and Path: 'http://localhost:3000/static/js/main.e0dea103.js'.
2018-10-16T14:29:18.106+0200	ERROR	[stacktrace]	model/stacktrace_frame.go:220	No Sourcemap available for Service Name: 'client', Service Version: '1.0.0' and Path: 'http://localhost:3000/static/js/main.e0dea103.js'.
2018-10-16T14:29:18.106+0200	ERROR	[stacktrace]	model/stacktrace_frame.go:168	failed to apply sourcemap No Sourcemap available for Service Name: 'client', Service Version: '1.0.0' and Path: 'http://localhost:3000/static/js/main.e0dea103.js'.
2018-10-16T14:29:18.106+0200	ERROR	[stacktrace]	model/stacktrace_frame.go:220	No Sourcemap available for Service Name: 'client', Service Version: '1.0.0' and Path: 'http://localhost:3000/static/js/main.e0dea103.js'.
2018-10-16T14:29:18.106+0200	ERROR	[stacktrace]	model/stacktrace_frame.go:168	failed to apply sourcemap No Sourcemap available for Service Name: 'client', Service Version: '1.0.0' and Path: 'http://localhost:3000/static/js/main.e0dea103.js'.
2018-10-16T14:29:18.106+0200	ERROR	[stacktrace]	model/stacktrace_frame.go:220	No Sourcemap available for Service Name: 'client', Service Version: '1.0.0' and Path: 'http://localhost:3000/static/js/main.e0dea103.js'.
2018-10-16T14:29:18.106+0200	ERROR	[stacktrace]	model/stacktrace_frame.go:168	failed to apply sourcemap No Sourcemap available for Service Name: 'client', Service Version: '1.0.0' and Path: 'http://localhost:3000/static/js/main.e0dea103.js'.
2018-10-16T14:29:18.106+0200	ERROR	[stacktrace]	model/stacktrace_frame.go:220	No Sourcemap available for Service Name: 'client', Service Version: '1.0.0' and Path: 'http://localhost:3000/static/js/main.e0dea103.js'.
2018-10-16T14:29:18.106+0200	ERROR	[stacktrace]	model/stacktrace_frame.go:168	failed to apply sourcemap No Sourcemap available for Service Name: 'client', Service Version: '1.0.0' and Path: 'http://localhost:3000/static/js/main.e0dea103.js'.
2018-10-16T14:29:18.107+0200	ERROR	[stacktrace]	model/stacktrace_frame.go:220	No Sourcemap available for Service Name: 'client', Service Version: '1.0.0' and Path: 'http://localhost:3000/static/js/main.e0dea103.js'.
2018-10-16T14:29:18.107+0200	ERROR	[stacktrace]	model/stacktrace_frame.go:168	failed to apply sourcemap No Sourcemap available for Service Name: 'client', Service Version: '1.0.0' and Path: 'http://localhost:3000/dashboard'.
2018-10-16T14:29:18.107+0200	ERROR	[stacktrace]	model/stacktrace_frame.go:220	No Sourcemap available for Service Name: 'client', Service Version: '1.0.0' and Path: 'http://localhost:3000/dashboard'.
2018-10-16T14:29:18.107+0200	ERROR	[stacktrace]	model/stacktrace_frame.go:168	failed to apply sourcemap No Sourcemap available for Service Name: 'client', Service Version: '1.0.0' and Path: 'http://localhost:3000/dashboard'.
2018-10-16T14:29:18.107+0200	ERROR	[stacktrace]	model/stacktrace_frame.go:220	No Sourcemap available for Service Name: 'client', Service Version: '1.0.0' and Path: 'http://localhost:3000/dashboard'.
```

Becomes:

```
2018-10-16T15:18:13.121+0200	ERROR	[stacktrace]	model/stacktrace.go:88	No Sourcemap available for Service Name: 'client', Service Version: '1.0.0' and Path: 'http://localhost:3000/static/js/main.e0dea103.js'.
2018-10-16T15:18:13.132+0200	ERROR	[stacktrace]	model/stacktrace.go:88	No Sourcemap available for Service Name: 'client', Service Version: '1.0.0' and Path: 'http://localhost:3000/dashboard'.
```

