### PR TITLE
improve debian package upgrade

### DIFF
--- a/packaging/files/linux/deb-post-install.sh.tmpl
+++ b/packaging/files/linux/deb-post-install.sh.tmpl
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 
-#   On Debian,
-#       $1=configure : is set to 'configure' and if $2 is set, it is an upgrade
-
-if [ -z "$2" ]; then
-  chown -R apm-server:apm-server /var/lib/apm-server /var/log/apm-server /etc/apm-server/apm-server.yml
-fi
+chown -R apm-server:apm-server /var/lib/apm-server /var/log/apm-server /etc/apm-server/apm-server.yml
 
 systemctl daemon-reload 2> /dev/null
 exit 0


### PR DESCRIPTION
With the `apm-server` user change from 6.x to 7.0 in #1833, the default debian install of apm-server can't be restarted without user intervention after upgrading.  By always making perm changes on debian package install, this manual step is removed bringing it in sync with what happens with RPM-installs and with user expectations, based on 7.0 beta feedback.

related to #2022