### PR TITLE
[docs] Config YML updates

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -109,7 +109,7 @@ apm-server:
     # to all error and transaction documents sent to the RUM endpoint.
     #source_mapping:
 
-      # Sourcemapping is enabled by default for RUM events.
+      # Sourcemapping is enabled by default.
       #enabled: true
 
       # Source maps are always fetched from Elasticsearch, by default using the output.elasticsearch configuration.

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -1,15 +1,15 @@
-################### APM Server Configuration #########################
+######################### APM Server Configuration #########################
 
-############################# APM Server ######################################
+################################ APM Server ################################
 
 apm-server:
-  # Defines the host and port the server is listening on.  use "unix:/path/to.sock" to listen on a unix domain socket.
+  # Defines the host and port the server is listening on. Use "unix:/path/to.sock" to listen on a unix domain socket.
   host: "{{ .listen_hostport }}"
 
   # Maximum permitted size in bytes of a request's header accepted by the server to be processed.
   #max_header_size: 1048576
 
-  # Maximum idle time until the server closes a connection.
+  # Maximum amount of time to wait for the next incoming request before underlying connection is closed.
   #idle_timeout: 45s
 
   # Maximum permitted duration for reading an entire request.
@@ -18,39 +18,37 @@ apm-server:
   # Maximum permitted duration for writing a response.
   #write_timeout: 30s
 
-  # Maximum duration in seconds before releasing resources when shutting down the server.
+  # Maximum duration before releasing resources when shutting down the server.
   #shutdown_timeout: 5s
 
-  # Maximum allowed size in bytes of a single event
+  # Maximum permitted size in bytes of an event accepted by the server to be processed.
   #max_event_size: 307200
 
-  #--
+  # Maximum number of new connections to accept simultaneously (0 means unlimited).
+  #max_connections: 0
 
-  # Maximum number of new connections to accept simultaneously (0 means unlimited)
-  # max_connections: 0
-
-  # Authorization token to be checked. If a token is set here the agents must
-  # send their token in the following format: Authorization: Bearer <secret-token>.
+  # Authorization token for sending data to the APM server. If a token is set, the
+  # agents must send it in the following format: Authorization: Bearer <secret-token>.
   # It is recommended to use an authorization token in combination with SSL enabled,
-  # and save the token in the apm-server keystore.
+  # and save the token in the apm-server keystore. The token is not used for RUM endpoints.
   #secret_token:
 
   # Enable secure communication between APM agents and the server. By default ssl is disabled.
   #ssl:
     #enabled: false
 
-    # Configure a list of root certificate authorities for verifying client certificates
+    # Configure a list of root certificate authorities for verifying client certificates.
     #certificate_authorities: []
 
-    # Path to file containing the certificate for server authentication
-    # Needs to be configured when ssl is enabled
+    # Path to file containing the certificate for server authentication.
+    # Needs to be configured when ssl is enabled.
     #certificate: ''
 
-    # Path to file containing server certificate key
-    # Needs to be configured when ssl is enabled
+    # Path to file containing server certificate key.
+    # Needs to be configured when ssl is enabled.
     #key: ''
 
-    # Optional configuration options for ssl communication
+    # Optional configuration options for ssl communication.
 
     # Passphrase for decrypting the Certificate Key.
     # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
@@ -59,10 +57,10 @@ apm-server:
     # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.2 are enabled.
     #supported_protocols: [TLSv1.1, TLSv1.2]
 
-    # Configure cipher suites to be used for SSL connections
+    # Configure cipher suites to be used for SSL connections.
     #cipher_suites: []
 
-    # Configure curve types for ECDHE based cipher suites
+    # Configure curve types for ECDHE based cipher suites.
     #curve_types: []
 
     # Configure which type of client authentication is supported.
@@ -74,9 +72,8 @@ apm-server:
     # susceptible to man-in-the-middle attacks. Use only for testing. Default is `full`.
     #ssl.verification_mode: full
 
-
+  # Enable Real User Monitoring (RUM) Support. By default RUM is disabled.
   #rum:
-    # To enable real user monitoring (RUM) support set this to true.
     #enabled: false
 
     #event_rate:
@@ -96,7 +93,7 @@ apm-server:
     # User-agents will send an origin header that will be validated against this list.
     # An origin is made of a protocol scheme, host and port, without the url path.
     # Allowed origins in this setting can have * to match anything (eg.: http://*.example.com)
-    # If an item in the list is a single '*', everything will be allowed
+    # If an item in the list is a single '*', everything will be allowed.
     #allow_origins : ['*']
 
     # Regexp to be matched against a stacktrace frame's `file_name` and `abs_path` attributes.
@@ -108,11 +105,11 @@ apm-server:
     # The default pattern excludes stacktrace frames that have a filename starting with '/webpack'
     #exclude_from_grouping: "^/webpack"
 
-    # If a source map has previously been uploaded, source mapping is automatically applied
+    # If a source map has previously been uploaded, source mapping is automatically applied.
     # to all error and transaction documents sent to the RUM endpoint.
     #source_mapping:
 
-      # Sourcemapping is enabled by default for RUM events
+      # Sourcemapping is enabled by default for RUM events.
       #enabled: true
 
       # Source maps are always fetched from Elasticsearch, by default using the output.elasticsearch configuration.
@@ -120,9 +117,9 @@ apm-server:
       # This setting only affects sourcemap reads - the output determines where sourcemaps are written.
       #elasticsearch:
         # Array of hosts to connect to.
-        # Scheme and port can be left out and will be set to the default (http and 9200)
-        # In case you specify and additional path, the scheme is required: http://localhost:9200/path
-        # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+        # Scheme and port can be left out and will be set to the default (`http` and `9200`).
+        # In case you specify and additional path, the scheme is required: `http://localhost:9200/path`.
+        # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
         # hosts: ["localhost:9200"]
 
         # Optional protocol and basic auth credentials.
@@ -141,28 +138,30 @@ apm-server:
       #index_pattern: "apm-*-sourcemap*"
 
 
-  # If set to true, APM Server augments data received by the agent with the original IP of the backend server,
-  # or the IP and User Agent of the real user (RUM requests). It defaults to true.
+  # If true (default), APM Server captures the IP of the instrumented service
+  # or the IP and User Agent of the real user (RUM requests).
   #capture_personal_data: true
 
-  # golang expvar support - https://golang.org/pkg/expvar/
+  # Enable APM Server golang expvar support (https://golang.org/pkg/expvar/).
   #expvar:
-    # Set to true to expose expvar
     #enabled: false
 
-    # Url to expose expvar
+    # Url to expose expvar.
     #url: "/debug/vars"
 
   # Instrumentation support for the server's HTTP endpoints and event publisher.
   #instrumentation:
     # Set to true to enable instrumentation of the APM Server itself.
     #enabled: false
+
     # Environment in which the APM Server is running on (eg: staging, production, etc.)
     #environment: ""
+
     # Remote hosts to report instrumentation results to.
     #hosts:
     #  - http://remote-apm-server:8200
-    # Remote apm-servers' secret_token
+
+    # secret_token for the remote apm-servers.
     #secret_token:
 
   # A pipeline is a definition of processors applied to documents when ingesting them to Elasticsearch.
@@ -173,7 +172,7 @@ apm-server:
   # You can manually register a pipeline, or use this configuration option to ensure
   # the pipeline is loaded and registered at the configured Elasticsearch instances.
   # Find the default pipeline configuration at `ingest/pipeline/definition.json`.
-  # Automatic pipeline registration requires the output.elasticsearch` to be enabled and configured.
+  # Automatic pipeline registration requires the `output.elasticsearch` to be enabled and configured.
   #register.ingest.pipeline:
     # Registers APM pipeline definition in Elasticsearch on APM Server startup. Defaults to true.
     #enabled: true
@@ -191,9 +190,7 @@ apm-server:
   # For ILM to be applied, The configured output must be set to Elasticsearch and the instance
   # needs to support ILM. Otherwise APM Server falls back to ordinary index management without ILM.
   #
-  # Disable ILM by setting it to `false`.
-  #
-  # Defaults to `auto`.
+  # Defaults to "auto". Disable ILM by setting it to `false`.
   #ilm.enabled: "auto"
 
   # When using APM agent configuration, information fetched from Kibana will be cached in memory for some time.
@@ -201,12 +198,12 @@ apm-server:
   #agent.config.cache.expiration: 30s
 
   #kibana:
-    # For APM Agent configuration in Kibana, enabled must be true
+    # For APM Agent configuration in Kibana, enabled must be true.
     #enabled: false
 
-    # Scheme and port can be left out and will be set to the default (http and 5601)
-    # In case you specify an additional path, the scheme is required: http://localhost:5601/path
-    # IPv6 addresses should always be defined as: https://[2001:db8::1]:5601
+    # Scheme and port can be left out and will be set to the default (`http` and `5601`).
+    # In case you specify an additional path, the scheme is required: `http://localhost:5601/path`.
+    # IPv6 addresses should always be defined as: `https://[2001:db8::1]:5601`.
     #host: "localhost:5601"
 
     # Optional protocol and basic auth credentials.
@@ -214,7 +211,7 @@ apm-server:
     #username: "elastic"
     #password: "changeme"
 
-    # Optional HTTP path
+    # Optional HTTP path.
     #path: ""
 
     # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
