### PR TITLE
ci(jenkins): revert none agent

### DIFF
--- a/.ci/check-changelogs.groovy
+++ b/.ci/check-changelogs.groovy
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent none
+  agent any
   environment {
     REPO = 'apm-server'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ import groovy.transform.Field
 
 /**
 This is the git commit sha which it's required to be used in different stages.
-It does store the env GIT_BASE_COMMIT
+It does store the env GIT_SHA
 */
 @Field def gitCommit
 
@@ -63,7 +63,7 @@ pipeline {
         gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script {
-          gitCommit = env.GIT_BASE_COMMIT
+          gitCommit = env.GIT_SHA
           dir("${BASE_DIR}"){
             env.GO_VERSION = readFile(".go-version").trim()
             def regexps =[

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,16 +1,8 @@
 #!/usr/bin/env groovy
 @Library('apm@current') _
 
-import groovy.transform.Field
-
-/**
-This is the git commit sha which it's required to be used in different stages.
-It does store the env GIT_SHA
-*/
-@Field def gitCommit
-
 pipeline {
-  agent none
+  agent any
   environment {
     REPO = 'apm-server'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -63,7 +55,6 @@ pipeline {
         gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script {
-          gitCommit = env.GIT_SHA
           dir("${BASE_DIR}"){
             env.GO_VERSION = readFile(".go-version").trim()
             def regexps =[
@@ -345,10 +336,10 @@ pipeline {
         log(level: 'INFO', text: "Launching Async ${env.GITHUB_CHECK_ITS_NAME}")
         build(job: env.ITS_PIPELINE, propagate: false, wait: false,
               parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'All'),
-                           string(name: 'BUILD_OPTS', value: "--apm-server-build https://github.com/elastic/${env.REPO}@${gitCommit}"),
+                           string(name: 'BUILD_OPTS', value: "--apm-server-build https://github.com/elastic/${env.REPO}@${env.GIT_BASE_COMMIT}"),
                            string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                           string(name: 'GITHUB_CHECK_SHA1', value: gitCommit)])
+                           string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
         githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
       }
     }


### PR DESCRIPTION
This reverts https://github.com/elastic/apm-server/pull/2633 and https://github.com/elastic/apm-server/pull/2617

## Highlights
- As long as we use the share step `gitCheckout` we might need to use the agent top-level to share the env variables between stages.
- It's not ideal but even though the changes were quite straight, its behavior was not as expected. 
- Let's keep the pipeline stable for now and we will figure out what's going on.