### PR TITLE
speed up integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -189,9 +189,15 @@ pipeline {
           }
           post {
             always {
+              coverageReport("${BASE_DIR}/build/coverage")
               junit(allowEmptyResults: true,
                 keepLongStdio: true,
-                testResults: "${BASE_DIR}/build/junit-*.xml")
+                testResults: "${BASE_DIR}/build/junit-*.xml"
+              )
+              catchError(buildResult: 'SUCCESS', message: 'Failed to grab test results tar files', stageResult: 'SUCCESS') {
+                tar(file: "coverage-files.tgz", archive: true, dir: "coverage", pathPrefix: "${BASE_DIR}/build")
+              }
+              codecov(repo: env.REPO, basedir: "${BASE_DIR}", secret: "${CODECOV_SECRET}")
             }
           }
         }
@@ -222,16 +228,9 @@ pipeline {
           }
           post {
             always {
-              coverageReport("${BASE_DIR}/build/coverage")
-              junit(allowEmptyResults: true,
-                keepLongStdio: true,
-                testResults: "${BASE_DIR}/build/junit-*.xml,${BASE_DIR}/build/TEST-*.xml"
-              )
               catchError(buildResult: 'SUCCESS', message: 'Failed to grab test results tar files', stageResult: 'SUCCESS') {
                 tar(file: "system-tests-linux-files.tgz", archive: true, dir: "system-tests", pathPrefix: "${BASE_DIR}/build")
-                tar(file: "coverage-files.tgz", archive: true, dir: "coverage", pathPrefix: "${BASE_DIR}/build")
               }
-              codecov(repo: env.REPO, basedir: "${BASE_DIR}", secret: "${CODECOV_SECRET}")
             }
           }
         }

--- a/script/jenkins/linux-test.sh
+++ b/script/jenkins/linux-test.sh
@@ -11,16 +11,6 @@ jenkins_setup
 #}
 #trap cleanup EXIT
 
-make test-deps testsuite
-
-export COV_DIR="build/coverage"
-
-for i in "full.cov" "integration.cov" "system.cov" "unit.cov"
-do
-  name=$(basename ${i} .cov)
-  if [ -f "${COV_DIR}/${i}" ]; then 
-    go tool cover -html="${COV_DIR}/${i}" -o "${COV_DIR}/coverage-${name}-report.html"
-    gocover-cobertura < "${COV_DIR}/${i}" > "${COV_DIR}/coverage-${name}-report.xml"
-  fi
-done
-exit 0
+make update
+make system-tests-environment
+make stop-environment

--- a/script/jenkins/unit-test.sh
+++ b/script/jenkins/unit-test.sh
@@ -6,7 +6,12 @@ source ./_beats/dev-tools/common.bash
 jenkins_setup
 
 export OUT_FILE="build/test-report.out"
+export COV_DIR="build/coverage"
 
 make update prepare-tests test-deps
-(go test -race ./... -v 2>&1 | tee ${OUT_FILE}) || echo -e "\033[31;49mTests FAILED\033[0m"
+
+(gotestcover -race -coverprofile=${COV_DIR}/unit.cov -v ./... 2>&1 | tee ${OUT_FILE}) || echo -e "\033[31;49mTests FAILED\033[0m"
+
 cat ${OUT_FILE} | go-junit-report > build/junit-apm-server-report.xml
+go tool cover -html="${COV_DIR}/unit.cov" -o "${COV_DIR}/coverage-unit-report.html"
+gocover-cobertura < "${COV_DIR}/unit.cov" > "${COV_DIR}/coverage-unit-report.xml"

--- a/script/jenkins/unit-test.sh
+++ b/script/jenkins/unit-test.sh
@@ -8,6 +8,8 @@ jenkins_setup
 export OUT_FILE="build/test-report.out"
 export COV_DIR="build/coverage"
 
+mkdir -p {COV_DIR}
+
 make update prepare-tests test-deps
 
 (gotestcover -race -coverprofile=${COV_DIR}/unit.cov -v ./... 2>&1 | tee ${OUT_FILE}) || echo -e "\033[31;49mTests FAILED\033[0m"

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -81,6 +81,7 @@ class ServerSetUpBaseTest(BaseTest):
 
     def config(self):
         return {"ssl_enabled": "false",
+                "queue_flush": 0,
                 "path": os.path.abspath(self.working_dir) + "/log/*"}
 
     def setUp(self):
