### PR TITLE
[docs][7.x] Backport documentation

### DIFF
--- a/changelogs/7.0.asciidoc
+++ b/changelogs/7.0.asciidoc
@@ -4,7 +4,7 @@
 https://github.com/elastic/apm-server/compare/6.7...7.0[View commits]
 
 // * <<release-notes-7.0.0>>
-// * <<release-notes-7.0.0-rc2>>
+* <<release-notes-7.0.0-rc2>>
 * <<release-notes-7.0.0-rc1>>
 * <<release-notes-7.0.0-beta1>>
 * <<release-notes-7.0.0-alpha2>>
@@ -13,10 +13,14 @@ https://github.com/elastic/apm-server/compare/6.7...7.0[View commits]
 ////
 [[release-notes-7.0.0]]
 === APM Server version 7.0.0
+////
 
 [[release-notes-7.0.0-rc2]]
 === APM Server version 7.0.0-rc2
-////
+
+https://github.com/elastic/apm-server/compare/v7.0.0-rc1...v7.0.0-rc2[View commits]
+
+No significant changes.
 
 [[release-notes-7.0.0-rc1]]
 === APM Server version 7.0.0-rc1

--- a/changelogs/7.0.asciidoc
+++ b/changelogs/7.0.asciidoc
@@ -1,9 +1,11 @@
 [[release-notes-7.0]]
 == APM Server version 7.0
 
+https://github.com/elastic/apm-server/compare/6.7...7.0[View commits]
+
 // * <<release-notes-7.0.0>>
 // * <<release-notes-7.0.0-rc2>>
-// * <<release-notes-7.0.0-rc1>>
+* <<release-notes-7.0.0-rc1>>
 * <<release-notes-7.0.0-beta1>>
 * <<release-notes-7.0.0-alpha2>>
 * <<release-notes-7.0.0-alpha1>>
@@ -14,23 +16,27 @@
 
 [[release-notes-7.0.0-rc2]]
 === APM Server version 7.0.0-rc2
+////
 
 [[release-notes-7.0.0-rc1]]
 === APM Server version 7.0.0-rc1
 
-==== Bugfix
+https://github.com/elastic/apm-server/compare/v7.0.0-beta1...v7.0.0-rc1[View commits]
+
+[float]
+==== Bug fixes
 
 - Ensure setup cmd uses expected configuration {pull}1934[1934]. 
-- Ensure host.name is not added {pull}1934[1934].
-- Update Go version to 1.11.5 {pull}1840[1840] {pull}1950[1950].
+- Ensure host.name is not added {pull}1934[1934], {pull}1982[1982].
+- Update Go version to 1.11.5 {pull}1840[1840], {pull}1950[1950].
 - Ensure enabling user-agent pipeline indexes data at the same key by default {pull}1966[1966].
 - Request and Response headers are stored in a canonicalized way {pull}1966[1966].
-////
+- Use changed processor handling from libbeat {pull}1982[1982].
 
 [[release-notes-7.0.0-beta1]]
 === APM Server version 7.0.0-beta1
 
-https://github.com/elastic/apm-server/compare/v6.7.0\...v7.0.0[View commits]
+https://github.com/elastic/apm-server/compare/v7.0.0-alpha2...v7.0.0-beta1[View commits]
 
 [float]
 ==== Breaking Changes

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -8,4 +8,4 @@
 [float]
 ==== Removed
 
-https://github.com/elastic/apm-server/compare/v7.0.0-beta1...master[View commits]
+https://github.com/elastic/apm-server/compare/v7.0.0-rc2...master[View commits]

--- a/docs/configuring-ingest.asciidoc
+++ b/docs/configuring-ingest.asciidoc
@@ -4,43 +4,42 @@
 [[configuring-ingest-node]]
 == Parse data using ingest node pipelines
 
-With the Elasticsearch output you can configure the APM Server to use
-{elasticsearch}/ingest.html[ingest node] to pre-process documents before indexing them.
-A pipeline defines processors that operate on your data.
-For example, a pipeline can define one processor to remove a field and another to rename a field.
+You can configure APM Server to use an {ref}/ingest.html[ingest node]
+to pre-process documents before indexing them in Elasticsearch.
 
