### PR TITLE
[docs][7.0] Remove arbitrary python expressions

### DIFF
--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -92,7 +92,7 @@ ifeval::[("{beatname_lc}"=="functionbeat")]
 |<<package-command,`package`>> |{package-command-short-desc}.
 |<<remove-command,`remove`>> |{remove-command-short-desc}.
 endif::[]
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="metricbeat")]
+ifndef::apm-server[]
 |<<modules-command,`modules`>> |{modules-command-short-desc}.
 endif::[]
 |<<run-command,`run`>> |{run-command-short-desc}.
@@ -389,7 +389,7 @@ Shows help for the `remove` command.
 -----
 endif::[]
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="metricbeat")]
+ifndef::apm-server[]
 [[modules-command]]
 ==== `modules` command
 

--- a/docs/copied-from-beats/shared-docker.asciidoc
+++ b/docs/copied-from-beats/shared-docker.asciidoc
@@ -46,7 +46,7 @@ ifndef::apm-server[]
 Running {beatname_uc} with the setup command will create the index pattern and
 load visualizations, dashboards, and machine learning jobs.  Run this command:
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="metricbeat") or ("{beatname_lc}"=="heartbeat") or ("{beatname_lc}"=="journalbeat")]
+ifndef::apm-server[]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
 docker run \
@@ -113,7 +113,7 @@ curl -L -O {dockerconfig}
 One way to configure {beatname_uc} on Docker is to provide +{beatname_lc}.docker.yml+ via a volume mount.
 With +docker run+, the volume mount can be specified like this:
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="journalbeat")]
+ifndef::apm-server[]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
 docker run -d \
@@ -175,7 +175,7 @@ docker run -d \
 --------------------------------------------
 endif::[]
 
-ifeval::[("{beatname_lc}"=="heartbeat") or ("{beatname_lc}"=="apm-server")]
+ifdef::apm-server[]
 ["source", "sh", subs="attributes"]
 --------------------------------------------
 docker run -d \
@@ -195,7 +195,7 @@ using the syntax shown earlier.
 
 ===== Customize your configuration
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="metricbeat")]
+ifndef::apm-server[]
 
 The +{beatname_lc}.docker.yml+ file you downloaded earlier is configured to deploy Beats modules based on the Docker labels applied to your containers.  See <<configuration-autodiscover-hints>> for more details. Add labels to your application Docker containers, and they will be picked up by the Beats autodiscover feature when they are deployed.  Here is an example command for an Apache HTTP Server container with labels to configure the Filebeat and Metricbeat modules for the Apache HTTP Server:
 
@@ -216,7 +216,7 @@ docker run \
 
 endif::[]
 
-ifeval::[("{beatname_lc}"!="filebeat") and ("{beatname_lc}"!="metricbeat")]
+ifdef::apm-server[]
 
 The +{beatname_lc}.docker.yml+ downloaded earlier should be customized for your environment. See <<configuring-howto-{beatname_lc}>> for more details. Edit the configuration file and customize it to match your environment then re-deploy your {beatname_uc} container.
 endif::[]

--- a/docs/copied-from-beats/shared-path-config.asciidoc
+++ b/docs/copied-from-beats/shared-path-config.asciidoc
@@ -17,7 +17,7 @@ The `path` section of the +{beatname_lc}.yml+ config file contains configuration
 options that define where {beatname_uc} looks for its files. For example, {beatname_uc}
 looks for the Elasticsearch template file in the configuration path and writes
 log files in the logs path.
-ifeval::["{beatname_lc}"=="filebeat" or "{beatname_lc}"=="winlogbeat"]
+ifndef::apm-server[]
 {beatname_uc} looks for its registry files in the data path.
 endif::[]
 


### PR DESCRIPTION
For https://github.com/elastic/docs/pull/1083. A few more problems that weren't showing up on the local build.

In Asciidoctor, the old python expressions with `or` all evaluate to `true`. This PR updates them to `ifdef` or `ifndef` directives.