### PR TITLE
[7.3] Enclose etag and IfNoneMatch header in double quotes. (#2407)

### DIFF
--- a/beater/agent_config_handler.go
+++ b/beater/agent_config_handler.go
@@ -48,6 +48,7 @@ func agentConfigHandler(kbClient *kibana.Client, enabled bool, config *agentConf
 
 		query, requestErr := buildQuery(r)
 		cfg, upstreamEtag, internalErr := fetcher.Fetch(query, requestErr)
+		etag := fmt.Sprintf("\"%s\"", upstreamEtag)
 
 		var resp interface{}
 		var state int
@@ -70,13 +71,13 @@ func agentConfigHandler(kbClient *kibana.Client, enabled bool, config *agentConf
 			resp = nil
 			state = http.StatusNotFound
 			headerCacheControlVal = errHeaderCacheControl
-		case clientEtag != "" && clientEtag == upstreamEtag:
-			w.Header().Set(headerEtag, clientEtag)
+		case clientEtag != "" && clientEtag == etag:
+			w.Header().Set(headerEtag, etag)
 			resp = nil
 			state = http.StatusNotModified
 			headerCacheControlVal = defaultHeaderCacheControl
 		case upstreamEtag != "":
-			w.Header().Set(headerEtag, upstreamEtag)
+			w.Header().Set(headerEtag, etag)
 			fallthrough
 		default:
 			resp = cfg

--- a/beater/agent_config_handler_test.go
+++ b/beater/agent_config_handler_test.go
@@ -52,11 +52,11 @@ var testcases = map[string]struct {
 			},
 		}),
 		method:                 http.MethodGet,
-		requestHeader:          map[string]string{headerIfNoneMatch: "1"},
+		requestHeader:          map[string]string{headerIfNoneMatch: `"` + "1" + `"`},
 		queryParams:            map[string]string{"service.name": "opbeans-node"},
 		respStatus:             http.StatusNotModified,
 		respCacheControlHeader: "max-age=4, must-revalidate",
-		respEtagHeader:         "1",
+		respEtagHeader:         "\"1\"",
 	},
 
 	"ModifiedWithoutEtag": {
@@ -87,7 +87,7 @@ var testcases = map[string]struct {
 		requestHeader:          map[string]string{headerIfNoneMatch: "2"},
 		queryParams:            map[string]string{"service.name": "opbeans-java"},
 		respStatus:             http.StatusOK,
-		respEtagHeader:         "1",
+		respEtagHeader:         "\"1\"",
 		respCacheControlHeader: "max-age=4, must-revalidate",
 		respBody:               true,
 	},

--- a/changelogs/7.3.asciidoc
+++ b/changelogs/7.3.asciidoc
@@ -20,7 +20,7 @@ https://github.com/elastic/apm-server/compare/v7.2.1\...v7.3.0[View commits]
 [float]
 ==== Added
 - Support adding transaction and span information to metrics  {pull}2265[2265],{pull}2287[2287].
-- Initial support for remote agent configuration, requires Kibana {pull}2289[2289],{pull}2301[2301]{pull}2386[2386].
+- Initial support for remote agent configuration, requires Kibana {pull}2289[2289],{pull}2301[2301],{pull}2386[2386],{pull}2407[2407].
 - Add basic caching to remote agent configuration {pull}2337[2337].
 - Enable APM pipeline by default {pull}2301[2301].
 - Add fields required by breakdown graphs APM pipeline by default {pull}2315[2315],{pull}2397[2397].


### PR DESCRIPTION
Backports the following commits to 7.3:
 - Enclose etag and IfNoneMatch header in double quotes.  (#2407)