### PR TITLE
[docs] Updates build script and description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ notice: python-env
 	@$(PYTHON_ENV)/bin/python ${ES_BEATS}/dev-tools/generate_notice.py . -e '_beats' -s "./vendor/github.com/elastic/beats" -b "Apm Server" --beats-origin <($(PYTHON_ENV)/bin/python script/generate_notice_overrides.py)
 
 .PHONY: apm-docs
-apm-docs:  ## @build Builds the APM documents
+apm-docs:  ## @build Builds the documentation for APM Server and APM Overview
 	@rm -rf build/html_docs
 	sh script/build_apm_docs.sh ${BEAT_NAME} ${BEAT_PATH}/docs ${BUILD_DIR}
 

--- a/_beats/libbeat/scripts/Makefile
+++ b/_beats/libbeat/scripts/Makefile
@@ -367,7 +367,7 @@ endif
 endif
 
 .PHONY: docs
-docs:  ## @build Builds the documents for the beat
+docs:  ## @build Builds the documentation for the beat
 	@if [ -d $(XPACK_DIR) ]; then \
 		sh ${ES_BEATS}/script/build_docs.sh ${BEAT_NAME} ${BEAT_PATH}/docs ${BUILD_DIR} ${XPACK_DIR}; \
 	else \
@@ -375,7 +375,7 @@ docs:  ## @build Builds the documents for the beat
 	fi
 
 .PHONY: docs-preview
-docs-preview:  ## @build Preview the documents for the beat in the browser
+docs-preview:  ## @build Previews the documentation for the beat in the browser
 	PREVIEW=1 $(MAKE) docs
 
 ### SETUP commands ###

--- a/_beats/script/build_docs.sh
+++ b/_beats/script/build_docs.sh
@@ -37,5 +37,5 @@ do
     params="$params --resource=${resource_dir}"
   fi
 
-  $docs_dir/build_docs.pl $params --doc "$index" -out "$dest_dir"
+  $docs_dir/build_docs $params --doc "$index" --out "$dest_dir"
 done

--- a/script/build_apm_docs.sh
+++ b/script/build_apm_docs.sh
@@ -28,5 +28,5 @@ do
   dest_dir="$html_dir/${name}/${index_path}"
   mkdir -p "$dest_dir"
   params="--chunk=1"
-  $docs_dir/build_docs.pl $params --doc "$index" -out "$dest_dir"
+  $docs_dir/build_docs $params --doc "$index" --out "$dest_dir"
 done


### PR DESCRIPTION
Moves `make docs`, `make docs-preview`, and `make apm-docs` to the new docker build script. Updates the help descriptions to be more clear.

Some of this needs to be persisted in the beats repo. Here's the PR for that: https://github.com/elastic/beats/pull/12522