### PR TITLE
Enable pipelines by default

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -141,7 +141,7 @@ apm-server:
   #
   #register.ingest.pipeline:
     # Registers pipeline definitions in Elasticsearch on APM Server startup. Defaults to false.
-    #enabled: false
+    #enabled: true
 
     # Overwrites existing pipeline definitions in Elasticsearch. Defaults to true.
     #overwrite: true

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -141,7 +141,7 @@ apm-server:
   #
   #register.ingest.pipeline:
     # Registers pipeline definitions in Elasticsearch on APM Server startup. Defaults to false.
-    #enabled: false
+    #enabled: true
 
     # Overwrites existing pipeline definitions in Elasticsearch. Defaults to true.
     #overwrite: true

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -141,7 +141,7 @@ apm-server:
   #
   #register.ingest.pipeline:
     # Registers pipeline definitions in Elasticsearch on APM Server startup. Defaults to false.
-    #enabled: false
+    #enabled: true
 
     # Overwrites existing pipeline definitions in Elasticsearch. Defaults to true.
     #overwrite: true

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -108,8 +108,7 @@ func New(b *beat.Beat, ucfg *common.Config) (beat.Beater, error) {
 		logger:  logger,
 	}
 
-	shouldSetupPipelines := beaterConfig.Register.Ingest.Pipeline.isEnabled() || b.InSetupCmd
-
+	shouldSetupPipelines := beaterConfig.Register.Ingest.Pipeline.isEnabled()
 	if isElasticsearchOutput(b) && shouldSetupPipelines {
 		logger.Info("Registering pipeline callback.")
 		err := bt.registerPipelineCallback(b)

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -108,9 +108,7 @@ func New(b *beat.Beat, ucfg *common.Config) (beat.Beater, error) {
 		logger:  logger,
 	}
 
-	// setup pipelines if explicitly directed to or setup --pipelines and config is not set at all
-	shouldSetupPipelines := beaterConfig.Register.Ingest.Pipeline.isEnabled() ||
-		(b.InSetupCmd && beaterConfig.Register.Ingest.Pipeline.Enabled == nil)
+	shouldSetupPipelines := beaterConfig.Register.Ingest.Pipeline.isEnabled() || b.InSetupCmd
 
 	if isElasticsearchOutput(b) && shouldSetupPipelines {
 		logger.Info("Registering pipeline callback.")

--- a/beater/config.go
+++ b/beater/config.go
@@ -169,7 +169,7 @@ func (s *SourceMapping) isSetup() bool {
 }
 
 func (c *pipelineConfig) isEnabled() bool {
-	return c != nil && (c.Enabled != nil && *c.Enabled)
+	return c == nil || c.Enabled == nil || *c.Enabled
 }
 
 func (c *pipelineConfig) shouldOverwrite() bool {

--- a/beater/config_test.go
+++ b/beater/config_test.go
@@ -281,8 +281,8 @@ func TestPipeline(t *testing.T) {
 		c                  *pipelineConfig
 		enabled, overwrite bool
 	}{
-		{c: nil, enabled: false, overwrite: false},
-		{c: &pipelineConfig{}, enabled: false, overwrite: false},
+		{c: nil, enabled: true, overwrite: false},
+		{c: &pipelineConfig{}, enabled: true, overwrite: false},
 		{c: &pipelineConfig{Enabled: &falsy, Overwrite: &truthy},
 			enabled: false, overwrite: true},
 		{c: &pipelineConfig{Enabled: &truthy, Overwrite: &falsy},

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -8,6 +8,7 @@
 [float]
 ==== Added
 
+- Register pipelines by default {pull}2106[2106].
 
 [float]
 ==== Removed


### PR DESCRIPTION
related: https://github.com/elastic/apm-server/issues/1283

- [x] needs changelog
- [ ] needs docs update
- [x] consider deprecating `setup pipelines` cmd