### PR TITLE
Update Go to 1.10.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.6
+FROM golang:1.10.8
 MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 RUN set -x && \

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To get started with APM please see our [Getting Started Guide](https://www.elast
 
 ### Requirements
 
-* [Golang](https://golang.org/dl/) 1.10.6
+* [Golang](https://golang.org/dl/) 1.10.8
 
 ### Install
 

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -10,6 +10,7 @@ https://github.com/elastic/apm-server/compare/6.5\...6.x[View commits]
 - Add `span.sync` property to intake json spec and index field in ES. {pull}1548[1548].
 - Make `service.framework` properties optional and nullable {pull}1546[1546].
 - Add `transaction.sampled` to errors {pull}1662[1662].
+- Update Go to 1.10.8 {pull}XXX[XXX].
 
 [float]
 ==== Bug fixes

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -10,7 +10,7 @@ https://github.com/elastic/apm-server/compare/6.5\...6.x[View commits]
 - Add `span.sync` property to intake json spec and index field in ES. {pull}1548[1548].
 - Make `service.framework` properties optional and nullable {pull}1546[1546].
 - Add `transaction.sampled` to errors {pull}1662[1662].
-- Update Go to 1.10.8 {pull}XXX[XXX].
+- Update Go to 1.10.8 {pull}1832[1832].
 
 [float]
 ==== Bug fixes

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,7 +1,7 @@
 :stack-version: 6.6.0
 :doc-branch: 6.6
 :branch: {doc-branch}
-:go-version: 1.10.6
+:go-version: 1.10.8
 :release-state: unreleased
 :python: 2.7.9
 :docker: 1.12

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.6
+FROM golang:1.10.8
 MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 RUN set -x && \


### PR DESCRIPTION
This is a security release. For details see [release announcement](https://groups.google.com/forum/#!topic/golang-announce/mVeX35iXuSw).

related to https://github.com/elastic/beats/pull/10304

to be ported to 6.x.