@@ -149,7 +150,7 @@ class ElasticTest(ServerBaseTest):
         cfg.update({
             "elasticsearch_host": self.get_elasticsearch_url(),
             "file_enabled": "false",
-            "kibana_host": self.get_kibana_url(),
+            "kibana_enabled": "false",
         })
         cfg.update(self.config_overrides)
         return cfg
@@ -208,13 +209,13 @@ class ElasticTest(ServerBaseTest):
         assert r.status_code == 202, r.status_code
 
         # make sure template is loaded
-        self.wait_until(
-            lambda: self.log_contains("Finished loading index template"),
-            max_timeout=max_timeout)
-        self.wait_until(lambda: self.es.indices.exists(query_index))
+        # self.wait_until(
+        #    lambda: self.log_contains("Finished loading index template"),
+        #    max_timeout=max_timeout)
+        #self.wait_until(lambda: self.es.indices.exists(query_index))
         # Quick wait to give documents some time to be sent to the index
         # This is not required but speeds up the tests
-        time.sleep(0.1)
+        time.sleep(2)
         self.es.indices.refresh(index=query_index)
 
         self.wait_until(
@@ -269,6 +270,7 @@ class ClientSideBaseTest(ServerBaseTest):
     def config(self):
         cfg = super(ClientSideBaseTest, self).config()
         cfg.update({"enable_rum": "true",
+                    "kibana_enabled": "false",
                     "smap_cache_expiration": "200"})
         cfg.update(self.config_overrides)
         return cfg
@@ -301,6 +303,8 @@ class ClientSideBaseTest(ServerBaseTest):
                                 'bundle_filepath': bundle_filepath,
                                 'service_name': service_name
                                 })
+        time.sleep(2)
+        self.es.indices.refresh()
         return r
 
 

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -208,12 +208,7 @@ class ElasticTest(ServerBaseTest):
                               headers={'content-type': 'application/x-ndjson'})
         assert r.status_code == 202, r.status_code
 
-        # make sure template is loaded
-        # self.wait_until(
-        #    lambda: self.log_contains("Finished loading index template"),
-        #    max_timeout=max_timeout)
-        #self.wait_until(lambda: self.es.indices.exists(query_index))
-        # Quick wait to give documents some time to be sent to the index
+        # Wait to give documents some time to be sent to the index
         # This is not required but speeds up the tests
         time.sleep(2)
         self.es.indices.refresh(index=query_index)
@@ -303,6 +298,7 @@ class ClientSideBaseTest(ServerBaseTest):
                                 'bundle_filepath': bundle_filepath,
                                 'service_name': service_name
                                 })
+        # Wait to give documents some time to be sent to the index before refresh
         time.sleep(2)
         self.es.indices.refresh()
         return r

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -195,3 +195,5 @@ logging:
 
     # Number of rotated log files to keep. Oldest files will be deleted first.
     #keepfiles: 7
+
+queue.mem.flush.min_events: {{ queue_flush }}

--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -16,6 +16,14 @@ class AgentConfigurationIntegrationTest(ElasticTest):
         "acm_cache_expiration": "1s",
     }
 