@@ -231,10 +228,10 @@ apm-server:
     # 1.2 are enabled.
     #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-    # List of root certificates for HTTPS server verifications
+    # List of root certificates for HTTPS server verifications.
     #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-    # Certificate for SSL client authentication
+    # Certificate for SSL client authentication.
     #ssl.certificate: "/etc/pki/client/cert.pem"
 
     # Client Certificate Key
@@ -244,20 +241,20 @@ apm-server:
     # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
     #ssl.key_passphrase: ''
 
-    # Configure cipher suites to be used for SSL connections
+    # Configure cipher suites to be used for SSL connections.
     #ssl.cipher_suites: []
 
-    # Configure curve types for ECDHE based cipher suites
+    # Configure curve types for ECDHE based cipher suites.
     #ssl.curve_types: []
 
-#================================ General ======================================
+#================================= General =================================
 
-# Internal queue configuration for buffering events to be published.
+# Data is buffered in a memory queue before it is published to the configured output.
+# The memory queue will present all available events (up to the outputs
+# bulk_max_size) to the output, the moment the output is ready to serve
+# another batch of events.
 #queue:
-  # Queue type by name (default 'mem')
-  # The memory queue will present all available events (up to the outputs
-  # bulk_max_size) to the output, the moment the output is ready to server
-  # another batch of events.
+  # Queue type by name (default 'mem').
   #mem:
     # Max number of events the queue can buffer.
     #events: 4096
@@ -270,17 +267,16 @@ apm-server:
     #flush.min_events: 2048
 
     # Maximum duration after which events are available to the outputs,
-    # if the number of events stored in the queue is < min_flush_events.
+    # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
 
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
 #max_procs:
 
+#================================= Template =================================
 
-#============================== Template =====================================
-
-# A template is used to set the mapping in Elasticsearch
+# A template is used to set the mapping in Elasticsearch.
 # By default template loading is enabled and the template is loaded.
 # These settings can be adjusted to load your own template or overwrite existing ones.
 
@@ -296,13 +292,13 @@ apm-server:
 # The template name and pattern has to be set in case the elasticsearch index pattern is modified.
 #setup.template.pattern: "apm-%{[observer.version]}-*"
 
-# Path to fields.yml file to generate the template
+# Path to fields.yml file to generate the template.
 #setup.template.fields: "${path.config}/fields.yml"
 
-# Overwrite existing template
+# Overwrite existing template.
 #setup.template.overwrite: false
 
-# Elasticsearch template settings
+# Elasticsearch template settings.
 #setup.template.settings:
 
   # A dictionary of settings to place into the settings.index dictionary
@@ -314,8 +310,7 @@ apm-server:
     #number_of_routing_shards: 30
     #mapping.total_fields.limit: 2000
 
-
-#============================= Elastic Cloud ==================================
+#============================= Elastic Cloud =============================
 
 # These settings simplify using APM Server with the Elastic Cloud (https://cloud.elastic.co/).
 
@@ -327,16 +322,16 @@ apm-server:
 # `output.elasticsearch.password` settings. The format is `<user>:<pass>`.
 #cloud.auth:
 
-#================================ Outputs =====================================
+#================================ Outputs =================================
 
-# Configure what output to use when sending the data collected by apm-server.
+# Configure the output to use when sending the data collected by apm-server.
 
-#-------------------------- Elasticsearch output ------------------------------
+#-------------------------- Elasticsearch output --------------------------
 output.elasticsearch:
   # Array of hosts to connect to.
-  # Scheme and port can be left out and will be set to the default (http and 9200)
-  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
-  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  # Scheme and port can be left out and will be set to the default (`http` and `9200`).
+  # In case you specify and additional path, the scheme is required: `http://localhost:9200/path`.
+  # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
   hosts: ["{{ .elasticsearch_hostport }}"]
 
   # Boolean flag to enable or disable the output module.
@@ -358,7 +353,7 @@ output.elasticsearch:
   # Number of workers per Elasticsearch host.
   #worker: 1
 
-  # By using the configuration below, apm documents are stored to separate indices,
+  # By using the configuration below, APM documents are stored to separate indices,
   # depending on their `processor.event`:
   # - error
   # - transaction
@@ -368,10 +363,10 @@ output.elasticsearch:
   # The indices are all prefixed with `apm-%{[observer.version]}`.
   # To allow managing indices based on their age, all indices (except for sourcemaps)
   # end with the information of the day they got indexed.
-  # e.g. "apm-6.3.0-transaction-2018.03.20"
+  # e.g. "apm-7.3.0-transaction-2019.07.20"
   #
   # Be aware that you can only specify one Elasticsearch template.
-  # In case you modify the index patterns you must also update those configurations accordingly,
+  # If you modify the index patterns you must also update these configurations accordingly,
   # as they need to be aligned:
   # * `setup.template.name`
   # * `setup.template.pattern`
@@ -404,17 +399,17 @@ output.elasticsearch:
   # A pipeline is a definition of processors applied to documents when ingesting them to Elasticsearch.
   # APM Server comes with a default pipeline definition, located at `ingest/pipeline/definition.json`, which is
   # loaded to Elasticsearch by default (see `apm-server.register.ingest.pipeline`).
-  # APM pipeline is enabled by default. For disabling set `pipeline: _none`.
+  # APM pipeline is enabled by default. To disable it, set `pipeline: _none`.
   #pipeline: "apm"
 
-  # Optional HTTP Path
+  # Optional HTTP Path.
   #path: "/elasticsearch"
 
-  # Custom HTTP headers to add to each request
+  # Custom HTTP headers to add to each request.
   #headers:
   #  X-My-Header: Contents of the header
 
-  # Proxy server url
+  # Proxy server url.
   #proxy_url: http://proxy:3128
 
   # The number of times a particular Elasticsearch index operation is attempted. If
@@ -454,10 +449,10 @@ output.elasticsearch:
   # 1.2 are enabled.
   #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # List of root certificates for HTTPS server verifications
+  # List of root certificates for HTTPS server verifications.
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for SSL client authentication
+  # Certificate for SSL client authentication.
   #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
@@ -467,35 +462,35 @@ output.elasticsearch:
   # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
   #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for SSL connections
+  # Configure cipher suites to be used for SSL connections.
   #ssl.cipher_suites: []
 
-  # Configure curve types for ECDHE based cipher suites
+  # Configure curve types for ECDHE based cipher suites.
   #ssl.curve_types: []
 
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-#----------------------------- Console output ---------------------------------
+#----------------------------- Console output -----------------------------
 #output.console:
   # Boolean flag to enable or disable the output module.
   #enabled: false
 
-  # Configure JSON encoding
+  # Configure JSON encoding.
   #codec.json:
-    # Pretty-print JSON event
+    # Pretty-print JSON event.
     #pretty: false
 
     # Configure escaping HTML symbols in strings.
     #escape_html: false
 
-#----------------------------- Logstash output ---------------------------------
+#---------------------------- Logstash output -----------------------------
 #output.logstash:
   # Boolean flag to enable or disable the output module.
   #enabled: false
 
-  # The Logstash hosts
+  # The Logstash hosts.
   #hosts: ["localhost:5044"]
 
   # Number of workers per Logstash host.
@@ -511,7 +506,7 @@ output.elasticsearch:
   # connection will be re-established.  A value of `0s` (the default) will
   # disable this feature.
   #
-  # Not yet supported for async connections (i.e. with the "pipelining" option set)
+  # Not yet supported for async connections (i.e. with the "pipelining" option set).
   #ttl: 30s
 
   # Optional load balance the events between the Logstash hosts. Default is false.
@@ -561,10 +556,10 @@ output.elasticsearch:
   # 1.2 are enabled.
   #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # List of root certificates for HTTPS server verifications
+  # List of root certificates for HTTPS server verifications.
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for SSL client authentication
+  # Certificate for SSL client authentication.
   #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
@@ -574,17 +569,17 @@ output.elasticsearch:
   # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
   #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for SSL connections
+  # Configure cipher suites to be used for SSL connections.
   #ssl.cipher_suites: []
 
-  # Configure curve types for ECDHE based cipher suites
+  # Configure curve types for ECDHE based cipher suites.
   #ssl.curve_types: []
 
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-#------------------------------- Kafka output ----------------------------------
+#------------------------------ Kafka output ------------------------------
 #output.kafka:
   # Boolean flag to enable or disable the output module.
   #enabled: false
@@ -622,7 +617,7 @@ output.elasticsearch:
   # Kafka version libbeat is assumed to run against. Defaults to the "1.0.0".
   #version: '1.0.0'
 
-  # Configure JSON encoding
+  # Configure JSON encoding.
   #codec.json:
     # Pretty print json event
     #pretty: false
@@ -708,10 +703,10 @@ output.elasticsearch:
   # 1.2 are enabled.
   #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # List of root certificates for HTTPS server verifications
+  # List of root certificates for HTTPS server verifications.
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for SSL client authentication
+  # Certificate for SSL client authentication.
   #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
@@ -721,17 +716,17 @@ output.elasticsearch:
   # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
   #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for SSL connections
+  # Configure cipher suites to be used for SSL connections.
   #ssl.cipher_suites: []
 
-  # Configure curve types for ECDHE based cipher suites
+  # Configure curve types for ECDHE based cipher suites.
   #ssl.curve_types: []
 
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-#================================= Paths ======================================
+#================================= Paths ==================================
 
 # The home path for the apm-server installation. This is the default base path
 # for all other path settings and for miscellaneous files that come with the
