### PR TITLE
[6.x][docs] Backport documentation

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -6,7 +6,7 @@ https://github.com/elastic/apm-server/compare/6.5\...6.x[View commits]
 [float]
 === Added
 
-- Set some configuration defaults (setup.template.settings.index.*, logging.metrics.enabled) in code {pull}1494[1494].
+- Set some configuration defaults (`setup.template.settings.index.*`, `logging.metrics.enabled`) in code {pull}1494[1494].
 - Add `span.sync` property to intake json spec and index field in ES. {pull}1548[1548].
 - Make `service.framework` properties optional and nullable {pull}1546[1546].
 - Add `transaction.sampled` to errors {pull}1662[1662].
@@ -23,6 +23,6 @@ https://github.com/elastic/apm-server/compare/6.5\...6.x[View commits]
 [float]
 ==== Bug fixes
 
-- Fix index pattern bundled with Kibana to be in sync with ES template pull{1571}[1571].
-- Ensure all `transaction.marks.*.*` values are stored as scaled floats. pull{1704}[1704].
+- Fix index pattern bundled with Kibana to be in sync with ES template {pull}1571[1571].
+- Ensure all `transaction.marks.*.*` values are stored as scaled floats {pull}1704[1704].
 - Prevent slice out of bounds panic when sourcemap line numbers are off {pull}1764[1764].

--- a/docs/events-api.asciidoc
+++ b/docs/events-api.asciidoc
@@ -8,9 +8,9 @@ Events can be:
 * Transactions
 * Spans
 * Errors
-* Metricsets
+* Metrics
 
-You can learn more about events in the {apm-get-started-ref}/apm-data-model.html[APM Data Model] documentation. 
+You can learn more about events in the {apm-overview-ref-v}/apm-data-model.html[APM Data Model]. 
 
 [[events-api-endpoint]]
 [float]
@@ -102,7 +102,7 @@ The APM Server uses a collection of JSON Schemas for validating requests to the 
 * <<transaction-api, Transactions>>
 * <<span-api, Spans>>
 * <<error-api, Errors>>
-* <<metricset-api, Metricsets>>
+* <<metricset-api, Metrics>>
 * <<example-intakev2-events, Example Request Body>>
 
 include::./metadata-api.asciidoc[]

--- a/docs/exploring-es-data.asciidoc
+++ b/docs/exploring-es-data.asciidoc
@@ -9,11 +9,11 @@ Read the <<upgrading-to-65,upgrading to 6.5 guide>> for more information.
 
 By default, Elastic APM data is stored in separated indices in the following formats:
 ------------------------------------------------------------
-apm-%{[version]}-sourcemap
-apm-%{[version]}-error-%{+yyyy.MM.dd}
 apm-%{[version]}-transaction-%{+yyyy.MM.dd}
 apm-%{[version]}-span-%{+yyyy.MM.dd}
+apm-%{[version]}-error-%{+yyyy.MM.dd}
 apm-%{[version]}-metric-%{+yyyy.MM.dd}
+apm-%{[version]}-sourcemap
 ------------------------------------------------------------
 
 If you're unfamiliar with the data types shown above, they are described in the {apm-get-started-ref}/apm-data-model.html[APM data model].
@@ -29,10 +29,10 @@ GET _cat/indices/apm*
 
 Default APM `template` and `indices`:
 
-//* <<fields>>
 * <<transaction-indices>>
 * <<span-indices>>
 * <<error-indices>>
+* <<metricset-indices>>
 * <<sourcemap-indices>>
 
 

--- a/docs/guide/agent-server-compatibility.asciidoc
+++ b/docs/guide/agent-server-compatibility.asciidoc
@@ -1,5 +1,5 @@
 [[agent-server-compatibility]]
-== Agent/Server Compatibility
+== Agent/Server compatibility
 
 Below is a chart that outlines the compatibility between different versions of the APM agents and the APM Server. 
 

--- a/docs/guide/agent-server-compatibility.asciidoc
+++ b/docs/guide/agent-server-compatibility.asciidoc
@@ -1,11 +1,31 @@
 [[agent-server-compatibility]]
 == Agent/Server compatibility
 
-Below is a chart that outlines the compatibility between different versions of the APM agents and the APM Server. 
+Below is a chart that outlines the compatibility between different versions of the APM agents and the APM Server.
 
 NOTE: APM Server version 6.5 introduced a new way for APM agents to communicate with the APM Server.
 To take advantage of new features,
 it is recommended that you update to the newest version of the applicable agent.
+
+[float]
+[[go-compatibility]]
+==== Go Agent Compatibility
+
+[options="header"]
+|=======================================================================
+|Agent Version |APM Server Version
+|1.x |>= 6.5
+|=======================================================================
+
+[float]
+[[java-compatibility]]
+==== Java Agent Compatibility
+
+[options="header"]
+|=======================================================================
+|Agent Version |APM Server Version
+|1.x |>= 6.5
+|=======================================================================
 
 [float]
 [[nodejs-compatibility]]
@@ -25,7 +45,7 @@ it is recommended that you update to the newest version of the applicable agent.
 [options="header"]
 |=======================================================================
 |Agent Version |APM Server Version
-|2.x/3.x |6.2-6.x
+|2.x, 3.x |6.2-6.x
 |4.x |>= 6.5
 |=======================================================================
 
@@ -41,26 +61,6 @@ it is recommended that you update to the newest version of the applicable agent.
 |=======================================================================
 
 [float]
