### PR TITLE
Update beats framework to 33b789c

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -245,7 +245,7 @@ SOFTWARE.
 --------------------------------------------------------------------
 Dependency: github.com/elastic/beats
 Version: master
-Revision: d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6
+Revision: 33b789cbfb95a852d0d75b7c8316da3be801d55f
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/beats/LICENSE.txt:
 --------------------------------------------------------------------
@@ -311,7 +311,7 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-ucfg
-Revision: 581f7b1fe9d84f4c18ef0694d6e0eb944a925dae
+Revision: 0539807037ce820e147797f051ff32b05f4f9288
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-ucfg/LICENSE:
 --------------------------------------------------------------------

--- a/_beats/dev-tools/ecs-migration.yml
+++ b/_beats/dev-tools/ecs-migration.yml
@@ -129,6 +129,159 @@
 
 # Filebeat modules
 
+# Auditd module
+
+- from: auditd.log.acct
+  to: user.name
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.pid
+  to: process.pid
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.ppid
+  to: process.ppid
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.res
+  to: event.outcome
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.record_type
+  to: event.action
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.arch
+  to: host.architecture
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.gid
+  to: user.group.id
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.uid
+  to: user.id
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.agid
+  to: user.audit.group.id
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.auid
+  to: user.audit.id
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.fsgid
+  to: user.filesystem.group.id
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.egid
+  to: user.effective.group.id
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.euid
+  to: user.effective.id
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.sgid
+  to: user.saved.group.id
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.suid
+  to: user.saved.id
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.ogid
+  to: user.owner.group.id
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.ouid
+  to: user.owner.id
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.terminal
+  to: user.terminal
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.comm
+  to: process.name
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.cmd
+  to: process.args
+  alias: false
+  beat: filebeat
+  comment: Was a cmdline string, whereas args is an array of keywords.
+
+- from: auditd.log.exe
+  to: process.executable
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.msg
+  to: message
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.src
+  to: source.address
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.dst
+  to: destination.address
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.geoip.continent_name
+  to: source.geo.continent_name
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.geoip.country_iso_code
+  to: source.geo.country_iso_code
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.geoip.location
+  to: source.geo.location
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.geoip.region_name
+  to: source.geo.region_name
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.geoip.city_name
+  to: source.geo.city_name
+  alias: true
+  beat: filebeat
+
+- from: auditd.log.geoip.region_iso_code
+  to: source.geo.region_iso_code
+  alias: true
+  beat: filebeat
+
 # Suricata module
 
 - from: source_ecs.ip
@@ -1386,6 +1539,82 @@
 - from: http.request.body
   to: http.request.body.content
   alias: false
+  beat: metricbeat
+
+### System
+
+- from: system.process.name
+  to: process.name
+  alias: true
+  beat: metricbeat
+
+- from: system.process.pid
+  to: process.pid
+  alias: true
+  beat: metricbeat
+
+- from: system.process.ppid
+  to: process.ppid
+  alias: true
+  beat: metricbeat
+
+- from: system.process.pgid
+  to: process.pgid
+  alias: true
+  beat: metricbeat
+
+- from: system.process.cwd
+  to: process.working_directory
+  alias: true
+  beat: metricbeat
+
+- from: system.process.username
+  to: user.name
+  alias: true
+  beat: metricbeat
+
+### Kibana
+
+- from: kibana.stats.uuid
+  to: service.id
+  alias: true
+  beat: metricbeat
+
+- from: kibana.stats.transport_address
+  to: service.address
+  alias: true
+  beat: metricbeat
+
+- from: kibana.stats.version
+  to: service.version
+  alias: true
+  beat: metricbeat
+
+- from: kibana.status.uuid
+  to: service.id
+  alias: true
+  beat: metricbeat
+
+- from: kibana.status.version.number
+  to: service.version
+  alias: true
+  beat: metricbeat
+
+### Logstash
+
+- from: logstash.node.host
+  to: service.hostname
+  alias: true
+  beat: metricbeat
+
+- from: logstash.node.version
+  to: service.version
+  alias: true
+  beat: metricbeat
+
+- from: logstash.node.jvm.pid
+  to: process.pid
+  alias: true
   beat: metricbeat
 
 ### Zookeeper

--- a/_beats/libbeat/tests/system/beat/beat.py
+++ b/_beats/libbeat/tests/system/beat/beat.py
@@ -221,6 +221,8 @@ class TestCase(unittest.TestCase, ComposeMixin):
     def render_config_template(self, template_name=None,
                                output=None, **kargs):
 
+        print("render config")
+
         # Init defaults
         if template_name is None:
             template_name = self.beat_name

