### PR TITLE
[7.x] Add service.environment to spans. (#2500)

### DIFF
--- a/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json
@@ -31,6 +31,7 @@
                 "name": "transaction"
             },
             "service": {
+                "environment": "staging",
                 "name": "backendspans"
             },
             "span": {
@@ -84,6 +85,7 @@
                 "name": "transaction"
             },
             "service": {
+                "environment": "prod",
                 "name": "backendspans"
             },
             "span": {
@@ -144,6 +146,7 @@
                 "name": "transaction"
             },
             "service": {
+                "environment": "staging",
                 "name": "backendspans"
             },
             "span": {
@@ -199,6 +202,7 @@
                 "name": "transaction"
             },
             "service": {
+                "environment": "staging",
                 "name": "backendspans"
             },
             "span": {
@@ -254,6 +258,7 @@
                 "name": "transaction"
             },
             "service": {
+                "environment": "staging",
                 "name": "service1"
             },
             "span": {

--- a/docs/data/elasticsearch/generated/spans.json
+++ b/docs/data/elasticsearch/generated/spans.json
@@ -14,6 +14,7 @@
                 "name": "transaction"
             },
             "service": {
+                "environment": "staging",
                 "name": "backendspans"
             },
             "span": {
@@ -50,6 +51,7 @@
                 "name": "transaction"
             },
             "service": {
+                "environment": "prod",
                 "name": "backendspans"
             },
             "span": {
@@ -93,6 +95,7 @@
                 "name": "transaction"
             },
             "service": {
+                "environment": "staging",
                 "name": "backendspans"
             },
             "span": {
@@ -131,6 +134,7 @@
                 "name": "transaction"
             },
             "service": {
+                "environment": "staging",
                 "name": "backendspans"
             },
             "span": {
@@ -169,6 +173,7 @@
                 "name": "transaction"
             },
             "service": {
+                "environment": "staging",
                 "name": "service1"
             },
             "span": {

--- a/model/metadata/service.go
+++ b/model/metadata/service.go
@@ -90,9 +90,10 @@ func (s *Service) MinimalFields() common.MapStr {
 	if s == nil {
 		return nil
 	}
-	f := common.MapStr{}
-	utility.Set(f, "name", s.Name)
-	return f
+	svc := common.MapStr{}
+	utility.Set(svc, "name", s.Name)
+	utility.Set(svc, "environment", s.Environment)
+	return svc
 }
 
 func (s *Service) Fields() common.MapStr {
@@ -101,7 +102,6 @@ func (s *Service) Fields() common.MapStr {
 	}
 	svc := s.MinimalFields()
 	utility.Set(svc, "version", s.Version)
-	utility.Set(svc, "environment", s.Environment)
 
 	lang := common.MapStr{}
 	utility.Set(lang, "name", s.Language.Name)

--- a/model/span/event_test.go
+++ b/model/span/event_test.go
@@ -230,8 +230,8 @@ func TestDecodeSpan(t *testing.T) {
 func TestSpanTransform(t *testing.T) {
 	path := "test/path"
 	start := 0.65
-	serviceName := "myService"
-	service := metadata.Service{Name: &serviceName}
+	serviceName, env := "myService", "staging"
+	service := metadata.Service{Name: &serviceName, Environment: &env}
 	hexId, parentId, traceId := "0147258369012345", "abcdef0123456789", "01234567890123456789abcdefa"
 	subtype := "myspansubtype"
 	action := "myspanquery"
@@ -250,7 +250,7 @@ func TestSpanTransform(t *testing.T) {
 			Event: Event{Timestamp: timestamp},
 			Output: common.MapStr{
 				"processor": common.MapStr{"event": "span", "name": "transaction"},
-				"service":   common.MapStr{"name": "myService"},
+				"service":   common.MapStr{"name": serviceName, "environment": env},
 				"span": common.MapStr{
 					"duration": common.MapStr{"us": 0},
 					"name":     "",
@@ -307,7 +307,7 @@ func TestSpanTransform(t *testing.T) {
 				},
 				"labels":    common.MapStr{"label.a": 12},
 				"processor": common.MapStr{"event": "span", "name": "transaction"},
-				"service":   common.MapStr{"name": "myService"},
+				"service":   common.MapStr{"name": serviceName, "environment": env},
 				"timestamp": common.MapStr{"us": int64(float64(timestampUs) + start*1000)},
 				"trace":     common.MapStr{"id": traceId},
 				"parent":    common.MapStr{"id": parentId},

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationOptionalTimestamps.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationOptionalTimestamps.approved.json
@@ -82,6 +82,7 @@
                 "name": "transaction"
             },
             "service": {
+                "environment": "staging",
                 "name": "backendspans"
             },
             "span": {

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationSpans.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationSpans.approved.json
@@ -14,6 +14,7 @@
                 "name": "transaction"
             },
             "service": {
+                "environment": "staging",
                 "name": "backendspans"
             },
             "span": {
@@ -50,6 +51,7 @@
                 "name": "transaction"
             },
             "service": {
+                "environment": "prod",
                 "name": "backendspans"
             },
             "span": {
@@ -93,6 +95,7 @@
                 "name": "transaction"
             },
             "service": {
+                "environment": "staging",
                 "name": "backendspans"
             },
             "span": {
@@ -131,6 +134,7 @@
                 "name": "transaction"
             },
             "service": {
+                "environment": "staging",
                 "name": "backendspans"
             },
             "span": {
@@ -169,6 +173,7 @@
                 "name": "transaction"
             },
             "service": {
+                "environment": "staging",
                 "name": "service1"
             },
             "span": {

--- a/tests/system/spans.approved.json
+++ b/tests/system/spans.approved.json
@@ -45,7 +45,8 @@
                 "name": "transaction"
             },
             "service": {
-                "name": "1234_service-12a3"
+                "name": "1234_service-12a3",
+                "environment": "staging"
             },
             "span": {
                 "id": "2aaaaaaaaaaaaaaa",
@@ -135,7 +136,8 @@
                 }
             },
             "service": {
-                "name": "serviceabc"
+                "name": "serviceabc",
+                "environment": "staging"
             },
             "transaction": {
                 "id": "85925e55b43f4342"
@@ -199,7 +201,8 @@
                 "name": "transaction"
             },
             "service": {
-                "name": "1234_service-12a3"
+                "name": "1234_service-12a3",
+                "environment": "staging"
             },
             "span": {
                 "id": "3aaaaaaaaaaaaaaa",
@@ -270,7 +273,8 @@
                 "name": "transaction"
             },
             "service": {
-                "name": "1234_service-12a3"
+                "name": "1234_service-12a3",
+                "environment": "staging"
             },
             "span": {
                 "id": "0aaaaaaaaaaaaaaa",
@@ -400,7 +404,8 @@
                 "event": "span"
             },
             "service": {
-                "name": "1234_service-12a3"
+                "name": "1234_service-12a3",
+                "environment": "staging"
             },
             "span": {
                 "id": "1aaaaaaaaaaaaaaa",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add service.environment to spans.  (#2500)