-[[java-compatibility]]
-==== Java Agent Compatibility
-
-[options="header"]
-|=======================================================================
-|Agent Version |APM Server Version
-|1.x |>= 6.5
-|=======================================================================
-
-[float]
-[[go-compatibility]]
-==== Go Agent Compatibility
-
-[options="header"]
-|=======================================================================
-|Agent Version |APM Server Version
-|1.x |>= 6.5
-|=======================================================================
-
-[float]
 [[rum-compatibility]]
 ==== RUM Agent Compatibility
 
@@ -69,5 +69,5 @@ it is recommended that you update to the newest version of the applicable agent.
 |Agent Version |APM Server Version
 |0.x |6.3-6.4
 |1.x |6.4
-|2.x |>= 6.5
+|2.x, 3.x |>= 6.5
 |=======================================================================

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -3,9 +3,15 @@
 
 Elastic APM agents capture different types of information from within their instrumented applications - namely `transactions`, `spans`, and `errors`. 
 
-* <<transactions,Transaction>>
-* <<transaction-spans,Spans>>
-* <<errors,Errors>>
+*<<errors,`Errors`>>* contain information about the error or exception that was captured.
+
+*<<transaction-spans,`Spans`>>* contain information about a specific code path that has been executed.
+They measure from the start to end of an activity,
+and they can have a parent/child relationship with other spans. 
+
+*<<transactions,`Transactions`>>* are a special kind of span that have extra metadata associated with them.
+You can think of transactions as the highest level of work you're measuring within a service.
+For example, serving an HTTP request or running a specific background job.
 
 [[transactions]]
 === Transactions

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -1,53 +1,26 @@
 [[apm-data-model]]
 == Data Model
 
-Elastic APM agents capture different types of information from within their instrumented applications - namely `transactions`, `spans`, and `errors`. 
+Elastic APM agents capture different types of information from within their instrumented applications - namely `spans`, `transactions`, `errors`, and `metrics`. 
 
-*<<errors,`Errors`>>* contain information about the error or exception that was captured.
-
-*<<transaction-spans,`Spans`>>* contain information about a specific code path that has been executed.
-They measure from the start to end of an activity,
-and they can have a parent/child relationship with other spans. 
-
-*<<transactions,`Transactions`>>* are a special kind of span that have extra metadata associated with them.
-You can think of transactions as the highest level of work you're measuring within a service.
-For example, serving an HTTP request or running a specific background job.
-
-[[transactions]]
-=== Transactions
-
-A transaction describes an event captured by an Elastic APM agent instrumenting a service. Some examples of a transaction might be:
-
-* An HTTP request
-* A background job
-
-A transaction contains:
-
-* The timestamp and duration of the event
-* A unique id, type, and name
-* A result (e.g. a response code)
-* Some contextual data (see below for details)
-* Other relevant information depending on the agent. Example: The JavaScript RUM captures transaction marks,
-which are points in time relative to the start of the transaction with some label.
-
-[[transactions-context]]
-include::../context.asciidoc[]
-
-Agents decide whether to sample transactions or not,
-and provide settings to control sampling behavior.
-If sampled,
-the <<transaction-spans,spans>> of a transaction are sent and stored as separate documents. Within one transaction there can be several, or no spans captured. 
-
-Transactions are stored in {apm-server-ref}/transaction-indices.html[transaction indices].
+* <<transaction-spans>>
+* <<transactions>>
+* <<errors>>
+* <<metrics>>
 
 [[transaction-spans]]
 === Spans
-Transactions can have 0, 1, or many spans. Spans have a `transaction.id` attribute that refers to their parent transaction. They also have a `parent.id` attribute that refers to the parent span, or their transaction.
 
-Agents typically automatically instrument a variety of of libraries,
-but also provide an API for ad hoc instrumentation of specific code paths. 
-A span contains information about a specific code path that has been executed as part of a transaction.
-This information includes:
+*Spans* contain information about a specific code path that has been executed.
+They measure from the start to end of an activity,
+and they can have a parent/child relationship with other spans.
+
+Agents automatically instrument a variety of libraries to capture these spans from within your application.
+In addition, you can use the Agent API for ad hoc instrumentation of specific code paths. 
+
+Spans have a `transaction.id` attribute that refers to their parent <<transactions,transaction>>.
+They also have a `parent.id` attribute that refers to their parent span, or their transaction.
+Other span data includes:
 
 * start time
 * duration
@@ -55,13 +28,8 @@ This information includes:
 * type
 * `stack trace` (optional)
 
-As an example, if a database query happens within a sampled transaction,
-a span describing the database query will be created.
-The name of this span will contain information about the query itself,
-and the type of this span will contain information about the database.
-
-Spans are stored in {apm-server-ref}/span-indices.html[span indices].
-Note that these indices are separate from {apm-server-ref}/transaction-indices.html[transaction indices] by default.
+Spans are stored in {apm-server-ref-v}/span-indices.html[span indices].
+Note that these indices are separate from {apm-server-ref-v}/transaction-indices.html[transaction indices] by default.
 
 [float]
 [[dropped-spans]]
@@ -90,24 +58,79 @@ Unforseen errors may cause spans to go missing.
 Because the agent notifies the server about how many spans there should be,
 the number of missing spans is able to be calculated and shown in the UI.
 
