### PR TITLE
[docs] Update ES output config

### DIFF
--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -635,21 +635,17 @@ endif::[]
 
 ===== `max_retries`
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="winlogbeat")]
-
+ifdef::ignores_max_retries[]
 {beatname_uc} ignores the `max_retries` setting and retries indefinitely.
-
 endif::[]
 
-ifeval::[("{beatname_lc}"!="filebeat") and ("{beatname_lc}"!="winlogbeat")]
-
+ifndef::ignores_max_retries[]
 The number of times to retry publishing an event after a publishing failure.
 After the specified number of retries, the events are typically dropped.
 
 Set `max_retries` to a value less than 0 to retry until all events are published.
 
 The default is 3.
-
 endif::[]
 
 
@@ -841,7 +837,7 @@ output.logstash:
 
 Time to live for a connection to Logstash after which the connection will be re-established.
 Useful when Logstash hosts represent load balancers. Since the connections to Logstash hosts
-are sticky operating behind load balancers can lead to uneven load distribution between the instances.
+are sticky, operating behind load balancers can lead to uneven load distribution between the instances.
 Specifying a TTL on the connection allows to achieve equal connection distribution between the
 instances.  Specifying a TTL of 0 will disable this feature.
 
@@ -902,21 +898,17 @@ The number of seconds to wait for responses from the Logstash server before timi
 
 ===== `max_retries`
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="winlogbeat")]
-
+ifdef::ignores_max_retries[]
 {beatname_uc} ignores the `max_retries` setting and retries indefinitely.
-
 endif::[]
 
-ifeval::[("{beatname_lc}"!="filebeat") and ("{beatname_lc}"!="winlogbeat")]
-
+ifndef::ignores_max_retries[]
 The number of times to retry publishing an event after a publishing failure.
 After the specified number of retries, the events are typically dropped.
 
 Set `max_retries` to a value less than 0 to retry until all events are published.
 
 The default is 3.
-
 endif::[]
 
 ===== `bulk_max_size`
@@ -1138,21 +1130,17 @@ metadata for the configured topics. The default is true.
 
 ===== `max_retries`
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="winlogbeat")]
-
+ifdef::ignores_max_retries[]
 {beatname_uc} ignores the `max_retries` setting and retries indefinitely.
-
 endif::[]
 
-ifeval::[("{beatname_lc}"!="filebeat") and ("{beatname_lc}"!="winlogbeat")]
-
+ifndef::ignores_max_retries[]
 The number of times to retry publishing an event after a publishing failure.
 After the specified number of retries, the events are typically dropped.
 
 Set `max_retries` to a value less than 0 to retry until all events are published.
 
 The default is 3.
-
 endif::[]
 
 ===== `bulk_max_size`
@@ -1398,21 +1386,17 @@ Redis after a network error. The default is 60s.
 
 ===== `max_retries`
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="winlogbeat")]
-
+ifdef::ignores_max_retries[]
 {beatname_uc} ignores the `max_retries` setting and retries indefinitely.
-
 endif::[]
 
-ifeval::["{beatname_lc}"!="filebeat" and "{beatname_lc}"!="winlogbeat"]
-
+ifndef::ignores_max_retries[]
 The number of times to retry publishing an event after a publishing failure.
 After the specified number of retries, the events are typically dropped.
 
 Set `max_retries` to a value less than 0 to retry until all events are published.
 
 The default is 3.
-
 endif::[]
 
 

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -79,7 +79,7 @@ output.elasticsearch:
 
 If the Elasticsearch nodes are defined by `IP:PORT`, then add `protocol: https` to the yaml file.
 
-[source,yaml]
+["source","yaml",subs="attributes,callouts"]
 ------------------------------------------------------------------------------
 output.elasticsearch:
   hosts: ["localhost"]
@@ -247,6 +247,7 @@ dashboards, you also need to set the `setup.dashboards.index` option (see
 <<configuration-dashboards>>).
 endif::no_dashboards[]
 
+ifndef::apm-server[]
 You can set the index dynamically by using a format string to access any event
 field. For example, this configuration uses a custom field, `fields.log_type`,
 to set the index:
@@ -265,6 +266,26 @@ With this configuration, all events with `log_type: normal` are sent to an
 index named +normal-{version}-{localdate}+, and all events with
 `log_type: critical` are sent to an index named
 +critical-{version}-{localdate}+.
