### PR TITLE
Docs: Fix APM cross document links (master)

### DIFF
--- a/docs/common-problems.asciidoc
+++ b/docs/common-problems.asciidoc
@@ -50,7 +50,7 @@ the {apm-agents-ref}/index.html[agent documentation] for details on what is auto
 The most likely cause for this is that you are using incompatible versions of agent and APM Server.
 For instance, APM Server 6.2.0 changed the Intake API spec and requires a minimum version of each agent.
 
-View the {apm-get-started-ref}/agent-server-compatibility.html[agent/server compatibility matrix] for more information.
+View the {apm-overview-ref-v}/agent-server-compatibility.html[agent/server compatibility matrix] for more information.
 
 [[event-too-large]]
 [float]

--- a/docs/configuration-rum.asciidoc
+++ b/docs/configuration-rum.asciidoc
@@ -1,7 +1,7 @@
 [[configuration-rum]]
 == Set up Real User Monitoring (RUM) support
 
-The {apm-rum-ref}/index.html[JavaScript RUM Agent] offers <<rum, real user monitoring (RUM)>> support.
+The {apm-rum-ref-v}/index.html[JavaScript RUM Agent] offers <<rum, real user monitoring (RUM)>> support.
 
 Example config with RUM enabled:
 

--- a/docs/data-ingestion.asciidoc
+++ b/docs/data-ingestion.asciidoc
@@ -107,7 +107,7 @@ For example, if you have a v1.x Node.js agent, and a v4.x Python agent, the Node
 
 In this instance, you'll need to adjust both the deprecated, and newly introduced <<configuration-process,configuration options>>. 
 
-TIP: Check the {apm-get-started-ref}/agent-server-compatibility.html[agent/server compatibility matrix] for compatibility information.
+TIP: Check the {apm-overview-ref-v}/agent-server-compatibility.html[agent/server compatibility matrix] for compatibility information.
 
 [[tune-es]]
 == Tune Elasticsearch

--- a/docs/events-api.asciidoc
+++ b/docs/events-api.asciidoc
@@ -10,7 +10,7 @@ Events can be:
 * Errors
 * Metricsets
 
-You can learn more about events in the {apm-get-started-ref}/apm-data-model.html[APM Data Model] documentation. 
+You can learn more about events in the {apm-overview-ref-v}/apm-data-model.html[APM Data Model] documentation. 
 
 [[events-api-endpoint]]
 [float]

--- a/docs/exploring-es-data.asciidoc
+++ b/docs/exploring-es-data.asciidoc
@@ -16,7 +16,7 @@ apm-%{[version]}-span-%{+yyyy.MM.dd}
 apm-%{[version]}-metric-%{+yyyy.MM.dd}
 ------------------------------------------------------------
 
-If you're unfamiliar with the data types shown above, they are described in the {apm-get-started-ref}/apm-data-model.html[APM data model].
+If you're unfamiliar with the data types shown above, they are described in the {apm-overview-ref-v}/apm-data-model.html[APM data model].
 
 TIP: If your APM data is being stored in a different format, you may be using an outdated `apm-server.yml` file. You must update your `apm-server.yml` file in order to take advantage of the new format of indices.
 

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -32,7 +32,7 @@ and provide settings to control sampling behavior.
 If sampled,
 the <<transaction-spans,spans>> of a transaction are sent and stored as separate documents. Within one transaction there can be several, or no spans captured. 
 
-Transactions are stored in {apm-server-ref}/transaction-indices.html[transaction indices].
+Transactions are stored in {apm-server-ref-v}/transaction-indices.html[transaction indices].
 
 [[transaction-spans]]
 === Spans
@@ -54,8 +54,8 @@ a span describing the database query will be created.
 The name of this span will contain information about the query itself,
 and the type of this span will contain information about the database.
 
-Spans are stored in {apm-server-ref}/span-indices.html[span indices].
-Note that these indices are separate from {apm-server-ref}/transaction-indices.html[transaction indices] by default.
+Spans are stored in {apm-server-ref-v}/span-indices.html[span indices].
+Note that these indices are separate from {apm-server-ref-v}/transaction-indices.html[transaction indices] by default.
 
 [float]
 [[dropped-spans]]
@@ -71,8 +71,8 @@ This note is then passed on to the user in the UI.
 Settings affecting dropped spans, and more details on why they might occur,
 are available in the relevant agent documentation:
 
-* {apm-node-ref}/configuration.html#transaction-max-spans[Node.js Agent max spans]
-* {apm-py-ref}/configuration.html[Python Agent max spans]
+* {apm-node-ref-v}/configuration.html#transaction-max-spans[Node.js Agent max spans]
+* {apm-py-ref-v}/configuration.html[Python Agent max spans]
 
 [float]
 [[missing-spans]]
