### PR TITLE
make apm-server.docker.yml generation consistent with apm-server.yml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,8 @@ endif
 is-beats-updated: python-env
 	@$(PYTHON_ENV)/bin/python ./script/is_beats_updated.py ${BEATS_VERSION}
 
-apm-server.docker.yml: apm-server.yml
-	@sed -E -e 's/^  hosts: \["localhost:9200"\]/  hosts: ["elasticsearch:9200"]/' -e 's/  host: "localhost:8200"/  host: "0.0.0.0:8200"/' < apm-server.yml > apm-server.docker.yml
+apm-server.docker.yml: _meta/beat.yml
+	@sed -E -e 's/^  hosts: \["localhost:9200"\]/  hosts: ["elasticsearch:9200"]/' -e 's/  host: "localhost:8200"/  host: "0.0.0.0:8200"/' < _meta/beat.yml > apm-server.docker.yml
 
 # Collects all dependencies and then calls update
 .PHONY: collect


### PR DESCRIPTION
`apm-server.yml == _meta/beat.yml`, so just use that directly.  Per discussion, in the future we could create another source of truth for configuration settings and generate each of these files but this should address the outstanding issue with apm-server.docker.yml.

fixes elastic/apm-server#2123 