### PR TITLE
[ILM] Enable ILM by default when supported by configured ES output.

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -172,11 +172,21 @@ apm-server:
     # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to true.
     #overwrite: true
 
-  # When ilm is set to true the APM Server will take care of ILM setup.
-  # Configurations in output.elasticsearch.index and output.elasticsearch.indices sections will be ignored
-  # ilm can only be enabled for output.elasticsearch
-  #ilm:
-    #enabled: false
+  # When ilm is set to `auto`, the APM Server checks a couple of preconditions:
+  # If a different output than Elasticsearch is configured, ILM will be disabled.
+  # If Elasticsearch output is configured, but specific `index` or `indices` settings are configured, ILM will be
+  # disabled, as it only works with default index settings.
+  # If the configured Elasticsearch instance is not eligible for ILM, ILM will also be disabled.
+  # If all preconditions are met, ILM will be enabled.
+  #
+  # When ILM is set to `true`, the APM Server ignores any configured index settings.
+  # For ILM to be applied, The configured output must be set to Elasticsearch and the instance
+  # needs to support ILM. Otherwise APM Server falls back to ordinary index management without ILM.
+  #
+  # Disable ILM by setting it to `false`.
+  #
+  # Defaults to `auto`.
+  #ilm.enabled: "auto"
 
   #kibana:
     # For agent remote configuration, enabled must be true

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -172,11 +172,21 @@ apm-server:
     # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to true.
     #overwrite: true
 
-  # When ilm is set to true the APM Server will take care of ILM setup.
-  # Configurations in output.elasticsearch.index and output.elasticsearch.indices sections will be ignored
-  # ilm can only be enabled for output.elasticsearch
-  #ilm:
-    #enabled: false
+  # When ilm is set to `auto`, the APM Server checks a couple of preconditions:
+  # If a different output than Elasticsearch is configured, ILM will be disabled.
+  # If Elasticsearch output is configured, but specific `index` or `indices` settings are configured, ILM will be
+  # disabled, as it only works with default index settings.
+  # If the configured Elasticsearch instance is not eligible for ILM, ILM will also be disabled.
+  # If all preconditions are met, ILM will be enabled.
+  #
+  # When ILM is set to `true`, the APM Server ignores any configured index settings.
+  # For ILM to be applied, The configured output must be set to Elasticsearch and the instance
+  # needs to support ILM. Otherwise APM Server falls back to ordinary index management without ILM.
+  #
+  # Disable ILM by setting it to `false`.
+  #
+  # Defaults to `auto`.
+  #ilm.enabled: "auto"
 
   #kibana:
     # For agent remote configuration, enabled must be true

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -172,11 +172,21 @@ apm-server:
     # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to true.
     #overwrite: true
 
-  # When ilm is set to true the APM Server will take care of ILM setup.
-  # Configurations in output.elasticsearch.index and output.elasticsearch.indices sections will be ignored
-  # ilm can only be enabled for output.elasticsearch
-  #ilm:
-    #enabled: false
+  # When ilm is set to `auto`, the APM Server checks a couple of preconditions:
+  # If a different output than Elasticsearch is configured, ILM will be disabled.
+  # If Elasticsearch output is configured, but specific `index` or `indices` settings are configured, ILM will be
+  # disabled, as it only works with default index settings.
+  # If the configured Elasticsearch instance is not eligible for ILM, ILM will also be disabled.
+  # If all preconditions are met, ILM will be enabled.
+  #
+  # When ILM is set to `true`, the APM Server ignores any configured index settings.
+  # For ILM to be applied, The configured output must be set to Elasticsearch and the instance
+  # needs to support ILM. Otherwise APM Server falls back to ordinary index management without ILM.
+  #
+  # Disable ILM by setting it to `false`.
+  #
+  # Defaults to `auto`.
+  #ilm.enabled: "auto"
 
   #kibana:
     # For agent remote configuration, enabled must be true

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -15,6 +15,7 @@
 - Enable APM pipeline by default {pull}2301[2301].
 - Add fields required by breakdown graphs APM pipeline by default {pull}2287[2287].
 - Require client auth when CA is configured and SSL enabled {pull}2340[2340].
+- Enable ILM by default when supported by configured Elasticsearch {pull}2356[2356].
 
 [float]
 ==== Removed

--- a/idxmgmt/feature.go
+++ b/idxmgmt/feature.go
@@ -1,0 +1,58 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package idxmgmt
+
+import (
+	libidxmgmt "github.com/elastic/beats/libbeat/idxmgmt"
+)
+
+type feature struct {
+	enabled, overwrite, load, supported bool
+
+	warn string
+	err  error
+}
+
+func newFeature(enabled, overwrite, supported bool, mode libidxmgmt.LoadMode) feature {
+	if mode == libidxmgmt.LoadModeUnset {
+		mode = libidxmgmt.LoadModeDisabled
+	}
+	if mode >= libidxmgmt.LoadModeOverwrite {
+		overwrite = true
+	}
+	if mode == libidxmgmt.LoadModeForce {
+		enabled = true
+	}
+	if !supported {
+		enabled = false
+	}
+	load := mode.Enabled() && enabled
+	return feature{
+		enabled:   enabled,
+		overwrite: overwrite,
+		load:      load,
+		supported: supported}
+}
+
+func (f *feature) warning() string {
+	return f.warn
+}
+
+func (f *feature) error() error {
+	return f.err
+}

--- a/idxmgmt/ilm/config.go
+++ b/idxmgmt/ilm/config.go
@@ -19,14 +19,33 @@ package ilm
 
 import (
 	"github.com/elastic/beats/libbeat/common/fmtstr"
+	libilm "github.com/elastic/beats/libbeat/idxmgmt/ilm"
 )
 
 const pattern = "000001"
 
-//Config for ILM supporter
+// Config for ILM supporter
 type Config struct {
-	Enabled    bool                      `config:"enabled"`
+	Mode       libilm.Mode               `config:"enabled"`
 	PolicyName *fmtstr.EventFormatString `config:"policy_name"`
 	AliasName  *fmtstr.EventFormatString `config:"alias_name"`
 	Event      string                    `config:"event"`
+}
+
+// Enabled indicates whether or not ILM should be enabled
+func (c *Config) Enabled() bool {
+	return c.Mode != libilm.ModeDisabled
+}
+
+// ModeString stringifies enabled mode
+// This is a workaround as strings should be generated in libbeat.
+func ModeString(m libilm.Mode) string {
+	switch m {
+	case libilm.ModeAuto:
+		return "auto"
+	case libilm.ModeEnabled:
+		return "true"
+	default:
+		return "false"
+	}
 }

--- a/idxmgmt/ilm/config_test.go
+++ b/idxmgmt/ilm/config_test.go
@@ -1,0 +1,62 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ilm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/libbeat/common"
+	libilm "github.com/elastic/beats/libbeat/idxmgmt/ilm"
+)
+
+func TestConfig(t *testing.T) {
+
+	t.Run("ValidInput", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			input string
+			mode  libilm.Mode
+		}{
+			"True":  {input: "true", mode: libilm.ModeEnabled},
+			"False": {input: "false", mode: libilm.ModeDisabled},
+			"Auto":  {input: "auto", mode: libilm.ModeAuto},
+		} {
+			t.Run(name, func(t *testing.T) {
+				inp, err := common.NewConfigFrom(map[string]string{"enabled": tc.input})
+				require.NoError(t, err)
+
+				var cfg Config
+				require.NoError(t, inp.Unpack(&cfg))
+				assert.Equal(t, tc.mode, cfg.Mode)
+			})
+		}
+	})
+
+	t.Run("Invalid Input", func(t *testing.T) {
+		for _, input := range []string{"invalid", ""} {
+			inp, err := common.NewConfigFrom(map[string]string{"enabled": input})
+			require.NoError(t, err)
+
+			var cfg Config
+			assert.Error(t, inp.Unpack(&cfg))
+		}
+	})
+
+}

--- a/idxmgmt/ilm/supporter_factory.go
+++ b/idxmgmt/ilm/supporter_factory.go
@@ -67,7 +67,7 @@ func MakeDefaultSupporter(log *logp.Logger, info beat.Info, cfg *common.Config) 
 		Pattern: pattern,
 	}
 
-	return libilm.NewStdSupport(log, libilm.ModeEnabled, alias, policy, false, true), nil
+	return libilm.NewStdSupport(log, ilmCfg.Mode, alias, policy, false, true), nil
 }
 
 func applyStaticFmtstr(info beat.Info, fmt *fmtstr.EventFormatString) (string, error) {

--- a/idxmgmt/ilm/supporter_factory_test.go
+++ b/idxmgmt/ilm/supporter_factory_test.go
@@ -60,6 +60,7 @@ func TestMakeDefaultSupporter(t *testing.T) {
 			"policy_name": "%{[observer.name]}-%{[observer.version]}-%{[beat.name]}-%{[beat.version]}",
 			"alias_name":  "alias-%{[observer.name]}-%{[observer.version]}-%{[beat.name]}-%{[beat.version]}",
 			"event":       "span",
+			"enabled":     "true",
 		})
 
 		s, err := MakeDefaultSupporter(nil, info, cfg)
@@ -69,6 +70,18 @@ func TestMakeDefaultSupporter(t *testing.T) {
 		assert.Equal(t, "alias-mockapm-9.9.9-mockapm-9.9.9", s.Alias().Name)
 		assert.Equal(t, "000001", s.Alias().Pattern)
 		assert.Equal(t, libilm.ModeEnabled, s.Mode())
+	})
+
+	t.Run("default mode", func(t *testing.T) {
+		cfg := common.MustNewConfigFrom(map[string]interface{}{
+			"policy_name": "policy",
+			"alias_name":  "alias",
+			"event":       "span",
+		})
+
+		s, err := MakeDefaultSupporter(nil, info, cfg)
+		require.NoError(t, err)
+		assert.Equal(t, libilm.ModeAuto, s.Mode())
 	})
 
 }

--- a/idxmgmt/indices.go
+++ b/idxmgmt/indices.go
@@ -67,20 +67,16 @@ func othersIdxNames() map[string]string {
 	}
 }
 
