### PR TITLE
[docs] Cherry-picks 6.7.1 and 7.0.0 release notes

### DIFF
--- a/changelogs/6.7.asciidoc
+++ b/changelogs/6.7.asciidoc
@@ -3,7 +3,18 @@
 
 https://github.com/elastic/apm-server/compare/6.6\...6.7[View commits]
 
+* <<release-notes-6.7.1>>
 * <<release-notes-6.7.0>>
+
+[[release-notes-6.7.1]]
+=== APM Server version 6.7.1
+
+https://github.com/elastic/apm-server/compare/v6.7.0\...v6.7.1[View commits]
+
+[float]
+==== Bug fixes
+
+- Remove IP fields from query in index pattern {pull}2046[2046].
 
 [[release-notes-6.7.0]]
 === APM Server version 6.7.0

--- a/changelogs/7.0.asciidoc
+++ b/changelogs/7.0.asciidoc
@@ -3,17 +3,68 @@
 
 https://github.com/elastic/apm-server/compare/6.7...7.0[View commits]
 
-// * <<release-notes-7.0.0>>
+* <<release-notes-7.0.0>>
 * <<release-notes-7.0.0-rc2>>
 * <<release-notes-7.0.0-rc1>>
 * <<release-notes-7.0.0-beta1>>
 * <<release-notes-7.0.0-alpha2>>
 * <<release-notes-7.0.0-alpha1>>
 
-////
 [[release-notes-7.0.0]]
 === APM Server version 7.0.0
-////
+
+coming[7.0.0]
+
+https://github.com/elastic/apm-server/compare/6.7...7.0[View commits]
+
+These release notes include all changes made in the alpha, beta, and RC releases of 7.0.0.
+
+Also see:
+
+* {apm-server-ref-v}/breaking-changes.html[Breaking changes in 7.0]
+
+[float]
+==== Added
+
+- Perform Basic license check on Elasticsearch connect {pull}2077[2077].
+- Update Elastic APM Go agent to v1.1.2 {pull}1711[1711], {pull}1728[1728].
+- Update response format of the healthcheck handler and prettyfy all JSON responses {pull}1748[1748].
+- Add `transaction.type` to error data {pull}1781[1781].
+- Change ownership to apm-server user/group for deb/rpm installs {pull}1833[1833].
+- Add `observer.version_major` {pull}1857[1857].
+- Move default index configuration to code {pull}1865[1865].
+- Change default user-agent pipeline to index information under root key `user_agent` {pull}1871[1871].
+- Use _doc as document type for Elasticsearch >= 7.0.0 https://github.com/elastic/beats/pull/9056[beats/9057].
+- Automatically cap signed integers to 63bits https://github.com/elastic/beats/pull/8991[beats/8991].
+- Build default distribution under the Elastic License. {pull}1645[1645].
+
+[float]
+==== Removed
+
+- Remove support for deprecated Intake v1 endpoints. {apm-overview-ref-v}/breaking-7.0.0.html#breaking-remove-v1[More information], {pull}1731[1731].
+- Remove `concurrent_requests` setting and use number of CPUs instead {pull}1749[1749].
+- Remove `frontend` setting {pull}1751[1751].
+- Remove `metrics.enabled` setting {pull}1759[1759].
+- Remove dashboards from being shipped with APM Server and all logic around them {pull}[1815].
+
+[float]
+==== Bug fixes
+
+- Fix index template always being overwritten {pull}2077[2077].
+- Ensure setup cmd uses expected configuration {pull}1934[1934]. 
+- Ensure `host.name` is not added {pull}1934[1934], {pull}1982[1982].
+- Ensure enabling user-agent pipeline indexes data at the same key by default {pull}1966[1966].
+- Request and Response headers are stored in a canonicalized way {pull}1966[1966].
+- Use changed processor handling from libbeat {pull}1982[1982].
+
+[float]
+==== Breaking Changes
+- Move fields in ES to be ECS compliant. {apm-overview-ref-v}/breaking-7.0.0.html#breaking-ecs[More information], {pull}1766[1766],{pull}1783[1783],{pull}1813[1813],{pull}1836[1836],{pull}1838[1838],{pull}1844[1844],{pull}1848[1848],{pull}1849[1849],{pull}1863[1863],{pull}1870[1870].
+- Rename `transaction.span_count.dropped.total` to `transaction.span_count.dropped` {pull}1809[1809].
+- Rename `span.hex_id` to `span.id` {pull}1811[1811].
+- Index `error.exception` as array of objects {pull}1825[1825]
+- Change `transaction.name` to keyword, add `transaction.name.text` {pull}1859[1859].
+- Change `error.culprit` to keyword, limit length on intake {pull}1859[1859].
 
 [[release-notes-7.0.0-rc2]]
 === APM Server version 7.0.0-rc2
