### PR TITLE
[ILM] change auto disabled message

### DIFF
--- a/idxmgmt/manager.go
+++ b/idxmgmt/manager.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	msgErrIlmDisabledES = "automatically disabled ILM as not supported by configured Elasticsearch"
-	msgIlmDisabledES    = "Automatically disabled ILM as not supported by configured Elasticsearch."
+	msgIlmDisabledES    = "Automatically disabled ILM as configured Elasticsearch not eligible for auto enabling."
 	msgIlmDisabledCfg   = "Automatically disabled ILM as custom index settings configured."
 	msgIdxCfgIgnored    = "Custom index configuration ignored when ILM is enabled."
 )


### PR DESCRIPTION
ILM auto defaults ot true only for ES >= 7.0. ILM supported by ES in
latest 6.x versions. Change log message for auto disabling ILM to avoid
confusion.

fixes elastic/apm-server#2472
