### PR TITLE
Adds initial support for agent remote configuration

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -183,6 +183,56 @@ apm-server:
   #ilm:
     #enabled: false
 
+  #kibana:
+    # For agent remote configuration, enabled must be true
+    #enabled: false
+
+    # Scheme and port can be left out and will be set to the default (http and 5601)
+    # In case you specify an additional path, the scheme is required: http://localhost:5601/path
+    # IPv6 addresses should always be defined as: https://[2001:db8::1]:5601
+    #host: "localhost:5601"
+
+    # Optional protocol and basic auth credentials.
+    #protocol: "https"
+    #username: "elastic"
+    #password: "changeme"
+
+    # Optional HTTP path
+    #path: ""
+
+    # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
+    #ssl.enabled: true
+
+    # Optional SSL configuration options. SSL is off by default, change the `protocol` option if you want to enable `https`.
+    # Configure SSL verification mode. If `none` is configured, all server hosts
+    # and certificates will be accepted. In this mode, SSL based connections are
+    # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+    # `full`.
+    #ssl.verification_mode: full
+
+    # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+    # 1.2 are enabled.
+    #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+    # List of root certificates for HTTPS server verifications
+    #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+    # Certificate for SSL client authentication
+    #ssl.certificate: "/etc/pki/client/cert.pem"
+
+    # Client Certificate Key
+    #ssl.key: "/etc/pki/client/cert.key"
+
+    # Optional passphrase for decrypting the Certificate Key.
+    # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
+    #ssl.key_passphrase: ''
+
+    # Configure cipher suites to be used for SSL connections
+    #ssl.cipher_suites: []
+
+    # Configure curve types for ECDHE based cipher suites
+    #ssl.curve_types: []
+
 #================================ General ======================================
 
 # Internal queue configuration for buffering events to be published.

--- a/agentcfg/fetch.go
+++ b/agentcfg/fetch.go
@@ -1,0 +1,67 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package agentcfg
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/common"
+
+	"github.com/elastic/apm-server/convert"
+	"github.com/elastic/beats/libbeat/kibana"
+)
+
+const endpoint = "/api/apm/settings/cm/search"
+
+var minVersion = common.Version{Major: 7, Minor: 3}
+
+// Fetch retrieves agent configuration from Kibana
+func Fetch(kbClient *kibana.Client, q Query, err error) (map[string]string, string, error) {
+	var doc Doc
+	resultBytes, err := request(kbClient, convert.ToReader(q), err)
+	err = convert.FromBytes(resultBytes, &doc, err)
+	return doc.Source.Settings, doc.ID, err
+}
+
+func request(kbClient *kibana.Client, r io.Reader, err error) ([]byte, error) {
+	if err != nil {
+		return nil, err
+	}
+	if kbClient == nil {
+		return nil, errors.New("No configured Kibana Client: provide apm-server.kibana.* settings")
+	}
+	if version := kbClient.GetVersion(); version.LessThan(&minVersion) {
+		return nil, errors.New(fmt.Sprintf("Needs Kibana version %s or higher", minVersion.String()))
+	}
+	resp, err := kbClient.Send(http.MethodPost, endpoint, nil, nil, r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	result, err := ioutil.ReadAll(resp.Body)
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, errors.New(string(result))
+	}
+	return result, err
+}

--- a/agentcfg/fetch_test.go
+++ b/agentcfg/fetch_test.go
@@ -1,0 +1,71 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package agentcfg
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-server/tests"
+	"github.com/elastic/beats/libbeat/kibana"
+)
+
+type m map[string]interface{}
+
+var q = Query{}
+
+func TestFetchNoClient(t *testing.T) {
+	kb, kerr := kibana.NewKibanaClient(nil)
+	_, _, ferr := Fetch(kb, q, kerr)
+	require.Error(t, ferr)
+	assert.Equal(t, ferr, kerr, kerr)
+}
+
+func TestFetchStringConversion(t *testing.T) {
+	kb := tests.MockKibana(http.StatusOK,
+		m{
+			"_id": "1",
+			"_source": m{
+				"settings": m{
+					"sampling_rate": 0.5,
+				},
+			},
+		})
+	result, etag, err := Fetch(kb, q, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "1", etag, etag)
+	assert.Equal(t, map[string]string{"sampling_rate": "0.5"}, result, result)
+}
+
+func TestFetchVersionCheck(t *testing.T) {
+	kb := tests.MockKibana(http.StatusOK, m{})
+	kb.Connection.Version.Major = 6
+	_, _, err := Fetch(kb, q, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "version")
+}
+
+func TestFetchError(t *testing.T) {
+	kb := tests.MockKibana(http.StatusNotFound, m{"error": "an error"})
+	_, _, err := Fetch(kb, q, nil)
+	require.Error(t, err)
+	assert.Equal(t, err.Error(), "{\"error\":\"an error\"}")
+}

