### PR TITLE
[6.x] mark metrics.enabled setting as deprecated

### DIFF
--- a/docs/configuration-process.asciidoc
+++ b/docs/configuration-process.asciidoc
@@ -59,6 +59,12 @@ Version 6.5 of the APM Server introduced a new intake API. You can learn more ab
 
 If you do not upgrade your APM Agent, you'll continue to use the deprecated v1 intake API endpoint, and thus, the following configuration options.
 
+[[metrics.enabled]]
+[float]
+==== `metrics` deprecated[6.5]
+Metrics endpoint for collecting application metrics.
+Enabled by default.
+
 [[max_unzipped_size]]
 [float]
 ==== `max_unzipped_size` deprecated[6.5]
@@ -137,12 +143,6 @@ Defaults to `debug/vars`.
 ==== `instrumentation.enabled`
 Enables self instrumentation of the APM Server itself.
 Disabled by default.
-
-[[metrics.enabled]]
-[float]
-==== `metrics`
-Metrics endpoint for collecting application metrics.
-Enabled by default.
 
 [[register.ingest.pipeline.enabled]]
 [float]


### PR DESCRIPTION
Goes in hand with https://github.com/elastic/apm-server/pull/1759/commits/125046055650ad6191678686717efba299199a79

- [ ] needs backport to 6.6 and 6.5