### PR TITLE
[7.x] [ILM] Enable ILM by default when supported by configured ES output. (#2356)

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -177,11 +177,21 @@ apm-server:
     # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to true.
     #overwrite: true
 
-  # When ilm is set to true the APM Server will take care of ILM setup.
-  # Configurations in output.elasticsearch.index and output.elasticsearch.indices sections will be ignored
-  # ilm can only be enabled for output.elasticsearch
-  #ilm:
-    #enabled: false
+  # When ilm is set to `auto`, the APM Server checks a couple of preconditions:
+  # If a different output than Elasticsearch is configured, ILM will be disabled.
+  # If Elasticsearch output is configured, but specific `index` or `indices` settings are configured, ILM will be
+  # disabled, as it only works with default index settings.
+  # If the configured Elasticsearch instance is not eligible for ILM, ILM will also be disabled.
+  # If all preconditions are met, ILM will be enabled.
+  #
+  # When ILM is set to `true`, the APM Server ignores any configured index settings.
+  # For ILM to be applied, The configured output must be set to Elasticsearch and the instance
+  # needs to support ILM. Otherwise APM Server falls back to ordinary index management without ILM.
+  #
+  # Disable ILM by setting it to `false`.
+  #
+  # Defaults to `auto`.
+  #ilm.enabled: "auto"
 
   # When using APM agent configuration, information fetched from Kibana will be cached in memory for some time.
   # Specify cache key expiration via this setting. Default is 30 seconds.

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -177,11 +177,21 @@ apm-server:
     # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to true.
     #overwrite: true
 
-  # When ilm is set to true the APM Server will take care of ILM setup.
-  # Configurations in output.elasticsearch.index and output.elasticsearch.indices sections will be ignored
-  # ilm can only be enabled for output.elasticsearch
-  #ilm:
-    #enabled: false
+  # When ilm is set to `auto`, the APM Server checks a couple of preconditions:
+  # If a different output than Elasticsearch is configured, ILM will be disabled.
+  # If Elasticsearch output is configured, but specific `index` or `indices` settings are configured, ILM will be
+  # disabled, as it only works with default index settings.
+  # If the configured Elasticsearch instance is not eligible for ILM, ILM will also be disabled.
+  # If all preconditions are met, ILM will be enabled.
+  #
+  # When ILM is set to `true`, the APM Server ignores any configured index settings.
+  # For ILM to be applied, The configured output must be set to Elasticsearch and the instance
+  # needs to support ILM. Otherwise APM Server falls back to ordinary index management without ILM.
+  #
+  # Disable ILM by setting it to `false`.
+  #
+  # Defaults to `auto`.
+  #ilm.enabled: "auto"
 
   # When using APM agent configuration, information fetched from Kibana will be cached in memory for some time.
   # Specify cache key expiration via this setting. Default is 30 seconds.

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -177,11 +177,21 @@ apm-server:
     # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to true.
     #overwrite: true
 
-  # When ilm is set to true the APM Server will take care of ILM setup.
-  # Configurations in output.elasticsearch.index and output.elasticsearch.indices sections will be ignored
-  # ilm can only be enabled for output.elasticsearch
-  #ilm:
-    #enabled: false
+  # When ilm is set to `auto`, the APM Server checks a couple of preconditions:
+  # If a different output than Elasticsearch is configured, ILM will be disabled.
+  # If Elasticsearch output is configured, but specific `index` or `indices` settings are configured, ILM will be
+  # disabled, as it only works with default index settings.
+  # If the configured Elasticsearch instance is not eligible for ILM, ILM will also be disabled.
+  # If all preconditions are met, ILM will be enabled.
+  #
+  # When ILM is set to `true`, the APM Server ignores any configured index settings.
+  # For ILM to be applied, The configured output must be set to Elasticsearch and the instance
+  # needs to support ILM. Otherwise APM Server falls back to ordinary index management without ILM.
+  #
+  # Disable ILM by setting it to `false`.
+  #
+  # Defaults to `auto`.
+  #ilm.enabled: "auto"
 
   # When using APM agent configuration, information fetched from Kibana will be cached in memory for some time.
   # Specify cache key expiration via this setting. Default is 30 seconds.

--- a/idxmgmt/feature.go
+++ b/idxmgmt/feature.go
@@ -1,0 +1,58 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package idxmgmt
+
+import (
+	libidxmgmt "github.com/elastic/beats/libbeat/idxmgmt"
+)
+
+type feature struct {
+	enabled, overwrite, load, supported bool
+
+	warn string
+	err  error
+}
+
+func newFeature(enabled, overwrite, supported bool, mode libidxmgmt.LoadMode) feature {
+	if mode == libidxmgmt.LoadModeUnset {
+		mode = libidxmgmt.LoadModeDisabled
+	}
+	if mode >= libidxmgmt.LoadModeOverwrite {
+		overwrite = true
+	}
+	if mode == libidxmgmt.LoadModeForce {
+		enabled = true
+	}
+	if !supported {
+		enabled = false
+	}
+	load := mode.Enabled() && enabled
+	return feature{
+		enabled:   enabled,
+		overwrite: overwrite,
+		load:      load,
+		supported: supported}
+}
+
+func (f *feature) warning() string {
+	return f.warn
+}
+
+func (f *feature) error() error {
+	return f.err
+}

--- a/idxmgmt/ilm/config.go
+++ b/idxmgmt/ilm/config.go
@@ -19,14 +19,33 @@ package ilm
 
 import (
 	"github.com/elastic/beats/libbeat/common/fmtstr"
+	libilm "github.com/elastic/beats/libbeat/idxmgmt/ilm"
 )
 
 const pattern = "000001"
 
-//Config for ILM supporter
+// Config for ILM supporter
 type Config struct {
-	Enabled    bool                      `config:"enabled"`
+	Mode       libilm.Mode               `config:"enabled"`
 	PolicyName *fmtstr.EventFormatString `config:"policy_name"`
 	AliasName  *fmtstr.EventFormatString `config:"alias_name"`
 	Event      string                    `config:"event"`
+}
+
+// Enabled indicates whether or not ILM should be enabled
+func (c *Config) Enabled() bool {
+	return c.Mode != libilm.ModeDisabled
+}
+
+// ModeString stringifies enabled mode
+// This is a workaround as strings should be generated in libbeat.
+func ModeString(m libilm.Mode) string {
+	switch m {
+	case libilm.ModeAuto:
+		return "auto"
+	case libilm.ModeEnabled:
+		return "true"
+	default:
+		return "false"
+	}
 }

--- a/idxmgmt/ilm/config_test.go
+++ b/idxmgmt/ilm/config_test.go
@@ -1,0 +1,62 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package ilm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/libbeat/common"
+	libilm "github.com/elastic/beats/libbeat/idxmgmt/ilm"
+)
+
+func TestConfig(t *testing.T) {
+
+	t.Run("ValidInput", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			input string
+			mode  libilm.Mode
+		}{
+			"True":  {input: "true", mode: libilm.ModeEnabled},
+			"False": {input: "false", mode: libilm.ModeDisabled},
+			"Auto":  {input: "auto", mode: libilm.ModeAuto},
+		} {
+			t.Run(name, func(t *testing.T) {
+				inp, err := common.NewConfigFrom(map[string]string{"enabled": tc.input})
+				require.NoError(t, err)
+
+				var cfg Config
+				require.NoError(t, inp.Unpack(&cfg))
+				assert.Equal(t, tc.mode, cfg.Mode)
+			})
+		}
+	})
+
+	t.Run("Invalid Input", func(t *testing.T) {
+		for _, input := range []string{"invalid", ""} {
+			inp, err := common.NewConfigFrom(map[string]string{"enabled": input})
+			require.NoError(t, err)
+
+			var cfg Config
+			assert.Error(t, inp.Unpack(&cfg))
+		}
+	})
+
+}

--- a/idxmgmt/ilm/supporter_factory.go
+++ b/idxmgmt/ilm/supporter_factory.go
@@ -67,7 +67,7 @@ func MakeDefaultSupporter(log *logp.Logger, info beat.Info, cfg *common.Config) 
 		Pattern: pattern,
 	}
 
