### PR TITLE
[docs] Add 6.6.1 release notes

### DIFF
--- a/changelogs/6.6.asciidoc
+++ b/changelogs/6.6.asciidoc
@@ -3,7 +3,15 @@
 
 https://github.com/elastic/apm-server/compare/6.5\...6.6[View commits]
 
+* <<release-notes-6.6.1>>
 * <<release-notes-6.6.0>>
+
+[[release-notes-6.6.1]]
+=== APM Server version 6.6.1
+
+https://github.com/elastic/apm-server/compare/v6.6.0\...v6.6.1[View commits]
+
+No significant changes.
 
 [[release-notes-6.6.0]]
 === APM Server version 6.6.0


### PR DESCRIPTION
Cherry picks https://github.com/elastic/apm-server/pull/1943/commits/b1a38b6159b2948fcce3a057abe23716ebee87e3 to `7.x`