### PR TITLE
Enable APM pipeline by default.

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -157,24 +157,19 @@ apm-server:
     # Remote apm-servers' secret_token
     #secret_token:
 
-  # A pipeline is a definition of processors applied to documents when writing them to Elasticsearch.
+  # A pipeline is a definition of processors applied to documents when ingesting them to Elasticsearch.
   # Using pipelines involves two steps:
   # (1) registering a pipeline
-  # (2) applying a pipeline during data ingestion (see `output.elasticsearch.pipelines`)
+  # (2) applying a pipeline during data ingestion (see `output.elasticsearch.pipeline`)
   #
-  # You can manually register pipelines, or use this configuration option to ensure
-  # pipelines are loaded and registered at the configured Elasticsearch instances.
-  # Automatic pipeline registration requires
-  # * `output.elasticsearch` to be enabled and configured.
-  # * having the required Elasticsearch Processor Plugins installed.
-  #   APM Server default pipelines require you to have the `Ingest User Agent Plugin` installed.
-  #   Find the default pipeline configuration at `ingest/pipeline/definition.json`.
-  #
+  # You can manually register a pipeline, or use this configuration option to ensure
+  # the pipeline is loaded and registered at the configured Elasticsearch instances.
+  # Find the default pipeline configuration at `ingest/pipeline/definition.json`.
+  # Automatic pipeline registration requires the output.elasticsearch` to be enabled and configured.
   #register.ingest.pipeline:
-    # Registers pipeline definitions in Elasticsearch on APM Server startup. Defaults to false.
-    #enabled: false
-
-    # Overwrites existing pipeline definitions in Elasticsearch. Defaults to true.
+    # Registers APM pipeline definition in Elasticsearch on APM Server startup. Defaults to true.
+    #enabled: true
+    # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to true.
     #overwrite: true
 
   # When ilm is set to true the APM Server will take care of ILM setup.
@@ -384,13 +379,11 @@ output.elasticsearch:
   #    when.contains:
   #      processor.event: "onboarding"
 
-  # A pipeline is a definition of processors applied to documents when writing them to Elasticsearch.
-  # APM Server comes with a default pipeline definition, located at `ingest/pipeline/definition.json`.
-  # Pipelines are disabled by default. To make use of them you have to:
-  # (1) ensure pipelines are registered in Elasticsearch, see `apm-server.register.ingest.pipeline`
-  # (2) enable the following:
-  #pipelines:
-  #- pipeline: "apm"
+  # A pipeline is a definition of processors applied to documents when ingesting them to Elasticsearch.
+  # APM Server comes with a default pipeline definition, located at `ingest/pipeline/definition.json`, which is
+  # loaded to Elasticsearch by default (see `apm-server.register.ingest.pipeline`).
+  # APM pipeline is enabled by default. For disabling set `pipeline: _none`.
+  #pipeline: "apm"
 
   # Optional HTTP Path
   #path: "/elasticsearch"

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -157,24 +157,19 @@ apm-server:
     # Remote apm-servers' secret_token
     #secret_token:
 
-  # A pipeline is a definition of processors applied to documents when writing them to Elasticsearch.
+  # A pipeline is a definition of processors applied to documents when ingesting them to Elasticsearch.
   # Using pipelines involves two steps:
   # (1) registering a pipeline
-  # (2) applying a pipeline during data ingestion (see `output.elasticsearch.pipelines`)
+  # (2) applying a pipeline during data ingestion (see `output.elasticsearch.pipeline`)
   #
-  # You can manually register pipelines, or use this configuration option to ensure
-  # pipelines are loaded and registered at the configured Elasticsearch instances.
-  # Automatic pipeline registration requires
-  # * `output.elasticsearch` to be enabled and configured.
-  # * having the required Elasticsearch Processor Plugins installed.
-  #   APM Server default pipelines require you to have the `Ingest User Agent Plugin` installed.
-  #   Find the default pipeline configuration at `ingest/pipeline/definition.json`.
-  #
+  # You can manually register a pipeline, or use this configuration option to ensure
+  # the pipeline is loaded and registered at the configured Elasticsearch instances.
+  # Find the default pipeline configuration at `ingest/pipeline/definition.json`.
+  # Automatic pipeline registration requires the output.elasticsearch` to be enabled and configured.
   #register.ingest.pipeline:
-    # Registers pipeline definitions in Elasticsearch on APM Server startup. Defaults to false.
-    #enabled: false
-
-    # Overwrites existing pipeline definitions in Elasticsearch. Defaults to true.
+    # Registers APM pipeline definition in Elasticsearch on APM Server startup. Defaults to true.
+    #enabled: true
+    # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to true.
     #overwrite: true
 
   # When ilm is set to true the APM Server will take care of ILM setup.
@@ -384,13 +379,11 @@ output.elasticsearch:
   #    when.contains:
   #      processor.event: "onboarding"
 
-  # A pipeline is a definition of processors applied to documents when writing them to Elasticsearch.
-  # APM Server comes with a default pipeline definition, located at `ingest/pipeline/definition.json`.
-  # Pipelines are disabled by default. To make use of them you have to:
-  # (1) ensure pipelines are registered in Elasticsearch, see `apm-server.register.ingest.pipeline`
-  # (2) enable the following:
-  #pipelines:
-  #- pipeline: "apm"
+  # A pipeline is a definition of processors applied to documents when ingesting them to Elasticsearch.
+  # APM Server comes with a default pipeline definition, located at `ingest/pipeline/definition.json`, which is
+  # loaded to Elasticsearch by default (see `apm-server.register.ingest.pipeline`).
+  # APM pipeline is enabled by default. For disabling set `pipeline: _none`.
+  #pipeline: "apm"
 
   # Optional HTTP Path
   #path: "/elasticsearch"

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -157,24 +157,19 @@ apm-server:
     # Remote apm-servers' secret_token
     #secret_token:
 
-  # A pipeline is a definition of processors applied to documents when writing them to Elasticsearch.
+  # A pipeline is a definition of processors applied to documents when ingesting them to Elasticsearch.
   # Using pipelines involves two steps:
   # (1) registering a pipeline
-  # (2) applying a pipeline during data ingestion (see `output.elasticsearch.pipelines`)
+  # (2) applying a pipeline during data ingestion (see `output.elasticsearch.pipeline`)
   #
-  # You can manually register pipelines, or use this configuration option to ensure
-  # pipelines are loaded and registered at the configured Elasticsearch instances.
-  # Automatic pipeline registration requires
-  # * `output.elasticsearch` to be enabled and configured.
-  # * having the required Elasticsearch Processor Plugins installed.
-  #   APM Server default pipelines require you to have the `Ingest User Agent Plugin` installed.
-  #   Find the default pipeline configuration at `ingest/pipeline/definition.json`.
-  #
+  # You can manually register a pipeline, or use this configuration option to ensure
+  # the pipeline is loaded and registered at the configured Elasticsearch instances.
+  # Find the default pipeline configuration at `ingest/pipeline/definition.json`.
+  # Automatic pipeline registration requires the output.elasticsearch` to be enabled and configured.
   #register.ingest.pipeline:
-    # Registers pipeline definitions in Elasticsearch on APM Server startup. Defaults to false.
-    #enabled: false
-
-    # Overwrites existing pipeline definitions in Elasticsearch. Defaults to true.
+    # Registers APM pipeline definition in Elasticsearch on APM Server startup. Defaults to true.
+    #enabled: true
+    # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to true.
     #overwrite: true
 
   # When ilm is set to true the APM Server will take care of ILM setup.
@@ -384,13 +379,11 @@ output.elasticsearch:
   #    when.contains:
   #      processor.event: "onboarding"
 
