### PR TITLE
[docs][7.x] Backport docs

### DIFF
--- a/changelogs/6.7.asciidoc
+++ b/changelogs/6.7.asciidoc
@@ -19,4 +19,4 @@ https://github.com/elastic/apm-server/compare/v6.6.0\...v6.7.0[View commits]
 [float]
 ==== Removed
 - Remove support for using dots in tags for experimental metricset endpoint {pull}1712[1712].
-- Remove formatting of `duration.us` to milliseconds in index pattern pull{1717}[1717].
+- Remove formatting of `duration.us` to milliseconds in index pattern {pull}1717[1717].

--- a/changelogs/7.0.asciidoc
+++ b/changelogs/7.0.asciidoc
@@ -1,18 +1,18 @@
 [[release-notes-7.0]]
 == APM Server version 7.0
 
-// * <<release-notes-7.7.0>>
-// * <<release-notes-7.7.0-rc2>>
-// * <<release-notes-7.7.0-rc1>>
+// * <<release-notes-7.0.0>>
+// * <<release-notes-7.0.0-rc2>>
+// * <<release-notes-7.0.0-rc1>>
 * <<release-notes-7.0.0-beta1>>
 * <<release-notes-7.0.0-alpha2>>
 * <<release-notes-7.0.0-alpha1>>
 
 ////
-[[release-notes-7.7.0]]
+[[release-notes-7.0.0]]
 === APM Server version 7.0.0
 
-[[release-notes-7.7.0-rc2]]
+[[release-notes-7.0.0-rc2]]
 === APM Server version 7.0.0-rc2
 
 [[release-notes-7.0.0-rc1]]
@@ -25,7 +25,6 @@
 - Update Go version to 1.11.5 {pull}1840[1840] {pull}1950[1950].
 - Ensure enabling user-agent pipeline indexes data at the same key by default {pull}1966[1966].
 - Request and Response headers are stored in a canonicalized way {pull}1966[1966].
-
 ////
 
 [[release-notes-7.0.0-beta1]]
@@ -35,7 +34,7 @@ https://github.com/elastic/apm-server/compare/v6.7.0\...v7.0.0[View commits]
 
 [float]
 ==== Breaking Changes
-- Move fields in ES to be ECS compliant. {apm-overview-ref-v}/breaking-7.7.0-beta1.html#breaking-ecs[More information], {pull}1766[1766],{pull}1783[1783],{pull}1813[1813],{pull}1836[1836],{pull}1838[1838],{pull}1844[1844],{pull}1848[1848],{pull}1849[1849],{pull}1863[1863],{pull}1870[1870].
+- Move fields in ES to be ECS compliant. {apm-overview-ref-v}/breaking-7.0.0-beta1.html#breaking-ecs[More information], {pull}1766[1766],{pull}1783[1783],{pull}1813[1813],{pull}1836[1836],{pull}1838[1838],{pull}1844[1844],{pull}1848[1848],{pull}1849[1849],{pull}1863[1863],{pull}1870[1870].
 
 [float]
 ==== Added
@@ -56,7 +55,7 @@ https://github.com/elastic/apm-server/compare/v6.7.0\...v7.0.0[View commits]
 [float]
 ==== Removed
 
-- Remove support for deprecated Intake v1 endpoints. {apm-overview-ref-v}/breaking-7.7.0-beta1.html#breaking-remove-v1[More information], {pull}1731[1731].
+- Remove support for deprecated Intake v1 endpoints. {apm-overview-ref-v}/breaking-7.0.0-beta1.html#breaking-remove-v1[More information], {pull}1731[1731].
 - Remove `concurrent_requests` setting and use number of CPUs instead {pull}1749[1749].
 - Remove `frontend` setting {pull}1751[1751].
 - Remove `metrics.enabled` setting {pull}1759[1759].

--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -10,9 +10,9 @@ As such, any breaking change in libbeat is also considered to be a breaking chan
 ==== 7.0
 * Removed deprecated Intake v1 API endpoints.
 Upgrade agents to a version that supports APM Server >= 6.5.
