### PR TITLE
[7.2] Enable overwriting ingest pipelines by default. (#2273)

### DIFF
--- a/beater/config.go
+++ b/beater/config.go
@@ -179,7 +179,7 @@ func (c *pipelineConfig) isEnabled() bool {
 }
 
 func (c *pipelineConfig) shouldOverwrite() bool {
-	return c != nil && (c.Overwrite != nil && *c.Overwrite)
+	return c != nil && (c.Overwrite == nil || *c.Overwrite)
 }
 
 func (c *rumConfig) memoizedSmapMapper() (sourcemap.Mapper, error) {

--- a/beater/config_test.go
+++ b/beater/config_test.go
@@ -290,7 +290,7 @@ func TestPipeline(t *testing.T) {
 		enabled, overwrite bool
 	}{
 		{c: nil, enabled: false, overwrite: false},
-		{c: &pipelineConfig{}, enabled: false, overwrite: false},
+		{c: &pipelineConfig{}, enabled: false, overwrite: true}, //default values
 		{c: &pipelineConfig{Enabled: &falsy, Overwrite: &truthy},
 			enabled: false, overwrite: true},
 		{c: &pipelineConfig{Enabled: &truthy, Overwrite: &falsy},

--- a/changelogs/7.2.asciidoc
+++ b/changelogs/7.2.asciidoc
@@ -3,12 +3,20 @@
 
 https://github.com/elastic/apm-server/compare/7.1\...7.2[View commits]
 
+* <<release-notes-7.2.1>>
 * <<release-notes-7.2.0>>
+
+[[release-notes-7.2.1]]
+=== APM Server version 7.2.1
+
+https://github.com/elastic/apm-server/compare/v7.2.0\...v7.2.1[View commits]
+
+[float]
+==== Bug fixes
+- Set `apm-server.register.ingest.pipeline.overwrite` to true by default {pull}2273[2273].
 
 [[release-notes-7.2.0]]
 === APM Server version 7.2.0
-
-https://github.com/elastic/apm-server/compare/v7.1.0\...v7.2.0[View commits]
 
 [float]
 ==== Added

--- a/tests/system/test_pipelines.py
+++ b/tests/system/test_pipelines.py
@@ -60,9 +60,9 @@ class SetupPipelinesDisabledTest(SetupPipelinesDefaultTest):
 
 
 class PipelineRegisterTest(ElasticTest):
+    # pipeline.overwrite should be enabled by default.
     config_overrides = {
         "register_pipeline_enabled": "true",
-        "register_pipeline_overwrite": "true"
     }
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")


### PR DESCRIPTION
Backports the following commits to 7.2:
 - Enable overwriting ingest pipelines by default.  (#2273)