### PR TITLE
 add top-level "observer" field

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -211,7 +211,7 @@ SOFTWARE.
 --------------------------------------------------------------------
 Dependency: github.com/elastic/beats
 Version: master
-Revision: 3a517205a5370d88c3e1dea7305a00de51790d93
+Revision: 2e2c62bd0853add6000bbf919a96f35f45a858d2
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/beats/LICENSE.txt:
 --------------------------------------------------------------------
@@ -253,7 +253,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-sysinfo
-Revision: 7b021494a9562d0c3f0422d49b9980709c5650e9
+Revision: 59ef8c0eae46c0929e3b219ac86368d4b5934f91
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-sysinfo/LICENSE.txt:
 --------------------------------------------------------------------

--- a/_beats/dev-tools/ecs-migration.yml
+++ b/_beats/dev-tools/ecs-migration.yml
@@ -54,6 +54,9 @@
   alias6: true
   alias: true
 
+
+# Processor fields
+
 # Docker processor
 - from: docker.container.id
   to: container.id
@@ -75,45 +78,38 @@
   alias6: false
   alias: true
 
-
-# Filebeat modules
-
-## Suricata module
-
-# Processor fields
-
 # Cloud
-- form: meta.cloud.provider
+- from: meta.cloud.provider
   to: cloud.provider
   alias: true
   alias6: true
 
-- form: meta.cloud.instance_id
+- from: meta.cloud.instance_id
   to: cloud.instance.id
   alias: true
   alias6: true
 
-- form: meta.cloud.instance_name
+- from: meta.cloud.instance_name
   to: cloud.instance.name
   alias: true
   alias6: true
 
-- form: meta.cloud.machine_type
+- from: meta.cloud.machine_type
   to: cloud.machine.type
   alias: true
   alias6: true
 
-- form: meta.cloud.availability_zone
+- from: meta.cloud.availability_zone
   to: cloud.availability_zone
   alias: true
   alias6: true
 
-- form: meta.cloud.project_id
+- from: meta.cloud.project_id
   to: cloud.project.id
   alias: true
   alias6: true
 
-- form: meta.cloud.region
+- from: meta.cloud.region
   to: cloud.region
   alias: true
   alias6: true
@@ -591,12 +587,27 @@
   to: http.version
   alias: true
 
+
 # Auditbeat
 
 ## From Auditbeat's auditd module.
 - from: source.hostname
   to: source.domain
   alias: true
+
+
+# Packetbeat
+
+- from: http.request.body
+  to: http.request.body.content
+  alias6: false
+  alias: false
+
+- from: http.response.body
+  to: http.response.body.content
+  alias6: false
+  alias: false
+
 
 # Metricbeat
 

--- a/_beats/vendor/vendor.json
+++ b/_beats/vendor/vendor.json
@@ -898,44 +898,44 @@
 		{
 			"checksumSHA1": "QhFIpuHPaV6hKejKcc2wm6y4MSQ=",
 			"path": "github.com/elastic/go-sysinfo",
-			"revision": "7b021494a9562d0c3f0422d49b9980709c5650e9",
-			"revisionTime": "2018-09-11T17:37:16Z"
+			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
+			"revisionTime": "2019-01-07T12:18:35Z"
 		},
 		{
 			"checksumSHA1": "GiZCjX17K265TtamGZZw4R2Jwbk=",
 			"path": "github.com/elastic/go-sysinfo/internal/registry",
-			"revision": "7b021494a9562d0c3f0422d49b9980709c5650e9",
-			"revisionTime": "2018-09-11T17:37:16Z"
+			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
+			"revisionTime": "2019-01-07T12:18:35Z"
 		},
 		{
-			"checksumSHA1": "432ecsMRmLpy5OvXMhQE/k9KWLQ=",
+			"checksumSHA1": "ovafihHzpBx9Y7+lZh9X5KwNCvE=",
 			"path": "github.com/elastic/go-sysinfo/providers/darwin",
-			"revision": "7b021494a9562d0c3f0422d49b9980709c5650e9",
-			"revisionTime": "2018-09-11T17:37:16Z"
+			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
+			"revisionTime": "2019-01-07T12:18:35Z"
 		},
 		{
-			"checksumSHA1": "1eCL0MsvmiyjNvh0tcnnR4rmcWk=",
+			"checksumSHA1": "AK76ZxnuvK02Dfpmj7b2TD/aiSI=",
 			"path": "github.com/elastic/go-sysinfo/providers/linux",
-			"revision": "7b021494a9562d0c3f0422d49b9980709c5650e9",
-			"revisionTime": "2018-09-11T17:37:16Z"
+			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
+			"revisionTime": "2019-01-07T12:18:35Z"
 		},
 		{
 			"checksumSHA1": "RWLvcP1w9ynKbuCqiW6prwd+EDU=",
 			"path": "github.com/elastic/go-sysinfo/providers/shared",
-			"revision": "7b021494a9562d0c3f0422d49b9980709c5650e9",
-			"revisionTime": "2018-09-11T17:37:16Z"
+			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
+			"revisionTime": "2019-01-07T12:18:35Z"
 		},
 		{
-			"checksumSHA1": "lWVD4w1xiAkFZgQPZAYz+fTZsrU=",
+			"checksumSHA1": "aF05MEkMjbRekzHlwFxmd5WBpeY=",
 			"path": "github.com/elastic/go-sysinfo/providers/windows",
-			"revision": "7b021494a9562d0c3f0422d49b9980709c5650e9",
-			"revisionTime": "2018-09-11T17:37:16Z"
+			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
+			"revisionTime": "2019-01-07T12:18:35Z"
 		},
 		{
-			"checksumSHA1": "tIqFxnZi9XvC70dMoZDSoUtEVQY=",
+			"checksumSHA1": "MLQioPEjULYbNqqCjfB1/cux08E=",
 			"path": "github.com/elastic/go-sysinfo/types",
-			"revision": "7b021494a9562d0c3f0422d49b9980709c5650e9",
-			"revisionTime": "2018-09-11T17:37:16Z"
+			"revision": "59ef8c0eae46c0929e3b219ac86368d4b5934f91",
+			"revisionTime": "2019-01-07T12:18:35Z"
 		},
 		{
 			"checksumSHA1": "tNszmkpuJYZMX8l8rlnvBDtoc1M=",

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -131,7 +131,7 @@ func (bt *beater) Run(b *beat.Beat) error {
 	}
 	defer tracer.Close()
 
-	pub, err := publish.NewPublisher(b.Publisher, bt.config.ShutdownTimeout, tracer)
+	pub, err := publish.NewPublisher(b.Info, b.Publisher, bt.config.ShutdownTimeout, tracer)
 	if err != nil {
 		return err
 	}

--- a/beater/integration_test.go
+++ b/beater/integration_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/elastic/apm-server/tests"
 	"github.com/elastic/apm-server/tests/loader"
 	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
 	jsonoutput "github.com/elastic/beats/libbeat/outputs/codec/json"
 	"github.com/elastic/beats/libbeat/version"
 )
@@ -39,9 +40,7 @@ import (
 func consumeOnboarding(t *testing.T, events <-chan beat.Event) *beat.Event {
 	select {
 	case e := <-events:
-		processor, err := e.Fields.GetValue("processor.name")
-		require.NoError(t, err, "missing processor.name")
-		require.Equal(t, "onboarding", processor)
+		assert.Equal(t, "onboarding", e.Fields["processor"].(common.MapStr)["name"])
 		return &e
 	case <-time.After(time.Second):
 		assert.Fail(t, "no events received")

--- a/beater/integration_test.go
+++ b/beater/integration_test.go
@@ -1,0 +1,155 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-server/tests"
+	"github.com/elastic/apm-server/tests/loader"
+	"github.com/elastic/beats/libbeat/beat"
+	jsonoutput "github.com/elastic/beats/libbeat/outputs/codec/json"
+	"github.com/elastic/beats/libbeat/version"
+)
+
+func consumeOnboarding(t *testing.T, events <-chan beat.Event) *beat.Event {
+	select {
+	case e := <-events:
+		processor, err := e.Fields.GetValue("processor.name")
+		require.NoError(t, err, "missing processor.name")
+		require.Equal(t, "onboarding", processor)
+		return &e
+	case <-time.After(time.Second):
+		assert.Fail(t, "no events received")
+	}
+	return nil
+}
+
+func collectEvents(events <-chan beat.Event, timeout time.Duration) []beat.Event {
+	var collected []beat.Event
+	for {
+		select {
+		case event := <-events:
+			collected = append(collected, event)
+		case <-time.After(timeout):
+			return collected
+		}
+	}
+}
+
+var timestampOverride = time.Date(2019, 1, 9, 21, 40, 53, 690, time.UTC)
+
+// adjustMissingTimestamp sets @timestamp and timestamp.us to known values for events that originally omitted a ts
+func adjustMissingTimestamp(event *beat.Event) {
+	if time.Now().Sub(event.Timestamp) < 5*time.Minute {
+		event.Timestamp = timestampOverride
+		event.Fields.Put("timestamp.us", timestampOverride.UnixNano()/1000)
+	}
+}
+
+// testPublish exercises the publishing pipeline, from apm-server intake to beat publishing.
+// It posts a payload to a running APM server via the intake API and gathers the resulting documents that would
+// normally be published to Elasticsearch.
+func testPublish(t *testing.T, apm *beater, events <-chan beat.Event, url string, payload io.Reader) []byte {
+	baseUrl, client := apm.client(false)
+	req, err := http.NewRequest(http.MethodPost, baseUrl+url, payload)
+	req.Header.Add("Content-Type", "application/x-ndjson")
+	rsp, err := client.Do(req)
+	require.NoError(t, err)
+	got := body(t, rsp)
+	assert.Equal(t, http.StatusAccepted, rsp.StatusCode, got)
+
+	consumeOnboarding(t, events)
+	var docs []map[string]interface{}
+	enc := jsonoutput.New(version.GetDefaultVersion(), jsonoutput.Config{Pretty: true})
+	for _, e := range collectEvents(events, time.Second) {
+		require.NoError(t, err)
+		adjustMissingTimestamp(&e)
+		doc, err := enc.Encode("apm-test", &e)
+		require.NoError(t, err)
+		var d map[string]interface{}
+		err = json.Unmarshal(doc, &d)
+		require.NoError(t, err)
+		docs = append(docs, d)
+	}
+	ret, err := json.Marshal(map[string]interface{}{"events": docs})
+	require.NoError(t, err)
+	return ret
+}
+
+func TestPublishIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow tc")
+	}
+
+	for _, tc := range []struct {
+		payload string
+		name    string
+	}{
+		{payload: "errors.ndjson", name: "Errors"},
+		{payload: "events.ndjson", name: "Events"},
+		{payload: "metricsets.ndjson", name: "Metricsets"},
+		{payload: "spans.ndjson", name: "Spans"},
+		{payload: "transactions.ndjson", name: "Transactions"},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// fresh APM Server for each run
+			events := make(chan beat.Event)
+			defer close(events)
+			apm, teardown, err := setupServer(t, nil, nil, events)
+			require.NoError(t, err)
+			defer teardown()
+
+			b, err := loader.LoadDataAsBytes(filepath.Join("../testdata/intake-v2/", tc.payload))
+			require.NoError(t, err)
+			docs := testPublish(t, apm, events, backendURL, bytes.NewReader(b))
+			tests.AssertApproveResult(t, "test_approved_es_documents/TestPublishIntegration"+tc.name, docs)
+		})
+	}
+}
+
+func TestPublishIntegrationOnboarding(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow tc")
+	}
+
+	events := make(chan beat.Event)
+	defer close(events)
+	_, teardown, err := setupServer(t, nil, nil, events)
+	require.NoError(t, err)
+	defer teardown()
+
+	event := consumeOnboarding(t, events)
+	otype, err := event.Fields.GetValue("observer.type")
+	require.NoError(t, err)
+	assert.Equal(t, "test-apm-server", otype.(string))
+	hasListen, err := event.Fields.HasKey("observer.listening")
+	require.NoError(t, err)
+	assert.True(t, hasListen, "missing field: observer.listening")
+}

--- a/beater/onboarding.go
+++ b/beater/onboarding.go
@@ -39,7 +39,7 @@ func notifyListening(config *Config, pubFct func(beat.Event)) {
 			Timestamp: time.Now(),
 			Fields: common.MapStr{
 				"processor": common.MapStr{"name": "onboarding", "event": "onboarding"},
-				"listening": config.Host,
+				"observer":  common.MapStr{"listening": config.Host},
 			},
 		}
 		pubFct(event)

--- a/beater/onboarding_test.go
+++ b/beater/onboarding_test.go
@@ -43,7 +43,7 @@ func TestNotifyUpServerDown(t *testing.T) {
 
 	notifyListening(config, publisher)
 
-	listening := saved.Fields["listening"].(string)
+	listening := saved.Fields["observer"].(common.MapStr)["listening"]
 	assert.Equal(t, config.Host, listening)
 
 	processor := saved.Fields["processor"].(common.MapStr)

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs/transport/transptest"
-	publishertesting "github.com/elastic/beats/libbeat/publisher/testing"
 )
 
 var tmpCertPath string
@@ -492,7 +491,8 @@ func TestServerSecureBadPassphrase(t *testing.T) {
 	}
 }
 
