### PR TITLE
ci(jenkins): notify first time contributor github check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
       options { skipDefaultCheckout() }
       steps {
         deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}")
+        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script {
           dir("${BASE_DIR}"){


### PR DESCRIPTION
Enable `githubNotifyFirstTimeContributor` parameter to notify the PR with a new GitHub check whether the checkout failed related with the first time contributor validation.

## Highlights
- Rather than creating a new GitHub check for each pipeline let's use the shared library to drive that particular behavior.
- Being explicit behavior rather than a default one. 

## How does it look like?

![image](https://user-images.githubusercontent.com/2871786/60285929-9169e300-9906-11e9-913a-c1d77eb3c4c7.png)