+[[transactions]]
+=== Transactions
+
+*Transactions* are a special kind of <<transaction-spans,span>> that have additional attributes associated with them.
+They describe an event captured by an Elastic APM agent instrumenting a service.
+You can think of transactions as the highest level of work you’re measuring within a service.
+As an example, a transaction might be a:
+
+* request to your server
+* batch job
+* background job
+* custom transaction type.
+
+Agents decide whether to sample transactions or not,
+and provide settings to control sampling behavior.
+If sampled, the <<transaction-spans,spans>> of a transaction are sent and stored as separate documents.
+Within one transaction there can be 0, 1, or many spans captured.
+
+A transaction contains:
+
+* The timestamp and duration of the event
+* A unique id, type, and name
+* A result (e.g. a response code)
+* Some contextual data (see below for details)
+* Other relevant information depending on the agent. Example: The JavaScript RUM captures transaction marks,
+which are points in time relative to the start of the transaction with some label.
+
+[[transactions-context]]
+include::../context.asciidoc[]
+
+Transactions are stored in {apm-server-ref-v}/transaction-indices.html[transaction indices].
+
 [[errors]]
 === Errors
 
-Errors are represented by a unique ID.
 An error event contains at least
 information about the original `exception` that occurred
 or about a `log` created when the exception occurred.
+For simplicity, errors are represented by a unique ID.
 
-Both the captured `exception` and the captured `log` of an error can contain a `stack trace`,
-helpful for debugging.
+Error data includes:
 
-The `culprit` of an error indicates where it originated.
-
-An error might relate to the <<transactions,transaction>> during which it happened,
+* Both the captured `exception` and the captured `log` of an error can contain a `stack trace`,
+which is helpful for debugging.
+* The `culprit` of an error indicates where it originated.
+* An error might relate to the <<transactions,transaction>> during which it happened,
 via the `transaction.id`.
-
-Errors also have some contextual data.
+* Some contextual data (see below).
 
 include::../context.asciidoc[]
 
-Errors are stored in {apm-server-ref}/error-indices.html[error indices].
+Errors are stored in {apm-server-ref-v}/error-indices.html[error indices].
+
+[[metrics]]
+=== Metrics
+
+APM agents automatically pick up basic host-level metrics,
+including system and process-level CPU and memory metrics.
+Agent specific metrics are also available,
+like {apm-java-ref-v}/metrics.html[JVM metrics] in the Java Agent,
+and {apm-go-ref-v}/metrics.html[Go runtime] metrics in the Go Agent.
+
+Infrastructure and application metrics are important sources of information when debugging production systems,
+which is why we've made it easy to filter metrics for specific hosts or containers in the Kibana {kibana-ref}/apm-ui.html.html[APM UI].
+
+Metrics have the `processor.event` property set to `metric`.
+
+Metrics are stored in {apm-server-ref-v}/metricset-indices.html[metric indices].
+
+For a full list of tracked metrics, see the relevant agent documentation:
+
+* {apm-go-ref-v}/metrics.html[Go]
+* {apm-java-ref-v}/metrics.html[Java]
+* {apm-node-ref-v}/metrics.html[Node.js]
+* {apm-py-ref-v}/metrics.html[Python]
+* {apm-ruby-ref-v}/metrics.html[Ruby]

--- a/docs/guide/apm-doc-directory.asciidoc
+++ b/docs/guide/apm-doc-directory.asciidoc
@@ -8,7 +8,7 @@ The following sections are designed to guide you through the available Elastic A
 
 You're here!
 The APM Overview is your launchpad for getting started with APM.
-We recommend reading all sections in this book to gain a deeper understanding of the Elastic APM ecosystem.
+We recommend reading through this documentation to gain a deeper understanding of the Elastic APM ecosystem.
 
 * <<overview>>
 * <<install-and-run>>
@@ -35,7 +35,7 @@ Here you can learn about {apm-server-ref-v}/installing.html[installation],
 === APM Agents
 
 APM agents are open source libraries that you install into your services.
-You may only need one, or you might use all six.
+You may only need one, or you might use all of them.
 Each agent has its own documentation:
 
 * {apm-go-ref}/introduction.html[Go agent]
@@ -48,7 +48,7 @@ Each agent has its own documentation:
 [float]
 === APM Kibana UI
 
-Application performance monitoring is all about visualizing data and bottlenecks, so it's crucial you understand how to use the {kibana-ref}/xpack-apm.html[Kibana APM UI]. The following sections will help you get started:
+Application performance monitoring is all about visualizing data and detecting bottlenecks, so it's crucial you understand how to use the {kibana-ref}/xpack-apm.html[Kibana APM UI]. The following sections will help you get started:
 
 * {kibana-ref}/apm-getting-started.html[Getting Started]
 * {kibana-ref}/apm-bottlenecks.html[Visualizing application bottlenecks]

