### PR TITLE
[docs] Update RUM links to 3.x

### DIFF
--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -11,7 +11,7 @@
 :server-branch: {doc-branch}
 :go-branch: 1.x
 :java-branch: 1.x
-:rum-branch: 2.x
+:rum-branch: 3.x
 :node-branch: 2.x
 :py-branch: 4.x
 :ruby-branch: 2.x


### PR DESCRIPTION
Update RUM links to point to `3.x` from APM Server.

Builds locally.