### PR TITLE
[docs][6.2] Remove arbitrary python expressions

### DIFF
--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -65,7 +65,7 @@ endif::[]
 <<keystore-command,`keystore`>>::
 {keystore-command-short-desc}.
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="metricbeat")]
+ifndef::apm-server[]
 
 <<modules-command,`modules`>>::
 {modules-command-short-desc}.
@@ -223,7 +223,7 @@ Shows help for the `keystore` command.
 see <<keystore>> for more examples.
 
 
-ifeval::[("{beatname_lc}"=="filebeat") or ("{beatname_lc}"=="metricbeat")]
+ifndef::apm-server[]
 
 [[modules-command]]
 ==== `modules` command

--- a/docs/copied-from-beats/shared-path-config.asciidoc
+++ b/docs/copied-from-beats/shared-path-config.asciidoc
@@ -17,7 +17,7 @@ The `path` section of the +{beatname_lc}.yml+ config file contains configuration
 options that define where {beatname_lc} looks for its files. For example, {beatname_uc}
 looks for the Elasticsearch template file in the configuration path and writes
 log files in the logs path.
-ifeval::["{beatname_lc}"=="filebeat" or "{beatname_lc}"=="winlogbeat"]
+ifndef::apm-server[]
 Filebeat and Winlogbeat look for their registry files in the data path.
 endif::[]
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -15,6 +15,7 @@ include::{asciidoc-dir}/../../shared/attributes62.asciidoc[]
 :libbeat: http://www.elastic.co/guide/en/beats/libbeat/{doc-branch}
 :logstashdoc: https://www.elastic.co/guide/en/logstash/{doc-branch}
 :elasticsearch: https://www.elastic.co/guide/en/elasticsearch/reference/{doc-branch}
+:apm-server:
 
 ifdef::env-github[]
 NOTE: For the best reading experience,


### PR DESCRIPTION
For https://github.com/elastic/docs/pull/1083. A few more problems that weren't showing up on the local build.

In Asciidoctor, the old python expressions with `or` all evaluate to `true`. This PR updates them to `ifdef` or `ifndef` directives.