### PR TITLE
[6.x] Test export subcommands (#1482)

### DIFF
--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -88,7 +88,13 @@ class ServerSetUpBaseTest(BaseTest):
         shutil.copy(self._beat_path_join(pipeline_def), target_dir)
 
         self.render_config_template(**self.config())
-        self.apmserver_proc = self.start_beat()
+        self.apmserver_proc = self.start_beat(**self.start_args())
+        self.wait_until_started()
+
+    def start_args(self):
+        return {}
+
+    def wait_until_started(self):
         self.wait_until(lambda: self.log_contains("Starting apm-server"))
 
     def assert_no_logged_warnings(self, suppress=None):

--- a/tests/system/test_export.py
+++ b/tests/system/test_export.py
@@ -1,0 +1,61 @@
+import json
+import os
+import yaml
+
+from apmserver import ServerSetUpBaseTest
+
+
+class SubCommandTest(ServerSetUpBaseTest):
+    def wait_until_started(self):
+        self.apmserver_proc.check_wait()
+
+        # command and go test output is combined in log, pull out the command output
+        log = self.get_log()
+        pos = -1
+        for _ in range(2):
+            # export always uses \n, not os.linesep
+            pos = log[:pos].rfind("\n")
+        self.command_output = log[:pos]
+        for trimmed in log[pos:].strip().splitlines():
+            # ensure only skipping expected lines
+            assert trimmed.split(None, 1)[0] in ("PASS", "coverage:"), trimmed
+
+
+class ExportConfigTest(SubCommandTest):
+    """
+    Test export config subcommand.
+    """
+
+    def start_args(self):
+        return {
+            "extra_args": ["export", "config"],
+            "logging_args": None,
+        }
+
+    def test_export_config(self):
+        """
+        Test export config works
+        """
+        config = yaml.load(self.command_output)
+        total_fields_limit = config['setup']['template']['settings']['index']['mapping']['total_fields']['limit']
+        assert total_fields_limit == 2000, total_fields_limit
+
+
+class ExportTemplateTest(SubCommandTest):
+    """
+    Test export template subcommand.
+    """
+
+    def start_args(self):
+        return {
+            "extra_args": ["export", "template"],
+            "logging_args": None,
+        }
+
+    def test_export_template(self):
+        """
+        Test export template works
+        """
+        template = json.loads(self.command_output)
+        total_fields_limit = template['settings']['index']['mapping']['total_fields']['limit']
+        assert total_fields_limit == 2000, total_fields_limit


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Test export subcommands  (#1482)