@@ -756,19 +751,17 @@ output.elasticsearch:
 # configuration file, the default is a logs subdirectory inside the home path.
 #path.logs: ${path.home}/logs
 
+#================================= Logging =================================
 
-#================================ Logging ======================================
-#
-# There are three options for the log output: syslog, file, stderr.
-# Under Windows systems, the log files are per default sent to the file output,
-# under all other system per default to syslog.
+# There are three options for the log output: syslog, file, and stderr.
+# Windows systems default to file output. All other systems default to syslog.
 
-# Sets log level. The default log level is info.
-# Available log levels are: error, warning, info, debug
+# Sets the minimum log level. The default log level is info.
+# Available log levels are: error, warning, info, or debug.
 #logging.level: info
 
-# Enable debug output for selected components. To enable all selectors use ["*"]
-# Other available selectors are "beat", "publish", "service"
+# Enable debug output for selected components. To enable all selectors use ["*"].
+# Other available selectors are "beat", "publish", or "service".
 # Multiple selectors can be chained.
 #logging.selectors: [ ]
 
@@ -784,8 +777,8 @@ output.elasticsearch:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# Logging to rotating files. Set logging.to_files to false to disable logging to
-# files.
+# Logging to rotating files. When true, writes all logging output to files.
+# The log files are automatically rotated when the log file size limit is reached.
 #logging.to_files: true
 #logging.files:
   # Configure the path where the logs are written. The default is the logs directory
@@ -796,7 +789,7 @@ output.elasticsearch:
   #name: apm-server
 
   # Configure log file size limit. If limit is reached, log file will be
-  # automatically rotated
+  # automatically rotated.
   #rotateeverybytes: 10485760 # = 10MB
 
   # Number of rotated log files to keep. Oldest files will be deleted first.
@@ -816,12 +809,11 @@ output.elasticsearch:
 # Set to true to log messages in json format.
 #logging.json: false
 
+#=============================== HTTP Endpoint ===============================
 
-#================================ HTTP Endpoint ======================================
-#
 # apm-server can expose internal metrics through a HTTP endpoint. For security
 # reasons the endpoint is disabled by default. This feature is currently experimental.
-# Stats can be access through http://localhost:5066/stats . For pretty JSON output
+# Stats can be access through http://localhost:5066/stats. For pretty JSON output
 # append ?pretty to the URL.
 
 # Defines if the HTTP endpoint is enabled.
@@ -833,7 +825,8 @@ output.elasticsearch:
 # Port on which the HTTP endpoint will bind. Default is 5066.
 #http.port: 5066
 
-#============================== X-pack Monitoring ===============================
+#============================= X-pack Monitoring =============================
+
 # APM server can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires x-pack monitoring to be enabled in Elasticsearch.  The
 # reporting is disabled by default.
@@ -854,9 +847,9 @@ output.elasticsearch:
   #password: ""
 
   # Array of hosts to connect to.
-  # Scheme and port can be left out and will be set to the default (http and 9200)
-  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
-  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  # Scheme and port can be left out and will be set to the default (`http` and `9200`).
+  # In case you specify and additional path, the scheme is required: `http://localhost:9200/path`.
+  # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
   #hosts: ["localhost:9200"]
 
   # Set gzip compression level.
@@ -867,11 +860,11 @@ output.elasticsearch:
     #param1: value1
     #param2: value2
 
-  # Custom HTTP headers to add to each request
+  # Custom HTTP headers to add to each request.
   #headers:
   #  X-My-Header: Contents of the header
 
-  # Proxy server url
+  # Proxy server url.
   #proxy_url: http://proxy:3128
 
   # The number of times a particular Elasticsearch index operation is attempted. If
@@ -911,10 +904,10 @@ output.elasticsearch:
   # 1.2 are enabled.
   #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # List of root certificates for HTTPS server verifications
+  # List of root certificates for HTTPS server verifications.
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for SSL client authentication
+  # Certificate for SSL client authentication.
   #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
@@ -924,10 +917,10 @@ output.elasticsearch:
   # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
   #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for SSL connections
+  # Configure cipher suites to be used for SSL connections.
   #ssl.cipher_suites: []
 
-  # Configure curve types for ECDHE based cipher suites
+  # Configure curve types for ECDHE based cipher suites.
   #ssl.curve_types: []
 
   # Configure what types of renegotiation are supported. Valid options are

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -142,7 +142,7 @@ apm-server:
   # or the IP and User Agent of the real user (RUM requests).
   #capture_personal_data: true
 
-  # Enable APM Server golang expvar support (https://golang.org/pkg/expvar/).
+  # Enable APM Server Golang expvar support (https://golang.org/pkg/expvar/).
   #expvar:
     #enabled: false
 

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -30,7 +30,7 @@ apm-server:
   # Authorization token for sending data to the APM server. If a token is set, the
   # agents must send it in the following format: Authorization: Bearer <secret-token>.
   # It is recommended to use an authorization token in combination with SSL enabled,
-  # and save the token in the apm-server keystore. The token is not used for RUM endpoints.
+  # and save the token in the apm-server keystore. The token is not used for the RUM endpoint.
   #secret_token:
 
   # Enable secure communication between APM agents and the server. By default ssl is disabled.

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -30,7 +30,7 @@ apm-server:
   # Authorization token for sending data to the APM server. If a token is set, the
   # agents must send it in the following format: Authorization: Bearer <secret-token>.
   # It is recommended to use an authorization token in combination with SSL enabled,
-  # and save the token in the apm-server keystore. The token is not used for RUM endpoints.
+  # and save the token in the apm-server keystore. The token is not used for the RUM endpoint.
   #secret_token:
 
   # Enable secure communication between APM agents and the server. By default ssl is disabled.
@@ -109,7 +109,7 @@ apm-server:
     # to all error and transaction documents sent to the RUM endpoint.
     #source_mapping:
 
-      # Sourcemapping is enabled by default for RUM events.
+      # Sourcemapping is enabled by default.
       #enabled: true
 
       # Source maps are always fetched from Elasticsearch, by default using the output.elasticsearch configuration.
@@ -142,7 +142,7 @@ apm-server:
   # or the IP and User Agent of the real user (RUM requests).
   #capture_personal_data: true
 
-  # Enable APM Server golang expvar support (https://golang.org/pkg/expvar/).
+  # Enable APM Server Golang expvar support (https://golang.org/pkg/expvar/).
   #expvar:
     #enabled: false
 

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -1,15 +1,15 @@
-################### APM Server Configuration #########################
+######################### APM Server Configuration #########################
 
-############################# APM Server ######################################
+################################ APM Server ################################
 
 apm-server:
-  # Defines the host and port the server is listening on.  use "unix:/path/to.sock" to listen on a unix domain socket.
+  # Defines the host and port the server is listening on. Use "unix:/path/to.sock" to listen on a unix domain socket.
   host: "0.0.0.0:8200"
 
   # Maximum permitted size in bytes of a request's header accepted by the server to be processed.
   #max_header_size: 1048576
 
-  # Maximum idle time until the server closes a connection.
+  # Maximum amount of time to wait for the next incoming request before underlying connection is closed.
   #idle_timeout: 45s
 
   # Maximum permitted duration for reading an entire request.
@@ -18,39 +18,37 @@ apm-server:
   # Maximum permitted duration for writing a response.
   #write_timeout: 30s
 
-  # Maximum duration in seconds before releasing resources when shutting down the server.
+  # Maximum duration before releasing resources when shutting down the server.
   #shutdown_timeout: 5s
 
-  # Maximum allowed size in bytes of a single event
+  # Maximum permitted size in bytes of an event accepted by the server to be processed.
   #max_event_size: 307200
 
-  #--
+  # Maximum number of new connections to accept simultaneously (0 means unlimited).
+  #max_connections: 0
 
-  # Maximum number of new connections to accept simultaneously (0 means unlimited)
-  # max_connections: 0
-
-  # Authorization token to be checked. If a token is set here the agents must
-  # send their token in the following format: Authorization: Bearer <secret-token>.
+  # Authorization token for sending data to the APM server. If a token is set, the
+  # agents must send it in the following format: Authorization: Bearer <secret-token>.
   # It is recommended to use an authorization token in combination with SSL enabled,
-  # and save the token in the apm-server keystore.
+  # and save the token in the apm-server keystore. The token is not used for RUM endpoints.
   #secret_token:
 
   # Enable secure communication between APM agents and the server. By default ssl is disabled.
   #ssl:
     #enabled: false
 
-    # Configure a list of root certificate authorities for verifying client certificates
+    # Configure a list of root certificate authorities for verifying client certificates.
     #certificate_authorities: []
 
-    # Path to file containing the certificate for server authentication
-    # Needs to be configured when ssl is enabled
+    # Path to file containing the certificate for server authentication.
+    # Needs to be configured when ssl is enabled.
     #certificate: ''
 
-    # Path to file containing server certificate key
-    # Needs to be configured when ssl is enabled
+    # Path to file containing server certificate key.
+    # Needs to be configured when ssl is enabled.
     #key: ''
 
-    # Optional configuration options for ssl communication
+    # Optional configuration options for ssl communication.
 
     # Passphrase for decrypting the Certificate Key.
     # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
