### PR TITLE
Remove metrics setting

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -124,11 +124,6 @@ apm-server:
     # Remote apm-servers' secret_token
     #secret_token:
 
-  # Metrics endpoint
-  #metrics:
-    # Set to false to disable the metrics endpoint
-    #enabled: true
-
   # A pipeline is a definition of processors applied to documents when writing them to Elasticsearch.
   # Using pipelines involves two steps:
   # (1) registering a pipeline

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -124,11 +124,6 @@ apm-server:
     # Remote apm-servers' secret_token
     #secret_token:
 
-  # Metrics endpoint
-  #metrics:
-    # Set to false to disable the metrics endpoint
-    #enabled: true
-
   # A pipeline is a definition of processors applied to documents when writing them to Elasticsearch.
   # Using pipelines involves two steps:
   # (1) registering a pipeline

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -124,11 +124,6 @@ apm-server:
     # Remote apm-servers' secret_token
     #secret_token:
 
-  # Metrics endpoint
-  #metrics:
-    # Set to false to disable the metrics endpoint
-    #enabled: true
-
   # A pipeline is a definition of processors applied to documents when writing them to Elasticsearch.
   # Using pipelines involves two steps:
   # (1) registering a pipeline

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -91,9 +91,6 @@ func TestBeatConfig(t *testing.T) {
 					"library_pattern":       "^custom",
 					"exclude_from_grouping": "^grouping",
 				},
-				"metrics": map[string]interface{}{
-					"enabled": false,
-				},
 				"register": map[string]interface{}{
 					"ingest": map[string]interface{}{
 						"pipeline": map[string]interface{}{
@@ -132,9 +129,6 @@ func TestBeatConfig(t *testing.T) {
 					LibraryPattern:      "^custom",
 					ExcludeFromGrouping: "^grouping",
 					beatVersion:         "6.2.0",
-				},
-				Metrics: &metricsConfig{
-					Enabled: &falsy,
 				},
 				Register: &registerConfig{
 					Ingest: &ingestConfig{
@@ -206,9 +200,6 @@ func TestBeatConfig(t *testing.T) {
 					LibraryPattern:      "rum",
 					ExcludeFromGrouping: "^/webpack",
 					beatVersion:         "6.2.0",
-				},
-				Metrics: &metricsConfig{
-					Enabled: &truthy,
 				},
 				Register: &registerConfig{
 					Ingest: &ingestConfig{

--- a/beater/config.go
+++ b/beater/config.go
@@ -44,7 +44,6 @@ type Config struct {
 	SSL                 *SSLConfig             `config:"ssl"`
 	MaxConnections      int                    `config:"max_connections"`
 	Expvar              *ExpvarConfig          `config:"expvar"`
-	Metrics             *metricsConfig         `config:"metrics"`
 	AugmentEnabled      bool                   `config:"capture_personal_data"`
 	SelfInstrumentation *InstrumentationConfig `config:"instrumentation"`
 	RumConfig           *rumConfig             `config:"rum"`
@@ -70,10 +69,6 @@ type rumConfig struct {
 type eventRate struct {
 	Limit   int `config:"limit"`
 	LruSize int `config:"lru_size"`
-}
-
-type metricsConfig struct {
-	Enabled *bool `config:"enabled"`
 }
 
 type registerConfig struct {
@@ -149,10 +144,6 @@ func (c *rumConfig) isEnabled() bool {
 	return c != nil && (c.Enabled != nil && *c.Enabled)
 }
 
-func (c *metricsConfig) isEnabled() bool {
-	return c != nil && (c.Enabled == nil || *c.Enabled)
-}
-
 func (s *SourceMapping) isSetup() bool {
 	return s != nil && (s.EsConfig != nil)
 }
@@ -216,7 +207,6 @@ func defaultRum(beatVersion string) *rumConfig {
 }
 
 func defaultConfig(beatVersion string) *Config {
-	metricsEnabled := true
 	pipelineEnabled, pipelineOverwrite := false, true
 	return &Config{
 		Host:            net.JoinHostPort("localhost", DefaultPort),
@@ -231,9 +221,6 @@ func defaultConfig(beatVersion string) *Config {
 		Expvar: &ExpvarConfig{
 			Enabled: new(bool),
 			Url:     "/debug/vars",
-		},
-		Metrics: &metricsConfig{
-			Enabled: &metricsEnabled,
 		},
 		RumConfig: &rumConfig{
 			EventRate: &eventRate{

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -15,6 +15,7 @@
 - Remove support for deprecated Intake v1 endpoints {pull}1731[1731].
 - Remove `concurrent_requests` setting and use number of CPUs instead {pull}1749[1749].
 - Remove `frontend` setting {pull}1751[1751].
+- Remove `metrics.enabled` setting {pull}1759[1759].
 
 [float]
 ==== Bug fixes

--- a/docs/configuration-process.asciidoc
+++ b/docs/configuration-process.asciidoc
@@ -102,12 +102,6 @@ Defaults to `debug/vars`.
 Enables self instrumentation of the APM Server itself.
 Disabled by default.
 
-[[metrics.enabled]]
-[float]
-==== `metrics`
-Metrics endpoint for collecting application metrics.
-Enabled by default.
-
 [[register.ingest.pipeline.enabled]]
 [float]
 ==== `register.ingest.pipeline.enabled`

--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -179,6 +179,11 @@ This configuration option is no longer supported. Please see <<configuration-apm
 
 This configuration option is no longer supported. Please see <<configuration-apm-server>> for current configuration options.
 
+[role="exclude",id="metrics.enabled"]
+=== `metrics.enabled`
+
+This configuration option is no longer supported. Please see <<configuration-apm-server>> for current configuration options.
+
 [role="exclude",id="max_request_queue_time"]
 === `max_request_queue_time`
 

--- a/docs/upgrading-to-65.asciidoc
+++ b/docs/upgrading-to-65.asciidoc
@@ -118,8 +118,13 @@ The data format remains unchanged.
 
 The Metricsets endpoint, previously `/v1/metrics`,
 has also integrated with the new intake endpoint at `/intake/v2/events`.
-In terms of functionality, the only change relates to timestamps.
-See the <<metricset-api, metricset documentation>> for more information.
+There are two changes to be aware of:
+
+* Timestamps are now UTC based and formatted as microseconds since Unix epoch.
+* The `metrics.enabled` setting has been deprecated and only applies to `v1/metrics`.
+Metricsets can't be disabled in v2.
+
+See the <<metricset-api, metricset schema>> for more information.
 
 [float]
 [[server-config-changes-65]]


### PR DESCRIPTION
This is not used any more since https://github.com/elastic/apm-server/pull/1731/files#diff-31f9c87c519544cc8f4fbdae985b0d0eL164

As per https://github.com/elastic/apm-server/pull/1737, it doesn't make sense to keep the option around and should be the agent's call whether to enable/disable.

- [x] Needs changelog
- [x] Might worth clarification note to `metrics-api-changes-65`, to be backported
