### PR TITLE
Update Go to 1.11.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.4
+FROM golang:1.11.5
 MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 RUN set -x && \

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To get started with APM please see our [Getting Started Guide](https://www.elast
 
 ### Requirements
 
-* [Golang](https://golang.org/dl/) 1.11.4
+* [Golang](https://golang.org/dl/) 1.11.5
 
 ### Install
 

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -4,7 +4,6 @@
 [float]
 ==== Added
 
-- Update Go version to 1.11.4 {pull}1700[1700].
 - Update Elastic APM Go agent to v1.1.2 {pull}1711[1711], {pull}1728[1728].
 - Allow numbers and boolean values for `transaction.tags`, `span.tags`, `metricset.tags` {pull}1712[1712].
 - Update response format of the healthcheck handler and prettyfy all JSON responses {pull}1748[1748].
@@ -12,6 +11,7 @@
 - Rename transaction.span_count.dropped.total to transaction.span_count.dropped {pull}1809[1809].
 - Rename span.hex_id to span.id {pull}1811[1811].
 - Index error.exception as array of objects {pull}1825[1825]
+- Update Go version to 1.11.5 {pull}1840[1840].
 
 [float]
 ==== Removed

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,7 +1,7 @@
 :stack-version: 7.0.0-alpha2
 :doc-branch: master
 :branch: {doc-branch}
-:go-version: 1.11.4
+:go-version: 1.11.5
 :release-state: prerelease
 :python: 2.7.9
 :docker: 1.12

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.4
+FROM golang:1.11.5
 MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
 RUN set -x && \


### PR DESCRIPTION
This is a security release. For details see [release announcement](https://groups.google.com/forum/#!topic/golang-announce/mVeX35iXuSw).
