### PR TITLE
[docs] Update documentation copied from beats

### DIFF
--- a/_beats/script/build_docs.sh
+++ b/_beats/script/build_docs.sh
@@ -37,5 +37,5 @@ do
     params="$params --resource=${resource_dir}"
   fi
 
-  $docs_dir/build_docs.pl $params --doc "$index" -out "$dest_dir"
+  $docs_dir/build_docs $params --doc "$index" --out "$dest_dir"
 done

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -742,14 +742,15 @@ output.elasticsearch:
 # reporting is disabled by default.
 
 # Set to true to enable the monitoring reporter.
-#xpack.monitoring.enabled: false
+#monitoring.enabled: false
 
-# Uncomment to send the metrics to Elasticsearch. Most settings from the
-# Elasticsearch output are accepted here as well. Any setting that is not set is
-# automatically inherited from the Elasticsearch output configuration, so if you
-# have the Elasticsearch output configured, you can simply uncomment the
-# following line.
-#xpack.monitoring.elasticsearch:
+# Most settings from the Elasticsearch output are accepted here as well.
+# Note that these settings should be configured to point to your Elasticsearch *monitoring* cluster.
+# Any setting that is not set is automatically inherited from the Elasticsearch
+# output configuration. This means that if you have the Elasticsearch output configured,
+# you can simply uncomment the following line.
+#monitoring.elasticsearch:
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "apm_system"

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -742,14 +742,15 @@ output.elasticsearch:
 # reporting is disabled by default.
 
 # Set to true to enable the monitoring reporter.
-#xpack.monitoring.enabled: false
+#monitoring.enabled: false
 
-# Uncomment to send the metrics to Elasticsearch. Most settings from the
-# Elasticsearch output are accepted here as well. Any setting that is not set is
-# automatically inherited from the Elasticsearch output configuration, so if you
-# have the Elasticsearch output configured, you can simply uncomment the
-# following line.
-#xpack.monitoring.elasticsearch:
+# Most settings from the Elasticsearch output are accepted here as well.
+# Note that these settings should be configured to point to your Elasticsearch *monitoring* cluster.
+# Any setting that is not set is automatically inherited from the Elasticsearch
+# output configuration. This means that if you have the Elasticsearch output configured,
+# you can simply uncomment the following line.
+#monitoring.elasticsearch:
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "apm_system"

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -742,14 +742,15 @@ output.elasticsearch:
 # reporting is disabled by default.
 
 # Set to true to enable the monitoring reporter.
-#xpack.monitoring.enabled: false
+#monitoring.enabled: false
 
-# Uncomment to send the metrics to Elasticsearch. Most settings from the
-# Elasticsearch output are accepted here as well. Any setting that is not set is
-# automatically inherited from the Elasticsearch output configuration, so if you
-# have the Elasticsearch output configured, you can simply uncomment the
-# following line.
-#xpack.monitoring.elasticsearch:
+# Most settings from the Elasticsearch output are accepted here as well.
+# Note that these settings should be configured to point to your Elasticsearch *monitoring* cluster.
+# Any setting that is not set is automatically inherited from the Elasticsearch
+# output configuration. This means that if you have the Elasticsearch output configured,
+# you can simply uncomment the following line.
+#monitoring.elasticsearch:
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #username: "apm_system"

--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -658,12 +658,23 @@ modules to load pipelines for.
 endif::[]
 
 ifeval::["{beatname_lc}"!="filebeat"]
+
+ifndef::no_dashboards[]
 ["source","sh",subs="attributes"]
 -----
 {beatname_lc} setup --dashboards
 {beatname_lc} setup --machine-learning
 {beatname_lc} setup --template
 -----
+endif::no_dashboards[]
+ifdef::no_dashboards[]
+["source","sh",subs="attributes"]
+-----
+{beatname_lc} setup --machine-learning
+{beatname_lc} setup --template
+-----
+endif::no_dashboards[]
+
 endif::[]
 
 [[test-command]]

--- a/docs/copied-from-beats/monitoring/monitoring-beats.asciidoc
+++ b/docs/copied-from-beats/monitoring/monitoring-beats.asciidoc
@@ -17,11 +17,11 @@
 [partintro]
 --
 
-NOTE: {monitoring} for {beatname_uc} requires {es} {beat_monitoring_version} or later.
+NOTE: The {monitor-features} for {beatname_uc} require {es} {beat_monitoring_version} or later.
 
-{monitoring} enables you to easily monitor {beatname_uc} from {kib}. For more
+The {stack} {monitor-features} enable you to easily monitor {beatname_uc} from {kib}. For more
 information, see
