### PR TITLE
Make client_auth optional by default.

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -65,11 +65,10 @@ apm-server:
     # Configure curve types for ECDHE based cipher suites
     #curve_types: []
 
-    # Configure which types of client authentication are supported.
-    # Options are `none`, `optional`, and `required`.
-    # It is strongly recommended to always set to `required`
-    # Default is `required`.
-    #client_authentication: "required"
+    # Configure which type of client authentication is supported.
+    # Options are `none`, `optional`, and `required`. Default is `optional`.
+    #client_authentication: "optional"
+
 
   #rum:
     # To enable real user monitoring (RUM) support set this to true.

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -65,11 +65,10 @@ apm-server:
     # Configure curve types for ECDHE based cipher suites
     #curve_types: []
 
-    # Configure which types of client authentication are supported.
-    # Options are `none`, `optional`, and `required`.
-    # It is strongly recommended to always set to `required`
-    # Default is `required`.
-    #client_authentication: "required"
+    # Configure which type of client authentication is supported.
+    # Options are `none`, `optional`, and `required`. Default is `optional`.
+    #client_authentication: "optional"
+
 
   #rum:
     # To enable real user monitoring (RUM) support set this to true.

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -65,11 +65,10 @@ apm-server:
     # Configure curve types for ECDHE based cipher suites
     #curve_types: []
 
