### PR TITLE
[7.2] Disable overwriting ingest pipelines by default. (#2452)

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -175,7 +175,7 @@ apm-server:
     #enabled: false
 
     # Overwrites existing pipeline definitions in Elasticsearch. Defaults to true.
-    #overwrite: true
+    #overwrite: false
 
   # When ilm is set to true the APM Server will take care of ILM setup.
   # Configurations in output.elasticsearch.index and output.elasticsearch.indices sections will be ignored

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -175,7 +175,7 @@ apm-server:
     #enabled: false
 
     # Overwrites existing pipeline definitions in Elasticsearch. Defaults to true.
-    #overwrite: true
+    #overwrite: false
 
   # When ilm is set to true the APM Server will take care of ILM setup.
   # Configurations in output.elasticsearch.index and output.elasticsearch.indices sections will be ignored

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -175,7 +175,7 @@ apm-server:
     #enabled: false
 
     # Overwrites existing pipeline definitions in Elasticsearch. Defaults to true.
-    #overwrite: true
+    #overwrite: false
 
   # When ilm is set to true the APM Server will take care of ILM setup.
   # Configurations in output.elasticsearch.index and output.elasticsearch.indices sections will be ignored

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -211,9 +211,8 @@ func TestBeatConfig(t *testing.T) {
 				Register: &registerConfig{
 					Ingest: &ingestConfig{
 						Pipeline: &pipelineConfig{
-							Enabled:   &falsy,
-							Overwrite: nil,
-							Path:      filepath.Join("ingest", "pipeline", "definition.json"),
+							Enabled: &falsy,
+							Path:    filepath.Join("ingest", "pipeline", "definition.json"),
 						},
 					},
 				},

--- a/beater/config.go
+++ b/beater/config.go
@@ -179,7 +179,7 @@ func (c *pipelineConfig) isEnabled() bool {
 }
 
 func (c *pipelineConfig) shouldOverwrite() bool {
-	return c != nil && (c.Overwrite == nil || *c.Overwrite)
+	return c != nil && (c.Overwrite != nil && *c.Overwrite)
 }
 
 func (c *rumConfig) memoizedSmapMapper() (sourcemap.Mapper, error) {

--- a/beater/config_test.go
+++ b/beater/config_test.go
@@ -290,7 +290,7 @@ func TestPipeline(t *testing.T) {
 		enabled, overwrite bool
 	}{
 		{c: nil, enabled: false, overwrite: false},
-		{c: &pipelineConfig{}, enabled: false, overwrite: true}, //default values
+		{c: &pipelineConfig{}, enabled: false, overwrite: false}, //default values
 		{c: &pipelineConfig{Enabled: &falsy, Overwrite: &truthy},
 			enabled: false, overwrite: true},
 		{c: &pipelineConfig{Enabled: &truthy, Overwrite: &falsy},

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -322,7 +322,7 @@ func TestServerSourcemapElasticsearch(t *testing.T) {
 			expected: []string{"localhost:5200"},
 			config: m{
 				"rum": m{
-					"enabled":                            "true",
+					"enabled": "true",
 					"source_mapping.elasticsearch.hosts": []string{"localhost:5200"},
 				},
 			},

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -322,7 +322,7 @@ func TestServerSourcemapElasticsearch(t *testing.T) {
 			expected: []string{"localhost:5200"},
 			config: m{
 				"rum": m{
-					"enabled": "true",
+					"enabled":                            "true",
 					"source_mapping.elasticsearch.hosts": []string{"localhost:5200"},
 				},
 			},

--- a/changelogs/7.2.asciidoc
+++ b/changelogs/7.2.asciidoc
@@ -12,8 +12,8 @@ https://github.com/elastic/apm-server/compare/7.1\...7.2[View commits]
 https://github.com/elastic/apm-server/compare/v7.2.0\...v7.2.1[View commits]
 
 [float]
-==== Bug fixes
-- Set `apm-server.register.ingest.pipeline.overwrite` to true by default {pull}2273[2273].
+==== Known issues
+- Pipelines are overwritten by default - `apm-server.register.ingest.pipeline.overwrite` defaults to true.  Set `apm-server.register.ingest.pipeline.overwrite` to `false` explicitly to work around this.
 
 [[release-notes-7.2.0]]
 === APM Server version 7.2.0

--- a/tests/system/test_pipelines.py
+++ b/tests/system/test_pipelines.py
@@ -59,7 +59,6 @@ class SetupPipelinesDisabledTest(SetupPipelinesDefaultTest):
         assert self.log_contains("No pipeline callback registered")
 
 
-
 class PipelineRegisterTest(ElasticTest):
     config_overrides = {
         "register_pipeline_enabled": "true",

--- a/tests/system/test_pipelines.py
+++ b/tests/system/test_pipelines.py
@@ -59,10 +59,11 @@ class SetupPipelinesDisabledTest(SetupPipelinesDefaultTest):
         assert self.log_contains("No pipeline callback registered")
 
 
+
 class PipelineRegisterTest(ElasticTest):
-    # pipeline.overwrite should be enabled by default.
     config_overrides = {
         "register_pipeline_enabled": "true",
+        "register_pipeline_overwrite": "true"
     }
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
@@ -79,10 +80,9 @@ class PipelineRegisterTest(ElasticTest):
             assert pipeline[pipeline_id]['description'] == pipeline_desc
 
 
-class PipelineDisableOverwriteTest(ElasticTest):
+class PipelineDefaultOverwriteTest(ElasticTest):
     config_overrides = {
         "register_pipeline_enabled": "true",
-        "register_pipeline_overwrite": "false"
     }
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")


### PR DESCRIPTION
Backports the following commits to 7.2:

* Disable overwriting ingest pipelines by default. (#2452)
