### PR TITLE
[7.x] make apm-server.docker.yml generation consistent with apm-server.yml (#2234)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ endif
 is-beats-updated: python-env
 	@$(PYTHON_ENV)/bin/python ./script/is_beats_updated.py ${BEATS_VERSION}
 
-apm-server.docker.yml: apm-server.yml
-	@sed -E -e 's/^  hosts: \["localhost:9200"\]/  hosts: ["elasticsearch:9200"]/' -e 's/  host: "localhost:8200"/  host: "0.0.0.0:8200"/' < apm-server.yml > apm-server.docker.yml
+apm-server.docker.yml: _meta/beat.yml
+	@sed -E -e 's/^  hosts: \["localhost:9200"\]/  hosts: ["elasticsearch:9200"]/' -e 's/  host: "localhost:8200"/  host: "0.0.0.0:8200"/' < _meta/beat.yml > apm-server.docker.yml
 
 # Collects all dependencies and then calls update
 .PHONY: collect


### PR DESCRIPTION
Backports the following commits to 7.x:
 - make apm-server.docker.yml generation consistent with apm-server.yml  (#2234)