### PR TITLE
Update beats framework to 5554677

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ NOW=$(shell date -u '+%Y-%m-%dT%H:%M:%S')
 GOBUILD_FLAGS=-i -ldflags "-s -X $(BEAT_PATH)/vendor/github.com/elastic/beats/libbeat/version.buildTime=$(NOW) -X $(BEAT_PATH)/vendor/github.com/elastic/beats/libbeat/version.commit=$(COMMIT_ID)"
 MAGE_IMPORT_PATH=${BEAT_PATH}/vendor/github.com/magefile/mage
 
-.DEFAULT_GOAL := ${BEAT_NAME}
+# overwrite some beats targets cleanly
+.OVER := original-
 
 # Path to the libbeat Makefile
 -include $(ES_BEATS)/libbeat/scripts/Makefile

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -245,7 +245,7 @@ SOFTWARE.
 --------------------------------------------------------------------
 Dependency: github.com/elastic/beats
 Version: master
-Revision: 96e059d2c28214536905d8691af0505106ede3ea
+Revision: 5554677dc86b78f48b1ff2a214c661f5f78cbfe1
 License type (autodetected): Apache-2.0
 ./vendor/github.com/elastic/beats/LICENSE.txt:
 --------------------------------------------------------------------

--- a/_beats/dev-tools/ecs-migration.yml
+++ b/_beats/dev-tools/ecs-migration.yml
@@ -463,7 +463,26 @@
 - from: system.auth.hostname
   to: host.hostname
   alias: true
-  copy_to: false
+  beat: filebeat
+
+- from: system.auth.message
+  to: message
+  alias: true
+  beat: filebeat
+
+- from: system.auth.program
+  to: process.name
+  alias: true
+  beat: filebeat
+
+- from: system.auth.timestamp
+  to: '@timestamp'
+  alias: true
+  beat: filebeat
+
+- from: system.auth.user
+  to: user.name
+  alias: true
   beat: filebeat
 
 - from: system.auth.pid
@@ -476,12 +495,22 @@
   alias: true
   beat: filebeat
 
+- from: system.auth.groupadd.name
+  to: group.name
+  alias: true
+  beat: filebeat
+
+- from: system.auth.useradd.gid
+  to: group.id
+  alias: true
+  beat: filebeat
+
 - from: system.auth.useradd.uid
   to: user.id
   alias: true
   beat: filebeat
 
-- from: system.auth.useradd.user
+- from: system.auth.useradd.name
   to: user.name
   alias: true
   beat: filebeat
@@ -681,11 +710,6 @@
   beat: filebeat
 
 ## Elasticsearch module
-
-- from: elasticsearch.audit.event_type
-  to: event.type
-  alias: true
-  beat: filebeat
 
 - from: elasticsearch.audit.origin_address
   to: source.ip
@@ -1150,6 +1174,11 @@
   beat: filebeat
 
 ## NGINX module
+
+- from: nginx.access.remote_ip
+  to: source.address
+  alias: true
+  beat: filebeat
 
 - from: nginx.access.user_name
   to: user.name

--- a/_beats/libbeat/scripts/Makefile
+++ b/_beats/libbeat/scripts/Makefile
@@ -101,6 +101,7 @@ include $(ES_BEATS)/dev-tools/make/mage.mk
 
 ### BUILDING ###
 
+.DEFAULT_GOAL := ${BEAT_NAME}
 
 ${BEAT_NAME}: $(GOFILES_ALL) ## @build build the beat application
 	go build $(GOBUILD_FLAGS)
@@ -128,15 +129,15 @@ check: check-headers python-env prepare-tests ## @build Checks project and sourc
 	@${FIND} -wholename "*tests/system/test_*.py" -perm ${PERM_EXEC} -exec false {} + || (echo "Python test files shouldn't be executable, otherwise nose doesn't find them" && false)
 	@${FIND} -name "*.yml" -perm ${PERM_EXEC} -exec false {} + || (echo "YAML files should not be executable" && false)
 
-.PHONY: check-headers
-check-headers:
+.PHONY: $(.OVER)check-headers
+$(.OVER)check-headers:
 ifndef CHECK_HEADERS_DISABLED
 	@go get -u github.com/elastic/go-licenser
 	@go-licenser -d -license ${LICENSE}
 endif
 
-.PHONY: add-headers
-add-headers:
+.PHONY: $(.OVER)add-headers
+$(.OVER)add-headers:
 ifndef CHECK_HEADERS_DISABLED
 	@go get github.com/elastic/go-licenser
 	@go-licenser -license ${LICENSE}
@@ -381,8 +382,8 @@ docs-preview:  ## @build Preview the documents for the beat in the browser
 ES_URL?=http://localhost:9200
 KIBANA_URL?=http://localhost:5601
 
-.PHONY: import-dashboards
-import-dashboards: update ${BEAT_NAME}
+.PHONY: $(.OVER)import-dashboards
+$(.OVER)import-dashboards: update ${BEAT_NAME}
 	${BEAT_GOPATH}/src/${BEAT_PATH}/${BEAT_NAME} setup -E setup.dashboards.directory=${PWD}/_meta/kibana.generated -E setup.kibana.host=${KIBANA_URL} --dashboards
 
 ### CONTAINER ENVIRONMENT ####

--- a/_beats/libbeat/tests/system/beat/beat.py
+++ b/_beats/libbeat/tests/system/beat/beat.py
@@ -408,6 +408,30 @@ class TestCase(unittest.TestCase, ComposeMixin):
 
         return counter
 
+    def log_contains_countmap(self, pattern, capture_group, logfile=None):
+        """
+        Returns a map of the number of appearances of each captured group in the log file
+        """
+        counts = {}
+
+        if logfile is None:
+            logfile = self.beat_name + ".log"
+
+        try:
+            with open(os.path.join(self.working_dir, logfile), "r") as f:
+                for line in f:
+                    res = pattern.search(line)
+                    if res is not None:
+                        capt = res.group(capture_group)
+                        if capt in counts:
+                            counts[capt] += 1
+                        else:
+                            counts[capt] = 1
+        except IOError:
+            pass
+
+        return counts
+
     def output_lines(self, output_file=None):
         """ Count number of lines in a file."""
         if output_file is None:

--- a/_beats/testing/environments/docker/kafka/Dockerfile
+++ b/_beats/testing/environments/docker/kafka/Dockerfile
@@ -4,14 +4,14 @@ ENV KAFKA_HOME /kafka
 # The advertised host is kafka. This means it will not work if container is started locally and connected from localhost to it
 ENV KAFKA_ADVERTISED_HOST kafka
 ENV KAFKA_LOGS_DIR="/kafka-logs"
-ENV KAFKA_VERSION 2.1.0
+ENV KAFKA_VERSION 2.1.1
 ENV _JAVA_OPTIONS "-Djava.net.preferIPv4Stack=true"
 ENV TERM=linux
 
 RUN apt-get update && apt-get install -y curl openjdk-8-jre-headless netcat
 
 RUN mkdir -p ${KAFKA_LOGS_DIR} && mkdir -p ${KAFKA_HOME} && curl -s -o $INSTALL_DIR/kafka.tgz \
-    "http://ftp.wayne.edu/apache/kafka/${KAFKA_VERSION}/kafka_2.11-${KAFKA_VERSION}.tgz" && \
+    "http://mirror.easyname.ch/apache/kafka/${KAFKA_VERSION}/kafka_2.11-${KAFKA_VERSION}.tgz" && \
     tar xzf ${INSTALL_DIR}/kafka.tgz -C ${KAFKA_HOME} --strip-components 1
 
 ADD run.sh /run.sh

