### PR TITLE
Ensure Kibana client reconnects.

### DIFF
--- a/agentcfg/cache.go
+++ b/agentcfg/cache.go
@@ -47,7 +47,7 @@ func newCache(logger *logp.Logger, exp time.Duration) *cache {
 }
 
 func (c *cache) fetchAndAdd(q Query, fn func(Query) (*Doc, error)) (doc *Doc, err error) {
-	id := q.id()
+	id := q.ID()
 
 	// return from cache if possible
 	doc, found := c.fetch(id)

--- a/agentcfg/cache_test.go
+++ b/agentcfg/cache_test.go
@@ -45,7 +45,7 @@ func newCacheSetup(service string, exp time.Duration, init bool) cacheSetup {
 		doc: &defaultDoc,
 	}
 	if init {
-		setup.c.add(setup.q.id(), setup.doc)
+		setup.c.add(setup.q.ID(), setup.doc)
 	}
 	return setup
 }
@@ -75,7 +75,7 @@ func TestCache_fetchAndAdd(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				//ensure value is cached afterwards
-				cachedDoc, found := setup.c.fetch(setup.q.id())
+				cachedDoc, found := setup.c.fetch(setup.q.ID())
 				assert.True(t, found)
 				assert.Equal(t, doc, cachedDoc)
 			}
@@ -89,7 +89,7 @@ func TestCache_fetchAndAdd(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, doc)
 		time.Sleep(exp)
-		nilDoc, found := setup.c.fetch(setup.q.id())
+		nilDoc, found := setup.c.fetch(setup.q.ID())
 		assert.False(t, found)
 		assert.Nil(t, nilDoc)
 	})