@@ -59,10 +57,10 @@ apm-server:
     # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.2 are enabled.
     #supported_protocols: [TLSv1.1, TLSv1.2]
 
-    # Configure cipher suites to be used for SSL connections
+    # Configure cipher suites to be used for SSL connections.
     #cipher_suites: []
 
-    # Configure curve types for ECDHE based cipher suites
+    # Configure curve types for ECDHE based cipher suites.
     #curve_types: []
 
     # Configure which type of client authentication is supported.
@@ -74,9 +72,8 @@ apm-server:
     # susceptible to man-in-the-middle attacks. Use only for testing. Default is `full`.
     #ssl.verification_mode: full
 
-
+  # Enable Real User Monitoring (RUM) Support. By default RUM is disabled.
   #rum:
-    # To enable real user monitoring (RUM) support set this to true.
     #enabled: false
 
     #event_rate:
@@ -96,7 +93,7 @@ apm-server:
     # User-agents will send an origin header that will be validated against this list.
     # An origin is made of a protocol scheme, host and port, without the url path.
     # Allowed origins in this setting can have * to match anything (eg.: http://*.example.com)
-    # If an item in the list is a single '*', everything will be allowed
+    # If an item in the list is a single '*', everything will be allowed.
     #allow_origins : ['*']
 
     # Regexp to be matched against a stacktrace frame's `file_name` and `abs_path` attributes.
@@ -108,11 +105,11 @@ apm-server:
     # The default pattern excludes stacktrace frames that have a filename starting with '/webpack'
     #exclude_from_grouping: "^/webpack"
 
-    # If a source map has previously been uploaded, source mapping is automatically applied
+    # If a source map has previously been uploaded, source mapping is automatically applied.
     # to all error and transaction documents sent to the RUM endpoint.
     #source_mapping:
 
-      # Sourcemapping is enabled by default for RUM events
+      # Sourcemapping is enabled by default for RUM events.
       #enabled: true
 
       # Source maps are always fetched from Elasticsearch, by default using the output.elasticsearch configuration.
@@ -120,9 +117,9 @@ apm-server:
       # This setting only affects sourcemap reads - the output determines where sourcemaps are written.
       #elasticsearch:
         # Array of hosts to connect to.
-        # Scheme and port can be left out and will be set to the default (http and 9200)
-        # In case you specify and additional path, the scheme is required: http://localhost:9200/path
-        # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+        # Scheme and port can be left out and will be set to the default (`http` and `9200`).
+        # In case you specify and additional path, the scheme is required: `http://localhost:9200/path`.
+        # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
         # hosts: ["localhost:9200"]
 
         # Optional protocol and basic auth credentials.
@@ -141,28 +138,30 @@ apm-server:
       #index_pattern: "apm-*-sourcemap*"
 
 
-  # If set to true, APM Server augments data received by the agent with the original IP of the backend server,
-  # or the IP and User Agent of the real user (RUM requests). It defaults to true.
+  # If true (default), APM Server captures the IP of the instrumented service
+  # or the IP and User Agent of the real user (RUM requests).
   #capture_personal_data: true
 
-  # golang expvar support - https://golang.org/pkg/expvar/
+  # Enable APM Server golang expvar support (https://golang.org/pkg/expvar/).
   #expvar:
-    # Set to true to expose expvar
     #enabled: false
 
-    # Url to expose expvar
+    # Url to expose expvar.
     #url: "/debug/vars"
 
   # Instrumentation support for the server's HTTP endpoints and event publisher.
   #instrumentation:
     # Set to true to enable instrumentation of the APM Server itself.
     #enabled: false
+
     # Environment in which the APM Server is running on (eg: staging, production, etc.)
     #environment: ""
+
     # Remote hosts to report instrumentation results to.
     #hosts:
     #  - http://remote-apm-server:8200
-    # Remote apm-servers' secret_token
+
+    # secret_token for the remote apm-servers.
     #secret_token:
 
   # A pipeline is a definition of processors applied to documents when ingesting them to Elasticsearch.
@@ -173,7 +172,7 @@ apm-server:
   # You can manually register a pipeline, or use this configuration option to ensure
   # the pipeline is loaded and registered at the configured Elasticsearch instances.
   # Find the default pipeline configuration at `ingest/pipeline/definition.json`.
-  # Automatic pipeline registration requires the output.elasticsearch` to be enabled and configured.
+  # Automatic pipeline registration requires the `output.elasticsearch` to be enabled and configured.
   #register.ingest.pipeline:
     # Registers APM pipeline definition in Elasticsearch on APM Server startup. Defaults to true.
     #enabled: true
@@ -191,9 +190,7 @@ apm-server:
   # For ILM to be applied, The configured output must be set to Elasticsearch and the instance
   # needs to support ILM. Otherwise APM Server falls back to ordinary index management without ILM.
   #
-  # Disable ILM by setting it to `false`.
-  #
-  # Defaults to `auto`.
+  # Defaults to "auto". Disable ILM by setting it to `false`.
   #ilm.enabled: "auto"
 
   # When using APM agent configuration, information fetched from Kibana will be cached in memory for some time.
@@ -201,12 +198,12 @@ apm-server:
   #agent.config.cache.expiration: 30s
 
   #kibana:
-    # For APM Agent configuration in Kibana, enabled must be true
+    # For APM Agent configuration in Kibana, enabled must be true.
     #enabled: false
 
-    # Scheme and port can be left out and will be set to the default (http and 5601)
-    # In case you specify an additional path, the scheme is required: http://localhost:5601/path
-    # IPv6 addresses should always be defined as: https://[2001:db8::1]:5601
+    # Scheme and port can be left out and will be set to the default (`http` and `5601`).
+    # In case you specify an additional path, the scheme is required: `http://localhost:5601/path`.
+    # IPv6 addresses should always be defined as: `https://[2001:db8::1]:5601`.
     #host: "localhost:5601"
 
     # Optional protocol and basic auth credentials.
@@ -214,7 +211,7 @@ apm-server:
     #username: "elastic"
     #password: "changeme"
 
-    # Optional HTTP path
+    # Optional HTTP path.
     #path: ""
 
     # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
@@ -231,10 +228,10 @@ apm-server:
     # 1.2 are enabled.
     #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-    # List of root certificates for HTTPS server verifications
+    # List of root certificates for HTTPS server verifications.
     #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-    # Certificate for SSL client authentication
+    # Certificate for SSL client authentication.
     #ssl.certificate: "/etc/pki/client/cert.pem"
 
     # Client Certificate Key
@@ -244,20 +241,20 @@ apm-server:
     # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
     #ssl.key_passphrase: ''
 
-    # Configure cipher suites to be used for SSL connections
+    # Configure cipher suites to be used for SSL connections.
     #ssl.cipher_suites: []
 
-    # Configure curve types for ECDHE based cipher suites
+    # Configure curve types for ECDHE based cipher suites.
     #ssl.curve_types: []
 
-#================================ General ======================================
+#================================= General =================================
 
-# Internal queue configuration for buffering events to be published.
+# Data is buffered in a memory queue before it is published to the configured output.
+# The memory queue will present all available events (up to the outputs
+# bulk_max_size) to the output, the moment the output is ready to serve
+# another batch of events.
 #queue:
-  # Queue type by name (default 'mem')
-  # The memory queue will present all available events (up to the outputs
-  # bulk_max_size) to the output, the moment the output is ready to server
-  # another batch of events.
+  # Queue type by name (default 'mem').
   #mem:
     # Max number of events the queue can buffer.
     #events: 4096
@@ -270,17 +267,16 @@ apm-server:
     #flush.min_events: 2048
 
     # Maximum duration after which events are available to the outputs,
-    # if the number of events stored in the queue is < min_flush_events.
+    # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
 
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
 #max_procs:
 
+#================================= Template =================================
 
-#============================== Template =====================================
-
-# A template is used to set the mapping in Elasticsearch
+# A template is used to set the mapping in Elasticsearch.
 # By default template loading is enabled and the template is loaded.
 # These settings can be adjusted to load your own template or overwrite existing ones.
 
@@ -296,13 +292,13 @@ apm-server:
 # The template name and pattern has to be set in case the elasticsearch index pattern is modified.
 #setup.template.pattern: "apm-%{[observer.version]}-*"
 
-# Path to fields.yml file to generate the template
+# Path to fields.yml file to generate the template.
 #setup.template.fields: "${path.config}/fields.yml"
 
-# Overwrite existing template
+# Overwrite existing template.
 #setup.template.overwrite: false
 
-# Elasticsearch template settings
+# Elasticsearch template settings.
 #setup.template.settings:
 
   # A dictionary of settings to place into the settings.index dictionary
@@ -314,8 +310,7 @@ apm-server:
     #number_of_routing_shards: 30
     #mapping.total_fields.limit: 2000
 
-
-#============================= Elastic Cloud ==================================
+#============================= Elastic Cloud =============================
 
 # These settings simplify using APM Server with the Elastic Cloud (https://cloud.elastic.co/).
 
@@ -327,16 +322,16 @@ apm-server:
 # `output.elasticsearch.password` settings. The format is `<user>:<pass>`.
 #cloud.auth:
 
-#================================ Outputs =====================================
+#================================ Outputs =================================
 
-# Configure what output to use when sending the data collected by apm-server.
+# Configure the output to use when sending the data collected by apm-server.
 
-#-------------------------- Elasticsearch output ------------------------------
+#-------------------------- Elasticsearch output --------------------------
 output.elasticsearch:
   # Array of hosts to connect to.