-{apm-overview-ref-v}/breaking-7.7.0-beta1.html#breaking-remove-v1[More information].
+{apm-overview-ref-v}/breaking-7.0.0-beta1.html#breaking-remove-v1[More information].
 * Moved fields in Elasticsearch to be compliant with the Elastic Common Schema (ECS).
-{apm-overview-ref-v}/breaking-7.7.0-beta1.html#breaking-ecs[More information and changed fields].
+{apm-overview-ref-v}/breaking-7.0.0-beta1.html#breaking-ecs[More information and changed fields].
 * {beats-ref}/breaking-changes-7.0.html[Breaking changes in libbeat]
 
 [float]

--- a/docs/configuring.asciidoc
+++ b/docs/configuring.asciidoc
@@ -27,6 +27,8 @@ include::./copied-from-beats/shared-ssl-config.asciidoc[]
 
 include::./template-config.asciidoc[]
 
+include::./ilm-setup.asciidoc[]
+
 include::./copied-from-beats/loggingconfig.asciidoc[]
 
 include::./configuration-rum.asciidoc[]

--- a/docs/copied-from-beats/repositories.asciidoc
+++ b/docs/copied-from-beats/repositories.asciidoc
@@ -27,13 +27,13 @@ to sign all our packages. It is available from https://pgp.mit.edu.
 
 ifeval::["{release-state}"=="unreleased"]
 
-Version {stack-version} of Beats has not yet been released.
+Version {stack-version} of {repo} has not yet been released.
 
 endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 
-To add the Beats repository for APT:
+To add the {repo} repository for APT:
 
 . Download and install the Public Signing Key:
 +
@@ -50,19 +50,19 @@ sudo apt-get install apt-transport-https
 --------------------------------------------------
 
 ifeval::["{release-state}"=="prerelease"]
-. Save the repository definition to  +/etc/apt/sources.list.d/elastic-6.x-prerelease.list+:
+. Save the repository definition to  +/etc/apt/sources.list.d/elastic-{major-version}-prerelease.list+:
 +
 ["source","sh",subs="attributes"]
 --------------------------------------------------
-echo "deb https://artifacts.elastic.co/packages/6.x-prerelease/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x-prerelease.list
+echo "deb https://artifacts.elastic.co/packages/{major-version}-prerelease/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{major-version}-prerelease.list
 --------------------------------------------------
 endif::[]
 ifeval::["{release-state}"=="released"]
-. Save the repository definition to  +/etc/apt/sources.list.d/elastic-6.x.list+:
+. Save the repository definition to  +/etc/apt/sources.list.d/elastic-{major-version}.list+:
 +
 ["source","sh",subs="attributes"]
 --------------------------------------------------
-echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-6.x.list
+echo "deb https://artifacts.elastic.co/packages/{major-version}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{major-version}.list
 --------------------------------------------------
 endif::[]
 +
@@ -102,13 +102,13 @@ endif::[]
 
 ifeval::["{release-state}"=="unreleased"]
 
-Version {stack-version} of Beats has not yet been released.
+Version {stack-version} of {repo} has not yet been released.
 
 endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 
-To add the Beats repository for YUM:
+To add the {repo} repository for YUM:
 
 . Download and install the public signing key:
 +
@@ -123,9 +123,9 @@ your `/etc/yum.repos.d/` directory and add the following lines:
 ifeval::["{release-state}"=="prerelease"]
 ["source","sh",subs="attributes"]
 --------------------------------------------------
-[elastic-6.x-prerelease]
-name=Elastic repository for 6.x prerelease packages
-baseurl=https://artifacts.elastic.co/packages/6.x-prerelease/yum
+[elastic-{major-version}-prerelease]
+name=Elastic repository for {major-version} prerelease packages
+baseurl=https://artifacts.elastic.co/packages/{major-version}-prerelease/yum
 gpgcheck=1
 gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
 enabled=1
@@ -136,9 +136,9 @@ endif::[]
 ifeval::["{release-state}"=="released"]
 ["source","sh",subs="attributes"]
 --------------------------------------------------
