### PR TITLE
[docs] make update-beats-docs

### DIFF
--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -36,7 +36,7 @@ ifdef::has_ml_jobs[]
 endif::[]
 
 ifdef::no_dashboards[]
-:setup-command-short-desc: Sets up the initial environment, including the ES index template.
+:setup-command-short-desc: Sets up the initial environment, including the ES index template
 endif::no_dashboards[]
 
 ifndef::has_ml_jobs,no_dashboards[]
@@ -548,20 +548,6 @@ the end of the file is reached. By default harvesters are closed after
 `close_inactive` is reached.
 endif::[]
 
-*`--setup`*::
-Loads the initial setup, including: 
-
-* Elasticsearch template
-ifdef::has_ml_jobs[]
-* Machine learning jobs
-endif::has_ml_jobs[]
-ifndef::no_dashboards[]
-* {kib} index pattern
-* {kib} dashboards
-endif::no_dashboards[]
-
-If you want to use the command without running {beatname_uc}, use the <<setup-command,`setup`>> command instead.
-
 ifeval::["{beatname_lc}"=="metricbeat"]
 *`--system.hostfs MOUNT_POINT`*::
 
@@ -582,14 +568,14 @@ endif::[]
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} run -e --setup
+{beatname_lc} run -e
 -----
 
 Or:
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} -e --setup
+{beatname_lc} -e
 -----
 
 [[setup-command]]
@@ -609,8 +595,8 @@ ifdef::has_ml_jobs[]
 necessary to analyze data for anomalies.
 endif::[]
 
-Use this command instead of `run --setup` when you want to set up the
-environment without actually running {beatname_uc} and ingesting data.
+Use this command if you want to set up the environment without actually running
+{beatname_uc} and ingesting data.
 
 *SYNOPSIS*
 

--- a/docs/copied-from-beats/loggingconfig.asciidoc
+++ b/docs/copied-from-beats/loggingconfig.asciidoc
@@ -19,6 +19,7 @@ ifndef::serverless[]
 The logging system can write logs to the syslog or rotate log files. If logging
 is not explicitly configured the file output is used.
 
+ifndef::win_only[]
 ["source","yaml",subs="attributes"]
 ----
 logging.level: info
@@ -29,6 +30,20 @@ logging.files:
   keepfiles: 7
   permissions: 0644
 ----
+endif::win_only[]
+
+ifdef::win_only[]
+["source","yaml",subs="attributes"]
+----
+logging.level: info
+logging.to_files: true
+logging.files:
+  path: C:{backslash}ProgramData{backslash}{beatname_lc}{backslash}Logs
+  name: {beatname_lc}
+  keepfiles: 7
+  permissions: 0644
+----
+endif::win_only[]
 
 TIP: In addition to setting logging options in the config file, you can modify
 the logging output configuration from the command line. See

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -817,7 +817,7 @@ NOTE: Events bigger than <<kafka-max_message_bytes,`max_message_bytes`>> will be
 [[kafka-compatibility]]
 ==== Compatibility
 
-This output works with all Kafka versions in between 0.11 and 2.0.0. Older versions
+This output works with all Kafka versions in between 0.11 and 2.1.0. Older versions
 might work as well, but are not supported.
 
 ==== Configuration options

--- a/docs/copied-from-beats/security/basic-auth.asciidoc
+++ b/docs/copied-from-beats/security/basic-auth.asciidoc
@@ -29,7 +29,7 @@ You can create roles from the **Management / Roles** UI in {kib} or through the
 ifeval::["{beatname_lc}"!="filebeat"]
 ["source","sh",subs="attributes,callouts"]
 ---------------------------------------------------------------
-POST _xpack/security/role/{beat_default_index_prefix}_writer
+POST _security/role/{beat_default_index_prefix}_writer
 {
   "cluster": ["manage_index_templates","monitor"],
   "indices": [
@@ -40,13 +40,14 @@ POST _xpack/security/role/{beat_default_index_prefix}_writer
   ]
 }
 ---------------------------------------------------------------
+// CONSOLE
 <1> If you use a custom {beatname_uc} index pattern, specify that pattern
 instead of the default ++{beat_default_index_prefix}-*++ pattern.
 endif::[]
 ifeval::["{beatname_lc}"=="filebeat"]
 ["source","sh",subs="attributes,callouts"]
 ---------------------------------------------------------------
