### PR TITLE
[7.0] Make Ingest pipeline path explicit (#1963)

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -300,7 +300,7 @@ output.elasticsearch:
   #      processor.event: "onboarding"
 
   # A pipeline is a definition of processors applied to documents when writing them to Elasticsearch.
-  # APM Server comes with a default pipeline definition, located at `ingets/pipeline/definition.json`.
+  # APM Server comes with a default pipeline definition, located at `ingest/pipeline/definition.json`.
   # Pipelines are disabled by default. To make use of them you have to:
   # (1) ensure pipelines are registered in Elasticsearch, see `apm-server.register.ingest.pipeline`
   # (2) enable the following:

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -296,7 +296,7 @@ output.elasticsearch:
         processor.event: "onboarding"
 
   # A pipeline is a definition of processors applied to documents when writing them to Elasticsearch.
-  # APM Server comes with a default pipeline definition, located at `ingets/pipeline/definition.json`.
+  # APM Server comes with a default pipeline definition, located at `ingest/pipeline/definition.json`.
   # Pipelines are disabled by default. To make use of them you have to:
   # (1) ensure pipelines are registered in Elasticsearch, see `apm-server.register.ingest.pipeline`
   # (2) enable the following:

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -300,7 +300,7 @@ output.elasticsearch:
   #      processor.event: "onboarding"
 
   # A pipeline is a definition of processors applied to documents when writing them to Elasticsearch.
-  # APM Server comes with a default pipeline definition, located at `ingets/pipeline/definition.json`.
+  # APM Server comes with a default pipeline definition, located at `ingest/pipeline/definition.json`.
   # Pipelines are disabled by default. To make use of them you have to:
   # (1) ensure pipelines are registered in Elasticsearch, see `apm-server.register.ingest.pipeline`
   # (2) enable the following:

--- a/beater/config.go
+++ b/beater/config.go
@@ -29,6 +29,7 @@ import (
 	"github.com/elastic/apm-server/sourcemap"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/outputs"
+	"github.com/elastic/beats/libbeat/paths"
 )
 
 const DefaultPort = "8200"
@@ -243,7 +244,8 @@ func defaultConfig(beatVersion string) *Config {
 				Pipeline: &pipelineConfig{
 					Enabled:   &pipelineEnabled,
 					Overwrite: &pipelineOverwrite,
-					Path:      filepath.Join("ingest", "pipeline", "definition.json"),
+					Path: paths.Resolve(paths.Home,
+						filepath.Join("ingest", "pipeline", "definition.json")),
 				}},
 		},
 	}


### PR DESCRIPTION
Backports the following commits to 7.0:
 - Make Ingest pipeline path explicit  (#1963)