### PR TITLE
[docs] Document metrics

### DIFF
--- a/docs/events-api.asciidoc
+++ b/docs/events-api.asciidoc
@@ -8,9 +8,9 @@ Events can be:
 * Transactions
 * Spans
 * Errors
-* Metricsets
+* Metrics
 
-You can learn more about events in the {apm-overview-ref-v}/apm-data-model.html[APM Data Model] documentation. 
+You can learn more about events in the {apm-overview-ref-v}/apm-data-model.html[APM Data Model]. 
 
 [[events-api-endpoint]]
 [float]
@@ -102,7 +102,7 @@ The APM Server uses a collection of JSON Schemas for validating requests to the 
 * <<transaction-api, Transactions>>
 * <<span-api, Spans>>
 * <<error-api, Errors>>
-* <<metricset-api, Metricsets>>
+* <<metricset-api, Metrics>>
 * <<example-intake-events, Example Request Body>>
 
 include::./metadata-api.asciidoc[]

--- a/docs/exploring-es-data.asciidoc
+++ b/docs/exploring-es-data.asciidoc
@@ -6,11 +6,11 @@
 
 By default, Elastic APM data is stored in separated indices in the following formats:
 ------------------------------------------------------------
-apm-%{[version]}-sourcemap
-apm-%{[version]}-error-%{+yyyy.MM.dd}
 apm-%{[version]}-transaction-%{+yyyy.MM.dd}
 apm-%{[version]}-span-%{+yyyy.MM.dd}
+apm-%{[version]}-error-%{+yyyy.MM.dd}
 apm-%{[version]}-metric-%{+yyyy.MM.dd}
+apm-%{[version]}-sourcemap
 ------------------------------------------------------------
 
 If you're unfamiliar with the data types shown above, they are described in the {apm-overview-ref-v}/apm-data-model.html[APM data model].
@@ -26,10 +26,10 @@ GET _cat/indices/apm*
 
 Default APM `template` and `indices`:
 
-//* <<fields>>
 * <<transaction-indices>>
 * <<span-indices>>
 * <<error-indices>>
+* <<metricset-indices>>
 * <<sourcemap-indices>>
 
 

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -1,64 +1,32 @@
 [[apm-data-model]]
 == Data Model
 
-Elastic APM agents capture different types of information from within their instrumented applications - namely `transactions`, `spans`, and `errors`. 
+Elastic APM agents capture different types of information from within their instrumented applications - namely `spans`, `transactions`, `errors`, and `metrics`. 
 
-*<<errors,`Errors`>>* contain information about the error or exception that was captured.
-
-*<<transaction-spans,`Spans`>>* contain information about a specific code path that has been executed.
-They measure from the start to end of an activity,
-and they can have a parent/child relationship with other spans. 
-
-*<<transactions,`Transactions`>>* are a special kind of span that have extra metadata associated with them.
-You can think of transactions as the highest level of work you're measuring within a service.
-For example, serving an HTTP request or running a specific background job.
-
-[[transactions]]
-=== Transactions
-
-A transaction describes an event captured by an Elastic APM agent instrumenting a service. Some examples of a transaction might be:
-
-* An HTTP request
-* A background job
-
-A transaction contains:
-
-* The timestamp and duration of the event
-* A unique id, type, and name
-* A result (e.g. a response code)
-* Some contextual data (see below for details)
-* Other relevant information depending on the agent. Example: The JavaScript RUM captures transaction marks,
-which are points in time relative to the start of the transaction with some label.
-
-[[transactions-context]]
-include::../context.asciidoc[]
-
-Agents decide whether to sample transactions or not,
-and provide settings to control sampling behavior.
-If sampled,
-the <<transaction-spans,spans>> of a transaction are sent and stored as separate documents. Within one transaction there can be several, or no spans captured. 
-
-Transactions are stored in {apm-server-ref-v}/transaction-indices.html[transaction indices].
+* <<transaction-spans>>
+* <<transactions>>
+* <<errors>>
+* <<metrics>>
 
 [[transaction-spans]]
 === Spans
-Transactions can have 0, 1, or many spans. Spans have a `transaction.id` attribute that refers to their parent transaction. They also have a `parent.id` attribute that refers to the parent span, or their transaction.
 