-{xpack-ref}/xpack-monitoring.html[Monitoring the Elastic Stack] and
+{stack-ov}/xpack-monitoring.html[Monitoring the {stack}] and
 {kibana-ref}/beats-page.html[Beats Monitoring Metrics].
 
 To configure {beatname_uc} to collect and send monitoring metrics:
@@ -30,35 +30,34 @@ To configure {beatname_uc} to collect and send monitoring metrics:
 data to {es}. For example, you can use the built-in +{beat_monitoring_user}+ user or
 assign the built-in +{beat_monitoring_user}+ role to another user. For more
 information, see
-{xpack-ref}/setting-up-authentication.html[Setting Up User Authentication] and
-{xpack-ref}/built-in-roles.html[Built-in Roles].
+{stack-ov}/setting-up-authentication.html[Setting Up User Authentication] and
+{stack-ov}/built-in-roles.html[Built-in Roles].
 
-. Add the `xpack.monitoring` settings in the {beatname_uc} configuration file. If you
-configured {es} output, specify the following minimal configuration:
+. Add the `monitoring` settings in the {beatname_uc} configuration file. If you
+configured the {es} output and want to send {beatname_uc} monitoring events to
+the same {es} cluster, specify the following minimal configuration:
 +
 --
 [source, yml]
 --------------------
-xpack.monitoring.enabled: true
+monitoring.enabled: true
 --------------------
 
-If you configured a different output, such as {ls}, you must specify additional
-configuration options. For example:
+If you configured a different output, such as {ls} or you want to send {beatname_uc}
+monitoring events to a separate {es} cluster (referred to as the _monitoring cluster_),
+you must specify additional configuration options. For example:
 
 ["source","yml",subs="attributes"]
 --------------------
-xpack.monitoring:
+monitoring:
   enabled: true
   elasticsearch:
-    hosts: ["https://example.com:9200", "https://example2.com:9200"]
+    hosts: ["https://example.com:9200", "https://example2.com:9200"] <1>
     username: {beat_monitoring_user}
     password: somepassword
 --------------------
-
-NOTE: Currently you must send monitoring data to the same cluster as all other events.
-If you configured {es} output, do not specify additional hosts in the monitoring
-configuration.
-
+<1> This setting identifies the hosts and port numbers of {es} nodes
+that are part of the monitoring cluster.
 --
 
 . {kibana-ref}/monitoring-xpack-kibana.html[Configure monitoring in {kib}].

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -79,7 +79,7 @@ output.elasticsearch:
 
 If the Elasticsearch nodes are defined by `IP:PORT`, then add `protocol: https` to the yaml file.
 
-["source","yaml",subs="attributes,callouts"]
+[source,yaml]
 ------------------------------------------------------------------------------
 output.elasticsearch:
   hosts: ["localhost"]
@@ -249,7 +249,7 @@ endif::no_dashboards[]
 
 You can set the index dynamically by using a format string to access any event
 field. For example, this configuration uses a custom field, `fields.log_type`,
-to set the index: 
+to set the index:
 
 ["source","yaml",subs="attributes"]
 ------------------------------------------------------------------------------
@@ -261,13 +261,13 @@ output.elasticsearch:
 <1> We recommend including +{beat_version_key}+ in the name to avoid mapping issues
 when you upgrade.
 
-With this configuration, all events with `log_type: normal` are sent to an 
+With this configuration, all events with `log_type: normal` are sent to an
 index named +normal-{version}-{localdate}+, and all events with
 `log_type: critical` are sent to an index named
 +critical-{version}-{localdate}+.
 
 TIP: To learn how to add custom fields to events, see the
-<<libbeat-configuration-fields,`fields`>> option.  
+<<libbeat-configuration-fields,`fields`>> option.
 
 See the <<indices-option-es,`indices`>> setting for other ways to set the index
 dynamically.
@@ -285,7 +285,7 @@ matches, the <<index-option-es,`index`>> setting is used.
 Rule settings:
 
 *`index`*:: The index format string to use. If this string contains field
-references, such as `%{[fields.name]}`, the fields must exist, or the rule fails. 
+references, such as `%{[fields.name]}`, the fields must exist, or the rule fails.
 
 *`mappings`*:: A dictionary that takes the value returned by `index` and maps it
 to a new name.
@@ -347,7 +347,7 @@ ifndef::no_ilm[]
 [[ilm-es]]
 ===== `ilm`
 
