### PR TITLE
[6.x] prevent slice out of bounds error (#1764)

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -16,4 +16,5 @@ https://github.com/elastic/apm-server/compare/6.5\...6.x[View commits]
 ==== Bug fixes
 
 - Fix index pattern bundled with Kibana to be in sync with ES template pull{1571}[1571].
-- Ensure all `transaction.marks.*.*` values are stored as scaled floats. pull{1704}[1704]
+- Ensure all `transaction.marks.*.*` values are stored as scaled floats. pull{1704}[1704].
+- Prevent slice out of bounds panic when sourcemap line numbers are off {pull}1764[1764].

--- a/sourcemap/mapper.go
+++ b/sourcemap/mapper.go
@@ -106,6 +106,12 @@ func subSlice(from, to int, content []string) []string {
 	if from < 0 {
 		from = 0
 	}
+	if to < 0 {
+		to = 0
+	}
+	if from > len(content) {
+		from = len(content)
+	}
 	if to > len(content) {
 		to = len(content)
 	}

--- a/sourcemap/mapper_test.go
+++ b/sourcemap/mapper_test.go
@@ -77,6 +77,9 @@ func TestSubSlice(t *testing.T) {
 		{2, 4, []string{"c", "d"}},
 		{-1, 1, []string{"a"}},
 		{4, 10, []string{"e", "f"}},
+		// relevant test cases because we don't control the input and can not panic
+		{-5, -3, []string{}},
+		{8, 10, []string{}},
 	} {
 		assert.Equal(t, test.rs, subSlice(test.start, test.end, src))
 	}


### PR DESCRIPTION
Backports the following commits to 6.x:
 - prevent slice out of bounds error  (#1764)