### PR TITLE
[docs] Remove dashboard references in beats

### DIFF
--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -16,13 +16,13 @@
 
 :deploy-command-short-desc: Deploys the specified function to your serverless environment
 
-ifndef::no_dashboards_apm[]
+ifndef::no_dashboards[]
 :export-command-short-desc: Exports the configuration, index template, or a dashboard to stdout
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
-ifdef::no_dashboards_apm[]
+ifdef::no_dashboards[]
 :export-command-short-desc: Exports the configuration or index template to stdout
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
 :help-command-short-desc: Shows help for any command
 :keystore-command-short-desc: Manages the <<keystore,secrets keystore>>
@@ -35,11 +35,11 @@ ifdef::has_ml_jobs[]
 :setup-command-short-desc: Sets up the initial environment, including the index template, {kib} dashboards (when available), and machine learning jobs (when available)
 endif::[]
 
-ifdef::no_dashboards_apm[]
+ifdef::no_dashboards[]
 :setup-command-short-desc: Sets up the initial environment, including the ES index template.
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
-ifndef::has_ml_jobs,no_dashboards_apm[]
+ifndef::has_ml_jobs,no_dashboards[]
 :setup-command-short-desc: Sets up the initial environment, including the index template and {kib} dashboards (when available)
 endif::[]
 
@@ -55,15 +55,15 @@ endif::[]
 <titleabbrev>Command reference</titleabbrev>
 ++++
 
-ifndef::no_dashboards_apm[]
+ifndef::no_dashboards[]
 {beatname_uc} provides a command-line interface for starting {beatname_uc} and
 performing common tasks, like testing configuration files and loading dashboards.
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
-ifdef::no_dashboards_apm[]
+ifdef::no_dashboards[]
 {beatname_uc} provides a command-line interface for starting {beatname_uc} and
 performing common tasks, like testing configuration files.
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
 The command-line also supports <<global-flags,global flags>>
 for controlling global behaviors.
@@ -142,17 +142,17 @@ endif::[]
 [[export-command]]
 ==== `export` command
 
-ifndef::no_dashboards_apm[]
+ifndef::no_dashboards[]
 {export-command-short-desc}. You can use this
 command to quickly view your configuration, see the contents of the index
 template, or export a dashboard from {kib}.
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
-ifdef::no_dashboards_apm[]
+ifdef::no_dashboards[]
 {export-command-short-desc}. You can use this
 command to quickly view your configuration or see the contents of the index
 template.
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
 *SYNOPSIS*
 
@@ -167,7 +167,7 @@ endif::no_dashboards_apm[]
 Exports the current configuration to stdout. If you use the `-c` flag, this
 command exports the configuration that's defined in the specified file.
 
-ifndef::no_dashboards_apm[]
+ifndef::no_dashboards[]
 [[dashboard-subcommand]]*`dashboard`*::
 Exports a dashboard. You can use this option to store a dashboard on disk in a
 module and load it automatically. For example, to export the dashboard to a JSON
@@ -190,7 +190,7 @@ To load the dashboard, copy the generated `dashboard.json` file into the
 +
 If {kib} is not running on `localhost:5061`, you must also adjust the
 {beatname_uc} configuration under `setup.kibana`.
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
 [[template-subcommand]]*`template`*::
 Exports the index template to stdout. You can specify the `--es.version` and
@@ -216,31 +216,31 @@ When used with <<template-subcommand,`template`>>, sets the base name to use for
 the index template. If this flag is not specified, the default base name is
 +{beatname_lc}+.
 
-ifndef::no_dashboards_apm[]
+ifndef::no_dashboards[]
 *`--id DASHBOARD_ID`*::
 When used with <<dashboard-subcommand,`dashboard`>>, specifies the dashboard ID.
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
 {global-flags}
 
 *EXAMPLES*
 
