### PR TITLE
Specify minimal events on Intake API and ES level.

### DIFF
--- a/beater/integration_test.go
+++ b/beater/integration_test.go
@@ -107,6 +107,7 @@ func TestPublishIntegration(t *testing.T) {
 		{payload: "metricsets.ndjson", name: "Metricsets"},
 		{payload: "spans.ndjson", name: "Spans"},
 		{payload: "transactions.ndjson", name: "Transactions"},
+		{payload: "minimal.ndjson", name: "MinimalEvents"},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {

--- a/beater/test_approved_es_documents/TestPublishIntegrationMinimalEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationMinimalEvents.approved.json
@@ -1,0 +1,302 @@
+{
+    "events": [
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "8.0.0"
+            },
+            "@timestamp": "2019-01-09T21:40:53.000Z",
+            "agent": {
+                "name": "elastic-node",
+                "version": "3.14.0"
+            },
+            "error": {
+                "grouping_key": "0b9cba09845a097a271c6beb4c6207f3",
+                "id": "abcdef0123456789",
+                "log": {
+                    "message": "error log message"
+                }
+            },
+            "host": {
+                "ip": "127.0.0.1"
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "8.0.0",
+                "version_major": 8
+            },
+            "processor": {
+                "event": "error",
+                "name": "error"
+            },
+            "service": {
+                "name": "1234_service-12a3"
+            },
+            "timestamp": {
+                "us": 1547070053000000
+            }
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "8.0.0"
+            },
+            "@timestamp": "2019-01-09T21:40:53.000Z",
+            "agent": {
+                "name": "elastic-node",
+                "version": "3.14.0"
+            },
+            "error": {
+                "exception": [
+                    {
+                        "message": "error exception message"
+                    }
+                ],
+                "grouping_key": "3a1fb5609458fbb132b44d8fc7cde104",
+                "id": "abcdef0123456790"
+            },
+            "host": {
+                "ip": "127.0.0.1"
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "8.0.0",
+                "version_major": 8
+            },
+            "processor": {
+                "event": "error",
+                "name": "error"
+            },
+            "service": {
+                "name": "1234_service-12a3"
+            },
+            "timestamp": {
+                "us": 1547070053000000
+            }
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "8.0.0"
+            },
+            "@timestamp": "2019-01-09T21:40:53.000Z",
+            "agent": {
+                "name": "elastic-node",
+                "version": "3.14.0"
+            },
+            "error": {
+                "exception": [
+                    {
+                        "type": "error exception type"
+                    }
+                ],
+                "grouping_key": "fa405fa2bd848dab17207e7b544d9ad4",
+                "id": "abcdef0123456791"
+            },
+            "host": {
+                "ip": "127.0.0.1"
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "8.0.0",
+                "version_major": 8
+            },
+            "processor": {
+                "event": "error",
+                "name": "error"
+            },
+            "service": {
+                "name": "1234_service-12a3"
+            },
+            "timestamp": {
+                "us": 1547070053000000
+            }
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "8.0.0"
+            },
+            "@timestamp": "2019-01-09T21:40:53.000Z",
+            "agent": {
+                "name": "elastic-node",
+                "version": "3.14.0"
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "8.0.0",
+                "version_major": 8
+            },
+            "parent": {
+                "id": "ab23456a89012345"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "service": {
+                "name": "1234_service-12a3"
+            },
+            "span": {
+                "duration": {
+                    "us": 3564
+                },
+                "id": "0123456a89012345",
+                "name": "GET /api/types",
+                "start": {
+                    "us": 1845
+                },
+                "type": "request"
+            },
+            "timestamp": {
+                "us": 1547070053000000
+            },
+            "trace": {
+                "id": "0123456789abcdef0123456789abcdef"
+            },
+            "transaction": {
+                "id": "ab23456a89012345"
+            }
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "8.0.0"
+            },
+            "@timestamp": "2018-08-30T18:53:27.154Z",
+            "agent": {
+                "name": "elastic-node",
+                "version": "3.14.0"
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "8.0.0",
+                "version_major": 8
+            },
+            "parent": {
+                "id": "ab23456a89012345"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "service": {
+                "name": "1234_service-12a3"
+            },
+            "span": {
+                "duration": {
+                    "us": 3564
+                },
+                "id": "0123456a89012345",
+                "name": "GET /api/types",
+                "type": "request"
+            },
+            "timestamp": {
+                "us": 1535655207154000
+            },
+            "trace": {
+                "id": "0123456789abcdef0123456789abcdef"
+            },
+            "transaction": {
+                "id": "ab23456a89012345"
+            }
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "8.0.0"
+            },
+            "@timestamp": "2019-01-09T21:40:53.000Z",
+            "agent": {
+                "name": "elastic-node",
+                "version": "3.14.0"
+            },
+            "host": {
+                "ip": "127.0.0.1"
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "8.0.0",
+                "version_major": 8
+            },
+            "processor": {
+                "event": "transaction",
+                "name": "transaction"
+            },
+            "service": {
+                "name": "1234_service-12a3"
+            },
+            "timestamp": {
+                "us": 1547070053000000
+            },
+            "trace": {
+                "id": "01234567890123456789abcdefabcdef"
+            },
+            "transaction": {
+                "duration": {
+                    "us": 32592
+                },
+                "id": "abcdef1478523690",
+                "sampled": true,
+                "span_count": {
+                    "started": 0
+                },
+                "type": "request"
+            }
+        },
+        {
+            "@metadata": {
+                "beat": "apm-test",
+                "type": "_doc",
+                "version": "8.0.0"
+            },
+            "@timestamp": "2017-05-30T18:53:42.281Z",
+            "agent": {
+                "name": "elastic-node",
+                "version": "3.14.0"
+            },
+            "host": {
+                "ip": "127.0.0.1"
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "8.0.0",
+                "version_major": 8
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "name": "1234_service-12a3"
+            }
+        }
+    ]
+}