--- a/vendor/github.com/elastic/beats/libbeat/cmd/instance/beat.go
+++ b/vendor/github.com/elastic/beats/libbeat/cmd/instance/beat.go
@@ -39,6 +39,10 @@ import (
 	errw "github.com/pkg/errors"
 	"go.uber.org/zap"
 
+	sysinfo "github.com/elastic/go-sysinfo"
+	"github.com/elastic/go-sysinfo/types"
+	ucfg "github.com/elastic/go-ucfg"
+
 	"github.com/elastic/beats/libbeat/api"
 	"github.com/elastic/beats/libbeat/asset"
 	"github.com/elastic/beats/libbeat/beat"
@@ -66,9 +70,6 @@ import (
 	"github.com/elastic/beats/libbeat/publisher/processing"
 	svc "github.com/elastic/beats/libbeat/service"
 	"github.com/elastic/beats/libbeat/version"
-	sysinfo "github.com/elastic/go-sysinfo"
-	"github.com/elastic/go-sysinfo/types"
-	ucfg "github.com/elastic/go-ucfg"
 )
 
 // Beat provides the runnable and configurable instance of a beat.
@@ -102,8 +103,10 @@ type beatConfig struct {
 	Keystore      *common.Config `config:"keystore"`
 
 	// output/publishing related configurations
-	Pipeline   pipeline.Config `config:",inline"`
-	Monitoring *common.Config  `config:"xpack.monitoring"`
+	Pipeline pipeline.Config `config:",inline"`
+
+	// monitoring settings
+	MonitoringBeatConfig monitoring.BeatConfig `config:",inline"`
 
 	// central management settings
 	Management *common.Config `config:"management"`
@@ -284,6 +287,11 @@ func (b *Beat) createBeater(bt beat.Creator) (beat.Beater, error) {
 		return nil, err
 	}
 
+	err = b.registerClusterUUIDFetching()
+	if err != nil {
+		return nil, err
+	}
+
 	reg := monitoring.Default.GetRegistry("libbeat")
 	if reg == nil {
 		reg = monitoring.Default.NewRegistry("libbeat")
@@ -361,11 +369,17 @@ func (b *Beat) launch(settings Settings, bt beat.Creator) error {
 		return err
 	}
 
-	if b.Config.Monitoring.Enabled() {
+	monitoringCfg, reporterSettings, err := monitoring.SelectConfig(b.Config.MonitoringBeatConfig)
+	if err != nil {
+		return err
+	}
+
+	if monitoringCfg.Enabled() {
 		settings := report.Settings{
 			DefaultUsername: settings.Monitoring.DefaultUsername,
+			Format:          reporterSettings.Format,
 		}
-		reporter, err := report.New(b.Info, settings, b.Config.Monitoring, b.Config.Output)
+		reporter, err := report.New(b.Info, settings, monitoringCfg, b.Config.Output)
 		if err != nil {
 			return err
 		}
@@ -759,8 +773,7 @@ func (b *Beat) registerESIndexManagement() error {
 	return nil
 }
 
-// Build and return a callback to load index template into ES
-func (b *Beat) indexSetupCallback() func(esClient *elasticsearch.Client) error {
+func (b *Beat) indexSetupCallback() elasticsearch.ConnectCallback {
 	return func(esClient *elasticsearch.Client) error {
 		m := b.index.Manager(esClient, idxmgmt.BeatsAssets(b.Fields))
 		return m.Setup(true, true)
@@ -788,6 +801,47 @@ func (b *Beat) createOutput(stats outputs.Observer, cfg common.ConfigNamespace) 
 	}
 
 	return outputs.Load(b.index, b.Info, stats, cfg.Name(), cfg.Config())
+}
+
+func (b *Beat) registerClusterUUIDFetching() error {
+	if b.Config.Output.Name() == "elasticsearch" {
+		callback, err := b.clusterUUIDFetchingCallback()
+		if err != nil {
+			return err
+		}
+		elasticsearch.RegisterConnectCallback(callback)
+	}
+	return nil
+}
+
+// Build and return a callback to fetch the Elasticsearch cluster_uuid for monitoring
+func (b *Beat) clusterUUIDFetchingCallback() (elasticsearch.ConnectCallback, error) {
+	stateRegistry := monitoring.GetNamespace("state").GetRegistry()
+	elasticsearchRegistry := stateRegistry.NewRegistry("outputs.elasticsearch")
+	clusterUUIDRegVar := monitoring.NewString(elasticsearchRegistry, "cluster_uuid")
+
+	callback := func(esClient *elasticsearch.Client) error {
+		var response struct {
+			ClusterUUID string `json:"cluster_uuid"`
+		}
+
+		status, body, err := esClient.Request("GET", "/", "", nil, nil)
+		if err != nil {
+			return errw.Wrap(err, "error querying /")
+		}
+		if status > 299 {
+			return fmt.Errorf("Error querying /. Status: %d. Response body: %s", status, body)
+		}
+		err = json.Unmarshal(body, &response)
+		if err != nil {
+			return fmt.Errorf("Error unmarshaling json when querying /. Body: %s", body)
+		}
+
+		clusterUUIDRegVar.Set(response.ClusterUUID)
+		return nil
+	}
+
+	return callback, nil
 }
 
 // handleError handles the given error by logging it and then returning the

--- a/vendor/github.com/elastic/beats/libbeat/monitoring/monitoring.go
+++ b/vendor/github.com/elastic/beats/libbeat/monitoring/monitoring.go
@@ -17,7 +17,19 @@
 
 package monitoring
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/cfgwarn"
+	"github.com/elastic/beats/libbeat/monitoring/report"
+)
+
+// BeatConfig represents the part of the $BEAT.yml to do with monitoring settings
+type BeatConfig struct {
+	XPackMonitoring *common.Config `config:"xpack.monitoring"`
+	Monitoring      *common.Config `config:"monitoring"`
+}
 
 type Mode uint8
 
@@ -28,6 +40,11 @@ const (
 
 	// Full reports all metrics
 	Full
+)
+
+var (
+	errMonitoringBothConfigEnabled = errors.New("both xpack.monitoring.* and monitoring.* cannot be set. Prefer to set monitoring.* and set monitoring.elasticsearch.hosts to monitoring cluster hosts")
+	warnMonitoringDeprecatedConfig = "xpack.monitoring.* settings are deprecated. Use monitoring.* instead, but set monitoring.elasticsearch.hosts to monitoring cluster hosts"
 )
 
 // Default is the global default metrics registry provided by the monitoring package.
@@ -66,4 +83,22 @@ func Remove(name string) {
 
 func Clear() error {
 	return Default.Clear()
+}
+
+// SelectConfig selects the appropriate monitoring configuration based on the user's settings in $BEAT.yml. Users may either
+// use xpack.monitoring.* settings OR monitoring.* settings but not both.
+func SelectConfig(beatCfg BeatConfig) (*common.Config, *report.Settings, error) {
+	switch {
+	case beatCfg.Monitoring.Enabled() && beatCfg.XPackMonitoring.Enabled():
+		return nil, nil, errMonitoringBothConfigEnabled
+	case beatCfg.XPackMonitoring.Enabled():
+		cfgwarn.Deprecate("7.0", warnMonitoringDeprecatedConfig)
+		monitoringCfg := beatCfg.XPackMonitoring
+		return monitoringCfg, &report.Settings{Format: report.FormatXPackMonitoringBulk}, nil
+	case beatCfg.Monitoring.Enabled():
+		monitoringCfg := beatCfg.Monitoring
+		return monitoringCfg, &report.Settings{Format: report.FormatBulk}, nil
+	default:
+		return nil, nil, nil
+	}
 }

--- a/vendor/github.com/elastic/beats/libbeat/monitoring/report/elasticsearch/client.go
+++ b/vendor/github.com/elastic/beats/libbeat/monitoring/report/elasticsearch/client.go
@@ -20,6 +20,7 @@ package elasticsearch
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -34,17 +35,20 @@ import (
 type publishClient struct {
 	es     *esout.Client
 	params map[string]string
+	format report.Format
 }
 
 func newPublishClient(
 	es *esout.Client,
 	params map[string]string,
-) *publishClient {
+	format report.Format,
+) (*publishClient, error) {
 	p := &publishClient{
 		es:     es,
 		params: params,
+		format: format,
 	}
-	return p
+	return p, nil
 }
 
 func (c *publishClient) Connect() error {
@@ -84,6 +88,7 @@ func (c *publishClient) Connect() error {
 	}
 
 	debugf("XPack monitoring is enabled")
+
 	return nil
 }
 
@@ -97,11 +102,16 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 	var reason error
 	for _, event := range events {
 
-		// Extract time
+		// Extract type
 		t, err := event.Content.Meta.GetValue("type")
 		if err != nil {
 			logp.Err("Type not available in monitoring reported. Please report this error: %s", err)
 			continue
+		}
+
+		typ, ok := t.(string)
+		if !ok {
+			logp.Err("monitoring type is not a string")
 		}
 
 		var params = map[string]string{}
@@ -120,22 +130,12 @@ func (c *publishClient) Publish(batch publisher.Batch) error {
 			}
 		}
 
-		meta := common.MapStr{
-			"_index":   "",
-			"_routing": nil,
-			"_type":    t,
+		switch c.format {
+		case report.FormatXPackMonitoringBulk:
+			err = c.publishXPackBulk(params, event, typ)
+		case report.FormatBulk:
+			err = c.publishBulk(event, typ)
 		}
-		bulk := [2]interface{}{
-			common.MapStr{"index": meta},
-			report.Event{
-				Timestamp: event.Content.Timestamp,
-				Fields:    event.Content.Fields,
-			},
-		}
-
-		// Currently one request per event is sent. Reason is that each event can contain different
-		// interval params and X-Pack requires to send the interval param.
-		_, err = c.es.SendMonitoringBulk(params, bulk[:])
 
 		if err != nil {
 			failed = append(failed, event)
@@ -157,4 +157,76 @@ func (c *publishClient) Test(d testing.Driver) {
 
 func (c *publishClient) String() string {
 	return "publish(" + c.es.String() + ")"
+}
+
+func (c *publishClient) publishXPackBulk(params map[string]string, event publisher.Event, typ string) error {
+	meta := common.MapStr{
+		"_index":   "",
+		"_routing": nil,
+		"_type":    typ,
+	}
+	bulk := [2]interface{}{
+		common.MapStr{"index": meta},
+		report.Event{
+			Timestamp: event.Content.Timestamp,
+			Fields:    event.Content.Fields,
+		},
+	}
+
+	// Currently one request per event is sent. Reason is that each event can contain different
+	// interval params and X-Pack requires to send the interval param.
+	_, err := c.es.SendMonitoringBulk(params, bulk[:])
+	return err
+}
+
+func (c *publishClient) publishBulk(event publisher.Event, typ string) error {
+	meta := common.MapStr{
+		"_index":   getMonitoringIndexName(),
+		"_routing": nil,
+	}
+
+	if c.es.GetVersion().Major < 7 {
+		meta["_type"] = "doc"
+	}
+
+	action := common.MapStr{
+		"index": meta,
+	}
+
+	event.Content.Fields.Put("timestamp", event.Content.Timestamp)
+
+	fields := common.MapStr{
+		"type": typ,
+		typ:    event.Content.Fields,
+	}
+
+	interval, err := event.Content.Meta.GetValue("interval_ms")
+	if err != nil {
+		return errors.Wrap(err, "could not determine interval_ms field")
+	}
+	fields.Put("interval_ms", interval)
+
+	clusterUUID, err := event.Content.Meta.GetValue("cluster_uuid")
+	if err != nil && err != common.ErrKeyNotFound {
+		return errors.Wrap(err, "could not determine cluster_uuid field")
+	}
+	fields.Put("cluster_uuid", clusterUUID)
+
+	document := report.Event{
+		Timestamp: event.Content.Timestamp,
+		Fields:    fields,
+	}
+	bulk := [2]interface{}{action, document}
+
+	// Currently one request per event is sent. Reason is that each event can contain different
+	// interval params and X-Pack requires to send the interval param.
+	// FIXME: index name (first param below)
+	_, err = c.es.BulkWith(getMonitoringIndexName(), "", nil, nil, bulk[:])
+	return err
+}
+
+func getMonitoringIndexName() string {
+	version := 7
+	date := time.Now().Format("2006.01.02")
+	return fmt.Sprintf(".monitoring-beats-%v-%s", version, date)
 }

--- a/vendor/github.com/elastic/beats/libbeat/monitoring/report/elasticsearch/config.go
+++ b/vendor/github.com/elastic/beats/libbeat/monitoring/report/elasticsearch/config.go
@@ -20,6 +20,8 @@ package elasticsearch
 import (
 	"time"
 
+	"github.com/elastic/beats/libbeat/monitoring/report"
+
 	"github.com/elastic/beats/libbeat/common/transport/tlscommon"
 )
 
@@ -43,6 +45,7 @@ type config struct {
 	BufferSize       int               `config:"buffer_size"`
 	Tags             []string          `config:"tags"`
 	Backoff          backoff           `config:"backoff"`
+	Format           report.Format     `config:"_format"`
 }
 
 type backoff struct {

--- a/vendor/github.com/elastic/beats/libbeat/monitoring/report/elasticsearch/elasticsearch.go
+++ b/vendor/github.com/elastic/beats/libbeat/monitoring/report/elasticsearch/elasticsearch.go
@@ -19,6 +19,7 @@ package elasticsearch
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"math/rand"
 	"net/url"
@@ -97,10 +98,15 @@ func defaultConfig(settings report.Settings) config {
 			Init: 1 * time.Second,
 			Max:  60 * time.Second,
 		},
+		Format: report.FormatXPackMonitoringBulk,
 	}
 
 	if settings.DefaultUsername != "" {
 		c.Username = settings.DefaultUsername
+	}
+
+	if settings.Format != report.FormatUnknown {
+		c.Format = settings.Format
 	}
 
 	return c
@@ -291,15 +297,23 @@ func (r *reporter) snapshotLoop(namespace, prefix string, period time.Duration) 
 		if len(r.tags) > 0 {
 			fields["tags"] = r.tags
 		}
+
+		meta := common.MapStr{
+			"type":        "beats_" + namespace,
+			"interval_ms": int64(period / time.Millisecond),
+			// Converting to seconds as interval only accepts `s` as unit
+			"params": map[string]string{"interval": strconv.Itoa(int(period/time.Second)) + "s"},
+		}
+
+		clusterUUID := getClusterUUID()
+		if clusterUUID != "" {
+			meta.Put("cluster_uuid", clusterUUID)
+		}
+
 		r.client.Publish(beat.Event{
 			Timestamp: ts,
 			Fields:    fields,
-			Meta: common.MapStr{
-				"type":        "beats_" + namespace,
-				"interval_ms": int64(period / time.Millisecond),
-				// Converting to seconds as interval only accepts `s` as unit
-				"params": map[string]string{"interval": strconv.Itoa(int(period/time.Second)) + "s"},
-			},
+			Meta:      meta,
 		})
 	}
 }
@@ -333,7 +347,11 @@ func makeClient(
 		return nil, err
 	}
 
-	return newPublishClient(esClient, params), nil
+	if config.Format != report.FormatXPackMonitoringBulk && config.Format != report.FormatBulk {
+		return nil, fmt.Errorf("unknown reporting format: %v", config.Format)
+	}
+
+	return newPublishClient(esClient, params, config.Format)
 }
 
 func closing(log *logp.Logger, c io.Closer) {
@@ -366,4 +384,20 @@ func makeMeta(beat beat.Info) common.MapStr {
 		"host":    beat.Hostname,
 		"uuid":    beat.ID,
 	}
+}
+
+func getClusterUUID() string {
+	stateRegistry := monitoring.GetNamespace("state").GetRegistry()
+	outputsRegistry := stateRegistry.GetRegistry("outputs")
+	if outputsRegistry == nil {
+		return ""
+	}
+
+	elasticsearchRegistry := outputsRegistry.GetRegistry("elasticsearch")
+	if elasticsearchRegistry == nil {
+		return ""
+	}
+
+	snapshot := monitoring.CollectFlatSnapshot(elasticsearchRegistry, monitoring.Full, false)
+	return snapshot.Strings["cluster_uuid"]
 }

--- a/vendor/github.com/elastic/beats/libbeat/monitoring/report/report.go
+++ b/vendor/github.com/elastic/beats/libbeat/monitoring/report/report.go
@@ -25,6 +25,23 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
+// Format encodes the type of format to report monitoring data in. This
+// is currently only being used by the elaticsearch reporter.
+// This is a hack that is necessary so we can map certain monitoring
+// configuration options to certain behaviors in reporters. Depending on
+// the configuration option used, the correct format is set, and reporters
+// that know how to interpret the format use it to choose the appropriate
+// reporting behavior.
+type Format int
+
+// Enumerations of various Formats. A reporter can choose whether to
+// interpret this setting or not, and if so, how to interpret it.
+const (
+	FormatUnknown Format = iota // to protect against zero-value errors
+	FormatXPackMonitoringBulk
+	FormatBulk
+)
+
 type config struct {
 	// allow for maximum one reporter being configured
 	Reporter common.ConfigNamespace `config:",inline"`
@@ -32,6 +49,7 @@ type config struct {
 
 type Settings struct {
 	DefaultUsername string
+	Format          Format
 }
 
 type Reporter interface {
@@ -59,7 +77,7 @@ func New(
 	cfg *common.Config,
 	outputs common.ConfigNamespace,
 ) (Reporter, error) {
-	name, cfg, err := getReporterConfig(cfg, outputs)
+	name, cfg, err := getReporterConfig(cfg, settings, outputs)
 	if err != nil {
 		return nil, err
 	}
@@ -73,10 +91,11 @@ func New(
 }
 
 func getReporterConfig(
-	cfg *common.Config,
+	monitoringConfig *common.Config,
+	settings Settings,
 	outputs common.ConfigNamespace,
 ) (string, *common.Config, error) {
-	cfg = collectSubObject(cfg)
+	cfg := collectSubObject(monitoringConfig)
 	config := defaultConfig
 	if err := cfg.Unpack(&config); err != nil {
 		return "", nil, err
@@ -96,7 +115,7 @@ func getReporterConfig(
 			}{}
 			rc.Unpack(&hosts)
 
-			if len(hosts.Hosts) > 0 {
+			if settings.Format == FormatXPackMonitoringBulk && len(hosts.Hosts) > 0 {
 				pathMonHosts := rc.PathOf("hosts")
 				pathOutHost := outCfg.PathOf("hosts")
 				err := fmt.Errorf("'%v' and '%v' are configured", pathMonHosts, pathOutHost)

--- a/vendor/github.com/elastic/beats/libbeat/outputs/elasticsearch/client.go
+++ b/vendor/github.com/elastic/beats/libbeat/outputs/elasticsearch/client.go
@@ -77,7 +77,8 @@ type ClientSettings struct {
 	Observer           outputs.Observer
 }
 
-type connectCallback func(client *Client) error
+// ConnectCallback defines the type for the function to be called when the Elasticsearch client successfully connects to the cluster
+type ConnectCallback func(client *Client) error
 
 // Connection manages the connection for a given client.
 type Connection struct {

--- a/vendor/github.com/elastic/beats/libbeat/outputs/elasticsearch/elasticsearch.go
+++ b/vendor/github.com/elastic/beats/libbeat/outputs/elasticsearch/elasticsearch.go
@@ -54,7 +54,7 @@ var (
 // Callbacks must not depend on the result of a previous one,
 // because the ordering is not fixed.
 type callbacksRegistry struct {
-	callbacks map[uuid.UUID]connectCallback
+	callbacks map[uuid.UUID]ConnectCallback
 	mutex     sync.Mutex
 }
 
@@ -66,7 +66,7 @@ var connectCallbackRegistry = newCallbacksRegistry()
 var globalCallbackRegistry = newCallbacksRegistry()
 
 // RegisterGlobalCallback register a global callbacks.
-func RegisterGlobalCallback(callback connectCallback) (uuid.UUID, error) {
+func RegisterGlobalCallback(callback ConnectCallback) (uuid.UUID, error) {
 	globalCallbackRegistry.mutex.Lock()
 	defer globalCallbackRegistry.mutex.Unlock()
 
@@ -88,14 +88,14 @@ func RegisterGlobalCallback(callback connectCallback) (uuid.UUID, error) {
 
 func newCallbacksRegistry() callbacksRegistry {
 	return callbacksRegistry{
-		callbacks: make(map[uuid.UUID]connectCallback),
+		callbacks: make(map[uuid.UUID]ConnectCallback),
 	}
 }
 
 // RegisterConnectCallback registers a callback for the elasticsearch output
 // The callback is called each time the client connects to elasticsearch.
 // It returns the key of the newly added callback, so it can be deregistered later.
-func RegisterConnectCallback(callback connectCallback) (uuid.UUID, error) {
+func RegisterConnectCallback(callback ConnectCallback) (uuid.UUID, error) {
 	connectCallbackRegistry.mutex.Lock()
 	defer connectCallbackRegistry.mutex.Unlock()
 

--- a/vendor/github.com/elastic/beats/libbeat/processors/actions/checks.go
+++ b/vendor/github.com/elastic/beats/libbeat/processors/actions/checks.go
@@ -79,3 +79,25 @@ func allowedFields(fields ...string) func(*common.Config) error {
 		return nil
 	}
 }
+
+func mutuallyExclusiveRequiredFields(fields ...string) func(*common.Config) error {
+	return func(cfg *common.Config) error {
+		var foundField string
+		for _, field := range cfg.GetFields() {
+			for _, f := range fields {
+				if field == f {
+					if len(foundField) == 0 {
+						foundField = field
+					} else {
+						return fmt.Errorf("field %s and %s are mutually exclusive", foundField, field)
+					}
+				}
+			}
+		}
+
+		if len(foundField) == 0 {
+			return fmt.Errorf("missing option, select one from %v", fields)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/elastic/beats/libbeat/processors/actions/truncate_fields.go
+++ b/vendor/github.com/elastic/beats/libbeat/processors/actions/truncate_fields.go
@@ -1,0 +1,198 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package actions
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/processors"
+)
+
+type truncateFieldsConfig struct {
+	Fields        []string `config:"fields"`
+	MaxBytes      int      `config:"max_bytes" validate:"min=0"`
+	MaxChars      int      `config:"max_characters" validate:"min=0"`
+	IgnoreMissing bool     `config:"ignore_missing"`
+	FailOnError   bool     `config:"fail_on_error"`
+}
+
+type truncateFields struct {
+	config   truncateFieldsConfig
+	truncate truncater
+}
+
+type truncater func(*truncateFields, []byte) ([]byte, bool, error)
+
+func init() {
+	processors.RegisterPlugin("truncate_fields",
+		configChecked(newTruncateFields,
+			requireFields("fields"),
+			mutuallyExclusiveRequiredFields("max_bytes", "max_characters"),
+		),
+	)
+}
+
+func newTruncateFields(c *common.Config) (processors.Processor, error) {
+	var config truncateFieldsConfig
+	err := c.Unpack(&config)
+	if err != nil {
+		return nil, fmt.Errorf("fail to unpack the truncate_fields configuration: %s", err)
+	}
+
+	var truncateFunc truncater
+	if config.MaxBytes > 0 {
+		truncateFunc = (*truncateFields).truncateBytes
+	} else {
+		truncateFunc = (*truncateFields).truncateCharacters
+	}
+
+	return &truncateFields{
+		config:   config,
+		truncate: truncateFunc,
+	}, nil
+}
+
+func (f *truncateFields) Run(event *beat.Event) (*beat.Event, error) {
+	var backup common.MapStr
+	if f.config.FailOnError {
+		backup = event.Fields.Clone()
+	}
+
+	for _, field := range f.config.Fields {
+		event, err := f.truncateSingleField(field, event)
+		if err != nil && f.config.FailOnError {
+			logp.Debug("truncate_fields", "Failed to truncate fields: %s", err)
+			event.Fields = backup
+			return event, err
+		}
+	}
+
+	return event, nil
+}
+
+func (f *truncateFields) truncateSingleField(field string, event *beat.Event) (*beat.Event, error) {
+	v, err := event.GetValue(field)
+	if err != nil {
+		if f.config.IgnoreMissing && errors.Cause(err) == common.ErrKeyNotFound {
+			return event, nil
+		}
+		return event, errors.Wrapf(err, "could not fetch value for key: %s", field)
+	}
+
+	switch value := v.(type) {
+	case []byte:
+		return f.addTruncatedByte(field, value, event)
+	case string:
+		return f.addTruncatedString(field, value, event)
+	default:
+		return event, fmt.Errorf("value cannot be truncated: %+v", value)
+	}
+
+}
+
+func (f *truncateFields) addTruncatedString(field, value string, event *beat.Event) (*beat.Event, error) {
+	truncated, isTruncated, err := f.truncate(f, []byte(value))
+	if err != nil {
+		return event, err
+	}
+	_, err = event.PutValue(field, string(truncated))
+	if err != nil {
+		return event, fmt.Errorf("could not add truncated string value for key: %s, Error: %+v", field, err)
+	}
+
+	if isTruncated {
+		common.AddTagsWithKey(event.Fields, "log.flags", []string{"truncated"})
+	}
+
+	return event, nil
+}
+
+func (f *truncateFields) addTruncatedByte(field string, value []byte, event *beat.Event) (*beat.Event, error) {
+	truncated, isTruncated, err := f.truncate(f, value)
+	if err != nil {
+		return event, err
+	}
+	_, err = event.PutValue(field, truncated)
+	if err != nil {
+		return event, fmt.Errorf("could not add truncated byte slice value for key: %s, Error: %+v", field, err)
+	}
+
+	if isTruncated {
+		common.AddTagsWithKey(event.Fields, "log.flags", []string{"truncated"})
+	}
+
+	return event, nil
+}
+
+func (f *truncateFields) truncateBytes(value []byte) ([]byte, bool, error) {
+	size := len(value)
+	if size <= f.config.MaxBytes {
+		return value, false, nil
+	}
+
+	size = f.config.MaxBytes
+	truncated := make([]byte, size)
+	n := copy(truncated, value[:size])
+	if n != size {
+		return nil, false, fmt.Errorf("unexpected number of bytes were copied")
+	}
+	return truncated, true, nil
+}
+
+func (f *truncateFields) truncateCharacters(value []byte) ([]byte, bool, error) {
+	count := utf8.RuneCount(value)
+	if count <= f.config.MaxChars {
+		return value, false, nil
+	}
+
+	count = f.config.MaxChars
+	r := bytes.NewReader(value)
+	w := bytes.NewBuffer(nil)
+
+	for i := 0; i < count; i++ {
+		r, _, err := r.ReadRune()
+		if err != nil {
+			return nil, false, err
+		}
+
+		_, err = w.WriteRune(r)
+		if err != nil {
+			return nil, false, err
+		}
+	}
+
+	return w.Bytes(), true, nil
+}
+
+func (f *truncateFields) String() string {
+	var limit string
+	if f.config.MaxBytes > 0 {
+		limit = fmt.Sprintf("max_bytes=%d", f.config.MaxBytes)
+	} else {
+		limit = fmt.Sprintf("max_characters=%d", f.config.MaxChars)
+	}
+	return "truncate_fields=" + strings.Join(f.config.Fields, ", ") + limit
+}

--- a/vendor/github.com/elastic/beats/libbeat/processors/add_docker_metadata/add_docker_metadata.go
+++ b/vendor/github.com/elastic/beats/libbeat/processors/add_docker_metadata/add_docker_metadata.go
@@ -87,7 +87,7 @@ func buildDockerMetadataProcessor(cfg *common.Config, watcherConstructor docker.
 	var sourceProcessor processors.Processor
 	if config.MatchSource {
 		var procConf, _ = common.NewConfigFrom(map[string]interface{}{
-			"field":     "source",
+			"field":     "log.file.path",
 			"separator": string(os.PathSeparator),
 			"index":     config.SourceIndex,
 			"target":    dockerContainerIDKey,
@@ -123,10 +123,10 @@ func lazyCgroupCacheInit(d *addDockerMetadata) {
 func (d *addDockerMetadata) Run(event *beat.Event) (*beat.Event, error) {
 	var cid string
 	var err error
-
-	// Extract CID from the filepath contained in the "source" field.
+	// Extract CID from the filepath contained in the "log.file.path" field.
 	if d.sourceProcessor != nil {
-		if event.Fields["source"] != nil {
+		lfp, _ := event.Fields.GetValue("log.file.path")
+		if lfp != nil {
 			event, err = d.sourceProcessor.Run(event)
 			if err != nil {
 				d.log.Debugf("Error while extracting container ID from source path: %v", err)

--- a/vendor/github.com/elastic/beats/x-pack/libbeat/licenser/elastic_fetcher.go
+++ b/vendor/github.com/elastic/beats/x-pack/libbeat/licenser/elastic_fetcher.go
@@ -72,11 +72,7 @@ func (st *State) UnmarshalJSON(b []byte) error {
 
 // UnmarshalJSON takes a bytes array and transform the int64 to a golang time.
 func (et *expiryTime) UnmarshalJSON(b []byte) error {
-	if len(b) < 0 {
-		return fmt.Errorf("invalid value for expiry time, received: '%s'", string(b))
-	}
-
-	ts, err := strconv.Atoi(string(b))
+	ts, err := strconv.ParseInt(string(b), 0, 64)
 	if err != nil {
 		return errors.Wrap(err, "could not parse value for expiry time")
 	}

--- a/vendor/github.com/elastic/beats/x-pack/libbeat/licenser/license.go
+++ b/vendor/github.com/elastic/beats/x-pack/libbeat/licenser/license.go
@@ -6,8 +6,6 @@ package licenser
 
 import (
 	"time"
-
-	"github.com/gofrs/uuid"
 )
 
 // License represents the license of this beat, the license is fetched and returned from
@@ -27,7 +25,7 @@ import (
 // mode is the license in operation. (effective license)
 // status is the type installed is active or not.
 type License struct {
-	UUID        uuid.UUID   `json:"uid"`
+	UUID        string      `json:"uid"`
 	Type        LicenseType `json:"type"`
 	Mode        LicenseType `json:"mode"`
 	Status      State       `json:"status"`
@@ -54,7 +52,7 @@ type Base struct {
 	Available bool `json:"available"`
 }
 
-// Defines all the avaiables features
+// Defines all the available features
 type graph struct{ *Base }
 type logstash struct{ *Base }
 type ml struct{ *Base }

--- a/vendor/github.com/elastic/beats/x-pack/libbeat/licenser/manager.go
+++ b/vendor/github.com/elastic/beats/x-pack/libbeat/licenser/manager.go
@@ -29,7 +29,7 @@ func mustUUIDV4() uuid.UUID {
 // OSSLicense default license to use.
 var (
 	OSSLicense = &License{
-		UUID:   mustUUIDV4(),
+		UUID:   mustUUIDV4().String(),
 		Type:   OSS,
 		Mode:   OSS,
 		Status: Active,

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -6,1130 +6,1130 @@
 			"checksumSHA1": "eruIVA8JnsB23rVKjETHvqJ0sj8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/DataDog/zstd",
 			"path": "github.com/DataDog/zstd",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "AzjRkOQtVBTwIw4RJLTygFhJs3s=",
 			"origin": "github.com/elastic/beats/vendor/github.com/Microsoft/go-winio",
 			"path": "github.com/Microsoft/go-winio",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "Yn3uTky/UjksI76cPRAxXomzMKM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/Shopify/sarama",
 			"path": "github.com/Shopify/sarama",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "DYv6Q1+VfnUVxMwvk5IshAClLvw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/Sirupsen/logrus",
 			"path": "github.com/Sirupsen/logrus",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "Te1xRugxHQMAg7EvbIUuPWm8fvU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/StackExchange/wmi",
 			"path": "github.com/StackExchange/wmi",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "dvabztWVQX8f6oMLRyv4dLH+TGY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/davecgh/go-spew/spew",
 			"path": "github.com/davecgh/go-spew/spew",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "Gj+xR1VgFKKmFXYOJMnAczC3Znk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/distribution/digestset",
 			"path": "github.com/docker/distribution/digestset",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "2Fe4D6PGaVE2he4fUeenLmhC1lE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/distribution/reference",
 			"path": "github.com/docker/distribution/reference",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "UL2NF1EGiSsQoEfvycnuZIcUbZY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api",
 			"path": "github.com/docker/docker/api",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "KMFpbV3mlrbc41d2DYnq05QYpSc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types",
 			"path": "github.com/docker/docker/api/types",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "jVJDbe0IcyjoKc2xbohwzQr+FF0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/blkiodev",
 			"path": "github.com/docker/docker/api/types/blkiodev",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "AeSC0BOu1uapkGqfSXtfVSpwJzs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/container",
 			"path": "github.com/docker/docker/api/types/container",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "4XuWn5+wgYwUsw604jvYMklq4Hc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/events",
 			"path": "github.com/docker/docker/api/types/events",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "J2OKngfI3vgswudr9PZVUFcRRu0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/filters",
 			"path": "github.com/docker/docker/api/types/filters",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "yeB781yxPhnN6OXQ9/qSsyih3ek=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/image",
 			"path": "github.com/docker/docker/api/types/image",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "UK+VdM648oWzyqE4OqttgmPqjoA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/mount",
 			"path": "github.com/docker/docker/api/types/mount",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "Gskp+nvbVe8Gk1xPLHylZvNmqTg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/network",
 			"path": "github.com/docker/docker/api/types/network",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "r2vWq7Uc3ExKzMqYgH0b4AKjLKY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/registry",
 			"path": "github.com/docker/docker/api/types/registry",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "VTxWyFud/RedrpllGdQonVtGM/A=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/strslice",
 			"path": "github.com/docker/docker/api/types/strslice",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "ZaizCpJ3eBcfR9ywpLaJd4AhM9k=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/swarm",
 			"path": "github.com/docker/docker/api/types/swarm",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "B7ZwKzrv3t3Vlox6/bYMHhMjsM8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/time",
 			"path": "github.com/docker/docker/api/types/time",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "uDPQ3nHsrvGQc9tg/J9OSC4N5dQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/versions",
 			"path": "github.com/docker/docker/api/types/versions",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "IBJy2zPEnYmcFJ3lM1eiRWnCxTA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/api/types/volume",
 			"path": "github.com/docker/docker/api/types/volume",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "c6OyeEvpQDvVLhrJSxgjEZv1tF8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/client",
 			"path": "github.com/docker/docker/client",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "jmo/t2zXAxirEPoFucNPXA/1SEc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/ioutils",
 			"path": "github.com/docker/docker/pkg/ioutils",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "ndnAFCfsGC3upNQ6jAEwzxcurww=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/longpath",
 			"path": "github.com/docker/docker/pkg/longpath",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "kr46EAa+FsUcWxOq6edyX6BUzE4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/system",
 			"path": "github.com/docker/docker/pkg/system",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "8I0Ez+aUYGpsDEVZ8wN/Ztf6Zqs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/docker/pkg/tlsconfig",
 			"path": "github.com/docker/docker/pkg/tlsconfig",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "JbiWTzH699Sqz25XmDlsARpMN9w=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-connections/nat",
 			"path": "github.com/docker/go-connections/nat",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "jUfDG3VQsA2UZHvvIXncgiddpYA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-connections/sockets",
 			"path": "github.com/docker/go-connections/sockets",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "tuSzlS1UQ03+5Fvtqr5hI5sLLhA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-connections/tlsconfig",
 			"path": "github.com/docker/go-connections/tlsconfig",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "ambe8F4AofPxChCJssXXwWphQQ8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/go-units",
 			"path": "github.com/docker/go-units",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "sNAU9ojYVUhO6dVXey6T3JhRQpw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/docker/libtrust",
 			"path": "github.com/docker/libtrust",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "rhLUtXvcmouYuBwOq9X/nYKzvNg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/dustin/go-humanize",
 			"path": "github.com/dustin/go-humanize",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "y2Kh4iPlgCPXSGTCcFpzePYdzzg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/eapache/go-resiliency/breaker",
 			"path": "github.com/eapache/go-resiliency/breaker",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "WHl96RVZlOOdF4Lb1OOadMpw8ls=",
 			"origin": "github.com/elastic/beats/vendor/github.com/eapache/go-xerial-snappy",
 			"path": "github.com/eapache/go-xerial-snappy",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "oCCs6kDanizatplM5e/hX76busE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/eapache/queue",
 			"path": "github.com/eapache/queue",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "X1W+5VRVoE0q+dWQC42IUnIrbOI=",
 			"path": "github.com/elastic/beats/dev-tools/mage",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "PBTxyr6OotF2pda9n8gMeGUkfLA=",
 			"path": "github.com/elastic/beats/filebeat/generator",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "cDyXG8WG+dr1ai7qCnhbJ6N3OyY=",
 			"path": "github.com/elastic/beats/filebeat/scripts/generator",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "y34pfVnTprxa4BvLKfiBbqTJaGA=",
 			"path": "github.com/elastic/beats/libbeat/api",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "3cMzsLhs9W65wKpzZLiSB4i73mc=",
 			"path": "github.com/elastic/beats/libbeat/asset",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "+XIt3467v/mRmLoIs6stBev5kUY=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "ZCQyqZn3NFfAJo//PSd1YASvytY=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/appenders/config",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "gYzafDSTZSwto35HHYZi7Ix6yKw=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/builder",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "IifZH9hzzPymGV2XQfQ/tFR4uSE=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/meta",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "OZUNXFIdj23SONU9ydK6X1hKlBA=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/providers/docker",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "m9yIpAuVVFufXqxoxsRwj1WFWQk=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/providers/jolokia",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "cwQOLzZo7ef8+vOdhDc+ZVlPMMw=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/providers/kubernetes",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "eaKz8KWZXYHpLvBCIRN3V8J7G18=",
 			"path": "github.com/elastic/beats/libbeat/autodiscover/template",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "qt64FenKin4Pmp5IBv+XtsUi0yA=",
 			"path": "github.com/elastic/beats/libbeat/beat",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "CFiXoZkNdZtYgfMUXhNJDrXE7FI=",
+			"checksumSHA1": "BPu1SSRwUQakj2hXPc3I8k5HQgQ=",
 			"path": "github.com/elastic/beats/libbeat/cfgfile",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "/IuTlhYU7mcJKhOHniR06bWGnxg=",
 			"path": "github.com/elastic/beats/libbeat/cloudid",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "yfFh5TbZE56TmMV87ORakzRtLRc=",
 			"path": "github.com/elastic/beats/libbeat/cmd",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "iGV716P1H+4sFSGJdHew23eUOnE=",
 			"path": "github.com/elastic/beats/libbeat/cmd/export",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "5rAovFyiUYoknxNSyCvxIh2GAt4=",
+			"checksumSHA1": "vribzQKEfO+N1fvP7Tpt41zt2vE=",
 			"path": "github.com/elastic/beats/libbeat/cmd/instance",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "FZW7PkwBFzSm0Y3qoz4pgYL17Qs=",
 			"path": "github.com/elastic/beats/libbeat/cmd/test",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "/JQnnXc2leXjIbPEO7z3tj4Epu4=",
 			"path": "github.com/elastic/beats/libbeat/common",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "lFYRu/M9CL6/povZOeBYui9/laI=",
 			"path": "github.com/elastic/beats/libbeat/common/atomic",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "O5lD0j+tTM5lZkSzPE9KaxiHTeY=",
 			"path": "github.com/elastic/beats/libbeat/common/backoff",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Fxbw/7lPbh9dY3HH5k8sc4PU6Yo=",
 			"path": "github.com/elastic/beats/libbeat/common/bus",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "zRpP/UzB/wFQNLceGdVgC4QqviM=",
 			"path": "github.com/elastic/beats/libbeat/common/cfgtype",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "d0pIynyart5HMe7IKw3wtIH2R48=",
 			"path": "github.com/elastic/beats/libbeat/common/cfgwarn",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "gagye6XHCqSCAVjpdJAGSOd06Uw=",
 			"path": "github.com/elastic/beats/libbeat/common/cli",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Ps5fuDikiF/KR7BeQqRkIztHxVY=",
 			"path": "github.com/elastic/beats/libbeat/common/docker",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Gxdi0z5FpIG68TQBD+zho4pEBlU=",
 			"path": "github.com/elastic/beats/libbeat/common/dtfmt",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "jbY1pbQtRWeQk0RV1wSMgkRAgJk=",
 			"path": "github.com/elastic/beats/libbeat/common/file",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "vSs1uzCmbsEzpBPxA4whpJviEBY=",
 			"path": "github.com/elastic/beats/libbeat/common/flowhash",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "pt4OCbyb9z7fgJEidmOx6mua0h8=",
 			"path": "github.com/elastic/beats/libbeat/common/fmtstr",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "K8hsg9OHpVHm7A43uq+TdX5DRc4=",
 			"path": "github.com/elastic/beats/libbeat/common/jsontransform",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "syBGSam2yNQZRz41QgXaAOWWQn4=",
 			"path": "github.com/elastic/beats/libbeat/common/kafka",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "/0orukOMfUZKhGiGDaMcVcEf5xA=",
 			"path": "github.com/elastic/beats/libbeat/common/kubernetes",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "tX/nsD/KEE0KCWECoPyx5CHNPdc=",
 			"path": "github.com/elastic/beats/libbeat/common/match",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "jLi8S5eaG9uPawGF105+Z8dkesc=",
 			"path": "github.com/elastic/beats/libbeat/common/reload",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "uMo9yaQAFfFG9iOsmdhQokffvpc=",
 			"path": "github.com/elastic/beats/libbeat/common/safemapstr",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "719FzIxi7bvpmh3Z1Ugn1VzY7Ro=",
 			"path": "github.com/elastic/beats/libbeat/common/schema",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "uffmniMUvoDPoH/udr7ogkh062E=",
 			"path": "github.com/elastic/beats/libbeat/common/schema/mapstriface",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "tZSvsfUQvhPhFjowAUkRntjtuCc=",
 			"path": "github.com/elastic/beats/libbeat/common/seccomp",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "idXNC65t9dEVukD08AM6/L2p/RE=",
 			"path": "github.com/elastic/beats/libbeat/common/streambuf",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "IQGJeUodp0fl4Zy8W1rBzWtWSWA=",
 			"path": "github.com/elastic/beats/libbeat/common/terminal",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "NByKtWaf9vFTp6K338x8XA1xycw=",
 			"path": "github.com/elastic/beats/libbeat/common/transport/tlscommon",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "mKnP/8VOfmP1+9RK3M7ES3SQQ3I=",
 			"path": "github.com/elastic/beats/libbeat/conditions",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "LRrDnnMknoFSPRwm8FvQvsrRZhY=",
 			"path": "github.com/elastic/beats/libbeat/dashboards",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Tn+4O4FlSxSOxGF9qkH363wQCtA=",
 			"path": "github.com/elastic/beats/libbeat/feature",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Qe3OwrLlg7ZrkPcbPI36pwTgJxQ=",
 			"path": "github.com/elastic/beats/libbeat/generator/fields",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "318/8WL2KiTQNBbBWiBE6iFKoFg=",
 			"path": "github.com/elastic/beats/libbeat/idxmgmt",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "dFrKmkaPypSJvQw5WaW0WqEFjuI=",
 			"path": "github.com/elastic/beats/libbeat/idxmgmt/ilm",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "krdjLK+gZhQpyqW24pQygLa57/I=",
 			"path": "github.com/elastic/beats/libbeat/keystore",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "I8BmSltR9jb1cXbJ3z0qv75/FQE=",
 			"path": "github.com/elastic/beats/libbeat/kibana",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "M9mSRhP65Jnf/yk2qtZU6FM9OUw=",
 			"path": "github.com/elastic/beats/libbeat/logp",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "bM+Zvy63NmXBfPQZYZmWBCo/UIk=",
 			"path": "github.com/elastic/beats/libbeat/logp/configure",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "F/nzOXIrS9ui9wBLhuYa6M0fDEw=",
 			"path": "github.com/elastic/beats/libbeat/management",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "EGs9VRKr10XQ6QXvJxyMeX3rxdI=",
 			"path": "github.com/elastic/beats/libbeat/mapping",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "/qNmzEvnTPNTKsZG8NgDzJZ+6f8=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/cpu",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "ASezoo5ifdtv1UwROTGAu+VbNJA=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/host",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "lXmDdjbZAQJWerhniNifgiD+Fgs=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/memory",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "+cI2jq/bUsjqPA7RsN9SJ8nE4xc=",
 			"path": "github.com/elastic/beats/libbeat/metric/system/process",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "JaqeGyZo3TRATCeVaKSZ9+K+O5E=",
+			"checksumSHA1": "Wgqdg8ooYnpwFyXHwAvfq7+z33w=",
 			"path": "github.com/elastic/beats/libbeat/monitoring",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "+wdf9YlsiFYofUdPuovqskNoZnw=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/adapter",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "8rqXWL9EN+JXokIj4mNhd7GKXNY=",
+			"checksumSHA1": "VNBF1uWUqTgAKqi7chDC63dpDno=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "JqocY5qMu61NdeyKmHb57Pjc/fI=",
+			"checksumSHA1": "7D3ybHghR/ySVkF76wx0DH18CIA=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report/elasticsearch",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "FJhQn6mS1pcNkFLFjFPulLZjC9w=",
 			"path": "github.com/elastic/beats/libbeat/monitoring/report/log",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "ueIlWpPNgtKmH9MINun26RPPY2k=",
 			"path": "github.com/elastic/beats/libbeat/outputs",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "CsWdZfYNuwBA2/RhAybzEf93qq4=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "dO9pXcIpo6PH5yxMbJUSb/BYbkc=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec/format",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "DbeMJiVepl/K4NXgWHHc2KyCpg0=",
 			"path": "github.com/elastic/beats/libbeat/outputs/codec/json",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "oGzibF8p3OLvTRGLoQi+ny7zN5A=",
 			"path": "github.com/elastic/beats/libbeat/outputs/console",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "Y8enGbqkxn1alc27+3K2xj8K6X0=",
+			"checksumSHA1": "kRkPQnSwpPBeh33Kc0ckM/nkTjU=",
 			"path": "github.com/elastic/beats/libbeat/outputs/elasticsearch",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "tMYYeBk2SmTet6FUrltPtfeCY/U=",
 			"path": "github.com/elastic/beats/libbeat/outputs/fileout",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "lBCMUBRin5C8cY4K8hc8ai+hu6A=",
 			"path": "github.com/elastic/beats/libbeat/outputs/kafka",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "0YSMsaDcPs65eNX2CJBtTy24aGg=",
 			"path": "github.com/elastic/beats/libbeat/outputs/logstash",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "NJv+STaa3bEOeVra8WkEgOtzQic=",
 			"path": "github.com/elastic/beats/libbeat/outputs/outil",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "FXa52r8DUyJyiSRI6SjErh6PHds=",
 			"path": "github.com/elastic/beats/libbeat/outputs/redis",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "ImdqSpCufsbWiNECpdZ0KeeQidM=",
 			"path": "github.com/elastic/beats/libbeat/outputs/transport",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "qPVudVlj4dE+HHMe4WGlaf4mFCo=",
 			"path": "github.com/elastic/beats/libbeat/outputs/transport/transptest",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "hb8M4qSLzgDXpQmdQfEyB7aChhI=",
 			"path": "github.com/elastic/beats/libbeat/paths",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "OVd5zDYdT/3QK2zj1M+BMPP0AIo=",
 			"path": "github.com/elastic/beats/libbeat/plugin",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "mZPFjfOJC55KjFDeu2IUAMgenhQ=",
 			"path": "github.com/elastic/beats/libbeat/processors",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "ZRBaZKvvWXH/RaYAvrKWlQVtQnE=",
+			"checksumSHA1": "/l1Zuuf+uglfDJVYmaST9hq3U+g=",
 			"path": "github.com/elastic/beats/libbeat/processors/actions",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "RVRXCHX2k6pBw8dIF4Wfnvl0JLA=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_cloud_metadata",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "V7tDhZoqPF1uRicI+5pTSjIJJws=",
+			"checksumSHA1": "Oj8ierk7XV5oPrf9H2tN/BicGTQ=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_docker_metadata",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "54ntVwDjzVDjhsLtgWYuWc25Upg=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_host_metadata",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "+JS4JL7RPI5MHb5H0MYqNm3Twjs=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_kubernetes_metadata",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "YyD/0oAETx7KqXq85Z0mjkY/Xz4=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_locale",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "LCBbhOT9n16YuQejCxmUpfggilA=",
 			"path": "github.com/elastic/beats/libbeat/processors/add_process_metadata",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "P8hCKTh+cDccJgM/8bqxGOhHQis=",
 			"path": "github.com/elastic/beats/libbeat/processors/communityid",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "GPOwd0zJ0tegXVcvzagvJMuw9qU=",
 			"path": "github.com/elastic/beats/libbeat/processors/dissect",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "32dCS/48D7mQ16FLoSWZn3RRzXY=",
 			"path": "github.com/elastic/beats/libbeat/processors/dns",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "7kYMLJJXmsDd9GyXgq9Z9eJdqrk=",
 			"path": "github.com/elastic/beats/libbeat/publisher",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "3lRU4d8X4NyPiCAml4LjDm3o928=",
 			"path": "github.com/elastic/beats/libbeat/publisher/includes",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "z5QPa207EQ5uQ/uRroxU1U4DtYk=",
 			"path": "github.com/elastic/beats/libbeat/publisher/pipeline",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "8wiczYiVOBkEqtK/tYPZA47BZGw=",
 			"path": "github.com/elastic/beats/libbeat/publisher/processing",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "RaONy2th8fDi9BF5U+lYu5bto4Y=",
 			"path": "github.com/elastic/beats/libbeat/publisher/queue",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "ZUwitg43Gan3j0V+ZjM+5Y/ibb8=",
 			"path": "github.com/elastic/beats/libbeat/publisher/queue/memqueue",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "dkG+1gq5pvcpU9f8BUZMEg+9oTI=",
 			"path": "github.com/elastic/beats/libbeat/publisher/queue/spool",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "fZ5S9LEZUcy5JlhwpHBn4MGNjOg=",
 			"path": "github.com/elastic/beats/libbeat/publisher/testing",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "vZZFb4M2d2t7tG3n2UEQeTk/lEM=",
 			"path": "github.com/elastic/beats/libbeat/scripts/cmd/global_fields",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "PqZjacjR7/w5mHFS9u7JXTc73dQ=",
 			"path": "github.com/elastic/beats/libbeat/service",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "lwUE8T0YlE4zdRE5RJvUowkQK1E=",
 			"path": "github.com/elastic/beats/libbeat/template",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "Ifly/yeBS+Ok0/PKez4lSqzu8JI=",
 			"path": "github.com/elastic/beats/libbeat/testing",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "9Kx3lCJSTPeXCsHnZrieI/zim1c=",
 			"path": "github.com/elastic/beats/libbeat/version",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "YRKEeQXsNj81zjG9gpkCyVpLKJs=",
 			"path": "github.com/elastic/beats/licenses",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "cUrFMhDnU7TaDevT/2ktmlFZdGQ=",
 			"path": "github.com/elastic/beats/x-pack/libbeat/cmd",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
-			"checksumSHA1": "BVekVtFZRY59bcLLXg4fLommV1I=",
+			"checksumSHA1": "k4fgaYBFVNNyURWitIpBn9jInXM=",
 			"path": "github.com/elastic/beats/x-pack/libbeat/licenser",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "PaMhQKDNfjHc3ONDLzd6lVvAVMs=",
 			"path": "github.com/elastic/beats/x-pack/libbeat/management",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
 		{
 			"checksumSHA1": "gRzvVNCF4bfdWjGDm+xJhQdEucY=",
 			"path": "github.com/elastic/beats/x-pack/libbeat/management/api",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z",
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z",
 			"version": "master",
 			"versionExact": "master"
 		},
@@ -1143,519 +1143,519 @@
 			"checksumSHA1": "3jizmlZPCyo6FAZY8Trk9jA8NH4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-lumber/client/v2",
 			"path": "github.com/elastic/go-lumber/client/v2",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "m6HLKpDAZlkTTQMqabf3aT6TQ/s=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-lumber/protocol/v2",
 			"path": "github.com/elastic/go-lumber/protocol/v2",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "TatpgVf9fhQp1GtNwSyNw5cgVKM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-seccomp-bpf",
 			"path": "github.com/elastic/go-seccomp-bpf",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "qTs7QT+GC2Dr4aFoLFHCkAOoVeU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-seccomp-bpf/arch",
 			"path": "github.com/elastic/go-seccomp-bpf/arch",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "W459MQNQ8qF6qmzLO/QLevTKZlU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform",
 			"path": "github.com/elastic/go-structform",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "BnoVvQlbw1jk1oveTVQtG+dhGRs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform/cborl",
 			"path": "github.com/elastic/go-structform/cborl",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "xjEIhANt0tAq4FjndVCLQhCXkQo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform/gotype",
 			"path": "github.com/elastic/go-structform/gotype",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "BIRSw/+jqs6VTgRx4MXJy453oGQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform/internal/unsafe",
 			"path": "github.com/elastic/go-structform/internal/unsafe",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "VPkz0hvtlbDDObJJZoTrjF2CN68=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform/json",
 			"path": "github.com/elastic/go-structform/json",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "zRLY43OHR3VYw3fu3XznhxziC4E=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform/ubjson",
 			"path": "github.com/elastic/go-structform/ubjson",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "QC8/6yQsm4f+zZo14ExnFtyiaXk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-structform/visitors",
 			"path": "github.com/elastic/go-structform/visitors",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "QhFIpuHPaV6hKejKcc2wm6y4MSQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo",
 			"path": "github.com/elastic/go-sysinfo",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "GiZCjX17K265TtamGZZw4R2Jwbk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo/internal/registry",
 			"path": "github.com/elastic/go-sysinfo/internal/registry",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "ovafihHzpBx9Y7+lZh9X5KwNCvE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo/providers/darwin",
 			"path": "github.com/elastic/go-sysinfo/providers/darwin",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "OyI+VwDiT4UZjncsDr1GYg1xcdw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo/providers/linux",
 			"path": "github.com/elastic/go-sysinfo/providers/linux",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "RWLvcP1w9ynKbuCqiW6prwd+EDU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo/providers/shared",
 			"path": "github.com/elastic/go-sysinfo/providers/shared",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "aF05MEkMjbRekzHlwFxmd5WBpeY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo/providers/windows",
 			"path": "github.com/elastic/go-sysinfo/providers/windows",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "MLQioPEjULYbNqqCjfB1/cux08E=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-sysinfo/types",
 			"path": "github.com/elastic/go-sysinfo/types",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "bNf3GDGhZh86bfCIMM5c5AYfo3g=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile",
 			"path": "github.com/elastic/go-txfile",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "scDqDI8APDj/tB973/ehmPufSLc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/dev-tools/lib/mage/gotool",
 			"path": "github.com/elastic/go-txfile/dev-tools/lib/mage/gotool",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "/WzE2caCHChUpoRAlXDU5uLTU5I=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/dev-tools/lib/mage/mgenv",
 			"path": "github.com/elastic/go-txfile/dev-tools/lib/mage/mgenv",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "kD/TFYofNqdOjb0nMN0w3LC/nNU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/dev-tools/lib/mage/xbuild",
 			"path": "github.com/elastic/go-txfile/dev-tools/lib/mage/xbuild",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "re2W5hqGml/Q8vnx+DT3ooUNWxo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/internal/cleanup",
 			"path": "github.com/elastic/go-txfile/internal/cleanup",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "HjNNDapvfXgOJqs7l7pS3ho6SSI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/internal/invariant",
 			"path": "github.com/elastic/go-txfile/internal/invariant",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "HLMF+V6Pt3YLUNOgmd2nR+vz9vM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/internal/iter",
 			"path": "github.com/elastic/go-txfile/internal/iter",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "EAIqvdq5S3FNBoTBAI/U02AwTSU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/internal/strbld",
 			"path": "github.com/elastic/go-txfile/internal/strbld",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "lejstOrGPfa+tJohvIOK/AjdLa4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/internal/vfs",
 			"path": "github.com/elastic/go-txfile/internal/vfs",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "Wqp2VCpbcmfOFuZJrYkaxpvQQrE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/internal/vfs/osfs",
 			"path": "github.com/elastic/go-txfile/internal/vfs/osfs",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "LYeqHmalUZgk3oOHtJyPOKlM/j4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/pq",
 			"path": "github.com/elastic/go-txfile/pq",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "fCx++6A9uzyCsDUanAIJb77u0MI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-txfile/txerr",
 			"path": "github.com/elastic/go-txfile/txerr",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "b91TSC0atoGVSMZdKuWTYsMOGiM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg",
 			"path": "github.com/elastic/go-ucfg",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "X+R/CD8SokJrmlxFTx2nSevRDhQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/cfgutil",
 			"path": "github.com/elastic/go-ucfg/cfgutil",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "/pq8HNEdzHmky9S9HSo1WofXQ4Y=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/flag",
 			"path": "github.com/elastic/go-ucfg/flag",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "esXpiQlEvTOUwsE0nNesso8albo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/internal/parse",
 			"path": "github.com/elastic/go-ucfg/internal/parse",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "cfMNsyQm0gZOV0hRJrBSdKDQSBo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/json",
 			"path": "github.com/elastic/go-ucfg/json",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "PJCBACDGPhnRAEqjGPMPCMjbj4o=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-ucfg/yaml",
 			"path": "github.com/elastic/go-ucfg/yaml",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "rnd3qf1FE22X3MxXWbetqq6EoBk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/go-windows",
 			"path": "github.com/elastic/go-windows",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "ux0d5xvItes2abrOlpEyQWeJeqM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar",
 			"path": "github.com/elastic/gosigar",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "TX9y4oPL5YmT4Gb/OU4GIPTdQB4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/cgroup",
 			"path": "github.com/elastic/gosigar/cgroup",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "hPqGM3DENaGfipEODoyZ4mKogTQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/sys",
 			"path": "github.com/elastic/gosigar/sys",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "mLq5lOyD0ZU39ysXuf1ETOLJ+f0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/sys/linux",
 			"path": "github.com/elastic/gosigar/sys/linux",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "Xx3lvjjqPwlFQ2aBjxtXSeDmD4c=",
 			"origin": "github.com/elastic/beats/vendor/github.com/elastic/gosigar/sys/windows",
 			"path": "github.com/elastic/gosigar/sys/windows",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "Klc34HULvwvY4cGA/D8HmqtXLqw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s",
 			"path": "github.com/ericchiang/k8s",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "y8fNiBLSoGojnUsGDsdLlsJYyqQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/apiextensions/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/apiextensions/v1beta1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "JxQ/zEWQSrncYNKifCuMctq+Tsw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/apps/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/apps/v1beta1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "bjklGt/pc6kWOZewAw87Hchw5oY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authentication/v1",
 			"path": "github.com/ericchiang/k8s/apis/authentication/v1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "LExhnM9Vn0LQoLQWszQ7aIxDxb4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authentication/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/authentication/v1beta1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "GM+PzOiBoq3cxx4h5RKVUb3UH60=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authorization/v1",
 			"path": "github.com/ericchiang/k8s/apis/authorization/v1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "zfr5oUVjbWRfvXi2LJiGMfFeDQY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/authorization/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/authorization/v1beta1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "izkXNDp5a5WP45jU0hSfTrwyfvM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/autoscaling/v1",
 			"path": "github.com/ericchiang/k8s/apis/autoscaling/v1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "FryZuAxWn4Ig8zc913w9BdfYzvs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/batch/v1",
 			"path": "github.com/ericchiang/k8s/apis/batch/v1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "ylo7Z8wyJD+tmICB7wsOVIBpO+U=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/batch/v2alpha1",
 			"path": "github.com/ericchiang/k8s/apis/batch/v2alpha1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "+d8+mSdkdcPWQIpczXDZZW0lrjg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/certificates/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/certificates/v1beta1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "S7AvxmCe/+WoFP/v9lZr0Mv66qg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/core/v1",
 			"path": "github.com/ericchiang/k8s/apis/core/v1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "cWPoP6XZN7WMnEVMPcgPgg3Aw9Q=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/extensions/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/extensions/v1beta1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "vaNrBPcGWeDd1rXl8+uN08uxWhE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/imagepolicy/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/imagepolicy/v1alpha1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "UNTTH+Ppu4vImnF+bPkG3/NR3gg=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/meta/v1",
 			"path": "github.com/ericchiang/k8s/apis/meta/v1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "Mmyg9Wh+FCVR6fV8MGEKRxvqZ2k=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/policy/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/policy/v1beta1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "bvwYS/wrBkyAfvCjzMbi/vKamrQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/rbac/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/rbac/v1alpha1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "m1Tde18NwewnvJoOYL3uykNcBuM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/rbac/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/rbac/v1beta1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "JirJkoeIkWJRNrbprsQvqwisxds=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/resource",
 			"path": "github.com/ericchiang/k8s/apis/resource",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "rQZ69PjEClQQ+PGEHRKzkGVVQyw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/settings/v1alpha1",
 			"path": "github.com/ericchiang/k8s/apis/settings/v1alpha1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "pp0AetmPoKy7Rz0zNhBwUpExkbc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/storage/v1",
 			"path": "github.com/ericchiang/k8s/apis/storage/v1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "WeACcIrS4EkeBm8TTftwuVniaWk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/apis/storage/v1beta1",
 			"path": "github.com/ericchiang/k8s/apis/storage/v1beta1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "Su6wSR8V8HL2QZsF8icJ0R9AFq8=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/runtime",
 			"path": "github.com/ericchiang/k8s/runtime",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "8ETrRvIaXPfD21N7fa8kdbumL00=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/runtime/schema",
 			"path": "github.com/ericchiang/k8s/runtime/schema",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "cMk3HE8/81ExHuEs0F5sZCclOFs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/util/intstr",
 			"path": "github.com/ericchiang/k8s/util/intstr",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "fobEKiMk5D7IGvCSwh4HdG1o98c=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ericchiang/k8s/watch/versioned",
 			"path": "github.com/ericchiang/k8s/watch/versioned",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "AANTVr9CVVyzsgviODY6Wi2thuM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/fatih/color",
 			"path": "github.com/fatih/color",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "2UmMbNHc8FBr98mJFN1k8ISOIHk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/garyburd/redigo/internal",
 			"path": "github.com/garyburd/redigo/internal",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "507OiSqTxfGCje7xDT5eq9CCaNQ=",
 			"origin": "github.com/elastic/beats/vendor/github.com/garyburd/redigo/redis",
 			"path": "github.com/garyburd/redigo/redis",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "ImX1uv6O09ggFeBPUJJ2nu7MPSA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/ghodss/yaml",
 			"path": "github.com/ghodss/yaml",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "2VgF+qja44x3wPTp8U8TZEU6FWw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/go-ole/go-ole",
 			"path": "github.com/go-ole/go-ole",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "Q0ZOcJW0fqOefDzEdn+PJHOeSgI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/go-ole/go-ole/oleutil",
 			"path": "github.com/go-ole/go-ole/oleutil",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "OFaReqy4hyrLlTTYFmcqkvidHsQ=",
@@ -1681,15 +1681,15 @@
 			"checksumSHA1": "kBeNcaKk56FguvPSUCEaH6AxpRc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/golang/protobuf/proto",
 			"path": "github.com/golang/protobuf/proto",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "p/8vSviYF91gFflhrt5vkyksroo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/golang/snappy",
 			"path": "github.com/golang/snappy",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "d9PxF1XQGLMJZRct2R8qVM/eYlE=",
@@ -1707,29 +1707,29 @@
 			"checksumSHA1": "40vJyUB4ezQSn/NSadsKEOrudMc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/inconshreveable/mousetrap",
 			"path": "github.com/inconshreveable/mousetrap",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "l9wW52CYGbmO/NGwYZ/Op2QTmaA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/joeshaw/multierror",
 			"path": "github.com/joeshaw/multierror",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "IH4jnWcj4d4h+hgsHsHOWg/F+rk=",
 			"origin": "github.com/elastic/beats/vendor/github.com/jstemmer/go-junit-report/formatter",
 			"path": "github.com/jstemmer/go-junit-report/formatter",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "Tx9cQqKFUHzu1l6H2XEl8G7ivlI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/jstemmer/go-junit-report/parser",
 			"path": "github.com/jstemmer/go-junit-report/parser",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "pa+ZwMzIv+u+BlL8Q2xgL9cQtJg=",
@@ -1741,36 +1741,36 @@
 			"checksumSHA1": "KKxbAKrKrfd33YPpkNsDmTN3S+M=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/compress/flate",
 			"path": "github.com/klauspost/compress/flate",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "+azPXaZpPF14YHRghNAer13ThQU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/compress/zlib",
 			"path": "github.com/klauspost/compress/zlib",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "R6zKqn31GjJH1G8W/api7fAW0RU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/cpuid",
 			"path": "github.com/klauspost/cpuid",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "BM6ZlNJmtKy3GBoWwg2X55gnZ4A=",
 			"origin": "github.com/elastic/beats/vendor/github.com/klauspost/crc32",
 			"path": "github.com/klauspost/crc32",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "ASXhLVfIA2mzHf+7muYxT38JaHU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage",
 			"path": "github.com/magefile/mage",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "KODorM0Am1g55qObNz3jVOdRVFs=",
@@ -1783,29 +1783,29 @@
 			"checksumSHA1": "fHpo/9Tke6VFfZZAT+PRnoNOiiY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage/internal",
 			"path": "github.com/magefile/mage/internal",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "RVSwuhHOfojhN74rfwRe4AktDIA=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage/mage",
 			"path": "github.com/magefile/mage/mage",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "irRTBkCBnOGMX+PZhOdHFUckgBY=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage/mg",
 			"path": "github.com/magefile/mage/mg",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "QGt/JRmNp+D+lO0hHZsUUyH7y5U=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage/parse",
 			"path": "github.com/magefile/mage/parse",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "fEuDveZzYX6oqYOT9jqyZROun/Q=",
@@ -1818,15 +1818,15 @@
 			"checksumSHA1": "4JzH55TcYdctQksrCafgKT8lZRU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage/sh",
 			"path": "github.com/magefile/mage/sh",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "91U4Tlwnjdmwjd0w/XNw3+fxFKo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/magefile/mage/target",
 			"path": "github.com/magefile/mage/target",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "He+VtZO7BsPDCZhZtJ1IkNp629o=",
@@ -1839,50 +1839,50 @@
 			"checksumSHA1": "qNkx9+OTwZI6aFv7K9zuFCGODUw=",
 			"origin": "github.com/elastic/beats/vendor/github.com/mattn/go-colorable",
 			"path": "github.com/mattn/go-colorable",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "U6lX43KDDlNOn+Z0Yyww+ZzHfFo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/mattn/go-isatty",
 			"path": "github.com/mattn/go-isatty",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "VsImZoqjaqgwK+u/4eIEzQhuRNM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/miekg/dns",
 			"path": "github.com/miekg/dns",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "sWdAYPKyaT4SW8hNQNpRS0sU4lU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/mitchellh/hashstructure",
 			"path": "github.com/mitchellh/hashstructure",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "2AyUkWjutec6p+470tgio8mYOxI=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/go-digest",
 			"path": "github.com/opencontainers/go-digest",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "eOMCORUm8KxiGSy0hBuQsMsxauo=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/image-spec/specs-go",
 			"path": "github.com/opencontainers/image-spec/specs-go",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "9YujSsJjiLGkQMzwWycsjqR340k=",
 			"origin": "github.com/elastic/beats/vendor/github.com/opencontainers/image-spec/specs-go/v1",
 			"path": "github.com/opencontainers/image-spec/specs-go/v1",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "JVGDxPn66bpe6xEiexs1r+y6jF0=",
@@ -1894,15 +1894,15 @@
 			"checksumSHA1": "WmrPO1ovmQ7t7hs9yZGbr2SAoM4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pierrec/lz4",
 			"path": "github.com/pierrec/lz4",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "IT4sX58d+e8osXHV5U6YCSdB/uE=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pierrec/xxHash/xxHash32",
 			"path": "github.com/pierrec/xxHash/xxHash32",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "e6T/9bM7ah7mQJVVIaTuCw/63Uo=",
@@ -1914,50 +1914,50 @@
 			"checksumSHA1": "PdQm3s8DoVJ17Vk8n7o5iPa7PK0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pkg/errors",
 			"path": "github.com/pkg/errors",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "LuFv4/jlrmFNnDb/5SCSEPAM9vU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/pmezard/go-difflib/difflib",
 			"path": "github.com/pmezard/go-difflib/difflib",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "Etvt6mgzvD7ARf4Ux03LHfgSlzU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/prometheus/procfs",
 			"path": "github.com/prometheus/procfs",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "lv9rIcjbVEGo8AT1UCUZXhXrfQc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/prometheus/procfs/internal/util",
 			"path": "github.com/prometheus/procfs/internal/util",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "EekY1iRG9JY74mDD0jsbFCWbAFs=",
 			"origin": "github.com/elastic/beats/vendor/github.com/prometheus/procfs/nfs",
 			"path": "github.com/prometheus/procfs/nfs",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "yItvTQLUVqm/ArLEbvEhqG0T5a0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/prometheus/procfs/xfs",
 			"path": "github.com/prometheus/procfs/xfs",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "LmajbO3+qtbE7JA0MQ29PXbmKNM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/rcrowley/go-metrics",
 			"path": "github.com/rcrowley/go-metrics",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "epQZICCcThx99PQo7m/HuWN5kpQ=",
@@ -2032,43 +2032,43 @@
 			"checksumSHA1": "e7mAb9jMke2ASQGZepFgOmfBFzM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/spf13/cobra",
 			"path": "github.com/spf13/cobra",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "STxYqRb4gnlSr3mRpT+Igfdz/kM=",
 			"origin": "github.com/elastic/beats/vendor/github.com/spf13/pflag",
 			"path": "github.com/spf13/pflag",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "c6pbpF7eowwO59phRTpF8cQ80Z0=",
 			"origin": "github.com/elastic/beats/vendor/github.com/stretchr/testify/assert",
 			"path": "github.com/stretchr/testify/assert",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "wnEANt4k5X/KGwoFyfSSnpxULm4=",
 			"origin": "github.com/elastic/beats/vendor/github.com/stretchr/testify/require",
 			"path": "github.com/stretchr/testify/require",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "CpcG17Q/0k1g2uy8AL26Uu7TouU=",
 			"origin": "github.com/elastic/beats/vendor/github.com/theckman/go-flock",
 			"path": "github.com/theckman/go-flock",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "H7tCgNt2ajKK4FBJIDNlevu9MAc=",
 			"origin": "github.com/elastic/beats/vendor/github.com/urso/go-bin",
 			"path": "github.com/urso/go-bin",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "8Kj0VH496b0exuyv4wAF4CXa7Y4=",
@@ -2228,169 +2228,169 @@
 			"checksumSHA1": "HedK9m8E8iyib4bIBtIX7xprOgo=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/atomic",
 			"path": "go.uber.org/atomic",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "JDGx7hehaQunZySwPs7yvdUs2m8=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/multierr",
 			"path": "go.uber.org/multierr",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "5BYbiKEkYykvfjSaNYDuQpBqglo=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap",
 			"path": "go.uber.org/zap",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "HYo/9nwrY08NQA+2ItPOAH8IFW8=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/buffer",
 			"path": "go.uber.org/zap/buffer",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "MuxOAtZEsJitlWBzhmpm2vGiHok=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/internal/bufferpool",
 			"path": "go.uber.org/zap/internal/bufferpool",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "uC0L9eCSAYcCWNC8udJk/t1vvIU=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/internal/color",
 			"path": "go.uber.org/zap/internal/color",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "b80CJExrVpXu3SA1iCQ6uLqTn2c=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/internal/exit",
 			"path": "go.uber.org/zap/internal/exit",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "mRD6lujPvXPkbC3+byNwO/bNVu8=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/zapcore",
 			"path": "go.uber.org/zap/zapcore",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "gyBmIfDZslmQGKnqisJ/p7oHbQc=",
 			"origin": "github.com/elastic/beats/vendor/go.uber.org/zap/zaptest/observer",
 			"path": "go.uber.org/zap/zaptest/observer",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "2LpxYGSf068307b7bhAuVjvzLLc=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/crypto/ed25519",
 			"path": "golang.org/x/crypto/ed25519",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "0JTAFXPkankmWcZGQJGScLDiaN8=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/crypto/ed25519/internal/edwards25519",
 			"path": "golang.org/x/crypto/ed25519/internal/edwards25519",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "1MGpGDQqnUoRpv7VEcQrXOBydXE=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/crypto/pbkdf2",
 			"path": "golang.org/x/crypto/pbkdf2",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "6U7dCaxxIMjf5V02iWgyAwppczw=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/crypto/ssh/terminal",
 			"path": "golang.org/x/crypto/ssh/terminal",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "uX2McdP4VcQ6zkAF0Q4oyd0rFtU=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/bpf",
 			"path": "golang.org/x/net/bpf",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "dr5+PfIRzXeN+l1VG+s0lea9qz8=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/context",
 			"path": "golang.org/x/net/context",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "WHc3uByvGaMcnSoI21fhzYgbOgg=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/context/ctxhttp",
 			"path": "golang.org/x/net/context/ctxhttp",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "TWcqN2+KUWtdqnu18rruwn14UEQ=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/http2",
 			"path": "golang.org/x/net/http2",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "ezWhc7n/FtqkLDQKeU2JbW+80tE=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/http2/hpack",
 			"path": "golang.org/x/net/http2/hpack",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "RcrB7tgYS/GMW4QrwVdMOTNqIU8=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/idna",
 			"path": "golang.org/x/net/idna",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "5JWn/wMC+EWNDKI/AYE4JifQF54=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/internal/iana",
 			"path": "golang.org/x/net/internal/iana",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "YsXlbexuTtUXHyhSv927ILOkf6A=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/internal/socket",
 			"path": "golang.org/x/net/internal/socket",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "zPTKyZ1C55w1fk1W+/qGE15jaek=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/ipv4",
 			"path": "golang.org/x/net/ipv4",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "3L3n7qKMO9X8E1ibA5mExKvwbmI=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/ipv6",
 			"path": "golang.org/x/net/ipv6",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "3xyuaSNmClqG4YWC7g0isQIbUTc=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/lex/httplex",
 			"path": "golang.org/x/net/lex/httplex",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "whCSspa9pYarl527EuhPz91cbUE=",
@@ -2402,8 +2402,8 @@
 			"checksumSHA1": "QEm/dePZ0lOnyOs+m22KjXfJ/IU=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/net/proxy",
 			"path": "golang.org/x/net/proxy",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "S0DP7Pn7sZUmXc55IzZnNvERu6s=",
@@ -2415,78 +2415,78 @@
 			"checksumSHA1": "nc3RG2Qgzn2aup/3/4RusWr+X0g=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/unix",
 			"path": "golang.org/x/sys/unix",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "Hi7BmkvZh4plNNLGDHfPnCKy3i8=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows",
 			"path": "golang.org/x/sys/windows",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "P9OIhD26uWlIST/me4TYnvseCoY=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/registry",
 			"path": "golang.org/x/sys/windows/registry",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "Fes9OIPy6lS/ghzodqAbMlZZTTQ=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/svc",
 			"path": "golang.org/x/sys/windows/svc",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "e9KJPWrdqg5PMkbE2w60Io8rY4M=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/svc/debug",
 			"path": "golang.org/x/sys/windows/svc/debug",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "uVlUSSKplihZG7N+QJ6fzDZ4Kh8=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/sys/windows/svc/eventlog",
 			"path": "golang.org/x/sys/windows/svc/eventlog",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "CbpjEkkOeh0fdM/V8xKDdI0AA88=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/text/secure/bidirule",
 			"path": "golang.org/x/text/secure/bidirule",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "ziMb9+ANGRJSSIuxYdRbA+cDRBQ=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/text/transform",
 			"path": "golang.org/x/text/transform",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "w8kDfZ1Ug+qAcVU0v8obbu3aDOY=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/text/unicode/bidi",
 			"path": "golang.org/x/text/unicode/bidi",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "BCNYmf4Ek93G4lk5x3ucNi/lTwA=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/text/unicode/norm",
 			"path": "golang.org/x/text/unicode/norm",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "vGfePfr0+weQUeTM/71mu+LCFuE=",
 			"origin": "github.com/elastic/beats/vendor/golang.org/x/time/rate",
 			"path": "golang.org/x/time/rate",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "5QK10eoScnyEh8dD3PfZf8gMXn8=",
@@ -2530,15 +2530,15 @@
 			"checksumSHA1": "fALlQNY1fM99NesfLJ50KguWsio=",
 			"origin": "github.com/elastic/beats/vendor/gopkg.in/yaml.v2",
 			"path": "gopkg.in/yaml.v2",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		},
 		{
 			"checksumSHA1": "ZDOewomjpADMDyjKRW5rP15519M=",
 			"origin": "github.com/elastic/beats/vendor/howett.net/plist",
 			"path": "howett.net/plist",
-			"revision": "96e059d2c28214536905d8691af0505106ede3ea",
-			"revisionTime": "2019-03-28T17:04:27Z"
+			"revision": "5554677dc86b78f48b1ff2a214c661f5f78cbfe1",
+			"revisionTime": "2019-04-05T18:09:50Z"
 		}
 	],
 	"rootPath": "github.com/elastic/apm-server"


### PR DESCRIPTION
Major changes from libbeat:
* Fix index template always being overwritten - elastic/beats#11671
* Perform Basic license check on Elasticsearch connect - elastic/beats#11296 + elastic/beats#11649
* Support shipping directly to monitoring cluster elastic/beats#9260

and finally address these make warnings:
```
$ make
Makefile:48: warning: overriding commands for target `check-headers'
_beats/libbeat/scripts/Makefile:135: warning: ignoring old commands for target `check-headers'
Makefile:56: warning: overriding commands for target `add-headers'
_beats/libbeat/scripts/Makefile:142: warning: ignoring old commands for target `add-headers'
Makefile:149: warning: overriding commands for target `import-dashboards'
```