### PR TITLE
add geoip + default pipeline definitions

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -306,7 +306,7 @@ output.elasticsearch:
   # (1) ensure pipelines are registered in Elasticsearch, see `apm-server.register.ingest.pipeline`
   # (2) enable the following:
   #pipelines:
-  #- pipeline: "apm_user_agent"
+  #- pipeline: "apm"
 
   # Optional HTTP Path
   #path: "/elasticsearch"

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -306,7 +306,7 @@ output.elasticsearch:
   # (1) ensure pipelines are registered in Elasticsearch, see `apm-server.register.ingest.pipeline`
   # (2) enable the following:
   #pipelines:
-  #- pipeline: "apm_user_agent"
+  #- pipeline: "apm"
 
   # Optional HTTP Path
   #path: "/elasticsearch"

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -306,7 +306,7 @@ output.elasticsearch:
   # (1) ensure pipelines are registered in Elasticsearch, see `apm-server.register.ingest.pipeline`
   # (2) enable the following:
   #pipelines:
-  #- pipeline: "apm_user_agent"
+  #- pipeline: "apm"
 
   # Optional HTTP Path
   #path: "/elasticsearch"

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -11,6 +11,7 @@
 - Return response body with number of accepted events when queries pass a `verbose` param. {pull}2110[2110].
 - Add Idle timeout to server config {pull}2122[2122].
 - Upgrade Go to 1.12.4 {pull}2132[2132].
+- Add geoip processing to the default ingest pipeline {pull}2177[2177].
 
 [float]
 ==== Removed

--- a/ingest/pipeline/definition.json
+++ b/ingest/pipeline/definition.json
@@ -1,4 +1,23 @@
-[{
+[
+{
+  "id": "apm",
+  "body": {
+    "description" : "Default enrichment for APM events",
+    "processors" : [
+      {
+        "pipeline": {
+          "name": "apm_user_agent"
+        }
+      },
+      {
+        "pipeline": {
+          "name": "apm_user_geo"
+        }
+      }
+    ]
+  }
+},
+{
   "id": "apm_user_agent",
   "body": {
     "description" : "Add user agent information for APM events",
@@ -12,4 +31,21 @@
       }
     ]
   }
-}]
+},
+{
+  "id": "apm_user_geo",
+  "body": {
+    "description" : "Add user geo information for APM events",
+    "processors" : [
+      {
+        "geoip" : {
+          "database_file": "GeoLite2-City.mmdb",
+          "field": "client.ip",
+          "target_field": "client.geo",
+          "ignore_missing": true
+        }
+      }
+    ]
+  }
+}
+]

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -216,11 +216,11 @@ class ElasticTest(ServerBaseTest):
 
         # Cleanup pipelines
         self.es.ingest.delete_pipeline(id="*")
-        # Write empyt pipeline for user_agent
+        # Write empty default pipeline
         self.es.ingest.put_pipeline(
-            id="apm_user_agent",
-            body={"description": "user agent test", "processors": []})
-        self.wait_until(lambda: self.es.ingest.get_pipeline("apm_user_agent"))
+            id="apm",
+            body={"description": "empty apm test pipeline", "processors": []})
+        self.wait_until(lambda: self.es.ingest.get_pipeline("apm"))
 
         super(ElasticTest, self).setUp()
 

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -564,14 +564,17 @@ class PipelineRegisterTest(ElasticTest):
     }
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    def test_default_pipeline_registered(self):
-        pipeline_id = "apm_user_agent"
-        default_desc = "Add user agent information for APM events"
+    def test_default_pipelines_registered(self):
+        pipelines = [
+            ("apm_user_agent", "Add user agent information for APM events"),
+            ("apm_user_geoip", "Add user geo information for APM events"),
+            ("apm", "Default enrichment for APM events"),
+        ]
         loaded_msg = "Pipeline successfully registered"
-        self.wait_until(lambda: self.log_contains(loaded_msg),
-                        max_timeout=5)
-        pipeline = self.es.ingest.get_pipeline(id=pipeline_id)
-        assert pipeline[pipeline_id]['description'] == default_desc
+        self.wait_until(lambda: self.log_contains(loaded_msg), max_timeout=5)
+        for pipeline_id, pipeline_desc in pipeline_ids:
+            pipeline = self.es.ingest.get_pipeline(id=pipeline_id)
+            assert pipeline[pipeline_id]['description'] == pipeline_desc
 
 
 class PipelineDisableOverwriteTest(ElasticTest):

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -567,7 +567,7 @@ class PipelineRegisterTest(ElasticTest):
     def test_default_pipelines_registered(self):
         pipelines = [
             ("apm_user_agent", "Add user agent information for APM events"),
-            ("apm_user_geoip", "Add user geo information for APM events"),
+            ("apm_user_geo", "Add user geo information for APM events"),
             ("apm", "Default enrichment for APM events"),
         ]
         loaded_msg = "Pipeline successfully registered"

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -572,7 +572,7 @@ class PipelineRegisterTest(ElasticTest):
         ]
         loaded_msg = "Pipeline successfully registered"
         self.wait_until(lambda: self.log_contains(loaded_msg), max_timeout=5)
-        for pipeline_id, pipeline_desc in pipeline_ids:
+        for pipeline_id, pipeline_desc in pipelines:
             pipeline = self.es.ingest.get_pipeline(id=pipeline_id)
             assert pipeline[pipeline_id]['description'] == pipeline_desc
 


### PR DESCRIPTION
Adds two new pipeline definitions without changing the existing `apm_user_agent`:
* `apm_user_geo` - only GeoIP resolution of `client.ip` to `client.geo`
* `apm` - both `apm_user_agent` and `apm_user_geo`

updates the default pipeline suggested in apm-server.yml

closes #1283 