### PR TITLE
build just the default packages

### DIFF
--- a/script/jenkins/package.sh
+++ b/script/jenkins/package.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 set -euox pipefail
 
+# linux/amd64 is in the default list already, set here
+# to prevent jenkins_release.sh from adding more PLATFORMS
+export PLATFORMS="${PLATFORMS:-+linux/amd64}"
+
  ./_beats/dev-tools/jenkins_release.sh


### PR DESCRIPTION
Discovered in https://github.com/elastic/apm-server/pull/2268#discussion_r297240735, the other platforms aren't valuable for apm-server so skip building them to speed up the build.