### PR TITLE
abort server startup on sourcemap configuration error

### DIFF
--- a/beater/server.go
+++ b/beater/server.go
@@ -34,7 +34,10 @@ import (
 )
 
 func newServer(config *Config, tracer *apm.Tracer, report publish.Reporter) (*http.Server, error) {
-	mux := newMuxer(config, report)
+	mux, err := newMuxer(config, report)
+	if err != nil {
+		return nil, err
+	}
 
 	server := &http.Server{
 		Addr: config.Host,

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -231,6 +231,16 @@ func TestServerRumSwitch(t *testing.T) {
 	}
 }
 
+func TestServerSourcemapBadConfig(t *testing.T) {
+	ucfg, err := common.NewConfigFrom(m{"rum": m{"enabled": true, "source_mapping": m{"elasticsearch": m{"hosts": []string{}}}}})
+	require.NoError(t, err)
+	_, teardown, err := setupServer(t, ucfg, nil, nil)
+	if err == nil {
+		defer teardown()
+	}
+	require.Error(t, err)
+}
+
 func TestServerCORS(t *testing.T) {
 	true := true
 	tests := []struct {

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -5,6 +5,7 @@
 ==== Bug fixes
 - Require client authentication by default when `apm-server.ssl.enabled` is true {pull}2224[2224].
 - Set `apm-server.register.ingest.pipeline.overwrite` to true by default {pull}2273[2273].
+- Abort server startup on sourcemap configuration error {pull}2278[2278].
 
 [float]
 ==== Added


### PR DESCRIPTION
found while working on #2201, it impacts a few operations that may fail:

https://github.com/elastic/apm-server/blob/51942e8429f3073191988e438cd98e31cba99396/beater/route_config.go#L145

https://github.com/elastic/apm-server/blob/51942e8429f3073191988e438cd98e31cba99396/beater/route_config.go#L193