-  # A pipeline is a definition of processors applied to documents when writing them to Elasticsearch.
-  # APM Server comes with a default pipeline definition, located at `ingest/pipeline/definition.json`.
-  # Pipelines are disabled by default. To make use of them you have to:
-  # (1) ensure pipelines are registered in Elasticsearch, see `apm-server.register.ingest.pipeline`
-  # (2) enable the following:
-  #pipelines:
-  #- pipeline: "apm"
+  # A pipeline is a definition of processors applied to documents when ingesting them to Elasticsearch.
+  # APM Server comes with a default pipeline definition, located at `ingest/pipeline/definition.json`, which is
+  # loaded to Elasticsearch by default (see `apm-server.register.ingest.pipeline`).
+  # APM pipeline is enabled by default. For disabling set `pipeline: _none`.
+  #pipeline: "apm"
 
   # Optional HTTP Path
   #path: "/elasticsearch"

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -144,7 +144,7 @@ func TestBeatConfig(t *testing.T) {
 					},
 				},
 				Kibana:   common.MustNewConfigFrom(map[string]interface{}{"enabled": "true"}),
-				pipeline: "apm",
+				pipeline: defaultAPMPipeline,
 			},
 		},
 		"merge config with default": {
@@ -220,7 +220,7 @@ func TestBeatConfig(t *testing.T) {
 					},
 				},
 				Kibana:   common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
-				pipeline: "apm",
+				pipeline: defaultAPMPipeline,
 			},
 		},
 	}

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -94,7 +94,6 @@ func TestBeatConfig(t *testing.T) {
 				"register": map[string]interface{}{
 					"ingest": map[string]interface{}{
 						"pipeline": map[string]interface{}{
-							"enabled":   true,
 							"overwrite": false,
 							"path":      filepath.Join("tmp", "definition.json"),
 						},
@@ -144,7 +143,8 @@ func TestBeatConfig(t *testing.T) {
 						},
 					},
 				},
-				Kibana: common.MustNewConfigFrom(map[string]interface{}{"enabled": "true"}),
+				Kibana:   common.MustNewConfigFrom(map[string]interface{}{"enabled": "true"}),
+				pipeline: "apm",
 			},
 		},
 		"merge config with default": {
@@ -214,12 +214,13 @@ func TestBeatConfig(t *testing.T) {
 					Ingest: &ingestConfig{
 						Pipeline: &pipelineConfig{
 							Enabled:   &falsy,
-							Overwrite: nil,
+							Overwrite: &truthy,
 							Path:      filepath.Join("ingest", "pipeline", "definition.json"),
 						},
 					},
 				},
-				Kibana: common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
+				Kibana:   common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
+				pipeline: "apm",
 			},
 		},
 	}

