### PR TITLE
[7.x] Add caching to Agent Remote Configuration handling (#2337)

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -183,6 +183,10 @@ apm-server:
   #ilm:
     #enabled: false
 
+  # When using APM agent configuration, information fetched from Kibana will be cached in memory for some time.
+  # Specify cache key expiration via this setting. Default is 30 seconds.
+  #agent.config.cache.expiration: 30s
+
   #kibana:
     # For agent remote configuration, enabled must be true
     #enabled: false

--- a/agentcfg/cache.go
+++ b/agentcfg/cache.go
@@ -1,0 +1,83 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package agentcfg
+
+import (
+	"time"
+
+	gocache "github.com/patrickmn/go-cache"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+const (
+	cleanupInterval time.Duration = 60 * time.Second
+)
+
+type cache struct {
+	logger  *logp.Logger
+	exp     time.Duration
+	gocache *gocache.Cache
+}
+
+func newCache(logger *logp.Logger, exp time.Duration) *cache {
+	if logger == nil {
+		logger = logp.NewLogger("agentcfg")
+	}
+	logger.Infof("Cache creation with default expiration %v.", exp)
+	return &cache{
+		logger:  logger,
+		exp:     exp,
+		gocache: gocache.New(exp, cleanupInterval)}
+}
+
+func (c *cache) fetchAndAdd(q Query, fn func(Query) (*Doc, error)) (doc *Doc, err error) {
+	id := q.id()
+
+	// return from cache if possible
+	doc, found := c.fetch(id)
+	if found {
+		return
+	}
+
+	// call fn to retrieve resource from external source
+	doc, err = fn(q)
+	if err != nil {
+		return
+	}
+
+	// add resource to cache
+	c.add(id, doc)
+	return
+}
+
+func (c *cache) add(id string, doc *Doc) {
+	c.gocache.SetDefault(id, doc)
+	if !c.logger.IsDebug() {
+		return
+	}
+	c.logger.Debugf("Cache size %v. Added ID %v.", c.gocache.ItemCount(), id)
+}
+
+func (c *cache) fetch(id string) (*Doc, bool) {
+	val, found := c.gocache.Get(id)
+	if !found || val == nil {
+		return nil, found
+	}
+	return val.(*Doc), found
+}

--- a/agentcfg/cache_test.go
+++ b/agentcfg/cache_test.go
@@ -1,0 +1,142 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package agentcfg
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	defaultDoc  = Doc{Source: Source{Settings: Settings{"a": "default"}}}
+	externalDoc = Doc{Source: Source{Settings: Settings{"a": "b"}}}
+)
+
+type cacheSetup struct {
+	q   Query
+	c   *cache
+	doc *Doc
+}
+
+func newCacheSetup(service string, exp time.Duration, init bool) cacheSetup {
+	setup := cacheSetup{
+		q:   Query{Service: Service{Name: service}},
+		c:   newCache(nil, exp),
+		doc: &defaultDoc,
+	}
+	if init {
+		setup.c.add(setup.q.id(), setup.doc)
+	}
+	return setup
+}
+
+func TestCache_fetchAndAdd(t *testing.T) {
+	exp := time.Second
+	for name, tc := range map[string]struct {
+		fn   func(query Query) (*Doc, error)
+		init bool
+
+		doc  *Doc
+		fail bool
+	}{
+		"DocFromCache":         {fn: testFn, init: true, doc: &defaultDoc},
+		"DocFromFunctionFails": {fn: testFnErr, fail: true},
+		"DocFromFunction":      {fn: testFn, doc: &externalDoc},
+		"EmptyDocFromFunction": {fn: testFnSettingsNil, doc: &Doc{Source: Source{Settings: Settings{}}}},
+		"NilDocFromFunction":   {fn: testFnNil},
+	} {
+		t.Run(name, func(t *testing.T) {
+			setup := newCacheSetup(name, exp, tc.init)
+
+			doc, err := setup.c.fetchAndAdd(setup.q, tc.fn)
+			assert.Equal(t, tc.doc, doc)
+			if tc.fail {
+				require.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				//ensure value is cached afterwards
+				cachedDoc, found := setup.c.fetch(setup.q.id())
+				assert.True(t, found)
+				assert.Equal(t, doc, cachedDoc)
+			}
+		})
+	}
+
+	t.Run("CacheKeyExpires", func(t *testing.T) {
+		exp := 100 * time.Millisecond
+		setup := newCacheSetup(t.Name(), exp, false)
+		doc, err := setup.c.fetchAndAdd(setup.q, testFn)
+		require.NoError(t, err)
+		require.NotNil(t, doc)
+		time.Sleep(exp)
+		nilDoc, found := setup.c.fetch(setup.q.id())
+		assert.False(t, found)
+		assert.Nil(t, nilDoc)
+	})
+}
+
+func BenchmarkFetchAndAdd(b *testing.B) {
+	// this micro benchmark only accounts for the underlying cache
+	// providing some benchmark baseline in case the cache library changes in the future
+	// It does not compare cache vs. external call, as this should rather be embedded in
+	// some integration test. It also doesn't account for potentially increased CPU usage through
+	// background processes taking care of expiring keys.
+
+	b.Run("FetchFromCache", func(b *testing.B) {
+		// intialize the cache and add a document to it before the benchmark,
+		// to ensure docs are only fetched from cache
+		exp := 5 * time.Minute
+		setup := newCacheSetup(b.Name(), exp, true)
+		for i := 0; i < b.N; i++ {
+			setup.c.fetchAndAdd(setup.q, testFn)
+		}
+	})
+
+	b.Run("FetchAndAddToCache", func(b *testing.B) {
+		// intialize the cache, test adding random docs to cache
+		// to ensure a fetch and add operation per call
+		exp := 5 * time.Minute
+		setup := newCacheSetup(b.Name(), exp, false)
+		q := Query{Service: Service{}}
+		for i := 0; i < b.N; i++ {
+			q.Service.Name = string(b.N)
+			setup.c.fetchAndAdd(q, testFn)
+		}
+	})
+}
+
+func testFnErr(_ Query) (*Doc, error) {
+	return nil, errors.New("testFn fails")
+}
+
+func testFnNil(_ Query) (*Doc, error) {
+	return nil, nil
+}
+
+func testFnSettingsNil(_ Query) (*Doc, error) {
+	return &Doc{Source: Source{Settings: Settings{}}}, nil
+}
+
+func testFn(_ Query) (*Doc, error) {
+	return &externalDoc, nil
+}

--- a/agentcfg/fetch_test.go
+++ b/agentcfg/fetch_test.go
@@ -20,23 +20,29 @@ package agentcfg
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/apm-server/tests"
 	"github.com/elastic/beats/libbeat/kibana"
+
+	"github.com/elastic/apm-server/tests"
 )
 
 type m map[string]interface{}
 
