### PR TITLE
[docs] Document upper limit for fields

### DIFF
--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -1,7 +1,7 @@
 [[apm-data-model]]
 == Data Model
 
-Elastic APM agents capture different types of information from within their instrumented applications - namely `spans`, `transactions`, `errors`, and `metrics`. 
+Elastic APM agents capture different types of information from within their instrumented applications - namely `spans`, `transactions`, `errors`, and `metrics`.
 
 * <<transaction-spans>>
 * <<transactions>>
@@ -26,6 +26,9 @@ A span contains:
 * name
 * type
 * `stack trace` (optional)
+
+TIP: Most agents limit keyword fields (e.g. `span.id`) to 1024 characters,
+and non-keyword fields (e.g. `span.start.us`) to 10,000 characters.
 
 Spans are stored in {apm-server-ref-v}/span-indices.html[span indices].
 Note that these indices are separate from {apm-server-ref-v}/transaction-indices.html[transaction indices] by default.
@@ -86,6 +89,9 @@ which are points in time relative to the start of the transaction with some labe
 In addition, the agents provide some settings for users to capture customized information. This data is stored as not-indexed in a `custom` object.
 Searchable information is stored as `labels` instead.
 
+TIP: Most agents limit keyword fields (e.g. `transaction.name`) to 1024 characters,
+and non-keyword fields (e.g. `labels`) to 10,000 characters.
+
 Transactions are stored in {apm-server-ref-v}/transaction-indices.html[transaction indices].
 
 [[errors]]
@@ -108,6 +114,9 @@ include::../context.asciidoc[]
 In addition, the agents provide some settings for users to capture customized information. This data is stored as not-indexed in a `custom` object.
 Searchable information is stored as `labels` instead.
 
+TIP: Most agents limit keyword fields (e.g. `error.id`) to 1024 characters,
+and non-keyword fields (e.g. `error.exception.message`) to 10,000 characters.
+
 Errors are stored in {apm-server-ref-v}/error-indices.html[error indices].
 
 [[metrics]]
@@ -123,6 +132,9 @@ Infrastructure and application metrics are important sources of information when
 which is why we've made it easy to filter metrics for specific hosts or containers in the Kibana {kibana-ref}/metrics.html[metrics overview].
 
 Metrics have the `processor.event` property set to `metric`.
+
+TIP: Most agents limit keyword fields (e.g. `processor.event`) to 1024 characters,
+and non-keyword fields (e.g. `system.memory.total`) to 10,000 characters.
 
 Metrics are stored in {apm-server-ref-v}/metricset-indices.html[metric indices].
 


### PR DESCRIPTION
Closes https://github.com/elastic/apm-dev/issues/400.
Related to https://github.com/elastic/apm-dev/issues/302.

I added the note on upper limits for fields to the apm-data-model documentation. It seemed to be the best location, but I'm open to other ideas if anyone has any. 