-func setupServer(t *testing.T, cfg *common.Config, beatConfig *beat.BeatConfig, events chan beat.Event) (*beater, func(), error) {
+func setupServer(t *testing.T, cfg *common.Config, beatConfig *beat.BeatConfig,
+	events chan beat.Event) (*beater, func(), error) {
 	if testing.Short() {
 		t.Skip("skipping server test")
 	}
@@ -508,8 +508,8 @@ func setupServer(t *testing.T, cfg *common.Config, beatConfig *beat.BeatConfig, 
 	var pub beat.Pipeline
 	if events != nil {
 		// capture events
-		pubClient := publishertesting.NewChanClientWith(events)
-		pub = publishertesting.PublisherWithClient(pubClient)
+		pubClient := NewChanClientWith(events)
+		pub = DummyPipeline(pubClient)
 	} else {
 		// don't capture events
 		pub = DummyPipeline()

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs/transport/transptest"
+	publishertesting "github.com/elastic/beats/libbeat/publisher/testing"
 )
 
 var tmpCertPath string
@@ -66,7 +67,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestServerOk(t *testing.T) {
-	apm, teardown, err := setupServer(t, nil, nil)
+	apm, teardown, err := setupServer(t, nil, nil, nil)
 	require.NoError(t, err)
 	defer teardown()
 
@@ -80,7 +81,7 @@ func TestServerOk(t *testing.T) {
 }
 
 func TestServerRoot(t *testing.T) {
-	apm, teardown, err := setupServer(t, nil, nil)
+	apm, teardown, err := setupServer(t, nil, nil, nil)
 	require.NoError(t, err)
 	defer teardown()
 
@@ -137,7 +138,7 @@ func TestServerRootWithToken(t *testing.T) {
 	badToken := "Verysecret"
 	ucfg, err := common.NewConfigFrom(map[string]interface{}{"secret_token": token})
 	assert.NoError(t, err)
-	apm, teardown, err := setupServer(t, ucfg, nil)
+	apm, teardown, err := setupServer(t, ucfg, nil, nil)
 	require.NoError(t, err)
 	defer teardown()
 	baseUrl, client := apm.client(false)
@@ -181,7 +182,7 @@ func TestServerTcpNoPort(t *testing.T) {
 		"host": "localhost",
 	})
 	assert.NoError(t, err)
-	btr, teardown, err := setupServer(t, ucfg, nil)
+	btr, teardown, err := setupServer(t, ucfg, nil, nil)
 	require.NoError(t, err)
 	defer teardown()
 
@@ -209,7 +210,7 @@ func TestServerOkUnix(t *testing.T) {
 	addr := tmpTestUnix(t)
 	ucfg, err := common.NewConfigFrom(m{"host": "unix:" + addr})
 	assert.NoError(t, err)
-	btr, stop, err := setupServer(t, ucfg, nil)
+	btr, stop, err := setupServer(t, ucfg, nil, nil)
 	require.NoError(t, err)
 	defer stop()
 
@@ -222,7 +223,7 @@ func TestServerOkUnix(t *testing.T) {
 }
 
 func TestServerHealth(t *testing.T) {
-	apm, teardown, err := setupServer(t, nil, nil)
+	apm, teardown, err := setupServer(t, nil, nil, nil)
 	require.NoError(t, err)
 	defer teardown()
 
@@ -238,7 +239,7 @@ func TestServerHealth(t *testing.T) {
 func TestServerRumSwitch(t *testing.T) {
 	ucfg, err := common.NewConfigFrom(m{"rum": m{"enabled": true, "allow_origins": []string{"*"}}})
 	assert.NoError(t, err)
-	apm, teardown, err := setupServer(t, ucfg, nil)
+	apm, teardown, err := setupServer(t, ucfg, nil, nil)
 	require.NoError(t, err)
 	defer teardown()
 
@@ -297,7 +298,7 @@ func TestServerCORS(t *testing.T) {
 		ucfg, err := common.NewConfigFrom(m{"rum": m{"enabled": true, "allow_origins": test.allowedOrigins}})
 		assert.NoError(t, err)
 		var apm *beater
-		apm, teardown, err = setupServer(t, ucfg, nil)
+		apm, teardown, err = setupServer(t, ucfg, nil, nil)
 		require.NoError(t, err)
 		baseUrl, client := apm.client(false)
 
@@ -316,7 +317,7 @@ func TestServerCORS(t *testing.T) {
 }
 
 func TestServerNoContentType(t *testing.T) {
-	apm, teardown, err := setupServer(t, nil, nil)
+	apm, teardown, err := setupServer(t, nil, nil, nil)
 	require.NoError(t, err)
 	defer teardown()
 
@@ -391,7 +392,7 @@ func TestServerSourcemapElasticsearch(t *testing.T) {
 			continue
 		}
 		beatConfig.Output.Unpack(ocfg)
-		apm, teardown, err := setupServer(t, ucfg, &beatConfig)
+		apm, teardown, err := setupServer(t, ucfg, &beatConfig, nil)
 		if assert.NoError(t, err) {
 			assert.Equal(t, testCase.expected, apm.smapElasticsearchHosts())
 		}
@@ -444,7 +445,7 @@ func TestServerSSL(t *testing.T) {
 	for idx, test := range tests {
 		var apm *beater
 		var err error
-		apm, teardown, err = setupServer(t, withSSL(t, test.domain, test.passphrase), nil)
+		apm, teardown, err = setupServer(t, withSSL(t, test.domain, test.passphrase), nil, nil)
 		require.NoError(t, err)
 		baseUrl, client := apm.client(test.insecure)
 		if test.overrideProtocol {
@@ -483,7 +484,7 @@ func TestServerSecureBadPassphrase(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	_, _, err = setupServer(t, cfg, nil)
+	_, _, err = setupServer(t, cfg, nil, nil)
 	if assert.Error(t, err) {
 		b := strings.Contains(err.Error(), "no PEM blocks") ||
 			strings.Contains(err.Error(), "failed to parse private key")
@@ -491,7 +492,7 @@ func TestServerSecureBadPassphrase(t *testing.T) {
 	}
 }
 
-func setupServer(t *testing.T, cfg *common.Config, beatConfig *beat.BeatConfig) (*beater, func(), error) {
+func setupServer(t *testing.T, cfg *common.Config, beatConfig *beat.BeatConfig, events chan beat.Event) (*beater, func(), error) {
 	if testing.Short() {
 		t.Skip("skipping server test")
 	}
@@ -503,7 +504,18 @@ func setupServer(t *testing.T, cfg *common.Config, beatConfig *beat.BeatConfig) 
 		err := cfg.Unpack(baseConfig)
 		require.NoError(t, err)
 	}
-	btr, stop, err := setupBeater(t, DummyPipeline(), baseConfig, beatConfig)
+
+	var pub beat.Pipeline
+	if events != nil {
+		// capture events
+		pubClient := publishertesting.NewChanClientWith(events)
+		pub = publishertesting.PublisherWithClient(pubClient)
+	} else {
+		// don't capture events
+		pub = DummyPipeline()
+	}
+
+	btr, stop, err := setupBeater(t, pub, baseConfig, beatConfig)
 	if err == nil {
 		assert.NotEqual(t, btr.config.Host, "localhost:0", "config.Host unmodified")
 	}

--- a/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
@@ -1,0 +1,483 @@
+{
+    "events": [
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "7.0.0"
+            },
+            "@timestamp": "2017-05-09T15:04:05.999Z",
+            "context": {
+                "custom": {
+                    "and_objects": {
+                        "foo": [
+                            "bar",
+                            "baz"
+                        ]
+                    },
+                    "my_key": 1,
+                    "some_other_value": "foo bar"
+                },
+                "process": {
+                    "argv": [
+                        "node",
+                        "server.js"
+                    ],
+                    "pid": 1234,
+                    "ppid": 6789,
+                    "title": "node"
+                },
+                "request": {
+                    "body": "Hello World",
+                    "cookies": {
+                        "c1": "v1",
+                        "c2": "v2"
+                    },
+                    "env": {
+                        "GATEWAY_INTERFACE": "CGI/1.1",
+                        "SERVER_SOFTWARE": "nginx"
+                    },
+                    "headers": {
+                        "array": [
+                            "foo",
+                            "bar",
+                            "baz"
+                        ],
+                        "content-type": "text/html",
+                        "cookie": "c1=v1; c2=v2",
+                        "some-other-header": "foo",
+                        "user-agent": "Mozilla Chrome Edge"
+                    },
+                    "http_version": "1.1",
+                    "method": "POST",
+                    "socket": {
+                        "encrypted": true,
+                        "remote_address": "12.53.12.1"
+                    },
+                    "url": {
+                        "full": "https://www.example.com/p/a/t/h?query=string#hash",
+                        "hash": "#hash",
+                        "hostname": "www.example.com",
+                        "pathname": "/p/a/t/h",
+                        "port": "8080",
+                        "protocol": "https:",
+                        "raw": "/p/a/t/h?query=string#hash",
+                        "search": "?query=string"
+                    }
+                },
+                "response": {
+                    "finished": true,
+                    "headers": {
+                        "content-type": "application/json"
+                    },
+                    "headers_sent": true,
+                    "status_code": 200
+                },
+                "service": {
+                    "agent": {
+                        "name": "elastic-node",
+                        "version": "3.14.0"
+                    },
+                    "environment": "staging",
+                    "framework": {
+                        "name": "Express",
+                        "version": "1.2.3"
+                    },
+                    "language": {
+                        "name": "ecmascript",
+                        "version": "8"
+                    },
+                    "name": "1234_service-12a3",
+                    "runtime": {
+                        "name": "node",
+                        "version": "8.0.0"
+                    },
+                    "version": "5.1.3"
+                },
+                "system": {
+                    "architecture": "x64",
+                    "hostname": "prod1.example.com",
+                    "ip": "127.0.0.1",
+                    "platform": "darwin"
+                },
+                "tags": {
+                    "organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8"
+                },
+                "user": {
+                    "email": "foo@example.com",
+                    "id": 99,
+                    "username": "foo"
+                }
+            },
+            "error": {
+                "culprit": "my.module.function_name",
+                "exception": {
+                    "attributes": {
+                        "foo": "bar"
+                    },
+                    "code": "42",
+                    "handled": false,
+                    "message": "The username root is unknown",
+                    "module": "__builtins__",
+                    "stacktrace": [
+                        {
+                            "abs_path": "/real/file/name.py",
+                            "context": {
+                                "post": [
+                                    "line4",
+                                    "line5"
+                                ],
+                                "pre": [
+                                    "line1",
+                                    "line2"
+                                ]
+                            },
+                            "exclude_from_grouping": false,
+                            "filename": "file/name.py",
+                            "function": "foo",
+                            "library_frame": true,
+                            "line": {
+                                "column": 4,
+                                "context": "line3",
+                                "number": 3
+                            },
+                            "module": "App::MyModule",
+                            "vars": {
+                                "key": "value"
+                            }
+                        },
+                        {
+                            "abs_path": "/Users/watson/code/node_modules/elastic/lib/instrumentation/index.js",
+                            "context": {
+                                "post": [
+                                    "    ins.currentTransaction = prev",
+                                    "    return result",
+                                    "}",
+                                    "}",
+                                    "",
+                                    "Instrumentation.prototype._recoverTransaction = function (trans) {",
+                                    "  if (this.currentTransaction === trans) return"
+                                ],
+                                "pre": [
+                                    "  var trans = this.currentTransaction",
+                                    "",
+                                    "  return instrumented",
+                                    "",
+                                    "  function instrumented () {",
+                                    "    var prev = ins.currentTransaction",
+                                    "    ins.currentTransaction = trans"
+                                ]
+                            },
+                            "exclude_from_grouping": false,
+                            "filename": "lib/instrumentation/index.js",
+                            "function": "instrumented",
+                            "line": {
+                                "context": "    var result = original.apply(this, arguments)",
+                                "number": 102
+                            },
+                            "vars": {
+                                "key": "value"
+                            }
+                        }
+                    ],
+                    "type": "DbError"
+                },
+                "grouping_key": "50f62f37edffc4630c6655ba3ecfcf46",
+                "id": "0123456789012345",
+                "log": {
+                    "level": "warning",
+                    "logger_name": "my.logger.name",
+                    "message": "My service could not talk to the database named foobar",
+                    "param_message": "My service could not talk to the database named %s",
+                    "stacktrace": [
+                        {
+                            "abs_path": "/real/file/name.py",
+                            "context": {
+                                "post": [
+                                    "line4",
+                                    "line5"
+                                ],
+                                "pre": [
+                                    "line1",
+                                    "line2"
+                                ]
+                            },
+                            "exclude_from_grouping": false,
+                            "filename": "/webpack/file/name.py",
+                            "function": "foo",
+                            "library_frame": false,
+                            "line": {
+                                "column": 4,
+                                "context": "line3",
+                                "number": 3
+                            },
+                            "module": "App::MyModule",
+                            "vars": {
+                                "key": "value"
+                            }
+                        },
+                        {
+                            "abs_path": "/Users/watson/code/node_modules/elastic/lib/instrumentation/index.js",
+                            "context": {
+                                "post": [
+                                    "    ins.currentTransaction = prev",
+                                    "    return result",
+                                    "}",
+                                    "}",
+                                    "",
+                                    "Instrumentation.prototype._recoverTransaction = function (trans) {",
+                                    "  if (this.currentTransaction === trans) return"
+                                ],
+                                "pre": [
+                                    "  var trans = this.currentTransaction",
+                                    "",
+                                    "  return instrumented",
+                                    "",
+                                    "  function instrumented () {",
+                                    "    var prev = ins.currentTransaction",
+                                    "    ins.currentTransaction = trans"
+                                ]
+                            },
+                            "exclude_from_grouping": false,
+                            "filename": "lib/instrumentation/index.js",
+                            "function": "instrumented",
+                            "line": {
+                                "context": "    var result = original.apply(this, arguments)",
+                                "number": 102
+                            },
+                            "vars": {
+                                "key": "value"
+                            }
+                        }
+                    ]
+                }
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "7.0.0"
+            },
+            "processor": {
+                "event": "error",
+                "name": "error"
+            },
+            "timestamp": {
+                "us": 1494342245999999
+            }
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "7.0.0"
+            },
+            "@timestamp": "2018-08-09T14:59:05.999Z",
+            "context": {
+                "process": {
+                    "argv": [
+                        "node",
+                        "server.js"
+                    ],
+                    "pid": 1234,
+                    "ppid": 6789,
+                    "title": "node"
+                },
+                "service": {
+                    "agent": {
+                        "name": "elastic-node",
+                        "version": "3.14.0"
+                    },
+                    "environment": "staging",
+                    "framework": {
+                        "name": "Express",
+                        "version": "1.2.3"
+                    },
+                    "language": {
+                        "name": "ecmascript",
+                        "version": "8"
+                    },
+                    "name": "1234_service-12a3",
+                    "runtime": {
+                        "name": "node",
+                        "version": "8.0.0"
+                    },
+                    "version": "5.1.3"
+                },
+                "system": {
+                    "architecture": "x64",
+                    "hostname": "prod1.example.com",
+                    "ip": "127.0.0.1",
+                    "platform": "darwin"
+                }
+            },
+            "error": {
+                "exception": {
+                    "message": "Cannot read property 'baz' no defined"
+                },
+                "grouping_key": "ae0232fed4cb40e7ebc62a585a421d60",
+                "id": "cdefab0123456789"
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "7.0.0"
+            },
+            "processor": {
+                "event": "error",
+                "name": "error"
+            },
+            "timestamp": {
+                "us": 1533826745999000
+            }
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "7.0.0"
+            },
+            "@timestamp": "2019-01-09T21:40:53.000Z",
+            "context": {
+                "process": {
+                    "argv": [
+                        "node",
+                        "server.js"
+                    ],
+                    "pid": 1234,
+                    "ppid": 6789,
+                    "title": "node"
+                },
+                "service": {
+                    "agent": {
+                        "name": "elastic-node",
+                        "version": "3.14.0"
+                    },
+                    "environment": "staging",
+                    "framework": {
+                        "name": "Express",
+                        "version": "1.2.3"
+                    },
+                    "language": {
+                        "name": "ecmascript",
+                        "version": "8"
+                    },
+                    "name": "1234_service-12a3",
+                    "runtime": {
+                        "name": "node",
+                        "version": "8.0.0"
+                    },
+                    "version": "5.1.3"
+                },
+                "system": {
+                    "architecture": "x64",
+                    "hostname": "prod1.example.com",
+                    "ip": "127.0.0.1",
+                    "platform": "darwin"
+                }
+            },
+            "error": {
+                "exception": {
+                    "type": "DbError"
+                },
+                "grouping_key": "c3868d6704b923014eaffea034e70a3d",
+                "id": "cdefab0123456780"
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "7.0.0"
+            },
+            "processor": {
+                "event": "error",
+                "name": "error"
+            },
+            "timestamp": {
+                "us": 1547070053000000
+            }
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "7.0.0"
+            },
+            "@timestamp": "2018-08-09T15:04:05.999Z",
+            "context": {
+                "process": {
+                    "argv": [
+                        "node",
+                        "server.js"
+                    ],
+                    "pid": 1234,
+                    "ppid": 6789,
+                    "title": "node"
+                },
+                "service": {
+                    "agent": {
+                        "name": "elastic-node",
+                        "version": "3.14.0"
+                    },
+                    "environment": "staging",
+                    "framework": {
+                        "name": "Express",
+                        "version": "1.2.3"
+                    },
+                    "language": {
+                        "name": "ecmascript",
+                        "version": "8"
+                    },
+                    "name": "1234_service-12a3",
+                    "runtime": {
+                        "name": "node",
+                        "version": "8.0.0"
+                    },
+                    "version": "5.1.3"
+                },
+                "system": {
+                    "architecture": "x64",
+                    "hostname": "prod1.example.com",
+                    "ip": "127.0.0.1",
+                    "platform": "darwin"
+                }
+            },
+            "error": {
+                "grouping_key": "d6b3f958dfea98dc9ed2b57d5f0c48bb",
+                "id": "abcdef0123456789",
+                "log": {
+                    "level": "custom log level",
+                    "message": "Cannot read property 'baz' of undefined"
+                }
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "7.0.0"
+            },
+            "parent": {
+                "id": "9632587410abcdef"
+            },
+            "processor": {
+                "event": "error",
+                "name": "error"
+            },
+            "timestamp": {
+                "us": 1533827045999000
+            },
+            "trace": {
+                "id": "0123456789abcdeffedcba0123456789"
+            },
+            "transaction": {
+                "id": "1234567890987654",
+                "sampled": true
+            }
+        }
+    ]
+}

--- a/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
@@ -1,0 +1,213 @@
+{
+    "events": [
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "7.0.0"
+            },
+            "@timestamp": "2018-08-09T15:04:05.999Z",
+            "context": {
+                "process": {
+                    "pid": 1234
+                },
+                "service": {
+                    "agent": {
+                        "name": "elastic-node",
+                        "version": "3.14.0"
+                    },
+                    "framework": {
+                        "name": "emac"
+                    },
+                    "language": {
+                        "name": "ecmascript"
+                    },
+                    "name": "1234_service-12a3"
+                },
+                "system": {
+                    "ip": "127.0.0.1"
+                }
+            },
+            "error": {
+                "grouping_key": "d6b3f958dfea98dc9ed2b57d5f0c48bb",
+                "id": "abcdef0123456789",
+                "log": {
+                    "level": "custom log level",
+                    "message": "Cannot read property 'baz' of undefined"
+                }
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "7.0.0"
+            },
+            "processor": {
+                "event": "error",
+                "name": "error"
+            },
+            "timestamp": {
+                "us": 1533827045999000
+            }
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "7.0.0"
+            },
+            "@timestamp": "2019-01-09T21:40:53.000Z",
+            "context": {
+                "service": {
+                    "agent": {
+                        "name": "elastic-node",
+                        "version": "3.14.0"
+                    },
+                    "name": "1234_service-12a3"
+                }
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "7.0.0"
+            },
+            "parent": {
+                "id": "ab23456a89012345"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "span": {
+                "duration": {
+                    "us": 3564
+                },
+                "hex_id": "0123456a89012345",
+                "name": "GET /api/types",
+                "start": {
+                    "us": 1845
+                },
+                "type": "request"
+            },
+            "timestamp": {
+                "us": 1547070053000000
+            },
+            "trace": {
+                "id": "0123456789abcdef0123456789abcdef"
+            },
+            "transaction": {
+                "id": "ab23456a89012345"
+            }
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "7.0.0"
+            },
+            "@timestamp": "2018-08-30T18:53:27.154Z",
+            "context": {
+                "process": {
+                    "pid": 1234
+                },
+                "service": {
+                    "agent": {
+                        "name": "elastic-node",
+                        "version": "3.14.0"
+                    },
+                    "framework": {
+                        "name": "emac"
+                    },
+                    "language": {
+                        "name": "ecmascript"
+                    },
+                    "name": "1234_service-12a3"
+                },
+                "system": {
+                    "ip": "127.0.0.1"
+                }
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "7.0.0"
+            },
+            "processor": {
+                "event": "transaction",
+                "name": "transaction"
+            },
+            "timestamp": {
+                "us": 1535655207154000
+            },
+            "trace": {
+                "id": "01234567890123456789abcdefabcdef"
+            },
+            "transaction": {
+                "duration": {
+                    "us": 32592
+                },
+                "id": "abcdef1478523690",
+                "result": "200",
+                "sampled": true,
+                "span_count": {
+                    "started": 0
+                },
+                "type": "request"
+            }
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "7.0.0"
+            },
+            "@timestamp": "2017-05-30T18:53:42.281Z",
+            "context": {
+                "process": {
+                    "pid": 1234
+                },
+                "service": {
+                    "agent": {
+                        "name": "elastic-node",
+                        "version": "3.14.0"
+                    },
+                    "framework": {
+                        "name": "emac"
+                    },
+                    "language": {
+                        "name": "ecmascript"
+                    },
+                    "name": "1234_service-12a3"
+                },
+                "system": {
+                    "ip": "127.0.0.1"
+                }
+            },
+            "go": {
+                "memstats": {
+                    "heap": {
+                        "sys": {
+                            "bytes": 61235
+                        }
+                    }
+                }
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "7.0.0"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            }
+        }
+    ]
+}

--- a/beater/test_approved_es_documents/TestPublishIntegrationMetricsets.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationMetricsets.approved.json
@@ -1,0 +1,110 @@
+{
+    "events": [
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "7.0.0"
+            },
+            "@timestamp": "2017-05-30T18:53:42.281Z",
+            "byte_counter": 1,
+            "context": {
+                "process": {
+                    "pid": 1234
+                },
+                "service": {
+                    "agent": {
+                        "name": "elastic-node",
+                        "version": "3.14.0"
+                    },
+                    "language": {
+                        "name": "ecmascript"
+                    },
+                    "name": "1234_service-12a3"
+                },
+                "tags": {
+                    "code": 200,
+                    "some": "abc",
+                    "success": true
+                }
+            },
+            "dotted": {
+                "float": {
+                    "gauge": 6.12
+                }
+            },
+            "double_gauge": 3.141592653589793,
+            "float_gauge": 9.16,
+            "integer_gauge": 42767,
+            "long_gauge": 3147483648,
+            "negative": {
+                "d": {
+                    "o": {
+                        "t": {
+                            "t": {
+                                "e": {
+                                    "d": -1022
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "7.0.0"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "short_counter": 227
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "7.0.0"
+            },
+            "@timestamp": "2017-05-30T18:53:42.281Z",
+            "context": {
+                "process": {
+                    "pid": 1234
+                },
+                "service": {
+                    "agent": {
+                        "name": "elastic-node",
+                        "version": "3.14.0"
+                    },
+                    "language": {
+                        "name": "ecmascript"
+                    },
+                    "name": "1234_service-12a3"
+                }
+            },
+            "go": {
+                "memstats": {
+                    "heap": {
+                        "sys": {
+                            "bytes": 6520832
+                        }
+                    }
+                }
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "7.0.0"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            }
+        }
+    ]
+}

--- a/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json
@@ -1,0 +1,327 @@
+{
+    "events": [
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "7.0.0"
+            },
+            "@timestamp": "2018-07-30T18:53:42.281Z",
+            "context": {
+                "service": {
+                    "agent": {
+                        "name": "elastic-node",
+                        "version": "3.14.0"
+                    },
+                    "name": "backendspans"
+                }
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "7.0.0"
+            },
+            "parent": {
+                "id": "abcdef0123456789"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "span": {
+                "duration": {
+                    "us": 141581
+                },
+                "hex_id": "abcdef01234567",
+                "name": "GET /api/types",
+                "type": "request"
+            },
+            "timestamp": {
+                "us": 1532976822281000
+            },
+            "trace": {
+                "id": "fdedef0123456789abcdef9876543210"
+            },
+            "transaction": {
+                "id": "01af25874dec69dd"
+            }
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "7.0.0"
+            },
+            "@timestamp": "2018-07-30T18:53:42.281Z",
+            "context": {
+                "service": {
+                    "agent": {
+                        "name": "elastic-node",
+                        "version": "3.14.0"
+                    },
+                    "name": "backendspans"
+                }
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "7.0.0"
+            },
+            "parent": {
+                "id": "0000000011111111"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "span": {
+                "duration": {
+                    "us": 32592
+                },
+                "hex_id": "1234abcdef567895",
+                "name": "GET /api/types",
+                "start": {
+                    "us": 22000
+                },
+                "type": "request"
+            },
+            "timestamp": {
+                "us": 1532976822281000
+            },
+            "trace": {
+                "id": "abcdef0123456789abcdef9876543210"
+            },
+            "transaction": {
+                "id": "ab45781d265894fe"
+            }
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "7.0.0"
+            },
+            "@timestamp": "2019-01-09T21:40:53.000Z",
+            "context": {
+                "service": {
+                    "agent": {
+                        "name": "elastic-node",
+                        "version": "3.14.0"
+                    },
+                    "name": "backendspans"
+                },
+                "tags": {
+                    "tag1": "value1",
+                    "tag2": 123,
+                    "tag3": 12.34,
+                    "tag4": true
+                }
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "7.0.0"
+            },
+            "parent": {
+                "id": "abcdefabcdef7890"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "span": {
+                "duration": {
+                    "us": 3564
+                },
+                "hex_id": "0123456a89012345",
+                "name": "GET /api/types",
+                "start": {
+                    "us": 1845
+                },
+                "type": "request"
+            },
+            "timestamp": {
+                "us": 1547070053000000
+            },
+            "trace": {
+                "id": "abcdef0123456789abcdef9876543210"
+            },
+            "transaction": {
+                "id": "ab23456a89012345"
+            }
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "7.0.0"
+            },
+            "@timestamp": "2019-01-09T21:40:53.000Z",
+            "context": {
+                "service": {
+                    "agent": {
+                        "name": "elastic-node",
+                        "version": "3.14.0"
+                    },
+                    "name": "backendspans"
+                }
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "7.0.0"
+            },
+            "parent": {
+                "id": "ababcdcdefefabde"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "span": {
+                "action": "call",
+                "duration": {
+                    "us": 13980
+                },
+                "hex_id": "abcde56a89012345",
+                "name": "get /api/types",
+                "start": {
+                    "us": 0
+                },
+                "subtype": "http",
+                "sync": false,
+                "type": "request"
+            },
+            "timestamp": {
+                "us": 1547070053000000
+            },
+            "trace": {
+                "id": "abcdef0123456789abcdef9876543210"
+            },
+            "transaction": {
+                "id": "bed3456a89012345"
+            }
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "7.0.0"
+            },
+            "@timestamp": "2019-01-09T21:40:53.000Z",
+            "context": {
+                "db": {
+                    "instance": "customers",
+                    "statement": "SELECT * FROM product_types WHERE user_id=?",
+                    "type": "sql",
+                    "user": "readonly_user"
+                },
+                "http": {
+                    "method": "GET",
+                    "status_code": 200,
+                    "url": "http://localhost:8000"
+                },
+                "service": {
+                    "agent": {
+                        "name": "elastic-node",
+                        "version": "3.14.0"
+                    },
+                    "name": "backendspans"
+                }
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "7.0.0"
+            },
+            "parent": {
+                "id": "abcdef0123456789"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "span": {
+                "action": "query",
+                "duration": {
+                    "us": 3781
+                },
+                "hex_id": "1234567890aaaade",
+                "name": "SELECT FROM product_types",
+                "stacktrace": [
+                    {
+                        "exclude_from_grouping": false,
+                        "filename": "net.js",
+                        "line": {
+                            "number": 547
+                        }
+                    },
+                    {
+                        "context": {
+                            "post": [
+                                "    ins.currentTransaction = prev",
+                                "}"
+                            ]
+                        },
+                        "exclude_from_grouping": false,
+                        "filename": "file2.js",
+                        "line": {
+                            "number": 12
+                        }
+                    },
+                    {
+                        "abs_path": "net.js",
+                        "context": {
+                            "post": [
+                                "    ins.currentTransaction = prev",
+                                "    return result"
+                            ],
+                            "pre": [
+                                "  var trans = this.currentTransaction",
+                                ""
+                            ]
+                        },
+                        "exclude_from_grouping": false,
+                        "filename": "net.js",
+                        "function": "onread",
+                        "library_frame": true,
+                        "line": {
+                            "column": 4,
+                            "context": "line3",
+                            "number": 547
+                        },
+                        "module": "some module",
+                        "vars": {
+                            "key": "value"
+                        }
+                    }
+                ],
+                "start": {
+                    "us": 2830
+                },
+                "subtype": "postgresql",
+                "sync": true,
+                "type": "db"
+            },
+            "timestamp": {
+                "us": 1547070053000000
+            },
+            "trace": {
+                "id": "abcdef0123456789abcdef9876543210"
+            },
+            "transaction": {
+                "id": "aff4567890aaaade"
+            }
+        }
+    ]
+}

--- a/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json
@@ -1,0 +1,321 @@
+{
+    "events": [
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "7.0.0"
+            },
+            "@timestamp": "2019-01-09T21:40:53.000Z",
+            "context": {
+                "process": {
+                    "argv": [
+                        "node",
+                        "server.js"
+                    ],
+                    "pid": 1234,
+                    "ppid": 6789,
+                    "title": "node"
+                },
+                "service": {
+                    "agent": {
+                        "name": "elastic-node",
+                        "version": "3.14.0"
+                    },
+                    "environment": "staging",
+                    "framework": {
+                        "name": "Express",
+                        "version": "1.2.3"
+                    },
+                    "language": {
+                        "name": "ecmascript",
+                        "version": "8"
+                    },
+                    "name": "1234_service-12a3",
+                    "runtime": {
+                        "name": "node",
+                        "version": "8.0.0"
+                    },
+                    "version": "5.1.3"
+                },
+                "system": {
+                    "architecture": "x64",
+                    "hostname": "prod1.example.com",
+                    "ip": "127.0.0.1",
+                    "platform": "darwin"
+                }
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "7.0.0"
+            },
+            "parent": {
+                "id": "abcdefabcdef01234567"
+            },
+            "processor": {
+                "event": "transaction",
+                "name": "transaction"
+            },
+            "timestamp": {
+                "us": 1547070053000000
+            },
+            "trace": {
+                "id": "0123456789abcdef0123456789abcdef"
+            },
+            "transaction": {
+                "duration": {
+                    "us": 32592
+                },
+                "id": "945254c567a5417e",
+                "sampled": true,
+                "span_count": {
+                    "started": 43
+                },
+                "type": "request"
+            }
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "7.0.0"
+            },
+            "@timestamp": "2017-05-30T18:53:27.154Z",
+            "context": {
+                "custom": {
+                    "(": "not a valid regex and that is fine",
+                    "and_objects": {
+                        "foo": [
+                            "bar",
+                            "baz"
+                        ]
+                    },
+                    "my_key": 1,
+                    "some_other_value": "foo bar"
+                },
+                "process": {
+                    "argv": [
+                        "node",
+                        "server.js"
+                    ],
+                    "pid": 1234,
+                    "ppid": 6789,
+                    "title": "node"
+                },
+                "request": {
+                    "body": {
+                        "additional": {
+                            "bar": 123,
+                            "req": "additional information"
+                        },
+                        "str": "hello world"
+                    },
+                    "cookies": {
+                        "c1": "v1",
+                        "c2": "v2"
+                    },
+                    "env": {
+                        "GATEWAY_INTERFACE": "CGI/1.1",
+                        "SERVER_SOFTWARE": "nginx"
+                    },
+                    "headers": {
+                        "array": [
+                            "foo",
+                            "bar",
+                            "baz"
+                        ],
+                        "content-type": "text/html",
+                        "cookie": "c1=v1; c2=v2",
+                        "some-other-header": "foo",
+                        "user-agent": "Mozilla Chrome Edge"
+                    },
+                    "http_version": "1.1",
+                    "method": "POST",
+                    "socket": {
+                        "encrypted": true,
+                        "remote_address": "12.53.12.1"
+                    },
+                    "url": {
+                        "full": "https://www.example.com/p/a/t/h?query=string#hash",
+                        "hash": "#hash",
+                        "hostname": "www.example.com",
+                        "pathname": "/p/a/t/h",
+                        "port": "8080",
+                        "protocol": "https:",
+                        "raw": "/p/a/t/h?query=string#hash",
+                        "search": "?query=string"
+                    }
+                },
+                "response": {
+                    "finished": true,
+                    "headers": {
+                        "content-type": "application/json"
+                    },
+                    "headers_sent": true,
+                    "status_code": 200
+                },
+                "service": {
+                    "agent": {
+                        "name": "elastic-node",
+                        "version": "3.14.0"
+                    },
+                    "environment": "staging",
+                    "framework": {
+                        "name": "Express",
+                        "version": "1.2.3"
+                    },
+                    "language": {
+                        "name": "ecmascript",
+                        "version": "8"
+                    },
+                    "name": "1234_service-12a3",
+                    "runtime": {
+                        "name": "node",
+                        "version": "8.0.0"
+                    },
+                    "version": "5.1.3"
+                },
+                "system": {
+                    "architecture": "x64",
+                    "hostname": "prod1.example.com",
+                    "ip": "127.0.0.1",
+                    "platform": "darwin"
+                },
+                "tags": {
+                    "organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8",
+                    "tag2": 12,
+                    "tag3": 12.45,
+                    "tag4": false
+                },
+                "user": {
+                    "email": "foo@example.com",
+                    "id": "99",
+                    "username": "foo"
+                }
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "7.0.0"
+            },
+            "processor": {
+                "event": "transaction",
+                "name": "transaction"
+            },
+            "timestamp": {
+                "us": 1496170407154000
+            },
+            "trace": {
+                "id": "0acd456789abcdef0123456789abcdef"
+            },
+            "transaction": {
+                "duration": {
+                    "us": 32592
+                },
+                "id": "4340a8e0df1906ecbfa9",
+                "name": "GET /api/types",
+                "result": "success",
+                "sampled": true,
+                "span_count": {
+                    "started": 17
+                },
+                "type": "request"
+            }
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "7.0.0"
+            },
+            "@timestamp": "2018-07-30T18:53:42.281Z",
+            "context": {
+                "process": {
+                    "argv": [
+                        "node",
+                        "server.js"
+                    ],
+                    "pid": 1234,
+                    "ppid": 6789,
+                    "title": "node"
+                },
+                "request": {
+                    "method": "POST"
+                },
+                "service": {
+                    "agent": {
+                        "name": "elastic-node",
+                        "version": "3.14.0"
+                    },
+                    "environment": "staging",
+                    "framework": {
+                        "name": "Express",
+                        "version": "1.2.3"
+                    },
+                    "language": {
+                        "name": "ecmascript",
+                        "version": "8"
+                    },
+                    "name": "1234_service-12a3",
+                    "runtime": {
+                        "name": "node",
+                        "version": "8.0.0"
+                    },
+                    "version": "5.1.3"
+                },
+                "system": {
+                    "architecture": "x64",
+                    "hostname": "prod1.example.com",
+                    "ip": "127.0.0.1",
+                    "platform": "darwin"
+                }
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "7.0.0"
+            },
+            "processor": {
+                "event": "transaction",
+                "name": "transaction"
+            },
+            "timestamp": {
+                "us": 1532976822281000
+            },
+            "trace": {
+                "id": "0acd456789abcdef0123456789abcdef"
+            },
+            "transaction": {
+                "duration": {
+                    "us": 13980
+                },
+                "id": "cdef4340a8e0df19",
+                "marks": {
+                    "another_mark": {
+                        "some_float": 10,
+                        "some_long": 10
+                    },
+                    "navigationTiming": {
+                        "appBeforeBootstrap": 608.9300000000001,
+                        "navigationStart": -21
+                    }
+                },
+                "sampled": true,
+                "span_count": {
+                    "dropped": {
+                        "total": 55
+                    },
+                    "started": 436
+                },
+                "type": "request"
+            }
+        }
+    ]
+}

--- a/beater/tracing_test.go
+++ b/beater/tracing_test.go
@@ -173,7 +173,7 @@ func setupTestServerInstrumentation(t *testing.T, enabled bool) (chan beat.Event
 
 	// onboarding event
 	e := <-events
-	assert.Contains(t, e.Fields, "listening")
+	assert.Equal(t, "onboarding", e.Fields["processor"].(common.MapStr)["name"])
 
 	// Send a transaction request so we have something to trace.
 	baseUrl, client := beater.client(false)

--- a/vendor/github.com/elastic/beats/NOTICE.txt
+++ b/vendor/github.com/elastic/beats/NOTICE.txt
@@ -584,7 +584,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-sysinfo
-Revision: 7b021494a9562d0c3f0422d49b9980709c5650e9
+Revision: 59ef8c0eae46c0929e3b219ac86368d4b5934f91
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-sysinfo/LICENSE.txt:
 --------------------------------------------------------------------

--- a/vendor/github.com/elastic/beats/libbeat/autodiscover/appenders/config/config.go
+++ b/vendor/github.com/elastic/beats/libbeat/autodiscover/appenders/config/config.go
@@ -1,0 +1,112 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/autodiscover"
+	"github.com/elastic/beats/libbeat/autodiscover/template"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/bus"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
+	"github.com/elastic/beats/libbeat/conditions"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+func init() {
+	autodiscover.Registry.AddAppender("config", NewConfigAppender)
+}
+
+type config struct {
+	ConditionConfig *conditions.Config `config:"condition"`
+	Config          *common.Config     `config:"config"`
+}
+
+type configAppender struct {
+	condition conditions.Condition
+	config    common.MapStr
+}
+
+// NewConfigAppender creates a configAppender that can append templatized configs into built configs
+func NewConfigAppender(cfg *common.Config) (autodiscover.Appender, error) {
+	cfgwarn.Beta("The config appender is beta")
+
+	config := config{}
+	err := cfg.Unpack(&config)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unpack config appender due to error: %+v", err)
+	}
+
+	var cond conditions.Condition
+
+	if config.ConditionConfig != nil {
+		cond, err = conditions.NewCondition(config.ConditionConfig)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to create condition due to error")
+		}
+	}
+
+	// Unpack the config
+	cf := common.MapStr{}
+	err = config.Config.Unpack(&cf)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to unpack config due to error")
+	}
+
+	return &configAppender{condition: cond, config: cf}, nil
+}
+
+// Append adds configuration into configs built by builds/templates. It applies conditions to filter out
+// configs to apply, applies them and tries to apply templates if any are present.
+func (c *configAppender) Append(event bus.Event) {
+	cfgsRaw, ok := event["config"]
+	// There are no configs
+	if !ok {
+		return
+	}
+
+	cfgs, ok := cfgsRaw.([]*common.Config)
+	// Config key doesnt have an array of config objects
+	if !ok {
+		return
+	}
+	if c.condition == nil || c.condition.Check(common.MapStr(event)) == true {
+		// Merge the template with all the configs
+		for _, cfg := range cfgs {
+			cf := common.MapStr{}
+			err := cfg.Unpack(&cf)
+			if err != nil {
+				logp.Debug("config", "unable to unpack config due to error: %v", err)
+				continue
+			}
+			err = cfg.Merge(&c.config)
+			if err != nil {
+				logp.Debug("config", "unable to merge configs due to error: %v", err)
+			}
+		}
+
+		// Apply the template
+		template.ApplyConfigTemplate(event, cfgs)
+	}
+
+	// Replace old config with newly appended configs
+	event["config"] = cfgs
+}

--- a/vendor/github.com/elastic/beats/libbeat/autodiscover/config.go
+++ b/vendor/github.com/elastic/beats/libbeat/autodiscover/config.go
@@ -19,7 +19,6 @@ package autodiscover
 
 import (
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/conditions"
 )
 
 // Config settings for Autodiscover
@@ -39,6 +38,5 @@ type BuilderConfig struct {
 
 // AppenderConfig settings
 type AppenderConfig struct {
-	Type            string             `config:"type"`
-	ConditionConfig *conditions.Config `config:"condition"`
+	Type string `config:"type"`
 }

--- a/vendor/github.com/elastic/beats/libbeat/beat/pipeline.go
+++ b/vendor/github.com/elastic/beats/libbeat/beat/pipeline.go
@@ -76,6 +76,10 @@ type ClientConfig struct {
 	// if the normalization step should be skipped set this to true.
 	SkipNormalization bool
 
+	// By default events are decorated with agent metadata.
+	// To skip adding that metadata set this to true.
+	SkipAgentMetadata bool
+
 	// ACK handler strategies.
 	// Note: ack handlers are run in another go-routine owned by the publisher pipeline.
 	//       They should not block for to long, to not block the internal buffers for

--- a/vendor/github.com/elastic/beats/libbeat/cmd/instance/imports.go
+++ b/vendor/github.com/elastic/beats/libbeat/cmd/instance/imports.go
@@ -18,6 +18,7 @@
 package instance
 
 import (
+	_ "github.com/elastic/beats/libbeat/autodiscover/appenders/config" // Register autodiscover appenders
 	_ "github.com/elastic/beats/libbeat/autodiscover/providers/docker" // Register autodiscover providers
 	_ "github.com/elastic/beats/libbeat/autodiscover/providers/jolokia"
 	_ "github.com/elastic/beats/libbeat/autodiscover/providers/kubernetes"

--- a/vendor/github.com/elastic/beats/libbeat/dashboards/export.go
+++ b/vendor/github.com/elastic/beats/libbeat/dashboards/export.go
@@ -18,7 +18,6 @@
 package dashboards
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -32,7 +31,8 @@ import (
 )
 
 const (
-	dashboardPerm = 0644
+	// OutputPermission is the permission of dashboard output files.
+	OutputPermission = 0644
 )
 
 // ListYML is the yaml file which contains list of available dashboards.
@@ -92,10 +92,6 @@ func SaveToFile(dashboard common.MapStr, filename, root string, version common.V
 	}
 
 	out := filepath.Join(root, dashboardsPath, filename)
-	bytes, err := json.Marshal(dashboard)
-	if err != nil {
-		return err
-	}
 
-	return ioutil.WriteFile(out, bytes, dashboardPerm)
+	return ioutil.WriteFile(out, []byte(dashboard.StringToPrint()), OutputPermission)
 }

--- a/vendor/github.com/elastic/beats/libbeat/outputs/codec/json/json.go
+++ b/vendor/github.com/elastic/beats/libbeat/outputs/codec/json/json.go
@@ -34,17 +34,18 @@ type Encoder struct {
 	folder *gotype.Iterator
 
 	version string
-	config  config
+	config  Config
 }
 
-type config struct {
+// Config is used to pass encoding parameters to New.
+type Config struct {
 	Pretty     bool
 	EscapeHTML bool
 }
 
-var defaultConfig = config{
+var defaultConfig = Config{
 	Pretty:     false,
-	EscapeHTML: true,
+	EscapeHTML: false,
 }
 
 func init() {
@@ -56,16 +57,13 @@ func init() {
 			}
 		}
 
-		return New(config.Pretty, config.EscapeHTML, info.Version), nil
+		return New(info.Version, config), nil
 	})
 }
 
 // New creates a new json Encoder.
-func New(pretty, escapeHTML bool, version string) *Encoder {
-	e := &Encoder{version: version, config: config{
-		Pretty:     pretty,
-		EscapeHTML: escapeHTML,
-	}}
+func New(version string, config Config) *Encoder {
+	e := &Encoder{version: version, config: config}
 	e.reset()
 	return e
 }

--- a/vendor/github.com/elastic/beats/libbeat/outputs/console/console.go
+++ b/vendor/github.com/elastic/beats/libbeat/outputs/console/console.go
@@ -70,7 +70,10 @@ func makeConsole(
 			return outputs.Fail(err)
 		}
 	} else {
-		enc = json.New(config.Pretty, true, beat.Version)
+		enc = json.New(beat.Version, json.Config{
+			Pretty:     config.Pretty,
+			EscapeHTML: false,
+		})
 	}
 
 	index := beat.Beat

--- a/vendor/github.com/elastic/beats/libbeat/outputs/elasticsearch/config.go
+++ b/vendor/github.com/elastic/beats/libbeat/outputs/elasticsearch/config.go
@@ -61,7 +61,7 @@ var (
 		Timeout:          90 * time.Second,
 		MaxRetries:       3,
 		CompressionLevel: 0,
-		EscapeHTML:       true,
+		EscapeHTML:       false,
 		TLS:              nil,
 		LoadBalance:      true,
 		Backoff: Backoff{

--- a/vendor/github.com/elastic/beats/libbeat/outputs/logstash/config.go
+++ b/vendor/github.com/elastic/beats/libbeat/outputs/logstash/config.go
@@ -26,7 +26,6 @@ import (
 
 type Config struct {
 	Index            string                `config:"index"`
-	Port             int                   `config:"port"`
 	LoadBalance      bool                  `config:"loadbalance"`
 	BulkMaxSize      int                   `config:"bulk_max_size"`
 	SlowStart        bool                  `config:"slow_start"`
@@ -47,7 +46,6 @@ type Backoff struct {
 }
 
 var defaultConfig = Config{
-	Port:             5044,
 	LoadBalance:      false,
 	Pipelining:       2,
 	BulkMaxSize:      2048,
@@ -60,7 +58,7 @@ var defaultConfig = Config{
 		Init: 1 * time.Second,
 		Max:  60 * time.Second,
 	},
-	EscapeHTML: true,
+	EscapeHTML: false,
 }
 
 func newConfig() *Config {

--- a/vendor/github.com/elastic/beats/libbeat/outputs/logstash/enc.go
+++ b/vendor/github.com/elastic/beats/libbeat/outputs/logstash/enc.go
@@ -23,7 +23,10 @@ import (
 )
 
 func makeLogstashEventEncoder(info beat.Info, escapeHTML bool, index string) func(interface{}) ([]byte, error) {
-	enc := json.New(false, escapeHTML, info.Version)
+	enc := json.New(info.Version, json.Config{
+		Pretty:     false,
+		EscapeHTML: escapeHTML,
+	})
 	return func(event interface{}) (d []byte, err error) {
 		d, err = enc.Encode(index, event.(*beat.Event))
 		if err != nil {

--- a/vendor/github.com/elastic/beats/libbeat/outputs/logstash/logstash.go
+++ b/vendor/github.com/elastic/beats/libbeat/outputs/logstash/logstash.go
@@ -20,6 +20,7 @@ package logstash
 import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/common/transport/tlscommon"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
@@ -29,6 +30,7 @@ import (
 const (
 	minWindowSize             int = 1
 	defaultStartMaxWindowSize int = 10
+	defaultPort                   = 5044
 )
 
 var debugf = logp.MakeDebug("logstash")
@@ -44,6 +46,11 @@ func makeLogstash(
 ) (outputs.Group, error) {
 	if !cfg.HasField("index") {
 		cfg.SetString("index", -1, beat.Beat)
+	}
+
+	err := cfgwarn.CheckRemoved6xSettings(cfg, "port")
+	if err != nil {
+		return outputs.Fail(err)
 	}
 
 	config := newConfig()
@@ -72,7 +79,7 @@ func makeLogstash(
 	for i, host := range hosts {
 		var client outputs.NetworkClient
 
-		conn, err := transport.NewClient(transp, "tcp", host, config.Port)
+		conn, err := transport.NewClient(transp, "tcp", host, defaultPort)
 		if err != nil {
 			return outputs.Fail(err)
 		}

--- a/vendor/github.com/elastic/beats/libbeat/outputs/redis/config.go
+++ b/vendor/github.com/elastic/beats/libbeat/outputs/redis/config.go
@@ -30,7 +30,6 @@ type redisConfig struct {
 	Password    string                `config:"password"`
 	Index       string                `config:"index"`
 	Key         string                `config:"key"`
-	Port        int                   `config:"port"`
 	LoadBalance bool                  `config:"loadbalance"`
 	Timeout     time.Duration         `config:"timeout"`
 	BulkMaxSize int                   `config:"bulk_max_size"`
@@ -50,7 +49,6 @@ type backoff struct {
 
 var (
 	defaultConfig = redisConfig{
-		Port:        6379,
 		LoadBalance: true,
 		Timeout:     5 * time.Second,
 		BulkMaxSize: 2048,

--- a/vendor/github.com/elastic/beats/libbeat/outputs/redis/redis.go
+++ b/vendor/github.com/elastic/beats/libbeat/outputs/redis/redis.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
 	"github.com/elastic/beats/libbeat/common/transport/tlscommon"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
@@ -40,6 +41,7 @@ var debugf = logp.MakeDebug("redis")
 const (
 	defaultWaitRetry    = 1 * time.Second
 	defaultMaxWaitRetry = 60 * time.Second
+	defaultPort         = 6379
 )
 
 func init() {
@@ -54,6 +56,11 @@ func makeRedis(
 
 	if !cfg.HasField("index") {
 		cfg.SetString("index", -1, beat.Beat)
+	}
+
+	err := cfgwarn.CheckRemoved6xSettings(cfg, "port")
+	if err != nil {
+		return outputs.Fail(err)
 	}
 
 	// ensure we have a `key` field in settings
@@ -116,7 +123,7 @@ func makeRedis(
 			return outputs.Fail(err)
 		}
 
-		conn, err := transport.NewClient(transp, "tcp", host, config.Port)
+		conn, err := transport.NewClient(transp, "tcp", host, defaultPort)
 		if err != nil {
 			return outputs.Fail(err)
 		}

--- a/vendor/github.com/elastic/beats/libbeat/publisher/pipeline/module.go
+++ b/vendor/github.com/elastic/beats/libbeat/publisher/pipeline/module.go
@@ -80,13 +80,6 @@ func Load(
 		Annotations: Annotations{
 			Event: config.EventMetadata,
 			Builtin: common.MapStr{
-				"agent": common.MapStr{
-					"type":         beatInfo.Beat,
-					"hostname":     beatInfo.Hostname,
-					"version":      beatInfo.Version,
-					"id":           beatInfo.ID.String(),
-					"ephemeral_id": beatInfo.EphemeralID.String(),
-				},
 				"host": common.MapStr{
 					"name": name,
 				},
@@ -95,10 +88,6 @@ func Load(
 				},
 			},
 		},
-	}
-
-	if name != beatInfo.Hostname {
-		settings.Annotations.Builtin.Put("agent.name", name)
 	}
 
 	queueBuilder, err := createQueueBuilder(config.Queue, monitors)

--- a/vendor/github.com/elastic/go-sysinfo/providers/darwin/host_darwin_amd64.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/darwin/host_darwin_amd64.go
@@ -218,5 +218,9 @@ func (r *reader) time(h *host) {
 }
 
 func (r *reader) uniqueID(h *host) {
-	// TODO: call gethostuuid(uuid [16]byte, timespec)
+	v, err := MachineID()
+	if r.addErr(err) {
+		return
+	}
+	h.info.UniqueID = v
 }

--- a/vendor/github.com/elastic/go-sysinfo/providers/linux/process_linux.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/linux/process_linux.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prometheus/procfs"
@@ -36,7 +37,6 @@ func (s linuxSystem) Processes() ([]types.Process, error) {
 	if err != nil {
 		return nil, err
 	}
-	s.procFS.Path()
 
 	processes := make([]types.Process, 0, len(procs))
 	for _, proc := range procs {
@@ -69,8 +69,12 @@ type process struct {
 	info *types.ProcessInfo
 }
 
+func (p *process) PID() int {
+	return p.Proc.PID
+}
+
 func (p *process) path(pa ...string) string {
-	return p.fs.Path(append([]string{strconv.Itoa(p.PID)}, pa...)...)
+	return p.fs.Path(append([]string{strconv.Itoa(p.PID())}, pa...)...)
 }
 
 func (p *process) CWD() (string, error) {
@@ -115,7 +119,7 @@ func (p *process) Info() (types.ProcessInfo, error) {
 
 	p.info = &types.ProcessInfo{
 		Name:      stat.Comm,
-		PID:       p.PID,
+		PID:       p.PID(),
 		PPID:      stat.PPID,
 		CWD:       cwd,
 		Exe:       exe,
@@ -202,6 +206,37 @@ func (p *process) Capabilities() (*types.CapabilityInfo, error) {
 	}
 
 	return readCapabilities(content)
+}
+
+func (p *process) User() (types.UserInfo, error) {
+	content, err := ioutil.ReadFile(p.path("status"))
+	if err != nil {
+		return types.UserInfo{}, err
+	}
+
+	var user types.UserInfo
+	err = parseKeyValue(content, ":", func(key, value []byte) error {
+		// See proc(5) for the format of /proc/[pid]/status
+		switch string(key) {
+		case "Uid":
+			ids := strings.Split(string(value), "\t")
+			if len(ids) >= 3 {
+				user.UID = ids[0]
+				user.EUID = ids[1]
+				user.SUID = ids[2]
+			}
+		case "Gid":
+			ids := strings.Split(string(value), "\t")
+			if len(ids) >= 3 {
+				user.GID = ids[0]
+				user.EGID = ids[1]
+				user.SGID = ids[2]
+			}
+		}
+		return nil
+	})
+
+	return user, nil
 }
 
 func ticksToDuration(ticks uint64) time.Duration {

--- a/vendor/github.com/elastic/go-sysinfo/providers/windows/arch_windows.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/windows/arch_windows.go
@@ -18,7 +18,7 @@
 package windows
 
 import (
-	"github.com/elastic/go-windows"
+	windows "github.com/elastic/go-windows"
 )
 
 func Architecture() (string, error) {

--- a/vendor/github.com/elastic/go-sysinfo/providers/windows/boottime_windows.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/windows/boottime_windows.go
@@ -20,7 +20,7 @@ package windows
 import (
 	"time"
 
-	"github.com/elastic/go-windows"
+	windows "github.com/elastic/go-windows"
 	"github.com/pkg/errors"
 )
 

--- a/vendor/github.com/elastic/go-sysinfo/providers/windows/host_windows.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/windows/host_windows.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/elastic/go-windows"
+	windows "github.com/elastic/go-windows"
 	"github.com/joeshaw/multierror"
 	"github.com/pkg/errors"
 

--- a/vendor/github.com/elastic/go-sysinfo/providers/windows/kernel_windows.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/windows/kernel_windows.go
@@ -18,7 +18,7 @@
 package windows
 
 import (
-	"github.com/elastic/go-windows"
+	windows "github.com/elastic/go-windows"
 )
 
 const windowsKernelExe = `C:\Windows\System32\ntoskrnl.exe`

--- a/vendor/github.com/elastic/go-sysinfo/providers/windows/os_windows.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/windows/os_windows.go
@@ -37,6 +37,7 @@ func OperatingSystem() (*types.OSInfo, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, `failed to open HKLM\%v`, path)
 	}
+	defer k.Close()
 
 	osInfo := &types.OSInfo{
 		Family:   "windows",

--- a/vendor/github.com/elastic/go-sysinfo/providers/windows/process_windows.go
+++ b/vendor/github.com/elastic/go-sysinfo/providers/windows/process_windows.go
@@ -26,8 +26,9 @@ import (
 	"unsafe"
 
 	"github.com/pkg/errors"
+	syswin "golang.org/x/sys/windows"
 
-	"github.com/elastic/go-windows"
+	windows "github.com/elastic/go-windows"
 
 	"github.com/elastic/go-sysinfo/types"
 )
@@ -45,6 +46,12 @@ func (s windowsSystem) Processes() (procs []types.Process, err error) {
 	procs = make([]types.Process, 0, len(pids))
 	var proc types.Process
 	for _, pid := range pids {
+		if pid == 0 || pid == 4 {
+			// The Idle and System processes (PIDs 0 and 4) can never be
+			// opened by user-level code (see documentation for OpenProcess).
+			continue
+		}
+
 		if proc, err = s.Process(int(pid)); err == nil {
 			procs = append(procs, proc)
 		}
@@ -66,6 +73,10 @@ func (s windowsSystem) Self() (types.Process, error) {
 type process struct {
 	pid  int
 	info types.ProcessInfo
+}
+
+func (p *process) PID() int {
+	return p.pid
 }
 
 func newProcess(pid int) (*process, error) {
@@ -239,6 +250,45 @@ func (p *process) open() (handle syscall.Handle, err error) {
 
 func (p *process) Info() (types.ProcessInfo, error) {
 	return p.info, nil
+}
+
+func (p *process) User() (types.UserInfo, error) {
+	handle, err := p.open()
+	if err != nil {
+		return types.UserInfo{}, errors.Wrap(err, "OpenProcess failed")
+	}
+	defer syscall.CloseHandle(handle)
+
+	var accessToken syswin.Token
+	err = syswin.OpenProcessToken(syswin.Handle(handle), syscall.TOKEN_QUERY, &accessToken)
+	if err != nil {
+		return types.UserInfo{}, errors.Wrap(err, "OpenProcessToken failed")
+	}
+	defer accessToken.Close()
+
+	tokenUser, err := accessToken.GetTokenUser()
+	if err != nil {
+		return types.UserInfo{}, errors.Wrap(err, "GetTokenUser failed")
+	}
+
+	sid, err := tokenUser.User.Sid.String()
+	if err != nil {
+		return types.UserInfo{}, errors.Wrap(err, "failed to look up user SID")
+	}
+
+	tokenGroup, err := accessToken.GetTokenPrimaryGroup()
+	if err != nil {
+		return types.UserInfo{}, errors.Wrap(err, "GetTokenPrimaryGroup failed")
+	}
+	gsid, err := tokenGroup.PrimaryGroup.String()
+	if err != nil {
+		return types.UserInfo{}, errors.Wrap(err, "failed to look up primary group SID")
+	}
+
+	return types.UserInfo{
+		UID: sid,
+		GID: gsid,
+	}, nil
 }
 
 func (p *process) Memory() (types.MemoryInfo, error) {

--- a/vendor/github.com/elastic/go-sysinfo/types/process.go
+++ b/vendor/github.com/elastic/go-sysinfo/types/process.go
@@ -23,6 +23,8 @@ type Process interface {
 	CPUTimer
 	Info() (ProcessInfo, error)
 	Memory() (MemoryInfo, error)
+	User() (UserInfo, error)
+	PID() int
 }
 
 type ProcessInfo struct {
@@ -33,6 +35,38 @@ type ProcessInfo struct {
 	Exe       string    `json:"exe"`
 	Args      []string  `json:"args"`
 	StartTime time.Time `json:"start_time"`
+}
+
+// UserInfo contains information about the UID and GID
+// values of a process.
+type UserInfo struct {
+	// UID is the user ID.
+	// On Linux and Darwin (macOS) this is the real user ID.
+	// On Windows, this is the security identifier (SID) of the
+	// user account of the process access token.
+	UID string `json:"uid"`
+
+	// On Linux and Darwin (macOS) this is the effective user ID.
+	// On Windows, this is empty.
+	EUID string `json:"euid"`
+
+	// On Linux and Darwin (macOS) this is the saved user ID.
+	// On Windows, this is empty.
+	SUID string `json:"suid"`
+
+	// GID is the primary group ID.
+	// On Linux and Darwin (macOS) this is the real group ID.
+	// On Windows, this is the security identifier (SID) of the
+	// primary group of the process access token.
+	GID string `json:"gid"`
+
+	// On Linux and Darwin (macOS) this is the effective group ID.
+	// On Windows, this is empty.
+	EGID string `json:"egid"`
+
+	// On Linux and Darwin (macOS) this is the saved group ID.
+	// On Windows, this is empty.
+	SGID string `json:"sgid"`
 }
 
 type Environment interface {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -6,1051 +6,1059 @@
 			"checksumSHA1": "AzjRkOQtVBTwIw4RJLTygFhJs3s=",
 			"origin": "github.com/elastic/beats/vendor/github.com/Microsoft/go-winio",
 			"path": "github.com/Microsoft/go-winio",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "xtc8w70mCuQvuQBNGR4L2uFFacg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/Shopify/sarama",
 			"path": "github.com/Shopify/sarama",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "DYv6Q1+VfnUVxMwvk5IshAClLvw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/Sirupsen/logrus",
 			"path": "github.com/Sirupsen/logrus",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "Te1xRugxHQMAg7EvbIUuPWm8fvU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/StackExchange/wmi",
 			"path": "github.com/StackExchange/wmi",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "dvabztWVQX8f6oMLRyv4dLH+TGY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/davecgh/go-spew/spew",
 			"path": "github.com/davecgh/go-spew/spew",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "Gj+xR1VgFKKmFXYOJMnAczC3Znk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/distribution/digestset",
 			"path": "github.com/docker/distribution/digestset",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "2Fe4D6PGaVE2he4fUeenLmhC1lE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/distribution/reference",
 			"path": "github.com/docker/distribution/reference",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "UL2NF1EGiSsQoEfvycnuZIcUbZY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api",
 			"path": "github.com/docker/docker/api",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "KMFpbV3mlrbc41d2DYnq05QYpSc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types",
 			"path": "github.com/docker/docker/api/types",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "jVJDbe0IcyjoKc2xbohwzQr+FF0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/blkiodev",
 			"path": "github.com/docker/docker/api/types/blkiodev",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "AeSC0BOu1uapkGqfSXtfVSpwJzs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/container",
 			"path": "github.com/docker/docker/api/types/container",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "4XuWn5+wgYwUsw604jvYMklq4Hc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/events",
 			"path": "github.com/docker/docker/api/types/events",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "J2OKngfI3vgswudr9PZVUFcRRu0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/filters",
 			"path": "github.com/docker/docker/api/types/filters",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "yeB781yxPhnN6OXQ9/qSsyih3ek=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/image",
 			"path": "github.com/docker/docker/api/types/image",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "UK+VdM648oWzyqE4OqttgmPqjoA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/mount",
 			"path": "github.com/docker/docker/api/types/mount",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "Gskp+nvbVe8Gk1xPLHylZvNmqTg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/network",
 			"path": "github.com/docker/docker/api/types/network",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "r2vWq7Uc3ExKzMqYgH0b4AKjLKY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/registry",
 			"path": "github.com/docker/docker/api/types/registry",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "VTxWyFud/RedrpllGdQonVtGM/A=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/strslice",
 			"path": "github.com/docker/docker/api/types/strslice",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "ZaizCpJ3eBcfR9ywpLaJd4AhM9k=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/swarm",
 			"path": "github.com/docker/docker/api/types/swarm",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "B7ZwKzrv3t3Vlox6/bYMHhMjsM8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/time",
 			"path": "github.com/docker/docker/api/types/time",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "uDPQ3nHsrvGQc9tg/J9OSC4N5dQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/versions",
 			"path": "github.com/docker/docker/api/types/versions",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "IBJy2zPEnYmcFJ3lM1eiRWnCxTA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/volume",
 			"path": "github.com/docker/docker/api/types/volume",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "c6OyeEvpQDvVLhrJSxgjEZv1tF8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/client",
 			"path": "github.com/docker/docker/client",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "jmo/t2zXAxirEPoFucNPXA/1SEc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/ioutils",
 			"path": "github.com/docker/docker/pkg/ioutils",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "ndnAFCfsGC3upNQ6jAEwzxcurww=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/longpath",
 			"path": "github.com/docker/docker/pkg/longpath",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "kr46EAa+FsUcWxOq6edyX6BUzE4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/system",
 			"path": "github.com/docker/docker/pkg/system",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "8I0Ez+aUYGpsDEVZ8wN/Ztf6Zqs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/tlsconfig",
 			"path": "github.com/docker/docker/pkg/tlsconfig",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "JbiWTzH699Sqz25XmDlsARpMN9w=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-connections/nat",
 			"path": "github.com/docker/go-connections/nat",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "jUfDG3VQsA2UZHvvIXncgiddpYA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-connections/sockets",
 			"path": "github.com/docker/go-connections/sockets",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "tuSzlS1UQ03+5Fvtqr5hI5sLLhA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-connections/tlsconfig",
 			"path": "github.com/docker/go-connections/tlsconfig",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "ambe8F4AofPxChCJssXXwWphQQ8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-units",
 			"path": "github.com/docker/go-units",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "sNAU9ojYVUhO6dVXey6T3JhRQpw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/libtrust",
 			"path": "github.com/docker/libtrust",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "rhLUtXvcmouYuBwOq9X/nYKzvNg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/dustin/go-humanize",
 			"path": "github.com/dustin/go-humanize",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "y2Kh4iPlgCPXSGTCcFpzePYdzzg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/eapache/go-resiliency/breaker",
 			"path": "github.com/eapache/go-resiliency/breaker",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "WHl96RVZlOOdF4Lb1OOadMpw8ls=",
 			"origin": "github.com/elastic/beats/vendor/github.com/eapache/go-xerial-snappy",
 			"path": "github.com/eapache/go-xerial-snappy",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "oCCs6kDanizatplM5e/hX76busE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/eapache/queue",
 			"path": "github.com/eapache/queue",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "nTAfsyN9qjfbx7z2KkucLgNjQ/M=",
 			"path": "github.com/elastic/beats/dev-tools/mage",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "PBTxyr6OotF2pda9n8gMeGUkfLA=",
 			"path": "github.com/elastic/beats/filebeat/generator",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "cDyXG8WG+dr1ai7qCnhbJ6N3OyY=",
 			"path": "github.com/elastic/beats/filebeat/scripts/generator",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "y34pfVnTprxa4BvLKfiBbqTJaGA=",
 			"path": "github.com/elastic/beats/libbeat/api",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "jdF9pc6DLHh4yqO8BsLKx28JWB8=",
 			"path": "github.com/elastic/beats/libbeat/asset",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "OOgoVXWHRzkMd/wR/4kVHPUcjeo=",
+			"checksumSHA1": "+XIt3467v/mRmLoIs6stBev5kUY=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
+			"version": "master",
+			"versionExact": "master"
+		},
+		{
+			"checksumSHA1": "ZCQyqZn3NFfAJo//PSd1YASvytY=",
+			"path": "github.com/elastic/beats/libbeat/autodiscover/appenders/config",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "pW/XBpb2BIceplyuoqvwTtowH7c=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/builder",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "IifZH9hzzPymGV2XQfQ/tFR4uSE=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/meta",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "qa5L8m7V3k+IDBxSXm28wbZt0m0=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/providers/docker",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "m9yIpAuVVFufXqxoxsRwj1WFWQk=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/providers/jolokia",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "W42L3gTFnIDgUmDWuzNNHBMTp/g=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/providers/kubernetes",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "eaKz8KWZXYHpLvBCIRN3V8J7G18=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/template",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "JfMCAWtwAz/VkzKV6BCKdkJFg+E=",
+			"checksumSHA1": "q6ONX7eAZIh7SOyjolFxTDIoPrg=",
 			"path": "github.com/elastic/beats/libbeat/beat",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "on1AvBp8HIr6d+LHAc2J00kYmNk=",
 			"path": "github.com/elastic/beats/libbeat/cfgfile",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "/IuTlhYU7mcJKhOHniR06bWGnxg=",
 			"path": "github.com/elastic/beats/libbeat/cloudid",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "LO2fl5uHLfZGPpefAzihmBijwxE=",
 			"path": "github.com/elastic/beats/libbeat/cmd",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "UevBsvMHLoB5FLXkdGTZSjzzt4A=",
 			"path": "github.com/elastic/beats/libbeat/cmd/export",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "on/9JdQwCHB9k+vGm0OnNZSUMIg=",
+			"checksumSHA1": "kbjCMcy4WYOtZ7UHdREipgpZrtQ=",
 			"path": "github.com/elastic/beats/libbeat/cmd/instance",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "TGW7SUpyY5XCLRjLW2n62yDKqBk=",
 			"path": "github.com/elastic/beats/libbeat/cmd/test",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "duJNVmnho/2XlSTWXmHTPZts00c=",
 			"path": "github.com/elastic/beats/libbeat/common",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "lFYRu/M9CL6/povZOeBYui9/laI=",
 			"path": "github.com/elastic/beats/libbeat/common/atomic",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Fxbw/7lPbh9dY3HH5k8sc4PU6Yo=",
 			"path": "github.com/elastic/beats/libbeat/common/bus",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "zRpP/UzB/wFQNLceGdVgC4QqviM=",
 			"path": "github.com/elastic/beats/libbeat/common/cfgtype",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "d0pIynyart5HMe7IKw3wtIH2R48=",
 			"path": "github.com/elastic/beats/libbeat/common/cfgwarn",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "/mBln/rCzmDjCB/4p16fSapi3BY=",
 			"path": "github.com/elastic/beats/libbeat/common/cli",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Ps5fuDikiF/KR7BeQqRkIztHxVY=",
 			"path": "github.com/elastic/beats/libbeat/common/docker",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Gxdi0z5FpIG68TQBD+zho4pEBlU=",
 			"path": "github.com/elastic/beats/libbeat/common/dtfmt",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "EVdZcCfcyrMUtePDFMOSBxkS71M=",
 			"path": "github.com/elastic/beats/libbeat/common/file",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "pt4OCbyb9z7fgJEidmOx6mua0h8=",
 			"path": "github.com/elastic/beats/libbeat/common/fmtstr",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "K8hsg9OHpVHm7A43uq+TdX5DRc4=",
 			"path": "github.com/elastic/beats/libbeat/common/jsontransform",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "IUy7SaiQLG2N7awyTi+KIxSa2/Y=",
 			"path": "github.com/elastic/beats/libbeat/common/kafka",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "BH+8hGKzaQ5PRnliGzYC6rljyFQ=",
 			"path": "github.com/elastic/beats/libbeat/common/kubernetes",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "tX/nsD/KEE0KCWECoPyx5CHNPdc=",
 			"path": "github.com/elastic/beats/libbeat/common/match",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "t6Ww0oDbdOkUF9TRIk70q7XYbic=",
 			"path": "github.com/elastic/beats/libbeat/common/reload",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "uMo9yaQAFfFG9iOsmdhQokffvpc=",
 			"path": "github.com/elastic/beats/libbeat/common/safemapstr",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "719FzIxi7bvpmh3Z1Ugn1VzY7Ro=",
 			"path": "github.com/elastic/beats/libbeat/common/schema",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "uffmniMUvoDPoH/udr7ogkh062E=",
 			"path": "github.com/elastic/beats/libbeat/common/schema/mapstriface",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "7AAflfE+cNTNalC2Iwq2vOhgMGI=",
 			"path": "github.com/elastic/beats/libbeat/common/seccomp",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "idXNC65t9dEVukD08AM6/L2p/RE=",
 			"path": "github.com/elastic/beats/libbeat/common/streambuf",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "IQGJeUodp0fl4Zy8W1rBzWtWSWA=",
 			"path": "github.com/elastic/beats/libbeat/common/terminal",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "ODPRKH/GaduyvOJE5v/Kkfz61nQ=",
 			"path": "github.com/elastic/beats/libbeat/common/transport/tlscommon",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "E50QfAprh0Wnfcwcj270Fd0LDwk=",
 			"path": "github.com/elastic/beats/libbeat/conditions",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "f9GUDX5swkqSdMAQPfOZBesIsgs=",
+			"checksumSHA1": "S56LqEyT+NNyDhTXi639Q+xWANM=",
 			"path": "github.com/elastic/beats/libbeat/dashboards",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Tn+4O4FlSxSOxGF9qkH363wQCtA=",
 			"path": "github.com/elastic/beats/libbeat/feature",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "truChp2Hs3eCi16akfGnd/KxbkQ=",
 			"path": "github.com/elastic/beats/libbeat/generator/fields",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "oCxiX/n/vxFGtjEN7kEHI6zjTzc=",
 			"path": "github.com/elastic/beats/libbeat/keystore",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "B712FjF+WlGGdR2wDhF2JcEUJHA=",
 			"path": "github.com/elastic/beats/libbeat/kibana",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "M9mSRhP65Jnf/yk2qtZU6FM9OUw=",
 			"path": "github.com/elastic/beats/libbeat/logp",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "bM+Zvy63NmXBfPQZYZmWBCo/UIk=",
 			"path": "github.com/elastic/beats/libbeat/logp/configure",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "F/nzOXIrS9ui9wBLhuYa6M0fDEw=",
 			"path": "github.com/elastic/beats/libbeat/management",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "/qNmzEvnTPNTKsZG8NgDzJZ+6f8=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/cpu",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "2cKcYUGYn9pOpQgo7yjAZebBLkk=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/host",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "lXmDdjbZAQJWerhniNifgiD+Fgs=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/memory",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "rKh4Kc2nLHGP/l9XUQuYwLFZ2sk=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/process",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "JaqeGyZo3TRATCeVaKSZ9+K+O5E=",
 			"path": "github.com/elastic/beats/libbeat/monitoring",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "F5IrP0kPaBMWp0NkeET2M10gRMQ=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/adapter",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "8rqXWL9EN+JXokIj4mNhd7GKXNY=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "WLKHJV4+rwv6VBph5dnJ6N0FK6A=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report/elasticsearch",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "FJhQn6mS1pcNkFLFjFPulLZjC9w=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report/log",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "FZaXmupAGOg8vf8rAMrLYAgbLMA=",
 			"path": "github.com/elastic/beats/libbeat/outputs",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "CsWdZfYNuwBA2/RhAybzEf93qq4=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "dO9pXcIpo6PH5yxMbJUSb/BYbkc=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec/format",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "i2d3BQjYIR1zQAQ4CpybU33y9kQ=",
+			"checksumSHA1": "DbeMJiVepl/K4NXgWHHc2KyCpg0=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec/json",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "wPfUoEHJoJmdt4p+GDR3cRRh32Q=",
+			"checksumSHA1": "8zlgJqlqCEbCDiLf9llQHUWxKRY=",
 			"path": "github.com/elastic/beats/libbeat/outputs/console",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "7dZuu6VIEe3z5cuDbt0vAWCwWRk=",
+			"checksumSHA1": "+x9BQFGtVvmbQqceGijLCeAC5Rw=",
 			"path": "github.com/elastic/beats/libbeat/outputs/elasticsearch",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "OMBMu8h0ji4xQwmv7ifk0wIefek=",
 			"path": "github.com/elastic/beats/libbeat/outputs/fileout",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "EaH7PayqnRdJUmktczmJtjWZWds=",
 			"path": "github.com/elastic/beats/libbeat/outputs/kafka",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "IVwYXvCEiyfqN+O/bpbG0OVzxF8=",
+			"checksumSHA1": "VgP3a7VyNnGdV2VMN9CsGxctL50=",
 			"path": "github.com/elastic/beats/libbeat/outputs/logstash",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "NJv+STaa3bEOeVra8WkEgOtzQic=",
 			"path": "github.com/elastic/beats/libbeat/outputs/outil",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "YNn7Zso2lmcE3evgBDbCd1p4k1A=",
+			"checksumSHA1": "2VAmH6FTwTIWXBDc+K2XXKKf95c=",
 			"path": "github.com/elastic/beats/libbeat/outputs/redis",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "ThEQrqa9WEUapIawwzyIvVZjnXQ=",
 			"path": "github.com/elastic/beats/libbeat/outputs/transport",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "qPVudVlj4dE+HHMe4WGlaf4mFCo=",
 			"path": "github.com/elastic/beats/libbeat/outputs/transport/transptest",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "hb8M4qSLzgDXpQmdQfEyB7aChhI=",
 			"path": "github.com/elastic/beats/libbeat/paths",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "OVd5zDYdT/3QK2zj1M+BMPP0AIo=",
 			"path": "github.com/elastic/beats/libbeat/plugin",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "lhUKTNKAJqUl7dgyZN8En9B2Vnw=",
 			"path": "github.com/elastic/beats/libbeat/processors",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "IYLNfiWN8aRJYFfwtZ8Ou/Teo4k=",
 			"path": "github.com/elastic/beats/libbeat/processors/actions",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "sWTU7BhKo5OMt1paCTY90K9EZlw=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_cloud_metadata",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "xYQ27ik08Luyu9no2IYTdtSyQVY=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_docker_metadata",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "5rGfO0MHcaryX4OZ/3PxeQUIj2s=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_host_metadata",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "PGsBuH7EkCUdOTdnZIePSemWT9A=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_kubernetes_metadata",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "GuCfa00ie8z+j57QYlZK3eRow2Y=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_locale",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "DBwVa3qeDITixLDliPsRVDOOWpo=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_process_metadata",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "tDlkiqQL3vTTh8jLS1JBwhZMC7o=",
 			"path": "github.com/elastic/beats/libbeat/processors/dissect",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "6YfWrbwMSQ7clCDTVFK3afNai3o=",
 			"path": "github.com/elastic/beats/libbeat/processors/dns",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "7kYMLJJXmsDd9GyXgq9Z9eJdqrk=",
 			"path": "github.com/elastic/beats/libbeat/publisher",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "3lRU4d8X4NyPiCAml4LjDm3o928=",
 			"path": "github.com/elastic/beats/libbeat/publisher/includes",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "8Dbmx7gsDc2OTDt2iv3TsfaUkWk=",
+			"checksumSHA1": "XStH7SX5cxj8jIBWgRSvyaSu7MY=",
 			"path": "github.com/elastic/beats/libbeat/publisher/pipeline",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "RaONy2th8fDi9BF5U+lYu5bto4Y=",
 			"path": "github.com/elastic/beats/libbeat/publisher/queue",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "ZUwitg43Gan3j0V+ZjM+5Y/ibb8=",
 			"path": "github.com/elastic/beats/libbeat/publisher/queue/memqueue",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "MsDBerW6GVdoNOH9yVNFIuB4V5c=",
 			"path": "github.com/elastic/beats/libbeat/publisher/queue/spool",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "fZ5S9LEZUcy5JlhwpHBn4MGNjOg=",
 			"path": "github.com/elastic/beats/libbeat/publisher/testing",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "vZZFb4M2d2t7tG3n2UEQeTk/lEM=",
 			"path": "github.com/elastic/beats/libbeat/scripts/cmd/global_fields",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "/645Ga6dGiQjHQIBSct5CYaRoj8=",
 			"path": "github.com/elastic/beats/libbeat/service",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "bmPVgg80Gb2h4tAprPjhMurwCaA=",
 			"path": "github.com/elastic/beats/libbeat/template",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Ifly/yeBS+Ok0/PKez4lSqzu8JI=",
 			"path": "github.com/elastic/beats/libbeat/testing",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "+0zBIGqXGbgm86imWcTq9kQyTgw=",
 			"path": "github.com/elastic/beats/libbeat/version",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "YRKEeQXsNj81zjG9gpkCyVpLKJs=",
 			"path": "github.com/elastic/beats/licenses",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "lfgOq9q3kd8U+SB9ig3GfKfM84s=",
 			"path": "github.com/elastic/beats/x-pack/libbeat/cmd",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "MU/6VMQWlkIxft/tiU25U2+F9y8=",
 			"path": "github.com/elastic/beats/x-pack/libbeat/management",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "5xYktHe1+WhNE4my2NE3zakZqmc=",
 			"path": "github.com/elastic/beats/x-pack/libbeat/management/api",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z",
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z",
 			"version": "master",
 			"versionExact": "master"
 		},
@@ -1058,498 +1066,498 @@
 			"checksumSHA1": "3jizmlZPCyo6FAZY8Trk9jA8NH4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-lumber/client/v2",
 			"path": "github.com/elastic/go-lumber/client/v2",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "m6HLKpDAZlkTTQMqabf3aT6TQ/s=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-lumber/protocol/v2",
 			"path": "github.com/elastic/go-lumber/protocol/v2",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "TatpgVf9fhQp1GtNwSyNw5cgVKM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-seccomp-bpf",
 			"path": "github.com/elastic/go-seccomp-bpf",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "qTs7QT+GC2Dr4aFoLFHCkAOoVeU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-seccomp-bpf/arch",
 			"path": "github.com/elastic/go-seccomp-bpf/arch",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "W459MQNQ8qF6qmzLO/QLevTKZlU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform",
 			"path": "github.com/elastic/go-structform",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "BnoVvQlbw1jk1oveTVQtG+dhGRs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform/cborl",
 			"path": "github.com/elastic/go-structform/cborl",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "xjEIhANt0tAq4FjndVCLQhCXkQo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform/gotype",
 			"path": "github.com/elastic/go-structform/gotype",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "BIRSw/+jqs6VTgRx4MXJy453oGQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform/internal/unsafe",
 			"path": "github.com/elastic/go-structform/internal/unsafe",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "VPkz0hvtlbDDObJJZoTrjF2CN68=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform/json",
 			"path": "github.com/elastic/go-structform/json",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "zRLY43OHR3VYw3fu3XznhxziC4E=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform/ubjson",
 			"path": "github.com/elastic/go-structform/ubjson",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "QC8/6yQsm4f+zZo14ExnFtyiaXk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform/visitors",
 			"path": "github.com/elastic/go-structform/visitors",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "QhFIpuHPaV6hKejKcc2wm6y4MSQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo",
 			"path": "github.com/elastic/go-sysinfo",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "GiZCjX17K265TtamGZZw4R2Jwbk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo/internal/registry",
 			"path": "github.com/elastic/go-sysinfo/internal/registry",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
-			"checksumSHA1": "432ecsMRmLpy5OvXMhQE/k9KWLQ=",
+			"checksumSHA1": "ovafihHzpBx9Y7+lZh9X5KwNCvE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo/providers/darwin",
 			"path": "github.com/elastic/go-sysinfo/providers/darwin",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
-			"checksumSHA1": "1eCL0MsvmiyjNvh0tcnnR4rmcWk=",
+			"checksumSHA1": "AK76ZxnuvK02Dfpmj7b2TD/aiSI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo/providers/linux",
 			"path": "github.com/elastic/go-sysinfo/providers/linux",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "RWLvcP1w9ynKbuCqiW6prwd+EDU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo/providers/shared",
 			"path": "github.com/elastic/go-sysinfo/providers/shared",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
-			"checksumSHA1": "lWVD4w1xiAkFZgQPZAYz+fTZsrU=",
+			"checksumSHA1": "aF05MEkMjbRekzHlwFxmd5WBpeY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo/providers/windows",
 			"path": "github.com/elastic/go-sysinfo/providers/windows",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
-			"checksumSHA1": "tIqFxnZi9XvC70dMoZDSoUtEVQY=",
+			"checksumSHA1": "MLQioPEjULYbNqqCjfB1/cux08E=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo/types",
 			"path": "github.com/elastic/go-sysinfo/types",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "tNszmkpuJYZMX8l8rlnvBDtoc1M=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile",
 			"path": "github.com/elastic/go-txfile",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "re2W5hqGml/Q8vnx+DT3ooUNWxo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/internal/cleanup",
 			"path": "github.com/elastic/go-txfile/internal/cleanup",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "HjNNDapvfXgOJqs7l7pS3ho6SSI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/internal/invariant",
 			"path": "github.com/elastic/go-txfile/internal/invariant",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "HLMF+V6Pt3YLUNOgmd2nR+vz9vM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/internal/iter",
 			"path": "github.com/elastic/go-txfile/internal/iter",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "EAIqvdq5S3FNBoTBAI/U02AwTSU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/internal/strbld",
 			"path": "github.com/elastic/go-txfile/internal/strbld",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "lejstOrGPfa+tJohvIOK/AjdLa4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/internal/vfs",
 			"path": "github.com/elastic/go-txfile/internal/vfs",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "Wqp2VCpbcmfOFuZJrYkaxpvQQrE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/internal/vfs/osfs",
 			"path": "github.com/elastic/go-txfile/internal/vfs/osfs",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "NO6sRhSBLtJxWPpTvwWEqSQh65I=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/pq",
 			"path": "github.com/elastic/go-txfile/pq",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "fCx++6A9uzyCsDUanAIJb77u0MI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/txerr",
 			"path": "github.com/elastic/go-txfile/txerr",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "Yb61Nqnh+3igFci61hv9WYgk/hc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg",
 			"path": "github.com/elastic/go-ucfg",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "X+R/CD8SokJrmlxFTx2nSevRDhQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/cfgutil",
 			"path": "github.com/elastic/go-ucfg/cfgutil",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "zC8mCPW/pPPNcuHQOc/B/Ej1W1U=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/flag",
 			"path": "github.com/elastic/go-ucfg/flag",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "esXpiQlEvTOUwsE0nNesso8albo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/internal/parse",
 			"path": "github.com/elastic/go-ucfg/internal/parse",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "5mXUhhlPdvcAFKiQENInTJWrtQM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/json",
 			"path": "github.com/elastic/go-ucfg/json",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "Bg6vistPQLftv2fEYB7GWwSExv8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/yaml",
 			"path": "github.com/elastic/go-ucfg/yaml",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "rnd3qf1FE22X3MxXWbetqq6EoBk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-windows",
 			"path": "github.com/elastic/go-windows",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "RPOLNUpw00QUUaA/U4YbPVf6WlA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar",
 			"path": "github.com/elastic/gosigar",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "TX9y4oPL5YmT4Gb/OU4GIPTdQB4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/cgroup",
 			"path": "github.com/elastic/gosigar/cgroup",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "hPqGM3DENaGfipEODoyZ4mKogTQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/sys",
 			"path": "github.com/elastic/gosigar/sys",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "mLq5lOyD0ZU39ysXuf1ETOLJ+f0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/sys/linux",
 			"path": "github.com/elastic/gosigar/sys/linux",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "qDsgp2kAeI9nhj565HUScaUyjU4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/sys/windows",
 			"path": "github.com/elastic/gosigar/sys/windows",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "Klc34HULvwvY4cGA/D8HmqtXLqw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s",
 			"path": "github.com/ericchiang/k8s",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "y8fNiBLSoGojnUsGDsdLlsJYyqQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/apiextensions/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/apiextensions/v1beta1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "JxQ/zEWQSrncYNKifCuMctq+Tsw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/apps/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/apps/v1beta1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "bjklGt/pc6kWOZewAw87Hchw5oY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authentication/v1",
 			"path": "github.com/ericchiang/k8s/apis/authentication/v1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "LExhnM9Vn0LQoLQWszQ7aIxDxb4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authentication/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/authentication/v1beta1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "GM+PzOiBoq3cxx4h5RKVUb3UH60=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authorization/v1",
 			"path": "github.com/ericchiang/k8s/apis/authorization/v1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "zfr5oUVjbWRfvXi2LJiGMfFeDQY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authorization/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/authorization/v1beta1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "izkXNDp5a5WP45jU0hSfTrwyfvM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/autoscaling/v1",
 			"path": "github.com/ericchiang/k8s/apis/autoscaling/v1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "FryZuAxWn4Ig8zc913w9BdfYzvs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/batch/v1",
 			"path": "github.com/ericchiang/k8s/apis/batch/v1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "ylo7Z8wyJD+tmICB7wsOVIBpO+U=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/batch/v2alpha1",
 			"path": "github.com/ericchiang/k8s/apis/batch/v2alpha1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "+d8+mSdkdcPWQIpczXDZZW0lrjg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/certificates/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/certificates/v1beta1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "S7AvxmCe/+WoFP/v9lZr0Mv66qg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/core/v1",
 			"path": "github.com/ericchiang/k8s/apis/core/v1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "cWPoP6XZN7WMnEVMPcgPgg3Aw9Q=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/extensions/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/extensions/v1beta1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "vaNrBPcGWeDd1rXl8+uN08uxWhE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/imagepolicy/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/imagepolicy/v1alpha1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "UNTTH+Ppu4vImnF+bPkG3/NR3gg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/meta/v1",
 			"path": "github.com/ericchiang/k8s/apis/meta/v1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "Mmyg9Wh+FCVR6fV8MGEKRxvqZ2k=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/policy/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/policy/v1beta1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "bvwYS/wrBkyAfvCjzMbi/vKamrQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/rbac/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/rbac/v1alpha1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "m1Tde18NwewnvJoOYL3uykNcBuM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/rbac/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/rbac/v1beta1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "JirJkoeIkWJRNrbprsQvqwisxds=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/resource",
 			"path": "github.com/ericchiang/k8s/apis/resource",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "rQZ69PjEClQQ+PGEHRKzkGVVQyw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/settings/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/settings/v1alpha1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "pp0AetmPoKy7Rz0zNhBwUpExkbc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/storage/v1",
 			"path": "github.com/ericchiang/k8s/apis/storage/v1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "WeACcIrS4EkeBm8TTftwuVniaWk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/storage/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/storage/v1beta1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "Su6wSR8V8HL2QZsF8icJ0R9AFq8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/runtime",
 			"path": "github.com/ericchiang/k8s/runtime",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "8ETrRvIaXPfD21N7fa8kdbumL00=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/runtime/schema",
 			"path": "github.com/ericchiang/k8s/runtime/schema",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "cMk3HE8/81ExHuEs0F5sZCclOFs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/util/intstr",
 			"path": "github.com/ericchiang/k8s/util/intstr",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "fobEKiMk5D7IGvCSwh4HdG1o98c=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/watch/versioned",
 			"path": "github.com/ericchiang/k8s/watch/versioned",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "AANTVr9CVVyzsgviODY6Wi2thuM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/fatih/color",
 			"path": "github.com/fatih/color",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "2UmMbNHc8FBr98mJFN1k8ISOIHk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/garyburd/redigo/internal",
 			"path": "github.com/garyburd/redigo/internal",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "507OiSqTxfGCje7xDT5eq9CCaNQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/garyburd/redigo/redis",
 			"path": "github.com/garyburd/redigo/redis",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "ImX1uv6O09ggFeBPUJJ2nu7MPSA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ghodss/yaml",
 			"path": "github.com/ghodss/yaml",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "2VgF+qja44x3wPTp8U8TZEU6FWw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/go-ole/go-ole",
 			"path": "github.com/go-ole/go-ole",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "Q0ZOcJW0fqOefDzEdn+PJHOeSgI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/go-ole/go-ole/oleutil",
 			"path": "github.com/go-ole/go-ole/oleutil",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "OFaReqy4hyrLlTTYFmcqkvidHsQ=",
@@ -1575,15 +1583,15 @@
 			"checksumSHA1": "kBeNcaKk56FguvPSUCEaH6AxpRc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/golang/protobuf/proto",
 			"path": "github.com/golang/protobuf/proto",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "p/8vSviYF91gFflhrt5vkyksroo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/golang/snappy",
 			"path": "github.com/golang/snappy",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "d9PxF1XQGLMJZRct2R8qVM/eYlE=",
@@ -1601,29 +1609,29 @@
 			"checksumSHA1": "40vJyUB4ezQSn/NSadsKEOrudMc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/inconshreveable/mousetrap",
 			"path": "github.com/inconshreveable/mousetrap",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "l9wW52CYGbmO/NGwYZ/Op2QTmaA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/joeshaw/multierror",
 			"path": "github.com/joeshaw/multierror",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "IH4jnWcj4d4h+hgsHsHOWg/F+rk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/jstemmer/go-junit-report/formatter",
 			"path": "github.com/jstemmer/go-junit-report/formatter",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "Tx9cQqKFUHzu1l6H2XEl8G7ivlI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/jstemmer/go-junit-report/parser",
 			"path": "github.com/jstemmer/go-junit-report/parser",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "pa+ZwMzIv+u+BlL8Q2xgL9cQtJg=",
@@ -1635,36 +1643,36 @@
 			"checksumSHA1": "KKxbAKrKrfd33YPpkNsDmTN3S+M=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/compress/flate",
 			"path": "github.com/klauspost/compress/flate",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "+azPXaZpPF14YHRghNAer13ThQU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/compress/zlib",
 			"path": "github.com/klauspost/compress/zlib",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "R6zKqn31GjJH1G8W/api7fAW0RU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/cpuid",
 			"path": "github.com/klauspost/cpuid",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "BM6ZlNJmtKy3GBoWwg2X55gnZ4A=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/crc32",
 			"path": "github.com/klauspost/crc32",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "ASXhLVfIA2mzHf+7muYxT38JaHU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage",
 			"path": "github.com/magefile/mage",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "KODorM0Am1g55qObNz3jVOdRVFs=",
@@ -1677,29 +1685,29 @@
 			"checksumSHA1": "fHpo/9Tke6VFfZZAT+PRnoNOiiY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage/internal",
 			"path": "github.com/magefile/mage/internal",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "RVSwuhHOfojhN74rfwRe4AktDIA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage/mage",
 			"path": "github.com/magefile/mage/mage",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "irRTBkCBnOGMX+PZhOdHFUckgBY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage/mg",
 			"path": "github.com/magefile/mage/mg",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "QGt/JRmNp+D+lO0hHZsUUyH7y5U=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage/parse",
 			"path": "github.com/magefile/mage/parse",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "fEuDveZzYX6oqYOT9jqyZROun/Q=",
@@ -1712,15 +1720,15 @@
 			"checksumSHA1": "4JzH55TcYdctQksrCafgKT8lZRU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage/sh",
 			"path": "github.com/magefile/mage/sh",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "91U4Tlwnjdmwjd0w/XNw3+fxFKo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage/target",
 			"path": "github.com/magefile/mage/target",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "He+VtZO7BsPDCZhZtJ1IkNp629o=",
@@ -1733,50 +1741,50 @@
 			"checksumSHA1": "qNkx9+OTwZI6aFv7K9zuFCGODUw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/mattn/go-colorable",
 			"path": "github.com/mattn/go-colorable",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "U6lX43KDDlNOn+Z0Yyww+ZzHfFo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/mattn/go-isatty",
 			"path": "github.com/mattn/go-isatty",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "VsImZoqjaqgwK+u/4eIEzQhuRNM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/miekg/dns",
 			"path": "github.com/miekg/dns",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "sWdAYPKyaT4SW8hNQNpRS0sU4lU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/mitchellh/hashstructure",
 			"path": "github.com/mitchellh/hashstructure",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "2AyUkWjutec6p+470tgio8mYOxI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/go-digest",
 			"path": "github.com/opencontainers/go-digest",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "eOMCORUm8KxiGSy0hBuQsMsxauo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/image-spec/specs-go",
 			"path": "github.com/opencontainers/image-spec/specs-go",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "9YujSsJjiLGkQMzwWycsjqR340k=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/image-spec/specs-go/v1",
 			"path": "github.com/opencontainers/image-spec/specs-go/v1",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "JVGDxPn66bpe6xEiexs1r+y6jF0=",
@@ -1788,15 +1796,15 @@
 			"checksumSHA1": "WmrPO1ovmQ7t7hs9yZGbr2SAoM4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pierrec/lz4",
 			"path": "github.com/pierrec/lz4",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "IT4sX58d+e8osXHV5U6YCSdB/uE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pierrec/xxHash/xxHash32",
 			"path": "github.com/pierrec/xxHash/xxHash32",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "e6T/9bM7ah7mQJVVIaTuCw/63Uo=",
@@ -1808,50 +1816,50 @@
 			"checksumSHA1": "PdQm3s8DoVJ17Vk8n7o5iPa7PK0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pkg/errors",
 			"path": "github.com/pkg/errors",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pmezard/go-difflib/difflib",
 			"path": "github.com/pmezard/go-difflib/difflib",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "Etvt6mgzvD7ARf4Ux03LHfgSlzU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/prometheus/procfs",
 			"path": "github.com/prometheus/procfs",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "lv9rIcjbVEGo8AT1UCUZXhXrfQc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/prometheus/procfs/internal/util",
 			"path": "github.com/prometheus/procfs/internal/util",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "EekY1iRG9JY74mDD0jsbFCWbAFs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/prometheus/procfs/nfs",
 			"path": "github.com/prometheus/procfs/nfs",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "yItvTQLUVqm/ArLEbvEhqG0T5a0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/prometheus/procfs/xfs",
 			"path": "github.com/prometheus/procfs/xfs",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "KAzbLjI9MzW2tjfcAsK75lVRp6I=",
 			"origin": "github.com/elastic/beats/vendor/github.com/rcrowley/go-metrics",
 			"path": "github.com/rcrowley/go-metrics",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "epQZICCcThx99PQo7m/HuWN5kpQ=",
@@ -1926,43 +1934,43 @@
 			"checksumSHA1": "e7mAb9jMke2ASQGZepFgOmfBFzM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/spf13/cobra",
 			"path": "github.com/spf13/cobra",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "STxYqRb4gnlSr3mRpT+Igfdz/kM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/spf13/pflag",
 			"path": "github.com/spf13/pflag",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "c6pbpF7eowwO59phRTpF8cQ80Z0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/stretchr/testify/assert",
 			"path": "github.com/stretchr/testify/assert",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "wnEANt4k5X/KGwoFyfSSnpxULm4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/stretchr/testify/require",
 			"path": "github.com/stretchr/testify/require",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "CpcG17Q/0k1g2uy8AL26Uu7TouU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/theckman/go-flock",
 			"path": "github.com/theckman/go-flock",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "H7tCgNt2ajKK4FBJIDNlevu9MAc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/urso/go-bin",
 			"path": "github.com/urso/go-bin",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "8Kj0VH496b0exuyv4wAF4CXa7Y4=",
@@ -2122,169 +2130,169 @@
 			"checksumSHA1": "HedK9m8E8iyib4bIBtIX7xprOgo=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/atomic",
 			"path": "go.uber.org/atomic",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "JDGx7hehaQunZySwPs7yvdUs2m8=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/multierr",
 			"path": "go.uber.org/multierr",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "5BYbiKEkYykvfjSaNYDuQpBqglo=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap",
 			"path": "go.uber.org/zap",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "HYo/9nwrY08NQA+2ItPOAH8IFW8=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/buffer",
 			"path": "go.uber.org/zap/buffer",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "MuxOAtZEsJitlWBzhmpm2vGiHok=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/internal/bufferpool",
 			"path": "go.uber.org/zap/internal/bufferpool",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "uC0L9eCSAYcCWNC8udJk/t1vvIU=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/internal/color",
 			"path": "go.uber.org/zap/internal/color",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "b80CJExrVpXu3SA1iCQ6uLqTn2c=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/internal/exit",
 			"path": "go.uber.org/zap/internal/exit",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "mRD6lujPvXPkbC3+byNwO/bNVu8=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/zapcore",
 			"path": "go.uber.org/zap/zapcore",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "gyBmIfDZslmQGKnqisJ/p7oHbQc=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/zaptest/observer",
 			"path": "go.uber.org/zap/zaptest/observer",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "2LpxYGSf068307b7bhAuVjvzLLc=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/crypto/ed25519",
 			"path": "golang.org/x/crypto/ed25519",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "0JTAFXPkankmWcZGQJGScLDiaN8=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/crypto/ed25519/internal/edwards25519",
 			"path": "golang.org/x/crypto/ed25519/internal/edwards25519",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "1MGpGDQqnUoRpv7VEcQrXOBydXE=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/crypto/pbkdf2",
 			"path": "golang.org/x/crypto/pbkdf2",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "6U7dCaxxIMjf5V02iWgyAwppczw=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/crypto/ssh/terminal",
 			"path": "golang.org/x/crypto/ssh/terminal",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "uX2McdP4VcQ6zkAF0Q4oyd0rFtU=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/bpf",
 			"path": "golang.org/x/net/bpf",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "dr5+PfIRzXeN+l1VG+s0lea9qz8=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/context",
 			"path": "golang.org/x/net/context",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "WHc3uByvGaMcnSoI21fhzYgbOgg=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/context/ctxhttp",
 			"path": "golang.org/x/net/context/ctxhttp",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "TWcqN2+KUWtdqnu18rruwn14UEQ=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/http2",
 			"path": "golang.org/x/net/http2",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "ezWhc7n/FtqkLDQKeU2JbW+80tE=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/http2/hpack",
 			"path": "golang.org/x/net/http2/hpack",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "RcrB7tgYS/GMW4QrwVdMOTNqIU8=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/idna",
 			"path": "golang.org/x/net/idna",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "5JWn/wMC+EWNDKI/AYE4JifQF54=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/internal/iana",
 			"path": "golang.org/x/net/internal/iana",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "YsXlbexuTtUXHyhSv927ILOkf6A=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/internal/socket",
 			"path": "golang.org/x/net/internal/socket",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "zPTKyZ1C55w1fk1W+/qGE15jaek=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/ipv4",
 			"path": "golang.org/x/net/ipv4",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "3L3n7qKMO9X8E1ibA5mExKvwbmI=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/ipv6",
 			"path": "golang.org/x/net/ipv6",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "3xyuaSNmClqG4YWC7g0isQIbUTc=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/lex/httplex",
 			"path": "golang.org/x/net/lex/httplex",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "whCSspa9pYarl527EuhPz91cbUE=",
@@ -2296,8 +2304,8 @@
 			"checksumSHA1": "QEm/dePZ0lOnyOs+m22KjXfJ/IU=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/proxy",
 			"path": "golang.org/x/net/proxy",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "S0DP7Pn7sZUmXc55IzZnNvERu6s=",
@@ -2309,78 +2317,78 @@
 			"checksumSHA1": "nc3RG2Qgzn2aup/3/4RusWr+X0g=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/unix",
 			"path": "golang.org/x/sys/unix",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "Hi7BmkvZh4plNNLGDHfPnCKy3i8=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows",
 			"path": "golang.org/x/sys/windows",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "P9OIhD26uWlIST/me4TYnvseCoY=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/registry",
 			"path": "golang.org/x/sys/windows/registry",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "Fes9OIPy6lS/ghzodqAbMlZZTTQ=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/svc",
 			"path": "golang.org/x/sys/windows/svc",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "e9KJPWrdqg5PMkbE2w60Io8rY4M=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/svc/debug",
 			"path": "golang.org/x/sys/windows/svc/debug",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "uVlUSSKplihZG7N+QJ6fzDZ4Kh8=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/svc/eventlog",
 			"path": "golang.org/x/sys/windows/svc/eventlog",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "CbpjEkkOeh0fdM/V8xKDdI0AA88=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/text/secure/bidirule",
 			"path": "golang.org/x/text/secure/bidirule",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "ziMb9+ANGRJSSIuxYdRbA+cDRBQ=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/text/transform",
 			"path": "golang.org/x/text/transform",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "w8kDfZ1Ug+qAcVU0v8obbu3aDOY=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/text/unicode/bidi",
 			"path": "golang.org/x/text/unicode/bidi",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "BCNYmf4Ek93G4lk5x3ucNi/lTwA=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/text/unicode/norm",
 			"path": "golang.org/x/text/unicode/norm",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "vGfePfr0+weQUeTM/71mu+LCFuE=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/time/rate",
 			"path": "golang.org/x/time/rate",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "5QK10eoScnyEh8dD3PfZf8gMXn8=",
@@ -2424,15 +2432,15 @@
 			"checksumSHA1": "fALlQNY1fM99NesfLJ50KguWsio=",
 			"origin": "github.com/elastic/beats/vendor/gopkg.in/yaml.v2",
 			"path": "gopkg.in/yaml.v2",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		},
 		{
 			"checksumSHA1": "ZDOewomjpADMDyjKRW5rP15519M=",
 			"origin": "github.com/elastic/beats/vendor/howett.net/plist",
 			"path": "howett.net/plist",
-			"revision": "3a517205a5370d88c3e1dea7305a00de51790d93",
-			"revisionTime": "2019-01-07T10:56:54Z"
+			"revision": "2e2c62bd0853add6000bbf919a96f35f45a858d2",
+			"revisionTime": "2019-01-09T17:34:48Z"
 		}
 	],
 	"rootPath": "github.com/elastic/apm-server"


### PR DESCRIPTION
Enables `SkipAgentMetadata` to suppress the top-level agent fields, but does not move context.system.agent there yet.

for #1683