### PR TITLE
[APM-CI] allow disable the kibana update check stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,7 @@ pipeline {
     booleanParam(name: 'bench_ci', defaultValue: true, description: 'Enable benchmarks')
     booleanParam(name: 'doc_ci', defaultValue: true, description: 'Enable build documentation')
     booleanParam(name: 'releaser_ci', defaultValue: true, description: 'Enable build the release packages')
+    booleanParam(name: 'kibana_update_ci', defaultValue: true, description: 'Enable build the Check kibana Obj. Updated')
   }
   stages {
     /**
@@ -334,6 +335,10 @@ pipeline {
         PATH = "${env.PATH}:${env.WORKSPACE}/bin"
         HOME = "${env.WORKSPACE}"
         GOPATH = "${env.WORKSPACE}"
+      }
+      when {
+        beforeAgent true
+        expression { return params.kibana_update_ci }
       }
       steps {
         deleteDir()


### PR DESCRIPTION
In case we want to disable the `Check kibana Obj. Updated` stage