### PR TITLE
correct typo for word can cited as 'an'

### DIFF
--- a/docs/guide/overview.asciidoc
+++ b/docs/guide/overview.asciidoc
@@ -35,7 +35,7 @@ Elasticsearch is used to store APM performance metrics and make use of its aggre
 
 {kibana-ref}/xpack-apm.html[*Kibana*] is an open source analytics and visualization platform designed to work with Elasticsearch.
 You use Kibana to search, view, and interact with data stored in Elasticsearch.
-You an use Kibana to visualize APM data by utilizing the dedicated APM UI bundled in Basic license,
+You can use Kibana to visualize APM data by utilizing the dedicated APM UI bundled in Basic license,
 or the pre-built, open source,
 Kibana dashboards that can be loaded directly via the {kibana-ref}/apm-getting-started.html[APM Kibana UI].
 


### PR DESCRIPTION
Hi - I was reading docs on the web site and saw this, happy to start contributing.

From this public page: 
https://www.elastic.co/guide/en/apm/get-started/current/overview.html

![Screen Shot 2019-06-06 at 4 28 42 PM](https://user-images.githubusercontent.com/12970373/59065110-f5563a00-8879-11e9-9632-a9b82aa3aa38.png)
