### PR TITLE
Update release notes for 6.5.1

### DIFF
--- a/changelogs/6.5.asciidoc
+++ b/changelogs/6.5.asciidoc
@@ -3,7 +3,13 @@
 
 https://github.com/elastic/apm-server/compare/6.4\...6.5[View commits]
 
+* <<release-notes-6.5.1>>
 * <<release-notes-6.5.0>>
+
+[[release-notes-6.5.1]]
+=== APM Server version 6.5.1
+
+https://github.com/elastic/apm-server/compare/v6.5.0\...v6.5.1[View commits]
 
 [[release-notes-6.5.0]]
 === APM Server version 6.5.0


### PR DESCRIPTION
needs to be backported to `6.x` and `6.5`. 