### PR TITLE
[6.7] Remove ilm-policy from export and setup cmd.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,4 +72,24 @@ func init() {
 			DefaultUsername: "apm_system",
 		},
 	})
+
+	// remove ilm-policy from export commands
+	for _, cmd := range RootCmd.ExportCmd.Commands() {
+		if cmd.Name() == "ilm-policy" {
+			RootCmd.ExportCmd.RemoveCommand(cmd)
+		}
+	}
+	// only add defined flags to setup command
+	setup := RootCmd.SetupCmd
+	setup.Short = "Setup Elasticsearch index template and pipelines"
+	setup.Long = `This command does initial setup of the environment:
+ * Index mapping template in Elasticsearch to ensure fields are mapped.
+ * Ingest pipelines
+ * Kibana dashboards
+`
+	setup.ResetFlags()
+	setup.Flags().Bool("template", false, "Setup index template")
+	// for compatibility reasons we need to still support dashboards.
+	setup.Flags().Bool("dashboards", false, "Setup dashboards")
+	setup.Flags().Bool("pipelines", false, "Setup Ingest pipelines")
 }


### PR DESCRIPTION
fixes elastic/apm-server#1983

In 6.6 beats introduced ILM as beta feature. APM Server does not document, nor actively support it, but inherits the logic. This means, someone _could_ configure to run the server with ILM enabled and use the `setup` and `export` cmds for `ilm-policy`. This is not a great experience, for several reasons, one of them is that the implemented beta logic does not work well with current APM index strategies. For 6.x there is currently no way of restricting a users configuration, but we can remove the `ilm-policy` from the `setup` and `export` cmd.

Proposal:
Keep the logic unchanged for 6.6 as it is already released and ILM is in _beta_ in beats, and not documented in APM Server.
Remove the `setup` and `export` cmd for `ilm-policy` in 6.7.