--- a/beater/config.go
+++ b/beater/config.go
@@ -53,6 +53,8 @@ type Config struct {
 	Register            *registerConfig         `config:"register"`
 	Mode                Mode                    `config:"mode"`
 	Kibana              *common.Config          `config:"kibana"`
+
+	pipeline string
 }
 
 type ExpvarConfig struct {
@@ -176,7 +178,7 @@ func (s *SourceMapping) isSetup() bool {
 }
 
 func (c *pipelineConfig) isEnabled() bool {
-	return c != nil && (c.Enabled != nil && *c.Enabled)
+	return c != nil && (c.Enabled == nil || *c.Enabled)
 }
 
 func (c *pipelineConfig) shouldOverwrite() bool {
@@ -234,6 +236,7 @@ func defaultRum(beatVersion string) *rumConfig {
 }
 
 func defaultConfig(beatVersion string) *Config {
+	pipeline := true
 	return &Config{
 		Host:            net.JoinHostPort("localhost", DefaultPort),
 		MaxHeaderSize:   1 * 1024 * 1024, // 1mb
@@ -268,11 +271,14 @@ func defaultConfig(beatVersion string) *Config {
 		Register: &registerConfig{
 			Ingest: &ingestConfig{
 				Pipeline: &pipelineConfig{
+					Enabled:   &pipeline,
+					Overwrite: &pipeline,
 					Path: paths.Resolve(paths.Home,
 						filepath.Join("ingest", "pipeline", "definition.json")),
 				}},
 		},
-		Mode:   ModeProduction,
-		Kibana: common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
+		Mode:     ModeProduction,
+		Kibana:   common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
+		pipeline: "apm",
 	}
 }

--- a/beater/config.go
+++ b/beater/config.go
@@ -33,7 +33,12 @@ import (
 	"github.com/elastic/beats/libbeat/paths"
 )
 
-const DefaultPort = "8200"
+const (
+	// DefaultPort of APM Server
+	DefaultPort = "8200"
+
+	defaultAPMPipeline = "apm"
+)
 
 type Config struct {
 	Host                string                  `config:"host"`
@@ -279,6 +284,6 @@ func defaultConfig(beatVersion string) *Config {
 		},
 		Mode:     ModeProduction,
 		Kibana:   common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
-		pipeline: "apm",
+		pipeline: defaultAPMPipeline,
 	}
 }

--- a/beater/config_test.go
+++ b/beater/config_test.go
@@ -290,7 +290,7 @@ func TestPipeline(t *testing.T) {
 		enabled, overwrite bool
 	}{
 		{c: nil, enabled: false, overwrite: false},
-		{c: &pipelineConfig{}, enabled: false, overwrite: true}, //default values
+		{c: &pipelineConfig{}, enabled: true, overwrite: true}, //default values
 		{c: &pipelineConfig{Enabled: &falsy, Overwrite: &truthy},
 			enabled: false, overwrite: true},
 		{c: &pipelineConfig{Enabled: &truthy, Overwrite: &falsy},

--- a/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
@@ -3,6 +3,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -310,6 +311,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -402,6 +404,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -500,6 +503,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },

--- a/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
@@ -3,6 +3,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -70,6 +71,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -124,6 +126,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -198,6 +201,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },

--- a/beater/test_approved_es_documents/TestPublishIntegrationMetricsets.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationMetricsets.approved.json
@@ -3,6 +3,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -90,6 +91,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },

--- a/beater/test_approved_es_documents/TestPublishIntegrationMinimalEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationMinimalEvents.approved.json
@@ -3,6 +3,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -46,6 +47,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -91,6 +93,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -136,6 +139,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -186,6 +190,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -233,6 +238,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -283,6 +289,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },

--- a/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json
@@ -3,6 +3,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -55,6 +56,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -108,6 +110,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -168,6 +171,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -221,6 +225,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },

