### PR TITLE
v2: minor refactor of stream handling

### DIFF
--- a/beater/route_config.go
+++ b/beater/route_config.go
@@ -225,8 +225,11 @@ func (v v2Route) Handler(url string, c *Config, report publish.Reporter) http.Ha
 	)
 
 	v2Handler := v2Handler{
-		requestDecoder:  reqDecoder,
-		streamProcessor: &stream.StreamProcessor{Tconfig: v.transformConfig(c)},
+		requestDecoder: reqDecoder,
+		streamProcessor: &stream.StreamProcessor{
+			Tconfig:      v.transformConfig(c),
+			MaxEventSize: c.MaxEventSize,
+		},
 	}
 
 	if url == V2RumURL {

--- a/beater/v2_handler.go
+++ b/beater/v2_handler.go
@@ -106,10 +106,7 @@ func (v *v2Handler) sendResponse(logger *logp.Logger, w http.ResponseWriter, sr 
 
 func (v *v2Handler) sendError(logger *logp.Logger, w http.ResponseWriter, err *stream.Error) {
 	sr := stream.Result{}
-	sr.Add(&stream.Error{
-		Type:    stream.MethodForbiddenErrType,
-		Message: "only POST requests are supported",
-	})
+	sr.Add(err)
 	v.sendResponse(logger, w, &sr)
 	return
 }

--- a/decoder/line_reader.go
+++ b/decoder/line_reader.go
@@ -28,16 +28,14 @@ var ErrLineTooLong = errors.New("Line exceeded permitted length")
 
 // LineReader reads length-limited lines from streams using a limited amount of memory.
 type LineReader struct {
-	reader        io.Reader
 	br            *bufio.Reader
 	maxLineLength int
 	skip          bool
 }
 
-func NewLineReader(reader io.Reader, maxLineLength int) *LineReader {
+func NewLineReader(reader *bufio.Reader, maxLineLength int) *LineReader {
 	return &LineReader{
-		reader:        reader,
-		br:            bufio.NewReaderSize(reader, maxLineLength),
+		br:            reader,
 		maxLineLength: maxLineLength,
 	}
 }

--- a/decoder/line_reader_test.go
+++ b/decoder/line_reader_test.go
@@ -18,6 +18,7 @@
 package decoder
 
 import (
+	"bufio"
 	"bytes"
 	"io"
 	"testing"
@@ -28,7 +29,7 @@ import (
 
 func TestLineReaderEmpty(t *testing.T) {
 	readBuf := bytes.NewBufferString("")
-	lr := NewLineReader(readBuf, 10)
+	lr := NewLineReader(bufio.NewReaderSize(readBuf, 10), 10)
 
 	buf, err := lr.ReadLine()
 	assert.Equal(t, io.EOF, err)
@@ -43,7 +44,7 @@ func TestLineReader(t *testing.T) {
 		iotest.DataErrReader,
 	} {
 		readBuf := bytes.NewBufferString("line1\nline2\n01234567890123456789\nline4\nline5")
-		lr := NewLineReader(r(readBuf), 10)
+		lr := NewLineReader(bufio.NewReaderSize(r(readBuf), 10), 10)
 
 		buf, err := lr.ReadLine()
 		assert.NoError(t, err)
@@ -76,7 +77,7 @@ func TestLineReaderEndWithNewline(t *testing.T) {
 		iotest.DataErrReader,
 	} {
 		readBuf := bytes.NewBufferString("line1\nline2\n01234567890123456789\nline4\nline5\n")
-		lr := NewLineReader(r(readBuf), 10)
+		lr := NewLineReader(bufio.NewReaderSize(r(readBuf), 10), 10)
 
 		buf, err := lr.ReadLine()
 		assert.NoError(t, err)
@@ -112,7 +113,7 @@ func TestLineReaderTwoLongLines(t *testing.T) {
 		iotest.DataErrReader,
 	} {
 		readBuf := bytes.NewBufferString("line1\nlong-string-with-no-newlines-at-all\nanother-long-string-with-no-newlines-at-all\nline2")
-		lr := NewLineReader(r(readBuf), 10)
+		lr := NewLineReader(bufio.NewReaderSize(r(readBuf), 10), 10)
 
 		buf, err := lr.ReadLine()
 		assert.NoError(t, err)
@@ -140,7 +141,7 @@ func TestLineReaderNoLines(t *testing.T) {
 		iotest.DataErrReader,
 	} {
 		readBuf := bytes.NewBufferString("line1\nlong-string-with-no-newlines-at-all\nanother-long-string-with-no-newlines-at-all")
-		lr := NewLineReader(r(readBuf), 10)
+		lr := NewLineReader(bufio.NewReaderSize(r(readBuf), 10), 10)
 
 		buf, err := lr.ReadLine()
 		assert.NoError(t, err)
@@ -179,7 +180,7 @@ func TestLineReaderDeadline(t *testing.T) {
 	readBuf := bytes.NewBufferString("line1\nline2\nlong-string-with-no-newlines-at-all")
 	reader := DeadlineReader(readBuf)
 
-	lr := NewLineReader(reader, 10)
+	lr := NewLineReader(bufio.NewReaderSize(reader, 10), 10)
 
 	buf, err := lr.ReadLine()
 	assert.NoError(t, err)
@@ -201,7 +202,7 @@ func TestLineReaderDeadline(t *testing.T) {
 func TestLineReaderShort(t *testing.T) {
 	readBuf := bytes.NewBufferString("line1\nline2")
 
-	lr := NewLineReader(readBuf, 1024)
+	lr := NewLineReader(bufio.NewReaderSize(readBuf, 1024), 1024)
 
 	buf, err := lr.ReadLine()
 	assert.NoError(t, err)

--- a/decoder/stream_decoder.go
+++ b/decoder/stream_decoder.go
@@ -19,29 +19,12 @@ package decoder
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
-	"strings"
 )
 
-func NDJSONStreamDecodeCompressedWithLimit(req *http.Request, lineLimit int) (*NDJSONStreamReader, error) {
-	contentType := req.Header.Get("Content-Type")
-	if !strings.Contains(contentType, "application/x-ndjson") {
-		return nil, fmt.Errorf("invalid content type: '%s'", req.Header.Get("Content-Type"))
-	}
-
-	reader, err := CompressedRequestReader(req)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewNDJSONStreamReader(reader, lineLimit), nil
-}
-
-func NewNDJSONStreamReader(reader io.Reader, lineLimit int) *NDJSONStreamReader {
-	return &NDJSONStreamReader{reader: NewLineReader(reader, lineLimit)}
+func NewNDJSONStreamReader(reader *LineReader) *NDJSONStreamReader {
+	return &NDJSONStreamReader{reader: reader}
 }
 
 type NDJSONStreamReader struct {

--- a/decoder/stream_decoder_test.go
+++ b/decoder/stream_decoder_test.go
@@ -18,6 +18,7 @@
 package decoder
 
 import (
+	"bufio"
 	"bytes"
 	"strings"
 	"testing"
@@ -61,7 +62,7 @@ func TestNDStreamReader(t *testing.T) {
 		},
 	}
 	buf := bytes.NewBufferString(strings.Join(lines, "\n"))
-	n := NewNDJSONStreamReader(buf, 20)
+	n := NewNDJSONStreamReader(NewLineReader(bufio.NewReaderSize(buf, 20), 20))
 
 	for idx, test := range expected {
 		out, err := n.Read()

--- a/processor/stream/benchmark_test.go
+++ b/processor/stream/benchmark_test.go
@@ -22,12 +22,9 @@ import (
 	"context"
 	"errors"
 	"io/ioutil"
-	"math"
 	"path/filepath"
 	"runtime"
 	"testing"
-
-	r "golang.org/x/time/rate"
 
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/apm-server/tests/loader"
@@ -47,8 +44,8 @@ func BenchmarkStreamProcessor(b *testing.B) {
 		b.Error(err)
 	}
 	//ensure to not hit rate limit as blocking wait would be measured otherwise
-	rl := r.NewLimiter(r.Limit(math.MaxFloat64-1), math.MaxInt32)
-	sp := &StreamProcessor{MaxEventSize: 100000}
+	// rl := r.NewLimiter(r.Limit(math.MaxFloat64-1), math.MaxInt32)
+	sp := &StreamProcessor{MaxEventSize: 300 * 1024}
 	for _, f := range files {
 		b.Run(f.Name(), func(b *testing.B) {
 			data, err := loader.LoadDataAsBytes(filepath.Join(dir, f.Name()))
@@ -63,7 +60,7 @@ func BenchmarkStreamProcessor(b *testing.B) {
 				b.StopTimer()
 				r.Reset(data)
 				b.StartTimer()
-				sp.HandleStream(context.Background(), rl, map[string]interface{}{}, ioutil.NopCloser(r), report)
+				sp.HandleStream(context.Background(), nil, map[string]interface{}{}, r, report)
 			}
 		})
 	}

--- a/processor/stream/benchmark_test.go
+++ b/processor/stream/benchmark_test.go
@@ -27,9 +27,10 @@ import (
 	"runtime"
 	"testing"
 
+	"golang.org/x/time/rate"
+
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/apm-server/tests/loader"
-	"golang.org/x/time/rate"
 )
 
 func BenchmarkStreamProcessor(b *testing.B) {

--- a/processor/stream/package_tests/error_attrs_test.go
+++ b/processor/stream/package_tests/error_attrs_test.go
@@ -28,7 +28,7 @@ import (
 
 func errorProcSetup() *tests.ProcessorSetup {
 	return &tests.ProcessorSetup{
-		Proc:            &V2TestProcessor{StreamProcessor: stream.StreamProcessor{}},
+		Proc:            &V2TestProcessor{StreamProcessor: stream.StreamProcessor{MaxEventSize: lrSize}},
 		FullPayloadPath: "../testdata/intake-v2/errors.ndjson",
 		TemplatePaths: []string{
 			"../../../model/error/_meta/fields.yml",

--- a/processor/stream/package_tests/metadata_attrs_test.go
+++ b/processor/stream/package_tests/metadata_attrs_test.go
@@ -18,6 +18,7 @@
 package package_tests
 
 import (
+	"bufio"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -82,7 +83,8 @@ func getMetadataEventAttrs(t *testing.T, prefix string) *tests.Set {
 	payloadStream, err := loader.LoadDataAsStream("../testdata/intake-v2/only-metadata.ndjson")
 	require.NoError(t, err)
 
-	metadata, err := decoder.NewNDJSONStreamReader(payloadStream, 100*1024).Read()
+	lr := decoder.NewLineReader(bufio.NewReader(payloadStream), lrSize)
+	metadata, err := decoder.NewNDJSONStreamReader(lr).Read()
 	require.NoError(t, err)
 
 	contextMetadata := metadata["metadata"]

--- a/processor/stream/package_tests/metricset_attrs_test.go
+++ b/processor/stream/package_tests/metricset_attrs_test.go
@@ -28,7 +28,7 @@ import (
 
 func metricsetProcSetup() *tests.ProcessorSetup {
 	return &tests.ProcessorSetup{
-		Proc:            &V2TestProcessor{StreamProcessor: stream.StreamProcessor{}},
+		Proc:            &V2TestProcessor{StreamProcessor: stream.StreamProcessor{MaxEventSize: lrSize}},
 		FullPayloadPath: "../testdata/intake-v2/metricsets.ndjson",
 		TemplatePaths: []string{
 			"../../../model/metricset/_meta/fields.yml",

--- a/processor/stream/package_tests/span_attrs_test.go
+++ b/processor/stream/package_tests/span_attrs_test.go
@@ -28,7 +28,7 @@ import (
 
 func spanProcSetup() *tests.ProcessorSetup {
 	return &tests.ProcessorSetup{
-		Proc:            &V2TestProcessor{StreamProcessor: stream.StreamProcessor{}},
+		Proc:            &V2TestProcessor{StreamProcessor: stream.StreamProcessor{MaxEventSize: lrSize}},
 		FullPayloadPath: "../testdata/intake-v2/spans.ndjson",
 		Schema:          schema.ModelSchema,
 		SchemaPrefix:    "span",

--- a/processor/stream/package_tests/transaction_attrs_test.go
+++ b/processor/stream/package_tests/transaction_attrs_test.go
@@ -28,7 +28,7 @@ import (
 
 func transactionProcSetup() *tests.ProcessorSetup {
 	return &tests.ProcessorSetup{
-		Proc:            &V2TestProcessor{StreamProcessor: stream.StreamProcessor{}},
+		Proc:            &V2TestProcessor{StreamProcessor: stream.StreamProcessor{MaxEventSize: lrSize}},
 		FullPayloadPath: "../testdata/intake-v2/transactions.ndjson",
 		Schema:          schema.ModelSchema,
 		SchemaPrefix:    "transaction",


### PR DESCRIPTION
* refactors `v2Handler` into smaller pieces and makes it oblivious to NDJSON reading
* rate limiting is now an explicit argument to `HandleStream` instead of packed in the context
* NewNDJSONStreamReader simplified so it just takes a `LineReader`
* LineReader takes a `bufio.Reader` as an argument instead of creating it, allowing for reuse