### PR TITLE
[6.x] metrics is not experimental anymore (#1737)

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -145,7 +145,7 @@ apm-server:
     # Remote apm-servers' secret_token
     #secret_token:
 
-  # Experimental Metrics endpoint
+  # Metrics endpoint
   #metrics:
     # Set to false to disable the metrics endpoint
     #enabled: true

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -145,7 +145,7 @@ apm-server:
     # Remote apm-servers' secret_token
     #secret_token:
 
-  # Experimental Metrics endpoint
+  # Metrics endpoint
   #metrics:
     # Set to false to disable the metrics endpoint
     #enabled: true

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -145,7 +145,7 @@ apm-server:
     # Remote apm-servers' secret_token
     #secret_token:
 
-  # Experimental Metrics endpoint
+  # Metrics endpoint
   #metrics:
     # Set to false to disable the metrics endpoint
     #enabled: true

--- a/docs/configuration-process.asciidoc
+++ b/docs/configuration-process.asciidoc
@@ -141,7 +141,7 @@ Disabled by default.
 [[metrics.enabled]]
 [float]
 ==== `metrics`
-Experimental Metrics endpoint for collecting application metrics.
+Metrics endpoint for collecting application metrics.
 Enabled by default.
 
 [[register.ingest.pipeline.enabled]]


### PR DESCRIPTION
Backports the following commits to 6.x:
 - metrics is not experimental anymore  (#1737)