### PR TITLE
Allow the Docker image to be run as a random user id

### DIFF
--- a/_beats/dev-tools/packaging/templates/docker/Dockerfile.tmpl
+++ b/_beats/dev-tools/packaging/templates/docker/Dockerfile.tmpl
@@ -17,6 +17,7 @@ LABEL \
 
 ENV ELASTIC_CONTAINER "true"
 ENV PATH={{ $beatHome }}:$PATH
+ENV BEAT_STRICT_PERMS "false"
 
 COPY beat {{ $beatHome }}
 COPY docker-entrypoint /usr/local/bin/docker-entrypoint
@@ -25,10 +26,10 @@ RUN chmod 755 /usr/local/bin/docker-entrypoint
 RUN groupadd --gid 1000 {{ .BeatName }}
 
 RUN mkdir {{ $beatHome }}/data {{ $beatHome }}/logs && \
-    chown -R root:{{ .BeatName }} {{ $beatHome }} && \
-    find {{ $beatHome }} -type d -exec chmod 0750 {} \; && \
-    find {{ $beatHome }} -type f -exec chmod 0640 {} \; && \
-    chmod 0750 {{ $beatBinary }} && \
+    chown -R root:root {{ $beatHome }} && \
+    find {{ $beatHome }} -type d -exec chmod 0770 {} \; && \
+    find {{ $beatHome }} -type f -exec chmod 0660 {} \; && \
+    chmod 0770 {{ $beatBinary }} && \
 {{- if .linux_capabilities }}
     setcap {{ .linux_capabilities }} {{ $beatBinary }} && \
 {{- end }}
@@ -38,7 +39,7 @@ RUN mkdir {{ $beatHome }}/data {{ $beatHome }}/logs && \
     chmod 0770 {{ $beatHome }}/data {{ $beatHome }}/logs
 
 {{- if ne .user "root" }}
-RUN useradd -M --uid 1000 --gid 1000 --home {{ $beatHome }} {{ .user }}
+RUN useradd -M --uid 1000 --gid 1000 --groups 0 --home {{ $beatHome }} {{ .user }}
 {{- end }}
 USER {{ .user }}
 


### PR DESCRIPTION
Hi,

I'm working on the compatibility of ECK with Kubernetes and Openshift.
On secured Kubernetes environments the user ID used to run a container is "random", you can't really predict it advance. Consequently we can't start the APM server container because it expects to be run with the user 1000 or 0 (root)

This PR brings some compatibility with such environments, based on the fact that on secured Kubernetes clusters and on Openshift the only thing you know is that the user is always a member of the root group.

You can find more details here: https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines

Thank you

