### PR TITLE
[docs][7.2] Add .NET agent links and information (#2316)

### DIFF
--- a/docs/common-problems.asciidoc
+++ b/docs/common-problems.asciidoc
@@ -270,4 +270,4 @@ with configurable size and time between flushes.
 * **Ruby Agent** - Internal queue with configurable size:
 {apm-ruby-ref}/configuration.html#config-api-buffer-size[`api_buffer_size`].
 * **RUM Agent** - No internal queue. Data is lost.
-// * **.NET Agent** - No internal queue. Data is lost.
+* **.NET Agent** - No internal queue. Data is lost.

--- a/docs/guide/agent-server-compatibility.asciidoc
+++ b/docs/guide/agent-server-compatibility.asciidoc
@@ -24,6 +24,16 @@ Below is a chart that outlines the compatibility between different versions of t
 |=======================================================================
 
 [float]
+[[dotnet-compatibility]]
+==== .NET Agent Compatibility
+
+[options="header"]
+|=======================================================================
+|Agent Version |APM Server Version
+|1.0.0-beta1 |>= 6.5
+|=======================================================================
+
+[float]
 [[nodejs-compatibility]]
 ==== Node.js Agent Compatibility
 

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -205,6 +205,7 @@ Defining too many unique fields in an index is a condition that can lead to a
 |*Labels API links*
 v|*Go:* {apm-go-ref-v}/api.html#context-set-tag[`SetTag`]
 *Java:* {apm-java-ref-v}/public-api.html#api-transaction-add-tag[`addLabel`]
+*.NET:* {apm-dotnet-ref-v}/public-api.html#api-transaction-tags[`Tags`]
 *Node.js:* {apm-node-ref-v}/agent-api.html#apm-set-tag[`setTag`] \| {apm-node-ref-v}/agent-api.html#apm-add-tags[`addTags`]
 *Python:* {apm-py-ref-v}/api.html#api-tag[`tag`]
 *Ruby:* {apm-ruby-ref-v}/api.html#api-agent-set-tag[`set_tag`]
@@ -236,6 +237,7 @@ IMPORTANT: Setting a circular object, large object, or a non JSON serializable o
 |*Custom context API links*
 v|*Go:* _coming soon_
 *Java:* _coming soon_
+*.NET:* _coming soon_
 *Node.js:* {apm-node-ref-v}/agent-api.html#apm-set-custom-context[`setCustomContext`]
 *Python:* {apm-py-ref-v}/api.html#api-set-custom-context[`set_custom_context`]
 *Ruby:* {apm-ruby-ref-v}/api.html#api-agent-set-custom-context[`set_custom_context`]
@@ -258,6 +260,7 @@ Indexed means the data is searchable and aggregatable in Elasticsearch.
 |*User context API links*
 v|*Go:* {apm-go-ref-v}/api.html#context-set-username[`SetUsername`] \| {apm-go-ref-v}/api.html#context-set-user-id[`SetUserID`] \| {apm-go-ref-v}/api.html#context-set-user-email[`SetUserEmail`]
 *Java:* {apm-java-ref-v}/public-api.html#api-transaction-set-user[`setUser`]
+*.NET* _coming soon_
 *Node.js:* {apm-node-ref-v}/agent-api.html#apm-set-user-context[`setUserContext`]
 *Python:* {apm-py-ref-v}/api.html#api-set-user-context[`set_user_context`]
 *Ruby:* {apm-ruby-ref-v}/api.html#api-agent-set-user[`set_user`]

--- a/docs/guide/apm-doc-directory.asciidoc
+++ b/docs/guide/apm-doc-directory.asciidoc
@@ -40,6 +40,7 @@ Each agent has its own documentation:
 
 * {apm-go-ref}/introduction.html[Go agent]
 * {apm-java-ref}/intro.html[Java agent]
+* {apm-dotnet-ref-v}/intro.html[.NET agent]
 * {apm-node-ref}/intro.html[Node.js agent]
 * {apm-py-ref}/getting-started.html[Python agent]
 * {apm-ruby-ref}/introduction.html[Ruby agent]

--- a/docs/guide/install-and-run.asciidoc
+++ b/docs/guide/install-and-run.asciidoc
@@ -88,7 +88,7 @@ please see the full {apm-server-ref-v}/index.html[APM Server documentation].
 === Install and configure APM agents
 
 Agents are written in the same language as your service.
-Currently Elastic APM has agents for Go, Java, Node.js, Python, Ruby, and JavaScript RUM.
+Currently Elastic APM has agents for Go, Java, .NET, Node.js, Python, Ruby, and JavaScript RUM.
 
 // todo: fix this sentence
 Setting up a new service to be monitored requires installing the agent,
@@ -112,6 +112,12 @@ NOTE: Check the <<agent-server-compatibility,Agent/Server compatibility matrix>>
 |{apm-java-ref}/intro.html[Introduction]
 |{apm-java-ref}/supported-technologies-details.html[Supported technologies]
 |{apm-java-ref}/configuration.html[Config]
+
+.2+|.NET
+3+|The .NET agent automatically instruments ASP.NET Core applications, while .NET Framework applications can be instrumented with the public API.
+|{apm-dotnet-ref-v}/intro.html[Introduction]
+|
+|{apm-dotnet-ref-v}/configuration.html[Config]
 
 .2+|Node.js
 3+|The Node.js agent automatically instruments Express, hapi, Koa, and Restify out of the box.

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -16,6 +16,7 @@
 :node-branch: 2.x
 :py-branch: 4.x
 :ruby-branch: 2.x
+:dotnet-branch: current
 
 // Agent links
 :apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{py-branch}
@@ -24,3 +25,4 @@
 :apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{ruby-branch}
 :apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{java-branch}
 :apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{go-branch}
+:apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{dotnet-branch}


### PR DESCRIPTION
Backports the following commits to `7.2`

* docs: add .NET agent links and information #2316