### PR TITLE
ignore unavailable agent configuration index during setup.

### DIFF
--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -185,8 +185,9 @@ class ElasticTest(ServerBaseTest):
             self.wait_until(lambda: not self.es.indices.exists_template(idx))
 
         # truncate, don't delete agent configuration index since it's only created when kibana starts up
-        self.es.delete_by_query(self.index_acm, {"query": {"match_all": {}}}, wait_for_completion=True)
-        self.wait_until(lambda: self.es.count(index=self.index_acm)["count"] == 0)
+        self.es.delete_by_query(self.index_acm, {"query": {"match_all": {}}},
+                                ignore_unavailable=True, wait_for_completion=True)
+        self.wait_until(lambda: self.es.count(index=self.index_acm, ignore_unavailable=True)["count"] == 0)
         # Cleanup pipelines
         self.es.ingest.delete_pipeline(id="*")
 

--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -70,7 +70,8 @@ class AgentConfigurationIntegrationTest(ElasticTest):
         })
         self.assertFalse(r2.content)
 
-        create_config_rsp = self.create_service_config({"sample_rate": "0.05"}, service_name)
+        create_config_rsp = self.create_service_config({"transaction_sample_rate": "0.05"}, service_name)
+        create_config_rsp.raise_for_status()
         assert create_config_rsp.status_code == 200, create_config_rsp.status_code
         create_config_result = create_config_rsp.json()
         assert create_config_result["result"] == "created"
@@ -86,7 +87,7 @@ class AgentConfigurationIntegrationTest(ElasticTest):
             "message": "handled request",
             "response_code": 200,
         })
-        self.assertDictEqual({"sample_rate": "0.05"}, r3.json())
+        self.assertDictEqual({"transaction_sample_rate": "0.05"}, r3.json())
 
         # not modified on re-request
         r3_again = requests.get(self.agent_config_url,
@@ -117,7 +118,7 @@ class AgentConfigurationIntegrationTest(ElasticTest):
         })
         self.assertFalse(r4.content)
 
-        create_config_with_env_rsp = self.create_service_config({"sample_rate": "0.15"}, service_name, env=service_env)
+        create_config_with_env_rsp = self.create_service_config({"transaction_sample_rate": "0.15"}, service_name, env=service_env)
         assert create_config_with_env_rsp.status_code == 200, create_config_with_env_rsp.status_code
         create_config_with_env_result = create_config_with_env_rsp.json()
         assert create_config_with_env_result["result"] == "created"
@@ -131,7 +132,7 @@ class AgentConfigurationIntegrationTest(ElasticTest):
                           },
                           headers={"Content-Type": "application/x-ndjson"})
         assert r5.status_code == 200, r5.status_code
-        self.assertDictEqual({"sample_rate": "0.15"}, r5.json())
+        self.assertDictEqual({"transaction_sample_rate": "0.15"}, r5.json())
         expect_log.append({
             "level": "info",
             "message": "handled request",
@@ -156,7 +157,7 @@ class AgentConfigurationIntegrationTest(ElasticTest):
         })
 
         updated_config_with_env_rsp = self.update_service_config(
-            {"sample_rate": "0.99"}, create_config_with_env_id, service_name, env=service_env)
+            {"transaction_sample_rate": "0.99"}, create_config_with_env_id, service_name, env=service_env)
         assert updated_config_with_env_rsp.status_code == 200, updated_config_with_env_rsp.status_code
         # TODO (gr): remove when cache can be disabled via config
         # wait for cache to purge
@@ -173,7 +174,7 @@ class AgentConfigurationIntegrationTest(ElasticTest):
                                           # "If-None-Match": r5.headers["Etag"],
                                       })
         assert r5_post_update.status_code == 200, r5_post_update.status_code
-        self.assertDictEqual({"sample_rate": "0.99"}, r5_post_update.json())
+        self.assertDictEqual({"transaction_sample_rate": "0.99"}, r5_post_update.json())
         expect_log.append({
             "level": "info",
             "message": "handled request",

--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -118,7 +118,8 @@ class AgentConfigurationIntegrationTest(ElasticTest):
         })
         self.assertFalse(r4.content)
 
-        create_config_with_env_rsp = self.create_service_config({"transaction_sample_rate": 0.15}, service_name, env=service_env)
+        create_config_with_env_rsp = self.create_service_config(
+            {"transaction_sample_rate": 0.15}, service_name, env=service_env)
         assert create_config_with_env_rsp.status_code == 200, create_config_with_env_rsp.status_code
         create_config_with_env_result = create_config_with_env_rsp.json()
         assert create_config_with_env_result["result"] == "created"

--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -70,7 +70,7 @@ class AgentConfigurationIntegrationTest(ElasticTest):
         })
         self.assertFalse(r2.content)
 
-        create_config_rsp = self.create_service_config({"transaction_sample_rate": "0.05"}, service_name)
+        create_config_rsp = self.create_service_config({"transaction_sample_rate": 0.05}, service_name)
         create_config_rsp.raise_for_status()
         assert create_config_rsp.status_code == 200, create_config_rsp.status_code
         create_config_result = create_config_rsp.json()
@@ -118,7 +118,7 @@ class AgentConfigurationIntegrationTest(ElasticTest):
         })
         self.assertFalse(r4.content)
 
-        create_config_with_env_rsp = self.create_service_config({"transaction_sample_rate": "0.15"}, service_name, env=service_env)
+        create_config_with_env_rsp = self.create_service_config({"transaction_sample_rate": 0.15}, service_name, env=service_env)
         assert create_config_with_env_rsp.status_code == 200, create_config_with_env_rsp.status_code
         create_config_with_env_result = create_config_with_env_rsp.json()
         assert create_config_with_env_result["result"] == "created"
@@ -157,7 +157,7 @@ class AgentConfigurationIntegrationTest(ElasticTest):
         })
 
         updated_config_with_env_rsp = self.update_service_config(
-            {"transaction_sample_rate": "0.99"}, create_config_with_env_id, service_name, env=service_env)
+            {"transaction_sample_rate": 0.99}, create_config_with_env_id, service_name, env=service_env)
         assert updated_config_with_env_rsp.status_code == 200, updated_config_with_env_rsp.status_code
         # TODO (gr): remove when cache can be disabled via config
         # wait for cache to purge


### PR DESCRIPTION
kibana creates that index - when testing without kibana it will not exist.  When testing with kibana, tests that depend on that index will fail if it is missing, no need to fail during setup
