### PR TITLE
[docs] Add manual ILM instructions

### DIFF
--- a/docs/configuring.asciidoc
+++ b/docs/configuring.asciidoc
@@ -27,6 +27,8 @@ include::./copied-from-beats/shared-ssl-config.asciidoc[]
 
 include::./template-config.asciidoc[]
 
+include::./ilm-setup.asciidoc[]
+
 include::./copied-from-beats/loggingconfig.asciidoc[]
 
 include::./configuration-rum.asciidoc[]

--- a/docs/ilm-setup.asciidoc
+++ b/docs/ilm-setup.asciidoc
@@ -1,11 +1,16 @@
+[role="xpack"]
+[[manual-ilm-setup]]
 == Manual index lifecycle management
 
-APM Server allows users to manually set up an index lifecylce managment (ILM) policy.
-This setup is made possible because of Elasticsearch's
-{ref}/using-policies-rollover.html#using-policies-rollover[index rollover] action.
+APM Server can take advantage of the index lifecycle management (ILM) capabilities of Elasticsearch.
+ILM enables you to automate how you want to manage your indices over time.
+You can base actions on factors such as shard size and performance requirements. 
 
-Follow the guide below to set up a custom ILM policy for span indices.
+The guide below will help you set up a custom ILM policy for span indices.
 You can repeat the actions for any other indices.
+
+NOTE: If you're migrating from an existing setup,
+any indices present before ILM was configured will need to be managed manually.
 
 . Set up the default index template
 +
@@ -22,11 +27,13 @@ This is accomplished by running the <<setup-command,`setup --template`>> command
 
 . Create a policy for spans.
 +
-Rollover actions are triggered when one or more criteria are met.
-In this example, we're creating a policy named `apm_span_policy`.
+Index lifecycle management will manage an index based on its defined policy.
+Policies only need to be created once, and will persist through version upgrades.
+Let's create a policy named `apm_span_policy`.
 +
-This policy rolls data over to a new index after _1 day_, or _50gb_, whichever comes first.
-It also tells the old indexes to delete after _10 days_.
+This policy defines two rollover criteria: `"max_age": "1d"`, and `"max_size": "50gb"`.
+When one or more of these criteria are met, the policy rolls data over into a new index.
+`apm_span_policy` also tells the old indexes to delete after _10 days_.
 All of these values can be customized to your specific needs.
 +
 --
@@ -66,6 +73,9 @@ To use the index lifecycle management policy created in the previous step,
 you need to specify it in the index template used to create the indices.
 The following template associates `apm_span_policy` with indices created from the +apm-{stack-version}-span-ilm+ template.
 +
+NOTE: Because we're utilizing the current stack-version ({stack-version}) in this step,
+this action will need to be performed as a part of each version upgrade.
++
 --
 ["source","js",subs="attributes"]
 -----------------------
@@ -74,8 +84,6 @@ PUT _template/apm-{stack-version}-span-ilm
   "order": 2,
   "index_patterns": ["apm-{stack-version}-span-*"], <1>
   "settings": {
-    "number_of_shards": 1,
-    "number_of_replicas": 1,
     "index.lifecycle.name": "apm_span_policy", <2>
     "index.lifecycle.rollover_alias": "apm-{stack-version}-span"
   }
@@ -89,6 +97,8 @@ PUT _template/apm-{stack-version}-span-ilm
 . Create the index and alias.
 +
 Now we can create the first index: +apm-{stack-version}-span-000001+.
++
+NOTE: This action will need to be performed as a part of each version upgrade.
 +
 --
 ["source","js",subs="attributes"]
@@ -144,13 +154,18 @@ The response should be similar to this:
 }
 -----------------------
 --
++
+You can also verify and adjust your configuration via Kibana's {kibana-ref}/index-lifecycle-policies.html[management]. 
 
 . Modify APM Server's configuration.
 +
-You'll need to modify the default index configuration in <<apm-server-configuration,`apm-server.yml`>>.
+Next, modify the default index configuration in <<apm-server-configuration,`apm-server.yml`>>.
 Trim off the date template from each index you are setting up ILM for,
 so that APM Server is always writing events to the same place.
 The name of your modified index configuration must match the `is_write_index` alias created previously
++
+It's important to note that `apm-server.yml` overwrites defaults rather than being merged.
+This means you'll need to configure each index in the file, even if it's not using ILM.
 +
 --
 ["source","yml",subs="attributes"]
@@ -166,7 +181,7 @@ output.elasticsearch:
 
 . Start apm-server.
 +
-Your ILM policy should now be up and running!
+Your ILM configuration should now be up and running!
 
 .. Monitor ILM status as events flow:
 +

