### PR TITLE
Change response format of the root handler and prettify JSON response

### DIFF
--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -20,7 +20,6 @@ package beater
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -98,13 +97,12 @@ func TestServerRoot(t *testing.T) {
 
 	checkResponse := func(hasOk bool) func(t *testing.T, res *http.Response) {
 		return func(t *testing.T, res *http.Response) {
-			var rsp map[string]interface{}
 			b, err := ioutil.ReadAll(res.Body)
 			require.NoError(t, err)
-			if err := json.Unmarshal(b, &rsp); err != nil {
-				t.Fatal(err, b)
-			}
-			assert.Equal(t, hasOk, rsp["ok"] != nil, string(b))
+			rsp := string(b)
+			assert.Contains(t, rsp, "build_date")
+			assert.Contains(t, rsp, "build_sha")
+			assert.Contains(t, rsp, "version")
 		}
 	}
 

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -7,6 +7,7 @@
 - Update Go version to 1.11.4 {pull}1700[1700].
 - Update Elastic APM Go agent to v1.1.2 {pull}1711[1711], {pull}1728[1728].
 - Allow numbers and boolean values for `transaction.tags`, `span.tags`, `metricset.tags` {pull}1712[1712].
+- Update response format of the healthcheck handler and prettyfy all JSON responses {pull}1748[1748].
 
 [float]
 ==== Removed


### PR DESCRIPTION
fixes #1679 

Before and after:

`curl -H "Accept: blabla"  http://localhost:8200`

```
{"build_date":"2019-01-09T10:14:34Z","build_sha":"352dce789ccb9a0237cb5d97d58381ef375ad276","version":"7.0.0"}
```

`curl -H "Accept: blabla"  http://localhost:8200`

```
build_date:"2019-01-09T10:12:19Z"
build_sha:"fe25172f74ba25f58a043bb8685bea2c906ecfb0"
version:"7.0.0"
```

`curl http://localhost:8200`

```
{"ok":{"build_date":"2019-01-09T10:14:34Z","build_sha":"352dce789ccb9a0237cb5d97d58381ef375ad276","version":"7.0.0"}}
```

`curl http://localhost:8200`

```
{
  "build_date": "2019-01-09T10:12:19Z",
  "build_sha": "fe25172f74ba25f58a043bb8685bea2c906ecfb0",
  "version": "7.0.0"
}
```

`curl http://localhost:8200/intake/v2/events`

```
{"accepted":0,"errors":[{"message":"only POST requests are supported"}]}
```
 
`curl http://localhost:8200/intake/v2/events`

```
{
  "accepted": 0,
  "errors": [
    {
      "message": "only POST requests are supported"
    }
  ]
}
```

Alternative: get rid of the text/plain responses altogether, eg. Elasticsearch always return JSON no matter the `Accept` header.

At minimum `apm-integration-testing`, agents and Cloud team need to be aware of this.

- [x] needs changelog
