### PR TITLE
[6.x] fix timestamp spec definition for v1 (#1464)

### DIFF
--- a/docs/spec/timestamp_rfc3339.json
+++ b/docs/spec/timestamp_rfc3339.json
@@ -1,9 +1,9 @@
 {
-    "$id": "doc/spec/timestamp_epoch.json",
-    "title": "Timestamp Epoch",
-    "description": "Object with 'timestamp' property.",
+    "$id": "doc/spec/timestamp_rfc3339.json",
+    "title": "Timestamp",
+    "description": "Used for '@timestamp' property.",
     "type": ["object"],
-    "properties": {  
+    "properties": {
         "timestamp": {
             "type": ["string", "null"],
             "pattern": "Z$",

--- a/model/error/generated/schema/payload.go
+++ b/model/error/generated/schema/payload.go
@@ -535,11 +535,11 @@ const PayloadSchema = `{
         { "required": ["exception"], "properties": {"exception": { "type": "object" }} },
         { "required": ["log"], "properties": {"log": { "type": "object" }} }
     ]  },
-                    {     "$id": "doc/spec/timestamp_epoch.json",
-    "title": "Timestamp Epoch",
-    "description": "Object with 'timestamp' property.",
+                    {     "$id": "doc/spec/timestamp_rfc3339.json",
+    "title": "Timestamp",
+    "description": "Used for '@timestamp' property.",
     "type": ["object"],
-    "properties": {  
+    "properties": {
         "timestamp": {
             "type": ["string", "null"],
             "pattern": "Z$",

--- a/model/metricset/generated/schema/payload.go
+++ b/model/metricset/generated/schema/payload.go
@@ -67,11 +67,11 @@ const PayloadSchema = `{
         }
     },
     "required": ["samples"]  },
-        {     "$id": "doc/spec/timestamp_epoch.json",
-    "title": "Timestamp Epoch",
-    "description": "Object with 'timestamp' property.",
+        {     "$id": "doc/spec/timestamp_rfc3339.json",
+    "title": "Timestamp",
+    "description": "Used for '@timestamp' property.",
     "type": ["object"],
-    "properties": {  
+    "properties": {
         "timestamp": {
             "type": ["string", "null"],
             "pattern": "Z$",

--- a/model/transaction/generated/schema/payload.go
+++ b/model/transaction/generated/schema/payload.go
@@ -395,11 +395,11 @@ const PayloadSchema = `{
         }
     },
     "required": ["duration", "type"]  }, 
-                    {     "$id": "doc/spec/timestamp_epoch.json",
-    "title": "Timestamp Epoch",
-    "description": "Object with 'timestamp' property.",
+                    {     "$id": "doc/spec/timestamp_rfc3339.json",
+    "title": "Timestamp",
+    "description": "Used for '@timestamp' property.",
     "type": ["object"],
-    "properties": {  
+    "properties": {
         "timestamp": {
             "type": ["string", "null"],
             "pattern": "Z$",


### PR DESCRIPTION
Backports the following commits to 6.x:
 - fix timestamp spec definition for v1  (#1464)