### PR TITLE
[6.4] backport script/jenkins/package.sh

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -94,6 +94,38 @@ func TestPackages() error {
 	return mage.TestPackages()
 }
 
+// TestPackagesInstall integration tests the generated packages
+func TestPackagesInstall() error {
+	// make the test script available to containers first
+	copy := &mage.CopyTask{
+		Source: "tests/packaging/test.sh",
+		Dest:   mage.MustExpand("{{.PWD}}/build/distributions/test.sh"),
+		Mode:   0755,
+	}
+	if err := copy.Execute(); err != nil {
+		return err
+	}
+	defer sh.Rm(copy.Dest)
+
+	goTest := sh.OutCmd("go", "test")
+	var args []string
+	if mg.Verbose() {
+		args = append(args, "-v")
+	}
+	args = append(args, mage.MustExpand("tests/packaging/package_test.go"))
+	args = append(args, "-files", mage.MustExpand("{{.PWD}}/build/distributions/*"))
+	args = append(args, "-tags=package")
+
+	if out, err := goTest(args...); err != nil {
+		if !mg.Verbose() {
+			fmt.Println(out)
+		}
+		return err
+	}
+
+	return nil
+}
+
 // Update updates the generated files (aka make update).
 func Update() error {
 	return sh.Run("make", "update")

--- a/script/jenkins/package.sh
+++ b/script/jenkins/package.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+source ./_beats/dev-tools/jenkins_release.sh
+
+mage -v TestPackagesInstall

--- a/script/jenkins/package.sh
+++ b/script/jenkins/package.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
 set -euox pipefail
 
-source ./_beats/dev-tools/jenkins_release.sh
-
-mage -v TestPackagesInstall
+ ./_beats/dev-tools/jenkins_release.sh

--- a/tests/packaging/Dockerfile.deb.install
+++ b/tests/packaging/Dockerfile.deb.install
@@ -1,0 +1,9 @@
+FROM debian:jessie
+
+ARG apm_server_pkg
+COPY $apm_server_pkg $apm_server_pkg
+RUN dpkg -i $apm_server_pkg
+
+COPY test.sh test.sh
+
+CMD ./test.sh

--- a/tests/packaging/Dockerfile.rpm.install
+++ b/tests/packaging/Dockerfile.rpm.install
@@ -1,0 +1,11 @@
+FROM centos:7
+
+RUN yum install -y initscripts
+
+ARG apm_server_pkg
+COPY $apm_server_pkg $apm_server_pkg
+RUN rpm -ivh $apm_server_pkg
+
+COPY test.sh test.sh
+
+CMD ./test.sh

--- a/tests/packaging/package_test.go
+++ b/tests/packaging/package_test.go
@@ -1,0 +1,82 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build package
+
+package test
+
+import (
+	"flag"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/magefile/mage/sh"
+)
+
+var (
+	files = flag.String("files", "build/distributions/*", "filepath glob containing package files")
+)
+
+func TestDeb(t *testing.T) {
+	debs := getFiles(t, regexp.MustCompile(`\.deb$`))
+	if len(debs) == 0 {
+		t.Fatal("no debs found")
+	}
+	for _, deb := range debs {
+		checkInstall(t, deb, "Dockerfile.deb.install")
+	}
+}
+
+func TestRpm(t *testing.T) {
+	rpms := getFiles(t, regexp.MustCompile(`\.rpm$`))
+	if len(rpms) == 0 {
+		t.Fatal("no rpms found")
+	}
+	for _, rpm := range rpms {
+		checkInstall(t, rpm, "Dockerfile.rpm.install")
+	}
+}
+
+func checkInstall(t *testing.T, pkg, dockerfile string) {
+	dir, file := filepath.Split(pkg)
+	imageId, err := sh.Output(
+		"docker", "build", "--no-cache", "-q", "-f", dockerfile,
+		"--build-arg", fmt.Sprintf("apm_server_pkg=%s", file), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := sh.Run("docker", "run", "--rm", imageId); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func getFiles(t *testing.T, pattern *regexp.Regexp) []string {
+	matches, err := filepath.Glob(*files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs := matches[:0]
+	for _, f := range matches {
+		if pattern.MatchString(filepath.Base(f)) {
+			fs = append(fs, f)
+		}
+	}
+
+	return fs
+}

--- a/tests/packaging/test.sh
+++ b/tests/packaging/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+/etc/init.d/apm-server start && \
+	sleep 2 && \
+	stat /var/lib/apm-server/meta.json /var/log/apm-server/apm-server && \
+	/etc/init.d/apm-server stop


### PR DESCRIPTION
Jenkins now uses `script/jenkins/package.sh` for all package tests - this change creates that file as a wrapper around what was originally used for package tests. 

Backports the following commits to 6.4:
 - test rpm and deb installation  (#1421)
 - restore old package tests  (#1450)