### PR TITLE
[beater] Improve Response Writing

### DIFF
--- a/beater/agent_config_handler_integration_test.go
+++ b/beater/agent_config_handler_integration_test.go
@@ -1,0 +1,110 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/elastic/beats/libbeat/common"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-server/beater/beatertest"
+	"github.com/elastic/apm-server/beater/headers"
+	"github.com/elastic/apm-server/beater/request"
+	"github.com/elastic/apm-server/tests"
+)
+
+func TestAgentConfigHandler_RequireAuthorizationMiddleware(t *testing.T) {
+	t.Run("Unauthorized", func(t *testing.T) {
+		cfg := cfgEnabledACM()
+		cfg.SecretToken = "1234"
+		rec := requestToACMHandler(t, cfg)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		tests.AssertApproveResult(t, acmApprovalPath(t.Name()), rec.Body.Bytes())
+	})
+
+	t.Run("Authorized", func(t *testing.T) {
+		cfg := cfgEnabledACM()
+		cfg.SecretToken = "1234"
+		h, err := agentConfigHandler(cfg, beatertest.NilReporter)
+		require.NoError(t, err)
+		c, rec := beatertest.DefaultContextWithResponseRecorder()
+		c.Request.Header.Set(headers.Authorization, "Bearer 1234")
+		h(c)
+
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		tests.AssertApproveResult(t, acmApprovalPath(t.Name()), rec.Body.Bytes())
+	})
+}
+
+func TestAgentConfigHandler_KillSwitchMiddleware(t *testing.T) {
+	t.Run("Off", func(t *testing.T) {
+		rec := requestToACMHandler(t, DefaultConfig(beatertest.MockBeatVersion()))
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		tests.AssertApproveResult(t, acmApprovalPath(t.Name()), rec.Body.Bytes())
+
+	})
+
+	t.Run("On", func(t *testing.T) {
+		rec := requestToACMHandler(t, cfgEnabledACM())
+
+		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		tests.AssertApproveResult(t, acmApprovalPath(t.Name()), rec.Body.Bytes())
+	})
+}
+
+func TestAgentConfigHandler_PanicMiddleware(t *testing.T) {
+	h, err := agentConfigHandler(DefaultConfig(beatertest.MockBeatVersion()), beatertest.NilReporter)
+	require.NoError(t, err)
+	rec := &beatertest.WriterPanicOnce{}
+	c := &request.Context{}
+	c.Reset(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	h(c)
+	assert.Equal(t, http.StatusInternalServerError, rec.StatusCode)
+	tests.AssertApproveResult(t, acmApprovalPath(t.Name()), rec.Body.Bytes())
+}
+
+func TestAgentConfigHandler_MonitoringMiddleware(t *testing.T) {
+	beatertest.ClearRegistry(serverMetrics, ACMResultIDToMonitoringInt)
+	requestToACMHandler(t, DefaultConfig(beatertest.MockBeatVersion()))
+	equal, result := beatertest.CompareMonitoringInt(map[request.ResultID]int{request.IDRequestCount: 1}, ACMResultIDToMonitoringInt)
+	assert.True(t, equal, result)
+}
+
+func requestToACMHandler(t *testing.T, cfg *Config) *httptest.ResponseRecorder {
+	h, err := agentConfigHandler(cfg, beatertest.NilReporter)
+	require.NoError(t, err)
+	c, rec := beatertest.DefaultContextWithResponseRecorder()
+	h(c)
+	return rec
+}
+
+func cfgEnabledACM() *Config {
+	cfg := DefaultConfig(beatertest.MockBeatVersion())
+	cfg.Kibana = common.MustNewConfigFrom(map[string]interface{}{"enabled": "true"})
+	return cfg
+}
+
+func acmApprovalPath(f string) string { return "test_integration/acm/" + f }

--- a/beater/agent_config_handler_integration_test.go
+++ b/beater/agent_config_handler_integration_test.go
@@ -87,9 +87,12 @@ func TestAgentConfigHandler_PanicMiddleware(t *testing.T) {
 }
 
 func TestAgentConfigHandler_MonitoringMiddleware(t *testing.T) {
-	beatertest.ClearRegistry(serverMetrics, ACMResultIDToMonitoringInt)
-	requestToACMHandler(t, DefaultConfig(beatertest.MockBeatVersion()))
-	equal, result := beatertest.CompareMonitoringInt(map[request.ResultID]int{request.IDRequestCount: 1}, ACMResultIDToMonitoringInt)
+	h, err := agentConfigHandler(DefaultConfig(beatertest.MockBeatVersion()), beatertest.NilReporter)
+	require.NoError(t, err)
+	c, _ := beatertest.DefaultContextWithResponseRecorder()
+
+	expected := map[request.ResultID]int{request.IDRequestCount: 1}
+	equal, result := beatertest.CompareMonitoringInt(h, c, expected, serverMetrics, ACMResultIDToMonitoringInt)
 	assert.True(t, equal, result)
 }
 

--- a/beater/asset_handler.go
+++ b/beater/asset_handler.go
@@ -30,31 +30,37 @@ import (
 	"github.com/elastic/apm-server/utility"
 )
 
-func newAssetHandler(dec decoder.ReqDecoder, processor asset.Processor, cfg transform.Config, report publish.Reporter) request.Handler {
+// AssetHandler returns a request.Handler for managing asset requests.
+func AssetHandler(dec decoder.ReqDecoder, processor asset.Processor, cfg transform.Config, report publish.Reporter) request.Handler {
 	return func(c *request.Context) {
 		if c.Request.Method != "POST" {
-			request.SendStatus(c, request.MethodNotAllowedResponse)
+			c.Result.SetDefault(request.IDResponseErrorsMethodNotAllowed)
+			c.Write()
 			return
 		}
 
 		data, err := dec(c.Request)
 		if err != nil {
-			if strings.Contains(err.Error(), "request body too large") {
-				request.SendStatus(c, request.RequestTooLargeResponse)
-				return
+			if strings.Contains(err.Error(), request.KeywordResponseErrorsRequestTooLarge) {
+				c.Result.SetDefault(request.IDResponseErrorsRequestTooLarge)
+			} else {
+				c.Result.SetDefault(request.IDResponseErrorsDecode)
 			}
-			request.SendStatus(c, request.CannotDecodeResponse(err))
+			c.Result.Err = err
+			c.Write()
 			return
 		}
 
 		if err = processor.Validate(data); err != nil {
-			request.SendStatus(c, request.CannotValidateResponse(err))
+			c.Result.SetWithError(request.IDResponseErrorsValidate, err)
+			c.Write()
 			return
 		}
 
 		metadata, transformables, err := processor.Decode(data)
 		if err != nil {
-			request.SendStatus(c, request.CannotDecodeResponse(err))
+			c.Result.SetWithError(request.IDResponseErrorsDecode, err)
+			c.Write()
 			return
 		}
 
@@ -63,22 +69,21 @@ func newAssetHandler(dec decoder.ReqDecoder, processor asset.Processor, cfg tran
 			Config:      cfg,
 			Metadata:    *metadata,
 		}
-
 		req := publish.PendingReq{Transformables: transformables, Tcontext: tctx}
-		ctx := c.Request.Context()
-		span, ctx := apm.StartSpan(ctx, "Send", "Reporter")
+		span, ctx := apm.StartSpan(c.Request.Context(), "Send", "Reporter")
 		defer span.End()
 		req.Trace = !span.Dropped()
 
 		if err = report(ctx, req); err != nil {
 			if err == publish.ErrChannelClosed {
-				request.SendStatus(c, request.ServerShuttingDownResponse(err))
-				return
+				c.Result.SetWithError(request.IDResponseErrorsShuttingDown, err)
+			} else {
+				c.Result.SetWithError(request.IDResponseErrorsFullQueue, err)
 			}
-			request.SendStatus(c, request.FullQueueResponse(err))
-			return
+			c.Write()
 		}
 
-		request.SendStatus(c, request.AcceptedResponse)
+		c.Result.SetDefault(request.IDResponseValidAccepted)
+		c.Write()
 	}
 }

--- a/beater/asset_handler.go
+++ b/beater/asset_handler.go
@@ -42,11 +42,10 @@ func AssetHandler(dec decoder.ReqDecoder, processor asset.Processor, cfg transfo
 		data, err := dec(c.Request)
 		if err != nil {
 			if strings.Contains(err.Error(), request.MapResultIDToStatus[request.IDResponseErrorsRequestTooLarge].Keyword) {
-				c.Result.SetDefault(request.IDResponseErrorsRequestTooLarge)
+				c.Result.SetWithError(request.IDResponseErrorsRequestTooLarge, err)
 			} else {
-				c.Result.SetDefault(request.IDResponseErrorsDecode)
+				c.Result.SetWithError(request.IDResponseErrorsDecode, err)
 			}
-			c.Result.Err = err
 			c.Write()
 			return
 		}

--- a/beater/asset_handler.go
+++ b/beater/asset_handler.go
@@ -41,7 +41,7 @@ func AssetHandler(dec decoder.ReqDecoder, processor asset.Processor, cfg transfo
 
 		data, err := dec(c.Request)
 		if err != nil {
-			if strings.Contains(err.Error(), request.KeywordResponseErrorsRequestTooLarge) {
+			if strings.Contains(err.Error(), request.MapResultIDToStatus[request.IDResponseErrorsRequestTooLarge].Keyword) {
 				c.Result.SetDefault(request.IDResponseErrorsRequestTooLarge)
 			} else {
 				c.Result.SetDefault(request.IDResponseErrorsDecode)

--- a/beater/asset_handler_test.go
+++ b/beater/asset_handler_test.go
@@ -50,14 +50,16 @@ func TestNewAssetHandler(t *testing.T) {
 				return nil, errors.New("error decoding request body too large")
 			},
 			code: http.StatusRequestEntityTooLarge,
-			body: beatertest.ResultErrWrap(request.MapResultIDToStatus[request.IDResponseErrorsRequestTooLarge].Keyword),
+			body: beatertest.ResultErrWrap(fmt.Sprintf("%s: error decoding request body too large",
+				request.MapResultIDToStatus[request.IDResponseErrorsRequestTooLarge].Keyword)),
 		},
 		"decode": {
 			dec: func(r *http.Request) (map[string]interface{}, error) {
 				return nil, errors.New("foo")
 			},
 			code: http.StatusBadRequest,
-			body: beatertest.ResultErrWrap(request.MapResultIDToStatus[request.IDResponseErrorsDecode].Keyword),
+			body: beatertest.ResultErrWrap(fmt.Sprintf("%s: foo",
+				request.MapResultIDToStatus[request.IDResponseErrorsDecode].Keyword)),
 		},
 		"validate": {
 			dec:  func(req *http.Request) (map[string]interface{}, error) { return nil, nil },

--- a/beater/asset_handler_test.go
+++ b/beater/asset_handler_test.go
@@ -43,33 +43,33 @@ func TestNewAssetHandler(t *testing.T) {
 		"method": {
 			r:    httptest.NewRequest(http.MethodGet, "/", nil),
 			code: http.StatusMethodNotAllowed,
-			body: beatertest.ResultErrWrap(request.KeywordResponseErrorsMethodNotAllowed),
+			body: beatertest.ResultErrWrap(request.MapResultIDToStatus[request.IDResponseErrorsMethodNotAllowed].Keyword),
 		},
 		"large": {
 			dec: func(r *http.Request) (map[string]interface{}, error) {
 				return nil, errors.New("error decoding request body too large")
 			},
 			code: http.StatusRequestEntityTooLarge,
-			body: beatertest.ResultErrWrap(request.KeywordResponseErrorsRequestTooLarge),
+			body: beatertest.ResultErrWrap(request.MapResultIDToStatus[request.IDResponseErrorsRequestTooLarge].Keyword),
 		},
 		"decode": {
 			dec: func(r *http.Request) (map[string]interface{}, error) {
 				return nil, errors.New("foo")
 			},
 			code: http.StatusBadRequest,
-			body: beatertest.ResultErrWrap(request.KeywordResponseErrorsDecode),
+			body: beatertest.ResultErrWrap(request.MapResultIDToStatus[request.IDResponseErrorsDecode].Keyword),
 		},
 		"validate": {
 			dec:  func(req *http.Request) (map[string]interface{}, error) { return nil, nil },
 			code: http.StatusBadRequest,
-			body: beatertest.ResultErrWrap(fmt.Sprintf("%s: no input", request.KeywordResponseErrorsValidate)),
+			body: beatertest.ResultErrWrap(fmt.Sprintf("%s: no input", request.MapResultIDToStatus[request.IDResponseErrorsValidate].Keyword)),
 		},
 		"processorDecode": {
 			dec: func(*http.Request) (map[string]interface{}, error) {
 				return map[string]interface{}{"mockProcessor": "xyz"}, nil
 			},
 			code: http.StatusBadRequest,
-			body: beatertest.ResultErrWrap(fmt.Sprintf("%s: processor decode error", request.KeywordResponseErrorsDecode)),
+			body: beatertest.ResultErrWrap(fmt.Sprintf("%s: processor decode error", request.MapResultIDToStatus[request.IDResponseErrorsDecode].Keyword)),
 		},
 		"shuttingDown": {
 			reporter: func(ctx context.Context, p publish.PendingReq) error {
@@ -77,14 +77,14 @@ func TestNewAssetHandler(t *testing.T) {
 			},
 			code: http.StatusServiceUnavailable,
 			body: beatertest.ResultErrWrap(fmt.Sprintf("%s: %s",
-				request.KeywordResponseErrorsShuttingDown, publish.ErrChannelClosed)),
+				request.MapResultIDToStatus[request.IDResponseErrorsShuttingDown].Keyword, publish.ErrChannelClosed)),
 		},
 		"queue": {
 			reporter: func(ctx context.Context, p publish.PendingReq) error {
 				return errors.New("500")
 			},
 			code: http.StatusServiceUnavailable,
-			body: beatertest.ResultErrWrap(fmt.Sprintf("%s: 500", request.KeywordResponseErrorsFullQueue)),
+			body: beatertest.ResultErrWrap(fmt.Sprintf("%s: 500", request.MapResultIDToStatus[request.IDResponseErrorsFullQueue].Keyword)),
 		},
 		"valid": {
 			code: http.StatusAccepted,

--- a/beater/asset_handler_test.go
+++ b/beater/asset_handler_test.go
@@ -1,0 +1,157 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pkg/errors"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-server/beater/beatertest"
+	"github.com/elastic/apm-server/beater/request"
+	"github.com/elastic/apm-server/decoder"
+	"github.com/elastic/apm-server/model/metadata"
+	"github.com/elastic/apm-server/processor/asset"
+	"github.com/elastic/apm-server/publish"
+	"github.com/elastic/apm-server/transform"
+)
+
+func TestNewAssetHandler(t *testing.T) {
+
+	testcases := map[string]testcaseT{
+		"method": {
+			r:    httptest.NewRequest(http.MethodGet, "/", nil),
+			code: http.StatusMethodNotAllowed,
+			body: beatertest.ResultErrWrap(request.KeywordResponseErrorsMethodNotAllowed),
+		},
+		"large": {
+			dec: func(r *http.Request) (map[string]interface{}, error) {
+				return nil, errors.New("error decoding request body too large")
+			},
+			code: http.StatusRequestEntityTooLarge,
+			body: beatertest.ResultErrWrap(request.KeywordResponseErrorsRequestTooLarge),
+		},
+		"decode": {
+			dec: func(r *http.Request) (map[string]interface{}, error) {
+				return nil, errors.New("foo")
+			},
+			code: http.StatusBadRequest,
+			body: beatertest.ResultErrWrap(request.KeywordResponseErrorsDecode),
+		},
+		"validate": {
+			dec:  func(req *http.Request) (map[string]interface{}, error) { return nil, nil },
+			code: http.StatusBadRequest,
+			body: beatertest.ResultErrWrap(fmt.Sprintf("%s: no input", request.KeywordResponseErrorsValidate)),
+		},
+		"processorDecode": {
+			dec: func(*http.Request) (map[string]interface{}, error) {
+				return map[string]interface{}{"mockProcessor": "xyz"}, nil
+			},
+			code: http.StatusBadRequest,
+			body: beatertest.ResultErrWrap(fmt.Sprintf("%s: processor decode error", request.KeywordResponseErrorsDecode)),
+		},
+		"shuttingDown": {
+			reporter: func(ctx context.Context, p publish.PendingReq) error {
+				return publish.ErrChannelClosed
+			},
+			code: http.StatusServiceUnavailable,
+			body: beatertest.ResultErrWrap(fmt.Sprintf("%s: %s",
+				request.KeywordResponseErrorsShuttingDown, publish.ErrChannelClosed)),
+		},
+		"queue": {
+			reporter: func(ctx context.Context, p publish.PendingReq) error {
+				return errors.New("500")
+			},
+			code: http.StatusServiceUnavailable,
+			body: beatertest.ResultErrWrap(fmt.Sprintf("%s: 500", request.KeywordResponseErrorsFullQueue)),
+		},
+		"valid": {
+			code: http.StatusAccepted,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			tc.setup()
+
+			// test assertion
+			assert.Equal(t, tc.code, tc.w.Code)
+			assert.Equal(t, tc.body, tc.w.Body.String())
+
+		})
+	}
+}
+
+type testcaseT struct {
+	w         *httptest.ResponseRecorder
+	r         *http.Request
+	dec       decoder.ReqDecoder
+	processor asset.Processor
+	reporter  func(ctx context.Context, p publish.PendingReq) error
+
+	code int
+	body string
+}
+
+func (tc *testcaseT) setup() {
+	if tc.w == nil {
+		tc.w = httptest.NewRecorder()
+	}
+	if tc.r == nil {
+		tc.r = httptest.NewRequest(http.MethodPost, "/", nil)
+	}
+	if tc.dec == nil {
+		tc.dec = func(*http.Request) (map[string]interface{}, error) {
+			return map[string]interface{}{"foo": "bar"}, nil
+		}
+	}
+	if tc.processor == nil {
+		tc.processor = &mockProcessor{}
+	}
+	if tc.reporter == nil {
+		tc.reporter = beatertest.NilReporter
+	}
+	c := &request.Context{}
+	c.Reset(tc.w, tc.r)
+	h := AssetHandler(tc.dec, tc.processor, transform.Config{}, tc.reporter)
+	h(c)
+}
+
+type mockProcessor struct{}
+
+func (p *mockProcessor) Validate(m map[string]interface{}) error {
+	if m == nil {
+		return errors.New("no input")
+	}
+	return nil
+}
+func (p *mockProcessor) Decode(m map[string]interface{}) (*metadata.Metadata, []transform.Transformable, error) {
+	if _, ok := m["mockProcessor"]; ok {
+		return nil, nil, errors.New("processor decode error")
+	}
+	return &metadata.Metadata{}, nil, nil
+}
+func (p *mockProcessor) Name() string {
+	return "mockProcessor"
+}

--- a/beater/backend_handler_integration_test.go
+++ b/beater/backend_handler_integration_test.go
@@ -1,0 +1,53 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-server/beater/beatertest"
+	"github.com/elastic/apm-server/beater/request"
+)
+
+func TestBackendHandler_MonitoringMiddleware(t *testing.T) {
+	beatertest.ClearRegistry(serverMetrics, IntakeResultIDToMonitoringInt)
+	requestToBackend(t, DefaultConfig(beatertest.MockBeatVersion()))
+	// send GET request resulting in 405 MethodNotAllowed error
+	expected := map[request.ResultID]int{
+		request.IDRequestCount:                   1,
+		request.IDResponseCount:                  1,
+		request.IDResponseErrorsCount:            1,
+		request.IDResponseErrorsMethodNotAllowed: 1}
+	equal, result := beatertest.CompareMonitoringInt(expected, IntakeResultIDToMonitoringInt)
+	assert.True(t, equal, result)
+}
+
+func requestToBackend(t *testing.T, cfg *Config) *httptest.ResponseRecorder {
+	h, err := backendHandler(cfg, beatertest.NilReporter)
+	require.NoError(t, err)
+	c, rec := beatertest.DefaultContextWithResponseRecorder()
+	h(c)
+	return rec
+}
+
+//TODO: add more integration tests for the actual middleware

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -52,7 +52,7 @@ func TestBeatConfig(t *testing.T) {
 	}{
 		"default config": {
 			conf:       map[string]interface{}{},
-			beaterConf: defaultConfig("6.2.0"),
+			beaterConf: DefaultConfig("6.2.0"),
 		},
 		"overwrite default config": {
 			conf: map[string]interface{}{
@@ -120,9 +120,9 @@ func TestBeatConfig(t *testing.T) {
 					Enabled: &truthy,
 					Url:     "/debug/vars",
 				},
-				RumConfig: &rumConfig{
+				RumConfig: &RumConfig{
 					Enabled: &truthy,
-					EventRate: &eventRate{
+					EventRate: &EventRate{
 						Limit:   7200,
 						LruSize: 2000,
 					},
@@ -135,9 +135,9 @@ func TestBeatConfig(t *testing.T) {
 					ExcludeFromGrouping: "^grouping",
 					beatVersion:         "6.2.0",
 				},
-				Register: &registerConfig{
-					Ingest: &ingestConfig{
-						Pipeline: &pipelineConfig{
+				Register: &RegisterConfig{
+					Ingest: &IngestConfig{
+						Pipeline: &PipelineConfig{
 							Enabled:   &truthy,
 							Overwrite: &falsy,
 							Path:      filepath.Join("tmp", "definition.json"),
@@ -145,8 +145,8 @@ func TestBeatConfig(t *testing.T) {
 					},
 				},
 				Kibana:      common.MustNewConfigFrom(map[string]interface{}{"enabled": "true"}),
-				AgentConfig: &agentConfig{Cache: &Cache{Expiration: 2 * time.Minute}},
-				pipeline:    defaultAPMPipeline,
+				AgentConfig: &AgentConfig{Cache: &Cache{Expiration: 2 * time.Minute}},
+				Pipeline:    defaultAPMPipeline,
 			},
 		},
 		"merge config with default": {
@@ -195,9 +195,9 @@ func TestBeatConfig(t *testing.T) {
 					Enabled: &truthy,
 					Url:     "/debug/vars",
 				},
-				RumConfig: &rumConfig{
+				RumConfig: &RumConfig{
 					Enabled: &truthy,
-					EventRate: &eventRate{
+					EventRate: &EventRate{
 						Limit:   300,
 						LruSize: 1000,
 					},
@@ -212,17 +212,17 @@ func TestBeatConfig(t *testing.T) {
 					ExcludeFromGrouping: "^/webpack",
 					beatVersion:         "6.2.0",
 				},
-				Register: &registerConfig{
-					Ingest: &ingestConfig{
-						Pipeline: &pipelineConfig{
+				Register: &RegisterConfig{
+					Ingest: &IngestConfig{
+						Pipeline: &PipelineConfig{
 							Enabled: &falsy,
 							Path:    filepath.Join("ingest", "pipeline", "definition.json"),
 						},
 					},
 				},
 				Kibana:      common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
-				AgentConfig: &agentConfig{Cache: &Cache{Expiration: 30 * time.Second}},
-				pipeline:    defaultAPMPipeline,
+				AgentConfig: &AgentConfig{Cache: &Cache{Expiration: 30 * time.Second}},
+				Pipeline:    defaultAPMPipeline,
 			},
 		},
 	}

--- a/beater/beatertest/config.go
+++ b/beater/beatertest/config.go
@@ -15,20 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package beater
+package beatertest
 
-import (
-	"github.com/elastic/apm-server/beater/request"
-)
-
-// Middleware wraps a request.Handler
-type Middleware func(request.Handler) request.Handler
-
-// WithMiddleware wraps a request.Handler into given middleware functions,
-// maintaining order from the last to the first middleware
-func WithMiddleware(h request.Handler, m ...Middleware) request.Handler {
-	for i := len(m) - 1; i >= 0; i-- {
-		h = m[i](h)
-	}
-	return h
-}
+// MockBeatVersion returns a beat version for testing
+func MockBeatVersion() string { return "8.0.0" }

--- a/beater/beatertest/context.go
+++ b/beater/beatertest/context.go
@@ -1,0 +1,77 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beatertest
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/elastic/apm-server/beater/request"
+)
+
+// DefaultContextWithResponseRecorder returns a context and response recorder for testing purposes
+// It is set to send a GET request to the root path.
+func DefaultContextWithResponseRecorder() (*request.Context, *httptest.ResponseRecorder) {
+	return ContextWithResponseRecorder(http.MethodGet, "/")
+}
+
+// ContextWithResponseRecorder returns a custom context and response recorder for testing purposes
+// It is set to use the passed in request method and path
+func ContextWithResponseRecorder(m string, target string) (*request.Context, *httptest.ResponseRecorder) {
+	w := httptest.NewRecorder()
+	c := &request.Context{}
+	c.Reset(w, httptest.NewRequest(m, target, nil))
+	return c, w
+}
+
+// WriterPanicOnce implements the http.ResponseWriter interface
+// It panics once when any method is called.
+type WriterPanicOnce struct {
+	StatusCode int
+	Body       bytes.Buffer
+	panicked   bool
+}
+
+// Header panics if it is the first call to the struct, otherwise returns empty Header
+func (w *WriterPanicOnce) Header() http.Header {
+	if !w.panicked {
+		w.panicked = true
+		panic(errors.New("panic on Header"))
+	}
+	return http.Header{}
+}
+
+// Write panics if it is the first call to the struct, otherwise it writes the given bytes to the body
+func (w *WriterPanicOnce) Write(b []byte) (int, error) {
+	if !w.panicked {
+		w.panicked = true
+		panic(errors.New("panic on Write"))
+	}
+	return w.Body.Write(b)
+}
+
+// WriteHeader panics if it is the first call to the struct, otherwise it writes the given status code
+func (w *WriterPanicOnce) WriteHeader(statusCode int) {
+	if !w.panicked {
+		w.panicked = true
+		panic(errors.New("panic on WriteHeader"))
+	}
+	w.StatusCode = statusCode
+}

--- a/beater/beatertest/handler.go
+++ b/beater/beatertest/handler.go
@@ -15,32 +15,27 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package beater
+package beatertest
 
 import (
-	"fmt"
 	"net/http"
-	"runtime/debug"
 
 	"github.com/elastic/apm-server/beater/request"
 )
 
-func panicHandler() middleware {
-	return func(h request.Handler) request.Handler {
-		return func(c *request.Context) {
-
-			defer func() {
-				if r := recover(); r != nil {
-					var ok bool
-					var err error
-					if err, ok = r.(error); !ok {
-						err = fmt.Errorf("internal server error %+v", r)
-					}
-					c.Stacktrace = string(debug.Stack())
-					c.SendError(nil, fmt.Sprintf("panic handling request: %s", err.Error()), http.StatusInternalServerError)
-				}
-			}()
-			h(c)
-		}
-	}
+// Handler403 sets a 403 ID and status code to the context's response and calls Write()
+func Handler403(c *request.Context) {
+	c.Result.ID = request.IDResponseErrorsForbidden
+	c.Result.StatusCode = http.StatusForbidden
+	c.Write()
 }
+
+// Handler202 sets a 202 ID and status code to the context's response and calls Write()
+func Handler202(c *request.Context) {
+	c.Result.ID = request.IDResponseValidAccepted
+	c.Result.StatusCode = http.StatusAccepted
+	c.Write()
+}
+
+// HandlerIdle doesn't do anything but implement the request.Handler type
+func HandlerIdle(c *request.Context) {}

--- a/beater/beatertest/monitoring.go
+++ b/beater/beatertest/monitoring.go
@@ -1,0 +1,86 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beatertest
+
+import (
+	"fmt"
+
+	"github.com/elastic/beats/libbeat/monitoring"
+
+	"github.com/elastic/apm-server/beater/request"
+)
+
+// ClearRegistry sets all counters to 0 and removes all registered counters from the registry
+// Only use this in test environments
+func ClearRegistry(r *monitoring.Registry, fn func(id request.ResultID) *monitoring.Int) {
+	for _, id := range AllRequestResultIDs() {
+		i := fn(id)
+		if i != nil {
+			i.Set(0)
+		}
+	}
+	r.Clear()
+}
+
+// CompareMonitoringInt matches expected with real monitoring counters and
+// returns false and an a string showind diffs if not matching
+func CompareMonitoringInt(expected map[request.ResultID]int, fn func(id request.ResultID) *monitoring.Int) (bool, string) {
+	var result string
+	for _, id := range AllRequestResultIDs() {
+		monitoringIntVal := int64(0)
+		monitoringInt := fn(id)
+		if monitoringInt != nil {
+			monitoringIntVal = monitoringInt.Get()
+		}
+		expectedVal := int64(0)
+		if val, included := expected[id]; included {
+			expectedVal = int64(val)
+		}
+		if expectedVal != monitoringIntVal {
+			result += fmt.Sprintf("[%s] Expected: %d, Received: %d", id, expectedVal, monitoringIntVal)
+		}
+	}
+
+	return len(result) == 0, result
+}
+
+// AllRequestResultIDs returns all registered request.ResultIDs (needs to be manually maintained)
+func AllRequestResultIDs() []request.ResultID {
+	return []request.ResultID{
+		request.IDUnset,
+		request.IDRequestCount,
+		request.IDResponseCount,
+		request.IDResponseErrorsCount,
+		request.IDResponseValidCount,
+		request.IDResponseValidNotModified,
+		request.IDResponseValidOK,
+		request.IDResponseValidAccepted,
+		request.IDResponseErrorsForbidden,
+		request.IDResponseErrorsUnauthorized,
+		request.IDResponseErrorsNotFound,
+		request.IDResponseErrorsInvalidQuery,
+		request.IDResponseErrorsRequestTooLarge,
+		request.IDResponseErrorsDecode,
+		request.IDResponseErrorsValidate,
+		request.IDResponseErrorsRateLimit,
+		request.IDResponseErrorsMethodNotAllowed,
+		request.IDResponseErrorsFullQueue,
+		request.IDResponseErrorsShuttingDown,
+		request.IDResponseErrorsServiceUnavailable,
+		request.IDResponseErrorsInternal}
+}

--- a/beater/beatertest/reporter.go
+++ b/beater/beatertest/reporter.go
@@ -15,20 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package beater
+package beatertest
 
 import (
-	"github.com/elastic/apm-server/beater/request"
+	"context"
+
+	"github.com/elastic/apm-server/publish"
 )
 
-// Middleware wraps a request.Handler
-type Middleware func(request.Handler) request.Handler
-
-// WithMiddleware wraps a request.Handler into given middleware functions,
-// maintaining order from the last to the first middleware
-func WithMiddleware(h request.Handler, m ...Middleware) request.Handler {
-	for i := len(m) - 1; i >= 0; i-- {
-		h = m[i](h)
-	}
-	return h
-}
+// NilReporter is a noop implementation of the reporter interface
+func NilReporter(ctx context.Context, p publish.PendingReq) error { return nil }

--- a/beater/beatertest/result.go
+++ b/beater/beatertest/result.go
@@ -15,20 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package beater
+package beatertest
 
-import (
-	"github.com/elastic/apm-server/beater/request"
-)
+import "fmt"
 
-// Middleware wraps a request.Handler
-type Middleware func(request.Handler) request.Handler
-
-// WithMiddleware wraps a request.Handler into given middleware functions,
-// maintaining order from the last to the first middleware
-func WithMiddleware(h request.Handler, m ...Middleware) request.Handler {
-	for i := len(m) - 1; i >= 0; i-- {
-		h = m[i](h)
-	}
-	return h
-}
+// ResultErrWrap wraps given input into the expected result error string
+func ResultErrWrap(s string) string { return fmt.Sprintf("{\"error\":\"%+v\"}\n", s) }

--- a/beater/context_pool_test.go
+++ b/beater/context_pool_test.go
@@ -1,0 +1,81 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-server/beater/request"
+)
+
+func TestContextPool(t *testing.T) {
+	// This test ensures that request.Context instances are reused from a pool, while
+	// the Request stored inside a context is always set fresh
+	// The test is important to avoid mixing up separate requests in a reused context.
+
+	p := newContextPool()
+
+	// mockhHandler adds the context and it's request to dedicated slices
+	var contexts, requests []interface{}
+	var mu sync.Mutex
+	mockHandler := func(c *request.Context) {
+		mu.Lock()
+		defer mu.Unlock()
+		contexts = append(contexts, c)
+		requests = append(requests, c.Request)
+	}
+
+	// runs 3 parallel go routines with 5 requests per go routine
+	var wg sync.WaitGroup
+	concRuns, runs := 10, 300
+	for i := 0; i < concRuns; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < runs; j++ {
+				w := httptest.NewRecorder()
+				r := httptest.NewRequest(http.MethodGet, "/", nil)
+				p.handler(mockHandler).ServeHTTP(w, r)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// all contexts and requests should be stored in the slices
+	assert.Equal(t, runs*concRuns, len(requests))
+	assert.Equal(t, runs*concRuns, len(contexts))
+
+	// but only concRuns unique contexts should have been used,
+	// while all requests must be unique.
+	countUnique := func(s []interface{}) int {
+		l := make(map[interface{}]struct{})
+		for _, item := range s {
+			if _, set := l[item]; !set {
+				l[item] = struct{}{}
+			}
+		}
+		return len(l)
+	}
+	assert.Equal(t, runs*concRuns, countUnique(requests))
+	assert.True(t, countUnique(contexts) < runs*concRuns) // contexts get reused, but not deterministic how many exactly
+}

--- a/beater/intake_handler.go
+++ b/beater/intake_handler.go
@@ -119,12 +119,7 @@ func sendResponse(c *request.Context, sr *stream.Result) {
 
 	set := func(c int, i request.ResultID) {
 		if c > code {
-			if i == request.IDResponseErrorsMethodNotAllowed {
-				// TODO: remove exception and use StatusMethodNotAllowed (breaking bugfix)
-				code = http.StatusBadRequest
-			} else {
-				code = request.MapResultIDToStatus[i].Code
-			}
+			code = c
 			id = i
 		}
 	}
@@ -133,21 +128,23 @@ L:
 	for _, err := range sr.Errors {
 		switch err.Type {
 		case stream.MethodForbiddenErrType:
+			// TODO: remove exception case and use StatusMethodNotAllowed (breaking bugfix)
 			set(http.StatusBadRequest, request.IDResponseErrorsMethodNotAllowed)
 		case stream.InputTooLargeErrType:
+			// TODO: remove exception case and use StatusRequestEntityTooLarge (breaking bugfix)
 			set(http.StatusBadRequest, request.IDResponseErrorsRequestTooLarge)
 		case stream.InvalidInputErrType:
-			set(http.StatusBadRequest, request.IDResponseErrorsValidate)
+			set(request.MapResultIDToStatus[request.IDResponseErrorsValidate].Code, request.IDResponseErrorsValidate)
 		case stream.RateLimitErrType:
-			set(http.StatusTooManyRequests, request.IDResponseErrorsRateLimit)
+			set(request.MapResultIDToStatus[request.IDResponseErrorsRateLimit].Code, request.IDResponseErrorsRateLimit)
 		case stream.QueueFullErrType:
-			set(http.StatusServiceUnavailable, request.IDResponseErrorsFullQueue)
+			set(request.MapResultIDToStatus[request.IDResponseErrorsFullQueue].Code, request.IDResponseErrorsFullQueue)
 			break L
 		case stream.ShuttingDownErrType:
-			set(http.StatusServiceUnavailable, request.IDResponseErrorsShuttingDown)
+			set(request.MapResultIDToStatus[request.IDResponseErrorsShuttingDown].Code, request.IDResponseErrorsShuttingDown)
 			break L
 		default:
-			set(http.StatusInternalServerError, request.IDResponseErrorsInternal)
+			set(request.MapResultIDToStatus[request.IDResponseErrorsInternal].Code, request.IDResponseErrorsInternal)
 		}
 	}
 

--- a/beater/intake_handler.go
+++ b/beater/intake_handler.go
@@ -26,6 +26,8 @@ import (
 
 	"golang.org/x/time/rate"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/monitoring"
 
 	"github.com/elastic/apm-server/beater/headers"
@@ -47,75 +49,117 @@ var (
 	resultIDToCounter = map[request.ResultID]*monitoring.Int{}
 )
 
-func intakeResultIDToMonitoringInt(name request.ResultID) *monitoring.Int {
+// IntakeResultIDToMonitoringInt takes a request.ResultID and maps it to a monitoring counter. If the ID is UnsetID,
+// nil is returned.
+func IntakeResultIDToMonitoringInt(name request.ResultID) *monitoring.Int {
 	if i, ok := resultIDToCounter[name]; ok {
+		return i
+	}
+
+	//TODO: remove this to also count unset IDs as indicator that some ID has not been set
+	if name == request.IDUnset {
+		return nil
+	}
+
+	if i, ok := monitoring.Get(string(name)).(*monitoring.Int); ok {
+		mu.Lock()
+		defer mu.Unlock()
+		resultIDToCounter[name] = i
 		return i
 	}
 
 	mu.Lock()
 	defer mu.Unlock()
-	if i, ok := monitoring.Get(string(name)).(*monitoring.Int); ok {
-		resultIDToCounter[name] = i
-		return i
-	}
 	ct := counter(name)
 	resultIDToCounter[name] = ct
 	return ct
 }
 
-func statusCode(sr *stream.Result) (int, request.ResultID) {
-	var code int
-	var id request.ResultID
-	highestCode := http.StatusAccepted
-	monitoringID := request.IDResponseValidAccepted
-	for _, err := range sr.Errors {
-		switch err.Type {
-		case stream.MethodForbiddenErrType:
-			code = http.StatusBadRequest
-			id = request.IDResponseErrorsMethodNotAllowed
-		case stream.InputTooLargeErrType:
-			code = http.StatusBadRequest
-			id = request.IDResponseErrorsRequestTooLarge
-		case stream.InvalidInputErrType:
-			code = http.StatusBadRequest
-			id = request.IDResponseErrorsValidate
-		case stream.QueueFullErrType:
-			code = http.StatusServiceUnavailable
-			id = request.IDResponseErrorsFullQueue
-		case stream.ShuttingDownErrType:
-			code = http.StatusServiceUnavailable
-			id = request.IDResponseErrorsShuttingDown
-		case stream.RateLimitErrType:
-			code = http.StatusTooManyRequests
-			id = request.IDResponseErrorsRateLimit
-		default:
-			code = http.StatusInternalServerError
-			id = request.IDResponseErrorsInternal
+// IntakeHandler returns a request.Handler for managing intake requests for backend and rum events.
+func IntakeHandler(dec decoder.ReqDecoder, processor *stream.Processor, rlc *rlCache, report publish.Reporter) request.Handler {
+	return func(c *request.Context) {
+
+		serr := validateRequest(c.Request)
+		if serr != nil {
+			sendError(c, serr)
+			return
 		}
-		if code > highestCode {
-			highestCode = code
-			monitoringID = id
+
+		rl, serr := rateLimit(c.Request, rlc)
+		if serr != nil {
+			sendError(c, serr)
+			return
 		}
+
+		reader, serr := bodyReader(c.Request)
+		if serr != nil {
+			sendError(c, serr)
+			return
+		}
+
+		// extract metadata information from the request, like user-agent or remote address
+		reqMeta, err := dec(c.Request)
+		if err != nil {
+			sr := stream.Result{}
+			sr.Add(err)
+			sendResponse(c, &sr)
+			return
+		}
+		res := processor.HandleStream(c.Request.Context(), rl, reqMeta, reader, report)
+
+		sendResponse(c, res)
 	}
-	return highestCode, monitoringID
 }
 
 func sendResponse(c *request.Context, sr *stream.Result) {
-	statusCode, id := statusCode(sr)
-	c.MonitoringID = id
-	if statusCode == http.StatusAccepted {
-		if _, ok := c.Request.URL.Query()["verbose"]; ok {
-			c.Send(sr, statusCode)
-		} else {
-			c.WriteHeader(statusCode)
+	code := http.StatusAccepted
+	id := request.IDResponseValidAccepted
+	keyword := request.KeywordResponseValidAccepted
+	err := errors.New(sr.Error())
+	var body interface{}
+
+	set := func(c int, i request.ResultID, k string) {
+		if c > code {
+			code = c
+			id = i
+			keyword = k
 		}
-	} else {
+	}
+
+L:
+	for _, err := range sr.Errors {
+		switch err.Type {
+		case stream.MethodForbiddenErrType:
+			set(http.StatusBadRequest, request.IDResponseErrorsMethodNotAllowed, request.KeywordResponseErrorsMethodNotAllowed)
+		case stream.InputTooLargeErrType:
+			set(http.StatusBadRequest, request.IDResponseErrorsRequestTooLarge, request.KeywordResponseErrorsRequestTooLarge)
+		case stream.InvalidInputErrType:
+			set(http.StatusBadRequest, request.IDResponseErrorsValidate, request.KeywordResponseErrorsValidate)
+		case stream.RateLimitErrType:
+			set(http.StatusTooManyRequests, request.IDResponseErrorsRateLimit, request.KeywordResponseErrorsRateLimit)
+		case stream.QueueFullErrType:
+			set(http.StatusServiceUnavailable, request.IDResponseErrorsFullQueue, request.KeywordResponseErrorsFullQueue)
+			break L
+		case stream.ShuttingDownErrType:
+			set(http.StatusServiceUnavailable, request.IDResponseErrorsShuttingDown, request.KeywordResponseErrorsShuttingDown)
+			break L
+		default:
+			set(http.StatusInternalServerError, request.IDResponseErrorsInternal, request.KeywordResponseErrorsInternal)
+		}
+	}
+
+	if code >= http.StatusBadRequest {
 		// this signals to the client that we're closing the connection
 		// but also signals to http.Server that it should close it:
 		// https://golang.org/src/net/http/server.go#L1254
 		c.Header().Add(headers.Connection, "Close")
-		c.SendError(sr, sr.Error(), statusCode)
+		body = sr
+	} else if _, ok := c.Request.URL.Query()["verbose"]; ok {
+		body = sr
 	}
+
+	c.Result.Set(id, code, keyword, body, err)
+	c.Write()
 }
 
 func sendError(c *request.Context, err *stream.Error) {
@@ -163,38 +207,4 @@ func bodyReader(r *http.Request) (io.ReadCloser, *stream.Error) {
 		}
 	}
 	return reader, nil
-}
-
-func newIntakeHandler(dec decoder.ReqDecoder, processor *stream.Processor, rlc *rlCache, report publish.Reporter) request.Handler {
-	return func(c *request.Context) {
-		serr := validateRequest(c.Request)
-		if serr != nil {
-			sendError(c, serr)
-			return
-		}
-
-		rl, serr := rateLimit(c.Request, rlc)
-		if serr != nil {
-			sendError(c, serr)
-			return
-		}
-
-		reader, serr := bodyReader(c.Request)
-		if serr != nil {
-			sendError(c, serr)
-			return
-		}
-
-		// extract metadata information from the request, like user-agent or remote address
-		reqMeta, err := dec(c.Request)
-		if err != nil {
-			sr := stream.Result{}
-			sr.Add(err)
-			sendResponse(c, &sr)
-			return
-		}
-		res := processor.HandleStream(c.Request.Context(), rl, reqMeta, reader, report)
-
-		sendResponse(c, res)
-	}
 }

--- a/beater/intake_handler.go
+++ b/beater/intake_handler.go
@@ -119,7 +119,12 @@ func sendResponse(c *request.Context, sr *stream.Result) {
 
 	set := func(c int, i request.ResultID) {
 		if c > code {
-			code = request.MapResultIDToStatus[i].Code
+			if i == request.IDResponseErrorsMethodNotAllowed {
+				// TODO: remove exception and use StatusMethodNotAllowed (breaking bugfix)
+				code = http.StatusBadRequest
+			} else {
+				code = request.MapResultIDToStatus[i].Code
+			}
 			id = i
 		}
 	}

--- a/beater/intake_handler_test.go
+++ b/beater/intake_handler_test.go
@@ -295,7 +295,7 @@ func TestLineExceeded(t *testing.T) {
 		ctx := &request.Context{}
 		ctx.Reset(w, req)
 		WithMiddleware(handler, MonitoringHandler(monitoringFn))(ctx)
-		assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code, w.Body.String())
+		assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
 		assert.Equal(t, ct+1, requestTooLargeCounter.Get())
 		tests.AssertApproveResult(t, "test_approved_stream_result/TestLineExceeded", w.Body.Bytes())
 	})

--- a/beater/intake_handler_test.go
+++ b/beater/intake_handler_test.go
@@ -233,7 +233,7 @@ func TestWrongMethod(t *testing.T) {
 	ctx.Reset(w, req)
 	WithMiddleware(handler, MonitoringHandler(monitoringFn))(ctx)
 
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
 	assert.Equal(t, ct+1, methodNotAllowedCounter.Get())
 }
 
@@ -295,7 +295,7 @@ func TestLineExceeded(t *testing.T) {
 		ctx := &request.Context{}
 		ctx.Reset(w, req)
 		WithMiddleware(handler, MonitoringHandler(monitoringFn))(ctx)
-		assert.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+		assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code, w.Body.String())
 		assert.Equal(t, ct+1, requestTooLargeCounter.Get())
 		tests.AssertApproveResult(t, "test_approved_stream_result/TestLineExceeded", w.Body.Bytes())
 	})

--- a/beater/intake_handler_test.go
+++ b/beater/intake_handler_test.go
@@ -233,7 +233,7 @@ func TestWrongMethod(t *testing.T) {
 	ctx.Reset(w, req)
 	WithMiddleware(handler, MonitoringHandler(monitoringFn))(ctx)
 
-	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Equal(t, ct+1, methodNotAllowedCounter.Get())
 }
 

--- a/beater/log_handler.go
+++ b/beater/log_handler.go
@@ -51,6 +51,10 @@ func LogHandler() Middleware {
 			c.Logger = reqLogger
 			h(c)
 
+			if c.MultipleWriteAttempts() {
+				reqLogger.Warn("multiple write attempts")
+			}
+
 			keysAndValues := []interface{}{"response_code", c.Result.StatusCode}
 			if c.Result.Failure() {
 				if c.Result.Err != nil {

--- a/beater/onboarding_test.go
+++ b/beater/onboarding_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestNotifyUpServerDown(t *testing.T) {
-	config := defaultConfig("7.0.0")
+	config := DefaultConfig("7.0.0")
 	var saved beat.Event
 	var publisher = func(e beat.Event) { saved = e }
 

--- a/beater/panic_handler.go
+++ b/beater/panic_handler.go
@@ -42,17 +42,17 @@ func PanicHandler() Middleware {
 						recover()
 					}()
 
+					id := request.IDResponseErrorsInternal
+					status := request.MapResultIDToStatus[id]
+
 					// set the context's result and write response
 					var ok bool
 					var err error
 					if err, ok = r.(error); !ok {
-						err = errors.Wrap(err, request.MapResultIDToStatus[request.IDResponseErrorsInternal].Keyword)
+						err = errors.Wrap(err, status.Keyword)
 					}
-					c.Result.SetDefault(request.IDResponseErrorsInternal)
+					c.Result.Set(id, status.Code, status.Keyword, keywordPanic, err)
 					c.Result.Stacktrace = string(debug.Stack())
-					c.Result.Keyword = keywordPanic
-					c.Result.Body = keywordPanic
-					c.Result.Err = err
 
 					c.Write()
 				}

--- a/beater/panic_handler.go
+++ b/beater/panic_handler.go
@@ -46,7 +46,7 @@ func PanicHandler() Middleware {
 					var ok bool
 					var err error
 					if err, ok = r.(error); !ok {
-						err = errors.Wrap(err, request.KeywordResponseErrorsInternal)
+						err = errors.Wrap(err, request.MapResultIDToStatus[request.IDResponseErrorsInternal].Keyword)
 					}
 					c.Result.SetDefault(request.IDResponseErrorsInternal)
 					c.Result.Stacktrace = string(debug.Stack())

--- a/beater/request/context.go
+++ b/beater/request/context.go
@@ -66,6 +66,7 @@ func (c *Context) Header() http.Header {
 	return c.w.Header()
 }
 
+// MultipleWriteAttempts returns a boolean set to true if Write() was called multiple times.
 func (c *Context) MultipleWriteAttempts() bool {
 	return c.writeAttempts > 1
 }
@@ -73,9 +74,9 @@ func (c *Context) MultipleWriteAttempts() bool {
 // Write sets response headers, and writes the body to the response writer.
 // In case body is nil only the headers will be set.
 // In case statusCode indicates an error response, the body is also set as error in the context.
+// Only first call with write to http response.
 func (c *Context) Write() {
 	if c.MultipleWriteAttempts() {
-		c.Logger.Warn("Multiple write attempts.")
 		return
 	}
 	c.writeAttempts++

--- a/beater/request/context_test.go
+++ b/beater/request/context_test.go
@@ -71,6 +71,19 @@ func TestContext_Header(t *testing.T) {
 }
 
 func TestContext_Write(t *testing.T) {
+
+	t.Run("SecondWrite", func(t *testing.T) {
+		c, w := mockContextAccept("*/*")
+		c.Result = Result{Body: nil, StatusCode: http.StatusAccepted}
+		c.Write()
+		c.Result = Result{Body: nil, StatusCode: http.StatusBadRequest}
+		c.Write()
+
+		testHeaderXContentTypeOptions(t, c)
+		assert.Equal(t, http.StatusAccepted, w.Code)
+		assert.Empty(t, w.Body.String())
+	})
+
 	t.Run("EmptyBody", func(t *testing.T) {
 		c, w := mockContextAccept("*/*")
 		c.Result = Result{Body: nil, StatusCode: http.StatusAccepted}

--- a/beater/request/context_test.go
+++ b/beater/request/context_test.go
@@ -1,0 +1,189 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package request
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/logp"
+
+	"github.com/elastic/apm-server/beater/headers"
+)
+
+func TestContext_Reset(t *testing.T) {
+	w1 := httptest.NewRecorder()
+	w1.WriteHeader(http.StatusServiceUnavailable)
+	w2 := httptest.NewRecorder()
+	r1 := httptest.NewRequest(http.MethodGet, "/", nil)
+	r2 := httptest.NewRequest(http.MethodHead, "/new", nil)
+
+	c := Context{
+		Request: r1, w: w1,
+		Logger: logp.NewLogger(""),
+		Result: Result{
+			StatusCode: http.StatusServiceUnavailable,
+			Err:        errors.New("foo"),
+			Stacktrace: "bar",
+		},
+	}
+	c.Reset(w2, r2)
+
+	assert.Equal(t, http.MethodHead, c.Request.Method)
+	assert.Empty(t, c.Logger)
+	assert.False(t, c.TokenSet)
+	assert.False(t, c.Authorized)
+
+	assert.Equal(t, w2, c.w)
+
+	assert.Equal(t, http.StatusOK, c.Result.StatusCode)
+	assert.Empty(t, c.Result.Err)
+	assert.Empty(t, c.Result.Stacktrace)
+}
+
+func TestContext_Header(t *testing.T) {
+	w := httptest.NewRecorder()
+	w.Header().Set(headers.Etag, "abcd")
+	w.Header().Set(headers.Bearer, "foo")
+	c := Context{w: w}
+
+	h := http.Header{headers.Etag: []string{"abcd"}, headers.Bearer: []string{"foo"}}
+	assert.Equal(t, h, c.Header())
+}
+
+func TestContext_Write(t *testing.T) {
+	t.Run("EmptyBody", func(t *testing.T) {
+		c, w := mockContextAccept("*/*")
+		c.Result = Result{Body: nil, StatusCode: http.StatusAccepted}
+		c.Write()
+
+		testHeaderXContentTypeOptions(t, c)
+		assert.Equal(t, http.StatusAccepted, w.Code)
+		assert.Empty(t, w.Body.String())
+	})
+
+	t.Run("WrapStringBodyInMap", func(t *testing.T) {
+		c, w := mockContextAccept("")
+		body := "bar"
+		c.Result = Result{StatusCode: http.StatusBadRequest, Body: body}
+		c.Write()
+
+		testHeader(t, c, "text/plain; charset=utf-8")
+		assert.Equal(t, `{"error":"bar"}`+"\n", w.Body.String())
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("DoNotWrapStringBody", func(t *testing.T) {
+		c, w := mockContextAccept("text/html")
+		body := "bar"
+		c.Result = Result{StatusCode: http.StatusOK, Body: body}
+		c.Write()
+
+		testHeader(t, c, "text/plain; charset=utf-8")
+		assert.Equal(t, `bar`+"\n", w.Body.String())
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("DoNotWrapOtherBodyInMap", func(t *testing.T) {
+		c, w := mockContextAccept("application/text")
+		body := map[string]interface{}{"xyz": "bar"}
+		c.Result = Result{StatusCode: http.StatusBadRequest, Body: body}
+		c.Write()
+
+		testHeader(t, c, "text/plain; charset=utf-8")
+		assert.Equal(t, `{"xyz":"bar"}`+"\n", w.Body.String())
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Accept", func(t *testing.T) {
+		for name, tc := range map[string]struct {
+			acceptHeader                 string
+			body                         interface{}
+			expectedHeader, expectedBody string
+		}{
+			"application/json": {
+				acceptHeader:   "application/json",
+				body:           map[string]interface{}{"xyz": "bar"},
+				expectedHeader: "application/json",
+				expectedBody: `{
+  "xyz": "bar"
+}
+`,
+			},
+			"*/*": {
+				acceptHeader:   "*/*",
+				body:           map[string]interface{}{"xyz": "bar"},
+				expectedHeader: "application/json",
+				expectedBody: `{
+  "xyz": "bar"
+}
+`,
+			},
+			"jsonBody": {
+				acceptHeader:   "application/text",
+				body:           map[string]interface{}{"xyz": "bar"},
+				expectedHeader: "text/plain; charset=utf-8",
+				expectedBody:   `{"xyz":"bar"}` + "\n",
+			},
+			"application/text": {
+				acceptHeader:   "application/text",
+				body:           "foo",
+				expectedHeader: "text/plain; charset=utf-8",
+				expectedBody:   `foo` + "\n",
+			},
+			"empty": {
+				acceptHeader:   "",
+				body:           "foo",
+				expectedHeader: "text/plain; charset=utf-8",
+				expectedBody:   `foo` + "\n",
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				c, w := mockContextAccept(tc.acceptHeader)
+				c.Result = Result{StatusCode: http.StatusNotModified, Body: tc.body}
+				c.Write()
+
+				testHeader(t, c, tc.expectedHeader)
+				assert.Equal(t, tc.expectedBody, w.Body.String())
+				assert.Equal(t, http.StatusNotModified, w.Code)
+			})
+		}
+	})
+}
+
+func testHeaderXContentTypeOptions(t *testing.T, c *Context) {
+	assert.Equal(t, "nosniff", c.w.Header().Get(headers.XContentTypeOptions))
+}
+
+func testHeader(t *testing.T, c *Context, expected string) {
+	assert.Equal(t, expected, c.w.Header().Get(headers.ContentType))
+	testHeaderXContentTypeOptions(t, c)
+}
+
+func mockContextAccept(accept string) (*Context, *httptest.ResponseRecorder) {
+	c := &Context{}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodHead, "/", nil)
+	r.Header.Set(headers.Accept, accept)
+	c.Reset(w, r)
+	return c, w
+}

--- a/beater/request/result.go
+++ b/beater/request/result.go
@@ -23,128 +23,88 @@ import (
 	"github.com/pkg/errors"
 )
 
-//Ids can be used for monitoring counters
 const (
 
-	//IDRequestCount identifies all requests
-	IDRequestCount ResultID = "request.count"
-	//IDResponseCount identifies all responses
-	IDResponseCount ResultID = "response.count"
-	//IDResponseErrorsCount identifies all non successful responses
-	IDResponseErrorsCount ResultID = "response.errors.count"
-	//IDResponseValidCount identifies all successful responses
-	IDResponseValidCount ResultID = "response.valid.count"
+	// IDUnset identifies requests not covered by other IDs
+	IDUnset ResultID = "unset"
 
-	//IDResponseValidOK identifies responses with status code 200
+	// IDRequestCount identifies all requests
+	IDRequestCount ResultID = "request.count"
+	// IDResponseCount identifies all responses
+	IDResponseCount ResultID = "response.count"
+	// IDResponseErrorsCount identifies all non successful responses
+	IDResponseErrorsCount ResultID = "response.errors.count"
+	// IDResponseValidCount identifies all successful responses
+	IDResponseValidCount ResultID = "response.valid.count"
+	// IDResponseValidNotModified identifies all successful responses without a modified body
+	IDResponseValidNotModified ResultID = "response.valid.notmodified"
+
+	// IDResponseValidOK identifies responses with status code 200
 	IDResponseValidOK ResultID = "response.valid.ok"
-	//IDResponseValidAccepted identifies responses with status code 202
+	// IDResponseValidAccepted identifies responses with status code 202
 	IDResponseValidAccepted ResultID = "response.valid.accepted"
 
-	//IDResponseErrorsForbidden identifies responses for forbidden requests
+	// IDResponseErrorsForbidden identifies responses for forbidden requests
 	IDResponseErrorsForbidden ResultID = "response.errors.forbidden"
-	//IDResponseErrorsUnauthorized identifies responses for unauthorized requests
+	// IDResponseErrorsUnauthorized identifies responses for unauthorized requests
 	IDResponseErrorsUnauthorized ResultID = "response.errors.unauthorized"
-	//IDResponseErrorsRequestTooLarge identifies responses for too large requests
+	// IDResponseErrorsNotFound identifies responses where route was not found
+	IDResponseErrorsNotFound ResultID = "response.errors.notfound"
+	// IDResponseErrorsInvalidQuery identifies responses with invalid query sent
+	IDResponseErrorsInvalidQuery ResultID = "response.errors.invalidquery"
+	// IDResponseErrorsRequestTooLarge identifies responses for too large requests
 	IDResponseErrorsRequestTooLarge ResultID = "response.errors.toolarge"
-	//IDResponseErrorsDecode identifies responses for requests that could not be decoded
+	// IDResponseErrorsDecode identifies responses for requests that could not be decoded
 	IDResponseErrorsDecode ResultID = "response.errors.decode"
-	//IDResponseErrorsValidate identifies responses for invalid requests
+	// IDResponseErrorsValidate identifies responses for invalid requests
 	IDResponseErrorsValidate ResultID = "response.errors.validate"
-	//IDResponseErrorsRateLimit identifies responses for rate limited requests
+	// IDResponseErrorsRateLimit identifies responses for rate limited requests
 	IDResponseErrorsRateLimit ResultID = "response.errors.ratelimit"
-	//IDResponseErrorsMethodNotAllowed identifies responses for requests using a forbidden method
+	// IDResponseErrorsMethodNotAllowed identifies responses for requests using a forbidden method
 	IDResponseErrorsMethodNotAllowed ResultID = "response.errors.method"
-	//IDResponseErrorsFullQueue identifies responses when internal queue was full
+	// IDResponseErrorsFullQueue identifies responses when internal queue was full
 	IDResponseErrorsFullQueue ResultID = "response.errors.queue"
-	//IDResponseErrorsShuttingDown identifies responses requests occuring after channel was closed
+	// IDResponseErrorsShuttingDown identifies responses requests occuring after channel was closed
 	IDResponseErrorsShuttingDown ResultID = "response.errors.closed"
-	//IDResponseErrorsInternal identifies responses where internal errors occured
+	// IDResponseErrorsServiceUnavailable identifies responses where service was unavailable
+	IDResponseErrorsServiceUnavailable ResultID = "response.errors.unavailable"
+	// IDResponseErrorsInternal identifies responses where internal errors occured
 	IDResponseErrorsInternal ResultID = "response.errors.internal"
-)
+	// IDResponseErrorsServiceUnavailable identifies responses where resource is unavailable
 
-var (
-	//OKResponse represents status 200
-	OKResponse = Result{
-		StatusCode: http.StatusOK,
-		ID:         IDResponseValidOK,
-	}
-	//AcceptedResponse represents status 200
-	AcceptedResponse = Result{
-		StatusCode: http.StatusAccepted,
-		ID:         IDResponseValidAccepted,
-	}
-	//InternalErrorResponse represents status 500
-	InternalErrorResponse = func(err error) Result {
-		return Result{
-			Err:        errors.Wrap(err, "internal error"),
-			StatusCode: http.StatusInternalServerError,
-			ID:         IDResponseErrorsInternal,
-		}
-	}
-	//ForbiddenResponse represents status 403
-	ForbiddenResponse = func(err error) Result {
-		return Result{
-			Err:        errors.Wrap(err, "forbidden request"),
-			StatusCode: http.StatusForbidden,
-			ID:         IDResponseErrorsForbidden,
-		}
-	}
-	//UnauthorizedResponse represents status 401
-	UnauthorizedResponse = Result{
-		Err:        errors.New("invalid token"),
-		StatusCode: http.StatusUnauthorized,
-		ID:         IDResponseErrorsUnauthorized,
-	}
-	//RequestTooLargeResponse represents status 413
-	RequestTooLargeResponse = Result{
-		Err:        errors.New("request body too large"),
-		StatusCode: http.StatusRequestEntityTooLarge,
-		ID:         IDResponseErrorsRequestTooLarge,
-	}
-	//CannotDecodeResponse represents status 400 because of decoding errors
-	CannotDecodeResponse = func(err error) Result {
-		return Result{
-			Err:        errors.Wrap(err, "data decoding error"),
-			StatusCode: http.StatusBadRequest,
-			ID:         IDResponseErrorsDecode,
-		}
-	}
-	//CannotValidateResponse represents status 400 because of validation errors
-	CannotValidateResponse = func(err error) Result {
-		return Result{
-			Err:        errors.Wrap(err, "data validation error"),
-			StatusCode: http.StatusBadRequest,
-			ID:         IDResponseErrorsValidate,
-		}
-	}
-	//RateLimitedResponse represents status 429
-	RateLimitedResponse = Result{
-		Err:        errors.New("too many requests"),
-		StatusCode: http.StatusTooManyRequests,
-		ID:         IDResponseErrorsRateLimit,
-	}
-	//MethodNotAllowedResponse represents status 405
-	MethodNotAllowedResponse = Result{
-		Err:        errors.New("only POST requests are supported"),
-		StatusCode: http.StatusMethodNotAllowed,
-		ID:         IDResponseErrorsMethodNotAllowed,
-	}
-	//FullQueueResponse represents status 503 because internal memory queue is full
-	FullQueueResponse = func(err error) Result {
-		return Result{
-			Err:        errors.Wrap(err, "queue is full"),
-			StatusCode: http.StatusServiceUnavailable,
-			ID:         IDResponseErrorsFullQueue,
-		}
-	}
-	//ServerShuttingDownResponse represents status 503 because server is shutting down
-	ServerShuttingDownResponse = func(err error) Result {
-		return Result{
-			Err:        errors.New("server is shutting down"),
-			StatusCode: http.StatusServiceUnavailable,
-			ID:         IDResponseErrorsShuttingDown,
-		}
-	}
+	// KeywordResponseValidOK represents keyword for valid request
+	KeywordResponseValidOK = "request ok"
+	// KeywordResponseValidAccepted represents keyword for accepted request
+	KeywordResponseValidAccepted = "request accepted"
+	// KeywordResponseNotModified represents keyword for unmodified resource
+	KeywordResponseNotModified = "not modified"
+
+	// KeywordResponseErrorsForbidden represents keyword for forbidden request
+	KeywordResponseErrorsForbidden = "forbidden request"
+	// KeywordResponseErrorsUnauthorized represents keyword for request with invalid security token
+	KeywordResponseErrorsUnauthorized = "invalid token"
+	// KeywordResponseErrorsNotFound represents keyword for resource not found
+	KeywordResponseErrorsNotFound = "404 page not found"
+	// KeywordResponseErrorsInvalidQuery represents keyword for invalid query
+	KeywordResponseErrorsInvalidQuery = "invalid query"
+	// KeywordResponseErrorsRequestTooLarge represents keyword for body too large
+	KeywordResponseErrorsRequestTooLarge = "request body too large"
+	// KeywordResponseErrorsDecode represents keyword for error while decoding request body
+	KeywordResponseErrorsDecode = "data decoding error"
+	// KeywordResponseErrorsValidate represents keyword for error while validating request body
+	KeywordResponseErrorsValidate = "data validation error"
+	// KeywordResponseErrorsRateLimit represents keyword for rate limit hit
+	KeywordResponseErrorsRateLimit = "too many requests"
+	// KeywordResponseErrorsMethodNotAllowed represents keyword for method not allowed
+	KeywordResponseErrorsMethodNotAllowed = "only POST requests are supported"
+	// KeywordResponseErrorsFullQueue represents keyword for internal memory queue full
+	KeywordResponseErrorsFullQueue = "queue is full"
+	// KeywordResponseErrorsShuttingDown represents keyword for server shutting down
+	KeywordResponseErrorsShuttingDown = "server is shutting down"
+	// KeywordResponseErrorsServiceUnavailable represents keyword for service unavailable
+	KeywordResponseErrorsServiceUnavailable = "service unavailable"
+	// KeywordResponseErrorsInternal represents keyword for internal error
+	KeywordResponseErrorsInternal = "internal error"
 )
 
 //ResultID unique string identifying a requests Result
@@ -160,20 +120,128 @@ type Result struct {
 	Stacktrace string
 }
 
-//SendStatus initiates response writing for a given context
-//TODO: move to Context when reworking response handling.
-func SendStatus(c *Context, res Result) {
-	if res.Err != nil {
-		body := map[string]interface{}{"error": res.Err.Error()}
-		//TODO: refactor response handling: get rid of additional `error` and just pass in error
-		c.SendError(body, body, res.StatusCode)
-		return
+// Reset sets result to it's empty values
+func (r *Result) Reset() {
+	r.ID = IDUnset
+	r.StatusCode = http.StatusOK
+	r.Keyword = ""
+	r.Body = nil
+	r.Err = nil
+	r.Stacktrace = ""
+}
 
-	}
-	if res.Body == nil {
-		c.WriteHeader(res.StatusCode)
+// SetDefault derives information about the result solely from the ID.
+func (r *Result) SetDefault(id ResultID) {
+	r.set(id, nil, nil)
+}
+
+// SetWithError derives information about the result from the given ID and the error.
+// The body is derived from the error in case the result describes a failure.
+func (r *Result) SetWithError(id ResultID, err error) {
+	r.set(id, nil, err)
+}
+
+// SetWithBody derives information about the result from the given ID. The body is set to the passed value.
+func (r *Result) SetWithBody(id ResultID, body interface{}) {
+	r.set(id, body, nil)
+}
+
+// Set allows for the most flexibility in setting a result's properties.
+// The error and body information are derived from the given parameters.
+func (r *Result) Set(id ResultID, statusCode int, keyword string, body interface{}, err error) {
+	if r == nil {
 		return
 	}
+	r.ID = id
+	r.StatusCode = statusCode
+	r.Keyword = keyword
+	r.Body = body
+	r.Err = err
 
-	c.Send(res.Body, res.StatusCode)
+	if r.Failure() {
+		if err == nil {
+			r.Err = errors.New(keyword)
+		}
+		if r.Body == nil {
+			r.Body = r.Err.Error()
+		}
+	}
+}
+
+// Failure returns a bool indicating whether it is describing a successful result or not
+func (r *Result) Failure() bool {
+	return r.StatusCode >= http.StatusBadRequest
+}
+
+func (r *Result) set(id ResultID, body interface{}, err error) {
+	if r == nil {
+		return
+	}
+	statusCode := http.StatusInternalServerError
+	keyword := KeywordResponseErrorsInternal
+
+	switch id {
+	case IDResponseValidOK:
+		statusCode = http.StatusOK
+		keyword = KeywordResponseValidOK
+
+	case IDResponseValidAccepted:
+		statusCode = http.StatusAccepted
+		keyword = KeywordResponseValidAccepted
+
+	case IDResponseValidNotModified:
+		statusCode = http.StatusNotModified
+		keyword = KeywordResponseNotModified
+
+	case IDResponseErrorsForbidden:
+		statusCode = http.StatusForbidden
+		keyword = KeywordResponseErrorsForbidden
+
+	case IDResponseErrorsUnauthorized:
+		statusCode = http.StatusUnauthorized
+		keyword = KeywordResponseErrorsUnauthorized
+
+	case IDResponseErrorsNotFound:
+		statusCode = http.StatusNotFound
+		keyword = KeywordResponseErrorsNotFound
+
+	case IDResponseErrorsInvalidQuery:
+		statusCode = http.StatusBadRequest
+		keyword = KeywordResponseErrorsInvalidQuery
+
+	case IDResponseErrorsRequestTooLarge:
+		statusCode = http.StatusRequestEntityTooLarge
+		keyword = KeywordResponseErrorsRequestTooLarge
+
+	case IDResponseErrorsDecode:
+		statusCode = http.StatusBadRequest
+		keyword = KeywordResponseErrorsDecode
+
+	case IDResponseErrorsValidate:
+		statusCode = http.StatusBadRequest
+		keyword = KeywordResponseErrorsValidate
+
+	case IDResponseErrorsRateLimit:
+		statusCode = http.StatusTooManyRequests
+		keyword = KeywordResponseErrorsRateLimit
+
+	case IDResponseErrorsMethodNotAllowed:
+		statusCode = http.StatusMethodNotAllowed
+		keyword = KeywordResponseErrorsMethodNotAllowed
+
+	case IDResponseErrorsFullQueue:
+		statusCode = http.StatusServiceUnavailable
+		keyword = KeywordResponseErrorsFullQueue
+
+	case IDResponseErrorsShuttingDown:
+		statusCode = http.StatusServiceUnavailable
+		keyword = KeywordResponseErrorsShuttingDown
+
+	case IDResponseErrorsServiceUnavailable:
+		statusCode = http.StatusServiceUnavailable
+		keyword = KeywordResponseErrorsServiceUnavailable
+	}
+	err = errors.Wrap(err, keyword)
+	r.Set(id, statusCode, keyword, body, err)
+
 }

--- a/beater/request/result.go
+++ b/beater/request/result.go
@@ -36,9 +36,9 @@ const (
 	IDResponseErrorsCount ResultID = "response.errors.count"
 	// IDResponseValidCount identifies all successful responses
 	IDResponseValidCount ResultID = "response.valid.count"
+
 	// IDResponseValidNotModified identifies all successful responses without a modified body
 	IDResponseValidNotModified ResultID = "response.valid.notmodified"
-
 	// IDResponseValidOK identifies responses with status code 200
 	IDResponseValidOK ResultID = "response.valid.ok"
 	// IDResponseValidAccepted identifies responses with status code 202
@@ -71,46 +71,41 @@ const (
 	// IDResponseErrorsInternal identifies responses where internal errors occured
 	IDResponseErrorsInternal ResultID = "response.errors.internal"
 	// IDResponseErrorsServiceUnavailable identifies responses where resource is unavailable
-
-	// KeywordResponseValidOK represents keyword for valid request
-	KeywordResponseValidOK = "request ok"
-	// KeywordResponseValidAccepted represents keyword for accepted request
-	KeywordResponseValidAccepted = "request accepted"
-	// KeywordResponseNotModified represents keyword for unmodified resource
-	KeywordResponseNotModified = "not modified"
-
-	// KeywordResponseErrorsForbidden represents keyword for forbidden request
-	KeywordResponseErrorsForbidden = "forbidden request"
-	// KeywordResponseErrorsUnauthorized represents keyword for request with invalid security token
-	KeywordResponseErrorsUnauthorized = "invalid token"
-	// KeywordResponseErrorsNotFound represents keyword for resource not found
-	KeywordResponseErrorsNotFound = "404 page not found"
-	// KeywordResponseErrorsInvalidQuery represents keyword for invalid query
-	KeywordResponseErrorsInvalidQuery = "invalid query"
-	// KeywordResponseErrorsRequestTooLarge represents keyword for body too large
-	KeywordResponseErrorsRequestTooLarge = "request body too large"
-	// KeywordResponseErrorsDecode represents keyword for error while decoding request body
-	KeywordResponseErrorsDecode = "data decoding error"
-	// KeywordResponseErrorsValidate represents keyword for error while validating request body
-	KeywordResponseErrorsValidate = "data validation error"
-	// KeywordResponseErrorsRateLimit represents keyword for rate limit hit
-	KeywordResponseErrorsRateLimit = "too many requests"
-	// KeywordResponseErrorsMethodNotAllowed represents keyword for method not allowed
-	KeywordResponseErrorsMethodNotAllowed = "only POST requests are supported"
-	// KeywordResponseErrorsFullQueue represents keyword for internal memory queue full
-	KeywordResponseErrorsFullQueue = "queue is full"
-	// KeywordResponseErrorsShuttingDown represents keyword for server shutting down
-	KeywordResponseErrorsShuttingDown = "server is shutting down"
-	// KeywordResponseErrorsServiceUnavailable represents keyword for service unavailable
-	KeywordResponseErrorsServiceUnavailable = "service unavailable"
-	// KeywordResponseErrorsInternal represents keyword for internal error
-	KeywordResponseErrorsInternal = "internal error"
 )
 
-//ResultID unique string identifying a requests Result
+var (
+	// MapResultIDToStatus takes a ResultID and maps it to a status
+	MapResultIDToStatus = map[ResultID]Status{
+		IDUnset:                            {Code: 0, Keyword: ""},
+		IDResponseValidOK:                  {Code: http.StatusOK, Keyword: "request ok"},
+		IDResponseValidAccepted:            {Code: http.StatusAccepted, Keyword: "request accepted"},
+		IDResponseValidNotModified:         {Code: http.StatusNotModified, Keyword: "not modified"},
+		IDResponseErrorsForbidden:          {Code: http.StatusForbidden, Keyword: "forbidden request"},
+		IDResponseErrorsUnauthorized:       {Code: http.StatusUnauthorized, Keyword: "invalid token"},
+		IDResponseErrorsNotFound:           {Code: http.StatusNotFound, Keyword: "404 page not found"},
+		IDResponseErrorsRequestTooLarge:    {Code: http.StatusRequestEntityTooLarge, Keyword: "request body too large"},
+		IDResponseErrorsInvalidQuery:       {Code: http.StatusBadRequest, Keyword: "invalid query"},
+		IDResponseErrorsDecode:             {Code: http.StatusBadRequest, Keyword: "data decoding error"},
+		IDResponseErrorsValidate:           {Code: http.StatusBadRequest, Keyword: "data validation error"},
+		IDResponseErrorsMethodNotAllowed:   {Code: http.StatusMethodNotAllowed, Keyword: "only POST requests are supported"},
+		IDResponseErrorsRateLimit:          {Code: http.StatusTooManyRequests, Keyword: "too many requests"},
+		IDResponseErrorsFullQueue:          {Code: http.StatusServiceUnavailable, Keyword: "queue is full"},
+		IDResponseErrorsShuttingDown:       {Code: http.StatusServiceUnavailable, Keyword: "server is shutting down"},
+		IDResponseErrorsServiceUnavailable: {Code: http.StatusServiceUnavailable, Keyword: "service unavailable"},
+		IDResponseErrorsInternal:           {Code: http.StatusInternalServerError, Keyword: "internal error"},
+	}
+)
+
+// ResultID unique string identifying a requests Result
 type ResultID string
 
-//Result holds information about a processed request
+// Status holds statuscode and keyword information
+type Status struct {
+	Code    int
+	Keyword string
+}
+
+// Result holds information about a processed request
 type Result struct {
 	ID         ResultID
 	StatusCode int
@@ -177,71 +172,17 @@ func (r *Result) set(id ResultID, body interface{}, err error) {
 	if r == nil {
 		return
 	}
-	statusCode := http.StatusInternalServerError
-	keyword := KeywordResponseErrorsInternal
 
-	switch id {
-	case IDResponseValidOK:
-		statusCode = http.StatusOK
-		keyword = KeywordResponseValidOK
+	var statusCode int
+	var keyword string
+	if status, ok := MapResultIDToStatus[id]; ok {
+		statusCode = status.Code
+		keyword = status.Keyword
+	} else {
 
-	case IDResponseValidAccepted:
-		statusCode = http.StatusAccepted
-		keyword = KeywordResponseValidAccepted
-
-	case IDResponseValidNotModified:
-		statusCode = http.StatusNotModified
-		keyword = KeywordResponseNotModified
-
-	case IDResponseErrorsForbidden:
-		statusCode = http.StatusForbidden
-		keyword = KeywordResponseErrorsForbidden
-
-	case IDResponseErrorsUnauthorized:
-		statusCode = http.StatusUnauthorized
-		keyword = KeywordResponseErrorsUnauthorized
-
-	case IDResponseErrorsNotFound:
-		statusCode = http.StatusNotFound
-		keyword = KeywordResponseErrorsNotFound
-
-	case IDResponseErrorsInvalidQuery:
-		statusCode = http.StatusBadRequest
-		keyword = KeywordResponseErrorsInvalidQuery
-
-	case IDResponseErrorsRequestTooLarge:
-		statusCode = http.StatusRequestEntityTooLarge
-		keyword = KeywordResponseErrorsRequestTooLarge
-
-	case IDResponseErrorsDecode:
-		statusCode = http.StatusBadRequest
-		keyword = KeywordResponseErrorsDecode
-
-	case IDResponseErrorsValidate:
-		statusCode = http.StatusBadRequest
-		keyword = KeywordResponseErrorsValidate
-
-	case IDResponseErrorsRateLimit:
-		statusCode = http.StatusTooManyRequests
-		keyword = KeywordResponseErrorsRateLimit
-
-	case IDResponseErrorsMethodNotAllowed:
-		statusCode = http.StatusMethodNotAllowed
-		keyword = KeywordResponseErrorsMethodNotAllowed
-
-	case IDResponseErrorsFullQueue:
-		statusCode = http.StatusServiceUnavailable
-		keyword = KeywordResponseErrorsFullQueue
-
-	case IDResponseErrorsShuttingDown:
-		statusCode = http.StatusServiceUnavailable
-		keyword = KeywordResponseErrorsShuttingDown
-
-	case IDResponseErrorsServiceUnavailable:
-		statusCode = http.StatusServiceUnavailable
-		keyword = KeywordResponseErrorsServiceUnavailable
+		statusCode = MapResultIDToStatus[IDResponseErrorsInternal].Code
+		keyword = MapResultIDToStatus[IDResponseErrorsInternal].Keyword
 	}
 	err = errors.Wrap(err, keyword)
 	r.Set(id, statusCode, keyword, body, err)
-
 }

--- a/beater/request/result_test.go
+++ b/beater/request/result_test.go
@@ -1,0 +1,86 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package request
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pkg/errors"
+)
+
+func TestResult_Reset(t *testing.T) {
+	r := Result{
+		ID:         IDResponseErrorsInternal,
+		StatusCode: http.StatusServiceUnavailable,
+		Keyword:    "some keyword",
+		Body:       []interface{}{1, "foo"},
+		Err:        errors.New("foo"),
+		Stacktrace: "bar",
+	}
+	r.Reset()
+	assert.Equal(t, r.ID, IDUnset)
+	assert.Equal(t, http.StatusOK, r.StatusCode)
+	for _, prop := range []interface{}{r.Keyword, r.Body, r.Err, r.Stacktrace} {
+		assert.Empty(t, prop)
+	}
+}
+
+func TestResult_Set(t *testing.T) {
+	t.Run("StatusOK", func(t *testing.T) {
+		id, statusCode, keyword := IDRequestCount, http.StatusMultipleChoices, "multiple"
+		body, err, stacktrace := "foo", errors.New("bar"), "x: bar"
+		r := Result{Stacktrace: stacktrace}
+		r.Set(id, statusCode, keyword, body, err)
+		assert.Equal(t, id, r.ID)
+		assert.Equal(t, statusCode, r.StatusCode)
+		assert.Equal(t, keyword, r.Keyword)
+		assert.Equal(t, body, r.Body)
+		assert.Equal(t, err, r.Err)
+		assert.Equal(t, stacktrace, r.Stacktrace)
+	})
+
+	t.Run("SetErrToKeyword", func(t *testing.T) {
+		r := Result{}
+		r.Set(IDUnset, http.StatusBadRequest, KeywordResponseErrorsValidate, "foo", nil)
+		assert.Equal(t, KeywordResponseErrorsValidate, r.Err.Error())
+		assert.Equal(t, "foo", r.Body)
+	})
+	t.Run("SetBodyToKeyword", func(t *testing.T) {
+		r := Result{}
+		r.Set(IDUnset, http.StatusServiceUnavailable, KeywordResponseErrorsFullQueue, nil, nil)
+		assert.Equal(t, KeywordResponseErrorsFullQueue, r.Err.Error())
+		assert.Equal(t, string(KeywordResponseErrorsFullQueue), r.Body)
+	})
+	t.Run("SetBodyToErr", func(t *testing.T) {
+		err := errors.New("xyz")
+		r := Result{}
+		r.Set(IDUnset, http.StatusBadRequest, KeywordResponseErrorsDecode, nil, err)
+		assert.Equal(t, err, r.Err)
+		assert.Equal(t, err.Error(), r.Body)
+	})
+}
+
+func TestResult_Failure(t *testing.T) {
+	assert.False(t, (&Result{StatusCode: http.StatusOK}).Failure())
+	assert.False(t, (&Result{StatusCode: http.StatusPermanentRedirect}).Failure())
+	assert.True(t, (&Result{StatusCode: http.StatusBadRequest}).Failure())
+	assert.True(t, (&Result{StatusCode: http.StatusServiceUnavailable}).Failure())
+}

--- a/beater/request/result_test.go
+++ b/beater/request/result_test.go
@@ -59,20 +59,21 @@ func TestResult_Set(t *testing.T) {
 
 	t.Run("SetErrToKeyword", func(t *testing.T) {
 		r := Result{}
-		r.Set(IDUnset, http.StatusBadRequest, KeywordResponseErrorsValidate, "foo", nil)
-		assert.Equal(t, KeywordResponseErrorsValidate, r.Err.Error())
+		r.Set(IDUnset, http.StatusBadRequest, MapResultIDToStatus[IDResponseErrorsValidate].Keyword, "foo", nil)
+		assert.Equal(t, MapResultIDToStatus[IDResponseErrorsValidate].Keyword, r.Err.Error())
 		assert.Equal(t, "foo", r.Body)
 	})
 	t.Run("SetBodyToKeyword", func(t *testing.T) {
 		r := Result{}
-		r.Set(IDUnset, http.StatusServiceUnavailable, KeywordResponseErrorsFullQueue, nil, nil)
-		assert.Equal(t, KeywordResponseErrorsFullQueue, r.Err.Error())
-		assert.Equal(t, string(KeywordResponseErrorsFullQueue), r.Body)
+		fullQueue := MapResultIDToStatus[IDResponseErrorsFullQueue].Keyword
+		r.Set(IDUnset, http.StatusServiceUnavailable, fullQueue, nil, nil)
+		assert.Equal(t, fullQueue, r.Err.Error())
+		assert.Equal(t, string(fullQueue), r.Body)
 	})
 	t.Run("SetBodyToErr", func(t *testing.T) {
 		err := errors.New("xyz")
 		r := Result{}
-		r.Set(IDUnset, http.StatusBadRequest, KeywordResponseErrorsDecode, nil, err)
+		r.Set(IDUnset, http.StatusBadRequest, MapResultIDToStatus[IDResponseErrorsDecode].Keyword, nil, err)
 		assert.Equal(t, err, r.Err)
 		assert.Equal(t, err.Error(), r.Body)
 	})

--- a/beater/root_handler_test.go
+++ b/beater/root_handler_test.go
@@ -1,0 +1,68 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/elastic/beats/libbeat/version"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-server/beater/beatertest"
+)
+
+//TODO: check if it is breaking to return 404 body not always in plain text
+func TestRootHandler(t *testing.T) {
+	t.Run("404", func(t *testing.T) {
+		c, w := beatertest.ContextWithResponseRecorder(http.MethodGet, "/abc/xyz")
+		RootHandler()(c)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		assert.Equal(t, `{"error":"404 page not found"}`+"\n", w.Body.String())
+	})
+
+	t.Run("ok", func(t *testing.T) {
+		c, w := beatertest.ContextWithResponseRecorder(http.MethodGet, "/")
+		RootHandler()(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "", w.Body.String())
+	})
+
+	t.Run("unauthorized", func(t *testing.T) {
+		c, w := beatertest.ContextWithResponseRecorder(http.MethodGet, "/")
+		RootHandler()(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "", w.Body.String())
+	})
+
+	t.Run("authorized", func(t *testing.T) {
+		c, w := beatertest.ContextWithResponseRecorder(http.MethodGet, "/")
+		c.Authorized = true
+		RootHandler()(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		body := fmt.Sprintf("{\"build_date\":\"0001-01-01T00:00:00Z\",\"build_sha\":\"%s\",\"version\":\"%s\"}\n",
+			version.Commit(), version.GetDefaultVersion())
+		assert.Equal(t, body, w.Body.String())
+	})
+}

--- a/beater/rum_handler_integration_test.go
+++ b/beater/rum_handler_integration_test.go
@@ -1,0 +1,53 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-server/beater/beatertest"
+	"github.com/elastic/apm-server/beater/request"
+)
+
+func TestRumHandler_MonitoringMiddleware(t *testing.T) {
+	beatertest.ClearRegistry(serverMetrics, IntakeResultIDToMonitoringInt)
+	requestToRum(t, DefaultConfig(beatertest.MockBeatVersion()))
+	// send GET request resulting in 403 Forbidden error
+	expected := map[request.ResultID]int{
+		request.IDRequestCount:            1,
+		request.IDResponseCount:           1,
+		request.IDResponseErrorsCount:     1,
+		request.IDResponseErrorsForbidden: 1}
+	equal, result := beatertest.CompareMonitoringInt(expected, IntakeResultIDToMonitoringInt)
+	assert.True(t, equal, result)
+}
+
+func requestToRum(t *testing.T, cfg *Config) *httptest.ResponseRecorder {
+	h, err := rumHandler(cfg, beatertest.NilReporter)
+	require.NoError(t, err)
+	c, rec := beatertest.DefaultContextWithResponseRecorder()
+	h(c)
+	return rec
+}
+
+//TODO: add more integration tests for the actual middleware

--- a/beater/rum_handler_integration_test.go
+++ b/beater/rum_handler_integration_test.go
@@ -18,7 +18,6 @@
 package beater
 
 import (
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,24 +29,19 @@ import (
 )
 
 func TestRumHandler_MonitoringMiddleware(t *testing.T) {
-	beatertest.ClearRegistry(serverMetrics, IntakeResultIDToMonitoringInt)
-	requestToRum(t, DefaultConfig(beatertest.MockBeatVersion()))
-	// send GET request resulting in 403 Forbidden error
+	h, err := rumHandler(DefaultConfig(beatertest.MockBeatVersion()), beatertest.NilReporter)
+	require.NoError(t, err)
+	c, _ := beatertest.DefaultContextWithResponseRecorder()
+
+	// send GET request resulting in 403 Forbidden error as RUM is disabled by default
 	expected := map[request.ResultID]int{
 		request.IDRequestCount:            1,
 		request.IDResponseCount:           1,
 		request.IDResponseErrorsCount:     1,
 		request.IDResponseErrorsForbidden: 1}
-	equal, result := beatertest.CompareMonitoringInt(expected, IntakeResultIDToMonitoringInt)
-	assert.True(t, equal, result)
-}
 
-func requestToRum(t *testing.T, cfg *Config) *httptest.ResponseRecorder {
-	h, err := rumHandler(cfg, beatertest.NilReporter)
-	require.NoError(t, err)
-	c, rec := beatertest.DefaultContextWithResponseRecorder()
-	h(c)
-	return rec
+	equal, result := beatertest.CompareMonitoringInt(h, c, expected, serverMetrics, IntakeResultIDToMonitoringInt)
+	assert.True(t, equal, result)
 }
 
 //TODO: add more integration tests for the actual middleware

--- a/beater/server.go
+++ b/beater/server.go
@@ -33,7 +33,7 @@ import (
 )
 
 func newServer(config *Config, tracer *apm.Tracer, report publish.Reporter) (*http.Server, error) {
-	mux, err := newMuxer(config, report)
+	mux, err := NewMuxer(config, report)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func doNotTrace(req *http.Request) bool {
 func run(logger *logp.Logger, server *http.Server, lis net.Listener, config *Config) error {
 	logger.Infof("Starting apm-server [%s built %s]. Hit CTRL-C to stop it.", version.Commit(), version.BuildTime())
 	logger.Infof("Listening on: %s", server.Addr)
-	switch config.RumConfig.isEnabled() {
+	switch config.RumConfig.IsEnabled() {
 	case true:
 		logger.Info("RUM endpoints enabled!")
 	case false:

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -43,8 +43,6 @@ import (
 	"github.com/elastic/apm-server/tests/loader"
 )
 
-type m map[string]interface{}
-
 func TestServerOk(t *testing.T) {
 	apm, teardown, err := setupServer(t, nil, nil, nil)
 	require.NoError(t, err)
@@ -99,7 +97,7 @@ func TestServerRoot(t *testing.T) {
 		{path: "/", expectStatus: http.StatusOK, expectContentType: plain, assertions: checkResponse(false)},
 		{path: "/", accept: &jsonContent, expectStatus: http.StatusOK, expectContentType: jsonContent, assertions: checkResponse(true)},
 		{path: "/foo", expectStatus: http.StatusNotFound, expectContentType: plain},
-		{path: "/foo", accept: &jsonContent, expectStatus: http.StatusNotFound, expectContentType: plain},
+		{path: "/foo", accept: &jsonContent, expectStatus: http.StatusNotFound, expectContentType: jsonContent},
 	}
 	for _, testCase := range testCases {
 		res := rootRequest(testCase.path, testCase.accept)

--- a/beater/smap_handler_integration_test.go
+++ b/beater/smap_handler_integration_test.go
@@ -1,0 +1,125 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-server/beater/beatertest"
+	"github.com/elastic/apm-server/beater/headers"
+	"github.com/elastic/apm-server/beater/request"
+	"github.com/elastic/apm-server/tests"
+)
+
+func TestSmapHandler_RequireAuthorizationMiddleware(t *testing.T) {
+	t.Run("Unauthorized", func(t *testing.T) {
+		cfg := cfgEnabledSmap()
+		cfg.SecretToken = "1234"
+		rec := requestToSmapHandler(t, cfg)
+
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		tests.AssertApproveResult(t, assetApprovalPath(t.Name()), rec.Body.Bytes())
+	})
+
+	t.Run("Authorized", func(t *testing.T) {
+		cfg := cfgEnabledSmap()
+		cfg.SecretToken = "1234"
+		h, err := sourcemapHandler(cfg, beatertest.NilReporter)
+		require.NoError(t, err)
+		c, rec := beatertest.ContextWithResponseRecorder(http.MethodPost, "/")
+		c.Request.Header.Set(headers.Authorization, "Bearer 1234")
+		h(c)
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		tests.AssertApproveResult(t, assetApprovalPath(t.Name()), rec.Body.Bytes())
+	})
+}
+
+func TestSmapHandler_KillSwitchMiddleware(t *testing.T) {
+	t.Run("OffRum", func(t *testing.T) {
+		rec := requestToSmapHandler(t, DefaultConfig(beatertest.MockBeatVersion()))
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		tests.AssertApproveResult(t, assetApprovalPath(t.Name()), rec.Body.Bytes())
+	})
+
+	t.Run("OffSourcemap", func(t *testing.T) {
+		cfg := DefaultConfig(beatertest.MockBeatVersion())
+		rum := true
+		cfg.RumConfig.Enabled = &rum
+		cfg.RumConfig.SourceMapping.Enabled = new(bool)
+		rec := requestToSmapHandler(t, cfg)
+
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+		tests.AssertApproveResult(t, assetApprovalPath(t.Name()), rec.Body.Bytes())
+	})
+
+	t.Run("On", func(t *testing.T) {
+		rec := requestToSmapHandler(t, cfgEnabledSmap())
+
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		tests.AssertApproveResult(t, assetApprovalPath(t.Name()), rec.Body.Bytes())
+	})
+}
+
+func TestAssetHandler_LogMiddleware(t *testing.T) {
+	//TODO: How to test?
+}
+
+func TestAssetHandler_PanicMiddleware(t *testing.T) {
+	h, err := sourcemapHandler(DefaultConfig(beatertest.MockBeatVersion()), beatertest.NilReporter)
+	require.NoError(t, err)
+	rec := &beatertest.WriterPanicOnce{}
+	c := &request.Context{}
+	c.Reset(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	h(c)
+	assert.Equal(t, http.StatusInternalServerError, rec.StatusCode)
+	tests.AssertApproveResult(t, assetApprovalPath(t.Name()), rec.Body.Bytes())
+}
+
+func TestAssetHandler_MonitoringMiddleware(t *testing.T) {
+	t.Run("Default", func(t *testing.T) {
+		beatertest.ClearRegistry(serverMetrics, IntakeResultIDToMonitoringInt)
+		requestToSmapHandler(t, DefaultConfig(beatertest.MockBeatVersion()))
+		equal, result := beatertest.CompareMonitoringInt(map[request.ResultID]int{request.IDRequestCount: 1}, ACMResultIDToMonitoringInt)
+		assert.True(t, equal, result)
+	})
+}
+
+func requestToSmapHandler(t *testing.T, cfg *Config) *httptest.ResponseRecorder {
+	h, err := sourcemapHandler(cfg, beatertest.NilReporter)
+	require.NoError(t, err)
+	c, rec := beatertest.ContextWithResponseRecorder(http.MethodPost, "/")
+	h(c)
+	return rec
+}
+
+func cfgEnabledSmap() *Config {
+	cfg := DefaultConfig(beatertest.MockBeatVersion())
+	t := true
+	cfg.RumConfig.Enabled = &t
+	return cfg
+}
+
+func assetApprovalPath(f string) string { return "test_integration/asset/" + f }

--- a/beater/test_integration/acm/TestAgentConfigHandler_KillSwitchMiddleware/Off.approved.json
+++ b/beater/test_integration/acm/TestAgentConfigHandler_KillSwitchMiddleware/Off.approved.json
@@ -1,0 +1,3 @@
+{
+    "error": "forbidden request: endpoint is disabled"
+}

--- a/beater/test_integration/acm/TestAgentConfigHandler_KillSwitchMiddleware/On.approved.json
+++ b/beater/test_integration/acm/TestAgentConfigHandler_KillSwitchMiddleware/On.approved.json
@@ -1,0 +1,3 @@
+{
+    "error": "unable to retrieve connection to Kibana"
+}

--- a/beater/test_integration/acm/TestAgentConfigHandler_PanicMiddleware.approved.json
+++ b/beater/test_integration/acm/TestAgentConfigHandler_PanicMiddleware.approved.json
@@ -1,0 +1,3 @@
+{
+    "error": "panic handling request"
+}

--- a/beater/test_integration/acm/TestAgentConfigHandler_RequireAuthorizationMiddleware/Authorized.approved.json
+++ b/beater/test_integration/acm/TestAgentConfigHandler_RequireAuthorizationMiddleware/Authorized.approved.json
@@ -1,0 +1,3 @@
+{
+    "error": "unable to retrieve connection to Kibana"
+}

--- a/beater/test_integration/acm/TestAgentConfigHandler_RequireAuthorizationMiddleware/Unauthorized.approved.json
+++ b/beater/test_integration/acm/TestAgentConfigHandler_RequireAuthorizationMiddleware/Unauthorized.approved.json
@@ -1,0 +1,3 @@
+{
+    "error": "invalid token"
+}

--- a/beater/test_integration/acm/TestAssetHandler_PanicMiddleware.approved.json
+++ b/beater/test_integration/acm/TestAssetHandler_PanicMiddleware.approved.json
@@ -1,0 +1,3 @@
+{
+    "error": "panic handling request"
+}

--- a/beater/test_integration/asset/TestAssetHandler_PanicMiddleware.approved.json
+++ b/beater/test_integration/asset/TestAssetHandler_PanicMiddleware.approved.json
@@ -1,0 +1,3 @@
+{
+    "error": "panic handling request"
+}

--- a/beater/test_integration/asset/TestSmapHandler_KillSwitchMiddleware/OffRum.approved.json
+++ b/beater/test_integration/asset/TestSmapHandler_KillSwitchMiddleware/OffRum.approved.json
@@ -1,0 +1,3 @@
+{
+    "error": "forbidden request: endpoint is disabled"
+}

--- a/beater/test_integration/asset/TestSmapHandler_KillSwitchMiddleware/OffSourcemap.approved.json
+++ b/beater/test_integration/asset/TestSmapHandler_KillSwitchMiddleware/OffSourcemap.approved.json
@@ -1,0 +1,3 @@
+{
+    "error": "forbidden request: endpoint is disabled"
+}

--- a/beater/test_integration/asset/TestSmapHandler_KillSwitchMiddleware/On.approved.json
+++ b/beater/test_integration/asset/TestSmapHandler_KillSwitchMiddleware/On.approved.json
@@ -1,0 +1,3 @@
+{
+    "error": "data decoding error"
+}

--- a/beater/test_integration/asset/TestSmapHandler_KillSwitchMiddleware/On.approved.json
+++ b/beater/test_integration/asset/TestSmapHandler_KillSwitchMiddleware/On.approved.json
@@ -1,3 +1,3 @@
 {
-    "error": "data decoding error"
+    "error": "data decoding error: invalid content type: "
 }

--- a/beater/test_integration/asset/TestSmapHandler_RequireAuthorizationMiddleware/Authorized.approved.json
+++ b/beater/test_integration/asset/TestSmapHandler_RequireAuthorizationMiddleware/Authorized.approved.json
@@ -1,0 +1,3 @@
+{
+    "error": "data decoding error"
+}

--- a/beater/test_integration/asset/TestSmapHandler_RequireAuthorizationMiddleware/Authorized.approved.json
+++ b/beater/test_integration/asset/TestSmapHandler_RequireAuthorizationMiddleware/Authorized.approved.json
@@ -1,3 +1,3 @@
 {
-    "error": "data decoding error"
+    "error": "data decoding error: invalid content type: "
 }

--- a/beater/test_integration/asset/TestSmapHandler_RequireAuthorizationMiddleware/Unauthorized.approved.json
+++ b/beater/test_integration/asset/TestSmapHandler_RequireAuthorizationMiddleware/Unauthorized.approved.json
@@ -1,0 +1,3 @@
+{
+    "error": "invalid token"
+}

--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -216,7 +216,7 @@ class AgentConfigurationKibanaDownIntegrationTest(ElasticTest):
         self.assertDictContainsSubset({
             "level": "error",
             "message": "error handling request",
-            "error": {"error": "invalid token"},
+            "error": "invalid token",
             "response_code": 401,
         }, config_request_logs[0])
         self.assertDictContainsSubset({
@@ -243,6 +243,6 @@ class AgentConfigurationKibanaDisabledIntegrationTest(ElasticTest):
         self.assertDictContainsSubset({
             "level": "error",
             "message": "error handling request",
-            "error": {"error": "forbidden request: endpoint is disabled"},
+            "error": "forbidden request: endpoint is disabled",
             "response_code": 403,
         }, config_request_logs[0])


### PR DESCRIPTION
As part of the `beater` refactoring in #2489 this PR improves how response bodies are written, without changing the actual logic to not break between minor versions. 
This will help improving response writing in the future. 

There is one change in how a 404 body is returned if the path does not exist: Currently only a plain/text response was given, ignoring the `accept` header. This has been changed to return a json body if accepted.

It also introduces a `beatertest` package offering some shared test setup handling.

As a preparation of splitting up the logic into sub packages of `beater` some methods and structs have been exported. 

~Running some local benchmarks with `hey-apm` shows slightly improved (not significant) `index-rate` for this branch compared to `master`.~
update: New benchmarks need to be run after more refactoring before merging back to master, but this PR is only against a feature branch.