### PR TITLE
fix: remove duplicate entries from apm-server.yml

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -197,21 +197,6 @@ apm-server:
 #max_procs:
 
 
-#==================== Elasticsearch template setting ==========================
-
-# Elasticsearch template settings
-#setup.template.settings:
-
-  # A dictionary of settings to place into the settings.index dictionary
-  # of the Elasticsearch template. For more details, please check
-  # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html
-  #index:
-    #number_of_shards: 1
-    #codec: best_compression
-    #number_of_routing_shards: 30
-    #mapping.total_fields.limit: 2000
-
-
 #============================== Template =====================================
 
 # A template is used to set the mapping in Elasticsearch
@@ -246,6 +231,7 @@ apm-server:
     #number_of_shards: 1
     #codec: best_compression
     #number_of_routing_shards: 30
+    #mapping.total_fields.limit: 2000
 
   # A dictionary of settings for the _source field. For more details, please check
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -197,21 +197,6 @@ apm-server:
 #max_procs:
 
 
-#==================== Elasticsearch template setting ==========================
-
-# Elasticsearch template settings
-#setup.template.settings:
-
-  # A dictionary of settings to place into the settings.index dictionary
-  # of the Elasticsearch template. For more details, please check
-  # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html
-  #index:
-    #number_of_shards: 1
-    #codec: best_compression
-    #number_of_routing_shards: 30
-    #mapping.total_fields.limit: 2000
-
-
 #============================== Template =====================================
 
 # A template is used to set the mapping in Elasticsearch
@@ -246,6 +231,7 @@ apm-server:
     #number_of_shards: 1
     #codec: best_compression
     #number_of_routing_shards: 30
+    #mapping.total_fields.limit: 2000
 
   # A dictionary of settings for the _source field. For more details, please check
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -197,21 +197,6 @@ apm-server:
 #max_procs:
 
 
-#==================== Elasticsearch template setting ==========================
-
-# Elasticsearch template settings
-#setup.template.settings:
-
-  # A dictionary of settings to place into the settings.index dictionary
-  # of the Elasticsearch template. For more details, please check
-  # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html
-  #index:
-    #number_of_shards: 1
-    #codec: best_compression
-    #number_of_routing_shards: 30
-    #mapping.total_fields.limit: 2000
-
-
 #============================== Template =====================================
 
 # A template is used to set the mapping in Elasticsearch
@@ -246,6 +231,7 @@ apm-server:
     #number_of_shards: 1
     #codec: best_compression
     #number_of_routing_shards: 30
+    #mapping.total_fields.limit: 2000
 
   # A dictionary of settings for the _source field. For more details, please check
   # https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-source-field.html


### PR DESCRIPTION
`setup.template.settings` have been listed twice:
https://github.com/elastic/apm-server/compare/master...simitt:remove-duplicate-settings?expand=1#diff-7400bb261a1bc5bd91499ecf67970098L202
and 
https://github.com/elastic/apm-server/compare/master...simitt:remove-duplicate-settings?expand=1#diff-7400bb261a1bc5bd91499ecf67970098R224