### PR TITLE
[7.x] ES fields: Index socket.remote_address as client.ip (#2588)

### DIFF
--- a/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
@@ -13,6 +13,9 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
+            "client": {
+                "ip": "12.53.12.1"
+            },
             "container": {
                 "id": "container-id"
             },

--- a/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json
@@ -117,6 +117,9 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
+            "client": {
+                "ip": "12.53.12.1"
+            },
             "container": {
                 "id": "container-id"
             },

--- a/docs/data/elasticsearch/generated/errors.json
+++ b/docs/data/elasticsearch/generated/errors.json
@@ -7,6 +7,9 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
+            "client": {
+                "ip": "12.53.12.1"
+            },
             "container": {
                 "id": "container-id"
             },

--- a/docs/data/elasticsearch/generated/transactions.json
+++ b/docs/data/elasticsearch/generated/transactions.json
@@ -94,6 +94,9 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
+            "client": {
+                "ip": "12.53.12.1"
+            },
             "container": {
                 "id": "container-id"
             },

--- a/model/context.go
+++ b/model/context.go
@@ -29,6 +29,7 @@ import (
 	"github.com/elastic/beats/libbeat/common"
 )
 
+// Context holds all information sent under key context
 type Context struct {
 	Http         *Http
 	Url          *Url
@@ -40,12 +41,14 @@ type Context struct {
 	Experimental interface{}
 }
 
+// Http bundles information related to an http request and its response
 type Http struct {
 	Version  *string
 	Request  *Req
 	Response *Resp
 }
 
+// Url describes request URL and its components
 type Url struct {
 	Original *string
 	Scheme   *string
@@ -57,14 +60,19 @@ type Url struct {
 	Fragment *string
 }
 
+// Page consists of Url string and referer
 type Page struct {
 	Url     *string
 	Referer *string
 }
 
+// Labels holds user defined information nested under key tags
 type Labels common.MapStr
+
+// Custom holds user defined information nested under key custom
 type Custom common.MapStr
 
+// Req bundles information related to an http request
 type Req struct {
 	Method  string
 	Body    interface{}
@@ -74,11 +82,13 @@ type Req struct {
 	Cookies interface{}
 }
 
+// Socket indicates whether an http request was encrypted and the initializers remote address
 type Socket struct {
 	RemoteAddress *string
 	Encrypted     *bool
 }
 
+// Resp bundles information related to an http requests response
 type Resp struct {
 	Finished    *bool
 	StatusCode  *int
@@ -86,6 +96,7 @@ type Resp struct {
 	Headers     http.Header
 }
 
+// DecodeContext parses all information from input, nested under key context and returns an instance of Context.
 func DecodeContext(input interface{}, cfg Config, err error) (*Context, error) {
 	if input == nil || err != nil {
 		return nil, err
@@ -132,16 +143,7 @@ func DecodeContext(input interface{}, cfg Config, err error) (*Context, error) {
 
 }
 
-func addUserAgent(user *metadata.User, h *Http) *metadata.User {
-	if ua := h.UserAgent(); ua != "" {
-		if user == nil {
-			user = &metadata.User{}
-		}
-		user.UserAgent = &ua
-	}
-	return user
-}
-
+// Fields returns common.MapStr holding transformed data for attribute url.
 func (url *Url) Fields() common.MapStr {
 	if url == nil {
 		return nil
@@ -158,6 +160,7 @@ func (url *Url) Fields() common.MapStr {
 	return fields
 }
 
+// Fields returns common.MapStr holding transformed data for attribute http.
 func (h *Http) Fields() common.MapStr {
 	if h == nil {
 		return nil
@@ -170,6 +173,21 @@ func (h *Http) Fields() common.MapStr {
 	return fields
 }
 
+// ClientFields returns common.MapStr holding transformed data for attribute client. If given data include IP information,
+// data are returned unchanged, otherwise IP information will be extracted from http data if possible.
+func (h *Http) ClientFields(fields common.MapStr) common.MapStr {
+	if fields != nil && fields["ip"] != nil {
+		return fields
+	}
+	if h == nil ||
+		h.Request == nil || h.Request.Socket == nil ||
+		h.Request.Socket.RemoteAddress == nil || *h.Request.Socket.RemoteAddress == "" {
+		return fields
+	}
+	return common.MapStr{"ip": *h.Request.Socket.RemoteAddress}
+}
+
+// UserAgent parses User Agent information from attribute http.
 func (h *Http) UserAgent() string {
 	if h == nil || h.Request == nil {
 		return ""
@@ -178,6 +196,7 @@ func (h *Http) UserAgent() string {
 	return dec.UserAgentHeader(h.Request.Headers)
 }
 
+// Fields returns common.MapStr holding transformed data for attribute page.
 func (page *Page) Fields() common.MapStr {
 	if page == nil {
 		return nil
@@ -188,6 +207,7 @@ func (page *Page) Fields() common.MapStr {
 	return fields
 }
 
+// Fields returns common.MapStr holding transformed data for attribute label.
 func (labels *Labels) Fields() common.MapStr {
 	if labels == nil {
 		return nil
@@ -195,11 +215,22 @@ func (labels *Labels) Fields() common.MapStr {
 	return common.MapStr(*labels)
 }
 
+// Fields returns common.MapStr holding transformed data for attribute custom.
 func (custom *Custom) Fields() common.MapStr {
 	if custom == nil {
 		return nil
 	}
 	return common.MapStr(*custom)
+}
+
+func addUserAgent(user *metadata.User, h *Http) *metadata.User {
+	if ua := h.UserAgent(); ua != "" {
+		if user == nil {
+			user = &metadata.User{}
+		}
+		user.UserAgent = &ua
+	}
+	return user
 }
 
 func decodeUrl(raw common.MapStr, err error) (*Url, error) {

--- a/model/error/event.go
+++ b/model/error/event.go
@@ -193,7 +193,7 @@ func (e *Event) Transform(tctx *transform.Context) []beat.Event {
 	tctx.Metadata.Set(fields)
 	// then add event specific information
 	utility.Update(fields, "user", e.User.Fields())
-	utility.DeepUpdate(fields, "client", e.User.ClientFields())
+	utility.DeepUpdate(fields, "client", e.Http.ClientFields(e.User.ClientFields()))
 	utility.DeepUpdate(fields, "user_agent", e.User.UserAgentFields())
 	utility.DeepUpdate(fields, "service", e.Service.Fields())
 	utility.DeepUpdate(fields, "agent", e.Service.AgentFields())

--- a/model/transaction/event.go
+++ b/model/transaction/event.go
@@ -180,7 +180,7 @@ func (e *Event) Transform(tctx *transform.Context) []beat.Event {
 
 	// then merge event specific information
 	utility.Update(fields, "user", e.User.Fields())
-	utility.DeepUpdate(fields, "client", e.User.ClientFields())
+	utility.DeepUpdate(fields, "client", e.Http.ClientFields(e.User.ClientFields()))
 	utility.DeepUpdate(fields, "user_agent", e.User.UserAgentFields())
 	utility.DeepUpdate(fields, "service", e.Service.Fields())
 	utility.DeepUpdate(fields, "agent", e.Service.AgentFields())

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationErrors.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationErrors.approved.json
@@ -7,6 +7,9 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
+            "client": {
+                "ip": "12.53.12.1"
+            },
             "container": {
                 "id": "container-id"
             },

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationTransactions.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationTransactions.approved.json
@@ -94,6 +94,9 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
+            "client": {
+                "ip": "12.53.12.1"
+            },
             "container": {
                 "id": "container-id"
             },

--- a/tests/system/error.approved.json
+++ b/tests/system/error.approved.json
@@ -190,6 +190,20 @@
                     "status_code": 200
                 }
             },
+            "client": {
+                "ip": "12.53.12.1",
+                "geo": {
+                    "region_iso_code": "US-IN",
+                    "country_iso_code": "US",
+                    "city_name": "Indianapolis",
+                    "location": {
+                        "lat": 39.9115,
+                        "lon": -86.0706
+                    },
+                    "continent_name": "North America",
+                    "region_name": "Indiana"
+                }
+            },
             "url": {
                 "domain": "www.example.com",
                 "fragment": "#hash",

--- a/tests/system/transaction.approved.json
+++ b/tests/system/transaction.approved.json
@@ -132,6 +132,20 @@
                 },
                 "version": "1.1"
             },
+            "client": {
+                "ip": "12.53.12.1",
+                "geo": {
+                    "region_iso_code": "US-IN",
+                    "country_iso_code": "US",
+                    "city_name": "Indianapolis",
+                    "location": {
+                        "lat": 39.9115,
+                        "lon": -86.0706
+                    },
+                    "continent_name": "North America",
+                    "region_name": "Indiana"
+                }
+            },
             "labels": {
                 "number_code": 2,
                 "bool_error": false,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ES fields: Index socket.remote_address as client.ip  (#2588)