### PR TITLE
[docs] 7.0 documentation backports

### DIFF
--- a/changelogs/6.7.asciidoc
+++ b/changelogs/6.7.asciidoc
@@ -3,7 +3,18 @@
 
 https://github.com/elastic/apm-server/compare/6.6\...6.7[View commits]
 
+* <<release-notes-6.7.1>>
 * <<release-notes-6.7.0>>
+
+[[release-notes-6.7.1]]
+=== APM Server version 6.7.1
+
+https://github.com/elastic/apm-server/compare/v6.7.0\...v6.7.1[View commits]
+
+[float]
+==== Bug fixes
+
+- Remove IP fields from query in index pattern {pull}2046[2046].
 
 [[release-notes-6.7.0]]
 === APM Server version 6.7.0

--- a/docs/configuration-rum.asciidoc
+++ b/docs/configuration-rum.asciidoc
@@ -8,7 +8,8 @@ Example config with RUM enabled:
 ["source","yaml"]
 ----
 apm-server.rum.enabled: true
-apm-server.rum.rate_limit: 10
+apm-server.rum.event_rate.limit: 300
+apm-server.rum.event_rate.lru_size: 1000
 apm-server.rum.allow_origins: ['*']
 apm-server.rum.library_pattern: "node_modules|bower_components|~"
 apm-server.rum.exclude_from_grouping: "^/webpack"
@@ -22,7 +23,7 @@ apm-server.rum.source_mapping.index_pattern: "apm-*-sourcemap*"
 [[rum-enable]]
 [float]
 ==== `enabled`
-For enabling RUM support, set the `apm-server.rum.enabled` to `true`.
+To enable RUM support, set `apm-server.rum.enabled` to `true`.
 By default this is disabled.
 
 [float]

--- a/docs/guide/agent-server-compatibility.asciidoc
+++ b/docs/guide/agent-server-compatibility.asciidoc
@@ -65,5 +65,5 @@ Below is a chart that outlines the compatibility between different versions of t
 |Agent Version |APM Server Version
 |0.x |6.3-6.4
 |1.x |6.4
-|2.x, 3.x |>= 6.5
+|2.x, 3.x, 4.x |>= 6.5
 |=======================================================================

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -1,7 +1,7 @@
 [[apm-data-model]]
 == Data Model
 
-Elastic APM agents capture different types of information from within their instrumented applications - namely `spans`, `transactions`, `errors`, and `metrics`. 
+Elastic APM agents capture different types of information from within their instrumented applications - namely `spans`, `transactions`, `errors`, and `metrics`.
 
 * <<transaction-spans>>
 * <<transactions>>
@@ -26,6 +26,9 @@ A span contains:
 * name
 * type
 * `stack trace` (optional)
+
+TIP: Most agents limit keyword fields (e.g. `span.id`) to 1024 characters,
+and non-keyword fields (e.g. `span.start.us`) to 10,000 characters.
 
 Spans are stored in {apm-server-ref-v}/span-indices.html[span indices].
 Note that these indices are separate from {apm-server-ref-v}/transaction-indices.html[transaction indices] by default.
@@ -86,6 +89,9 @@ which are points in time relative to the start of the transaction with some labe
 In addition, the agents provide some settings for users to capture customized information. This data is stored as not-indexed in a `custom` object.
 Searchable information is stored as `labels` instead.
 
+TIP: Most agents limit keyword fields (e.g. `transaction.name`) to 1024 characters,
+and non-keyword fields (e.g. `labels`) to 10,000 characters.
+
 Transactions are stored in {apm-server-ref-v}/transaction-indices.html[transaction indices].
 
 [[errors]]
@@ -108,6 +114,9 @@ include::../context.asciidoc[]
 In addition, the agents provide some settings for users to capture customized information. This data is stored as not-indexed in a `custom` object.
 Searchable information is stored as `labels` instead.
 
+TIP: Most agents limit keyword fields (e.g. `error.id`) to 1024 characters,
+and non-keyword fields (e.g. `error.exception.message`) to 10,000 characters.
+
 Errors are stored in {apm-server-ref-v}/error-indices.html[error indices].
 
 [[metrics]]
@@ -123,6 +132,9 @@ Infrastructure and application metrics are important sources of information when
 which is why we've made it easy to filter metrics for specific hosts or containers in the Kibana {kibana-ref}/metrics.html[metrics overview].
 
 Metrics have the `processor.event` property set to `metric`.
+
+TIP: Most agents limit keyword fields (e.g. `processor.event`) to 1024 characters,
+and non-keyword fields (e.g. `system.memory.total`) to 10,000 characters.
 
 Metrics are stored in {apm-server-ref-v}/metricset-indices.html[metric indices].
 

--- a/docs/guide/distributed-tracing.asciidoc
+++ b/docs/guide/distributed-tracing.asciidoc
@@ -12,11 +12,3 @@ The Timeline visualization has been redesigned to show all of the transactions f
 
 [role="screenshot"]
 image::distributed-tracing.jpg[distribute tracing in the UI]
-
-NOTE: As we're still working on enhancing the distributed tracing experience in the UI,
-we're flagging the feature as beta in the UI.
-
-Should you still encounter any bug or issues,
-please reach out in the https://github.com/elastic/apm[APM GitHub repository].
-For questions and feature requests,
-visit our https://discuss.elastic.co/c/apm[discussion forum].

--- a/docs/rum.asciidoc
+++ b/docs/rum.asciidoc
@@ -4,7 +4,7 @@
 --
 Real User Monitoring captures user interaction with clients such as web browsers.
 The {apm-rum-ref-v}/index.html[JavaScript Agent] is Elastic's RUM Agent.
-To use it you need to <<rum-enable,enable RUM support>> in the APM Server.
+To use it you need to <<configuration-rum,enable RUM support>> in the APM Server.
 --
 
 [[sourcemaps]]

--- a/docs/sourcemap-api.asciidoc
+++ b/docs/sourcemap-api.asciidoc
@@ -1,6 +1,8 @@
 [[sourcemap-api]]
 == Sourcemap Upload API
 
+IMPORTANT: You must <<configuration-rum,enable RUM support>> in the APM Server for this endpoint to work.
+
 The APM Server exposes an API endpoint to upload source maps for <<rum, real user monitoring (RUM)>>.
 
 [[sourcemap-endpoint]]


### PR DESCRIPTION
Backports the following commits to `7.0`:

* [docs] 6.7.1 Version bump and release notes elastic/apm-server#2064
* docs: update RUM and DT (#2090)
* docs: upper limit for fields (#2093)