### PR TITLE
Log errors on error log level.

### DIFF
--- a/beater/intake_handler.go
+++ b/beater/intake_handler.go
@@ -96,7 +96,7 @@ func (v *intakeHandler) sendResponse(logger *logp.Logger, w http.ResponseWriter,
 		w.Header().Add("Connection", "Close")
 		send(w, r, sr, statusCode)
 
-		logger.Infow("error handling request", "error", sr.Error())
+		logger.Errorw("error handling request", "error", sr.Error())
 	}
 }
 


### PR DESCRIPTION
Request failures for Intake API should be logged on log level `error` instead of log level `info`. 

implements #2124 