### PR TITLE
[DOCS] Bump doc version to 6.5.4

### DIFF
--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 6.5.3
+:stack-version: 6.5.4
 :doc-branch: 6.5
 :branch: {doc-branch}
 :go-version: 1.10.6


### PR DESCRIPTION
This PR updates the documentation version from 6.5.3 to 6.5.4.