### PR TITLE
[docs] Update redirect page for dashboards

### DIFF
--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -258,5 +258,5 @@ Loading dashboards from APM Server is no longer supported. Please see the {kiban
 
 Loading Kibana dashboards from APM Server is no longer supported.
 Please use the {kibana-ref}/xpack-apm.html[Kibana APM UI] instead.
-As an alternative, select dashboards and visualizations are available in the
+As an alternative, a small number of dashboards and visualizations are available in the
 https://github.com/elastic/apm-contrib/tree/master/apm-ui[apm-contrib] repository.

--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -256,4 +256,7 @@ Loading dashboards from APM Server is no longer supported. Please see the {kiban
 [role="exclude",id="load-kibana-dashboards"]
 === Dashboards
 
-Loading dashboards from APM Server is no longer supported. Please see the {kibana-ref}/xpack-apm.html[Kibana APM UI] documentation.
+Loading Kibana dashboards from APM Server is no longer supported.
+Please use the {kibana-ref}/xpack-apm.html[Kibana APM UI] instead.
+As an alternative, select dashboards and visualizations are available in the
+https://github.com/elastic/apm-contrib/tree/master/apm-ui[apm-contrib] repository.


### PR DESCRIPTION
Adds info about `apm-contrib` to the dashboards redirect page