### PR TITLE
[docs] Update Logstash output documentation

### DIFF
--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -761,8 +761,8 @@ ifdef::apm-server[]
 for more about the `@metadata` field.
 <2> The default is {beat_default_index_prefix}. To change this value, set the
 <<logstash-index,`index`>> option in the {beatname_uc} config file.
-<3> The pipeline
-<4> The IP address of APM Server 
+<3> Why am I seeing pipeline here?
+<4> The IP address of APM Server .
 <3> The current version of {beatname_uc}.
 endif::[]
 
@@ -800,34 +800,39 @@ ifdef::apm-server[]
 [source,logstash]
 ------
 input {
-  beats {
-    port => 5044
-  }
+    beats {
+        port => 5044
+    }
 }
 
 filter {
-  if [@metadata][beat] == "apm-server" { <1>
-    if [processor][event] == "sourcemap" {
-      mutate { add_field => { "[@metadata][index]" => "apm-%{[@metadata][version]}-sourcemap" } } <2>
-    } else {
-      mutate { add_field => { "[@metadata][index]" => "apm-%{[@metadata][version]}-%{[processor][event]}" } } <3>
+    if [@metadata][beat] == "apm" {
+        if [processor][event] == "sourcemap" {
+            mutate {
+                add_field => { "[@metadata][index]" => "%{[@metadata][beat]}-%{[@metadata][version]}-%{[processor][event]}" } <1>
+            }
+        } else {
+            mutate {
+                add_field => { "[@metadata][index]" => "%{[@metadata][beat]}-%{[@metadata][version]}-%{[processor][event]}-%{+yyyy.MM.dd}" } <2>
+            }
+        }
     }
-  } else {
-    mutate { add_field => { "[@metadata][index]" => "%{[@metadata][beat]}-%{[@metadata][version]}" } } <4>
-  }
 }
 
 output {
-  elasticsearch {
-    hosts => ["http://localhost:9200"]
-    index => "%{[@metadata][index]}"
-  }
+    elasticsearch {
+        hosts => ["http://localhost:9200"]
+        index => "%{[@metadata][index]}"
+    }
 }
 ------
-<1> Checks for data coming from APM Server
-<2> Sourcemap indices are 
-<3>
-<4> Default output index for non APM data 
+<1> Creates a new field named `@metadata.index`.
+`%{[@metadata][beat]}` sets the first part of the index name to the value of the `beat` metadata field.
+`%{[@metadata][version]}` sets the second part to {beatname_uc}'s version.
+`%{[processor][event]}` sets the final part based on the APM event type.
+For example: +{beat_default_index_prefix}-{version}-sourcemap+.
+<2> In addition to the above rules, this pattern appends a date to the `index` name so Logstash creates a new index each day.
+For example: +{beat_default_index_prefix}-{version}-transaction-{sample_date_0}+.
 endif::[]
 
 Events indexed into Elasticsearch with the Logstash configuration shown here
@@ -858,12 +863,7 @@ You can specify the following options in the `logstash` section of the
 The enabled config is a boolean setting to enable or disable the output. If set
 to false, the output is disabled.
 
-ifndef:apm-server[]
 The default value is `true`.
-endif::[]
-ifdef:apm-server[]
-The default value is `false`.
-endif::[]
 
 [[hosts]]
 ===== `hosts`

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -723,6 +723,7 @@ include::./shared-logstash-config.asciidoc[]
 Every event sent to Logstash contains the following metadata fields that you can
 use in Logstash for indexing and filtering:
 
+ifndef::apm-server[]
 ["source","json",subs="attributes"]
 ------------------------------------------------------------------------------
 {
@@ -739,6 +740,31 @@ for more about the `@metadata` field.
 <2> The default is {beat_default_index_prefix}. To change this value, set the
 <<logstash-index,`index`>> option in the {beatname_uc} config file.
 <3> The current version of {beatname_uc}.
+endif::[]
+
+ifdef::apm-server[]
+["source","json",subs="attributes"]
+------------------------------------------------------------------------------
+{
+    ...
+    "@metadata": { <1>
+      "beat": "{beat_default_index_prefix}", <2>
+      "pipeline":"apm", <3>
+      "ip_address":"127.0.0.1", <4>
+      "version": "{stack-version}" <5>
+   }
+    }
+}
+------------------------------------------------------------------------------
+<1> {beatname_uc} uses the `@metadata` field to send metadata to Logstash. See the
+{logstash-ref}/event-dependent-configuration.html#metadata[Logstash documentation]
+for more about the `@metadata` field.
+<2> The default is {beat_default_index_prefix}. To change this value, set the
+<<logstash-index,`index`>> option in the {beatname_uc} config file.
+<3> The pipeline
+<4> The IP address of APM Server 
+<3> The current version of {beatname_uc}.
+endif::[]
 
 You can access this metadata from within the Logstash config file to set values
 dynamically based on the contents of the metadata.
@@ -832,7 +858,12 @@ You can specify the following options in the `logstash` section of the
 The enabled config is a boolean setting to enable or disable the output. If set
 to false, the output is disabled.
 
-The default value is true.
+ifndef:apm-server[]
+The default value is `true`.
+endif::[]
+ifdef:apm-server[]
+The default value is `false`.
+endif::[]
 
 [[hosts]]
 ===== `hosts`

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -750,9 +750,7 @@ ifdef::apm-server[]
     "@metadata": { <1>
       "beat": "{beat_default_index_prefix}", <2>
       "pipeline":"apm", <3>
-      "ip_address":"127.0.0.1", <4>
-      "version": "{stack-version}" <5>
-   }
+      "version": "{stack-version}" <4>
     }
 }
 ------------------------------------------------------------------------------
