### PR TITLE
[6.x] avoid/fix deprecation warnings (#1703)

### DIFF
--- a/beater/client.go
+++ b/beater/client.go
@@ -36,7 +36,7 @@ func insecureClient() *http.Client {
 func isServerUp(secure bool, host string, numRetries int, retryInterval time.Duration) bool {
 	client := insecureClient()
 	var check = func() bool {
-		url := url.URL{Scheme: "http", Host: host, Path: "healthcheck"}
+		url := url.URL{Scheme: "http", Host: host, Path: "/"}
 		if secure {
 			url.Scheme = "https"
 		}

--- a/beater/common_handlers.go
+++ b/beater/common_handlers.go
@@ -162,7 +162,7 @@ func newMuxer(beaterConfig *Config, report publish.Reporter) *http.ServeMux {
 	for path, route := range V1Routes {
 		logger.Infof("Path %s added to request handler", path)
 
-		mux.Handle(path, route.Handler(route.Processor, beaterConfig, report))
+		mux.Handle(path, route.Handler(route.Processor, beaterConfig, report, path != SourcemapsURL))
 	}
 
 	for path, route := range V2Routes {
@@ -172,7 +172,7 @@ func newMuxer(beaterConfig *Config, report publish.Reporter) *http.ServeMux {
 	}
 
 	mux.Handle(rootURL, rootHandler(beaterConfig.SecretToken))
-	mux.Handle(HealthCheckURL, healthCheckHandler())
+	mux.Handle(DeprecatedHealthCheckURL, healthCheckHandler())
 
 	if beaterConfig.Expvar.isEnabled() {
 		path := beaterConfig.Expvar.Url

--- a/beater/server.go
+++ b/beater/server.go
@@ -54,7 +54,7 @@ func doNotTrace(req *http.Request) bool {
 		// or we will go into a continuous cycle.
 		return true
 	}
-	if req.URL.Path == HealthCheckURL {
+	if req.URL.Path == HealthCheckURL || req.URL.Path == DeprecatedHealthCheckURL {
 		// Don't trace healthcheck requests.
 		return true
 	}

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       kibana:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f" ,"http://apm-server:8200/healthcheck"]
+      test: ["CMD", "curl", "-f" ,"http://apm-server:8200/"]
     labels:
       - "co.elatic.apm.stack-version=${STACK_VERSION}"
 

--- a/tests/system/test_requests.py
+++ b/tests/system/test_requests.py
@@ -75,7 +75,7 @@ class Test(ServerBaseTest):
         assert r.status_code == 403, r.status_code
 
     def test_healthcheck(self):
-        healtcheck_url = 'http://localhost:8200/healthcheck'
+        healtcheck_url = 'http://localhost:8200/'
         r = requests.get(healtcheck_url)
         assert r.status_code == 200, r.status_code
 


### PR DESCRIPTION
Backports the following commits to 6.x:
 - avoid/fix deprecation warnings  (#1703)