### PR TITLE
[7.x] Log warning for RUM allow_origins setting '*'. (#2499)

### DIFF
--- a/beater/server.go
+++ b/beater/server.go
@@ -79,6 +79,12 @@ func run(logger *logp.Logger, server *http.Server, lis net.Listener, config *Con
 	switch config.RumConfig.isEnabled() {
 	case true:
 		logger.Info("RUM endpoints enabled!")
+		for _, s := range config.RumConfig.AllowOrigins {
+			if s == "*" {
+				logger.Warn("CORS related setting `apm-server.rum.allow_origins` allows all origins. Consider more restrictive setting for production use.")
+				break
+			}
+		}
 	case false:
 		logger.Info("RUM endpoints disabled.")
 	}

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -119,7 +119,9 @@ class ServerSetUpBaseTest(BaseTest):
         # tests the Beat is confused since it thinks it is running as a service.
         winErr = "ERR Error: The service process could not connect to the service controller."
 
-        suppress = suppress + ["WARN EXPERIMENTAL", "WARN BETA", "WARN.*deprecated", winErr]
+        corsWarn = "WARN\t.*CORS related setting .* Consider more restrictive setting for production use."
+
+        suppress = suppress + ["WARN EXPERIMENTAL", "WARN BETA", "WARN.*deprecated", winErr, corsWarn]
         log = self.get_log()
         for s in suppress:
             log = re.sub(s, "", log)


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Log warning for RUM allow_origins setting '*'.  (#2499)