### PR TITLE
ci: set sync stage to unstable on failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -352,7 +352,9 @@ pipeline {
         deleteDir()
         unstash 'source'
         dir("${BASE_DIR}"){
-          sh './script/jenkins/sync.sh'
+          catchError(buildResult: 'SUCCESS', message: 'Sync Kibana is not updated', stageResult: 'UNSTABLE') {
+            sh './script/jenkins/sync.sh'
+          }
         }
       }
     }


### PR DESCRIPTION
Backport of the same change in the master, it allows completing the build even do the Sync stage fails, and mark the sync stage as unstable.