--- a/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json
@@ -3,6 +3,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -106,6 +107,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },
@@ -295,6 +297,7 @@
         {
             "@metadata": {
                 "beat": "apm-test",
+                "pipeline": "apm",
                 "type": "_doc",
                 "version": "8.0.0"
             },

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -12,6 +12,7 @@
 - Support more SSL config options for agent/server communication {pull}2224[2224].
 - Support adding transaction and span information to metrics  {pull}2265[2265],{pull}2281[2281],{pull}2287[2287].
 - Initial support for remote agent configuration, requires Kibana {pull}2289[2289].
+- Enable APM pipeline by default {pull}2301[2301].
 
 [float]
 ==== Removed

--- a/docs/configuration-process.asciidoc
+++ b/docs/configuration-process.asciidoc
@@ -111,13 +111,13 @@ Disabled by default.
 [[register.ingest.pipeline.enabled]]
 [float]
 ==== `register.ingest.pipeline.enabled`
-Loads default pipeline definition to Elasticsearch on APM Server startup.
+Loads the default pipeline definition to Elasticsearch on APM Server startup.
 Defaults to true.
 
 [[register.ingest.pipeline.overwrite]]
 [float]
 ==== `register.ingest.pipeline.overwrite`
-Overwrites existing APM pipeline definition in Elasticsearch.
+Overwrites the existing APM pipeline definition in Elasticsearch.
 Defaults to true.
 
 [float]

--- a/docs/configuration-process.asciidoc
+++ b/docs/configuration-process.asciidoc
@@ -111,13 +111,14 @@ Disabled by default.
 [[register.ingest.pipeline.enabled]]
 [float]
 ==== `register.ingest.pipeline.enabled`
-Loads pipeline definitions to Elasticsearch on APM Server startup.
-Defaults to false.
+Loads default pipeline definition to Elasticsearch on APM Server startup.
+Defaults to true.
 
 [[register.ingest.pipeline.overwrite]]
 [float]
 ==== `register.ingest.pipeline.overwrite`
-Overwrites existing pipeline definitions in Elasticsearch. Defaults to true.
+Overwrites existing APM pipeline definition in Elasticsearch.
+Defaults to true.
 
 [float]
 === Configuration options: `queue.mem.*`

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -493,8 +493,8 @@ With this configuration, all events with `processor.event: transaction` are sent
 named `transaction_pipeline`. Similarly, all events with `processor.event: error` are sent to a
 pipeline named `error_pipeline`.
 
-The pipeline defaults to `apm`, adding user agent and geo ip information to events.
-For disabling any pipeline you can configure `output.elasticsearch.pipeline: _none`.
+The default pipeline is `apm`. It adds user agent and geo ip information to events.
+To disable this, or any other pipeline, set `output.elasticsearch.pipeline: _none`.
 endif::apm-server[]
 
 TIP: To learn how to add custom fields to events, see the
@@ -630,7 +630,7 @@ With this configuration, all events with `processor.event: transaction` are sent
 named `transaction_pipeline`, all events with `processor.event: error` are sent to a
 pipeline named `error_pipeline`, etc.
 
-If any pipelines are defined, the default `apm` pipeline will be deactivated.
+NOTE: Defining any pipeline will deactivate the default `apm` pipeline.
 endif::apm-server[]
 
 For more information about ingest node pipelines, see

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -492,6 +492,9 @@ output.elasticsearch:
 With this configuration, all events with `processor.event: transaction` are sent to a pipeline
 named `transaction_pipeline`. Similarly, all events with `processor.event: error` are sent to a
 pipeline named `error_pipeline`.
+
+The pipeline defaults to `apm`, adding user agent and geo ip information to events.
+For disabling any pipeline you can configure `output.elasticsearch.pipeline: _none`.
 endif::apm-server[]
 
 TIP: To learn how to add custom fields to events, see the
@@ -626,6 +629,8 @@ output.elasticsearch:
 With this configuration, all events with `processor.event: transaction` are sent to a pipeline
 named `transaction_pipeline`, all events with `processor.event: error` are sent to a
 pipeline named `error_pipeline`, etc.
+
+If any pipelines are defined, the default `apm` pipeline will be deactivated.
 endif::apm-server[]
 
 For more information about ingest node pipelines, see

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -57,9 +57,12 @@ apm-server:
   expvar.url: {{ expvar_url }}
   {% endif %}
 
-  register.ingest.pipeline:
-    enabled: {{ register_pipeline_enabled }}
-    overwrite: {{ register_pipeline_overwrite  }}
+  {% if register_pipeline_enabled %}
+  register.ingest.pipeline.enabled: {{ register_pipeline_enabled }}
+  {% endif %}
+  {% if register_pipeline_overwrite %}
+  register.ingest.pipeline.overwrite: {{ register_pipeline_overwrite  }}
+  {% endif %}
 
   {% if mode %}
   mode: {{ mode }}
@@ -106,9 +109,13 @@ output.elasticsearch:
   index: {{ override_index }}
   {% endif %}
 
-  {% if register_pipeline_enabled %}
+  {% if disable_pipeline %}
+  pipeline: _none
+  {% endif %}
+
+  {% if disable_pipelines %}
   pipelines:
-  - pipeline: "apm"
+  - pipeline: _none
   {% endif %}
 
 {% endif %}

--- a/tests/system/error.approved.json
+++ b/tests/system/error.approved.json
@@ -209,7 +209,11 @@
                 "email": "foo@example.com"
             },
             "user_agent": {
-                "original": "Mozilla Chrome Edge"
+                "original": "Mozilla Chrome Edge",
+                "name": "Other",
+                "device": {
+                    "name": "Other"
+                }
             },
             "labels": {
                 "organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8",

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -559,8 +559,8 @@ class MetricsIntegrationTest(ElasticTest):
 
 class ExperimentalBaseTest(ElasticTest):
     def check_experimental_key_indexed(self, experimental):
-        loaded_msg = "No pipeline callback registered"
-        self.wait_until(lambda: self.log_contains(loaded_msg), max_timeout=5)
+        loaded_msg = "Registered Ingest Pipelines successfully."
+        self.wait_until(lambda: self.log_contains(loaded_msg), max_timeout=10)
         self.load_docs_with_template(self.get_payload_path("experimental.ndjson"),
                                      self.intake_url, 'transaction', 2)
 

--- a/tests/system/test_pipelines.py
+++ b/tests/system/test_pipelines.py
@@ -1,9 +1,13 @@
 import unittest
 from apmserver import ElasticTest, SubCommandTest, get_elasticsearch_url
-from beat.beat import INTEGRATION_TESTS
+from beat.beat import INTEGRATION_TESTS, TimeoutError
 from elasticsearch import Elasticsearch, NotFoundError
+from nose.tools import raises
 
 
+# APM Server `setup`
+
+@unittest.skipUnless(INTEGRATION_TESTS, "integration test")
 class SetupPipelinesDefaultTest(SubCommandTest):
     pipeline_name = "apm_user_agent"
 
@@ -38,13 +42,13 @@ class SetupPipelinesDefaultTest(SubCommandTest):
 
         assert should_exist == present, "expected {}pipelines".format("" if should_exist else "no ")
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_setup_pipelines(self):
         self.assert_pipeline_presence(True)
         assert self.log_contains("Pipeline successfully registered: apm_user_agent")
         assert self.log_contains("Registered Ingest Pipelines successfully.")
 
 
+@unittest.skipUnless(INTEGRATION_TESTS, "integration test")
 class SetupPipelinesDisabledTest(SetupPipelinesDefaultTest):
     def config(self):
         cfg = super(SetupPipelinesDisabledTest, self).config()
@@ -53,19 +57,17 @@ class SetupPipelinesDisabledTest(SetupPipelinesDefaultTest):
         })
         return cfg
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_setup_pipelines(self):
         self.assert_pipeline_presence(False)
         assert self.log_contains("No pipeline callback registered")
 
 
