### PR TITLE
[beater] Add context handlers and adapt log handling

### DIFF
--- a/beater/agent_config_handler.go
+++ b/beater/agent_config_handler.go
@@ -54,7 +54,7 @@ func agentConfigHandler(kbClient kibana.Client, config *agentConfig, secretToken
 	cacheControl := fmt.Sprintf("max-age=%v, must-revalidate", config.Cache.Expiration.Seconds())
 	fetcher := agentcfg.NewFetcher(kbClient, config.Cache.Expiration)
 
-	var handler = func(c *request.Context) {
+	handler := func(c *request.Context) {
 		sendResp := wrap(c)
 		sendErr := wrapErr(c, secretToken)
 
@@ -63,7 +63,7 @@ func agentConfigHandler(kbClient kibana.Client, config *agentConfig, secretToken
 			return
 		}
 
-		query, requestErr := buildQuery(c.Req)
+		query, requestErr := buildQuery(c.Request)
 		if requestErr != nil {
 			if strings.Contains(requestErr.Error(), errMsgMethodUnsupported) {
 				sendErr(http.StatusMethodNotAllowed, errMsgMethodUnsupported, requestErr.Error())
@@ -81,7 +81,7 @@ func agentConfigHandler(kbClient kibana.Client, config *agentConfig, secretToken
 
 		etag := fmt.Sprintf("\"%s\"", upstreamEtag)
 		c.Header().Set(headers.Etag, etag)
-		if etag == c.Req.Header.Get(headers.IfNoneMatch) {
+		if etag == c.Request.Header.Get(headers.IfNoneMatch) {
 			sendResp(nil, http.StatusNotModified, cacheControl)
 		} else {
 			sendResp(cfg, http.StatusOK, cacheControl)

--- a/beater/asset_handler.go
+++ b/beater/asset_handler.go
@@ -39,7 +39,7 @@ type assetHandler struct {
 
 func (h *assetHandler) Handle(beaterConfig *Config, report publish.Reporter) Handler {
 	return func(c *request.Context) {
-		res := h.processRequest(c.Req, report)
+		res := h.processRequest(c.Request, report)
 		sendStatus(c, res)
 	}
 }

--- a/beater/asset_handler.go
+++ b/beater/asset_handler.go
@@ -23,6 +23,7 @@ import (
 
 	"go.elastic.co/apm"
 
+	"github.com/elastic/apm-server/beater/request"
 	"github.com/elastic/apm-server/decoder"
 	"github.com/elastic/apm-server/processor/asset"
 	"github.com/elastic/apm-server/publish"
@@ -36,11 +37,11 @@ type assetHandler struct {
 	tconfig        transform.Config
 }
 
-func (h *assetHandler) Handle(beaterConfig *Config, report publish.Reporter) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		res := h.processRequest(r, report)
-		sendStatus(w, r, res)
-	})
+func (h *assetHandler) Handle(beaterConfig *Config, report publish.Reporter) Handler {
+	return func(c *request.Context) {
+		res := h.processRequest(c.Req, report)
+		sendStatus(c, res)
+	}
 }
 
 func (h *assetHandler) processRequest(r *http.Request, report publish.Reporter) serverResponse {

--- a/beater/common_handler.go
+++ b/beater/common_handler.go
@@ -141,7 +141,7 @@ var (
 
 func requestTimeHandler(h Handler) Handler {
 	return func(c *request.Context) {
-		c.Req = c.Req.WithContext(utility.ContextWithRequestTime(c.Req.Context(), time.Now()))
+		c.Request = c.Request.WithContext(utility.ContextWithRequestTime(c.Request.Context(), time.Now()))
 		h(c)
 	}
 }
@@ -158,7 +158,7 @@ func killSwitchHandler(killSwitch bool, h Handler) Handler {
 
 func authHandler(secretToken string, h Handler) Handler {
 	return func(c *request.Context) {
-		if !isAuthorized(c.Req, secretToken) {
+		if !isAuthorized(c.Request, secretToken) {
 			sendStatus(c, unauthorizedResponse)
 			return
 		}
@@ -196,10 +196,10 @@ func corsHandler(allowedOrigins []string, h Handler) Handler {
 	return func(c *request.Context) {
 
 		// origin header is always set by the browser
-		origin := c.Req.Header.Get(headers.Origin)
+		origin := c.Request.Header.Get(headers.Origin)
 		validOrigin := isAllowed(origin)
 
-		if c.Req.Method == http.MethodOptions {
+		if c.Request.Method == http.MethodOptions {
 
 			// setting the ACAO header is the way to tell the browser to go ahead with the request
 			if validOrigin {

--- a/beater/handler.go
+++ b/beater/handler.go
@@ -15,20 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package utility
+package beater
 
-import "net/http"
+import "github.com/elastic/apm-server/beater/request"
 
-type recordingResponseWriter struct {
-	http.ResponseWriter
-	Code int
-}
-
-func NewRecordingResponseWriter(w http.ResponseWriter) *recordingResponseWriter {
-	return &recordingResponseWriter{w, http.StatusOK}
-}
-
-func (lrw *recordingResponseWriter) WriteHeader(code int) {
-	lrw.ResponseWriter.WriteHeader(code)
-	lrw.Code = code
-}
+// Handler specifies the handler type that is implemented by middleware and apm handlers
+type Handler func(c *request.Context)

--- a/beater/intake_handler.go
+++ b/beater/intake_handler.go
@@ -85,7 +85,7 @@ func (v *intakeHandler) sendResponse(c *request.Context, sr *stream.Result) {
 
 	if statusCode == http.StatusAccepted {
 		responseSuccesses.Inc()
-		if _, ok := c.Req.URL.Query()["verbose"]; ok {
+		if _, ok := c.Request.URL.Query()["verbose"]; ok {
 			c.Send(sr, statusCode)
 		} else {
 			c.WriteHeader(statusCode)
@@ -150,33 +150,33 @@ func (v *intakeHandler) bodyReader(r *http.Request) (io.ReadCloser, *stream.Erro
 func (v *intakeHandler) Handle(beaterConfig *Config, report publish.Reporter) Handler {
 	return func(c *request.Context) {
 
-		serr := v.validateRequest(c.Req)
+		serr := v.validateRequest(c.Request)
 		if serr != nil {
 			v.sendError(c, serr)
 			return
 		}
 
-		rl, serr := v.rateLimit(c.Req)
+		rl, serr := v.rateLimit(c.Request)
 		if serr != nil {
 			v.sendError(c, serr)
 			return
 		}
 
-		reader, serr := v.bodyReader(c.Req)
+		reader, serr := v.bodyReader(c.Request)
 		if serr != nil {
 			v.sendError(c, serr)
 			return
 		}
 
 		// extract metadata information from the request, like user-agent or remote address
-		reqMeta, err := v.requestDecoder(c.Req)
+		reqMeta, err := v.requestDecoder(c.Request)
 		if err != nil {
 			sr := stream.Result{}
 			sr.Add(err)
 			v.sendResponse(c, &sr)
 			return
 		}
-		res := v.streamProcessor.HandleStream(c.Req.Context(), rl, reqMeta, reader, report)
+		res := v.streamProcessor.HandleStream(c.Request.Context(), rl, reqMeta, reader, report)
 
 		v.sendResponse(c, res)
 	}

--- a/beater/intake_handler.go
+++ b/beater/intake_handler.go
@@ -21,18 +21,18 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"golang.org/x/time/rate"
 
+	"github.com/elastic/beats/libbeat/monitoring"
+
 	"github.com/elastic/apm-server/beater/headers"
+	"github.com/elastic/apm-server/beater/request"
 	"github.com/elastic/apm-server/decoder"
 	"github.com/elastic/apm-server/processor/stream"
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/apm-server/utility"
-	"github.com/elastic/beats/libbeat/logp"
-	"github.com/elastic/beats/libbeat/monitoring"
 )
 
 type intakeHandler struct {
@@ -78,43 +78,32 @@ func (v *intakeHandler) statusCode(sr *stream.Result) (int, *monitoring.Int) {
 	return highestCode, monitoringCt
 }
 
-func (v *intakeHandler) sendResponse(logger *logp.Logger, w http.ResponseWriter, r *http.Request, sr *stream.Result) {
+func (v *intakeHandler) sendResponse(c *request.Context, sr *stream.Result) {
 	statusCode, counter := v.statusCode(sr)
 	responseCounter.Inc()
 	counter.Inc()
 
 	if statusCode == http.StatusAccepted {
 		responseSuccesses.Inc()
-		if _, ok := r.URL.Query()["verbose"]; ok {
-			send(w, r, sr, statusCode)
+		if _, ok := c.Req.URL.Query()["verbose"]; ok {
+			c.Send(sr, statusCode)
 		} else {
-			w.WriteHeader(statusCode)
+			c.WriteHeader(statusCode)
 		}
 	} else {
 		responseErrors.Inc()
-		logger.Errorw("error handling request", "error", sr.Error(), "response_code", statusCode)
 		// this signals to the client that we're closing the connection
 		// but also signals to http.Server that it should close it:
 		// https://golang.org/src/net/http/server.go#L1254
-		w.Header().Add(headers.Connection, "Close")
-		send(w, r, sr, statusCode)
+		c.Header().Add(headers.Connection, "Close")
+		c.SendError(sr, sr.Error(), statusCode)
 	}
 }
 
-func send(w http.ResponseWriter, r *http.Request, body interface{}, statusCode int) {
-	var n int
-	if acceptsJSON(r) {
-		n = sendJSON(w, body, statusCode)
-	} else {
-		n = sendPlain(w, body, statusCode)
-	}
-	w.Header().Set(headers.ContentLength, strconv.Itoa(n))
-}
-
-func (v *intakeHandler) sendError(logger *logp.Logger, w http.ResponseWriter, r *http.Request, err *stream.Error) {
+func (v *intakeHandler) sendError(c *request.Context, err *stream.Error) {
 	sr := stream.Result{}
 	sr.Add(err)
-	v.sendResponse(logger, w, r, &sr)
+	v.sendResponse(c, &sr)
 }
 
 func (v *intakeHandler) validateRequest(r *http.Request) *stream.Error {
@@ -158,38 +147,37 @@ func (v *intakeHandler) bodyReader(r *http.Request) (io.ReadCloser, *stream.Erro
 	return reader, nil
 }
 
-func (v *intakeHandler) Handle(beaterConfig *Config, report publish.Reporter) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger := requestLogger(r)
+func (v *intakeHandler) Handle(beaterConfig *Config, report publish.Reporter) Handler {
+	return func(c *request.Context) {
 
-		serr := v.validateRequest(r)
+		serr := v.validateRequest(c.Req)
 		if serr != nil {
-			v.sendError(logger, w, r, serr)
+			v.sendError(c, serr)
 			return
 		}
 
-		rl, serr := v.rateLimit(r)
+		rl, serr := v.rateLimit(c.Req)
 		if serr != nil {
-			v.sendError(logger, w, r, serr)
+			v.sendError(c, serr)
 			return
 		}
 
-		reader, serr := v.bodyReader(r)
+		reader, serr := v.bodyReader(c.Req)
 		if serr != nil {
-			v.sendError(logger, w, r, serr)
+			v.sendError(c, serr)
 			return
 		}
 
 		// extract metadata information from the request, like user-agent or remote address
-		reqMeta, err := v.requestDecoder(r)
+		reqMeta, err := v.requestDecoder(c.Req)
 		if err != nil {
 			sr := stream.Result{}
 			sr.Add(err)
-			v.sendResponse(logger, w, r, &sr)
+			v.sendResponse(c, &sr)
 			return
 		}
-		res := v.streamProcessor.HandleStream(r.Context(), rl, reqMeta, reader, report)
+		res := v.streamProcessor.HandleStream(c.Req.Context(), rl, reqMeta, reader, report)
 
-		v.sendResponse(logger, w, r, res)
-	})
+		v.sendResponse(c, res)
+	}
 }

--- a/beater/intake_handler_test.go
+++ b/beater/intake_handler_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/elastic/beats/libbeat/monitoring"
 
 	"github.com/elastic/apm-server/beater/headers"
-	btcontext "github.com/elastic/apm-server/beater/request"
+	"github.com/elastic/apm-server/beater/request"
 	"github.com/elastic/apm-server/decoder"
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/apm-server/tests"
@@ -49,7 +49,7 @@ func TestInvalidContentType(t *testing.T) {
 	c := defaultConfig("7.0.0")
 	handler, err := (&backendRoute).Handler("", c, nil)
 	require.NoError(t, err)
-	ctx := &btcontext.Context{}
+	ctx := &request.Context{}
 	ctx.Reset(w, req)
 	handler(ctx)
 
@@ -67,7 +67,7 @@ func TestEmptyRequest(t *testing.T) {
 	c := defaultConfig("7.0.0")
 	handler, err := (&backendRoute).Handler("", c, nil)
 	require.NoError(t, err)
-	ctx := &btcontext.Context{}
+	ctx := &request.Context{}
 	ctx.Reset(w, req)
 	handler(ctx)
 
@@ -95,7 +95,7 @@ func TestRequestDecoderError(t *testing.T) {
 
 	handler, err := testRouteWithFaultyDecoder.Handler("", c, nil)
 	require.NoError(t, err)
-	ctx := &btcontext.Context{}
+	ctx := &request.Context{}
 	ctx.Reset(w, req)
 	handler(ctx)
 
@@ -239,7 +239,7 @@ func sendReq(c *Config, route *intakeRoute, url string, p string, repErr error) 
 	}
 
 	w := httptest.NewRecorder()
-	ctx := &btcontext.Context{}
+	ctx := &request.Context{}
 	ctx.Reset(w, req)
 	logHandler(handler)(ctx)
 	return w, nil
@@ -253,7 +253,7 @@ func TestWrongMethod(t *testing.T) {
 	require.NoError(t, err)
 
 	ct := methodNotAllowedCounter.Get()
-	ctx := &btcontext.Context{}
+	ctx := &request.Context{}
 	ctx.Reset(w, req)
 	handler(ctx)
 
@@ -287,7 +287,7 @@ func TestLineExceeded(t *testing.T) {
 	assert.False(t, lineLimitExceededInTestData(c.MaxEventSize))
 	handler, err := (&backendRoute).Handler("", c, nilReport)
 	require.NoError(t, err)
-	ctx := &btcontext.Context{}
+	ctx := &request.Context{}
 	ctx.Reset(w, req)
 	handler(ctx)
 
@@ -305,7 +305,7 @@ func TestLineExceeded(t *testing.T) {
 	w = httptest.NewRecorder()
 
 	ct := requestTooLargeCounter.Get()
-	ctx = &btcontext.Context{}
+	ctx = &request.Context{}
 	ctx.Reset(w, req)
 	handler(ctx)
 	assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())

--- a/beater/log_handler.go
+++ b/beater/log_handler.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"net/http"
+
+	"github.com/gofrs/uuid"
+
+	"github.com/elastic/beats/libbeat/logp"
+
+	"github.com/elastic/apm-server/beater/headers"
+	"github.com/elastic/apm-server/beater/request"
+	logs "github.com/elastic/apm-server/log"
+	"github.com/elastic/apm-server/utility"
+)
+
+func logHandler(h Handler) Handler {
+	logger := logp.NewLogger(logs.Request)
+
+	return func(c *request.Context) {
+		requestCounter.Inc()
+		reqID, err := uuid.NewV4()
+		if err != nil {
+			sendStatus(c, internalErrorResponse(err))
+		}
+
+		reqLogger := logger.With(
+			"request_id", reqID,
+			"method", c.Req.Method,
+			"URL", c.Req.URL,
+			"content_length", c.Req.ContentLength,
+			"remote_address", utility.RemoteAddr(c.Req),
+			"user-agent", c.Req.Header.Get(headers.UserAgent))
+
+		h(c)
+
+		keysAndValues := []interface{}{"response_code", c.StatusCode()}
+		if c.StatusCode() >= http.StatusBadRequest {
+			keysAndValues = append(keysAndValues, "error", c.Error())
+			if c.Stacktrace() != "" {
+				keysAndValues = append(keysAndValues, "stacktrace", c.Stacktrace())
+			}
+			reqLogger.Errorw("error handling request", keysAndValues...)
+			return
+		}
+
+		reqLogger.Infow("handled request", keysAndValues...)
+	}
+}

--- a/beater/log_handler.go
+++ b/beater/log_handler.go
@@ -42,19 +42,19 @@ func logHandler(h Handler) Handler {
 
 		reqLogger := logger.With(
 			"request_id", reqID,
-			"method", c.Req.Method,
-			"URL", c.Req.URL,
-			"content_length", c.Req.ContentLength,
-			"remote_address", utility.RemoteAddr(c.Req),
-			"user-agent", c.Req.Header.Get(headers.UserAgent))
+			"method", c.Request.Method,
+			"URL", c.Request.URL,
+			"content_length", c.Request.ContentLength,
+			"remote_address", utility.RemoteAddr(c.Request),
+			"user-agent", c.Request.Header.Get(headers.UserAgent))
 
 		h(c)
 
-		keysAndValues := []interface{}{"response_code", c.StatusCode()}
-		if c.StatusCode() >= http.StatusBadRequest {
-			keysAndValues = append(keysAndValues, "error", c.Error())
-			if c.Stacktrace() != "" {
-				keysAndValues = append(keysAndValues, "stacktrace", c.Stacktrace())
+		keysAndValues := []interface{}{"response_code", c.StatusCode}
+		if c.StatusCode >= http.StatusBadRequest {
+			keysAndValues = append(keysAndValues, "error", c.Err)
+			if c.Stacktrace != "" {
+				keysAndValues = append(keysAndValues, "stacktrace", c.Stacktrace)
 			}
 			reqLogger.Errorw("error handling request", keysAndValues...)
 			return

--- a/beater/mux.go
+++ b/beater/mux.go
@@ -1,0 +1,92 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"expvar"
+	"net/http"
+	"sync"
+
+	"github.com/elastic/apm-server/beater/request"
+	"github.com/elastic/apm-server/kibana"
+	logs "github.com/elastic/apm-server/log"
+	"github.com/elastic/apm-server/publish"
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+type contextPool struct {
+	p sync.Pool
+}
+
+func newContextPool() *contextPool {
+	pool := contextPool{}
+	pool.p.New = func() interface{} {
+		return &request.Context{}
+	}
+	return &pool
+}
+
+func (pool *contextPool) handler(h Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c := pool.p.Get().(*request.Context)
+		defer pool.p.Put(c)
+		c.Reset(w, r)
+
+		logHandler(panicHandler(h))(c)
+	})
+}
+
+func newMuxer(beaterConfig *Config, report publish.Reporter) (*http.ServeMux, error) {
+	pool := newContextPool()
+	mux := http.NewServeMux()
+	logger := logp.NewLogger(logs.Handler)
+
+	for path, route := range AssetRoutes {
+		logger.Infof("Path %s added to request handler", path)
+		handler, err := route.Handler(route.Processor, beaterConfig, report)
+		if err != nil {
+			return nil, err
+		}
+		mux.Handle(path, pool.handler(handler))
+	}
+	for path, route := range IntakeRoutes {
+		logger.Infof("Path %s added to request handler", path)
+
+		handler, err := route.Handler(path, beaterConfig, report)
+		if err != nil {
+			return nil, err
+		}
+		mux.Handle(path, pool.handler(handler))
+	}
+
+	var kbClient kibana.Client
+	if beaterConfig.Kibana.Enabled() {
+		kbClient = kibana.NewConnectingClient(beaterConfig.Kibana)
+	}
+	mux.Handle(agentConfigURL, pool.handler(agentConfigHandler(kbClient, beaterConfig.AgentConfig, beaterConfig.SecretToken)))
+	logger.Infof("Path %s added to request handler", agentConfigURL)
+
+	mux.Handle(rootURL, pool.handler(rootHandler(beaterConfig.SecretToken)))
+
+	if beaterConfig.Expvar.isEnabled() {
+		path := beaterConfig.Expvar.Url
+		logger.Infof("Path %s added to request handler", path)
+		mux.Handle(path, expvar.Handler())
+	}
+	return mux, nil
+}

--- a/beater/panicHandler.go
+++ b/beater/panicHandler.go
@@ -35,7 +35,7 @@ func panicHandler(h Handler) Handler {
 				if err, ok = r.(error); !ok {
 					err = fmt.Errorf("internal server error %+v", r)
 				}
-				c.AddStacktrace(string(debug.Stack()))
+				c.Stacktrace = string(debug.Stack())
 				c.SendError(nil, fmt.Sprintf("panic handling request: %s", err.Error()), http.StatusInternalServerError)
 			}
 		}()

--- a/beater/panic_handler_test.go
+++ b/beater/panic_handler_test.go
@@ -1,0 +1,60 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-server/beater/request"
+)
+
+func TestPanicHandler(t *testing.T) {
+
+	setupContext := func() *request.Context {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		c := &request.Context{}
+		c.Reset(w, r)
+		return c
+	}
+
+	t.Run("NoPanic", func(t *testing.T) {
+		h := func(c *request.Context) { c.WriteHeader(http.StatusAccepted) }
+		c := setupContext()
+		panicHandler(h)(c)
+		require.Equal(t, http.StatusAccepted, c.StatusCode())
+		assert.Empty(t, c.Error())
+		assert.Empty(t, c.Stacktrace())
+	})
+
+	t.Run("HandlePanic", func(t *testing.T) {
+		h := func(c *request.Context) { panic("panic xyz") }
+		c := setupContext()
+		panicHandler(h)(c)
+		require.Equal(t, http.StatusInternalServerError, c.StatusCode())
+		assert.Contains(t, c.Error(), "panic xyz")
+		assert.NotNil(t, c.Stacktrace())
+	})
+
+}

--- a/beater/panic_handler_test.go
+++ b/beater/panic_handler_test.go
@@ -43,18 +43,18 @@ func TestPanicHandler(t *testing.T) {
 		h := func(c *request.Context) { c.WriteHeader(http.StatusAccepted) }
 		c := setupContext()
 		panicHandler(h)(c)
-		require.Equal(t, http.StatusAccepted, c.StatusCode())
-		assert.Empty(t, c.Error())
-		assert.Empty(t, c.Stacktrace())
+		require.Equal(t, http.StatusAccepted, c.StatusCode)
+		assert.Empty(t, c.Err)
+		assert.Empty(t, c.Stacktrace)
 	})
 
 	t.Run("HandlePanic", func(t *testing.T) {
 		h := func(c *request.Context) { panic("panic xyz") }
 		c := setupContext()
 		panicHandler(h)(c)
-		require.Equal(t, http.StatusInternalServerError, c.StatusCode())
-		assert.Contains(t, c.Error(), "panic xyz")
-		assert.NotNil(t, c.Stacktrace())
+		require.Equal(t, http.StatusInternalServerError, c.StatusCode)
+		assert.Contains(t, c.Err, "panic xyz")
+		assert.NotNil(t, c.Stacktrace)
 	})
 
 }

--- a/beater/request/context.go
+++ b/beater/request/context.go
@@ -1,0 +1,165 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package request
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/elastic/apm-server/beater/headers"
+	logs "github.com/elastic/apm-server/log"
+
+	"github.com/elastic/beats/libbeat/logp"
+)
+
+const (
+	mimeTypeAny             = "*/*"
+	mimeTypeApplicationJSON = "application/json"
+)
+
+var (
+	mimeTypesJSON = []string{mimeTypeAny, mimeTypeApplicationJSON}
+)
+
+// Context abstracts request and response information for http requests
+type Context struct {
+	Req *http.Request
+
+	statusCode int
+	err        interface{}
+	stacktrace string
+
+	w http.ResponseWriter
+}
+
+// Reset allows to reuse a context by removing all request specific information
+func (c *Context) Reset(w http.ResponseWriter, r *http.Request) {
+	c.Req = r
+
+	c.w = w
+	c.statusCode = http.StatusOK
+	c.err = ""
+	c.stacktrace = ""
+}
+
+// Header returns the http.Header of the context's writer
+func (c *Context) Header() http.Header {
+	return c.w.Header()
+}
+
+// StatusCode returns the context's status code
+func (c *Context) StatusCode() int {
+	return c.statusCode
+}
+
+// Error returns the context's error
+func (c *Context) Error() interface{} {
+	return c.err
+}
+
+// Stacktrace returns the context's stacktrace
+func (c *Context) Stacktrace() string {
+	return c.stacktrace
+}
+
+// AddStacktrace sets a stacktrace for the context
+func (c *Context) AddStacktrace(stacktrace string) {
+	c.stacktrace = stacktrace
+}
+
+//TODO: All of the below methods will be changed during the response handling refactoring
+
+// WriteHeader sets status code in context and call the http.ResponseWriter method
+func (c *Context) WriteHeader(statusCode int) {
+	c.w.WriteHeader(statusCode)
+	c.statusCode = statusCode
+}
+
+// SendNotFoundErr is moved from the rootHandler and will be removed in the following refactoring
+func (c *Context) SendNotFoundErr() {
+	c.statusCode = http.StatusNotFound
+	http.NotFound(c.w, c.Req)
+}
+
+// Send is taking care of writing the response
+func (c *Context) Send(body interface{}, statusCode int) {
+	c.SendError(body, nil, statusCode)
+}
+
+// SendError sets and error and writes the response
+func (c *Context) SendError(body, err interface{}, statusCode int) {
+	c.err = err
+	c.w.Header().Set(headers.XContentTypeOptions, "nosniff")
+
+	if body == nil {
+		c.WriteHeader(statusCode)
+		return
+	}
+
+	if c.acceptJSON() {
+		c.sendJSON(body, statusCode)
+	} else {
+		c.sendPlain(body, statusCode)
+	}
+}
+
+func (c *Context) sendJSON(body interface{}, statusCode int) {
+	c.Header().Set(headers.ContentType, "application/json")
+	c.WriteHeader(statusCode)
+	buf, err := json.MarshalIndent(body, "", "  ")
+	if err != nil {
+		logp.NewLogger(logs.Response).Errorf("Error while generating a JSON error response: %v", err)
+		c.sendPlain(body, statusCode)
+		return
+	}
+
+	buf = append(buf, "\n"...)
+	n, _ := c.w.Write(buf)
+	c.w.Header().Set(headers.ContentLength, strconv.Itoa(n))
+}
+
+func (c *Context) sendPlain(body interface{}, statusCode int) {
+	c.Header().Set(headers.ContentType, "text/plain; charset=utf-8")
+	c.WriteHeader(statusCode)
+	var b []byte
+	var err error
+	if bStr, ok := body.(string); ok {
+		b = []byte(bStr + "\n")
+	} else {
+		b, err = json.Marshal(body)
+		if err != nil {
+			b = []byte(fmt.Sprintf("%+v", body))
+		}
+		b = append(b, "\n"...)
+	}
+	n, _ := c.w.Write(b)
+	c.w.Header().Set(headers.ContentLength, strconv.Itoa(n))
+}
+
+func (c *Context) acceptJSON() bool {
+	acceptHeader := c.Req.Header.Get(headers.Accept)
+	for _, s := range mimeTypesJSON {
+		if strings.Contains(acceptHeader, s) {
+			return true
+		}
+	}
+	return false
+}

--- a/beater/root_handler.go
+++ b/beater/root_handler.go
@@ -40,12 +40,12 @@ func rootHandler(secretToken string) Handler {
 	}
 
 	return func(c *request.Context) {
-		if c.Req.URL.Path != "/" {
+		if c.Request.URL.Path != "/" {
 			c.SendNotFoundErr()
 			return
 		}
 
-		if isAuthorized(c.Req, secretToken) {
+		if isAuthorized(c.Request, secretToken) {
 			sendStatus(c, detailedOkResponse)
 			return
 		}


### PR DESCRIPTION
This is the first of a series of PRs for refactoring the `beater` handling wrt logging, monitoring and writing response, more infos in the meta issue #2489 . 

This PR introduces a `Context` struct abstracting the `http.ResponseWriter` and the `*http.Request` and a `ContextPool` that takes care of reusing idle `Context` instances. 

This PR aims for minimal changes to keep reviews easier. It contains _TODOs_ that will be addressed in follow up PRs before merging back to `master`. 

Partially implements #2201 