--- a/docs/guide/apm-doc-directory.asciidoc
+++ b/docs/guide/apm-doc-directory.asciidoc
@@ -1,0 +1,86 @@
+[[doc-directory]]
+== Documentation directory
+
+The following sections are designed to guide you through the available Elastic APM documentation.
+
+[float]
+=== APM Overview
+
+You're here!
+The APM Overview is your launchpad for getting started with APM.
+We recommend reading all sections in this book to gain a deeper understanding of the Elastic APM ecosystem.
+
+* <<overview>>
+* <<install-and-run>>
+* <<apm-data-model>>
+* <<distributed-tracing>>
+* <<agent-server-compatibility>>
+
+TIP: Want to skip straight to installation?
+Simply use an existing cluster or grab a fresh installation of the Elastic Stack,
+spin up an APM Server, and add a bit of code to instrument your app with agents.
+Full details are available on the <<install-and-run,install and run>> page.
+
+[float]
+=== APM Server
+
+The APM Server receives data from APM agents and converts that data into Elasticsearch documents.
+The {apm-server-ref-v}/index.html[APM Server reference] provides everything you need when it comes to working with the server.
+Here you can learn about {apm-server-ref-v}/installing.html[installation],
+{apm-server-ref-v}/configuring-howto-apm-server.html[configuration],
+{apm-server-ref-v}/securing-apm-server.html[security],
+{apm-server-ref-v}/monitoring.html[monitoring], and more.
+
+[float]
+=== APM Agents
+
+APM agents are open source libraries that you install into your services.
+You may only need one, or you might use all six.
+Each agent has its own documentation:
+
+* {apm-go-ref}/introduction.html[Go agent]
+* {apm-java-ref}/intro.html[Java agent]
+* {apm-node-ref}/intro.html[Node.js agent]
+* {apm-py-ref}/getting-started.html[Python agent]
+* {apm-ruby-ref}/introduction.html[Ruby agent]
+* {apm-rum-ref}/intro.html[JavaScript Real User Monitoring (RUM) agent]
+
+[float]
+=== APM Kibana UI
+
+Application performance monitoring is all about visualizing data and bottlenecks, so it's crucial you understand how to use the {kibana-ref}/xpack-apm.html[Kibana APM UI]. The following sections will help you get started:
+
+* {kibana-ref}/apm-getting-started.html[Getting Started]
+* {kibana-ref}/apm-bottlenecks.html[Visualizing application bottlenecks]
+* {kibana-ref}/apm-ui.html[Using the APM UI]
+
+APM also has built-in integrations with Machine Learning. To learn more about this feature, refer to the Kibana UI documentation for {kibana-ref}/machine-learning-integration.html[Machine learning integration].
+
+TIP: If you'd like to dive deeper into Kibana, the general {kibana-ref}/index.html[Kibana documentation] is also helpful.
+
+[float]
+=== Troubleshooting
+
+If you run into trouble, there are three places you can look for help:
+Troubleshooting documentation, GitHub repositories, and our discussion forum.
+
+[float]
+==== Troubleshooting documentation
+
+The APM Server and some of the APM agents have troubleshooting guides:
+
+* {apm-server-ref-v}/troubleshooting.html[Server troubleshooting]
+* {apm-java-ref}/trouble-shooting.html[Java agent troubleshooting]
+* {apm-node-ref}/troubleshooting.html[Node.js agent troubleshooting]
+* {apm-rum-ref}/troubleshooting.html[RUM troubleshooting]
+
+[float]
+==== GitHub repositories
+
+Elastic APM is open source! Our https://github.com/elastic?utf8=%E2%9C%93&q=apm[GitHub repositories] have a plethora of knowledge available in the form of code, issues, and PRs.
+
+[float]
+==== Discussion forum
+
+For additional questions and feature requests,
+visit our https://discuss.elastic.co/c/apm[discussion forum].

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -9,13 +9,15 @@ endif::[]
 [[gettting-started]]
 = APM Overview
 
+include::./apm-doc-directory.asciidoc[]
+
 include::./overview.asciidoc[]
+
+include::./install-and-run.asciidoc[]
 
 include::./apm-data-model.asciidoc[]
 
 include::./distributed-tracing.asciidoc[]
-
-include::./install-and-run.asciidoc[]
 
 include::./agent-server-compatibility.asciidoc[]
 

--- a/docs/guide/install-and-run.asciidoc
+++ b/docs/guide/install-and-run.asciidoc
@@ -115,7 +115,7 @@ NOTE: Be sure to check the <<agent-server-compatibility,Agent/Server compatibili
 3+|The Node.js agent automatically instruments Express, hapi, Koa, and Restify out of the box.
 |{apm-node-ref}/intro.html[Introduction]
 |{apm-node-ref}/supported-technologies.html[Supported technologies]
-|{apm-node-ref}/advanced-setup.html#configuring-the-agent[Config]
+|{apm-node-ref}/configuring-the-agent.html[Config]
 
 .2+|Python
 3+|The Python agent automatically instruments Django and Flask out of the box.

--- a/docs/guide/install-and-run.asciidoc
+++ b/docs/guide/install-and-run.asciidoc
@@ -1,112 +1,140 @@
 [[install-and-run]]
-== Install and run Elastic APM
+== Install and run
 
-To get started using Elastic APM,
-you need to have:
+This page is designed to make it easy to install and run the components of Elastic APM.
+Simply follow the step-by-step links below, and you'll be up and running in no time.
+Let's get started.
 
-* {apm-agents-ref}/index.html[APM agents] installed in your services
-* {apm-server-ref-v}/index.html[APM Server]
-* {ref}/index.html[Elasticsearch]
-* {kibana-ref}[Kibana]
+* <<before-installation>>
+* <<install-elasticsearch>>
+* <<install-kibana>>
+* <<apm-server>>
+* <<kibana-dashboards>>
+* <<agents>>
 
-IMPORTANT: For best results, ensure you're using the same version of Elasticsearch, Kibana, and APM Server.
+[float]
+[[before-installation]]
+=== Before you begin
 