@@ -761,9 +759,9 @@ ifdef::apm-server[]
 for more about the `@metadata` field.
 <2> The default is {beat_default_index_prefix}. To change this value, set the
 <<logstash-index,`index`>> option in the {beatname_uc} config file.
-<3> Why am I seeing pipeline here?
-<4> The IP address of APM Server.
-<5> The current version of {beatname_uc}.
+<3> The default pipeline configuration: `apm`. Additional pipelines can be enabled
+with a {logstash-ref}/use-ingest-pipelines.html[Logstash pipeline config].
+<4> The current version of {beatname_uc}.
 endif::[]
 
 You can access this metadata from within the Logstash config file to set values

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -762,8 +762,8 @@ for more about the `@metadata` field.
 <2> The default is {beat_default_index_prefix}. To change this value, set the
 <<logstash-index,`index`>> option in the {beatname_uc} config file.
 <3> Why am I seeing pipeline here?
-<4> The IP address of APM Server .
-<3> The current version of {beatname_uc}.
+<4> The IP address of APM Server.
+<5> The current version of {beatname_uc}.
 endif::[]
 
 You can access this metadata from within the Logstash config file to set values
@@ -843,9 +843,27 @@ NOTE: If ILM is not being used, set `index` to `%{[@metadata][beat]}-%{[@metadat
 endif::[]
 
 ifdef::apm-server[]
-NOTE: If ILM is not being used, set `index` to `%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}` instead so Logstash creates an index per day, based on the `@timestamp` value of the events coming from Beats.
-endif::[]
+==== Logstash and ILM
 
+When used with {apm-server-ref}/manual-ilm-setup.html[Index lifecycle management], Logstash does not need to create a new index each day.
+Here's a sample Logstash configuration file that would accomplish this:
+
+[source,logstash]
+------
+input {
+    beats {
+        port => 5044
+    }
+}
+
+output {
+    elasticsearch {
+        hosts => ["http://localhost:9200"]
+        index => "%{[@metadata][beat]}-%{[@metadata][version]}-%{[processor][event]}"
+    }
+}
+------
+endif::[]
 
 ==== Compatibility
 

--- a/docs/copied-from-beats/outputconfig.asciidoc
+++ b/docs/copied-from-beats/outputconfig.asciidoc
@@ -730,7 +730,6 @@ use in Logstash for indexing and filtering:
     "@metadata": { <1>
       "beat": "{beat_default_index_prefix}", <2>
       "version": "{stack-version}" <3>
-      "type": "doc" <4>
     }
 }
 ------------------------------------------------------------------------------
@@ -739,21 +738,16 @@ use in Logstash for indexing and filtering:
 for more about the `@metadata` field.
 <2> The default is {beat_default_index_prefix}. To change this value, set the
 <<logstash-index,`index`>> option in the {beatname_uc} config file.
-<3> The beats current version.
-<4> The value of `type` is currently hardcoded to `doc`. It was used by previous
-Logstash configs to set the type of the document in Elasticsearch.
-
-
-WARNING: The `@metadata.type` field, added by the Logstash output, is
-deprecated, hardcoded to `doc`, and will be removed in {beatname_uc} 7.0.
+<3> The current version of {beatname_uc}.
 
 You can access this metadata from within the Logstash config file to set values
 dynamically based on the contents of the metadata.
 
-For example, the following Logstash configuration file for versions 2.x and
-5.x sets Logstash to use the index and document type reported by Beats for
-indexing events into Elasticsearch:
+For example, the following Logstash configuration file for version 7.x sets
+Logstash to use the index reported by {beatname_uc} for indexing events
+into Elasticsearch:
 
+ifndef::apm-server[]
 [source,logstash]
 ------------------------------------------------------------------------------
 
@@ -774,11 +768,53 @@ output {
 of the `beat` metadata field and `%{[@metadata][version]}` sets the second part to
 the Beat's version. For example:
 +{beat_default_index_prefix}-{version}+.
+endif::[]
+
+ifdef::apm-server[]
+[source,logstash]
+------
+input {
+  beats {
+    port => 5044
+  }
+}
+
+filter {
+  if [@metadata][beat] == "apm-server" { <1>
+    if [processor][event] == "sourcemap" {
+      mutate { add_field => { "[@metadata][index]" => "apm-%{[@metadata][version]}-sourcemap" } } <2>
+    } else {
+      mutate { add_field => { "[@metadata][index]" => "apm-%{[@metadata][version]}-%{[processor][event]}" } } <3>
+    }
+  } else {
+    mutate { add_field => { "[@metadata][index]" => "%{[@metadata][beat]}-%{[@metadata][version]}" } } <4>
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => ["http://localhost:9200"]
+    index => "%{[@metadata][index]}"
+  }
+}
+------
+<1> Checks for data coming from APM Server
+<2> Sourcemap indices are 
+<3>
+<4> Default output index for non APM data 
+endif::[]
 
 Events indexed into Elasticsearch with the Logstash configuration shown here
-will be similar to events directly indexed by Beats into Elasticsearch.
+will be similar to events directly indexed by {beatname_uc} into Elasticsearch.
 
+ifndef::apm-server[]
 NOTE: If ILM is not being used, set `index` to `%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}` instead so Logstash creates an index per day, based on the `@timestamp` value of the events coming from Beats.
+endif::[]
+
+ifdef::apm-server[]
+NOTE: If ILM is not being used, set `index` to `%{[@metadata][beat]}-%{[@metadata][version]}-%{+YYYY.MM.dd}` instead so Logstash creates an index per day, based on the `@timestamp` value of the events coming from Beats.
+endif::[]
+
 
 ==== Compatibility
 


### PR DESCRIPTION
This PR updates the output config documentation for Logstash. Closes #1631. These changes will also need to be made in elastic/beats.

**A preview of the following changes to `logstash-output.html` is available [here](http://apm-server_2691.docs-preview.app.elstc.co/guide/en/apm/server/master/logstash-output.html).**

* Replaces "The Beat" with "APM Server"
* Updates `@metadata` information
* Adds two sample logstash configs for APM users

Here is the logstash config I got to work with APM. It'd be great if someone with more logstash experience could take a look and recommend any improvements.

```conf
input {
    beats {
        port => 5044
    }
}