-Configuration options for index lifecycle management. 
+Configuration options for index lifecycle management.
 
 See <<ilm>> for more information.
 endif::no_ilm[]
@@ -369,7 +369,7 @@ For more information, see <<configuring-ingest-node>>.
 
 You can set the ingest node pipeline dynamically by using a format string to
 access any event field. For example, this configuration uses a custom field,
-`fields.log_type`, to set the pipeline for each event: 
+`fields.log_type`, to set the pipeline for each event:
 
 ["source","yaml",subs="attributes"]
 ------------------------------------------------------------------------------
@@ -384,7 +384,7 @@ named `normal_pipeline`, and all events with `log_type: critical` are sent to a
 pipeline named `critical_pipeline`.
 
 TIP: To learn how to add custom fields to events, see the
-<<libbeat-configuration-fields,`fields`>> option.   
+<<libbeat-configuration-fields,`fields`>> option.
 
 See the <<pipelines-option-es,`pipelines`>> setting for other ways to set the
 ingest node pipeline dynamically.
@@ -403,7 +403,7 @@ Rule settings:
 
 *`pipeline`*:: The pipeline format string to use. If this string contains field
 references, such as `%{[fields.name]}`, the fields must exist, or the rule
-fails.  
+fails.
 
 *`mappings`*:: A dictionary that takes the value returned by `pipeline` and maps
 it to a new name.
@@ -870,7 +870,7 @@ topic: '%{[fields.log_topic]}'
 -----
 
 TIP: To learn how to add custom fields to events, see the
-<<libbeat-configuration-fields,`fields`>> option.  
+<<libbeat-configuration-fields,`fields`>> option.
 
 See the <<topics-option-kafka,`topics`>> setting for other ways to set the
 topic dynamically.
@@ -889,7 +889,7 @@ Rule settings:
 
 *`topic`*:: The topic format string to use.  If this string contains field
 references, such as `%{[fields.name]}`, the fields must exist, or the rule
-fails. 
+fails.
 
 *`mappings`*:: A dictionary that takes the value returned by `topic` and maps it
 to a new name.
@@ -901,7 +901,7 @@ match.
 ifndef::no-processors[]
 All the <<conditions,conditions>> supported by processors are also supported
 here.
-endif::no-processors[] 
+endif::no-processors[]
 
 
 ===== `key`
@@ -954,6 +954,10 @@ Kafka metadata update settings. The metadata do contain information about
 brokers, topics, partition, and active leaders to use for publishing.
 
 *`refresh_frequency`*:: Metadata refresh interval. Defaults to 10 minutes.
+
+*`full`*:: Strategy to use when fetching metadata, when this option is `true`, the client will maintain
+a full set of metadata for all the available topics, if the this option is set to `false` it will only refresh the
+metadata for the configured topics. The default is true.
 
 *`retry.max`*:: Total number of metadata update retries when cluster is in middle of leader election. The default is 3.
 
@@ -1099,7 +1103,7 @@ output.redis:
 
 
 TIP: To learn how to add custom fields to events, see the
-<<libbeat-configuration-fields,`fields`>> option.  
+<<libbeat-configuration-fields,`fields`>> option.
 
 See the <<keys-option-redis,`keys`>> setting for other ways to set the key
 dynamically.

--- a/docs/copied-from-beats/repositories.asciidoc
+++ b/docs/copied-from-beats/repositories.asciidoc
@@ -56,6 +56,7 @@ ifeval::["{release-state}"=="prerelease"]
 --------------------------------------------------
 echo "deb https://artifacts.elastic.co/packages/{major-version}-prerelease/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{major-version}-prerelease.list
 --------------------------------------------------
++
 endif::[]
 ifeval::["{release-state}"=="released"]
 . Save the repository definition to  +/etc/apt/sources.list.d/elastic-{major-version}.list+:
@@ -64,7 +65,34 @@ ifeval::["{release-state}"=="released"]
 --------------------------------------------------
 echo "deb https://artifacts.elastic.co/packages/{major-version}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{major-version}.list
 --------------------------------------------------
++
 endif::[]
+[NOTE]
+==================================================
+
+The package is free to use under the Elastic license. An alternative package
+which contains only features that are available under the Apache 2.0 license is
+also available. To install it, use the following sources list:
+
+ifeval::["{release-state}"=="prerelease"]
+
+["source","sh",subs="attributes"]
+--------------------------------------------------
+echo "deb https://artifacts.elastic.co/packages/oss-{major-version}-prerelease/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{major-version}-prerelease.list
+--------------------------------------------------
+
+endif::[]
+
+ifeval::["{release-state}"!="prerelease"]
+
+["source","sh",subs="attributes"]
+--------------------------------------------------
+echo "deb https://artifacts.elastic.co/packages/oss-{major-version}/apt stable main" | sudo tee -a /etc/apt/sources.list.d/elastic-{major-version}.list
+--------------------------------------------------
+
+endif::[]
+
+==================================================
 +
 [WARNING]
 ==================================================