-First, you'll need to install and start an Elasticsearch cluster and Kibana. Information on how to do this can be found in the {stack-gs}/get-started-elastic-stack.html[Elastic Stack getting started guide]. Specifically, the {stack-gs}/get-started-elastic-stack.html#install-elasticsearch[install Elasticsearch], and {stack-gs}/get-started-elastic-stack.html#install-kibana[install Kibana] sections.
+* See the https://www.elastic.co/support/matrix[Elastic Support
+Matrix] for information about supported operating systems and product
+compatibility.
+* Verify that your system meets the
+https://www.elastic.co/support/matrix#matrix_jvm[minimum JVM requirements] for {es}.
 
-The following sections show how to get started quickly with Elastic APM on a local machine.
+IMPORTANT: For best results, ensure you’re using the same version of Elasticsearch, Kibana, and APM Server.
+
+NOTE: The following links assume you're using the current version of the Elasticstack.
+If you're not, it's easy to adjust the version of the documentation after you land on each page.
+
+[float]
+[[install-elasticsearch]]
+=== Install and run Elasticsearch
+
+You'll need to install an Elasticsearch cluster, and make sure it's up and running:
+
+* {stack-gs}/get-started-elastic-stack.html#install-elasticsearch[Install Elasticsearch]
+* {stack-gs}/get-started-elastic-stack.html#_make_sure_elasticsearch_is_up_and_running[Make sure elasticsearch is up and running]
+
+[float]
+[[install-kibana]]
+=== Install and run Kibana
+
+Now we'll install Kibana and open up the web interface:
+
+* {stack-gs}/get-started-elastic-stack.html#install-kibana[Install Kibana]
+* {stack-gs}/get-started-elastic-stack.html#_launch_the_kibana_web_interface[Launch the Kibana Web Interface]
 
 [[apm-server]]
 [float]
 === Install and run APM Server
 
-First, https://www.elastic.co/downloads/apm/apm-server[download APM Server] for your operating system and extract the package.
+You've made it to the fun part - Let's get APM Server up and running:
 
-In a production environment you would put APM Server on its own machines,
-similar to how you run Elasticsearch.
-You _can_ run it on the same machines as Elasticsearch,
-but this is not recommended,
-as the processes will be competing for resources.
+* {apm-server-ref-v}/installing.html[Install APM Server]
+* {apm-server-ref-v}/setting-up-and-running.html[Set up and Run APM Server]
 
-To start APM Server, run:
+Use the config file if you need to change the default configuration that APM Server uses to connect to Elasticsearch,
+or if you need to specify credentials:
 
-[source,bash]
-----------------------------------
-./apm-server -e
-----------------------------------
-
-It will try to connect to Elasticsearch on localhost port 9200 and expose an API to agents on port 8200.
-You can change the defaults by supplying different addresses on the command line:
-
-[source,bash]
-----------------------------------
-./apm-server -e -E output.elasticsearch.hosts=ElasticsearchAddress:9200 -E apm-server.host=localhost:8200
-----------------------------------
-
-Or you can update the `apm-server.yml` configuration file:
-
-[source,yaml]
-----------------------------------
-apm-server:
-  host: localhost:8200
-
-output:
-  elasticsearch:
-    hosts: ElasticsearchAddress:9200
-----------------------------------
-
-NOTE: If you are using an X-Pack secured version of Elastic Stack,
-you need to specify credentials in the config file:
-
-[source,yaml]
-----
-output.elasticsearch:
-  hosts: ["ElasticsearchAddress:9200"]
-  username: "elastic"
-  password: "elastic"
-----
-
-
+* {apm-server-ref-v}/configuring-howto-apm-server.html[Configuring APM Server]
+** {apm-server-ref-v}/configuration-process.html[General configuration options]
+** {apm-server-ref-v}/elasticsearch-output.html[Configure the Elasticsearch output]
 
 [[secure-api-access]]
-[float]
-==== Secure access to the API
-If you change the listen address from `localhost` to something that is accessible from outside of the machine,
+If you do change the listen address from `localhost` to something that is accessible from outside of the machine,
 we recommend setting up firewall rules to ensure that only your own systems can access the API.
 Alternatively,
 you can use a {apm-server-ref}/securing-apm-server.html[secret token and TLS].
 
-If you have APM Server running on the same host as your service, you can configure it to listen on a Unix domain socket.
+If you have APM Server running on the same host as your service,
+you can configure it to listen on a Unix domain socket.
+
+[[more-information]]
+TIP: For detailed instructions on how to install and secure APM Server in your server environment,
+including details on how to run APM Server in a highly available environment,
+please see the full {apm-server-ref-v}/index.html[APM Server documentation].
 
 [[kibana-dashboards]]
 [float]
-==== Install the Kibana dashboards
+=== Install the Kibana dashboards
 
-From APM Server and Kibana 6.4 on you can load dashboards directly via the {kibana-ref}/apm-getting-started.html[APM 
-Kibana UI].
-
-See an example screenshot of a Kibana dashboard:
-
-image::kibana-dashboard.png[Screenshot of a Kibana Dashboard]
-
-[[more-information]]
-[float]
-=== More information
-For detailed instructions on how to install and secure APM Server in your server environment,
-including details on how to run APM Server in a highly available environment,
-please see {apm-server-ref}/index.html[APM Server documentation].
-
-Once APM Server is up and running,
-you need to install an agent in your service.
+Load APM dashboards directly in Kibana via the {kibana-ref}/apm-getting-started.html[APM - Getting started] page.
 
 [[agents]]
 [float]
 === Install and configure APM agents
 
 Agents are written in the same language as your service.
