### PR TITLE
start 6.6.0 and 7.0.0-alpha* release notes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,4 +1,5 @@
 include::./changelogs/head.asciidoc[]
+include::./changelogs/7.0.asciidoc[]
 include::./changelogs/6.5.asciidoc[]
 include::./changelogs/6.4.asciidoc[]
 include::./changelogs/6.3.asciidoc[]

--- a/changelogs/6.6.asciidoc
+++ b/changelogs/6.6.asciidoc
@@ -1,0 +1,24 @@
+[[release-notes-6.6]]
+== APM Server version 6.6
+
+https://github.com/elastic/apm-server/compare/6.5\...6.6[View commits]
+
+* <<release-notes-6.6.0>>
+
+[[release-notes-6.6.0]]
+=== APM Server version 6.6.0
+
+https://github.com/elastic/apm-server/compare/v6.5.4\...v6.6.0[View commits]
+
+[float]
+==== Added
+
+- Add `span.sync` property to intake json spec and index field in ES. {pull}1548[1548].
+- Make `service.framework` properties optional and nullable {pull}1546[1546].
+- Add optional `span.subtype` and `span.action` properties. {pull}1618[1618].
+- Add `transaction.sampled` to errors {pull}1662[1662].
+
+[float]
+==== Bug fixes
+
+- Fix index pattern bundled with Kibana to be in sync with ES template pull{1571}[1571].

--- a/changelogs/7.0.asciidoc
+++ b/changelogs/7.0.asciidoc
@@ -1,0 +1,21 @@
+[[release-notes-7.0]]
+== APM Server version 7.0 alpha
+
+* <<release-notes-7.0.0-alpha2>>
+* <<release-notes-7.0.0-alpha1>>
+
+[[release-notes-7.0.0-alpha2]]
+=== APM Server version 7.0.0-alpha2
+
+[float]
+==== Added
+
+- Update Go to 1.11.2 {pull}1605[1605].
+- Use _doc as document type for Elasticsearch >= 7.0.0 https://github.com/elastic/beats/pull/9056[beats/9057].
+- Automatically cap signed integers to 63bits https://github.com/elastic/beats/pull/8991[beats/8991].
+- Build default distribution under the Elastic License. {pull}1645[1645].
+
+[[release-notes-7.0.0-alpha1]]
+=== APM Server version 7.0.0-alpha1
+
+No significant changes.

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -1,22 +1,4 @@
 [[release-notes-head]]
 == APM Server version HEAD
 
-https://github.com/elastic/apm-server/compare/6.5\...master[View commits]
-
-[float]
-=== Added
-
-- Set some configuration defaults (setup.template.settings.index.*, logging.metrics.enabled) in code {pull}1494[1494].
-- Add `span.sync` property to intake json spec and index field in ES. {pull}1548[1548].
-- Make `service.framework` properties optional and nullable {pull}1546[1546].
-- Update Go to 1.11.2 {pull}1605[1605].
-- Use _doc as document type for Elasticsearch >= 7.0.0 https://github.com/elastic/beats/pull/9056[beats/9057].
-- Automatically cap signed integers to 63bits https://github.com/elastic/beats/pull/8991[beats/8991].
-- Add optional `span.subtype` and `span.action` properties. {pull}1618[1618].
-- Build default distribution under the Elastic License. {pull}1645[1645].
-- Add `transaction.sampled` to errors {pull}1662[1662].
-
-[float]
-==== Bug fixes
-
-- Fix index pattern bundled with Kibana to be in sync with ES template pull{1571}[1571].
+https://github.com/elastic/apm-server/compare/v7.0.0-alpha2...master[View commits]

--- a/docs/guide/apm-release-notes.asciidoc
+++ b/docs/guide/apm-release-notes.asciidoc
@@ -3,6 +3,21 @@
 == Release notes
 
 [float]
+==== APM version 7.0.0-alpha2
+
+No significant changes.
+
+[float]
+==== APM version 7.0.0-alpha1
+
+No significant changes.
+
+////
+[float]
+==== APM version 6.6.0
+////
+
+[float]
 ==== APM version 6.5.0
 
 [float]

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -11,7 +11,10 @@
 This following section summarizes the changes in each release.
 
 
-* <<release-notes-head>>
+* <<release-notes-7.0>>
+////
+* <<release-notes-6.6>>
+////
 * <<release-notes-6.5>>
 * <<release-notes-6.4>>
 * <<release-notes-6.3>>


### PR DESCRIPTION
Start breaking out release notes and changelogs for 7.0.0-alpha2 and 6.6.0, backfilling 7.0.0-alpha1 along the way.  

With 6.6.0 changelog to be remain commented out until the release there is a little space here:
![image](https://user-images.githubusercontent.com/83483/50254789-73528180-03bd-11e9-8478-00705259087b.png)
but I think it actually works.



