### PR TITLE
[docs] Remove old attributes

### DIFF
--- a/docs/configuring-ingest.asciidoc
+++ b/docs/configuring-ingest.asciidoc
@@ -5,7 +5,7 @@
 == Parse data using ingest node pipelines
 
 With the Elasticsearch output you can configure the APM Server to use
-{elasticsearch}/ingest.html[ingest node] to pre-process documents before indexing them.
+{ref}/ingest.html[ingest node] to pre-process documents before indexing them.
 A pipeline defines processors that operate on your data.
 For example, a pipeline can define one processor to remove a field and another to rename a field.
 
@@ -79,4 +79,4 @@ output.elasticsearch:
 ------------------------------------------------------------------------------
 
 For more information about defining a pre-processing pipeline, see the
-{elasticsearch}/ingest.html[Ingest Node] documentation.
+{ref}/ingest.html[Ingest Node] documentation.

--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -841,7 +841,7 @@ Sets the path for log files. See the <<directory-layout>> section for details.
 *`--strict.perms`*::
 Sets strict permission checking on configuration files. The default is
 `-strict.perms=true`. See
-{libbeat}/config-file-permissions.html[Config file ownership and permissions] in
+{beats-ref}/config-file-permissions.html[Config file ownership and permissions] in
 the _Beats Platform Reference_ for more information.
 
 *`-v, --v`*::

--- a/docs/copied-from-beats/https.asciidoc
+++ b/docs/copied-from-beats/https.asciidoc
@@ -13,7 +13,7 @@
 To secure the communication between {beatname_uc} and Elasticsearch, you can use
 HTTPS and basic authentication. Basic authentication for Elasticsearch is
 available when you enable {security} (see
-{securitydoc}/elasticsearch-security.html[Securing the {stack}] and <<securing-beats>>).
+{stack-ov}/elasticsearch-security.html[Securing the {stack}] and <<securing-beats>>).
 If you aren't using {security}, you can use a web proxy instead.
 
 Here is a sample configuration:

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -555,7 +555,7 @@ use in Logstash for indexing and filtering:
 }
 ------------------------------------------------------------------------------
 <1> {beatname_uc} uses the `@metadata` field to send metadata to Logstash. See the
-{logstashdoc}/event-dependent-configuration.html#metadata[Logstash documentation]
+{logstash-ref}/event-dependent-configuration.html#metadata[Logstash documentation]
 for more about the `@metadata` field.
 <2> The default is {beat_default_index_prefix}. To change this value, set the
 <<logstash-index,`index`>> option in the {beatname_uc} config file.

--- a/docs/copied-from-beats/security/linux-seccomp.asciidoc
+++ b/docs/copied-from-beats/security/linux-seccomp.asciidoc
@@ -21,7 +21,7 @@ can be customized through configuration as well.
 A seccomp policy is architecture specific due to the fact that system calls vary
 by architecture. {beatname_uc} includes a whitelist seccomp policy for the
 amd64 and 386 architectures. You can view those policies
-https://github.com/elastic/beats/tree/{doc-branch}/libbeat/common/seccomp[here].
+https://github.com/elastic/beats/tree/{branch}/libbeat/common/seccomp[here].
 
 [float]
 [[seccomp-policy-config]]

--- a/docs/copied-from-beats/security/securing-beats.asciidoc
+++ b/docs/copied-from-beats/security/securing-beats.asciidoc
@@ -7,7 +7,7 @@
 ++++
 
 If you want {beatname_uc} to connect to a cluster that has
-{securitydoc}/elasticsearch-security.html[{security}] enabled, there are extra
+{stack-ov}/elasticsearch-security.html[{security}] enabled, there are extra
 configuration steps:
 
 . <<beats-basic-auth>>.

--- a/docs/copied-from-beats/shared-configuring.asciidoc
+++ b/docs/copied-from-beats/shared-configuring.asciidoc
@@ -9,5 +9,5 @@ that shows all non-deprecated options.
 endif::[]
 
 TIP: See the
-{libbeat}/config-file-format.html[Config File Format] section of the
+{beats-ref}/config-file-format.html[Config File Format] section of the
 _Beats Platform Reference_ for more about the structure of the config file.

--- a/docs/copied-from-beats/shared-ssl-logstash-config.asciidoc
+++ b/docs/copied-from-beats/shared-ssl-logstash-config.asciidoc
@@ -20,7 +20,7 @@ To use SSL mutual authentication:
 document. There are many online resources available that describe how to create certificates.
 +
 TIP: If you are using {security}, you can use the
-{elasticsearch}/certutil.html[elasticsearch-certutil tool] to generate certificates.
+{ref}/certutil.html[elasticsearch-certutil tool] to generate certificates.
 
 . Configure {beatname_uc} to use SSL. In the +{beatname_lc}.yml+ config file, specify the following settings under
 `ssl`:
@@ -51,7 +51,7 @@ For more information about these configuration options, see <<configuration-ssl>
 * `ssl_certificate` and `ssl_key`: Specify the certificate and key that Logstash uses to authenticate with the client.
 * `ssl_verify_mode`: Specifies whether the Logstash server verifies the client certificate against the CA. You
 need to specify either `peer` or `force_peer` to make the server ask for the certificate and validate it. If you