-func indices(cfg *common.Config) (*common.Config, error) {
+func indices(cfg *esIndexConfig) (*common.Config, error) {
 	var idcsCfg = common.NewConfig()
-	var customESIdxCfg esIndexConfig
-	if err := cfg.Unpack(&customESIdxCfg); err != nil {
-		return nil, err
-	}
 
 	// set defaults
-	if customESIdxCfg.Index == "" {
+	if cfg.Index == "" {
 		// set fallback default index
 		idcsCfg.SetString("index", -1, defaultIndex)
 
 		// set default indices if not set
-		if customESIdxCfg.Indices == nil {
+		if cfg.Indices == nil {
 			if indicesCfg, err := common.NewConfigFrom(indicesConditions(false)); err == nil {
 				idcsCfg.SetChild("indices", -1, indicesCfg)
 			}
@@ -88,20 +84,20 @@ func indices(cfg *common.Config) (*common.Config, error) {
 	}
 
 	// use custom config settings where available
-	if customESIdxCfg.Index != "" {
-		if err := idcsCfg.SetString("index", -1, customESIdxCfg.Index); err != nil {
+	if cfg.Index != "" {
+		if err := idcsCfg.SetString("index", -1, cfg.Index); err != nil {
 			return nil, err
 		}
 	}
-	if customESIdxCfg.Indices != nil {
-		if err := idcsCfg.SetChild("indices", -1, customESIdxCfg.Indices); err != nil {
+	if cfg.Indices != nil {
+		if err := idcsCfg.SetChild("indices", -1, cfg.Indices); err != nil {
 			return nil, err
 		}
 	}
 	return idcsCfg, nil
 }
 
-func ilmIndices(_ *common.Config) (*common.Config, error) {
+func ilmIndices() (*common.Config, error) {
 	var idcsCfg = common.NewConfig()
 
 	// set fallback index

--- a/idxmgmt/manager.go
+++ b/idxmgmt/manager.go
@@ -1,0 +1,262 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package idxmgmt
+
+import (
+	"fmt"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/logp"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/apm-server/idxmgmt/ilm"
+	"github.com/elastic/beats/libbeat/common"
+	libidxmgmt "github.com/elastic/beats/libbeat/idxmgmt"
+	libilm "github.com/elastic/beats/libbeat/idxmgmt/ilm"
+)
+
+const ilmDisabledESErr = "automatically disabled ILM as not supported by configured Elasticsearch"
+const ilmDisabledESMsg = "Automatically disabled ILM as not supported by configured Elasticsearch."
+const ilmDisabledCfgMsg = "Automatically disabled ILM as custom index settings configured."
+
+type manager struct {
+	supporter     *supporter
+	clientHandler libidxmgmt.ClientHandler
+	assets        libidxmgmt.Asseter
+}
+
+func (m *manager) VerifySetup(loadTemplate, loadILM libidxmgmt.LoadMode) (bool, string) {
+	ilmSupporters, err := ilmSupporters(m.supporter.ilmConfig.Mode, m.supporter.log, m.supporter.info)
+	if err != nil {
+		return false, err.Error()
+	}
+	templateFeature := m.templateFeature(loadTemplate)
+	ilmFeature := m.ilmFeature(ilmSupporters, loadILM)
+
+	if err := ilmFeature.error(); err != nil {
+		return false, err.Error()
+	}
+
+	if ilmFeature.load && !templateFeature.load {
+		return false, "Loading ILM policy and write alias without loading template " +
+			"is not recommended. Check your configuration."
+	}
+	if templateFeature.load && !ilmFeature.load && ilmFeature.enabled {
+		return false, "Loading template with ILM settings whithout loading ILM policy and alias can lead " +
+			"to issues and is not recommended. Check your configuration"
+	}
+
+	var warn string
+
+	if ilmWarn := ilmFeature.warning(); ilmWarn != "" {
+		warn += ilmWarn
+	}
+	if !ilmFeature.load && ilmFeature.supported {
+		warn += "ILM policy and write alias loading not enabled. "
+	}
+	if !templateFeature.load {
+		warn += "Template loading not enabled."
+	}
+	return warn == "", warn
+}
+
+func (m *manager) Setup(loadTemplate, loadILM libidxmgmt.LoadMode) error {
+	log := m.supporter.log
+
+	//setup index management:
+	//(0) preparation step
+	//(1) load general apm template
+	//(2) load policy per event type
+	//(3) create template per event respecting lifecycle settings
+	//(4) load write alias per event type AFTER the template has been created,
+	//    as this step also automatically creates an index, it is important the matching templates are already there
+
+	//(0) prepare template and ilm handlers, check if ILM is supported, fall back to ordinary index handling otherwise
+	ilmSupporters, err := ilmSupporters(m.supporter.ilmConfig.Mode, log, m.supporter.info)
+	if err != nil {
+		return err
+	}
+	ilmFeature := m.ilmFeature(ilmSupporters, loadILM)
+	if warn := ilmFeature.warning(); warn != "" {
+		log.Warn(warn)
+	}
+	if err := ilmFeature.error(); err != nil {
+		log.Error(err)
+	}
+
+	templateFeature := m.templateFeature(loadTemplate)
+	m.supporter.templateConfig.Enabled = templateFeature.enabled
+	m.supporter.templateConfig.Overwrite = templateFeature.overwrite
+
+	//(1) load general apm template
+	//only set to user configured name and pattern if ilm is disabled
+	//default template name and pattern, must be the same whether or not ilm is enabled or not,
+	//allowing former templates to be overwritten
+	if err := m.loadTemplate(templateFeature, ilmFeature); err != nil {
+		return err
+	}
+
+	for _, ilmSupporter := range ilmSupporters {
+		//(2) load event type policies, respecting ILM settings
+		loaded, err := m.loadPolicy(ilmFeature, ilmSupporter)
+		if err != nil {
+			return err
+		}
+		overwriteTemplate := templateFeature.overwrite || loaded
+
+		// (3) load event type specific template respecting index lifecycle information
+		if err := m.loadEventTemplate(templateFeature, ilmFeature, ilmSupporter, overwriteTemplate); err != nil {
+			return err
+		}
+
+		//(4) load ilm write aliases
+		//    ensure write aliases are created AFTER template creation
+		if err := m.loadAlias(ilmFeature, ilmSupporter); err != nil {
+			return err
+		}
+	}
+
+	log.Info("Finished index management setup.")
+	return nil
+}
+
+func (m *manager) templateFeature(loadMode libidxmgmt.LoadMode) feature {
+	return newFeature(m.supporter.templateConfig.Enabled, m.supporter.templateConfig.Overwrite, true, loadMode)
+}
+
+func (m *manager) ilmFeature(ilmSupporters []libilm.Supporter, loadMode libidxmgmt.LoadMode) feature {
+	if !m.supporter.ilmConfig.Enabled() {
+		return newFeature(m.supporter.ilmConfig.Enabled(), false, true, loadMode)
+	}
+
+	var supported = true
+	var warn, err string
+	if m.supporter.esIdxCfg.customized() {
+		supported = false
+		warn = ilmDisabledCfgMsg
+	}
+	for _, ilmSupporter := range ilmSupporters {
+		if enabled, _ := ilmSupporter.Manager(m.clientHandler).Enabled(); !enabled {
+			supported = false
+			if m.supporter.ilmConfig.Mode == libilm.ModeEnabled {
+				err = ilmDisabledESErr
+				break
+			}
+			warn = ilmDisabledESMsg
+			break
+		}
+	}
+	f := newFeature(m.supporter.ilmConfig.Enabled(), false, supported, loadMode)
+	f.warn = warn
+	if err != "" {
+		f.err = errors.New(err)
+	}
+	return f
+}
+
+func (m *manager) loadTemplate(templateFeature, ilmFeature feature) error {
+	if !templateFeature.load {
+		return nil
+	}
+	if ilmFeature.enabled || m.supporter.templateConfig.Name == "" && m.supporter.templateConfig.Pattern == "" {
+		m.supporter.templateConfig.Name = fmt.Sprintf("%s-%s", apmPrefix, apmVersion)
+		m.supporter.log.Infof("Set setup.template.name to '%s'.", m.supporter.templateConfig.Name)
+		m.supporter.templateConfig.Pattern = m.supporter.templateConfig.Name + "*"
+		m.supporter.log.Infof("Set setup.template.pattern to '%s'.", m.supporter.templateConfig.Pattern)
+	}
+	if err := m.clientHandler.Load(m.supporter.templateConfig, m.supporter.info,
+		m.assets.Fields(m.supporter.info.Beat), m.supporter.migration); err != nil {
+		return fmt.Errorf("error loading Elasticsearch template: %+v", err)
+	}
+	m.supporter.log.Infof("Finished loading index template.")
+	return nil
+}
+
+func (m *manager) loadEventTemplate(templateFeature, ilmFeature feature, ilmSupporter libilm.Supporter, overwrite bool) error {
+	if !templateFeature.load {
+		return nil
+	}
+	templateCfg := ilm.Template(ilmFeature.enabled, templateFeature.enabled, overwrite,
+		ilmSupporter.Alias().Name,
+		ilmSupporter.Policy().Name)
+
+	if err := m.clientHandler.Load(templateCfg, m.supporter.info, nil, m.supporter.migration); err != nil {
+		return errors.Wrapf(err, "error loading template %+v", templateCfg.Name)
+	}
+	m.supporter.log.Infof("Finished template setup for %s.", templateCfg.Name)
+	return nil
+}
+
+func (m *manager) loadPolicy(ilmFeature feature, ilmSupporter libilm.Supporter) (bool, error) {
+	if !ilmFeature.load {
+		return false, nil
+	}
+	policy := ilmSupporter.Policy().Name
+	policyCreated, err := ilmSupporter.Manager(m.clientHandler).EnsurePolicy(ilmFeature.overwrite)
+	if err != nil {
+		return policyCreated, err
+	}
+	if !policyCreated {
+		m.supporter.log.Infof("ILM policy %s exists already.", policy)
+		return false, nil
+	}
+	m.supporter.log.Infof("ILM policy %s successfully loaded.", policy)
+	return true, nil
+}
+func (m *manager) loadAlias(ilmFeature feature, ilmSupporter libilm.Supporter) error {
+	if !ilmFeature.load {
+		return nil
+	}
+
+	alias := ilmSupporter.Alias().Name
+	if err := ilmSupporter.Manager(m.clientHandler).EnsureAlias(); err != nil {
+		if libilm.ErrReason(err) != libilm.ErrAliasAlreadyExists {
+			return err
+		}
+		m.supporter.log.Infof("Write alias %s exists already.", alias)
+		return nil
+	}
+	m.supporter.log.Infof("Write alias %s successfully generated.", alias)
+	return nil
+}
+
+func ilmSupporters(mode libilm.Mode, logger *logp.Logger, info beat.Info) ([]libilm.Supporter, error) {
+	var (
+		ilmSupporters []libilm.Supporter
+		err           error
+		ilmCfg        *common.Config
+	)
+
+	for event, index := range eventIdxNames(false) {
+		if ilmCfg, err = common.NewConfigFrom(common.MapStr{
+			"enabled":     ilm.ModeString(mode),
+			"event":       event,
+			"policy_name": idxStr(event, ""),
+			"alias_name":  index},
+		); err != nil {
+			return nil, errors.Wrapf(err, "error creating index-management config")
+		}
+		ilmSupporter, err := ilm.MakeDefaultSupporter(logger, info, ilmCfg)
+		if err != nil {
+			return nil, err
+		}
+		ilmSupporters = append(ilmSupporters, ilmSupporter)
+	}
+	return ilmSupporters, nil
+}

--- a/idxmgmt/manager_test.go
+++ b/idxmgmt/manager_test.go
@@ -1,0 +1,385 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package idxmgmt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	libidxmgmt "github.com/elastic/beats/libbeat/idxmgmt"
+	libilm "github.com/elastic/beats/libbeat/idxmgmt/ilm"
+	"github.com/elastic/beats/libbeat/template"
+)
+
+func TestIndexManager_VerifySetup(t *testing.T) {
+	for name, setup := range map[string]struct {
+		tmpl              bool
+		ilm               string
+		loadTmpl, loadILM libidxmgmt.LoadMode
+		version           string
+
+		ok   bool
+		warn string
+	}{
+		"load template with ilm without loading ilm": {
+			ilm: "true", loadILM: libidxmgmt.LoadModeDisabled,
+			tmpl: true, loadTmpl: libidxmgmt.LoadModeEnabled,
+			warn: "whithout loading ILM policy and alias",
+		},
+		"load ilm without template": {
+			ilm: "true", loadILM: libidxmgmt.LoadModeEnabled,
+			loadTmpl: libidxmgmt.LoadModeEnabled,
+			warn:     "without loading template is not recommended",
+		},
+		"template disabled but loading enabled": {
+			ilm: "false", loadILM: libidxmgmt.LoadModeEnabled,
+			loadTmpl: libidxmgmt.LoadModeEnabled,
+			warn:     "loading not enabled",
+		},
+		"ilm disabled but loading enabled": {
+			ilm: "false", loadILM: libidxmgmt.LoadModeEnabled,
+			tmpl: true, loadTmpl: libidxmgmt.LoadModeEnabled,
+			warn: "loading not enabled",
+		},
+		"ilm loading disabled": {
+			ilm: "true", loadILM: libidxmgmt.LoadModeDisabled,
+			loadTmpl: libidxmgmt.LoadModeEnabled,
+			warn:     "loading not enabled",
+		},
+		"template loading disabled": {
+			ilm: "false", loadILM: libidxmgmt.LoadModeEnabled,
+			tmpl: true, loadTmpl: libidxmgmt.LoadModeDisabled,
+			warn: "loading not enabled",
+		},
+		"ilm enabled but not supported": {
+			version: "6.2.0",
+			ilm:     "true", loadILM: libidxmgmt.LoadModeEnabled,
+			loadTmpl: libidxmgmt.LoadModeEnabled,
+			warn:     "automatically disabled ILM",
+		},
+		"ilm auto but not supported": {
+			loadTmpl: libidxmgmt.LoadModeEnabled,
+			version:  "6.2.0",
+			tmpl:     true,
+			ilm:      "auto", loadILM: libidxmgmt.LoadModeEnabled,
+			warn: "Automatically disabled ILM",
+		},
+		"everything enabled": {
+			tmpl: true, loadTmpl: libidxmgmt.LoadModeEnabled,
+			ilm: "true", loadILM: libidxmgmt.LoadModeEnabled,
+			ok: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := common.NewConfigFrom(common.MapStr{
+				"apm-server.ilm.enabled": setup.ilm,
+				"setup.template.enabled": setup.tmpl,
+			})
+			require.NoError(t, err)
+			support, err := MakeDefaultSupporter(nil, beat.Info{}, cfg)
+			require.NoError(t, err)
+			version := setup.version
+			if version == "" {
+				version = "7.0.0"
+			}
+			manager := support.Manager(newMockClientHandler(version), nil)
+			ok, warn := manager.VerifySetup(setup.loadTmpl, setup.loadILM)
+			require.Equal(t, setup.ok, ok, warn)
+			assert.Contains(t, warn, setup.warn)
+		})
+	}
+}
+
+func TestManager_Setup(t *testing.T) {
+	fields := []byte("apm-server fields")
+
+	type testCase struct {
+		cfg            common.MapStr
+		tLoad, ilmLoad libidxmgmt.LoadMode
+
+		tCt, tWithILMCt, pCt, aCt int
+		version                   string
+		err                       error
+	}
+
+	var testCasesEnabled = map[string]testCase{
+		"Default": {
+			tLoad: libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
+			tCt: 5, tWithILMCt: 4, pCt: 3, aCt: 3,
+		},
+		"LoadTemplateAndILM": {
+			cfg:   common.MapStr{"apm-server.ilm.enabled": true},
+			tLoad: libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
+			tCt: 5, tWithILMCt: 4, pCt: 3, aCt: 3,
+		},
+		"DisabledILM": {
+			cfg:   common.MapStr{"apm-server.ilm.enabled": false},
+			tLoad: libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
+			tCt: 5,
+		},
+		"DisabledTemplate": {
+			cfg:   common.MapStr{"setup.template.enabled": false},
+			tLoad: libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
+			pCt: 3, aCt: 3,
+		},
+		"DisabledTemplateAndILM": {
+			cfg:   common.MapStr{"setup.template.enabled": false, "apm-server.ilm.enabled": false},
+			tLoad: libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
+		},
+		"LoadModeDisabledILM": {
+			tLoad: libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeDisabled,
+			tCt: 5, tWithILMCt: 4,
+		},
+		"LoadModeDisabledTemplate": {
+			tLoad: libidxmgmt.LoadModeDisabled, ilmLoad: libidxmgmt.LoadModeEnabled,
+			pCt: 3, aCt: 3,
+		},
+		"LoadModeDisabledTemplateAndILM": {
+			tLoad:   libidxmgmt.LoadModeDisabled,
+			ilmLoad: libidxmgmt.LoadModeDisabled,
+		},
+	}
+
+	var testCasesLoadModeUnset = map[string]testCase{
+		"DefaultLoadModeUnset": {
+			tCt: 0, tWithILMCt: 0, pCt: 0, aCt: 0,
+		},
+	}
+
+	var testCasesLoadModeOverwrite = map[string]testCase{
+		// used for `./apm-server setup template`, `apm-server setup index-managemet`
+
+		"DisabledILMAndTemplateLoadModeOverwrite": {
+			cfg:     common.MapStr{"setup.template.enabled": false, "apm-server.ilm.enabled": false},
+			tLoad:   libidxmgmt.LoadModeOverwrite,
+			ilmLoad: libidxmgmt.LoadModeOverwrite,
+		},
+		"LoadModeOverwriteTemplateLoadModeDisabledILM": {
+			// used for `./apm-server setup template`
+			tLoad:   libidxmgmt.LoadModeOverwrite,
+			ilmLoad: libidxmgmt.LoadModeDisabled,
+			tCt:     5, tWithILMCt: 4,
+		},
+		"LoadModeOverwriteILMLoadModeDisabledTemplate": {
+			tLoad:   libidxmgmt.LoadModeDisabled,
+			ilmLoad: libidxmgmt.LoadModeOverwrite,
+			pCt:     4, aCt: 3,
+		},
+		"LoadModeOverwriteWhenDisabled": {
+			// used for `./apm-server setup template`, `apm-server setup index-managemet`
+			tLoad:   libidxmgmt.LoadModeOverwrite,
+			ilmLoad: libidxmgmt.LoadModeOverwrite,
+			tCt:     5, tWithILMCt: 4, pCt: 4, aCt: 3,
+		},
+	}
+
+	var testCasesLoadModeForce = map[string]testCase{
+		// used for `./apm-server export template`
+
+		"LoadModeForceTemplateLoadModeDisabledILM": {
+			cfg:     common.MapStr{"setup.template.enabled": false, "apm-server.ilm.enabled": false},
+			tLoad:   libidxmgmt.LoadModeForce,
+			ilmLoad: libidxmgmt.LoadModeDisabled,
+			tCt:     5,
+		},
+		"LoadModeForceILMLoadModeDisabledTemplate": {
+			// used for `./apm-server export ilm-policy`
+			cfg:     common.MapStr{"setup.template.enabled": false, "apm-server.ilm.enabled": false},
+			tLoad:   libidxmgmt.LoadModeDisabled,
+			ilmLoad: libidxmgmt.LoadModeForce,
+			pCt:     4, aCt: 3,
+		},
+		"LoadModeForceWhenDisabled": {
+			cfg:     common.MapStr{"setup.template.enabled": false, "apm-server.ilm.enabled": false},
+			tLoad:   libidxmgmt.LoadModeForce,
+			ilmLoad: libidxmgmt.LoadModeForce,
+			tCt:     5, tWithILMCt: 4, pCt: 4, aCt: 3,
+		},
+	}
+
+	var testCasesILMNotSupportedByES = map[string]testCase{
+		"DisabledAndUnsupportedILM": {
+			version: "6.2.0",
+			cfg:     common.MapStr{"apm-server.ilm.enabled": false},
+			tLoad:   libidxmgmt.LoadModeEnabled,
+			ilmLoad: libidxmgmt.LoadModeEnabled,
+			tCt:     5,
+		},
+		"AutoAndUnsupportedILM": {
+			version: "6.2.0",
+			cfg:     common.MapStr{"apm-server.ilm.enabled": "auto"},
+			tLoad:   libidxmgmt.LoadModeEnabled,
+			ilmLoad: libidxmgmt.LoadModeEnabled,
+			tCt:     5,
+		},
+		"EnabledAndUnsupportedILM": {
+			version: "6.2.0",
+			cfg:     common.MapStr{"apm-server.ilm.enabled": true},
+			tLoad:   libidxmgmt.LoadModeEnabled,
+			ilmLoad: libidxmgmt.LoadModeEnabled,
+			tCt:     5,
+		},
+		"ForceModeWhenUnsupportedILM": {
+			version: "6.2.0",
+			cfg:     common.MapStr{"apm-server.ilm.enabled": true},
+			tLoad:   libidxmgmt.LoadModeForce,
+			ilmLoad: libidxmgmt.LoadModeForce,
+			tCt:     5,
+		},
+	}
+	var testCasesILMNotSupportedByIndexSettings = map[string]testCase{
+		"ESIndexConfigured": {
+			cfg: common.MapStr{
+				"apm-server.ilm.enabled":     "auto",
+				"setup.template.name":        "custom",
+				"setup.template.pattern":     "custom",
+				"output.elasticsearch.index": "custom"},
+			tLoad:   libidxmgmt.LoadModeEnabled,
+			ilmLoad: libidxmgmt.LoadModeEnabled,
+			tCt:     5,
+		},
+		"ESIndicesConfigured": {
+			cfg: common.MapStr{
+				"apm-server.ilm.enabled": "auto",
+				"setup.template.name":    "custom",
+				"setup.template.pattern": "custom",
+				"output.elasticsearch.indices": []common.MapStr{{
+					"index": "apm-custom-%{[observer.version]}-metric",
+					"when": map[string]interface{}{
+						"contains": map[string]interface{}{"processor.event": "metric"}}}}},
+			tLoad:   libidxmgmt.LoadModeEnabled,
+			ilmLoad: libidxmgmt.LoadModeEnabled,
+			tCt:     5,
+		},
+	}
+
+	for _, test := range []map[string]testCase{
+		testCasesEnabled,
+		testCasesLoadModeUnset,
+		testCasesLoadModeOverwrite,
+		testCasesLoadModeForce,
+		testCasesILMNotSupportedByES,
+		testCasesILMNotSupportedByIndexSettings,
+	} {
+		for name, tc := range test {
+			t.Run(name, func(t *testing.T) {
+				version := tc.version
+				if version == "" {
+					version = "7.2.0"
+				}
+
+				ch := newMockClientHandler(version)
+				m := defaultSupporter(t, tc.cfg).Manager(ch, libidxmgmt.BeatsAssets(fields))
+				idxManager := m.(*manager)
+				err := idxManager.Setup(tc.tLoad, tc.ilmLoad)
+				if tc.err == nil {
+					require.NoError(t, err)
+				} else {
+					require.Error(t, err)
+					assert.Equal(t, ErrILMNotSupported, err)
+				}
+
+				assert.Equal(t, tc.pCt, len(ch.policies), "policies")
+				assert.Equal(t, tc.aCt, len(ch.aliases), "aliases")
+				require.Equal(t, tc.tCt, ch.tmplLoadCt, "templates")
+				assert.Equal(t, tc.tWithILMCt, ch.tmplLoadWithILMCt, "ILM templates")
+				if tc.tCt > 0 {
+					assert.Equal(t, 1, ch.tmplLoadCt-ch.tmplOrderILMCt, "order template")
+					assert.Equal(t, tc.tCt-1, ch.tmplOrderILMCt, "order ILM template")
+				}
+			})
+		}
+	}
+}
+
+//TODO: test error logs when ILM not supported
+
+type mockClientHandler struct {
+	aliases, policies []string
+
+	tmplLoadCt, tmplLoadWithILMCt int
+	tmplOrderILMCt                int
+	tmplForce                     bool
+
+	esVersion *common.Version
+}
+
+var existingILM = fmt.Sprintf("apm-%s-transaction", info.Version)
+var ErrILMNotSupported = errors.New("ILM not supported")
+var esMinILMVersion = common.MustNewVersion("6.6.0")
+
+func newMockClientHandler(esVersion string) *mockClientHandler {
+	return &mockClientHandler{esVersion: common.MustNewVersion(esVersion)}
+}
+
+func (h *mockClientHandler) Load(config template.TemplateConfig, _ beat.Info, fields []byte, migration bool) error {
+	h.tmplLoadCt++
+	if config.Settings.Index != nil && config.Settings.Index["lifecycle.name"] != nil {
+		h.tmplLoadWithILMCt++
+		if len(fields) > 0 {
+			return errors.New("fields should be empty")
+		}
+	}
+	if config.Order == 2 {
+		h.tmplOrderILMCt++
+	}
+	if config.Order != 1 && config.Order != 2 {
+		return errors.New("unexpected template order")
+	}
+	h.tmplForce = config.Overwrite
+	return nil
+}
+
+func (h *mockClientHandler) CheckILMEnabled(mode libilm.Mode) (bool, error) {
+	if mode == libilm.ModeDisabled {
+		return false, nil
+	}
+	avail := !h.esVersion.LessThan(esMinILMVersion)
+	if avail {
+		return true, nil
+	}
+
+	if mode == libilm.ModeAuto {
+		return false, nil
+	}
+	return false, ErrILMNotSupported
+}
+
+func (h *mockClientHandler) HasAlias(name string) (bool, error) {
+	return name == existingILM, nil
+}
+
+func (h *mockClientHandler) CreateAlias(alias libilm.Alias) error {
+	h.aliases = append(h.aliases, alias.Name)
+	return nil
+}
+
+func (h *mockClientHandler) HasILMPolicy(name string) (bool, error) {
+	return name == existingILM, nil
+}
+
+func (h *mockClientHandler) CreateILMPolicy(policy libilm.Policy) error {
+	h.policies = append(h.policies, policy.Name)
+	return nil
+}

--- a/idxmgmt/supporter.go
+++ b/idxmgmt/supporter.go
@@ -20,14 +20,19 @@ package idxmgmt
 import (
 	"fmt"
 
-	"github.com/elastic/apm-server/idxmgmt/ilm"
+	"github.com/pkg/errors"
+	"go.uber.org/atomic"
+
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	libidxmgmt "github.com/elastic/beats/libbeat/idxmgmt"
+	libilm "github.com/elastic/beats/libbeat/idxmgmt/ilm"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs"
 	"github.com/elastic/beats/libbeat/outputs/outil"
 	"github.com/elastic/beats/libbeat/template"
+
+	"github.com/elastic/apm-server/idxmgmt/ilm"
 )
 
 // The index management supporter holds information around ES template, ILM strategy and index setup for Elasticsearch.
@@ -42,6 +47,8 @@ import (
 // - the default index and indices that are set.
 //
 
+const esKey = "elasticsearch"
+
 type supporter struct {
 	log            *logp.Logger
 	info           beat.Info
@@ -49,24 +56,70 @@ type supporter struct {
 	ilmConfig      ilm.Config
 	esIdxCfg       *esIndexConfig
 	migration      bool
+	ilmSupporters  []libilm.Supporter
+
+	st indexState
 }
 
-type selector outil.Selector
+type indexState struct {
+	ilmEnabled atomic.Bool
+	isSet      atomic.Bool
+}
+
+type defaultIndexSelector outil.Selector
+
+type ilmIndexSelector struct {
+	defaultSel defaultIndexSelector
+	ilmSel     outil.Selector
+	st         *indexState
+}
 
 func newSupporter(
 	log *logp.Logger,
 	info beat.Info,
 	templateConfig template.TemplateConfig,
 	ilmConfig ilm.Config,
-	esOutputConfig *esIndexConfig,
+	outConfig common.ConfigNamespace,
 ) (*supporter, error) {
+
+	var (
+		esIdxCfg *esIndexConfig
+		mode     = ilmConfig.Mode
+		st       = indexState{}
+	)
+
+	if outConfig.Name() == esKey {
+		if err := outConfig.Config().Unpack(&esIdxCfg); err != nil {
+			return nil, fmt.Errorf("unpacking output elasticsearch index config fails: %+v", err)
+		}
+
+		if err := checkTemplateESSettings(templateConfig, esIdxCfg); err != nil {
+			return nil, err
+		}
+	}
+
+	if outConfig.Name() != esKey ||
+		ilmConfig.Mode == libilm.ModeDisabled ||
+		ilmConfig.Mode == libilm.ModeAuto && esIdxCfg.customized() {
+
+		mode = libilm.ModeDisabled
+		st.isSet.CAS(false, true)
+	}
+
+	ilmSupporters, err := ilmSupporters(log, mode, info)
+	if err != nil {
+		return nil, err
+	}
+
 	return &supporter{
 		log:            log,
 		info:           info,
 		templateConfig: templateConfig,
 		ilmConfig:      ilmConfig,
-		esIdxCfg:       esOutputConfig,
+		esIdxCfg:       esIdxCfg,
 		migration:      false,
+		st:             st,
+		ilmSupporters:  ilmSupporters,
 	}, nil
 }
 
@@ -78,6 +131,7 @@ func (s *supporter) Manager(
 	clientHandler libidxmgmt.ClientHandler,
 	assets libidxmgmt.Asseter,
 ) libidxmgmt.Manager {
+	s.setIlmState(clientHandler)
 	return &manager{
 		supporter:     s,
 		clientHandler: clientHandler,
@@ -86,23 +140,31 @@ func (s *supporter) Manager(
 }
 
 func (s *supporter) BuildSelector(cfg *common.Config) (outputs.IndexSelector, error) {
-	if s.ilmConfig.Enabled() {
-		idcs, err := ilmIndices(cfg)
-		return s.buildSelector(idcs, err)
-	}
-	return s.buildSelector(indices(cfg))
-}
-
-func (s selector) Select(evt *beat.Event) (string, error) {
-	if idx := getEventCustomIndex(evt); idx != "" {
-		return idx, nil
-	}
-	return outil.Selector(s).Select(evt)
-}
-
-func (s *supporter) buildSelector(cfg *common.Config, err error) (outputs.IndexSelector, error) {
+	sel, err := s.buildSelector(indices(cfg))
 	if err != nil {
 		return nil, err
+	}
+	ordIdxSel := defaultIndexSelector(sel)
+
+	if s.st.isSet.Load() && !s.st.ilmEnabled.Load() {
+		return ordIdxSel, nil
+	}
+
+	ilmSel, err := s.buildSelector(ilmIndices(cfg))
+	if err != nil {
+		return nil, err
+	}
+
+	return &ilmIndexSelector{
+		defaultSel: ordIdxSel,
+		ilmSel:     ilmSel,
+		st:         &s.st,
+	}, nil
+}
+
+func (s *supporter) buildSelector(cfg *common.Config, err error) (outil.Selector, error) {
+	if err != nil {
+		return outil.Selector{}, err
 	}
 
 	buildSettings := outil.Settings{
@@ -111,12 +173,50 @@ func (s *supporter) buildSelector(cfg *common.Config, err error) (outputs.IndexS
 		EnableSingleOnly: true,
 		FailEmpty:        true,
 	}
-	indexSel, err := outil.BuildSelectorFromConfig(cfg, buildSettings)
-	if err != nil {
-		return nil, err
+	return outil.BuildSelectorFromConfig(cfg, buildSettings)
+}
+
+func (s *supporter) setIlmState(handler libidxmgmt.ClientHandler) {
+	stSet := func() { s.st.isSet.CAS(false, true) }
+
+	if s.st.isSet.Load() {
+		return
+	}
+	if s.st.ilmEnabled.Load() {
+		stSet()
+		return
 	}
 
-	return selector(indexSel), nil
+	for _, ilmSupporter := range s.ilmSupporters {
+		if enabled, err := ilmSupporter.Manager(handler).Enabled(); !enabled || err != nil {
+			stSet()
+			return
+		}
+	}
+
+	s.st.ilmEnabled.CAS(false, true)
+	stSet()
+}
+
+func (s *ilmIndexSelector) Select(evt *beat.Event) (string, error) {
+	if idx := getEventCustomIndex(evt); idx != "" {
+		return idx, nil
+	}
+	if !s.st.isSet.Load() {
+		return "", errors.New("setup not finished")
+	}
+
+	if s.st.ilmEnabled.Load() {
+		return s.ilmSel.Select(evt)
+	}
+	return s.defaultSel.Select(evt)
+}
+
+func (s defaultIndexSelector) Select(evt *beat.Event) (string, error) {
+	if idx := getEventCustomIndex(evt); idx != "" {
+		return idx, nil
+	}
+	return outil.Selector(s).Select(evt)
 }
 
 // this logic is copied and aligned with handling in beats.
@@ -142,4 +242,40 @@ func getEventCustomIndex(evt *beat.Event) string {
 	}
 
 	return ""
+}
+
+func checkTemplateESSettings(tmplCfg template.TemplateConfig, esIndexCfg *esIndexConfig) error {
+	if !tmplCfg.Enabled || esIndexCfg == nil {
+		return nil
+	}
+
+	if esIndexCfg.Index != "" && (tmplCfg.Name == "" || tmplCfg.Pattern == "") {
+		return errors.New("`setup.template.name` and `setup.template.pattern` have to be set if `output.elasticsearch` index name is modified")
+	}
+	return nil
+}
+
+func ilmSupporters(log *logp.Logger, mode libilm.Mode, info beat.Info) ([]libilm.Supporter, error) {
+	var (
+		ilmSupporters []libilm.Supporter
+		err           error
+		ilmCfg        *common.Config
+	)
+
+	for event, index := range eventIdxNames(false) {
+		if ilmCfg, err = common.NewConfigFrom(common.MapStr{
+			"enabled":     ilm.ModeString(mode),
+			"event":       event,
+			"policy_name": idxStr(event, ""),
+			"alias_name":  index},
+		); err != nil {
+			return nil, errors.Wrapf(err, "error creating index-management config")
+		}
+		ilmSupporter, err := ilm.MakeDefaultSupporter(log, info, ilmCfg)
+		if err != nil {
+			return nil, err
+		}
+		ilmSupporters = append(ilmSupporters, ilmSupporter)
+	}
+	return ilmSupporters, nil
 }

--- a/idxmgmt/supporter_factory.go
+++ b/idxmgmt/supporter_factory.go
@@ -18,7 +18,6 @@
 package idxmgmt
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/elastic/beats/libbeat/beat"
@@ -56,33 +55,12 @@ func MakeDefaultSupporter(log *logp.Logger, info beat.Info, configRoot *common.C
 		return nil, fmt.Errorf("unpacking template config fails: %+v", err)
 	}
 
-	var esIdxCfg *esIndexConfig
-	if cfg.Output.Name() == "elasticsearch" {
-		if err := cfg.Output.Config().Unpack(&esIdxCfg); err != nil {
-			return nil, fmt.Errorf("unpacking output elasticsearch index config fails: %+v", err)
-		}
-		if err := checkTemplateESSettings(tmplConfig, esIdxCfg); err != nil {
-			return nil, err
-		}
-	}
-
 	if log == nil {
 		log = logp.NewLogger(logName)
 	} else {
 		log = log.Named(logName)
 	}
-	return newSupporter(log, info, tmplConfig, ilmConfig, esIdxCfg)
-}
-
-func checkTemplateESSettings(tmplCfg template.TemplateConfig, esIndexCfg *esIndexConfig) error {
-	if !tmplCfg.Enabled {
-		return nil
-	}
-
-	if esIndexCfg.Index != "" && (tmplCfg.Name == "" || tmplCfg.Pattern == "") {
-		return errors.New("`setup.template.name` and `setup.template.pattern` have to be set if `output.elasticsearch` index name is modified")
-	}
-	return nil
+	return newSupporter(log, info, tmplConfig, ilmConfig, cfg.Output)
 }
 
 func unpackTemplateConfig(cfg *common.Config) (template.TemplateConfig, error) {

--- a/idxmgmt/supporter_factory_test.go
+++ b/idxmgmt/supporter_factory_test.go
@@ -1,0 +1,80 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package idxmgmt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+)
+
+func TestMakeDefaultSupporter(t *testing.T) {
+	info := beat.Info{}
+
+	buildSupporter := func(c map[string]interface{}) (*supporter, error) {
+		cfg, err := common.NewConfigFrom(c)
+		require.NoError(t, err)
+		s, err := MakeDefaultSupporter(nil, info, cfg)
+		if s != nil {
+			return s.(*supporter), err
+		}
+		return nil, err
+	}
+
+	t.Run("StdSupporter", func(t *testing.T) {
+		s, err := buildSupporter(map[string]interface{}{
+			"apm-server.ilm.enabled":       "auto",
+			"setup.template.enabled":       "true",
+			"output.elasticsearch.enabled": "true",
+		})
+		require.NoError(t, err)
+
+		assert.True(t, s.Enabled())
+		assert.NotNil(t, s.log)
+		assert.True(t, s.templateConfig.Enabled)
+		assert.True(t, s.ilmConfig.Enabled())
+		assert.Equal(t, &esIndexConfig{}, s.esIdxCfg)
+	})
+
+	t.Run("ILMDisabled", func(t *testing.T) {
+		s, err := buildSupporter(map[string]interface{}{
+			"apm-server.ilm.enabled":       "false",
+			"setup.template.enabled":       "true",
+			"setup.template.name":          "custom",
+			"setup.template.pattern":       "custom",
+			"output.elasticsearch.index":   "custom-index",
+			"output.elasticsearch.enabled": "true",
+		})
+		require.NoError(t, err)
+		assert.False(t, s.ilmConfig.Enabled())
+	})
+	t.Run("SetupTemplateConfigConflicting", func(t *testing.T) {
+		s, err := buildSupporter(map[string]interface{}{
+			"output.elasticsearch.index": "custom-index",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "`setup.template.name` and `setup.template.pattern` have to be set ")
+		assert.Nil(t, s)
+
+	})
+}

--- a/idxmgmt/supporter_test.go
+++ b/idxmgmt/supporter_test.go
@@ -110,6 +110,7 @@ func TestIndexSupport_BuildSelector(t *testing.T) {
 		meta     common.MapStr
 		noIlm    string
 		withIlm  string
+		ilmAuto  string
 		expected string
 		cfg      common.MapStr
 		fields   common.MapStr
@@ -156,27 +157,29 @@ func TestIndexSupport_BuildSelector(t *testing.T) {
 			withIlm: "apm-7.0.0-meta", //meta overwrites ilm
 			fields:  common.MapStr{"processor.event": "span"},
 			meta:    common.MapStr{"alias": "apm-7.0.0-meta", "index": "test-123"},
-			cfg:     common.MapStr{"index": "apm-customized"},
+			cfg:     common.MapStr{"output.elasticsearch.index": "apm-customized"},
 		},
-		"MateInformationIndex": {
+		"MetaInformationIndex": {
 			noIlm:   fmt.Sprintf("apm-7.0.0-%s", day),
 			withIlm: fmt.Sprintf("apm-7.0.0-%s", day), //meta overwrites ilm
 			fields:  common.MapStr{"processor.event": "span"},
 			meta:    common.MapStr{"index": "apm-7.0.0"},
-			cfg:     common.MapStr{"index": "apm-customized"},
+			cfg:     common.MapStr{"output.elasticsearch.index": "apm-customized"},
 		},
 		"CustomIndex": {
 			noIlm:   "apm-customized",
 			withIlm: "apm-7.0.0-metric", //custom index ignored when ilm enabled
+			ilmAuto: "apm-customized",   //custom respected for ilm auto
 			fields:  common.MapStr{"processor.event": "metric"},
-			cfg:     common.MapStr{"index": "apm-customized"},
+			cfg:     common.MapStr{"output.elasticsearch.index": "apm-customized"},
 		},
-		"differentCustomIndices": {
+		"DifferentCustomIndices": {
 			noIlm:   fmt.Sprintf("apm-7.0.0-%s", day),
-			withIlm: "apm-7.0.0-metric", //custom index ignored when ilm enabled
+			withIlm: "apm-7.0.0-metric",               //custom index ignored when ilm enabled
+			ilmAuto: fmt.Sprintf("apm-7.0.0-%s", day), //custom respected for ilm auto
 			fields:  common.MapStr{"processor.event": "metric"},
 			cfg: common.MapStr{
-				"indices": []common.MapStr{{
+				"output.elasticsearch.indices": []common.MapStr{{
 					"index": "apm-custom-%{[observer.version]}-metric",
 					"when": map[string]interface{}{
 						"contains": map[string]interface{}{"processor.event": "error"}}}},
@@ -184,10 +187,11 @@ func TestIndexSupport_BuildSelector(t *testing.T) {
 		},
 		"CustomIndices": {
 			noIlm:   "apm-custom-7.0.0-metric",
-			withIlm: "apm-7.0.0-metric", //custom index ignored when ilm enabled
+			withIlm: "apm-7.0.0-metric",        //custom index ignored when ilm enabled
+			ilmAuto: "apm-custom-7.0.0-metric", //custom respected for ilm auto
 			fields:  common.MapStr{"processor.event": "metric"},
 			cfg: common.MapStr{
-				"indices": []common.MapStr{{
+				"output.elasticsearch.indices": []common.MapStr{{
 					"index": "apm-custom-%{[observer.version]}-metric",
 					"when": map[string]interface{}{
 						"contains": map[string]interface{}{"processor.event": "metric"}}}},
@@ -201,12 +205,11 @@ func TestIndexSupport_BuildSelector(t *testing.T) {
 	checkIndexSelector := func(t *testing.T, name string, test testdata, handler libidxmgmt.ClientHandler) {
 		t.Run(name, func(t *testing.T) {
 			// create initialized supporter and selector
+
 			supporter := defaultSupporter(t, test.cfg)
 			supporter.setIlmState(handler)
 
-			cfg, err := common.NewConfigFrom(test.cfg)
-			require.NoError(t, err)
-			s, err := supporter.BuildSelector(cfg)
+			s, err := supporter.BuildSelector(nil)
 			require.NoError(t, err)
 
 			// test selected index
@@ -224,27 +227,30 @@ func TestIndexSupport_BuildSelector(t *testing.T) {
 		//ilm true and supported
 		test.cfg["apm-server.ilm.enabled"] = true
 		test.expected = test.withIlm
-		checkIndexSelector(t, name, test, ilmSupportedHandler)
+		checkIndexSelector(t, "ILMTrueSupported"+name, test, ilmSupportedHandler)
 
 		//ilm true but unsupported
 		test.cfg["apm-server.ilm.enabled"] = true
 		test.expected = test.noIlm
-		checkIndexSelector(t, name, test, ilmUnsupportedHandler)
+		checkIndexSelector(t, "ILMTrueUnsupported"+name, test, ilmUnsupportedHandler)
 
 		//ilm=false
 		test.cfg["apm-server.ilm.enabled"] = false
 		test.expected = test.noIlm
-		checkIndexSelector(t, name, test, ilmSupportedHandler)
+		checkIndexSelector(t, "ILMFalse"+name, test, ilmSupportedHandler)
 
 		//ilm=auto and supported
 		test.cfg["apm-server.ilm.enabled"] = "auto"
 		test.expected = test.withIlm
-		checkIndexSelector(t, name, test, ilmSupportedHandler)
+		if test.ilmAuto != "" {
+			test.expected = test.ilmAuto
+		}
+		checkIndexSelector(t, "ILMAutoSupported"+name, test, ilmSupportedHandler)
 
 		//ilm auto but unsupported
 		test.cfg["apm-server.ilm.enabled"] = "auto"
 		test.expected = test.noIlm
-		checkIndexSelector(t, name, test, ilmUnsupportedHandler)
+		checkIndexSelector(t, "ILMAutoUnsupported"+name, test, ilmUnsupportedHandler)
 	}
 
 	t.Run("uninitializedSupporter", func(t *testing.T) {

--- a/idxmgmt/supporter_test.go
+++ b/idxmgmt/supporter_test.go
@@ -18,7 +18,6 @@
 package idxmgmt
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -29,24 +28,9 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	libidxmgmt "github.com/elastic/beats/libbeat/idxmgmt"
-	libilm "github.com/elastic/beats/libbeat/idxmgmt/ilm"
-	"github.com/elastic/beats/libbeat/template"
 )
 
-type mockClientHandler struct {
-	aliases, policies []string
-
-	tmplLoadCt, tmplLoadWithILMCt int
-	tmplOrderILMCt                int
-	tmplForce                     bool
-
-	ilmSupported bool
-}
-
-var (
-	info          = beat.Info{Beat: "testbeat", Version: "1.1.0"}
-	ilmEnabledKey = "apm-server.ilm.enabled"
-)
+var info = beat.Info{Beat: "testbeat", Version: "1.1.0"}
 
 func defaultSupporter(t *testing.T, c common.MapStr) libidxmgmt.Supporter {
 	cfg, err := common.NewConfigFrom(c)
@@ -64,13 +48,25 @@ func TestIndexSupport_Enabled(t *testing.T) {
 		"template default": {
 			expected: true,
 		},
-		"template disabled": {
-			expected: false,
-			cfg:      common.MapStr{"setup.template.enabled": false},
-		},
 		"template enabled": {
 			expected: true,
 			cfg:      common.MapStr{"setup.template.enabled": true},
+		},
+		"template and ilm disabled": {
+			expected: false,
+			cfg:      common.MapStr{"setup.template.enabled": false, "apm-server.ilm.enabled": false},
+		},
+		"ilm enabled": {
+			expected: true,
+			cfg:      common.MapStr{"setup.template.enabled": false, "apm-server.ilm.enabled": true},
+		},
+		"ilm auto": {
+			expected: true,
+			cfg:      common.MapStr{"setup.template.enabled": false, "apm-server.ilm.enabled": "auto"},
+		},
+		"ilm default": {
+			expected: true,
+			cfg:      common.MapStr{"setup.template.enabled": false},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -192,244 +188,16 @@ func TestIndexSupport_BuildSelector(t *testing.T) {
 	}
 
 	for name, test := range cases {
-		//ilm=false
-		test.expected = test.noIlm
-		checkIndexSelector(t, name, test)
-
 		//ilm=true
 		test.expected = test.withIlm
+		checkIndexSelector(t, name, test)
+
+		//ilm=false
+		test.expected = test.noIlm
 		if test.cfg == nil {
 			test.cfg = common.MapStr{}
 		}
-		test.cfg[ilmEnabledKey] = true
+		test.cfg["apm-server.ilm.enabled"] = false
 		checkIndexSelector(t, name, test)
 	}
-}
-
-func TestIndexManager_VerifySetup(t *testing.T) {
-	for name, setup := range map[string]struct {
-		tmpl, ilm         bool
-		loadTmpl, loadILM libidxmgmt.LoadMode
-		ok                bool
-		warn              string
-	}{
-		"load template with ilm without loading ilm": {
-			ilm: true, tmpl: true,
-			loadTmpl: libidxmgmt.LoadModeEnabled, loadILM: libidxmgmt.LoadModeDisabled,
-			warn: "whithout loading ILM policy and alias",
-		},
-		"load ilm without template": {
-			ilm: true, loadILM: libidxmgmt.LoadModeEnabled,
-			warn: "without loading template is not recommended",
-		},
-		"template disabled but loading enabled": {
-			loadTmpl: libidxmgmt.LoadModeEnabled,
-			warn:     "loading not enabled",
-		},
-		"ilm disabled but loading enabled": {
-			loadILM: libidxmgmt.LoadModeEnabled, tmpl: true,
-			warn: "loading not enabled",
-		},
-		"ilm enabled but loading disabled": {
-			ilm: true, loadILM: libidxmgmt.LoadModeDisabled,
-			warn: "loading not enabled",
-		},
-		"template enabled but loading disabled": {
-			tmpl: true, loadTmpl: libidxmgmt.LoadModeDisabled,
-			warn: "loading not enabled",
-		},
-		"everything enabled": {
-			tmpl: true, loadTmpl: libidxmgmt.LoadModeEnabled, ilm: true, loadILM: libidxmgmt.LoadModeEnabled,
-			ok: true,
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			cfg, err := common.NewConfigFrom(common.MapStr{
-				"apm-server.ilm.enabled": setup.ilm,
-				"setup.template.enabled": setup.tmpl,
-			})
-			require.NoError(t, err)
-			support, err := MakeDefaultSupporter(nil, beat.Info{}, cfg)
-			require.NoError(t, err)
-			manager := support.Manager(newMockClientHandler(true), nil)
-			ok, warn := manager.VerifySetup(setup.loadTmpl, setup.loadILM)
-			assert.Equal(t, setup.ok, ok)
-			assert.Contains(t, warn, setup.warn)
-		})
-	}
-}
-
-func TestManager_Setup(t *testing.T) {
-	fields := []byte("apm-server fields")
-	errIlmNotSupported := "ILM not supported"
-	for name, test := range map[string]struct {
-		cfg                       common.MapStr
-		tLoad, ilmLoad            libidxmgmt.LoadMode
-		tCt, tWithILMCt, pCt, aCt int
-		ilmSupported              bool
-		errMsg                    string
-	}{
-		"default load template without ilm": {
-			ilmSupported: true,
-			cfg:          nil,
-			tLoad:        libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
-			tCt: 5,
-		},
-		"load template without ilm": {
-			ilmSupported: true,
-			tLoad:        libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
-			tCt: 5,
-		},
-		"no dependency on ilm support": {
-			ilmSupported: false,
-			tLoad:        libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
-			tCt: 5,
-		},
-		"load template with ilm settings": {
-			ilmSupported: true,
-			cfg:          common.MapStr{"apm-server.ilm.enabled": true},
-			tLoad:        libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeDisabled,
-			tCt: 5, tWithILMCt: 4,
-		},
-		"load template with ilm settings when ilm is not supported": {
-			ilmSupported: false,
-			cfg:          common.MapStr{"apm-server.ilm.enabled": true},
-			tLoad:        libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeDisabled,
-			errMsg: errIlmNotSupported,
-			tCt:    0, tWithILMCt: 0,
-		},
-		"load template disabled": {
-			ilmSupported: true,
-			cfg:          nil,
-			tLoad:        libidxmgmt.LoadModeDisabled,
-		},
-		"template disabled": {
-			ilmSupported: true,
-			cfg:          common.MapStr{"setup.template.enabled": false},
-			tLoad:        libidxmgmt.LoadModeEnabled,
-		},
-		"force load template": {
-			ilmSupported: true,
-			cfg:          nil,
-			tLoad:        libidxmgmt.LoadModeForce,
-			tCt:          5,
-		},
-		"template disabled ilm enabled loading disabled": {
-			ilmSupported: true,
-			cfg:          common.MapStr{"apm-server.ilm.enabled": true, "setup.template.enabled": false},
-			ilmLoad:      libidxmgmt.LoadModeUnset,
-		},
-		"do not load template load ilm": {
-			ilmSupported: true,
-			cfg:          common.MapStr{"apm-server.ilm.enabled": true, "setup.template.enabled": false},
-			ilmLoad:      libidxmgmt.LoadModeEnabled,
-			pCt:          3, aCt: 3,
-		},
-		"try loading ilm when ilm not supported": {
-			ilmSupported: false,
-			cfg:          common.MapStr{"apm-server.ilm.enabled": true, "setup.template.enabled": false},
-			ilmLoad:      libidxmgmt.LoadModeEnabled,
-			errMsg:       errIlmNotSupported,
-			tCt:          0, tWithILMCt: 0,
-		},
-		"do not load template force load ilm": {
-			ilmSupported: true,
-			cfg:          common.MapStr{"apm-server.ilm.enabled": true},
-			tLoad:        libidxmgmt.LoadModeDisabled, ilmLoad: libidxmgmt.LoadModeForce,
-			pCt: 4, aCt: 3,
-		},
-		"load template and ilm": {
-			ilmSupported: true,
-			cfg:          common.MapStr{"apm-server.ilm.enabled": true},
-			tLoad:        libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
-			tCt: 5, tWithILMCt: 4, pCt: 3, aCt: 3,
-		},
-		"try loading template and ilm when ilm is not supported": {
-			ilmSupported: false,
-			cfg:          common.MapStr{"apm-server.ilm.enabled": true},
-			tLoad:        libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
-			errMsg: errIlmNotSupported,
-			tCt:    0, tWithILMCt: 0,
-		},
-		"force load template force load ilm": {
-			ilmSupported: true,
-			cfg:          common.MapStr{"apm-server.ilm.enabled": true},
-			tLoad:        libidxmgmt.LoadModeForce, ilmLoad: libidxmgmt.LoadModeForce,
-			tCt: 5, tWithILMCt: 4, pCt: 4, aCt: 3,
-		},
-	} {
-
-		t.Run(name, func(t *testing.T) {
-			ch := newMockClientHandler(test.ilmSupported)
-			m := defaultSupporter(t, test.cfg).Manager(ch, libidxmgmt.BeatsAssets(fields))
-			idxManager := m.(*manager)
-			err := idxManager.Setup(test.tLoad, test.ilmLoad)
-			if test.errMsg == "" {
-				require.NoError(t, err)
-			} else {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), test.errMsg)
-			}
-
-			assert.Equal(t, test.pCt, len(ch.policies))
-			assert.Equal(t, test.aCt, len(ch.aliases))
-			require.Equal(t, test.tCt, ch.tmplLoadCt)
-			assert.Equal(t, test.tWithILMCt, ch.tmplLoadWithILMCt)
-			if test.tCt > 0 {
-				assert.Equal(t, 1, ch.tmplLoadCt-ch.tmplOrderILMCt)
-				assert.Equal(t, test.tCt-1, ch.tmplOrderILMCt)
-			}
-		})
-	}
-
-}
-
-var existingILM = fmt.Sprintf("apm-%s-transaction", info.Version)
-
-func newMockClientHandler(ilmSupported bool) *mockClientHandler {
-	return &mockClientHandler{ilmSupported: ilmSupported}
-}
-
-func (h *mockClientHandler) Load(config template.TemplateConfig, _ beat.Info, fields []byte, migration bool) error {
-	h.tmplLoadCt++
-	if config.Settings.Index != nil && config.Settings.Index["lifecycle.name"] != nil {
-		h.tmplLoadWithILMCt++
-		if len(fields) > 0 {
-			return errors.New("fields should be empty")
-		}
-	}
-	if config.Order == 2 {
-		h.tmplOrderILMCt++
-	}
-	if config.Order != 1 && config.Order != 2 {
-		return errors.New("unexpected template order")
-	}
-	h.tmplForce = config.Overwrite
-	return nil
-}
-
-func (h *mockClientHandler) CheckILMEnabled(m libilm.Mode) (bool, error) {
-	enabled := m == libilm.ModeEnabled
-	if h.ilmSupported {
-		return enabled, nil
-	}
-	return enabled, errors.New("ILM not supported")
-}
-
-func (h *mockClientHandler) HasAlias(name string) (bool, error) {
-	return name == existingILM, nil
-}
-
-func (h *mockClientHandler) CreateAlias(alias libilm.Alias) error {
-	h.aliases = append(h.aliases, alias.Name)
-	return nil
-}
-
-func (h *mockClientHandler) HasILMPolicy(name string) (bool, error) {
-	return name == existingILM, nil
-}
-
-func (h *mockClientHandler) CreateILMPolicy(policy libilm.Policy) error {
-	h.policies = append(h.policies, policy.Name)
-	return nil
 }

--- a/idxmgmt/supporter_test.go
+++ b/idxmgmt/supporter_test.go
@@ -41,10 +41,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	libidxmgmt "github.com/elastic/beats/libbeat/idxmgmt"
-	"github.com/stretchr/testify/require"
 )
 
 var (

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -29,12 +29,12 @@ class BaseTest(TestCase):
         cls.index_name_pattern = "apm-*"
 
         cls.index_onboarding = "apm-{}-onboarding-{}".format(cls.apm_version, cls.day)
-        cls.index_error = "apm-{}-error-2017.05.09".format(cls.apm_version)
-        cls.index_rum_error = "apm-{}-error-2017.12.08".format(cls.apm_version)
-        cls.index_transaction = "apm-{}-transaction-2017.05.30".format(cls.apm_version)
-        cls.index_span = "apm-{}-span-2017.05.30".format(cls.apm_version)
-        cls.index_rum_span = "apm-{}-span-2017.12.08".format(cls.apm_version)
-        cls.index_metric = "apm-{}-metric-2017.05.30".format(cls.apm_version)
+        cls.index_error = "apm-{}-error".format(cls.apm_version)
+        cls.index_rum_error = "apm-{}-error".format(cls.apm_version)
+        cls.index_transaction = "apm-{}-transaction".format(cls.apm_version)
+        cls.index_span = "apm-{}-span".format(cls.apm_version)
+        cls.index_rum_span = "apm-{}-span".format(cls.apm_version)
+        cls.index_metric = "apm-{}-metric".format(cls.apm_version)
         cls.index_smap = "apm-{}-sourcemap".format(cls.apm_version)
         cls.indices = [cls.index_onboarding, cls.index_error,
                        cls.index_transaction, cls.index_span, cls.index_metric, cls.index_smap]

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -64,6 +64,9 @@ class BaseTest(TestCase):
     def get_event_payload(self, name="events.ndjson"):
         return self.get_payload(name)
 
+    def ilm_index(self, index):
+        return "{}-000001".format(index)
+
 
 class ServerSetUpBaseTest(BaseTest):
     host = "http://localhost:8200"
@@ -380,6 +383,15 @@ def get_elasticsearch_url():
 
 
 class SubCommandTest(ServerSetUpBaseTest):
+
+    def config(self):
+        cfg = super(SubCommandTest, self).config()
+        cfg.update({
+            "elasticsearch_host": get_elasticsearch_url(),
+            "file_enabled": "false",
+        })
+        return cfg
+
     def wait_until_started(self):
         self.apmserver_proc.check_wait()
 

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -27,13 +27,10 @@ class BaseTest(TestCase):
 
         cls.index_name = "apm-{}".format(cls.apm_version)
         cls.index_name_pattern = "apm-*"
-
         cls.index_onboarding = "apm-{}-onboarding-{}".format(cls.apm_version, cls.day)
         cls.index_error = "apm-{}-error".format(cls.apm_version)
-        cls.index_rum_error = "apm-{}-error".format(cls.apm_version)
         cls.index_transaction = "apm-{}-transaction".format(cls.apm_version)
         cls.index_span = "apm-{}-span".format(cls.apm_version)
-        cls.index_rum_span = "apm-{}-span".format(cls.apm_version)
         cls.index_metric = "apm-{}-metric".format(cls.apm_version)
         cls.index_smap = "apm-{}-sourcemap".format(cls.apm_version)
         cls.indices = [cls.index_onboarding, cls.index_error,
@@ -221,7 +218,7 @@ class ElasticTest(ServerBaseTest):
                 self.check_for_no_smap(err["log"])
 
     def check_backend_span_sourcemap(self, count=1):
-        rs = self.es.search(index=self.index_rum_span, params={"rest_total_hits_as_int": "true"})
+        rs = self.es.search(index=self.index_span, params={"rest_total_hits_as_int": "true"})
         assert rs['hits']['total'] == count, "found {} documents, expected {}".format(
             rs['hits']['total'], count)
         for doc in rs['hits']['hits']:
@@ -290,7 +287,7 @@ class ClientSideElasticTest(ClientSideBaseTest, ElasticTest):
         )
 
     def check_rum_error_sourcemap(self, updated, expected_err=None, count=1):
-        rs = self.es.search(index=self.index_rum_error, params={"rest_total_hits_as_int": "true"})
+        rs = self.es.search(index=self.index_error, params={"rest_total_hits_as_int": "true"})
         assert rs['hits']['total'] == count, "found {} documents, expected {}".format(
             rs['hits']['total'], count)
         for doc in rs['hits']['hits']:
@@ -301,7 +298,7 @@ class ClientSideElasticTest(ClientSideBaseTest, ElasticTest):
                 self.check_smap(err["log"], updated, expected_err)
 
     def check_rum_transaction_sourcemap(self, updated, expected_err=None, count=1):
-        rs = self.es.search(index=self.index_rum_span, params={"rest_total_hits_as_int": "true"})
+        rs = self.es.search(index=self.index_span, params={"rest_total_hits_as_int": "true"})
         assert rs['hits']['total'] == count, "found {} documents, expected {}".format(
             rs['hits']['total'], count)
         for doc in rs['hits']['hits']:

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -68,6 +68,10 @@ apm-server:
   mode: {{ mode }}
   {% endif %}
 
+  {% if ilm_enabled %}
+  ilm.enabled: {{ ilm_enabled }}
+  {% endif %}
+
 ############################# Setup ##########################################
 
 {% if override_template %}

--- a/tests/system/test_export.py
+++ b/tests/system/test_export.py
@@ -140,7 +140,8 @@ class TestExportTemplateWithILM(SubCommandTest):
     def start_args(self):
         return {
             "extra_args": ["export", "template", "--dir", self.dir,
-                           "-E", "apm-server.ilm.enabled=true"],
+                           "-E", "apm-server.ilm.enabled=true",
+                           "-E", "output.elasticsearch.enabled=true"],
         }
 
     def setUp(self):
@@ -171,6 +172,7 @@ class TestExportTemplateWithILM(SubCommandTest):
             with open(file) as f:
                 template = json.load(f)
             assert template['index_patterns'] == [name + '*']
+            assert template['settings']['index'] is not None
             assert template['settings']['index']['lifecycle.name'] == name
             assert template['settings']['index']['lifecycle.rollover_alias'] == name
             assert 'mapping' not in template
@@ -185,7 +187,7 @@ class TestExportILMPolicy(SubCommandTest):
     def start_args(self):
         return {
             "extra_args": ["export", "ilm-policy", "--dir", self.dir,
-                           "-E", "apm-server.ilm.enabled=false"],
+                           "-E", "apm-server.ilm.enabled=true"],
         }
 
     def setUp(self):
@@ -209,13 +211,13 @@ class TestExportILMPolicy(SubCommandTest):
             assert "delete" not in policy["policy"]["phases"]
 
 
-class TestExportILMPolicyDisabledTest(TestExportILMPolicy):
+class TestExportILMPolicyILMDisabled(TestExportILMPolicy):
     """
-    Test export ilm-policy regardless of enabled setting
+    Test export ilm-policy independent of ILM enabled state
     """
 
     def start_args(self):
         return {
             "extra_args": ["export", "ilm-policy", "--dir", self.dir,
-                           "-E", "apm-server.ilm.enabled=true"],
+                           "-E", "apm-server.ilm.enabled=false"],
         }

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -611,6 +611,7 @@ class ExperimentalBaseTest(ElasticTest):
         self.load_docs_with_template(self.get_payload_path("experimental.ndjson"),
                                      self.intake_url, 'transaction', 2)
         self.wait_until(lambda: self.log_contains("3 events have been published"), max_timeout=10)
+        self.wait_until(lambda: self.log_contains("Server stopped"), max_timeout=10)
 
         self.assert_no_logged_warnings()
 

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -611,8 +611,7 @@ class ExperimentalBaseTest(ElasticTest):
         self.load_docs_with_template(self.get_payload_path("experimental.ndjson"),
                                      self.intake_url, 'transaction', 2)
         self.wait_until(lambda: self.log_contains("3 events have been published"), max_timeout=10)
-        self.wait_until(lambda: self.log_contains("Server stopped"), max_timeout=10)
-
+        time.sleep(1)
         self.assert_no_logged_warnings()
 
         for idx in [self.index_transaction, self.index_span, self.index_error]:

--- a/tests/system/test_pipelines.py
+++ b/tests/system/test_pipelines.py
@@ -11,14 +11,6 @@ from nose.tools import raises
 class SetupPipelinesDefaultTest(SubCommandTest):
     pipeline_name = "apm_user_agent"
 
-    def config(self):
-        cfg = super(SubCommandTest, self).config()
-        cfg.update({
-            "elasticsearch_host": get_elasticsearch_url(),
-            "file_enabled": "false",
-        })
-        return cfg
-
     def start_args(self):
         return {
             "logging_args": ["-v", "-d", "*"],

--- a/tests/system/test_pipelines.py
+++ b/tests/system/test_pipelines.py
@@ -88,15 +88,12 @@ class PipelineDefaultTest(ElasticTest):
                                      self.intake_url, 'transaction', 3)
 
         entries = self.es.search(index=self.index_transaction)['hits']['hits']
+        ua_found = False
         for e in entries:
             src = e['_source']
-            ua = src['user_agent']
-            id = src['transaction']['id']
-            if id != "4340a8e0df1906ecbfa9":
-                # transaction with id '4340a8e0df1906ecbfa9' has user agent info set
-                assert ua is None
-                continue
-            else:
+            if 'user_agent' in src:
+                ua_found = True
+                ua = src['user_agent']
                 assert ua is not None
                 assert ua["original"] == "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 " \
                                          "(KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36, Mozilla Chrome Edge"
@@ -106,6 +103,7 @@ class PipelineDefaultTest(ElasticTest):
                 assert ua["os"]["version"] == "10.10.5"
                 assert ua["os"]["full"] == "Mac OS X 10.10.5"
                 assert ua["device"]["name"] == "Other"
+        assert ua_found
 
 
 @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
@@ -116,19 +114,18 @@ class PipelineConfigurationNoneTest(ElasticTest):
         self.wait_until(lambda: self.log_contains("Finished index management setup."), max_timeout=5)
         self.load_docs_with_template(self.get_payload_path("transactions.ndjson"),
                                      self.intake_url, 'transaction', 3)
-
+        uaFound = False
         entries = self.es.search(index=self.index_transaction)['hits']['hits']
         for e in entries:
             src = e['_source']
-            ua = src['user_agent']
-            if src['transaction']['id'] != "4340a8e0df1906ecbfa9":
-                # transaction with id '4340a8e0df1906ecbfa9' has user agent info set
-                continue
-            else:
+            if 'user_agent' in src:
+                uaFound = True
+                ua = src['user_agent']
                 assert ua is not None
                 assert ua["original"] == "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 " \
                                          "(KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36, Mozilla Chrome Edge"
                 assert 'name' not in ua
+        assert uaFound
 
 
 @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
@@ -141,17 +138,17 @@ class PipelinesConfigurationNoneTest(ElasticTest):
                                      self.intake_url, 'transaction', 3)
 
         entries = self.es.search(index=self.index_transaction)['hits']['hits']
+        uaFound = False
         for e in entries:
             src = e['_source']
-            ua = src['user_agent']
-            if src['transaction']['id'] != "4340a8e0df1906ecbfa9":
-                # transaction with id '4340a8e0df1906ecbfa9' has user agent info set
-                continue
-            else:
+            if 'user_agent' in src:
+                uaFound = True
+                ua = src['user_agent']
                 assert ua is not None
                 assert ua["original"] == "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 " \
                                          "(KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36, Mozilla Chrome Edge"
                 assert 'name' not in ua
+        assert uaFound
 
 
 @unittest.skipUnless(INTEGRATION_TESTS, "integration test")


### PR DESCRIPTION
This PR changes default value for `apm-server.ilm.enabled` from `false` to `auto`.

On startup or setup cmd the server determines if preconditions are fulfilled for enabling ILM.
ILM will be enabled when supported by configured ES, and no custom index and indices settings are configured for `output.elasticsearch`.

When `apm-server.ilm.enabled` is set to `false`, ILM is turned off. 

When `apm-server.ilm.enabled` is set to `true`, the server checks if custom `output.elasticsearch.index` or `output.elasticsearch.indices` configuration is set. If set, the server refuses to start up and fails with according error message. 
Otherwise the server also checks if ES supports ILM. Since the configured ES might not immediately be available (temporary connection loss, currently starting up, ..) the server cannot produce a hard failure. Once the server retrieves a connection to ES, it logs a warning and automatically falls back to ordinary index setup if ILM is not supported. 


* [x] changelog
* [x] notify cloud
* [ ] adapt docs (@bmorelli25 could you change the ILM docs to reflect these changes?)
* [ ] add testcases to testplan
* [x] adapt system tests to changed default

implements elastic/apm-server#2241 


====== 
Special testcases:
 * `./apm-server -e -E apm-server.ilm.enabled=true -E setup.template.name=custom -E setup.template.pattern=custom -E output.elasticsearch.index=custom` 
~refuses to startup with message 
```Exiting: `apm-server.ilm.enabled:true` is not allowed when custom `output.elasticsearch` index names are configured```~
Update: logs a message, enables ILM and ignores `index` configurtaion as otherwise it would be a breaking change to what users could have set up upgrading from `7.2`.
 * `./apm-server -e -E apm-server.ilm.enabled=true` with ES not supporting ILM: 
starts but falls back to ordinary index management and is logging: 
`ERROR	[index-management]	idxmgmt/manager.go:97	automatically disabled ILM as not supported by configured output`
 * `./apm-server -e  -E apm-server.ilm.enabled=auto -E setup.template.name=custom -E setup.template.pattern=custom -E output.elasticsearch.index=custom` 
falls back to ordinary index management and is logging: 
```WARN	[index-management]	idxmgmt/manager.go:97	Automatically disabled ILM as custom index settings configured.```
 * `./apm-server -e  -E apm-server.ilm.enabled=auto` with ES not supporting ILM 
falls back to ordinary index management and is logging: 
 `WARN	[index-management]	idxmgmt/manager.go:94	Automatically disabled ILM as not supported by configured output.`

Same behavior when testing with `setup` command.