### PR TITLE
expect UTC indices in test

### DIFF
--- a/idxmgmt/supporter_test.go
+++ b/idxmgmt/supporter_test.go
@@ -76,7 +76,7 @@ func TestIndexSupport_TemplateConfig(t *testing.T) {
 }
 
 func TestIndexSupport_BuildSelector(t *testing.T) {
-	today := time.Now()
+	today := time.Now().UTC()
 	day := today.Format("2006.01.02")
 	testdata := map[string]struct {
 		meta     common.MapStr


### PR DESCRIPTION
Came across this at 21:00 EST / 0100 UTC:

```
--- FAIL: TestIndexSupport_BuildSelector (0.01s)
    --- FAIL: TestIndexSupport_BuildSelector/with_meta_information (0.00s)
        supporter_test.go:168: 
            	Error Trace:	supporter_test.go:168
            	Error:      	Not equal: 
            	            	expected: "apm-7.0.0-2019.03.19"
            	            	actual  : "apm-7.0.0-2019.03.20"
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1 +1 @@
            	            	-apm-7.0.0-2019.03.19
            	            	+apm-7.0.0-2019.03.20
            	Test:       	TestIndexSupport_BuildSelector/with_meta_information
    --- FAIL: TestIndexSupport_BuildSelector/meta_information_overwrites_config (0.00s)
        supporter_test.go:168: 
            	Error Trace:	supporter_test.go:168
            	Error:      	Not equal: 
            	            	expected: "apm-7.0.0-2019.03.19"
            	            	actual  : "apm-7.0.0-2019.03.20"
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1 +1 @@
            	            	-apm-7.0.0-2019.03.19
            	            	+apm-7.0.0-2019.03.20
            	Test:       	TestIndexSupport_BuildSelector/meta_information_overwrites_config
```