### PR TITLE
[docs][7.x] Fix documentation build errors

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,4 +1,3 @@
-include::./changelogs/head.asciidoc[]
 include::./changelogs/7.3.asciidoc[]
 include::./changelogs/7.2.asciidoc[]
 include::./changelogs/7.1.asciidoc[]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,4 +1,6 @@
 include::./changelogs/head.asciidoc[]
+include::./changelogs/7.3.asciidoc[]
+include::./changelogs/7.2.asciidoc[]
 include::./changelogs/7.1.asciidoc[]
 include::./changelogs/7.0.asciidoc[]
 include::./changelogs/6.8.asciidoc[]

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -10,6 +10,8 @@
 --
 This following sections summarizes the changes in each release.
 
+* <<release-notes-7.3>>
+* <<release-notes-7.2>>
 * <<release-notes-7.1>>
 * <<release-notes-7.0>>
 * <<release-notes-6.8>>
@@ -20,8 +22,6 @@ This following sections summarizes the changes in each release.
 * <<release-notes-6.3>>
 * <<release-notes-6.2>>
 * <<release-notes-6.1>>
-
-
 --
 
 include::{root-dir}/CHANGELOG.asciidoc[]


### PR DESCRIPTION
Removes head, adds 7.3 and 7.2 links.