+endif::apm-server[]
+
+ifdef::apm-server[]
+You can set the index dynamically by using a format string to access any event
+field. For example, this configuration uses the field, `processor.event`,
+to set the index:
+
+["source","yaml",subs="attributes"]
+------------------------------------------------------------------------------
+output.elasticsearch:
+  hosts: ["http://localhost:9200"]
+  index: "apm-%\{[observer.version]\}-%\{[processor.event]\}-%\{+yyyy.MM.dd}\" <1>
+------------------------------------------------------------------------------
+
+<1> We recommend including +{beat_version_key}+ in the name to avoid mapping issues
+when you upgrade.
+
+With this configuration,
+all events are separated by their `processor.event` into different indices.
+endif::apm-server[]
 
 TIP: To learn how to add custom fields to events, see the
 <<libbeat-configuration-fields,`fields`>> option.
@@ -299,6 +320,7 @@ All the <<conditions,conditions>> supported by processors are also supported
 here.
 endif::no-processors[]
 
+ifndef::apm-server[]
 The following example sets the index based on whether the `message` field
 contains the specified string:
 
@@ -340,6 +362,70 @@ This configuration results in indices named `sev1`, `sev2`, and `sev3`.
 
 The `mappings` setting simplifies the configuration, but is limited to string
 values. You cannot specify format strings within the mapping pairs.
+endif::apm-server[]
+
+ifdef::apm-server[]
+The following example sets the index based on whether the `processor.event` field
+contains the specified string:
+
+["source","yaml",subs="attributes"]
+------------------------------------------------------------------------------
+output.elasticsearch:
+  hosts: ["http://localhost:9200"]
+  indices:
+   - index: "apm-%{[observer.version]}-sourcemap"
+      when.contains:
+        processor.event: "sourcemap"
+  
+   - index: "apm-%{[observer.version]}-error-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "error"
+  
+   - index: "apm-%{[observer.version]}-transaction-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "transaction"
+  
+   - index: "apm-%{[observer.version]}-span-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "span"
+  
+   - index: "apm-%{[observer.version]}-metric-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "metric"
+  
+   - index: "apm-%{[observer.version]}-onboarding-%{+yyyy.MM.dd}"
+      when.contains:
+        processor.event: "onboarding"
+------------------------------------------------------------------------------
+
+This is the default configuration for {beatname_uc} and results in indices
+named in the following format: +"apm-%\{[{beat_version_key}]\}-{type\}-%\{+yyyy.MM.dd\}"+
+For example: +"apm-{version}-transaction-{localdate}"+.
+
+The following example sets the index by taking the name returned by the `index`
+format string and mapping it to a new name that's used for the index:
+
+["source","yaml"]
+------------------------------------------------------------------------------
+output.elasticsearch:
+  hosts: ["http://localhost:9200"]
+  indices:
+    - index: "%{[processor.event]}"
+      mappings:
+        sourcemap:    "apm-sourcemap"
+        error:        "apm-error"
+        transaction:  "apm-transaction"
+        span:         "apm-span"
+        metric:       "apm-metric"
+        onboarding:   "apm-onboarding"
+      default:        "apm"
+------------------------------------------------------------------------------
+
+This configuration results in indices named `apm-sourcemap`, `apm-error`, etc.
+
+The `mappings` setting simplifies the configuration, but is limited to string
+values. You cannot specify format strings within the mapping pairs.
+endif::apm-server[]
 
 //TODO: MOVE ILM OPTIONS TO APPEAR LOGICALLY BASED ON LOCATION IN THE YAML FILE.
 
@@ -367,6 +453,7 @@ output.elasticsearch:
 
 For more information, see <<configuring-ingest-node>>.
 
+ifndef::apm-server[]
 You can set the ingest node pipeline dynamically by using a format string to
 access any event field. For example, this configuration uses a custom field,
 `fields.log_type`, to set the pipeline for each event:
@@ -382,6 +469,25 @@ output.elasticsearch:
 With this configuration, all events with `log_type: normal` are sent to a pipeline
 named `normal_pipeline`, and all events with `log_type: critical` are sent to a
 pipeline named `critical_pipeline`.
+endif::apm-server[]
+
+ifdef::apm-server[]
+You can set the ingest node pipeline dynamically by using a format string to
+access any event field. For example, this configuration uses the field,
+`processor.event`, to set the pipeline for each event:
+
+["source","yaml",subs="attributes"]
+------------------------------------------------------------------------------
+output.elasticsearch:
+  hosts: ["http://localhost:9200"]
+  pipeline: "%\{[processor.event]\}_pipeline"
+------------------------------------------------------------------------------
+
+
+With this configuration, all events with `processor.event: transaction` are sent to a pipeline
+named `transaction_pipeline`. Similarly, all events with `processor.event: error` are sent to a
+pipeline named `error_pipeline`.
+endif::apm-server[]
 
 TIP: To learn how to add custom fields to events, see the
 <<libbeat-configuration-fields,`fields`>> option.
