### PR TITLE
[docs] bump stack-version and release-state for 7.0.0

### DIFF
--- a/changelogs/7.0.asciidoc
+++ b/changelogs/7.0.asciidoc
@@ -13,8 +13,6 @@ https://github.com/elastic/apm-server/compare/6.7...7.0[View commits]
 [[release-notes-7.0.0]]
 === APM Server version 7.0.0
 
-coming[7.0.0]
-
 https://github.com/elastic/apm-server/compare/6.7...7.0[View commits]
 
 These release notes include all changes made in the alpha, beta, and RC releases of 7.0.0.

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,9 +1,9 @@
-:stack-version: 7.0.0-rc2
+:stack-version: 7.0.0
 :major-version: 7.x
 :doc-branch: 7.0
 :branch: {doc-branch}
 :go-version: 1.11.5
-:release-state: prerelease
+:release-state: released
 :python: 2.7.9
 :docker: 1.12
 :docker-compose: 1.11


### PR DESCRIPTION
* Bump `stack-version`
* Bump `release-state`
* Strip `coming[7.0.0]` tag