### PR TITLE
[docs][6.7] Backport documentation

### DIFF
--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -1,0 +1,33 @@
+[[breaking-changes]]
+=== Breaking Changes
+APM Server is built on top of {beats-ref}/index.html[libbeat].
+As such, any breaking change in libbeat is also considered to be a breaking change in APM Server.
+
+[float]
+==== HEAD
+
+[float]
+==== 6.7
+* There are no breaking changes in APM Server.
+
+[float]
+==== 6.6
+* There are no breaking changes in APM Server.
+
+[float]
+==== 6.5
+* There are no breaking changes in APM Server.
+* Advanced users may find the <<upgrading-to-65,upgrading to 6.5 guide>> useful.
+
+[float]
+==== 6.4
+* Indexing the `onboarding` document in it's own index by default.
+
+[float]
+==== 6.3
+* Indexing events in separate indices by default.
+* {beats-ref}/breaking-changes-6.3.html[Breaking changes in libbeat]
+
+[float]
+==== 6.2
+* APM Server GA

--- a/docs/configuring-ingest.asciidoc
+++ b/docs/configuring-ingest.asciidoc
@@ -4,43 +4,42 @@
 [[configuring-ingest-node]]
 == Parse data using ingest node pipelines
 
-With the Elasticsearch output you can configure the APM Server to use
-{elasticsearch}/ingest.html[ingest node] to pre-process documents before indexing them.
-A pipeline defines processors that operate on your data.
-For example, a pipeline can define one processor to remove a field and another to rename a field.
+You can configure APM Server to use an {ref}/ingest.html[ingest node]
+to pre-process documents before indexing them in Elasticsearch.
 
-Using pipelines involves two steps.
-First you need to <<register-pipelines,register a pipeline>> in Elasticsearch.
-Then the pipeline needs to be <<apply-pipelines, applied during data ingestion>>.
+A pipeline is a definition of a series of processors that operate on your data.
+For example, a pipeline can define one processor to remove a field, and another to rename a field.
+Using pipelines involves two steps:
+
+. First, you need to <<register-pipelines,register a pipeline>> in Elasticsearch.
+. Then, the pipeline needs to be <<apply-pipelines, applied during data ingestion>>.
 
 [[register-pipelines]]
 [float]
-=== Registering Pipelines in Elasticsearch
-For registering a pipeline in Elasticsearch you can either manually upload
-a pipeline definition or you can configure APM Server to register pipelines on startup.
+=== Register pipelines in Elasticsearch
+To register a pipeline in Elasticsearch, you can either configure APM Server to
+register pipelines on startup, or you can manually upload a pipeline definition.
 
 [[register-pipelines-apm-server]]
 [float]
 ==== Register pipelines on APM Server startup
-Automatic pipeline registration requires `output.elasticsearch` to be enabled and configured,
-as well as having the required Elasticsearch plugins installed.
+Automatic pipeline registration requires `output.elasticsearch` to be enabled and configured.
 
-APM Server default pipelines require you to have the Ingest user agent plugin installed.
-If pipelines are enabled but required plugins are missing, 
-the APM Server will not be able to properly connect to the Elasticsearch output.
-Find the default pipeline configuration at `ingest/pipeline/definition.json` of your APM Server
-installation's home directory.
-In case you want to add, change or remove pipelines in Elasticsearch,
-you can simply change the definitions in this file
-and restart your APM Server or run `apm-server setup --pipelines`
+Navigate to APM Server's home directory and find the default pipeline configuration at
+`ingest/pipeline/definition.json`.
+To add, change, or remove pipelines in Elasticsearch,
+change the definitions in this file and restart your APM Server or run `apm-server setup --pipelines`.
 
-By default pipeline registration is disabled.
+By default, pipeline registration is disabled.
 See how to <<register.ingest.pipeline.enabled,configure pipeline registration>>.
 
 [[register-pipelines-manual]]
 [float]
 ==== Manually upload pipeline definitions
-For example, consider the following pipeline in a file named `pipeline.json`:
+
+You can manually upload pipeline definitions by describing them in a file.
+Consider the following sample pipeline in a file named `pipeline.json`.
+This pipeline definition converts the value of `beat.name` to lowercase before indexing each document.
 
 [source,json]
 ------------------------------------------------------------------------------
