### PR TITLE
[6.5] Docs: move agent links to server repo

### DIFF
--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -6,3 +6,20 @@
 :python: 2.7.9
 :docker: 1.12
 :docker-compose: 1.11
+
+// Agent versions
+:server-branch: {branch}
+:go-branch: 1.x
+:java-branch: 1.x
+:rum-branch: 2.x
+:node-branch: 2.x
+:py-branch: 4.x
+:ruby-branch: 2.x
+
+// Agent links
+:apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{py-branch}
+:apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{node-branch}
+:apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/js-base/{rum-branch}
+:apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{ruby-branch}
+:apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{java-branch}
+:apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{go-branch}


### PR DESCRIPTION
See elastic/apm-server#1648 for details. Need to move agent links out of `docs` repo and into `apm-server` repo. 