-  # Scheme and port can be left out and will be set to the default (http and 9200)
-  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
-  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  # Scheme and port can be left out and will be set to the default (`http` and `9200`).
+  # In case you specify and additional path, the scheme is required: `http://localhost:9200/path`.
+  # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
   hosts: ["elasticsearch:9200"]
 
   # Boolean flag to enable or disable the output module.
@@ -358,7 +353,7 @@ output.elasticsearch:
   # Number of workers per Elasticsearch host.
   #worker: 1
 
-  # By using the configuration below, apm documents are stored to separate indices,
+  # By using the configuration below, APM documents are stored to separate indices,
   # depending on their `processor.event`:
   # - error
   # - transaction
@@ -368,10 +363,10 @@ output.elasticsearch:
   # The indices are all prefixed with `apm-%{[observer.version]}`.
   # To allow managing indices based on their age, all indices (except for sourcemaps)
   # end with the information of the day they got indexed.
-  # e.g. "apm-6.3.0-transaction-2018.03.20"
+  # e.g. "apm-7.3.0-transaction-2019.07.20"
   #
   # Be aware that you can only specify one Elasticsearch template.
-  # In case you modify the index patterns you must also update those configurations accordingly,
+  # If you modify the index patterns you must also update these configurations accordingly,
   # as they need to be aligned:
   # * `setup.template.name`
   # * `setup.template.pattern`
@@ -404,17 +399,17 @@ output.elasticsearch:
   # A pipeline is a definition of processors applied to documents when ingesting them to Elasticsearch.
   # APM Server comes with a default pipeline definition, located at `ingest/pipeline/definition.json`, which is
   # loaded to Elasticsearch by default (see `apm-server.register.ingest.pipeline`).
-  # APM pipeline is enabled by default. For disabling set `pipeline: _none`.
+  # APM pipeline is enabled by default. To disable it, set `pipeline: _none`.
   #pipeline: "apm"
 
-  # Optional HTTP Path
+  # Optional HTTP Path.
   #path: "/elasticsearch"
 
-  # Custom HTTP headers to add to each request
+  # Custom HTTP headers to add to each request.
   #headers:
   #  X-My-Header: Contents of the header
 
-  # Proxy server url
+  # Proxy server url.
   #proxy_url: http://proxy:3128
 
   # The number of times a particular Elasticsearch index operation is attempted. If
@@ -454,10 +449,10 @@ output.elasticsearch:
   # 1.2 are enabled.
   #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # List of root certificates for HTTPS server verifications
+  # List of root certificates for HTTPS server verifications.
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for SSL client authentication
+  # Certificate for SSL client authentication.
   #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
@@ -467,35 +462,35 @@ output.elasticsearch:
   # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
   #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for SSL connections
+  # Configure cipher suites to be used for SSL connections.
   #ssl.cipher_suites: []
 
-  # Configure curve types for ECDHE based cipher suites
+  # Configure curve types for ECDHE based cipher suites.
   #ssl.curve_types: []
 
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-#----------------------------- Console output ---------------------------------
+#----------------------------- Console output -----------------------------
 #output.console:
   # Boolean flag to enable or disable the output module.
   #enabled: false
 
-  # Configure JSON encoding
+  # Configure JSON encoding.
   #codec.json:
-    # Pretty-print JSON event
+    # Pretty-print JSON event.
     #pretty: false
 
     # Configure escaping HTML symbols in strings.
     #escape_html: false
 
-#----------------------------- Logstash output ---------------------------------
+#---------------------------- Logstash output -----------------------------
 #output.logstash:
   # Boolean flag to enable or disable the output module.
   #enabled: false
 
-  # The Logstash hosts
+  # The Logstash hosts.
   #hosts: ["localhost:5044"]
 
   # Number of workers per Logstash host.
@@ -511,7 +506,7 @@ output.elasticsearch:
   # connection will be re-established.  A value of `0s` (the default) will
   # disable this feature.
   #
-  # Not yet supported for async connections (i.e. with the "pipelining" option set)
+  # Not yet supported for async connections (i.e. with the "pipelining" option set).
   #ttl: 30s
 
   # Optional load balance the events between the Logstash hosts. Default is false.
@@ -561,10 +556,10 @@ output.elasticsearch:
   # 1.2 are enabled.
   #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # List of root certificates for HTTPS server verifications
+  # List of root certificates for HTTPS server verifications.
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for SSL client authentication
+  # Certificate for SSL client authentication.
   #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
@@ -574,17 +569,17 @@ output.elasticsearch:
   # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
   #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for SSL connections
+  # Configure cipher suites to be used for SSL connections.
   #ssl.cipher_suites: []
 
-  # Configure curve types for ECDHE based cipher suites
+  # Configure curve types for ECDHE based cipher suites.
   #ssl.curve_types: []
 
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-#------------------------------- Kafka output ----------------------------------
+#------------------------------ Kafka output ------------------------------
 #output.kafka:
   # Boolean flag to enable or disable the output module.
   #enabled: false
@@ -622,7 +617,7 @@ output.elasticsearch:
   # Kafka version libbeat is assumed to run against. Defaults to the "1.0.0".
   #version: '1.0.0'
 
-  # Configure JSON encoding
+  # Configure JSON encoding.
   #codec.json:
     # Pretty print json event
     #pretty: false
@@ -708,10 +703,10 @@ output.elasticsearch:
   # 1.2 are enabled.
   #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # List of root certificates for HTTPS server verifications
+  # List of root certificates for HTTPS server verifications.
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for SSL client authentication
+  # Certificate for SSL client authentication.
   #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
@@ -721,17 +716,17 @@ output.elasticsearch:
   # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
   #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for SSL connections
+  # Configure cipher suites to be used for SSL connections.
   #ssl.cipher_suites: []
 
-  # Configure curve types for ECDHE based cipher suites
+  # Configure curve types for ECDHE based cipher suites.
   #ssl.curve_types: []
 
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-#================================= Paths ======================================
+#================================= Paths ==================================
 
 # The home path for the apm-server installation. This is the default base path
 # for all other path settings and for miscellaneous files that come with the
@@ -756,19 +751,17 @@ output.elasticsearch:
 # configuration file, the default is a logs subdirectory inside the home path.
 #path.logs: ${path.home}/logs
 
+#================================= Logging =================================
 
-#================================ Logging ======================================
-#
-# There are three options for the log output: syslog, file, stderr.
-# Under Windows systems, the log files are per default sent to the file output,
-# under all other system per default to syslog.
+# There are three options for the log output: syslog, file, and stderr.
+# Windows systems default to file output. All other systems default to syslog.
 
-# Sets log level. The default log level is info.
-# Available log levels are: error, warning, info, debug
+# Sets the minimum log level. The default log level is info.
+# Available log levels are: error, warning, info, or debug.
 #logging.level: info
 
-# Enable debug output for selected components. To enable all selectors use ["*"]
-# Other available selectors are "beat", "publish", "service"
+# Enable debug output for selected components. To enable all selectors use ["*"].
+# Other available selectors are "beat", "publish", or "service".
 # Multiple selectors can be chained.
 #logging.selectors: [ ]
 
@@ -784,8 +777,8 @@ output.elasticsearch:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# Logging to rotating files. Set logging.to_files to false to disable logging to
-# files.
+# Logging to rotating files. When true, writes all logging output to files.
+# The log files are automatically rotated when the log file size limit is reached.
 #logging.to_files: true
 #logging.files:
   # Configure the path where the logs are written. The default is the logs directory
@@ -796,7 +789,7 @@ output.elasticsearch:
   #name: apm-server
 
   # Configure log file size limit. If limit is reached, log file will be
-  # automatically rotated
+  # automatically rotated.
   #rotateeverybytes: 10485760 # = 10MB
 
   # Number of rotated log files to keep. Oldest files will be deleted first.
@@ -816,12 +809,11 @@ output.elasticsearch:
 # Set to true to log messages in json format.
 #logging.json: false
 
+#=============================== HTTP Endpoint ===============================
 
-#================================ HTTP Endpoint ======================================
-#
 # apm-server can expose internal metrics through a HTTP endpoint. For security
 # reasons the endpoint is disabled by default. This feature is currently experimental.
-# Stats can be access through http://localhost:5066/stats . For pretty JSON output
+# Stats can be access through http://localhost:5066/stats. For pretty JSON output
 # append ?pretty to the URL.
 
 # Defines if the HTTP endpoint is enabled.
@@ -833,7 +825,8 @@ output.elasticsearch:
 # Port on which the HTTP endpoint will bind. Default is 5066.
 #http.port: 5066
 
-#============================== X-pack Monitoring ===============================
+#============================= X-pack Monitoring =============================
+
 # APM server can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires x-pack monitoring to be enabled in Elasticsearch.  The
 # reporting is disabled by default.
@@ -854,9 +847,9 @@ output.elasticsearch:
   #password: ""
 
   # Array of hosts to connect to.
-  # Scheme and port can be left out and will be set to the default (http and 9200)
-  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
-  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  # Scheme and port can be left out and will be set to the default (`http` and `9200`).
+  # In case you specify and additional path, the scheme is required: `http://localhost:9200/path`.
+  # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
   #hosts: ["localhost:9200"]
 
   # Set gzip compression level.
