### PR TITLE
[docs] make rum-allow-origins format clear

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -89,7 +89,7 @@ apm-server:
 
     #-- General RUM settings
 
-    # Comma separated list of permitted origins for real user monitoring.
+    # A list of permitted origins for real user monitoring.
     # User-agents will send an origin header that will be validated against this list.
     # An origin is made of a protocol scheme, host and port, without the url path.
     # Allowed origins in this setting can have * to match anything (eg.: http://*.example.com)

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -89,7 +89,7 @@ apm-server:
 
     #-- General RUM settings
 
-    # Comma separated list of permitted origins for real user monitoring.
+    # A list of permitted origins for real user monitoring.
     # User-agents will send an origin header that will be validated against this list.
     # An origin is made of a protocol scheme, host and port, without the url path.
     # Allowed origins in this setting can have * to match anything (eg.: http://*.example.com)

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -89,7 +89,7 @@ apm-server:
 
     #-- General RUM settings
 
-    # Comma separated list of permitted origins for real user monitoring.
+    # A list of permitted origins for real user monitoring.
     # User-agents will send an origin header that will be validated against this list.
     # An origin is made of a protocol scheme, host and port, without the url path.
     # Allowed origins in this setting can have * to match anything (eg.: http://*.example.com)

--- a/docs/configuration-rum.asciidoc
+++ b/docs/configuration-rum.asciidoc
@@ -43,7 +43,7 @@ Defaults to 1000.
 [float]
 [[rum-allow-origins]]
 ==== `allow_origins`
-Comma separated list of permitted origins for RUM support.
+A list of permitted origins for RUM support.
 User-agents send an Origin header that will be validated against this list.
 This is done automatically by modern browsers as part of the https://www.w3.org/TR/cors/[CORS specification].
 An origin is made of a protocol scheme, host and port, without the URL path.


### PR DESCRIPTION
There was some confusion around the _comma separated list_, and since in yml it would also be valid to specify in the following format, it makes sense to just describe _a list_.
```
allow_origins:
  - "foo"
  - "bar"
```
cc @nachogiljaldo 