### PR TITLE
[7.x] rename agent config endpoint (#2303)

### DIFF
--- a/beater/route_config.go
+++ b/beater/route_config.go
@@ -37,7 +37,7 @@ import (
 const (
 	rootURL = "/"
 
-	agentConfigURL = "/v1/agent/configs"
+	agentConfigURL = "/config/v1/agents"
 
 	// intake v2
 	backendURL = "/intake/v2/events"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - rename agent config endpoint  (#2303)