### PR TITLE
docs: WIP tuning and config updates

### DIFF
--- a/docs/common-problems.asciidoc
+++ b/docs/common-problems.asciidoc
@@ -51,6 +51,15 @@ For instance, APM Server 6.2.0 changed the Intake API spec and requires a minimu
 
 View the {apm-get-started-ref}/agent-server-compatibility.html[agent/server compatibility matrix] for more information.
 
+[[event-too-large]]
+[float]
+=== HTTP 400: Event too large
+
+NOTE: Version 6.5 of the APM Server introduced a new intake API (v2). This error only applies to users using **v2** of the intake API. You can learn more about this change in the <<intake-api-changes-65, intake API changes>> documentation. 
+
+APM Agents communicate with the APM server by sending events in an HTTP request. Each event is sent as its own line in the HTTP request body. If events are too large, you should consider increasing the <<max_event_size,`max_event_size`>>
+setting in the APM Server, and adjusting relevant settings in the agent.
+
 [[unauthorized]]
 [float]
 === HTTP 401: Invalid token
@@ -71,15 +80,6 @@ is coming from an origin not whitelisted in `apm-server.rum.allow_origins`. See 
 NOTE: Version 6.5 of the APM Server introduced a new intake API (v2). This error only applies to users using **v1** of the intake API. You can learn more about this change in the <<intake-api-changes-65, intake API changes>> documentation. 
 
 The agent is collecting too much data and sending it all at once. Consider increasing the <<configuration-v1-api,`apm-server.max_unzipped_size`>>
-setting in the APM Server, and adjusting relevant settings in the agent.
-
-[[event-too-large]]
-[float]
-=== HTTP 413: Event too large
-
-NOTE: Version 6.5 of the APM Server introduced a new intake API (v2). This error only applies to users using **v2** of the intake API. You can learn more about this change in the <<intake-api-changes-65, intake API changes>> documentation. 
-
-APM Agents communicate with the APM server by sending events in an HTTP request. Each event is sent as its own line in the HTTP request body. If events are too large, you should consider increasing the <<max_event_size,`max_event_size`>>
 setting in the APM Server, and adjusting relevant settings in the agent.
 
 [[queue-full]]

--- a/docs/common-problems.asciidoc
+++ b/docs/common-problems.asciidoc
@@ -47,7 +47,9 @@ the {apm-agents-ref}/index.html[agent documentation] for details on what is auto
 === HTTP 400: Data decoding error / Data validation error
 
 The most likely cause for this is that you are using incompatible versions of agent and APM Server.
-For instance, APM Server 6.2.0 changed the Intake API spec and requires a minimum version of each agent.
+For instance, APM Server 6.5 redesigned the Intake API and requires a minimum version of each agent.
+
+View the {apm-get-started-ref}/agent-server-compatibility.html[agent/server compatibility matrix] for more information.
 
 [[unauthorized]]
 [float]
@@ -66,7 +68,7 @@ is coming from an origin not whitelisted in `apm-server.rum.allow_origins`. See 
 [float]
 === HTTP 413: Request body too large
 
-The agent is collecting too much data and sending it all at once. Consider increasing the `apm-server.max_unzipped_size`
+The agent is collecting too much data and sending it all at once. Consider increasing the <<configuration-v1-api,`apm-server.max_unzipped_size`>>
 setting in the APM Server, and adjust relevant settings in the agent.
 
 [[queue-full]]
@@ -75,14 +77,15 @@ setting in the APM Server, and adjust relevant settings in the agent.
 
 APM Server has an internal queue that helps to:
 
-* buffer data temporarily if Elasticsearch is intermittently unavailable
-* handle sudden large spikes of data
-* send documents to Elasticsearch in bulk, instead of individually
+* Buffer data temporarily if Elasticsearch is intermittently unavailable
+* Handle sudden large spikes of data
+* Send documents to Elasticsearch in bulk, instead of individually
 
 When the queue has reached the maximum size,
 APM Server returns an HTTP 503 status with the message "Queue is full".
 
-A full queue generally means that the agents collect more data than APM server is able to process.
+In <<intake-api-changes-65,v1>> of the intake API,
+a full queue generally means that the agents collect more data than APM server is able to process.
 This might happen when APM Server is not configured properly for the size of your Elasticsearch cluster,
 or because your Elasticsearch cluster is underpowered or not configured properly for the given workload.
 
