### PR TITLE
[docs] Add deb/rpm running instructions

### DIFF
--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -8,6 +8,7 @@ similar to how you run Elasticsearch.
 You _can_ run it on the same machines as Elasticsearch,
 but this is not recommended,
 as the processes will be competing for resources.
+
 To start APM Server, run:
 
 [source,bash]
@@ -23,6 +24,21 @@ You can change the defaults by supplying a different address on the command line
 ----------------------------------
 ./apm-server -e -E output.elasticsearch.hosts=ElasticsearchAddress:9200 -E apm-server.host=localhost:8200
 ----------------------------------
+
+[float]
+[[running-deb-rpm]]
+=== Debian / RPM Package
+
+When using a packaged version of apm-server, the installation creates an `apm-server` user.
+To start the APM Server in this case, run:
+
+[source,bash]
+----------------------------------
+sudo -u apm-server apm-server -e [FLAGS]
+----------------------------------
+
+For Debian and RPM, you’ll find the APM Server configuration file at `/etc/apm-server/apm-server.yml`.
+See the <<_deb_and_rpm,deb & rpm default paths>> for a full directory layout.
 
 [[apm-server-configuration]]
 === Configuration file

--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -27,9 +27,9 @@ You can change the defaults by supplying a different address on the command line
 
 [float]
 [[running-deb-rpm]]
-=== Debian / RPM Package
+=== Debian Package / RPM
 
-When using a packaged version of apm-server, the installation creates an `apm-server` user.
+The Debian package and RPM installations of APM Server create an `apm-server` user.
 To start the APM Server in this case, run:
 
 [source,bash]
@@ -37,7 +37,7 @@ To start the APM Server in this case, run:
 sudo -u apm-server apm-server -e [FLAGS]
 ----------------------------------
 
-For Debian and RPM, you’ll find the APM Server configuration file at `/etc/apm-server/apm-server.yml`.
+By default, APM Server loads its configuration file from `/etc/apm-server/apm-server.yml`.
 See the <<_deb_and_rpm,deb & rpm default paths>> for a full directory layout.
 
 [[apm-server-configuration]]

--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -34,7 +34,7 @@ To start the APM Server in this case, run:
 
 [source,bash]
 ----------------------------------
-sudo -u apm-server apm-server -e [FLAGS]
+sudo -u apm-server apm-server [<argument...>]
 ----------------------------------
 
 By default, APM Server loads its configuration file from `/etc/apm-server/apm-server.yml`.


### PR DESCRIPTION
Fixes #2017.

Note: Decided to link to the directory layout instead of documenting where files live on this page.
<img width="636" alt="Screen Shot 2019-03-25 at 12 10 40 PM" src="https://user-images.githubusercontent.com/5618806/54947286-2ff53b00-4ef7-11e9-82f3-127fb94a10b6.png">