@@ -104,4 +104,4 @@ Errors also have some contextual data.
 
 include::../context.asciidoc[]
 
-Errors are stored in {apm-server-ref}/error-indices.html[error indices].
+Errors are stored in {apm-server-ref-v}/error-indices.html[error indices].

--- a/docs/guide/apm-release-notes.asciidoc
+++ b/docs/guide/apm-release-notes.asciidoc
@@ -8,7 +8,7 @@
 [float]
 ===== New features
 
-Elastic APM now enables {apm-get-started-ref}/distributed-tracing.html[distributed tracing].
+Elastic APM now enables {apm-overview-ref-v}/distributed-tracing.html[distributed tracing].
 
 *APM Server*
 

--- a/docs/guide/install-and-run.asciidoc
+++ b/docs/guide/install-and-run.asciidoc
@@ -73,7 +73,7 @@ output.elasticsearch:
 If you change the listen address from `localhost` to something that is accessible from outside of the machine,
 we recommend setting up firewall rules to ensure that only your own systems can access the API.
 Alternatively,
-you can use a {apm-server-ref}/securing-apm-server.html[secret token and TLS].
+you can use a {apm-server-ref-v}/securing-apm-server.html[secret token and TLS].
 
 If you have APM Server running on the same host as your service, you can configure it to listen on a Unix domain socket.
 
@@ -93,7 +93,7 @@ image::kibana-dashboard.png[Screenshot of a Kibana Dashboard]
 === More information
 For detailed instructions on how to install and secure APM Server in your server environment,
 including details on how to run APM Server in a highly available environment,
-please see {apm-server-ref}/index.html[APM Server documentation].
+please see {apm-server-ref-v}/index.html[APM Server documentation].
 
 Once APM Server is up and running,
 you need to install an agent in your service.
@@ -130,28 +130,28 @@ The Node.js agent automatically instruments Express,
 hapi,
 Koa,
 and Restify out of the box.
-See the {apm-node-ref}/index.html[APM Node.js Agent documentation] for more information.
+See the {apm-node-ref-v}/index.html[APM Node.js Agent documentation] for more information.
 
 [[python-agent]]
 [float]
 ==== Install the Python agent
 
 The Python agent automatically instruments Django and Flask out of the box.
-See the {apm-py-ref}/index.html[APM Python Agent documentation] for more information.
+See the {apm-py-ref-v}/index.html[APM Python Agent documentation] for more information.
 
 [[ruby-agent]]
 [float]
 ==== Install the Ruby agent
 
 The Ruby agent automatically instruments Rails out of the box.
-See the {apm-ruby-ref}/index.html[APM Ruby Agent documentation] for more information.
+See the {apm-ruby-ref-v}/index.html[APM Ruby Agent documentation] for more information.
 
 [[java-agent]]
 [float]
 ==== Install the Java Agent
 
 The Java agent automatically instruments Servlet API, Spring MVC, and Spring Boot out of the box.
-See the {apm-java-ref}/index.html[APM Java Agent documentation] for more information.
+See the {apm-java-ref-v}/index.html[APM Java Agent documentation] for more information.
 
 [[go-agent]]
 [float]
@@ -159,11 +159,11 @@ See the {apm-java-ref}/index.html[APM Java Agent documentation] for more informa
 
 The Go agent automatically instruments Gorilla and Gin,
 as well as support for Go's built-in net/http and database/sql drivers.
-See the {apm-go-ref}/index.html[APM Go Agent documentation] for more information.
+See the {apm-go-ref-v}/index.html[APM Go Agent documentation] for more information.
 
 [[rum-agent]]
 [float]
 ==== Install the RUM JavaScript agent
 
 Real User Monitoring (RUM) captures user interactions with clients such as web browsers.
-See the {apm-rum-ref}/index.html[APM RUM JavaScript Agent documentation] for more information.
+See the {apm-rum-ref-v}/index.html[APM RUM JavaScript Agent documentation] for more information.

--- a/docs/guide/overview.asciidoc
+++ b/docs/guide/overview.asciidoc
@@ -24,7 +24,7 @@ Elastic APM consists of four components:
 
 * {ref}/index.html[Elasticsearch]
 * {apm-agents-ref}/index.html[APM agents]
-* {apm-server-ref}/index.html[APM Server]
+* {apm-server-ref-v}/index.html[APM Server]
 * {kibana-ref}/xpack-apm.html[Kibana APM UI]
 
 image::apm-architecture.png[Architecture of Elastic APM]

--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -11,12 +11,12 @@ and as such it leverages its functionality.
 To get an overview of the whole Elastic APM system,
  also have a look at:
 
