### PR TITLE
[docs][7.1] Documentation backports

### DIFF
--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -1564,8 +1564,11 @@ endif::[]
 ++++
 
 ifdef::apm-server[]
-NOTE: This page refers to using a separate instance of APM Server with an existing Elasticsearch Service deployment.
-APM Server is not yet supported on Elasticsearch Service.
+NOTE: This page refers to using a separate instance of APM Server with an existing
+https://www.elastic.co/cloud/elasticsearch-service[Elasticsearch Service deployment].
+If you want to use APM on Elastic Cloud, see the cloud docs:
+{cloud}/ec-create-deployment.html[Create your deployment] or
+{cloud}/ec-manage-apm-settings.html[Add APM user settings].
 endif::apm-server[]
 
 {beatname_uc} comes with two settings that simplify the output configuration

--- a/docs/guide/overview.asciidoc
+++ b/docs/guide/overview.asciidoc
@@ -35,7 +35,7 @@ Elasticsearch is used to store APM performance metrics and make use of its aggre
 
 {kibana-ref}/xpack-apm.html[*Kibana*] is an open source analytics and visualization platform designed to work with Elasticsearch.
 You use Kibana to search, view, and interact with data stored in Elasticsearch.
-You an use Kibana to visualize APM data by utilizing the dedicated APM UI bundled in Basic license,
+You can use Kibana to visualize APM data by utilizing the dedicated APM UI bundled in Basic license,
 or the pre-built, open source,
 Kibana dashboards that can be loaded directly via the {kibana-ref}/apm-getting-started.html[APM Kibana UI].
 

--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -256,4 +256,7 @@ Loading dashboards from APM Server is no longer supported. Please see the {kiban
 [role="exclude",id="load-kibana-dashboards"]
 === Dashboards
 
-Loading dashboards from APM Server is no longer supported. Please see the {kibana-ref}/xpack-apm.html[Kibana APM UI] documentation.
+Loading Kibana dashboards from APM Server is no longer supported.
+Please use the {kibana-ref}/xpack-apm.html[Kibana APM UI] instead.
+As an alternative, a small number of dashboards and visualizations are available in the
+https://github.com/elastic/apm-contrib/tree/master/apm-ui[apm-contrib] repository.


### PR DESCRIPTION
Backports the following documentation commits to `7.1`:

* correct typo for word can cited as 'an' (#2263)
* [docs] Update redirect page for dashboards (#2269)
* [docs] Fix APM on cloud bug (#2270)