### PR TITLE
Enclose etag and IfNoneMatch header in double quotes.

### DIFF
--- a/beater/agent_config_handler.go
+++ b/beater/agent_config_handler.go
@@ -95,10 +95,6 @@ func agentConfigHandler(kbClient *kibana.Client, enabled bool, config *agentConf
 			authHandler(secretToken, handler)))
 }
 
-func etag(t string) string {
-	return fmt.Sprintf("\"%s\"", t)
-}
-
 // Returns (zero, error) if request body can't be unmarshalled or service.name is missing
 // Returns (zero, zero) if request method is not GET or POST
 func buildQuery(r *http.Request) (query agentcfg.Query, err error) {

--- a/beater/agent_config_handler_test.go
+++ b/beater/agent_config_handler_test.go
@@ -53,11 +53,11 @@ var testcases = map[string]struct {
 			},
 		}),
 		method:                 http.MethodGet,
-		requestHeader:          map[string]string{headers.IfNoneMatch: "1"},
+		requestHeader:          map[string]string{headers.IfNoneMatch: `"` + "1" + `"`},
 		queryParams:            map[string]string{"service.name": "opbeans-node"},
 		respStatus:             http.StatusNotModified,
 		respCacheControlHeader: "max-age=4, must-revalidate",
-		respEtagHeader:         "1",
+		respEtagHeader:         "\"1\"",
 	},
 
 	"ModifiedWithoutEtag": {
@@ -88,7 +88,7 @@ var testcases = map[string]struct {
 		requestHeader:          map[string]string{headers.IfNoneMatch: "2"},
 		queryParams:            map[string]string{"service.name": "opbeans-java"},
 		respStatus:             http.StatusOK,
-		respEtagHeader:         "1",
+		respEtagHeader:         "\"1\"",
 		respCacheControlHeader: "max-age=4, must-revalidate",
 		respBody:               true,
 	},


### PR DESCRIPTION
fixes elastic/apm-server#2404

needs backport to `7.x` and `7.3`.