-Agents typically automatically instrument a variety of of libraries,
-but also provide an API for ad hoc instrumentation of specific code paths. 
-A span contains information about a specific code path that has been executed as part of a transaction.
-This information includes:
+*Spans* contain information about a specific code path that has been executed.
+They measure from the start to end of an activity,
+and they can have a parent/child relationship with other spans.
+
+Agents automatically instrument a variety of libraries to capture these spans from within your application.
+In addition, you can use the Agent API for ad hoc instrumentation of specific code paths. 
+
+Spans have a `transaction.id` attribute that refers to their parent <<transactions,transaction>>.
+They also have a `parent.id` attribute that refers to their parent span, or their transaction.
+Other span data includes:
 
 * start time
 * duration
 * name
 * type
 * `stack trace` (optional)
-
-As an example, if a database query happens within a sampled transaction,
-a span describing the database query will be created.
-The name of this span will contain information about the query itself,
-and the type of this span will contain information about the database.
 
 Spans are stored in {apm-server-ref-v}/span-indices.html[span indices].
 Note that these indices are separate from {apm-server-ref-v}/transaction-indices.html[transaction indices] by default.
@@ -90,24 +58,75 @@ Unforseen errors may cause spans to go missing.
 Because the agent notifies the server about how many spans there should be,
 the number of missing spans is able to be calculated and shown in the UI.
 
+[[transactions]]
+=== Transactions
+
+*Transactions* are a special kind of <<transaction-spans,span>> that have extra metadata associated with them.
+They describe an event captured by an Elastic APM agent instrumenting a service.
+You can think of transactions as the highest level of work you’re measuring within a service.
+As an example, a transaction might be a:
+
+* request to your server
+* batch job
+* background job
+* custom transaction type.
+
+Agents decide whether to sample transactions or not,
+and provide settings to control sampling behavior.
+If sampled, the <<transaction-spans,spans>> of a transaction are sent and stored as separate documents.
+Within one transaction there can be 0, 1, or many spans captured.
+
+A transaction contains:
+
+* The timestamp and duration of the event
+* A unique id, type, and name
+* A result (e.g. a response code)
+* Some contextual data (see below for details)
+* Other relevant information depending on the agent. Example: The JavaScript RUM captures transaction marks,
+which are points in time relative to the start of the transaction with some label.
+
+[[transactions-context]]
+include::../context.asciidoc[]
+
+Transactions are stored in {apm-server-ref-v}/transaction-indices.html[transaction indices].
+
 [[errors]]
 === Errors
 
-Errors are represented by a unique ID.
 An error event contains at least
 information about the original `exception` that occurred
 or about a `log` created when the exception occurred.
+For simplicity, errors are represented by a unique ID.
 
-Both the captured `exception` and the captured `log` of an error can contain a `stack trace`,
-helpful for debugging.
+Error data includes:
 
-The `culprit` of an error indicates where it originated.
-
-An error might relate to the <<transactions,transaction>> during which it happened,
+* Both the captured `exception` and the captured `log` of an error can contain a `stack trace`,
+which is helpful for debugging.
+* The `culprit` of an error indicates where it originated.
+* An error might relate to the <<transactions,transaction>> during which it happened,
 via the `transaction.id`.
-
-Errors also have some contextual data.
+* Some contextual data (see below).
 
 include::../context.asciidoc[]
 
 Errors are stored in {apm-server-ref-v}/error-indices.html[error indices].
+
+[[metrics]]
+=== Metrics
+
+APM agents automatically pick up basic host-level metrics, including system and process-level CPU and memory metrics.
+Agent specific metrics are also available, like {apm-java-ref-v}/metrics.html[JVM metrics] in the Java Agent, and {apm-go-ref-v}/metrics.html[Go runtime] metrics in the Go Agent.
+
+Infrastructure and application metrics are important sources of information when debugging production systems, which is why we've made it easy to filter metrics for specific hosts or containers on the {kibana-ref}/metrics.html[Kibana Metrics overview] page.
+
+Metrics have the `processor.event` property set to `metric`.
+
+Metrics are stored in {apm-server-ref-v}/metricset-indices.html[metric indices].
+
+For a full list of tracked metrics, see the relevant agent documentation:
+
+* {apm-go-ref-v}/metrics.html[Go]
+* {apm-java-ref-v}/metrics.html[Java]
+* {apm-node-ref-v}/metrics.html[Node.js]
+* {apm-py-ref-v}/metrics.html[Python]
+* {apm-ruby-ref-v}/metrics.html[Ruby].

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -114,10 +114,14 @@ Errors are stored in {apm-server-ref-v}/error-indices.html[error indices].
 [[metrics]]
 === Metrics
 