-	return libilm.NewStdSupport(log, libilm.ModeEnabled, alias, policy, false, true), nil
+	return libilm.NewStdSupport(log, ilmCfg.Mode, alias, policy, false, true), nil
 }
 
 func applyStaticFmtstr(info beat.Info, fmt *fmtstr.EventFormatString) (string, error) {

--- a/idxmgmt/ilm/supporter_factory_test.go
+++ b/idxmgmt/ilm/supporter_factory_test.go
@@ -60,6 +60,7 @@ func TestMakeDefaultSupporter(t *testing.T) {
 			"policy_name": "%{[observer.name]}-%{[observer.version]}-%{[beat.name]}-%{[beat.version]}",
 			"alias_name":  "alias-%{[observer.name]}-%{[observer.version]}-%{[beat.name]}-%{[beat.version]}",
 			"event":       "span",
+			"enabled":     "true",
 		})
 
 		s, err := MakeDefaultSupporter(nil, info, cfg)
@@ -69,6 +70,18 @@ func TestMakeDefaultSupporter(t *testing.T) {
 		assert.Equal(t, "alias-mockapm-9.9.9-mockapm-9.9.9", s.Alias().Name)
 		assert.Equal(t, "000001", s.Alias().Pattern)
 		assert.Equal(t, libilm.ModeEnabled, s.Mode())
+	})
+
+	t.Run("default mode", func(t *testing.T) {
+		cfg := common.MustNewConfigFrom(map[string]interface{}{
+			"policy_name": "policy",
+			"alias_name":  "alias",
+			"event":       "span",
+		})
+
+		s, err := MakeDefaultSupporter(nil, info, cfg)
+		require.NoError(t, err)
+		assert.Equal(t, libilm.ModeAuto, s.Mode())
 	})
 
 }

--- a/idxmgmt/indices.go
+++ b/idxmgmt/indices.go
@@ -30,6 +30,18 @@ const (
 	apmSuffix  = "-%{+yyyy.MM.dd}"
 )
 
+type esIndexConfig struct {
+	Index   string         `config:"index"`
+	Indices *common.Config `config:"indices"`
+}
+
+func (cfg *esIndexConfig) customized() bool {
+	if cfg == nil {
+		return false
+	}
+	return cfg.Index != "" || cfg.Indices != nil
+}
+
 var defaultIndex = fmt.Sprintf("%s-%s%s", apmPrefix, apmVersion, apmSuffix)
 
 func idxStr(name string, suffix string) string {
@@ -55,16 +67,16 @@ func othersIdxNames() map[string]string {
 	}
 }
 