-Currently Elastic APM has agents for Node.js, Python, Ruby, Java, Go, and JavaScript RUM.
+Currently Elastic APM has agents for Go, Java, Node.js, Python, Ruby, and JavaScript RUM.
 
+// todo: fix this sentence
 Setting up a new service to be monitored requires installing the agent,
 and configuring it with the address of your APM Server and the service name.
+
+NOTE: Be sure to check the <<agent-server-compatibility,Agent/Server compatibility matrix>> to ensure you're using agents that are compatible with your version of Elasticsearch
+
+[cols="h,,,"]
+|=======================================================================
+|Agent
+3+| More information
+
+.2+|Go
+3+|The Go agent automatically instruments Gorilla and Gin, as well as support for Go’s built-in net/http and database/sql drivers.
+|{apm-go-ref}/introduction.html[Introduction]
+|{apm-go-ref}/supported-tech.html[Supported technologies]
+|{apm-go-ref}/configuration.html[Config]
+
+.2+|Java
+3+|The Java agent automatically instruments Servlet API, Spring MVC, and Spring Boot out of the box.
+|{apm-java-ref}/intro.html[Introduction]
+|{apm-java-ref}/supported-technologies-details.html[Supported technologies]
+|{apm-java-ref}/configuration.html[Config]
+
+.2+|Node.js
+3+|The Node.js agent automatically instruments Express, hapi, Koa, and Restify out of the box.
+|{apm-node-ref}/intro.html[Introduction]
+|{apm-node-ref}/supported-technologies.html[Supported technologies]
+|{apm-node-ref}/advanced-setup.html#configuring-the-agent[Config]
+
+.2+|Python
+3+|The Python agent automatically instruments Django and Flask out of the box.
+|{apm-py-ref}/getting-started.html[Getting Started]
+|
+|{apm-py-ref}/configuration.html[Config]
+
+.2+|Ruby
+3+|The Ruby agent automatically instruments Rails out of the box.
+|{apm-ruby-ref}/introduction.html[Introduction]
+|{apm-ruby-ref}/supported-technologies.html[Supported technologies]
+|{apm-ruby-ref}/configuration.html[Config]
+
+.2+|RUM
+3+|Real User Monitoring (RUM) captures user interactions with clients such as web browsers.
+|{apm-rum-ref}/intro.html[Introduction]
+|
+|{apm-rum-ref}/configuration.html[Config]
+|=======================================================================
 
 [[choose-service-name]]
 [float]
@@ -122,48 +150,8 @@ Make sure you choose a good service name before you get started.
 The service name can only contain alphanumeric characters,
 spaces, underscores, and dashes (must match `^[a-zA-Z0-9 _-]+$`).
 
-[[nodejs-agent]]
 [float]
-==== Install the Node.js agent
+=== Next steps
 
-The Node.js agent automatically instruments Express,
-hapi,
-Koa,
-and Restify out of the box.
-See the {apm-node-ref}/index.html[APM Node.js Agent documentation] for more information.
-
-[[python-agent]]
-[float]
-==== Install the Python agent
-
-The Python agent automatically instruments Django and Flask out of the box.
-See the {apm-py-ref}/index.html[APM Python Agent documentation] for more information.
-
-[[ruby-agent]]
-[float]
-==== Install the Ruby agent
-
-The Ruby agent automatically instruments Rails out of the box.
-See the {apm-ruby-ref}/index.html[APM Ruby Agent documentation] for more information.
-
-[[java-agent]]
-[float]
-==== Install the Java Agent
-
-The Java agent automatically instruments Servlet API, Spring MVC, and Spring Boot out of the box.
-See the {apm-java-ref}/index.html[APM Java Agent documentation] for more information.
-
-[[go-agent]]
-[float]
-==== Install the Go Agent
-
-The Go agent automatically instruments Gorilla and Gin,
-as well as support for Go's built-in net/http and database/sql drivers.
-See the {apm-go-ref}/index.html[APM Go Agent documentation] for more information.
-
-[[rum-agent]]
-[float]
-==== Install the RUM JavaScript agent
-
-Real User Monitoring (RUM) captures user interactions with clients such as web browsers.
-See the {apm-rum-ref}/index.html[APM RUM JavaScript Agent documentation] for more information.
+Just like that, you're up and running with Elastic APM!
+Don't forget to check out the <<concepts>> and <<apm-data-model>> documentation to gain a deeper understanding of how Elastic APM works. 

--- a/docs/guide/install-and-run.asciidoc
+++ b/docs/guide/install-and-run.asciidoc
@@ -22,7 +22,7 @@ compatibility.
 * Verify that your system meets the
 https://www.elastic.co/support/matrix#matrix_jvm[minimum JVM requirements] for {es}.
 
-IMPORTANT: For best results, ensure you’re using the same version of Elasticsearch, Kibana, and APM Server.
+IMPORTANT: You must ensure you’re using the same version of Elasticsearch, Kibana, and APM Server.
 
 NOTE: The following links assume you're using the current version of the Elasticstack.
 If you're not, it's easy to adjust the version of the documentation after you land on each page.
@@ -92,7 +92,7 @@ Currently Elastic APM has agents for Go, Java, Node.js, Python, Ruby, and JavaSc
 Setting up a new service to be monitored requires installing the agent,
 and configuring it with the address of your APM Server and the service name.
 
