### PR TITLE
[7.3] build just the default packages (#2368)

### DIFF
--- a/script/jenkins/package.sh
+++ b/script/jenkins/package.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 set -euox pipefail
 
+# linux/amd64 is in the default list already, set here
+# to prevent jenkins_release.sh from adding more PLATFORMS
+export PLATFORMS="${PLATFORMS:-+linux/amd64}"
+
  ./_beats/dev-tools/jenkins_release.sh


### PR DESCRIPTION
Backports the following commits to 7.3:
 - build just the default packages  (#2368)