### PR TITLE
abort if server is never created

### DIFF
--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -414,7 +414,9 @@ func setupBeater(t *testing.T, publisher beat.Pipeline, ucfg *common.Config, bea
 	}()
 
 	btr := beatBeater.(*beater)
-	btr.wait()
+	if err := btr.wait(); err != nil {
+		return nil, nil, err
+	}
 
 	url, client := btr.client(true)
 	go func() {


### PR DESCRIPTION
This should address some of the panics we've seen under test, like:

```
14:34:09 --- FAIL: TestServerOkUnix (2.00s)
14:34:09 panic: runtime error: invalid memory address or nil pointer dereference [recovered]
14:34:09 	panic: runtime error: invalid memory address or nil pointer dereference
14:34:09 [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1076c74]
14:34:09 
14:34:09 goroutine 692 [running]:
14:34:09 testing.tRunner.func1(0xc0004ab400)
14:34:09 	/usr/local/go/src/testing/testing.go:792 +0x6a7
14:34:09 panic(0x119a320, 0x1b3b0a0)
14:34:09 	/usr/local/go/src/runtime/panic.go:513 +0x1b9
14:34:09 github.com/elastic/apm-server/beater.(*beater).client(0xc0005b4b10, 0x1366101, 0x0, 0x0, 0x0)
14:34:09 	/go/src/github.com/elastic/apm-server/beater/beater_test.go:334 +0x134
14:34:09 github.com/elastic/apm-server/beater.setupBeater(0xc0004ab400, 0x1370a40, 0xc00008cb00, 0xc0005b4270, 0x0, 0x0, 0x0, 0x13, 0xc0003cde08)
14:34:09 	/go/src/github.com/elastic/apm-server/beater/beater_test.go:419 +0x401
14:34:09 github.com/elastic/apm-server/beater.setupServer(0xc0004ab400, 0xc0005b4060, 0x0, 0x0, 0x0, 0x0, 0x0, 0x201)
14:34:09 	/go/src/github.com/elastic/apm-server/beater/server_test.go:518 +0x25d
14:34:09 github.com/elastic/apm-server/beater.TestServerOkUnix(0xc0004ab400)
14:34:09 	/go/src/github.com/elastic/apm-server/beater/server_test.go:210 +0x1e5
14:34:09 testing.tRunner(0xc0004ab400, 0x1297d80)
14:34:09 	/usr/local/go/src/testing/testing.go:827 +0x163
14:34:09 created by testing.(*T).Run
14:34:09 	/usr/local/go/src/testing/testing.go:878 +0x65a
14:34:09 FAIL	github.com/elastic/apm-server/beater	45.525s
```

Test will still fail as the server is not started in a timely manner, but at least we'll have a nice error message.