### PR TITLE
[docs] Add metadata landing page

### DIFF
--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -26,3 +26,5 @@ include::./agent-server-compatibility.asciidoc[]
 include::./apm-breaking-changes.asciidoc[]
 
 include::./apm-release-notes.asciidoc[]
+
+include::./redirects.asciidoc[]

--- a/docs/guide/redirects.asciidoc
+++ b/docs/guide/redirects.asciidoc
@@ -1,0 +1,9 @@
+["appendix",role="exclude",id="redirects"]
+= Deleted pages
+
+The following pages do not exist. They may have moved, been deleted, or have not been created yet.
+
+[role="exclude",id="metadata"]
+=== Metadata
+
+This page is coming soon. Please see the <<apm-data-model,APM Data Model>> for now.


### PR DESCRIPTION
Creates a placeholder landing page/link for https://github.com/elastic/apm-server/issues/2111.
Unblocks the docs from https://github.com/elastic/kibana/pull/35150.

The link from Kibana will be:
```js
// formatted
{config.docs.base_url}guide/en/apm/get-started/{config.docs.version}/metadata.html
// which points here in master
https://www.elastic.co/guide/en/apm/get-started/master/metadata.html
```

The placeholder in master looks like this. It is not public facing, and will not be accessible unless users click on the link from the master branch in Kibana.
<img width="770" alt="Screen Shot 2019-04-17 at 11 56 20 AM" src="https://user-images.githubusercontent.com/5618806/56313614-da800880-6107-11e9-8306-5db80b061f3b.png">


Note: I've decided to call the anchor "metadata". If anyone thinks a different name is more appropriate, please say so. 