### PR TITLE
enable pipeline registration for setup --pipelines

### DIFF
--- a/_beats/libbeat/tests/system/beat/beat.py
+++ b/_beats/libbeat/tests/system/beat/beat.py
@@ -220,9 +220,6 @@ class TestCase(unittest.TestCase, ComposeMixin):
 
     def render_config_template(self, template_name=None,
                                output=None, **kargs):
-
-        print("render config")
-
         # Init defaults
         if template_name is None:
             template_name = self.beat_name

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -75,7 +75,11 @@ func New(b *beat.Beat, ucfg *common.Config) (beat.Beater, error) {
 		logger:  logger,
 	}
 
-	if isElasticsearchOutput(b) && beaterConfig.Register.Ingest.Pipeline.isEnabled() {
+	// setup pipelines if explicitly directed to or setup --pipelines and config is not set at all
+	shouldSetupPipelines := beaterConfig.Register.Ingest.Pipeline.isEnabled() ||
+		(b.InSetupCmd && beaterConfig.Register.Ingest.Pipeline.Enabled == nil)
+
+	if isElasticsearchOutput(b) && shouldSetupPipelines {
 		logger.Info("Registering pipeline callback.")
 		err := bt.registerPipelineCallback(b)
 		if err != nil {

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -205,7 +205,7 @@ func TestBeatConfig(t *testing.T) {
 					Ingest: &ingestConfig{
 						Pipeline: &pipelineConfig{
 							Enabled:   &falsy,
-							Overwrite: &truthy,
+							Overwrite: nil,
 							Path:      filepath.Join("ingest", "pipeline", "definition.json"),
 						},
 					},

--- a/beater/config.go
+++ b/beater/config.go
@@ -227,7 +227,6 @@ func defaultRum(beatVersion string) *rumConfig {
 }
 
 func defaultConfig(beatVersion string) *Config {
-	pipelineEnabled, pipelineOverwrite := false, true
 	return &Config{
 		Host:            net.JoinHostPort("localhost", DefaultPort),
 		MaxHeaderSize:   1 * 1024 * 1024, // 1mb
@@ -261,8 +260,6 @@ func defaultConfig(beatVersion string) *Config {
 		Register: &registerConfig{
 			Ingest: &ingestConfig{
 				Pipeline: &pipelineConfig{
-					Enabled:   &pipelineEnabled,
-					Overwrite: &pipelineOverwrite,
 					Path: paths.Resolve(paths.Home,
 						filepath.Join("ingest", "pipeline", "definition.json")),
 				}},

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -425,9 +425,6 @@ def get_elasticsearch_url():
 
 
 class SubCommandTest(ServerSetUpBaseTest):
-    def tearDown(self):
-        super(ServerSetUpBaseTest, self).tearDown()
-
     def wait_until_started(self):
         self.apmserver_proc.check_wait()
 

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -425,6 +425,9 @@ def get_elasticsearch_url():
 
 
 class SubCommandTest(ServerSetUpBaseTest):
+    def tearDown(self):
+        super(ServerSetUpBaseTest, self).tearDown()
+
     def wait_until_started(self):
         self.apmserver_proc.check_wait()
 

--- a/tests/system/test_setup.py
+++ b/tests/system/test_setup.py
@@ -1,9 +1,64 @@
 import unittest
 
-from apmserver import SubCommandTest, get_elasticsearch_url
+from apmserver import ElasticTest, SubCommandTest, get_elasticsearch_url
 from beat.beat import INTEGRATION_TESTS
-from elasticsearch import Elasticsearch
+from elasticsearch import Elasticsearch, NotFoundError
+from elasticsearch.client import IngestClient
 
+
+class SetupPipelinesDefaultTest(SubCommandTest):
+    pipeline_name = "apm_user_agent"
+
+    def config(self):
+        cfg = super(SubCommandTest, self).config()
+        cfg.update({
+            "elasticsearch_host": get_elasticsearch_url(),
+            "file_enabled": "false",
+        })
+        return cfg
+
+    def start_args(self):
+        return {
+            "logging_args": ["-v", "-d", "*"],
+            "extra_args":   ["-e",
+                             "setup",
+                             "--pipelines"]
+        }
+
+    def setUp(self):
+        # TODO (gr): consolidate with ElasticTest
+        self.es = Elasticsearch([get_elasticsearch_url()])
+        self.es.ingest.delete_pipeline(id="*")
+        super(SetupPipelinesDefaultTest, self).setUp()
+
+    def assert_pipeline_presence(self, should_exist=False):
+        try:
+            self.es.ingest.get_pipeline(self.pipeline_name)
+            present = True
+        except NotFoundError:
+            present = False
+
+        assert should_exist == present, "expected {}pipelines".format("" if should_exist else "no ")
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_setup_pipelines(self):
+        self.assert_pipeline_presence(True)
+        assert self.log_contains("Pipeline successfully registered: apm_user_agent")
+        assert self.log_contains("Registered Ingest Pipelines successfully.")
+
+
+class SetupPipelinesDisabledTest(SetupPipelinesDefaultTest):
+    def config(self):
+        cfg = super(SetupPipelinesDisabledTest, self).config()
+        cfg.update({
+            "register_pipeline_enabled": "false",
+        })
+        return cfg
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_setup_pipelines(self):
+        self.assert_pipeline_presence(False)
+        assert self.log_contains("No pipeline callback registered")
 
 class SetupTemplateDefaultTest(SubCommandTest):
     """

--- a/tests/system/test_setup.py
+++ b/tests/system/test_setup.py
@@ -60,6 +60,7 @@ class SetupPipelinesDisabledTest(SetupPipelinesDefaultTest):
         self.assert_pipeline_presence(False)
         assert self.log_contains("No pipeline callback registered")
 
+
 class SetupTemplateDefaultTest(SubCommandTest):
     """
     Test setup template subcommand with default option.


### PR DESCRIPTION
setup pipelines if explicitly directed to or doing `setup --pipelines` and the config is not set at all

fixes #2008 