@@ -103,7 +106,7 @@ You have a few options to solve this problem:
 === HTTP 503: Request timed out waiting to be processed
 
 This happens when APM Server exceeds the maximum number of requests that it can process concurrently.
-This limit is determined by the `apm-server.concurrent_requests` configuration parameter deprecated[6.5].
+This limit is determined by the <<concurrent_requests,`apm-server.concurrent_requests`>> configuration parameter deprecated[6.5].
 
 To alleviate this problem,
 you can try to:

--- a/docs/common-problems.asciidoc
+++ b/docs/common-problems.asciidoc
@@ -47,7 +47,7 @@ the {apm-agents-ref}/index.html[agent documentation] for details on what is auto
 === HTTP 400: Data decoding error / Data validation error
 
 The most likely cause for this is that you are using incompatible versions of agent and APM Server.
-For instance, APM Server 6.5 redesigned the Intake API and requires a minimum version of each agent.
+For instance, APM Server 6.2.0 changed the Intake API spec and requires a minimum version of each agent.
 
 View the {apm-get-started-ref}/agent-server-compatibility.html[agent/server compatibility matrix] for more information.
 
@@ -68,8 +68,19 @@ is coming from an origin not whitelisted in `apm-server.rum.allow_origins`. See 
 [float]
 === HTTP 413: Request body too large
 
+NOTE: Version 6.5 of the APM Server introduced a new intake API (v2). This error only applies to users using **v1** of the intake API. You can learn more about this change in the <<intake-api-changes-65, intake API changes>> documentation. 
+
 The agent is collecting too much data and sending it all at once. Consider increasing the <<configuration-v1-api,`apm-server.max_unzipped_size`>>
-setting in the APM Server, and adjust relevant settings in the agent.
+setting in the APM Server, and adjusting relevant settings in the agent.
+
+[[event-too-large]]
+[float]
+=== HTTP 413: Event too large
+
+NOTE: Version 6.5 of the APM Server introduced a new intake API (v2). This error only applies to users using **v2** of the intake API. You can learn more about this change in the <<intake-api-changes-65, intake API changes>> documentation. 
+
+APM Agents communicate with the APM server by sending events in an HTTP request. Each event is sent as its own line in the HTTP request body. If events are too large, you should consider increasing the <<max_event_size,`max_event_size`>>
+setting in the APM Server, and adjusting relevant settings in the agent.
 
 [[queue-full]]
 [float]

--- a/docs/configuration-rum.asciidoc
+++ b/docs/configuration-rum.asciidoc
@@ -34,6 +34,7 @@ Version 6.5 of the APM Server introduced a new intake API. You can learn more ab
 If you do not upgrade your APM Agent, you'll continue to use the deprecated v1 RUM intake API endpoint, and thus, the following configuration options.
 
 [float]
+[[rate_limit_v1]]
 ==== `rate_limit` deprecated[6.5]
 Rate limit per second and IP address for requests sent to the RUM endpoint.
 If the rate limit is hit, the APM Server will return an HTTP status code `429`.
@@ -49,6 +50,7 @@ Version 6.5 of the APM Server introduced a new intake API. You can learn more ab
 The following configuration options only affect users that have upgraded their agent to take advantage of the new v2 intake API. 
 
 [float]
+[[event_rate.limit]]
 ==== `event_rate.limit`
 Defines the maximum amount of events allowed to be sent to the APM Server v2 RUM endpoint per ip per second.
 Defaults to 300.

--- a/docs/data-ingestion.asciidoc
+++ b/docs/data-ingestion.asciidoc
@@ -13,12 +13,17 @@ This section explains how to adapt data ingestion according to your needs.
 [[tune-apm-server]]
 == Tune APM Server
 
+Version 6.5 of the APM Server introduced a new <<intake-api,intake API>>. If you have not upgraded your APM Agent, you'll continue to use the deprecated v1 intake API endpoint. If you have upgraded your agent, you'll use the new v2 intake API endpoint. Understanding which endpoint your APM Agents use to communicate with your APM Server is vital to correctly tuning your data ingestion. Read the <<intake-api-changes-65, intake API changes>> documentation to learn more.
+
+Tuning topics:
 
 * <<tune-output-config>>
 * <<adjust-queue-size>>
 * <<adjust-concurrent-requests>>
 * <<add-apm-server-instances>>
 * <<reduce-payload-size>>
+* <<adjust-event-rate>>
+* <<use-v1-and-v2>>
 
 [[tune-output-config]]
 [float]
