### PR TITLE
[docs] Clarify -e flag when running APM Server

### DIFF
--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -16,7 +16,7 @@ To start APM Server, run:
 ./apm-server -e
 ----------------------------------
 
-NOTE: The `-e` <<global-flags,global flag>> enables logs to stdout and disables syslog/file output.
+NOTE: The `-e` <<global-flags,global flag>> enables logging to stderr and disables syslog/file output.
 Remove this flag if you've enabled logging in the configuration file.
 
 You should see APM Server start up.

--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -18,6 +18,7 @@ To start APM Server, run:
 
 NOTE: The `-e` <<global-flags,global flag>> enables logging to stderr and disables syslog/file output.
 Remove this flag if you've enabled logging in the configuration file.
+For linux systems, see <<running-with-systemd,APM Server status and logs>>.
 
 You should see APM Server start up.
 It will try to connect to Elasticsearch on localhost port 9200 and expose an API to agents on port 8200.

--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -16,6 +16,9 @@ To start APM Server, run:
 ./apm-server -e
 ----------------------------------
 
+NOTE: The `-e` <<global-flags,global flag>> enables logs to stdout and disables syslog/file output.
+Remove this flag if you've enabled logging in the configuration file.
+
 You should see APM Server start up.
 It will try to connect to Elasticsearch on localhost port 9200 and expose an API to agents on port 8200.
 You can change the defaults by supplying a different address on the command line:


### PR DESCRIPTION
Clarifies what `-e` flag does in the "setting up and running" section of APM Server documentation.