### PR TITLE
[TLS] Align client_auth handling to beats changes and add description for verification_mode

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -69,6 +69,11 @@ apm-server:
     # Options are `none`, `optional`, and `required`. Default is `optional`.
     #client_authentication: "optional"
 
+    # Configure SSL verification mode. If `none` is configured, all hosts and
+    # certificates will be accepted. In this mode, SSL-based connections are
+    # susceptible to man-in-the-middle attacks. Use only for testing. Default is `full`.
+    #ssl.verification_mode: full
+
 
   #rum:
     # To enable real user monitoring (RUM) support set this to true.

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -69,6 +69,11 @@ apm-server:
     # Options are `none`, `optional`, and `required`. Default is `optional`.
     #client_authentication: "optional"
 
+    # Configure SSL verification mode. If `none` is configured, all hosts and
+    # certificates will be accepted. In this mode, SSL-based connections are
+    # susceptible to man-in-the-middle attacks. Use only for testing. Default is `full`.
+    #ssl.verification_mode: full
+
 
   #rum:
     # To enable real user monitoring (RUM) support set this to true.

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -69,6 +69,11 @@ apm-server:
     # Options are `none`, `optional`, and `required`. Default is `optional`.
     #client_authentication: "optional"
 
+    # Configure SSL verification mode. If `none` is configured, all hosts and
+    # certificates will be accepted. In this mode, SSL-based connections are
+    # susceptible to man-in-the-middle attacks. Use only for testing. Default is `full`.
+    #ssl.verification_mode: full
+
 
   #rum:
     # To enable real user monitoring (RUM) support set this to true.

--- a/beater/config.go
+++ b/beater/config.go
@@ -141,7 +141,7 @@ func newConfig(version string, ucfg *common.Config) (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		if !ssl.HasField("client_authentication") {
+		if !ssl.HasField("certificate_authorities") && !ssl.HasField("client_authentication") {
 			if err := ucfg.SetString("ssl.client_authentication", -1, "optional"); err != nil {
 				return nil, err
 			}

--- a/beater/config_test.go
+++ b/beater/config_test.go
@@ -167,39 +167,13 @@ func TestConfig(t *testing.T) {
 	}
 	for idx, test := range cases {
 		cfg, err := yaml.NewConfig(test.config)
-		assert.NoError(t, err)
-
+		require.NoError(t, err)
 		var beaterConfig Config
 		err = cfg.Unpack(&beaterConfig)
-		assert.NoError(t, err)
+		require.NoError(t, err)
+
 		msg := fmt.Sprintf("Test number %v failed. Config: %v, ExpectedConfig: %v", idx, beaterConfig, test.expectedConfig)
 		assert.Equal(t, test.expectedConfig, beaterConfig, msg)
-	}
-}
-
-func TestIsSSLEnabled(t *testing.T) {
-	truthy := true
-	falsy := false
-	cases := []struct {
-		tlsServerCfg *tlscommon.ServerConfig
-		expected     bool
-	}{
-		{tlsServerCfg: nil, expected: false},
-		{tlsServerCfg: &tlscommon.ServerConfig{Enabled: nil}, expected: true},
-		{tlsServerCfg: &tlscommon.ServerConfig{Certificate: outputs.CertificateConfig{Certificate: "Cert"}}, expected: true},
-		{tlsServerCfg: &tlscommon.ServerConfig{Certificate: outputs.CertificateConfig{Certificate: "Cert", Key: "key"}}, expected: true},
-		{tlsServerCfg: &tlscommon.ServerConfig{Certificate: outputs.CertificateConfig{Certificate: "Cert", Key: "key"}, Enabled: &falsy}, expected: false},
-		{tlsServerCfg: &tlscommon.ServerConfig{Enabled: &truthy}, expected: true},
-		{tlsServerCfg: &tlscommon.ServerConfig{Enabled: &falsy}, expected: false},
-	}
-
-	for idx, test := range cases {
-		name := fmt.Sprintf("%v %v->%v", idx, test.tlsServerCfg, test.expected)
-		t.Run(name, func(t *testing.T) {
-			b := test.expected
-			isEnabled := test.tlsServerCfg.IsEnabled()
-			assert.Equal(t, b, isEnabled, "ssl tlsServerCfg but should be %v", b)
-		})
 	}
 }
 
@@ -303,4 +277,69 @@ func TestPipeline(t *testing.T) {
 		assert.Equal(t, test.overwrite, test.c.shouldOverwrite(),
 			fmt.Sprintf("<%v> shouldOverwrite() expected %v", idx, test.overwrite))
 	}
+}
+
+func TestTLSSettings(t *testing.T) {
+
+	t.Run("ClientAuthentication", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			config map[string]interface{}
+
+			tls *tlscommon.ServerConfig
+		}{
+			"Defaults": {
+				config: map[string]interface{}{"ssl": nil},
+				tls:    &tlscommon.ServerConfig{ClientAuth: 3},
+			},
+			"ConfiguredToRequired": {
+				config: map[string]interface{}{"ssl": map[string]interface{}{"client_authentication": "required"}},
+				tls:    &tlscommon.ServerConfig{ClientAuth: 4},
+			},
+			"ConfiguredToNone": {
+				config: map[string]interface{}{"ssl": map[string]interface{}{"client_authentication": "none"}},
+				tls:    &tlscommon.ServerConfig{ClientAuth: 0},
+			},
+			"DefaultRequiredByCA": {
+				config: map[string]interface{}{"ssl": map[string]interface{}{
+					"certificate_authorities": []string{"./path"}}},
+				tls: &tlscommon.ServerConfig{ClientAuth: 4},
+			},
+			"ConfiguredWithCA": {
+				config: map[string]interface{}{"ssl": map[string]interface{}{
+					"certificate_authorities": []string{"./path"}, "client_authentication": "none"}},
+				tls: &tlscommon.ServerConfig{ClientAuth: 0},
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				ucfgCfg, err := common.NewConfigFrom(tc.config)
+				require.NoError(t, err)
+
+				cfg, err := newConfig("9.9.9", ucfgCfg)
+				require.NoError(t, err)
+				assert.Equal(t, tc.tls.ClientAuth, cfg.TLS.ClientAuth)
+			})
+		}
+	})
+
+	t.Run("Enabled", func(t *testing.T) {
+		truthy := true
+		falsy := false
+		for name, tc := range map[string]struct {
+			tlsServerCfg *tlscommon.ServerConfig
+			expected     bool
+		}{
+			"NoConfig":          {tlsServerCfg: nil, expected: false},
+			"SSL":               {tlsServerCfg: &tlscommon.ServerConfig{Enabled: nil}, expected: true},
+			"WithCert":          {tlsServerCfg: &tlscommon.ServerConfig{Certificate: outputs.CertificateConfig{Certificate: "Cert"}}, expected: true},
+			"WithCertAndKey":    {tlsServerCfg: &tlscommon.ServerConfig{Certificate: outputs.CertificateConfig{Certificate: "Cert", Key: "key"}}, expected: true},
+			"ConfiguredToFalse": {tlsServerCfg: &tlscommon.ServerConfig{Certificate: outputs.CertificateConfig{Certificate: "Cert", Key: "key"}, Enabled: &falsy}, expected: false},
+			"ConfiguredToTrue":  {tlsServerCfg: &tlscommon.ServerConfig{Enabled: &truthy}, expected: true},
+		} {
+			t.Run(name, func(t *testing.T) {
+				b := tc.expected
+				isEnabled := tc.tlsServerCfg.IsEnabled()
+				assert.Equal(t, b, isEnabled, "ssl tlsServerCfg but should be %v", b)
+			})
+		}
+	})
 }

