### PR TITLE
[7.x] [don't-merge] Sync config via mage respecting docker defaults

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,12 +66,9 @@ endif
 is-beats-updated: python-env
 	@$(PYTHON_ENV)/bin/python ./script/is_beats_updated.py ${BEATS_VERSION}
 
-apm-server.docker.yml: _meta/beat.yml
-	@sed -E -e 's/^  hosts: \["localhost:9200"\]/  hosts: ["elasticsearch:9200"]/' -e 's/  host: "localhost:8200"/  host: "0.0.0.0:8200"/' < _meta/beat.yml > apm-server.docker.yml
-
 # Collects all dependencies and then calls update
 .PHONY: collect
-collect: fields go-generate add-headers create-docs notice apm-server.docker.yml
+collect: fields go-generate add-headers create-docs notice
 
 .PHONY: go-generate
 go-generate:

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -4,7 +4,7 @@
 
 apm-server:
   # Defines the host and port the server is listening on.  use "unix:/path/to.sock" to listen on a unix domain socket.
-  host: "localhost:8200"
+  host: "{{ .listen_hostport }}"
 
   # Maximum permitted size in bytes of a request's header accepted by the server to be processed.
   #max_header_size: 1048576
@@ -270,7 +270,7 @@ output.elasticsearch:
   # Scheme and port can be left out and will be set to the default (http and 9200)
   # In case you specify and additional path, the scheme is required: http://localhost:9200/path
   # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
-  hosts: ["localhost:9200"]
+  hosts: ["{{ .elasticsearch_hostport }}"]
 
   # Boolean flag to enable or disable the output module.
   #enabled: true

--- a/magefile.go
+++ b/magefile.go
@@ -84,6 +84,37 @@ func Clean() error {
 	return mage.Clean()
 }
 
+func Config() error {
+	if err := mage.Config(mage.ShortConfigType, shortConfigFileParams(), "."); err != nil {
+		return err
+	}
+	return mage.Config(mage.DockerConfigType, dockerConfigFileParams(), ".")
+}
+
+func shortConfigFileParams() mage.ConfigFileParams {
+	return mage.ConfigFileParams{
+		ShortParts: []string{
+			mage.OSSBeatDir("_meta/beat.yml"),
+		},
+		ExtraVars: map[string]interface{}{
+			"elasticsearch_hostport": "localhost:9200",
+			"listen_hostport":        "localhost:" + beater.DefaultPort,
+		},
+	}
+}
+
+func dockerConfigFileParams() mage.ConfigFileParams {
+	return mage.ConfigFileParams{
+		DockerParts: []string{
+			mage.OSSBeatDir("_meta/beat.yml"),
+		},
+		ExtraVars: map[string]interface{}{
+			"elasticsearch_hostport": "elasticsearch:9200",
+			"listen_hostport":        "0.0.0.0:" + beater.DefaultPort,
+		},
+	}
+}
+
 // Package packages the Beat for distribution.
 // Use SNAPSHOT=true to build snapshots.
 // Use PLATFORMS to control the target platforms.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Sync config via mage respecting docker defaults (#2320)