### PR TITLE
[docs] sourcemapping.enabled config

### DIFF
--- a/docs/configuration-rum.asciidoc
+++ b/docs/configuration-rum.asciidoc
@@ -13,6 +13,7 @@ apm-server.rum.event_rate.lru_size: 1000
 apm-server.rum.allow_origins: ['*']
 apm-server.rum.library_pattern: "node_modules|bower_components|~"
 apm-server.rum.exclude_from_grouping: "^/webpack"
+apm-server.rum.source_mapping.enabled: true
 apm-server.rum.source_mapping.cache.expiration: 5m
 apm-server.rum.source_mapping.index_pattern: "apm-*-sourcemap*"
 ----
@@ -63,6 +64,12 @@ Default value is `"node_modules|bower_components|~"`.
 RegExp to be matched against a stacktrace frame's `file_name`.
 If the RegExp matches, the stacktrace frame is excluded from being used for calculating error groups.
 The default pattern excludes stacktrace frames that have a filename starting with `/webpack`.
+
+[[config-sourcemapping-enabled]]
+[float]
+==== `source_mapping.enabled`
+Used to enable/disable <<sourcemaps,sourcemapping>> for RUM events.
+Defaults to `true`.
 
 [[config-sourcemapping-elasticsearch]]
 [float]

--- a/docs/rum.asciidoc
+++ b/docs/rum.asciidoc
@@ -15,7 +15,9 @@ A source map library helps by mapping the minified files back to the the origina
 
 APM Server provides a <<sourcemap-api,Source Map API>> for uploading source maps.
 
-Source maps are then automatically applied to all incoming transactions and errors.
+By default, <<config-sourcemapping-enabled>> is set to `true`.
+This means if a source map has previously been uploaded,
+source mapping will automatically be applied all incoming transactions and errors.
 
 Source maps are cached in memory for as long as the <<rum-sourcemap-cache,cache expiration>> setting indicates.
 


### PR DESCRIPTION
Simple docs on `sourcemapping.enabled`.

For #2488. Closes #2674.

Needs backport.