-[elastic-6.x]
-name=Elastic repository for 6.x packages
-baseurl=https://artifacts.elastic.co/packages/6.x/yum
+[elastic-{major-version}]
+name=Elastic repository for {major-version} packages
+baseurl=https://artifacts.elastic.co/packages/{major-version}/yum
 gpgcheck=1
 gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
 enabled=1
@@ -155,7 +155,7 @@ running:
 sudo yum install {beatname_pkg}
 --------------------------------------------------
 
-. To configure the Beat to start automatically during boot, run:
+. To configure {beatname_uc} to start automatically during boot, run:
 +
 ["source","sh",subs="attributes"]
 --------------------------------------------------

--- a/docs/guide/apm-breaking-changes.asciidoc
+++ b/docs/guide/apm-breaking-changes.asciidoc
@@ -3,13 +3,13 @@
 
 This section discusses the changes that you need to be aware of when migrating your application from one version of APM to another.
 
-* <<breaking-7.7.0-beta1, APM version 7.7.0-beta1>>
+* <<breaking-7.0.0-beta1, APM version 7.0.0-beta1>>
 * <<breaking-6.4.0, APM version 6.4.0>>
 
 Also see <<apm-release-notes>>.
 
-[[breaking-7.7.0-beta1]]
-=== Breaking changes in 7.7.0-beta1
+[[breaking-7.0.0-beta1]]
+=== Breaking changes in 7.0.0-beta1
 
 APM Server::
 +

--- a/docs/guide/apm-release-notes.asciidoc
+++ b/docs/guide/apm-release-notes.asciidoc
@@ -7,12 +7,12 @@ For a full list of changes, see the
 {apm-server-ref-v}/release-notes.html[APM Server Release Notes] or the
 {kibana-ref}/release-notes.html[Kibana Release Notes].
 
-// * <<release-notes-7.7.0>>
-// * <<release-notes-7.7.0-rc2>>
-// * <<release-notes-7.7.0-rc1>>
-* <<release-notes-7.7.0-beta1>>
-* <<release-notes-7.7.0-alpha2>>
-* <<release-notes-7.7.0-alpha1>>
+// * <<release-notes-7.0.0>>
+// * <<release-notes-7.0.0-rc2>>
+// * <<release-notes-7.0.0-rc1>>
+* <<release-notes-7.0.0-beta1>>
+* <<release-notes-7.0.0-alpha2>>
+* <<release-notes-7.0.0-alpha1>>
 // * <<release-notes-6.7.0>>
 * <<release-notes-6.6.0>>
 * <<release-notes-6.5.0>>
@@ -20,23 +20,23 @@ For a full list of changes, see the
 * <<release-notes-6.4.0>>
 
 ////
-[[release-notes-7.7.0]]
+[[release-notes-7.0.0]]
 === APM version 7.0.0
 
-[[release-notes-7.7.0-rc2]]
+[[release-notes-7.0.0-rc2]]
 === APM version 7.0.0-rc2
 
-[[release-notes-7.7.0-rc1]]
+[[release-notes-7.0.0-rc1]]
 === APM version 7.0.0-rc1
 ////
 
-[[release-notes-7.7.0-beta1]]
+[[release-notes-7.0.0-beta1]]
 === APM version 7.0.0-beta1
 
 [float]
 ==== Breaking Changes
 
-See <<breaking-7.7.0-beta1>>
+See <<breaking-7.0.0-beta1>>
 
 [float]
 ==== New features
@@ -49,12 +49,12 @@ See <<breaking-7.7.0-beta1>>
 
 * Added support for frozen indices.
 
-[[release-notes-7.7.0-alpha2]]
+[[release-notes-7.0.0-alpha2]]
 === APM version 7.0.0-alpha2
 
 No significant changes.
 
-[[release-notes-7.7.0-alpha1]]
+[[release-notes-7.0.0-alpha1]]
 === APM version 7.0.0-alpha1
 
 No significant changes.