--- a/_beats/vendor/vendor.json
+++ b/_beats/vendor/vendor.json
@@ -1109,52 +1109,52 @@
 			"versionExact": "v0.0.6"
 		},
 		{
-			"checksumSHA1": "Yb61Nqnh+3igFci61hv9WYgk/hc=",
+			"checksumSHA1": "b91TSC0atoGVSMZdKuWTYsMOGiM=",
 			"path": "github.com/elastic/go-ucfg",
-			"revision": "92d43887f91851c9936621665af7f796f4d03412",
-			"revisionTime": "2018-10-26T17:42:06Z",
-			"version": "v0.6.5",
-			"versionExact": "v0.6.5"
+			"revision": "0539807037ce820e147797f051ff32b05f4f9288",
+			"revisionTime": "2019-01-28T11:18:48Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
 			"checksumSHA1": "X+R/CD8SokJrmlxFTx2nSevRDhQ=",
 			"path": "github.com/elastic/go-ucfg/cfgutil",
-			"revision": "581f7b1fe9d84f4c18ef0694d6e0eb944a925dae",
-			"revisionTime": "2018-07-13T14:04:29Z",
-			"version": "v0.6.1",
-			"versionExact": "v0.6.1"
+			"revision": "0539807037ce820e147797f051ff32b05f4f9288",
+			"revisionTime": "2019-01-28T11:18:48Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
-			"checksumSHA1": "zC8mCPW/pPPNcuHQOc/B/Ej1W1U=",
+			"checksumSHA1": "/pq8HNEdzHmky9S9HSo1WofXQ4Y=",
 			"path": "github.com/elastic/go-ucfg/flag",
-			"revision": "581f7b1fe9d84f4c18ef0694d6e0eb944a925dae",
-			"revisionTime": "2018-07-13T14:04:29Z",
-			"version": "v0.6.1",
-			"versionExact": "v0.6.1"
+			"revision": "0539807037ce820e147797f051ff32b05f4f9288",
+			"revisionTime": "2019-01-28T11:18:48Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
 			"checksumSHA1": "esXpiQlEvTOUwsE0nNesso8albo=",
 			"path": "github.com/elastic/go-ucfg/internal/parse",
-			"revision": "581f7b1fe9d84f4c18ef0694d6e0eb944a925dae",
-			"revisionTime": "2018-07-13T14:04:29Z",
-			"version": "v0.6.1",
-			"versionExact": "v0.6.1"
+			"revision": "0539807037ce820e147797f051ff32b05f4f9288",
+			"revisionTime": "2019-01-28T11:18:48Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
-			"checksumSHA1": "5mXUhhlPdvcAFKiQENInTJWrtQM=",
+			"checksumSHA1": "cfMNsyQm0gZOV0hRJrBSdKDQSBo=",
 			"path": "github.com/elastic/go-ucfg/json",
-			"revision": "581f7b1fe9d84f4c18ef0694d6e0eb944a925dae",
-			"revisionTime": "2018-07-13T14:04:29Z",
-			"version": "v0.6.1",
-			"versionExact": "v0.6.1"
+			"revision": "0539807037ce820e147797f051ff32b05f4f9288",
+			"revisionTime": "2019-01-28T11:18:48Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
-			"checksumSHA1": "Bg6vistPQLftv2fEYB7GWwSExv8=",
+			"checksumSHA1": "PJCBACDGPhnRAEqjGPMPCMjbj4o=",
 			"path": "github.com/elastic/go-ucfg/yaml",
-			"revision": "581f7b1fe9d84f4c18ef0694d6e0eb944a925dae",
-			"revisionTime": "2018-07-13T14:04:29Z",
-			"version": "v0.6.1",
-			"versionExact": "v0.6.1"
+			"revision": "0539807037ce820e147797f051ff32b05f4f9288",
+			"revisionTime": "2019-01-28T11:18:48Z",
+			"version": "v0.7.0",
+			"versionExact": "v0.7.0"
 		},
 		{
 			"checksumSHA1": "rnd3qf1FE22X3MxXWbetqq6EoBk=",

--- a/vendor/github.com/elastic/beats/NOTICE.txt
+++ b/vendor/github.com/elastic/beats/NOTICE.txt
@@ -667,8 +667,8 @@ Apache License 2.0
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-ucfg
-Version: v0.6.5
-Revision: 92d43887f91851c9936621665af7f796f4d03412
+Version: v0.7.0
+Revision: 0539807037ce820e147797f051ff32b05f4f9288
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/go-ucfg/LICENSE:
 --------------------------------------------------------------------

--- a/vendor/github.com/elastic/beats/libbeat/cfgfile/cfgfile.go
+++ b/vendor/github.com/elastic/beats/libbeat/cfgfile/cfgfile.go
@@ -18,7 +18,6 @@
 package cfgfile
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -34,7 +33,6 @@ var (
 	// be called prior to flags.Parse().
 	configfiles = common.StringArrFlag(nil, "c", "beat.yml", "Configuration file, relative to path.config")
 	overwrites  = common.SettingFlag(nil, "E", "Configuration overwrite")
-	testConfig  = flag.Bool("configtest", false, "Test configuration and exit.")
 
 	// Additional default settings, that must be available for variable expansion
 	defaults = common.MustNewConfigFrom(map[string]interface{}{
@@ -198,9 +196,4 @@ func GetPathConfig() string {
 	}
 	// TODO: Do we need this or should we always return *homePath?
 	return ""
-}
-
-// IsTestConfig returns whether or not this is configuration used for testing
-func IsTestConfig() bool {
-	return *testConfig
 }

--- a/vendor/github.com/elastic/beats/libbeat/cmd/run.go
+++ b/vendor/github.com/elastic/beats/libbeat/cmd/run.go
@@ -46,14 +46,6 @@ func genRunCmd(settings instance.Settings, beatCreator beat.Creator, runFlags *p
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("httpprof"))
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("cpuprofile"))
 	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("memprofile"))
-	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("setup"))
-
-	// TODO deprecate in favor of subcommands (7.0):
-	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("configtest"))
-	runCmd.Flags().AddGoFlag(flag.CommandLine.Lookup("version"))
-
-	runCmd.Flags().MarkDeprecated("version", "use version subcommand")
-	runCmd.Flags().MarkDeprecated("configtest", "use test config subcommand")
 
 	if runFlags != nil {
 		runCmd.Flags().AddFlagSet(runFlags)

--- a/vendor/github.com/elastic/beats/libbeat/common/config.go
+++ b/vendor/github.com/elastic/beats/libbeat/common/config.go
@@ -188,6 +188,14 @@ func (c *Config) PathOf(field string) string {
 	return c.access().PathOf(field, ".")
 }
 
+func (c *Config) Remove(name string, idx int) (bool, error) {
+	return c.access().Remove(name, idx, configOpts...)
+}
+
+func (c *Config) Has(name string, idx int) (bool, error) {
+	return c.access().Has(name, idx, configOpts...)
+}
+
 func (c *Config) HasField(name string) bool {
 	return c.access().HasField(name)
 }

--- a/vendor/github.com/elastic/beats/libbeat/metric/system/process/process.go
+++ b/vendor/github.com/elastic/beats/libbeat/metric/system/process/process.go
@@ -45,14 +45,16 @@ type ProcsMap map[int]*Process
 // Process is the structure which holds the information of a process running on the host.
 // It includes pid, gid and it interacts with gosigar to fetch process data from the host.
 type Process struct {
-	Pid             int    `json:"pid"`
-	Ppid            int    `json:"ppid"`
-	Pgid            int    `json:"pgid"`
-	Name            string `json:"name"`
-	Username        string `json:"username"`
-	State           string `json:"state"`
-	CmdLine         string `json:"cmdline"`
-	Cwd             string `json:"cwd"`
+	Pid             int      `json:"pid"`
+	Ppid            int      `json:"ppid"`
+	Pgid            int      `json:"pgid"`
+	Name            string   `json:"name"`
+	Username        string   `json:"username"`
+	State           string   `json:"state"`
+	Args            []string `json:"args"`
+	CmdLine         string   `json:"cmdline"`
+	Cwd             string   `json:"cwd"`
+	Executable      string   `json:"executable"`
 	Mem             sigar.ProcMem
 	Cpu             sigar.ProcTime
 	SampleTime      time.Time
@@ -98,15 +100,16 @@ func newProcess(pid int, cmdline string, env common.MapStr) (*Process, error) {
 	}
 
 	proc := Process{
-		Pid:      pid,
-		Ppid:     state.Ppid,
-		Pgid:     state.Pgid,
-		Name:     state.Name,
-		Username: state.Username,
-		State:    getProcState(byte(state.State)),
-		CmdLine:  cmdline,
-		Cwd:      exe.Cwd,
-		Env:      env,
+		Pid:        pid,
+		Ppid:       state.Ppid,
+		Pgid:       state.Pgid,
+		Name:       state.Name,
+		Username:   state.Username,
+		State:      getProcState(byte(state.State)),
+		CmdLine:    cmdline,
+		Cwd:        exe.Cwd,
+		Executable: exe.Name,
+		Env:        env,
 	}
 
 	return &proc, nil
@@ -130,12 +133,16 @@ func (proc *Process) getDetails(envPredicate func(string) bool) error {
 		return fmt.Errorf("error getting process cpu time for pid=%d: %v", proc.Pid, err)
 	}
 
-	if proc.CmdLine == "" {
+	if len(proc.Args) == 0 {
 		args := sigar.ProcArgs{}
 		if err := args.Get(proc.Pid); err != nil && !sigar.IsNotImplemented(err) {
 			return fmt.Errorf("error getting process arguments for pid=%d: %v", proc.Pid, err)
 		}
-		proc.CmdLine = strings.Join(args.List, " ")
+		proc.Args = args.List
+	}
+
+	if proc.CmdLine == "" && len(proc.Args) > 0 {
+		proc.CmdLine = strings.Join(proc.Args, " ")
 	}
 
 	if fd, err := getProcFDUsage(proc.Pid); err != nil {
@@ -283,12 +290,20 @@ func (procStats *Stats) getProcessEvent(process *Process) common.MapStr {
 		},
 	}
 
+	if len(process.Args) > 0 {
+		proc["args"] = process.Args
+	}
+
 	if process.CmdLine != "" {
 		proc["cmdline"] = process.CmdLine
 	}
 
 	if process.Cwd != "" {
 		proc["cwd"] = process.Cwd
+	}
+
+	if process.Executable != "" {
+		proc["exe"] = process.Executable
 	}
 
 	if len(process.Env) > 0 {

--- a/vendor/github.com/elastic/beats/libbeat/template/template.go
+++ b/vendor/github.com/elastic/beats/libbeat/template/template.go
@@ -46,6 +46,7 @@ type Template struct {
 	name        string
 	pattern     string
 	beatVersion common.Version
+	beatName    string
 	esVersion   common.Version
 	config      TemplateConfig
 	migration   bool
@@ -116,6 +117,7 @@ func New(beatVersion string, beatName string, esVersion common.Version, config T
 		name:        name,
 		beatVersion: *bV,
 		esVersion:   esVersion,
+		beatName:    beatName,
 		config:      config,
 		migration:   migration,
 	}, nil
@@ -189,7 +191,7 @@ func (t *Template) Generate(properties common.MapStr, dynamicTemplates []common.
 		keyPattern: patterns,
 
 		"mappings": buildMappings(
-			t.beatVersion, t.esVersion,
+			t.beatVersion, t.esVersion, t.beatName,
 			properties,
 			append(dynamicTemplates, buildDynTmpl(t.esVersion)),
 			common.MapStr(t.config.Settings.Source),
@@ -215,6 +217,7 @@ func buildPatternSettings(ver common.Version, pattern string) (string, interface
 
 func buildMappings(
 	beatVersion, esVersion common.Version,
+	beatName string,
 	properties common.MapStr,
 	dynTmpls []common.MapStr,
 	source common.MapStr,
@@ -222,6 +225,7 @@ func buildMappings(
 	mapping := common.MapStr{
 		"_meta": common.MapStr{
 			"version": beatVersion.String(),
+			"beat":    beatName,
 		},
 		"date_detection":    defaultDateDetection,
 		"dynamic_templates": dynTmpls,

--- a/vendor/github.com/elastic/beats/x-pack/libbeat/management/api/convert.go
+++ b/vendor/github.com/elastic/beats/x-pack/libbeat/management/api/convert.go
@@ -1,0 +1,79 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package api
+
+import (
+	"fmt"
+	"strings"
+)
+
+type converter func(map[string]interface{}) (map[string]interface{}, error)
+
+var mapper = map[string]converter{
+	".inputs":  noopConvert,
+	".modules": convertMultiple,
+	"output":   convertSingle,
+}
+
+var errSubTypeNotFound = fmt.Errorf("'%s' key not found", subTypeKey)
+
+var (
+	subTypeKey = "_sub_type"
+	moduleKey  = "module"
+)
+
+func selectConverter(t string) converter {
+	for k, v := range mapper {
+		if strings.Index(t, k) > -1 {
+			return v
+		}
+	}
+	return noopConvert
+}
+
+func convertSingle(m map[string]interface{}) (map[string]interface{}, error) {
+	subType, err := extractSubType(m)
+	if err != nil {
+		return nil, err
+	}
+
+	delete(m, subTypeKey)
+	newMap := map[string]interface{}{subType: m}
+	return newMap, nil
+}
+
+func convertMultiple(m map[string]interface{}) (map[string]interface{}, error) {
+	subType, err := extractSubType(m)
+	if err != nil {
+		return nil, err
+	}
+
+	v, ok := m[moduleKey]
+
+	if ok && v != subType {
+		return nil, fmt.Errorf("module key already exist in the raw document and doesn't match the 'sub_type', expecting '%s' and received '%s", subType, v)
+	}
+
+	m[moduleKey] = subType
+	delete(m, subTypeKey)
+	return m, nil
+}
+
+func noopConvert(m map[string]interface{}) (map[string]interface{}, error) {
+	return m, nil
+}
+
+func extractSubType(m map[string]interface{}) (string, error) {
+	subType, ok := m[subTypeKey]
+	if !ok {
+		return "", errSubTypeNotFound
+	}
+
+	k, ok := subType.(string)
+	if !ok {
+		return "", fmt.Errorf("invalid type for `sub_type`, expecting a string received %T", subType)
+	}
+	return k, nil
+}

--- a/vendor/github.com/elastic/beats/x-pack/libbeat/management/api/doc.go
+++ b/vendor/github.com/elastic/beats/x-pack/libbeat/management/api/doc.go
@@ -1,0 +1,69 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+/*
+The Kibana CM Api returns a configuration format which cannot be ingested directly by our
+configuration parser, it need to be transformed from the generic format into an adapted format
+which is dependant on the type of configuration.
+
+
+Translations:
+
+Type: output
+
+{
+    "configuration_blocks": [
+
+        {
+            "config": {
+              "_sub_type": "elasticsearch"
+              "_id": "12312341231231"
+              "hosts": [ "localhost" ],
+              "password": "foobar"
+              "username": "elastic"
+            },
+            "type": "output"
+        }
+    ]
+}
+
+YAML representation:
+
+{
+	"elasticsearch": {
+		"hosts": [ "localhost" ],
+		"password": "foobar"
+		"username": "elastic"
+	}
+}
+
+
+Type: *.modules
+
+{
+    "configuration_blocks": [
+
+        {
+            "config": {
+              "_sub_type": "system"
+              "_id": "12312341231231"
+							"path" "foobar"
+            },
+            "type": "filebeat.module"
+        }
+    ]
+}
+
+YAML representation:
+
+[
+{
+	"module": "system"
+	"path": "foobar"
+}
+]
+
+*/
+
+package api

--- a/vendor/github.com/elastic/go-ucfg/CHANGELOG.md
+++ b/vendor/github.com/elastic/go-ucfg/CHANGELOG.md
@@ -14,6 +14,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [0.7.0]
+
+### Added
+- Add (*Config).Has. #127
+- Add (*Config).Remove. #126
+
+### Removed
+- Remove CI and support for go versions <1.10. #128
+
 ## [0.6.5]
 
 ### Added
@@ -225,8 +234,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Introduced CHANGELOG.md for documenting changes to ucfg.
 
 
-[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.6.5...HEAD
-[0.6.4]: https://github.com/elastic/go-ucfg/compare/v0.6.4...v0.6.5
+[Unreleased]: https://github.com/elastic/go-ucfg/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/elastic/go-ucfg/compare/v0.6.5...v0.7.0
+[0.6.5]: https://github.com/elastic/go-ucfg/compare/v0.6.4...v0.6.5
 [0.6.4]: https://github.com/elastic/go-ucfg/compare/v0.6.3...v0.6.4
 [0.6.3]: https://github.com/elastic/go-ucfg/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/elastic/go-ucfg/compare/v0.6.1...v0.6.2

--- a/vendor/github.com/elastic/go-ucfg/README.md
+++ b/vendor/github.com/elastic/go-ucfg/README.md
@@ -89,4 +89,4 @@ The above uses `Counter` as the config variable. ucfg assures that the value is 
 
 ucfg has the following requirements:
 
-* Golang 1.7+
+* Golang 1.10+

--- a/vendor/github.com/elastic/go-ucfg/error.go
+++ b/vendor/github.com/elastic/go-ucfg/error.go
@@ -61,6 +61,8 @@ type criticalError struct {
 var (
 	ErrMissing = errors.New("missing field")
 
+	ErrNoParse = errors.New("parsing dynamic configs is disabled")
+
 	ErrCyclicReference = errors.New("cyclic reference detected")
 
 	ErrDuplicateValidator = errors.New("validator already registered")
@@ -257,6 +259,11 @@ func raiseUnsupportedInputType(ctx context, meta *Meta, v reflect.Value) Error {
 		v.Type(), v)
 
 	return raiseCritical(reason, messagePath(reason, meta, message, ctx.path(".")))
+}
+
+func raiseNoParse(ctx context, meta *Meta) Error {
+	reason := ErrNoParse
+	return raisePathErr(reason, meta, "", ctx.path("."))
 }
 
 func raiseNil(reason error) Error {

--- a/vendor/github.com/elastic/go-ucfg/fieldset.go
+++ b/vendor/github.com/elastic/go-ucfg/fieldset.go
@@ -22,7 +22,7 @@ type fieldSet struct {
 	parent *fieldSet
 }
 
-func NewFieldSet(parent *fieldSet) *fieldSet {
+func newFieldSet(parent *fieldSet) *fieldSet {
 	return &fieldSet{
 		fields: map[string]struct{}{},
 		parent: parent,

--- a/vendor/github.com/elastic/go-ucfg/flag/file.go
+++ b/vendor/github.com/elastic/go-ucfg/flag/file.go
@@ -24,8 +24,17 @@ import (
 	"github.com/elastic/go-ucfg"
 )
 
+// FileLoader is used by NewFlagFiles to define customer file loading functions
+// for different file extensions.
 type FileLoader func(name string, opts ...ucfg.Option) (*ucfg.Config, error)
 
+// NewFlagFiles create a new flag, that will load external configurations file
+// when being used. Configurations loaded from multiple files will be merged
+// into one common Config object.  If cfg is not nil, then the loaded
+// configurations will be merged into cfg.
+// The extensions parameter define custom file loaders for different file
+// extensions. If extensions contains an entry with key "", then this loader
+// will be used as default fallback.
 func NewFlagFiles(
 	cfg *ucfg.Config,
 	extensions map[string]FileLoader,

--- a/vendor/github.com/elastic/go-ucfg/json/json.go
+++ b/vendor/github.com/elastic/go-ucfg/json/json.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/go-ucfg"
 )
 
+// NewConfig creates a new configuration object from the JSON string passed via in.
 func NewConfig(in []byte, opts ...ucfg.Option) (*ucfg.Config, error) {
 	var m interface{}
 	if err := json.Unmarshal(in, &m); err != nil {
@@ -32,12 +33,15 @@ func NewConfig(in []byte, opts ...ucfg.Option) (*ucfg.Config, error) {
 	return ucfg.NewFrom(m, opts...)
 }
 
+// NewConfigWithFile loads a new configuration object from an external JSON file.
 func NewConfigWithFile(name string, opts ...ucfg.Option) (*ucfg.Config, error) {
 	input, err := ioutil.ReadFile(name)
 	if err != nil {
 		return nil, err
 	}
 
-	opts = append([]ucfg.Option{ucfg.MetaData(ucfg.Meta{name})}, opts...)
+	opts = append([]ucfg.Option{
+		ucfg.MetaData(ucfg.Meta{Source: name}),
+	}, opts...)
 	return NewConfig(input, opts...)
 }

--- a/vendor/github.com/elastic/go-ucfg/opts.go
+++ b/vendor/github.com/elastic/go-ucfg/opts.go
@@ -33,6 +33,7 @@ type options struct {
 	env          []*Config
 	resolvers    []func(name string) (string, error)
 	varexp       bool
+	noParse      bool
 
 	configValueHandling configHandling
 
@@ -137,7 +138,7 @@ func doResolveNOOP(o *options) {
 }
 
 var (
-	// ReplacesValues option configures all merging and unpacking operations to
+	// ReplaceValues option configures all merging and unpacking operations to
 	// replace old dictionaries and arrays while merging. Value merging can be
 	// overwritten in unpack by using struct tags.
 	ReplaceValues = makeOptValueHandling(cfgReplaceValue)
@@ -170,7 +171,7 @@ func makeOptions(opts []Option) *options {
 		validatorTag: "validate",
 		pathSep:      "", // no separator by default
 		parsed:       map[string]spliceValue{},
-		activeFields: NewFieldSet(nil),
+		activeFields: newFieldSet(nil),
 	}
 	for _, opt := range opts {
 		opt(&o)

--- a/vendor/github.com/elastic/go-ucfg/reify.go
+++ b/vendor/github.com/elastic/go-ucfg/reify.go
@@ -189,7 +189,7 @@ func reifyMap(opts *options, to reflect.Value, from *Config) Error {
 		to.Set(reflect.MakeMap(to.Type()))
 	}
 	for k, value := range fields {
-		opts.activeFields = NewFieldSet(parentFields)
+		opts.activeFields = newFieldSet(parentFields)
 		key := reflect.ValueOf(k)
 
 		old := to.MapIndex(key)
@@ -249,7 +249,7 @@ func reifyStruct(opts *options, orig reflect.Value, cfg *Config) Error {
 				opts = tmp
 			}
 
-			opts.activeFields = NewFieldSet(parentFields)
+			opts.activeFields = newFieldSet(parentFields)
 
 			vField := to.Field(i)
 			validators, err := parseValidatorTags(stField.Tag.Get(opts.validatorTag))
@@ -656,7 +656,7 @@ func doReifyPrimitive(
 	}
 
 	previous := opts.opts.activeFields
-	opts.opts.activeFields = NewFieldSet(previous)
+	opts.opts.activeFields = newFieldSet(previous)
 	valT, err := val.typ(opts.opts)
 	if err != nil {
 		ctx := val.Context()

--- a/vendor/github.com/elastic/go-ucfg/types.go
+++ b/vendor/github.com/elastic/go-ucfg/types.go
@@ -377,7 +377,7 @@ func (c cfgSub) reify(opts *options) (interface{}, error) {
 	case len(fields) > 0 && len(arr) == 0:
 		m := make(map[string]interface{})
 		for k, v := range fields {
-			opts.activeFields = NewFieldSet(parentFields)
+			opts.activeFields = newFieldSet(parentFields)
 			var err error
 			if m[k], err = v.reify(opts); err != nil {
 				return nil, err
@@ -387,7 +387,7 @@ func (c cfgSub) reify(opts *options) (interface{}, error) {
 	case len(fields) == 0 && len(arr) > 0:
 		m := make([]interface{}, len(arr))
 		for i, v := range arr {
-			opts.activeFields = NewFieldSet(parentFields)
+			opts.activeFields = newFieldSet(parentFields)
 			var err error
 			if m[i], err = v.reify(opts); err != nil {
 				return nil, err
@@ -397,14 +397,14 @@ func (c cfgSub) reify(opts *options) (interface{}, error) {
 	default:
 		m := make(map[string]interface{})
 		for k, v := range fields {
-			opts.activeFields = NewFieldSet(parentFields)
+			opts.activeFields = newFieldSet(parentFields)
 			var err error
 			if m[k], err = v.reify(opts); err != nil {
 				return nil, err
 			}
 		}
 		for i, v := range arr {
-			opts.activeFields = NewFieldSet(parentFields)
+			opts.activeFields = newFieldSet(parentFields)
 			var err error
 			m[fmt.Sprintf("%d", i)], err = v.reify(opts)
 			if err != nil {
@@ -554,6 +554,10 @@ func (s spliceDynValue) String() string {
 }
 
 func parseValue(p *cfgPrimitive, opts *options, str string) (value, error) {
+	if opts.noParse {
+		return nil, raiseNoParse(p.ctx, p.meta())
+	}
+
 	ifc, err := parse.Value(str)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/elastic/go-ucfg/ucfg.go
+++ b/vendor/github.com/elastic/go-ucfg/ucfg.go
@@ -83,7 +83,7 @@ func New() *Config {
 	}
 }
 
-// NustNewFrom creates a new config object normalizing and copying from into the new
+// MustNewFrom creates a new config object normalizing and copying from into the new
 // Config object. MustNewFrom uses Merge to copy from.
 //
 // MustNewFrom supports the options: PathSep, MetaData, StructTag, VarExp
@@ -126,10 +126,48 @@ func (c *Config) GetFields() []string {
 	return names
 }
 
+// Has checks if a field by the given path+idx configuration exists.
+// Has returns an error if the path can not be resolved because a primitive
+// value is found in the middle of the traversal.
+func (c *Config) Has(name string, idx int, options ...Option) (bool, error) {
+	opts := makeOptions(options)
+	p := parsePathIdx(name, opts.pathSep, idx)
+	return p.Has(c, opts)
+}
+
 // HasField checks if c has a top-level named key name.
 func (c *Config) HasField(name string) bool {
 	_, ok := c.fields.get(name)
 	return ok
+}
+
+// Remove removes a setting from the config. If the configuration references
+// another configuration namespace, then the setting will be removed from the
+// linked reference.
+// Remove returns true if the setting was removed. If the path can't be
+// resolved (e.g. due to type mismatch) Remove will return an error.
+//
+// Settings can be created on Unpack via Env, Resolve, and ResolveEnv. Settings
+// generated dynamically on Unpack can not be removed. Remove ignores any
+// configured environments and will return an error if a value can not be
+// removed for this reason.
+//
+// The setting path is constructed from name and idx. If name is set and idx is -1,
+// only the name is used to access the setting by name. If name is empty, idx
+// must be >= 0, assuming the Config is a list. If both name and idx are set,
+// the name must point to a list.
+//
+// Remove supports the options: PathSep
+func (c *Config) Remove(name string, idx int, options ...Option) (bool, error) {
+	opts := makeOptions(options)
+
+	// ignore environments
+	opts.env = nil
+	opts.resolvers = nil
+	opts.noParse = true
+
+	p := parsePathIdx(name, opts.pathSep, idx)
+	return p.Remove(c, opts)
 }
 
 // Path gets the absolute path of c separated by sep. If c is a root-Config an
@@ -217,6 +255,26 @@ func (f *fields) dict() map[string]value {
 
 func (f *fields) array() []value {
 	return f.a
+}
+
+func (f *fields) del(name string) bool {
+	_, exists := f.d[name]
+	if exists {
+		delete(f.d, name)
+	}
+	return exists
+}
+
+func (f *fields) delAt(i int) bool {
+	a := f.a
+	if i < 0 || len(a) <= i {
+		return false
+	}
+
+	copy(a[i:], a[i+1:])
+	a[len(a)-1] = nil
+	f.a = a[:len(a)-1]
+	return true
 }
 
 func (f *fields) set(name string, v value) {

--- a/vendor/github.com/elastic/go-ucfg/unpack.go
+++ b/vendor/github.com/elastic/go-ucfg/unpack.go
@@ -155,12 +155,7 @@ func implementsUnpacker(t reflect.Type) bool {
 
 	// method receiver is known, check config parameters being compatible
 	tIn := method.Type.In(1)
-	acceptsConfig := tConfig.ConvertibleTo(tIn) || tConfigPtr.ConvertibleTo(tIn)
-	if !acceptsConfig {
-		return false
-	}
-
-	return true
+	return tConfig.ConvertibleTo(tIn) || tConfigPtr.ConvertibleTo(tIn)
 }
 
 func unpackWith(opts *options, v reflect.Value, with value) Error {

--- a/vendor/github.com/elastic/go-ucfg/yaml/yaml.go
+++ b/vendor/github.com/elastic/go-ucfg/yaml/yaml.go
@@ -25,6 +25,7 @@ import (
 	"github.com/elastic/go-ucfg"
 )
 
+// NewConfig creates a new configuration object from the YAML string passed via in.
 func NewConfig(in []byte, opts ...ucfg.Option) (*ucfg.Config, error) {
 	var m interface{}
 	if err := yaml.Unmarshal(in, &m); err != nil {
@@ -34,12 +35,15 @@ func NewConfig(in []byte, opts ...ucfg.Option) (*ucfg.Config, error) {
 	return ucfg.NewFrom(m, opts...)
 }
 
+// NewConfigWithFile loads a new configuration object from an external JSON file.
 func NewConfigWithFile(name string, opts ...ucfg.Option) (*ucfg.Config, error) {
 	input, err := ioutil.ReadFile(name)
 	if err != nil {
 		return nil, err
 	}
 
-	opts = append([]ucfg.Option{ucfg.MetaData(ucfg.Meta{name})}, opts...)
+	opts = append([]ucfg.Option{
+		ucfg.MetaData(ucfg.Meta{Source: name}),
+	}, opts...)
 	return NewConfig(input, opts...)
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -6,1074 +6,1074 @@
 			"checksumSHA1": "eruIVA8JnsB23rVKjETHvqJ0sj8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/DataDog/zstd",
 			"path": "github.com/DataDog/zstd",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "AzjRkOQtVBTwIw4RJLTygFhJs3s=",
 			"origin": "github.com/elastic/beats/vendor/github.com/Microsoft/go-winio",
 			"path": "github.com/Microsoft/go-winio",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "Yn3uTky/UjksI76cPRAxXomzMKM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/Shopify/sarama",
 			"path": "github.com/Shopify/sarama",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "DYv6Q1+VfnUVxMwvk5IshAClLvw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/Sirupsen/logrus",
 			"path": "github.com/Sirupsen/logrus",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "Te1xRugxHQMAg7EvbIUuPWm8fvU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/StackExchange/wmi",
 			"path": "github.com/StackExchange/wmi",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "dvabztWVQX8f6oMLRyv4dLH+TGY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/davecgh/go-spew/spew",
 			"path": "github.com/davecgh/go-spew/spew",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "Gj+xR1VgFKKmFXYOJMnAczC3Znk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/distribution/digestset",
 			"path": "github.com/docker/distribution/digestset",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "2Fe4D6PGaVE2he4fUeenLmhC1lE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/distribution/reference",
 			"path": "github.com/docker/distribution/reference",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "UL2NF1EGiSsQoEfvycnuZIcUbZY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api",
 			"path": "github.com/docker/docker/api",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "KMFpbV3mlrbc41d2DYnq05QYpSc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types",
 			"path": "github.com/docker/docker/api/types",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "jVJDbe0IcyjoKc2xbohwzQr+FF0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/blkiodev",
 			"path": "github.com/docker/docker/api/types/blkiodev",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "AeSC0BOu1uapkGqfSXtfVSpwJzs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/container",
 			"path": "github.com/docker/docker/api/types/container",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "4XuWn5+wgYwUsw604jvYMklq4Hc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/events",
 			"path": "github.com/docker/docker/api/types/events",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "J2OKngfI3vgswudr9PZVUFcRRu0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/filters",
 			"path": "github.com/docker/docker/api/types/filters",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "yeB781yxPhnN6OXQ9/qSsyih3ek=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/image",
 			"path": "github.com/docker/docker/api/types/image",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "UK+VdM648oWzyqE4OqttgmPqjoA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/mount",
 			"path": "github.com/docker/docker/api/types/mount",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "Gskp+nvbVe8Gk1xPLHylZvNmqTg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/network",
 			"path": "github.com/docker/docker/api/types/network",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "r2vWq7Uc3ExKzMqYgH0b4AKjLKY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/registry",
 			"path": "github.com/docker/docker/api/types/registry",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "VTxWyFud/RedrpllGdQonVtGM/A=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/strslice",
 			"path": "github.com/docker/docker/api/types/strslice",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "ZaizCpJ3eBcfR9ywpLaJd4AhM9k=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/swarm",
 			"path": "github.com/docker/docker/api/types/swarm",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "B7ZwKzrv3t3Vlox6/bYMHhMjsM8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/time",
 			"path": "github.com/docker/docker/api/types/time",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "uDPQ3nHsrvGQc9tg/J9OSC4N5dQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/versions",
 			"path": "github.com/docker/docker/api/types/versions",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "IBJy2zPEnYmcFJ3lM1eiRWnCxTA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/volume",
 			"path": "github.com/docker/docker/api/types/volume",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "c6OyeEvpQDvVLhrJSxgjEZv1tF8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/client",
 			"path": "github.com/docker/docker/client",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "jmo/t2zXAxirEPoFucNPXA/1SEc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/ioutils",
 			"path": "github.com/docker/docker/pkg/ioutils",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "ndnAFCfsGC3upNQ6jAEwzxcurww=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/longpath",
 			"path": "github.com/docker/docker/pkg/longpath",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "kr46EAa+FsUcWxOq6edyX6BUzE4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/system",
 			"path": "github.com/docker/docker/pkg/system",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "8I0Ez+aUYGpsDEVZ8wN/Ztf6Zqs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/tlsconfig",
 			"path": "github.com/docker/docker/pkg/tlsconfig",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "JbiWTzH699Sqz25XmDlsARpMN9w=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-connections/nat",
 			"path": "github.com/docker/go-connections/nat",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "jUfDG3VQsA2UZHvvIXncgiddpYA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-connections/sockets",
 			"path": "github.com/docker/go-connections/sockets",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "tuSzlS1UQ03+5Fvtqr5hI5sLLhA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-connections/tlsconfig",
 			"path": "github.com/docker/go-connections/tlsconfig",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "ambe8F4AofPxChCJssXXwWphQQ8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-units",
 			"path": "github.com/docker/go-units",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "sNAU9ojYVUhO6dVXey6T3JhRQpw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/libtrust",
 			"path": "github.com/docker/libtrust",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "rhLUtXvcmouYuBwOq9X/nYKzvNg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/dustin/go-humanize",
 			"path": "github.com/dustin/go-humanize",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "y2Kh4iPlgCPXSGTCcFpzePYdzzg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/eapache/go-resiliency/breaker",
 			"path": "github.com/eapache/go-resiliency/breaker",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "WHl96RVZlOOdF4Lb1OOadMpw8ls=",
 			"origin": "github.com/elastic/beats/vendor/github.com/eapache/go-xerial-snappy",
 			"path": "github.com/eapache/go-xerial-snappy",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "oCCs6kDanizatplM5e/hX76busE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/eapache/queue",
 			"path": "github.com/eapache/queue",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "hJrpRbxMr9cI+5bh+Havv1Ynb0g=",
 			"path": "github.com/elastic/beats/dev-tools/mage",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "PBTxyr6OotF2pda9n8gMeGUkfLA=",
 			"path": "github.com/elastic/beats/filebeat/generator",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "cDyXG8WG+dr1ai7qCnhbJ6N3OyY=",
 			"path": "github.com/elastic/beats/filebeat/scripts/generator",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "y34pfVnTprxa4BvLKfiBbqTJaGA=",
 			"path": "github.com/elastic/beats/libbeat/api",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "3cMzsLhs9W65wKpzZLiSB4i73mc=",
 			"path": "github.com/elastic/beats/libbeat/asset",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "+XIt3467v/mRmLoIs6stBev5kUY=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "ZCQyqZn3NFfAJo//PSd1YASvytY=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/appenders/config",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "pW/XBpb2BIceplyuoqvwTtowH7c=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/builder",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "IifZH9hzzPymGV2XQfQ/tFR4uSE=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/meta",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "qa5L8m7V3k+IDBxSXm28wbZt0m0=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/providers/docker",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "m9yIpAuVVFufXqxoxsRwj1WFWQk=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/providers/jolokia",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "W42L3gTFnIDgUmDWuzNNHBMTp/g=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/providers/kubernetes",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "eaKz8KWZXYHpLvBCIRN3V8J7G18=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/template",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "q6ONX7eAZIh7SOyjolFxTDIoPrg=",
 			"path": "github.com/elastic/beats/libbeat/beat",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "on1AvBp8HIr6d+LHAc2J00kYmNk=",
+			"checksumSHA1": "WTJu5thCAkzlalDS0POgNIlNisA=",
 			"path": "github.com/elastic/beats/libbeat/cfgfile",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "/IuTlhYU7mcJKhOHniR06bWGnxg=",
 			"path": "github.com/elastic/beats/libbeat/cloudid",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "00CE0KB722BkCCMX+JvO1IABf2o=",
+			"checksumSHA1": "QrPJanJhJv+67HtgIU8NPuqdszQ=",
 			"path": "github.com/elastic/beats/libbeat/cmd",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "gtAD4Qstpme/wXjPiEFBbsqT1XE=",
 			"path": "github.com/elastic/beats/libbeat/cmd/export",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "iwf1ZGj5L0T8YNIioOG2ToNRRJ0=",
+			"checksumSHA1": "mp2NdigjX6rfTKuNZIhfqQ0dPVw=",
 			"path": "github.com/elastic/beats/libbeat/cmd/instance",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "TGW7SUpyY5XCLRjLW2n62yDKqBk=",
 			"path": "github.com/elastic/beats/libbeat/cmd/test",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "MuXbMF8xTuVUVyR1va0Ur7GCwXA=",
+			"checksumSHA1": "qlYiSDn7lBuedNcWaZ1zjkHgzM4=",
 			"path": "github.com/elastic/beats/libbeat/common",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "lFYRu/M9CL6/povZOeBYui9/laI=",
 			"path": "github.com/elastic/beats/libbeat/common/atomic",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "O5lD0j+tTM5lZkSzPE9KaxiHTeY=",
 			"path": "github.com/elastic/beats/libbeat/common/backoff",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Fxbw/7lPbh9dY3HH5k8sc4PU6Yo=",
 			"path": "github.com/elastic/beats/libbeat/common/bus",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "zRpP/UzB/wFQNLceGdVgC4QqviM=",
 			"path": "github.com/elastic/beats/libbeat/common/cfgtype",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "d0pIynyart5HMe7IKw3wtIH2R48=",
 			"path": "github.com/elastic/beats/libbeat/common/cfgwarn",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "/mBln/rCzmDjCB/4p16fSapi3BY=",
 			"path": "github.com/elastic/beats/libbeat/common/cli",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Ps5fuDikiF/KR7BeQqRkIztHxVY=",
 			"path": "github.com/elastic/beats/libbeat/common/docker",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Gxdi0z5FpIG68TQBD+zho4pEBlU=",
 			"path": "github.com/elastic/beats/libbeat/common/dtfmt",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "EVdZcCfcyrMUtePDFMOSBxkS71M=",
 			"path": "github.com/elastic/beats/libbeat/common/file",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "pt4OCbyb9z7fgJEidmOx6mua0h8=",
 			"path": "github.com/elastic/beats/libbeat/common/fmtstr",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "K8hsg9OHpVHm7A43uq+TdX5DRc4=",
 			"path": "github.com/elastic/beats/libbeat/common/jsontransform",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "IUy7SaiQLG2N7awyTi+KIxSa2/Y=",
 			"path": "github.com/elastic/beats/libbeat/common/kafka",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "1pLErQUHOLQU8MCTdUm2PjfQZ/g=",
 			"path": "github.com/elastic/beats/libbeat/common/kubernetes",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "tX/nsD/KEE0KCWECoPyx5CHNPdc=",
 			"path": "github.com/elastic/beats/libbeat/common/match",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "t6Ww0oDbdOkUF9TRIk70q7XYbic=",
 			"path": "github.com/elastic/beats/libbeat/common/reload",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "uMo9yaQAFfFG9iOsmdhQokffvpc=",
 			"path": "github.com/elastic/beats/libbeat/common/safemapstr",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "719FzIxi7bvpmh3Z1Ugn1VzY7Ro=",
 			"path": "github.com/elastic/beats/libbeat/common/schema",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "uffmniMUvoDPoH/udr7ogkh062E=",
 			"path": "github.com/elastic/beats/libbeat/common/schema/mapstriface",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "7AAflfE+cNTNalC2Iwq2vOhgMGI=",
 			"path": "github.com/elastic/beats/libbeat/common/seccomp",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "idXNC65t9dEVukD08AM6/L2p/RE=",
 			"path": "github.com/elastic/beats/libbeat/common/streambuf",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "IQGJeUodp0fl4Zy8W1rBzWtWSWA=",
 			"path": "github.com/elastic/beats/libbeat/common/terminal",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "NByKtWaf9vFTp6K338x8XA1xycw=",
 			"path": "github.com/elastic/beats/libbeat/common/transport/tlscommon",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "E50QfAprh0Wnfcwcj270Fd0LDwk=",
 			"path": "github.com/elastic/beats/libbeat/conditions",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "kXUjHPeCp2HU6sXtfoPcP6vVMRA=",
 			"path": "github.com/elastic/beats/libbeat/dashboards",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Tn+4O4FlSxSOxGF9qkH363wQCtA=",
 			"path": "github.com/elastic/beats/libbeat/feature",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "4cf2wL/oJiHEvg30ZTVEmxN4y/I=",
 			"path": "github.com/elastic/beats/libbeat/generator/fields",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "oCxiX/n/vxFGtjEN7kEHI6zjTzc=",
 			"path": "github.com/elastic/beats/libbeat/keystore",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "USuoVV8AYetxgv+2bto39fheDAM=",
 			"path": "github.com/elastic/beats/libbeat/kibana",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "M9mSRhP65Jnf/yk2qtZU6FM9OUw=",
 			"path": "github.com/elastic/beats/libbeat/logp",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "bM+Zvy63NmXBfPQZYZmWBCo/UIk=",
 			"path": "github.com/elastic/beats/libbeat/logp/configure",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "F/nzOXIrS9ui9wBLhuYa6M0fDEw=",
 			"path": "github.com/elastic/beats/libbeat/management",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "/qNmzEvnTPNTKsZG8NgDzJZ+6f8=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/cpu",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "ASezoo5ifdtv1UwROTGAu+VbNJA=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/host",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "lXmDdjbZAQJWerhniNifgiD+Fgs=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/memory",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "rKh4Kc2nLHGP/l9XUQuYwLFZ2sk=",
+			"checksumSHA1": "+cI2jq/bUsjqPA7RsN9SJ8nE4xc=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/process",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "JaqeGyZo3TRATCeVaKSZ9+K+O5E=",
 			"path": "github.com/elastic/beats/libbeat/monitoring",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "+wdf9YlsiFYofUdPuovqskNoZnw=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/adapter",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "8rqXWL9EN+JXokIj4mNhd7GKXNY=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "CkxEr3L/N3RIJG3n+3q7AL3x8a0=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report/elasticsearch",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "FJhQn6mS1pcNkFLFjFPulLZjC9w=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report/log",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "XV2ojQn9G7CoVU9dyVpmA5h3or8=",
 			"path": "github.com/elastic/beats/libbeat/outputs",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "CsWdZfYNuwBA2/RhAybzEf93qq4=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "dO9pXcIpo6PH5yxMbJUSb/BYbkc=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec/format",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "DbeMJiVepl/K4NXgWHHc2KyCpg0=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec/json",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "8zlgJqlqCEbCDiLf9llQHUWxKRY=",
 			"path": "github.com/elastic/beats/libbeat/outputs/console",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "JXID0Vu/u842WRqvuQcRWdBpiNg=",
 			"path": "github.com/elastic/beats/libbeat/outputs/elasticsearch",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "OMBMu8h0ji4xQwmv7ifk0wIefek=",
 			"path": "github.com/elastic/beats/libbeat/outputs/fileout",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "EaH7PayqnRdJUmktczmJtjWZWds=",
 			"path": "github.com/elastic/beats/libbeat/outputs/kafka",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "VgP3a7VyNnGdV2VMN9CsGxctL50=",
 			"path": "github.com/elastic/beats/libbeat/outputs/logstash",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "NJv+STaa3bEOeVra8WkEgOtzQic=",
 			"path": "github.com/elastic/beats/libbeat/outputs/outil",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "tQpLRv6kQs7dXiLE0oODZgnnqIw=",
 			"path": "github.com/elastic/beats/libbeat/outputs/redis",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "ThEQrqa9WEUapIawwzyIvVZjnXQ=",
 			"path": "github.com/elastic/beats/libbeat/outputs/transport",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "qPVudVlj4dE+HHMe4WGlaf4mFCo=",
 			"path": "github.com/elastic/beats/libbeat/outputs/transport/transptest",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "hb8M4qSLzgDXpQmdQfEyB7aChhI=",
 			"path": "github.com/elastic/beats/libbeat/paths",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "OVd5zDYdT/3QK2zj1M+BMPP0AIo=",
 			"path": "github.com/elastic/beats/libbeat/plugin",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "lhUKTNKAJqUl7dgyZN8En9B2Vnw=",
 			"path": "github.com/elastic/beats/libbeat/processors",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "YXrUdy69ur3Vr7+0E7tJbleTKIE=",
 			"path": "github.com/elastic/beats/libbeat/processors/actions",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "sWTU7BhKo5OMt1paCTY90K9EZlw=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_cloud_metadata",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "+du/yK51pLLSQ8V4t2IuDsD8Kl8=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_docker_metadata",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "O2+13p4BQ8zwBdKP1CTXg07FneA=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_host_metadata",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "PGsBuH7EkCUdOTdnZIePSemWT9A=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_kubernetes_metadata",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "GuCfa00ie8z+j57QYlZK3eRow2Y=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_locale",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "k8VzQtW0F61GAR9U/sU9opAUimU=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_process_metadata",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "tDlkiqQL3vTTh8jLS1JBwhZMC7o=",
 			"path": "github.com/elastic/beats/libbeat/processors/dissect",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "6YfWrbwMSQ7clCDTVFK3afNai3o=",
 			"path": "github.com/elastic/beats/libbeat/processors/dns",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "7kYMLJJXmsDd9GyXgq9Z9eJdqrk=",
 			"path": "github.com/elastic/beats/libbeat/publisher",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "3lRU4d8X4NyPiCAml4LjDm3o928=",
 			"path": "github.com/elastic/beats/libbeat/publisher/includes",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "bdpMsWHNOKGh2kjW8XJRZzBaPgs=",
 			"path": "github.com/elastic/beats/libbeat/publisher/pipeline",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "RaONy2th8fDi9BF5U+lYu5bto4Y=",
 			"path": "github.com/elastic/beats/libbeat/publisher/queue",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "ZUwitg43Gan3j0V+ZjM+5Y/ibb8=",
 			"path": "github.com/elastic/beats/libbeat/publisher/queue/memqueue",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "rCUlfIA9IxHYfwvYYDzeFosoi7E=",
 			"path": "github.com/elastic/beats/libbeat/publisher/queue/spool",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "fZ5S9LEZUcy5JlhwpHBn4MGNjOg=",
 			"path": "github.com/elastic/beats/libbeat/publisher/testing",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "vZZFb4M2d2t7tG3n2UEQeTk/lEM=",
 			"path": "github.com/elastic/beats/libbeat/scripts/cmd/global_fields",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "/645Ga6dGiQjHQIBSct5CYaRoj8=",
 			"path": "github.com/elastic/beats/libbeat/service",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "QFUySp2iXDRKddkdnmLH1b3u3Ig=",
+			"checksumSHA1": "MsksyxXqRMe3cjCp6fQTG6sOMeE=",
 			"path": "github.com/elastic/beats/libbeat/template",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Ifly/yeBS+Ok0/PKez4lSqzu8JI=",
 			"path": "github.com/elastic/beats/libbeat/testing",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "+0zBIGqXGbgm86imWcTq9kQyTgw=",
 			"path": "github.com/elastic/beats/libbeat/version",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "YRKEeQXsNj81zjG9gpkCyVpLKJs=",
 			"path": "github.com/elastic/beats/licenses",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "T66ogclJ8hBtTpz53Jy686Qmnpk=",
 			"path": "github.com/elastic/beats/x-pack/libbeat/cmd",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "XP552HOy/HC3Yq57ddUn0Ctgr5c=",
 			"path": "github.com/elastic/beats/x-pack/libbeat/management",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "6Yc+tAd8mE5bpjF7qN1j6ypA5T0=",
+			"checksumSHA1": "QV4MCtZBhywsCip+EzjYhUgtB34=",
 			"path": "github.com/elastic/beats/x-pack/libbeat/management/api",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z",
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z",
 			"version": "master",
 			"versionExact": "master"
 		},
@@ -1081,519 +1081,519 @@
 			"checksumSHA1": "3jizmlZPCyo6FAZY8Trk9jA8NH4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-lumber/client/v2",
 			"path": "github.com/elastic/go-lumber/client/v2",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "m6HLKpDAZlkTTQMqabf3aT6TQ/s=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-lumber/protocol/v2",
 			"path": "github.com/elastic/go-lumber/protocol/v2",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "TatpgVf9fhQp1GtNwSyNw5cgVKM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-seccomp-bpf",
 			"path": "github.com/elastic/go-seccomp-bpf",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "qTs7QT+GC2Dr4aFoLFHCkAOoVeU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-seccomp-bpf/arch",
 			"path": "github.com/elastic/go-seccomp-bpf/arch",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "W459MQNQ8qF6qmzLO/QLevTKZlU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform",
 			"path": "github.com/elastic/go-structform",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "BnoVvQlbw1jk1oveTVQtG+dhGRs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform/cborl",
 			"path": "github.com/elastic/go-structform/cborl",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "xjEIhANt0tAq4FjndVCLQhCXkQo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform/gotype",
 			"path": "github.com/elastic/go-structform/gotype",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "BIRSw/+jqs6VTgRx4MXJy453oGQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform/internal/unsafe",
 			"path": "github.com/elastic/go-structform/internal/unsafe",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "VPkz0hvtlbDDObJJZoTrjF2CN68=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform/json",
 			"path": "github.com/elastic/go-structform/json",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "zRLY43OHR3VYw3fu3XznhxziC4E=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform/ubjson",
 			"path": "github.com/elastic/go-structform/ubjson",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "QC8/6yQsm4f+zZo14ExnFtyiaXk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform/visitors",
 			"path": "github.com/elastic/go-structform/visitors",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "QhFIpuHPaV6hKejKcc2wm6y4MSQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo",
 			"path": "github.com/elastic/go-sysinfo",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "GiZCjX17K265TtamGZZw4R2Jwbk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo/internal/registry",
 			"path": "github.com/elastic/go-sysinfo/internal/registry",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "ovafihHzpBx9Y7+lZh9X5KwNCvE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo/providers/darwin",
 			"path": "github.com/elastic/go-sysinfo/providers/darwin",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "AK76ZxnuvK02Dfpmj7b2TD/aiSI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo/providers/linux",
 			"path": "github.com/elastic/go-sysinfo/providers/linux",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "RWLvcP1w9ynKbuCqiW6prwd+EDU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo/providers/shared",
 			"path": "github.com/elastic/go-sysinfo/providers/shared",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "aF05MEkMjbRekzHlwFxmd5WBpeY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo/providers/windows",
 			"path": "github.com/elastic/go-sysinfo/providers/windows",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "MLQioPEjULYbNqqCjfB1/cux08E=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo/types",
 			"path": "github.com/elastic/go-sysinfo/types",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "bNf3GDGhZh86bfCIMM5c5AYfo3g=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile",
 			"path": "github.com/elastic/go-txfile",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "scDqDI8APDj/tB973/ehmPufSLc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/dev-tools/lib/mage/gotool",
 			"path": "github.com/elastic/go-txfile/dev-tools/lib/mage/gotool",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "/WzE2caCHChUpoRAlXDU5uLTU5I=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/dev-tools/lib/mage/mgenv",
 			"path": "github.com/elastic/go-txfile/dev-tools/lib/mage/mgenv",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "kD/TFYofNqdOjb0nMN0w3LC/nNU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/dev-tools/lib/mage/xbuild",
 			"path": "github.com/elastic/go-txfile/dev-tools/lib/mage/xbuild",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "re2W5hqGml/Q8vnx+DT3ooUNWxo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/internal/cleanup",
 			"path": "github.com/elastic/go-txfile/internal/cleanup",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "HjNNDapvfXgOJqs7l7pS3ho6SSI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/internal/invariant",
 			"path": "github.com/elastic/go-txfile/internal/invariant",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "HLMF+V6Pt3YLUNOgmd2nR+vz9vM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/internal/iter",
 			"path": "github.com/elastic/go-txfile/internal/iter",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "EAIqvdq5S3FNBoTBAI/U02AwTSU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/internal/strbld",
 			"path": "github.com/elastic/go-txfile/internal/strbld",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "lejstOrGPfa+tJohvIOK/AjdLa4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/internal/vfs",
 			"path": "github.com/elastic/go-txfile/internal/vfs",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "Wqp2VCpbcmfOFuZJrYkaxpvQQrE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/internal/vfs/osfs",
 			"path": "github.com/elastic/go-txfile/internal/vfs/osfs",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "LYeqHmalUZgk3oOHtJyPOKlM/j4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/pq",
 			"path": "github.com/elastic/go-txfile/pq",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "fCx++6A9uzyCsDUanAIJb77u0MI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/txerr",
 			"path": "github.com/elastic/go-txfile/txerr",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
-			"checksumSHA1": "Yb61Nqnh+3igFci61hv9WYgk/hc=",
+			"checksumSHA1": "b91TSC0atoGVSMZdKuWTYsMOGiM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg",
 			"path": "github.com/elastic/go-ucfg",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "X+R/CD8SokJrmlxFTx2nSevRDhQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/cfgutil",
 			"path": "github.com/elastic/go-ucfg/cfgutil",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
-			"checksumSHA1": "zC8mCPW/pPPNcuHQOc/B/Ej1W1U=",
+			"checksumSHA1": "/pq8HNEdzHmky9S9HSo1WofXQ4Y=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/flag",
 			"path": "github.com/elastic/go-ucfg/flag",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "esXpiQlEvTOUwsE0nNesso8albo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/internal/parse",
 			"path": "github.com/elastic/go-ucfg/internal/parse",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
-			"checksumSHA1": "5mXUhhlPdvcAFKiQENInTJWrtQM=",
+			"checksumSHA1": "cfMNsyQm0gZOV0hRJrBSdKDQSBo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/json",
 			"path": "github.com/elastic/go-ucfg/json",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
-			"checksumSHA1": "Bg6vistPQLftv2fEYB7GWwSExv8=",
+			"checksumSHA1": "PJCBACDGPhnRAEqjGPMPCMjbj4o=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/yaml",
 			"path": "github.com/elastic/go-ucfg/yaml",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "rnd3qf1FE22X3MxXWbetqq6EoBk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-windows",
 			"path": "github.com/elastic/go-windows",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "ux0d5xvItes2abrOlpEyQWeJeqM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar",
 			"path": "github.com/elastic/gosigar",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "TX9y4oPL5YmT4Gb/OU4GIPTdQB4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/cgroup",
 			"path": "github.com/elastic/gosigar/cgroup",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "hPqGM3DENaGfipEODoyZ4mKogTQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/sys",
 			"path": "github.com/elastic/gosigar/sys",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "mLq5lOyD0ZU39ysXuf1ETOLJ+f0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/sys/linux",
 			"path": "github.com/elastic/gosigar/sys/linux",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "Xx3lvjjqPwlFQ2aBjxtXSeDmD4c=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/sys/windows",
 			"path": "github.com/elastic/gosigar/sys/windows",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "Klc34HULvwvY4cGA/D8HmqtXLqw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s",
 			"path": "github.com/ericchiang/k8s",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "y8fNiBLSoGojnUsGDsdLlsJYyqQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/apiextensions/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/apiextensions/v1beta1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "JxQ/zEWQSrncYNKifCuMctq+Tsw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/apps/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/apps/v1beta1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "bjklGt/pc6kWOZewAw87Hchw5oY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authentication/v1",
 			"path": "github.com/ericchiang/k8s/apis/authentication/v1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "LExhnM9Vn0LQoLQWszQ7aIxDxb4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authentication/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/authentication/v1beta1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "GM+PzOiBoq3cxx4h5RKVUb3UH60=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authorization/v1",
 			"path": "github.com/ericchiang/k8s/apis/authorization/v1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "zfr5oUVjbWRfvXi2LJiGMfFeDQY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authorization/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/authorization/v1beta1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "izkXNDp5a5WP45jU0hSfTrwyfvM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/autoscaling/v1",
 			"path": "github.com/ericchiang/k8s/apis/autoscaling/v1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "FryZuAxWn4Ig8zc913w9BdfYzvs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/batch/v1",
 			"path": "github.com/ericchiang/k8s/apis/batch/v1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "ylo7Z8wyJD+tmICB7wsOVIBpO+U=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/batch/v2alpha1",
 			"path": "github.com/ericchiang/k8s/apis/batch/v2alpha1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "+d8+mSdkdcPWQIpczXDZZW0lrjg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/certificates/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/certificates/v1beta1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "S7AvxmCe/+WoFP/v9lZr0Mv66qg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/core/v1",
 			"path": "github.com/ericchiang/k8s/apis/core/v1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "cWPoP6XZN7WMnEVMPcgPgg3Aw9Q=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/extensions/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/extensions/v1beta1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "vaNrBPcGWeDd1rXl8+uN08uxWhE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/imagepolicy/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/imagepolicy/v1alpha1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "UNTTH+Ppu4vImnF+bPkG3/NR3gg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/meta/v1",
 			"path": "github.com/ericchiang/k8s/apis/meta/v1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "Mmyg9Wh+FCVR6fV8MGEKRxvqZ2k=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/policy/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/policy/v1beta1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "bvwYS/wrBkyAfvCjzMbi/vKamrQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/rbac/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/rbac/v1alpha1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "m1Tde18NwewnvJoOYL3uykNcBuM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/rbac/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/rbac/v1beta1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "JirJkoeIkWJRNrbprsQvqwisxds=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/resource",
 			"path": "github.com/ericchiang/k8s/apis/resource",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "rQZ69PjEClQQ+PGEHRKzkGVVQyw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/settings/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/settings/v1alpha1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "pp0AetmPoKy7Rz0zNhBwUpExkbc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/storage/v1",
 			"path": "github.com/ericchiang/k8s/apis/storage/v1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "WeACcIrS4EkeBm8TTftwuVniaWk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/storage/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/storage/v1beta1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "Su6wSR8V8HL2QZsF8icJ0R9AFq8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/runtime",
 			"path": "github.com/ericchiang/k8s/runtime",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "8ETrRvIaXPfD21N7fa8kdbumL00=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/runtime/schema",
 			"path": "github.com/ericchiang/k8s/runtime/schema",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "cMk3HE8/81ExHuEs0F5sZCclOFs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/util/intstr",
 			"path": "github.com/ericchiang/k8s/util/intstr",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "fobEKiMk5D7IGvCSwh4HdG1o98c=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/watch/versioned",
 			"path": "github.com/ericchiang/k8s/watch/versioned",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "AANTVr9CVVyzsgviODY6Wi2thuM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/fatih/color",
 			"path": "github.com/fatih/color",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "2UmMbNHc8FBr98mJFN1k8ISOIHk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/garyburd/redigo/internal",
 			"path": "github.com/garyburd/redigo/internal",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "507OiSqTxfGCje7xDT5eq9CCaNQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/garyburd/redigo/redis",
 			"path": "github.com/garyburd/redigo/redis",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "ImX1uv6O09ggFeBPUJJ2nu7MPSA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ghodss/yaml",
 			"path": "github.com/ghodss/yaml",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "2VgF+qja44x3wPTp8U8TZEU6FWw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/go-ole/go-ole",
 			"path": "github.com/go-ole/go-ole",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "Q0ZOcJW0fqOefDzEdn+PJHOeSgI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/go-ole/go-ole/oleutil",
 			"path": "github.com/go-ole/go-ole/oleutil",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "OFaReqy4hyrLlTTYFmcqkvidHsQ=",
@@ -1619,15 +1619,15 @@
 			"checksumSHA1": "kBeNcaKk56FguvPSUCEaH6AxpRc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/golang/protobuf/proto",
 			"path": "github.com/golang/protobuf/proto",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "p/8vSviYF91gFflhrt5vkyksroo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/golang/snappy",
 			"path": "github.com/golang/snappy",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "d9PxF1XQGLMJZRct2R8qVM/eYlE=",
@@ -1645,29 +1645,29 @@
 			"checksumSHA1": "40vJyUB4ezQSn/NSadsKEOrudMc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/inconshreveable/mousetrap",
 			"path": "github.com/inconshreveable/mousetrap",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "l9wW52CYGbmO/NGwYZ/Op2QTmaA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/joeshaw/multierror",
 			"path": "github.com/joeshaw/multierror",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "IH4jnWcj4d4h+hgsHsHOWg/F+rk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/jstemmer/go-junit-report/formatter",
 			"path": "github.com/jstemmer/go-junit-report/formatter",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "Tx9cQqKFUHzu1l6H2XEl8G7ivlI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/jstemmer/go-junit-report/parser",
 			"path": "github.com/jstemmer/go-junit-report/parser",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "pa+ZwMzIv+u+BlL8Q2xgL9cQtJg=",
@@ -1679,36 +1679,36 @@
 			"checksumSHA1": "KKxbAKrKrfd33YPpkNsDmTN3S+M=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/compress/flate",
 			"path": "github.com/klauspost/compress/flate",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "+azPXaZpPF14YHRghNAer13ThQU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/compress/zlib",
 			"path": "github.com/klauspost/compress/zlib",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "R6zKqn31GjJH1G8W/api7fAW0RU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/cpuid",
 			"path": "github.com/klauspost/cpuid",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "BM6ZlNJmtKy3GBoWwg2X55gnZ4A=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/crc32",
 			"path": "github.com/klauspost/crc32",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "ASXhLVfIA2mzHf+7muYxT38JaHU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage",
 			"path": "github.com/magefile/mage",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "KODorM0Am1g55qObNz3jVOdRVFs=",
@@ -1721,29 +1721,29 @@
 			"checksumSHA1": "fHpo/9Tke6VFfZZAT+PRnoNOiiY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage/internal",
 			"path": "github.com/magefile/mage/internal",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "RVSwuhHOfojhN74rfwRe4AktDIA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage/mage",
 			"path": "github.com/magefile/mage/mage",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "irRTBkCBnOGMX+PZhOdHFUckgBY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage/mg",
 			"path": "github.com/magefile/mage/mg",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "QGt/JRmNp+D+lO0hHZsUUyH7y5U=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage/parse",
 			"path": "github.com/magefile/mage/parse",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "fEuDveZzYX6oqYOT9jqyZROun/Q=",
@@ -1756,15 +1756,15 @@
 			"checksumSHA1": "4JzH55TcYdctQksrCafgKT8lZRU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage/sh",
 			"path": "github.com/magefile/mage/sh",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "91U4Tlwnjdmwjd0w/XNw3+fxFKo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage/target",
 			"path": "github.com/magefile/mage/target",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "He+VtZO7BsPDCZhZtJ1IkNp629o=",
@@ -1777,50 +1777,50 @@
 			"checksumSHA1": "qNkx9+OTwZI6aFv7K9zuFCGODUw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/mattn/go-colorable",
 			"path": "github.com/mattn/go-colorable",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "U6lX43KDDlNOn+Z0Yyww+ZzHfFo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/mattn/go-isatty",
 			"path": "github.com/mattn/go-isatty",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "VsImZoqjaqgwK+u/4eIEzQhuRNM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/miekg/dns",
 			"path": "github.com/miekg/dns",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "sWdAYPKyaT4SW8hNQNpRS0sU4lU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/mitchellh/hashstructure",
 			"path": "github.com/mitchellh/hashstructure",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "2AyUkWjutec6p+470tgio8mYOxI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/go-digest",
 			"path": "github.com/opencontainers/go-digest",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "eOMCORUm8KxiGSy0hBuQsMsxauo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/image-spec/specs-go",
 			"path": "github.com/opencontainers/image-spec/specs-go",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "9YujSsJjiLGkQMzwWycsjqR340k=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/image-spec/specs-go/v1",
 			"path": "github.com/opencontainers/image-spec/specs-go/v1",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "JVGDxPn66bpe6xEiexs1r+y6jF0=",
@@ -1832,15 +1832,15 @@
 			"checksumSHA1": "WmrPO1ovmQ7t7hs9yZGbr2SAoM4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pierrec/lz4",
 			"path": "github.com/pierrec/lz4",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "IT4sX58d+e8osXHV5U6YCSdB/uE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pierrec/xxHash/xxHash32",
 			"path": "github.com/pierrec/xxHash/xxHash32",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "e6T/9bM7ah7mQJVVIaTuCw/63Uo=",
@@ -1852,50 +1852,50 @@
 			"checksumSHA1": "PdQm3s8DoVJ17Vk8n7o5iPa7PK0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pkg/errors",
 			"path": "github.com/pkg/errors",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pmezard/go-difflib/difflib",
 			"path": "github.com/pmezard/go-difflib/difflib",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "Etvt6mgzvD7ARf4Ux03LHfgSlzU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/prometheus/procfs",
 			"path": "github.com/prometheus/procfs",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "lv9rIcjbVEGo8AT1UCUZXhXrfQc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/prometheus/procfs/internal/util",
 			"path": "github.com/prometheus/procfs/internal/util",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "EekY1iRG9JY74mDD0jsbFCWbAFs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/prometheus/procfs/nfs",
 			"path": "github.com/prometheus/procfs/nfs",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "yItvTQLUVqm/ArLEbvEhqG0T5a0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/prometheus/procfs/xfs",
 			"path": "github.com/prometheus/procfs/xfs",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "LmajbO3+qtbE7JA0MQ29PXbmKNM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/rcrowley/go-metrics",
 			"path": "github.com/rcrowley/go-metrics",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "epQZICCcThx99PQo7m/HuWN5kpQ=",
@@ -1970,43 +1970,43 @@
 			"checksumSHA1": "e7mAb9jMke2ASQGZepFgOmfBFzM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/spf13/cobra",
 			"path": "github.com/spf13/cobra",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "STxYqRb4gnlSr3mRpT+Igfdz/kM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/spf13/pflag",
 			"path": "github.com/spf13/pflag",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "c6pbpF7eowwO59phRTpF8cQ80Z0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/stretchr/testify/assert",
 			"path": "github.com/stretchr/testify/assert",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "wnEANt4k5X/KGwoFyfSSnpxULm4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/stretchr/testify/require",
 			"path": "github.com/stretchr/testify/require",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "CpcG17Q/0k1g2uy8AL26Uu7TouU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/theckman/go-flock",
 			"path": "github.com/theckman/go-flock",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "H7tCgNt2ajKK4FBJIDNlevu9MAc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/urso/go-bin",
 			"path": "github.com/urso/go-bin",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "8Kj0VH496b0exuyv4wAF4CXa7Y4=",
@@ -2166,169 +2166,169 @@
 			"checksumSHA1": "HedK9m8E8iyib4bIBtIX7xprOgo=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/atomic",
 			"path": "go.uber.org/atomic",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "JDGx7hehaQunZySwPs7yvdUs2m8=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/multierr",
 			"path": "go.uber.org/multierr",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "5BYbiKEkYykvfjSaNYDuQpBqglo=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap",
 			"path": "go.uber.org/zap",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "HYo/9nwrY08NQA+2ItPOAH8IFW8=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/buffer",
 			"path": "go.uber.org/zap/buffer",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "MuxOAtZEsJitlWBzhmpm2vGiHok=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/internal/bufferpool",
 			"path": "go.uber.org/zap/internal/bufferpool",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "uC0L9eCSAYcCWNC8udJk/t1vvIU=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/internal/color",
 			"path": "go.uber.org/zap/internal/color",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "b80CJExrVpXu3SA1iCQ6uLqTn2c=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/internal/exit",
 			"path": "go.uber.org/zap/internal/exit",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "mRD6lujPvXPkbC3+byNwO/bNVu8=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/zapcore",
 			"path": "go.uber.org/zap/zapcore",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "gyBmIfDZslmQGKnqisJ/p7oHbQc=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/zaptest/observer",
 			"path": "go.uber.org/zap/zaptest/observer",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "2LpxYGSf068307b7bhAuVjvzLLc=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/crypto/ed25519",
 			"path": "golang.org/x/crypto/ed25519",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "0JTAFXPkankmWcZGQJGScLDiaN8=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/crypto/ed25519/internal/edwards25519",
 			"path": "golang.org/x/crypto/ed25519/internal/edwards25519",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "1MGpGDQqnUoRpv7VEcQrXOBydXE=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/crypto/pbkdf2",
 			"path": "golang.org/x/crypto/pbkdf2",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "6U7dCaxxIMjf5V02iWgyAwppczw=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/crypto/ssh/terminal",
 			"path": "golang.org/x/crypto/ssh/terminal",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "uX2McdP4VcQ6zkAF0Q4oyd0rFtU=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/bpf",
 			"path": "golang.org/x/net/bpf",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "dr5+PfIRzXeN+l1VG+s0lea9qz8=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/context",
 			"path": "golang.org/x/net/context",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "WHc3uByvGaMcnSoI21fhzYgbOgg=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/context/ctxhttp",
 			"path": "golang.org/x/net/context/ctxhttp",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "TWcqN2+KUWtdqnu18rruwn14UEQ=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/http2",
 			"path": "golang.org/x/net/http2",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "ezWhc7n/FtqkLDQKeU2JbW+80tE=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/http2/hpack",
 			"path": "golang.org/x/net/http2/hpack",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "RcrB7tgYS/GMW4QrwVdMOTNqIU8=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/idna",
 			"path": "golang.org/x/net/idna",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "5JWn/wMC+EWNDKI/AYE4JifQF54=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/internal/iana",
 			"path": "golang.org/x/net/internal/iana",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "YsXlbexuTtUXHyhSv927ILOkf6A=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/internal/socket",
 			"path": "golang.org/x/net/internal/socket",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "zPTKyZ1C55w1fk1W+/qGE15jaek=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/ipv4",
 			"path": "golang.org/x/net/ipv4",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "3L3n7qKMO9X8E1ibA5mExKvwbmI=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/ipv6",
 			"path": "golang.org/x/net/ipv6",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "3xyuaSNmClqG4YWC7g0isQIbUTc=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/lex/httplex",
 			"path": "golang.org/x/net/lex/httplex",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "whCSspa9pYarl527EuhPz91cbUE=",
@@ -2340,8 +2340,8 @@
 			"checksumSHA1": "QEm/dePZ0lOnyOs+m22KjXfJ/IU=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/proxy",
 			"path": "golang.org/x/net/proxy",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "S0DP7Pn7sZUmXc55IzZnNvERu6s=",
@@ -2353,78 +2353,78 @@
 			"checksumSHA1": "nc3RG2Qgzn2aup/3/4RusWr+X0g=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/unix",
 			"path": "golang.org/x/sys/unix",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "Hi7BmkvZh4plNNLGDHfPnCKy3i8=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows",
 			"path": "golang.org/x/sys/windows",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "P9OIhD26uWlIST/me4TYnvseCoY=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/registry",
 			"path": "golang.org/x/sys/windows/registry",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "Fes9OIPy6lS/ghzodqAbMlZZTTQ=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/svc",
 			"path": "golang.org/x/sys/windows/svc",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "e9KJPWrdqg5PMkbE2w60Io8rY4M=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/svc/debug",
 			"path": "golang.org/x/sys/windows/svc/debug",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "uVlUSSKplihZG7N+QJ6fzDZ4Kh8=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/svc/eventlog",
 			"path": "golang.org/x/sys/windows/svc/eventlog",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "CbpjEkkOeh0fdM/V8xKDdI0AA88=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/text/secure/bidirule",
 			"path": "golang.org/x/text/secure/bidirule",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "ziMb9+ANGRJSSIuxYdRbA+cDRBQ=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/text/transform",
 			"path": "golang.org/x/text/transform",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "w8kDfZ1Ug+qAcVU0v8obbu3aDOY=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/text/unicode/bidi",
 			"path": "golang.org/x/text/unicode/bidi",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "BCNYmf4Ek93G4lk5x3ucNi/lTwA=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/text/unicode/norm",
 			"path": "golang.org/x/text/unicode/norm",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "vGfePfr0+weQUeTM/71mu+LCFuE=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/time/rate",
 			"path": "golang.org/x/time/rate",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "5QK10eoScnyEh8dD3PfZf8gMXn8=",
@@ -2468,15 +2468,15 @@
 			"checksumSHA1": "fALlQNY1fM99NesfLJ50KguWsio=",
 			"origin": "github.com/elastic/beats/vendor/gopkg.in/yaml.v2",
 			"path": "gopkg.in/yaml.v2",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		},
 		{
 			"checksumSHA1": "ZDOewomjpADMDyjKRW5rP15519M=",
 			"origin": "github.com/elastic/beats/vendor/howett.net/plist",
 			"path": "howett.net/plist",
-			"revision": "d5fb4fa35bd967cfd1a94f5ee5e91f97b45952a6",
-			"revisionTime": "2019-01-30T12:00:44Z"
+			"revision": "33b789cbfb95a852d0d75b7c8316da3be801d55f",
+			"revisionTime": "2019-01-31T05:42:32Z"
 		}
 	],
 	"rootPath": "github.com/elastic/apm-server"


### PR DESCRIPTION
This update removes the  `--setup` flag for the `./apm-server run` command, and removes the last piece of `dashboard` related information showing up in apm-server commands. 