-var q = Query{}
+var testExp = time.Nanosecond
+
+func query(name string) Query {
+	return Query{Service: Service{Name: name}}
+}
 
 func TestFetchNoClient(t *testing.T) {
 	kb, kerr := kibana.NewKibanaClient(nil)
-	_, _, ferr := Fetch(kb, q, kerr)
+	_, _, ferr := NewFetcher(kb, testExp).Fetch(query(t.Name()), kerr)
 	require.Error(t, ferr)
-	assert.Equal(t, ferr, kerr, kerr)
+	assert.Equal(t, kerr, ferr)
 }
 
 func TestFetchStringConversion(t *testing.T) {
@@ -49,23 +55,62 @@ func TestFetchStringConversion(t *testing.T) {
 				},
 			},
 		})
-	result, etag, err := Fetch(kb, q, nil)
+	result, etag, err := NewFetcher(kb, testExp).Fetch(query(t.Name()), nil)
 	require.NoError(t, err)
 	assert.Equal(t, "1", etag, etag)
-	assert.Equal(t, map[string]string{"sampling_rate": "0.5"}, result, result)
+	assert.Equal(t, map[string]string{"sampling_rate": "0.5"}, result)
 }
 
 func TestFetchVersionCheck(t *testing.T) {
 	kb := tests.MockKibana(http.StatusOK, m{})
 	kb.Connection.Version.Major = 6
-	_, _, err := Fetch(kb, q, nil)
+	_, _, err := NewFetcher(kb, testExp).Fetch(query(t.Name()), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "version")
 }
 
 func TestFetchError(t *testing.T) {
-	kb := tests.MockKibana(http.StatusNotFound, m{"error": "an error"})
-	_, _, err := Fetch(kb, q, nil)
+	kb := tests.MockKibana(http.StatusExpectationFailed, m{"error": "an error"})
+	_, _, err := NewFetcher(kb, testExp).Fetch(query(t.Name()), nil)
 	require.Error(t, err)
-	assert.Equal(t, err.Error(), "{\"error\":\"an error\"}")
+	assert.Equal(t, "{\"error\":\"an error\"}", err.Error())
+}
+
+func TestFetchWithCaching(t *testing.T) {
+	fetch := func(f *Fetcher, samplingRate float64) map[string]string {
+
+		client := func(samplingRate float64) *kibana.Client {
+			return tests.MockKibana(http.StatusOK,
+				m{
+					"_id": "1",
+					"_source": m{
+						"settings": m{
+							"sampling_rate": samplingRate,
+						},
+					},
+				})
+		}
+		f.kbClient = client(samplingRate)
+
+		result, id, err := f.Fetch(query(t.Name()), nil)
+		require.NoError(t, err)
+		require.Equal(t, "1", id)
+		return result
+	}
+
+	fetcher := NewFetcher(nil, time.Minute)
+
+	// nothing cached yet
+	result := fetch(fetcher, 0.5)
+	assert.Equal(t, map[string]string{"sampling_rate": "0.5"}, result)
+
+	// next fetch runs against cache
+	result = fetch(fetcher, 0.8)
+	assert.Equal(t, map[string]string{"sampling_rate": "0.5"}, result)
+
+	// after key is expired, fetch from Kibana again
+	fetcher.docCache.gocache.Delete(query(t.Name()).id())
+	result = fetch(fetcher, 0.7)
+	assert.Equal(t, map[string]string{"sampling_rate": "0.7"}, result)
+
 }

