### PR TITLE
[Docs] Backport docs to 7.0

### DIFF
--- a/changelogs/7.0.asciidoc
+++ b/changelogs/7.0.asciidoc
@@ -1,14 +1,20 @@
 [[release-notes-7.0]]
 == APM Server version 7.0
 
-////
-* <<release-notes-7.0.0-rc1>>
-////
+// * <<release-notes-7.7.0>>
+// * <<release-notes-7.7.0-rc2>>
+// * <<release-notes-7.7.0-rc1>>
 * <<release-notes-7.0.0-beta1>>
 * <<release-notes-7.0.0-alpha2>>
 * <<release-notes-7.0.0-alpha1>>
 
 ////
+[[release-notes-7.7.0]]
+=== APM Server version 7.0.0
+
+[[release-notes-7.7.0-rc2]]
+=== APM Server version 7.0.0-rc2
+
 [[release-notes-7.0.0-rc1]]
 === APM Server version 7.0.0-rc1
 
@@ -17,7 +23,6 @@
 - Ensure setup cmd uses expected configuration {pull}1934[1934]. 
 - Ensure host.name is not added {pull}1934[1934].
 - Update Go version to 1.11.5 {pull}1840[1840] {pull}1950[1950].
-
 ////
 
 [[release-notes-7.0.0-beta1]]
@@ -27,7 +32,7 @@ https://github.com/elastic/apm-server/compare/v6.7.0\...v7.0.0[View commits]
 
 [float]
 ==== Breaking Changes
-- Move fields in ES to be ECS compliant {pull}1766[1766],{pull}1783[1783],{pull}1813[1813],{pull}1836[1836],{pull}1838[1838],{pull}1844[1844],{pull}1848[1848],{pull}1849[1849],{pull}1863[1863],{pull}1870[1870]
+- Move fields in ES to be ECS compliant. {apm-overview-ref-v}/breaking-7.7.0-beta1.html#breaking-ecs[More information], {pull}1766[1766],{pull}1783[1783],{pull}1813[1813],{pull}1836[1836],{pull}1838[1838],{pull}1844[1844],{pull}1848[1848],{pull}1849[1849],{pull}1863[1863],{pull}1870[1870].
 
 [float]
 ==== Added
@@ -48,7 +53,7 @@ https://github.com/elastic/apm-server/compare/v6.7.0\...v7.0.0[View commits]
 [float]
 ==== Removed
 
-- Remove support for deprecated Intake v1 endpoints {pull}1731[1731].
+- Remove support for deprecated Intake v1 endpoints. {apm-overview-ref-v}/breaking-7.7.0-beta1.html#breaking-remove-v1[More information], {pull}1731[1731].
 - Remove `concurrent_requests` setting and use number of CPUs instead {pull}1749[1749].
 - Remove `frontend` setting {pull}1751[1751].
 - Remove `metrics.enabled` setting {pull}1759[1759].

--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -1,0 +1,34 @@
+[[breaking-changes]]
+=== Breaking Changes
+APM Server is built on top of {beats-ref}/index.html[libbeat].
+As such, any breaking change in libbeat is also considered to be a breaking change in APM Server.
+
+[float]
+==== HEAD
+
+[float]
+==== 7.0
+* Removed deprecated Intake v1 API endpoints.
+Upgrade agents to a version that supports APM Server >= 6.5.
+{apm-overview-ref-v}/breaking-7.7.0-beta1.html#breaking-remove-v1[More information].
+* Moved fields in Elasticsearch to be compliant with the Elastic Common Schema (ECS).
+{apm-overview-ref-v}/breaking-7.7.0-beta1.html#breaking-ecs[More information and changed fields].
+* {beats-ref}/breaking-changes-7.0.html[Breaking changes in libbeat]
+
+[float]
+==== 6.5
+* There are no breaking changes in APM Server.
+* Advanced users may find the <<upgrading-to-65,upgrading to 6.5 guide>> useful.
+
+[float]
+==== 6.4
+* Indexing the `onboarding` document in it's own index by default.
+
+[float]
+==== 6.3
+* Indexing events in separate indices by default.
+* {beats-ref}/breaking-changes-6.3.html[Breaking changes in libbeat]
+
+[float]
+==== 6.2
+* APM Server GA

--- a/docs/context.asciidoc
+++ b/docs/context.asciidoc
@@ -1,10 +1,6 @@
-The contextual data describes the environment in which an event is recorded.
-It includes the `service`, the `system` where the service runs, and the `process`.
-
-It can also contain information about the authenticated `user`.
-
-An event's context can also include information about an authenticated `user`, a request leading to it, or a response.
-For instance, HTTP requests context have `url`, `cookies`, `body`, `headers`, etc.
-
-The agents provide some settings for users to capture customized information. This data is stored as not-indexed in a `custom` object.
-Searchable information is stored as `tags` instead.
+* Data about the environment in which the event is recorded:
+** Service - environment, framework, language, etc.
+** Host - architecture, hostname, IP, etc.
+** Process - args, PID, PPID, etc.
+** URL - full, domain, port, query, etc.
+** User - (if supplied) email, ID, username, etc.

--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -36,7 +36,7 @@ ifdef::has_ml_jobs[]
 endif::[]
 
 ifdef::no_dashboards[]
