### PR TITLE
Disable overwriting ingest pipelines by default.

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -174,8 +174,8 @@ apm-server:
   #register.ingest.pipeline:
     # Registers APM pipeline definition in Elasticsearch on APM Server startup. Defaults to true.
     #enabled: true
-    # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to true.
-    #overwrite: true
+    # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to false.
+    #overwrite: false
 
   # When ilm is set to `auto`, the APM Server checks a couple of preconditions:
   # If a different output than Elasticsearch is configured, ILM will be disabled.

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -174,8 +174,8 @@ apm-server:
   #register.ingest.pipeline:
     # Registers APM pipeline definition in Elasticsearch on APM Server startup. Defaults to true.
     #enabled: true
-    # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to true.
-    #overwrite: true
+    # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to false.
+    #overwrite: false
 
   # When ilm is set to `auto`, the APM Server checks a couple of preconditions:
   # If a different output than Elasticsearch is configured, ILM will be disabled.

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -174,8 +174,8 @@ apm-server:
   #register.ingest.pipeline:
     # Registers APM pipeline definition in Elasticsearch on APM Server startup. Defaults to true.
     #enabled: true
-    # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to true.
-    #overwrite: true
+    # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to false.
+    #overwrite: false
 
   # When ilm is set to `auto`, the APM Server checks a couple of preconditions:
   # If a different output than Elasticsearch is configured, ILM will be disabled.

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -215,9 +215,8 @@ func TestBeatConfig(t *testing.T) {
 				Register: &registerConfig{
 					Ingest: &ingestConfig{
 						Pipeline: &pipelineConfig{
-							Enabled:   &falsy,
-							Overwrite: &truthy,
-							Path:      filepath.Join("ingest", "pipeline", "definition.json"),
+							Enabled: &falsy,
+							Path:    filepath.Join("ingest", "pipeline", "definition.json"),
 						},
 					},
 				},

--- a/beater/config.go
+++ b/beater/config.go
@@ -192,7 +192,7 @@ func (c *pipelineConfig) isEnabled() bool {
 }
 
 func (c *pipelineConfig) shouldOverwrite() bool {
-	return c != nil && (c.Overwrite == nil || *c.Overwrite)
+	return c != nil && (c.Overwrite != nil && *c.Overwrite)
 }
 
 func (c *rumConfig) memoizedSmapMapper() (sourcemap.Mapper, error) {
@@ -281,8 +281,7 @@ func defaultConfig(beatVersion string) *Config {
 		Register: &registerConfig{
 			Ingest: &ingestConfig{
 				Pipeline: &pipelineConfig{
-					Enabled:   &pipeline,
-					Overwrite: &pipeline,
+					Enabled: &pipeline,
 					Path: paths.Resolve(paths.Home,
 						filepath.Join("ingest", "pipeline", "definition.json")),
 				}},

--- a/beater/config_test.go
+++ b/beater/config_test.go
@@ -264,7 +264,7 @@ func TestPipeline(t *testing.T) {
 		enabled, overwrite bool
 	}{
 		{c: nil, enabled: false, overwrite: false},
-		{c: &pipelineConfig{}, enabled: true, overwrite: true}, //default values
+		{c: &pipelineConfig{}, enabled: true, overwrite: false}, //default values
 		{c: &pipelineConfig{Enabled: &falsy, Overwrite: &truthy},
 			enabled: false, overwrite: true},
 		{c: &pipelineConfig{Enabled: &truthy, Overwrite: &falsy},

--- a/changelogs/7.2.asciidoc
+++ b/changelogs/7.2.asciidoc
@@ -12,8 +12,8 @@ https://github.com/elastic/apm-server/compare/7.1\...7.2[View commits]
 https://github.com/elastic/apm-server/compare/v7.2.0\...v7.2.1[View commits]
 
 [float]
-==== Bug fixes
-- Set `apm-server.register.ingest.pipeline.overwrite` to true by default {pull}2273[2273].
+==== Known issues
+- `apm-server.register.ingest.pipeline.overwrite` set to true by default {pull}[].
 
 [[release-notes-7.2.0]]
 === APM Server version 7.2.0

--- a/changelogs/7.2.asciidoc
+++ b/changelogs/7.2.asciidoc
@@ -13,7 +13,7 @@ https://github.com/elastic/apm-server/compare/v7.2.0\...v7.2.1[View commits]
 
 [float]
 ==== Known issues
-- `apm-server.register.ingest.pipeline.overwrite` set to true by default {pull}[].
+- Pipelines are overwritten by default - `apm-server.register.ingest.pipeline.overwrite` defaults to true.  Set `apm-server.register.ingest.pipeline.overwrite` to `false` explicitly to work around this.
 
 [[release-notes-7.2.0]]
 === APM Server version 7.2.0

--- a/changelogs/7.3.asciidoc
+++ b/changelogs/7.3.asciidoc
@@ -13,7 +13,6 @@ https://github.com/elastic/apm-server/compare/v7.2.1\...v7.3.0[View commits]
 
 [float]
 ==== Bug fixes
-- Set `apm-server.register.ingest.pipeline.overwrite` to true by default {pull}2273[2273].
 - Abort server startup on sourcemap configuration error {pull}2278[2278].
 - Process all user-agent information from headers {pull}2271[2271].
 

--- a/tests/system/test_pipelines.py
+++ b/tests/system/test_pipelines.py
@@ -54,6 +54,7 @@ class SetupPipelinesDisabledTest(SetupPipelinesDefaultTest):
         assert self.log_contains("No pipeline callback registered")
 
 
+@unittest.skipUnless(INTEGRATION_TESTS, "integration test")
 class PipelineRegisterTest(ElasticTest):
     def test_default_pipelines_registered(self):
         pipelines = [

--- a/tests/system/test_pipelines.py
+++ b/tests/system/test_pipelines.py
@@ -176,7 +176,6 @@ class PipelineDefaultDisableRegisterOverwriteTest(ElasticTest):
 
 @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
 class PipelineEnableRegisterOverwriteTest(ElasticTest):
-
     config_overrides = {
         "register_pipeline_overwrite": "true"
     }


### PR DESCRIPTION
fixes elastic/apm-server#2440
Reverting changes from https://github.com/elastic/apm-server/pull/2273.

Needs to be backported until `7.2`