--- a/agentcfg/fetch_test.go
+++ b/agentcfg/fetch_test.go
@@ -71,7 +71,7 @@ func TestFetchError(t *testing.T) {
 	kb := tests.MockKibana(http.StatusMultipleChoices, m{"error": "an error"}, mockVersion, true)
 	_, _, err := NewFetcher(kb, testExp).Fetch(query(t.Name()), nil)
 	require.Error(t, err)
-	assert.Equal(t, "multiple configurations found: {\"error\":\"an error\"}", err.Error())
+	assert.Contains(t, err.Error(), ErrMsgMultipleChoices)
 }
 
 func TestExpectationFailed(t *testing.T) {

--- a/agentcfg/model.go
+++ b/agentcfg/model.go
@@ -66,7 +66,8 @@ type Query struct {
 	Service Service `json:"service"`
 }
 
-func (q Query) id() string {
+// ID returns the unique id for the query
+func (q Query) ID() string {
 	var str strings.Builder
 	str.WriteString(q.Service.Name)
 	if q.Service.Environment != "" {

--- a/beater/agent_config_handler.go
+++ b/beater/agent_config_handler.go
@@ -100,10 +100,10 @@ func agentConfigHandler(kbClient kibana.Client, config *agentConfig, secretToken
 
 func validateKbClient(client kibana.Client) (bool, string, string) {
 	if client == nil {
-		return false, errMsgKibanaDisabled, ""
+		return false, errMsgKibanaDisabled, errMsgKibanaDisabled
 	}
 	if !client.Connected() {
-		return false, errMsgNoKibanaConnection, ""
+		return false, errMsgNoKibanaConnection, errMsgNoKibanaConnection
 	}
 	if supported, _ := client.SupportsVersion(minKibanaVersion); !supported {
 		version, _ := client.GetVersion()
@@ -148,7 +148,7 @@ func wrap(w http.ResponseWriter, r *http.Request) func(interface{}, int, string)
 
 func wrapErr(w http.ResponseWriter, r *http.Request, token string) func(int, string, string) {
 	authErrMsg := func(errMsg, logMsg string) map[string]string {
-		if token == "" || logMsg == "" {
+		if token == "" {
 			return map[string]string{"error": errMsg}
 		}
 		return map[string]string{"error": logMsg}

--- a/beater/agent_config_handler_test.go
+++ b/beater/agent_config_handler_test.go
@@ -178,7 +178,7 @@ func TestAgentConfigHandler(t *testing.T) {
 	for name, tc := range testcases {
 
 		runTest := func(t *testing.T, body, token string) {
-			h := agentConfigHandler(tc.kbClient, true, &cfg, token)
+			h := agentConfigHandler(tc.kbClient, &cfg, token)
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(tc.method, target(tc.queryParams), nil)
 			for k, v := range tc.requestHeader {
@@ -211,7 +211,7 @@ func TestAgentConfigHandler(t *testing.T) {
 
 func TestAgentConfigDisabled(t *testing.T) {
 	cfg := agentConfig{Cache: &Cache{Expiration: time.Nanosecond}}
-	h := agentConfigHandler(nil, false, &cfg, "")
+	h := agentConfigHandler(nil, &cfg, "")
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/config", nil)
@@ -232,7 +232,7 @@ func TestAgentConfigHandlerPostOk(t *testing.T) {
 	}, mockVersion, true)
 
 	var cfg = agentConfig{Cache: &Cache{Expiration: time.Nanosecond}}
-	h := agentConfigHandler(kb, true, &cfg, "")
+	h := agentConfigHandler(kb, &cfg, "")
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodPost, "/config", convert.ToReader(m{

--- a/beater/agent_config_handler_test.go
+++ b/beater/agent_config_handler_test.go
@@ -19,136 +19,192 @@ package beater
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
-	"github.com/elastic/beats/libbeat/kibana"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/libbeat/common"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/elastic/apm-server/agentcfg"
 	"github.com/elastic/apm-server/beater/headers"
 	"github.com/elastic/apm-server/convert"
+	"github.com/elastic/apm-server/kibana"
 	"github.com/elastic/apm-server/tests"
 )
 
-var testcases = map[string]struct {
-	kbClient      *kibana.Client
-	requestHeader map[string]string
-	queryParams   map[string]string
-	method        string
+var (
+	mockVersion = *common.MustNewVersion("7.3.0")
 
-	respStatus                             int
-	respBody                               bool
-	respEtagHeader, respCacheControlHeader string
-}{
-	"NotModified": {
-		kbClient: tests.MockKibana(http.StatusOK, m{
-			"_id": "1",
-			"_source": m{
-				"settings": m{
-					"sampling_rate": 0.5,
+	testcases = map[string]struct {
+		kbClient      kibana.Client
+		requestHeader map[string]string
+		queryParams   map[string]string
+		method        string
+
+		respStatus                             int
+		respBody, respBodyToken                string
+		respEtagHeader, respCacheControlHeader string
+	}{
+		"NotModified": {
+			kbClient: tests.MockKibana(http.StatusOK, m{
+				"_id": "1",
+				"_source": m{
+					"settings": m{
+						"sampling_rate": 0.5,
+					},
 				},
-			},
-		}),
-		method:                 http.MethodGet,
-		requestHeader:          map[string]string{headers.IfNoneMatch: `"` + "1" + `"`},
-		queryParams:            map[string]string{"service.name": "opbeans-node"},
-		respStatus:             http.StatusNotModified,
-		respCacheControlHeader: "max-age=4, must-revalidate",
-		respEtagHeader:         "\"1\"",
-	},
+			}, mockVersion, true),
+			method:                 http.MethodGet,
+			requestHeader:          map[string]string{headers.IfNoneMatch: `"` + "1" + `"`},
+			queryParams:            map[string]string{"service.name": "opbeans-node"},
+			respStatus:             http.StatusNotModified,
+			respCacheControlHeader: "max-age=4, must-revalidate",
+			respEtagHeader:         "\"1\"",
+		},
 
-	"ModifiedWithoutEtag": {
-		kbClient: tests.MockKibana(http.StatusOK, m{
-			"_source": m{
-				"settings": m{
-					"sampling_rate": 0.5,
+		"ModifiedWithoutEtag": {
+			kbClient: tests.MockKibana(http.StatusOK, m{
+				"_source": m{
+					"settings": m{
+						"sampling_rate": 0.5,
+					},
 				},
-			},
-		}),
-		method:                 http.MethodGet,
-		queryParams:            map[string]string{"service.name": "opbeans-java"},
-		respStatus:             http.StatusOK,
-		respCacheControlHeader: "max-age=4, must-revalidate",
-		respBody:               true,
-	},
+			}, mockVersion, true),
+			method:                 http.MethodGet,
+			queryParams:            map[string]string{"service.name": "opbeans-java"},
+			respStatus:             http.StatusOK,
+			respCacheControlHeader: "max-age=4, must-revalidate",
+			respBody:               `{"sampling_rate":"0.5"}`,
+			respBodyToken:          `{"sampling_rate":"0.5"}`,
+		},
 
-	"ModifiedWithEtag": {
-		kbClient: tests.MockKibana(http.StatusOK, m{
-			"_id": "1",
-			"_source": m{
-				"settings": m{
-					"sampling_rate": 0.5,
+		"ModifiedWithEtag": {
+			kbClient: tests.MockKibana(http.StatusOK, m{
+				"_id": "1",
+				"_source": m{
+					"settings": m{
+						"sampling_rate": 0.5,
+					},
 				},
-			},
-		}),
-		method:                 http.MethodGet,
-		requestHeader:          map[string]string{headers.IfNoneMatch: "2"},
-		queryParams:            map[string]string{"service.name": "opbeans-java"},
-		respStatus:             http.StatusOK,
-		respEtagHeader:         "\"1\"",
-		respCacheControlHeader: "max-age=4, must-revalidate",
-		respBody:               true,
-	},
+			}, mockVersion, true),
+			method:                 http.MethodGet,
+			requestHeader:          map[string]string{headers.IfNoneMatch: "2"},
+			queryParams:            map[string]string{"service.name": "opbeans-java"},
+			respStatus:             http.StatusOK,
+			respEtagHeader:         "\"1\"",
+			respCacheControlHeader: "max-age=4, must-revalidate",
+			respBody:               `{"sampling_rate":"0.5"}`,
+			respBodyToken:          `{"sampling_rate":"0.5"}`,
+		},
 
-	"InternalError": {
-		kbClient: tests.MockKibana(http.StatusExpectationFailed, m{
-			"_id": "1", "_source": ""},
-		),
-		method:                 http.MethodGet,
-		queryParams:            map[string]string{"service.name": "opbeans-ruby"},
-		respStatus:             http.StatusServiceUnavailable,
-		respCacheControlHeader: "max-age=300, must-revalidate",
-		respBody:               true,
-	},
+		"SendToKibanaFailed": {
+			kbClient:               tests.MockKibana(http.StatusBadGateway, m{}, mockVersion, true),
+			method:                 http.MethodGet,
+			queryParams:            map[string]string{"service.name": "opbeans-ruby"},
+			respStatus:             http.StatusServiceUnavailable,
+			respCacheControlHeader: "max-age=300, must-revalidate",
+			respBody:               agentcfg.ErrMsgSendToKibanaFailed,
+			respBodyToken:          fmt.Sprintf("%s: testerror", agentcfg.ErrMsgSendToKibanaFailed),
+		},
 
-	"StatusNotFoundError": {
-		kbClient:               tests.MockKibana(http.StatusNotFound, m{}),
-		method:                 http.MethodGet,
-		queryParams:            map[string]string{"service.name": "opbeans-python"},
-		respStatus:             http.StatusNotFound,
-		respCacheControlHeader: "max-age=300, must-revalidate",
-	},
+		"MultipleConfigs": {
+			kbClient:               tests.MockKibana(http.StatusMultipleChoices, m{"s1": 1}, mockVersion, true),
+			method:                 http.MethodGet,
+			queryParams:            map[string]string{"service.name": "opbeans-ruby"},
+			respStatus:             http.StatusServiceUnavailable,
+			respCacheControlHeader: "max-age=300, must-revalidate",
+			respBody:               agentcfg.ErrMsgMultipleChoices,
+			respBodyToken:          fmt.Sprintf("%s: {\"s1\":1}", agentcfg.ErrMsgMultipleChoices),
+		},
 
-	"NoService": {
-		kbClient:               tests.MockKibana(http.StatusOK, m{}),
-		method:                 http.MethodGet,
-		respStatus:             http.StatusBadRequest,
-		respBody:               true,
-		respCacheControlHeader: "max-age=300, must-revalidate",
-	},
+		"NoConnection": {
+			kbClient:               tests.MockKibana(http.StatusServiceUnavailable, m{}, mockVersion, false),
+			method:                 http.MethodGet,
+			respStatus:             http.StatusServiceUnavailable,
+			respCacheControlHeader: "max-age=300, must-revalidate",
+			respBody:               errMsgNoKibanaConnection,
+			respBodyToken:          errMsgNoKibanaConnection,
+		},
 
-	"MethodNotAllowed": {
-		kbClient:               tests.MockKibana(http.StatusOK, m{}),
-		method:                 http.MethodPut,
-		respStatus:             http.StatusMethodNotAllowed,
-		respCacheControlHeader: "max-age=300, must-revalidate",
-	},
-}
+		"InvalidVersion": {
+			kbClient:               tests.MockKibana(http.StatusServiceUnavailable, m{}, *common.MustNewVersion("7.2.0"), true),
+			method:                 http.MethodGet,
+			respStatus:             http.StatusServiceUnavailable,
+			respCacheControlHeader: "max-age=300, must-revalidate",
+			respBody:               errMsgKibanaVersionNotCompatible,
+			respBodyToken: "min required Kibana version 7.3.0," +
+				" configured Kibana version {version:7.2.0 Major:7 Minor:2 Bugfix:0 Meta:}",
+		},
+
+		"StatusNotFoundError": {
+			kbClient:               tests.MockKibana(http.StatusNotFound, m{}, mockVersion, true),
+			method:                 http.MethodGet,
+			queryParams:            map[string]string{"service.name": "opbeans-python"},
+			respStatus:             http.StatusNotFound,
+			respCacheControlHeader: "max-age=300, must-revalidate",
+			respBody:               errMsgConfigNotFound,
+			respBodyToken:          "no config found for opbeans-python",
+		},
+
+		"NoService": {
+			kbClient:               tests.MockKibana(http.StatusOK, m{}, mockVersion, true),
+			method:                 http.MethodGet,
+			respStatus:             http.StatusBadRequest,
+			respBody:               errMsgInvalidQuery,
+			respBodyToken:          `service.name is required`,
+			respCacheControlHeader: "max-age=300, must-revalidate",
+		},
+
+		"MethodNotAllowed": {
+			kbClient:               tests.MockKibana(http.StatusOK, m{}, mockVersion, true),
+			method:                 http.MethodPut,
+			respStatus:             http.StatusMethodNotAllowed,
+			respCacheControlHeader: "max-age=300, must-revalidate",
+			respBody:               errMsgMethodUnsupported,
+			respBodyToken:          fmt.Sprintf("%s: PUT", errMsgMethodUnsupported),
+		},
+	}
+)
 
 func TestAgentConfigHandler(t *testing.T) {
 	var cfg = agentConfig{Cache: &Cache{Expiration: 4 * time.Second}}
 
 	for name, tc := range testcases {
-		t.Run(name, func(t *testing.T) {
-			h := agentConfigHandler(tc.kbClient, true, &cfg, "")
+
+		runTest := func(t *testing.T, body, token string) {
+			h := agentConfigHandler(tc.kbClient, true, &cfg, token)
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(tc.method, target(tc.queryParams), nil)
 			for k, v := range tc.requestHeader {
 				r.Header.Set(k, v)
 			}
+			r.Header.Set("Authorization", "Bearer "+token)
 			h.ServeHTTP(w, r)
 
-			assert.Equal(t, tc.respStatus, w.Code)
+			require.Equal(t, tc.respStatus, w.Code)
 			assert.Equal(t, tc.respCacheControlHeader, w.Header().Get(headers.CacheControl))
 			assert.Equal(t, tc.respEtagHeader, w.Header().Get(headers.Etag))
-			if tc.respBody {
-				assert.NotEmpty(t, w.Body)
-			} else {
+			if body == "" {
 				assert.Empty(t, w.Body)
+			} else {
+				b, err := ioutil.ReadAll(w.Body)
+				require.NoError(t, err)
+				assert.Equal(t, body+"\n", string(b))
 			}
+		}
+
+		t.Run(name+"NoSecretToken", func(t *testing.T) {
+			runTest(t, tc.respBody, "")
+		})
+
+		t.Run(name+"WithSecretToken", func(t *testing.T) {
+			runTest(t, tc.respBodyToken, "1234")
 		})
 	}
 }
@@ -173,7 +229,7 @@ func TestAgentConfigHandlerPostOk(t *testing.T) {
 				"sampling_rate": 0.5,
 			},
 		},
-	})
+	}, mockVersion, true)
 
 	var cfg = agentConfig{Cache: &Cache{Expiration: time.Nanosecond}}
 	h := agentConfigHandler(kb, true, &cfg, "")

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -35,7 +35,6 @@ import (
 	"github.com/elastic/beats/libbeat/beat"
 	"github.com/elastic/beats/libbeat/cfgfile"
 	"github.com/elastic/beats/libbeat/common"
-	"github.com/elastic/beats/libbeat/kibana"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/outputs/elasticsearch"
 
@@ -199,15 +198,7 @@ func (bt *beater) Run(b *beat.Beat) error {
 		return nil
 	}
 
-	var kbClient *kibana.Client
-	if bt.config.Kibana.Enabled() {
-		kbClient, err = kibana.NewKibanaClient(bt.config.Kibana)
-		if err != nil {
-			bt.logger.Error(err.Error())
-		}
-	}
-
-	bt.server, err = newServer(bt.config, tracer, kbClient, pub.Send)
+	bt.server, err = newServer(bt.config, tracer, pub.Send)
 	if err != nil {
 		bt.logger.Error("failed to create new server:", err)
 		return nil

--- a/beater/common_handler.go
+++ b/beater/common_handler.go
@@ -337,11 +337,17 @@ func sendPlain(w http.ResponseWriter, body interface{}, statusCode int) int {
 	w.Header().Set(headers.XContentTypeOptions, "nosniff")
 	w.WriteHeader(statusCode)
 
-	b, err := json.Marshal(body)
-	if err != nil {
-		b = []byte(fmt.Sprintf("%v", body))
+	var b []byte
+	var err error
+	if bStr, ok := body.(string); ok {
+		b = []byte(bStr + "\n")
+	} else {
+		b, err = json.Marshal(body)
+		if err != nil {
+			b = []byte(fmt.Sprintf("%+v", body))
+		}
+		b = append(b, "\n"...)
 	}
-	b = append(b, "\n"...)
 	n, _ := w.Write(b)
 	return n
 }

--- a/beater/onboarding_test.go
+++ b/beater/onboarding_test.go
@@ -40,7 +40,7 @@ func TestNotifyUpServerDown(t *testing.T) {
 	defer lis.Close()
 	config.Host = lis.Addr().String()
 
-	server, err := newServer(config, apm.DefaultTracer, nil, nopReporter)
+	server, err := newServer(config, apm.DefaultTracer, nopReporter)
 	require.NoError(t, err)
 	go run(logp.NewLogger("onboarding_test"), server, lis, config)
 

--- a/beater/route_config.go
+++ b/beater/route_config.go
@@ -114,11 +114,11 @@ func newMuxer(beaterConfig *Config, report publish.Reporter) (*http.ServeMux, er
 		mux.Handle(path, handler)
 	}
 
-	mux.Handle(agentConfigURL, agentConfigHandler(
-		kibana.NewConnectingClient(beaterConfig.Kibana),
-		beaterConfig.Kibana.Enabled(),
-		beaterConfig.AgentConfig,
-		beaterConfig.SecretToken))
+	var kbClient kibana.Client
+	if beaterConfig.Kibana.Enabled() {
+		kbClient = kibana.NewConnectingClient(beaterConfig.Kibana)
+	}
+	mux.Handle(agentConfigURL, agentConfigHandler(kbClient, beaterConfig.AgentConfig, beaterConfig.SecretToken))
 	logger.Infof("Path %s added to request handler", agentConfigURL)
 
 	mux.Handle(rootURL, rootHandler(beaterConfig.SecretToken))

--- a/beater/server.go
+++ b/beater/server.go
@@ -28,13 +28,12 @@ import (
 
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/beats/libbeat/common/transport/tlscommon"
-	"github.com/elastic/beats/libbeat/kibana"
 	"github.com/elastic/beats/libbeat/logp"
 	"github.com/elastic/beats/libbeat/version"
 )
 
-func newServer(config *Config, tracer *apm.Tracer, kbClient *kibana.Client, report publish.Reporter) (*http.Server, error) {
-	mux, err := newMuxer(config, kbClient, report)
+func newServer(config *Config, tracer *apm.Tracer, report publish.Reporter) (*http.Server, error) {
+	mux, err := newMuxer(config, report)
 	if err != nil {
 		return nil, err
 	}

--- a/changelogs/7.3.asciidoc
+++ b/changelogs/7.3.asciidoc
@@ -20,7 +20,7 @@ https://github.com/elastic/apm-server/compare/v7.2.1\...v7.3.0[View commits]
 [float]
 ==== Added
 - Support adding transaction and span information to metrics  {pull}2265[2265],{pull}2287[2287].
-- Initial support for remote agent configuration, requires Kibana {pull}2289[2289],{pull}2301[2301]{pull}2386[2386].
+- Initial support for remote agent configuration, requires Kibana {pull}2289[2289],{pull}2301[2301],{pull}2386[2386],{pull}2421[2421].
 - Add basic caching to remote agent configuration {pull}2337[2337].
 - Enable APM pipeline by default {pull}2301[2301].
 - Add fields required by breakdown graphs APM pipeline by default {pull}2315[2315],{pull}2397[2397].

--- a/changelogs/7.3.asciidoc
+++ b/changelogs/7.3.asciidoc
@@ -20,7 +20,7 @@ https://github.com/elastic/apm-server/compare/v7.2.1\...v7.3.0[View commits]
 [float]
 ==== Added
 - Support adding transaction and span information to metrics  {pull}2265[2265],{pull}2287[2287].
-- Initial support for remote agent configuration, requires Kibana {pull}2289[2289],{pull}2301[2301],{pull}2386[2386],{pull}2421[2421].
+- Initial support for remote agent configuration, requires Kibana {pull}2289[2289],{pull}2301[2301],{pull}2386[2386],{pull}2407[2407],{pull}2421[2421].
 - Add basic caching to remote agent configuration {pull}2337[2337].
 - Enable APM pipeline by default {pull}2301[2301].
 - Add fields required by breakdown graphs APM pipeline by default {pull}2315[2315],{pull}2397[2397].

--- a/kibana/connecting_client.go
+++ b/kibana/connecting_client.go
@@ -1,0 +1,132 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kibana
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/backoff"
+	"github.com/elastic/beats/libbeat/kibana"
+	"github.com/elastic/beats/libbeat/logp"
+
+	logs "github.com/elastic/apm-server/log"
+)
+
+const (
+	initBackoff = time.Second
+	maxBackoff  = 30 * time.Second
+)
+
+var errNotConnected = errors.New("unable to retrieve connection to Kibana")
+
+// Client provides an interface for Kibana Clients
+type Client interface {
+	// Send tries to send request to Kibana and returns unparsed response
+	Send(string, string, url.Values, http.Header, io.Reader) (*http.Response, error)
+	// GetVersion returns Kibana version or an error
+	GetVersion() (common.Version, error)
+	// Connected indicates whether or not a connection to Kibana has been established
+	Connected() bool
+	// SupportsVersion compares given version to version of connected Kibana instance
+	SupportsVersion(v *common.Version) (bool, error)
+}
+
+// ConnectingClient implements Client interface
+type ConnectingClient struct {
+	client *kibana.Client
+	cfg    *common.Config
+	m      sync.Mutex
+}
+
+// NewConnectingClient returns instance of ConnectingClient and starts a background routine trying to connect
+// to configured Kibana instance, using JitterBackoff for establishing connection.
+func NewConnectingClient(cfg *common.Config) Client {
+	c := &ConnectingClient{cfg: cfg}
+
+	go func() {
+		log := logp.NewLogger(logs.Kibana)
+		done := make(chan struct{})
+		jitterBackoff := backoff.NewEqualJitterBackoff(done, initBackoff, maxBackoff)
+		for c.client == nil {
+			log.Info("Trying to obtain connection to Kibana.")
+			err := c.connect()
+			if err != nil {
+				log.Errorf("failed to obtain connection to Kibana: %s", err.Error())
+			}
+			backoff.WaitOnError(jitterBackoff, err)
+		}
+		log.Info("Successfully obtained connection to Kibana.")
+	}()
+	return c
+}
+
+// Send tries to send a request to Kibana via established connection and returns unparsed response
+// If no connection is established an error is returned
+func (c *ConnectingClient) Send(method, extraPath string, params url.Values,
+	headers http.Header, body io.Reader) (*http.Response, error) {
+
+	if !c.Connected() {
+		return nil, errNotConnected
+	}
+	return c.client.Send(method, extraPath, params, headers, body)
+}
+
+// GetVersion returns Kibana version or an error
+// If no connection is established an error is returned
+func (c *ConnectingClient) GetVersion() (common.Version, error) {
+	if !c.Connected() {
+		return common.Version{}, errNotConnected
+	}
+	return c.client.GetVersion(), nil
+}
+
+// Connected checks if a connection has been established
+func (c *ConnectingClient) Connected() bool { return c.client != nil }
+
+// SupportsVersion checks if connected Kibana instance is compatible to given version
+// If no connection is established an error is returned
+func (c *ConnectingClient) SupportsVersion(v *common.Version) (bool, error) {
+	if !c.Connected() {
+		return false, errNotConnected
+	}
+	return v.LessThanOrEqual(false, &c.client.Version), nil
+}
+
+func (c *ConnectingClient) connect() error {
+	if c.client != nil {
+		return nil
+	}
+	c.m.Lock()
+	defer c.m.Unlock()
+	if c.client != nil {
+		return nil
+	}
+	kbClient, err := kibana.NewKibanaClient(c.cfg)
+	if err != nil {
+		return err
+	}
+	c.client = kbClient
+	return nil
+}

--- a/kibana/connecting_client.go
+++ b/kibana/connecting_client.go
@@ -70,7 +70,7 @@ func NewConnectingClient(cfg *common.Config) Client {
 			done := make(chan struct{})
 			jitterBackoff := backoff.NewEqualJitterBackoff(done, initBackoff, maxBackoff)
 			for c.client == nil {
-				log.Info("Trying to obtain connection to Kibana.")
+				log.Debug("Trying to obtain connection to Kibana.")
 				err := c.connect()
 				if err != nil {
 					log.Errorf("failed to obtain connection to Kibana: %s", err.Error())

--- a/kibana/connecting_client_test.go
+++ b/kibana/connecting_client_test.go
@@ -1,0 +1,137 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kibana
+
+import (
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/kibana"
+
+	"github.com/elastic/apm-server/convert"
+)
+
+func TestNewConnectingClientFrom(t *testing.T) {
+	c := NewConnectingClient(mockCfg)
+	require.NotNil(t, c)
+	assert.Nil(t, c.(*ConnectingClient).client)
+	assert.Equal(t, mockCfg, c.(*ConnectingClient).cfg)
+}
+
+func TestConnectingClient_Send(t *testing.T) {
+	t.Run("Send", func(t *testing.T) {
+		c := mockClient()
+		r, err := c.Send(http.MethodGet, "", nil, nil, nil)
+		require.NoError(t, err)
+		assert.Equal(t, mockBody, r.Body)
+		assert.Equal(t, mockStatus, r.StatusCode)
+	})
+
+	t.Run("SendError", func(t *testing.T) {
+		c := NewConnectingClient(mockCfg)
+		r, err := c.Send(http.MethodGet, "", nil, nil, nil)
+		require.Error(t, err)
+		assert.Equal(t, err, errNotConnected)
+		assert.Nil(t, r)
+	})
+}
+
+func TestConnectingClient_GetVersion(t *testing.T) {
+	t.Run("GetVersion", func(t *testing.T) {
+		c := mockClient()
+		v, err := c.GetVersion()
+		require.NoError(t, err)
+		assert.Equal(t, mockVersion, v)
+	})
+
+	t.Run("GetVersionError", func(t *testing.T) {
+		c := NewConnectingClient(mockCfg)
+		v, err := c.GetVersion()
+		require.Error(t, err)
+		assert.Equal(t, err, errNotConnected)
+		assert.Equal(t, common.Version{}, v)
+	})
+}
+
+func TestConnectingClient_SupportsVersion(t *testing.T) {
+	t.Run("SupportsVersionTrue", func(t *testing.T) {
+		c := mockClient()
+		s, err := c.SupportsVersion(common.MustNewVersion("7.3.0"))
+		require.NoError(t, err)
+		assert.True(t, s)
+	})
+	t.Run("SupportsVersionFalse", func(t *testing.T) {
+		c := mockClient()
+		s, err := c.SupportsVersion(common.MustNewVersion("7.4.0"))
+		require.NoError(t, err)
+		assert.False(t, s)
+	})
+
+	t.Run("SupportsVersionError", func(t *testing.T) {
+		c := NewConnectingClient(mockCfg)
+		s, err := c.SupportsVersion(common.MustNewVersion("7.3.0"))
+		require.Error(t, err)
+		assert.Equal(t, err, errNotConnected)
+		assert.False(t, s)
+	})
+}
+
+func TestConnectingClient_Connected(t *testing.T) {
+	t.Run("Connected", func(t *testing.T) {
+		c := mockClient()
+		require.True(t, c.Connected())
+	})
+
+	t.Run("NotConnected", func(t *testing.T) {
+		c := NewConnectingClient(mockCfg)
+		require.False(t, c.Connected())
+	})
+}
+
+type rt struct {
+	resp *http.Response
+}
+
+var (
+	mockCfg     = common.MustNewConfigFrom(`{"enabled": "false", "host": "non-existing"}`)
+	mockBody    = ioutil.NopCloser(convert.ToReader(`{"response": "ok"}`))
+	mockStatus  = http.StatusOK
+	mockVersion = *common.MustNewVersion("7.3.0")
+)
+
+// RoundTrip implements the Round Tripper interface
+func (rt rt) RoundTrip(r *http.Request) (*http.Response, error) {
+	return rt.resp, nil
+}
+func mockClient() *ConnectingClient {
+	return &ConnectingClient{client: &kibana.Client{
+		Connection: kibana.Connection{
+			HTTP: &http.Client{
+				Transport: rt{resp: &http.Response{
+					StatusCode: mockStatus,
+					Body:       mockBody}},
+			},
+			Version: mockVersion,
+		},
+	}}
+}

--- a/log/selectors.go
+++ b/log/selectors.go
@@ -23,6 +23,7 @@ const (
 	Handler         = "handler"
 	Ilm             = "ilm"
 	IndexManagement = "index-management"
+	Kibana          = "kibana"
 	Onboarding      = "onboarding"
 	Pipelines       = "pipelines"
 	Request         = "request"
@@ -32,5 +33,4 @@ const (
 	Stacktrace      = "stacktrace"
 	Tracing         = "tracing"
 	Transform       = "transform"
-	Kibana          = "kibana"
 )

--- a/log/selectors.go
+++ b/log/selectors.go
@@ -32,4 +32,5 @@ const (
 	Stacktrace      = "stacktrace"
 	Tracing         = "tracing"
 	Transform       = "transform"
+	Kibana          = "kibana"
 )

--- a/tests/system/test_integration_logging.py
+++ b/tests/system/test_integration_logging.py
@@ -84,6 +84,7 @@ class LoggingIntegrationAuth(ElasticTest):
             "level": "error",
             "message": "error handling request",
             "response_code": 503,
+            "error": "unable to retrieve connection to Kibana",
         }, config_request_logs[1])
 
 


### PR DESCRIPTION
Implement Kibana client wrapper that takes care of obtaining a valid
Kibana client, in case client cannot be obtained on startup.
Align returned response body to whether or not the user sends a secret token.
Log full error messages. 

fixes elastic/apm-server#2371