-* {apm-node-ref}/index.html[APM Node.js Agent]
-* {apm-py-ref}/index.html[APM Python Agent]
-* {apm-ruby-ref}/index.html[APM Ruby Agent]
-* {apm-go-ref}/index.html[APM Go Agent]
-* {apm-java-ref}/index.html[APM Java Agent]
-* {apm-rum-ref}/index.html[APM RUM JavaScript Agent]
+* {apm-node-ref-v}/index.html[APM Node.js Agent]
+* {apm-py-ref-v}/index.html[APM Python Agent]
+* {apm-ruby-ref-v}/index.html[APM Ruby Agent]
+* {apm-go-ref-v}/index.html[APM Go Agent]
+* {apm-java-ref-v}/index.html[APM Java Agent]
+* {apm-rum-ref-v}/index.html[APM RUM JavaScript Agent]
 * {ref}/index.html[Elasticsearch]
 
 

--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -8,22 +8,22 @@ The following pages have moved or been deleted.
 [role="exclude",id="event-types"]
 === Event types
 
-This page has moved. Please see {apm-get-started-ref}/apm-data-model.html[APM data model].
+This page has moved. Please see {apm-overview-ref-v}/apm-data-model.html[APM data model].
 
 [role="exclude",id="errors"]
 === Errors
 
-This page has moved. Please see {apm-get-started-ref}/errors.html[Errors].
+This page has moved. Please see {apm-overview-ref-v}/errors.html[Errors].
 
 [role="exclude",id="transactions"]
 === Transactions
 
-This page has moved. Please see {apm-get-started-ref}/transactions.html[Transactions].
+This page has moved. Please see {apm-overview-ref-v}/transactions.html[Transactions].
 
 [role="exclude",id="transactions-spans"]
 === Spans
 
-This page has moved. Please see {apm-get-started-ref}/transaction-spans.html[Spans].
+This page has moved. Please see {apm-overview-ref-v}/transaction-spans.html[Spans].
 
 // Error API
 

--- a/docs/rum.asciidoc
+++ b/docs/rum.asciidoc
@@ -3,7 +3,7 @@
 [partintro]
 --
 Real User Monitoring captures user interaction with clients such as web browsers.
-The {apm-rum-ref}/index.html[JavaScript Agent] is Elastic's RUM Agent.
+The {apm-rum-ref-v}/index.html[JavaScript Agent] is Elastic's RUM Agent.
 To use it you need to <<rum-enable,enable RUM support>> in the APM Server.
 --
 

--- a/docs/upgrading-to-65.asciidoc
+++ b/docs/upgrading-to-65.asciidoc
@@ -20,7 +20,7 @@ you can view https://www.elastic.co/guide/en/apm/server/6.4/overview.html[previo
 and APM Server.
 . Upgrade your {apm-agents-ref}/index.html[APM Agent].
 
-Check the {apm-get-started-ref}/agent-server-compatibility.html[agent/server compatibility matrix] for more details on which APM agents are compatible with APM Server version 6.5.
+Check the {apm-overview-ref-v}/agent-server-compatibility.html[agent/server compatibility matrix] for more details on which APM agents are compatible with APM Server version 6.5.
 
 IMPORTANT: You must upgrade the APM Server before upgrading your APM Agent.
 New agents do not support APM Server <6.5 and will not work if you upgrade in the wrong order.
@@ -160,7 +160,7 @@ There have been a number of changes to the Elasticsearch schema for 6.5.
 An important change to note is the addition of the `trace` and `parent` keys,
 which have been added to errors, transactions, and spans.
 Both only hold a field `id`.
-These new keys are essential to taking advantage of APM's new {apm-get-started-ref}/distributed-tracing.html[distributed tracing] feature.
+These new keys are essential to taking advantage of APM's new {apm-overview-ref-v}/distributed-tracing.html[distributed tracing] feature.
 
 [float]
 [[es-error-changes-65]]

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -11,7 +11,7 @@
 :server-branch: {doc-branch}
 :go-branch: 1.x
 :java-branch: 1.x
-:js-base-branch: 2.x
+:rum-branch: 2.x
 :node-branch: 2.x
-:python-branch: 4.x
+:py-branch: 4.x
 :ruby-branch: 2.x

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -6,3 +6,12 @@
 :python: 2.7.9
 :docker: 1.12
 :docker-compose: 1.11
+
+// APM Agent versions
+:server-branch: {doc-branch}
+:go-branch: 1.x
+:java-branch: 1.x
+:js-base-branch: 2.x
+:node-branch: 2.x
+:python-branch: 4.x
+:ruby-branch: 2.x


### PR DESCRIPTION
Will be opening PRs in other branches as well. This needs to be backported to 6.5. 

Updates master/6.5 docs to point to the following agent versions:
```
:go-branch: 1.x
:java-branch: 1.x
:rum-branch: 2.x
:node-branch: 2.x
:py-branch: 4.x
:ruby-branch: 2.x
```

More info: elastic/apm/issues/19