-ifndef::no_dashboards_apm[]
+ifndef::no_dashboards[]
 ["source","sh",subs="attributes"]
 -----
 {beatname_lc} export config
 {beatname_lc} export template --es.version {stack-version} --index myindexname
 {beatname_lc} export dashboard --id="a7b35890-8baa-11e8-9676-ef67484126fb" > dashboard.json
 -----
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
-ifdef::no_dashboards_apm[]
+ifdef::no_dashboards[]
 ["source","sh",subs="attributes"]
 -----
 {beatname_lc} export config
 {beatname_lc} export template --es.version {stack-version} --index myindexname
 -----
-endif::no_dashboards_apm[]
+endif::no_dashboards[]
 
 [[help-command]]
 ==== `help` command
@@ -549,16 +549,17 @@ the end of the file is reached. By default harvesters are closed after
 endif::[]
 
 *`--setup`*::
+Loads the initial setup, including: 
+
+* Elasticsearch template
 ifdef::has_ml_jobs[]
-Loads the initial setup, including Elasticsearch template, {kib} index pattern,
-{kib} dashboards (when available), and Machine learning jobs.
+* Machine learning jobs
 endif::has_ml_jobs[]
-ifdef::no_dashboards[]
-Loads the initial setup, including Elasticsearch template.
+ifndef::no_dashboards[]
+* {kib} index pattern
+* {kib} dashboards
 endif::no_dashboards[]
-ifndef::has_ml_jobs,no_dashboards[]
-Loads the initial setup, including Elasticsearch template, {kib} index pattern, and {kib} dashboards (when available).
-endif::has_ml_jobs,no_dashboards[]
+
 If you want to use the command without running {beatname_uc}, use the <<setup-command,`setup`>> command instead.
 
 ifeval::["{beatname_lc}"=="metricbeat"]

--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -554,7 +554,7 @@ Loads the initial setup, including Elasticsearch template, {kib} index pattern,
 {kib} dashboards (when available), and Machine learning jobs.
 endif::has_ml_jobs[]
 ifdef::no_dashboards[]
-Loads the initial setup, including Elasticsearch template and {kib} index pattern.
+Loads the initial setup, including Elasticsearch template.
 endif::no_dashboards[]
 ifndef::has_ml_jobs,no_dashboards[]
 Loads the initial setup, including Elasticsearch template, {kib} index pattern, and {kib} dashboards (when available).

--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -15,7 +15,15 @@
 :global-flags: Also see <<global-flags,Global flags>>.
 
 :deploy-command-short-desc: Deploys the specified function to your serverless environment
+
+ifndef::no_dashboards_apm[]
 :export-command-short-desc: Exports the configuration, index template, or a dashboard to stdout
+endif::no_dashboards_apm[]
+
+ifdef::no_dashboards_apm[]
+:export-command-short-desc: Exports the configuration or index template to stdout
+endif::no_dashboards_apm[]
+
 :help-command-short-desc: Shows help for any command
 :keystore-command-short-desc: Manages the <<keystore,secrets keystore>>
 :modules-command-short-desc: Manages configured modules
@@ -23,22 +31,16 @@
 :remove-command-short-desc: Removes the specified function from your serverless environment
 :run-command-short-desc: Runs {beatname_uc}. This command is used by default if you start {beatname_uc} without specifying a command
 
-ifndef::deprecate_dashboard_loading[]
-
 ifdef::has_ml_jobs[]
 :setup-command-short-desc: Sets up the initial environment, including the index template, {kib} dashboards (when available), and machine learning jobs (when available)
 endif::[]
 
-ifndef::has_ml_jobs[]
+ifdef::no_dashboards_apm[]
+:setup-command-short-desc: Sets up the initial environment, including the ES index template.
+endif::no_dashboards_apm[]
+
+ifndef::has_ml_jobs,no_dashboards_apm[]
 :setup-command-short-desc: Sets up the initial environment, including the index template and {kib} dashboards (when available)
-endif::[]
-
-endif::[]
-
-ifdef::deprecate_dashboard_loading[]
-
-:setup-command-short-desc: Sets up the initial environment, including the ES index template and {kib} dashboards (deprecated).
-
 endif::[]
 
 :update-command-short-desc: Updates the specified function
