### PR TITLE
Add missing nil check

### DIFF
--- a/beater/v2_handler.go
+++ b/beater/v2_handler.go
@@ -114,8 +114,7 @@ func (v *v2Handler) Handle(beaterConfig *Config, report publish.Reporter) http.H
 		}
 
 		ctx := r.Context()
-		if v.rlc != nil {
-			rl := v.rlc.getRateLimiter(utility.RemoteAddr(r))
+		if rl, ok := v.rlc.getRateLimiter(utility.RemoteAddr(r)); ok {
 			if !rl.Allow() {
 				sr := stream.Result{}
 				sr.Add(&stream.Error{


### PR DESCRIPTION
`getRateLimiter` can return `nil`, but is not checked at the call point https://github.com/elastic/apm-server/compare/master...jalvz:rl-nil-fix?expand=1#diff-ce6c26e750f0443c52c10a357e08e82aR118

`NewRlCache` prevents that scenario now, but we could break it if eg. we change its implementation - this PR makes it more explicit.

I don't know if this has been discussed before, @simitt lmk if I got something wrong.