@@ -43,14 +48,17 @@ The <<configuring-output,output configuration>> section shows more details.
 APM Server uses an internal queue to buffer incoming events.
 A larger queue can retain more data if Elasticsearch is unavailable for longer periods,
 and it alleviates problems that might result from sudden spikes of traffic.
-You can adjust the queue size by overriding `queue.mem.events`.
-Increasing `queue.mem.events` can significantly affect APM Server memory usage.
+You can adjust the queue size by overriding <<mem.events,`queue.mem.events`>>.
+Increasing <<mem.events,`queue.mem.events`>> can significantly affect APM Server memory usage.
 
 [[adjust-concurrent-requests]]
 [float]
 === Adjust concurrent requests deprecated[6.5]
+
+IMPORTANT: This setting only impacts agents using **v1** of the APM Server <<intake-api,intake API>>.
+
 APM Server has a limit to how many requests can be processed concurrently.
-This limit is determined by the `apm-server.concurrent_requests` setting.
+This limit is determined by the <<concurrent_requests,`apm-server.concurrent_requests`>> setting.
 Increasing this value will improve throughput, but it can significantly affect APM Server memory usage.
 
 [[add-apm-server-instances]]
@@ -76,6 +84,30 @@ This will cause agents to send smaller and more frequent requests.
 Optionally you can also <<reduce-sample-rate, reduce the sample rate>> or <<reduce-stacktrace, reduce the amount of stacktraces>>.
 
 Read more in the {apm-agents-ref}/index.html[agents documentation].
+
+[[adjust-event-rate]]
+[float]
+=== Adjust RUM event rate limit
+
+IMPORTANT: This setting impacts agents using **v2** of the APM Server <<intake-api,intake API>>. If you're using an agent that supports v1, see the <<server-config-changes-65, server configuration changes>> documentation.
+
+Agents make use of long running requests and flush as many events over a single request as possible. Thus, the rate limiter for RUM is bound to the number of _events_ sent per second, per IP. 
+
+If the rate limit is hit while events on an established request are sent, the request is not immediately terminated. The intake of events is only throttled to <<event_rate.limit,`event_rate.limit`>>, which means that events are queued and processed slower. Only when the allowed buffer queue is also full, does the request get terminated with a `429 - rate limit exceeded` HTTP response. If an agent tries to establish a new request, but the rate limit is already hit, a `429` will be sent immediately.
+
+Increasing the <<event_rate.limit,`event_rate.limit`>> default value will help avoid `rate limit exceeded` errors.
+
+[[use-v1-and-v2]]
+[float]
+=== Tuning APM Server using both v1 and v2 intake API
+
+Depending on your agent versions, it is possible that the APM Server may need to communicate with the agents by using both of the intake API versions. 
+
+For example, if you have a v1.x Node.js agent, and a v4.x Python agent, the Node.js agent will communicate via the v1 endpoint, and the Python agent will communicate via the v2 endpoint. 
+
+In this instance, you'll need to adjust both the deprecated, and newly introduced <<configuration-process,configuration options>>. 
+
+TIP: Check the {apm-get-started-ref}/agent-server-compatibility.html[agent/server compatibility matrix] for compatibility information.
 
 [[tune-es]]
 == Tune Elasticsearch

--- a/docs/upgrading-to-65.asciidoc
+++ b/docs/upgrading-to-65.asciidoc
@@ -145,6 +145,10 @@ but if you have a load balancer in front of the APM server you may notice connec
 TIP: If you are updating APM Server from version 6.3 or earlier,
 you may not be using an updated `apm-server.yml` configuration file. Update your `apm-server.yml` configuration file to take advantage of new configuration options.
 
+RUM configuration changes:
+
+* <<event_rate.limit,`event_rate.limit`>> has replaced the deprecated <<rate_limit_v1,`rate_limit`>>. In v1 of the intake API, the RUM rate limiter was bound to the number of _requests_ per second, per IP. In v2, the rate limiter has changed to be bound to the number of _events_ sent per second, per IP. 
+
 
 [float]
 [[es-schema-changes-65]]


### PR DESCRIPTION
This PR adds the additional tuning and configuration updates that weren't covered in #1530.

Data Ingestion
• Added a note about v1 vs v2 (#1537)
• Adding RUM event rate limit (would this make more sense in common problems?) 
• Tuning APM Server using both v1 and v2 (#1537)

Upgrading to 6.5
• Added section on RUM config changes

Common Problems
• Added links where needed