--- a/agentcfg/model.go
+++ b/agentcfg/model.go
@@ -1,0 +1,72 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package agentcfg
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	// ServiceName keyword
+	ServiceName = "service.name"
+	// ServiceEnv keyword
+	ServiceEnv = "service.environment"
+)
+
+// Doc represents an elasticsearch document
+type Doc struct {
+	ID     string `json:"_id"`
+	Source Source `json:"_source"`
+}
+
+// Source represents the elasticsearch _source field of a document
+type Source struct {
+	Settings Settings `json:"settings"`
+}
+
+// Settings hold agent configuration
+type Settings map[string]string
+
+// UnmarshalJSON overrides default method to convert any JSON type to string
+func (s *Settings) UnmarshalJSON(b []byte) error {
+	in := make(map[string]interface{})
+	out := make(map[string]string)
+	err := json.Unmarshal(b, &in)
+	for k, v := range in {
+		out[k] = fmt.Sprintf("%v", v)
+	}
+	*s = out
+	return err
+}
+
+// NewQuery creates a Query struct
+func NewQuery(name, env string) Query {
+	return Query{Service{name, env}}
+}
+
+// Query represents an URL body or query params for agent configuration
+type Query struct {
+	Service Service `json:"service"`
+}
+
+// Service holds supported attributes for querying configuration
+type Service struct {
+	Name        string `json:"name"`
+	Environment string `json:"environment,omitempty"`
+}

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -183,6 +183,56 @@ apm-server:
   #ilm:
     #enabled: false
 
+  #kibana:
+    # For agent remote configuration, enabled must be true
+    #enabled: false
+
+    # Scheme and port can be left out and will be set to the default (http and 5601)
+    # In case you specify an additional path, the scheme is required: http://localhost:5601/path
+    # IPv6 addresses should always be defined as: https://[2001:db8::1]:5601
+    #host: "localhost:5601"
+
+    # Optional protocol and basic auth credentials.
+    #protocol: "https"
+    #username: "elastic"
+    #password: "changeme"
+
+    # Optional HTTP path
+    #path: ""
+
+    # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
+    #ssl.enabled: true
+
+    # Optional SSL configuration options. SSL is off by default, change the `protocol` option if you want to enable `https`.
+    # Configure SSL verification mode. If `none` is configured, all server hosts
+    # and certificates will be accepted. In this mode, SSL based connections are
+    # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+    # `full`.
+    #ssl.verification_mode: full
+
+    # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+    # 1.2 are enabled.
+    #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+    # List of root certificates for HTTPS server verifications
+    #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+    # Certificate for SSL client authentication
+    #ssl.certificate: "/etc/pki/client/cert.pem"
+
+    # Client Certificate Key
+    #ssl.key: "/etc/pki/client/cert.key"
+
+    # Optional passphrase for decrypting the Certificate Key.
+    # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
+    #ssl.key_passphrase: ''
+
+    # Configure cipher suites to be used for SSL connections
+    #ssl.cipher_suites: []
+
+    # Configure curve types for ECDHE based cipher suites
+    #ssl.curve_types: []
+
 #================================ General ======================================
 
 # Internal queue configuration for buffering events to be published.

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -183,6 +183,56 @@ apm-server:
   #ilm:
     #enabled: false
 