-APM agents automatically pick up basic host-level metrics, including system and process-level CPU and memory metrics.
-Agent specific metrics are also available, like {apm-java-ref-v}/metrics.html[JVM metrics] in the Java Agent, and {apm-go-ref-v}/metrics.html[Go runtime] metrics in the Go Agent.
+APM agents automatically pick up basic host-level metrics,
+including system and process-level CPU and memory metrics.
+Agent specific metrics are also available,
+like {apm-java-ref-v}/metrics.html[JVM metrics] in the Java Agent,
+and {apm-go-ref-v}/metrics.html[Go runtime] metrics in the Go Agent.
 
-Infrastructure and application metrics are important sources of information when debugging production systems, which is why we've made it easy to filter metrics for specific hosts or containers on the {kibana-ref}/metrics.html[Kibana Metrics overview] page.
+Infrastructure and application metrics are important sources of information when debugging production systems,
+which is why we've made it easy to filter metrics for specific hosts or containers in the Kibana {kibana-ref}/metrics.html[metrics overview].
 
 Metrics have the `processor.event` property set to `metric`.
 
@@ -129,4 +133,4 @@ For a full list of tracked metrics, see the relevant agent documentation:
 * {apm-java-ref-v}/metrics.html[Java]
 * {apm-node-ref-v}/metrics.html[Node.js]
 * {apm-py-ref-v}/metrics.html[Python]
-* {apm-ruby-ref-v}/metrics.html[Ruby].
+* {apm-ruby-ref-v}/metrics.html[Ruby]

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -61,7 +61,7 @@ the number of missing spans is able to be calculated and shown in the UI.
 [[transactions]]
 === Transactions
 
-*Transactions* are a special kind of <<transaction-spans,span>> that have extra metadata associated with them.
+*Transactions* are a special kind of <<transaction-spans,span>> that have additional attributes associated with them.
 They describe an event captured by an Elastic APM agent instrumenting a service.
 You can think of transactions as the highest level of work you’re measuring within a service.
 As an example, a transaction might be a:

--- a/docs/metricset-api.asciidoc
+++ b/docs/metricset-api.asciidoc
@@ -1,13 +1,13 @@
 [[metricset-api]]
-=== Metricsets
+=== Metrics
 
-Metricsets contain application metric data captured by an APM agent. 
+Metrics contain application metric data captured by an APM agent. 
 
 [[metricset-schema]]
 [float]
-==== Metricset Schema
+==== Metric Schema
 
-The APM Server uses JSON Schema for validating requests. The specification for metricsets is defined below:
+The APM Server uses JSON Schema for validating requests. The specification for metrics is defined below:
 
 [source,json]
 ----

--- a/docs/metricset-indices.asciidoc
+++ b/docs/metricset-indices.asciidoc
@@ -1,13 +1,13 @@
 [[metricset-indices]]
-== Metricset Indices
+== Metric Indices
 
-Metricsets are by default stored to indices of the format `apm-[version]-metric-[date]`.
+By default, metrics are stored to indices of the format `apm-[version]-metric-[date]`.
 
 [[metricset-example]]
 [float]
 === Example Documents
 
-See how metricset documents can look like when indexed in Elasticsearch:
+Here's what a metric document looks like when indexed in Elasticsearch:
 
 [source,json]
 ----


### PR DESCRIPTION
* ~WIP~
* ~Needs https://github.com/elastic/kibana/pull/28621 to be merged first.~

Adds metrics documentation, and makes the APM Data Model easier to understand. Closes elastic/apm-server#1060