### PR TITLE
index pattern sync check symmetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,8 +134,7 @@ bench:
 .PHONY: are-kibana-objects-updated
 are-kibana-objects-updated: python-env
 	@$(MAKE) clean update apm-server
-	@./apm-server export index-pattern > index-pattern.json
-	@$(PYTHON_ENV)/bin/python ./script/are_kibana_saved_objects_updated.py --branch ${BEATS_VERSION}
+	@$(PYTHON_ENV)/bin/python ./script/are_kibana_saved_objects_updated.py --branch ${BEATS_VERSION} <(./apm-server export index-pattern)
 
 .PHONY: register-pipelines
 register-pipelines: update ${BEAT_NAME}

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ bench:
 are-kibana-objects-updated: python-env
 	@$(MAKE) clean update apm-server
 	@./apm-server export index-pattern > index-pattern.json
-	@$(PYTHON_ENV)/bin/python ./script/are_kibana_saved_objects_updated.py ${BEATS_VERSION}
+	@$(PYTHON_ENV)/bin/python ./script/are_kibana_saved_objects_updated.py --branch ${BEATS_VERSION}
 
 .PHONY: register-pipelines
 register-pipelines: update ${BEAT_NAME}


### PR DESCRIPTION
https://github.com/elastic/kibana/pull/30837 revealed a hole in the sync pattern check - fields that were removed from the index pattern in apm-server but not kibana would not trigger a failure.  This change remedies that.

In addition, `branch` becomes an optional argument to accommodate  `file://` prefixed repo paths, where branch is not needed.  Instead, the generated index pattern is now required, removing the need to persist `apm-server.json` on disk.