### PR TITLE
v1 intake: remove request limits for CORS OPTIONS requests

### DIFF
--- a/beater/common_handlers_test.go
+++ b/beater/common_handlers_test.go
@@ -80,13 +80,11 @@ func TestOPTIONS(t *testing.T) {
 	config.RumConfig.Enabled = &enabled
 
 	requestTaken := make(chan struct{}, 1)
+	done := make(chan struct{}, 1)
 
 	h := rumHandler(config, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		requestTaken <- struct{}{}
-		select {
-		case <-time.After(time.Second * 1):
-			return
-		}
+		<-done
 	}))
 
 	// use this to block the single allowed concurrent requests
@@ -103,6 +101,7 @@ func TestOPTIONS(t *testing.T) {
 	r := httptest.NewRequest("OPTIONS", "/", nil)
 	h.ServeHTTP(w, r)
 	assert.Equal(t, 200, w.Code, w.Body.String())
+	done <- struct{}{}
 }
 
 func TestOkBody(t *testing.T) {

--- a/beater/common_handlers_test.go
+++ b/beater/common_handlers_test.go
@@ -72,6 +72,39 @@ func TestConcurrency(t *testing.T) {
 	assert.True(t, concurrentWait.Get() > 20, strconv.FormatInt(concurrentWait.Get(), 10))
 }
 
+func TestOPTIONS(t *testing.T) {
+	config := defaultConfig("7.0.0")
+	config.ConcurrentRequests = 1
+	config.MaxRequestQueueTime = time.Second
+	enabled := true
+	config.RumConfig.Enabled = &enabled
+
+	requestTaken := make(chan struct{}, 1)
+
+	h := rumHandler(config, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requestTaken <- struct{}{}
+		select {
+		case <-time.After(time.Second * 1):
+			return
+		}
+	}))
+
+	// use this to block the single allowed concurrent requests
+	go func() {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("POST", "/", nil)
+		h.ServeHTTP(w, r)
+	}()
+
+	<-requestTaken
+
+	// send a new request which should be allowed through
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("OPTIONS", "/", nil)
+	h.ServeHTTP(w, r)
+	assert.Equal(t, 200, w.Code, w.Body.String())
+}
+
 func TestOkBody(t *testing.T) {
 	req, err := http.NewRequest("POST", "_", nil)
 	assert.Nil(t, err)

--- a/beater/route_config.go
+++ b/beater/route_config.go
@@ -150,9 +150,9 @@ func backendHandler(beaterConfig *Config, h http.Handler) http.Handler {
 func rumHandler(beaterConfig *Config, h http.Handler) http.Handler {
 	return killSwitchHandler(beaterConfig.RumConfig.isEnabled(),
 		requestTimeHandler(
-			concurrencyLimitHandler(beaterConfig,
-				ipRateLimitHandler(beaterConfig.RumConfig.RateLimit,
-					corsHandler(beaterConfig.RumConfig.AllowOrigins, h)))))
+			corsHandler(beaterConfig.RumConfig.AllowOrigins,
+				concurrencyLimitHandler(beaterConfig,
+					ipRateLimitHandler(beaterConfig.RumConfig.RateLimit, h)))))
 }
 
 func metricsHandler(beaterConfig *Config, h http.Handler) http.Handler {


### PR DESCRIPTION
Always respond with a 200 to OPTIONS requests bypassing any rate limit
or concurrent requests limits.

Closes https://github.com/elastic/apm-server/issues/1434.
