### PR TITLE
[docs][6.4] Remove arbitrary python expressions

### DIFF
--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -81,7 +81,7 @@ endif::[]
 |<<export-command,`export`>> |{export-command-short-desc}.
 |<<help-command,`help`>> |{help-command-short-desc}.
 |<<keystore-command,`keystore`>> |{keystore-command-short-desc}.
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="metricbeat")]
+ifndef::apm-server[]
 |<<modules-command,`modules`>> |{modules-command-short-desc}.
 endif::[]
 |<<run-command,`run`>> |{run-command-short-desc}.
@@ -229,7 +229,7 @@ Shows help for the `keystore` command.
 see <<keystore>> for more examples.
 
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="metricbeat")]
+ifndef::apm-server[]
 
 [[modules-command]]
 ==== `modules` command

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -1031,7 +1031,7 @@ ifndef::apm-server[]
 
 endif::[]
 
-ifeval::["{beatname_lc}"!="filebeat" and "{beatname_lc}"!="winlogbeat"]
+ifdef::apm-server[]
 
 The number of times to retry publishing an event after a publishing failure.
 After the specified number of retries, the events are typically dropped.

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -311,13 +311,13 @@ endif::[]
 
 ===== `max_retries`
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="winlogbeat")]
+ifndef::apm-server[]
 
 {beatname_uc} ignores the `max_retries` setting and retries indefinitely.
 
 endif::[]
 
-ifeval::[("{beatname_lc}"!="filebeat") and ("{beatname_lc}"!="winlogbeat")]
+ifdef::apm-server[]
 
 The number of times to retry publishing an event after a publishing failure.
 After the specified number of retries, the events are typically dropped.
@@ -586,13 +586,13 @@ The number of seconds to wait for responses from the Logstash server before timi
 
 ===== `max_retries`
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="winlogbeat")]
+ifndef::apm-server[]
 
 {beatname_uc} ignores the `max_retries` setting and retries indefinitely.
 
 endif::[]
 
-ifeval::[("{beatname_lc}"!="filebeat") and ("{beatname_lc}"!="winlogbeat")]
+ifdef::apm-server[]
 
 The number of times to retry publishing an event after a publishing failure.
 After the specified number of retries, the events are typically dropped.
@@ -797,13 +797,13 @@ brokers, topics, partition, and active leaders to use for publishing.
 
 ===== `max_retries`
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="winlogbeat")]
+ifndef::apm-server[]
 
 {beatname_uc} ignores the `max_retries` setting and retries indefinitely.
 
 endif::[]
 
-ifeval::[("{beatname_lc}"!="filebeat") and ("{beatname_lc}"!="winlogbeat")]
+ifdef::apm-server[]
 
 The number of times to retry publishing an event after a publishing failure.
 After the specified number of retries, the events are typically dropped.
@@ -1025,7 +1025,7 @@ The Redis connection timeout in seconds. The default is 5 seconds.
 
 ===== `max_retries`
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="winlogbeat")]
+ifndef::apm-server[]
 
 {beatname_uc} ignores the `max_retries` setting and retries indefinitely.
 

--- a/docs/copied-from-beats/shared-path-config.asciidoc
+++ b/docs/copied-from-beats/shared-path-config.asciidoc
@@ -17,7 +17,7 @@ The `path` section of the +{beatname_lc}.yml+ config file contains configuration
 options that define where {beatname_uc} looks for its files. For example, {beatname_uc}
 looks for the Elasticsearch template file in the configuration path and writes
 log files in the logs path.
-ifeval::["{beatname_lc}"=="filebeat" or "{beatname_lc}"=="winlogbeat"]
+ifndef::apm-server[]
 {beatname_uc} looks for its registry files in the data path.
 endif::[]
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -18,6 +18,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
 :securitydoc: https://www.elastic.co/guide/en/elastic-stack-overview/{doc-branch}
 :deprecate_dashboard_loading: 6.4.0
+:apm-server:
 
 ifdef::env-github[]
 NOTE: For the best reading experience,


### PR DESCRIPTION
For https://github.com/elastic/docs/pull/1083. A few more problems that weren't showing up on the local build.

In Asciidoctor, the old python expressions with `or` all evaluate to `true`. This PR updates them to `ifdef` or `ifndef` directives.