### PR TITLE
ci(jenkins): trigger async ITs and update github check for the pull request

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
     CODECOV_SECRET = 'secret/apm-team/ci/apm-server-codecov'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
-    ITS_PIPELINE = 'apm-integration-tests-mbp/PR-470'
+    ITS_PIPELINE = 'apm-integration-tests-mbp/master'
   }
   options {
     timeout(time: 1, unit: 'HOURS')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ pipeline {
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
     CODECOV_SECRET = 'secret/apm-team/ci/apm-server-codecov'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
+    ITS_PIPELINE = 'apm-integration-tests-mbp/PR-470'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -390,15 +391,13 @@ pipeline {
       }
       steps {
         log(level: 'INFO', text: 'Launching Async ITs')
-        script {
-          def buildId = build(job: '/apm-integration-tests-mbp/PR-470', propagate: false, wait: false,
-                              parameters: [string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
-                                           string(name: 'BUILD_OPTS', value: ''),
-                                           string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
-                                           string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                                           string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
-          githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: buildId.absoluteUrl)
-        }
+        build(job: env.ITS_PIPELINE, propagate: false, wait: false,
+              parameters: [string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
+                           string(name: 'BUILD_OPTS', value: ''),
+                           string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
+                           string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
+                           string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
+        githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
       }
     }
     /**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -374,6 +374,21 @@ pipeline {
         }
       }
     }
+    stage('Integration Tests') {
+      agent none
+      when {
+        beforeAgent true
+        expression { return params.its_ci }
+      }
+      steps {
+        log(level: 'INFO', text: 'Launching Async ITs')
+        githubNotify(context: 'Integration Tests', description: 'Integration Tests ...', status: 'PENDING', targetUrl: ' ')
+        // TODO: missing to notify the downstream what GH check is required to be updated.
+        build(job: '/apm-integration-tests-mbp/master', propagate: false, quietPeriod: 10, wait: false,
+              parameters: [string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
+                           string(name: 'BUILD_OPTS', value: '')])
+      }
+    }
     /**
       build release packages.
     */
@@ -418,22 +433,6 @@ pipeline {
             sharedPublicly: true,
             showInline: true)
         }
-      }
-    }
-
-    stage('Integration Tests') {
-      agent none
-      when {
-        beforeAgent true
-        expression { return params.its_ci }
-      }
-      steps {
-        log(level: 'INFO', text: 'Launching Async ITs')
-        githubNotify(context: 'Integration Tests', description: 'Integration Tests ...', status: 'PENDING', targetUrl: ' ')
-        // TODO: missing to notify the downstream what GH check is required to be updated.
-        build(job: '/apm-integration-tests-mbp/master', propagate: false, quietPeriod: 10, wait: false,
-              parameters: [string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
-                           string(name: 'BUILD_OPTS', value: '')])
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,6 @@ pipeline {
     issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
   }
   parameters {
-    string(name: 'ELASTIC_STACK_VERSION', defaultValue: '7.0.0', description: 'Elastic Stack Git branch/tag to use when running ITs.')
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
     booleanParam(name: 'linux_ci', defaultValue: true, description: 'Enable Linux build')
     booleanParam(name: 'windows_ci', defaultValue: true, description: 'Enable Windows CI')
@@ -392,8 +391,7 @@ pipeline {
       steps {
         log(level: 'INFO', text: 'Launching Async ITs')
         build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-              parameters: [string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
-                           string(name: 'BUILD_OPTS', value: "--apm-server-build https://github.com/${env.CHANGE_FORK}/${env.REPO}@${env.CHANGE_BRANCH}"),
+              parameters: [string(name: 'BUILD_OPTS', value: "--apm-server-build https://github.com/${env.CHANGE_FORK}/${env.REPO}@${env.CHANGE_BRANCH}"),
                            string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                            string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
     CODECOV_SECRET = 'secret/apm-team/ci/apm-server-codecov'
+    GITHUB_CHECK_ITS_NAME = 'Integration Tests'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -382,11 +383,14 @@ pipeline {
       }
       steps {
         log(level: 'INFO', text: 'Launching Async ITs')
-        githubNotify(context: 'Integration Tests', description: 'Integration Tests ...', status: 'PENDING', targetUrl: ' ')
+        githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: ' ')
         // TODO: missing to notify the downstream what GH check is required to be updated.
-        build(job: '/apm-integration-tests-mbp/master', propagate: false, quietPeriod: 10, wait: false,
+        build(job: '/apm-integration-tests-mbp/PR-470', propagate: false, quietPeriod: 10, wait: false,
               parameters: [string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
-                           string(name: 'BUILD_OPTS', value: '')])
+                           string(name: 'BUILD_OPTS', value: ''),
+                           string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
+                           string(name: 'GITHUB_CHECK_REPO', value: 'apm-server'),
+                           string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_COMMIT)])
       }
     }
     /**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -397,7 +397,7 @@ pipeline {
                            string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                            string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
-        githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
+        githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
       }
     }
     /**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -391,7 +391,7 @@ pipeline {
       steps {
         log(level: 'INFO', text: 'Launching Async ITs')
         build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-              parameters: [string(name: 'BUILD_OPTS', value: "--apm-server-build https://github.com/${env.CHANGE_FORK}/${env.REPO}@${env.CHANGE_BRANCH}"),
+              parameters: [string(name: 'BUILD_OPTS', value: "--apm-server-build https://github.com/elastic/${env.REPO}@${env.GIT_BASE_COMMIT}"),
                            string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                            string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -381,7 +381,13 @@ pipeline {
       agent none
       when {
         beforeAgent true
-        expression { return params.its_ci }
+        allOf {
+          anyOf {
+            environment name: 'GIT_BUILD_CAUSE', value: 'pr'
+            expression { return !params.Run_As_Master_Branch }
+          }
+          expression { return params.its_ci }
+        }
       }
       steps {
         log(level: 'INFO', text: 'Launching Async ITs')
@@ -392,7 +398,7 @@ pipeline {
                            string(name: 'BUILD_OPTS', value: ''),
                            string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                            string(name: 'GITHUB_CHECK_REPO', value: 'apm-server'),
-                           string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_COMMIT)])
+                           string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
       }
     }
     /**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -372,8 +372,6 @@ pipeline {
           unstash 'source'
           dir("${BASE_DIR}"){
             sh './script/jenkins/sync.sh'
-            sh 'env | sort'
-            sh 'git status && git rev-parse HEAD'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -393,7 +393,7 @@ pipeline {
         log(level: 'INFO', text: 'Launching Async ITs')
         build(job: env.ITS_PIPELINE, propagate: false, wait: false,
               parameters: [string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
-                           string(name: 'BUILD_OPTS', value: "--apm-server-build https://github.com/elastic/${env.REPO}@${env.GIT_BASE_COMMIT}"),
+                           string(name: 'BUILD_OPTS', value: "--apm-server-build https://github.com/${env.CHANGE_FORK}/${env.REPO}@${env.CHANGE_BRANCH}"),
                            string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                            string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -391,7 +391,8 @@ pipeline {
       steps {
         log(level: 'INFO', text: 'Launching Async ITs')
         build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-              parameters: [string(name: 'BUILD_OPTS', value: "--apm-server-build https://github.com/elastic/${env.REPO}@${env.GIT_BASE_COMMIT}"),
+              parameters: [booleanParam(name: 'Run_As_Master_Branch', value: true),
+                           string(name: 'BUILD_OPTS', value: "--apm-server-build https://github.com/elastic/${env.REPO}@${env.GIT_BASE_COMMIT}"),
                            string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                            string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -371,6 +371,8 @@ pipeline {
           unstash 'source'
           dir("${BASE_DIR}"){
             sh './script/jenkins/sync.sh'
+            sh 'env | sort'
+            sh 'git status && git rev-parse HEAD'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -393,7 +393,7 @@ pipeline {
         log(level: 'INFO', text: 'Launching Async ITs')
         build(job: env.ITS_PIPELINE, propagate: false, wait: false,
               parameters: [string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
-                           string(name: 'BUILD_OPTS', value: ''),
+                           string(name: 'BUILD_OPTS', value: "--apm-server-build https://github.com/elastic/${env.REPO}@${env.GIT_BASE_COMMIT}"),
                            string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                            string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
     CODECOV_SECRET = 'secret/apm-team/ci/apm-server-codecov'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
-    ITS_PIPELINE = 'apm-integration-tests-mbp/master'
+    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -391,7 +391,7 @@ pipeline {
       steps {
         log(level: 'INFO', text: 'Launching Async ITs')
         build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-              parameters: [booleanParam(name: 'Run_As_Master_Branch', value: true),
+              parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'All'),
                            string(name: 'BUILD_OPTS', value: "--apm-server-build https://github.com/elastic/${env.REPO}@${env.GIT_BASE_COMMIT}"),
                            string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -390,13 +390,15 @@ pipeline {
       }
       steps {
         log(level: 'INFO', text: 'Launching Async ITs')
-        def buildId = build(job: '/apm-integration-tests-mbp/PR-470', propagate: false, wait: false,
-                            parameters: [string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
-                                         string(name: 'BUILD_OPTS', value: ''),
-                                         string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
-                                         string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                                         string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
-        githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: buildId.absoluteUrl)
+        script {
+          def buildId = build(job: '/apm-integration-tests-mbp/PR-470', propagate: false, wait: false,
+                              parameters: [string(name: 'ELASTIC_STACK_VERSION', value: params.ELASTIC_STACK_VERSION),
+                                           string(name: 'BUILD_OPTS', value: ''),
+                                           string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
+                                           string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
+                                           string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
+          githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: buildId.absoluteUrl)
+        }
       }
     }
     /**


### PR DESCRIPTION
fixes https://github.com/elastic/apm-integration-testing/issues/41

## Highlights
- It's triggered for each PR by default and disabled to any upstream branches.
- Trigger the Integration Tests, aka ITs, pipelines from https://github.com/elastic/apm-integration-testing based on PRs or on demand, aka manually.
- It does trigger only the `All` stage in the ITs. Refers to: https://github.com/elastic/apm-integration-testing/blob/master/.ci/scripts/all.sh
- ITs should be async.
- This new stage notifies the GitHub check with the status of the execution.
- Depends on https://github.com/elastic/apm-integration-testing/pull/470

## Tasks
- [x] Agree with the stakeholders
- [x] https://github.com/elastic/apm-server/pull/2290/files#r294312797 