### PR TITLE
[docs] 6.7 release-state

### DIFF
--- a/changelogs/6.7.asciidoc
+++ b/changelogs/6.7.asciidoc
@@ -11,7 +11,7 @@ https://github.com/elastic/apm-server/compare/6.6\...6.7[View commits]
 https://github.com/elastic/apm-server/compare/v6.6.0\...v6.7.0[View commits]
 
 [float]
-=== Added
+==== Added
 
 - Allow numbers and boolean values for `transaction.tags`, `span.tags`, `metricset.tags` {pull}1712[1712].
 - Retrieve `span.subtype` and `span.action` from `span.type` if not given {pull}1843[1843].

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -2,7 +2,7 @@
 :doc-branch: 6.7
 :branch: {doc-branch}
 :go-version: 1.10.8
-:release-state: unreleased
+:release-state: released
 :python: 2.7.9
 :docker: 1.12
 :docker-compose: 1.11


### PR DESCRIPTION
In preparation for the `6.7` release,this PR updates the release state to "released".  I'll merge this when the time is right. 

@graphaelli / @jalvz  - can you verify the `6.7` release notes below look good to go:

https://github.com/elastic/apm-server/blob/56b4ebe0088c9a15ea5eb5f4d491da19f08c1bc6/changelogs/6.7.asciidoc#L6-L22