### PR TITLE
feat(ci): use isGitRegionMatch step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,23 +58,17 @@ pipeline {
         script {
           dir("${BASE_DIR}"){
             env.GO_VERSION = readFile(".go-version")
-            if(env.CHANGE_TARGET){
-              def regexps =[
-                "^_beats",
-                "^apm-server.yml",
-                "^apm-server.docker.yml",
-                "^magefile.go",
-                "^ingest",
-                "^packaging",
-                "^tests/packaging",
-                "^vendor/github.com/elastic/beats"
-              ]
-              def changes = sh(label: 'Check paths changed', script: "git diff --name-only origin/${env.CHANGE_TARGET}...${env.GIT_SHA} > git-diff.txt",returnStdout: true)
-              def match = regexps.find{ regexp ->
-                  sh(script: "grep '${regexp}' git-diff.txt",returnStatus: true) == 0
-              }
-              env.BEATS_UPDATED = (match != null)
-            }
+            def regexps =[
+              "^_beats",
+              "^apm-server.yml",
+              "^apm-server.docker.yml",
+              "^magefile.go",
+              "^ingest",
+              "^packaging",
+              "^tests/packaging",
+              "^vendor/github.com/elastic/beats"
+            ]
+            env.BEATS_UPDATED = isGitRegionMatch(regexps: regexps)
           }
         }
       }


### PR DESCRIPTION
Uses the `isGitRegionMatch` step which it's defined in the shared library.

## Test Cases

In the below screesnhot, the left page shows the console output for this particular PR, further details: [here](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-server%2Fapm-server-mbp/detail/PR-2388/3/pipeline/23) while the right one shows the previous implementation.

![image](https://user-images.githubusercontent.com/2871786/60719952-1a91a300-9f21-11e9-8a46-9709c9e55ffa.png)

