### PR TITLE
[7.x] [ACM] Create Etag from settings struct. (#2441)

### DIFF
--- a/agentcfg/cache_test.go
+++ b/agentcfg/cache_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 var (
-	defaultDoc  = Doc{Source: Source{Settings: Settings{"a": "default"}}}
-	externalDoc = Doc{Source: Source{Settings: Settings{"a": "b"}}}
+	defaultDoc  = Doc{Settings: Settings{"a": "default"}}
+	externalDoc = Doc{Settings: Settings{"a": "b"}}
 )
 
 type cacheSetup struct {
@@ -62,7 +62,7 @@ func TestCache_fetchAndAdd(t *testing.T) {
 		"DocFromCache":         {fn: testFn, init: true, doc: &defaultDoc},
 		"DocFromFunctionFails": {fn: testFnErr, fail: true},
 		"DocFromFunction":      {fn: testFn, doc: &externalDoc},
-		"EmptyDocFromFunction": {fn: testFnSettingsNil, doc: &Doc{Source: Source{Settings: Settings{}}}},
+		"EmptyDocFromFunction": {fn: testFnSettingsNil, doc: &Doc{Settings: Settings{}}},
 		"NilDocFromFunction":   {fn: testFnNil},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -134,7 +134,7 @@ func testFnNil(_ Query) (*Doc, error) {
 }
 
 func testFnSettingsNil(_ Query) (*Doc, error) {
-	return &Doc{Source: Source{Settings: Settings{}}}, nil
+	return &Doc{Settings: Settings{}}, nil
 }
 
 func testFn(_ Query) (*Doc, error) {

--- a/agentcfg/model_test.go
+++ b/agentcfg/model_test.go
@@ -1,0 +1,76 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package agentcfg
+
+import (
+	"crypto/md5"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewDoc(t *testing.T) {
+	t.Run("InvalidInput", func(t *testing.T) {
+		d, err := NewDoc([]byte("some string"))
+		assert.Error(t, err)
+		assert.Empty(t, d)
+	})
+
+	t.Run("EmptyInput", func(t *testing.T) {
+		d, err := NewDoc([]byte{})
+		require.NoError(t, err)
+		expectedDoc := Doc{
+			Settings: map[string]string{},
+			ID:       fmt.Sprintf("%x", md5.Sum([]byte{}))}
+		assert.Equal(t, &expectedDoc, d)
+	})
+
+	t.Run("ValidInput", func(t *testing.T) {
+		inp := []byte(`{"_id": "1234", 
+"_source": {"settings":{"sample_rate":0.5,"name":"testconfig","sampling":true,
+"b":["b", "a"],
+"nested":{"ab":"val","ac":[3,1,2],"aa":{"c":45.6}}}}}`)
+
+		settings := Settings{
+			"b":           "b,a",
+			"sample_rate": "0.5",
+			"name":        "testconfig",
+			"sampling":    "true",
+			"nested.ab":   "val",
+			"nested.ac":   "3,1,2",
+			"nested.aa.c": "45.6",
+		}
+
+		var b []byte
+		b = append(b, []byte("b_b,a")...)
+		b = append(b, []byte("name_testconfig")...)
+		b = append(b, []byte("nested.aa.c_45.6")...)
+		b = append(b, []byte("nested.ab_val")...)
+		b = append(b, []byte("nested.ac_3,1,2")...)
+		b = append(b, []byte("sample_rate_0.5")...)
+		b = append(b, []byte("sampling_true")...)
+		id := fmt.Sprintf("%x", md5.Sum(b))
+
+		d, err := NewDoc(inp)
+		require.NoError(t, err)
+		assert.Equal(t, &Doc{Settings: settings, ID: id}, d)
+	})
+}

--- a/agentcfg/query.go
+++ b/agentcfg/query.go
@@ -1,0 +1,49 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package agentcfg
+
+const (
+	// ServiceName keyword
+	ServiceName = "service.name"
+	// ServiceEnv keyword
+	ServiceEnv = "service.environment"
+)
+
+// Query represents an URL body or query params for agent configuration
+type Query struct {
+	Service Service `json:"service"`
+}
+
+// Service holds supported attributes for querying configuration
+type Service struct {
+	Name        string `json:"name"`
+	Environment string `json:"environment,omitempty"`
+}
+
+// NewQuery creates a Query struct
+func NewQuery(name, env string) Query {
+	return Query{Service{name, env}}
+}
+
+// ID returns the unique id for the query
+func (q Query) ID() string {
+	if q.Service.Environment == "" {
+		return q.Service.Name
+	}
+	return q.Service.Name + "_" + q.Service.Environment
+}

--- a/beater/agent_config_handler.go
+++ b/beater/agent_config_handler.go
@@ -80,16 +80,10 @@ func agentConfigHandler(kbClient kibana.Client, config *agentConfig, secretToken
 		}
 
 		etag := fmt.Sprintf("\"%s\"", upstreamEtag)
-		switch {
-		case len(cfg) == 0:
-			sendResp(nil, http.StatusOK, cacheControl)
-		case upstreamEtag == "":
-			sendResp(cfg, http.StatusOK, cacheControl)
-		case etag == r.Header.Get(headers.IfNoneMatch):
-			w.Header().Set(headers.Etag, etag)
+		w.Header().Set(headers.Etag, etag)
+		if etag == r.Header.Get(headers.IfNoneMatch) {
 			sendResp(nil, http.StatusNotModified, cacheControl)
-		default:
-			w.Header().Set(headers.Etag, etag)
+		} else {
 			sendResp(cfg, http.StatusOK, cacheControl)
 		}
 	})

--- a/changelogs/7.3.asciidoc
+++ b/changelogs/7.3.asciidoc
@@ -19,7 +19,7 @@ https://github.com/elastic/apm-server/compare/v7.2.1\...v7.3.0[View commits]
 [float]
 ==== Added
 - Support adding transaction and span information to metrics  {pull}2265[2265],{pull}2287[2287].
-- Initial support for remote agent configuration, requires Kibana {pull}2289[2289],{pull}2301[2301],{pull}2386[2386],{pull}2407[2407],{pull}2421[2421],{pull}2443[2443].
+- Initial support for remote agent configuration, requires Kibana {pull}2289[2289],{pull}2301[2301],{pull}2386[2386],{pull}2407[2407],{pull}2421[2421],{pull}2441[2441],{pull}2443[2443].
 - Add basic caching to remote agent configuration {pull}2337[2337].
 - Enable APM pipeline by default {pull}2301[2301].
 - Add fields required by breakdown graphs APM pipeline by default {pull}2315[2315],{pull}2397[2397].

--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -68,7 +68,7 @@ class AgentConfigurationIntegrationTest(ElasticTest):
             "message": "handled request",
             "response_code": 200,
         })
-        self.assertFalse(r2.content)
+        self.assertDictEqual({}, r2.json())
 
         create_config_rsp = self.create_service_config({"transaction_sample_rate": 0.05}, service_name)
         create_config_rsp.raise_for_status()
@@ -116,7 +116,7 @@ class AgentConfigurationIntegrationTest(ElasticTest):
             "message": "handled request",
             "response_code": 200,
         })
-        self.assertFalse(r4.content)
+        self.assertDictEqual({}, r4.json())
 
         create_config_with_env_rsp = self.create_service_config(
             {"transaction_sample_rate": 0.15}, service_name, env=service_env)
@@ -164,7 +164,6 @@ class AgentConfigurationIntegrationTest(ElasticTest):
         # wait for cache to purge
         time.sleep(1.1)  # sleep much more than acm_cache_expiration to reduce flakiness
 
-        # TODO (gr): include If-None-Match header - https://github.com/elastic/apm-server/issues/2434
         r5_post_update = requests.get(self.agent_config_url,
                                       params={
                                           "service.name": service_name,
@@ -172,7 +171,7 @@ class AgentConfigurationIntegrationTest(ElasticTest):
                                       },
                                       headers={
                                           "Content-Type": "application/x-ndjson",
-                                          # "If-None-Match": r5.headers["Etag"],
+                                          "If-None-Match": r5.headers["Etag"],
                                       })
         assert r5_post_update.status_code == 200, r5_post_update.status_code
         self.assertDictEqual({"transaction_sample_rate": "0.99"}, r5_post_update.json())


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ACM] Create Etag from settings struct.  (#2441)