+    def config(self):
+        cfg = super(ElasticTest, self).config()
+        cfg.update({
+            "kibana_host": self.get_kibana_url(),
+        })
+        cfg.update(self.config_overrides)
+        return cfg
+
     def create_service_config(self, settings, name, env=None, _id="new"):
         data = {
             "service": {"name": name},

--- a/tests/system/test_pipelines.py
+++ b/tests/system/test_pipelines.py
@@ -158,7 +158,8 @@ class MissingPipelineTest(ElasticTest):
 class PipelineDefaultDisableRegisterOverwriteTest(ElasticTest):
 
     config_overrides = {
-        "register_pipeline_overwrite": "false"
+        "register_pipeline_overwrite": "false",
+        "queue_flush": 2048,
     }
 
     def setUp(self):
@@ -178,7 +179,8 @@ class PipelineDefaultDisableRegisterOverwriteTest(ElasticTest):
 @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
 class PipelineEnableRegisterOverwriteTest(ElasticTest):
     config_overrides = {
-        "register_pipeline_overwrite": "true"
+        "register_pipeline_overwrite": "true",
+        "queue_flush": 2048,
     }
 
     def setUp(self):
@@ -191,9 +193,8 @@ class PipelineEnableRegisterOverwriteTest(ElasticTest):
         self.wait_until(lambda: es.ingest.get_pipeline("apm"))
 
     def test_pipeline_overwritten(self):
-        loaded_msg = "Pipeline successfully registered"
+        loaded_msg = "Registered Ingest Pipelines successfully"
         self.wait_until(lambda: self.log_contains(loaded_msg))
         pipeline_id = "apm"
-        pipeline = self.wait_until(lambda: self.es.ingest.get_pipeline(id=pipeline_id),
-                                   name="fetching pipeline {}".format(pipeline_id))
-        assert pipeline[pipeline_id]['description'] == "Default enrichment for APM events"
+        self.wait_until(lambda: self.es.ingest.get_pipeline(id=pipeline_id)[pipeline_id]['description'] == "Default enrichment for APM events",
+                        name="fetching pipeline {}".format(pipeline_id))

--- a/tests/system/test_requests.py
+++ b/tests/system/test_requests.py
@@ -109,10 +109,6 @@ class ClientSideTest(ClientSideBaseTest):
         r = self.request_intake()
         assert r.status_code == 202, r.status_code
 
-    def test_sourcemap_upload(self):
-        r = self.upload_sourcemap(file_name='bundle.js.map')
-        assert r.status_code == 202, r.status_code
-
     def test_sourcemap_upload_fail(self):
         path = self._beat_path_join(
             'testdata',

--- a/tests/system/test_setup_index_management.py
+++ b/tests/system/test_setup_index_management.py
@@ -2,7 +2,6 @@ import os
 from nose.plugins.attrib import attr
 import unittest
 import logging
-import time
 from elasticsearch import Elasticsearch, NotFoundError, RequestError
 from apmserver import BaseTest, ElasticTest
 from nose.tools import raises

--- a/tests/system/test_setup_index_management.py
+++ b/tests/system/test_setup_index_management.py
@@ -2,6 +2,7 @@ import os
 from nose.plugins.attrib import attr
 import unittest
 import logging
+import time
 from elasticsearch import Elasticsearch, NotFoundError, RequestError
 from apmserver import BaseTest, ElasticTest
 from nose.tools import raises
@@ -220,6 +221,9 @@ class TestCommandSetupIndexManagement(BaseTest):
 
 
 class TestRunIndexManagementDefault(ElasticTest):
+
+    config_overrides = {"queue_flush": 2048}
+
     def setUp(self):
         super(TestRunIndexManagementDefault, self).setUp()
 
@@ -236,6 +240,9 @@ class TestRunIndexManagementDefault(ElasticTest):
 
 
 class TestRunIndexManagementWithoutILM(ElasticTest):
+
+    config_overrides = {"queue_flush": 2048}
+
     def setUp(self):
         super(TestRunIndexManagementWithoutILM, self).setUp()
 


### PR DESCRIPTION
This change reduces `INTEGRATION_TESTS=1 make system-tests` from ~8:30 mins on my machine to ~4:30 mins

The issue is that beats takes more than 0.1 seconds to index data on elasticsearch, so the refresh call was happening before the docs were inserted.

This change makes the refresh call actually effective.

~~Still, the whole suite runs locally in about 10 minutes; but the build on CI however takes easily 30 minutes, so we should look a bit into the Jenkins pipeline imo.~~

~~@elastic/observablt-robots any pointers on that above would be great. Are you aware of any points of contention? I inspected some pipeline logs top to bottom without reaching conclusion, but I feel there is a lot of scaffolding (git commands, make commands, docker downloads, etc)~~

On another note: I also feel that we are over-testing, we should be more frugal creating and waiting on documents; but probably doesn't make a lot of sense to invest more time on it now. Just a note for the future.

fixes elastic/apm-server#2539 