@@ -867,11 +860,11 @@ output.elasticsearch:
     #param1: value1
     #param2: value2
 
-  # Custom HTTP headers to add to each request
+  # Custom HTTP headers to add to each request.
   #headers:
   #  X-My-Header: Contents of the header
 
-  # Proxy server url
+  # Proxy server url.
   #proxy_url: http://proxy:3128
 
   # The number of times a particular Elasticsearch index operation is attempted. If
@@ -911,10 +904,10 @@ output.elasticsearch:
   # 1.2 are enabled.
   #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # List of root certificates for HTTPS server verifications
+  # List of root certificates for HTTPS server verifications.
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for SSL client authentication
+  # Certificate for SSL client authentication.
   #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
@@ -924,10 +917,10 @@ output.elasticsearch:
   # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
   #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for SSL connections
+  # Configure cipher suites to be used for SSL connections.
   #ssl.cipher_suites: []
 
-  # Configure curve types for ECDHE based cipher suites
+  # Configure curve types for ECDHE based cipher suites.
   #ssl.curve_types: []
 
   # Configure what types of renegotiation are supported. Valid options are

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -30,7 +30,7 @@ apm-server:
   # Authorization token for sending data to the APM server. If a token is set, the
   # agents must send it in the following format: Authorization: Bearer <secret-token>.
   # It is recommended to use an authorization token in combination with SSL enabled,
-  # and save the token in the apm-server keystore. The token is not used for RUM endpoints.
+  # and save the token in the apm-server keystore. The token is not used for the RUM endpoint.
   #secret_token:
 
   # Enable secure communication between APM agents and the server. By default ssl is disabled.
@@ -109,7 +109,7 @@ apm-server:
     # to all error and transaction documents sent to the RUM endpoint.
     #source_mapping:
 
-      # Sourcemapping is enabled by default for RUM events.
+      # Sourcemapping is enabled by default.
       #enabled: true
 
       # Source maps are always fetched from Elasticsearch, by default using the output.elasticsearch configuration.
@@ -142,7 +142,7 @@ apm-server:
   # or the IP and User Agent of the real user (RUM requests).
   #capture_personal_data: true
 
-  # Enable APM Server golang expvar support (https://golang.org/pkg/expvar/).
+  # Enable APM Server Golang expvar support (https://golang.org/pkg/expvar/).
   #expvar:
     #enabled: false
 

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -1,15 +1,15 @@
-################### APM Server Configuration #########################
+######################### APM Server Configuration #########################
 
-############################# APM Server ######################################
+################################ APM Server ################################
 
 apm-server:
-  # Defines the host and port the server is listening on.  use "unix:/path/to.sock" to listen on a unix domain socket.
+  # Defines the host and port the server is listening on. Use "unix:/path/to.sock" to listen on a unix domain socket.
   host: "localhost:8200"
 
   # Maximum permitted size in bytes of a request's header accepted by the server to be processed.
   #max_header_size: 1048576
 
-  # Maximum idle time until the server closes a connection.
+  # Maximum amount of time to wait for the next incoming request before underlying connection is closed.
   #idle_timeout: 45s
 
   # Maximum permitted duration for reading an entire request.
@@ -18,39 +18,37 @@ apm-server:
   # Maximum permitted duration for writing a response.
   #write_timeout: 30s
 
-  # Maximum duration in seconds before releasing resources when shutting down the server.
+  # Maximum duration before releasing resources when shutting down the server.
   #shutdown_timeout: 5s
 
-  # Maximum allowed size in bytes of a single event
+  # Maximum permitted size in bytes of an event accepted by the server to be processed.
   #max_event_size: 307200
 
-  #--
+  # Maximum number of new connections to accept simultaneously (0 means unlimited).
+  #max_connections: 0
 
-  # Maximum number of new connections to accept simultaneously (0 means unlimited)
-  # max_connections: 0
-
-  # Authorization token to be checked. If a token is set here the agents must
-  # send their token in the following format: Authorization: Bearer <secret-token>.
+  # Authorization token for sending data to the APM server. If a token is set, the
+  # agents must send it in the following format: Authorization: Bearer <secret-token>.
   # It is recommended to use an authorization token in combination with SSL enabled,
-  # and save the token in the apm-server keystore.
+  # and save the token in the apm-server keystore. The token is not used for RUM endpoints.
   #secret_token:
 
   # Enable secure communication between APM agents and the server. By default ssl is disabled.
   #ssl:
     #enabled: false
 
-    # Configure a list of root certificate authorities for verifying client certificates
+    # Configure a list of root certificate authorities for verifying client certificates.
     #certificate_authorities: []
 
-    # Path to file containing the certificate for server authentication
-    # Needs to be configured when ssl is enabled
+    # Path to file containing the certificate for server authentication.
+    # Needs to be configured when ssl is enabled.
     #certificate: ''
 
-    # Path to file containing server certificate key
-    # Needs to be configured when ssl is enabled
+    # Path to file containing server certificate key.
+    # Needs to be configured when ssl is enabled.
     #key: ''
 
-    # Optional configuration options for ssl communication
+    # Optional configuration options for ssl communication.
 
     # Passphrase for decrypting the Certificate Key.
     # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
@@ -59,10 +57,10 @@ apm-server:
     # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.2 are enabled.
     #supported_protocols: [TLSv1.1, TLSv1.2]
 
-    # Configure cipher suites to be used for SSL connections
+    # Configure cipher suites to be used for SSL connections.
     #cipher_suites: []
 
-    # Configure curve types for ECDHE based cipher suites
+    # Configure curve types for ECDHE based cipher suites.
     #curve_types: []
 
     # Configure which type of client authentication is supported.
@@ -74,9 +72,8 @@ apm-server:
     # susceptible to man-in-the-middle attacks. Use only for testing. Default is `full`.
     #ssl.verification_mode: full
 
-
+  # Enable Real User Monitoring (RUM) Support. By default RUM is disabled.
   #rum:
-    # To enable real user monitoring (RUM) support set this to true.
     #enabled: false
 
     #event_rate:
@@ -96,7 +93,7 @@ apm-server:
     # User-agents will send an origin header that will be validated against this list.
     # An origin is made of a protocol scheme, host and port, without the url path.
     # Allowed origins in this setting can have * to match anything (eg.: http://*.example.com)
-    # If an item in the list is a single '*', everything will be allowed
+    # If an item in the list is a single '*', everything will be allowed.
     #allow_origins : ['*']
 
     # Regexp to be matched against a stacktrace frame's `file_name` and `abs_path` attributes.
@@ -108,11 +105,11 @@ apm-server:
     # The default pattern excludes stacktrace frames that have a filename starting with '/webpack'
     #exclude_from_grouping: "^/webpack"
 
-    # If a source map has previously been uploaded, source mapping is automatically applied
+    # If a source map has previously been uploaded, source mapping is automatically applied.
     # to all error and transaction documents sent to the RUM endpoint.
     #source_mapping:
 
-      # Sourcemapping is enabled by default for RUM events
+      # Sourcemapping is enabled by default for RUM events.
       #enabled: true
 
       # Source maps are always fetched from Elasticsearch, by default using the output.elasticsearch configuration.
@@ -120,9 +117,9 @@ apm-server:
       # This setting only affects sourcemap reads - the output determines where sourcemaps are written.
       #elasticsearch:
         # Array of hosts to connect to.
-        # Scheme and port can be left out and will be set to the default (http and 9200)
-        # In case you specify and additional path, the scheme is required: http://localhost:9200/path
-        # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+        # Scheme and port can be left out and will be set to the default (`http` and `9200`).
+        # In case you specify and additional path, the scheme is required: `http://localhost:9200/path`.
+        # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
         # hosts: ["localhost:9200"]
 
         # Optional protocol and basic auth credentials.
@@ -141,28 +138,30 @@ apm-server:
       #index_pattern: "apm-*-sourcemap*"
 
 
-  # If set to true, APM Server augments data received by the agent with the original IP of the backend server,
-  # or the IP and User Agent of the real user (RUM requests). It defaults to true.
+  # If true (default), APM Server captures the IP of the instrumented service
+  # or the IP and User Agent of the real user (RUM requests).
   #capture_personal_data: true
 
-  # golang expvar support - https://golang.org/pkg/expvar/
+  # Enable APM Server golang expvar support (https://golang.org/pkg/expvar/).
   #expvar:
-    # Set to true to expose expvar
     #enabled: false
 
-    # Url to expose expvar
+    # Url to expose expvar.
     #url: "/debug/vars"
 
   # Instrumentation support for the server's HTTP endpoints and event publisher.
   #instrumentation:
     # Set to true to enable instrumentation of the APM Server itself.
     #enabled: false
+
     # Environment in which the APM Server is running on (eg: staging, production, etc.)
     #environment: ""
+
     # Remote hosts to report instrumentation results to.
     #hosts:
     #  - http://remote-apm-server:8200
-    # Remote apm-servers' secret_token
+
+    # secret_token for the remote apm-servers.
     #secret_token:
 
   # A pipeline is a definition of processors applied to documents when ingesting them to Elasticsearch.
@@ -173,7 +172,7 @@ apm-server:
   # You can manually register a pipeline, or use this configuration option to ensure
   # the pipeline is loaded and registered at the configured Elasticsearch instances.
   # Find the default pipeline configuration at `ingest/pipeline/definition.json`.