@@ -146,6 +174,34 @@ autorefresh=1
 type=rpm-md
 --------------------------------------------------
 endif::[]
++
+[NOTE]
+==================================================
+
+The package is free to use under the Elastic license. An alternative package
+which contains only features that are available under the Apache 2.0 license is
+also available. To install it, use the following `baseurl` in your
+`.repo` file:
+
+ifeval::["{release-state}"=="prerelease"]
+
+["source","sh",subs="attributes"]
+--------------------------------------------------
+baseurl=https://artifacts.elastic.co/packages/oss-{major-version}-prerelease/yum
+--------------------------------------------------
+
+endif::[]
+
+ifeval::["{release-state}"!="prerelease"]
+
+["source","sh",subs="attributes"]
+--------------------------------------------------
+baseurl=https://artifacts.elastic.co/packages/oss-{major-version}/yum
+--------------------------------------------------
+
+endif::[]
+
+==================================================
 +
 Your repository is ready to use. For example, you can install {beatname_uc} by
 running:

--- a/docs/copied-from-beats/shared-docker.asciidoc
+++ b/docs/copied-from-beats/shared-docker.asciidoc
@@ -44,7 +44,11 @@ ifndef::apm-server[]
 ==== Run the {beatname_uc} setup
 
 Running {beatname_uc} with the setup command will create the index pattern and
-load visualizations, dashboards, and machine learning jobs.  Run this command:
+load visualizations
+ifndef::no_dashboards[]
+, dashboards,
+endif::no_dashboards[]
+and machine learning jobs.  Run this command:
 
 ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="metricbeat") or ("{beatname_lc}"=="heartbeat") or ("{beatname_lc}"=="journalbeat")]
 ["source", "sh", subs="attributes"]

--- a/docs/copied-from-beats/shared-path-config.asciidoc
+++ b/docs/copied-from-beats/shared-path-config.asciidoc
@@ -11,7 +11,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 [[configuration-path]]
-== Set up project paths
+== Configure project paths
 
 The `path` section of the +{beatname_lc}.yml+ config file contains configuration
 options that define where {beatname_uc} looks for its files. For example, {beatname_uc}

--- a/docs/copied-from-beats/shared-ssl-config.asciidoc
+++ b/docs/copied-from-beats/shared-ssl-config.asciidoc
@@ -28,6 +28,19 @@ ifndef::only-elasticsearch[]
 Also see <<configuring-ssl-logstash>>.
 endif::[]
 
+ifndef::no_kibana[]
+Example Kibana endpoint config with SSL enabled:
+
+[source,yaml]
+----
+setup.kibana.host: "https://192.0.2.255:5601"
+setup.kibana.ssl.enabled: true
+setup.kibana.ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+setup.kibana.ssl.certificate: "/etc/pki/client/cert.pem"
+setup.kibana.ssl.key: "/etc/pki/client/cert.key"
+----
+endif::no_kibana[]
+
 ifeval::["{beatname_lc}"=="heartbeat"]
 Example monitor with SSL enabled:
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -20,6 +20,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :sample_date_1: 2019.03.11
 :sample_date_2: 2019.03.12
 :repo: apm-server
+:no_kibana:
 :no_ilm:
 :no-processors:
 :no-indices-rules:


### PR DESCRIPTION
Updating some docs copied from beats. Everything is pretty straight forward, though I have two comments:

* ~My main concern is with the changes to `monitoring-beats.asciidoc`. Looks like https://github.com/elastic/beats/pull/9260 introduced a new class of settings named `monitoring.*`, which I can't get to work in APM Server. Can a dev confirm these doc changes should be left out for now?~ edit: Just realized I was trying this in `7.0`, not `master`. This change works in master. Should we also update `apm-server.yml` to use the new settings name?
* A separate build issue was causing my `make update-beats-docs` command to fail. To try and fix it, I updated the build_docs script to use the dockerized build command. This seems to work fine. Might make sense to update now that the `.pl` version has reached EOL. 

Related https://github.com/elastic/beats/pull/11823
Closes https://github.com/elastic/apm-server/pull/1957
Closes https://github.com/elastic/apm-server/issues/2083