### PR TITLE
[6.x] Skip flaky test (#1799)

### DIFF
--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -497,6 +497,7 @@ func TestServerSSL(t *testing.T) {
 }
 
 func TestServerSecureBadPassphrase(t *testing.T) {
+	t.Skip("flaky test")
 	withSSL(t, "127.0.0.1", "foo")
 	name := path.Join(tmpCertPath, t.Name())
 	cfg, err := common.NewConfigFrom(map[string]map[string]interface{}{


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Skip flaky test  (#1799)