### PR TITLE
[docs] Add OpenTracing bridge

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -19,6 +19,8 @@ include::./apm-data-model.asciidoc[]
 
 include::./distributed-tracing.asciidoc[]
 
+include::./opentracing.asciidoc[]
+
 include::./agent-server-compatibility.asciidoc[]
 
 include::./apm-release-notes.asciidoc[]

--- a/docs/guide/opentracing.asciidoc
+++ b/docs/guide/opentracing.asciidoc
@@ -1,0 +1,19 @@
+[[opentracing]]
+== OpenTracing bridge
+
+All Elastic APM agents have https://opentracing.io/[OpenTracing] compatible bridges.
+
+The OpenTracing bridge allows you to create Elastic APM <<transactions,transactions>> and <<transaction-spans,spans>> using the OpenTracing API.
+This means you can reuse your existing OpenTracing instrumentation to quickly and easily begin using Elastic APM.
+
+[float]
+=== Agent specific details
+
+Not all features of the OpenTracing API are supported. In addition, there are some Elastic APM specific tags you should be aware of. Please see the relevant Agent documentation for more detailed information:
+
+* {apm-go-ref}/opentracing.html[Go agent]
+* {apm-java-ref}/opentracing-bridge.html[Java agent]
+* {apm-node-ref}/opentracing.html[Node.js agent]
+* {apm-py-ref}/opentracing-bridge.html[Python agent]
+* {apm-ruby-ref}/opentracing.html[Ruby agent]
+* {apm-rum-ref}/opentracing.html[JavaScript Real User Monitoring (RUM) agent]


### PR DESCRIPTION
Adds a section on OpenTracing to the APM Overview. I think it makes more sense for the specifics on this to live in the agent docs, so this is really just an arrow pointing there with a small amount of information. @felixbarny, would you mind taking a look at this and letting me know if you think there's anything else that should be included here?