### PR TITLE
[docs] Update current branch for dotnet-branch

### DIFF
--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -21,7 +21,7 @@
 :node-branch: 2.x
 :py-branch: 5.x
 :ruby-branch: 2.x
-:dotnet-branch: current
+:dotnet-branch: 1.x
 
 // Agent links
 :apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{py-branch}


### PR DESCRIPTION
Updates the current branch for the `dotnet-branch` attribute. It is important we do this so that if a link gets removed in `current` down the road it will not break old documentation branches.

This needs to be backported.
