### PR TITLE
[7.x] Enable overwriting ingest pipelines by default. (#2273)

### DIFF
--- a/beater/config.go
+++ b/beater/config.go
@@ -174,7 +174,7 @@ func (c *pipelineConfig) isEnabled() bool {
 }
 
 func (c *pipelineConfig) shouldOverwrite() bool {
-	return c != nil && (c.Overwrite != nil && *c.Overwrite)
+	return c != nil && (c.Overwrite == nil || *c.Overwrite)
 }
 
 func (c *rumConfig) memoizedSmapMapper() (sourcemap.Mapper, error) {

--- a/beater/config_test.go
+++ b/beater/config_test.go
@@ -285,7 +285,7 @@ func TestPipeline(t *testing.T) {
 		enabled, overwrite bool
 	}{
 		{c: nil, enabled: false, overwrite: false},
-		{c: &pipelineConfig{}, enabled: false, overwrite: false},
+		{c: &pipelineConfig{}, enabled: false, overwrite: true}, //default values
 		{c: &pipelineConfig{Enabled: &falsy, Overwrite: &truthy},
 			enabled: false, overwrite: true},
 		{c: &pipelineConfig{Enabled: &truthy, Overwrite: &falsy},

--- a/tests/system/test_pipelines.py
+++ b/tests/system/test_pipelines.py
@@ -60,9 +60,9 @@ class SetupPipelinesDisabledTest(SetupPipelinesDefaultTest):
 
 
 class PipelineRegisterTest(ElasticTest):
+    # pipeline.overwrite should be enabled by default.
     config_overrides = {
         "register_pipeline_enabled": "true",
-        "register_pipeline_overwrite": "true"
     }
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Enable overwriting ingest pipelines by default.  (#2273)