### PR TITLE
Docs: Asciidoctor compatibility (6.8) (#2567)

### DIFF
--- a/docs/copied-from-beats/monitoring/monitoring-beats.asciidoc
+++ b/docs/copied-from-beats/monitoring/monitoring-beats.asciidoc
@@ -36,15 +36,14 @@ information, see
 . Add the `xpack.monitoring` settings in the {beatname_uc} configuration file. If you
 configured {es} output, specify the following minimal configuration:
 +
---
 [source, yml]
 --------------------
 xpack.monitoring.enabled: true
 --------------------
-
++
 If you configured a different output, such as {ls}, you must specify additional
 configuration options. For example:
-
++
 ["source","yml",subs="attributes"]
 --------------------
 xpack.monitoring:
@@ -54,12 +53,10 @@ xpack.monitoring:
     username: {beat_monitoring_user}
     password: somepassword
 --------------------
-
++
 NOTE: Currently you must send monitoring data to the same cluster as all other events.
 If you configured {es} output, do not specify additional hosts in the monitoring
 configuration.
-
---
 
 . {kibana-ref}/monitoring-xpack-kibana.html[Configure monitoring in {kib}].
 


### PR DESCRIPTION
Fixes all build errors I found when trying to build the docs using
asciidoctor in the master branch.