-  # Automatic pipeline registration requires the output.elasticsearch` to be enabled and configured.
+  # Automatic pipeline registration requires the `output.elasticsearch` to be enabled and configured.
   #register.ingest.pipeline:
     # Registers APM pipeline definition in Elasticsearch on APM Server startup. Defaults to true.
     #enabled: true
@@ -191,9 +190,7 @@ apm-server:
   # For ILM to be applied, The configured output must be set to Elasticsearch and the instance
   # needs to support ILM. Otherwise APM Server falls back to ordinary index management without ILM.
   #
-  # Disable ILM by setting it to `false`.
-  #
-  # Defaults to `auto`.
+  # Defaults to "auto". Disable ILM by setting it to `false`.
   #ilm.enabled: "auto"
 
   # When using APM agent configuration, information fetched from Kibana will be cached in memory for some time.
@@ -201,12 +198,12 @@ apm-server:
   #agent.config.cache.expiration: 30s
 
   #kibana:
-    # For APM Agent configuration in Kibana, enabled must be true
+    # For APM Agent configuration in Kibana, enabled must be true.
     #enabled: false
 
-    # Scheme and port can be left out and will be set to the default (http and 5601)
-    # In case you specify an additional path, the scheme is required: http://localhost:5601/path
-    # IPv6 addresses should always be defined as: https://[2001:db8::1]:5601
+    # Scheme and port can be left out and will be set to the default (`http` and `5601`).
+    # In case you specify an additional path, the scheme is required: `http://localhost:5601/path`.
+    # IPv6 addresses should always be defined as: `https://[2001:db8::1]:5601`.
     #host: "localhost:5601"
 
     # Optional protocol and basic auth credentials.
@@ -214,7 +211,7 @@ apm-server:
     #username: "elastic"
     #password: "changeme"
 
-    # Optional HTTP path
+    # Optional HTTP path.
     #path: ""
 
     # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
@@ -231,10 +228,10 @@ apm-server:
     # 1.2 are enabled.
     #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-    # List of root certificates for HTTPS server verifications
+    # List of root certificates for HTTPS server verifications.
     #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-    # Certificate for SSL client authentication
+    # Certificate for SSL client authentication.
     #ssl.certificate: "/etc/pki/client/cert.pem"
 
     # Client Certificate Key
@@ -244,20 +241,20 @@ apm-server:
     # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
     #ssl.key_passphrase: ''
 
-    # Configure cipher suites to be used for SSL connections
+    # Configure cipher suites to be used for SSL connections.
     #ssl.cipher_suites: []
 
-    # Configure curve types for ECDHE based cipher suites
+    # Configure curve types for ECDHE based cipher suites.
     #ssl.curve_types: []
 
-#================================ General ======================================
+#================================= General =================================
 
-# Internal queue configuration for buffering events to be published.
+# Data is buffered in a memory queue before it is published to the configured output.
+# The memory queue will present all available events (up to the outputs
+# bulk_max_size) to the output, the moment the output is ready to serve
+# another batch of events.
 #queue:
-  # Queue type by name (default 'mem')
-  # The memory queue will present all available events (up to the outputs
-  # bulk_max_size) to the output, the moment the output is ready to server
-  # another batch of events.
+  # Queue type by name (default 'mem').
   #mem:
     # Max number of events the queue can buffer.
     #events: 4096
@@ -270,17 +267,16 @@ apm-server:
     #flush.min_events: 2048
 
     # Maximum duration after which events are available to the outputs,
-    # if the number of events stored in the queue is < min_flush_events.
+    # if the number of events stored in the queue is < `flush.min_events`.
     #flush.timeout: 1s
 
 # Sets the maximum number of CPUs that can be executing simultaneously. The
 # default is the number of logical CPUs available in the system.
 #max_procs:
 
+#================================= Template =================================
 
-#============================== Template =====================================
-
-# A template is used to set the mapping in Elasticsearch
+# A template is used to set the mapping in Elasticsearch.
 # By default template loading is enabled and the template is loaded.
 # These settings can be adjusted to load your own template or overwrite existing ones.
 
@@ -296,13 +292,13 @@ apm-server:
 # The template name and pattern has to be set in case the elasticsearch index pattern is modified.
 #setup.template.pattern: "apm-%{[observer.version]}-*"
 
-# Path to fields.yml file to generate the template
+# Path to fields.yml file to generate the template.
 #setup.template.fields: "${path.config}/fields.yml"
 
-# Overwrite existing template
+# Overwrite existing template.
 #setup.template.overwrite: false
 
-# Elasticsearch template settings
+# Elasticsearch template settings.
 #setup.template.settings:
 
   # A dictionary of settings to place into the settings.index dictionary
@@ -314,8 +310,7 @@ apm-server:
     #number_of_routing_shards: 30
     #mapping.total_fields.limit: 2000
 
-
-#============================= Elastic Cloud ==================================
+#============================= Elastic Cloud =============================
 
 # These settings simplify using APM Server with the Elastic Cloud (https://cloud.elastic.co/).
 
@@ -327,16 +322,16 @@ apm-server:
 # `output.elasticsearch.password` settings. The format is `<user>:<pass>`.
 #cloud.auth:
 
-#================================ Outputs =====================================
+#================================ Outputs =================================
 
-# Configure what output to use when sending the data collected by apm-server.
+# Configure the output to use when sending the data collected by apm-server.
 
-#-------------------------- Elasticsearch output ------------------------------
+#-------------------------- Elasticsearch output --------------------------
 output.elasticsearch:
   # Array of hosts to connect to.
-  # Scheme and port can be left out and will be set to the default (http and 9200)
-  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
-  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  # Scheme and port can be left out and will be set to the default (`http` and `9200`).
+  # In case you specify and additional path, the scheme is required: `http://localhost:9200/path`.
+  # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
   hosts: ["localhost:9200"]
 
   # Boolean flag to enable or disable the output module.
@@ -358,7 +353,7 @@ output.elasticsearch:
   # Number of workers per Elasticsearch host.
   #worker: 1
 
-  # By using the configuration below, apm documents are stored to separate indices,
+  # By using the configuration below, APM documents are stored to separate indices,
   # depending on their `processor.event`:
   # - error
   # - transaction
@@ -368,10 +363,10 @@ output.elasticsearch:
   # The indices are all prefixed with `apm-%{[observer.version]}`.
   # To allow managing indices based on their age, all indices (except for sourcemaps)
   # end with the information of the day they got indexed.
-  # e.g. "apm-6.3.0-transaction-2018.03.20"
+  # e.g. "apm-7.3.0-transaction-2019.07.20"
   #
   # Be aware that you can only specify one Elasticsearch template.
-  # In case you modify the index patterns you must also update those configurations accordingly,
+  # If you modify the index patterns you must also update these configurations accordingly,
   # as they need to be aligned:
   # * `setup.template.name`
   # * `setup.template.pattern`
@@ -404,17 +399,17 @@ output.elasticsearch:
   # A pipeline is a definition of processors applied to documents when ingesting them to Elasticsearch.
   # APM Server comes with a default pipeline definition, located at `ingest/pipeline/definition.json`, which is
   # loaded to Elasticsearch by default (see `apm-server.register.ingest.pipeline`).
-  # APM pipeline is enabled by default. For disabling set `pipeline: _none`.
+  # APM pipeline is enabled by default. To disable it, set `pipeline: _none`.
   #pipeline: "apm"
 
-  # Optional HTTP Path
+  # Optional HTTP Path.
   #path: "/elasticsearch"
 
-  # Custom HTTP headers to add to each request
+  # Custom HTTP headers to add to each request.
   #headers:
   #  X-My-Header: Contents of the header
 
-  # Proxy server url
+  # Proxy server url.
   #proxy_url: http://proxy:3128
 
   # The number of times a particular Elasticsearch index operation is attempted. If
@@ -454,10 +449,10 @@ output.elasticsearch:
   # 1.2 are enabled.
   #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # List of root certificates for HTTPS server verifications
+  # List of root certificates for HTTPS server verifications.
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for SSL client authentication
+  # Certificate for SSL client authentication.
   #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
@@ -467,35 +462,35 @@ output.elasticsearch:
   # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
   #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for SSL connections
+  # Configure cipher suites to be used for SSL connections.
   #ssl.cipher_suites: []
 
-  # Configure curve types for ECDHE based cipher suites
+  # Configure curve types for ECDHE based cipher suites.
   #ssl.curve_types: []
 
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-#----------------------------- Console output ---------------------------------
+#----------------------------- Console output -----------------------------
 #output.console:
   # Boolean flag to enable or disable the output module.
   #enabled: false
 
-  # Configure JSON encoding
+  # Configure JSON encoding.
   #codec.json:
-    # Pretty-print JSON event
+    # Pretty-print JSON event.
     #pretty: false
 
     # Configure escaping HTML symbols in strings.
     #escape_html: false
 
-#----------------------------- Logstash output ---------------------------------
+#---------------------------- Logstash output -----------------------------
 #output.logstash:
   # Boolean flag to enable or disable the output module.
   #enabled: false
 
-  # The Logstash hosts
+  # The Logstash hosts.
   #hosts: ["localhost:5044"]
 
   # Number of workers per Logstash host.
@@ -511,7 +506,7 @@ output.elasticsearch:
   # connection will be re-established.  A value of `0s` (the default) will
   # disable this feature.
   #