@@ -53,15 +55,15 @@ endif::[]
 <titleabbrev>Command reference</titleabbrev>
 ++++
 
-ifndef::deprecate_dashboard_loading[]
+ifndef::no_dashboards_apm[]
 {beatname_uc} provides a command-line interface for starting {beatname_uc} and
 performing common tasks, like testing configuration files and loading dashboards.
-endif::[]
+endif::no_dashboards_apm[]
 
-ifdef::deprecate_dashboard_loading[]
+ifdef::no_dashboards_apm[]
 {beatname_uc} provides a command-line interface for starting {beatname_uc} and
-performing common tasks, like testing configuration files and loading dashboards (deprecated).
-endif::[]
+performing common tasks, like testing configuration files.
+endif::no_dashboards_apm[]
 
 The command-line also supports <<global-flags,global flags>>
 for controlling global behaviors.
@@ -140,9 +142,17 @@ endif::[]
 [[export-command]]
 ==== `export` command
 
+ifndef::no_dashboards_apm[]
 {export-command-short-desc}. You can use this
 command to quickly view your configuration, see the contents of the index
 template, or export a dashboard from {kib}.
+endif::no_dashboards_apm[]
+
+ifdef::no_dashboards_apm[]
+{export-command-short-desc}. You can use this
+command to quickly view your configuration or see the contents of the index
+template.
+endif::no_dashboards_apm[]
 
 *SYNOPSIS*
 
@@ -157,6 +167,7 @@ template, or export a dashboard from {kib}.
 Exports the current configuration to stdout. If you use the `-c` flag, this
 command exports the configuration that's defined in the specified file.
 
+ifndef::no_dashboards_apm[]
 [[dashboard-subcommand]]*`dashboard`*::
 Exports a dashboard. You can use this option to store a dashboard on disk in a
 module and load it automatically. For example, to export the dashboard to a JSON
@@ -179,14 +190,17 @@ To load the dashboard, copy the generated `dashboard.json` file into the
 +
 If {kib} is not running on `localhost:5061`, you must also adjust the
 {beatname_uc} configuration under `setup.kibana`.
+endif::no_dashboards_apm[]
 
 [[template-subcommand]]*`template`*::
 Exports the index template to stdout. You can specify the `--es.version` and
 `--index` flags to further define what gets exported.
 
+ifndef::apm-server[]
 [[ilm-policy-subcommand]]
 *`ilm-policy`*::
 Exports ILM policy to stdout.
+endif::apm-server[]
 
 *FLAGS*
 
@@ -202,20 +216,31 @@ When used with <<template-subcommand,`template`>>, sets the base name to use for
 the index template. If this flag is not specified, the default base name is
 +{beatname_lc}+.
 
+ifndef::no_dashboards_apm[]
 *`--id DASHBOARD_ID`*::
 When used with <<dashboard-subcommand,`dashboard`>>, specifies the dashboard ID.
+endif::no_dashboards_apm[]
 
 {global-flags}
 
 *EXAMPLES*
 
+ifndef::no_dashboards_apm[]
 ["source","sh",subs="attributes"]
 -----
 {beatname_lc} export config
 {beatname_lc} export template --es.version {stack-version} --index myindexname
 {beatname_lc} export dashboard --id="a7b35890-8baa-11e8-9676-ef67484126fb" > dashboard.json
 -----
+endif::no_dashboards_apm[]
 
+ifdef::no_dashboards_apm[]
+["source","sh",subs="attributes"]
+-----
+{beatname_lc} export config
+{beatname_lc} export template --es.version {stack-version} --index myindexname
+-----
+endif::no_dashboards_apm[]
 
 [[help-command]]
 ==== `help` command
@@ -524,19 +549,17 @@ the end of the file is reached. By default harvesters are closed after
 endif::[]
 
 *`--setup`*::