-Using pipelines involves two steps.
-First you need to <<register-pipelines,register a pipeline>> in Elasticsearch.
-Then the pipeline needs to be <<apply-pipelines, applied during data ingestion>>.
+A pipeline is a definition of a series of processors that operate on your data.
+For example, a pipeline can define one processor to remove a field, and another to rename a field.
+Using pipelines involves two steps:
+
+. First, you need to <<register-pipelines,register a pipeline>> in Elasticsearch.
+. Then, the pipeline needs to be <<apply-pipelines, applied during data ingestion>>.
 
 [[register-pipelines]]
 [float]
-=== Registering Pipelines in Elasticsearch
-For registering a pipeline in Elasticsearch you can either manually upload
-a pipeline definition or you can configure APM Server to register pipelines on startup.
+=== Register pipelines in Elasticsearch
+To register a pipeline in Elasticsearch, you can either configure APM Server to
+register pipelines on startup, or you can manually upload a pipeline definition.
 
 [[register-pipelines-apm-server]]
 [float]
 ==== Register pipelines on APM Server startup
-Automatic pipeline registration requires `output.elasticsearch` to be enabled and configured,
-as well as having the required Elasticsearch plugins installed.
+Automatic pipeline registration requires `output.elasticsearch` to be enabled and configured.
 
-APM Server default pipelines require you to have the Ingest user agent plugin installed.
-If pipelines are enabled but required plugins are missing, 
-the APM Server will not be able to properly connect to the Elasticsearch output.
-Find the default pipeline configuration at `ingest/pipeline/definition.json` of your APM Server
-installation's home directory.
-In case you want to add, change or remove pipelines in Elasticsearch,
-you can simply change the definitions in this file
-and restart your APM Server or run `apm-server setup --pipelines`
+Navigate to APM Server's home directory and find the default pipeline configuration at
+`ingest/pipeline/definition.json`.
+To add, change, or remove pipelines in Elasticsearch,
+change the definitions in this file and restart your APM Server or run `apm-server setup --pipelines`.
 
-By default pipeline registration is disabled.
+By default, pipeline registration is disabled.
 See how to <<register.ingest.pipeline.enabled,configure pipeline registration>>.
 
 [[register-pipelines-manual]]
 [float]
 ==== Manually upload pipeline definitions
-For example, consider the following pipeline in a file named `pipeline.json`:
+
+You can manually upload pipeline definitions by describing them in a file.
+Consider the following sample pipeline in a file named `pipeline.json`.
+This pipeline definition converts the value of `beat.name` to lowercase before indexing each document.
 
 [source,json]
 ------------------------------------------------------------------------------
@@ -56,20 +55,19 @@ For example, consider the following pipeline in a file named `pipeline.json`:
 }
 ------------------------------------------------------------------------------
 
-To register the pipeline run:
+To register this pipeline, run:
 
 [source,shell]
 ------------------------------------------------------------------------------
 curl -H 'Content-Type: application/json' -XPUT 'http://localhost:9200/_ingest/pipeline/test-pipeline' -d @pipeline.json
 ------------------------------------------------------------------------------
 
-This pipeline definition converts the value of `beat.name` to lowercase before indexing each document.
 
 [[apply-pipelines]]
 [float]
 === Apply pipelines during data ingestion
 To specify which pipelines to apply during data ingestion,
-add the pipeline IDs in the `pipelines` option under `elasticsearch` in the +apm-server.yml+ file:
+add the pipeline IDs to the `pipelines` option under `elasticsearch` in the +apm-server.yml+ file:
 
 [source,yaml]
 ------------------------------------------------------------------------------
@@ -78,5 +76,5 @@ output.elasticsearch:
   - pipeline: "test-pipeline"
 ------------------------------------------------------------------------------
 
-For more information about defining a pre-processing pipeline, see the
-{elasticsearch}/ingest.html[Ingest Node] documentation.
+TIP: More information on defining a pre-processing pipeline is available in the
+{ref}/ingest.html[ingest node] documentation.