-class PipelineRegisterTest(ElasticTest):
-    # pipeline.overwrite should be enabled by default.
-    config_overrides = {
-        "register_pipeline_enabled": "true",
-    }
+# APM Server `run`
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+@unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+class PipelineDefaultTest(ElasticTest):
+    # pipeline.overwrite enabled by default.
+
     def test_default_pipelines_registered(self):
         pipelines = [
             ("apm_user_agent", "Add user agent information for APM events"),
@@ -73,18 +75,18 @@ class PipelineRegisterTest(ElasticTest):
             ("apm", "Default enrichment for APM events"),
         ]
         loaded_msg = "Pipeline successfully registered"
-        self.wait_until(lambda: self.log_contains(loaded_msg), max_timeout=5)
+        self.wait_until(lambda: self.log_contains(loaded_msg))
         for pipeline_id, pipeline_desc in pipelines:
             pipeline = self.es.ingest.get_pipeline(id=pipeline_id)
             assert pipeline[pipeline_id]['description'] == pipeline_desc
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    def test_default_pipelines_applied(self):
+    def test_pipeline_applied(self):
+        # setup
         self.wait_until(lambda: self.log_contains("Registered Ingest Pipelines successfully"), max_timeout=5)
         self.wait_until(lambda: self.log_contains("Finished index management setup."), max_timeout=5)
-
         self.load_docs_with_template(self.get_payload_path("transactions.ndjson"),
                                      self.intake_url, 'transaction', 3)
+
         entries = self.es.search(index=self.index_transaction)['hits']['hits']
         for e in entries:
             src = e['_source']
@@ -106,22 +108,81 @@ class PipelineRegisterTest(ElasticTest):
                 assert ua["device"]["name"] == "Other"
 
 
