### PR TITLE
sync changelogs/release notes to 7.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,4 +1,5 @@
 include::./changelogs/7.0.asciidoc[]
+include::./changelogs/6.8.asciidoc[]
 include::./changelogs/6.7.asciidoc[]
 include::./changelogs/6.6.asciidoc[]
 include::./changelogs/6.5.asciidoc[]

--- a/changelogs/6.7.asciidoc
+++ b/changelogs/6.7.asciidoc
@@ -3,8 +3,19 @@
 
 https://github.com/elastic/apm-server/compare/6.6\...6.7[View commits]
 
+* <<release-notes-6.7.2>>
 * <<release-notes-6.7.1>>
 * <<release-notes-6.7.0>>
+
+[[release-notes-6.7.2]]
+=== APM Server version 6.7.2
+
+https://github.com/elastic/apm-server/compare/v6.7.1\...v6.7.2[View commits]
+
+[float]
+==== Bug fixes
+
+- Fix numeric user id decoding {pull}2147[2147].
 
 [[release-notes-6.7.1]]
 === APM Server version 6.7.1
@@ -26,8 +37,10 @@ https://github.com/elastic/apm-server/compare/v6.6.0\...v6.7.0[View commits]
 
 - Allow numbers and boolean values for `transaction.tags`, `span.tags`, `metricset.tags` {pull}1712[1712].
 - Retrieve `span.subtype` and `span.action` from `span.type` if not given {pull}1843[1843].
+- Set default query fields in index pattern {pull}1996[1996].
 
 [float]
 ==== Removed
 - Remove support for using dots in tags for experimental metricset endpoint {pull}1712[1712].
 - Remove formatting of `duration.us` to milliseconds in index pattern {pull}1717[1717].
+

--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -1,0 +1,16 @@
+[[release-notes-6.8]]
+== APM Server version 6.8
+
+https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
+
+* <<release-notes-6.8.0>>
+
+[[release-notes-6.8.0]]
+=== APM Server version 6.8.0
+
+https://github.com/e2astic/apm-server/compare/v6.7.1\...v6.8.0[View commits]
+
+[float]
+==== Bug fixes
+
+- Fix numeric user id decoding {pull}2147[2147].

--- a/docs/guide/apm-release-notes.asciidoc
+++ b/docs/guide/apm-release-notes.asciidoc
@@ -8,6 +8,7 @@ For a full list of changes, see the
 {kibana-ref}/release-notes.html[Kibana Release Notes].
 
 * <<release-highlights-7.0.0>>
+* <<release-notes-6.8.0>>
 * <<release-notes-6.7.0>>
 * <<release-notes-6.6.0>>
 * <<release-notes-6.5.0>>
@@ -37,6 +38,11 @@ See <<breaking-7.0.0>>
 
 * Links from APM to Infra may produce unexpected results due to a problem with the time range included in those links.
 Fixed in 7.0.1.
+
+[[release-notes-6.8.0]]
+=== APM version 6.8.0
+
+No new features.
 
 [[release-notes-6.7.0]]
 === APM version 6.7.0


### PR DESCRIPTION
A bit mixed on adding 6.8.0 release notes to 7.0 since it was released after 7.0 but went for it as most users would probably expect them to be there.