### PR TITLE
[7.x] Fix flaky tests, default value for agent config cache. (#2376)

### DIFF
--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -222,7 +222,7 @@ func TestBeatConfig(t *testing.T) {
 					},
 				},
 				Kibana:      common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
-				AgentConfig: &agentConfig{Cache: &Cache{Expiration: 10 * time.Second}},
+				AgentConfig: &agentConfig{Cache: &Cache{Expiration: 30 * time.Second}},
 				pipeline:    defaultAPMPipeline,
 			},
 		},

--- a/beater/config.go
+++ b/beater/config.go
@@ -289,7 +289,7 @@ func defaultConfig(beatVersion string) *Config {
 		},
 		Mode:        ModeProduction,
 		Kibana:      common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
-		AgentConfig: &agentConfig{Cache: &Cache{Expiration: 10 * time.Second}},
+		AgentConfig: &agentConfig{Cache: &Cache{Expiration: 30 * time.Second}},
 		pipeline:    defaultAPMPipeline,
 	}
 }

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -548,7 +548,6 @@ class SourcemappingCacheIntegrationTest(SmapCacheBaseTest):
         # ensure smap is not in cache any more
         time.sleep(1)
 
-        time.sleep(30)
         # after cache expiration no sourcemap should be found any more
         self.load_docs_with_template(self.get_error_payload_path(),
                                      self.intake_url,

--- a/tests/system/test_pipelines.py
+++ b/tests/system/test_pipelines.py
@@ -74,8 +74,8 @@ class PipelineDefaultTest(ElasticTest):
 
     def test_pipeline_applied(self):
         # setup
-        self.wait_until(lambda: self.log_contains("Registered Ingest Pipelines successfully"), max_timeout=5)
-        self.wait_until(lambda: self.log_contains("Finished index management setup."), max_timeout=5)
+        self.wait_until(lambda: self.log_contains("Registered Ingest Pipelines successfully"))
+        self.wait_until(lambda: self.log_contains("Finished index management setup."))
         self.load_docs_with_template(self.get_payload_path("transactions.ndjson"),
                                      self.intake_url, 'transaction', 3)
 
@@ -103,7 +103,7 @@ class PipelineConfigurationNoneTest(ElasticTest):
     config_overrides = {"disable_pipeline": True}
 
     def test_pipeline_not_applied(self):
-        self.wait_until(lambda: self.log_contains("Finished index management setup."), max_timeout=5)
+        self.wait_until(lambda: self.log_contains("Finished index management setup."))
         self.load_docs_with_template(self.get_payload_path("transactions.ndjson"),
                                      self.intake_url, 'transaction', 3)
         uaFound = False
@@ -125,7 +125,7 @@ class PipelinesConfigurationNoneTest(ElasticTest):
     config_overrides = {"disable_pipelines": True}
 
     def test_pipeline_not_applied(self):
-        self.wait_until(lambda: self.log_contains("Finished index management setup."), max_timeout=5)
+        self.wait_until(lambda: self.log_contains("Finished index management setup."))
         self.load_docs_with_template(self.get_payload_path("transactions.ndjson"),
                                      self.intake_url, 'transaction', 3)
 
@@ -149,11 +149,11 @@ class MissingPipelineTest(ElasticTest):
 
     @raises(TimeoutError)
     def test_pipeline_not_registered(self):
-        self.wait_until(lambda: self.log_contains("No pipeline callback registered"), max_timeout=5)
-        self.wait_until(lambda: self.log_contains("Finished index management setup."), max_timeout=5)
+        self.wait_until(lambda: self.log_contains("No pipeline callback registered"))
+        self.wait_until(lambda: self.log_contains("Finished index management setup."))
         # ensure events get stored properly nevertheless
         self.load_docs_with_template(self.get_payload_path("transactions.ndjson"),
-                                     self.intake_url, 'transaction', 3, max_timeout=3)
+                                     self.intake_url, 'transaction', 3)
 
 
 @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
@@ -173,5 +173,4 @@ class PipelineDisableRegisterOverwriteTest(ElasticTest):
 
     def test_pipeline_not_overwritten(self):
         loaded_msg = "Pipeline already registered"
-        self.wait_until(lambda: self.log_contains(loaded_msg),
-                        max_timeout=5)
+        self.wait_until(lambda: self.log_contains(loaded_msg))


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix flaky tests, default value for agent config cache.  (#2376)