### PR TITLE
[ACM] Create Etag from settings struct.

### DIFF
--- a/agentcfg/cache_test.go
+++ b/agentcfg/cache_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 var (
-	defaultDoc  = Doc{Source: Source{Settings: Settings{"a": "default"}}}
-	externalDoc = Doc{Source: Source{Settings: Settings{"a": "b"}}}
+	defaultDoc  = Doc{Settings: Settings{"a": "default"}}
+	externalDoc = Doc{Settings: Settings{"a": "b"}}
 )
 
 type cacheSetup struct {
@@ -62,7 +62,7 @@ func TestCache_fetchAndAdd(t *testing.T) {
 		"DocFromCache":         {fn: testFn, init: true, doc: &defaultDoc},
 		"DocFromFunctionFails": {fn: testFnErr, fail: true},
 		"DocFromFunction":      {fn: testFn, doc: &externalDoc},
-		"EmptyDocFromFunction": {fn: testFnSettingsNil, doc: &Doc{Source: Source{Settings: Settings{}}}},
+		"EmptyDocFromFunction": {fn: testFnSettingsNil, doc: &Doc{Settings: Settings{}}},
 		"NilDocFromFunction":   {fn: testFnNil},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -134,7 +134,7 @@ func testFnNil(_ Query) (*Doc, error) {
 }
 
 func testFnSettingsNil(_ Query) (*Doc, error) {
-	return &Doc{Source: Source{Settings: Settings{}}}, nil
+	return &Doc{Settings: Settings{}}, nil
 }
 
 func testFn(_ Query) (*Doc, error) {

--- a/agentcfg/fetch_test.go
+++ b/agentcfg/fetch_test.go
@@ -18,6 +18,7 @@
 package agentcfg
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
@@ -39,84 +40,96 @@ var (
 	mockVersion = *common.MustNewVersion("7.3.0")
 )
 
+func TestFetcher_Fetch(t *testing.T) {
+	t.Run("ErrorInput", func(t *testing.T) {
+		kerr := errors.New("test error")
+		_, _, ferr := NewFetcher(&kibana.ConnectingClient{}, testExp).Fetch(query(t.Name()), kerr)
+		require.Error(t, ferr)
+		assert.Equal(t, kerr, ferr)
+	})
+
+	t.Run("FetchError", func(t *testing.T) {
+		kb := tests.MockKibana(http.StatusMultipleChoices, m{"error": "an error"}, mockVersion, true)
+		_, _, err := NewFetcher(kb, testExp).Fetch(query(t.Name()), nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), ErrMsgMultipleChoices)
+	})
+
+	t.Run("ExpectationFailed", func(t *testing.T) {
+		kb := tests.MockKibana(http.StatusExpectationFailed, m{"error": "an error"}, mockVersion, true)
+		_, _, err := NewFetcher(kb, testExp).Fetch(query(t.Name()), nil)
+		require.Error(t, err)
+		assert.Equal(t, "{\"error\":\"an error\"}", err.Error())
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		kb := tests.MockKibana(http.StatusNotFound, m{}, mockVersion, true)
+
+		result, etag, err := NewFetcher(kb, testExp).Fetch(query(t.Name()), nil)
+		require.NoError(t, err)
+		assert.Empty(t, etag)
+		assert.Nil(t, result)
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		kb := tests.MockKibana(http.StatusOK, mockDoc(0.5), mockVersion, true)
+		b, err := json.Marshal(mockDoc(0.5))
+		require.NoError(t, err)
+		doc, err := NewDoc(b)
+		require.NoError(t, err)
+
+		result, etag, err := NewFetcher(kb, testExp).Fetch(query(t.Name()), nil)
+		require.NoError(t, err)
+		assert.Equal(t, doc.ID, etag)
+		assert.Equal(t, doc.Settings, Settings(result))
+	})
+
+	t.Run("FetchFromCache", func(t *testing.T) {
+
+		fetch := func(f *Fetcher, kibanaSamplingRate, expectedSamplingRate float64) {
+
+			client := func(samplingRate float64) kibana.Client {
+				return tests.MockKibana(http.StatusOK, mockDoc(samplingRate), mockVersion, true)
+			}
+			f.kbClient = client(kibanaSamplingRate)
+
+			b, err := json.Marshal(mockDoc(expectedSamplingRate))
+			require.NoError(t, err)
+			doc, err := NewDoc(b)
+			require.NoError(t, err)
+
+			result, etag, err := f.Fetch(query(t.Name()), nil)
+			require.NoError(t, err)
+			assert.Equal(t, doc.ID, etag)
+			assert.Equal(t, doc.Settings, Settings(result))
+		}
+
+		fetcher := NewFetcher(nil, time.Minute)
+
+		// nothing cached yet
+		fetch(fetcher, 0.5, 0.5)
+
+		// next fetch runs against cache
+		fetch(fetcher, 0.8, 0.5)
+
+		// after key is expired, fetch from Kibana again
+		fetcher.docCache.gocache.Delete(query(t.Name()).ID())
+		fetch(fetcher, 0.7, 0.7)
+
+	})
+}
+
 func query(name string) Query {
 	return Query{Service: Service{Name: name}}
 }
 
-func TestFetchWithError(t *testing.T) {
-	kerr := errors.New("test error")
-	_, _, ferr := NewFetcher(&kibana.ConnectingClient{}, testExp).Fetch(query(t.Name()), kerr)
-	require.Error(t, ferr)
-	assert.Equal(t, kerr, ferr)
-}
-
-func TestFetchStringConversion(t *testing.T) {
-	kb := tests.MockKibana(http.StatusOK,
-		m{
-			"_id": "1",
-			"_source": m{
-				"settings": m{
-					"sampling_rate": 0.5,
-				},
+func mockDoc(sampleRate float64) m {
+	return m{
+		"_id": "1",
+		"_source": m{
+			"settings": m{
+				"sampling_rate": sampleRate,
 			},
 		},
-		mockVersion, true)
-	result, etag, err := NewFetcher(kb, testExp).Fetch(query(t.Name()), nil)
-	require.NoError(t, err)
-	assert.Equal(t, "1", etag, etag)
-	assert.Equal(t, map[string]string{"sampling_rate": "0.5"}, result)
-}
-
-func TestFetchError(t *testing.T) {
-	kb := tests.MockKibana(http.StatusMultipleChoices, m{"error": "an error"}, mockVersion, true)
-	_, _, err := NewFetcher(kb, testExp).Fetch(query(t.Name()), nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), ErrMsgMultipleChoices)
-}
-
-func TestExpectationFailed(t *testing.T) {
-	kb := tests.MockKibana(http.StatusExpectationFailed, m{"error": "an error"}, mockVersion, true)
-	_, _, err := NewFetcher(kb, testExp).Fetch(query(t.Name()), nil)
-	require.Error(t, err)
-	assert.Equal(t, "{\"error\":\"an error\"}", err.Error())
-}
-
-func TestFetchWithCaching(t *testing.T) {
-	fetch := func(f *Fetcher, samplingRate float64) map[string]string {
-
-		client := func(samplingRate float64) kibana.Client {
-			return tests.MockKibana(http.StatusOK,
-				m{
-					"_id": "1",
-					"_source": m{
-						"settings": m{
-							"sampling_rate": samplingRate,
-						},
-					},
-				},
-				mockVersion, true)
-		}
-		f.kbClient = client(samplingRate)
-
-		result, id, err := f.Fetch(query(t.Name()), nil)
-		require.NoError(t, err)
-		require.Equal(t, "1", id)
-		return result
 	}
-
-	fetcher := NewFetcher(nil, time.Minute)
-
-	// nothing cached yet
-	result := fetch(fetcher, 0.5)
-	assert.Equal(t, map[string]string{"sampling_rate": "0.5"}, result)
-
-	// next fetch runs against cache
-	result = fetch(fetcher, 0.8)
-	assert.Equal(t, map[string]string{"sampling_rate": "0.5"}, result)
-
-	// after key is expired, fetch from Kibana again
-	fetcher.docCache.gocache.Delete(query(t.Name()).ID())
-	result = fetch(fetcher, 0.7)
-	assert.Equal(t, map[string]string{"sampling_rate": "0.7"}, result)
-
 }

--- a/agentcfg/fetch_test.go
+++ b/agentcfg/fetch_test.go
@@ -64,11 +64,13 @@ func TestFetcher_Fetch(t *testing.T) {
 
 	t.Run("NotFound", func(t *testing.T) {
 		kb := tests.MockKibana(http.StatusNotFound, m{}, mockVersion, true)
+		doc, err := NewDoc([]byte{})
+		require.NoError(t, err)
 
 		result, etag, err := NewFetcher(kb, testExp).Fetch(query(t.Name()), nil)
 		require.NoError(t, err)
-		assert.Empty(t, etag)
-		assert.Nil(t, result)
+		assert.Equal(t, doc.ID, etag)
+		assert.Equal(t, doc.Settings, Settings(result))
 	})
 
 	t.Run("Success", func(t *testing.T) {

--- a/agentcfg/model.go
+++ b/agentcfg/model.go
@@ -21,7 +21,9 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"hash"
 	"sort"
+	"strings"
 )
 
 // Doc represents an elasticsearch document
@@ -33,36 +35,69 @@ type Doc struct {
 // Settings hold agent configuration
 type Settings map[string]string
 
-// NewDoc unmarshals given byte slice into t Doc instance
-func NewDoc(in []byte) (*Doc, error) {
-	if len(in) == 0 {
-		return &Doc{}, nil
-	}
-	var tmp tmpDoc
-	if err := json.Unmarshal(in, &tmp); err != nil {
-		return nil, err
+// NewDoc unmarshals given byte slice into a Doc instance
+func NewDoc(inp []byte) (*Doc, error) {
+	var doc Doc
+	settings, err := unmarshal(inp)
+	if settings == nil || err != nil {
+		return &doc, err
 	}
 
 	h := md5.New()
+	var out = map[string]string{}
+	if err := parse(settings, out, "", h); err != nil {
+		return &doc, err
+	}
+
+	doc.ID = fmt.Sprintf("%x", h.Sum(nil))
+	doc.Settings = out
+	return &doc, nil
+}
+
+func unmarshal(inp []byte) (map[string]interface{}, error) {
+	if len(inp) == 0 {
+		return nil, nil
+	}
+	type tmpDoc struct {
+		Source struct {
+			Settings map[string]interface{} `json:"settings"`
+		} `json:"_source"`
+	}
+	var tmp tmpDoc
+	if err := json.Unmarshal(inp, &tmp); err != nil {
+		return nil, err
+	}
+	return tmp.Source.Settings, nil
+}
+
+func parse(inp map[string]interface{}, out map[string]string, rootKey string, h hash.Hash) error {
 	var keys []string
-	for k := range tmp.Source.Settings {
+	for k := range inp {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-	out := make(map[string]string)
+	var localkey string
 	for _, k := range keys {
-		out[k] = fmt.Sprintf("%v", tmp.Source.Settings[k])
-		h.Write([]byte(fmt.Sprintf("%s_%v", k, tmp.Source.Settings[k])))
+		if rootKey == "" {
+			localkey = k
+		} else {
+			localkey = fmt.Sprintf("%s.%s", rootKey, k)
+		}
+		if inpMap, ok := inp[k].(map[string]interface{}); ok {
+			if err := parse(inpMap, out, localkey, h); err != nil {
+				return err
+			}
+		} else if inpArr, ok := inp[k].([]interface{}); ok {
+			var strArr = make([]string, len(inpArr))
+			for idx, entry := range inpArr {
+				strArr[idx] = fmt.Sprintf("%+v", entry)
+			}
+			out[localkey] = strings.Join(strArr, ",")
+			h.Write([]byte(fmt.Sprintf("%s_%v", localkey, out[localkey])))
+		} else {
+			out[localkey] = fmt.Sprintf("%+v", inp[k])
+			h.Write([]byte(fmt.Sprintf("%s_%v", localkey, inp[k])))
+		}
 	}
-
-	return &Doc{
-		ID:       fmt.Sprintf("%x", h.Sum(nil)),
-		Settings: out,
-	}, nil
-}
-
-type tmpDoc struct {
-	Source struct {
-		Settings map[string]interface{} `json:"settings"`
-	} `json:"_source"`
+	return nil
 }

--- a/agentcfg/model.go
+++ b/agentcfg/model.go
@@ -77,22 +77,21 @@ func parse(inp map[string]interface{}, out map[string]string, rootKey string, h 
 	for _, k := range keys {
 		localkey = dotKey(rootKey, k)
 
-		switch inp[k].(type) {
+		switch val := inp[k].(type) {
 		case map[string]interface{}:
-			if err := parse(inp[k].(map[string]interface{}), out, localkey, h); err != nil {
+			if err := parse(val, out, localkey, h); err != nil {
 				return err
 			}
 		case []interface{}:
-			inpArr := inp[k].([]interface{})
-			var strArr = make([]string, len(inpArr))
-			for idx, entry := range inpArr {
+			var strArr = make([]string, len(val))
+			for idx, entry := range val {
 				strArr[idx] = fmt.Sprintf("%+v", entry)
 			}
 			out[localkey] = strings.Join(strArr, ",")
 			h.Write([]byte(fmt.Sprintf("%s_%v", localkey, out[localkey])))
 		default:
-			out[localkey] = fmt.Sprintf("%+v", inp[k])
-			h.Write([]byte(fmt.Sprintf("%s_%v", localkey, inp[k])))
+			out[localkey] = fmt.Sprintf("%+v", val)
+			h.Write([]byte(fmt.Sprintf("%s_%v", localkey, val)))
 		}
 	}
 	return nil

--- a/agentcfg/model.go
+++ b/agentcfg/model.go
@@ -37,21 +37,18 @@ type Settings map[string]string
 
 // NewDoc unmarshals given byte slice into a Doc instance
 func NewDoc(inp []byte) (*Doc, error) {
-	var doc Doc
 	settings, err := unmarshal(inp)
 	if err != nil {
-		return &doc, err
+		return nil, err
 	}
 
 	h := md5.New()
 	var out = map[string]string{}
 	if err := parse(settings, out, "", h); err != nil {
-		return &doc, err
+		return nil, err
 	}
 
-	doc.ID = fmt.Sprintf("%x", h.Sum(nil))
-	doc.Settings = out
-	return &doc, nil
+	return &Doc{ID: fmt.Sprintf("%x", h.Sum(nil)), Settings: out}, nil
 }
 
 func unmarshal(inp []byte) (map[string]interface{}, error) {

--- a/agentcfg/model_test.go
+++ b/agentcfg/model_test.go
@@ -1,0 +1,71 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package agentcfg
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDoc(t *testing.T) {
+	t.Run("InvalidInput", func(t *testing.T) {
+		d, err := NewDoc([]byte("some string"))
+		assert.Error(t, err)
+		assert.Nil(t, d)
+	})
+
+	t.Run("EmptyInput", func(t *testing.T) {
+		d, err := NewDoc([]byte{})
+		assert.NoError(t, err)
+		assert.Empty(t, d)
+	})
+
+	t.Run("ValidInput", func(t *testing.T) {
+		m := map[string]interface{}{
+			"_id": "1234",
+			"_source": map[string]interface{}{
+				"settings": map[string]interface{}{
+					"sample_rate": 0.5,
+					"name":        "testconfig",
+				}}}
+		inp, err := json.Marshal(m)
+		require.NoError(t, err)
+
+		settings := Settings{
+			"sample_rate": "0.5",
+			"name":        "testconfig",
+		}
+		idBytes := []byte("1234")
+		sBytes, err := json.Marshal(map[string]interface{}{
+			"sample_rate": 0.5,
+			"name":        "testconfig"})
+		require.NoError(t, err)
+		b := append(idBytes, sBytes...)
+		id := fmt.Sprintf("%x", md5.Sum(b))
+
+		d, err := NewDoc(inp)
+		require.NoError(t, err)
+		assert.Equal(t, &Doc{Settings: settings, ID: id}, d)
+	})
+}

--- a/agentcfg/model_test.go
+++ b/agentcfg/model_test.go
@@ -36,16 +36,21 @@ func TestNewDoc(t *testing.T) {
 
 	t.Run("EmptyInput", func(t *testing.T) {
 		d, err := NewDoc([]byte{})
-		assert.NoError(t, err)
-		assert.Empty(t, d)
+		require.NoError(t, err)
+		expectedDoc := Doc{
+			Settings: map[string]string{},
+			ID:       fmt.Sprintf("%x", md5.Sum([]byte{}))}
+		assert.Equal(t, &expectedDoc, d)
 	})
 
 	t.Run("ValidInput", func(t *testing.T) {
 		inp := []byte(`{"_id": "1234", 
 "_source": {"settings":{"sample_rate":0.5,"name":"testconfig","sampling":true,
+"b":["b", "a"],
 "nested":{"ab":"val","ac":[3,1,2],"aa":{"c":45.6}}}}}`)
 
 		settings := Settings{
+			"b":           "b,a",
 			"sample_rate": "0.5",
 			"name":        "testconfig",
 			"sampling":    "true",
@@ -55,6 +60,7 @@ func TestNewDoc(t *testing.T) {
 		}
 
 		var b []byte
+		b = append(b, []byte("b_b,a")...)
 		b = append(b, []byte("name_testconfig")...)
 		b = append(b, []byte("nested.aa.c_45.6")...)
 		b = append(b, []byte("nested.ab_val")...)

--- a/agentcfg/model_test.go
+++ b/agentcfg/model_test.go
@@ -48,6 +48,7 @@ func TestNewDoc(t *testing.T) {
 				"settings": map[string]interface{}{
 					"sample_rate": 0.5,
 					"name":        "testconfig",
+					"sampling":    true,
 				}}}
 		inp, err := json.Marshal(m)
 		require.NoError(t, err)
@@ -55,13 +56,13 @@ func TestNewDoc(t *testing.T) {
 		settings := Settings{
 			"sample_rate": "0.5",
 			"name":        "testconfig",
+			"sampling":    "true",
 		}
-		idBytes := []byte("1234")
-		sBytes, err := json.Marshal(map[string]interface{}{
-			"sample_rate": 0.5,
-			"name":        "testconfig"})
-		require.NoError(t, err)
-		b := append(idBytes, sBytes...)
+
+		var b []byte
+		b = append(b, []byte("name_testconfig")...)
+		b = append(b, []byte("sample_rate_0.5")...)
+		b = append(b, []byte("sampling_true")...)
 		id := fmt.Sprintf("%x", md5.Sum(b))
 
 		d, err := NewDoc(inp)

--- a/agentcfg/model_test.go
+++ b/agentcfg/model_test.go
@@ -19,7 +19,6 @@ package agentcfg
 
 import (
 	"crypto/md5"
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestNewDoc(t *testing.T) {
 	t.Run("InvalidInput", func(t *testing.T) {
 		d, err := NewDoc([]byte("some string"))
 		assert.Error(t, err)
-		assert.Nil(t, d)
+		assert.Empty(t, d)
 	})
 
 	t.Run("EmptyInput", func(t *testing.T) {
@@ -42,25 +41,24 @@ func TestNewDoc(t *testing.T) {
 	})
 
 	t.Run("ValidInput", func(t *testing.T) {
-		m := map[string]interface{}{
-			"_id": "1234",
-			"_source": map[string]interface{}{
-				"settings": map[string]interface{}{
-					"sample_rate": 0.5,
-					"name":        "testconfig",
-					"sampling":    true,
-				}}}
-		inp, err := json.Marshal(m)
-		require.NoError(t, err)
+		inp := []byte(`{"_id": "1234", 
+"_source": {"settings":{"sample_rate":0.5,"name":"testconfig","sampling":true,
+"nested":{"ab":"val","ac":[3,1,2],"aa":{"c":45.6}}}}}`)
 
 		settings := Settings{
 			"sample_rate": "0.5",
 			"name":        "testconfig",
 			"sampling":    "true",
+			"nested.ab":   "val",
+			"nested.ac":   "3,1,2",
+			"nested.aa.c": "45.6",
 		}
 
 		var b []byte
 		b = append(b, []byte("name_testconfig")...)
+		b = append(b, []byte("nested.aa.c_45.6")...)
+		b = append(b, []byte("nested.ab_val")...)
+		b = append(b, []byte("nested.ac_3,1,2")...)
 		b = append(b, []byte("sample_rate_0.5")...)
 		b = append(b, []byte("sampling_true")...)
 		id := fmt.Sprintf("%x", md5.Sum(b))

--- a/agentcfg/query.go
+++ b/agentcfg/query.go
@@ -17,10 +17,6 @@
 
 package agentcfg
 
-import (
-	"strings"
-)
-
 const (
 	// ServiceName keyword
 	ServiceName = "service.name"
@@ -46,11 +42,8 @@ func NewQuery(name, env string) Query {
 
 // ID returns the unique id for the query
 func (q Query) ID() string {
-	var str strings.Builder
-	str.WriteString(q.Service.Name)
-	if q.Service.Environment != "" {
-		str.WriteString("_")
-		str.WriteString(q.Service.Environment)
+	if q.Service.Environment == "" {
+		return q.Service.Name
 	}
-	return str.String()
+	return q.Service.Name + "_" + q.Service.Environment
 }

--- a/agentcfg/query.go
+++ b/agentcfg/query.go
@@ -1,0 +1,56 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package agentcfg
+
+import (
+	"strings"
+)
+
+const (
+	// ServiceName keyword
+	ServiceName = "service.name"
+	// ServiceEnv keyword
+	ServiceEnv = "service.environment"
+)
+
+// Query represents an URL body or query params for agent configuration
+type Query struct {
+	Service Service `json:"service"`
+}
+
+// Service holds supported attributes for querying configuration
+type Service struct {
+	Name        string `json:"name"`
+	Environment string `json:"environment,omitempty"`
+}
+
+// NewQuery creates a Query struct
+func NewQuery(name, env string) Query {
+	return Query{Service{name, env}}
+}
+
+// ID returns the unique id for the query
+func (q Query) ID() string {
+	var str strings.Builder
+	str.WriteString(q.Service.Name)
+	if q.Service.Environment != "" {
+		str.WriteString("_")
+		str.WriteString(q.Service.Environment)
+	}
+	return str.String()
+}

--- a/beater/agent_config_handler.go
+++ b/beater/agent_config_handler.go
@@ -82,8 +82,6 @@ func agentConfigHandler(kbClient kibana.Client, config *agentConfig, secretToken
 		case len(cfg) == 0:
 			logMsg := fmt.Sprintf("%s for %s", errMsgConfigNotFound, query.ID())
 			sendErr(http.StatusNotFound, errMsgConfigNotFound, logMsg)
-		case upstreamEtag == "":
-			sendResp(cfg, http.StatusOK, cacheControl)
 		case etag == r.Header.Get(headers.IfNoneMatch):
 			w.Header().Set(headers.Etag, etag)
 			sendResp(nil, http.StatusNotModified, cacheControl)

--- a/beater/agent_config_handler.go
+++ b/beater/agent_config_handler.go
@@ -80,14 +80,10 @@ func agentConfigHandler(kbClient kibana.Client, config *agentConfig, secretToken
 		}
 
 		etag := fmt.Sprintf("\"%s\"", upstreamEtag)
-		switch {
-		case len(cfg) == 0:
-			sendResp(nil, http.StatusOK, cacheControl)
-		case etag == r.Header.Get(headers.IfNoneMatch):
-			w.Header().Set(headers.Etag, etag)
+		w.Header().Set(headers.Etag, etag)
+		if etag == r.Header.Get(headers.IfNoneMatch) {
 			sendResp(nil, http.StatusNotModified, cacheControl)
-		default:
-			w.Header().Set(headers.Etag, etag)
+		} else {
 			sendResp(cfg, http.StatusOK, cacheControl)
 		}
 	})

--- a/beater/agent_config_handler_test.go
+++ b/beater/agent_config_handler_test.go
@@ -40,7 +40,7 @@ import (
 
 var (
 	mockVersion = *common.MustNewVersion("7.3.0")
-	mockEtag    = "61a98e293262279d6ad99e5739fdd1b8"
+	mockEtag    = "1c9588f5a4da71cdef992981a9c9735c"
 	errWrap     = func(s string) string { return fmt.Sprintf("{\"error\":\"%+v\"}\n", s) }
 	successBody = `{"sampling_rate":"0.5"}` + "\n"
 
@@ -175,8 +175,8 @@ func TestAgentConfigHandler(t *testing.T) {
 			h.ServeHTTP(w, r)
 
 			require.Equal(t, tc.respStatus, w.Code)
-			assert.Equal(t, tc.respCacheControlHeader, w.Header().Get(headers.CacheControl))
-			assert.Equal(t, tc.respEtagHeader, w.Header().Get(headers.Etag))
+			require.Equal(t, tc.respCacheControlHeader, w.Header().Get(headers.CacheControl))
+			require.Equal(t, tc.respEtagHeader, w.Header().Get(headers.Etag))
 			if body == "" {
 				assert.Empty(t, w.Body)
 			} else {

--- a/beater/agent_config_handler_test.go
+++ b/beater/agent_config_handler_test.go
@@ -18,6 +18,7 @@
 package beater
 
 import (
+	"crypto/md5"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -41,8 +42,10 @@ import (
 var (
 	mockVersion = *common.MustNewVersion("7.3.0")
 	mockEtag    = "1c9588f5a4da71cdef992981a9c9735c"
+	emptyEtag   = fmt.Sprintf("%x", md5.New().Sum([]byte{}))
 	errWrap     = func(s string) string { return fmt.Sprintf("{\"error\":\"%+v\"}\n", s) }
 	successBody = `{"sampling_rate":"0.5"}` + "\n"
+	emptyBody   = `{}` + "\n"
 
 	testcases = map[string]struct {
 		kbClient      kibana.Client
@@ -96,6 +99,9 @@ var (
 			queryParams:            map[string]string{"service.name": "opbeans-python"},
 			respStatus:             http.StatusOK,
 			respCacheControlHeader: "max-age=4, must-revalidate",
+			respEtagHeader:         `"` + emptyEtag + `"`,
+			respBody:               emptyBody,
+			respBodyToken:          emptyBody,
 		},
 
 		"SendToKibanaFailed": {

--- a/beater/agent_config_handler_test.go
+++ b/beater/agent_config_handler_test.go
@@ -40,6 +40,7 @@ import (
 
 var (
 	mockVersion = *common.MustNewVersion("7.3.0")
+	mockEtag    = "61a98e293262279d6ad99e5739fdd1b8"
 	errWrap     = func(s string) string { return fmt.Sprintf("{\"error\":\"%+v\"}\n", s) }
 	successBody = `{"sampling_rate":"0.5"}` + "\n"
 
@@ -63,27 +64,11 @@ var (
 				},
 			}, mockVersion, true),
 			method:                 http.MethodGet,
-			requestHeader:          map[string]string{headers.IfNoneMatch: `"` + "1" + `"`},
+			requestHeader:          map[string]string{headers.IfNoneMatch: `"` + mockEtag + `"`},
 			queryParams:            map[string]string{"service.name": "opbeans-node"},
 			respStatus:             http.StatusNotModified,
 			respCacheControlHeader: "max-age=4, must-revalidate",
-			respEtagHeader:         "\"1\"",
-		},
-
-		"ModifiedWithoutEtag": {
-			kbClient: tests.MockKibana(http.StatusOK, m{
-				"_source": m{
-					"settings": m{
-						"sampling_rate": 0.5,
-					},
-				},
-			}, mockVersion, true),
-			method:                 http.MethodGet,
-			queryParams:            map[string]string{"service.name": "opbeans-java"},
-			respStatus:             http.StatusOK,
-			respCacheControlHeader: "max-age=4, must-revalidate",
-			respBody:               successBody,
-			respBodyToken:          successBody,
+			respEtagHeader:         `"` + mockEtag + `"`,
 		},
 
 		"ModifiedWithEtag": {
@@ -99,7 +84,7 @@ var (
 			requestHeader:          map[string]string{headers.IfNoneMatch: "2"},
 			queryParams:            map[string]string{"service.name": "opbeans-java"},
 			respStatus:             http.StatusOK,
-			respEtagHeader:         "\"1\"",
+			respEtagHeader:         `"` + mockEtag + `"`,
 			respCacheControlHeader: "max-age=4, must-revalidate",
 			respBody:               successBody,
 			respBodyToken:          successBody,

--- a/changelogs/7.3.asciidoc
+++ b/changelogs/7.3.asciidoc
@@ -19,7 +19,7 @@ https://github.com/elastic/apm-server/compare/v7.2.1\...v7.3.0[View commits]
 [float]
 ==== Added
 - Support adding transaction and span information to metrics  {pull}2265[2265],{pull}2287[2287].
-- Initial support for remote agent configuration, requires Kibana {pull}2289[2289],{pull}2301[2301],{pull}2386[2386],{pull}2407[2407],{pull}2421[2421],{pull}2443[2443].
+- Initial support for remote agent configuration, requires Kibana {pull}2289[2289],{pull}2301[2301],{pull}2386[2386],{pull}2407[2407],{pull}2421[2421],{pull}2441[2441],{pull}2443[2443].
 - Add basic caching to remote agent configuration {pull}2337[2337].
 - Enable APM pipeline by default {pull}2301[2301].
 - Add fields required by breakdown graphs APM pipeline by default {pull}2315[2315],{pull}2397[2397].

--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -162,7 +162,6 @@ class AgentConfigurationIntegrationTest(ElasticTest):
         # wait for cache to purge
         time.sleep(1.1)  # sleep much more than acm_cache_expiration to reduce flakiness
 
-        # TODO (gr): include If-None-Match header - https://github.com/elastic/apm-server/issues/2434
         r5_post_update = requests.get(self.agent_config_url,
                                       params={
                                           "service.name": service_name,
@@ -170,7 +169,7 @@ class AgentConfigurationIntegrationTest(ElasticTest):
                                       },
                                       headers={
                                           "Content-Type": "application/x-ndjson",
-                                          # "If-None-Match": r5.headers["Etag"],
+                                          "If-None-Match": r5.headers["Etag"],
                                       })
         assert r5_post_update.status_code == 200, r5_post_update.status_code
         self.assertDictEqual({"sample_rate": "0.99"}, r5_post_update.json())

--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -68,7 +68,7 @@ class AgentConfigurationIntegrationTest(ElasticTest):
             "message": "handled request",
             "response_code": 200,
         })
-        self.assertFalse(r2.content)
+        self.assertDictEqual({}, r2.json())
 
         create_config_rsp = self.create_service_config({"sample_rate": "0.05"}, service_name)
         assert create_config_rsp.status_code == 200, create_config_rsp.status_code
@@ -115,7 +115,7 @@ class AgentConfigurationIntegrationTest(ElasticTest):
             "message": "handled request",
             "response_code": 200,
         })
-        self.assertFalse(r4.content)
+        self.assertDictEqual({}, r4.json())
 
         create_config_with_env_rsp = self.create_service_config({"sample_rate": "0.15"}, service_name, env=service_env)
         assert create_config_with_env_rsp.status_code == 200, create_config_with_env_rsp.status_code


### PR DESCRIPTION
To ensure Etag changes when config settings are updated, include config settings when calculating ID for config object.

fixes elastic/apm-server#2434


- [x] needs changelog entry

backport to `7.x` and `7.3`. 

fyi @felixbarny , @axw 