-ifdef::deprecate_dashboard_loading[]
-deprecated[{deprecate_dashboard_loading}]
-endif::[]
-+
 ifdef::has_ml_jobs[]
 Loads the initial setup, including Elasticsearch template, {kib} index pattern,
 {kib} dashboards (when available), and Machine learning jobs.
-endif::[]
-ifndef::has_ml_jobs[]
+endif::has_ml_jobs[]
+ifdef::no_dashboards[]
+Loads the initial setup, including Elasticsearch template and {kib} index pattern.
+endif::no_dashboards[]
+ifndef::has_ml_jobs,no_dashboards[]
 Loads the initial setup, including Elasticsearch template, {kib} index pattern, and {kib} dashboards (when available).
-endif::[]
+endif::has_ml_jobs,no_dashboards[]
 If you want to use the command without running {beatname_uc}, use the <<setup-command,`setup`>> command instead.
-
 
 ifeval::["{beatname_lc}"=="metricbeat"]
 *`--system.hostfs MOUNT_POINT`*::
@@ -575,8 +598,10 @@ Or:
 
 * The index template ensures that fields are mapped correctly in Elasticsearch.
 
+ifndef::no_dashboards[]
 * The {kib} dashboards make it easier for you to visualize {beatname_uc} data
 in {kib}.
+endif::no_dashboards[]
 
 ifdef::has_ml_jobs[]
 * The machine learning jobs contain the configuration information and metadata
@@ -596,21 +621,13 @@ environment without actually running {beatname_uc} and ingesting data.
 
 *FLAGS*
 
-ifndef::deprecate_dashboard_loading[]
+ifndef::no_dashboards[]
 *`--dashboards`*::
 Sets up the {kib} dashboards (when available). This option loads the dashboards
 from the {beatname_uc} package. For more options, such as loading customized
 dashboards, see {beatsdevguide}/import-dashboards.html[Importing Existing Beat
 Dashboards] in the _Beats Developer Guide_.
-endif::[]
-
-ifdef::deprecate_dashboard_loading[]
-*`--dashboards`*::
-
-deprecated[{deprecate_dashboard_loading}]
-+
-Sets up the {kib} dashboards only.
-endif::[]
+endif::no_dashboards[]
 
 *`-h, --help`*::
 Shows help for the `setup` command.

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -239,9 +239,6 @@ ifndef::no_dashboards[]
 If you are using the pre-built Kibana
 dashboards, you also need to set the `setup.dashboards.index` option (see
 <<configuration-dashboards>>).
-ifdef::deprecate_dashboard_loading[]
-deprecated[{deprecate_dashboard_loading}]
-endif::deprecate_dashboard_loading[]
 endif::no_dashboards[]
 
 You can set the index dynamically by using a format string to access any event

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -86,12 +86,18 @@ output.elasticsearch:
   protocol: "https"
   username: "{beatname_lc}_internal"
   password: "{pwd}"
-
 ------------------------------------------------------------------------------
 
 
 For more information about securing {beatname_uc}, see
 <<securing-{beatname_lc}>>.
+
+ifndef::no_ilm[]
+If you are indexing large amounts of time-series data, you might also want to
+configure {beatname_uc} to use index lifecycle management. For more information
+about configuring and using index lifecycle management with {beatname_uc}, see
+<<ilm>>.
+endif::no_ilm[]
 
 ==== Compatibility
 
@@ -334,6 +340,17 @@ This configuration results in indices named `sev1`, `sev2`, and `sev3`.
 
 The `mappings` setting simplifies the configuration, but is limited to string
 values. You cannot specify format strings within the mapping pairs.
+
+//TODO: MOVE ILM OPTIONS TO APPEAR LOGICALLY BASED ON LOCATION IN THE YAML FILE.
+
+ifndef::no_ilm[]
+[[ilm-es]]
+===== `ilm`
+
+Configuration options for index lifecycle management. 
+
+See <<ilm>> for more information.
+endif::no_ilm[]
 
 ifndef::no-pipeline[]
 [[pipeline-option-es]]