--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -841,7 +841,7 @@ Sets the path for log files. See the <<directory-layout>> section for details.
 *`--strict.perms`*::
 Sets strict permission checking on configuration files. The default is
 `-strict.perms=true`. See
-{libbeat}/config-file-permissions.html[Config file ownership and permissions] in
+{beats-ref}/config-file-permissions.html[Config file ownership and permissions] in
 the _Beats Platform Reference_ for more information.
 
 *`-v, --v`*::

--- a/docs/copied-from-beats/https.asciidoc
+++ b/docs/copied-from-beats/https.asciidoc
@@ -13,7 +13,7 @@
 To secure the communication between {beatname_uc} and Elasticsearch, you can use
 HTTPS and basic authentication. Basic authentication for Elasticsearch is
 available when you enable {security} (see
-{securitydoc}/elasticsearch-security.html[Securing the {stack}] and <<securing-beats>>).
+{stack-ov}/elasticsearch-security.html[Securing the {stack}] and <<securing-beats>>).
 If you aren't using {security}, you can use a web proxy instead.
 
 Here is a sample configuration:

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -555,7 +555,7 @@ use in Logstash for indexing and filtering:
 }
 ------------------------------------------------------------------------------
 <1> {beatname_uc} uses the `@metadata` field to send metadata to Logstash. See the
-{logstashdoc}/event-dependent-configuration.html#metadata[Logstash documentation]
+{logstash-ref}/event-dependent-configuration.html#metadata[Logstash documentation]
 for more about the `@metadata` field.
 <2> The default is {beat_default_index_prefix}. To change this value, set the
 <<logstash-index,`index`>> option in the {beatname_uc} config file.

--- a/docs/copied-from-beats/security/linux-seccomp.asciidoc
+++ b/docs/copied-from-beats/security/linux-seccomp.asciidoc
@@ -21,7 +21,7 @@ can be customized through configuration as well.
 A seccomp policy is architecture specific due to the fact that system calls vary
 by architecture. {beatname_uc} includes a whitelist seccomp policy for the
 amd64 and 386 architectures. You can view those policies
-https://github.com/elastic/beats/tree/{doc-branch}/libbeat/common/seccomp[here].
+https://github.com/elastic/beats/tree/{branch}/libbeat/common/seccomp[here].
 
 [float]
 [[seccomp-policy-config]]

--- a/docs/copied-from-beats/security/securing-beats.asciidoc
+++ b/docs/copied-from-beats/security/securing-beats.asciidoc
@@ -7,7 +7,7 @@
 ++++
 
 If you want {beatname_uc} to connect to a cluster that has
-{securitydoc}/elasticsearch-security.html[{security}] enabled, there are extra
+{stack-ov}/elasticsearch-security.html[{security}] enabled, there are extra
 configuration steps:
 
 . <<beats-basic-auth>>.

--- a/docs/copied-from-beats/shared-configuring.asciidoc
+++ b/docs/copied-from-beats/shared-configuring.asciidoc
@@ -9,5 +9,5 @@ that shows all non-deprecated options.
 endif::[]
 
 TIP: See the
-{libbeat}/config-file-format.html[Config File Format] section of the
+{beats-ref}/config-file-format.html[Config File Format] section of the
 _Beats Platform Reference_ for more about the structure of the config file.

--- a/docs/copied-from-beats/shared-ssl-logstash-config.asciidoc
+++ b/docs/copied-from-beats/shared-ssl-logstash-config.asciidoc
@@ -20,7 +20,7 @@ To use SSL mutual authentication:
 document. There are many online resources available that describe how to create certificates.
 +
 TIP: If you are using {security}, you can use the
-{elasticsearch}/certutil.html[elasticsearch-certutil tool] to generate certificates.
+{ref}/certutil.html[elasticsearch-certutil tool] to generate certificates.
 
 . Configure {beatname_uc} to use SSL. In the +{beatname_lc}.yml+ config file, specify the following settings under
 `ssl`:
