### PR TITLE
ci(jenkins): avoid builds in the master worker

### DIFF
--- a/.ci/check-changelogs.groovy
+++ b/.ci/check-changelogs.groovy
@@ -28,7 +28,7 @@ pipeline {
      Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout') {
-      agent { label 'master || immutable' }
+      agent { label 'immutable' }
       environment {
         PATH = "${env.PATH}:${env.WORKSPACE}/bin"
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
      Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout') {
-      agent { label 'master || immutable' }
+      agent { label 'immutable' }
       environment {
         PATH = "${env.PATH}:${env.WORKSPACE}/bin"
         HOME = "${env.WORKSPACE}"


### PR DESCRIPTION
## Highlights
- `master` worker could be used but causes bottlenecks in some cases.
- This will allow to use of another worker and get rid of any potential bottlenecks when the build queue is massive.