### PR TITLE
add empty dashboard list. Fixes #1905

### DIFF
--- a/_beats/libbeat/scripts/unpack_dashboards.py
+++ b/_beats/libbeat/scripts/unpack_dashboards.py
@@ -6,6 +6,8 @@ import argparse
 
 def transform_data(data, method):
     for obj in data["objects"]:
+        if "attributes" not in obj:
+            continue
         if "uiStateJSON" in obj["attributes"]:
             obj["attributes"]["uiStateJSON"] = method(obj["attributes"]["uiStateJSON"])
 

--- a/_meta/kibana/7/dashboard/apm-dashboards.json
+++ b/_meta/kibana/7/dashboard/apm-dashboards.json
@@ -1,0 +1,4 @@
+{
+    "objects": [{}], 
+    "version": "7.0.0-beta1"
+}


### PR DESCRIPTION
This lets APM Server start with the (now deprecated) setting `setup.dashboards.enabled: true`:
This is a quick fix while we work on a better long term solution. 

Will look to contribute the beats changes back to beats.

```
019-02-12T13:00:06.557+0100	INFO	instance/beat.go:273	Setup Beat: apm-server; Version: 7.0.0
2019-02-12T13:00:06.557+0100	INFO	elasticsearch/client.go:165	Elasticsearch url: http://localhost:9200
2019-02-12T13:00:06.557+0100	INFO	[publisher]	pipeline/module.go:113	Beat name: Rons-MacBook-Pro-133.local
2019-02-12T13:00:06.557+0100	INFO	[beater]	beater/beater.go:81	No pipeline callback registered
2019-02-12T13:00:06.558+0100	INFO	kibana/client.go:118	Kibana url: http://localhost:5601/fzq
2019-02-12T13:00:06.639+0100	INFO	kibana/client.go:118	Kibana url: http://localhost:5601/fzq
2019-02-12T13:00:09.150+0100	INFO	instance/beat.go:727	Kibana dashboards successfully loaded.
2019-02-12T13:00:09.150+0100	INFO	instance/beat.go:383	apm-server start running.
```