### PR TITLE
fix: use fixed dependencies on golang Docker container

### DIFF
--- a/.ci/docker/golang-mage/Dockerfile
+++ b/.ci/docker/golang-mage/Dockerfile
@@ -9,9 +9,9 @@ RUN git clone https://github.com/magefile/mage \
   && go run bootstrap.go \
   && mage -version \
   && cd /tools \
-  && go get golang.org/x/tools/cmd/benchcmp \
-  && go get github.com/t-yuki/gocover-cobertura \
-  && go get github.com/jstemmer/go-junit-report \
+  && go get github.com/elastic/apm-server/vendor/golang.org/x/tools/cmd/benchcmp \
+  && go get github.com/elastic/apm-server/vendor/github.com/t-yuki/gocover-cobertura \
+  && go get github.com/elastic/apm-server/vendor/github.com/jstemmer/go-junit-report \
   && go get github.com/kardianos/govendor \
   && go get github.com/elastic/go-licenser \
   && go get github.com/elastic/apm-server/vendor/github.com/pierrre/gotestcover \

--- a/.ci/docker/golang-mage/Dockerfile
+++ b/.ci/docker/golang-mage/Dockerfile
@@ -12,7 +12,7 @@ RUN git clone https://github.com/magefile/mage \
   && go get github.com/elastic/apm-server/vendor/golang.org/x/tools/cmd/benchcmp \
   && go get github.com/elastic/apm-server/vendor/github.com/t-yuki/gocover-cobertura \
   && go get github.com/elastic/apm-server/vendor/github.com/jstemmer/go-junit-report \
-  && go get github.com/kardianos/govendor \
+  && go get github.com/elastic/apm-server/vendor/github.com/kardianos/govendor \
   && go get github.com/elastic/go-licenser \
   && go get github.com/elastic/apm-server/vendor/github.com/pierrre/gotestcover \
   && go get github.com/elastic/apm-server/vendor/github.com/stretchr/testify/assert \


### PR DESCRIPTION
use fixed dependencies on golang Docker container

depends on https://github.com/elastic/apm-server/pull/2395
for elastic/apm-server#2394