-:setup-command-short-desc: Sets up the initial environment, including the ES index template.
+:setup-command-short-desc: Sets up the initial environment, including the ES index template
 endif::no_dashboards[]
 
 ifndef::has_ml_jobs,no_dashboards[]
@@ -548,20 +548,6 @@ the end of the file is reached. By default harvesters are closed after
 `close_inactive` is reached.
 endif::[]
 
-*`--setup`*::
-Loads the initial setup, including: 
-
-* Elasticsearch template
-ifdef::has_ml_jobs[]
-* Machine learning jobs
-endif::has_ml_jobs[]
-ifndef::no_dashboards[]
-* {kib} index pattern
-* {kib} dashboards
-endif::no_dashboards[]
-
-If you want to use the command without running {beatname_uc}, use the <<setup-command,`setup`>> command instead.
-
 ifeval::["{beatname_lc}"=="metricbeat"]
 *`--system.hostfs MOUNT_POINT`*::
 
@@ -582,14 +568,14 @@ endif::[]
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} run -e --setup
+{beatname_lc} run -e
 -----
 
 Or:
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} -e --setup
+{beatname_lc} -e
 -----
 
 [[setup-command]]
@@ -609,8 +595,8 @@ ifdef::has_ml_jobs[]
 necessary to analyze data for anomalies.
 endif::[]
 
-Use this command instead of `run --setup` when you want to set up the
-environment without actually running {beatname_uc} and ingesting data.
+Use this command if you want to set up the environment without actually running
+{beatname_uc} and ingesting data.
 
 *SYNOPSIS*
 

--- a/docs/copied-from-beats/loggingconfig.asciidoc
+++ b/docs/copied-from-beats/loggingconfig.asciidoc
@@ -19,6 +19,7 @@ ifndef::serverless[]
 The logging system can write logs to the syslog or rotate log files. If logging
 is not explicitly configured the file output is used.
 
+ifndef::win_only[]
 ["source","yaml",subs="attributes"]
 ----
 logging.level: info
@@ -29,6 +30,20 @@ logging.files:
   keepfiles: 7
   permissions: 0644
 ----
+endif::win_only[]
+
+ifdef::win_only[]
+["source","yaml",subs="attributes"]
+----
+logging.level: info
+logging.to_files: true
+logging.files:
+  path: C:{backslash}ProgramData{backslash}{beatname_lc}{backslash}Logs
+  name: {beatname_lc}
+  keepfiles: 7
+  permissions: 0644
+----
+endif::win_only[]
 
 TIP: In addition to setting logging options in the config file, you can modify
 the logging output configuration from the command line. See

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -817,7 +817,7 @@ NOTE: Events bigger than <<kafka-max_message_bytes,`max_message_bytes`>> will be
 [[kafka-compatibility]]
 ==== Compatibility
 
-This output works with all Kafka versions in between 0.11 and 2.0.0. Older versions
+This output works with all Kafka versions in between 0.11 and 2.1.0. Older versions
 might work as well, but are not supported.
 
 ==== Configuration options

--- a/docs/copied-from-beats/security/basic-auth.asciidoc
+++ b/docs/copied-from-beats/security/basic-auth.asciidoc
@@ -29,7 +29,7 @@ You can create roles from the **Management / Roles** UI in {kib} or through the
 ifeval::["{beatname_lc}"!="filebeat"]
 ["source","sh",subs="attributes,callouts"]
 ---------------------------------------------------------------
-POST _xpack/security/role/{beat_default_index_prefix}_writer
+POST _security/role/{beat_default_index_prefix}_writer
 {
   "cluster": ["manage_index_templates","monitor"],
   "indices": [
@@ -40,13 +40,14 @@ POST _xpack/security/role/{beat_default_index_prefix}_writer
   ]
 }
 ---------------------------------------------------------------
+// CONSOLE
 <1> If you use a custom {beatname_uc} index pattern, specify that pattern
 instead of the default ++{beat_default_index_prefix}-*++ pattern.
 endif::[]
 ifeval::["{beatname_lc}"=="filebeat"]
 ["source","sh",subs="attributes,callouts"]
 ---------------------------------------------------------------