@@ -51,7 +51,7 @@ For more information about these configuration options, see <<configuration-ssl>
 * `ssl_certificate` and `ssl_key`: Specify the certificate and key that Logstash uses to authenticate with the client.
 * `ssl_verify_mode`: Specifies whether the Logstash server verifies the client certificate against the CA. You
 need to specify either `peer` or `force_peer` to make the server ask for the certificate and validate it. If you
-specify `force_peer`, and {beatname_uc} doesn't provide a certificate, the Logstash connection will be closed. If you choose not to use {elasticsearch}/certutil.html[certutil], the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
+specify `force_peer`, and {beatname_uc} doesn't provide a certificate, the Logstash connection will be closed. If you choose not to use {ref}/certutil.html[certutil], the certificates that you obtain must allow for both `clientAuth` and `serverAuth` if the extended key usage extension is present.
 +
 For example:
 +

--- a/docs/copied-from-beats/shared-template-load.asciidoc
+++ b/docs/copied-from-beats/shared-template-load.asciidoc
@@ -16,7 +16,7 @@ the output is not Elasticsearch, you must
 <<load-template-manually,load the template manually>>. 
 endif::only-elasticsearch[]
 
-In Elasticsearch, {elasticsearch}/indices-templates.html[index
+In Elasticsearch, {ref}/indices-templates.html[index
 templates] are used to define settings and mappings that determine how fields
 should be analyzed.
 

--- a/docs/copied-from-beats/step-test-config.asciidoc
+++ b/docs/copied-from-beats/step-test-config.asciidoc
@@ -17,7 +17,7 @@ your config files are in the path expected by {beatname_uc} (see
 <<directory-layout>>), or use the `-c` flag to specify the path to the config
 file. Depending on your OS, you might run into file ownership issues when you
 run this test. See
-{libbeat}/config-file-permissions.html[Config File Ownership and Permissions]
+{beats-ref}/config-file-permissions.html[Config File Ownership and Permissions]
 in the _Beats Platform Reference_ for more information.
 
 endif::[]

--- a/docs/copied-from-beats/template-config.asciidoc
+++ b/docs/copied-from-beats/template-config.asciidoc
@@ -3,7 +3,7 @@
 == Load the Elasticsearch index template
 
 The `setup.template` section of the +{beatname_lc}.yml+ config file specifies
-the {elasticsearch}/indices-templates.html[index template] to use for setting
+the {ref}/indices-templates.html[index template] to use for setting
 mappings in Elasticsearch. If template loading is enabled (the default),
 {beatname_uc} loads the index template automatically after successfully
 connecting to Elasticsearch.
@@ -55,7 +55,7 @@ is false.
 
 *`setup.template.settings`*:: A dictionary of settings to place into the `settings.index` dictionary of the
 Elasticsearch template. For more details about the available Elasticsearch mapping options, please
-see the Elasticsearch {elasticsearch}/mapping.html[mapping reference].
+see the Elasticsearch {ref}/mapping.html[mapping reference].
 +
 Example:
 +
@@ -75,7 +75,7 @@ indices to another cluster, you will need to add additional template settings to
 underlying indices.
 
 *`setup.template.settings._source`*:: A dictionary of settings for the `_source` field. For the available settings,
-please see the Elasticsearch {elasticsearch}/mapping-source-field.html[reference].
+please see the Elasticsearch {ref}/mapping-source-field.html[reference].
 +
 Example:
 +

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -13,18 +13,13 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :beat_version_key: observer.version
 :dockerimage: docker.elastic.co/apm/{beatname_lc}:{version}
 :dockergithub: https://github.com/elastic/apm-server-docker/tree/{doc-branch}
+:dockerconfig: https://raw.githubusercontent.com/elastic/apm-server/{doc-branch}/apm-server.docker.yml
 :discuss_forum: apm
 :github_repo_name: apm-server
-:sample_date_0: 2018.12.10
-:sample_date_1: 2018.12.11
-:sample_date_2: 2018.12.12
-:libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
-:logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
-:elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
-:securitydoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
-:dockerconfig: https://raw.githubusercontent.com/elastic/apm-server/{doc-branch}/apm-server.docker.yml
+:sample_date_0: 2019.03.10
+:sample_date_1: 2019.03.11
+:sample_date_2: 2019.03.12
 :repo: apm-server
-:no_dashboards:
 :no_ilm:
 :no-processors:
 :no-indices-rules:

--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -48,7 +48,7 @@ For rpm and deb,
 you’ll find the configuration file at +/etc/{beatname_lc}/{beatname_lc}.yml+.
 For mac and win, look in the archive that you extracted.
 
-See {libbeat}/config-file-format.html[Config File Format] in _Beats Platform Reference_ for more about the structure of the config file.
+See {beats-ref}/config-file-format.html[Config File Format] in _Beats Platform Reference_ for more about the structure of the config file.
 
 [source,yaml]
 ----------------------------------

--- a/docs/upgrading-to-70.asciidoc
+++ b/docs/upgrading-to-70.asciidoc
@@ -1,0 +1,31 @@
+[[upgrading-to-70]]
+=== Upgrading to APM Server v7.0
+
+Before upgrading to APM Server v7.0,
+there are some {apm-overview-ref-v}/breaking-7.0.0-beta1.html[breaking changes]
+in the APM Server and the APM UI that you should be aware of.
+
+[[upgrade-steps-70]]
+==== Upgrade Steps
+
+Check the https://www.elastic.co/support/matrix#matrix_compatibility[Product Compatibility matrix]
+to determine if you need to upgrade Elasticsearch and Kibana. 
+
+. Upgrade {ref}/setup-upgrade.html[Elasticsearch]
+. Upgrade {kibana-ref}/upgrade.html[Kibana]
+. Ensure all of your APM agents are upgraded to a version that supports APM Server >= 6.5.
+The {apm-overview-ref-v}/agent-server-compatibility.html[agent/server compatibility matrix]
+will help determine compatibility.
+. Upgrade APM Server. (See below if upgrading from an RPM or Deb install)
+. Use the Kibana migration assistant, found in the Kibana Management tab,
+to migrate 6.x data to the 7.x format. 
+
+===== Upgrading from 6.x RPM or Deb install
+
+When upgrading from an RPM or Deb install,
+you'll be prompted with a warning saying the install is going to overwrite `/etc/apm-server/apm-server.yml`.
+Here's what you should do:
+
+. Back up your current `apm-server.yml` configuration file.
+. Accept the "overwrite" option from the `7.0` install.
+. Copy/Paste any configuration options you want to keep from the old config file to the new config file.

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -26,3 +26,5 @@ and applies the correct template automatically.
 include::./breaking-changes.asciidoc[]
 
 include::./upgrading-to-65.asciidoc[]
+
+include::./upgrading-to-70.asciidoc[]

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 7.0.0-rc2
+:stack-version: 7.1
 :major-version: 7.x
 :doc-branch: 7.x
 :branch: {doc-branch}

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 7.1.0
+:stack-version: 7.0.0-rc1
 :major-version: 7.x
 :doc-branch: 7.x
 :branch: {doc-branch}

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 7.0.0-rc1
+:stack-version: 7.0.0-rc2
 :major-version: 7.x
 :doc-branch: 7.x
 :branch: {doc-branch}
@@ -12,7 +12,7 @@
 :server-branch: {doc-branch}
 :go-branch: 1.x
 :java-branch: 1.x
-:rum-branch: 3.x
+:rum-branch: 4.x
 :node-branch: 2.x
 :py-branch: 4.x
 :ruby-branch: 2.x

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 7.1
+:stack-version: 7.1.0
 :major-version: 7.x
 :doc-branch: 7.x
 :branch: {doc-branch}


### PR DESCRIPTION
This PR backports the following commits to 7.x:

* [docs] Add 7.0 upgrading guide with deb/RPM instructions (#2054)
* [docs] Remove old attributes (#2053)
* [docs] Update ingest node documentation (#2061)
* [docs] 7.0.0-rc1 release notes (#2051)  …
* docs: changelog and updates rc2 (#2066)