### PR TITLE
avoid/fix deprecation warnings

### DIFF
--- a/beater/client.go
+++ b/beater/client.go
@@ -36,7 +36,7 @@ func insecureClient() *http.Client {
 func isServerUp(secure bool, host string, numRetries int, retryInterval time.Duration) bool {
 	client := insecureClient()
 	var check = func() bool {
-		url := url.URL{Scheme: "http", Host: host, Path: "healthcheck"}
+		url := url.URL{Scheme: "http", Host: host, Path: "/"}
 		if secure {
 			url.Scheme = "https"
 		}

--- a/beater/common_handlers.go
+++ b/beater/common_handlers.go
@@ -162,7 +162,7 @@ func newMuxer(beaterConfig *Config, report publish.Reporter) *http.ServeMux {
 	for path, route := range V1Routes {
 		logger.Infof("Path %s added to request handler", path)
 
-		mux.Handle(path, route.Handler(route.Processor, beaterConfig, report))
+		mux.Handle(path, route.Handler(route.Processor, beaterConfig, report, path != SourcemapsURL))
 	}
 
 	for path, route := range V2Routes {

--- a/beater/common_handlers.go
+++ b/beater/common_handlers.go
@@ -172,7 +172,7 @@ func newMuxer(beaterConfig *Config, report publish.Reporter) *http.ServeMux {
 	}
 
 	mux.Handle(rootURL, rootHandler(beaterConfig.SecretToken))
-	mux.Handle(HealthCheckURL, healthCheckHandler())
+	mux.Handle(DeprecatedHealthCheckURL, healthCheckHandler())
 
 	if beaterConfig.Expvar.isEnabled() {
 		path := beaterConfig.Expvar.Url

--- a/beater/route_config.go
+++ b/beater/route_config.go
@@ -53,7 +53,8 @@ var (
 	ClientSideErrorsURL               = "/v1/client-side/errors"
 	RumErrorsURL                      = "/v1/rum/errors"
 	MetricsURL                        = "/v1/metrics"
-	HealthCheckURL                    = "/healthcheck"
+	HealthCheckURL                    = "/"
+	DeprecatedHealthCheckURL          = "/healthcheck"
 )
 
 const v2BurstMultiplier = 3

--- a/beater/route_config.go
+++ b/beater/route_config.go
@@ -198,19 +198,29 @@ type v1Route struct {
 	topLevelRequestDecoder func(*Config) decoder.ReqDecoder
 }
 
-func (v *v1Route) Handler(p processor.Processor, beaterConfig *Config, report publish.Reporter) http.Handler {
-	decoder := v.configurableDecoder(beaterConfig, v.topLevelRequestDecoder(beaterConfig))
-	tconfig := v.transformConfig(beaterConfig)
+func deprecationHandler(h http.Handler) http.HandlerFunc {
 	var warned bool
-
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !warned {
 			logp.NewLogger("handler").Warn("Apm Server v1 API is deprecated, please update your agent version to switch to the v2 API")
 		}
 		warned = true
+		h.ServeHTTP(w, r)
+	})
+}
+
+func (v *v1Route) Handler(p processor.Processor, beaterConfig *Config, report publish.Reporter, deprecated bool) http.Handler {
+	decoder := v.configurableDecoder(beaterConfig, v.topLevelRequestDecoder(beaterConfig))
+	tconfig := v.transformConfig(beaterConfig)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		res := processRequest(r, p, tconfig, report, decoder)
 		sendStatus(w, r, res)
 	})
+
+	if deprecated {
+		handler = deprecationHandler(handler)
+	}
 
 	return v.wrappingHandler(beaterConfig, handler)
 }

--- a/beater/server.go
+++ b/beater/server.go
@@ -54,7 +54,7 @@ func doNotTrace(req *http.Request) bool {
 		// or we will go into a continuous cycle.
 		return true
 	}
-	if req.URL.Path == HealthCheckURL {
+	if req.URL.Path == HealthCheckURL || req.URL.Path == DeprecatedHealthCheckURL {
 		// Don't trace healthcheck requests.
 		return true
 	}

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       kibana:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f" ,"http://apm-server:8200/healthcheck"]
+      test: ["CMD", "curl", "-f" ,"http://apm-server:8200/"]
     labels:
       - "co.elatic.apm.stack-version=${STACK_VERSION}"
 

--- a/tests/system/test_requests.py
+++ b/tests/system/test_requests.py
@@ -75,7 +75,7 @@ class Test(ServerBaseTest):
         assert r.status_code == 403, r.status_code
 
     def test_healthcheck(self):
-        healtcheck_url = 'http://localhost:8200/healthcheck'
+        healtcheck_url = 'http://localhost:8200/'
         r = requests.get(healtcheck_url)
         assert r.status_code == 200, r.status_code
 


### PR DESCRIPTION
* don't trigger deprecation warning on startup, by using new healthcheck endpoint
* don't log deprecation warning for `/assets/v1/sourcemaps` fixes #1701