@@ -56,20 +55,19 @@ For example, consider the following pipeline in a file named `pipeline.json`:
 }
 ------------------------------------------------------------------------------
 
-To register the pipeline run:
+To register this pipeline, run:
 
 [source,shell]
 ------------------------------------------------------------------------------
 curl -H 'Content-Type: application/json' -XPUT 'http://localhost:9200/_ingest/pipeline/test-pipeline' -d @pipeline.json
 ------------------------------------------------------------------------------
 
-This pipeline definition converts the value of `beat.name` to lowercase before indexing each document.
 
 [[apply-pipelines]]
 [float]
 === Apply pipelines during data ingestion
 To specify which pipelines to apply during data ingestion,
-add the pipeline IDs in the `pipelines` option under `elasticsearch` in the +apm-server.yml+ file:
+add the pipeline IDs to the `pipelines` option under `elasticsearch` in the +apm-server.yml+ file:
 
 [source,yaml]
 ------------------------------------------------------------------------------
@@ -78,5 +76,5 @@ output.elasticsearch:
   - pipeline: "test-pipeline"
 ------------------------------------------------------------------------------
 
-For more information about defining a pre-processing pipeline, see the
-{elasticsearch}/ingest.html[Ingest Node] documentation.
+TIP: More information on defining a pre-processing pipeline is available in the
+{ref}/ingest.html[ingest node] documentation.

--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -709,7 +709,7 @@ Sets the path for log files. See the <<directory-layout>> section for details.
 *`--strict.perms`*::
 Sets strict permission checking on configuration files. The default is
 `-strict.perms=true`. See
-{libbeat}/config-file-permissions.html[Config file ownership and permissions] in
+{beats-ref}/config-file-permissions.html[Config file ownership and permissions] in
 the _Beats Platform Reference_ for more information.
 
 *`-v, --v`*::

--- a/docs/copied-from-beats/https.asciidoc
+++ b/docs/copied-from-beats/https.asciidoc
@@ -13,7 +13,7 @@
 To secure the communication between {beatname_uc} and Elasticsearch, you can use
 HTTPS and basic authentication. Basic authentication for Elasticsearch is
 available when you enable {security} (see
-{securitydoc}/elasticsearch-security.html[Securing the {stack}] and <<securing-beats>>).
+{stack-ov}/elasticsearch-security.html[Securing the {stack}] and <<securing-beats>>).
 If you aren't using {security}, you can use a web proxy instead.
 
 Here is a sample configuration:

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -405,7 +405,7 @@ use in Logstash for indexing and filtering:
 }
 ------------------------------------------------------------------------------
 <1> {beatname_uc} uses the `@metadata` field to send metadata to Logstash. See the
-{logstashdoc}/event-dependent-configuration.html#metadata[Logstash documentation]
+{logstash-ref}/event-dependent-configuration.html#metadata[Logstash documentation]
 for more about the `@metadata` field.
 <2> The default is {beat_default_index_prefix}. To change this value, set the
 <<logstash-index,`index`>> option in the {beatname_uc} config file.

--- a/docs/copied-from-beats/security/linux-seccomp.asciidoc
+++ b/docs/copied-from-beats/security/linux-seccomp.asciidoc
@@ -21,7 +21,7 @@ can be customized through configuration as well.
 A seccomp policy is architecture specific due to the fact that system calls vary
 by architecture. {beatname_uc} includes a whitelist seccomp policy for the
 amd64 and 386 architectures. You can view those policies
-https://github.com/elastic/beats/tree/{doc-branch}/libbeat/common/seccomp[here].
+https://github.com/elastic/beats/tree/{branch}/libbeat/common/seccomp[here].
 
 [float]
 [[seccomp-policy-config]]

--- a/docs/copied-from-beats/security/securing-beats.asciidoc
+++ b/docs/copied-from-beats/security/securing-beats.asciidoc
@@ -7,7 +7,7 @@
 ++++
 
 If you want {beatname_uc} to connect to a cluster that has
