### PR TITLE
[docs] UI implications of transaction name and type

### DIFF
--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -97,6 +97,13 @@ which are points in time relative to the start of the transaction with some labe
 In addition, agents provide options for users to capture custom <<metadata, metadata>>.
 Metadata can be indexed - <<labels-fields,`labels`>>, or not-indexed - <<custom-fields,`custom`>>.
 
+Transactions are grouped by their `type` and `name` in the APM UI's {kibana-ref}/transactions.html[Transaction overview].
+If you're using a supported framework, APM agents will automatically handle the naming for you.
+If you're not, or if you wish to override the default, all agents have API methods to manually set the `type` and `name`.
+
+* `type` should be a keyword of specific relevance in the service's domain, e.g. request, backgroundjob, etc.
+* `name` should be a generic designation of a transaction in the scope of a single service, e.g. GET /users/:id.
+
 TIP: Most agents limit keyword fields (e.g. `labels`) to 1024 characters,
 non-keyword fields (e.g. `span.db.statement`) to 10,000 characters.
 

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -102,7 +102,7 @@ If you're using a supported framework, APM agents will automatically handle the 
 If you're not, or if you wish to override the default, all agents have API methods to manually set the `type` and `name`.
 
 * `type` should be a keyword of specific relevance in the service's domain, e.g. request, backgroundjob, etc.
-* `name` should be a generic designation of a transaction in the scope of a single service, e.g. GET /users/:id.
+* `name` should be a generic designation of a transaction in the scope of a single service, e.g. `GET /users/:id`.
 
 TIP: Most agents limit keyword fields (e.g. `labels`) to 1024 characters,
 non-keyword fields (e.g. `span.db.statement`) to 10,000 characters.

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -101,7 +101,7 @@ Transactions are grouped by their `type` and `name` in the APM UI's {kibana-ref}
 If you're using a supported framework, APM agents will automatically handle the naming for you.
 If you're not, or if you wish to override the default, all agents have API methods to manually set the `type` and `name`.
 
-* `type` should be a keyword of specific relevance in the service's domain, e.g. request, backgroundjob, etc.
+* `type` should be a keyword of specific relevance in the service's domain, e.g. `request`, `backgroundjob`, etc.
 * `name` should be a generic designation of a transaction in the scope of a single service, e.g. `GET /users/:id`.
 
 TIP: Most agents limit keyword fields (e.g. `labels`) to 1024 characters,

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -97,9 +97,11 @@ which are points in time relative to the start of the transaction with some labe
 In addition, agents provide options for users to capture custom <<metadata, metadata>>.
 Metadata can be indexed - <<labels-fields,`labels`>>, or not-indexed - <<custom-fields,`custom`>>.
 
-Transactions are grouped by their `type` and `name` in the APM UI's {kibana-ref}/transactions.html[Transaction overview].
+Transactions are grouped by their `type` and `name` in the APM UI's
+{kibana-ref}/transactions.html[Transaction overview].
 If you're using a supported framework, APM agents will automatically handle the naming for you.
-If you're not, or if you wish to override the default, all agents have API methods to manually set the `type` and `name`.
+If you're not, or if you wish to override the default,
+all agents have API methods to manually set the `type` and `name`.
 
 * `type` should be a keyword of specific relevance in the service's domain,
 e.g. `request`, `backgroundjob`, etc.

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -101,8 +101,10 @@ Transactions are grouped by their `type` and `name` in the APM UI's {kibana-ref}
 If you're using a supported framework, APM agents will automatically handle the naming for you.
 If you're not, or if you wish to override the default, all agents have API methods to manually set the `type` and `name`.
 
-* `type` should be a keyword of specific relevance in the service's domain, e.g. `request`, `backgroundjob`, etc.
-* `name` should be a generic designation of a transaction in the scope of a single service, e.g. `GET /users/:id`.
+* `type` should be a keyword of specific relevance in the service's domain,
+e.g. `request`, `backgroundjob`, etc.
+* `name` should be a generic designation of a transaction in the scope of a single service,
+e.g. `GET /users/:id`, `UsersController#show`, etc.
 
 TIP: Most agents limit keyword fields (e.g. `labels`) to 1024 characters,
 non-keyword fields (e.g. `span.db.statement`) to 10,000 characters.


### PR DESCRIPTION
Closes: https://github.com/elastic/apm-server/issues/2116

* Adds information on how the transaction name and type impact the Kibana UI.
* Adds recommendations for naming and typing transactions to the APM data model.

@watson, since you opened the initial issue, can you take a look? Any recommendations for improvement, especially around L104 & L105, are greatly appreciated.