### PR TITLE
Remove deprecated `frontend` setting namespace in favor of `rum`

### DIFF
--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -75,7 +75,7 @@ func TestBeatConfig(t *testing.T) {
 					"enabled": true,
 					"url":     "/debug/vars",
 				},
-				"frontend": map[string]interface{}{
+				"rum": map[string]interface{}{
 					"enabled": true,
 					"event_rate": map[string]interface{}{
 						"limit":    7200,
@@ -118,21 +118,6 @@ func TestBeatConfig(t *testing.T) {
 					Enabled: &truthy,
 					Url:     "/debug/vars",
 				},
-				FrontendConfig: &rumConfig{
-					Enabled: &truthy,
-					EventRate: &eventRate{
-						Limit:   7200,
-						LruSize: 2000,
-					},
-					AllowOrigins: []string{"example*"},
-					SourceMapping: &SourceMapping{
-						Cache:        &Cache{Expiration: 8 * time.Minute},
-						IndexPattern: "apm-test*",
-					},
-					LibraryPattern:      "^custom",
-					ExcludeFromGrouping: "^grouping",
-					beatVersion:         "6.2.0",
-				},
 				RumConfig: &rumConfig{
 					Enabled: &truthy,
 					EventRate: &eventRate{
@@ -174,17 +159,6 @@ func TestBeatConfig(t *testing.T) {
 					"enabled": true,
 					"url":     "/debug/vars",
 				},
-				"frontend": map[string]interface{}{
-					"enabled": true,
-					"event_rate": map[string]interface{}{
-						"lru_size": 200,
-					},
-					"source_mapping": map[string]interface{}{
-						"cache": map[string]interface{}{
-							"expiration": 4,
-						},
-					},
-				},
 				"rum": map[string]interface{}{
 					"enabled": true,
 					"source_mapping": map[string]interface{}{
@@ -215,23 +189,6 @@ func TestBeatConfig(t *testing.T) {
 				Expvar: &ExpvarConfig{
 					Enabled: &truthy,
 					Url:     "/debug/vars",
-				},
-				FrontendConfig: &rumConfig{
-					Enabled: &truthy,
-					EventRate: &eventRate{
-						Limit:   300,
-						LruSize: 200,
-					},
-					SourceMapping: &SourceMapping{
-						Cache: &Cache{
-							Expiration: 4 * time.Second,
-						},
-						IndexPattern: "apm-*-sourcemap*",
-					},
-					AllowOrigins:        []string{"*"},
-					LibraryPattern:      "node_modules|bower_components|~",
-					ExcludeFromGrouping: "^/webpack",
-					beatVersion:         "6.2.0",
 				},
 				RumConfig: &rumConfig{
 					Enabled: &truthy,

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -330,7 +330,7 @@ func TestServerSourcemapElasticsearch(t *testing.T) {
 			// source_mapping.elasticsearch.hosts set
 			expected: []string{"localhost:5200"},
 			config: m{
-				"frontend": m{
+				"rum": m{
 					"enabled":                            "true",
 					"source_mapping.elasticsearch.hosts": []string{"localhost:5200"},
 				},
@@ -340,7 +340,7 @@ func TestServerSourcemapElasticsearch(t *testing.T) {
 			// source_mapping.elasticsearch.hosts not set, elasticsearch.enabled = true
 			expected: []string{"localhost:5201"},
 			config: m{
-				"frontend": m{
+				"rum": m{
 					"enabled": "true",
 				},
 			},
@@ -355,7 +355,7 @@ func TestServerSourcemapElasticsearch(t *testing.T) {
 			// source_mapping.elasticsearch.hosts not set, elasticsearch.enabled = false
 			expected: nil,
 			config: m{
-				"frontend": m{
+				"rum": m{
 					"enabled": "true",
 				},
 			},

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -13,5 +13,6 @@
 - Remove formatting of `duration.us` to milliseconds in index pattern pull{1717}[1717].
 - Remove support for deprecated Intake v1 endpoints {pull}1731[1731].
 - Remove `concurrent_requests` setting and use number of CPUs instead {pull}1749[1749].
+- Remove `frontend` setting {pull}1751[1751].
 
 https://github.com/elastic/apm-server/compare/v7.0.0-alpha2...master[View commits]


### PR DESCRIPTION
Fixes #1745

Needs changelog