--- a/docs/ilm-setup.asciidoc
+++ b/docs/ilm-setup.asciidoc
@@ -1,0 +1,233 @@
+[role="xpack"]
+[[manual-ilm-setup]]
+== Manual index lifecycle management
+
+APM Server can take advantage of the index lifecycle management (ILM) capabilities of Elasticsearch.
+ILM enables you to automate how you want to manage your indices over time.
+You can base actions on factors such as shard size and performance requirements. 
+
+The guide below will help you set up a custom ILM policy for span indices.
+You can repeat the actions for any other indices.
+
+NOTE: If you're migrating from an existing setup,
+any indices present before ILM was configured will need to be managed manually.
+
+. *Set up the default index template.*
++
+If you haven't already, you'll need to set up the default index template.
+This is accomplished by running the <<setup-command,`setup --template`>> command.
++
+--
+[source,js]
+-----------------------
+./apm-server setup --template
+-----------------------
+// CONSOLE
+--
+
+. *Create a policy for spans.*
++
+Index lifecycle management will manage an index based on its defined policy.
+Policies only need to be created once, and will persist through version upgrades.
+Let's create a policy named `apm_span_policy`.
++
+This policy defines two rollover criteria: `"max_age": "1d"`, and `"max_size": "50gb"`.
+When one or more of these criteria are met, the policy rolls data over into a new index.
+`apm_span_policy` also tells the old indexes to delete after _10 days_.
+All of these values can be customized to your specific needs.
++
+--
+[source,js]
+-----------------------
+PUT _ilm/policy/apm_span_policy
+{
+  "policy": {
+    "phases": {
+      "hot": {
+        "actions": {
+          "rollover": {
+            "max_age": "1d", <1>
+            "max_size": "50gb" <2>
+          }
+        }
+      },
+      "delete": {
+        "min_age": "10d", <3>
+        "actions": {
+          "delete": {}
+        }
+      }
+    }
+  }
+}
+-----------------------
+// CONSOLE
+<1> Rollover after _1 day_
+<2> Rollover after _50gb_
+<3> Delete old indexes after _10 days_
+--
+
+. *Set up the ILM index template.*
++
+To use the index lifecycle management policy created in the previous step,
+you need to specify it in the index template used to create the indices.
+The following template associates `apm_span_policy` with indices created from the +apm-{stack-version}-span-ilm+ template.
++
+NOTE: Because we're utilizing the current stack-version ({stack-version}) in this step,
+this action will need to be performed as a part of each version upgrade.
++
+--
+["source","js",subs="attributes"]
+-----------------------
+PUT _template/apm-{stack-version}-span-ilm
+{
+  "order": 2,
+  "index_patterns": ["apm-{stack-version}-span-*"], <1>
+  "settings": {
+    "index.lifecycle.name": "apm_span_policy", <2>
+    "index.lifecycle.rollover_alias": "apm-{stack-version}-span"
+  }
+}
+-----------------------
+// CONSOLE
+<1> This template applies to all indices with the prefix +apm-{stack-version}-span-+
+<2> Associates `apm_span_policy` with all indices created with this template
+--
+
+. *Create the index and alias.*
++
+Now we can create the first index: +apm-{stack-version}-span-000001+.
++
+NOTE: This action will need to be performed as a part of each version upgrade.
++
+--
+["source","js",subs="attributes"]
+-----------------------
+PUT apm-{stack-version}-span-000001 <1>
+{
+  "aliases": {
+    "apm-{stack-version}-span":{
+      "is_write_index": true <2>
+    }
+  }
+}
+-----------------------
+// CONSOLE
+<1> The rollover action increments the suffix number for each subsequent index.
+<2> Designates this index as the write index for this alias.
+--
+
+. *Verify the ILM index template was applied.*
++
+--
+[source,js]
+-----------------------
+GET apm-*-span/_settings
+-----------------------
+// CONSOLE
+--
++
+The response should be similar to this:
++
+--
+["source","js",subs="attributes"]
+-----------------------
+{
+  "apm-{stack-version}-span-000001" : {
+    "settings" : {
+      "index" : {
+        "lifecycle" : {
+          "name" : "apm_span_policy",
+          "rollover_alias" : "apm-{stack-version}-span"
+        },
+        "number_of_shards" : "1",
+        "provided_name" : "apm-{stack-version}-span-000001",
+        "creation_date" : "1553024227938",
+        "number_of_replicas" : "1",
+        "uuid" : "6b5l-H7QTRK95FAodAN-wg",
+        "version" : {
+          "created" : "7000099"
+        }
+      }
+    }
+  }
+}
+-----------------------
+--
++
+You can also verify and adjust your configuration via Kibana's {kibana-ref}/index-lifecycle-policies.html[management]. 
+
+. *Repeat for other indices.*
++
+Repeat the previous steps for each index that will be using ILM.
++
+* Create a policy
+* Set up the ILM index template
+* Create the index and alias
+* Verify the ILM index template was applied
+
+. *Modify APM Server's configuration.*
++
+Finally, modify the default index configuration in <<apm-server-configuration,`apm-server.yml`>>.
+Trim off the date template from each index you are setting up ILM for,
+so that APM Server is always writing events to the same place.
+The name of your modified index configuration must match the `is_write_index` alias created previously
++
+It's important to note that `apm-server.yml` overwrites defaults rather than being merged.
+This means you'll need to configure all of your indices in the file, even if some are not using ILM.
++
+--
+["source","yml",subs="attributes"]
+-----------------------
+output.elasticsearch:
+  indices:
+    - index: "apm-{stack-version}-sourcemap"
+      when.contains:
+        processor.event: "sourcemap"
+    
+    - index: "apm-{stack-version}-error"
+      when.contains:
+        processor.event: "error"
+    
+    - index: "apm-{stack-version}-transaction"
+      when.contains:
+        processor.event: "transaction"
+
+    - index: "apm-{stack-version}-span"
+      when.contains:
+        processor.event: "span"
+    
+    - index: "apm-{stack-version}-metric"
+      when.contains:
+        processor.event: "metric"
+    
+    - index: "apm-{stack-version}-onboarding"
+      when.contains:
+        processor.event: "onboarding"
+-----------------------
+// CONSOLE
+--
+
+. *Start apm-server.*
++
+Your ILM configuration should now be up and running!
+
+.. Monitor ILM status as events flow:
++
+--
+[source,js]
+-----------------------
+GET apm-*/_ilm/explain?human
+-----------------------
+// CONSOLE
+--
+
+.. Monitor index status:
++
+--
+[source,js]
+-----------------------
+GET _cat/indices/apm*?v
+-----------------------
+// CONSOLE
+--

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -23,6 +23,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
 :securitydoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
 :dockerconfig: https://raw.githubusercontent.com/elastic/apm-server/{doc-branch}/apm-server.docker.yml
