### PR TITLE
Fail setup dashboard sooner

### DIFF
--- a/_meta/kibana/7/dashboard/apm-dashboards.json
+++ b/_meta/kibana/7/dashboard/apm-dashboards.json
@@ -1,4 +1,0 @@
-{
-    "objects": [{}], 
-    "version": "7.0.0-beta1"
-}

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -18,6 +18,7 @@
 package beater
 
 import (
+	"errors"
 	"net"
 	"net/http"
 	"net/url"
@@ -33,6 +34,7 @@ import (
 	"github.com/elastic/apm-server/pipelistener"
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
@@ -46,9 +48,38 @@ type beater struct {
 	logger  *logp.Logger
 }
 
+var (
+	setupDashboardRemoved = errors.New("setting 'setup.dashboards' has been removed")
+)
+
+// checkConfig verifies the global configuration doesn't use unsupported settings
+func checkConfig(logger *logp.Logger) error {
+	cfg, err := cfgfile.Load("", nil)
+	if err != nil {
+		return err
+	}
+
+	var s struct {
+		Dashboards *common.Config `config:"setup.dashboards"`
+	}
+	if err := cfg.Unpack(&s); err != nil {
+		return err
+	}
+	if s.Dashboards != nil {
+		if s.Dashboards.Enabled() {
+			return setupDashboardRemoved
+		}
+		logger.Warn(setupDashboardRemoved)
+	}
+	return nil
+}
+
 // Creates beater
 func New(b *beat.Beat, ucfg *common.Config) (beat.Beater, error) {
 	logger := logp.NewLogger("beater")
+	if err := checkConfig(logger); err != nil {
+		return nil, err
+	}
 	beaterConfig, err := newConfig(b.Info.Version, ucfg)
 	if err != nil {
 		return nil, err

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -56,7 +56,9 @@ var (
 func checkConfig(logger *logp.Logger) error {
 	cfg, err := cfgfile.Load("", nil)
 	if err != nil {
-		return err
+		// responsibility for failing to load configuration lies elsewhere
+		// this is not reachable after going through normal beat creation
+		return nil
 	}
 
 	var s struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,7 +41,7 @@ const IdxPattern = "apm"
 var RootCmd *cmd.BeatsRootCmd
 
 func init() {
-	overrides, _ := common.NewConfigFrom(map[string]interface{}{
+	overrides := common.MustNewConfigFrom(map[string]interface{}{
 		"logging": map[string]interface{}{
 			"metrics": map[string]interface{}{
 				"enabled": false,


### PR DESCRIPTION
closes #1997 

```
$ ./apm-server test config -E setup.dashboards.enabled=true
Exiting: setting 'setup.dashboards' has been removed

$ ./apm-server test config -E setup.dashboards.enabled=false -e
...
2019-03-15T16:42:28.306-0400	WARN	[beater]	beater/beater.go:72	setting 'setup.dashboards' has been removed
```

related to #1905