### PR TITLE
[docs][7.x] Update python agent version

### DIFF
--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -207,7 +207,7 @@ v|*Go:* {apm-go-ref-v}/api.html#context-set-tag[`SetTag`]
 *Java:* {apm-java-ref-v}/public-api.html#api-transaction-add-tag[`addLabel`]
 *.NET:* {apm-dotnet-ref-v}/public-api.html#api-transaction-tags[`Tags`]
 *Node.js:* {apm-node-ref-v}/agent-api.html#apm-set-tag[`setTag`] \| {apm-node-ref-v}/agent-api.html#apm-add-tags[`addTags`]
-*Python:* {apm-py-ref-v}/api.html#api-tag[`tag`]
+*Python:* {apm-py-ref-v}/api.html#api-label[`elasticapm.label()`]
 *Ruby:* {apm-ruby-ref-v}/api.html#api-agent-set-tag[`set_tag`]
 *Rum:* {apm-rum-ref-v}/agent-api.html#apm-add-tags[`addTags`]
 |===

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -14,7 +14,7 @@
 :java-branch: 1.x
 :rum-branch: 4.x
 :node-branch: 2.x
-:py-branch: 4.x
+:py-branch: 5.x
 :ruby-branch: 2.x
 :dotnet-branch: current
 


### PR DESCRIPTION
* Backports https://github.com/elastic/apm-server/pull/2519.
* Updates Python Agent links from APM Server & APM Overview to point to 5.x.
* It is expected that the docs build will fail on this PR.