### PR TITLE
[7.x] ci: move to use new windows-2019-immutable workers (#2503)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -132,7 +132,7 @@ pipeline {
         Build on a windows environment.
         */
         stage('windows build') {
-          agent { label 'windows' }
+          agent { label 'windows-2019-immutable' }
           options { skipDefaultCheckout() }
           when {
             beforeAgent true
@@ -223,7 +223,7 @@ pipeline {
         Finally archive the results.
         */
         stage('windows test') {
-          agent { label 'windows' }
+          agent { label 'windows-2019-immutable' }
           options { skipDefaultCheckout() }
           when {
             beforeAgent true


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ci: move to use new windows-2019-immutable workers  (#2503)