### PR TITLE
[6.x] Close default tracer

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -173,6 +173,7 @@ func (bt *beater) Run(b *beat.Beat) error {
 // initTracer configures and returns an elasticapm.Tracer for tracing
 // the APM server's own execution.
 func initTracer(info beat.Info, config *Config, logger *logp.Logger) (*elasticapm.Tracer, net.Listener, error) {
+	elasticapm.DefaultTracer.Close()
 	if !config.SelfInstrumentation.isEnabled() {
 		os.Setenv("ELASTIC_APM_ACTIVE", "false")
 		logger.Infof("self instrumentation is disabled")


### PR DESCRIPTION
As per https://github.com/elastic/apm-agent-go/issues/412#issuecomment-452162669