### PR TITLE
[tests] check all keys in events.

### DIFF
--- a/tests/system/error.approved.json
+++ b/tests/system/error.approved.json
@@ -5,20 +5,40 @@
         "_id": "YEUQC2IBWUGW2FxIuwuv",
         "_source": {
             "@timestamp": "2017-05-09T15:04:05.000Z",
-            "agent": {
-                "version": "3.14.0",
-                "name": "elastic-node"
+            "timestamp":{
+                "us": 1494342245000000
+            },
+            "ecs": {
+                "version": "1.0.0-beta2"
+            },
+            "observer": {
+                "type": "apm-server",
+                "ephemeral_id": "xxx",
+                "hostname": "xxx",
+                "version": "xxx",
+                "id": "xxx"
+            },
+            "container":{
+                "id":"container-id"
+            },
+            "kubernetes":{
+                "namespace":"namespace1",
+                "pod":{
+                    "uid":"pod-uid",
+                    "name":"pod-name"
+                }
             },
             "host": {
-                "platform": "darwin",
+                "os": {
+                    "platform": "darwin"
+                },
                 "hostname": "prod1.example.com",
                 "architecture": "x64",
                 "ip": "127.0.0.1"
             },
-            "observer": {
-                "hostname": "5d8dc22ccf3b",
-                "name": "5d8dc22ccf3b",
-                "version": "7.0.0-alpha1"
+            "agent": {
+                "version": "3.14.0",
+                "name": "elastic-node"
             },
             "processor": {
                 "event": "error",
@@ -27,7 +47,7 @@
             "process": {
                 "ppid": 7788,
                 "pid": 1234,
-                "argv": [
+                "args": [
                     "node",
                     "server.js"
                 ],
@@ -58,7 +78,7 @@
                 "id": "7f0e9d68c1854d21a6f44673ed561ec8"
             },
             "user": {
-                "username": "bar",
+                "name": "bar",
                 "id": 123,
                 "email": "bar@example.com"
             }
@@ -71,25 +91,45 @@
         "_id": "XkUQC2IBWUGW2FxIuwuv",
         "_source": {
             "@timestamp": "2017-05-09T15:04:05.999Z",
+            "timestamp":{
+                "us": 1494342245999999
+            },
+            "ecs":{
+                "version":"1.0.0-beta2"
+            },
+            "observer": {
+                "type": "apm-server",
+                "ephemeral_id": "xxx",
+                "hostname": "xxx",
+                "version": "xxx",
+                "id": "xxx"
+            },
+            "container":{
+                "id":"container-id"
+            },
+            "kubernetes":{
+                "namespace":"namespace1",
+                "pod":{
+                    "name":"pod-name",
+                    "uid":"pod-uid"
+                }
+            },
             "agent": {
                 "version": "3.14.0",
                 "name": "elastic-node"
             },
             "host": {
-                "platform": "darwin",
+                "os": {
+                    "platform": "darwin"
+                },
                 "hostname": "prod1.example.com",
                 "architecture": "x64",
                 "ip": "127.0.0.1"
             },
-            "observer": {
-                "hostname": "5d8dc22ccf3b",
-                "name": "5d8dc22ccf3b",
-                "version": "7.0.0-alpha1"
-            },
             "process": {
                 "ppid": 7788,
                 "pid": 1234,
-                "argv": [
+                "args": [
                     "node",
                     "server.js"
                 ],
@@ -164,7 +204,7 @@
                 "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79"
             },
             "user": {
-                "username": "foo",
+                "name": "foo",
                 "id": 99,
                 "email": "foo@example.com"
             },
@@ -331,9 +371,9 @@
                 "event": "error"
             },
             "user": {
-                "username": "bar",
-                "id": 123,
-                "email": "bar@example.com"
+                "name": "foo",
+                "id": "99",
+                "email": "foo@example.com"
             }
         },
         "_index": "test-apm-12-12-2017"
@@ -343,21 +383,41 @@
         "_type": "_doc",
         "_id": "X0UQC2IBWUGW2FxIuwuv",
         "_source": {
-            "@timestamp": "2017-05-09T15:04:05.100Z",
+            "@timestamp": "2017-05-09T15:04:05.000Z",
+            "timestamp":{
+                "us": 1494342245000000
+            },
+            "ecs":{
+                "version":"1.0.0-beta2"
+            },
+            "observer": {
+                "type": "apm-server",
+                "ephemeral_id": "xxx",
+                "hostname": "xxx",
+                "version": "xxx",
+                "id": "xxx"
+            },
+            "container":{
+                "id":"container-id"
+            },
+            "kubernetes":{
+                "namespace":"namespace1",
+                "pod":{
+                    "uid":"pod-uid",
+                    "name":"pod-name"
+                }
+            },
             "agent": {
                 "version": "3.14.0",
                 "name": "elastic-node"
             },
             "host": {
-                "platform": "darwin",
+                "os": {
+                    "platform": "darwin"
+                },
                 "hostname": "prod1.example.com",
                 "architecture": "x64",
                 "ip": "127.0.0.1"
-            },
-            "observer": {
-                "hostname": "5d8dc22ccf3b",
-                "name": "5d8dc22ccf3b",
-                "version": "7.0.0-alpha1"
             },
             "processor": {
                 "name": "error",
@@ -366,7 +426,7 @@
             "process": {
                 "ppid": 7788,
                 "pid": 1234,
-                "argv": [
+                "args": [
                     "node",
                     "server.js"
                 ],
@@ -398,7 +458,7 @@
                 "id": "8f0e9d68c1854d21a6f44673ed561ec8"
             },
             "user": {
-                "username": "bar",
+                "name": "bar",
                 "id": 123,
                 "email": "bar@example.com"
             }
@@ -411,20 +471,40 @@
         "_id": "YUUQC2IBWUGW2FxIuwuv",
         "_source": {
             "@timestamp": "2017-05-09T15:04:05.999Z",
+            "timestamp":{
+                "us": 1494342245999000
+            },
+            "ecs":{
+                "version":"1.0.0-beta2"
+            },
+            "observer": {
+                "type": "apm-server",
+                "ephemeral_id": "xxx",
+                "hostname": "xxx",
+                "version": "xxx",
+                "id": "xxx"
+            },
+            "container":{
+                "id":"container-id"
+            },
+            "kubernetes": {
+                "namespace": "namespace1",
+                "pod":{
+                    "uid":"pod-uid",
+                    "name":"pod-name"
+                }
+            },
             "agent": {
                 "version": "3.14.0",
                 "name": "elastic-node"
             },
             "host": {
-                "platform": "darwin",
+                "os": {
+                    "platform": "darwin"
+                },
                 "hostname": "prod1.example.com",
                 "architecture": "x64",
                 "ip": "127.0.0.1"
-            },
-            "observer": {
-                "version": "7.0.0-alpha1",
-                "name": "5d8dc22ccf3b",
-                "hostname": "5d8dc22ccf3b"
             },
             "processor": {
                 "name": "error",
@@ -433,7 +513,7 @@
             "process": {
                 "ppid": 7788,
                 "pid": 1234,
-                "argv": [
+                "args": [
                     "node",
                     "server.js"
                 ],
@@ -465,7 +545,7 @@
                 }
             },
             "user": {
-                "username": "bar",
+                "name": "bar",
                 "id": 123,
                 "email": "bar@example.com"
             }

--- a/tests/system/spans.approved.json
+++ b/tests/system/spans.approved.json
@@ -5,14 +5,40 @@
         "_id": "IkU4C2IBWUGW2FxIExjw",
         "_source": {
             "@timestamp": "2017-05-30T18:53:27.154Z",
+            "timestamp":{
+                "us": 1496170407154000
+            },
+            "ecs": {
+                "version": "1.0.0-beta2"
+            },
+            "observer": {
+                "type": "apm-server",
+                "ephemeral_id": "xxx",
+                "hostname": "xxx",
+                "version": "xxx",
+                "id": "xxx"
+            },
+            "container":{
+                "id":"container-id"
+            },
+            "kubernetes":{
+                "namespace":"namespace1",
+                "pod":{
+                    "uid":"pod-uid",
+                    "name":"pod-name"
+                }
+            },
+            "host": {
+                "os": {
+                    "platform": "darwin"
+                },
+                "hostname": "prod1.example.com",
+                "architecture": "x64",
+                "ip": "127.0.0.1"
+            },
             "agent": {
                 "version": "3.14.0",
                 "name": "elastic-node"
-            },
-            "observer": {
-                "hostname": "40c010b36edc",
-                "name": "40c010b36edc",
-                "version": "7.0.0-alpha1"
             },
             "processor": {
                 "event": "span",
@@ -34,6 +60,12 @@
             },
             "transaction": {
                 "id": "945254c567a5417e"
+            },
+            "parent": {
+                "id": "945254c567a5417e"
+            },
+            "trace": {
+                "id": "945254c567a5417eaaaaaaaaaaaaaaaa"
             }
         },
         "_index": "test-apm-12-12-2017"
@@ -44,14 +76,40 @@
         "_id": "J0U4C2IBWUGW2FxIExjw",
         "_source": {
             "@timestamp": "2017-05-30T18:53:42.281Z",
+            "timestamp":{
+                "us": 1496170422281000
+            },
+            "ecs": {
+                "version": "1.0.0-beta2"
+            },
+            "observer": {
+                "type": "apm-server",
+                "ephemeral_id": "xxx",
+                "hostname": "xxx",
+                "version": "xxx",
+                "id": "xxx"
+            },
+            "container":{
+                "id":"container-id"
+            },
+            "kubernetes":{
+                "namespace":"namespace1",
+                "pod":{
+                    "uid":"pod-uid",
+                    "name":"pod-name"
+                }
+            },
+            "host": {
+                "os": {
+                    "platform": "darwin"
+                },
+                "hostname": "prod1.example.com",
+                "architecture": "x64",
+                "ip": "127.0.0.1"
+            },
             "agent": {
                 "version": "3.14.0",
                 "name": "elastic-node"
-            },
-            "observer": {
-                "hostname": "40c010b36edc",
-                "name": "40c010b36edc",
-                "version": "7.0.0-alpha1"
             },
             "span": {
                 "id": "15aaaaaaaaaaaaaa",
@@ -76,7 +134,13 @@
                 "name": "1234_service-12a3"
             },
             "transaction": {
-                "id": "85925e55-b43f-4340-a8e0-df1906ecbfa9"
+                "id": "85925e55b43f4342"
+            },
+            "parent": {
+                "id": "85925e55b43f4342"
+            },
+            "trace": {
+                "id": "85925e55b43f4342aaaaaaaaaaaaaaaa"
             },
             "processor": {
                 "name": "transaction",
@@ -91,14 +155,40 @@
         "_id": "I0U4C2IBWUGW2FxIExjw",
         "_source": {
             "@timestamp": "2017-05-30T18:53:27.154Z",
+            "timestamp":{
+                "us": 1496170407154000
+            },
+            "ecs": {
+                "version": "1.0.0-beta2"
+            },
+            "observer": {
+                "type": "apm-server",
+                "ephemeral_id": "xxx",
+                "hostname": "xxx",
+                "version": "xxx",
+                "id": "xxx"
+            },
+            "container":{
+                "id":"container-id"
+            },
+            "kubernetes":{
+                "namespace":"namespace1",
+                "pod":{
+                    "uid":"pod-uid",
+                    "name":"pod-name"
+                }
+            },
+            "host": {
+                "os": {
+                    "platform": "darwin"
+                },
+                "hostname": "prod1.example.com",
+                "architecture": "x64",
+                "ip": "127.0.0.1"
+            },
             "agent": {
                 "version": "3.14.0",
                 "name": "elastic-node"
-            },
-            "observer": {
-                "hostname": "40c010b36edc",
-                "name": "40c010b36edc",
-                "version": "7.0.0-alpha1"
             },
             "processor": {
                 "event": "span",
@@ -120,6 +210,12 @@
             },
             "transaction": {
                 "id": "945254c567a5417e"
+            },
+            "parent": {
+                "id": "945254c567a5417e"
+            },
+            "trace": {
+                "id": "945254c567a5417eaaaaaaaaaaaaaaaa"
             }
         },
         "_index": "test-apm-12-12-2017"
@@ -130,14 +226,40 @@
         "_id": "IEU4C2IBWUGW2FxIExjw",
         "_source": {
             "@timestamp": "2017-05-30T18:53:27.154Z",
+            "timestamp":{
+                "us": 1496170407154000
+            },
+            "ecs": {
+                "version": "1.0.0-beta2"
+            },
+            "observer": {
+                "type": "apm-server",
+                "ephemeral_id": "xxx",
+                "hostname": "xxx",
+                "version": "xxx",
+                "id": "xxx"
+            },
+            "container":{
+                "id":"container-id"
+            },
+            "kubernetes":{
+                "namespace":"namespace1",
+                "pod":{
+                    "uid":"pod-uid",
+                    "name":"pod-name"
+                }
+            },
+            "host": {
+                "os": {
+                    "platform": "darwin"
+                },
+                "hostname": "prod1.example.com",
+                "architecture": "x64",
+                "ip": "127.0.0.1"
+            },
             "agent": {
                 "version": "3.14.0",
                 "name": "elastic-node"
-            },
-            "observer": {
-                "hostname": "40c010b36edc",
-                "name": "40c010b36edc",
-                "version": "7.0.0-alpha1"
             },
             "processor": {
                 "event": "span",
@@ -214,6 +336,12 @@
             "transaction": {
                 "id": "945254c567a5417e"
             },
+            "parent": {
+                "id": "945254c567a5417e"
+            },
+            "trace": {
+                "id": "945254c567a5417eaaaaaaaaaaaaaaaa"
+            },
             "labels": {
                 "span_tag": "something"
             }
@@ -226,14 +354,40 @@
         "_id": "IUU4C2IBWUGW2FxIExjw",
         "_source": {
             "@timestamp": "2017-05-30T18:53:27.154Z",
+            "timestamp":{
+                "us": 1496170407154000
+            },
+            "ecs": {
+                "version": "1.0.0-beta2"
+            },
+            "observer": {
+                "type": "apm-server",
+                "ephemeral_id": "xxx",
+                "hostname": "xxx",
+                "version": "xxx",
+                "id": "xxx"
+            },
+            "container":{
+                "id":"container-id"
+            },
+            "kubernetes":{
+                "namespace":"namespace1",
+                "pod":{
+                    "uid":"pod-uid",
+                    "name":"pod-name"
+                }
+            },
+            "host": {
+                "os": {
+                    "platform": "darwin"
+                },
+                "hostname": "prod1.example.com",
+                "architecture": "x64",
+                "ip": "127.0.0.1"
+            },
             "agent": {
                 "version": "3.14.0",
                 "name": "elastic-node"
-            },
-            "observer": {
-                "hostname": "40c010b36edc",
-                "name": "40c010b36edc",
-                "version": "7.0.0-alpha1"
             },
             "processor": {
                 "name": "transaction",
@@ -255,6 +409,12 @@
             },
             "transaction": {
                 "id": "945254c567a5417e"
+            },
+            "parent": {
+                "id": "945254c567a5417e"
+            },
+            "trace": {
+                "id": "945254c567a5417eaaaaaaaaaaaaaaaa"
             }
         },
         "_index": "test-apm-12-12-2017"

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -6,6 +6,7 @@ from apmserver import ElasticTest, ExpvarBaseTest
 from apmserver import ClientSideElasticTest, SmapIndexBaseTest, SmapCacheBaseTest
 from apmserver import SplitIndicesTest
 from beat.beat import INTEGRATION_TESTS
+from sets import Set
 
 
 class Test(ElasticTest):
@@ -114,20 +115,27 @@ class Test(ElasticTest):
         self.check_backend_error_sourcemap(count=4)
 
     def check_docs(self, approved, received, doc_type):
+        assert len(received) == len(approved)
         for rec_entry in received:
             checked = False
             rec = rec_entry['_source']
             rec_id = rec[doc_type]['id']
-            print approved
             for appr_entry in approved:
                 appr = appr_entry['_source']
                 if rec_id == appr[doc_type]['id']:
                     checked = True
-                    self.assert_docs(rec[doc_type], appr[doc_type])
-                    self.assert_docs(rec.get('context'), appr.get('context'))
-                    self.assert_docs(rec.get('http'), appr.get('http'))
-                    self.assert_docs(rec.get('url'), appr.get('url'))
-                    self.assert_docs(rec['processor'], appr['processor'])
+                    for k, v in rec.items():
+                        if k == "host":
+                            # TODO: fix https://github.com/elastic/apm-server/issues/1846
+                            #  then remove this exception handling and treat as other keys
+                            continue
+                        if k == "observer":
+                            expected = Set(["hostname", "version", "id", "ephemeral_id", "type"])
+                            rec_keys = Set(v.keys())
+                            assert len(expected.symmetric_difference(rec_keys)) == 0
+                            continue
+
+                        self.assert_docs(v, appr[k])
             assert checked, "New entry with id {}".format(rec_id)
 
     def assert_docs(self, received, approved):

--- a/tests/system/transaction.approved.json
+++ b/tests/system/transaction.approved.json
@@ -5,37 +5,57 @@
         "_type": "_doc",
         "_source": {
             "@timestamp": "2017-05-30T18:53:27.154Z",
-            "agent": {
-                "name": "1elastic-node",
-                "version": "3.14.0"
+            "timestamp":{
+                "us": 1496170407154000
             },
-            "host": {
-                "architecture": "x64",
-                "hostname": "prod1.example.com",
-                "platform": "darwin",
-                "ip": "1127.0.0.1"
+            "ecs": {
+                "version": "1.0.0-beta2"
             },
             "observer": {
-                "name": "123",
-                "version": "7.0.0-alpha1",
-                "hostname": "ed7e2cf02cd9"
+                "type": "apm-server",
+                "ephemeral_id": "xxx",
+                "hostname": "xxx",
+                "version": "xxx",
+                "id": "xxx"
+            },
+            "container":{
+                "id":"container-id"
+            },
+            "kubernetes":{
+                "namespace":"namespace1",
+                "pod":{
+                    "uid":"pod-uid",
+                    "name":"pod-name"
+                }
+            },
+            "host": {
+                "os": {
+                    "platform": "darwin"
+                },
+                "hostname": "prod1.example.com",
+                "architecture": "x64",
+                "ip": "127.0.0.1"
+            },
+            "agent": {
+                "name": "elastic-node",
+                "version": "3.14.0"
             },
             "processor": {
                 "name": "transaction",
                 "event": "transaction"
             },
             "process": {
-                "argv": [
+                "args": [
                     "node",
                     "server.js"
                 ],
-                "pid": 11234,
+                "pid": 1234,
                 "title": "node",
                 "ppid": 6789
             },
             "service": {
                 "runtime": {
-                    "name": "1node",
+                    "name": "node",
                     "version": "8.0.0"
                 },
                 "framework": {
@@ -51,7 +71,7 @@
                 "name": "1234_service-12a3"
             },
             "user": {
-                "id": "199",
+                "id": "99",
                 "email": "foo@example.com"
             },
             "url": {
@@ -149,6 +169,9 @@
                     "us": 32592
                 },
                 "result": "success"
+            },
+            "trace": {
+                "id": "945254c567a5417eaaaaaaaaaaaaaaaa"
             }
         },
         "_index": "test-apm-12-12-2017"
@@ -159,27 +182,47 @@
         "_type": "_doc",
         "_source": {
             "@timestamp": "2017-05-30T18:53:42.281Z",
+            "timestamp":{
+                "us": 1496170422281999
+            },
+            "ecs": {
+                "version": "1.0.0-beta2"
+            },
+            "observer": {
+                "type": "apm-server",
+                "ephemeral_id": "xxx",
+                "hostname": "xxx",
+                "version": "xxx",
+                "id": "xxx"
+            },
+            "container":{
+                "id":"container-id"
+            },
+            "kubernetes":{
+                "namespace":"namespace1",
+                "pod":{
+                    "uid":"pod-uid",
+                    "name":"pod-name"
+                }
+            },
+            "host": {
+                "os": {
+                    "platform": "darwin"
+                },
+                "hostname": "prod1.example.com",
+                "architecture": "x64",
+                "ip": "127.0.0.1"
+            },
             "agent": {
                 "name": "elastic-node",
                 "version": "3.14.0"
-            },
-            "host": {
-                "architecture": "x64",
-                "hostname": "prod1.example.com",
-                "platform": "darwin",
-                "ip": "127.0.0.1"
-            },
-            "observer": {
-                "name": "ed7e2cf02cd9",
-                "version": "7.0.0-alpha1",
-                "hostname": "ed7e2cf02cd9"
             },
             "processor": {
                 "name": "transaction",
                 "event": "transaction"
             },
             "process": {
-                "argv": [
+                "args": [
                     "node",
                     "server.js"
                 ],
@@ -218,10 +261,13 @@
                 },
                 "result": "200"
             },
+            "trace": {
+                "id": "85925e55b43f4342aaaaaaaaaaaaaaaa"
+            },
             "user": {
-                "email": "bar@user.com",
+                "email": "foo@bar.com",
                 "id": "123user",
-                "name": "bar"
+                "name": "foo"
             }
         },
         "_index": "test-apm-12-12-2017"
@@ -232,27 +278,47 @@
         "_type": "_doc",
         "_source": {
             "@timestamp": "2017-05-30T18:53:42.000Z",
+            "timestamp":{
+                "us": 1496170422000000
+            },
+            "ecs": {
+                "version": "1.0.0-beta2"
+            },
+            "observer": {
+                "type": "apm-server",
+                "ephemeral_id": "xxx",
+                "hostname": "xxx",
+                "version": "xxx",
+                "id": "xxx"
+            },
+            "container":{
+                "id":"container-id"
+            },
+            "kubernetes":{
+                "namespace":"namespace1",
+                "pod":{
+                    "uid":"pod-uid",
+                    "name":"pod-name"
+                }
+            },
+            "host": {
+                "os": {
+                    "platform": "darwin"
+                },
+                "hostname": "prod1.example.com",
+                "architecture": "x64",
+                "ip": "127.0.0.1"
+            },
             "agent": {
                 "name": "elastic-node",
                 "version": "3.14.0"
-            },
-            "host": {
-                "architecture": "x64",
-                "ip": "127.0.0.1",
-                "hostname": "prod1.example.com",
-                "platform": "darwin"
-            },
-            "observer": {
-                "name": "ed7e2cf02cd9",
-                "version": "7.0.0-alpha1",
-                "hostname": "ed7e2cf02cd9"
             },
             "processor": {
                 "name": "transaction",
                 "event": "transaction"
             },
             "process": {
-                "argv": [
+                "args": [
                     "node",
                     "server.js"
                 ],
@@ -290,10 +356,13 @@
                 },
                 "result": "200"
             },
+            "trace": {
+                "id": "85925e55b43f4341aaaaaaaaaaaaaaaa"
+            },
             "user": {
-                "email": "bar@user.com",
+                "email": "foo@bar.com",
                 "id": "123user",
-                "name": "bar"
+                "name": "foo"
             }
         },
         "_index": "test-apm-12-12-2017"
@@ -304,27 +373,47 @@
         "_type": "_doc",
         "_source": {
             "@timestamp": "2017-05-30T18:53:42.281Z",
+            "timestamp":{
+                "us": 1496170422281000
+            },
+            "ecs": {
+                "version": "1.0.0-beta2"
+            },
+            "observer": {
+                "type": "apm-server",
+                "ephemeral_id": "xxx",
+                "hostname": "xxx",
+                "version": "xxx",
+                "id": "xxx"
+            },
+            "container":{
+                "id":"container-id"
+            },
+            "kubernetes":{
+                "namespace":"namespace1",
+                "pod":{
+                    "uid":"pod-uid",
+                    "name":"pod-name"
+                }
+            },
+            "host": {
+                "os": {
+                    "platform": "darwin"
+                },
+                "hostname": "prod1.example.com",
+                "architecture": "x64",
+                "ip": "127.0.0.1"
+            },
             "agent": {
                 "name": "elastic-node",
                 "version": "3.14.0"
-            },
-            "host": {
-                "architecture": "x64",
-                "hostname": "prod1.example.com",
-                "platform": "darwin",
-                "ip": "127.0.0.1"
-            },
-            "observer": {
-                "name": "ed7e2cf02cd9",
-                "version": "7.0.0-alpha1",
-                "hostname": "ed7e2cf02cd9"
             },
             "processor": {
                 "name": "transaction",
                 "event": "transaction"
             },
             "process": {
-                "argv": [
+                "args": [
                     "node",
                     "server.js"
                 ],
@@ -362,10 +451,13 @@
                 "name": "GET /api/types",
                 "result": "failure"
             },
+            "trace": {
+                "id": "85925e55b43f4340aaaaaaaaaaaaaaaa"
+            },
             "user": {
-                "email": "bar@user.com",
+                "email": "foo@bar.com",
                 "id": "123user",
-                "name": "bar"
+                "name": "foo"
             }
         },
         "_index": "test-apm-12-12-2017"


### PR DESCRIPTION
The system approval tests did not actually check the whole document, but only everything under the event key, `@timestamp` and `context`. Since we are moving out everything from `context` all the other top level keys have not been tested. 

There are some exceptions:
- `observer`: The information in observer is related to where the apm-server is running, so most of the values cannot be checked. The test only looks at the keys being present. 
- `host`: libbeat does automatically set `host.name` which is considered a bug right now and needs to be removed, see https://github.com/elastic/apm-server/issues/1846