### PR TITLE
ci: notify on cleanup stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -449,7 +449,7 @@ pipeline {
     }
   }
   post {
-    always {
+    cleanup {
       notifyBuildResult()
     }
   }


### PR DESCRIPTION
move the notification of the build result to the cleanup stage, at the very end of the job.

related to https://github.com/elastic/apm-server/pull/2268