--- a/docs/ilm-setup.asciidoc
+++ b/docs/ilm-setup.asciidoc
@@ -1,0 +1,189 @@
+== Manual index lifecycle management
+
+APM Server allows users to manually set up an index lifecylce managment (ILM) policy.
+This setup is made possible because of Elasticsearch's
+{ref}/using-policies-rollover.html#using-policies-rollover[index rollover] action.
+
+Follow the guide below to set up a custom ILM policy for span indices.
+You can repeat the actions for any other indices.
+
+. Set up the default index template
++
+If you haven't already, you'll need to set up the default index template.
+This is accomplished by running the <<setup-command,`setup --template`>> command.
++
+--
+[source,js]
+-----------------------
+./apm-server setup --template
+-----------------------
+// CONSOLE
+--
+
+. Create a policy for spans.
++
+Rollover actions are triggered when one or more criteria are met.
+In this example, we're creating a policy named `apm_span_policy`.
++
+This policy rolls data over to a new index after _1 day_, or _50gb_, whichever comes first.
+It also tells the old indexes to delete after _10 days_.
+All of these values can be customized to your specific needs.
++
+--
+[source,js]
+-----------------------
+PUT _ilm/policy/apm_span_policy
+{
+  "policy": {
+    "phases": {
+      "hot": {
+        "actions": {
+          "rollover": {
+            "max_age": "1d", <1>
+            "max_size": "50gb" <2>
+          }
+        }
+      },
+      "delete": {
+        "min_age": "10d", <3>
+        "actions": {
+          "delete": {}
+        }
+      }
+    }
+  }
+}
+-----------------------
+// CONSOLE
+<1> Rollover after _1 day_
+<2> Rollover after _50gb_
+<3> Delete old indexes after _10 days_
+--
+
+. Set up the ILM index template.
++
+To use the index lifecycle management policy created in the previous step,
+you need to specify it in the index template used to create the indices.
+The following template associates `apm_span_policy` with indices created from the +apm-{stack-version}-span-ilm+ template.
++
+--
+["source","js",subs="attributes"]
+-----------------------
+PUT _template/apm-{stack-version}-span-ilm
+{
+  "order": 2,
+  "index_patterns": ["apm-{stack-version}-span-*"], <1>
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 1,
+    "index.lifecycle.name": "apm_span_policy", <2>
+    "index.lifecycle.rollover_alias": "apm-{stack-version}-span"
+  }
+}
+-----------------------
+// CONSOLE
+<1> This template applies to all indices with the prefix +apm-{stack-version}-span-+
+<2> Associates `apm_span_policy` with all indices created with this template
+--
+
+. Create the index and alias.
++
+Now we can create the first index: +apm-{stack-version}-span-000001+.
++
+--
+["source","js",subs="attributes"]
+-----------------------
+PUT apm-{stack-version}-span-000001 <1>
+{
+  "aliases": {
+    "apm-{stack-version}-span":{
+      "is_write_index": true <2>
+    }
+  }
+}
+-----------------------
+// CONSOLE
+<1> The rollover action increments the suffix number for each subsequent index.
+<2> Designates this index as the write index for this alias.
+--
+
+. Verify the ILM index template was applied.
++
+--
+[source,js]
+-----------------------
+GET apm-*-span/_settings
+-----------------------
+// CONSOLE
+--
++
+The response should be similar to this:
++
+--
+["source","js",subs="attributes"]
+-----------------------
+{
+  "apm-{stack-version}-span-000001" : {
+    "settings" : {
+      "index" : {
+        "lifecycle" : {
+          "name" : "apm_span_policy",
+          "rollover_alias" : "apm-{stack-version}-span"
+        },
+        "number_of_shards" : "1",
+        "provided_name" : "apm-{stack-version}-span-000001",
+        "creation_date" : "1553024227938",
+        "number_of_replicas" : "1",
+        "uuid" : "6b5l-H7QTRK95FAodAN-wg",
+        "version" : {
+          "created" : "7000099"
+        }
+      }
+    }
+  }
+}
+-----------------------
+--
+
+. Modify APM Server's configuration.
++
+You'll need to modify the default index configuration in <<apm-server-configuration,`apm-server.yml`>>.
+Trim off the date template from each index you are setting up ILM for,
+so that APM Server is always writing events to the same place.
+The name of your modified index configuration must match the `is_write_index` alias created previously
++
+--
+["source","yml",subs="attributes"]
+-----------------------
+output.elasticsearch:
+  indices:
+    - index: "apm-{stack-version}-span"
+      when.contains:
+        processor.event: "span"
+-----------------------
+// CONSOLE
+--
+
+. Start apm-server.
++
+Your ILM policy should now be up and running!
+
+.. Monitor ILM status as events flow:
++
+--
+[source,js]
+-----------------------
+GET apm-*/_ilm/explain?human
+-----------------------
+// CONSOLE
+--
+
+.. Monitor index status:
++
+--
+[source,js]
+-----------------------
+GET _cat/indices/apm*?v
+-----------------------
+// CONSOLE
+--

