### PR TITLE
ci(jenkins): 7d is not allowed but 1w instead

### DIFF
--- a/.ci/check-changelogs.groovy
+++ b/.ci/check-changelogs.groovy
@@ -22,7 +22,6 @@ pipeline {
   }
   triggers {
     cron 'H H(3-4) * * 1-5'
-    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
   }
   stages {
     /**
@@ -32,8 +31,6 @@ pipeline {
       agent { label 'master || immutable' }
       environment {
         PATH = "${env.PATH}:${env.WORKSPACE}/bin"
-        HOME = "${env.WORKSPACE}"
-        GOPATH = "${env.WORKSPACE}"
       }
       options { skipDefaultCheckout() }
       steps {
@@ -51,7 +48,6 @@ pipeline {
       environment {
         PATH = "${env.PATH}:${env.WORKSPACE}/bin"
         HOME = "${env.WORKSPACE}"
-        GOPATH = "${env.WORKSPACE}"
       }
       steps {
         deleteDir()

--- a/.ci/jobs/apm-server-check-changelogs-mbp.yml
+++ b/.ci/jobs/apm-server-check-changelogs-mbp.yml
@@ -38,5 +38,5 @@
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'
-    periodic-folder-trigger: 7d
+    periodic-folder-trigger: 1w
     prune-dead-branches: true


### PR DESCRIPTION
JJB failed when creating the job

```
16:22:06 2019-07-10 15:22:06,005 [jjbb.jenkins_server] [ERROR] '7d' is an invalid value for attribute name.periodic-folder-trigger
16:22:06 Valid values include: '1m', '2m', '5m', '10m', '15m', '20m', '25m', '30m', '1h', '2h', '4h', '8h', '12h', '1d', '2d', '1w', '2w', '4w'
16:22:06 Traceback (most recent call last):
```