### PR TITLE
prevent slice out of bounds error

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -11,13 +11,13 @@
 [float]
 ==== Removed
 - Remove support for using dots in tags for experimental metricset endpoint {pull}1712[1712].
-
-[float]
-==== Removed
-
 - Remove formatting of `duration.us` to milliseconds in index pattern pull{1717}[1717].
 - Remove support for deprecated Intake v1 endpoints {pull}1731[1731].
 - Remove `concurrent_requests` setting and use number of CPUs instead {pull}1749[1749].
 - Remove `frontend` setting {pull}1751[1751].
+
+[float]
+==== Bug fixes
+- Prevent slice out of bounds panic when sourcemap line numbers are off {pull}1764[1764].
 
 https://github.com/elastic/apm-server/compare/v7.0.0-alpha2...master[View commits]

--- a/sourcemap/mapper.go
+++ b/sourcemap/mapper.go
@@ -106,6 +106,12 @@ func subSlice(from, to int, content []string) []string {
 	if from < 0 {
 		from = 0
 	}
+	if to < 0 {
+		to = 0
+	}
+	if from > len(content) {
+		from = len(content)
+	}
 	if to > len(content) {
 		to = len(content)
 	}

--- a/sourcemap/mapper_test.go
+++ b/sourcemap/mapper_test.go
@@ -77,6 +77,9 @@ func TestSubSlice(t *testing.T) {
 		{2, 4, []string{"c", "d"}},
 		{-1, 1, []string{"a"}},
 		{4, 10, []string{"e", "f"}},
+		// relevant test cases because we don't control the input and can not panic
+		{-5, -3, []string{}},
+		{8, 10, []string{}},
 	} {
 		assert.Equal(t, test.rs, subSlice(test.start, test.end, src))
 	}


### PR DESCRIPTION
fixes #1760

this can happen eg. if the sourcemap file maps to a different version of the code producing a stacktrace, and the starting line number in the sourcemap is higher than the total line count in the code.


- [x] needs changelog
- [ ] needs backporting