### PR TITLE
fix automatic kibana sync

### DIFF
--- a/script/update_kibana_objects.py
+++ b/script/update_kibana_objects.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import json
 import tempfile
 import shlex
@@ -31,12 +32,11 @@ def call(cmd):
         sys.exit(code)
 
 
-def main():
+def main(branch):
     """
-    Updates the index pattern in kibana according to the current checked out branch in apm-server
+    Updates the index pattern in kibana in the specified branch (default "master")
 
     NOTES:
-    - apm-server should be on master or a release branch, and can't be in detached head state
     - `make && make update` must have been run previously
     """
 
@@ -44,8 +44,6 @@ def main():
     export = exec(apm_bin + " export index-pattern")
     index_pattern = json.loads(export)["objects"][0]
 
-    remote_branch = exec("git rev-parse --abbrev-ref --symbolic-full-name @{u}")
-    _, branch = remote_branch.split("/")
     remote_url = exec("git config remote.origin.url")
     gh_user = remote_url.split(":")[1].split("/")[0]
     print("branch: " + branch)
@@ -82,4 +80,7 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-b', default='master')
+    args = parser.parse_args()
+    main(args.branch)


### PR DESCRIPTION
Amends #2545 

The `git rev-parse` trick worked for me because I only had tried it in 7.x and master, where we were out of sync already.

But normally one wants to execute the sync on top of a `elastic/feature-branch`, and as `feature-branch` won't exist in the `kibana` remote, it will fail.
Literally first thing that came to mind this morning when I woke up.

So I suggest to take an explicit `branch` argument instead of git juggling. 
