### PR TITLE
[6.7] help with setup.dashboards deprecation

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,7 +38,7 @@ const IdxPattern = "apm"
 var RootCmd *cmd.BeatsRootCmd
 
 func init() {
-	overrides, _ := common.NewConfigFrom(map[string]interface{}{
+	overrides := common.MustNewConfigFrom(map[string]interface{}{
 		"logging": map[string]interface{}{
 			"metrics": map[string]interface{}{
 				"enabled": false,


### PR DESCRIPTION
Dashboard loading and the corresponding setup.dashboards configuration
have been deprecated since 6.4.  To enable a smoother transition to 7.0,
apm-server will log a warning when the option is set.

very similar to #1999 except does not prevent apm-server from starting since dashboards are still bundled with 6.7.