### PR TITLE
[docs] Brew install instructions

### DIFF
--- a/docs/brew.asciidoc
+++ b/docs/brew.asciidoc
@@ -1,0 +1,24 @@
+[[brew]]
+=== Install APM Server on macOS with Homebrew
+
+Elastic publishes Homebrew formulae so you can install the Elastic Stack, including APM Server, with the
+https://brew.sh/[Homebrew] package manager.
+
+To install with Homebrew, you first need to tap the
+Elastic Homebrew repository:
+
+[source,sh]
+-------------------------
+brew tap elastic/tap
+-------------------------
+
+Once you've tapped the Elastic Homebrew repo, you can use `brew install` to
+install the default distribution of APM Server:
+
+[source,sh]
+-------------------------
+brew install elastic/tap/apm-server-full
+-------------------------
+
+This installs the most recently released default distribution of APM Server.
+To install the OSS distribution, specify `elastic/tap/apm-server-oss`.

--- a/docs/copied-from-beats/shared-directory-layout.asciidoc
+++ b/docs/copied-from-beats/shared-directory-layout.asciidoc
@@ -90,6 +90,20 @@ the following simple command, all paths are set correctly:
 
 endif::mac_os,win_os[]
 
+ifdef::mac_os[]
+
+===== brew
+[cols="<h,<,<m",options="header",]
+|=======================================================================
+| Type   | Description | Location
+| home   | Home of the {beatname_uc} installation. | /usr/local/var/homebrew/linked/{beatname_lc}-full
+| bin    | The location for the binary files. | /usr/local/var/homebrew/linked/{beatname_lc}-full/bin
+| config | The location for configuration files. | /usr/local/etc/{beatname_lc}
+| data   | The location for persistent data files. | /usr/local/var/lib/{beatname_lc}
+| logs   | The location for the logs created by {beatname_uc}. | /usr/local/var/log/{beatname_lc}
+|=======================================================================
+endif::mac_os[]
+
 ifndef::win_only[]
 
 ["source","sh",subs="attributes"]

--- a/docs/copied-from-beats/shared-directory-layout.asciidoc
+++ b/docs/copied-from-beats/shared-directory-layout.asciidoc
@@ -90,20 +90,6 @@ the following simple command, all paths are set correctly:
 
 endif::mac_os,win_os[]
 
-ifdef::mac_os[]
-
-===== brew
-[cols="<h,<,<m",options="header",]
-|=======================================================================
-| Type   | Description | Location
-| home   | Home of the {beatname_uc} installation. | /usr/local/var/homebrew/linked/{beatname_lc}-full
-| bin    | The location for the binary files. | /usr/local/var/homebrew/linked/{beatname_lc}-full/bin
-| config | The location for configuration files. | /usr/local/etc/{beatname_lc}
-| data   | The location for persistent data files. | /usr/local/var/lib/{beatname_lc}
-| logs   | The location for the logs created by {beatname_uc}. | /usr/local/var/log/{beatname_lc}
-|=======================================================================
-endif::mac_os[]
-
 ifndef::win_only[]
 
 ["source","sh",subs="attributes"]
@@ -121,3 +107,17 @@ Start-Service {beatname_lc}
 ----------------------------------------------------------------------
 
 endif::win_only[]
+
+ifdef::mac_os[]
+
+===== brew
+[cols="<h,<,<m",options="header",]
+|=======================================================================
+| Type   | Description | Location
+| home   | Home of the {beatname_uc} installation. | /usr/local/var/homebrew/linked/{beatname_lc}-full
+| bin    | The location for the binary files. | /usr/local/var/homebrew/linked/{beatname_lc}-full/bin
+| config | The location for configuration files. | /usr/local/etc/{beatname_lc}
+| data   | The location for persistent data files. | /usr/local/var/lib/{beatname_lc}
+| logs   | The location for the logs created by {beatname_uc}. | /usr/local/var/log/{beatname_lc}
+|=======================================================================
+endif::mac_os[]

--- a/docs/installing.asciidoc
+++ b/docs/installing.asciidoc
@@ -4,9 +4,10 @@
 https://www.elastic.co/downloads/apm[Download APM Server] for your operating system and extract the package.
 Then follow the instructions on <<setting-up-and-running,Setting up and running APM Server>>.
 
-You can also install APM Server from our repositories or install as a service on Windows:
+You can also install APM Server from our repositories, on macOS with Homebrew, or as a service on Windows:
 
 * <<setup-repositories>>
+* <<brew>>
 * <<installing-on-windows>>
 
 To run APM Server in Docker, see <<running-on-docker>>.
@@ -14,5 +15,7 @@ To run APM Server in Docker, see <<running-on-docker>>.
 To run APM Server under systemd, see <<running-with-systemd>>.
 
 include::./copied-from-beats/repositories.asciidoc[]
+
+include::brew.asciidoc[]
 
 include::./installing-on-windows.asciidoc[]

--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -44,6 +44,24 @@ sudo -u apm-server apm-server [<argument...>]
 By default, APM Server loads its configuration file from `/etc/apm-server/apm-server.yml`.
 See the <<_deb_and_rpm,deb & rpm default paths>> for a full directory layout.
 
+[float]
+[[running-brew]]
+=== Brew
+
+To start APM Server, run:
+
+["source","sh"]
+-----
+apm-server -e
+-----
+
+To have launchd start APM Server and restart it at login, run:
+
+["source","sh"]
+-----
+brew services start elastic/tap/apm-server-full
+-----
+
 [[apm-server-configuration]]
 === Configuration file
 To configure APM Server, you can also update the `apm-server.yml` configuration file.


### PR DESCRIPTION
Adds brew install instructions per https://github.com/elastic/elasticsearch/pull/42915.
Closes https://github.com/elastic/apm-server/issues/2261.

~I can successfully start APM Server and send data to ES with these instructions. However, it seems 
 `apm-server setup --pipelines` doesn't work. I get the following error: `Exiting: open /usr/local/Cellar/apm-server-full/7.1.1/libexec/ingest/pipeline/definition.json: no such file or directory`. I can't figure out where the `definition.json` file defaults to.~ (fixed)