+  #kibana:
+    # For agent remote configuration, enabled must be true
+    #enabled: false
+
+    # Scheme and port can be left out and will be set to the default (http and 5601)
+    # In case you specify an additional path, the scheme is required: http://localhost:5601/path
+    # IPv6 addresses should always be defined as: https://[2001:db8::1]:5601
+    #host: "localhost:5601"
+
+    # Optional protocol and basic auth credentials.
+    #protocol: "https"
+    #username: "elastic"
+    #password: "changeme"
+
+    # Optional HTTP path
+    #path: ""
+
+    # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
+    #ssl.enabled: true
+
+    # Optional SSL configuration options. SSL is off by default, change the `protocol` option if you want to enable `https`.
+    # Configure SSL verification mode. If `none` is configured, all server hosts
+    # and certificates will be accepted. In this mode, SSL based connections are
+    # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+    # `full`.
+    #ssl.verification_mode: full
+
+    # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+    # 1.2 are enabled.
+    #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+    # List of root certificates for HTTPS server verifications
+    #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+    # Certificate for SSL client authentication
+    #ssl.certificate: "/etc/pki/client/cert.pem"
+
+    # Client Certificate Key
+    #ssl.key: "/etc/pki/client/cert.key"
+
+    # Optional passphrase for decrypting the Certificate Key.
+    # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
+    #ssl.key_passphrase: ''
+
+    # Configure cipher suites to be used for SSL connections
+    #ssl.cipher_suites: []
+
+    # Configure curve types for ECDHE based cipher suites
+    #ssl.curve_types: []
+
 #================================ General ======================================
 
 # Internal queue configuration for buffering events to be published.

--- a/beater/agent_config_handler.go
+++ b/beater/agent_config_handler.go
@@ -1,0 +1,94 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"net/http"
+
+	"github.com/elastic/apm-server/convert"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/kibana"
+
+	"github.com/elastic/apm-server/agentcfg"
+)
+
+func agentConfigHandler(kbClient *kibana.Client, secretToken string) http.Handler {
+
+	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		send := wrap(w, r)
+		clientEtag := r.Header.Get("If-None-Match")
+
+		query, requestErr := buildQuery(r)
+		cfg, upstreamEtag, internalErr := agentcfg.Fetch(kbClient, query, requestErr)
+
+		switch {
+		case requestErr != nil:
+			send(requestErr.Error(), http.StatusBadRequest)
+		case query == agentcfg.Query{}:
+			send(nil, http.StatusMethodNotAllowed)
+		case internalErr != nil:
+			send(internalErr.Error(), http.StatusInternalServerError)
+		case len(cfg) == 0:
+			send(nil, http.StatusNotFound)
+		case clientEtag != "" && clientEtag == upstreamEtag:
+			w.Header().Set("Cache-Control", "max-age=0")
+			send(nil, http.StatusNotModified)
+		case upstreamEtag != "":
+			w.Header().Set("Cache-Control", "max-age=0")
+			w.Header().Set("Etag", upstreamEtag)
+			fallthrough
+		default:
+			send(cfg, http.StatusOK)
+		}
+	})
+	return authHandler(secretToken, logHandler(handler))
+}
+
+// Returns (zero, error) if request body can't be unmarshalled or service.name is missing
+// Returns (zero, zero) if request method is not GET or POST
+func buildQuery(r *http.Request) (query agentcfg.Query, err error) {
+	switch r.Method {
+	case http.MethodPost:
+		err = convert.FromReader(r.Body, &query)
+	case http.MethodGet:
+		params := r.URL.Query()
+		query = agentcfg.NewQuery(
+			params.Get(agentcfg.ServiceName),
+			params.Get(agentcfg.ServiceEnv),
+		)
+	default:
+		return
+	}
+
+	if err == nil && query.Service.Name == "" {
+		err = errors.New(agentcfg.ServiceName + " is required")
+	}
+	return
+}
+
+func wrap(w http.ResponseWriter, r *http.Request) func(interface{}, int) {
+	return func(body interface{}, code int) {
+		if body == nil {
+			w.WriteHeader(code)
+		} else {
+			send(w, r, body, code)
+		}
+	}
+}

