### PR TITLE
[7.x] make the rate limiter reusable (#2706)

### DIFF
--- a/beater/api/intake_rum_integration_test.go
+++ b/beater/api/intake_rum_integration_test.go
@@ -42,7 +42,7 @@ func TestOPTIONS(t *testing.T) {
 	rumEnabled := true
 	cfg.RumConfig.Enabled = &rumEnabled
 	cfg.RumConfig.AllowOrigins = []string{"*"}
-	h := middleware.Wrap(
+	h, _ := middleware.Wrap(
 		func(c *request.Context) {
 			requestTaken <- struct{}{}
 			<-done

--- a/beater/api/ratelimit/lru_cache_test.go
+++ b/beater/api/ratelimit/lru_cache_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package intake
+package ratelimit
 
 import (
 	"testing"
@@ -34,7 +34,7 @@ func TestCacheInitFails(t *testing.T) {
 		{0, 1},
 		{1, -1},
 	} {
-		c, err := NewRateLimitLRUCache(test.size, test.limit, 3)
+		c, err := NewLRUCache(test.size, test.limit, 3)
 		assert.Error(t, err)
 		assert.Nil(t, c)
 	}
@@ -44,24 +44,24 @@ func TestCacheEviction(t *testing.T) {
 	cacheSize := 2
 	limit := 1 //multiplied times BurstMultiplier 3
 
-	rlc, err := NewRateLimitLRUCache(cacheSize, limit, 3)
+	rlc, err := NewLRUCache(cacheSize, limit, 3)
 	require.NoError(t, err)
 
 	// add new limiter
-	rlA, _ := rlc.RateLimiter("a")
+	rlA, _ := rlc.Acquire("a")
 	rlA.AllowN(time.Now(), 3)
 
 	// add new limiter
-	rlB, _ := rlc.RateLimiter("b")
+	rlB, _ := rlc.Acquire("b")
 	rlB.AllowN(time.Now(), 2)
 
 	// reuse evicted limiter rlA
-	rlC, _ := rlc.RateLimiter("c")
+	rlC, _ := rlc.Acquire("c")
 	assert.False(t, rlC.Allow())
 	assert.Equal(t, rlC, rlc.evictedLimiter)
 
 	// reuse evicted limiter rlB
-	rlD, _ := rlc.RateLimiter("a")
+	rlD, _ := rlc.Acquire("a")
 	assert.True(t, rlD.Allow())
 	assert.False(t, rlD.Allow())
 	assert.Equal(t, rlD, rlc.evictedLimiter)
@@ -73,27 +73,27 @@ func TestCacheEviction(t *testing.T) {
 }
 
 func TestCacheOk(t *testing.T) {
-	var rlc *RateLimitLRUCache
-	_, ok := rlc.RateLimiter("a")
+	var rlc *LRUCache
+	_, ok := rlc.Acquire("a")
 	assert.False(t, ok)
 
-	var cache = func() *RateLimitLRUCache {
-		rlc, err := NewRateLimitLRUCache(1, 1, 1)
+	var cache = func() *LRUCache {
+		rlc, err := NewLRUCache(1, 1, 1)
 		require.NoError(t, err)
 		return rlc
 	}
 
 	rlc = cache()
 	rlc.limit = -1
-	_, ok = rlc.RateLimiter("a")
+	_, ok = rlc.Acquire("a")
 	assert.False(t, ok)
 
 	rlc = cache()
 	rlc.cache = nil
-	_, ok = rlc.RateLimiter("a")
+	_, ok = rlc.Acquire("a")
 	assert.False(t, ok)
 
 	rlc = cache()
-	_, ok = rlc.RateLimiter("a")
+	_, ok = rlc.Acquire("a")
 	assert.True(t, ok)
 }

--- a/beater/middleware/authorization_middleware.go
+++ b/beater/middleware/authorization_middleware.go
@@ -28,7 +28,7 @@ import (
 
 // RequireAuthorizationMiddleware returns a Middleware to only let authorized requests pass through
 func RequireAuthorizationMiddleware(token string) Middleware {
-	return func(h request.Handler) request.Handler {
+	return func(h request.Handler) (request.Handler, error) {
 		return func(c *request.Context) {
 			c.TokenSet = tokenSet(token)
 
@@ -41,19 +41,19 @@ func RequireAuthorizationMiddleware(token string) Middleware {
 
 			c.Authorized = true
 			h(c)
-		}
+		}, nil
 	}
 }
 
 // SetAuthorizationMiddleware returns a middleware setting authorization information in the context without terminating the
 // request if it is not authorized
 func SetAuthorizationMiddleware(token string) Middleware {
-	return func(h request.Handler) request.Handler {
+	return func(h request.Handler) (request.Handler, error) {
 		return func(c *request.Context) {
 			c.Authorized = isAuthorized(c.Request, token)
 			c.TokenSet = tokenSet(token)
 			h(c)
-		}
+		}, nil
 	}
 }
 

--- a/beater/middleware/authorization_middleware_test.go
+++ b/beater/middleware/authorization_middleware_test.go
@@ -52,7 +52,7 @@ func TestRequireAuthorizationMiddleware(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			c, rec := beatertest.DefaultContextWithResponseRecorder()
 			c.Request.Header.Set(headers.Authorization, "Bearer "+tc.requestToken)
-			RequireAuthorizationMiddleware(tc.serverToken)(beatertest.Handler202)(c)
+			Apply(RequireAuthorizationMiddleware(tc.serverToken), beatertest.Handler202)(c)
 
 			assert.Equal(t, tc.authorized, c.Authorized)
 			assert.Equal(t, tc.tokenSet, c.TokenSet)
@@ -73,7 +73,7 @@ func TestSetAuthorizationMiddleware(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			c, rec := beatertest.DefaultContextWithResponseRecorder()
 			c.Request.Header.Set(headers.Authorization, "Bearer "+tc.requestToken)
-			SetAuthorizationMiddleware(tc.serverToken)(beatertest.Handler202)(c)
+			Apply(SetAuthorizationMiddleware(tc.serverToken), beatertest.Handler202)(c)
 
 			assert.Equal(t, tc.authorized, c.Authorized)
 			assert.Equal(t, tc.tokenSet, c.TokenSet)

--- a/beater/middleware/cors_middleware.go
+++ b/beater/middleware/cors_middleware.go
@@ -45,7 +45,7 @@ func CORSMiddleware(allowedOrigins []string) Middleware {
 		return false
 	}
 
-	return func(h request.Handler) request.Handler {
+	return func(h request.Handler) (request.Handler, error) {
 		return func(c *request.Context) {
 			// origin header is always set by the browser
 			origin := c.Request.Header.Get(headers.Origin)
@@ -82,6 +82,6 @@ func CORSMiddleware(allowedOrigins []string) Middleware {
 					errors.New("origin: '"+origin+"' is not allowed"))
 				c.Write()
 			}
-		}
+		}, nil
 	}
 }

--- a/beater/middleware/cors_middleware_test.go
+++ b/beater/middleware/cors_middleware_test.go
@@ -35,7 +35,7 @@ func TestCORSMiddleware(t *testing.T) {
 	cors := func(origin string, allowedOrigins []string, m string) (*request.Context, *httptest.ResponseRecorder) {
 		c, rec := beatertest.ContextWithResponseRecorder(m, "/")
 		c.Request.Header.Set(headers.Origin, origin)
-		CORSMiddleware(allowedOrigins)(beatertest.Handler202)(c)
+		Apply(CORSMiddleware(allowedOrigins), beatertest.Handler202)(c)
 		return c, rec
 	}
 

--- a/beater/middleware/kill_switch_middleware.go
+++ b/beater/middleware/kill_switch_middleware.go
@@ -27,7 +27,7 @@ const errDisabledMsg = "endpoint is disabled"
 
 // KillSwitchMiddleware returns a Middleware checking whether the path for the request is enabled
 func KillSwitchMiddleware(enabled bool) Middleware {
-	return func(h request.Handler) request.Handler {
+	return func(h request.Handler) (request.Handler, error) {
 		return func(c *request.Context) {
 			if enabled {
 				h(c)
@@ -35,6 +35,6 @@ func KillSwitchMiddleware(enabled bool) Middleware {
 				c.Result.SetWithError(request.IDResponseErrorsForbidden, errors.New(errDisabledMsg))
 				c.Write()
 			}
-		}
+		}, nil
 	}
 }

--- a/beater/middleware/kill_switch_middleware_test.go
+++ b/beater/middleware/kill_switch_middleware_test.go
@@ -29,12 +29,12 @@ import (
 func TestKillSwitchMiddleware(t *testing.T) {
 	t.Run("On", func(t *testing.T) {
 		c, rec := beatertest.DefaultContextWithResponseRecorder()
-		KillSwitchMiddleware(true)(beatertest.Handler202)(c)
+		Apply(KillSwitchMiddleware(true), beatertest.Handler202)(c)
 		assert.Equal(t, http.StatusAccepted, rec.Code)
 	})
 	t.Run("Off", func(t *testing.T) {
 		c, rec := beatertest.DefaultContextWithResponseRecorder()
-		KillSwitchMiddleware(false)(beatertest.Handler202)(c)
+		Apply(KillSwitchMiddleware(false), beatertest.Handler202)(c)
 		assert.Equal(t, http.StatusForbidden, rec.Code)
 	})
 }

--- a/beater/middleware/log_middleware.go
+++ b/beater/middleware/log_middleware.go
@@ -31,7 +31,7 @@ import (
 // LogMiddleware returns a middleware taking care of logging processing a request in the middleware and the request handler
 func LogMiddleware() Middleware {
 	logger := logp.NewLogger(logs.Request)
-	return func(h request.Handler) request.Handler {
+	return func(h request.Handler) (request.Handler, error) {
 
 		return func(c *request.Context) {
 			reqID, err := uuid.NewV4()
@@ -76,6 +76,6 @@ func LogMiddleware() Middleware {
 				reqLogger.Infow(keyword, keysAndValues...)
 			}
 
-		}
+		}, nil
 	}
 }

--- a/beater/middleware/log_middleware_test.go
+++ b/beater/middleware/log_middleware_test.go
@@ -66,7 +66,7 @@ func TestLogMiddleware(t *testing.T) {
 			name:       "Panic",
 			message:    "internal error",
 			level:      zapcore.ErrorLevel,
-			handler:    RecoverPanicMiddleware()(beatertest.HandlerPanic),
+			handler:    Apply(RecoverPanicMiddleware(), beatertest.HandlerPanic),
 			code:       http.StatusInternalServerError,
 			error:      errors.New("panic on Handle"),
 			stacktrace: true,
@@ -87,7 +87,7 @@ func TestLogMiddleware(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			c, rec := beatertest.DefaultContextWithResponseRecorder()
 			c.Request.Header.Set(headers.UserAgent, tc.name)
-			LogMiddleware()(tc.handler)(c)
+			Apply(LogMiddleware(), tc.handler)(c)
 			assert.Equal(t, tc.code, rec.Code)
 			for i, entry := range logp.ObserverLogs().TakeAll() {
 				// expect only one log entry per request

--- a/beater/middleware/middleware.go
+++ b/beater/middleware/middleware.go
@@ -22,13 +22,17 @@ import (
 )
 
 // Middleware wraps a request.Handler
-type Middleware func(request.Handler) request.Handler
+type Middleware func(request.Handler) (request.Handler, error)
 
 // Wrap wraps a request.Handler into given middleware functions,
 // maintaining order from the last to the first middleware
-func Wrap(h request.Handler, m ...Middleware) request.Handler {
+func Wrap(h request.Handler, m ...Middleware) (request.Handler, error) {
 	for i := len(m) - 1; i >= 0; i-- {
-		h = m[i](h)
+		var e error
+		h, e = m[i](h)
+		if e != nil {
+			return nil, e
+		}
 	}
-	return h
+	return h, nil
 }

--- a/beater/middleware/monitoring_middleware.go
+++ b/beater/middleware/monitoring_middleware.go
@@ -28,7 +28,7 @@ import (
 // MonitoringMiddleware returns a middleware that increases monitoring counters for collecting metrics
 // about request processing. As input parameter it takes a map capable of mapping a request.ResultID to a counter.
 func MonitoringMiddleware(m map[request.ResultID]*monitoring.Int) Middleware {
-	return func(h request.Handler) request.Handler {
+	return func(h request.Handler) (request.Handler, error) {
 		inc := func(id request.ResultID) {
 			if counter, ok := m[id]; ok {
 				counter.Inc()
@@ -47,7 +47,7 @@ func MonitoringMiddleware(m map[request.ResultID]*monitoring.Int) Middleware {
 			}
 
 			inc(c.Result.ID)
-		}
+		}, nil
 
 	}
 }

--- a/beater/middleware/monitoring_middleware_test.go
+++ b/beater/middleware/monitoring_middleware_test.go
@@ -41,7 +41,7 @@ func TestMonitoringHandler(t *testing.T) {
 		m map[request.ResultID]*monitoring.Int,
 	) {
 		c, _ := beatertest.DefaultContextWithResponseRecorder()
-		equal, result := beatertest.CompareMonitoringInt(MonitoringMiddleware(m)(h), c, expected, m)
+		equal, result := beatertest.CompareMonitoringInt(Apply(MonitoringMiddleware(m), h), c, expected, m)
 		assert.True(t, equal, result)
 	}
 
@@ -80,7 +80,7 @@ func TestMonitoringHandler(t *testing.T) {
 
 	t.Run("Panic", func(t *testing.T) {
 		checkMonitoring(t,
-			RecoverPanicMiddleware()(beatertest.HandlerPanic),
+			Apply(RecoverPanicMiddleware(), beatertest.HandlerPanic),
 			map[request.ResultID]int{
 				request.IDRequestCount:           1,
 				request.IDResponseCount:          1,

--- a/beater/middleware/recover_panic_middleware.go
+++ b/beater/middleware/recover_panic_middleware.go
@@ -30,7 +30,7 @@ const keywordPanic = "panic handling request"
 // RecoverPanicMiddleware returns a middleware ensuring that the Server recovers from panics,
 // while trying to write an according response.
 func RecoverPanicMiddleware() Middleware {
-	return func(h request.Handler) request.Handler {
+	return func(h request.Handler) (request.Handler, error) {
 		return func(c *request.Context) {
 
 			defer func() {
@@ -58,6 +58,6 @@ func RecoverPanicMiddleware() Middleware {
 				}
 			}()
 			h(c)
-		}
+		}, nil
 	}
 }

--- a/beater/middleware/recover_panic_middleware_test.go
+++ b/beater/middleware/recover_panic_middleware_test.go
@@ -35,7 +35,7 @@ func TestPanicHandler(t *testing.T) {
 
 	t.Run("NoPanic", func(t *testing.T) {
 		c, w := beatertest.DefaultContextWithResponseRecorder()
-		RecoverPanicMiddleware()(beatertest.Handler403)(c)
+		Apply(RecoverPanicMiddleware(), beatertest.Handler403)(c)
 
 		// response assertions
 		assert.Equal(t, http.StatusForbidden, w.Code)
@@ -48,7 +48,7 @@ func TestPanicHandler(t *testing.T) {
 	t.Run("HandlePanic", func(t *testing.T) {
 		h := func(c *request.Context) { panic(errors.New("panic xyz")) }
 		c, w := beatertest.DefaultContextWithResponseRecorder()
-		RecoverPanicMiddleware()(h)(c)
+		Apply(RecoverPanicMiddleware(), h)(c)
 
 		// response assertions
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
@@ -64,7 +64,7 @@ func TestPanicHandler(t *testing.T) {
 		w := &writerPanic{}
 		c := &request.Context{}
 		c.Reset(w, httptest.NewRequest(http.MethodGet, "/", nil))
-		RecoverPanicMiddleware()(beatertest.Handler202)(c)
+		Apply(RecoverPanicMiddleware(), beatertest.Handler202)(c)
 
 		// response assertions: cannot even write to writer, as it panics
 		assert.Equal(t, 0, w.StatusCode)

--- a/beater/middleware/request_time_middleware_test.go
+++ b/beater/middleware/request_time_middleware_test.go
@@ -29,6 +29,6 @@ import (
 func TestRequestTimeMiddleware(t *testing.T) {
 	c, _ := beatertest.DefaultContextWithResponseRecorder()
 	assert.Empty(t, utility.RequestTime(c.Request.Context()))
-	RequestTimeMiddleware()(beatertest.HandlerIdle)(c)
+	Apply(RequestTimeMiddleware(), beatertest.HandlerIdle)(c)
 	assert.NotEmpty(t, utility.RequestTime(c.Request.Context()))
 }

--- a/beater/request/context.go
+++ b/beater/request/context.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/elastic/apm-server/beater/api/ratelimit"
+
 	"github.com/elastic/apm-server/beater/headers"
 	logs "github.com/elastic/apm-server/log"
 	"github.com/elastic/beats/libbeat/logp"
@@ -38,14 +40,14 @@ var (
 
 // Context abstracts request and response information for http requests
 type Context struct {
-	Request              *http.Request
-	Logger               *logp.Logger
-	TokenSet, Authorized bool
-
-	Result Result
-
-	w             http.ResponseWriter
-	writeAttempts int
+	Request          *http.Request
+	Logger           *logp.Logger
+	RateLimitManager ratelimit.Manager
+	TokenSet         bool
+	Authorized       bool
+	Result           Result
+	w                http.ResponseWriter
+	writeAttempts    int
 }
 
 // Reset allows to reuse a context by removing all request specific information
@@ -54,7 +56,7 @@ func (c *Context) Reset(w http.ResponseWriter, r *http.Request) {
 	c.Logger = nil
 	c.TokenSet = false
 	c.Authorized = false
-
+	c.RateLimitManager = nil
 	c.Result.Reset()
 
 	c.w = w


### PR DESCRIPTION
Backports the following commits to 7.x:
 - make the rate limiter reusable  (#2706)