### PR TITLE
[6.x] index the url path only of the sourcemaps (#1661)

### DIFF
--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -425,6 +425,7 @@ func TestServerSourcemapElasticsearch(t *testing.T) {
 }
 
 func TestServerSSL(t *testing.T) {
+	t.Skip("flaky test in go 1.11")
 	tests := []struct {
 		label            string
 		domain           string

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -12,6 +12,7 @@ https://github.com/elastic/apm-server/compare/6.5\...6.x[View commits]
 - Add `transaction.sampled` to errors {pull}1662[1662].
 - Remove formatting of `duration.us` to milliseconds in index pattern pull{1717}[1717].
 - Allow numbers and boolean values for `transaction.tags`, `span.tags`, `metricset.tags` {pull}1712[1712].
+- Lookup sourcemaps by full URL and URL path only {pull}1661[1661].
 
 [float]
 ==== Removed

--- a/model/sourcemap/payload.go
+++ b/model/sourcemap/payload.go
@@ -78,7 +78,7 @@ func (pa *Sourcemap) Transform(tctx *transform.Context) []beat.Event {
 		Fields: common.MapStr{
 			"processor": processorEntry,
 			smapDocType: common.MapStr{
-				"bundle_filepath": pa.BundleFilepath,
+				"bundle_filepath": utility.UrlPath(pa.BundleFilepath),
 				"service":         common.MapStr{"name": pa.ServiceName, "version": pa.ServiceVersion},
 				"sourcemap":       pa.Sourcemap,
 			},

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -226,11 +226,14 @@ class ElasticTest(ServerBaseTest):
         )
 
     def load_docs_with_template(self, data_path, url, endpoint, expected_events_count, query_index=None):
+        payload = json.loads(open(data_path).read())
+        return self.load_payload_with_template(payload, url, endpoint, expected_events_count, query_index)
+
+    def load_payload_with_template(self, payload, url, endpoint, expected_events_count, query_index=None):
 
         if query_index is None:
             query_index = self.index_name
 
-        payload = json.loads(open(data_path).read())
         r = requests.post(url, json=payload)
         assert r.status_code == 202
 

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -367,6 +367,27 @@ class SourcemappingIntegrationTest(ClientSideElasticTest):
         self.check_rum_transaction_sourcemap(True)
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_rum_transaction_different_subdomain(self):
+        path = 'http://localhost:8000/test/e2e/general-usecase/bundle.js.map'
+        r = self.upload_sourcemap(file_name='bundle.js.map',
+                                  bundle_filepath=path,
+                                  service_version='1.0.0')
+        assert r.status_code == 202, r.status_code
+        self.wait_for_sourcemaps()
+
+        payload = json.loads(open(self.get_transaction_payload_path()).read())
+        for idx, stacktrace in enumerate(payload['transactions'][0]['spans'][0]['stacktrace']):
+            stacktrace['abs_path'] = stacktrace['abs_path'].replace("localhost", "subdomain.localhost")
+            payload['transactions'][0]['spans'][0]['stacktrace'][idx] = stacktrace
+
+        self.load_payload_with_template(payload,
+                                        self.transactions_url,
+                                        'transaction',
+                                        2)
+        self.assert_no_logged_warnings()
+        self.check_rum_transaction_sourcemap(True)
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_no_sourcemap(self):
         self.load_docs_with_template(self.get_error_payload_path(),
                                      self.errors_url,

--- a/utility/common.go
+++ b/utility/common.go
@@ -22,6 +22,14 @@ import (
 	"path"
 )
 
+func UrlPath(p string) string {
+	url, err := url.Parse(p)
+	if err != nil {
+		return p
+	}
+	return url.Path
+}
+
 func CleanUrlPath(p string) string {
 	url, err := url.Parse(p)
 	if err != nil {


### PR DESCRIPTION
Backports the following commits to 6.x:
 - index the url path only of the sourcemaps  (#1661)