--- a/docs/copied-from-beats/shared-docker.asciidoc
+++ b/docs/copied-from-beats/shared-docker.asciidoc
@@ -47,7 +47,7 @@ ifndef::apm-server[]
 Running {beatname_uc} with the setup command will create the index pattern and
 load visualizations, dashboards, and machine learning jobs.  Run this command:
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="metricbeat") or ("{beatname_lc}"=="heartbeat")]
+ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="metricbeat") or ("{beatname_lc}"=="heartbeat") or ("{beatname_lc}"=="journalbeat")]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
 docker run \
@@ -114,16 +114,16 @@ curl -L -O {dockerconfig}
 One way to configure {beatname_uc} on Docker is to provide +{beatname_lc}.docker.yml+ via a volume mount.
 With +docker run+, the volume mount can be specified like this:
 
-ifeval::["{beatname_lc}"=="filebeat"]
+ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="journalbeat")]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
 docker run -d \
-  --name=filebeat \
+  --name={beatname_lc} \
   --user=root \
-  --volume="$(pwd)/{beatname_lc}.docker.yml:/usr/share/filebeat/filebeat.yml:ro" \
+  --volume="$(pwd)/{beatname_lc}.docker.yml:/usr/share/{beatname_lc}/{beatname_lc}.yml:ro" \
   --volume="/var/lib/docker/containers:/var/lib/docker/containers:ro" \
   --volume="/var/run/docker.sock:/var/run/docker.sock:ro" \
-  {dockerimage} filebeat -e -strict.perms=false \
+  {dockerimage} {beatname_lc} -e -strict.perms=false \
   -E output.elasticsearch.hosts=["elasticsearch:9200"] <1> <2>
 --------------------------------------------
 endif::[]

--- a/docs/copied-from-beats/shared-template-load.asciidoc
+++ b/docs/copied-from-beats/shared-template-load.asciidoc
@@ -79,7 +79,7 @@ output.elasticsearch.index: "customname-%{[{beat_version_key}]}-%{+yyyy.MM.dd}"
 setup.template.name: "customname"
 setup.template.pattern: "customname-*"
 -----
-ifndef::deprecate_dashboard_loading,no_dashboards[]
+ifndef::no_dashboards[]
 +
 If you're using pre-built Kibana dashboards, also set the
 `setup.dashboards.index` option. For example: 
@@ -88,12 +88,11 @@ If you're using pre-built Kibana dashboards, also set the
 ----
 setup.dashboards.index: "customname-*"
 ----
-endif::[]
+endif::no_dashboards[]
 
-ifdef::deprecate_dashboard_loading[]
-+
+ifdef::no_dashboards[]
 Remember to change the index name when you load dashboards via the Kibana UI.
-endif::[]
+endif::no_dashboards[]
 
 See <<configuration-template>> for the full list of configuration options.
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -22,7 +22,8 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
 :securitydoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
 :dockerconfig: https://raw.githubusercontent.com/elastic/apm-server/{doc-branch}/apm-server.docker.yml
-:deprecate_dashboard_loading: 6.4.0
+:no_dashboards:
+:no_dashboards_apm:
 :no-processors:
 :no-indices-rules:
 :no_dashboards:

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -23,7 +23,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :securitydoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
 :dockerconfig: https://raw.githubusercontent.com/elastic/apm-server/{doc-branch}/apm-server.docker.yml
 :no_dashboards:
-:no_dashboards_apm:
+:no_ilm:
 :no-processors:
 :no-indices-rules:
 :no_dashboards:


### PR DESCRIPTION
* Removes remaining references to "dashboards" in the APM docs.
* Removes old `deprecate_dashboard_loading` attribute and replaces with `no_dashboards` (used by xpack and filebeat) where possible, and `no_dashboards_apm` where not possible.
* Cleans up a couple of the conditionals.
* Related to #1715.

Once this is approved I'll open a PR in the beats repo and make the persistent changes there.