### PR TITLE
ci: add labels to script commands

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
                 "^tests/packaging",
                 "^vendor/github.com/elastic/beats"
               ]
-              def changes = sh(script: "git diff --name-only origin/${env.CHANGE_TARGET}...${env.GIT_SHA} > git-diff.txt",returnStdout: true)
+              def changes = sh(label: 'Check paths changed', script: "git diff --name-only origin/${env.CHANGE_TARGET}...${env.GIT_SHA} > git-diff.txt",returnStdout: true)
               def match = regexps.find{ regexp ->
                   sh(script: "grep '${regexp}' git-diff.txt",returnStatus: true) == 0
               }
@@ -103,7 +103,7 @@ pipeline {
           deleteDir()
           unstash 'source'
           dir("${BASE_DIR}"){
-            sh './script/jenkins/intake.sh'
+            sh(label: 'Run intake', script: './script/jenkins/intake.sh')
           }
         }
       }
@@ -131,7 +131,7 @@ pipeline {
               deleteDir()
               unstash 'source'
               dir("${BASE_DIR}"){
-                sh './script/jenkins/build.sh'
+                sh(label: 'Linux build', script: './script/jenkins/build.sh')
               }
             }
           }
@@ -151,7 +151,7 @@ pipeline {
               deleteDir()
               unstash 'source'
               dir("${BASE_DIR}"){
-                powershell(script: '.\\script\\jenkins\\windows-build.ps1')
+                powershell(label: 'Windows build', script: '.\\script\\jenkins\\windows-build.ps1')
               }
             }
           }
@@ -181,7 +181,7 @@ pipeline {
               deleteDir()
               unstash 'source'
               dir("${BASE_DIR}"){
-                sh './script/jenkins/unit-test.sh'
+                sh(label: 'Run Unit tests', script: './script/jenkins/unit-test.sh')
               }
             }
           }
@@ -214,7 +214,7 @@ pipeline {
               deleteDir()
               unstash 'source'
               dir("${BASE_DIR}"){
-                sh './script/jenkins/linux-test.sh'
+                sh(label: 'Run Linux tests', script: './script/jenkins/linux-test.sh')
               }
             }
           }
@@ -248,7 +248,7 @@ pipeline {
               deleteDir()
               unstash 'source'
               dir("${BASE_DIR}"){
-                powershell(script: '.\\script\\jenkins\\windows-test.ps1')
+                powershell(label: 'Run Window tests', script: '.\\script\\jenkins\\windows-test.ps1')
               }
             }
           }
@@ -290,7 +290,7 @@ pipeline {
               deleteDir()
               unstash 'source'
               dir("${BASE_DIR}"){
-                sh './script/jenkins/bench.sh'
+                sh(label: 'Run benchmarks', script: './script/jenkins/bench.sh')
                 sendBenchmarks(file: 'bench.out', index: "benchmark-server")
               }
             }
@@ -372,7 +372,7 @@ pipeline {
           unstash 'source'
           dir("${BASE_DIR}"){
             catchError(buildResult: 'SUCCESS', message: 'Sync Kibana is not updated', stageResult: 'UNSTABLE') {
-              sh './script/jenkins/sync.sh'
+              sh(label: 'Test Sync', script: './script/jenkins/sync.sh')
             }
           }
         }


### PR DESCRIPTION
it adds labels to script commands, this makes you'd show a proper description of the step on the CI UI and in notifications.

related to https://github.com/elastic/apm-server/pull/2268