--- a/beater/agent_config_handler_test.go
+++ b/beater/agent_config_handler_test.go
@@ -1,0 +1,147 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-server/convert"
+	"github.com/elastic/apm-server/tests"
+)
+
+func TestAgentConfigHandlerGetOk(t *testing.T) {
+
+	kb := tests.MockKibana(http.StatusOK, m{
+		"_id": "1",
+		"_source": m{
+			"settings": m{
+				"sampling_rate": 0.5,
+			},
+		},
+	})
+
+	h := agentConfigHandler(kb, "")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/config?service.name=opbeans", nil)
+	h.ServeHTTP(w, r)
+
+	etagHeader := w.Header().Get("Etag")
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Equal(t, "1", etagHeader, etagHeader)
+}
+
+func TestAgentConfigHandlerPostOk(t *testing.T) {
+
+	kb := tests.MockKibana(http.StatusOK, m{
+		"_id": "1",
+		"_source": m{
+			"settings": m{
+				"sampling_rate": 0.5,
+			},
+		},
+	})
+
+	h := agentConfigHandler(kb, "")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/config", convert.ToReader(m{
+		"service": m{"name": "opbeans"}}))
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+}
+
+func TestAgentConfigHandlerBadMethod(t *testing.T) {
+
+	kb := tests.MockKibana(http.StatusOK, m{})
+
+	h := agentConfigHandler(kb, "")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/config?service.name=opbeans", nil)
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code, w.Body.String())
+}
+
+func TestAgentConfigHandlerNoService(t *testing.T) {
+
+	kb := tests.MockKibana(http.StatusOK, m{})
+
+	h := agentConfigHandler(kb, "")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/config", nil)
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+}
+
+func TestAgentConfigHandlerNotFound(t *testing.T) {
+
+	kb := tests.MockKibana(http.StatusOK, m{})
+
+	h := agentConfigHandler(kb, "")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/config?service.name=opbeans", nil)
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusNotFound, w.Code, w.Body.String())
+}
+
+func TestAgentConfigHandlerInternalError(t *testing.T) {
+
+	kb := tests.MockKibana(http.StatusOK, m{
+		"_id": "1", "_source": ""},
+	)
+
+	h := agentConfigHandler(kb, "")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/config?service.name=opbeans", nil)
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code, w.Body.String())
+}
+
+func TestAgentConfigHandlerNotModified(t *testing.T) {
+
+	kb := tests.MockKibana(http.StatusOK, m{
+		"_id": "1",
+		"_source": m{
+			"settings": m{
+				"sampling_rate": 0.5,
+			},
+		},
+	})
+
+	h := agentConfigHandler(kb, "")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/config?service.name=opbeans", nil)
+	r.Header.Set("If-None-Match", "1")
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusNotModified, w.Code, w.Body.String())
+}

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -35,6 +35,7 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/kibana"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
 
@@ -193,7 +194,15 @@ func (bt *beater) Run(b *beat.Beat) error {
 		return nil
 	}
 
-	bt.server, err = newServer(bt.config, tracer, pub.Send)
+	var kbClient *kibana.Client
+	if bt.config.Kibana.Enabled() {
+		kbClient, err = kibana.NewKibanaClient(bt.config.Kibana)
+		if err != nil {
+			bt.logger.Error(err.Error())
+		}
+	}
+
+	bt.server, err = newServer(bt.config, tracer, kbClient, pub.Send)
 	if err != nil {
 		bt.logger.Error("failed to create new server:", err)
 		return nil

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -100,6 +100,7 @@ func TestBeatConfig(t *testing.T) {
 						},
 					},
 				},
+				"kibana": map[string]interface{}{"enabled": "true"},
 			},
 			beaterConf: &Config{
 				Host:            "localhost:3000",
@@ -143,6 +144,7 @@ func TestBeatConfig(t *testing.T) {
 						},
 					},
 				},
+				Kibana: common.MustNewConfigFrom(map[string]interface{}{"enabled": "true"}),
 			},
 		},
 		"merge config with default": {
@@ -217,6 +219,7 @@ func TestBeatConfig(t *testing.T) {
 						},
 					},
 				},
+				Kibana: common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
 			},
 		},
 	}

--- a/beater/config.go
+++ b/beater/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	RumConfig           *rumConfig              `config:"rum"`
 	Register            *registerConfig         `config:"register"`
 	Mode                Mode                    `config:"mode"`
