### PR TITLE
Bugfix v2: Return proper error content type.

### DIFF
--- a/beater/common_handlers.go
+++ b/beater/common_handlers.go
@@ -443,11 +443,7 @@ func processRequest(r *http.Request, p processor.Processor, config transform.Con
 }
 
 func sendStatus(w http.ResponseWriter, r *http.Request, res serverResponse) {
-	contentType := "text/plain; charset=utf-8"
-	if acceptsJSON(r) {
-		contentType = "application/json"
-	}
-	w.Header().Set("Content-Type", contentType)
+	setContentType(w, r)
 	w.WriteHeader(res.code)
 
 	responseCounter.Inc()
@@ -476,6 +472,14 @@ func sendStatus(w http.ResponseWriter, r *http.Request, res serverResponse) {
 	} else {
 		sendPlain(w, fmt.Sprintf("%s", msg))
 	}
+}
+
+func setContentType(w http.ResponseWriter, r *http.Request) {
+	contentType := "text/plain; charset=utf-8"
+	if acceptsJSON(r) {
+		contentType = "application/json"
+	}
+	w.Header().Set("Content-Type", contentType)
 }
 
 func acceptsJSON(r *http.Request) bool {

--- a/beater/v2_handler_test.go
+++ b/beater/v2_handler_test.go
@@ -48,6 +48,8 @@ func TestInvalidContentType(t *testing.T) {
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	assert.Equal(t, "invalid content type: ''", w.Body.String())
+	assert.Equal(t, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
 }
 
 func TestEmptyRequest(t *testing.T) {
@@ -173,6 +175,7 @@ func sendReq(c *Config, route *v2Route, url string, p string, repErr error) (*ht
 	}
 	req := httptest.NewRequest("POST", url, bytes.NewBuffer(b))
 	req.Header.Add("Content-Type", "application/x-ndjson")
+	req.Header.Add("Accept", "application/json")
 
 	report := func(context.Context, publish.PendingReq) error {
 		return repErr
@@ -233,6 +236,7 @@ func TestV2LineExceeded(t *testing.T) {
 
 	req = httptest.NewRequest("POST", "/v2/intake", bytes.NewBuffer(b))
 	req.Header.Add("Content-Type", "application/x-ndjson")
+	req.Header.Add("Accept", "*/*")
 	w = httptest.NewRecorder()
 
 	ct := requestTooLargeCounter.Get()


### PR DESCRIPTION
fixes #1514 

V2 Endpoints now return proper content-type and content in proper format. On Success no body is returned so no content-type is set. On Failure content type is set to `application/json` if the _Accept_ header specifically requests json or it allows _any_ type. Otherwise it is set to `text/plain; charset=utf-8`.

Details to the bugfix: The `WriteHeader` needs to be called after all other headers have been set, but before the actual `Write` method is called. According to the [WriteHeader](https://golang.org/src/net/http/server.go?s=2977:5840#L83) docs there are two points  to consider:
* Changing the header map after a call to WriteHeader (or Write) has no effect unless the modified headers are trailers.
* If WriteHeader is not called explicitly, the first call to Write will trigger an implicit WriteHeader(http.StatusOK).