-func indices(cfg *common.Config) (*common.Config, error) {
+func indices(cfg *esIndexConfig) (*common.Config, error) {
 	var idcsCfg = common.NewConfig()
 
 	// set defaults
-	if !cfg.HasField("index") {
+	if cfg.Index == "" {
 		// set fallback default index
 		idcsCfg.SetString("index", -1, defaultIndex)
 
 		// set default indices if not set
-		if !cfg.HasField("indices") {
+		if cfg.Indices == nil {
 			if indicesCfg, err := common.NewConfigFrom(indicesConditions(false)); err == nil {
 				idcsCfg.SetChild("indices", -1, indicesCfg)
 			}
@@ -72,24 +84,20 @@ func indices(cfg *common.Config) (*common.Config, error) {
 	}
 
 	// use custom config settings where available
-	if cfg.HasField("index") {
-		indexName, err := cfg.String("index", -1)
-		if err != nil {
+	if cfg.Index != "" {
+		if err := idcsCfg.SetString("index", -1, cfg.Index); err != nil {
 			return nil, err
 		}
-		idcsCfg.SetString("index", -1, indexName)
 	}
-	if cfg.HasField("indices") {
-		sub, err := cfg.Child("indices", -1)
-		if err != nil {
+	if cfg.Indices != nil {
+		if err := idcsCfg.SetChild("indices", -1, cfg.Indices); err != nil {
 			return nil, err
 		}
-		idcsCfg.SetChild("indices", -1, sub)
 	}
 	return idcsCfg, nil
 }
 
-func ilmIndices(_ *common.Config) (*common.Config, error) {
+func ilmIndices() (*common.Config, error) {
 	var idcsCfg = common.NewConfig()
 
 	// set fallback index

--- a/idxmgmt/manager.go
+++ b/idxmgmt/manager.go
@@ -1,0 +1,230 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package idxmgmt
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/apm-server/idxmgmt/ilm"
+	libidxmgmt "github.com/elastic/beats/libbeat/idxmgmt"
+	libilm "github.com/elastic/beats/libbeat/idxmgmt/ilm"
+)
+
+const (
+	msgErrIlmDisabledES = "automatically disabled ILM as not supported by configured Elasticsearch"
+	msgIlmDisabledES    = "Automatically disabled ILM as not supported by configured Elasticsearch."
+	msgIlmDisabledCfg   = "Automatically disabled ILM as custom index settings configured."
+	msgIdxCfgIgnored    = "Custom index configuration ignored when ILM is enabled."
+)
+
+type manager struct {
+	supporter     *supporter
+	clientHandler libidxmgmt.ClientHandler
+	assets        libidxmgmt.Asseter
+}
+
+func (m *manager) VerifySetup(loadTemplate, loadILM libidxmgmt.LoadMode) (bool, string) {
+	templateFeature := m.templateFeature(loadTemplate)
+	ilmFeature := m.ilmFeature(loadILM)
+
+	if err := ilmFeature.error(); err != nil {
+		return false, err.Error()
+	}
+
+	if ilmFeature.load && !templateFeature.load {
+		return false, "Loading ILM policy and write alias without loading template " +
+			"is not recommended. Check your configuration."
+	}
+	if templateFeature.load && !ilmFeature.load && ilmFeature.enabled {
+		return false, "Loading template with ILM settings whithout loading ILM policy and alias can lead " +
+			"to issues and is not recommended. Check your configuration"
+	}
+
+	var warn string
+
+	if !ilmFeature.load && ilmFeature.supported {
+		warn = "ILM policy and write alias loading not enabled. "
+	}
+	if !templateFeature.load {
+		warn += "Template loading not enabled. "
+	}
+	if ilmWarn := ilmFeature.warning(); ilmWarn != "" {
+		warn += ilmWarn
+	}
+	return warn == "", warn
+}
+
+func (m *manager) Setup(loadTemplate, loadILM libidxmgmt.LoadMode) error {
+
+	log := m.supporter.log
+
+	//setup index management:
+	//(0) preparation step
+	//(1) load general apm template
+	//(2) load policy per event type
+	//(3) create template per event respecting lifecycle settings
+	//(4) load write alias per event type AFTER the template has been created,
+	//    as this step also automatically creates an index, it is important the matching templates are already there
+
+	//(0) prepare template and ilm handlers, check if ILM is supported, fall back to ordinary index handling otherwise
+
+	ilmFeature := m.ilmFeature(loadILM)
+	if warn := ilmFeature.warning(); warn != "" {
+		log.Warn(warn)
+	}
+	if err := ilmFeature.error(); err != nil {
+		log.Error(err)
+	}
+
+	templateFeature := m.templateFeature(loadTemplate)
+	m.supporter.templateConfig.Enabled = templateFeature.enabled
+	m.supporter.templateConfig.Overwrite = templateFeature.overwrite
+
+	//(1) load general apm template
+	//only set to user configured name and pattern if ilm is disabled
+	//default template name and pattern, must be the same whether or not ilm is enabled or not,
+	//allowing former templates to be overwritten
+	if err := m.loadTemplate(templateFeature, ilmFeature); err != nil {
+		return err
+	}
+
+	for _, ilmSupporter := range m.supporter.ilmSupporters {
+		//(2) load event type policies, respecting ILM settings
+		loaded, err := m.loadPolicy(ilmFeature, ilmSupporter)
+		if err != nil {
+			return err
+		}
+		overwriteTemplate := templateFeature.overwrite || loaded
+
+		// (3) load event type specific template respecting index lifecycle information
+		if err := m.loadEventTemplate(templateFeature, ilmFeature, ilmSupporter, overwriteTemplate); err != nil {
+			return err
+		}
+
+		//(4) load ilm write aliases
+		//    ensure write aliases are created AFTER template creation
+		if err := m.loadAlias(ilmFeature, ilmSupporter); err != nil {
+			return err
+		}
+	}
+
+	log.Info("Finished index management setup.")
+	return nil
+}
+
+func (m *manager) templateFeature(loadMode libidxmgmt.LoadMode) feature {
+	return newFeature(m.supporter.templateConfig.Enabled, m.supporter.templateConfig.Overwrite, true, loadMode)
+}
+
+func (m *manager) ilmFeature(loadMode libidxmgmt.LoadMode) feature {
+	if m.supporter.st.ilmEnabled.Load() {
+		f := newFeature(true, false, true, loadMode)
+		if m.supporter.esIdxCfg.customized() {
+			f.warn = msgIdxCfgIgnored
+		}
+		return f
+	}
+
+	var (
+		warn      string
+		err       error
+		supported = true
+	)
+	if m.supporter.ilmConfig.Mode == libilm.ModeAuto {
+		if m.supporter.esIdxCfg.customized() {
+			warn = msgIlmDisabledCfg
+		} else {
+			warn = msgIlmDisabledES
+			supported = false
+		}
+	} else if m.supporter.ilmConfig.Mode == libilm.ModeEnabled {
+		err = errors.New(msgErrIlmDisabledES)
+		supported = false
+	}
+	f := newFeature(false, false, supported, loadMode)
+	f.warn, f.err = warn, err
+	return f
+}
+
+func (m *manager) loadTemplate(templateFeature, ilmFeature feature) error {
+	if !templateFeature.load {
+		return nil
+	}
+	if ilmFeature.enabled || m.supporter.templateConfig.Name == "" && m.supporter.templateConfig.Pattern == "" {
+		m.supporter.templateConfig.Name = fmt.Sprintf("%s-%s", apmPrefix, apmVersion)
+		m.supporter.log.Infof("Set setup.template.name to '%s'.", m.supporter.templateConfig.Name)
+		m.supporter.templateConfig.Pattern = m.supporter.templateConfig.Name + "*"
+		m.supporter.log.Infof("Set setup.template.pattern to '%s'.", m.supporter.templateConfig.Pattern)
+	}
+	if err := m.clientHandler.Load(m.supporter.templateConfig, m.supporter.info,
+		m.assets.Fields(m.supporter.info.Beat), m.supporter.migration); err != nil {
+		return fmt.Errorf("error loading Elasticsearch template: %+v", err)
+	}
+	m.supporter.log.Infof("Finished loading index template.")
+	return nil
+}
+
+func (m *manager) loadEventTemplate(templateFeature, ilmFeature feature, ilmSupporter libilm.Supporter, overwrite bool) error {
+	if !templateFeature.load {
+		return nil
+	}
+	templateCfg := ilm.Template(ilmFeature.enabled, templateFeature.enabled, overwrite,
+		ilmSupporter.Alias().Name,
+		ilmSupporter.Policy().Name)
+
+	if err := m.clientHandler.Load(templateCfg, m.supporter.info, nil, m.supporter.migration); err != nil {
+		return errors.Wrapf(err, "error loading template %+v", templateCfg.Name)
+	}
+	m.supporter.log.Infof("Finished template setup for %s.", templateCfg.Name)
+	return nil
+}
+
+func (m *manager) loadPolicy(ilmFeature feature, ilmSupporter libilm.Supporter) (bool, error) {
+	if !ilmFeature.load {
+		return false, nil
+	}
+	policy := ilmSupporter.Policy().Name
+	policyCreated, err := ilmSupporter.Manager(m.clientHandler).EnsurePolicy(ilmFeature.overwrite)
+	if err != nil {
+		return policyCreated, err
+	}
+	if !policyCreated {
+		m.supporter.log.Infof("ILM policy %s exists already.", policy)
+		return false, nil
+	}
+	m.supporter.log.Infof("ILM policy %s successfully loaded.", policy)
+	return true, nil
+}
+func (m *manager) loadAlias(ilmFeature feature, ilmSupporter libilm.Supporter) error {
+	if !ilmFeature.load {
+		return nil
+	}
+
+	alias := ilmSupporter.Alias().Name
+	if err := ilmSupporter.Manager(m.clientHandler).EnsureAlias(); err != nil {
+		if libilm.ErrReason(err) != libilm.ErrAliasAlreadyExists {
+			return err
+		}
+		m.supporter.log.Infof("Write alias %s exists already.", alias)
+		return nil
+	}
+	m.supporter.log.Infof("Write alias %s successfully generated.", alias)
+	return nil
+}

--- a/idxmgmt/manager_test.go
+++ b/idxmgmt/manager_test.go
@@ -1,0 +1,414 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package idxmgmt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+	libidxmgmt "github.com/elastic/beats/libbeat/idxmgmt"
+	libilm "github.com/elastic/beats/libbeat/idxmgmt/ilm"
+	"github.com/elastic/beats/libbeat/template"
+)
+
+func TestManager_VerifySetup(t *testing.T) {
+	for name, setup := range map[string]struct {
+		tmpl              bool
+		ilm               string
+		loadTmpl, loadILM libidxmgmt.LoadMode
+		version           string
+		esCfg             common.MapStr
+
+		ok   bool
+		warn string
+	}{
+		"LoadTemplateWithoutILM": {
+			ilm: "true", loadILM: libidxmgmt.LoadModeDisabled,
+			tmpl: true, loadTmpl: libidxmgmt.LoadModeEnabled,
+			warn: "whithout loading ILM policy and alias",
+		},
+		"LoadILMWithoutTemplate": {
+			ilm: "true", loadILM: libidxmgmt.LoadModeEnabled,
+			loadTmpl: libidxmgmt.LoadModeEnabled,
+			warn:     "without loading template is not recommended",
+		},
+		"SetupTemplateDisabled": {
+			ilm: "false", loadILM: libidxmgmt.LoadModeEnabled,
+			loadTmpl: libidxmgmt.LoadModeEnabled,
+			warn:     "loading not enabled",
+		},
+		"SetupILMDisabled": {
+			ilm: "false", loadILM: libidxmgmt.LoadModeEnabled,
+			tmpl: true, loadTmpl: libidxmgmt.LoadModeEnabled,
+			warn: "loading not enabled",
+		},
+		"LoadILMDisabled": {
+			ilm: "true", loadILM: libidxmgmt.LoadModeDisabled,
+			loadTmpl: libidxmgmt.LoadModeEnabled,
+			warn:     "loading not enabled",
+		},
+		"LoadTemplateDisabled": {
+			ilm: "false", loadILM: libidxmgmt.LoadModeEnabled,
+			tmpl: true, loadTmpl: libidxmgmt.LoadModeDisabled,
+			warn: "loading not enabled",
+		},
+		"ILMEnabledButUnsupported": {
+			version: "6.2.0",
+			ilm:     "true", loadILM: libidxmgmt.LoadModeEnabled,
+			loadTmpl: libidxmgmt.LoadModeEnabled,
+			warn:     msgErrIlmDisabledES,
+		},
+		"ILMAutoButUnsupported": {
+			loadTmpl: libidxmgmt.LoadModeEnabled,
+			version:  "6.2.0",
+			tmpl:     true,
+			ilm:      "auto", loadILM: libidxmgmt.LoadModeEnabled,
+			warn: msgIlmDisabledES,
+		},
+		"ILMAutoCustomIndex": {
+			tmpl: true, loadTmpl: libidxmgmt.LoadModeEnabled,
+			ilm: "auto", loadILM: libidxmgmt.LoadModeEnabled,
+			esCfg: common.MapStr{"output.elasticsearch.index": "custom"},
+			warn:  msgIlmDisabledCfg,
+		},
+		"ILMAutoCustomIndices": {
+			tmpl: true, loadTmpl: libidxmgmt.LoadModeEnabled,
+			ilm: "auto", loadILM: libidxmgmt.LoadModeEnabled,
+			esCfg: common.MapStr{"output.elasticsearch.indices": []common.MapStr{{
+				"index": "apm-custom-%{[observer.version]}-metric",
+				"when": map[string]interface{}{
+					"contains": map[string]interface{}{"processor.event": "metric"}}}}},
+			warn: msgIlmDisabledCfg,
+		},
+		"ILMTrueCustomIndex": {
+			tmpl: true, loadTmpl: libidxmgmt.LoadModeEnabled,
+			ilm: "true", loadILM: libidxmgmt.LoadModeEnabled,
+			esCfg: common.MapStr{"output.elasticsearch.index": "custom"},
+			warn:  msgIdxCfgIgnored,
+		},
+		"LogstashOutput": {
+			tmpl: true, loadTmpl: libidxmgmt.LoadModeEnabled,
+			ilm: "true", loadILM: libidxmgmt.LoadModeEnabled,
+			esCfg: common.MapStr{
+				"output.elasticsearch.enabled": false,
+				"output.logstash.enabled":      true},
+			warn: "automatically disabled ILM",
+		},
+		"EverythingEnabled": {
+			tmpl: true, loadTmpl: libidxmgmt.LoadModeEnabled,
+			ilm: "true", loadILM: libidxmgmt.LoadModeEnabled,
+			ok: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := common.MapStr{
+				"apm-server.ilm.enabled": setup.ilm,
+				"setup.template.enabled": setup.tmpl,
+			}
+			if setup.esCfg != nil {
+				c.DeepUpdate(setup.esCfg)
+			}
+			support := defaultSupporter(t, c)
+			version := setup.version
+			if version == "" {
+				version = "7.0.0"
+			}
+			manager := support.Manager(newMockClientHandler(version), nil)
+			ok, warn := manager.VerifySetup(setup.loadTmpl, setup.loadILM)
+			require.Equal(t, setup.ok, ok, warn)
+			assert.Contains(t, warn, setup.warn)
+		})
+	}
+}
+
+func TestManager_Setup(t *testing.T) {
+	fields := []byte("apm-server fields")
+
+	type testCase struct {
+		cfg            common.MapStr
+		tLoad, ilmLoad libidxmgmt.LoadMode
+
+		tCt, tWithILMCt, pCt, aCt int
+		version                   string
+		err                       error
+	}
+
+	var testCasesEnabled = map[string]testCase{
+		"Default": {
+			tLoad: libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
+			tCt: 5, tWithILMCt: 4, pCt: 3, aCt: 3,
+		},
+		"LoadTemplateAndILM": {
+			cfg:   common.MapStr{"apm-server.ilm.enabled": true},
+			tLoad: libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
+			tCt: 5, tWithILMCt: 4, pCt: 3, aCt: 3,
+		},
+		"DisabledILM": {
+			cfg:   common.MapStr{"apm-server.ilm.enabled": false},
+			tLoad: libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
+			tCt: 5,
+		},
+		"DisabledTemplate": {
+			cfg:   common.MapStr{"setup.template.enabled": false},
+			tLoad: libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
+			pCt: 3, aCt: 3,
+		},
+		"DisabledTemplateAndILM": {
+			cfg:   common.MapStr{"setup.template.enabled": false, "apm-server.ilm.enabled": false},
+			tLoad: libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
+		},
+		"LoadModeDisabledILM": {
+			tLoad: libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeDisabled,
+			tCt: 5, tWithILMCt: 4,
+		},
+		"LoadModeDisabledTemplate": {
+			tLoad: libidxmgmt.LoadModeDisabled, ilmLoad: libidxmgmt.LoadModeEnabled,
+			pCt: 3, aCt: 3,
+		},
+		"LoadModeDisabledTemplateAndILM": {
+			tLoad:   libidxmgmt.LoadModeDisabled,
+			ilmLoad: libidxmgmt.LoadModeDisabled,
+		},
+	}
+
+	var testCasesLoadModeUnset = map[string]testCase{
+		"DefaultLoadModeUnset": {
+			tCt: 0, tWithILMCt: 0, pCt: 0, aCt: 0,
+		},
+	}
+
+	var testCasesLoadModeOverwrite = map[string]testCase{
+		// used for `./apm-server setup template`, `apm-server setup index-managemet`
+
+		"DisabledILMAndTemplateLoadModeOverwrite": {
+			cfg:     common.MapStr{"setup.template.enabled": false, "apm-server.ilm.enabled": false},
+			tLoad:   libidxmgmt.LoadModeOverwrite,
+			ilmLoad: libidxmgmt.LoadModeOverwrite,
+		},
+		"LoadModeOverwriteTemplateLoadModeDisabledILM": {
+			// used for `./apm-server setup template`
+			tLoad:   libidxmgmt.LoadModeOverwrite,
+			ilmLoad: libidxmgmt.LoadModeDisabled,
+			tCt:     5, tWithILMCt: 4,
+		},
+		"LoadModeOverwriteILMLoadModeDisabledTemplate": {
+			tLoad:   libidxmgmt.LoadModeDisabled,
+			ilmLoad: libidxmgmt.LoadModeOverwrite,
+			pCt:     4, aCt: 3,
+		},
+		"LoadModeOverwriteWhenDisabled": {
+			// used for `./apm-server setup template`, `apm-server setup index-managemet`
+			tLoad:   libidxmgmt.LoadModeOverwrite,
+			ilmLoad: libidxmgmt.LoadModeOverwrite,
+			tCt:     5, tWithILMCt: 4, pCt: 4, aCt: 3,
+		},
+	}
+
+	var testCasesLoadModeForce = map[string]testCase{
+		// used for `./apm-server export template`
+
+		"LoadModeForceTemplateLoadModeDisabledILM": {
+			cfg:     common.MapStr{"setup.template.enabled": false, "apm-server.ilm.enabled": false},
+			tLoad:   libidxmgmt.LoadModeForce,
+			ilmLoad: libidxmgmt.LoadModeDisabled,
+			tCt:     5,
+		},
+		"LoadModeForceILMLoadModeDisabledTemplate": {
+			// used for `./apm-server export ilm-policy`
+			cfg:     common.MapStr{"setup.template.enabled": false, "apm-server.ilm.enabled": false},
+			tLoad:   libidxmgmt.LoadModeDisabled,
+			ilmLoad: libidxmgmt.LoadModeForce,
+			pCt:     4, aCt: 3,
+		},
+		"LoadModeForceWhenDisabled": {
+			cfg:     common.MapStr{"setup.template.enabled": false, "apm-server.ilm.enabled": false},
+			tLoad:   libidxmgmt.LoadModeForce,
+			ilmLoad: libidxmgmt.LoadModeForce,
+			tCt:     5, tWithILMCt: 4, pCt: 4, aCt: 3,
+		},
+	}
+
+	var testCasesILMNotSupportedByES = map[string]testCase{
+		"DisabledAndUnsupportedILM": {
+			version: "6.2.0",
+			cfg:     common.MapStr{"apm-server.ilm.enabled": false},
+			tLoad:   libidxmgmt.LoadModeEnabled,
+			ilmLoad: libidxmgmt.LoadModeEnabled,
+			tCt:     5,
+		},
+		"AutoAndUnsupportedILM": {
+			version: "6.2.0",
+			cfg:     common.MapStr{"apm-server.ilm.enabled": "auto"},
+			tLoad:   libidxmgmt.LoadModeEnabled,
+			ilmLoad: libidxmgmt.LoadModeEnabled,
+			tCt:     5,
+		},
+		"EnabledAndUnsupportedILM": {
+			version: "6.2.0",
+			cfg:     common.MapStr{"apm-server.ilm.enabled": true},
+			tLoad:   libidxmgmt.LoadModeEnabled,
+			ilmLoad: libidxmgmt.LoadModeEnabled,
+			tCt:     5,
+		},
+		"ForceModeWhenUnsupportedILM": {
+			version: "6.2.0",
+			cfg:     common.MapStr{"apm-server.ilm.enabled": true},
+			tLoad:   libidxmgmt.LoadModeForce,
+			ilmLoad: libidxmgmt.LoadModeForce,
+			tCt:     5,
+		},
+	}
+	var testCasesILMNotSupportedByIndexSettings = map[string]testCase{
+		"ESIndexConfigured": {
+			cfg: common.MapStr{
+				"apm-server.ilm.enabled":     "auto",
+				"setup.template.name":        "custom",
+				"setup.template.pattern":     "custom",
+				"output.elasticsearch.index": "custom"},
+			tLoad:   libidxmgmt.LoadModeEnabled,
+			ilmLoad: libidxmgmt.LoadModeEnabled,
+			tCt:     5,
+		},
+		"ESIndicesConfigured": {
+			cfg: common.MapStr{
+				"apm-server.ilm.enabled": "auto",
+				"setup.template.name":    "custom",
+				"setup.template.pattern": "custom",
+				"output.elasticsearch.indices": []common.MapStr{{
+					"index": "apm-custom-%{[observer.version]}-metric",
+					"when": map[string]interface{}{
+						"contains": map[string]interface{}{"processor.event": "metric"}}}}},
+			tLoad:   libidxmgmt.LoadModeEnabled,
+			ilmLoad: libidxmgmt.LoadModeEnabled,
+			tCt:     5,
+		},
+	}
+
+	for _, test := range []map[string]testCase{
+		testCasesEnabled,
+		testCasesLoadModeUnset,
+		testCasesLoadModeOverwrite,
+		testCasesLoadModeForce,
+		testCasesILMNotSupportedByES,
+		testCasesILMNotSupportedByIndexSettings,
+	} {
+		for name, tc := range test {
+			t.Run(name, func(t *testing.T) {
+				version := tc.version
+				if version == "" {
+					version = "7.2.0"
+				}
+
+				ch := newMockClientHandler(version)
+				m := defaultSupporter(t, tc.cfg).Manager(ch, libidxmgmt.BeatsAssets(fields))
+				idxManager := m.(*manager)
+				err := idxManager.Setup(tc.tLoad, tc.ilmLoad)
+				if tc.err == nil {
+					require.NoError(t, err)
+				} else {
+					require.Error(t, err)
+					assert.Equal(t, ErrILMNotSupported, err)
+				}
+
+				assert.Equal(t, tc.pCt, len(ch.policies), "policies")
+				assert.Equal(t, tc.aCt, len(ch.aliases), "aliases")
+				require.Equal(t, tc.tCt, ch.tmplLoadCt, "templates")
+				assert.Equal(t, tc.tWithILMCt, ch.tmplLoadWithILMCt, "ILM templates")
+				if tc.tCt > 0 {
+					assert.Equal(t, 1, ch.tmplLoadCt-ch.tmplOrderILMCt, "order template")
+					assert.Equal(t, tc.tCt-1, ch.tmplOrderILMCt, "order ILM template")
+				}
+			})
+		}
+	}
+}
+
+type mockClientHandler struct {
+	aliases, policies []string
+
+	tmplLoadCt, tmplLoadWithILMCt int
+	tmplOrderILMCt                int
+	tmplForce                     bool
+
+	esVersion *common.Version
+}
+
+var existingILM = fmt.Sprintf("apm-%s-transaction", info.Version)
+var ErrILMNotSupported = errors.New("ILM not supported")
+var esMinILMVersion = common.MustNewVersion("6.6.0")
+
+func newMockClientHandler(esVersion string) *mockClientHandler {
+	return &mockClientHandler{esVersion: common.MustNewVersion(esVersion)}
+}
+
+func (h *mockClientHandler) Load(config template.TemplateConfig, _ beat.Info, fields []byte, migration bool) error {
+	h.tmplLoadCt++
+	if config.Settings.Index != nil && config.Settings.Index["lifecycle.name"] != nil {
+		h.tmplLoadWithILMCt++
+		if len(fields) > 0 {
+			return errors.New("fields should be empty")
+		}
+	}
+	if config.Order == 2 {
+		h.tmplOrderILMCt++
+	}
+	if config.Order != 1 && config.Order != 2 {
+		return errors.New("unexpected template order")
+	}
+	h.tmplForce = config.Overwrite
+	return nil
+}
+
+func (h *mockClientHandler) CheckILMEnabled(mode libilm.Mode) (bool, error) {
+	if mode == libilm.ModeDisabled {
+		return false, nil
+	}
+	avail := !h.esVersion.LessThan(esMinILMVersion)
+	if avail {
+		return true, nil
+	}
+
+	if mode == libilm.ModeAuto {
+		return false, nil
+	}
+	return false, ErrILMNotSupported
+}
+
+func (h *mockClientHandler) HasAlias(name string) (bool, error) {
+	return name == existingILM, nil
+}
+
+func (h *mockClientHandler) CreateAlias(alias libilm.Alias) error {
+	h.aliases = append(h.aliases, alias.Name)
+	return nil
+}
+
+func (h *mockClientHandler) HasILMPolicy(name string) (bool, error) {
+	return name == existingILM, nil
+}
+
+func (h *mockClientHandler) CreateILMPolicy(policy libilm.Policy) error {
+	h.policies = append(h.policies, policy.Name)
+	return nil
+}

--- a/idxmgmt/supporter_factory_test.go
+++ b/idxmgmt/supporter_factory_test.go
@@ -1,0 +1,80 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package idxmgmt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/common"
+)
+
+func TestMakeDefaultSupporter(t *testing.T) {
+	info := beat.Info{}
+
+	buildSupporter := func(c map[string]interface{}) (*supporter, error) {
+		cfg, err := common.NewConfigFrom(c)
+		require.NoError(t, err)
+		s, err := MakeDefaultSupporter(nil, info, cfg)
+		if s != nil {
+			return s.(*supporter), err
+		}
+		return nil, err
+	}
+
+	t.Run("StdSupporter", func(t *testing.T) {
+		s, err := buildSupporter(map[string]interface{}{
+			"apm-server.ilm.enabled":       "auto",
+			"setup.template.enabled":       "true",
+			"output.elasticsearch.enabled": "true",
+		})
+		require.NoError(t, err)
+
+		assert.True(t, s.Enabled())
+		assert.NotNil(t, s.log)
+		assert.True(t, s.templateConfig.Enabled)
+		assert.True(t, s.ilmConfig.Enabled())
+		assert.Equal(t, &esIndexConfig{}, s.esIdxCfg)
+	})
+
+	t.Run("ILMDisabled", func(t *testing.T) {
+		s, err := buildSupporter(map[string]interface{}{
+			"apm-server.ilm.enabled":       "false",
+			"setup.template.enabled":       "true",
+			"setup.template.name":          "custom",
+			"setup.template.pattern":       "custom",
+			"output.elasticsearch.index":   "custom-index",
+			"output.elasticsearch.enabled": "true",
+		})
+		require.NoError(t, err)
+		assert.False(t, s.ilmConfig.Enabled())
+	})
+	t.Run("SetupTemplateConfigConflicting", func(t *testing.T) {
+		s, err := buildSupporter(map[string]interface{}{
+			"output.elasticsearch.index": "custom-index",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "`setup.template.name` and `setup.template.pattern` have to be set ")
+		assert.Nil(t, s)
+
+	})
+}

--- a/idxmgmt/supporter_test.go
+++ b/idxmgmt/supporter_test.go
@@ -15,45 +15,58 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//// Licensed to Elasticsearch B.V. under one or more contributor
+//// license agreements. See the NOTICE file distributed with
+//// this work for additional information regarding copyright
+//// ownership. Elasticsearch B.V. licenses this file to you under
+//// the Apache License, Version 2.0 (the "License"); you may
+//// not use this file except in compliance with the License.
+//// You may obtain a copy of the License at
+////
+////     http://www.apache.org/licenses/LICENSE-2.0
+////
+//// Unless required by applicable law or agreed to in writing,
+//// software distributed under the License is distributed on an
+//// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//// KIND, either express or implied.  See the License for the
+//// specific language governing permissions and limitations
+//// under the License.
+//
 package idxmgmt
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/common"
 	libidxmgmt "github.com/elastic/beats/libbeat/idxmgmt"
-	libilm "github.com/elastic/beats/libbeat/idxmgmt/ilm"
-	"github.com/elastic/beats/libbeat/template"
 )
-
-type mockClientHandler struct {
-	aliases, policies []string
-
-	tmplLoadCt, tmplLoadWithILMCt int
-	tmplOrderILMCt                int
-	tmplForce                     bool
-
-	ilmSupported bool
-}
 
 var (
-	info          = beat.Info{Beat: "testbeat", Version: "1.1.0"}
-	ilmEnabledKey = "apm-server.ilm.enabled"
+	info  = beat.Info{Beat: "testbeat", Version: "1.1.0"}
+	today = time.Now().UTC()
+	day   = today.Format("2006.01.02")
 )
 
-func defaultSupporter(t *testing.T, c common.MapStr) libidxmgmt.Supporter {
+func defaultSupporter(t *testing.T, m common.MapStr) *supporter {
+	c := common.MapStr{
+		"output.elasticsearch.enabled": true,
+		"setup.template.name":          "custom",
+		"setup.template.pattern":       "custom*",
+	}
+	c.DeepUpdate(m)
+
 	cfg, err := common.NewConfigFrom(c)
 	require.NoError(t, err)
-	supporter, err := MakeDefaultSupporter(nil, info, cfg)
+	sup, err := MakeDefaultSupporter(nil, info, cfg)
 	require.NoError(t, err)
-	return supporter
+	return sup.(*supporter)
 }
 
 func TestIndexSupport_Enabled(t *testing.T) {
@@ -64,13 +77,25 @@ func TestIndexSupport_Enabled(t *testing.T) {
 		"template default": {
 			expected: true,
 		},
-		"template disabled": {
-			expected: false,
-			cfg:      common.MapStr{"setup.template.enabled": false},
-		},
 		"template enabled": {
 			expected: true,
 			cfg:      common.MapStr{"setup.template.enabled": true},
+		},
+		"template and ilm disabled": {
+			expected: false,
+			cfg:      common.MapStr{"setup.template.enabled": false, "apm-server.ilm.enabled": false},
+		},
+		"ilm enabled": {
+			expected: true,
+			cfg:      common.MapStr{"setup.template.enabled": false, "apm-server.ilm.enabled": true},
+		},
+		"ilm auto": {
+			expected: true,
+			cfg:      common.MapStr{"setup.template.enabled": false, "apm-server.ilm.enabled": "auto"},
+		},
+		"ilm default": {
+			expected: true,
+			cfg:      common.MapStr{"setup.template.enabled": false},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -78,92 +103,95 @@ func TestIndexSupport_Enabled(t *testing.T) {
 		})
 	}
 }
+
 func TestIndexSupport_BuildSelector(t *testing.T) {
-	today := time.Now().UTC()
-	day := today.Format("2006.01.02")
 
 	type testdata struct {
 		meta     common.MapStr
 		noIlm    string
 		withIlm  string
+		ilmAuto  string
 		expected string
 		cfg      common.MapStr
 		fields   common.MapStr
 	}
 
 	cases := map[string]testdata{
-		"default index": {
+		"DefaultIndex": {
 			noIlm:   fmt.Sprintf("apm-7.0.0-%s", day),
 			withIlm: fmt.Sprintf("apm-7.0.0-%s", day),
 			fields:  common.MapStr{},
 		},
-		"default onboarding": {
+		"DefaultOnboarding": {
 			noIlm:   fmt.Sprintf("apm-7.0.0-onboarding-%s", day),
 			withIlm: fmt.Sprintf("apm-7.0.0-onboarding-%s", day),
 			fields:  common.MapStr{"processor.event": "onboarding"},
 		},
-		"default error": {
+		"DefaultError": {
 			noIlm:   fmt.Sprintf("apm-7.0.0-error-%s", day),
 			withIlm: "apm-7.0.0-error",
 			fields:  common.MapStr{"processor.event": "error"},
 		},
-		"default span": {
+		"DefaultSpan": {
 			noIlm:   fmt.Sprintf("apm-7.0.0-span-%s", day),
 			withIlm: "apm-7.0.0-span",
 			fields:  common.MapStr{"processor.event": "span"},
 		},
-		"default transaction": {
+		"DefaultTransaction": {
 			noIlm:   fmt.Sprintf("apm-7.0.0-transaction-%s", day),
 			withIlm: "apm-7.0.0-transaction",
 			fields:  common.MapStr{"processor.event": "transaction"},
 		},
-		"default metric": {
+		"DefaultMetric": {
 			noIlm:   fmt.Sprintf("apm-7.0.0-metric-%s", day),
 			withIlm: "apm-7.0.0-metric",
 			fields:  common.MapStr{"processor.event": "metric"},
 		},
-		"default sourcemap": {
+		"DefaultSourcemap": {
 			noIlm:   "apm-7.0.0-sourcemap",
 			withIlm: "apm-7.0.0-sourcemap",
 			fields:  common.MapStr{"processor.event": "sourcemap"},
 		},
-		"meta alias information overwrites config": {
+		"MetaInformationAlias": {
 			noIlm:   "apm-7.0.0-meta",
 			withIlm: "apm-7.0.0-meta", //meta overwrites ilm
 			fields:  common.MapStr{"processor.event": "span"},
 			meta:    common.MapStr{"alias": "apm-7.0.0-meta", "index": "test-123"},
-			cfg:     common.MapStr{"index": "apm-customized"},
+			cfg:     common.MapStr{"output.elasticsearch.index": "apm-customized"},
 		},
-		"meta information overwrites config": {
+		"MetaInformationIndex": {
 			noIlm:   fmt.Sprintf("apm-7.0.0-%s", day),
 			withIlm: fmt.Sprintf("apm-7.0.0-%s", day), //meta overwrites ilm
 			fields:  common.MapStr{"processor.event": "span"},
 			meta:    common.MapStr{"index": "apm-7.0.0"},
-			cfg:     common.MapStr{"index": "apm-customized"},
+			cfg:     common.MapStr{"output.elasticsearch.index": "apm-customized"},
 		},
-		"custom index": {
+		"CustomIndex": {
 			noIlm:   "apm-customized",
 			withIlm: "apm-7.0.0-metric", //custom index ignored when ilm enabled
+			ilmAuto: "apm-customized",   //custom respected for ilm auto
 			fields:  common.MapStr{"processor.event": "metric"},
-			cfg:     common.MapStr{"index": "apm-customized"},
+			cfg:     common.MapStr{"output.elasticsearch.index": "apm-customized"},
 		},
-		"custom indices, fallback to default index": {
+		"DifferentCustomIndices": {
 			noIlm:   fmt.Sprintf("apm-7.0.0-%s", day),
-			withIlm: "apm-7.0.0-metric", //custom index ignored when ilm enabled
+			withIlm: "apm-7.0.0-metric",               //custom index ignored when ilm enabled
+			ilmAuto: fmt.Sprintf("apm-7.0.0-%s", day), //custom respected for ilm auto
 			fields:  common.MapStr{"processor.event": "metric"},
 			cfg: common.MapStr{
-				"indices": []common.MapStr{{
+				"output.elasticsearch.indices": []common.MapStr{{
 					"index": "apm-custom-%{[observer.version]}-metric",
 					"when": map[string]interface{}{
 						"contains": map[string]interface{}{"processor.event": "error"}}}},
 			},
 		},
-		"custom indices": {
+		"CustomIndices": {
 			noIlm:   "apm-custom-7.0.0-metric",
-			withIlm: "apm-7.0.0-metric", //custom index ignored when ilm enabled
+			withIlm: "apm-7.0.0-metric",        //custom index ignored when ilm enabled
+			ilmAuto: "apm-custom-7.0.0-metric", //custom respected for ilm auto
 			fields:  common.MapStr{"processor.event": "metric"},
 			cfg: common.MapStr{
-				"indices": []common.MapStr{{
+				"output.elasticsearch.indices": []common.MapStr{{
 					"index": "apm-custom-%{[observer.version]}-metric",
 					"when": map[string]interface{}{
 						"contains": map[string]interface{}{"processor.event": "metric"}}}},
@@ -171,265 +199,80 @@ func TestIndexSupport_BuildSelector(t *testing.T) {
 		},
 	}
 
-	checkIndexSelector := func(t *testing.T, name string, test testdata) {
+	ilmSupportedHandler := newMockClientHandler("7.2.0")
+	ilmUnsupportedHandler := newMockClientHandler("6.2.0")
+
+	checkIndexSelector := func(t *testing.T, name string, test testdata, handler libidxmgmt.ClientHandler) {
 		t.Run(name, func(t *testing.T) {
-			fields := test.fields
-			fields.Put("observer", common.MapStr{"version": "7.0.0"})
-			testEvent := &beat.Event{
-				Fields:    fields,
-				Meta:      test.meta,
-				Timestamp: today,
-			}
-			cfg, err := common.NewConfigFrom(test.cfg)
+			// create initialized supporter and selector
+
+			supporter := defaultSupporter(t, test.cfg)
+			supporter.setIlmState(handler)
+
+			s, err := supporter.BuildSelector(nil)
 			require.NoError(t, err)
 
-			s, err := defaultSupporter(t, test.cfg).BuildSelector(cfg)
-			assert.NoError(t, err)
-			idx, err := s.Select(testEvent)
-			assert.NoError(t, err)
+			// test selected index
+			idx, err := s.Select(testEvent(test.fields, test.meta))
+			require.NoError(t, err)
 			assert.Equal(t, test.expected, idx)
 		})
 	}
 
 	for name, test := range cases {
-		//ilm=false
-		test.expected = test.noIlm
-		checkIndexSelector(t, name, test)
-
-		//ilm=true
-		test.expected = test.withIlm
 		if test.cfg == nil {
 			test.cfg = common.MapStr{}
 		}
-		test.cfg[ilmEnabledKey] = true
-		checkIndexSelector(t, name, test)
-	}
-}
 
-func TestIndexManager_VerifySetup(t *testing.T) {
-	for name, setup := range map[string]struct {
-		tmpl, ilm         bool
-		loadTmpl, loadILM libidxmgmt.LoadMode
-		ok                bool
-		warn              string
-	}{
-		"load template with ilm without loading ilm": {
-			ilm: true, tmpl: true,
-			loadTmpl: libidxmgmt.LoadModeEnabled, loadILM: libidxmgmt.LoadModeDisabled,
-			warn: "whithout loading ILM policy and alias",
-		},
-		"load ilm without template": {
-			ilm: true, loadILM: libidxmgmt.LoadModeEnabled,
-			warn: "without loading template is not recommended",
-		},
-		"template disabled but loading enabled": {
-			loadTmpl: libidxmgmt.LoadModeEnabled,
-			warn:     "loading not enabled",
-		},
-		"ilm disabled but loading enabled": {
-			loadILM: libidxmgmt.LoadModeEnabled, tmpl: true,
-			warn: "loading not enabled",
-		},
-		"ilm enabled but loading disabled": {
-			ilm: true, loadILM: libidxmgmt.LoadModeDisabled,
-			warn: "loading not enabled",
-		},
-		"template enabled but loading disabled": {
-			tmpl: true, loadTmpl: libidxmgmt.LoadModeDisabled,
-			warn: "loading not enabled",
-		},
-		"everything enabled": {
-			tmpl: true, loadTmpl: libidxmgmt.LoadModeEnabled, ilm: true, loadILM: libidxmgmt.LoadModeEnabled,
-			ok: true,
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			cfg, err := common.NewConfigFrom(common.MapStr{
-				"apm-server.ilm.enabled": setup.ilm,
-				"setup.template.enabled": setup.tmpl,
-			})
-			require.NoError(t, err)
-			support, err := MakeDefaultSupporter(nil, beat.Info{}, cfg)
-			require.NoError(t, err)
-			manager := support.Manager(newMockClientHandler(true), nil)
-			ok, warn := manager.VerifySetup(setup.loadTmpl, setup.loadILM)
-			assert.Equal(t, setup.ok, ok)
-			assert.Contains(t, warn, setup.warn)
-		})
-	}
-}
+		//ilm true and supported
+		test.cfg["apm-server.ilm.enabled"] = true
+		test.expected = test.withIlm
+		checkIndexSelector(t, "ILMTrueSupported"+name, test, ilmSupportedHandler)
 
-func TestManager_Setup(t *testing.T) {
-	fields := []byte("apm-server fields")
-	errIlmNotSupported := "ILM not supported"
-	for name, test := range map[string]struct {
-		cfg                       common.MapStr
-		tLoad, ilmLoad            libidxmgmt.LoadMode
-		tCt, tWithILMCt, pCt, aCt int
-		ilmSupported              bool
-		errMsg                    string
-	}{
-		"default load template without ilm": {
-			ilmSupported: true,
-			cfg:          nil,
-			tLoad:        libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
-			tCt: 5,
-		},
-		"load template without ilm": {
-			ilmSupported: true,
-			tLoad:        libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
-			tCt: 5,
-		},
-		"no dependency on ilm support": {
-			ilmSupported: false,
-			tLoad:        libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
-			tCt: 5,
-		},
-		"load template with ilm settings": {
-			ilmSupported: true,
-			cfg:          common.MapStr{"apm-server.ilm.enabled": true},
-			tLoad:        libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeDisabled,
-			tCt: 5, tWithILMCt: 4,
-		},
-		"load template with ilm settings when ilm is not supported": {
-			ilmSupported: false,
-			cfg:          common.MapStr{"apm-server.ilm.enabled": true},
-			tLoad:        libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeDisabled,
-			errMsg: errIlmNotSupported,
-			tCt:    0, tWithILMCt: 0,
-		},
-		"load template disabled": {
-			ilmSupported: true,
-			cfg:          nil,
-			tLoad:        libidxmgmt.LoadModeDisabled,
-		},
-		"template disabled": {
-			ilmSupported: true,
-			cfg:          common.MapStr{"setup.template.enabled": false},
-			tLoad:        libidxmgmt.LoadModeEnabled,
-		},
-		"force load template": {
-			ilmSupported: true,
-			cfg:          nil,
-			tLoad:        libidxmgmt.LoadModeForce,
-			tCt:          5,
-		},
-		"template disabled ilm enabled loading disabled": {
-			ilmSupported: true,
-			cfg:          common.MapStr{"apm-server.ilm.enabled": true, "setup.template.enabled": false},
-			ilmLoad:      libidxmgmt.LoadModeUnset,
-		},
-		"do not load template load ilm": {
-			ilmSupported: true,
-			cfg:          common.MapStr{"apm-server.ilm.enabled": true, "setup.template.enabled": false},
-			ilmLoad:      libidxmgmt.LoadModeEnabled,
-			pCt:          3, aCt: 3,
-		},
-		"try loading ilm when ilm not supported": {
-			ilmSupported: false,
-			cfg:          common.MapStr{"apm-server.ilm.enabled": true, "setup.template.enabled": false},
-			ilmLoad:      libidxmgmt.LoadModeEnabled,
-			errMsg:       errIlmNotSupported,
-			tCt:          0, tWithILMCt: 0,
-		},
-		"do not load template force load ilm": {
-			ilmSupported: true,
-			cfg:          common.MapStr{"apm-server.ilm.enabled": true},
-			tLoad:        libidxmgmt.LoadModeDisabled, ilmLoad: libidxmgmt.LoadModeForce,
-			pCt: 4, aCt: 3,
-		},
-		"load template and ilm": {
-			ilmSupported: true,
-			cfg:          common.MapStr{"apm-server.ilm.enabled": true},
-			tLoad:        libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
-			tCt: 5, tWithILMCt: 4, pCt: 3, aCt: 3,
-		},
-		"try loading template and ilm when ilm is not supported": {
-			ilmSupported: false,
-			cfg:          common.MapStr{"apm-server.ilm.enabled": true},
-			tLoad:        libidxmgmt.LoadModeEnabled, ilmLoad: libidxmgmt.LoadModeEnabled,
-			errMsg: errIlmNotSupported,
-			tCt:    0, tWithILMCt: 0,
-		},
-		"force load template force load ilm": {
-			ilmSupported: true,
-			cfg:          common.MapStr{"apm-server.ilm.enabled": true},
-			tLoad:        libidxmgmt.LoadModeForce, ilmLoad: libidxmgmt.LoadModeForce,
-			tCt: 5, tWithILMCt: 4, pCt: 4, aCt: 3,
-		},
-	} {
+		//ilm true but unsupported
+		test.cfg["apm-server.ilm.enabled"] = true
+		test.expected = test.noIlm
+		checkIndexSelector(t, "ILMTrueUnsupported"+name, test, ilmUnsupportedHandler)
 
-		t.Run(name, func(t *testing.T) {
-			ch := newMockClientHandler(test.ilmSupported)
-			m := defaultSupporter(t, test.cfg).Manager(ch, libidxmgmt.BeatsAssets(fields))
-			idxManager := m.(*manager)
-			err := idxManager.Setup(test.tLoad, test.ilmLoad)
-			if test.errMsg == "" {
-				require.NoError(t, err)
-			} else {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), test.errMsg)
-			}
+		//ilm=false
+		test.cfg["apm-server.ilm.enabled"] = false
+		test.expected = test.noIlm
+		checkIndexSelector(t, "ILMFalse"+name, test, ilmSupportedHandler)
 
-			assert.Equal(t, test.pCt, len(ch.policies))
-			assert.Equal(t, test.aCt, len(ch.aliases))
-			require.Equal(t, test.tCt, ch.tmplLoadCt)
-			assert.Equal(t, test.tWithILMCt, ch.tmplLoadWithILMCt)
-			if test.tCt > 0 {
-				assert.Equal(t, 1, ch.tmplLoadCt-ch.tmplOrderILMCt)
-				assert.Equal(t, test.tCt-1, ch.tmplOrderILMCt)
-			}
-		})
-	}
-
-}
-
-var existingILM = fmt.Sprintf("apm-%s-transaction", info.Version)
-
-func newMockClientHandler(ilmSupported bool) *mockClientHandler {
-	return &mockClientHandler{ilmSupported: ilmSupported}
-}
-
-func (h *mockClientHandler) Load(config template.TemplateConfig, _ beat.Info, fields []byte, migration bool) error {
-	h.tmplLoadCt++
-	if config.Settings.Index != nil && config.Settings.Index["lifecycle.name"] != nil {
-		h.tmplLoadWithILMCt++
-		if len(fields) > 0 {
-			return errors.New("fields should be empty")
+		//ilm=auto and supported
+		test.cfg["apm-server.ilm.enabled"] = "auto"
+		test.expected = test.withIlm
+		if test.ilmAuto != "" {
+			test.expected = test.ilmAuto
 		}
+		checkIndexSelector(t, "ILMAutoSupported"+name, test, ilmSupportedHandler)
+
+		//ilm auto but unsupported
+		test.cfg["apm-server.ilm.enabled"] = "auto"
+		test.expected = test.noIlm
+		checkIndexSelector(t, "ILMAutoUnsupported"+name, test, ilmUnsupportedHandler)
 	}
-	if config.Order == 2 {
-		h.tmplOrderILMCt++
+
+	t.Run("uninitializedSupporter", func(t *testing.T) {
+		// create initialized supporter and selector
+		supporter := defaultSupporter(t, common.MapStr{})
+
+		s, err := supporter.BuildSelector(common.MustNewConfigFrom(common.MapStr{}))
+		require.NoError(t, err)
+
+		// test selected index
+		idx, err := s.Select(testEvent(common.MapStr{}, common.MapStr{}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "setup not finished")
+		assert.Equal(t, "", idx)
+	})
+}
+
+func testEvent(fields, meta common.MapStr) *beat.Event {
+	fields.Put("observer", common.MapStr{"version": "7.0.0"})
+	return &beat.Event{
+		Fields:    fields,
+		Meta:      meta,
+		Timestamp: today,
 	}
-	if config.Order != 1 && config.Order != 2 {
-		return errors.New("unexpected template order")
-	}
-	h.tmplForce = config.Overwrite
-	return nil
-}
-
-func (h *mockClientHandler) CheckILMEnabled(m libilm.Mode) (bool, error) {
-	enabled := m == libilm.ModeEnabled
-	if h.ilmSupported {
-		return enabled, nil
-	}
-	return enabled, errors.New("ILM not supported")
-}
-
-func (h *mockClientHandler) HasAlias(name string) (bool, error) {
-	return name == existingILM, nil
-}
-
-func (h *mockClientHandler) CreateAlias(alias libilm.Alias) error {
-	h.aliases = append(h.aliases, alias.Name)
-	return nil
-}
-
-func (h *mockClientHandler) HasILMPolicy(name string) (bool, error) {
-	return name == existingILM, nil
-}
-
-func (h *mockClientHandler) CreateILMPolicy(policy libilm.Policy) error {
-	h.policies = append(h.policies, policy.Name)
-	return nil
 }

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -27,14 +27,11 @@ class BaseTest(TestCase):
 
         cls.index_name = "apm-{}".format(cls.apm_version)
         cls.index_name_pattern = "apm-*"
-
         cls.index_onboarding = "apm-{}-onboarding-{}".format(cls.apm_version, cls.day)
-        cls.index_error = "apm-{}-error-2017.05.09".format(cls.apm_version)
-        cls.index_rum_error = "apm-{}-error-2017.12.08".format(cls.apm_version)
-        cls.index_transaction = "apm-{}-transaction-2017.05.30".format(cls.apm_version)
-        cls.index_span = "apm-{}-span-2017.05.30".format(cls.apm_version)
-        cls.index_rum_span = "apm-{}-span-2017.12.08".format(cls.apm_version)
-        cls.index_metric = "apm-{}-metric-2017.05.30".format(cls.apm_version)
+        cls.index_error = "apm-{}-error".format(cls.apm_version)
+        cls.index_transaction = "apm-{}-transaction".format(cls.apm_version)
+        cls.index_span = "apm-{}-span".format(cls.apm_version)
+        cls.index_metric = "apm-{}-metric".format(cls.apm_version)
         cls.index_smap = "apm-{}-sourcemap".format(cls.apm_version)
         cls.indices = [cls.index_onboarding, cls.index_error,
                        cls.index_transaction, cls.index_span, cls.index_metric, cls.index_smap]
@@ -66,6 +63,9 @@ class BaseTest(TestCase):
 
     def get_event_payload(self, name="events.ndjson"):
         return self.get_payload(name)
+
+    def ilm_index(self, index):
+        return "{}-000001".format(index)
 
 
 class ServerSetUpBaseTest(BaseTest):
@@ -221,7 +221,7 @@ class ElasticTest(ServerBaseTest):
                 self.check_for_no_smap(err["log"])
 
     def check_backend_span_sourcemap(self, count=1):
-        rs = self.es.search(index=self.index_rum_span, params={"rest_total_hits_as_int": "true"})
+        rs = self.es.search(index=self.index_span, params={"rest_total_hits_as_int": "true"})
         assert rs['hits']['total'] == count, "found {} documents, expected {}".format(
             rs['hits']['total'], count)
         for doc in rs['hits']['hits']:
@@ -290,7 +290,7 @@ class ClientSideElasticTest(ClientSideBaseTest, ElasticTest):
         )
 
     def check_rum_error_sourcemap(self, updated, expected_err=None, count=1):
-        rs = self.es.search(index=self.index_rum_error, params={"rest_total_hits_as_int": "true"})
+        rs = self.es.search(index=self.index_error, params={"rest_total_hits_as_int": "true"})
         assert rs['hits']['total'] == count, "found {} documents, expected {}".format(
             rs['hits']['total'], count)
         for doc in rs['hits']['hits']:
@@ -301,7 +301,7 @@ class ClientSideElasticTest(ClientSideBaseTest, ElasticTest):
                 self.check_smap(err["log"], updated, expected_err)
 
     def check_rum_transaction_sourcemap(self, updated, expected_err=None, count=1):
-        rs = self.es.search(index=self.index_rum_span, params={"rest_total_hits_as_int": "true"})
+        rs = self.es.search(index=self.index_span, params={"rest_total_hits_as_int": "true"})
         assert rs['hits']['total'] == count, "found {} documents, expected {}".format(
             rs['hits']['total'], count)
         for doc in rs['hits']['hits']:
@@ -383,6 +383,15 @@ def get_elasticsearch_url():
 
 
 class SubCommandTest(ServerSetUpBaseTest):
+
+    def config(self):
+        cfg = super(SubCommandTest, self).config()
+        cfg.update({
+            "elasticsearch_host": get_elasticsearch_url(),
+            "file_enabled": "false",
+        })
+        return cfg
+
     def wait_until_started(self):
         self.apmserver_proc.check_wait()
 

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -68,6 +68,10 @@ apm-server:
   mode: {{ mode }}
   {% endif %}
 
+  {% if ilm_enabled %}
+  ilm.enabled: {{ ilm_enabled }}
+  {% endif %}
+
 ############################# Setup ##########################################
 
 {% if override_template %}

--- a/tests/system/test_export.py
+++ b/tests/system/test_export.py
@@ -140,7 +140,8 @@ class TestExportTemplateWithILM(SubCommandTest):
     def start_args(self):
         return {
             "extra_args": ["export", "template", "--dir", self.dir,
-                           "-E", "apm-server.ilm.enabled=true"],
+                           "-E", "apm-server.ilm.enabled=true",
+                           "-E", "output.elasticsearch.enabled=true"],
         }
 
     def setUp(self):
@@ -171,6 +172,7 @@ class TestExportTemplateWithILM(SubCommandTest):
             with open(file) as f:
                 template = json.load(f)
             assert template['index_patterns'] == [name + '*']
+            assert template['settings']['index'] is not None
             assert template['settings']['index']['lifecycle.name'] == name
             assert template['settings']['index']['lifecycle.rollover_alias'] == name
             assert 'mapping' not in template
@@ -185,7 +187,7 @@ class TestExportILMPolicy(SubCommandTest):
     def start_args(self):
         return {
             "extra_args": ["export", "ilm-policy", "--dir", self.dir,
-                           "-E", "apm-server.ilm.enabled=false"],
+                           "-E", "apm-server.ilm.enabled=true"],
         }
 
     def setUp(self):
@@ -209,13 +211,13 @@ class TestExportILMPolicy(SubCommandTest):
             assert "delete" not in policy["policy"]["phases"]
 
 
-class TestExportILMPolicyDisabledTest(TestExportILMPolicy):
+class TestExportILMPolicyILMDisabled(TestExportILMPolicy):
     """
-    Test export ilm-policy regardless of enabled setting
+    Test export ilm-policy independent of ILM enabled state
     """
 
     def start_args(self):
         return {
             "extra_args": ["export", "ilm-policy", "--dir", self.dir,
-                           "-E", "apm-server.ilm.enabled=true"],
+                           "-E", "apm-server.ilm.enabled=false"],
         }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ILM] Enable ILM by default when supported by configured ES output.  (#2356)