+	Kibana              *common.Config          `config:"kibana"`
 }
 
 type ExpvarConfig struct {
@@ -271,6 +272,7 @@ func defaultConfig(beatVersion string) *Config {
 						filepath.Join("ingest", "pipeline", "definition.json")),
 				}},
 		},
-		Mode: ModeProduction,
+		Mode:   ModeProduction,
+		Kibana: common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
 	}
 }

--- a/beater/onboarding_test.go
+++ b/beater/onboarding_test.go
@@ -40,7 +40,7 @@ func TestNotifyUpServerDown(t *testing.T) {
 	defer lis.Close()
 	config.Host = lis.Addr().String()
 
-	server, err := newServer(config, apm.DefaultTracer, nopReporter)
+	server, err := newServer(config, apm.DefaultTracer, nil, nopReporter)
 	require.NoError(t, err)
 	go run(server, lis, config)
 

--- a/beater/server.go
+++ b/beater/server.go
@@ -22,19 +22,19 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/elastic/beats/libbeat/common/transport/tlscommon"
-
 	"go.elastic.co/apm"
 	"go.elastic.co/apm/module/apmhttp"
 	"golang.org/x/net/netutil"
 
 	"github.com/elastic/apm-server/publish"
+	"github.com/elastic/beats/libbeat/common/transport/tlscommon"
+	"github.com/elastic/beats/libbeat/kibana"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/version"
 )
 
-func newServer(config *Config, tracer *apm.Tracer, report publish.Reporter) (*http.Server, error) {
-	mux, err := newMuxer(config, report)
+func newServer(config *Config, tracer *apm.Tracer, kbClient *kibana.Client, report publish.Reporter) (*http.Server, error) {
+	mux, err := newMuxer(config, kbClient, report)
 	if err != nil {
 		return nil, err
 	}

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -11,6 +11,7 @@
 ==== Added
 - Support more SSL config options for agent/server communication {pull}2224[2224].
 - Support adding transaction and span information to metrics  {pull}2265[2265],{pull}2281[2281].
+- Initial support for remote agent configuration, requires Kibana {pull}2289[2289].
 
 [float]
 ==== Removed

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -1,0 +1,45 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package convert
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+)
+
+// FromReader reads the given reader into the given interface
+func FromReader(r io.ReadCloser, i interface{}) error {
+	var buf bytes.Buffer
+	_, err := buf.ReadFrom(r)
+	return FromBytes(buf.Bytes(), i, err)
+}
+
+// FromBytes reads the given byte slice into the given interface
+func FromBytes(bs []byte, i interface{}, err error) error {
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(bs, i)
+}
+
+// ToReader converts a marshall-able interface into a reader
+func ToReader(i interface{}) io.Reader {
+	b, _ := json.Marshal(i)
+	return bytes.NewReader(b)
+}

--- a/tests/kibana.go
+++ b/tests/kibana.go
@@ -1,0 +1,49 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tests
+
+import (
+	"io/ioutil"
+	"net/http"
+
+	"github.com/elastic/apm-server/convert"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/kibana"
+)
+
+type rt struct {
+	resp *http.Response
+}
+
+// RoundTrip implements the Round Tripper interface
+func (rt rt) RoundTrip(r *http.Request) (*http.Response, error) {
+	return rt.resp, nil
+}
+
+// MockKibana provides a fake connection for unit tests
+func MockKibana(respCode int, respBody map[string]interface{}) *kibana.Client {
+	resp := http.Response{StatusCode: respCode, Body: ioutil.NopCloser(convert.ToReader(respBody))}
+	return &kibana.Client{
+		Connection: kibana.Connection{
+			HTTP: &http.Client{
+				Transport: rt{resp: &resp},
+			},
+			Version: common.Version{Major: 10, Minor: 0},
+		},
+	}
+}


### PR DESCRIPTION
This introduces a new requirement (Kibana) and setting for it, in the `apm-server` namespace (disabled by default).
It also adds an endpoint `/v1/agent/configs` for agents to poll configuration, requiring them to be authenticated (except RUM).

Supersedes https://github.com/elastic/apm-server/pull/2095/

More info in https://github.com/elastic/apm/issues/4