### PR TITLE
[7.0] add systemd docs (#2102)

### DIFF
--- a/changelogs/7.0.asciidoc
+++ b/changelogs/7.0.asciidoc
@@ -35,6 +35,7 @@ Also see:
 - Use _doc as document type for Elasticsearch >= 7.0.0 https://github.com/elastic/beats/pull/9056[beats/9057].
 - Automatically cap signed integers to 63bits https://github.com/elastic/beats/pull/8991[beats/8991].
 - Build default distribution under the Elastic License. {pull}1645[1645].
+- Log to journald under systemd by default rather than file. To revert this behaviour override BEAT_LOG_OPTS with an empty value https://github.com/elastic/beats/pull/8942[beats/8942] via {pull}1645[1645].
 
 [float]
 ==== Removed
@@ -130,6 +131,7 @@ https://github.com/elastic/apm-server/compare/v7.0.0-alpha2...v7.0.0-beta1[View 
 - Use _doc as document type for Elasticsearch >= 7.0.0 https://github.com/elastic/beats/pull/9056[beats/9057].
 - Automatically cap signed integers to 63bits https://github.com/elastic/beats/pull/8991[beats/8991].
 - Build default distribution under the Elastic License. {pull}1645[1645].
+- Log to journald under systemd by default rather than file. To revert this behaviour override BEAT_LOG_OPTS with an empty value https://github.com/elastic/beats/pull/8942[beats/8942] via {pull}1645[1645].
 
 [[release-notes-7.0.0-alpha1]]
 === APM Server version 7.0.0-alpha1

--- a/docs/copied-from-beats/shared-systemd.asciidoc
+++ b/docs/copied-from-beats/shared-systemd.asciidoc
@@ -1,0 +1,103 @@
+[[running-with-systemd]]
+=== {beatname_uc} and systemd
+
+The DEB and RPM packages include a service unit for Linux systems with
+systemd. On these systems, you can manage {beatname_uc} by using the usual
+systemd commands.
+
+==== Start and stop {beatname_uc}
+
+Use `systemctl` to start or stop {beatname_uc}:
+
+["source", "sh", subs="attributes"]
+------------------------------------------------
+systemctl start {beatname_lc}
+------------------------------------------------
+
+["source", "sh", subs="attributes"]
+------------------------------------------------
+systemctl stop {beatname_lc}
+------------------------------------------------
+
+By default, the {beatname_uc} service starts automatically when the system
+boots. To enable or disable auto start use:
+
+["source", "sh", subs="attributes"]
+------------------------------------------------
+systemctl enable {beatname_lc}
+------------------------------------------------
+
+["source", "sh", subs="attributes"]
+------------------------------------------------
+systemctl disable {beatname_lc}
+------------------------------------------------
+
+
+==== {beatname_uc} status and logs
+
+To get the service status, use `systemctl`:
+
+["source", "sh", subs="attributes"]
+------------------------------------------------
+systemctl status {beatname_lc}
+------------------------------------------------
+
+Logs are stored by default in journald. To view the Logs, use `journalctl`:
+
+["source", "sh", subs="attributes"]
+------------------------------------------------
+journalctl -u {beatname_lc}.service
+------------------------------------------------
+
+NOTE: The unit file included in the packages sets the `-e` flag by default.
+This flag makes {beatname_uc} log to stderr and disables other log outputs.
+Systemd stores all output sent to stderr in journald.
+
+[float]
+=== Customize systemd unit for {beatname_uc}
+
+The systemd service unit file includes environment variables that you can
+override to change the default options.
+
+[cols="<h,<,<m",options="header",]
+|=======================================
+| Variable | Description | Default value
+| BEAT_LOG_OPTS | Log options | `-e`
+| BEAT_CONFIG_OPTS | Flags for configuration file path | +-c /etc/{beatname_lc}/{beatname_lc}.yml+
+| BEAT_PATH_OPTS | Other paths | +-path.home /usr/share/{beatname_lc} -path.config /etc/{beatname_lc} -path.data /var/lib/{beatname_lc} -path.logs /var/log/{beatname_lc}+
+|=======================================
+
+To override these variables, create a drop-in unit file in the
++/etc/systemd/system/{beatname_lc}.service.d+ directory.
+
+For example a file with the following content placed in
++/etc/systemd/system/{beatname_lc}.service.d/debug.conf+
+would override `BEAT_LOG_OPTS` to enable debug for Elasticsearch output.
+
+["source", "systemd", subs="attributes"]
+------------------------------------------------
+[Service]
+Environment="BEAT_LOG_OPTS=-e -d elasticsearch"
+------------------------------------------------
+
+To use settings from the {beatname_uc} file, empty the environment
+variable. For example:
+
+["source", "systemd", subs="attributes"]
+------------------------------------------------
+[Service]
+Environment="BEAT_LOG_OPTS="
+------------------------------------------------
+
+To apply your changes, reload the systemd configuration and restart
+the service:
+
+["source", "sh", subs="attributes"]
+------------------------------------------------
+systemctl daemon-reload
+systemctl restart {beatname_lc}
+------------------------------------------------
+
+NOTE: It is recommended that you use a configuration management tool to
+include drop-in unit files. If you need to add a drop-in manually, use
++systemctl edit {beatname_lc}.service+.

--- a/docs/installing.asciidoc
+++ b/docs/installing.asciidoc
@@ -11,6 +11,8 @@ You can also install APM Server from our repositories or install as a service on
 
 To run APM Server in Docker, see <<running-on-docker>>.
 
+To run APM Server under systemd, see <<running-with-systemd>>.
+
 include::./copied-from-beats/repositories.asciidoc[]
 
 include::./installing-on-windows.asciidoc[]

--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -86,3 +86,5 @@ include::./copied-from-beats/command-reference.asciidoc[]
 include::./copied-from-beats/shared-directory-layout.asciidoc[]
 
 include::./copied-from-beats/shared-docker.asciidoc[]
+
+include::./copied-from-beats/shared-systemd.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 7.0:
 - add systemd docs  (#2102)