### PR TITLE
[7.0] Align host.hostname with ECS under kubernetes (#2059)

### DIFF
--- a/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
@@ -178,7 +178,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "127.0.0.1",
                 "os": {
                     "platform": "darwin"
@@ -334,7 +334,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "127.0.0.1",
                 "os": {
                     "platform": "darwin"
@@ -425,7 +425,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "127.0.0.1",
                 "os": {
                     "platform": "darwin"
@@ -515,7 +515,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "127.0.0.1",
                 "os": {
                     "platform": "darwin"

--- a/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
@@ -26,6 +26,7 @@
                 }
             },
             "host": {
+                "hostname": "node-name",
                 "ip": "127.0.0.1"
             },
             "kubernetes": {
@@ -138,6 +139,7 @@
                 "version": "1.1.0-dev"
             },
             "host": {
+                "hostname": "node-name",
                 "ip": "127.0.0.1"
             },
             "kubernetes": {
@@ -220,6 +222,7 @@
                 }
             },
             "host": {
+                "hostname": "node-name",
                 "ip": "127.0.0.1"
             },
             "kubernetes": {

--- a/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json
@@ -19,7 +19,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "127.0.0.1",
                 "os": {
                     "platform": "darwin"
@@ -118,7 +118,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "127.0.0.1",
                 "os": {
                     "platform": "darwin"
@@ -305,7 +305,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "127.0.0.1",
                 "os": {
                     "platform": "darwin"

--- a/docs/data/elasticsearch/generated/errors.json
+++ b/docs/data/elasticsearch/generated/errors.json
@@ -170,7 +170,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "192.0.0.1",
                 "os": {
                     "platform": "darwin"
@@ -310,7 +310,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "192.0.0.1",
                 "os": {
                     "platform": "darwin"
@@ -385,7 +385,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "192.0.0.1",
                 "os": {
                     "platform": "darwin"
@@ -459,7 +459,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "192.0.0.1",
                 "os": {
                     "platform": "darwin"

--- a/docs/data/elasticsearch/generated/transactions.json
+++ b/docs/data/elasticsearch/generated/transactions.json
@@ -11,7 +11,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "192.0.0.1",
                 "os": {
                     "platform": "darwin"
@@ -94,7 +94,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "192.0.0.1",
                 "os": {
                     "platform": "darwin"
@@ -265,7 +265,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "192.0.0.1",
                 "os": {
                     "platform": "darwin"

--- a/model/metadata/system_test.go
+++ b/model/metadata/system_test.go
@@ -33,6 +33,8 @@ func TestSystemTransform(t *testing.T) {
 	platform := "darwin"
 	ip := "127.0.0.1"
 	empty := ""
+	nodename := "a.node"
+	podname := "a.pod"
 
 	tests := []struct {
 		System System
@@ -72,6 +74,59 @@ func TestSystemTransform(t *testing.T) {
 			Output: common.MapStr{
 				"architecture": architecture,
 				"hostname":     hostname,
+			},
+		},
+		// nodename and podname
+		{
+			System: System{
+				Hostname: &hostname,
+				Kubernetes: &Kubernetes{
+					NodeName: &nodename,
+					PodName:  &podname,
+				},
+			},
+			Output: common.MapStr{
+				"hostname": nodename,
+			},
+		},
+		// podname
+		{
+			System: System{
+				Hostname: &hostname,
+				Kubernetes: &Kubernetes{
+					PodName: &podname,
+				},
+			},
+			Output: common.MapStr{},
+		},
+		// poduid
+		{
+			System: System{
+				Hostname: &hostname,
+				Kubernetes: &Kubernetes{
+					PodUID: &podname, // any string
+				},
+			},
+			Output: common.MapStr{},
+		},
+		// namespace
+		{
+			System: System{
+				Hostname: &hostname,
+				Kubernetes: &Kubernetes{
+					Namespace: &podname, // any string
+				},
+			},
+			Output: common.MapStr{},
+		},
+		// non-nil kubernetes, currently not possible via intake
+		{
+			System: System{
+				Hostname:   &hostname,
+				Kubernetes: &Kubernetes{},
+			},
+			Output: common.MapStr{
+				"hostname": hostname,
 			},
 		},
 	}

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationErrors.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationErrors.approved.json
@@ -170,7 +170,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "192.0.0.1",
                 "os": {
                     "platform": "darwin"
@@ -310,7 +310,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "192.0.0.1",
                 "os": {
                     "platform": "darwin"
@@ -385,7 +385,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "192.0.0.1",
                 "os": {
                     "platform": "darwin"
@@ -459,7 +459,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "192.0.0.1",
                 "os": {
                     "platform": "darwin"

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
@@ -18,6 +18,7 @@
                 }
             },
             "host": {
+                "hostname": "node-name",
                 "ip": "192.0.0.1"
             },
             "kubernetes": {
@@ -98,6 +99,7 @@
                 "id": "container-id"
             },
             "host": {
+                "hostname": "node-name",
                 "ip": "192.0.0.1"
             },
             "kubernetes": {
@@ -164,6 +166,7 @@
                 }
             },
             "host": {
+                "hostname": "node-name",
                 "ip": "192.0.0.1"
             },
             "kubernetes": {

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationTransactions.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationTransactions.approved.json
@@ -11,7 +11,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "192.0.0.1",
                 "os": {
                     "platform": "darwin"
@@ -94,7 +94,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "192.0.0.1",
                 "os": {
                     "platform": "darwin"
@@ -265,7 +265,7 @@
             },
             "host": {
                 "architecture": "x64",
-                "hostname": "prod1.example.com",
+                "hostname": "node-name",
                 "ip": "192.0.0.1",
                 "os": {
                     "platform": "darwin"

--- a/tests/system/error.approved.json
+++ b/tests/system/error.approved.json
@@ -32,7 +32,6 @@
                 "os": {
                     "platform": "darwin"
                 },
-                "hostname": "prod1.example.com",
                 "architecture": "x64",
                 "ip": "127.0.0.1"
             },
@@ -122,7 +121,6 @@
                 "os": {
                     "platform": "darwin"
                 },
-                "hostname": "prod1.example.com",
                 "architecture": "x64",
                 "ip": "127.0.0.1"
             },
@@ -418,7 +416,6 @@
                 "os": {
                     "platform": "darwin"
                 },
-                "hostname": "prod1.example.com",
                 "architecture": "x64",
                 "ip": "127.0.0.1"
             },
@@ -505,7 +502,6 @@
                 "os": {
                     "platform": "darwin"
                 },
-                "hostname": "prod1.example.com",
                 "architecture": "x64",
                 "ip": "127.0.0.1"
             },

--- a/tests/system/transaction.approved.json
+++ b/tests/system/transaction.approved.json
@@ -32,7 +32,6 @@
                 "os": {
                     "platform": "darwin"
                 },
-                "hostname": "prod1.example.com",
                 "architecture": "x64",
                 "ip": "127.0.0.1"
             },
@@ -212,7 +211,6 @@
                 "os": {
                     "platform": "darwin"
                 },
-                "hostname": "prod1.example.com",
                 "architecture": "x64",
                 "ip": "127.0.0.1"
             },
@@ -308,7 +306,6 @@
                 "os": {
                     "platform": "darwin"
                 },
-                "hostname": "prod1.example.com",
                 "architecture": "x64",
                 "ip": "127.0.0.1"
             },
@@ -403,7 +400,6 @@
                 "os": {
                     "platform": "darwin"
                 },
-                "hostname": "prod1.example.com",
                 "architecture": "x64",
                 "ip": "127.0.0.1"
             },


### PR DESCRIPTION
Backports the following commits to 7.0:
 - Align host.hostname with ECS under kubernetes  (#2059)