+:repo: apm-server
 :no_dashboards:
 :no_ilm:
 :no-processors:

--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -8,6 +8,7 @@ similar to how you run Elasticsearch.
 You _can_ run it on the same machines as Elasticsearch,
 but this is not recommended,
 as the processes will be competing for resources.
+
 To start APM Server, run:
 
 [source,bash]
@@ -23,6 +24,21 @@ You can change the defaults by supplying a different address on the command line
 ----------------------------------
 ./apm-server -e -E output.elasticsearch.hosts=ElasticsearchAddress:9200 -E apm-server.host=localhost:8200
 ----------------------------------
+
+[float]
+[[running-deb-rpm]]
+=== Debian Package / RPM
+
+The Debian package and RPM installations of APM Server create an `apm-server` user.
+To start the APM Server in this case, run:
+
+[source,bash]
+----------------------------------
+sudo -u apm-server apm-server [<argument...>]
+----------------------------------
+
+By default, APM Server loads its configuration file from `/etc/apm-server/apm-server.yml`.
+See the <<_deb_and_rpm,deb & rpm default paths>> for a full directory layout.
 
 [[apm-server-configuration]]
 === Configuration file

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,4 +1,5 @@
 :stack-version: 7.1.0
+:major-version: 7.x
 :doc-branch: 7.x
 :branch: {doc-branch}
 :go-version: 1.11.5


### PR DESCRIPTION
This PR backports the following commits to 7.x:
* [docs] Add manual ILM instructions (#2033)
* [docs] fix 7.7.0 to 7.0.0 (#2034)
* [docs] fix release note links (#2035)  …
* docs: udpate repositories.asciidoc (#2042)
* [docs] Add deb/rpm running instructions (#2043) 