-specify `force_peer`, and {beatname_uc} doesn't provide a certificate, the Logstash connection will be closed. If you choose not to use {elasticsearch}/certutil.html[certutil], the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
+specify `force_peer`, and {beatname_uc} doesn't provide a certificate, the Logstash connection will be closed. If you choose not to use {ref}/certutil.html[certutil], the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
 +
 For example:
 +

--- a/docs/copied-from-beats/shared-template-load.asciidoc
+++ b/docs/copied-from-beats/shared-template-load.asciidoc
@@ -16,7 +16,7 @@ the output is not Elasticsearch, you must
 <<load-template-manually,load the template manually>>. 
 endif::only-elasticsearch[]
 
-In Elasticsearch, {elasticsearch}/indices-templates.html[index
+In Elasticsearch, {ref}/indices-templates.html[index
 templates] are used to define settings and mappings that determine how fields
 should be analyzed.
 

--- a/docs/copied-from-beats/step-test-config.asciidoc
+++ b/docs/copied-from-beats/step-test-config.asciidoc
@@ -17,7 +17,7 @@ your config files are in the path expected by {beatname_uc} (see
 <<directory-layout>>), or use the `-c` flag to specify the path to the config
 file. Depending on your OS, you might run into file ownership issues when you
 run this test. See
-{libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
+{beats-ref}/config-file-permissions.html[Config File Ownership and Permissions]
 in the _Beats Platform Reference_ for more information.
 
 endif::[]

--- a/docs/copied-from-beats/template-config.asciidoc
+++ b/docs/copied-from-beats/template-config.asciidoc
@@ -3,7 +3,7 @@
 == Load the Elasticsearch index template
 
 The `setup.template` section of the +{beatname_lc}.yml+ config file specifies
-the {elasticsearch}/indices-templates.html[index template] to use for setting
+the {ref}/indices-templates.html[index template] to use for setting
 mappings in Elasticsearch. If template loading is enabled (the default),
 {beatname_uc} loads the index template automatically after successfully
 connecting to Elasticsearch.
@@ -55,7 +55,7 @@ is false.
 
 *`setup.template.settings`*:: A dictionary of settings to place into the `settings.index` dictionary of the
 Elasticsearch template. For more details about the available Elasticsearch mapping options, please
-see the Elasticsearch {elasticsearch}/mapping.html[mapping reference].
+see the Elasticsearch {ref}/mapping.html[mapping reference].
 +
 Example:
 +
@@ -75,7 +75,7 @@ indices to another cluster, you will need to add additional template settings to
 underlying indices.
 
 *`setup.template.settings._source`*:: A dictionary of settings for the `_source` field. For the available settings,
-please see the Elasticsearch {elasticsearch}/mapping-source-field.html[reference].
+please see the Elasticsearch {ref}/mapping-source-field.html[reference].
 +
 Example:
 +

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -16,11 +16,10 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :dockerconfig: https://raw.githubusercontent.com/elastic/apm-server/{doc-branch}/apm-server.docker.yml
 :discuss_forum: apm
 :github_repo_name: apm-server
-:sample_date_0: 2018.12.10
-:sample_date_1: 2018.12.11
-:sample_date_2: 2018.12.12
+:sample_date_0: 2019.03.10
+:sample_date_1: 2019.03.11
+:sample_date_2: 2019.03.12
 :repo: apm-server
-:no_dashboards:
 :no_ilm:
 :no-processors:
 :no-indices-rules:

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -13,16 +13,12 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :beat_version_key: observer.version
 :dockerimage: docker.elastic.co/apm/{beatname_lc}:{version}
 :dockergithub: https://github.com/elastic/apm-server-docker/tree/{doc-branch}
+:dockerconfig: https://raw.githubusercontent.com/elastic/apm-server/{doc-branch}/apm-server.docker.yml
 :discuss_forum: apm
 :github_repo_name: apm-server
 :sample_date_0: 2018.12.10
 :sample_date_1: 2018.12.11
 :sample_date_2: 2018.12.12
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
-:logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
-:dockerconfig: https://raw.githubusercontent.com/elastic/apm-server/{doc-branch}/apm-server.docker.yml
 :repo: apm-server
 :no_dashboards:
 :no_ilm:

--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -48,7 +48,7 @@ For rpm and deb,
 you’ll find the configuration file at +/etc/{beatname_lc}/{beatname_lc}.yml+.
 For mac and win, look in the archive that you extracted.
 
-See {libbeat}/config-file-format.html[Config File Format] in _Beats Platform Reference_ for more about the structure of the config file.
+See {beats-ref}/config-file-format.html[Config File Format] in _Beats Platform Reference_ for more about the structure of the config file.
 
 [source,yaml]
 ----------------------------------


### PR DESCRIPTION
Removes old documentation attributes and replaces with the [shared](https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc) attributes.

See Beats PR: https://github.com/elastic/beats/pull/10956. Closes https://github.com/elastic/apm-server/issues/1964