filter {
    if [@metadata][beat] == "apm" {
        if [processor][event] == "sourcemap" {
            mutate {
                add_field => { "[@metadata][index]" => "%{[@metadata][beat]}-%{[@metadata][version]}-%{[processor][event]}" } <1>
            }
        } else {
            mutate {
                add_field => { "[@metadata][index]" => "%{[@metadata][beat]}-%{[@metadata][version]}-%{[processor][event]}-%{+yyyy.MM.dd}" } <2>
            }
        }
    }
}

output {
    elasticsearch {
        hosts => ["http://localhost:9200"]
        index => "%{[@metadata][index]}"
    }
}
```

In addition, the following configs work with manual ILM. Is one preferred over the others?

```conf
input {
    beats {
        port => 5044
    }
}

output {
    elasticsearch {
        hosts => ["http://localhost:9200"]
        index => "%{[@metadata][beat]}-%{[@metadata][version]}-%{[processor][event]}"
    }
}
```
vs

```conf
input {
    beats {
        port => 5044
    }
}

filter {
    if [@metadata][beat] == "apm" {
        mutate {
            add_field => { "[@metadata][index]" => "%{[@metadata][beat]}-%{[@metadata][version]}-%{[processor][event]}" }
        }
    }
}

output {
    elasticsearch {
        hosts => ["http://localhost:9200"]
        index => "%{[@metadata][index]}"
    }
}
```
