### PR TITLE
[7.0] bump requirements.txt versions (#2158)

### DIFF
--- a/_beats/libbeat/tests/system/requirements.txt
+++ b/_beats/libbeat/tests/system/requirements.txt
@@ -13,7 +13,7 @@ enum34==1.1.6
 functools32==3.2.3.post2
 idna==2.6
 ipaddress==1.0.19
-Jinja2==2.10
+Jinja2==2.10.1
 jsonschema==2.6.0
 MarkupSafe==1.0
 nose==1.3.7
@@ -25,7 +25,7 @@ requests==2.20.0
 six==1.11.0
 termcolor==1.1.0
 texttable==0.9.1
-urllib3==1.23
+urllib3==1.24.2
 websocket-client==0.47.0
 parameterized==0.6.1
 jsondiff==1.1.2


### PR DESCRIPTION
Backports the following commits to 7.0:
 - bump requirements.txt versions  (#2158)