### PR TITLE
fix: release stage should not be triggered always

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -421,7 +421,7 @@ pipeline {
             branch "v\\d?"
             tag "v\\d+\\.\\d+\\.\\d+*"
             expression { return params.Run_As_Master_Branch }
-            expression { return env.BEATS_UPDATED != "0" }
+            expression { return env.BEATS_UPDATED != "false" }
           }
           expression { return params.release_ci }
         }


### PR DESCRIPTION
The release stage is trigger on every branch merge, it is incorrect because the `BEATS_UPDATED` is wrong evaluated. This PR fixes the value check of `BEATS_UPDATED `

related to https://github.com/elastic/apm-server/pull/2268