@@ -44,7 +95,7 @@ https://github.com/elastic/apm-server/compare/v7.0.0-alpha2...v7.0.0-beta1[View 
 
 [float]
 ==== Breaking Changes
-- Move fields in ES to be ECS compliant. {apm-overview-ref-v}/breaking-7.0.0-beta1.html#breaking-ecs[More information], {pull}1766[1766],{pull}1783[1783],{pull}1813[1813],{pull}1836[1836],{pull}1838[1838],{pull}1844[1844],{pull}1848[1848],{pull}1849[1849],{pull}1863[1863],{pull}1870[1870].
+- Move fields in ES to be ECS compliant. {apm-overview-ref-v}/breaking-7.0.0.html#breaking-ecs[More information], {pull}1766[1766],{pull}1783[1783],{pull}1813[1813],{pull}1836[1836],{pull}1838[1838],{pull}1844[1844],{pull}1848[1848],{pull}1849[1849],{pull}1863[1863],{pull}1870[1870].
 
 [float]
 ==== Added
@@ -65,7 +116,7 @@ https://github.com/elastic/apm-server/compare/v7.0.0-alpha2...v7.0.0-beta1[View 
 [float]
 ==== Removed
 
-- Remove support for deprecated Intake v1 endpoints. {apm-overview-ref-v}/breaking-7.0.0-beta1.html#breaking-remove-v1[More information], {pull}1731[1731].
+- Remove support for deprecated Intake v1 endpoints. {apm-overview-ref-v}/breaking-7.0.0.html#breaking-remove-v1[More information], {pull}1731[1731].
 - Remove `concurrent_requests` setting and use number of CPUs instead {pull}1749[1749].
 - Remove `frontend` setting {pull}1751[1751].
 - Remove `metrics.enabled` setting {pull}1759[1759].

--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -10,9 +10,9 @@ As such, any breaking change in libbeat is also considered to be a breaking chan
 ==== 7.0
 * Removed deprecated Intake v1 API endpoints.
 Upgrade agents to a version that supports APM Server >= 6.5.
-{apm-overview-ref-v}/breaking-7.0.0-beta1.html#breaking-remove-v1[More information].
+{apm-overview-ref-v}/breaking-7.0.0.html#breaking-remove-v1[More information].
 * Moved fields in Elasticsearch to be compliant with the Elastic Common Schema (ECS).
-{apm-overview-ref-v}/breaking-7.0.0-beta1.html#breaking-ecs[More information and changed fields].
+{apm-overview-ref-v}/breaking-7.0.0.html#breaking-ecs[More information and changed fields].
 * {beats-ref}/breaking-changes-7.0.html[Breaking changes in libbeat]
 
 [float]

--- a/docs/guide/apm-breaking-changes.asciidoc
+++ b/docs/guide/apm-breaking-changes.asciidoc
@@ -3,7 +3,7 @@
 
 This section discusses the changes that you need to be aware of when migrating your application from one version of APM to another.
 
-* <<breaking-7.0.0-beta1, APM version 7.0.0-beta1>>
+* <<breaking-7.0.0, APM version 7.0.0>>
 * <<breaking-6.4.0, APM version 6.4.0>>
 
 Also see <<apm-release-notes>>.
@@ -14,13 +14,16 @@ Also see <<apm-release-notes>>.
 
 // end::notable-v8-breaking-changes[]
 
-[[breaking-7.0.0-beta1]]
-=== Breaking changes in 7.0.0-beta1
+[[breaking-7.0.0]]
+=== Breaking changes in 7.0.0
 
 APM Server::
 +
 [[breaking-remove-v1]]
-**Removed deprecated Intake v1 API endpoints.** Before upgrading APM Server, ensure all APM agents are upgraded to a version that supports APM Server >= 6.5. View the <<agent-server-compatibility, agent/server compatibility matrix>> to determine if your agent versions are compatible. 
+**Removed deprecated Intake v1 API endpoints.** Before upgrading APM Server,
+ensure all APM agents are upgraded to a version that supports APM Server >= 6.5.
+View the {apm-overview-ref-v}/agent-server-compatibility.html[agent/server compatibility matrix]
+to determine if your agent versions are compatible. 
 +
 [[breaking-ecs]]
 **Moved fields in Elasticsearch to be compliant with the Elastic Common Schema (ECS).**
@@ -28,18 +31,17 @@ APM has aligned with the field names defined in the
 https://github.com/elastic/ecs[Elastic Common Schema (ECS)].
 Utilizing this common schema will allow for easier data correlation within Elasticsearch.
 +
-See the <<ecs-compliance,ECS field changes>> table for full details on which fields have changed.
+See the {apm-overview-ref-v}/breaking-7.0.0.html#breaking-ecs[ECS field changes]
+table for full details on which fields have changed.
 
 APM UI::
 +
 [[breaking-new-endpoints]]