-{securitydoc}/elasticsearch-security.html[{security}] enabled, there are extra
+{stack-ov}/elasticsearch-security.html[{security}] enabled, there are extra
 configuration steps:
 
 . <<beats-basic-auth>>.

--- a/docs/copied-from-beats/shared-configuring.asciidoc
+++ b/docs/copied-from-beats/shared-configuring.asciidoc
@@ -9,5 +9,5 @@ that shows all non-deprecated options.
 endif::[]
 
 TIP: See the
-{libbeat}/config-file-format.html[Config File Format] section of the
+{beats-ref}/config-file-format.html[Config File Format] section of the
 _Beats Platform Reference_ for more about the structure of the config file.

--- a/docs/copied-from-beats/shared-ssl-logstash-config.asciidoc
+++ b/docs/copied-from-beats/shared-ssl-logstash-config.asciidoc
@@ -20,7 +20,7 @@ To use SSL mutual authentication:
 document. There are many online resources available that describe how to create certificates.
 +
 TIP: If you are using {security}, you can use the
-{elasticsearch}/certutil.html[elasticsearch-certutil tool] to generate certificates.
+{ref}/certutil.html[elasticsearch-certutil tool] to generate certificates.
 
 . Configure {beatname_uc} to use SSL. In the +{beatname_lc}.yml+ config file, specify the following settings under
 `ssl`:
@@ -51,7 +51,7 @@ For more information about these configuration options, see <<configuration-ssl>
 * `ssl_certificate` and `ssl_key`: Specify the certificate and key that Logstash uses to authenticate with the client.
 * `ssl_verify_mode`: Specifies whether the Logstash server verifies the client certificate against the CA. You
 need to specify either `peer` or `force_peer` to make the server ask for the certificate and validate it. If you
-specify `force_peer`, and {beatname_uc} doesn't provide a certificate, the Logstash connection will be closed. If you choose not to use {elasticsearch}/certutil.html[certutil], the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
+specify `force_peer`, and {beatname_uc} doesn't provide a certificate, the Logstash connection will be closed. If you choose not to use {ref}/certutil.html[certutil], the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
 +
 For example:
 +

