### PR TITLE
Set field limit, after testing with rally.

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -197,7 +197,7 @@ setup.template.settings:
     number_of_shards: 1
     codec: best_compression
     #number_of_routing_shards: 30
-    mapping.total_fields.limit: 1000
+    mapping.total_fields.limit: 2000
 
 
 #============================== Template =====================================

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -197,6 +197,7 @@ setup.template.settings:
     number_of_shards: 1
     codec: best_compression
     #number_of_routing_shards: 30
+    mapping.total_fields.limit: 1000
 
 
 #============================== Template =====================================

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -197,7 +197,7 @@ setup.template.settings:
     number_of_shards: 1
     codec: best_compression
     #number_of_routing_shards: 30
-    mapping.total_fields.limit: 1000
+    mapping.total_fields.limit: 2000
 
 
 #============================== Template =====================================

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -197,6 +197,7 @@ setup.template.settings:
     number_of_shards: 1
     codec: best_compression
     #number_of_routing_shards: 30
+    mapping.total_fields.limit: 1000
 
 
 #============================== Template =====================================

--- a/rally/README.md
+++ b/rally/README.md
@@ -7,7 +7,7 @@ repos.
 
 ## Starting a Race
 
-Currently APM track offers three different challenges. 
+Currently APM track offers four different challenges. 
 If you want to store results to a file, preserve temporary Elasticsearch, use a running Elasticsearch instance, etc. 
 please refer to rally's [command_line_reference](https://esrally.readthedocs.io/en/stable/command_line_reference.html#command-line-flags).
 
@@ -27,6 +27,34 @@ If you want to test only a dedicated event type, you can use the second challeng
 ```esrally --track-path=<local-path-to-apm-track> --track-params="event_type:'<event_type>'" --challenge=ingest-event-type```
 
 The same test data as for the default challenge are used.
+
+### High Field cardinality challenge
+
+With this challenge you can test for field explosion created by high cardinality of `tags` in `spans` or `transactions`.
+
+A preparation step is necessary to bring the data into the expected format.
+
+For preparing the benchmark tests with default data, run 
+```
+virtualenv -p python3 rally/.venv
+source rally/.venv/bin/activate
+pip install -r rally/_tools/requirements.txt
+python ./rally/_tools/prepare.py --skip-daily
+
+```
+
+By default 500 random tags are created. You can change that by applying cmd line options when starting the 
+preparation step. Use `python ./rally/_tools/prepare.py --help` for more information about available options.
+
+Base data used for this track are dumped from example Opbeans applications, instrumented with different agents. The dump was 
+created in October 2018. The base data are stored in a s3 bucket and consist of [error](`http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/apm/error_base.json.bzip2`), 
+[span](`http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/apm/span_base.json.bzip2`) and 
+[transaction](`http://benchmarks.elasticsearch.org.s3.amazonaws.com/corpora/apm/transaction_base.json.bzip2`) data.
+
+After preparing the test data, run: 
+
+```esrally --track-path=<local-path-to-apm-track> --track-params="event_type:'<span|transaction>'" --challenge=ingest-field-explosion```
+
 
 ### Test Query performance
 For testing query performance it can be important to have data split up into multiple daily indices. A preparation step 

