### PR TITLE
[docs] Fix 6.6 changelog rendering

### DIFF
--- a/changelogs/6.6.asciidoc
+++ b/changelogs/6.6.asciidoc
@@ -13,7 +13,7 @@ https://github.com/elastic/apm-server/compare/v6.5.4\...v6.6.0[View commits]
 [float]
 === Added
 
-- Set some configuration defaults (setup.template.settings.index.*, logging.metrics.enabled) in code {pull}1494[1494].
+- Set some configuration defaults (`setup.template.settings.index.*`, `logging.metrics.enabled`) in code {pull}1494[1494].
 - Add `span.sync` property to intake json spec and index field in ES. {pull}1548[1548].
 - Make `service.framework` properties optional and nullable {pull}1546[1546].
 - Add `transaction.sampled` to errors {pull}1662[1662].
@@ -22,6 +22,6 @@ https://github.com/elastic/apm-server/compare/v6.5.4\...v6.6.0[View commits]
 [float]
 ==== Bug fixes
 
-- Fix index pattern bundled with Kibana to be in sync with ES template pull{1571}[1571].
-- Ensure all `transaction.marks.*.*` values are stored as scaled floats. pull{1704}[1704].
+- Fix index pattern bundled with Kibana to be in sync with ES template {pull}1571[1571].
+- Ensure all `transaction.marks.*.*` values are stored as scaled floats {pull}1704[1704].
 - Prevent slice out of bounds panic when sourcemap line numbers are off {pull}1764[1764].


### PR DESCRIPTION
<img width="803" alt="screen shot 2019-01-29 at 7 57 50 am" src="https://user-images.githubusercontent.com/5618806/51921218-cd227000-239b-11e9-96c3-434f02eaf812.png">
