### PR TITLE
[7.x] Disable overwriting ingest pipelines by default. (#2452)

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -174,8 +174,8 @@ apm-server:
   #register.ingest.pipeline:
     # Registers APM pipeline definition in Elasticsearch on APM Server startup. Defaults to true.
     #enabled: true
-    # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to true.
-    #overwrite: true
+    # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to false.
+    #overwrite: false
 
   # When ilm is set to `auto`, the APM Server checks a couple of preconditions:
   # If a different output than Elasticsearch is configured, ILM will be disabled.

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -174,8 +174,8 @@ apm-server:
   #register.ingest.pipeline:
     # Registers APM pipeline definition in Elasticsearch on APM Server startup. Defaults to true.
     #enabled: true
-    # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to true.
-    #overwrite: true
+    # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to false.
+    #overwrite: false
 
   # When ilm is set to `auto`, the APM Server checks a couple of preconditions:
   # If a different output than Elasticsearch is configured, ILM will be disabled.

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -174,8 +174,8 @@ apm-server:
   #register.ingest.pipeline:
     # Registers APM pipeline definition in Elasticsearch on APM Server startup. Defaults to true.
     #enabled: true
-    # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to true.
-    #overwrite: true
+    # Overwrites existing APM pipeline definition in Elasticsearch. Defaults to false.
+    #overwrite: false
 
   # When ilm is set to `auto`, the APM Server checks a couple of preconditions:
   # If a different output than Elasticsearch is configured, ILM will be disabled.

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -215,9 +215,8 @@ func TestBeatConfig(t *testing.T) {
 				Register: &registerConfig{
 					Ingest: &ingestConfig{
 						Pipeline: &pipelineConfig{
-							Enabled:   &falsy,
-							Overwrite: &truthy,
-							Path:      filepath.Join("ingest", "pipeline", "definition.json"),
+							Enabled: &falsy,
+							Path:    filepath.Join("ingest", "pipeline", "definition.json"),
 						},
 					},
 				},

--- a/beater/config.go
+++ b/beater/config.go
@@ -197,7 +197,7 @@ func (c *pipelineConfig) isEnabled() bool {
 }
 
 func (c *pipelineConfig) shouldOverwrite() bool {
-	return c != nil && (c.Overwrite == nil || *c.Overwrite)
+	return c != nil && (c.Overwrite != nil && *c.Overwrite)
 }
 
 func (c *rumConfig) memoizedSmapMapper() (sourcemap.Mapper, error) {
@@ -286,8 +286,7 @@ func defaultConfig(beatVersion string) *Config {
 		Register: &registerConfig{
 			Ingest: &ingestConfig{
 				Pipeline: &pipelineConfig{
-					Enabled:   &pipeline,
-					Overwrite: &pipeline,
+					Enabled: &pipeline,
 					Path: paths.Resolve(paths.Home,
 						filepath.Join("ingest", "pipeline", "definition.json")),
 				}},

--- a/beater/config_test.go
+++ b/beater/config_test.go
@@ -264,7 +264,7 @@ func TestPipeline(t *testing.T) {
 		enabled, overwrite bool
 	}{
 		{c: nil, enabled: false, overwrite: false},
-		{c: &pipelineConfig{}, enabled: true, overwrite: true}, //default values
+		{c: &pipelineConfig{}, enabled: true, overwrite: false}, //default values
 		{c: &pipelineConfig{Enabled: &falsy, Overwrite: &truthy},
 			enabled: false, overwrite: true},
 		{c: &pipelineConfig{Enabled: &truthy, Overwrite: &falsy},

--- a/changelogs/7.2.asciidoc
+++ b/changelogs/7.2.asciidoc
@@ -12,8 +12,8 @@ https://github.com/elastic/apm-server/compare/7.1\...7.2[View commits]
 https://github.com/elastic/apm-server/compare/v7.2.0\...v7.2.1[View commits]
 
 [float]
-==== Bug fixes
-- Set `apm-server.register.ingest.pipeline.overwrite` to true by default {pull}2273[2273].
+==== Known issues
+- Pipelines are overwritten by default - `apm-server.register.ingest.pipeline.overwrite` defaults to true.  Set `apm-server.register.ingest.pipeline.overwrite` to `false` explicitly to work around this.
 
 [[release-notes-7.2.0]]
 === APM Server version 7.2.0

--- a/changelogs/7.3.asciidoc
+++ b/changelogs/7.3.asciidoc
@@ -13,7 +13,6 @@ https://github.com/elastic/apm-server/compare/v7.2.1\...v7.3.0[View commits]
 
 [float]
 ==== Bug fixes
-- Set `apm-server.register.ingest.pipeline.overwrite` to true by default {pull}2273[2273].
 - Abort server startup on sourcemap configuration error {pull}2278[2278].
 - Process all user-agent information from headers {pull}2271[2271].
 

--- a/tests/system/test_pipelines.py
+++ b/tests/system/test_pipelines.py
@@ -54,12 +54,8 @@ class SetupPipelinesDisabledTest(SetupPipelinesDefaultTest):
         assert self.log_contains("No pipeline callback registered")
 
 
-# APM Server `run`
-
 @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-class PipelineDefaultTest(ElasticTest):
-    # pipeline.overwrite enabled by default.
-
+class PipelineRegisterTest(ElasticTest):
     def test_default_pipelines_registered(self):
         pipelines = [
             ("apm_user_agent", "Add user agent information for APM events"),
@@ -159,13 +155,14 @@ class MissingPipelineTest(ElasticTest):
 
 
 @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-class PipelineDisableRegisterOverwriteTest(ElasticTest):
+class PipelineDefaultDisableRegisterOverwriteTest(ElasticTest):
+
     config_overrides = {
         "register_pipeline_overwrite": "false"
     }
 
     def setUp(self):
-        super(PipelineDisableRegisterOverwriteTest, self).setUp()
+        super(PipelineDefaultDisableRegisterOverwriteTest, self).setUp()
         es = Elasticsearch([self.get_elasticsearch_url()])
         # Write empty default pipeline
         es.ingest.put_pipeline(
@@ -176,3 +173,27 @@ class PipelineDisableRegisterOverwriteTest(ElasticTest):
     def test_pipeline_not_overwritten(self):
         loaded_msg = "Pipeline already registered"
         self.wait_until(lambda: self.log_contains(loaded_msg))
+
+
+@unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+class PipelineEnableRegisterOverwriteTest(ElasticTest):
+    config_overrides = {
+        "register_pipeline_overwrite": "true"
+    }
+
+    def setUp(self):
+        super(PipelineEnableRegisterOverwriteTest, self).setUp()
+        es = Elasticsearch([self.get_elasticsearch_url()])
+        # Write empty default pipeline
+        es.ingest.put_pipeline(
+            id="apm",
+            body={"description": "empty apm test pipeline", "processors": []})
+        self.wait_until(lambda: es.ingest.get_pipeline("apm"))
+
+    def test_pipeline_overwritten(self):
+        loaded_msg = "Pipeline successfully registered"
+        self.wait_until(lambda: self.log_contains(loaded_msg))
+        pipeline_id = "apm"
+        pipeline = self.wait_until(lambda: self.es.ingest.get_pipeline(id=pipeline_id),
+                                   name="fetching pipeline {}".format(pipeline_id))
+        assert pipeline[pipeline_id]['description'] == "Default enrichment for APM events"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Disable overwriting ingest pipelines by default.  (#2452)