### PR TITLE
Refactor http header strings. Add "X-Content-Type-Options: nosniff" header

### DIFF
--- a/beater/agent_config_handler.go
+++ b/beater/agent_config_handler.go
@@ -27,14 +27,12 @@ import (
 	"github.com/elastic/beats/libbeat/kibana"
 
 	"github.com/elastic/apm-server/agentcfg"
+	"github.com/elastic/apm-server/beater/headers"
 	"github.com/elastic/apm-server/convert"
 )
 
 const (
-	headerIfNoneMatch  = "If-None-Match"
-	headerEtag         = "Etag"
-	headerCacheControl = "Cache-Control"
-	errMaxAgeDuration  = 5 * time.Minute
+	errMaxAgeDuration = 5 * time.Minute
 )
 
 func agentConfigHandler(kbClient *kibana.Client, config *agentConfig, secretToken string) http.Handler {
@@ -44,7 +42,7 @@ func agentConfigHandler(kbClient *kibana.Client, config *agentConfig, secretToke
 
 	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		send := wrap(w, r)
-		clientEtag := r.Header.Get(headerIfNoneMatch)
+		clientEtag := r.Header.Get(headers.IfNoneMatch)
 
 		query, requestErr := buildQuery(r)
 		cfg, upstreamEtag, internalErr := fetcher.Fetch(query, requestErr)
@@ -71,19 +69,19 @@ func agentConfigHandler(kbClient *kibana.Client, config *agentConfig, secretToke
 			state = http.StatusNotFound
 			headerCacheControlVal = errHeaderCacheControl
 		case clientEtag != "" && clientEtag == upstreamEtag:
-			w.Header().Set(headerEtag, clientEtag)
+			w.Header().Set(headers.Etag, clientEtag)
 			resp = nil
 			state = http.StatusNotModified
 			headerCacheControlVal = defaultHeaderCacheControl
 		case upstreamEtag != "":
-			w.Header().Set(headerEtag, upstreamEtag)
+			w.Header().Set(headers.Etag, upstreamEtag)
 			fallthrough
 		default:
 			resp = cfg
 			state = http.StatusOK
 			headerCacheControlVal = defaultHeaderCacheControl
 		}
-		w.Header().Set(headerCacheControl, headerCacheControlVal)
+		w.Header().Set(headers.CacheControl, headerCacheControlVal)
 		send(resp, state)
 		// logHandler logs the rest
 		if state >= http.StatusBadRequest {

--- a/beater/agent_config_handler_test.go
+++ b/beater/agent_config_handler_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/apm-server/beater/headers"
 	"github.com/elastic/apm-server/convert"
 	"github.com/elastic/apm-server/tests"
 )
@@ -52,7 +53,7 @@ var testcases = map[string]struct {
 			},
 		}),
 		method:                 http.MethodGet,
-		requestHeader:          map[string]string{headerIfNoneMatch: "1"},
+		requestHeader:          map[string]string{headers.IfNoneMatch: "1"},
 		queryParams:            map[string]string{"service.name": "opbeans-node"},
 		respStatus:             http.StatusNotModified,
 		respCacheControlHeader: "max-age=4, must-revalidate",
@@ -84,7 +85,7 @@ var testcases = map[string]struct {
 			},
 		}),
 		method:                 http.MethodGet,
-		requestHeader:          map[string]string{headerIfNoneMatch: "2"},
+		requestHeader:          map[string]string{headers.IfNoneMatch: "2"},
 		queryParams:            map[string]string{"service.name": "opbeans-java"},
 		respStatus:             http.StatusOK,
 		respEtagHeader:         "1",
