### PR TITLE
fix repo install instructions

### DIFF
--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,5 +1,5 @@
 :stack-version: 7.3.0
-:major-version: 7.3
+:major-version: 7.x
 :doc-branch: 7.3
 :branch: {doc-branch}
 :go-version: 1.12.4


### PR DESCRIPTION
current instructions:

```
[elastic-7.3]
name=Elastic repository for 7.3 packages
baseurl=https://artifacts.elastic.co/packages/7.3/yum
gpgcheck=1
gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
enabled=1
autorefresh=1
type=rpm-md
```

should be:

```
baseurl=https://artifacts.elastic.co/packages/7.x/yum
```

same deal for apt