### PR TITLE
consolidate logging selectors

### DIFF
--- a/beater/agent_config_handler.go
+++ b/beater/agent_config_handler.go
@@ -85,8 +85,13 @@ func agentConfigHandler(kbClient *kibana.Client, config *agentConfig, secretToke
 		}
 		w.Header().Set(headerCacheControl, headerCacheControlVal)
 		send(resp, state)
+		// logHandler logs the rest
+		if state >= http.StatusBadRequest {
+			requestLogger(r).Errorw("error handling request", "response_code", state,
+				"error", resp)
+		}
 	})
-	return authHandler(secretToken, logHandler(handler))
+	return logHandler(authHandler(secretToken, handler))
 }
 
 // Returns (zero, error) if request body can't be unmarshalled or service.name is missing

--- a/beater/common_handler.go
+++ b/beater/common_handler.go
@@ -34,6 +34,7 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
 
+	logs "github.com/elastic/apm-server/log"
 	"github.com/elastic/apm-server/utility"
 )
 
@@ -149,7 +150,7 @@ func ContextWithReqLogger(ctx context.Context, rl *logp.Logger) context.Context 
 }
 
 func logHandler(h http.Handler) http.Handler {
-	logger := logp.NewLogger("request")
+	logger := logp.NewLogger(logs.Request)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestCounter.Inc()
@@ -305,7 +306,7 @@ func sendStatus(w http.ResponseWriter, r *http.Request, res serverResponse) {
 func requestLogger(r *http.Request) *logp.Logger {
 	logger, ok := r.Context().Value(reqLoggerKey{}).(*logp.Logger)
 	if !ok {
-		logger = logp.NewLogger("request")
+		logger = logp.NewLogger(logs.Request)
 	}
 	return logger
 }
@@ -320,7 +321,7 @@ func sendJSON(w http.ResponseWriter, body interface{}, statusCode int) int {
 	w.WriteHeader(statusCode)
 	buf, err := json.MarshalIndent(body, "", "  ")
 	if err != nil {
-		logp.NewLogger("response").Errorf("Error while generating a JSON error response: %v", err)
+		logp.NewLogger(logs.Response).Errorf("Error while generating a JSON error response: %v", err)
 		return sendPlain(w, body, statusCode)
 	}
 

--- a/beater/common_handler.go
+++ b/beater/common_handler.go
@@ -181,7 +181,7 @@ func logHandler(h http.Handler) http.Handler {
 		lw := utility.NewRecordingResponseWriter(w)
 		h.ServeHTTP(lw, r.WithContext(ContextWithReqLogger(r.Context(), reqLogger)))
 
-		if lw.Code <= 399 {
+		if lw.Code < http.StatusBadRequest {
 			reqLogger.Infow("handled request", []interface{}{"response_code", lw.Code}...)
 		}
 

--- a/beater/intake_handler.go
+++ b/beater/intake_handler.go
@@ -91,7 +91,7 @@ func (v *intakeHandler) sendResponse(logger *logp.Logger, w http.ResponseWriter,
 		}
 	} else {
 		responseErrors.Inc()
-		logger.Errorw("error handling request", "error", sr.Error())
+		logger.Errorw("error handling request", "error", sr.Error(), "response_code", statusCode)
 		// this signals to the client that we're closing the connection
 		// but also signals to http.Server that it should close it:
 		// https://golang.org/src/net/http/server.go#L1254

--- a/beater/onboarding.go
+++ b/beater/onboarding.go
@@ -23,10 +23,12 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
+
+	logs "github.com/elastic/apm-server/log"
 )
 
 func notifyListening(config *Config, pubFct func(beat.Event)) {
-	logp.NewLogger("onboarding").Info("Publishing onboarding document")
+	logp.NewLogger(logs.Onboarding).Info("Publishing onboarding document")
 	event := beat.Event{
 		Timestamp: time.Now(),
 		Fields: common.MapStr{

--- a/beater/onboarding_test.go
+++ b/beater/onboarding_test.go
@@ -18,6 +18,7 @@
 package beater
 
 import (
+	"github.com/elastic/beats/libbeat/logp"
 	"net"
 	"testing"
 
@@ -42,7 +43,7 @@ func TestNotifyUpServerDown(t *testing.T) {
 
 	server, err := newServer(config, apm.DefaultTracer, nil, nopReporter)
 	require.NoError(t, err)
-	go run(server, lis, config)
+	go run(logp.NewLogger("onboarding_test"), server, lis, config)
 
 	notifyListening(config, publisher)
 

--- a/beater/onboarding_test.go
+++ b/beater/onboarding_test.go
@@ -18,17 +18,16 @@
 package beater
 
 import (
-	"github.com/elastic/beats/libbeat/logp"
 	"net"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.elastic.co/apm"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
 )
 
 func TestNotifyUpServerDown(t *testing.T) {

--- a/beater/route_config.go
+++ b/beater/route_config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/elastic/beats/libbeat/kibana"
 
 	"github.com/elastic/apm-server/decoder"
+	logs "github.com/elastic/apm-server/log"
 	"github.com/elastic/apm-server/model"
 	"github.com/elastic/apm-server/processor/asset"
 	"github.com/elastic/apm-server/processor/asset/sourcemap"
@@ -93,7 +94,7 @@ var (
 
 func newMuxer(beaterConfig *Config, kbClient *kibana.Client, report publish.Reporter) (*http.ServeMux, error) {
 	mux := http.NewServeMux()
-	logger := logp.NewLogger("handler")
+	logger := logp.NewLogger(logs.Handler)
 
 	for path, route := range AssetRoutes {
 		logger.Infof("Path %s added to request handler", path)

--- a/beater/server.go
+++ b/beater/server.go
@@ -74,8 +74,7 @@ func doNotTrace(req *http.Request) bool {
 	return false
 }
 
-func run(server *http.Server, lis net.Listener, config *Config) error {
-	logger := logp.NewLogger("server")
+func run(logger *logp.Logger, server *http.Server, lis net.Listener, config *Config) error {
 	logger.Infof("Starting apm-server [%s built %s]. Hit CTRL-C to stop it.", version.Commit(), version.BuildTime())
 	logger.Infof("Listening on: %s", server.Addr)
 	switch config.RumConfig.isEnabled() {
@@ -102,8 +101,7 @@ func run(server *http.Server, lis net.Listener, config *Config) error {
 	return server.Serve(lis)
 }
 
-func stop(server *http.Server) {
-	logger := logp.NewLogger("server")
+func stop(logger *logp.Logger, server *http.Server) {
 	err := server.Shutdown(context.Background())
 	if err != nil {
 		logger.Error(err.Error())

--- a/idxmgmt/ilm/supporter_factory.go
+++ b/idxmgmt/ilm/supporter_factory.go
@@ -27,14 +27,16 @@ import (
 	"github.com/elastic/beats/libbeat/common/fmtstr"
 	libilm "github.com/elastic/beats/libbeat/idxmgmt/ilm"
 	"github.com/elastic/beats/libbeat/logp"
+
+	logs "github.com/elastic/apm-server/log"
 )
 
 // MakeDefaultSupporter creates the ILM supporter for APM that is passed to libbeat.
 func MakeDefaultSupporter(log *logp.Logger, info beat.Info, cfg *common.Config) (libilm.Supporter, error) {
 	if log == nil {
-		log = logp.NewLogger("ilm")
+		log = logp.NewLogger(logs.Ilm)
 	} else {
-		log = log.Named("ilm")
+		log = log.Named(logs.Ilm)
 	}
 
 	var ilmCfg Config

--- a/ingest/pipeline/register.go
+++ b/ingest/pipeline/register.go
@@ -21,13 +21,15 @@ import (
 	"encoding/json"
 	"io/ioutil"
 
+	logs "github.com/elastic/apm-server/log"
+
 	"github.com/elastic/beats/libbeat/logp"
 	es "github.com/elastic/beats/libbeat/outputs/elasticsearch"
 	"github.com/elastic/beats/libbeat/paths"
 )
 
 func RegisterPipelines(esClient *es.Client, overwrite bool, path string) error {
-	logger := logp.NewLogger("pipelines")
+	logger := logp.NewLogger(logs.Pipelines)
 	pipelines, err := loadPipelinesFromJSON(path)
 	if err != nil {
 		return err

--- a/log/selectors.go
+++ b/log/selectors.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package logs
 
 const (

--- a/log/selectors.go
+++ b/log/selectors.go
@@ -1,0 +1,17 @@
+package logs
+
+const (
+	Beater          = "beater"
+	Handler         = "handler"
+	Ilm             = "ilm"
+	IndexManagement = "index-management"
+	Onboarding      = "onboarding"
+	Pipelines       = "pipelines"
+	Request         = "request"
+	Response        = "response"
+	Server          = "server"
+	Sourcemap       = "sourcemap"
+	Stacktrace      = "stacktrace"
+	Tracing         = "tracing"
+	Transform       = "transform"
+)

--- a/log/selectors.go
+++ b/log/selectors.go
@@ -17,6 +17,7 @@
 
 package logs
 
+// logging selectors
 const (
 	Beater          = "beater"
 	Handler         = "handler"

--- a/model/metricset/event.go
+++ b/model/metricset/event.go
@@ -24,15 +24,17 @@ import (
 
 	"github.com/santhosh-tekuri/jsonschema"
 
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/monitoring"
+
+	logs "github.com/elastic/apm-server/log"
 	"github.com/elastic/apm-server/model"
 	"github.com/elastic/apm-server/model/metricset/generated/schema"
 	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/apm-server/validation"
-	"github.com/elastic/beats/libbeat/beat"
-	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/libbeat/monitoring"
 )
 
 const (
@@ -209,7 +211,7 @@ func (me *Metricset) Transform(tctx *transform.Context) []beat.Event {
 	fields := common.MapStr{}
 	for _, sample := range me.Samples {
 		if _, err := fields.Put(sample.Name, sample.Value); err != nil {
-			logp.NewLogger("transform").Warnf("failed to transform sample %#v", sample)
+			logp.NewLogger(logs.Transform).Warnf("failed to transform sample %#v", sample)
 			continue
 		}
 	}

--- a/model/sourcemap/payload.go
+++ b/model/sourcemap/payload.go
@@ -22,15 +22,17 @@ import (
 
 	"github.com/santhosh-tekuri/jsonschema"
 
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/logp"
+	"github.com/elastic/beats/libbeat/monitoring"
+
+	logs "github.com/elastic/apm-server/log"
 	"github.com/elastic/apm-server/model/sourcemap/generated/schema"
 	smap "github.com/elastic/apm-server/sourcemap"
 	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/apm-server/validation"
-	"github.com/elastic/beats/libbeat/beat"
-	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/libbeat/monitoring"
 )
 
 const (
@@ -65,7 +67,7 @@ func (pa *Sourcemap) Transform(tctx *transform.Context) []beat.Event {
 	}
 
 	if tctx.Config.SmapMapper == nil {
-		logp.NewLogger("sourcemap").Error("Sourcemap Accessor is nil, cache cannot be invalidated.")
+		logp.NewLogger(logs.Sourcemap).Error("Sourcemap Accessor is nil, cache cannot be invalidated.")
 	} else {
 		tctx.Config.SmapMapper.NewSourcemapAdded(smap.Id{
 			ServiceName:    pa.ServiceName,

--- a/model/stacktrace.go
+++ b/model/stacktrace.go
@@ -20,6 +20,8 @@ package model
 import (
 	"errors"
 
+	logs "github.com/elastic/apm-server/log"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/logp"
 
@@ -84,10 +86,12 @@ func (st *Stacktrace) Transform(tctx *transform.Context) []common.MapStr {
 		}
 		frames[idx] = fr.Transform(tctx)
 	}
-	logger := logp.NewLogger("stacktrace")
-	for errMsg := range sourcemapErrorSet {
-		if errMsg != "" {
-			logger.Warn(errMsg)
+	if len(sourcemapErrorSet) > 0 {
+		logger := logp.NewLogger(logs.Stacktrace)
+		for errMsg := range sourcemapErrorSet {
+			if errMsg != "" {
+				logger.Warn(errMsg)
+			}
 		}
 	}
 

--- a/sourcemap/accessor.go
+++ b/sourcemap/accessor.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 
 	"github.com/go-sourcemap/sourcemap"
-
-	"github.com/elastic/beats/libbeat/logp"
 )
 
 type Accessor interface {
@@ -36,8 +34,6 @@ type SmapAccessor struct {
 }
 
 func NewSmapAccessor(config Config) (*SmapAccessor, error) {
-	logp.NewLogger("sourcemap").Debugf("creating NewSmapAccessor for index: %s", config.Index)
-
 	es, err := NewElasticsearch(config.ElasticsearchConfig, config.Index)
 	if err != nil {
 		return nil, err

--- a/sourcemap/cache.go
+++ b/sourcemap/cache.go
@@ -25,11 +25,12 @@ import (
 	gocache "github.com/patrickmn/go-cache"
 
 	"github.com/elastic/beats/libbeat/logp"
+
+	logs "github.com/elastic/apm-server/log"
 )
 
 const (
 	minCleanupIntervalSeconds float64 = 60
-	loggerSelector            string  = "sourcemap"
 )
 
 type cache struct {
@@ -44,7 +45,10 @@ func newCache(expiration time.Duration) (*cache, error) {
 			Kind: InitError,
 		}
 	}
-	return &cache{goca: gocache.New(expiration, cleanupInterval(expiration)), logger: logp.NewLogger(loggerSelector)}, nil
+	return &cache{
+		goca:   gocache.New(expiration, cleanupInterval(expiration)),
+		logger: logp.NewLogger(logs.Sourcemap),
+	}, nil
 }
 
 func (c *cache) add(id Id, consumer *sourcemap.Consumer) {

--- a/sourcemap/elasticsearch.go
+++ b/sourcemap/elasticsearch.go
@@ -64,11 +64,11 @@ func NewElasticsearch(config *common.Config, index string) (*smapElasticsearch, 
 }
 
 func (e *smapElasticsearch) fetch(id Id) (*sourcemap.Consumer, error) {
-	if result, err := e.runESQuery(query(id)); err != nil {
+	result, err := e.runESQuery(query(id))
+	if err != nil {
 		return nil, err
-	} else {
-		return e.parseResult(result, id)
 	}
+	return e.parseResult(result, id)
 }
 
 func (e *smapElasticsearch) runESQuery(body map[string]interface{}) (*es.SearchResults, error) {

--- a/sourcemap/elasticsearch_test.go
+++ b/sourcemap/elasticsearch_test.go
@@ -51,7 +51,7 @@ func TestNoElasticsearchConnection(t *testing.T) {
 func TestParseResultNoSourcemap(t *testing.T) {
 	id := Id{Path: "/tmp"}
 	result := &es.SearchResults{}
-	c, err := parseResult(result, id)
+	c, err := (&smapElasticsearch{}).parseResult(result, id)
 	assert.Nil(t, c)
 	assert.NoError(t, err)
 }
@@ -66,7 +66,7 @@ func TestParseResultParseError(t *testing.T) {
 			Total: es.Total{Value: 1},
 		},
 	}
-	c, err := parseResult(result, id)
+	c, err := (&smapElasticsearch{}).parseResult(result, id)
 	assert.Nil(t, c)
 	assert.Error(t, err)
 	assert.Equal(t, (err.(Error)).Kind, ParseError)
@@ -79,7 +79,7 @@ func TestParseResultParseError(t *testing.T) {
 			Total: es.Total{Value: 1},
 		},
 	}
-	c, err = parseResult(result, id)
+	c, err = (&smapElasticsearch{}).parseResult(result, id)
 	assert.Nil(t, c)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Could not parse Sourcemap")

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -1,16 +1,19 @@
+from datetime import datetime, timedelta
+import json
 import os
 import re
 import shutil
+from time import gmtime, strftime
 
-import requests
 import sys
 import time
+
 from elasticsearch import Elasticsearch
-from datetime import datetime, timedelta
+import requests
+
 sys.path.append(os.path.join(os.path.dirname(__file__), '..',
                              '..', '_beats', 'libbeat', 'tests', 'system'))
 from beat.beat import TestCase, TimeoutError
-from time import gmtime, strftime
 
 
 class BaseTest(TestCase):
@@ -232,6 +235,13 @@ class ElasticTest(ServerBaseTest):
             return
         for frame in doc["stacktrace"]:
             assert "sourcemap" not in frame, frame
+
+    def intake_requests(self):
+        for line in self.get_log_lines():
+            jline = json.loads(line)
+            if jline.get("logger") == "request" and \
+                jline.get("method") == "POST" and jline.get("URL") == "/intake/v2/events":
+                yield jline
 
 
 class ClientSideBaseTest(ServerBaseTest):

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -240,7 +240,7 @@ class ElasticTest(ServerBaseTest):
         for line in self.get_log_lines():
             jline = json.loads(line)
             if jline.get("logger") == "request" and \
-                jline.get("method") == "POST" and jline.get("URL") == "/intake/v2/events":
+                    jline.get("method") == "POST" and jline.get("URL") == "/intake/v2/events":
                 yield jline
 
 

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -4,6 +4,7 @@ import os
 import re
 import shutil
 from time import gmtime, strftime
+from urlparse import urlparse
 
 import sys
 import time
@@ -73,6 +74,7 @@ class BaseTest(TestCase):
 
 class ServerSetUpBaseTest(BaseTest):
     host = "http://localhost:8200"
+    agent_config_url = "{}/{}".format(host, "config/v1/agents")
     intake_url = "{}/{}".format(host, 'intake/v2/events')
     expvar_url = "{}/{}".format(host, 'debug/vars')
 
@@ -236,11 +238,11 @@ class ElasticTest(ServerBaseTest):
         for frame in doc["stacktrace"]:
             assert "sourcemap" not in frame, frame
 
-    def intake_requests(self):
+    def logged_requests(self, url="/intake/v2/events"):
         for line in self.get_log_lines():
             jline = json.loads(line)
-            if jline.get("logger") == "request" and \
-                    jline.get("method") == "POST" and jline.get("URL") == "/intake/v2/events":
+            u = urlparse(jline.get("URL", ""))
+            if jline.get("logger") == "request" and u.path == url:
                 yield jline
 
 

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -144,7 +144,11 @@ output.elasticsearch:
 
 ############################# Logging #########################################
 
+{% if logging_json or logging_level %}
 logging:
+{% else %}
+#logging:
+{% endif %}
   # Send all logging output to syslog. On Windows default is false, otherwise
   # default is true.
   #to_syslog: true
@@ -156,11 +160,15 @@ logging:
   # Enable debug output for selected components.
   #selectors: []
 
+{% if logging_json %}
   # Set to true to log messages in json format.
   json: {{ logging_json|default("false") }}
+{% endif %}
 
+{% if logging_level %}
   # Set log level
   level: {{ logging_level|default("info") }}
+{% endif %}
 
   #files:
     # The directory where the log files will written to.

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -162,12 +162,12 @@ logging:
 
 {% if logging_json %}
   # Set to true to log messages in json format.
-  json: {{ logging_json|default("false") }}
+  json: {{ logging_json }}
 {% endif %}
 
 {% if logging_level %}
   # Set log level
-  level: {{ logging_level|default("info") }}
+  level: {{ logging_level }}
 {% endif %}
 
   #files:

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -4,6 +4,11 @@ apm-server:
   host: "localhost:8200"
   secret_token: {{ secret_token }}
 
+  {% if max_event_size %}
+  # Maximum allowed size in bytes of a single event
+  max_event_size: {{ max_event_size }}
+  {% endif %}
+
   {% if ssl_enabled %}
   ssl.enabled: {{ ssl_enabled }}
   {% endif %}
@@ -135,7 +140,7 @@ output.elasticsearch:
 
 ############################# Logging #########################################
 
-#logging:
+logging:
   # Send all logging output to syslog. On Windows default is false, otherwise
   # default is true.
   #to_syslog: true
@@ -147,8 +152,11 @@ output.elasticsearch:
   # Enable debug output for selected components.
   #selectors: []
 
+  # Set to true to log messages in json format.
+  json: {{ logging_json|default("false") }}
+
   # Set log level
-  #level: error
+  level: {{ logging_level|default("info") }}
 
   #files:
     # The directory where the log files will written to.

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -3,8 +3,6 @@ import os
 import time
 import unittest
 
-import requests
-
 from apmserver import ElasticTest, ExpvarBaseTest
 from apmserver import ClientSideElasticTest, SmapCacheBaseTest
 from apmserver import OverrideIndicesTest, OverrideIndicesFailureTest
@@ -545,71 +543,6 @@ class ExpvarCustomUrlIntegrationTest(ExpvarBaseTest):
         """expvar enabled, should 200"""
         r = self.get_debug_vars()
         assert r.status_code == 200, r.status_code
-
-
-class LoggingIntegrationTest(ElasticTest):
-    config_overrides = {
-        "logging_json": "true",
-    }
-
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    def test_log_valid_event(self):
-        with open(self.get_transaction_payload_path()) as f:
-            r = requests.post(self.intake_url,
-                              data=f,
-                              headers={'content-type': 'application/x-ndjson'})
-            assert r.status_code == 202, r.status_code
-            intake_request_logs = list(self.intake_requests())
-            assert len(intake_request_logs) == 1, "multiple requests found"
-            req = intake_request_logs[0]
-            self.assertDictContainsSubset({
-                "level": "info",
-                "message": "handled request",
-                "response_code": 202,
-            }, req)
-
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    def test_log_invalid_event(self):
-        with open(self.get_payload_path("invalid-event.ndjson")) as f:
-            r = requests.post(self.intake_url,
-                              data=f,
-                              headers={'content-type': 'application/x-ndjson'})
-            assert r.status_code == 400, r.status_code
-            intake_request_logs = list(self.intake_requests())
-            assert len(intake_request_logs) == 1, "multiple requests found"
-            req = intake_request_logs[0]
-            self.assertDictContainsSubset({
-                "level": "error",
-                "message": "error handling request",
-                "response_code": 400,
-            }, req)
-            error = req.get("error")
-            assert error.startswith("error validating JSON document against schema:"), json.dumps(req)
-
-
-class LoggingIntegrationEventSizeTest(ElasticTest):
-    config_overrides = {
-        "logging_json": "true",
-        "max_event_size": "100",
-    }
-
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    def test_log_event_size_exceeded(self):
-        with open(self.get_transaction_payload_path()) as f:
-            r = requests.post(self.intake_url,
-                              data=f,
-                              headers={'content-type': 'application/x-ndjson'})
-            assert r.status_code == 400, r.status_code
-            intake_request_logs = list(self.intake_requests())
-            assert len(intake_request_logs) == 1, "multiple requests found"
-            req = intake_request_logs[0]
-            self.assertDictContainsSubset({
-                "level": "error",
-                "message": "error handling request",
-                "response_code": 400,
-            }, req)
-            error = req.get("error")
-            assert error.startswith("event exceeded the permitted size."), json.dumps(req)
 
 
 class MetricsIntegrationTest(ElasticTest):

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -358,11 +358,11 @@ class SourcemappingIntegrationTest(ClientSideElasticTest):
 
         self.upload_sourcemap(file_name='bundle.js.map', bundle_filepath=path)
         self.wait_for_sourcemaps(3)
-        assert self.log_contains("Multiple sourcemaps found"), \
+        assert self.log_contains("2 sourcemaps found for service"), \
             "the 3rd fetch should query ES and find that there are 2 sourcemaps with the same caching key"
 
         self.assert_no_logged_warnings(
-            ["WARN.*Overriding sourcemap", "WARN.*Multiple sourcemaps"])
+            ["WARN.*Overriding sourcemap", "WARN.*2 sourcemaps found for service"])
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_rum_error(self):

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -1,7 +1,9 @@
-import os
 import json
-import unittest
+import os
 import time
+import unittest
+
+import requests
 
 from apmserver import ElasticTest, ExpvarBaseTest
 from apmserver import ClientSideElasticTest, SmapCacheBaseTest
@@ -543,6 +545,71 @@ class ExpvarCustomUrlIntegrationTest(ExpvarBaseTest):
         """expvar enabled, should 200"""
         r = self.get_debug_vars()
         assert r.status_code == 200, r.status_code
+
+
+class LoggingIntegrationTest(ElasticTest):
+    config_overrides = {
+        "logging_json": "true",
+    }
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_log_valid_event(self):
+        with open(self.get_transaction_payload_path()) as f:
+            r = requests.post(self.intake_url,
+                              data=f,
+                              headers={'content-type': 'application/x-ndjson'})
+            assert r.status_code == 202, r.status_code
+            intake_request_logs = list(self.intake_requests())
+            assert len(intake_request_logs) == 1, "multiple requests found"
+            req = intake_request_logs[0]
+            self.assertDictContainsSubset({
+                "level": "info",
+                "message": "handled request",
+                "response_code": 202,
+            }, req)
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_log_invalid_event(self):
+        with open(self.get_payload_path("invalid-event.ndjson")) as f:
+            r = requests.post(self.intake_url,
+                              data=f,
+                              headers={'content-type': 'application/x-ndjson'})
+            assert r.status_code == 400, r.status_code
+            intake_request_logs = list(self.intake_requests())
+            assert len(intake_request_logs) == 1, "multiple requests found"
+            req = intake_request_logs[0]
+            self.assertDictContainsSubset({
+                "level": "error",
+                "message": "error handling request",
+                "response_code": 400,
+            }, req)
+            error = req.get("error")
+            assert error.startswith("error validating JSON document against schema:"), json.dumps(req)
+
+
+class LoggingIntegrationEventSizeTest(ElasticTest):
+    config_overrides = {
+        "logging_json": "true",
+        "max_event_size": "100",
+    }
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_log_event_size_exceeded(self):
+        with open(self.get_transaction_payload_path()) as f:
+            r = requests.post(self.intake_url,
+                              data=f,
+                              headers={'content-type': 'application/x-ndjson'})
+            assert r.status_code == 400, r.status_code
+            intake_request_logs = list(self.intake_requests())
+            assert len(intake_request_logs) == 1, "multiple requests found"
+            req = intake_request_logs[0]
+            self.assertDictContainsSubset({
+                "level": "error",
+                "message": "error handling request",
+                "response_code": 400,
+            }, req)
+            error = req.get("error")
+            assert error.startswith("event exceeded the permitted size."), json.dumps(req)
 
 
 class MetricsIntegrationTest(ElasticTest):

--- a/tests/system/test_integration_logging.py
+++ b/tests/system/test_integration_logging.py
@@ -1,0 +1,72 @@
+import json
+import unittest
+
+import requests
+
+from apmserver import ElasticTest
+from beat.beat import INTEGRATION_TESTS
+
+
+class LoggingIntegrationTest(ElasticTest):
+    config_overrides = {
+        "logging_json": "true",
+    }
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_log_valid_event(self):
+        with open(self.get_transaction_payload_path()) as f:
+            r = requests.post(self.intake_url,
+                              data=f,
+                              headers={'content-type': 'application/x-ndjson'})
+            assert r.status_code == 202, r.status_code
+            intake_request_logs = list(self.intake_requests())
+            assert len(intake_request_logs) == 1, "multiple requests found"
+            req = intake_request_logs[0]
+            self.assertDictContainsSubset({
+                "level": "info",
+                "message": "handled request",
+                "response_code": 202,
+            }, req)
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_log_invalid_event(self):
+        with open(self.get_payload_path("invalid-event.ndjson")) as f:
+            r = requests.post(self.intake_url,
+                              data=f,
+                              headers={'content-type': 'application/x-ndjson'})
+            assert r.status_code == 400, r.status_code
+            intake_request_logs = list(self.intake_requests())
+            assert len(intake_request_logs) == 1, "multiple requests found"
+            req = intake_request_logs[0]
+            self.assertDictContainsSubset({
+                "level": "error",
+                "message": "error handling request",
+                "response_code": 400,
+            }, req)
+            error = req.get("error")
+            assert error.startswith("error validating JSON document against schema:"), json.dumps(req)
+
+
+class LoggingIntegrationEventSizeTest(ElasticTest):
+    config_overrides = {
+        "logging_json": "true",
+        "max_event_size": "100",
+    }
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_log_event_size_exceeded(self):
+        with open(self.get_transaction_payload_path()) as f:
+            r = requests.post(self.intake_url,
+                              data=f,
+                              headers={'content-type': 'application/x-ndjson'})
+            assert r.status_code == 400, r.status_code
+            intake_request_logs = list(self.intake_requests())
+            assert len(intake_request_logs) == 1, "multiple requests found"
+            req = intake_request_logs[0]
+            self.assertDictContainsSubset({
+                "level": "error",
+                "message": "error handling request",
+                "response_code": 400,
+            }, req)
+            error = req.get("error")
+            assert error.startswith("event exceeded the permitted size."), json.dumps(req)

--- a/tests/system/test_integration_logging.py
+++ b/tests/system/test_integration_logging.py
@@ -6,6 +6,8 @@ import requests
 from apmserver import ElasticTest
 from beat.beat import INTEGRATION_TESTS
 
+from apmserver import ElasticTest
+
 
 class LoggingIntegrationTest(ElasticTest):
     config_overrides = {
@@ -19,7 +21,7 @@ class LoggingIntegrationTest(ElasticTest):
                               data=f,
                               headers={'content-type': 'application/x-ndjson'})
             assert r.status_code == 202, r.status_code
-            intake_request_logs = list(self.intake_requests())
+            intake_request_logs = list(self.logged_requests())
             assert len(intake_request_logs) == 1, "multiple requests found"
             req = intake_request_logs[0]
             self.assertDictContainsSubset({
@@ -35,7 +37,7 @@ class LoggingIntegrationTest(ElasticTest):
                               data=f,
                               headers={'content-type': 'application/x-ndjson'})
             assert r.status_code == 400, r.status_code
-            intake_request_logs = list(self.intake_requests())
+            intake_request_logs = list(self.logged_requests())
             assert len(intake_request_logs) == 1, "multiple requests found"
             req = intake_request_logs[0]
             self.assertDictContainsSubset({
@@ -45,6 +47,44 @@ class LoggingIntegrationTest(ElasticTest):
             }, req)
             error = req.get("error")
             assert error.startswith("error validating JSON document against schema:"), json.dumps(req)
+
+
+class LoggingIntegrationAuth(ElasticTest):
+    config_overrides = {
+        "logging_json": "true",
+        "secret_token": "supersecret",
+    }
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_log_config_request(self):
+        r1 = requests.get(self.agent_config_url,
+                          headers={
+                              "Content-Type": "application/x-ndjson",
+                          })
+        assert r1.status_code == 401, r1.status_code
+
+        r2 = requests.get(self.agent_config_url,
+                          params={"service.name": "foo"},
+                          headers={
+                              "Content-Type": "application/x-ndjson",
+                              "Authorization": "Bearer " + self.config_overrides["secret_token"],
+                          })
+        assert r2.status_code == 500, r2.status_code
+
+        config_request_logs = list(self.logged_requests(url="/config/v1/agents"))
+        assert len(config_request_logs) == 2, config_request_logs
+        self.assertDictContainsSubset({
+            "level": "error",
+            "message": "error handling request",
+            "error": {"error": "invalid token"},
+            "response_code": 401,
+        }, config_request_logs[0])
+        self.assertDictContainsSubset({
+            "level": "error",
+            "message": "error handling request",
+            "error": "no configured Kibana Client: provide apm-server.kibana.* settings",
+            "response_code": 500,
+        }, config_request_logs[1])
 
 
 class LoggingIntegrationEventSizeTest(ElasticTest):
@@ -60,7 +100,7 @@ class LoggingIntegrationEventSizeTest(ElasticTest):
                               data=f,
                               headers={'content-type': 'application/x-ndjson'})
             assert r.status_code == 400, r.status_code
-            intake_request_logs = list(self.intake_requests())
+            intake_request_logs = list(self.logged_requests())
             assert len(intake_request_logs) == 1, "multiple requests found"
             req = intake_request_logs[0]
             self.assertDictContainsSubset({


### PR DESCRIPTION
Extracted some of the logging changes I've been kicking around:
* List all logging selectors in `github.com/elastic/apm-server/log`
* Start reducing logger creations
* Log status code for errored requests
* Propogate error on pipeline registration failure

for elastic/apm-server#2201 