### PR TITLE
[7.0] Fix counters and logs for processing requests.

### DIFF
--- a/beater/common_handler.go
+++ b/beater/common_handler.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -31,9 +32,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/ryanuber/go-glob"
 
-	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
+
+	"github.com/elastic/apm-server/utility"
 )
 
 const (
@@ -169,9 +171,10 @@ func logHandler(h http.Handler) http.Handler {
 			if r := recover(); r != nil {
 				var ok bool
 				if err, ok = r.(error); !ok {
-					err = fmt.Errorf("recovering from %+v", r)
+					err = fmt.Errorf("internal server error %+v", r)
 				}
-				reqLogger.Errorw("panic handling request", "error", err.Error())
+				reqLogger.Errorw("panic handling request",
+					"error", err.Error(), "stacktrace", string(debug.Stack()))
 			}
 		}()
 

--- a/beater/intake_handler.go
+++ b/beater/intake_handler.go
@@ -83,6 +83,8 @@ func (v *intakeHandler) sendResponse(logger *logp.Logger, w http.ResponseWriter,
 
 	if statusCode != http.StatusAccepted {
 		responseErrors.Inc()
+		logger.Errorw("error handling request", "error", sr.String())
+
 		// this signals to the client that we're closing the connection
 		// but also signals to http.Server that it should close it:
 		// https://golang.org/src/net/http/server.go#L1254
@@ -93,7 +95,6 @@ func (v *intakeHandler) sendResponse(logger *logp.Logger, w http.ResponseWriter,
 		} else {
 			sendPlain(w, sr.String(), statusCode)
 		}
-		logger.Infow("error handling request", "error", sr.String())
 	} else {
 		w.WriteHeader(statusCode)
 		responseSuccesses.Inc()

--- a/beater/intake_handler_test.go
+++ b/beater/intake_handler_test.go
@@ -29,13 +29,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/monitoring"
+
 	"github.com/elastic/apm-server/decoder"
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/apm-server/tests"
 	"github.com/elastic/apm-server/tests/loader"
 	"github.com/elastic/apm-server/transform"
-	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/monitoring"
 )
 
 func TestInvalidContentType(t *testing.T) {
@@ -93,51 +94,57 @@ func TestRequestDecoderError(t *testing.T) {
 }
 
 func TestRequestIntegration(t *testing.T) {
-	for _, test := range []struct {
-		name         string
+	for name, test := range map[string]struct {
 		code         int
 		path         string
 		reportingErr error
 		counter      *monitoring.Int
 	}{
-		{name: "Success", code: http.StatusAccepted, path: "errors.ndjson", counter: responseAccepted},
-		{name: "InvalidEvent", code: http.StatusBadRequest, path: "invalid-event.ndjson", counter: validateCounter},
-		{name: "InvalidJSONEvent", code: http.StatusBadRequest, path: "invalid-json-event.ndjson", counter: validateCounter},
-		{name: "InvalidJSONMetadata", code: http.StatusBadRequest, path: "invalid-json-metadata.ndjson", counter: validateCounter},
-		{name: "InvalidMetadata", code: http.StatusBadRequest, path: "invalid-metadata.ndjson", counter: validateCounter},
-		{name: "InvalidMetadata2", code: http.StatusBadRequest, path: "invalid-metadata-2.ndjson", counter: validateCounter},
-		{name: "UnrecognizedEvent", code: http.StatusBadRequest, path: "unrecognized-event.ndjson", counter: validateCounter},
-		{name: "Closing", code: http.StatusServiceUnavailable, path: "errors.ndjson", reportingErr: publish.ErrChannelClosed, counter: serverShuttingDownCounter},
-		{name: "FullQueue", code: http.StatusServiceUnavailable, path: "errors.ndjson", reportingErr: publish.ErrFull, counter: fullQueueCounter},
+		"Success":             {code: http.StatusAccepted, path: "errors.ndjson", counter: responseAccepted},
+		"InvalidEvent":        {code: http.StatusBadRequest, path: "invalid-event.ndjson", counter: validateCounter},
+		"InvalidJSONEvent":    {code: http.StatusBadRequest, path: "invalid-json-event.ndjson", counter: validateCounter},
+		"InvalidJSONMetadata": {code: http.StatusBadRequest, path: "invalid-json-metadata.ndjson", counter: validateCounter},
+		"InvalidMetadata":     {code: http.StatusBadRequest, path: "invalid-metadata.ndjson", counter: validateCounter},
+		"InvalidMetadata2":    {code: http.StatusBadRequest, path: "invalid-metadata-2.ndjson", counter: validateCounter},
+		"UnrecognizedEvent":   {code: http.StatusBadRequest, path: "unrecognized-event.ndjson", counter: validateCounter},
+		"Closing":             {code: http.StatusServiceUnavailable, path: "errors.ndjson", reportingErr: publish.ErrChannelClosed, counter: serverShuttingDownCounter},
+		"FullQueue":           {code: http.StatusServiceUnavailable, path: "errors.ndjson", reportingErr: publish.ErrFull, counter: fullQueueCounter},
 	} {
-		t.Run(test.name, func(t *testing.T) {
-			ctSuccess := responseSuccesses.Get()
-			ctFailure := responseErrors.Get()
-			ct := test.counter.Get()
+		for url, route := range map[string]intakeRoute{backendURL: backendRoute, rumURL: rumRoute} {
+			cfg := defaultConfig("7.0.0")
+			rum := true
+			cfg.RumConfig.Enabled = &rum
+			t.Run(name, func(t *testing.T) {
+				ctSuccess := responseSuccesses.Get()
+				ctFailure := responseErrors.Get()
+				ct := test.counter.Get()
+				reqCt := requestCounter.Get()
 
-			w, err := sendReq(defaultConfig("7.0.0"),
-				&backendRoute,
-				backendURL,
-				filepath.Join("../testdata/intake-v2/", test.path),
-				test.reportingErr)
-			require.NoError(t, err)
+				w, err := sendReq(cfg,
+					&route,
+					url,
+					filepath.Join("../testdata/intake-v2/", test.path),
+					test.reportingErr)
+				require.NoError(t, err)
 
-			assert.Equal(t, test.code, w.Code, w.Body.String())
-			assert.Equal(t, ct+1, test.counter.Get())
-			if test.code == http.StatusAccepted {
-				assert.Equal(t, 0, w.Body.Len())
-				assert.Equal(t, w.HeaderMap.Get("Content-Type"), "")
-				assert.Equal(t, ctSuccess+1, responseSuccesses.Get())
-				assert.Equal(t, ctFailure, responseErrors.Get())
-			} else {
-				assert.Equal(t, "application/json", w.HeaderMap.Get("Content-Type"))
-				assert.Equal(t, ctSuccess, responseSuccesses.Get())
-				assert.Equal(t, ctFailure+1, responseErrors.Get())
+				assert.Equal(t, test.code, w.Code, w.Body.String())
+				assert.Equal(t, ct+1, test.counter.Get())
+				assert.Equal(t, reqCt+1, requestCounter.Get())
+				if test.code == http.StatusAccepted {
+					assert.Equal(t, 0, w.Body.Len())
+					assert.Equal(t, w.HeaderMap.Get("Content-Type"), "")
+					assert.Equal(t, ctSuccess+1, responseSuccesses.Get())
+					assert.Equal(t, ctFailure, responseErrors.Get())
+				} else {
+					assert.Equal(t, "application/json", w.HeaderMap.Get("Content-Type"))
+					assert.Equal(t, ctSuccess, responseSuccesses.Get())
+					assert.Equal(t, ctFailure+1, responseErrors.Get())
 
-				body := w.Body.Bytes()
-				tests.AssertApproveResult(t, "test_approved_stream_result/TestRequestIntegration"+test.name, body)
-			}
-		})
+					body := w.Body.Bytes()
+					tests.AssertApproveResult(t, "test_approved_stream_result/TestRequestIntegration"+name, body)
+				}
+			})
+		}
 	}
 }
 

--- a/beater/intake_handler_test.go
+++ b/beater/intake_handler_test.go
@@ -94,6 +94,13 @@ func TestRequestDecoderError(t *testing.T) {
 }
 
 func TestRequestIntegration(t *testing.T) {
+	endpoints := []struct {
+		url   string
+		route intakeRoute
+	}{
+		{url: backendURL, route: backendRoute},
+		{url: rumURL, route: rumRoute},
+	}
 	for name, test := range map[string]struct {
 		code         int
 		path         string
@@ -110,7 +117,7 @@ func TestRequestIntegration(t *testing.T) {
 		"Closing":             {code: http.StatusServiceUnavailable, path: "errors.ndjson", reportingErr: publish.ErrChannelClosed, counter: serverShuttingDownCounter},
 		"FullQueue":           {code: http.StatusServiceUnavailable, path: "errors.ndjson", reportingErr: publish.ErrFull, counter: fullQueueCounter},
 	} {
-		for url, route := range map[string]intakeRoute{backendURL: backendRoute, rumURL: rumRoute} {
+		for _, endpoint := range endpoints {
 			cfg := defaultConfig("7.0.0")
 			rum := true
 			cfg.RumConfig.Enabled = &rum
@@ -121,8 +128,8 @@ func TestRequestIntegration(t *testing.T) {
 				reqCt := requestCounter.Get()
 
 				w, err := sendReq(cfg,
-					&route,
-					url,
+					&endpoint.route,
+					endpoint.url,
 					filepath.Join("../testdata/intake-v2/", test.path),
 					test.reportingErr)
 				require.NoError(t, err)

--- a/beater/route_config.go
+++ b/beater/route_config.go
@@ -118,9 +118,10 @@ func backendHandler(beaterConfig *Config, h http.Handler) http.Handler {
 }
 
 func rumHandler(beaterConfig *Config, h http.Handler) http.Handler {
-	return killSwitchHandler(beaterConfig.RumConfig.isEnabled(),
-		requestTimeHandler(
-			corsHandler(beaterConfig.RumConfig.AllowOrigins, h)))
+	return logHandler(
+		killSwitchHandler(beaterConfig.RumConfig.isEnabled(),
+			requestTimeHandler(
+				corsHandler(beaterConfig.RumConfig.AllowOrigins, h))))
 }
 
 func sourcemapHandler(beaterConfig *Config, h http.Handler) http.Handler {


### PR DESCRIPTION
Wraps requests to rum endpoint in the log handler to ensure logger is
set and request is counted.
Recover from potential server panics while processing requests and log
them.

implements #2143