### PR TITLE
[APM-CI] Use a released version of the pipeline shared library

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,5 @@
 #!/usr/bin/env groovy
+@Library('apm@v1.0.4') _
 
 pipeline {
   agent any


### PR DESCRIPTION
In order to use a stable version of the pipeline shared library we add the setting to use a released version.