@@ -417,6 +523,7 @@ All the <<conditions,conditions>> supported by processors are also supported
 here.
 endif::no-processors[]
 
+ifndef::apm-server[]
 The following example sends events to a specific pipeline based on whether the
 `message` field contains the specified string:
 
@@ -454,6 +561,67 @@ output.elasticsearch:
 With this configuration, all events with `log_type: critical` are sent to
 `sev1_pipeline`, all events with `log_type: normal` are sent to a
 `sev2_pipeline`, and all other events are sent to `sev3_pipeline`.
+endif::apm-server[]
+
+ifdef::apm-server[]
+The following example sends events to a specific pipeline based on whether the
+`processor.event` field contains the specified string:
+
+["source","yaml"]
+------------------------------------------------------------------------------
+output.elasticsearch:
+  hosts: ["http://localhost:9200"]
+  pipelines:
+    - pipeline: "sourcemap_pipeline"
+      when.contains:
+        processor.event: "sourcemap"
+    
+    - pipeline: "error_pipeline"
+      when.contains:
+        processor.event: "error"
+    
+    - pipeline: "transaction_pipeline"
+      when.contains:
+        processor.event: "transaction"
+    
+    - pipeline: "span_pipeline"
+      when.contains:
+        processor.event: "span"
+    
+    - pipeline: "metric_pipeline"
+      when.contains:
+        processor.event: "metric"
+    
+    - pipeline: "onboarding_pipeline"
+      when.contains:
+        processor.event: "onboarding"
+------------------------------------------------------------------------------
+
+
+The following example sets the pipeline by taking the name returned by the
+`pipeline` format string and mapping it to a new name that's used for the
+pipeline:
+
+["source","yaml"]
+------------------------------------------------------------------------------
+output.elasticsearch:
+  hosts: ["http://localhost:9200"]
+  pipelines:
+    - pipeline: "%{[processor.event]}"
+      mappings:
+        sourcemap:    "sourcemap_pipeline"
+        error:        "error_pipeline"
+        transaction:  "transaction_pipeline"
+        span:         "span_pipeline"
+        metric:       "metric_pipeline"
+        onboarding:   "onboarding_pipeline"
+      default: "apm_pipeline"
+------------------------------------------------------------------------------
+
+With this configuration, all events with `processor.event: transaction` are sent to a pipeline
+named `transaction_pipeline`, all events with `processor.event: error` are sent to a
+pipeline named `error_pipeline`, etc.
+endif::apm-server[]
 
 For more information about ingest node pipelines, see
 <<configuring-ingest-node>>.

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -280,8 +280,9 @@ output.elasticsearch:
   index: "apm-%\{[observer.version]\}-%\{[processor.event]\}-%\{+yyyy.MM.dd}\" <1>
 ------------------------------------------------------------------------------
 
-<1> We recommend including +{beat_version_key}+ in the name to avoid mapping issues
-when you upgrade.
+<1>  `observer` refers to {beatname_uc}. We recommend including
++{beat_version_key}+ in the name to avoid mapping issues when you upgrade
+{beatname_uc}.
 
 With this configuration,
 all events are separated by their `processor.event` into different indices.
@@ -397,6 +398,10 @@ output.elasticsearch:
       when.contains:
         processor.event: "onboarding"
 ------------------------------------------------------------------------------
+
+NOTE: `observer` refers to {beatname_uc}. We recommend including
++{beat_version_key}+ in the name to avoid mapping issues when you upgrade
+{beatname_uc}.
 
 This is the default configuration for {beatname_uc} and results in indices
 named in the following format: +"apm-%\{[{beat_version_key}]\}-{type\}-%\{+yyyy.MM.dd\}"+


### PR DESCRIPTION
Updates the Elasticsearch output config with APM Server fields. Unfortunately, I can't come up with a way to do this without introducing a bunch of new conditionals.

I've swapped out `fields.log_type` with `processor.event`, but open to other ideas, or using regexp if there are better examples.

**APM Issue:** closes https://github.com/elastic/apm-server/issues/2130. 
**Beats PR:** https://github.com/elastic/beats/pull/12034