--- a/docs/spec/metadata.json
+++ b/docs/spec/metadata.json
@@ -7,6 +7,9 @@
         "service": {
             "$ref": "service.json",
             "type": "object",
+            "required": ["name", "agent"],
+            "properties.name.type": "string",
+            "properties.agent.type": "string",
             "properties.agent.required": ["name", "version"],
             "properties.agent.properties.name.type": "string",
             "properties.agent.properties.version.type": "string",

--- a/model/metadata/generated/schema/metadata.go
+++ b/model/metadata/generated/schema/metadata.go
@@ -104,6 +104,9 @@ const ModelSchema = `{
         }
     },
             "type": "object",
+            "required": ["name", "agent"],
+            "properties.name.type": "string",
+            "properties.agent.type": "string",
             "properties.agent.required": ["name", "version"],
             "properties.agent.properties.name.type": "string",
             "properties.agent.properties.version.type": "string",

--- a/testdata/intake-v2/minimal.ndjson
+++ b/testdata/intake-v2/minimal.ndjson
@@ -1,0 +1,8 @@
+{"metadata": { "service": {"name": "1234_service-12a3", "agent": {"version": "3.14.0", "name": "elastic-node"}}}}
+{"error": {"id": "abcdef0123456789", "log": {"message": "error log message"}}}
+{"error": {"id": "abcdef0123456790", "exception": {"message": "error exception message"}}}
+{"error": {"id": "abcdef0123456791", "exception": {"type": "error exception type"}}}
+{"span": {"id": "0123456a89012345", "trace_id": "0123456789abcdef0123456789abcdef", "parent_id": "ab23456a89012345", "transaction_id": "ab23456a89012345", "name": "GET /api/types", "type": "request", "start": 1.845, "duration": 3.5642981}}
+{"span": {"id": "0123456a89012345", "trace_id": "0123456789abcdef0123456789abcdef", "parent_id": "ab23456a89012345", "transaction_id": "ab23456a89012345", "name": "GET /api/types", "type": "request", "timestamp": 1535655207154000, "duration": 3.5642981}}
+{"transaction": {"trace_id": "01234567890123456789abcdefabcdef", "id": "abcdef1478523690", "type": "request", "duration": 32.592981, "span_count": {"started": 0}}}
+{"metricset": {"samples": {}, "timestamp": 1496170422281000}}


### PR DESCRIPTION
Add testfiles with minimal events on Intake API and run integration tests to create minimal ES documents. Some events have more than one minimal spec.

fixes elastic/apm-server#1812

@elastic/apm-ui you could make use of how [minimal events](https://github.com/elastic/apm-server/compare/master...simitt:1812-minimal-events?expand=1#diff-59a7edd512bcf2b1c3e52e2d785017f7) look like in your automated tests (as discussed with @sqren some time ago). Please be aware that there are some event types (error, span) that have multiple possibilities how a minimal event can look like. E.g. an error event either has a `log` or an `exception` and if it has an `exception` then it either has an `exception.type` or an `exception.message`. All possibilities of how a minimal event can look like are covered with the examples. 