### PR TITLE
[7.x] Enclose etag and IfNoneMatch header in double quotes. (#2407)

### DIFF
--- a/beater/agent_config_handler.go
+++ b/beater/agent_config_handler.go
@@ -46,6 +46,7 @@ func agentConfigHandler(kbClient *kibana.Client, enabled bool, config *agentConf
 
 		query, requestErr := buildQuery(r)
 		cfg, upstreamEtag, internalErr := fetcher.Fetch(query, requestErr)
+		etag := fmt.Sprintf("\"%s\"", upstreamEtag)
 
 		var resp interface{}
 		var state int
@@ -68,13 +69,13 @@ func agentConfigHandler(kbClient *kibana.Client, enabled bool, config *agentConf
 			resp = nil
 			state = http.StatusNotFound
 			headerCacheControlVal = errHeaderCacheControl
-		case clientEtag != "" && clientEtag == upstreamEtag:
-			w.Header().Set(headers.Etag, clientEtag)
+		case clientEtag != "" && clientEtag == etag:
+			w.Header().Set(headers.Etag, etag)
 			resp = nil
 			state = http.StatusNotModified
 			headerCacheControlVal = defaultHeaderCacheControl
 		case upstreamEtag != "":
-			w.Header().Set(headers.Etag, upstreamEtag)
+			w.Header().Set(headers.Etag, etag)
 			fallthrough
 		default:
 			resp = cfg

--- a/beater/agent_config_handler_test.go
+++ b/beater/agent_config_handler_test.go
@@ -53,11 +53,11 @@ var testcases = map[string]struct {
 			},
 		}),
 		method:                 http.MethodGet,
-		requestHeader:          map[string]string{headers.IfNoneMatch: "1"},
+		requestHeader:          map[string]string{headers.IfNoneMatch: `"` + "1" + `"`},
 		queryParams:            map[string]string{"service.name": "opbeans-node"},
 		respStatus:             http.StatusNotModified,
 		respCacheControlHeader: "max-age=4, must-revalidate",
-		respEtagHeader:         "1",
+		respEtagHeader:         "\"1\"",
 	},
 
 	"ModifiedWithoutEtag": {
@@ -88,7 +88,7 @@ var testcases = map[string]struct {
 		requestHeader:          map[string]string{headers.IfNoneMatch: "2"},
 		queryParams:            map[string]string{"service.name": "opbeans-java"},
 		respStatus:             http.StatusOK,
-		respEtagHeader:         "1",
+		respEtagHeader:         "\"1\"",
 		respCacheControlHeader: "max-age=4, must-revalidate",
 		respBody:               true,
 	},


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Enclose etag and IfNoneMatch header in double quotes.  (#2407)