--- a/rally/challenges/default.json
+++ b/rally/challenges/default.json
@@ -41,7 +41,7 @@
     },
     {
       "name": "ingest-event-type",
-      "description": "Indexes the the error documents from the default corpus using Elasticsearch default settings. Documents don't have ids set, so all index operations are append only.",
+      "description": "Indexes only the defined event documents from the default corpus using Elasticsearch default settings. Documents don't have ids set, so all index operations are append only.",
       "default": false,
       "schedule": [
         {
@@ -57,6 +57,33 @@
         {
           "name": "index-apm-{{event_type}}",
           "operation": "index-append-{{event_type}}",
+          "warmup-time-period": 120,
+          "clients": {{bulk_indexing_clients | default(8)}}
+        },
+        {
+          "operation": "force-merge",
+          "clients": 1
+        } 
+      ]
+    },
+    {
+      "name": "ingest-field-explosion",
+      "description": "Indexes either span or transaction documents with a high cardinality of indexed fields (tags). Documents don't have ids set, so all index operations are append only.",
+      "default": false,
+      "schedule": [
+        {
+          "operation": "delete-index"
+        },
+        {
+          "operation": "create-index"
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": "check-cluster-health"
+        },
+        {
+          "name": "index-apm-{{event_type}}-tags",
+          "operation": "index-append-{{event_type}}-tags",
           "warmup-time-period": 120,
           "clients": {{bulk_indexing_clients | default(8)}}
         },

--- a/rally/challenges/default.json
+++ b/rally/challenges/default.json
@@ -84,7 +84,7 @@
         {
           "name": "index-apm-{{event_type}}-tags",
           "operation": "index-append-{{event_type}}-tags",
-          "warmup-time-period": 120,
+          "warmup-time-period": 240,
           "clients": {{bulk_indexing_clients | default(8)}}
         },
         {

--- a/rally/operations/default.json
+++ b/rally/operations/default.json
@@ -23,14 +23,14 @@
       "name": "index-append-transaction-tags",
       "operation-type": "bulk",
       "indices": ["apm-transaction-tags"],
-      "bulk-size": {{bulk_size | default(1000)}},
+      "bulk-size": {{bulk_size | default(50)}},
       "ingest-percentage": {{ingest_percentage | default(100)}}
     },
     {
       "name": "index-append-span-tags",
       "operation-type": "bulk",
       "indices": ["apm-span-tags"],
-      "bulk-size": {{bulk_size | default(1000)}},
+      "bulk-size": {{bulk_size | default(50)}},
       "ingest-percentage": {{ingest_percentage | default(100)}}
     },
     {% set comma = joiner() %}

--- a/rally/operations/default.json
+++ b/rally/operations/default.json
@@ -19,6 +19,20 @@
       "bulk-size": {{bulk_size | default(1000)}},
       "ingest-percentage": {{ingest_percentage | default(100)}}
     },
+    {
+      "name": "index-append-transaction-tags",
+      "operation-type": "bulk",
+      "indices": ["apm-transaction-tags"],
+      "bulk-size": {{bulk_size | default(1000)}},
+      "ingest-percentage": {{ingest_percentage | default(100)}}
+    },
+    {
+      "name": "index-append-span-tags",
+      "operation-type": "bulk",
+      "indices": ["apm-span-tags"],
+      "bulk-size": {{bulk_size | default(1000)}},
+      "ingest-percentage": {{ingest_percentage | default(100)}}
+    },
     {% set comma = joiner() %}
     {% for item in range(index_count) %}
     {{ comma() }}

--- a/rally/track.json
+++ b/rally/track.json
@@ -22,6 +22,16 @@
       "body": "index.json",
       "types": [ "type" ]
     },
+    {
+      "name": "apm-transaction-tags",
+      "body": "index.json",
+      "types": [ "type" ]
+    },
+    {
+      "name": "apm-span-tags",
+      "body": "index.json",
+      "types": [ "type" ]
+    },
     {% set comma = joiner() %}
     {% for item in range(index_count) %}
     {{ comma() }}
@@ -68,6 +78,22 @@
           "document-count": 1457292,
           "compressed-bytes": 250706365,
           "uncompressed-bytes": 13361279823
+        }
+      ]
+    },
+    {
+      "name": "apm-events-with-tags",
+      "target-type": "type",
+      "documents": [
+        {
+          "target-index": "apm-transaction-tags",
+          "source-file": "corpora/transaction-tags.json",
+          "document-count": 383498
+        },
+        {
+          "target-index": "apm-span-tags",
+          "source-file": "corpora/span-tags.json",
+          "document-count": 485764
         }
       ]
     },


### PR DESCRIPTION
Add rally challenge to test mapping explosion limits for APM.

implements #1291 

I did some tests using the APM rally challenge `ingest-field-explosion` on ES instances with the following results:

* 1gb ram, 1 node, 1 zone ES instance: read timeouts for more than 200 tags
* 4gb ram, 1node, 1 zone ES instance: read timeouts for more than 750 tags

The amount of fields other than `tags` is roughly 200. My suggestion is to set `1,000` as default value for `total_fields` for `6.5`. Setting it too low would cause errors when trying to write although the ES instance might be able to handle it. Setting the value too high would risk memory issues with the whole ES instance. 