-    # Configure which types of client authentication are supported.
-    # Options are `none`, `optional`, and `required`.
-    # It is strongly recommended to always set to `required`
-    # Default is `required`.
-    #client_authentication: "required"
+    # Configure which type of client authentication is supported.
+    # Options are `none`, `optional`, and `required`. Default is `optional`.
+    #client_authentication: "optional"
+
 
   #rum:
     # To enable real user monitoring (RUM) support set this to true.

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -28,12 +28,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/beats/libbeat/common/transport/tlscommon"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/transport/tlscommon"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 	pubs "github.com/elastic/beats/libbeat/publisher"
@@ -67,9 +66,10 @@ func TestBeatConfig(t *testing.T) {
 				"capture_personal_data": true,
 				"secret_token":          "1234random",
 				"ssl": map[string]interface{}{
-					"enabled":     true,
-					"key":         "1234key",
-					"certificate": "1234cert",
+					"enabled":               true,
+					"key":                   "1234key",
+					"certificate":           "1234cert",
+					"client_authentication": "none",
 				},
 				"expvar": map[string]interface{}{
 					"enabled": true,
@@ -113,7 +113,7 @@ func TestBeatConfig(t *testing.T) {
 				TLS: &tlscommon.ServerConfig{
 					Enabled:     &truthy,
 					Certificate: outputs.CertificateConfig{Certificate: "1234cert", Key: "1234key"},
-					ClientAuth:  4},
+					ClientAuth:  0},
 				AugmentEnabled: true,
 				Expvar: &ExpvarConfig{
 					Enabled: &truthy,
@@ -185,7 +185,7 @@ func TestBeatConfig(t *testing.T) {
 				TLS: &tlscommon.ServerConfig{
 					Enabled:     &truthy,
 					Certificate: outputs.CertificateConfig{Certificate: "", Key: ""},
-					ClientAuth:  4},
+					ClientAuth:  3},
 				AugmentEnabled: true,
 				Expvar: &ExpvarConfig{
 					Enabled: &truthy,

--- a/beater/config.go
+++ b/beater/config.go
@@ -127,6 +127,19 @@ func (m *Mode) Unpack(s string) error {
 
 func newConfig(version string, ucfg *common.Config) (*Config, error) {
 	c := defaultConfig(version)
+
+	if ucfg.HasField("ssl") {
+		ssl, err := ucfg.Child("ssl", -1)
+		if err != nil {
+			return nil, err
+		}
+		if !ssl.HasField("client_authentication") {
+			if err := ucfg.SetString("ssl.client_authentication", -1, "optional"); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	if err := ucfg.Unpack(c); err != nil {
 		return nil, errors.Wrap(err, "Error processing configuration")
 	}

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -8,7 +8,7 @@
 [float]
 ==== Added
 - Support more SSL config options for agent/server communication {pull}2224[2224].
-- Support adding transaction and span information to metrics  {pull}2265[2265].
+- Support adding transaction and span information to metrics  {pull}2265[2265],{pull}2281[2281].
 
 [float]
 ==== Removed

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -3,7 +3,6 @@
 
 [float]
 ==== Bug fixes
-- Require client authentication by default when `apm-server.ssl.enabled` is true {pull}2224[2224].
 - Set `apm-server.register.ingest.pipeline.overwrite` to true by default {pull}2273[2273].
 
 [float]

--- a/tests/system/test_access.py
+++ b/tests/system/test_access.py
@@ -165,7 +165,7 @@ class TestSSLEnabledNoClientVerificationTest(TestSecureServerBaseTest):
 
 
 class TestSSLEnabledOptionalClientVerificationTest(TestSecureServerBaseTest):
-    # no ssl_overrides necessary as `required` is default
+    # no ssl_overrides necessary as `optional` is default
 
     def test_https_no_certificate_ok(self):
         r = self.send_http_request(verify=self.ca_cert)

--- a/tests/system/test_access.py
+++ b/tests/system/test_access.py
@@ -154,9 +154,9 @@ class TestSSLEnabledNoClientVerificationTest(TestSecureServerBaseTest):
         r = self.send_http_request(verify=self.ca_cert)
         assert r.status_code == 202, r.status_code
 
-    @raises(ChunkedEncodingError)
     def test_http_fails(self):
-        self.send_http_request(protocol='http')
+        with self.assertRaises(Exception):
+            self.send_http_request(protocol='http')
 
     @raises(SSLError)
     def test_https_server_validation_fails(self):
@@ -165,8 +165,7 @@ class TestSSLEnabledNoClientVerificationTest(TestSecureServerBaseTest):
 
 
 class TestSSLEnabledOptionalClientVerificationTest(TestSecureServerBaseTest):
-    def ssl_overrides(self):
-        return {"ssl_client_authentication": "optional"}
+    # no ssl_overrides necessary as `required` is default
 
     def test_https_no_certificate_ok(self):
         r = self.send_http_request(verify=self.ca_cert)
@@ -184,7 +183,8 @@ class TestSSLEnabledOptionalClientVerificationTest(TestSecureServerBaseTest):
 
 
 class TestSSLEnabledRequiredClientVerificationTest(TestSecureServerBaseTest):
-    # no ssl_overrides necessary as `required` is default
+    def ssl_overrides(self):
+        return {"ssl_client_authentication": "required"}
 
     @raises(SSLError)
     def test_https_no_cert_fails(self):
@@ -202,9 +202,6 @@ class TestSSLEnabledRequiredClientVerificationTest(TestSecureServerBaseTest):
 
 
 class TestSSLDefaultSupportedProcotolsTest(TestSecureServerBaseTest):
-    def ssl_overrides(self):
-        return {"ssl_client_authentication": "none"}
-
     @raises(ssl.SSLError)
     def test_tls_v1_0(self):
         self.ssl_connect(protocol=ssl.PROTOCOL_TLSv1)
@@ -218,8 +215,7 @@ class TestSSLDefaultSupportedProcotolsTest(TestSecureServerBaseTest):
 
 class TestSSLSupportedProcotolsTest(TestSecureServerBaseTest):
     def ssl_overrides(self):
-        return {"ssl_client_authentication": "none",
-                "ssl_supported_protocols": ["TLSv1.2"]}
+        return {"ssl_supported_protocols": ["TLSv1.2"]}
 
     @raises(ssl.SSLError)
     def test_tls_v1_1(self):


### PR DESCRIPTION
This PR changes `ssl.client_authentication` from `required` to `optional`,  meaning that client certificates are verified if available. 

Client authentication is not considered to be a requirement for secure communication between APM agents and APM server, as an additional _token_ can be configured and provided for authentication. None of the agents currently support client authentication, so enforcing it as default does not seem reasonable. Changing the default would also mean a breaking change. 