--- a/agentcfg/model.go
+++ b/agentcfg/model.go
@@ -20,6 +20,7 @@ package agentcfg
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 const (
@@ -63,6 +64,16 @@ func NewQuery(name, env string) Query {
 // Query represents an URL body or query params for agent configuration
 type Query struct {
 	Service Service `json:"service"`
+}
+
+func (q Query) id() string {
+	var str strings.Builder
+	str.WriteString(q.Service.Name)
+	if q.Service.Environment != "" {
+		str.WriteString("_")
+		str.WriteString(q.Service.Environment)
+	}
+	return str.String()
 }
 
 // Service holds supported attributes for querying configuration

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -183,6 +183,10 @@ apm-server:
   #ilm:
     #enabled: false
 
+  # When using APM agent configuration, information fetched from Kibana will be cached in memory for some time.
+  # Specify cache key expiration via this setting. Default is 30 seconds.
+  #agent.config.cache.expiration: 30s
+
   #kibana:
     # For agent remote configuration, enabled must be true
     #enabled: false

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -183,6 +183,10 @@ apm-server:
   #ilm:
     #enabled: false
 
+  # When using APM agent configuration, information fetched from Kibana will be cached in memory for some time.
+  # Specify cache key expiration via this setting. Default is 30 seconds.
+  #agent.config.cache.expiration: 30s
+
   #kibana:
     # For agent remote configuration, enabled must be true
     #enabled: false

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -99,7 +99,8 @@ func TestBeatConfig(t *testing.T) {
 						},
 					},
 				},
-				"kibana": map[string]interface{}{"enabled": "true"},
+				"kibana":                        map[string]interface{}{"enabled": "true"},
+				"agent.config.cache.expiration": "2m",
 			},
 			beaterConf: &Config{
 				Host:            "localhost:3000",
@@ -143,8 +144,9 @@ func TestBeatConfig(t *testing.T) {
 						},
 					},
 				},
-				Kibana:   common.MustNewConfigFrom(map[string]interface{}{"enabled": "true"}),
-				pipeline: defaultAPMPipeline,
+				Kibana:      common.MustNewConfigFrom(map[string]interface{}{"enabled": "true"}),
+				AgentConfig: &agentConfig{Cache: &Cache{Expiration: 2 * time.Minute}},
+				pipeline:    defaultAPMPipeline,
 			},
 		},
 		"merge config with default": {
@@ -219,8 +221,9 @@ func TestBeatConfig(t *testing.T) {
 						},
 					},
 				},
-				Kibana:   common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
-				pipeline: defaultAPMPipeline,
+				Kibana:      common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
+				AgentConfig: &agentConfig{Cache: &Cache{Expiration: 10 * time.Second}},
+				pipeline:    defaultAPMPipeline,
 			},
 		},
 	}

--- a/beater/config.go
+++ b/beater/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	Register            *registerConfig         `config:"register"`
 	Mode                Mode                    `config:"mode"`
 	Kibana              *common.Config          `config:"kibana"`
+	AgentConfig         *agentConfig            `config:"agent.config"`
 
 	pipeline string
 }
@@ -95,6 +96,10 @@ type pipelineConfig struct {
 	Enabled   *bool `config:"enabled"`
 	Overwrite *bool `config:"overwrite"`
 	Path      string
+}
+
+type agentConfig struct {
+	Cache *Cache `config:"cache"`
 }
 
 type SourceMapping struct {
@@ -282,8 +287,9 @@ func defaultConfig(beatVersion string) *Config {
 						filepath.Join("ingest", "pipeline", "definition.json")),
 				}},
 		},
-		Mode:     ModeProduction,
-		Kibana:   common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
-		pipeline: defaultAPMPipeline,
+		Mode:        ModeProduction,
+		Kibana:      common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
+		AgentConfig: &agentConfig{Cache: &Cache{Expiration: 10 * time.Second}},
+		pipeline:    defaultAPMPipeline,
 	}
 }

--- a/beater/route_config.go
+++ b/beater/route_config.go
@@ -113,7 +113,9 @@ func newMuxer(beaterConfig *Config, kbClient *kibana.Client, report publish.Repo
 		mux.Handle(path, handler)
 	}
 
-	mux.Handle(agentConfigURL, agentConfigHandler(kbClient, beaterConfig.SecretToken))
+	mux.Handle(agentConfigURL, agentConfigHandler(kbClient, beaterConfig.AgentConfig, beaterConfig.SecretToken))
+	logger.Infof("Path %s added to request handler", agentConfigURL)
+
 	mux.Handle(rootURL, rootHandler(beaterConfig.SecretToken))
 
 	if beaterConfig.Expvar.isEnabled() {

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -32,7 +32,7 @@ func FromReader(r io.ReadCloser, i interface{}) error {
 
 // FromBytes reads the given byte slice into the given interface
 func FromBytes(bs []byte, i interface{}, err error) error {
-	if err != nil {
+	if err != nil || len(bs) == 0 {
 		return err
 	}
 	return json.Unmarshal(bs, i)


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add caching to Agent Remote Configuration handling  (#2337)