### PR TITLE
[docs] Backport docs 6.7

### DIFF
--- a/changelogs/6.6.asciidoc
+++ b/changelogs/6.6.asciidoc
@@ -3,8 +3,16 @@
 
 https://github.com/elastic/apm-server/compare/6.5\...6.6[View commits]
 
+* <<release-notes-6.6.2>>
 * <<release-notes-6.6.1>>
 * <<release-notes-6.6.0>>
+
+[[release-notes-6.6.2]]
+=== APM Server version 6.6.2
+
+https://github.com/elastic/apm-server/compare/v6.6.1\...v6.6.2[View commits]
+
+No significant changes.
 
 [[release-notes-6.6.1]]
 === APM Server version 6.6.1

--- a/docs/common-problems.asciidoc
+++ b/docs/common-problems.asciidoc
@@ -43,6 +43,9 @@ the response code to narrow down the possible causes (see sections below).
 Another reason for data not showing up is that the agent is not auto-instrumenting something you were expecting, check
 the {apm-agents-ref}/index.html[agent documentation] for details on what is automatically instrumented.
 
+APM Server currently relies on Elasticsearch to create indices that do not exist.
+As a result, Elasticsearch must be configured to allow {ref}/docs-index_.html#index-creation[automatic index creation] for APM indices.
+
 [[bad-request]]
 [float]
 === HTTP 400: Data decoding error / Data validation error

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -60,7 +60,11 @@ Example configuration:
 
 output.elasticsearch:
   hosts: ["https://localhost:9200"]
+<<<<<<< HEAD
   index: "{beatname_lc}-%{[beat.version]}-%{+yyyy.MM.dd}"
+=======
+  index: "{beat_default_index_prefix}-%{[{beat_version_key}]}-%{+yyyy.MM.dd}"
+>>>>>>> 1a4f76ba... [docs] Update index prefix in output config (#2024)
   ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
   ssl.certificate: "/etc/pki/client/cert.pem"
   ssl.key: "/etc/pki/client/cert.key"
@@ -81,7 +85,7 @@ output.elasticsearch:
 
 If the Elasticsearch nodes are defined by `IP:PORT`, then add `protocol: https` to the yaml file.
 
-[source,yaml]
+["source","yaml",subs="attributes,callouts"]
 ------------------------------------------------------------------------------
 output.elasticsearch:
   hosts: ["localhost"]
@@ -398,7 +402,7 @@ use in Logstash for indexing and filtering:
 {
     ...
     "@metadata": { <1>
-      "beat": "{beatname_lc}", <2>
+      "beat": "{beat_default_index_prefix}", <2>
       "version": "{stack-version}" <3>
       "type": "doc" <4>
     }
@@ -407,7 +411,7 @@ use in Logstash for indexing and filtering:
 <1> {beatname_uc} uses the `@metadata` field to send metadata to Logstash. See the
 {logstashdoc}/event-dependent-configuration.html#metadata[Logstash documentation]
 for more about the `@metadata` field.
-<2> The default is {beatname_lc}. To change this value, set the
+<2> The default is {beat_default_index_prefix}. To change this value, set the
 <<logstash-index,`index`>> option in the {beatname_uc} config file.
 <3> The beats current version.
 <4> The value of `type` is currently hardcoded to `doc`. It was used by previous
@@ -444,7 +448,7 @@ output {
 of the `beat` metadata field, `%{[@metadata][version]}` sets the second part to
 the Beat's version, and `%{+YYYY.MM.dd}` sets the third part of the
 name to a date based on the Logstash `@timestamp` field. For example:
-+{beatname_lc}-{version}-2017.03.29+.
++{beat_default_index_prefix}-{version}-2017.03.29+.
 
 Events indexed into Elasticsearch with the Logstash configuration shown here
 will be similar to events directly indexed by Beats into Elasticsearch.
@@ -573,8 +577,8 @@ that when a proxy is used the name resolution occurs on the proxy server.
 ===== `index`
 
 The index root name to write events to. The default is the Beat name. For
-example +"{beatname_lc}"+ generates +"[{beatname_lc}-]{version}-YYYY.MM.DD"+
-indices (for example, +"{beatname_lc}-{version}-2017.04.26"+).
+example +"{beat_default_index_prefix}"+ generates +"[{beat_default_index_prefix}-]{version}-YYYY.MM.DD"+
+indices (for example, +"{beat_default_index_prefix}-{version}-2017.04.26"+).
 
 ===== `ssl`
 

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -60,11 +60,7 @@ Example configuration:
 
 output.elasticsearch:
   hosts: ["https://localhost:9200"]
-<<<<<<< HEAD
-  index: "{beatname_lc}-%{[beat.version]}-%{+yyyy.MM.dd}"
-=======
   index: "{beat_default_index_prefix}-%{[{beat_version_key}]}-%{+yyyy.MM.dd}"
->>>>>>> 1a4f76ba... [docs] Update index prefix in output config (#2024)
   ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
   ssl.certificate: "/etc/pki/client/cert.pem"
   ssl.key: "/etc/pki/client/cert.key"

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -60,7 +60,7 @@ Example configuration:
 
 output.elasticsearch:
   hosts: ["https://localhost:9200"]
-  index: "{beat_default_index_prefix}-%{[{beat_version_key}]}-%{+yyyy.MM.dd}"
+  index: "{beat_default_index_prefix}-%{[{beat.version}]}-%{+yyyy.MM.dd}"
   ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
   ssl.certificate: "/etc/pki/client/cert.pem"
   ssl.key: "/etc/pki/client/cert.key"

--- a/docs/guide/install-and-run.asciidoc
+++ b/docs/guide/install-and-run.asciidoc
@@ -5,6 +5,18 @@ This page is designed to make it easy to install and run the components of Elast
 Simply follow the step-by-step links below, and you'll be up and running in no time.
 Let's get started.
 
+[TIP]
+==============
+You can skip having to install {es}, {kib}, and APM Server by using our
+https://www.elastic.co/cloud/elasticsearch-service[hosted {es} Service] on
+Elastic Cloud. The {es} Service is available on both AWS and GCP,
+and automatically configures APM Server to work with {es} and {kib}.
+Additional {cloud}/ec-manage-apm-settings.html[APM user settings] are also available.
+
+https://www.elastic.co/cloud/elasticsearch-service/signup[Try out the {es}
+Service for free].
+==============
+
 * <<before-installation>>
 * <<install-elasticsearch>>
 * <<install-kibana>>
@@ -16,15 +28,12 @@ Let's get started.
 [[before-installation]]
 === Before you begin
 
-* See the https://www.elastic.co/support/matrix[Elastic Support
-Matrix] for information about supported operating systems and product
-compatibility.
+* See the https://www.elastic.co/support/matrix[Elastic Support Matrix]
+for information about supported operating systems and product compatibility.
+We recommend you use the same version of Elasticsearch, Kibana, and APM Server.
 * Verify that your system meets the
 https://www.elastic.co/support/matrix#matrix_jvm[minimum JVM requirements] for {es}.
-
-IMPORTANT: You must ensure you’re using the same version of Elasticsearch, Kibana, and APM Server.
-
-NOTE: The following links assume you're using the current version of the Elasticstack.
+* The following links assume you're using the current version of the Elastic Stack.
 If you're not, it's easy to adjust the version of the documentation after you land on each page.
 
 [float]


### PR DESCRIPTION
Backports the following commits to 6.7
* docs: add 6.6.2 release notes (#1991)
* docs: update install instructions (#2009)
* note auto index creation troubleshooting (#2023)
* [docs] Update index prefix in output config (#2024)