### PR TITLE
[docs][7.0] Fix stack docs tagged region

### DIFF
--- a/docs/guide/apm-breaking-changes.asciidoc
+++ b/docs/guide/apm-breaking-changes.asciidoc
@@ -11,10 +11,10 @@ Also see <<apm-release-notes>>.
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
 
-// tag::notable-v7-breaking-changes[]
-
 [[breaking-7.0.0]]
 === Breaking changes in 7.0.0
+
+// tag::notable-v7-breaking-changes[]
 
 APM Server::
 +


### PR DESCRIPTION
Tagged region should not include the section header, otherwise this happens:
<img width="306" alt="Screen Shot 2019-04-08 at 2 25 01 PM" src="https://user-images.githubusercontent.com/5618806/55757963-39f45f00-5a0a-11e9-9b53-399a8912053c.png">
