### PR TITLE
[DOCS] Bump version to 6.7.0

### DIFF
--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 6.6.0
+:stack-version: 6.7.0
 :doc-branch: 6.x
 :branch: {doc-branch}
 :go-version: 1.10.6


### PR DESCRIPTION
This PR bumps the documentation version to 6.7.0