-POST _xpack/security/role/{beat_default_index_prefix}_writer
+POST _security/role/{beat_default_index_prefix}_writer
 {
   "cluster": ["manage_index_templates","monitor","manage_ingest_pipelines"], <1>
   "indices": [
@@ -65,6 +66,34 @@ instead of the default ++{beat_default_index_prefix}-*++ pattern.
 endif::[]
 --
 
+ifndef::no_ilm[]
+. If you plan to use {ref}/getting-started-index-lifecycle-management.html[index
+lifecycle management], create a role that has the following privileges. These
+privileges are required to load index lifecycle policies and create and manage
+rollover indices:
++
+* *Cluster:* `manage_ilm`
+* *Index:* `write`, `create_index`, `manage`, and `manage_ilm` on the 
+{beatname_uc} indices
++
+--
+["source","sh",subs="attributes"]
+---------------------------------------------------------------
+POST _xpack/security/role/{beat_default_index_prefix}_ilm
+{
+  "cluster": ["manage_ilm"],
+  "indices": [
+    {
+      "names": [ "{beat_default_index_prefix}-*","shrink-{beat_default_index_prefix}-*"],
+      "privileges": ["write","create_index","manage","manage_ilm"]
+    }
+  ]
+}
+---------------------------------------------------------------
+// CONSOLE
+--
+endif::no_ilm[]
+
 . Assign the writer role to the user that {beatname_uc} will use to connect to
 {es}. Make sure you also assign any roles that are required for specific
 features. For the list of features and required roles, see <<feature-roles>>.
@@ -81,7 +110,7 @@ named ++{beat_default_index_prefix}_internal++ that has the
 --
 ["source","sh",subs="attributes,callouts"]
 ---------------------------------------------------------------
-POST /_xpack/security/user/{beat_default_index_prefix}_internal
+POST /_security/user/{beat_default_index_prefix}_internal
 {
   "password" : "{pwd}",
   "roles" : [ "{beat_default_index_prefix}_writer","kibana_user"],

--- a/docs/copied-from-beats/security/securing-beats.asciidoc
+++ b/docs/copied-from-beats/security/securing-beats.asciidoc
@@ -44,39 +44,43 @@ password, set it up now.
 For more information about {security}, see
 {xpack-ref}/elasticsearch-security.html[Securing the {stack}].
 
-[float]
 [[feature-roles]]
 === {beatname_uc} features that require authorization
 
 After securing {beatname_uc}, make sure your users have the roles (or associated
-privileges) required to use these {beatname_uc} features. You must create the
-++{beat_default_index_prefix}_writer++ and
-++{beat_default_index_prefix}_reader++ roles (see <<beats-basic-auth>> and
-<<beats-user-access>>). The other roles are
-{xpack-ref}/built-in-roles.html[built-in].
+privileges) required to use these {beatname_uc} features. Note that some of the
+roles shown here are {xpack-ref}/built-in-roles.html[built-in], and some
+are user-defined.
 
 [options="header"]
 |=======
 |Feature | Role
-|Send data to a secured cluster   | ++{beat_default_index_prefix}_writer++
+|Send data to a secured cluster   | ++{beat_default_index_prefix}_writer++ footnoteref:[noteA,These roles are user-defined.]
 ifeval::["{beatname_lc}"=="filebeat"]
-|Run Filebeat modules | ++{beat_default_index_prefix}_writer++
+|Run Filebeat modules | ++{beat_default_index_prefix}_writer++ footnoteref:[noteA]
 endif::[]
-|Load index templates | ++{beat_default_index_prefix}_writer++ and `kibana_user`
+|Load index templates | ++{beat_default_index_prefix}_writer++ footnoteref:[noteA] and `kibana_user`
 ifndef::no_dashboards[]
-|Load {beatname_uc} dashboards into {kib} | ++{beat_default_index_prefix}_writer++ and `kibana_user`
+|Load {beatname_uc} dashboards into {kib} | ++{beat_default_index_prefix}_writer++ footnoteref:[noteA] and `kibana_user`
 endif::[]
 ifdef::has_ml_jobs[]
 |Load machine learning jobs | `machine_learning_admin`
 endif::[]
-|Read indices created by {beatname_uc} | ++{beat_default_index_prefix}_reader++ 
+|Read indices created by {beatname_uc} | ++{beat_default_index_prefix}_reader++ footnoteref:[noteA] 
 ifndef::no_dashboards[]
 |View {beatname_uc} dashboards in {kib} | `kibana_user`
 endif::[]
 ifdef::has_central_config[]
 |Store and manage configurations in a central location in {kib} | `beats_admin`
 endif::[]
+ifndef::no_ilm[]
+|Load index lifecycle policies and use index lifecycle management | +{beatname_lc}_ilm+ footnoteref:[noteA]
+endif::[]
 |=======
+
+To create the user-defined roles shown here, see <<beats-basic-auth>> and
+<<beats-user-access>>. You may want to define additional roles to provide more
+restrictive access.
 
 include::basic-auth.asciidoc[]
 

--- a/docs/copied-from-beats/security/securing-beats.asciidoc
+++ b/docs/copied-from-beats/security/securing-beats.asciidoc
@@ -66,7 +66,13 @@ endif::[]
 ifdef::has_ml_jobs[]
 |Load machine learning jobs | `machine_learning_admin`
 endif::[]
+ifndef::apm-server[]
 |Read indices created by {beatname_uc} | ++{beat_default_index_prefix}_reader++ footnoteref:[noteA] 
+endif::[]
+ifdef::apm-server[]
+|Read indices created by {beatname_uc} | ++{beat_default_index_prefix}_user++
+|View {beatname_uc} dashboards in {kib} | `kibana_user`
+endif::[]
 ifndef::no_dashboards[]
 |View {beatname_uc} dashboards in {kib} | `kibana_user`
 endif::[]

--- a/docs/copied-from-beats/shared-docker.asciidoc
+++ b/docs/copied-from-beats/shared-docker.asciidoc
@@ -5,8 +5,7 @@ Docker images for {beatname_uc} are available from the Elastic Docker
 registry. The base image is https://hub.docker.com/_/centos/[centos:7].
 
 A list of all published Docker images and tags is available at
-https://www.docker.elastic.co[www.docker.elastic.co]. The source code is in
-{dockergithub}[GitHub].
+https://www.docker.elastic.co[www.docker.elastic.co]. 
 
 These images are free to use under the Elastic license. They contain open source 
 and free commercial features and access to paid commercial features.  

--- a/docs/copied-from-beats/shared-logstash-config.asciidoc
+++ b/docs/copied-from-beats/shared-logstash-config.asciidoc
@@ -22,7 +22,7 @@ the {stack} getting started tutorial. Also see the documentation for the
 If you want to use {ls} to perform additional processing on the data collected by
 {beatname_uc}, you need to configure {beatname_uc} to use {ls}.
 
-To do this, you edit the {beatname_uc} configuration file to disable the Elasticsearch
+To do this, you edit the {beatname_uc} configuration file to disable the {es}
 output by commenting it out and enable the {ls} output by uncommenting the
 logstash section:
 
@@ -36,8 +36,14 @@ output.logstash:
 The `hosts` option specifies the {ls} server and the port (`5044`) where {ls} is configured to listen for incoming
 Beats connections.
 
-For this configuration, you must <<load-template-manually,load the index template into Elasticsearch manually>>
-because the options for auto loading the template are only available for the Elasticsearch output.
+For this configuration, you must <<load-template-manually,load the index template into {es} manually>>
+because the options for auto loading the template are only available for the {es} output.
+
+ifeval::["{beatname_lc}"=="filebeat"]
+Want to use <<filebeat-modules,{beatname_uc} modules>> with {ls}? You need to do
+some extra setup. For more information, see
+{logstash-ref}/filebeat-modules.html[Working with {beatname_uc} modules].
+endif::[]
 
 ifndef::win-only[]
 ifndef::apm-server[]


### PR DESCRIPTION
Updating Beats documentation. Most of these are small grammar or formatting changes.

I'm curious about the new roles added in the table to the `securing-beats.asciidoc` page. Are these relevant to APM Server:

https://github.com/elastic/apm-server/blob/30ba8f0d9227d331364ee707966c183f35b994bd/docs/copied-from-beats/security/securing-beats.asciidoc#L55-L84

If someone could take a look when they have time, that'd be 🔥

I'd like to backport these to `7.0` (#1954) and `7.x` (#1955)