### PR TITLE
[7.1] docs: update rum links (#2355)

### DIFF
--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -20,7 +20,7 @@
 // Agent links
 :apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{py-branch}
 :apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{node-branch}
-:apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/js-base/{rum-branch}
+:apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/rum-js/{rum-branch}
 :apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{ruby-branch}
 :apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{java-branch}
 :apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{go-branch}


### PR DESCRIPTION
Backports the following commits to 7.1:
 - docs: update rum links (#2355)