--- a/beater/config_test.go
+++ b/beater/config_test.go
@@ -321,6 +321,32 @@ func TestTLSSettings(t *testing.T) {
 		}
 	})
 
+	t.Run("VerificationMode", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			config map[string]interface{}
+			tls    *tlscommon.ServerConfig
+		}{
+			"Default": {
+				config: map[string]interface{}{"ssl": nil},
+				tls:    &tlscommon.ServerConfig{VerificationMode: tlscommon.VerifyFull}},
+			"ConfiguredToFull": {
+				config: map[string]interface{}{"ssl": map[string]interface{}{"verification_mode": "full"}},
+				tls:    &tlscommon.ServerConfig{VerificationMode: tlscommon.VerifyFull}},
+			"ConfiguredToNone": {
+				config: map[string]interface{}{"ssl": map[string]interface{}{"verification_mode": "none"}},
+				tls:    &tlscommon.ServerConfig{VerificationMode: tlscommon.VerifyNone}},
+		} {
+			t.Run(name, func(t *testing.T) {
+				ucfgCfg, err := common.NewConfigFrom(tc.config)
+				require.NoError(t, err)
+
+				cfg, err := newConfig("9.9.9", ucfgCfg)
+				require.NoError(t, err)
+				assert.Equal(t, tc.tls.VerificationMode, cfg.TLS.VerificationMode)
+			})
+		}
+	})
+
 	t.Run("Enabled", func(t *testing.T) {
 		truthy := true
 		falsy := false
@@ -338,7 +364,7 @@ func TestTLSSettings(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				b := tc.expected
 				isEnabled := tc.tlsServerCfg.IsEnabled()
-				assert.Equal(t, b, isEnabled, "ssl tlsServerCfg but should be %v", b)
+				assert.Equal(t, b, isEnabled)
 			})
 		}
 	})

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -14,6 +14,7 @@
 - Initial support for remote agent configuration, requires Kibana {pull}2289[2289].
 - Enable APM pipeline by default {pull}2301[2301].
 - Add fields required by breakdown graphs APM pipeline by default {pull}2287[2287].
+- Require client auth when CA is configured and SSL enabled {pull}2340[2340].
 
 [float]
 ==== Removed

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -32,8 +32,8 @@ apm-server:
   ssl.client_authentication: {{ ssl_client_authentication }}
   {% endif %}
 
-  {% if cipher_suites %}
-  ssl.cipher_suites: {{ cipher_suites }}
+  {% if ssl_cipher_suites %}
+  ssl.cipher_suites: {{ ssl_cipher_suites }}
   {% endif %}
 
   rum.enabled: {{ enable_rum }}


### PR DESCRIPTION
This PR adapts default settings for `client_authentication` when TLS is configured to latest changes in libbeat. It also documents and adds tests for the `verification_mode` setting. 

* [x] changelog entry
* [x] upgrade libbeat  

implements elastic/apm-server#2336