-**Moved to new data endpoints.**+
+**Moved to new data endpoints.**
 When you upgrade to 7.x, 
 data in indices created prior to 7.0 will not automatically appear in the APM UI.
 We offer a Kibana Migration Assistant (in the Kibana Management section) to help you migrate your data.
 The migration assistant will reindex your older data in the new ECS format.
-Be aware that this is a beta release.
-This script is **not** meant to be run on production data at this stage.
 
 [float]
 [[ecs-compliance]]

--- a/docs/guide/apm-release-notes.asciidoc
+++ b/docs/guide/apm-release-notes.asciidoc
@@ -7,62 +7,33 @@ For a full list of changes, see the
 {apm-server-ref-v}/release-notes.html[APM Server Release Notes] or the
 {kibana-ref}/release-notes.html[Kibana Release Notes].
 
-// * <<release-notes-7.0.0>>
-// * <<release-notes-7.0.0-rc2>>
-// * <<release-notes-7.0.0-rc1>>
-* <<release-notes-7.0.0-beta1>>
-* <<release-notes-7.0.0-alpha2>>
-* <<release-notes-7.0.0-alpha1>>
-// * <<release-notes-6.7.0>>
+* <<release-highlights-7.0.0>>
+* <<release-notes-6.7.0>>
 * <<release-notes-6.6.0>>
 * <<release-notes-6.5.0>>
 * <<release-notes-6.4.1>>
 * <<release-notes-6.4.0>>
 
-////
-[[release-notes-7.0.0]]
+
+[[release-highlights-7.0.0]]
 === APM version 7.0.0
-
-[[release-notes-7.0.0-rc2]]
-=== APM version 7.0.0-rc2
-
-[[release-notes-7.0.0-rc1]]
-=== APM version 7.0.0-rc1
-////
-
-[[release-notes-7.0.0-beta1]]
-=== APM version 7.0.0-beta1
 
 [float]
 ==== Breaking Changes
 
-See <<breaking-7.0.0-beta1>>
+See <<breaking-7.0.0>>
 
 [float]
 ==== New features
-
-*APM Server*
-
-* Change ownership to apm-server user/group for deb/rpm installs.
 
 *APM UI*
 
 * Added support for frozen indices.
 
-[[release-notes-7.0.0-alpha2]]
-=== APM version 7.0.0-alpha2
-
-No significant changes.
-
-[[release-notes-7.0.0-alpha1]]
-=== APM version 7.0.0-alpha1
-
-No significant changes.
-
-////
 [[release-notes-6.7.0]]
 === APM version 6.7.0
-////
+
+No new features.
 
 [[release-notes-6.6.0]]
 === APM version 6.6.0

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -11,7 +11,7 @@
 This following sections summarizes the changes in each release.
 
 * <<release-notes-7.0>>
-// * <<release-notes-6.7>>
+* <<release-notes-6.7>>
 * <<release-notes-6.6>>
 * <<release-notes-6.5>>
 * <<release-notes-6.4>>

--- a/docs/upgrading-to-70.asciidoc
+++ b/docs/upgrading-to-70.asciidoc
@@ -2,7 +2,7 @@
 === Upgrading to APM Server v7.0
 
 Before upgrading to APM Server v7.0,
-there are some {apm-overview-ref-v}/breaking-7.0.0-beta1.html[breaking changes]
+there are some {apm-overview-ref-v}/breaking-7.0.0.html[breaking changes]
 in the APM Server and the APM UI that you should be aware of.
 
 [[upgrade-steps-70]]
@@ -11,12 +11,12 @@ in the APM Server and the APM UI that you should be aware of.
 Check the https://www.elastic.co/support/matrix#matrix_compatibility[Product Compatibility matrix]
 to determine if you need to upgrade Elasticsearch and Kibana. 
 
-. Upgrade {ref}/setup-upgrade.html[Elasticsearch]
-. Upgrade {kibana-ref}/upgrade.html[Kibana]
+. Upgrade {ref}/setup-upgrade.html[Elasticsearch].
+. Upgrade {kibana-ref}/upgrade.html[Kibana].
 . Ensure all of your APM agents are upgraded to a version that supports APM Server >= 6.5.
 The {apm-overview-ref-v}/agent-server-compatibility.html[agent/server compatibility matrix]
 will help determine compatibility.
-. Upgrade APM Server. (See below if upgrading from an RPM or Deb install)
+. Upgrade APM Server (see below if upgrading from an RPM or Deb install).
 . Use the Kibana migration assistant, found in the Kibana Management tab,
 to migrate 6.x data to the 7.x format. 
 


### PR DESCRIPTION
Adds the following commits to `master`

* docs: 6.7.1 release notes (#2064)
* docs: add 7.0.0 breaking changes and release notes (#2073)