@@ -141,8 +142,8 @@ func TestAgentConfigHandler(t *testing.T) {
 			h.ServeHTTP(w, r)
 
 			assert.Equal(t, tc.respStatus, w.Code)
-			assert.Equal(t, tc.respCacheControlHeader, w.Header().Get(headerCacheControl))
-			assert.Equal(t, tc.respEtagHeader, w.Header().Get(headerEtag))
+			assert.Equal(t, tc.respCacheControlHeader, w.Header().Get(headers.CacheControl))
+			assert.Equal(t, tc.respEtagHeader, w.Header().Get(headers.Etag))
 			if tc.respBody {
 				assert.NotEmpty(t, w.Body)
 			} else {

--- a/beater/common_handler.go
+++ b/beater/common_handler.go
@@ -258,7 +258,7 @@ func corsHandler(allowedOrigins []string, h http.Handler) http.Handler {
 			}
 
 			// tell browsers to cache response requestHeaders for up to 1 hour (browsers might ignore this)
-			w.Header().Set(headers.AccessControlMaxAge, "")
+			w.Header().Set(headers.AccessControlMaxAge, "3600")
 			// origin must be part of the cache key so that we can handle multiple allowed origins
 			w.Header().Set(headers.Vary, "Origin")
 

--- a/beater/common_handler.go
+++ b/beater/common_handler.go
@@ -34,13 +34,14 @@ import (
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/monitoring"
 
+	"github.com/elastic/apm-server/beater/headers"
 	logs "github.com/elastic/apm-server/log"
 	"github.com/elastic/apm-server/utility"
 )
 
-const (
-	supportedHeaders = "Content-Type, Content-Encoding, Accept"
-	supportedMethods = "POST, OPTIONS"
+var (
+	supportedHeaders = fmt.Sprintf("%s, %s, %s", headers.ContentType, headers.ContentEncoding, headers.Accept)
+	supportedMethods = fmt.Sprintf("%s, %s", http.MethodPost, http.MethodOptions)
 )
 
 type serverResponse struct {
@@ -165,7 +166,7 @@ func logHandler(h http.Handler) http.Handler {
 			"URL", r.URL,
 			"content_length", r.ContentLength,
 			"remote_address", utility.RemoteAddr(r),
-			"user-agent", r.Header.Get("User-Agent"))
+			"user-agent", r.Header.Get(headers.UserAgent))
 
 		defer func() {
 			if r := recover(); r != nil {
@@ -223,9 +224,9 @@ func isAuthorized(req *http.Request, secretToken string) bool {
 	if secretToken == "" {
 		return true
 	}
-	header := req.Header.Get("Authorization")
+	header := req.Header.Get(headers.Authorization)
 	parts := strings.Split(header, " ")
-	if len(parts) != 2 || parts[0] != "Bearer" {
+	if len(parts) != 2 || parts[0] != headers.Bearer {
 		return false
 	}
 	return subtle.ConstantTimeCompare([]byte(parts[1]), []byte(secretToken)) == 1
@@ -245,33 +246,33 @@ func corsHandler(allowedOrigins []string, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		// origin header is always set by the browser
-		origin := r.Header.Get("Origin")
+		origin := r.Header.Get(headers.Origin)
 		validOrigin := isAllowed(origin)
 
-		if r.Method == "OPTIONS" {
+		if r.Method == http.MethodOptions {
 
 			// setting the ACAO header is the way to tell the browser to go ahead with the request
 			if validOrigin {
 				// do not set the configured origin(s), echo the received origin instead
-				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set(headers.AccessControlAllowOrigin, origin)
 			}
 
 			// tell browsers to cache response requestHeaders for up to 1 hour (browsers might ignore this)
-			w.Header().Set("Access-Control-Max-Age", "3600")
+			w.Header().Set(headers.AccessControlMaxAge, "")
 			// origin must be part of the cache key so that we can handle multiple allowed origins
-			w.Header().Set("Vary", "Origin")
+			w.Header().Set(headers.Vary, "Origin")
 
 			// required if Access-Control-Request-Method and Access-Control-Request-Headers are in the requestHeaders
-			w.Header().Set("Access-Control-Allow-Methods", supportedMethods)
-			w.Header().Set("Access-Control-Allow-Headers", supportedHeaders)
+			w.Header().Set(headers.AccessControlAllowMethods, supportedMethods)
+			w.Header().Set(headers.AccessControlAllowHeaders, supportedHeaders)
 
-			w.Header().Set("Content-Length", "0")
+			w.Header().Set(headers.ContentLength, "0")
 
 			sendStatus(w, r, okResponse)
 
 		} else if validOrigin {
 			// we need to check the origin and set the ACAO header in both the OPTIONS preflight and the actual request
-			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set(headers.AccessControlAllowOrigin, origin)
 			h.ServeHTTP(w, r)
 
 		} else {
@@ -312,12 +313,13 @@ func requestLogger(r *http.Request) *logp.Logger {
 }
 
 func acceptsJSON(r *http.Request) bool {
-	h := r.Header.Get("Accept")
+	h := r.Header.Get(headers.Accept)
 	return strings.Contains(h, "*/*") || strings.Contains(h, "application/json")
 }
 
 func sendJSON(w http.ResponseWriter, body interface{}, statusCode int) int {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(headers.ContentType, "application/json")
+	w.Header().Set(headers.XContentTypeOptions, "nosniff")
 	w.WriteHeader(statusCode)
 	buf, err := json.MarshalIndent(body, "", "  ")
 	if err != nil {
@@ -331,7 +333,8 @@ func sendJSON(w http.ResponseWriter, body interface{}, statusCode int) int {
 }
 
 func sendPlain(w http.ResponseWriter, body interface{}, statusCode int) int {
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set(headers.ContentType, "text/plain; charset=utf-8")
+	w.Header().Set(headers.XContentTypeOptions, "nosniff")
 	w.WriteHeader(statusCode)
 
 	b, err := json.Marshal(body)

--- a/beater/headers/keys.go
+++ b/beater/headers/keys.go
@@ -1,0 +1,40 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package headers
+
+// http header keys
+const (
+	Accept                    = "Accept"
+	AccessControlAllowHeaders = "Access-Control-Allow-Headers"
+	AccessControlAllowMethods = "Access-Control-Allow-Methods"
+	AccessControlAllowOrigin  = "Access-Control-Allow-Origin"
+	AccessControlMaxAge       = "Access-Control-Max-Age"
+	Authorization             = "Authorization"
+	Bearer                    = "Bearer"
+	CacheControl              = "Cache-Control"
+	Connection                = "Connection"
+	ContentEncoding           = "Content-Encoding"
+	ContentLength             = "Content-Length"
+	ContentType               = "Content-Type"
+	Etag                      = "Etag"
+	IfNoneMatch               = "If-None-Match"
+	Origin                    = "Origin"
+	UserAgent                 = "User-Agent"
+	Vary                      = "Vary"
+	XContentTypeOptions       = "X-Content-Type-Options"
+)


### PR DESCRIPTION
Set `nosniff` for all http responses against intake API. Move http header keys as constants to a central file.