-NOTE: Be sure to check the <<agent-server-compatibility,Agent/Server compatibility matrix>> to ensure you're using agents that are compatible with your version of Elasticsearch
+NOTE: Check the <<agent-server-compatibility,Agent/Server compatibility matrix>> to ensure you're using agents that are compatible with your version of Elasticsearch.
 
 [cols="h,,,"]
 |=======================================================================
@@ -100,7 +100,7 @@ NOTE: Be sure to check the <<agent-server-compatibility,Agent/Server compatibili
 3+| More information
 
 .2+|Go
-3+|The Go agent automatically instruments Gorilla and Gin, as well as support for Go’s built-in net/http and database/sql drivers.
+3+|The Go agent automatically instruments Gorilla and Gin, and has support for Go’s built-in net/http and database/sql drivers.
 |{apm-go-ref}/introduction.html[Introduction]
 |{apm-go-ref}/supported-tech.html[Supported technologies]
 |{apm-go-ref}/configuration.html[Config]
@@ -153,5 +153,5 @@ spaces, underscores, and dashes (must match `^[a-zA-Z0-9 _-]+$`).
 [float]
 === Next steps
 
-Just like that, you're up and running with Elastic APM!
+You're now up and running with Elastic APM!
 Don't forget to check out the <<concepts>> and <<apm-data-model>> documentation to gain a deeper understanding of how Elastic APM works. 

--- a/docs/guide/overview.asciidoc
+++ b/docs/guide/overview.asciidoc
@@ -14,62 +14,47 @@ so you can identify new errors as they appear and keep an eye on how many times 
 
 NOTE: This guide will indiscriminately use the word "service" for both services and applications.
 
-[[components]]
 [float]
-=== APM Components
+[[components]]
+== APM Components
 
 Elastic APM consists of four components:
 
-* {apm-agents-ref}/index.html[APM agents]
-* {apm-server-ref-v}/index.html[APM Server]
-* {ref}/index.html[Elasticsearch]
-* {kibana-ref}/xpack-apm.html[Kibana APM UI]
-
-image::apm-architecture.png[Architecture of Elastic APM]
-
-*APM agents* are open source libraries written in the same language as your service.
+{apm-agents-ref}/index.html[*APM agents*] are open source libraries written in the same language as your service.
 You install them into your service as you would install any other library.
 They instrument your code and collect performance data and errors at runtime.
 This data is buffered for a short period and sent on to APM Server.
 
-*APM Server* is an open source application written in Go which typically runs on dedicated servers.
+{apm-server-ref-v}/index.html[*APM Server*] is an open source application written in Go which typically runs on dedicated servers.
 It listens on port 8200 by default and receives data from agents through a JSON HTTP API.
 Then it creates documents from that data and stores them in Elasticsearch.
 
-*Elasticsearch* is a highly scalable open-source full-text search and analytics engine.
+{ref}/index.html[*Elasticsearch*] is a highly scalable open-source full-text search and analytics engine.
 It allows you to store, search, and analyze big volumes of data quickly and in near real time.
 Elasticsearch is used to store APM performance metrics and make use of its aggregations. 
 
-*Kibana* is an open source analytics and visualization platform designed to work with Elasticsearch.
+{kibana-ref}/xpack-apm.html[*Kibana*] is an open source analytics and visualization platform designed to work with Elasticsearch.
 You use Kibana to search, view, and interact with data stored in Elasticsearch.
 You can use Kibana to visualize APM data by utilizing the dedicated APM UI bundled in Basic license,
 or the pre-built, open source,
 Kibana dashboards that can be loaded directly via the {kibana-ref}/apm-getting-started.html[APM Kibana UI].
 
-[[concepts]]
-[float]
-=== APM Concepts
+image::apm-architecture.png[Architecture of Elastic APM]
 
 [float]
-==== Events
+[[concepts]]
+== APM Concepts
+
+[float]
+=== Events
 APM agents capture different types of information from within their instrumented applications, known as events.
 Events can be <<errors,`Errors`>>, <<transaction-spans,`Spans`>>, or <<transactions,`Transactions`>>.
 These events are then streamed to the APM Server which validates and processes the events. 
 
-*<<errors,`Errors`>>* contain information about the error or exception that was captured.
-
-*<<transaction-spans,`Spans`>>* contain information about a specific code path that has been executed.
-They measure from the start to end of an activity,
-and they can have a parent/child relationship with other spans. 
-
-*<<transactions,`Transactions`>>* are a special kind of span that have extra metadata associated with them.
-You can think of transactions as the highest level of work you're measuring within a service.
-For example, serving an HTTP request or running a specific background job.
-
-View the APM <<apm-data-model>> documentation for more information on Events. 
+View the APM <<apm-data-model,data model>> for more information on events. 
 
 [float]
-==== Component communication
+=== Component communication
 The APM Server is a {apm-server-ref-v}/why-separate-component.html[separate component by design] - it helps keep the agents light,
 prevents certain security risks,
 and improves compatibility across the Elastic and APM Stack.  
@@ -80,7 +65,7 @@ the server transforms the data into Elasticsearch documents and stores them in c
 In a matter of seconds you can start viewing your application performance data in Kibana.
 
 [float]
-==== Real User Monitoring (RUM)
+=== Real User Monitoring (RUM)
 Real User Monitoring captures user interaction with clients such as web browsers.
 The {apm-rum-ref-v}[JavaScript Agent] is Elastic’s RUM Agent.
 To use it you need to {apm-server-ref-v}/rum.html[enable RUM support] in the APM Server.