-class PipelineDisableOverwriteTest(ElasticTest):
+@unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+class PipelineConfigurationNoneTest(ElasticTest):
+    config_overrides = {"disable_pipeline": True}
+
+    def test_pipeline_not_applied(self):
+        self.wait_until(lambda: self.log_contains("Finished index management setup."), max_timeout=5)
+        self.load_docs_with_template(self.get_payload_path("transactions.ndjson"),
+                                     self.intake_url, 'transaction', 3)
+
+        entries = self.es.search(index=self.index_transaction)['hits']['hits']
+        for e in entries:
+            src = e['_source']
+            ua = src['user_agent']
+            if src['transaction']['id'] != "4340a8e0df1906ecbfa9":
+                # transaction with id '4340a8e0df1906ecbfa9' has user agent info set
+                continue
+            else:
+                assert ua is not None
+                assert ua["original"] == "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 " \
+                                         "(KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36, Mozilla Chrome Edge"
+                assert 'name' not in ua
+
+
+@unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+class PipelinesConfigurationNoneTest(ElasticTest):
+    config_overrides = {"disable_pipelines": True}
+
+    def test_pipeline_not_applied(self):
+        self.wait_until(lambda: self.log_contains("Finished index management setup."), max_timeout=5)
+        self.load_docs_with_template(self.get_payload_path("transactions.ndjson"),
+                                     self.intake_url, 'transaction', 3)
+
+        entries = self.es.search(index=self.index_transaction)['hits']['hits']
+        for e in entries:
+            src = e['_source']
+            ua = src['user_agent']
+            if src['transaction']['id'] != "4340a8e0df1906ecbfa9":
+                # transaction with id '4340a8e0df1906ecbfa9' has user agent info set
+                continue
+            else:
+                assert ua is not None
+                assert ua["original"] == "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 " \
+                                         "(KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36, Mozilla Chrome Edge"
+                assert 'name' not in ua
+
+
+@unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+class MissingPipelineTest(ElasticTest):
+    config_overrides = {"register_pipeline_enabled": "false"}
+
+    @raises(TimeoutError)
+    def test_pipeline_not_registered(self):
+        self.wait_until(lambda: self.log_contains("No pipeline callback registered"), max_timeout=5)
+        self.wait_until(lambda: self.log_contains("Finished index management setup."), max_timeout=5)
+        # ensure events get stored properly nevertheless
+        self.load_docs_with_template(self.get_payload_path("transactions.ndjson"),
+                                     self.intake_url, 'transaction', 3, max_timeout=3)
+
+
+@unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+class PipelineDisableRegisterOverwriteTest(ElasticTest):
     config_overrides = {
-        "register_pipeline_enabled": "true",
         "register_pipeline_overwrite": "false"
     }
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def setUp(self):
+        super(PipelineDisableRegisterOverwriteTest, self).setUp()
+        es = Elasticsearch([self.get_elasticsearch_url()])
+        # Write empty default pipeline
+        es.ingest.put_pipeline(
+            id="apm",
+            body={"description": "empty apm test pipeline", "processors": []})
+        self.wait_until(lambda: es.ingest.get_pipeline("apm"))
+
     def test_pipeline_not_overwritten(self):
         loaded_msg = "Pipeline already registered"
-        self.wait_until(lambda: self.log_contains(loaded_msg),
-                        max_timeout=5)
-
-
-class PipelineDisableTest(ElasticTest):
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    def test_pipeline_not_registered(self):
-        loaded_msg = "No pipeline callback registered"
         self.wait_until(lambda: self.log_contains(loaded_msg),
                         max_timeout=5)

--- a/tests/system/transaction.approved.json
+++ b/tests/system/transaction.approved.json
@@ -74,7 +74,11 @@
                 "email": "foo@example.com"
             },
             "user_agent": {
-                "original": "Mozilla Chrome Edge"
+                "original": "Mozilla Chrome Edge",
+                "name": "Other",
+                "device": {
+                    "name": "Other"
+                }
             },
             "url": {
                 "domain": "www.example.com",


### PR DESCRIPTION
Register and apply geo-ip and user-agent pipeline by default.

closes elastic/apm-server#1972 

* [x] update docs - @bmorelli25 please have a look at the changes. Once this is merged I can port them to libbeat.
* [x] changelog
* [x] notify cloud team 
* [x] manually verify that apm pipeline is registered and applied for output ES 
* [x] manually verify that apm pipeline is not registered and applied, but events properly ingested when using logstash output

