### PR TITLE
[7.x] auto-generate exception parent and remove property from the intake

### DIFF
--- a/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
@@ -113,7 +113,7 @@
                     },
                     {
                         "message": "on top of it, internet doesn't work",
-                        "parent": 0,
+                        "parent": 1,
                         "type": "ConnectionError"
                     }
                 ],

--- a/docs/data/elasticsearch/generated/errors.json
+++ b/docs/data/elasticsearch/generated/errors.json
@@ -104,7 +104,7 @@
                     },
                     {
                         "message": "on top of it, internet doesn't work",
-                        "parent": 0,
+                        "parent": 1,
                         "type": "ConnectionError"
                     }
                 ],

--- a/docs/spec/errors/error.json
+++ b/docs/spec/errors/error.json
@@ -93,10 +93,6 @@
                             },
                             "minItems": 0,
                             "description": "Exception tree"
-                        },
-                        "parent": {
-                            "type": ["integer", "null"],
-                            "description": "Parent exception index (0 based); if omitted the previous (depth-first) entry is the parent"
                         }
                     },
                     "anyOf": [

--- a/model/error/generated/schema/error.go
+++ b/model/error/generated/schema/error.go
@@ -460,10 +460,6 @@ const ModelSchema = `{
                             },
                             "minItems": 0,
                             "description": "Exception tree"
-                        },
-                        "parent": {
-                            "type": ["integer", "null"],
-                            "description": "Parent exception index (0 based); if omitted the previous (depth-first) entry is the parent"
                         }
                     },
                     "anyOf": [

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationErrors.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationErrors.approved.json
@@ -104,7 +104,7 @@
                     },
                     {
                         "message": "on top of it, internet doesn't work",
-                        "parent": 0,
+                        "parent": 1,
                         "type": "ConnectionError"
                     }
                 ],


### PR DESCRIPTION
Backports the following commits to 7.x:
 - auto-generate exception parent and remove property from the intake (#2609)