--- a/docs/ilm-setup.asciidoc
+++ b/docs/ilm-setup.asciidoc
@@ -12,7 +12,7 @@ You can repeat the actions for any other indices.
 NOTE: If you're migrating from an existing setup,
 any indices present before ILM was configured will need to be managed manually.
 
-. Set up the default index template
+. *Set up the default index template.*
 +
 If you haven't already, you'll need to set up the default index template.
 This is accomplished by running the <<setup-command,`setup --template`>> command.
@@ -25,7 +25,7 @@ This is accomplished by running the <<setup-command,`setup --template`>> command
 // CONSOLE
 --
 
-. Create a policy for spans.
+. *Create a policy for spans.*
 +
 Index lifecycle management will manage an index based on its defined policy.
 Policies only need to be created once, and will persist through version upgrades.
@@ -67,7 +67,7 @@ PUT _ilm/policy/apm_span_policy
 <3> Delete old indexes after _10 days_
 --
 
-. Set up the ILM index template.
+. *Set up the ILM index template.*
 +
 To use the index lifecycle management policy created in the previous step,
 you need to specify it in the index template used to create the indices.
@@ -94,7 +94,7 @@ PUT _template/apm-{stack-version}-span-ilm
 <2> Associates `apm_span_policy` with all indices created with this template
 --
 
-. Create the index and alias.
+. *Create the index and alias.*
 +
 Now we can create the first index: +apm-{stack-version}-span-000001+.
 +
@@ -117,7 +117,7 @@ PUT apm-{stack-version}-span-000001 <1>
 <2> Designates this index as the write index for this alias.
 --
 
-. Verify the ILM index template was applied.
+. *Verify the ILM index template was applied.*
 +
 --
 [source,js]
@@ -157,29 +157,58 @@ The response should be similar to this:
 +
 You can also verify and adjust your configuration via Kibana's {kibana-ref}/index-lifecycle-policies.html[management]. 
 
-. Modify APM Server's configuration.
+. *Repeat for other indices.*
 +
-Next, modify the default index configuration in <<apm-server-configuration,`apm-server.yml`>>.
+Repeat the previous steps for each index that will be using ILM.
++
+* Create a policy
+* Set up the ILM index template
+* Create the index and alias
+* Verify the ILM index template was applied
+
+. *Modify APM Server's configuration.*
++
+Finally, modify the default index configuration in <<apm-server-configuration,`apm-server.yml`>>.
 Trim off the date template from each index you are setting up ILM for,
 so that APM Server is always writing events to the same place.
 The name of your modified index configuration must match the `is_write_index` alias created previously
 +
 It's important to note that `apm-server.yml` overwrites defaults rather than being merged.
-This means you'll need to configure each index in the file, even if it's not using ILM.
+This means you'll need to configure all of your indices in the file, even if some are not using ILM.
 +
 --
 ["source","yml",subs="attributes"]
 -----------------------
 output.elasticsearch:
   indices:
+    - index: "apm-{stack-version}-sourcemap"
+      when.contains:
+        processor.event: "sourcemap"
+    
+    - index: "apm-{stack-version}-error"
+      when.contains:
+        processor.event: "error"
+    
+    - index: "apm-{stack-version}-transaction"
+      when.contains:
+        processor.event: "transaction"
+
     - index: "apm-{stack-version}-span"
       when.contains:
         processor.event: "span"
+    
+    - index: "apm-{stack-version}-metric"
+      when.contains:
+        processor.event: "metric"
+    
+    - index: "apm-{stack-version}-onboarding"
+      when.contains:
+        processor.event: "onboarding"
 -----------------------
 // CONSOLE
 --
 
-. Start apm-server.
+. *Start apm-server.*
 +
 Your ILM configuration should now be up and running!
 


### PR DESCRIPTION
Here's my first crack at manual ILM setup for APM Server. Closes https://github.com/elastic/apm-server/issues/1545.

Huge shoutout to @graphaelli for creating an awesome [walkthrough](https://github.com/elastic/apm-server/issues/1545#issuecomment-446817453) of the process.

Note: The asciidoc for this change is really ugly due to our `//console` tags not jiving with ordered lists.
