### PR TITLE
[docs][7.2] Fix fields.asciidoc for asciidoctor

### DIFF
--- a/_beats/libbeat/scripts/generate_fields_docs.py
+++ b/_beats/libbeat/scripts/generate_fields_docs.py
@@ -72,10 +72,12 @@ def document_field(output, field, field_path):
         if not field["enabled"]:
             output.write("{}\n\n".format("Object is not enabled."))
 
+    output.write("--\n\n")
+    
     if "multi_fields" in field:
         for subfield in field["multi_fields"]:
             document_field(output, subfield, field_path + "." + subfield["name"])
-    output.write("--\n\n")
+
 
 
 def fields_to_asciidoc(input, output, beat):

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -679,6 +679,8 @@ example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.
 Unparsed version of the user_agent.
 
 
+--
+
 *`user_agent.original.text`*::
 +
 --
@@ -686,8 +688,6 @@ type: text
 
 Software agent acting in behalf of a user, eg. a web browser / OS combination.
 
-
---
 
 --
 
@@ -1113,12 +1113,12 @@ type: keyword
 Generic designation of a transaction in the scope of a single service (eg. 'GET /users/:id').
 
 
+--
+
 *`transaction.name.text`*::
 +
 --
 type: text
-
---
 
 --
 


### PR DESCRIPTION
This makes 7.2 build in asciidoctor! Needs to be backported.

Closes https://github.com/elastic/apm-server/issues/2577. Related beats PR: https://github.com/elastic/beats/pull/12242.