--- a/docs/copied-from-beats/shared-template-load.asciidoc
+++ b/docs/copied-from-beats/shared-template-load.asciidoc
@@ -16,7 +16,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 
-In Elasticsearch, {elasticsearch}/indices-templates.html[index
+In Elasticsearch, {ref}/indices-templates.html[index
 templates] are used to define settings and mappings that determine how fields
 should be analyzed.
 

--- a/docs/copied-from-beats/template-config.asciidoc
+++ b/docs/copied-from-beats/template-config.asciidoc
@@ -3,7 +3,7 @@
 == Load the Elasticsearch index template
 
 The `setup.template` section of the +{beatname_lc}.yml+ config file specifies
-the {elasticsearch}/indices-templates.html[index template] to use for setting
+the {ref}/indices-templates.html[index template] to use for setting
 mappings in Elasticsearch. If template loading is enabled (the default),
 {beatname_uc} loads the index template automatically after successfully
 connecting to Elasticsearch.
@@ -55,7 +55,7 @@ is false.
 
 *`setup.template.settings`*:: A dictionary of settings to place into the `settings.index` dictionary of the
 Elasticsearch template. For more details about the available Elasticsearch mapping options, please
-see the Elasticsearch {elasticsearch}/mapping.html[mapping reference].
+see the Elasticsearch {ref}/mapping.html[mapping reference].
 +
 Example:
 +
@@ -70,7 +70,7 @@ setup.template.settings:
 ----------------------------------------------------------------------
 
 *`setup.template.settings._source`*:: A dictionary of settings for the `_source` field. For the available settings,
-please see the Elasticsearch {elasticsearch}/mapping-source-field.html[reference].
+please see the Elasticsearch {ref}/mapping-source-field.html[reference].
 +
 Example:
 +

--- a/docs/guide/apm-breaking-changes.asciidoc
+++ b/docs/guide/apm-breaking-changes.asciidoc
@@ -1,0 +1,50 @@
+[[apm-breaking-changes]]
+== Breaking changes
+
+This section discusses the changes that you need to be aware of when migrating your application from one version of APM to another.
+
+* <<breaking-6.4.0, APM version 6.4.0>>
+
+Also see <<apm-release-notes>>.
+
+[[breaking-6.4.0]]
+=== Breaking changes in 6.4.0
+
+We previously split APM data into separate indices (transaction, span, error, etc.).
+In 6.4 APM Kibana UI starts to leverage those separate indices for queries.
+
+In case you only update Kibana but run an older version of APM Server you will not be able to see any APM data by default.
+To fix this, use the {kibana-ref}/apm-settings-kb.html[Kibana APM settings] to specify the location of the APM index:
+["source","sh"]
+------------------------------------------------------------
+apm_oss.errorIndices: apm-*
+apm_oss.spanIndices: apm-*
+apm_oss.transactionIndices: apm-*
+apm_oss.onboardingIndices: apm-*
+------------------------------------------------------------
+
+In case you are upgrading APM Server from an older version, you might need to refresh your APM index pattern for certain APM UI features to work.
+Also ensure to add the new config options in `apm-server.yml` in case you keep your existing configuration file:
+["source","sh"]
+------------------------------------------------------------
+output.elasticsearch:
+  indices:
+    - index: "apm-%{[observer.version]}-sourcemap"
+      when.contains:
+        processor.event: "sourcemap"
+    - index: "apm-%{[observer.version]}-error-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "error"
+    - index: "apm-%{[observer.version]}-transaction-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "transaction"
+    - index: "apm-%{[observer.version]}-span-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "span"
+    - index: "apm-%{[observer.version]}-metric-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "metric"
+    - index: "apm-%{[observer.version]}-onboarding-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "onboarding"
+------------------------------------------------------------

--- a/docs/guide/apm-release-notes.asciidoc
+++ b/docs/guide/apm-release-notes.asciidoc
@@ -1,14 +1,41 @@
-[[kibana]]
 [[apm-release-notes]]
-== Release notes
+== Release highlights
+
+This section summarizes the most important APM changes in each release.
+
+For a full list of changes, see the
+{apm-server-ref-v}/release-notes.html[APM Server Release Notes] or the
+{kibana-ref}/release-notes.html[Kibana Release Notes].
+
+* <<release-notes-6.7.0>>
+* <<release-notes-6.6.0>>
+* <<release-notes-6.5.0>>
+* <<release-notes-6.4.1>>
+* <<release-notes-6.4.0>>
+
+[[release-notes-6.7.0]]
+=== APM version 6.7.0
+
+No significant changes.
+
+[[release-notes-6.6.0]]
+=== APM version 6.6.0
 
 [float]
-==== APM version 6.5.0
+==== New features
+
+* Elastic APM agents now automatically record certain <<metrics,infrastructure and application metrics>>.
+* Elastic APM agents support the W3C Trace Context.
+All agents now have <<opentracing,OpenTracing compatible bridges>>.
+* <<distributed-tracing,Distributed tracing>> is generally available.
+
+[[release-notes-6.5.0]]
+=== APM version 6.5.0
 
 [float]
-===== New features
+==== New features
 
-Elastic APM now enables {apm-get-started-ref}/distributed-tracing.html[distributed tracing].
+Elastic APM now enables {apm-overview-ref-v}/distributed-tracing.html[distributed tracing].
 
 *APM Server*
 
@@ -29,8 +56,8 @@ Elastic APM now enables {apm-get-started-ref}/distributed-tracing.html[distribut
 * Python switched to contextvars instead of thread locals for context tracking in Python 3.7
 * Node added support for Restify Framework, dropped support for Node.js 4 and 9
 
-[float]
-==== APM version 6.4.1
+[[release-notes-6.4.1]]
+=== APM version 6.4.1
 
 [float]
 ===== Bug Fixes
@@ -40,50 +67,13 @@ To fix this, the APM Kibana UI now falls back to use `apm-*` as default indices 
 Users can still leverage separate indices for queries by overriding the default values described in {kibana-ref}/apm-settings-kb.html[Kibana APM settings].
 
 
-[float]
-==== APM version 6.4.0
+[[release-notes-6.4.0]]
+=== APM version 6.4.0
 
 [float]
 ===== Breaking changes
 
-We previously split APM data into separate indices (transaction, span, error, etc.).
-In 6.4 APM Kibana UI starts to leverage those separate indices for queries.
-
-In case you only update Kibana but run an older version of APM Server you will not be able to see any APM data by default.
-To fix this, use the {kibana-ref}/apm-settings-kb.html[Kibana APM settings] to specify the location of the APM index:
-["source","sh"]
-------------------------------------------------------------
-apm_oss.errorIndices: apm-*
-apm_oss.spanIndices: apm-*
-apm_oss.transactionIndices: apm-*
-apm_oss.onboardingIndices: apm-*
-------------------------------------------------------------
-
-In case you are upgrading APM Server from an older version, you might need to refresh your APM index pattern for certain APM UI features to work.
-Also ensure to add the new config options in `apm-server.yml` in case you keep your existing configuration file:
-["source","sh"]
-------------------------------------------------------------
-output.elasticsearch:
-  indices:
-    - index: "apm-%{[beat.version]}-sourcemap"
-      when.contains:
-        processor.event: "sourcemap"
-    - index: "apm-%{[beat.version]}-error-%{+yyyy.MM.dd}"
-      when.contains:
-        processor.event: "error"
-    - index: "apm-%{[beat.version]}-transaction-%{+yyyy.MM.dd}"
-      when.contains:
-        processor.event: "transaction"
-    - index: "apm-%{[beat.version]}-span-%{+yyyy.MM.dd}"
-      when.contains:
-        processor.event: "span"
-    - index: "apm-%{[beat.version]}-metric-%{+yyyy.MM.dd}"
-      when.contains:
-        processor.event: "metric"
-    - index: "apm-%{[beat.version]}-onboarding-%{+yyyy.MM.dd}"
-      when.contains:
-        processor.event: "onboarding"
-------------------------------------------------------------
+See <<breaking-6.4.0>>.
 
 [float]
 ===== New features

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -19,6 +19,10 @@ include::./apm-data-model.asciidoc[]
 
 include::./distributed-tracing.asciidoc[]
 
+include::./opentracing.asciidoc[]
+
 include::./agent-server-compatibility.asciidoc[]
+
+include::./apm-breaking-changes.asciidoc[]
 
 include::./apm-release-notes.asciidoc[]

--- a/docs/guide/opentracing.asciidoc
+++ b/docs/guide/opentracing.asciidoc
@@ -1,0 +1,19 @@
+[[opentracing]]
+== OpenTracing bridge
+
+All Elastic APM agents have https://opentracing.io/[OpenTracing] compatible bridges.
+
+The OpenTracing bridge allows you to create Elastic APM <<transactions,transactions>> and <<transaction-spans,spans>> using the OpenTracing API.
+This means you can reuse your existing OpenTracing instrumentation to quickly and easily begin using Elastic APM.
+
+[float]
+=== Agent specific details
+
+Not all features of the OpenTracing API are supported. In addition, there are some Elastic APM specific tags you should be aware of. Please see the relevant Agent documentation for more detailed information:
+
+* {apm-go-ref}/opentracing.html[Go agent]
+* {apm-java-ref}/opentracing-bridge.html[Java agent]
+* {apm-node-ref}/opentracing.html[Node.js agent]
+* {apm-py-ref}/opentracing-bridge.html[Python agent]
+* {apm-ruby-ref}/opentracing.html[Ruby agent]
+* {apm-rum-ref}/opentracing.html[JavaScript Real User Monitoring (RUM) agent]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -11,15 +11,12 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :beat_default_index_prefix: apm
 :dockerimage: docker.elastic.co/apm/{beatname_lc}:{version}
 :dockergithub: https://github.com/elastic/apm-server-docker/tree/{doc-branch}
+:dockerconfig: https://raw.githubusercontent.com/elastic/apm-server/{doc-branch}/apm-server.docker.yml
 :discuss_forum: apm
 :github_repo_name: apm-server
 :sample_date_0: 2018.05.10
 :sample_date_1: 2018.05.11
 :sample_date_2: 2018.05.12
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
-:logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
 :deprecate_dashboard_loading: 6.4.0
 :repo: apm-server
 

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -8,8 +8,7 @@
 [partintro]
 
 --
-This following section summarizes the changes in each release.
-
+This following sections summarizes the changes in each release.
 
 * <<release-notes-6.7>>
 * <<release-notes-6.6>>

--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -48,7 +48,7 @@ For rpm and deb,
 you’ll find the configuration file at +/etc/{beatname_lc}/{beatname_lc}.yml+.
 For mac and win, look in the archive that you extracted.
 
-See {libbeat}/config-file-format.html[Config File Format] in _Beats Platform Reference_ for more about the structure of the config file.
+See {beats-ref}/config-file-format.html[Config File Format] in _Beats Platform Reference_ for more about the structure of the config file.
 
 [source,yaml]
 ----------------------------------

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -6,50 +6,26 @@ However, check out the <<breaking-changes, breaking changes>> section for except
 
 Before upgrading:
 
-* Review the <<release-notes,release notes>> and the <<breaking-changes, breaking changes>> 
-for changes between your current version and the one you are upgrading to.
-* Check the {stack-ref}/index.html[Elastic Stack Installation and Upgrade Guide] for guidance on how to upgrade your 
- Elastic Stack. 
- For a more tailored upgrade guide, try out the {upgrade_guide}[Interactive Upgrade Guide].
+* Review the APM Server <<release-notes,release notes>> and <<breaking-changes, breaking changes>> 
+for changes between your current APM Server version and the one you are upgrading to.
+* Visit the general APM {apm-overview-ref-v}/apm-release-notes.html[release highlights] and {apm-overview-ref-v}/apm-breaking-changes.html[breaking changes] for highlights and important changes.
+* Check the {stack-ref}/index.html[Elastic Stack Installation and Upgrade Guide] for guidance on how to upgrade your Elastic Stack. 
 
-When ready to actually upgrade your APM Server between minor versions, 
+When you're ready to upgrade your APM Server between minor versions, 
 simply install the new release.
 
-Ensure the configuration file `apm-server.yml` is configured properly again according to your needs.
-Be aware of newly added configuration options and their default settings.
-Also check out the documentation for <<configuring-howto-apm-server, configuration>>
-to read more about available configuration options.
+You'll want to take a look at the `apm-server.yml` configuration file after installing a new release.
+There may be newly added configuration options, and you'll want to be aware of their default settings.
+See <<configuring-howto-apm-server,Configuring APM Server>> for more information on available configuration options.
 
-If you set up index patterns and dashboards manually by running `./apm-server setup`, rerun
-the command to update the index pattern and the dashboards.
+If you set up index patterns and dashboards manually by running `./apm-server setup`,
+rerun the command to update the index pattern and the dashboards.
 
 When everything is properly configured and updated, start the APM server.
 
 When you start the APM server after upgrading, it creates new indices that use the current version,
 and applies the correct template automatically.
 
-[[breaking-changes]]
-=== Breaking Changes
-APM Server is built on top of {beats-ref}/index.html[libbeat].
-As such, any breaking change in libbeat is also considered to be a breaking change in APM Server.
-
-[float]
-==== HEAD 
-* There are no breaking changes in APM Server.
-* Advanced users may find the <<upgrading-to-65,upgrading to 6.5 guide>> useful.
-* https://www.elastic.co/guide/en/beats/libbeat/master/breaking-changes.html[Breaking changes in libbeat]
-
-[float]
-==== 6.4
-* Indexing the `onboarding` document in it's own index by default.
-
-[float]
-==== 6.3
-* Indexing events in separate indices by default.
-* https://www.elastic.co/guide/en/beats/libbeat/current/breaking-changes-6.3.html[Breaking changes in libbeat]
-
-[float]
-==== 6.2
-* APM Server GA
+include::./breaking-changes.asciidoc[]
 
 include::./upgrading-to-65.asciidoc[]


### PR DESCRIPTION
This PR backports the following commits to 6.7:

* [docs] 7.0 Breaking changes, Release highlights, Migration assistant, ECS changes #1940
* [docs] Remove old attributes (#2053)
* [docs] Update ingest node documentation (#2061)

Edit: This PR backports *only* the release highlights portion of elastic/apm-server#1940 