-POST _xpack/security/role/{beat_default_index_prefix}_writer
+POST _security/role/{beat_default_index_prefix}_writer
 {
   "cluster": ["manage_index_templates","monitor","manage_ingest_pipelines"], <1>
   "indices": [
@@ -65,6 +66,34 @@ instead of the default ++{beat_default_index_prefix}-*++ pattern.
 endif::[]
 --
 
+ifndef::no_ilm[]
+. If you plan to use {ref}/getting-started-index-lifecycle-management.html[index
+lifecycle management], create a role that has the following privileges. These
+privileges are required to load index lifecycle policies and create and manage
+rollover indices:
++
+* *Cluster:* `manage_ilm`
+* *Index:* `write`, `create_index`, `manage`, and `manage_ilm` on the 
+{beatname_uc} indices
++
+--
+["source","sh",subs="attributes"]
+---------------------------------------------------------------
+POST _xpack/security/role/{beat_default_index_prefix}_ilm
+{
+  "cluster": ["manage_ilm"],
+  "indices": [
+    {
+      "names": [ "{beat_default_index_prefix}-*","shrink-{beat_default_index_prefix}-*"],
+      "privileges": ["write","create_index","manage","manage_ilm"]
+    }
+  ]
+}
+---------------------------------------------------------------
+// CONSOLE
+--
+endif::no_ilm[]
+
 . Assign the writer role to the user that {beatname_uc} will use to connect to
 {es}. Make sure you also assign any roles that are required for specific
 features. For the list of features and required roles, see <<feature-roles>>.
@@ -81,7 +110,7 @@ named ++{beat_default_index_prefix}_internal++ that has the
 --
 ["source","sh",subs="attributes,callouts"]
 ---------------------------------------------------------------
-POST /_xpack/security/user/{beat_default_index_prefix}_internal
+POST /_security/user/{beat_default_index_prefix}_internal
 {
   "password" : "{pwd}",
   "roles" : [ "{beat_default_index_prefix}_writer","kibana_user"],

--- a/docs/copied-from-beats/security/securing-beats.asciidoc
+++ b/docs/copied-from-beats/security/securing-beats.asciidoc
@@ -44,39 +44,49 @@ password, set it up now.
 For more information about {security}, see
 {xpack-ref}/elasticsearch-security.html[Securing the {stack}].
 
-[float]
 [[feature-roles]]
 === {beatname_uc} features that require authorization
 
 After securing {beatname_uc}, make sure your users have the roles (or associated
-privileges) required to use these {beatname_uc} features. You must create the
-++{beat_default_index_prefix}_writer++ and
-++{beat_default_index_prefix}_reader++ roles (see <<beats-basic-auth>> and
-<<beats-user-access>>). The other roles are
-{xpack-ref}/built-in-roles.html[built-in].
+privileges) required to use these {beatname_uc} features. Note that some of the
+roles shown here are {xpack-ref}/built-in-roles.html[built-in], and some
+are user-defined.
 
 [options="header"]
 |=======
 |Feature | Role
-|Send data to a secured cluster   | ++{beat_default_index_prefix}_writer++
+|Send data to a secured cluster   | ++{beat_default_index_prefix}_writer++ footnoteref:[noteA,These roles are user-defined.]
 ifeval::["{beatname_lc}"=="filebeat"]
-|Run Filebeat modules | ++{beat_default_index_prefix}_writer++
+|Run Filebeat modules | ++{beat_default_index_prefix}_writer++ footnoteref:[noteA]
 endif::[]
-|Load index templates | ++{beat_default_index_prefix}_writer++ and `kibana_user`
+|Load index templates | ++{beat_default_index_prefix}_writer++ footnoteref:[noteA] and `kibana_user`
 ifndef::no_dashboards[]
-|Load {beatname_uc} dashboards into {kib} | ++{beat_default_index_prefix}_writer++ and `kibana_user`
+|Load {beatname_uc} dashboards into {kib} | ++{beat_default_index_prefix}_writer++ footnoteref:[noteA] and `kibana_user`
 endif::[]
 ifdef::has_ml_jobs[]
 |Load machine learning jobs | `machine_learning_admin`
 endif::[]
-|Read indices created by {beatname_uc} | ++{beat_default_index_prefix}_reader++ 
+ifndef::apm-server[]
+|Read indices created by {beatname_uc} | ++{beat_default_index_prefix}_reader++ footnoteref:[noteA] 
+endif::[]
+ifdef::apm-server[]
+|Read indices created by {beatname_uc} | ++{beat_default_index_prefix}_user++
+|View {beatname_uc} dashboards in {kib} | `kibana_user`
+endif::[]
 ifndef::no_dashboards[]
 |View {beatname_uc} dashboards in {kib} | `kibana_user`
 endif::[]
 ifdef::has_central_config[]
 |Store and manage configurations in a central location in {kib} | `beats_admin`
 endif::[]
+ifndef::no_ilm[]
+|Load index lifecycle policies and use index lifecycle management | +{beatname_lc}_ilm+ footnoteref:[noteA]
+endif::[]
 |=======
+
+To create the user-defined roles shown here, see <<beats-basic-auth>> and
+<<beats-user-access>>. You may want to define additional roles to provide more
+restrictive access.
 
 include::basic-auth.asciidoc[]
 

--- a/docs/copied-from-beats/security/user-access.asciidoc
+++ b/docs/copied-from-beats/security/user-access.asciidoc
@@ -6,17 +6,23 @@ To enable users to access the indices {beatname_uc} creates, grant them `read`
 and `view_index_metadata` privileges on the {beatname_uc} indices. If they're
 using {kib}, they also need the `kibana_user` role.
 
-. Create a reader role that has the `read` and `view_index_metadata` privileges
+ifdef::apm-server[]
+X-Pack security provides a built-in role called `apm_user` that you can explicitly assign to users.
+This role grants them the necessary `read` and `view_index_metadata` privileges on the {beatname_uc} indices.
+endif::apm-server[]
+
+ifndef::apm-server[]
+. Create a role that has the `read` and `view_index_metadata` privileges
 on the {beatname_uc} indices.
 +
 You can create roles from the **Management > Roles** UI in {kib} or through the
 `role` API. For example, the following request creates a role named
-++{beat_default_index_prefix}_reader++:
+++{access_role}++:
 +
 --
 ["source","sh",subs="attributes,callouts"]
 ---------------------------------------------------------------
-POST _xpack/security/role/{beat_default_index_prefix}_reader
+POST _security/role/{access_role}
 {
   "indices": [
     {
@@ -30,40 +36,43 @@ POST _xpack/security/role/{beat_default_index_prefix}_reader
 <1> If you use a custom {beatname_uc} index pattern, specify that pattern
 instead of the default ++{beat_default_index_prefix}-*++ pattern.
 --
+endif::apm-server[]
 
-. Assign your users the reader role so they can access the {beatname_uc}
-indices. For {kib} users who need to visualize the data, also assign the
-`kibana_user` role:
+. Assign your users the ++{access_role}++
+role so they can access the {beatname_uc} indices.
+For {kib} users who need to visualize the data,
+also assign the `kibana_user` role:
 
 .. If you're using the `native` realm, you can assign roles with the
 **Management > Users** UI in {kib} or through the `user` API. For example, the
-following request grants ++{beat_default_index_prefix}_user++ the
-++{beat_default_index_prefix}_reader++ and `kibana_user` roles:
+following request grants ++{beat_default_index_prefix}_account++ the
+++{access_role}++ and `kibana_user` roles:
 +
 --
 ["source", "sh", subs="attributes,callouts"]
 ---------------------------------------------------------------
-POST /_xpack/security/user/{beat_default_index_prefix}_user
+POST /_security/user/{beat_default_index_prefix}_account
 {
   "password" : "{pwd}",
-  "roles" : [ "{beat_default_index_prefix}_reader","kibana_user"],
-  "full_name" : "{beatname_uc} User"
+  "roles" : [ "{access_role}","kibana_user"],
+  "full_name" : "{beatname_uc} account"
 }
 ---------------------------------------------------------------
 // CONSOLE
 --
-.. If you're using the LDAP, Active Directory, or PKI realms, you assign the
-roles in the `role_mapping.yml` configuration file. For example, the following
-snippet grants ++{beatname_uc} User++ the ++{beat_default_index_prefix}_reader++
-and `kibana_user` roles:
+.. If you're using the LDAP, Active Directory, or PKI realms,
+you assign the roles in the `role_mapping.yml` configuration file.
+For example, the following snippet grants
+++{beat_default_index_prefix}_account++ the
+++{access_role}++ and `kibana_user` roles:
 +
 --
 ["source", "yaml", subs="attributes,callouts"]
 ---------------------------------------------------------------
-{beat_default_index_prefix}_reader:
-  - "cn={beatname_uc} User,dc=example,dc=com"
+{access_role}:
+  - "cn={beat_default_index_prefix}_account,dc=example,dc=com"
 kibana_user:
-  - "cn={beatname_uc} User,dc=example,dc=com"
+  - "cn={beat_default_index_prefix}_account,dc=example,dc=com"
 ---------------------------------------------------------------
 
 For more information, see

--- a/docs/copied-from-beats/shared-docker.asciidoc
+++ b/docs/copied-from-beats/shared-docker.asciidoc
@@ -5,8 +5,7 @@ Docker images for {beatname_uc} are available from the Elastic Docker
 registry. The base image is https://hub.docker.com/_/centos/[centos:7].
 
 A list of all published Docker images and tags is available at
-https://www.docker.elastic.co[www.docker.elastic.co]. The source code is in
-{dockergithub}[GitHub].
+https://www.docker.elastic.co[www.docker.elastic.co]. 
 
 These images are free to use under the Elastic license. They contain open source 
 and free commercial features and access to paid commercial features.  

--- a/docs/copied-from-beats/shared-logstash-config.asciidoc
+++ b/docs/copied-from-beats/shared-logstash-config.asciidoc
@@ -22,7 +22,7 @@ the {stack} getting started tutorial. Also see the documentation for the
 If you want to use {ls} to perform additional processing on the data collected by
 {beatname_uc}, you need to configure {beatname_uc} to use {ls}.
 
-To do this, you edit the {beatname_uc} configuration file to disable the Elasticsearch
+To do this, you edit the {beatname_uc} configuration file to disable the {es}
 output by commenting it out and enable the {ls} output by uncommenting the
 logstash section:
 
@@ -36,8 +36,14 @@ output.logstash:
 The `hosts` option specifies the {ls} server and the port (`5044`) where {ls} is configured to listen for incoming
 Beats connections.
 
-For this configuration, you must <<load-template-manually,load the index template into Elasticsearch manually>>
-because the options for auto loading the template are only available for the Elasticsearch output.
+For this configuration, you must <<load-template-manually,load the index template into {es} manually>>
+because the options for auto loading the template are only available for the {es} output.
+
+ifeval::["{beatname_lc}"=="filebeat"]
+Want to use <<filebeat-modules,{beatname_uc} modules>> with {ls}? You need to do
+some extra setup. For more information, see
+{logstash-ref}/filebeat-modules.html[Working with {beatname_uc} modules].
+endif::[]
 
 ifndef::win-only[]
 ifndef::apm-server[]

--- a/docs/field-name-changes.asciidoc
+++ b/docs/field-name-changes.asciidoc
@@ -1,0 +1,61 @@
+[frame="topbot",options="header"]
+|======================
+|Old Field|New Field
+|`beat.hostname`            |`observer.hostname`
+|`beat.name`            |`observer.type`
+|`beat.version`            |`observer.version`
+|`context.custom`            |`error.custom`
+|`context.db.instance`            |`span.db.instance`
+|`context.db.statement`            |`span.db.statement`
+|`context.db.type`            |`span.db.type`
+|`context.db.user`            |`span.db.user.name`
+|`context.http.method`            |`span.http.method`
+|`context.http.status_code`            |`span.http.response.status_code`
+|`context.http.url`            |`span.http.url.original`
+|`context.process.argv`            |`process.args`
+|`context.process.pid`            |`process.pid`
+|`context.process.ppid`            |`process.ppid`
+|`context.process.title`            |`process.title`
+|`context.request.body`            |`http.request.body.original`
+|`context.request.cookies`            |`http.request.cookies`
+|`context.request.env`            |`http.request.env`
+|`context.request.headers`            |`http.request.headers`
+|`context.request.http_version`            |`http.version`
+|`context.request.method`            |`http.request.method`
+|`context.request.socket`            |`http.request.socket`
+|`context.request.url.full`            |`url.full`
+|`context.request.url.hash`            |`url.fragment`
+|`context.request.url.hostname`            |`url.domain`
+|`context.request.url.pathname`            |`url.path`
+|`context.request.url.port`            |`url.port`
+|`context.request.url.protocol`            |`url.scheme`
+|`context.request.url.raw`            |`url.original`
+|`context.request.url.search`            |`url.query`
+|`context.response.finished`            |`http.response.finished`
+|`context.response.headers.content-type`            |`http.response.headers.content-type`
+|`context.response.headers_sent`            |`http.response.headers_sent`
+|`context.response.status_code`            |`http.response.status_code`
+|`context.service.agent.name`            |`agent.name`
+|`context.service.agent.version`            |`agent.version`
+|`context.service.environment`            |`service.environment`
+|`context.service.framework.name`            |`service.framework.name`
+|`context.service.framework.version`            |`service.framework.version`
+|`context.service.language.name`            |`service.language.name`
+|`context.service.language.version`            |`service.language.version`
+|`context.service.name`            |`service.name`
+|`context.service.runtime.name`            |`service.runtime.name`
+|`context.service.runtime.version`            |`service.runtime.version`
+|`context.service.version`            |`service.version`
+|`context.system.architecture`            |`host.architecture`
+|`context.system.hostname`            |`host.hostname`
+|`context.system.ip`            |`host.ip`
+|`context.system.platform`            |`host.os.platform`
+|`context.tags`            |`labels`
+|`context.user.email`            |`user.email`
+|`context.user.id`            |`user.id`
+|`context.user.ip`            |`client.ip`
+|`context.user.user-agent`            |`user_agent.original`
+|`context.user.username`            |`user.name`
+|`listening`            |`observer.listening`
+|======================
+

--- a/docs/guide/apm-breaking-changes.asciidoc
+++ b/docs/guide/apm-breaking-changes.asciidoc
@@ -1,0 +1,84 @@
+[[apm-breaking-changes]]
+== Breaking changes
+
+This section discusses the changes that you need to be aware of when migrating your application from one version of APM to another.
+
+* <<breaking-7.7.0-beta1, APM version 7.7.0-beta1>>
+* <<breaking-6.4.0, APM version 6.4.0>>
+
+Also see <<apm-release-notes>>.
+
+[[breaking-7.7.0-beta1]]
+=== Breaking changes in 7.7.0-beta1
+
+APM Server::
++
+[[breaking-remove-v1]]
+**Removed deprecated Intake v1 API endpoints.** Before upgrading APM Server, ensure all APM agents are upgraded to a version that supports APM Server >= 6.5. View the <<agent-server-compatibility, agent/server compatibility matrix>> to determine if your agent versions are compatible. 
++
+[[breaking-ecs]]
+**Moved fields in Elasticsearch to be compliant with the Elastic Common Schema (ECS).**
+APM has aligned with the field names defined in the
+https://github.com/elastic/ecs[Elastic Common Schema (ECS)].
+Utilizing this common schema will allow for easier data correlation within Elasticsearch.
++
+See the <<ecs-compliance,ECS field changes>> table for full details on which fields have changed.
+
+APM UI::
++
+[[breaking-new-endpoints]]
+**Moved to new data endpoints.**+
+When you upgrade to 7.x, 
+data in indices created prior to 7.0 will not automatically appear in the APM UI.
+We offer a Kibana Migration Assistant (in the Kibana Management section) to help you migrate your data.
+The migration assistant will reindex your older data in the new ECS format.
+Be aware that this is a beta release.
+This script is **not** meant to be run on production data at this stage.
+
+[float]
+[[ecs-compliance]]
+==== Elastic Common Schema field changes
+
+include::../field-name-changes.asciidoc[]
+
+[[breaking-6.4.0]]
+=== Breaking changes in 6.4.0
+
+We previously split APM data into separate indices (transaction, span, error, etc.).
+In 6.4 APM Kibana UI starts to leverage those separate indices for queries.
+
+In case you only update Kibana but run an older version of APM Server you will not be able to see any APM data by default.
+To fix this, use the {kibana-ref}/apm-settings-kb.html[Kibana APM settings] to specify the location of the APM index:
+["source","sh"]
+------------------------------------------------------------
+apm_oss.errorIndices: apm-*
+apm_oss.spanIndices: apm-*
+apm_oss.transactionIndices: apm-*
+apm_oss.onboardingIndices: apm-*
+------------------------------------------------------------
+
+In case you are upgrading APM Server from an older version, you might need to refresh your APM index pattern for certain APM UI features to work.
+Also ensure to add the new config options in `apm-server.yml` in case you keep your existing configuration file:
+["source","sh"]
+------------------------------------------------------------
+output.elasticsearch:
+  indices:
+    - index: "apm-%{[observer.version]}-sourcemap"
+      when.contains:
+        processor.event: "sourcemap"
+    - index: "apm-%{[observer.version]}-error-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "error"
+    - index: "apm-%{[observer.version]}-transaction-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "transaction"
+    - index: "apm-%{[observer.version]}-span-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "span"
+    - index: "apm-%{[observer.version]}-metric-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "metric"
+    - index: "apm-%{[observer.version]}-onboarding-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "onboarding"
+------------------------------------------------------------

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -18,12 +18,11 @@ and they can have a parent/child relationship with other spans.
 Agents automatically instrument a variety of libraries to capture these spans from within your application.
 In addition, you can use the Agent API for ad hoc instrumentation of specific code paths. 
 
-Spans have a `transaction.id` attribute that refers to their parent <<transactions,transaction>>.
-They also have a `parent.id` attribute that refers to their parent span, or their transaction.
-Other span data includes:
+A span contains:
 
-* start time
-* duration
+* A `transaction.id` attribute that refers to their parent <<transactions,transaction>>.
+* A `parent.id` attribute that refers to their parent span, or their transaction.
+* start time and duration
 * name
 * type
 * `stack trace` (optional)
@@ -78,15 +77,14 @@ Within one transaction there can be 0, 1, or many spans captured.
 
 A transaction contains:
 
-* The timestamp and duration of the event
+* The timestamp of the event
 * A unique id, type, and name
-* A result (e.g. a response code)
-* Some contextual data (see below for details)
-* Other relevant information depending on the agent. Example: The JavaScript RUM captures transaction marks,
+include::../context.asciidoc[]
+* Other relevant information depending on the agent. Example: The JavaScript RUM agent captures transaction marks,
 which are points in time relative to the start of the transaction with some label.
 
-[[transactions-context]]
-include::../context.asciidoc[]
+In addition, the agents provide some settings for users to capture customized information. This data is stored as not-indexed in a `custom` object.
+Searchable information is stored as `labels` instead.
 
 Transactions are stored in {apm-server-ref-v}/transaction-indices.html[transaction indices].
 
@@ -98,16 +96,17 @@ information about the original `exception` that occurred
 or about a `log` created when the exception occurred.
 For simplicity, errors are represented by a unique ID.
 
-Error data includes:
+An Error contains:
 
 * Both the captured `exception` and the captured `log` of an error can contain a `stack trace`,
 which is helpful for debugging.
 * The `culprit` of an error indicates where it originated.
 * An error might relate to the <<transactions,transaction>> during which it happened,
 via the `transaction.id`.
-* Some contextual data (see below).
-
 include::../context.asciidoc[]
+
+In addition, the agents provide some settings for users to capture customized information. This data is stored as not-indexed in a `custom` object.
+Searchable information is stored as `labels` instead.
 
 Errors are stored in {apm-server-ref-v}/error-indices.html[error indices].
 

--- a/docs/guide/apm-release-notes.asciidoc
+++ b/docs/guide/apm-release-notes.asciidoc
@@ -1,23 +1,42 @@
-[[kibana]]
 [[apm-release-notes]]
-== Release notes
+== Release highlights
 
-[float]
-=== APM version 7.0.0-beta
+This section summarizes the most important APM changes in each release.
+
+For a full list of changes, see the
+{apm-server-ref-v}/release-notes.html[APM Server Release Notes] or the
+{kibana-ref}/release-notes.html[Kibana Release Notes].
+
+// * <<release-notes-7.7.0>>
+// * <<release-notes-7.7.0-rc2>>
+// * <<release-notes-7.7.0-rc1>>
+* <<release-notes-7.7.0-beta1>>
+* <<release-notes-7.7.0-alpha2>>
+* <<release-notes-7.7.0-alpha1>>
+// * <<release-notes-6.7.0>>
+* <<release-notes-6.6.0>>
+* <<release-notes-6.5.0>>
+* <<release-notes-6.4.1>>
+* <<release-notes-6.4.0>>
+
+////
+[[release-notes-7.7.0]]
+=== APM version 7.0.0
+
+[[release-notes-7.7.0-rc2]]
+=== APM version 7.0.0-rc2
+
+[[release-notes-7.7.0-rc1]]
+=== APM version 7.0.0-rc1
+////
+
+[[release-notes-7.7.0-beta1]]
+=== APM version 7.0.0-beta1
 
 [float]
 ==== Breaking Changes
 
-*APM Server*
-
-* Removal of deprecated Intake v1 API endpoints.
-* Move fields in Elasticsearch to be ECS compliant.
-
-*APM UI*
-
-* Moving to new data endpoints. We are filtering out 6.x or lower. 
-We offer a Kibana Migration Assistant (in the Kibana Management section) to help you migrate your data. 
-Be aware that this script is **not** supposed to be run on production data at this stage, as this is a beta release.
+See <<breaking-7.7.0-beta1>>
 
 [float]
 ==== New features
@@ -30,23 +49,33 @@ Be aware that this script is **not** supposed to be run on production data at th
 
 * Added support for frozen indices.
 
-
-[float]
+[[release-notes-7.7.0-alpha2]]
 === APM version 7.0.0-alpha2
 
 No significant changes.
 
-[float]
+[[release-notes-7.7.0-alpha1]]
 === APM version 7.0.0-alpha1
 
 No significant changes.
 
 ////
-[float]
-=== APM version 6.6.0
+[[release-notes-6.7.0]]
+=== APM version 6.7.0
 ////
 
+[[release-notes-6.6.0]]
+=== APM version 6.6.0
+
 [float]
+==== New features
+
+* Elastic APM agents now automatically record certain <<metrics,infrastructure and application metrics>>.
+* Elastic APM agents support the W3C Trace Context.
+All agents now have <<opentracing,OpenTracing compatible bridges>>.
+* <<distributed-tracing,Distributed tracing>> is generally available.
+
+[[release-notes-6.5.0]]
 === APM version 6.5.0
 
 [float]
@@ -73,7 +102,7 @@ Elastic APM now enables {apm-overview-ref-v}/distributed-tracing.html[distribute
 * Python switched to contextvars instead of thread locals for context tracking in Python 3.7
 * Node added support for Restify Framework, dropped support for Node.js 4 and 9
 
-[float]
+[[release-notes-6.4.1]]
 === APM version 6.4.1
 
 [float]
@@ -84,50 +113,13 @@ To fix this, the APM Kibana UI now falls back to use `apm-*` as default indices 
 Users can still leverage separate indices for queries by overriding the default values described in {kibana-ref}/apm-settings-kb.html[Kibana APM settings].
 
 
-[float]
+[[release-notes-6.4.0]]
 === APM version 6.4.0
 
 [float]
 ==== Breaking changes
 
-We previously split APM data into separate indices (transaction, span, error, etc.).
-In 6.4 APM Kibana UI starts to leverage those separate indices for queries.
-
-In case you only update Kibana but run an older version of APM Server you will not be able to see any APM data by default.
-To fix this, use the {kibana-ref}/apm-settings-kb.html[Kibana APM settings] to specify the location of the APM index:
-["source","sh"]
-------------------------------------------------------------
-apm_oss.errorIndices: apm-*
-apm_oss.spanIndices: apm-*
-apm_oss.transactionIndices: apm-*
-apm_oss.onboardingIndices: apm-*
-------------------------------------------------------------
-
-In case you are upgrading APM Server from an older version, you might need to refresh your APM index pattern for certain APM UI features to work.
-Also ensure to add the new config options in `apm-server.yml` in case you keep your existing configuration file:
-["source","sh"]
-------------------------------------------------------------
-output.elasticsearch:
-  indices:
-    - index: "apm-%{[observer.version]}-sourcemap"
-      when.contains:
-        processor.event: "sourcemap"
-    - index: "apm-%{[observer.version]}-error-%{+yyyy.MM.dd}"
-      when.contains:
-        processor.event: "error"
-    - index: "apm-%{[observer.version]}-transaction-%{+yyyy.MM.dd}"
-      when.contains:
-        processor.event: "transaction"
-    - index: "apm-%{[observer.version]}-span-%{+yyyy.MM.dd}"
-      when.contains:
-        processor.event: "span"
-    - index: "apm-%{[observer.version]}-metric-%{+yyyy.MM.dd}"
-      when.contains:
-        processor.event: "metric"
-    - index: "apm-%{[observer.version]}-onboarding-%{+yyyy.MM.dd}"
-      when.contains:
-        processor.event: "onboarding"
-------------------------------------------------------------
+See <<breaking-6.4.0>>.
 
 [float]
 ==== New features

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -21,4 +21,6 @@ include::./distributed-tracing.asciidoc[]
 
 include::./agent-server-compatibility.asciidoc[]
 
+include::./apm-breaking-changes.asciidoc[]
+
 include::./apm-release-notes.asciidoc[]

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -19,6 +19,8 @@ include::./apm-data-model.asciidoc[]
 
 include::./distributed-tracing.asciidoc[]
 
+include::./opentracing.asciidoc[]
+
 include::./agent-server-compatibility.asciidoc[]
 
 include::./apm-breaking-changes.asciidoc[]

--- a/docs/guide/opentracing.asciidoc
+++ b/docs/guide/opentracing.asciidoc
@@ -1,0 +1,19 @@
+[[opentracing]]
+== OpenTracing bridge
+
+All Elastic APM agents have https://opentracing.io/[OpenTracing] compatible bridges.
+
+The OpenTracing bridge allows you to create Elastic APM <<transactions,transactions>> and <<transaction-spans,spans>> using the OpenTracing API.
+This means you can reuse your existing OpenTracing instrumentation to quickly and easily begin using Elastic APM.
+
+[float]
+=== Agent specific details
+
+Not all features of the OpenTracing API are supported. In addition, there are some Elastic APM specific tags you should be aware of. Please see the relevant Agent documentation for more detailed information:
+
+* {apm-go-ref}/opentracing.html[Go agent]
+* {apm-java-ref}/opentracing-bridge.html[Java agent]
+* {apm-node-ref}/opentracing.html[Node.js agent]
+* {apm-py-ref}/opentracing-bridge.html[Python agent]
+* {apm-ruby-ref}/opentracing.html[Ruby agent]
+* {apm-rum-ref}/opentracing.html[JavaScript Real User Monitoring (RUM) agent]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -9,6 +9,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :beat_monitoring_user_version: 6.5.0
 :beat_monitoring_version: 6.5
 :beat_default_index_prefix: apm
+:access_role: {beat_default_index_prefix}_user
 :beat_version_key: observer.version
 :dockerimage: docker.elastic.co/apm/{beatname_lc}:{version}
 :dockergithub: https://github.com/elastic/apm-server-docker/tree/{doc-branch}

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -8,13 +8,10 @@
 [partintro]
 
 --
-This following section summarizes the changes in each release.
-
+The following sections summarize the changes in each release.
 
 * <<release-notes-7.0>>
-////
-* <<release-notes-6.7>>
-////
+// * <<release-notes-6.7>>
 * <<release-notes-6.6>>
 * <<release-notes-6.5>>
 * <<release-notes-6.4>>

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -6,55 +6,23 @@ However, check out the <<breaking-changes, breaking changes>> section for except
 
 Before upgrading:
 
-* Review the <<release-notes,release notes>> and the <<breaking-changes, breaking changes>> 
-for changes between your current version and the one you are upgrading to.
-* Check the {stack-ref}/index.html[Elastic Stack Installation and Upgrade Guide] for guidance on how to upgrade your 
- Elastic Stack. 
- For a more tailored upgrade guide, try out the {upgrade_guide}[Interactive Upgrade Guide].
+* Review the APM Server <<release-notes,release notes>> and <<breaking-changes, breaking changes>> 
+for changes between your current APM Server version and the one you are upgrading to.
+* Visit the general APM {apm-overview-ref-v}/apm-release-notes.html[release highlights] and {apm-overview-ref-v}/apm-breaking-changes.html[breaking changes] for highlights and important changes.
+* Check the {stack-ref}/index.html[Elastic Stack Installation and Upgrade Guide] for guidance on how to upgrade your Elastic Stack. 
 
-When ready to actually upgrade your APM Server between minor versions, 
+When you're ready to upgrade your APM Server between minor versions, 
 simply install the new release.
 
-Ensure the configuration file `apm-server.yml` is configured properly again according to your needs.
-Be aware of newly added configuration options and their default settings.
-Also check out the documentation for <<configuring-howto-apm-server, configuration>>
-to read more about available configuration options.
-
-If you set up index patterns and dashboards manually by running `./apm-server setup`, rerun
-the command to update the index pattern and the dashboards.
+You'll want to take a look at the `apm-server.yml` configuration file after installing a new release.
+There may be newly added configuration options, and you'll want to be aware of their default settings.
+See <<configuring-howto-apm-server,Configuring APM Server>> for more information on available configuration options.
 
 When everything is properly configured and updated, start the APM server.
 
 When you start the APM server after upgrading, it creates new indices that use the current version,
 and applies the correct template automatically.
 
-[[breaking-changes]]
-=== Breaking Changes
-APM Server is built on top of {beats-ref}/index.html[libbeat].
-As such, any breaking change in libbeat is also considered to be a breaking change in APM Server.
-
-[float]
-==== HEAD
-* Support for v1 (deprecated in 6.5) has been removed. Before upgrading, ensure all agents are upgraded to at least a
-version that requires APM Server >= 6.5. View the {apm-overview-ref-v}/agent-server-compatibility.html[agent/server compatibility matrix] for more information.
-
-[float]
-==== 6.5
-* There are no breaking changes in APM Server.
-* Advanced users may find the <<upgrading-to-65,upgrading to 6.5 guide>> useful.
-* https://www.elastic.co/guide/en/beats/libbeat/master/breaking-changes.html[Breaking changes in libbeat]
-
-[float]
-==== 6.4
-* Indexing the `onboarding` document in it's own index by default.
-
-[float]
-==== 6.3
-* Indexing events in separate indices by default.
-* https://www.elastic.co/guide/en/beats/libbeat/current/breaking-changes-6.3.html[Breaking changes in libbeat]
-
-[float]
-==== 6.2
-* APM Server GA
+include::./breaking-changes.asciidoc[]
 
 include::./upgrading-to-65.asciidoc[]

--- a/script/renamed_fields.py
+++ b/script/renamed_fields.py
@@ -1,0 +1,40 @@
+# python renamed_fields.py > ../docs/field-name-changes.asciidoc
+import yaml
+
+
+def migration():
+    migration_fields = read_migration_fields()
+    print get_table(migration_fields)
+
+
+def get_table(migration_fields):
+    out = """[frame="topbot",options="header"]
+|======================
+|Old Field|New Field
+"""
+
+    for k in migration_fields:
+        out += '|`{}`            |`{}`\n'.format(k[0], k[1])
+
+    out += "|======================\n"
+
+    return out
+
+
+def read_migration_fields():
+    migration_fields = {}
+    migration_yml = "../_meta/ecs-migration.yml"
+    with open(migration_yml, 'r') as f:
+        migration = yaml.safe_load(f)
+        for k in migration:
+            if "beat" not in k or k["beat"] == beat:
+                if "to" in k and "from" in k:
+                    if not isinstance(k["to"], basestring):
+                        continue
+                    migration_fields[k["from"]] = k["to"]
+
+    return sorted(migration_fields.items(), key=lambda x: x[0])
+
+
+if __name__ == "__main__":
+    migration()


### PR DESCRIPTION
Backports the following commits to 7.0:

* [Docs] 7.0 Breaking changes, Release highlights, Migration assistant, ECS changes (#1940)
* [docs] Add apm_user role (#1916)
* docs: add opentracing bridge (#1887)
* [docs] make update-beats-docs (#1958)