### PR TITLE
[docs] Update link for "ccr-overview-beats" anchor

### DIFF
--- a/docs/copied-from-beats/template-config.asciidoc
+++ b/docs/copied-from-beats/template-config.asciidoc
@@ -71,7 +71,7 @@ setup.template.settings:
 
 NOTE: If you want to use {stack-ov}/xpack-ccr.html[{ccr}] to replicate {beatname_uc}
 indices to another cluster, you will need to add additional template settings to
-{stack-ov}/ccr-requirements.html#ccr-overview-beats[enable soft deletes] on the
+{ref}/ccr-overview.html#ccr-overview-beats[enable soft deletes] on the
 underlying indices.
 
 *`setup.template.settings._source`*:: A dictionary of settings for the `_source` field. For the available settings,

--- a/docs/copied-from-beats/template-config.asciidoc
+++ b/docs/copied-from-beats/template-config.asciidoc
@@ -71,7 +71,7 @@ setup.template.settings:
 
 NOTE: If you want to use {stack-ov}/xpack-ccr.html[{ccr}] to replicate {beatname_uc}
 indices to another cluster, you will need to add additional template settings to
-{ref}/ccr-overview.html#ccr-overview-beats[enable soft deletes] on the
+{ref}/ccr-requirements.html#ccr-overview-beats[enable soft deletes] on the
 underlying indices.
 
 *`setup.template.settings._source`*:: A dictionary of settings for the `_source` field. For the available settings,


### PR DESCRIPTION
elastic/elasticsearch#45704  and elastic/stack-docs#464  moves the
cross-cluster replication (CCR) docs from the Elastic Stack Overview to
the Elasticsearch Reference Guide.

This updates any links pointing to the old Elastic Stack Overview docs.
We've set up redirects so these links won't fail in the meantime. This
just removes a step for users.

### Dependencies
Don't merge this PR until the following PRs are merged:
- [x] elastic/elasticsearch#45704