### PR TITLE
Check if ILM is supported when configured.

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -12,7 +12,7 @@
 - Upgrade Go to 1.12.4 {pull}2132[2132].
 - Add geoip processing to the default ingest pipeline {pull}2177[2177].
 - Add ephemeral_id attribute in the metadata {pull}2179[2179].
-- Add ILM support for APM Server, using fixed policies {pull}2099[2099].
+- Add ILM support for APM Server, using fixed policies {pull}2099[2099],{pull}2209[2209].
 - Add `setup --index-management` cmd, deprecate `setup --template` cmd {pull}2180[2180],{pull}2099[2099].
 
 [float]

--- a/idxmgmt/supporter.go
+++ b/idxmgmt/supporter.go
@@ -176,20 +176,51 @@ func (m *manager) Setup(loadTemplate, loadILM libidxmgmt.LoadMode) error {
 	m.supporter.templateConfig.Overwrite = templateComponent.overwrite
 
 	//setup index management:
+	//(0) check if setup is supported
 	//(1) load general apm template
 	//(2) load policy per event type
 	//(3) create template per event respecting lifecycle settings
 	//(4) load write alias per event type AFTER the template has been created,
 	//    as this step also automatically creates an index, it is important the matching templates are already there
 
+	type ilmStruct struct {
+		manager   libilm.Manager
+		supporter libilm.Supporter
+	}
 	var (
-		ilmSupporter      libilm.Supporter
+		ilmInfo           []ilmStruct
 		err               error
 		ilmCfg            *common.Config
 		policyCreated     bool
 		overwriteTemplate = templateComponent.overwrite
 		templateCfg       template.TemplateConfig
 	)
+
+	//(0) prepare ilm handlers and check if setup is supported
+	//    fail early before anything is loaded if ILM is requested but not supported
+	for event, index := range eventIdxNames(false) {
+		if ilmCfg, err = common.NewConfigFrom(common.MapStr{
+			"enabled":     ilmComponent.enabled,
+			"event":       event,
+			"policy_name": idxStr(event, ""),
+			"alias_name":  index},
+		); err != nil {
+			return errors.Wrapf(err, "error creating index-management config")
+		}
+		ilmSupporter, err := ilm.MakeDefaultSupporter(log, m.supporter.info, ilmCfg)
+		if err != nil {
+			return err
+		}
+		ilmManager := ilmSupporter.Manager(m.clientHandler)
+
+		if ilmComponent.enabled {
+			// check if ILM is supported by the clientHandler
+			if _, err = ilmManager.Enabled(); err != nil {
+				return err
+			}
+		}
+		ilmInfo = append(ilmInfo, ilmStruct{manager: ilmManager, supporter: ilmSupporter})
+	}
 
 	//(1) load general apm template
 	//only set to user configured name and pattern if ilm is disabled
@@ -209,25 +240,13 @@ func (m *manager) Setup(loadTemplate, loadILM libidxmgmt.LoadMode) error {
 		log.Infof("Finished loading index template.")
 	}
 
-	for event, index := range eventIdxNames(false) {
-		if ilmCfg, err = common.NewConfigFrom(common.MapStr{
-			"enabled":     ilmComponent.enabled,
-			"event":       event,
-			"policy_name": idxStr(event, ""),
-			"alias_name":  index},
-		); err != nil {
-			return errors.Wrapf(err, "error creating index-management config")
-		}
-		if ilmSupporter, err = ilm.MakeDefaultSupporter(log, m.supporter.info, ilmCfg); err != nil {
-			return err
-		}
-		ilmManager := ilmSupporter.Manager(m.clientHandler)
-		policy := ilmSupporter.Policy().Name
-		alias := ilmSupporter.Alias().Name
+	for _, ilmInfo := range ilmInfo {
 
+		policy := ilmInfo.supporter.Policy().Name
+		alias := ilmInfo.supporter.Alias().Name
 		if ilmComponent.load {
 			//(2) load event type policies, respecting ILM settings
-			if policyCreated, err = ilmManager.EnsurePolicy(ilmComponent.overwrite); err != nil {
+			if policyCreated, err = ilmInfo.manager.EnsurePolicy(ilmComponent.overwrite); err != nil {
 				return err
 			}
 			if policyCreated {
@@ -250,7 +269,7 @@ func (m *manager) Setup(loadTemplate, loadILM libidxmgmt.LoadMode) error {
 		if ilmComponent.load {
 			//(4) load ilm write aliases
 			//    ensure write aliases are created AFTER template creation
-			if err = ilmManager.EnsureAlias(); err != nil {
+			if err = ilmInfo.manager.EnsureAlias(); err != nil {
 				if libilm.ErrReason(err) != libilm.ErrAliasAlreadyExists {
 					return err
 				}


### PR DESCRIPTION
Raise ILM not supported error early before any templates are loaded
to ensure clean state.

fixes elastic/apm-server#2208