### PR TITLE
[docs] Fix APM on cloud bug

### DIFF
--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -1568,7 +1568,8 @@ endif::[]
 ++++
 
 ifdef::apm-server[]
-NOTE: This page refers to using a separate instance of APM Server with an existing Elasticsearch Service deployment.
+NOTE: This page refers to using a separate instance of APM Server with an existing
+https://www.elastic.co/cloud/elasticsearch-service[Elasticsearch Service deployment].
 If you want to use APM on Elastic Cloud, see the cloud docs:
 {cloud}/ec-create-deployment.html[Create your deployment] or
 {cloud}/ec-manage-apm-settings.html[Add APM user settings].

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -1569,7 +1569,9 @@ endif::[]
 
 ifdef::apm-server[]
 NOTE: This page refers to using a separate instance of APM Server with an existing Elasticsearch Service deployment.
-APM Server is not yet supported on Elasticsearch Service.
+If you want to use APM on Elastic Cloud, see the cloud docs:
+{cloud}/ec-create-deployment.html[Create your deployment] or
+{cloud}/ec-manage-apm-settings.html[Add APM user settings].
 endif::apm-server[]
 
 {beatname_uc} comes with two settings that simplify the output configuration


### PR DESCRIPTION
* Removes old statement about APM not being on Cloud yet.
* Closes elastic/apm-server#2178 
* Persisted in the beats repo: https://github.com/elastic/beats/pull/12456