### PR TITLE
[7.3] [ACM] Return 200 instead of 404 for missing config. (#2458)

### DIFF
--- a/beater/agent_config_handler.go
+++ b/beater/agent_config_handler.go
@@ -77,14 +77,15 @@ func agentConfigHandler(kbClient kibana.Client, config *agentConfig, secretToken
 		}
 
 		cfg, upstreamEtag, internalErr := fetcher.Fetch(query, nil)
-		etag := fmt.Sprintf("\"%s\"", upstreamEtag)
-
-		switch {
-		case internalErr != nil:
+		if internalErr != nil {
 			sendErr(http.StatusServiceUnavailable, internalErrMsg(internalErr.Error()), internalErr.Error())
+			return
+		}
+
+		etag := fmt.Sprintf("\"%s\"", upstreamEtag)
+		switch {
 		case len(cfg) == 0:
-			logMsg := fmt.Sprintf("%s for %s", errMsgConfigNotFound, query.ID())
-			sendErr(http.StatusNotFound, errMsgConfigNotFound, logMsg)
+			sendResp(nil, http.StatusOK, cacheControl)
 		case upstreamEtag == "":
 			sendResp(cfg, http.StatusOK, cacheControl)
 		case etag == r.Header.Get(headerIfNoneMatch):

--- a/beater/agent_config_handler_test.go
+++ b/beater/agent_config_handler_test.go
@@ -104,6 +104,14 @@ var (
 			respBodyToken:          successBody,
 		},
 
+		"NoConfigFound": {
+			kbClient:               tests.MockKibana(http.StatusNotFound, m{}, mockVersion, true),
+			method:                 http.MethodGet,
+			queryParams:            map[string]string{"service.name": "opbeans-python"},
+			respStatus:             http.StatusOK,
+			respCacheControlHeader: "max-age=4, must-revalidate",
+		},
+
 		"SendToKibanaFailed": {
 			kbClient:               tests.MockKibana(http.StatusBadGateway, m{}, mockVersion, true),
 			method:                 http.MethodGet,
@@ -141,16 +149,6 @@ var (
 			respBody:               errWrap(errMsgKibanaVersionNotCompatible),
 			respBodyToken: errWrap("min required Kibana version 7.3.0," +
 				" configured Kibana version {version:7.2.0 Major:7 Minor:2 Bugfix:0 Meta:}"),
-		},
-
-		"StatusNotFoundError": {
-			kbClient:               tests.MockKibana(http.StatusNotFound, m{}, mockVersion, true),
-			method:                 http.MethodGet,
-			queryParams:            map[string]string{"service.name": "opbeans-python"},
-			respStatus:             http.StatusNotFound,
-			respCacheControlHeader: "max-age=300, must-revalidate",
-			respBody:               errWrap(errMsgConfigNotFound),
-			respBodyToken:          errWrap(fmt.Sprintf("%s for opbeans-python", errMsgConfigNotFound)),
 		},
 
 		"NoService": {

--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -62,13 +62,13 @@ class AgentConfigurationIntegrationTest(ElasticTest):
                           params={"service.name": service_name + "_cache_bust"},
                           headers={"Content-Type": "application/x-ndjson"},
                           )
-        assert r2.status_code == 404, r2.status_code
+        assert r2.status_code == 200, r2.status_code
         expect_log.append({
-            "level": "error",
-            "message": "error handling request",
-            "error": "no configuration available for {}_cache_bust".format(service_name),
-            "response_code": 404,
+            "level": "info",
+            "message": "handled request",
+            "response_code": 200,
         })
+        self.assertFalse(r2.content)
 
         create_config_rsp = self.create_service_config({"sample_rate": "0.05"}, service_name)
         assert create_config_rsp.status_code == 200, create_config_rsp.status_code
@@ -109,13 +109,13 @@ class AgentConfigurationIntegrationTest(ElasticTest):
                               "service.environment": bad_service_env,
                           },
                           headers={"Content-Type": "application/x-ndjson"})
-        assert r4.status_code == 404, r4.status_code
+        assert r4.status_code == 200, r4.status_code
         expect_log.append({
-            "level": "error",
-            "message": "error handling request",
-            "error": "no configuration available for {}_{}".format(service_name, bad_service_env),
-            "response_code": 404,
+            "level": "info",
+            "message": "handled request",
+            "response_code": 200,
         })
+        self.assertFalse(r4.content)
 
         create_config_with_env_rsp = self.create_service_config({"sample_rate": "0.15"}, service_name, env=service_env)
         assert create_config_with_env_rsp.status_code == 200, create_config_with_env_rsp.status_code


### PR DESCRIPTION
Backports the following commits to 7.3:
 - [ACM] Return 200 instead of 404 for missing config.  (#2458)