@@ -93,15 +78,9 @@ You will be able to measure metrics such as "Time to First Byte", `domInteractiv
 and `domComplete` which helps you discover performance issues within your client-side application as well as issues that relate to the latency of your server-side application.
 
 [float]
-==== Distributed Tracing
+=== Distributed Tracing
 Together, transactions and spans form a `Trace`.
 Traces are not events, but group together events that have a common root.
 
 All of our APM agents support <<distributed-tracing,distributed tracing>> out of the box.
 Distributed tracing enables you to analyze performance throughout your microservices architecture all in one view.
-
-[float]
-==== Get Started
-To get started, simply use an existing cluster or grab a fresh installation of the Elastic Stack,
-spin up an APM Server, and add a bit of code to instrument your app with agents.
-Full details are available on the <<install-and-run,install and run>> page.

--- a/docs/metadata-api.asciidoc
+++ b/docs/metadata-api.asciidoc
@@ -20,7 +20,11 @@ TIP: Metadata is stored under `context` when viewing documents in Elasticsearch.
 [float]
 ==== Kubernetes data
 
-APM agents automatically read kubernetes data and add it to the metadata that is sent to the APM Server. In most instances, agents are able to read this data from inside the container. If this is not the case, or if you wish to override this data, you can set environment variables for the agents to read. These environment variable are set via the kubernetes https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-pod-fields-as-values-for-environment-variables[Downward API]. Here's how you would add the environment variables to your kubernetes pod spec:
+APM agents automatically read kubernetes data and send it to the APM Server.
+In most instances, agents are able to read this data from inside the container.
+If this is not the case, or if you wish to override this data, you can set environment variables for the agents to read.
+These environment variable are set via the kubernetes https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-pod-fields-as-values-for-environment-variables[Downward API].
+Here's how you would add the environment variables to your kubernetes pod spec:
 
 [source,yaml]
 ----

--- a/docs/metadata-api.asciidoc
+++ b/docs/metadata-api.asciidoc
@@ -9,11 +9,49 @@ the APM Server hangs on to this information and applies it to other objects in t
 
 TIP: Metadata is stored under `context` when viewing documents in Elasticsearch. 
 
+* <<kubernetes-data>>
 * <<metadata-schema>>
 * <<metadata-service-schema>>
 * <<metadata-process-schema>>
 * <<metadata-system-schema>>
 * <<metadata-user-schema>>
+
+[[kubernetes-data]]
+[float]
+==== Kubernetes data
+
+APM agents automatically read kubernetes data and add it to the metadata that is sent to the APM Server. In most instances, agents are able to read this data from inside the container. If this is not the case, or if you wish to override this data, you can set environment variables for the agents to read. These environment variable are set via the kubernetes https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/#use-pod-fields-as-values-for-environment-variables[Downward API]. Here's how you would add the environment variables to your kubernetes pod spec:
+
+[source,yaml]
+----
+         - name: KUBERNETES_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: KUBERNETES_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: KUBERNETES_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: KUBERNETES_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
+----
+
+The table below maps these environment variables to the APM metadata event field:
+
+[options="header"]
+|=====
+|Environment variable |Metadata field name
+|KUBERNETES_NODE_NAME |system.kubernetes.node.name
+|KUBERNETES_POD_NAME |system.kubernetes.pod.name
+|KUBERNETES_NAMESPACE |system.kubernetes.namespace
+|KUBERNETES_POD_UID	|system.kubernetes.pod.uid
+|=====
 
 [[metadata-schema]]
 [float]

--- a/docs/metricset-api.asciidoc
+++ b/docs/metricset-api.asciidoc
@@ -1,13 +1,13 @@
 [[metricset-api]]
-=== Metricsets
+=== Metrics
 
-Metricsets contain application metric data captured by an APM agent. 
+Metrics contain application metric data captured by an APM agent. 
 
 [[metricset-schema]]
 [float]
-==== Metricset Schema
+==== Metric Schema
 
-The APM Server uses JSON Schema for validating requests. The specification for metricsets is defined below:
+The APM Server uses JSON Schema for validating requests. The specification for metrics is defined below:
 
 [source,json]
 ----

--- a/docs/metricset-indices.asciidoc
+++ b/docs/metricset-indices.asciidoc
@@ -1,13 +1,13 @@
 [[metricset-indices]]
-== Metricset Indices
+== Metric Indices
 
-Metricsets are by default stored to indices of the format `apm-[version]-metric-[date]`.
+By default, metrics are stored to indices of the format `apm-[version]-metric-[date]`.
 
 [[metricset-example]]
 [float]
 === Example Documents
 
-See how metricset documents can look like when indexed in Elasticsearch:
+Here's what a metric document looks like when indexed in Elasticsearch:
 
 [source,json]
 ----

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -11,7 +11,7 @@
 :server-branch: {doc-branch}
 :go-branch: 1.x
 :java-branch: 1.x
-:rum-branch: 2.x
+:rum-branch: 3.x
 :node-branch: 2.x
 :py-branch: 4.x
 :ruby-branch: 2.x


### PR DESCRIPTION
Backports the following documentation PRs to `6.x`:
* [docs] Add documentation directory (#1780)
* docs: fix 404 (#1861)
* [docs] Document metrics (#1831)
* docs: update rum links to 3.x (#1867)
* docs: update RUM compatibility (#1858)
* docs: add kubernetes metadata section (#1650)
* docs: fix changelog (#1854) (Backported from `6.6`)