### PR TITLE
Avoid nil errors in beater request results

### DIFF
--- a/beater/api/intake/handler.go
+++ b/beater/api/intake/handler.go
@@ -81,9 +81,6 @@ func Handler(dec decoder.ReqDecoder, processor *stream.Processor, rlm RateLimite
 func sendResponse(c *request.Context, sr *stream.Result) {
 	code := http.StatusAccepted
 	id := request.IDResponseValidAccepted
-	err := errors.New(sr.Error())
-	var body interface{}
-
 	set := func(c int, i request.ResultID) {
 		if c > code {
 			code = c
@@ -115,6 +112,7 @@ L:
 		}
 	}
 
+	var body interface{}
 	if code >= http.StatusBadRequest {
 		// this signals to the client that we're closing the connection
 		// but also signals to http.Server that it should close it:
@@ -124,7 +122,10 @@ L:
 	} else if _, ok := c.Request.URL.Query()["verbose"]; ok {
 		body = sr
 	}
-
+	var err error
+	if errMsg := sr.Error(); errMsg != "" {
+		err = errors.New(errMsg)
+	}
 	c.Result.Set(id, code, request.MapResultIDToStatus[id].Keyword, body, err)
 	c.Write()
 }

--- a/beater/api/intake/handler_test.go
+++ b/beater/api/intake/handler_test.go
@@ -152,6 +152,9 @@ func TestIntakeHandler(t *testing.T) {
 
 			if tc.code == http.StatusAccepted {
 				assert.NotNil(t, tc.w.Body.Len())
+				assert.Nil(t, tc.c.Result.Err)
+			} else {
+				assert.NotNil(t, tc.c.Result.Err)
 			}
 			body := tc.w.Body.Bytes()
 			approvals.AssertApproveResult(t, "test_approved/"+name, body)

--- a/beater/request/result_test.go
+++ b/beater/request/result_test.go
@@ -81,6 +81,94 @@ func TestResult_Set(t *testing.T) {
 	})
 }
 
+func TestResult_SetDefault(t *testing.T) {
+	t.Run("StatusAccepted", func(t *testing.T) {
+		id := IDResponseValidAccepted
+		r := Result{}
+		r.Reset()
+		r.SetDefault(id)
+		assert.Equal(t, id, r.ID)
+		assert.Equal(t, http.StatusAccepted, r.StatusCode)
+		assert.Equal(t, MapResultIDToStatus[id].Keyword, r.Keyword)
+		assert.Equal(t, nil, r.Body)
+		assert.Equal(t, nil, r.Err)
+		assert.Equal(t, "", r.Stacktrace)
+	})
+
+	t.Run("StatusForbidden", func(t *testing.T) {
+		id := IDResponseErrorsForbidden
+		r := Result{}
+		r.Reset()
+		r.SetDefault(id)
+		assert.Equal(t, id, r.ID)
+		assert.Equal(t, http.StatusForbidden, r.StatusCode)
+		assert.Equal(t, MapResultIDToStatus[id].Keyword, r.Keyword)
+		assert.Equal(t, r.Keyword, r.Body)
+		assert.Equal(t, r.Keyword, r.Err.Error())
+		assert.Equal(t, "", r.Stacktrace)
+	})
+}
+
+func TestResult_SetWithBody(t *testing.T) {
+	t.Run("StatusAccepted", func(t *testing.T) {
+		id := IDResponseValidAccepted
+		body := "some body"
+		r := Result{}
+		r.Reset()
+		r.SetWithBody(id, body)
+		assert.Equal(t, id, r.ID)
+		assert.Equal(t, http.StatusAccepted, r.StatusCode)
+		assert.Equal(t, MapResultIDToStatus[id].Keyword, r.Keyword)
+		assert.Equal(t, body, r.Body)
+		assert.Equal(t, nil, r.Err)
+		assert.Equal(t, "", r.Stacktrace)
+	})
+
+	t.Run("StatusForbidden", func(t *testing.T) {
+		id := IDResponseErrorsForbidden
+		body := "some body"
+		r := Result{}
+		r.Reset()
+		r.SetWithBody(id, body)
+		assert.Equal(t, id, r.ID)
+		assert.Equal(t, http.StatusForbidden, r.StatusCode)
+		assert.Equal(t, MapResultIDToStatus[id].Keyword, r.Keyword)
+		assert.Equal(t, body, r.Body)
+		assert.Equal(t, r.Keyword, r.Err.Error())
+		assert.Equal(t, "", r.Stacktrace)
+	})
+}
+
+func TestResult_SetWithError(t *testing.T) {
+	t.Run("StatusAccepted", func(t *testing.T) {
+		id := IDResponseValidAccepted
+		r := Result{}
+		r.Reset()
+		r.SetWithError(id, nil)
+		assert.Equal(t, id, r.ID)
+		assert.Equal(t, http.StatusAccepted, r.StatusCode)
+		assert.Equal(t, MapResultIDToStatus[id].Keyword, r.Keyword)
+		assert.Equal(t, nil, r.Body)
+		assert.Equal(t, nil, r.Err)
+		assert.Equal(t, "", r.Stacktrace)
+	})
+
+	t.Run("StatusForbidden", func(t *testing.T) {
+		id := IDResponseErrorsForbidden
+		err := errors.New("some error")
+		r := Result{}
+		r.Reset()
+		r.SetWithError(id, err)
+		assert.Equal(t, id, r.ID)
+		assert.Equal(t, http.StatusForbidden, r.StatusCode)
+		assert.Equal(t, MapResultIDToStatus[id].Keyword, r.Keyword)
+		wrappedErr := errors.Wrap(err, r.Keyword).Error()
+		assert.Equal(t, wrappedErr, r.Body)
+		assert.Equal(t, wrappedErr, r.Err.Error())
+		assert.Equal(t, "", r.Stacktrace)
+	})
+}
+
 func TestResult_Failure(t *testing.T) {
 	assert.False(t, (&Result{StatusCode: http.StatusOK}).Failure())
 	assert.False(t, (&Result{StatusCode: http.StatusPermanentRedirect}).Failure())


### PR DESCRIPTION
Ensure errors are only set if not nil.

fixes #2698

* [ ] needs backport to `7.4`