### PR TITLE
[6.4] Docs: move agent links to server repo

### DIFF
--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -13,3 +13,11 @@
 :node-branch: 1.x
 :py-branch: 3.x
 :ruby-branch: 1.x
+
+// Agent links
+:apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{py-branch}
+:apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{node-branch}
+:apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/js-base/{rum-branch}
+:apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{ruby-branch}
+:apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{java-branch}
+:apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{go-branch}

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -19,5 +19,3 @@
 :apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{node-branch}
 :apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/js-base/{rum-branch}
 :apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{ruby-branch}
-:apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{java-branch}
-:apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{go-branch}


### PR DESCRIPTION
See elastic/apm-server#1648 for details. Need to move agent links out of `docs` repo and into `apm-server` repo. 