### PR TITLE
Fix counters and logs for processing requests.

### DIFF
--- a/beater/common_handler.go
+++ b/beater/common_handler.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -30,9 +31,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/ryanuber/go-glob"
 
-	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
+
+	"github.com/elastic/apm-server/utility"
 )
 
 const (
@@ -168,9 +170,10 @@ func logHandler(h http.Handler) http.Handler {
 			if r := recover(); r != nil {
 				var ok bool
 				if err, ok = r.(error); !ok {
-					err = fmt.Errorf("recovering from %+v", r)
+					err = fmt.Errorf("internal server error %+v", r)
 				}
-				reqLogger.Errorw("panic handling request", "error", err.Error())
+				reqLogger.Errorw("panic handling request",
+					"error", err.Error(), "stacktrace", string(debug.Stack()))
 			}
 		}()
 

--- a/beater/common_handler.go
+++ b/beater/common_handler.go
@@ -164,12 +164,23 @@ func logHandler(h http.Handler) http.Handler {
 			"remote_address", utility.RemoteAddr(r),
 			"user-agent", r.Header.Get("User-Agent"))
 
+		defer func() {
+			if r := recover(); r != nil {
+				var ok bool
+				if err, ok = r.(error); !ok {
+					err = fmt.Errorf("recovering from %+v", r)
+				}
+				reqLogger.Errorw("panic handling request", "error", err.Error())
+			}
+		}()
+
 		lw := utility.NewRecordingResponseWriter(w)
 		h.ServeHTTP(lw, r.WithContext(ContextWithReqLogger(r.Context(), reqLogger)))
 
 		if lw.Code <= 399 {
 			reqLogger.Infow("handled request", []interface{}{"response_code", lw.Code}...)
 		}
+
 	})
 }
 

--- a/beater/intake_handler.go
+++ b/beater/intake_handler.go
@@ -91,7 +91,6 @@ func (v *intakeHandler) sendResponse(logger *logp.Logger, w http.ResponseWriter,
 	} else {
 		responseErrors.Inc()
 		logger.Errorw("error handling request", "error", sr.Error())
-
 		// this signals to the client that we're closing the connection
 		// but also signals to http.Server that it should close it:
 		// https://golang.org/src/net/http/server.go#L1254

--- a/beater/intake_handler.go
+++ b/beater/intake_handler.go
@@ -90,13 +90,13 @@ func (v *intakeHandler) sendResponse(logger *logp.Logger, w http.ResponseWriter,
 		}
 	} else {
 		responseErrors.Inc()
+		logger.Errorw("error handling request", "error", sr.Error())
+
 		// this signals to the client that we're closing the connection
 		// but also signals to http.Server that it should close it:
 		// https://golang.org/src/net/http/server.go#L1254
 		w.Header().Add("Connection", "Close")
 		send(w, r, sr, statusCode)
-
-		logger.Errorw("error handling request", "error", sr.Error())
 	}
 }
 

--- a/beater/intake_handler_test.go
+++ b/beater/intake_handler_test.go
@@ -95,6 +95,13 @@ func TestRequestDecoderError(t *testing.T) {
 }
 
 func TestRequestIntegration(t *testing.T) {
+	endpoints := []struct {
+		url   string
+		route intakeRoute
+	}{
+		{url: backendURL, route: backendRoute},
+		{url: rumURL, route: rumRoute},
+	}
 	for name, test := range map[string]struct {
 		code         int
 		path         string
@@ -112,7 +119,7 @@ func TestRequestIntegration(t *testing.T) {
 		"FullQueue":           {code: http.StatusServiceUnavailable, path: "errors.ndjson", reportingErr: publish.ErrFull, counter: fullQueueCounter},
 	} {
 
-		for url, route := range map[string]intakeRoute{backendURL: backendRoute, rumURL: rumRoute} {
+		for _, endpoint := range endpoints {
 			cfg := defaultConfig("7.0.0")
 			rum := true
 			cfg.RumConfig.Enabled = &rum
@@ -124,8 +131,8 @@ func TestRequestIntegration(t *testing.T) {
 				reqCt := requestCounter.Get()
 
 				w, err := sendReq(cfg,
-					&route,
-					url,
+					&endpoint.route,
+					endpoint.url,
 					filepath.Join("../testdata/intake-v2/", test.path),
 					test.reportingErr)
 				require.NoError(t, err)

--- a/beater/route_config.go
+++ b/beater/route_config.go
@@ -119,9 +119,10 @@ func backendHandler(beaterConfig *Config, h http.Handler) http.Handler {
 }
 
 func rumHandler(beaterConfig *Config, h http.Handler) http.Handler {
-	return killSwitchHandler(beaterConfig.RumConfig.isEnabled(),
-		requestTimeHandler(
-			corsHandler(beaterConfig.RumConfig.AllowOrigins, h)))
+	return logHandler(
+		killSwitchHandler(beaterConfig.RumConfig.isEnabled(),
+			requestTimeHandler(
+				corsHandler(beaterConfig.RumConfig.AllowOrigins, h))))
 }
 
 func sourcemapHandler(beaterConfig *Config, h http.Handler) http.Handler {


### PR DESCRIPTION
Wraps requests to rum endpoint in the log handler to ensure logger is
set and request is counted.
Recover from potential server panics while processing requests and log
them.

implements #2143