### PR TITLE
[7.3] Update kibana endpoint and introduce a killer switch to disable the (#2386)

### DIFF
--- a/agentcfg/fetch.go
+++ b/agentcfg/fetch.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	endpoint = "/api/apm/settings/cm/search"
+	endpoint = "/api/apm/settings/agent-configuration/search"
 )
 
 // Fetcher holds static information and information shared between requests.

--- a/beater/common_handler_test.go
+++ b/beater/common_handler_test.go
@@ -34,13 +34,16 @@ func TestIncCounter(t *testing.T) {
 	req.Header.Set("Accept", "application/json")
 	w := httptest.NewRecorder()
 
-	for i := 1; i <= 5; i++ {
-		for _, res := range []serverResponse{acceptedResponse, okResponse, forbiddenResponse(errors.New("")), unauthorizedResponse,
-			requestTooLargeResponse, rateLimitedResponse, methodNotAllowedResponse,
-			cannotValidateResponse(errors.New("")), cannotDecodeResponse(errors.New("")),
-			fullQueueResponse(errors.New("")), serverShuttingDownResponse(errors.New(""))} {
+	responseCounter.Set(0)
+	responseErrors.Set(0)
+	for _, res := range []serverResponse{acceptedResponse, okResponse, forbiddenResponse(errors.New("")), unauthorizedResponse,
+		requestTooLargeResponse, rateLimitedResponse, methodNotAllowedResponse,
+		cannotValidateResponse(errors.New("")), cannotDecodeResponse(errors.New("")),
+		fullQueueResponse(errors.New("")), serverShuttingDownResponse(errors.New(""))} {
+		res.counter.Set(0)
+		for i := 1; i <= 5; i++ {
 			sendStatus(w, req, res)
-			assert.Equal(t, int64(i), res.counter.Get())
+			assert.Equal(t, int64(i), res.counter.Get(), string(res.code))
 		}
 	}
 	assert.Equal(t, int64(55), responseCounter.Get())

--- a/beater/route_config.go
+++ b/beater/route_config.go
@@ -114,7 +114,7 @@ func newMuxer(beaterConfig *Config, kbClient *kibana.Client, report publish.Repo
 		mux.Handle(path, handler)
 	}
 
-	mux.Handle(agentConfigURL, agentConfigHandler(kbClient, beaterConfig.AgentConfig, beaterConfig.SecretToken))
+	mux.Handle(agentConfigURL, agentConfigHandler(kbClient, beaterConfig.Kibana.Enabled(), beaterConfig.AgentConfig, beaterConfig.SecretToken))
 	logger.Infof("Path %s added to request handler", agentConfigURL)
 
 	mux.Handle(rootURL, rootHandler(beaterConfig.SecretToken))

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -77,6 +77,11 @@ apm-server:
   ilm.enabled: {{ ilm_enabled }}
   {% endif %}
 
+  {% if kibana_enabled %}
+  kibana.enabled: {{ kibana_enabled }}
+  {% endif %}
+
+
 ############################# Setup ##########################################
 
 {% if override_template %}


### PR DESCRIPTION
Backports the following commits to 7.3:
 - Update kibana endpoint and introduce a killer switch to disable the  (#2386)