### PR TITLE
Index error.exception as array of objects

### DIFF
--- a/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
@@ -77,77 +77,79 @@
             },
             "error": {
                 "culprit": "my.module.function_name",
-                "exception": {
-                    "attributes": {
-                        "foo": "bar"
-                    },
-                    "code": "42",
-                    "handled": false,
-                    "message": "The username root is unknown",
-                    "module": "__builtins__",
-                    "stacktrace": [
-                        {
-                            "abs_path": "/real/file/name.py",
-                            "context": {
-                                "post": [
-                                    "line4",
-                                    "line5"
-                                ],
-                                "pre": [
-                                    "line1",
-                                    "line2"
-                                ]
-                            },
-                            "exclude_from_grouping": false,
-                            "filename": "file/name.py",
-                            "function": "foo",
-                            "library_frame": true,
-                            "line": {
-                                "column": 4,
-                                "context": "line3",
-                                "number": 3
-                            },
-                            "module": "App::MyModule",
-                            "vars": {
-                                "key": "value"
-                            }
+                "exception": [
+                    {
+                        "attributes": {
+                            "foo": "bar"
                         },
-                        {
-                            "abs_path": "/Users/watson/code/node_modules/elastic/lib/instrumentation/index.js",
-                            "context": {
-                                "post": [
-                                    "    ins.currentTransaction = prev",
-                                    "    return result",
-                                    "}",
-                                    "}",
-                                    "",
-                                    "Instrumentation.prototype._recoverTransaction = function (trans) {",
-                                    "  if (this.currentTransaction === trans) return"
-                                ],
-                                "pre": [
-                                    "  var trans = this.currentTransaction",
-                                    "",
-                                    "  return instrumented",
-                                    "",
-                                    "  function instrumented () {",
-                                    "    var prev = ins.currentTransaction",
-                                    "    ins.currentTransaction = trans"
-                                ]
+                        "code": "42",
+                        "handled": false,
+                        "message": "The username root is unknown",
+                        "module": "__builtins__",
+                        "stacktrace": [
+                            {
+                                "abs_path": "/real/file/name.py",
+                                "context": {
+                                    "post": [
+                                        "line4",
+                                        "line5"
+                                    ],
+                                    "pre": [
+                                        "line1",
+                                        "line2"
+                                    ]
+                                },
+                                "exclude_from_grouping": false,
+                                "filename": "file/name.py",
+                                "function": "foo",
+                                "library_frame": true,
+                                "line": {
+                                    "column": 4,
+                                    "context": "line3",
+                                    "number": 3
+                                },
+                                "module": "App::MyModule",
+                                "vars": {
+                                    "key": "value"
+                                }
                             },
-                            "exclude_from_grouping": false,
-                            "filename": "lib/instrumentation/index.js",
-                            "function": "instrumented",
-                            "line": {
-                                "context": "    var result = original.apply(this, arguments)",
-                                "number": 102
-                            },
-                            "vars": {
-                                "key": "value"
+                            {
+                                "abs_path": "/Users/watson/code/node_modules/elastic/lib/instrumentation/index.js",
+                                "context": {
+                                    "post": [
+                                        "    ins.currentTransaction = prev",
+                                        "    return result",
+                                        "}",
+                                        "}",
+                                        "",
+                                        "Instrumentation.prototype._recoverTransaction = function (trans) {",
+                                        "  if (this.currentTransaction === trans) return"
+                                    ],
+                                    "pre": [
+                                        "  var trans = this.currentTransaction",
+                                        "",
+                                        "  return instrumented",
+                                        "",
+                                        "  function instrumented () {",
+                                        "    var prev = ins.currentTransaction",
+                                        "    ins.currentTransaction = trans"
+                                    ]
+                                },
+                                "exclude_from_grouping": false,
+                                "filename": "lib/instrumentation/index.js",
+                                "function": "instrumented",
+                                "line": {
+                                    "context": "    var result = original.apply(this, arguments)",
+                                    "number": 102
+                                },
+                                "vars": {
+                                    "key": "value"
+                                }
                             }
-                        }
-                    ],
-                    "type": "DbError"
-                },
+                        ],
+                        "type": "DbError"
+                    }
+                ],
                 "grouping_key": "50f62f37edffc4630c6655ba3ecfcf46",
                 "id": "0123456789012345",
                 "log": {
@@ -296,9 +298,11 @@
                 "id": "container-id"
             },
             "error": {
-                "exception": {
-                    "message": "Cannot read property 'baz' no defined"
-                },
+                "exception": [
+                    {
+                        "message": "Cannot read property 'baz' no defined"
+                    }
+                ],
                 "grouping_key": "ae0232fed4cb40e7ebc62a585a421d60",
                 "id": "cdefab0123456789"
             },
@@ -381,9 +385,11 @@
                 "id": "container-id"
             },
             "error": {
-                "exception": {
-                    "type": "DbError"
-                },
+                "exception": [
+                    {
+                        "type": "DbError"
+                    }
+                ],
                 "grouping_key": "c3868d6704b923014eaffea034e70a3d",
                 "id": "cdefab0123456780"
             },

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -10,7 +10,8 @@
 - Update response format of the healthcheck handler and prettyfy all JSON responses {pull}1748[1748].
 - Add transaction.type to error data {pull}1781[1781].
 - Rename transaction.span_count.dropped.total to transaction.span_count.dropped {pull}1809[1809].
-- Rename span.hex_id to span.id {pull}XXX[XXX].
+- Rename span.hex_id to span.id {pull}1811[1811].
+- Index error.exception as array of objects {pull}1825[1825]
 
 [float]
 ==== Removed

--- a/docs/data/elasticsearch/generated/errors.json
+++ b/docs/data/elasticsearch/generated/errors.json
@@ -72,77 +72,79 @@
             },
             "error": {
                 "culprit": "my.module.function_name",
-                "exception": {
-                    "attributes": {
-                        "foo": "bar"
-                    },
-                    "code": "42",
-                    "handled": false,
-                    "message": "The username root is unknown",
-                    "module": "__builtins__",
-                    "stacktrace": [
-                        {
-                            "abs_path": "/real/file/name.py",
-                            "context": {
-                                "post": [
-                                    "line4",
-                                    "line5"
-                                ],
-                                "pre": [
-                                    "line1",
-                                    "line2"
-                                ]
-                            },
-                            "exclude_from_grouping": false,
-                            "filename": "file/name.py",
-                            "function": "foo",
-                            "library_frame": true,
-                            "line": {
-                                "column": 4,
-                                "context": "line3",
-                                "number": 3
-                            },
-                            "module": "App::MyModule",
-                            "vars": {
-                                "key": "value"
-                            }
+                "exception": [
+                    {
+                        "attributes": {
+                            "foo": "bar"
                         },
-                        {
-                            "abs_path": "/Users/watson/code/node_modules/elastic/lib/instrumentation/index.js",
-                            "context": {
-                                "post": [
-                                    "    ins.currentTransaction = prev",
-                                    "    return result",
-                                    "}",
-                                    "}",
-                                    "",
-                                    "Instrumentation.prototype._recoverTransaction = function (trans) {",
-                                    "  if (this.currentTransaction === trans) return"
-                                ],
-                                "pre": [
-                                    "  var trans = this.currentTransaction",
-                                    "",
-                                    "  return instrumented",
-                                    "",
-                                    "  function instrumented () {",
-                                    "    var prev = ins.currentTransaction",
-                                    "    ins.currentTransaction = trans"
-                                ]
+                        "code": "42",
+                        "handled": false,
+                        "message": "The username root is unknown",
+                        "module": "__builtins__",
+                        "stacktrace": [
+                            {
+                                "abs_path": "/real/file/name.py",
+                                "context": {
+                                    "post": [
+                                        "line4",
+                                        "line5"
+                                    ],
+                                    "pre": [
+                                        "line1",
+                                        "line2"
+                                    ]
+                                },
+                                "exclude_from_grouping": false,
+                                "filename": "file/name.py",
+                                "function": "foo",
+                                "library_frame": true,
+                                "line": {
+                                    "column": 4,
+                                    "context": "line3",
+                                    "number": 3
+                                },
+                                "module": "App::MyModule",
+                                "vars": {
+                                    "key": "value"
+                                }
                             },
-                            "exclude_from_grouping": false,
-                            "filename": "lib/instrumentation/index.js",
-                            "function": "instrumented",
-                            "line": {
-                                "context": "    var result = original.apply(this, arguments)",
-                                "number": 102
-                            },
-                            "vars": {
-                                "key": "value"
+                            {
+                                "abs_path": "/Users/watson/code/node_modules/elastic/lib/instrumentation/index.js",
+                                "context": {
+                                    "post": [
+                                        "    ins.currentTransaction = prev",
+                                        "    return result",
+                                        "}",
+                                        "}",
+                                        "",
+                                        "Instrumentation.prototype._recoverTransaction = function (trans) {",
+                                        "  if (this.currentTransaction === trans) return"
+                                    ],
+                                    "pre": [
+                                        "  var trans = this.currentTransaction",
+                                        "",
+                                        "  return instrumented",
+                                        "",
+                                        "  function instrumented () {",
+                                        "    var prev = ins.currentTransaction",
+                                        "    ins.currentTransaction = trans"
+                                    ]
+                                },
+                                "exclude_from_grouping": false,
+                                "filename": "lib/instrumentation/index.js",
+                                "function": "instrumented",
+                                "line": {
+                                    "context": "    var result = original.apply(this, arguments)",
+                                    "number": 102
+                                },
+                                "vars": {
+                                    "key": "value"
+                                }
                             }
-                        }
-                    ],
-                    "type": "DbError"
-                },
+                        ],
+                        "type": "DbError"
+                    }
+                ],
                 "grouping_key": "50f62f37edffc4630c6655ba3ecfcf46",
                 "id": "0123456789012345",
                 "log": {
@@ -279,9 +281,11 @@
                 "id": "container-id"
             },
             "error": {
-                "exception": {
-                    "message": "Cannot read property 'baz' no defined"
-                },
+                "exception": [
+                    {
+                        "message": "Cannot read property 'baz' no defined"
+                    }
+                ],
                 "grouping_key": "ae0232fed4cb40e7ebc62a585a421d60",
                 "id": "cdefab0123456789"
             },
@@ -352,9 +356,11 @@
                 "id": "container-id"
             },
             "error": {
-                "exception": {
-                    "type": "DbError"
-                },
+                "exception": [
+                    {
+                        "type": "DbError"
+                    }
+                ],
                 "grouping_key": "c3868d6704b923014eaffea034e70a3d",
                 "id": "cdefab0123456780"
             },

--- a/model/error/event.go
+++ b/model/error/event.go
@@ -294,7 +294,12 @@ func (e *Event) addException(tctx *transform.Context) {
 	st := e.Exception.Stacktrace.Transform(tctx)
 	utility.Add(ex, "stacktrace", st)
 
-	e.add("exception", ex)
+	// NOTE(axw) error.exception is an array of objects.
+	// For now, the array holds just one exception. Later,
+	// the array will hold each of the elements of a chained
+	// exception, starting with the outermost exception and
+	// ending with the root cause.
+	e.add("exception", []common.MapStr{ex})
 }
 
 func (e *Event) addLog(tctx *transform.Context) {

--- a/model/error/event_test.go
+++ b/model/error/event_test.go
@@ -302,7 +302,7 @@ func TestEventFields(t *testing.T) {
 		{
 			Event: Event{Exception: baseException(), Log: baseLog()},
 			Output: common.MapStr{
-				"exception":    common.MapStr{"message": "exception message"},
+				"exception":    []common.MapStr{{"message": "exception message"}},
 				"log":          common.MapStr{"message": "error log message"},
 				"grouping_key": baseExceptionGroupingKey,
 			},
@@ -311,7 +311,7 @@ func TestEventFields(t *testing.T) {
 		{
 			Event: Event{Exception: baseException()},
 			Output: common.MapStr{
-				"exception":    common.MapStr{"message": "exception message"},
+				"exception":    []common.MapStr{{"message": "exception message"}},
 				"grouping_key": baseExceptionGroupingKey,
 			},
 			Msg: "Minimal Event with exception",
@@ -319,7 +319,7 @@ func TestEventFields(t *testing.T) {
 		{
 			Event: Event{Exception: baseException().withCode("13")},
 			Output: common.MapStr{
-				"exception":    common.MapStr{"message": "exception message", "code": "13"},
+				"exception":    []common.MapStr{{"message": "exception message", "code": "13"}},
 				"grouping_key": baseExceptionGroupingKey,
 			},
 			Msg: "Minimal Event with exception and string code",
@@ -327,7 +327,7 @@ func TestEventFields(t *testing.T) {
 		{
 			Event: Event{Exception: baseException().withCode(13)},
 			Output: common.MapStr{
-				"exception":    common.MapStr{"message": "exception message", "code": "13"},
+				"exception":    []common.MapStr{{"message": "exception message", "code": "13"}},
 				"grouping_key": baseExceptionGroupingKey,
 			},
 			Msg: "Minimal Event wth exception and int code",
@@ -335,7 +335,7 @@ func TestEventFields(t *testing.T) {
 		{
 			Event: Event{Exception: baseException().withCode(13.0)},
 			Output: common.MapStr{
-				"exception":    common.MapStr{"message": "exception message", "code": "13"},
+				"exception":    []common.MapStr{{"message": "exception message", "code": "13"}},
 				"grouping_key": baseExceptionGroupingKey,
 			},
 			Msg: "Minimal Event wth exception and float code",
@@ -353,7 +353,7 @@ func TestEventFields(t *testing.T) {
 			Output: common.MapStr{
 				"id":      "45678",
 				"culprit": "some trigger",
-				"exception": common.MapStr{
+				"exception": []common.MapStr{{
 					"stacktrace": []common.MapStr{{
 						"filename":              "st file",
 						"line":                  common.MapStr{"number": 0},
@@ -369,7 +369,7 @@ func TestEventFields(t *testing.T) {
 					"attributes": common.MapStr{"k1": "val1"},
 					"type":       "error type",
 					"handled":    false,
-				},
+				}},
 				"log": common.MapStr{
 					"message":       "error log message",
 					"param_message": "param message",
@@ -487,7 +487,7 @@ func TestEvents(t *testing.T) {
 				"error": common.MapStr{
 					"grouping_key": "1d1e44ffdf01cad5117a72fd42e4fdf4",
 					"log":          common.MapStr{"message": "error log message"},
-					"exception": common.MapStr{
+					"exception": []common.MapStr{{
 						"message": "exception message",
 						"stacktrace": []common.MapStr{{
 							"exclude_from_grouping": false,
@@ -498,7 +498,7 @@ func TestEvents(t *testing.T) {
 								"updated": false,
 							},
 						}},
-					},
+					}},
 				},
 				"processor":   common.MapStr{"event": "error", "name": "error"},
 				"transaction": common.MapStr{"id": "945254c5-67a5-417e-8a4e-aa29efcbfb79", "sampled": true},

--- a/processor/stream/package_tests/error_attrs_test.go
+++ b/processor/stream/package_tests/error_attrs_test.go
@@ -42,8 +42,8 @@ func errorProcSetup() *tests.ProcessorSetup {
 func errorPayloadAttrsNotInFields() *tests.Set {
 	return tests.NewSet(
 		tests.Group("error.exception.attributes"),
-		"error.exception.stacktrace",
-		"error.log.stacktrace",
+		tests.Group("error.exception.stacktrace"),
+		tests.Group("error.log.stacktrace"),
 		tests.Group("context.user"),
 	)
 }

--- a/processor/stream/package_tests/span_attrs_test.go
+++ b/processor/stream/package_tests/span_attrs_test.go
@@ -41,7 +41,7 @@ func spanProcSetup() *tests.ProcessorSetup {
 
 func spanPayloadAttrsNotInFields() *tests.Set {
 	return tests.NewSet(
-		"span.stacktrace",
+		tests.Group("span.stacktrace"),
 		tests.Group("context.db"),
 		"context.http",
 		"context.http.url",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationErrors.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationErrors.approved.json
@@ -72,77 +72,79 @@
             },
             "error": {
                 "culprit": "my.module.function_name",
-                "exception": {
-                    "attributes": {
-                        "foo": "bar"
-                    },
-                    "code": "42",
-                    "handled": false,
-                    "message": "The username root is unknown",
-                    "module": "__builtins__",
-                    "stacktrace": [
-                        {
-                            "abs_path": "/real/file/name.py",
-                            "context": {
-                                "post": [
-                                    "line4",
-                                    "line5"
-                                ],
-                                "pre": [
-                                    "line1",
-                                    "line2"
-                                ]
-                            },
-                            "exclude_from_grouping": false,
-                            "filename": "file/name.py",
-                            "function": "foo",
-                            "library_frame": true,
-                            "line": {
-                                "column": 4,
-                                "context": "line3",
-                                "number": 3
-                            },
-                            "module": "App::MyModule",
-                            "vars": {
-                                "key": "value"
-                            }
+                "exception": [
+                    {
+                        "attributes": {
+                            "foo": "bar"
                         },
-                        {
-                            "abs_path": "/Users/watson/code/node_modules/elastic/lib/instrumentation/index.js",
-                            "context": {
-                                "post": [
-                                    "    ins.currentTransaction = prev",
-                                    "    return result",
-                                    "}",
-                                    "}",
-                                    "",
-                                    "Instrumentation.prototype._recoverTransaction = function (trans) {",
-                                    "  if (this.currentTransaction === trans) return"
-                                ],
-                                "pre": [
-                                    "  var trans = this.currentTransaction",
-                                    "",
-                                    "  return instrumented",
-                                    "",
-                                    "  function instrumented () {",
-                                    "    var prev = ins.currentTransaction",
-                                    "    ins.currentTransaction = trans"
-                                ]
+                        "code": "42",
+                        "handled": false,
+                        "message": "The username root is unknown",
+                        "module": "__builtins__",
+                        "stacktrace": [
+                            {
+                                "abs_path": "/real/file/name.py",
+                                "context": {
+                                    "post": [
+                                        "line4",
+                                        "line5"
+                                    ],
+                                    "pre": [
+                                        "line1",
+                                        "line2"
+                                    ]
+                                },
+                                "exclude_from_grouping": false,
+                                "filename": "file/name.py",
+                                "function": "foo",
+                                "library_frame": true,
+                                "line": {
+                                    "column": 4,
+                                    "context": "line3",
+                                    "number": 3
+                                },
+                                "module": "App::MyModule",
+                                "vars": {
+                                    "key": "value"
+                                }
                             },
-                            "exclude_from_grouping": false,
-                            "filename": "lib/instrumentation/index.js",
-                            "function": "instrumented",
-                            "line": {
-                                "context": "    var result = original.apply(this, arguments)",
-                                "number": 102
-                            },
-                            "vars": {
-                                "key": "value"
+                            {
+                                "abs_path": "/Users/watson/code/node_modules/elastic/lib/instrumentation/index.js",
+                                "context": {
+                                    "post": [
+                                        "    ins.currentTransaction = prev",
+                                        "    return result",
+                                        "}",
+                                        "}",
+                                        "",
+                                        "Instrumentation.prototype._recoverTransaction = function (trans) {",
+                                        "  if (this.currentTransaction === trans) return"
+                                    ],
+                                    "pre": [
+                                        "  var trans = this.currentTransaction",
+                                        "",
+                                        "  return instrumented",
+                                        "",
+                                        "  function instrumented () {",
+                                        "    var prev = ins.currentTransaction",
+                                        "    ins.currentTransaction = trans"
+                                    ]
+                                },
+                                "exclude_from_grouping": false,
+                                "filename": "lib/instrumentation/index.js",
+                                "function": "instrumented",
+                                "line": {
+                                    "context": "    var result = original.apply(this, arguments)",
+                                    "number": 102
+                                },
+                                "vars": {
+                                    "key": "value"
+                                }
                             }
-                        }
-                    ],
-                    "type": "DbError"
-                },
+                        ],
+                        "type": "DbError"
+                    }
+                ],
                 "grouping_key": "50f62f37edffc4630c6655ba3ecfcf46",
                 "id": "0123456789012345",
                 "log": {
@@ -279,9 +281,11 @@
                 "id": "container-id"
             },
             "error": {
-                "exception": {
-                    "message": "Cannot read property 'baz' no defined"
-                },
+                "exception": [
+                    {
+                        "message": "Cannot read property 'baz' no defined"
+                    }
+                ],
                 "grouping_key": "ae0232fed4cb40e7ebc62a585a421d60",
                 "id": "cdefab0123456789"
             },
@@ -352,9 +356,11 @@
                 "id": "container-id"
             },
             "error": {
-                "exception": {
-                    "type": "DbError"
-                },
+                "exception": [
+                    {
+                        "type": "DbError"
+                    }
+                ],
                 "grouping_key": "c3868d6704b923014eaffea034e70a3d",
                 "id": "cdefab0123456780"
             },

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationRumErrors.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationRumErrors.approved.json
@@ -27,64 +27,66 @@
             },
             "error": {
                 "culprit": "test/e2e/general-usecase/bundle.js.map",
-                "exception": {
-                    "message": "Uncaught Error: timeout test error",
-                    "stacktrace": [
-                        {
-                            "abs_path": "http://localhost:8000/test/../test/e2e/general-usecase/bundle.js.map",
-                            "exclude_from_grouping": false,
-                            "filename": "test/e2e/general-usecase/bundle.js.map",
-                            "function": "\u003canonymous\u003e",
-                            "library_frame": true,
-                            "line": {
-                                "column": 18,
-                                "number": 1
+                "exception": [
+                    {
+                        "message": "Uncaught Error: timeout test error",
+                        "stacktrace": [
+                            {
+                                "abs_path": "http://localhost:8000/test/../test/e2e/general-usecase/bundle.js.map",
+                                "exclude_from_grouping": false,
+                                "filename": "test/e2e/general-usecase/bundle.js.map",
+                                "function": "\u003canonymous\u003e",
+                                "library_frame": true,
+                                "line": {
+                                    "column": 18,
+                                    "number": 1
+                                }
+                            },
+                            {
+                                "abs_path": "http://localhost:8000/test/./e2e/general-usecase/bundle.js.map",
+                                "exclude_from_grouping": false,
+                                "filename": "~/test/e2e/general-usecase/bundle.js.map",
+                                "function": "invokeTask",
+                                "library_frame": false,
+                                "line": {
+                                    "column": 181,
+                                    "number": 1
+                                }
+                            },
+                            {
+                                "abs_path": "http://localhost:8000/test/e2e/general-usecase/bundle.js.map",
+                                "exclude_from_grouping": false,
+                                "filename": "~/test/e2e/general-usecase/bundle.js.map",
+                                "function": "runTask",
+                                "line": {
+                                    "column": 15,
+                                    "number": 1
+                                }
+                            },
+                            {
+                                "abs_path": "http://localhost:8000/test/e2e/general-usecase/bundle.js.map",
+                                "exclude_from_grouping": false,
+                                "filename": "~/test/e2e/general-usecase/bundle.js.map",
+                                "function": "invoke",
+                                "line": {
+                                    "column": 199,
+                                    "number": 1
+                                }
+                            },
+                            {
+                                "abs_path": "http://localhost:8000/test/e2e/general-usecase/bundle.js.map",
+                                "exclude_from_grouping": false,
+                                "filename": "~/test/e2e/general-usecase/bundle.js.map",
+                                "function": "timer",
+                                "line": {
+                                    "column": 33,
+                                    "number": 1
+                                }
                             }
-                        },
-                        {
-                            "abs_path": "http://localhost:8000/test/./e2e/general-usecase/bundle.js.map",
-                            "exclude_from_grouping": false,
-                            "filename": "~/test/e2e/general-usecase/bundle.js.map",
-                            "function": "invokeTask",
-                            "library_frame": false,
-                            "line": {
-                                "column": 181,
-                                "number": 1
-                            }
-                        },
-                        {
-                            "abs_path": "http://localhost:8000/test/e2e/general-usecase/bundle.js.map",
-                            "exclude_from_grouping": false,
-                            "filename": "~/test/e2e/general-usecase/bundle.js.map",
-                            "function": "runTask",
-                            "line": {
-                                "column": 15,
-                                "number": 1
-                            }
-                        },
-                        {
-                            "abs_path": "http://localhost:8000/test/e2e/general-usecase/bundle.js.map",
-                            "exclude_from_grouping": false,
-                            "filename": "~/test/e2e/general-usecase/bundle.js.map",
-                            "function": "invoke",
-                            "line": {
-                                "column": 199,
-                                "number": 1
-                            }
-                        },
-                        {
-                            "abs_path": "http://localhost:8000/test/e2e/general-usecase/bundle.js.map",
-                            "exclude_from_grouping": false,
-                            "filename": "~/test/e2e/general-usecase/bundle.js.map",
-                            "function": "timer",
-                            "line": {
-                                "column": 33,
-                                "number": 1
-                            }
-                        }
-                    ],
-                    "type": "Error"
-                },
+                        ],
+                        "type": "Error"
+                    }
+                ],
                 "grouping_key": "52fbc9c2d1a61bf905b4a11c708006fd",
                 "id": "aba2688e033848ce9c4e4005f1caa534",
                 "log": {

--- a/tests/fields.go
+++ b/tests/fields.go
@@ -153,10 +153,15 @@ func flattenMapStrStr(k string, v interface{}, prefix string, keysBlacklist *Set
 	if !isBlacklistedKey(keysBlacklist, key) {
 		flattened.Add(key)
 	}
-	_, okCommonMapStr := v.(common.MapStr)
-	_, okMapStr := v.(map[string]interface{})
-	if okCommonMapStr || okMapStr {
+	switch v := v.(type) {
+	case common.MapStr:
 		FlattenMapStr(v, key, keysBlacklist, flattened)
+	case map[string]interface{}:
+		FlattenMapStr(v, key, keysBlacklist, flattened)
+	case []common.MapStr:
+		for _, v := range v {
+			FlattenMapStr(v, key, keysBlacklist, flattened)
+		}
 	}
 }
 

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -254,8 +254,8 @@ class ElasticTest(ServerBaseTest):
             rs['hits']['total'], count)
         for doc in rs['hits']['hits']:
             err = doc["_source"]["error"]
-            if "exception" in err:
-                self.check_for_no_smap(err["exception"])
+            for exception in err.get("exception", []):
+                self.check_for_no_smap(exception)
             if "log" in err:
                 self.check_for_no_smap(err["log"])
 
@@ -338,8 +338,8 @@ class ClientSideElasticTest(ClientSideBaseTest, ElasticTest):
             rs['hits']['total'], count)
         for doc in rs['hits']['hits']:
             err = doc["_source"]["error"]
-            if "exception" in err:
-                self.check_smap(err["exception"], updated, expected_err)
+            for exception in err.get("exception", []):
+                self.check_smap(exception, updated, expected_err)
             if "log" in err:
                 self.check_smap(err["log"], updated, expected_err)
 

--- a/tests/system/error.approved.json
+++ b/tests/system/error.approved.json
@@ -51,9 +51,9 @@
                 }
             },
             "error": {
-                "exception": {
+                "exception": [{
                     "type": "connection error"
-                },
+                }],
                 "grouping_key": "18f82051862e494727fa20e0adc15711",
                 "id": "7f0e9d68c1854d21a6f44673ed561ec8"
             },
@@ -182,7 +182,7 @@
                 }
             },
             "error": {
-                "exception": {
+                "exception": [{
                     "stacktrace": [
                         {
                             "function": "foo",
@@ -252,7 +252,7 @@
                     },
                     "message": "The username root is unknown",
                     "type": "DbError"
-                },
+                }],
                 "grouping_key": "50f62f37edffc4630c6655ba3ecfcf46",
                 "id": "5f0e9d64c1854d21a6f44673ed561ec8",
                 "culprit": "my.module.function_name",
@@ -388,10 +388,10 @@
                 }
             },
             "error": {
-                "exception": {
+                "exception": [{
                     "message": "foo is not defined",
                     "code": "35"
-                },
+                }],
                 "grouping_key": "f6b5a2877d9b00d5b32b44c9db039f11",
                 "id": "8f0e9d68c1854d21a6f44673ed561ec8"
             },

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -224,8 +224,8 @@ class EnrichEventIntegrationTest(ClientSideElasticTest):
         for doc in rs['hits']['hits']:
             if "error" in doc["_source"]:
                 err = doc["_source"]["error"]
-                if "exception" in err:
-                    self.count_library_frames(err["exception"], l_frames)
+                for exception in err.get("exception", []):
+                    self.count_library_frames(exception, l_frames)
                 if "log" in err:
                     self.count_library_frames(err["log"], l_frames)
             elif "span" in doc["_source"]:


### PR DESCRIPTION
In order to support chained exceptions in the future,
we store exceptions as an array of objects. For now,
the array (if present) will have a single object.
Later, the array will have multiple elements, with
each exception object in the array corresponding to
the preceding exception object's cause.

Closes #1817