-  # Not yet supported for async connections (i.e. with the "pipelining" option set)
+  # Not yet supported for async connections (i.e. with the "pipelining" option set).
   #ttl: 30s
 
   # Optional load balance the events between the Logstash hosts. Default is false.
@@ -561,10 +556,10 @@ output.elasticsearch:
   # 1.2 are enabled.
   #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # List of root certificates for HTTPS server verifications
+  # List of root certificates for HTTPS server verifications.
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for SSL client authentication
+  # Certificate for SSL client authentication.
   #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
@@ -574,17 +569,17 @@ output.elasticsearch:
   # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
   #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for SSL connections
+  # Configure cipher suites to be used for SSL connections.
   #ssl.cipher_suites: []
 
-  # Configure curve types for ECDHE based cipher suites
+  # Configure curve types for ECDHE based cipher suites.
   #ssl.curve_types: []
 
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-#------------------------------- Kafka output ----------------------------------
+#------------------------------ Kafka output ------------------------------
 #output.kafka:
   # Boolean flag to enable or disable the output module.
   #enabled: false
@@ -622,7 +617,7 @@ output.elasticsearch:
   # Kafka version libbeat is assumed to run against. Defaults to the "1.0.0".
   #version: '1.0.0'
 
-  # Configure JSON encoding
+  # Configure JSON encoding.
   #codec.json:
     # Pretty print json event
     #pretty: false
@@ -708,10 +703,10 @@ output.elasticsearch:
   # 1.2 are enabled.
   #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # List of root certificates for HTTPS server verifications
+  # List of root certificates for HTTPS server verifications.
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for SSL client authentication
+  # Certificate for SSL client authentication.
   #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
@@ -721,17 +716,17 @@ output.elasticsearch:
   # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
   #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for SSL connections
+  # Configure cipher suites to be used for SSL connections.
   #ssl.cipher_suites: []
 
-  # Configure curve types for ECDHE based cipher suites
+  # Configure curve types for ECDHE based cipher suites.
   #ssl.curve_types: []
 
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
-#================================= Paths ======================================
+#================================= Paths ==================================
 
 # The home path for the apm-server installation. This is the default base path
 # for all other path settings and for miscellaneous files that come with the
@@ -756,19 +751,17 @@ output.elasticsearch:
 # configuration file, the default is a logs subdirectory inside the home path.
 #path.logs: ${path.home}/logs
 
+#================================= Logging =================================
 
-#================================ Logging ======================================
-#
-# There are three options for the log output: syslog, file, stderr.
-# Under Windows systems, the log files are per default sent to the file output,
-# under all other system per default to syslog.
+# There are three options for the log output: syslog, file, and stderr.
+# Windows systems default to file output. All other systems default to syslog.
 
-# Sets log level. The default log level is info.
-# Available log levels are: error, warning, info, debug
+# Sets the minimum log level. The default log level is info.
+# Available log levels are: error, warning, info, or debug.
 #logging.level: info
 
-# Enable debug output for selected components. To enable all selectors use ["*"]
-# Other available selectors are "beat", "publish", "service"
+# Enable debug output for selected components. To enable all selectors use ["*"].
+# Other available selectors are "beat", "publish", or "service".
 # Multiple selectors can be chained.
 #logging.selectors: [ ]
 
@@ -784,8 +777,8 @@ output.elasticsearch:
 # The period after which to log the internal metrics. The default is 30s.
 #logging.metrics.period: 30s
 
-# Logging to rotating files. Set logging.to_files to false to disable logging to
-# files.
+# Logging to rotating files. When true, writes all logging output to files.
+# The log files are automatically rotated when the log file size limit is reached.
 #logging.to_files: true
 #logging.files:
   # Configure the path where the logs are written. The default is the logs directory
@@ -796,7 +789,7 @@ output.elasticsearch:
   #name: apm-server
 
   # Configure log file size limit. If limit is reached, log file will be
-  # automatically rotated
+  # automatically rotated.
   #rotateeverybytes: 10485760 # = 10MB
 
   # Number of rotated log files to keep. Oldest files will be deleted first.
@@ -816,12 +809,11 @@ output.elasticsearch:
 # Set to true to log messages in json format.
 #logging.json: false
 
+#=============================== HTTP Endpoint ===============================
 
-#================================ HTTP Endpoint ======================================
-#
 # apm-server can expose internal metrics through a HTTP endpoint. For security
 # reasons the endpoint is disabled by default. This feature is currently experimental.
-# Stats can be access through http://localhost:5066/stats . For pretty JSON output
+# Stats can be access through http://localhost:5066/stats. For pretty JSON output
 # append ?pretty to the URL.
 
 # Defines if the HTTP endpoint is enabled.
@@ -833,7 +825,8 @@ output.elasticsearch:
 # Port on which the HTTP endpoint will bind. Default is 5066.
 #http.port: 5066
 
-#============================== X-pack Monitoring ===============================
+#============================= X-pack Monitoring =============================
+
 # APM server can export internal metrics to a central Elasticsearch monitoring
 # cluster.  This requires x-pack monitoring to be enabled in Elasticsearch.  The
 # reporting is disabled by default.
@@ -854,9 +847,9 @@ output.elasticsearch:
   #password: ""
 
   # Array of hosts to connect to.
-  # Scheme and port can be left out and will be set to the default (http and 9200)
-  # In case you specify and additional path, the scheme is required: http://localhost:9200/path
-  # IPv6 addresses should always be defined as: https://[2001:db8::1]:9200
+  # Scheme and port can be left out and will be set to the default (`http` and `9200`).
+  # In case you specify and additional path, the scheme is required: `http://localhost:9200/path`.
+  # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
   #hosts: ["localhost:9200"]
 
   # Set gzip compression level.
@@ -867,11 +860,11 @@ output.elasticsearch:
     #param1: value1
     #param2: value2
 
-  # Custom HTTP headers to add to each request
+  # Custom HTTP headers to add to each request.
   #headers:
   #  X-My-Header: Contents of the header
 
-  # Proxy server url
+  # Proxy server url.
   #proxy_url: http://proxy:3128
 
   # The number of times a particular Elasticsearch index operation is attempted. If
@@ -911,10 +904,10 @@ output.elasticsearch:
   # 1.2 are enabled.
   #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
 
-  # List of root certificates for HTTPS server verifications
+  # List of root certificates for HTTPS server verifications.
   #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
-  # Certificate for SSL client authentication
+  # Certificate for SSL client authentication.
   #ssl.certificate: "/etc/pki/client/cert.pem"
 
   # Client Certificate Key
@@ -924,10 +917,10 @@ output.elasticsearch:
   # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
   #ssl.key_passphrase: ''
 
-  # Configure cipher suites to be used for SSL connections
+  # Configure cipher suites to be used for SSL connections.
   #ssl.cipher_suites: []
 
-  # Configure curve types for ECDHE based cipher suites
+  # Configure curve types for ECDHE based cipher suites.
   #ssl.curve_types: []
 
   # Configure what types of renegotiation are supported. Valid options are

--- a/docs/configuration-process.asciidoc
+++ b/docs/configuration-process.asciidoc
@@ -143,7 +143,7 @@ A value of 0 (the default) ensures events are immediately available to be sent t
 [float]
 ==== `flush.timeout`
 Maximum duration after which events are available to the outputs,
-if the number of events stored in the queue is < _min_flush_events_.
+if the number of events stored in the queue is < `flush.min_events`.
 Default value is 1 second.
 
 [float]

--- a/docs/copied-from-beats/monitoring/shared-monitor-config.asciidoc
+++ b/docs/copied-from-beats/monitoring/shared-monitor-config.asciidoc
@@ -16,19 +16,19 @@
 <titleabbrev>Configuration options</titleabbrev>
 ++++
 
-You can specify the following options in the `xpack.monitoring` section of the
+You can specify the following options in the X-pack Monitoring section of the
 +{beatname_lc}.yml+ config file:
 
 [float]
-=== `enabled`
+=== `monitoring.enabled`
 
-The `enabled` config is a boolean setting to enable or disable {monitoring}.
+The `monitoring.enabled` config is a boolean setting to enable or disable {monitoring}.
 If set to `true`, monitoring is enabled.
 
 The default value is `false`.
 
 [float]
-=== `elasticsearch`
+=== `monitoring.elasticsearch`
 
 The {es} instances that you want to ship your {beatname_uc} metrics to. This
 configuration option contains the following fields:

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -20,7 +20,7 @@ endif::[]
 
 ifndef::only-elasticsearch[]
 You configure {beatname_uc} to write to a specific output by setting options
-in the `output` section of the +{beatname_lc}.yml+ config file. Only a single
+in the `Outputs` section of the +{beatname_lc}.yml+ config file. Only a single
 output may be defined.
 
 The following topics describe how to configure each supported output:


### PR DESCRIPTION
Closes #2120. 

* A lot of these changes are consistency related. Specifically, I made the headers the same size, ensured consistent spacing, and added periods where they were forgotten. I think they make the YML file look cleaner, but at the end of the day they aren't _super_ necessary, so I can undo them if you want to make the diff cleaner.
* Fixed some spelling/grammar issues
* Clarifications on what certain settings do.
* Fixed a few inconsistencies between the docs and the YML files. Most of these are also upstream in the Beats repo and will need to be persisted there.

@jalvz - perhaps we can chat about what you have in mind for irrelevant options to be deemphasized.
