### PR TITLE
Refactor rate limit logic

### DIFF
--- a/beater/api/config_agent_integration_test.go
+++ b/beater/api/config_agent_integration_test.go
@@ -48,7 +48,7 @@ func TestConfigAgentHandler_AuthorizationMiddleware(t *testing.T) {
 	t.Run("Authorized", func(t *testing.T) {
 		cfg := configEnabledConfigAgent()
 		cfg.SecretToken = "1234"
-		h, err := configAgentHandler(cfg, beatertest.NilReporter)
+		h, err := backendAgentConfigHandler(cfg, beatertest.NilReporter)
 		require.NoError(t, err)
 		c, rec := beatertest.DefaultContextWithResponseRecorder()
 		c.Request.Header.Set(headers.Authorization, "Bearer 1234")
@@ -77,7 +77,7 @@ func TestConfigAgentHandler_KillSwitchMiddleware(t *testing.T) {
 }
 
 func TestConfigAgentHandler_PanicMiddleware(t *testing.T) {
-	h, err := configAgentHandler(config.DefaultConfig(beatertest.MockBeatVersion()), beatertest.NilReporter)
+	h, err := backendAgentConfigHandler(config.DefaultConfig(beatertest.MockBeatVersion()), beatertest.NilReporter)
 	require.NoError(t, err)
 	rec := &beatertest.WriterPanicOnce{}
 	c := &request.Context{}
@@ -88,7 +88,7 @@ func TestConfigAgentHandler_PanicMiddleware(t *testing.T) {
 }
 
 func TestConfigAgentHandler_MonitoringMiddleware(t *testing.T) {
-	h, err := configAgentHandler(config.DefaultConfig(beatertest.MockBeatVersion()), beatertest.NilReporter)
+	h, err := backendAgentConfigHandler(config.DefaultConfig(beatertest.MockBeatVersion()), beatertest.NilReporter)
 	require.NoError(t, err)
 	c, _ := beatertest.ContextWithResponseRecorder(http.MethodPost, "/")
 
@@ -103,7 +103,7 @@ func TestConfigAgentHandler_MonitoringMiddleware(t *testing.T) {
 }
 
 func requestToConfigAgentHandler(t *testing.T, cfg *config.Config) *httptest.ResponseRecorder {
-	h, err := configAgentHandler(cfg, beatertest.NilReporter)
+	h, err := backendAgentConfigHandler(cfg, beatertest.NilReporter)
 	require.NoError(t, err)
 	c, rec := beatertest.DefaultContextWithResponseRecorder()
 	h(c)

--- a/beater/api/intake/handler.go
+++ b/beater/api/intake/handler.go
@@ -50,8 +50,9 @@ func Handler(dec decoder.ReqDecoder, processor *stream.Processor, report publish
 			return
 		}
 
-		ipRateLimiter, ok := c.RateLimiter.PerIP(c.Request)
-		if ok && !ipRateLimiter.Allow() {
+		ipRateLimiter := c.RateLimiter.ForIP(c.Request)
+		ok := ipRateLimiter == nil || ipRateLimiter.Allow()
+		if !ok {
 			sendError(c, &stream.Error{
 				Type: stream.RateLimitErrType, Message: "rate limit exceeded"})
 			return

--- a/beater/api/intake/handler.go
+++ b/beater/api/intake/handler.go
@@ -23,10 +23,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/elastic/apm-server/beater/api/ratelimit"
-
 	"github.com/pkg/errors"
-	"golang.org/x/time/rate"
 
 	"github.com/elastic/beats/libbeat/monitoring"
 
@@ -35,7 +32,6 @@ import (
 	"github.com/elastic/apm-server/decoder"
 	"github.com/elastic/apm-server/processor/stream"
 	"github.com/elastic/apm-server/publish"
-	"github.com/elastic/apm-server/utility"
 )
 
 var (
@@ -54,9 +50,10 @@ func Handler(dec decoder.ReqDecoder, processor *stream.Processor, report publish
 			return
 		}
 
-		rateLimiter, serr := rateLimit(c.Request, c.RateLimitManager)
-		if serr != nil {
-			sendError(c, serr)
+		ipRateLimiter, ok := c.RateLimiter.PerIP(c.Request)
+		if ok && !ipRateLimiter.Allow() {
+			sendError(c, &stream.Error{
+				Type: stream.RateLimitErrType, Message: "rate limit exceeded"})
 			return
 		}
 
@@ -74,7 +71,7 @@ func Handler(dec decoder.ReqDecoder, processor *stream.Processor, report publish
 			sendResponse(c, &sr)
 			return
 		}
-		res := processor.HandleStream(c.Request.Context(), rateLimiter, reqMeta, reader, report)
+		res := processor.HandleStream(c.Request.Context(), ipRateLimiter, reqMeta, reader, report)
 
 		sendResponse(c, res)
 	}
@@ -152,22 +149,6 @@ func validateRequest(r *http.Request) *stream.Error {
 		}
 	}
 	return nil
-}
-
-func rateLimit(r *http.Request, manager ratelimit.Manager) (*rate.Limiter, *stream.Error) {
-	if manager == nil {
-		return nil, nil
-	}
-	if rateLimit, ok := manager.Acquire(utility.RemoteAddr(r)); ok {
-		if !rateLimit.Allow() {
-			return nil, &stream.Error{
-				Type:    stream.RateLimitErrType,
-				Message: "rate limit exceeded",
-			}
-		}
-		return rateLimit, nil
-	}
-	return nil, nil
 }
 
 func bodyReader(r *http.Request) (io.ReadCloser, *stream.Error) {

--- a/beater/api/intake/handler_test.go
+++ b/beater/api/intake/handler_test.go
@@ -44,10 +44,9 @@ import (
 	"github.com/elastic/apm-server/transform"
 )
 
-var rateLimit, _ = ratelimit.NewStore(1, 0, 0)
-
 func TestIntakeHandler(t *testing.T) {
-
+	var rateLimit, err = ratelimit.NewStore(1, 0, 0)
+	require.NoError(t, err)
 	for name, tc := range map[string]testcaseIntakeHandler{
 		"Method": {
 			path: "errors.ndjson",

--- a/beater/api/intake_rum_integration_test.go
+++ b/beater/api/intake_rum_integration_test.go
@@ -47,7 +47,7 @@ func TestOPTIONS(t *testing.T) {
 			requestTaken <- struct{}{}
 			<-done
 		},
-		rumMiddleware(cfg)...)
+		rumMiddleware(cfg, intake.MonitoringMap)...)
 
 	// use this to block the single allowed concurrent requests
 	go func() {

--- a/beater/api/mux.go
+++ b/beater/api/mux.go
@@ -46,7 +46,7 @@ const (
 	// RootPath defines the server's root path
 	RootPath = "/"
 
-	// ConfigAgent defines the path to query for agent config management
+	// AgentConfigPath defines the path to query for agent config management
 	AgentConfigPath = "/config/v1/agents"
 
 	// IntakePath defines the path to ingest monitored events

--- a/beater/api/mux.go
+++ b/beater/api/mux.go
@@ -47,7 +47,7 @@ const (
 	RootPath = "/"
 
 	// ConfigAgent defines the path to query for agent config management
-	ConfigAgent = "/config/v1/agents"
+	AgentConfigPath = "/config/v1/agents"
 
 	// IntakePath defines the path to ingest monitored events
 	IntakePath = "/intake/v2/events"
@@ -76,7 +76,7 @@ func NewMux(beaterConfig *config.Config, report publish.Reporter) (*http.ServeMu
 	routeMap := []route{
 		{RootPath, rootHandler},
 		{AssetSourcemapPath, sourcemapHandler},
-		{ConfigAgent, configAgentHandler},
+		{AgentConfigPath, backendAgentConfigHandler},
 		{IntakeRUMPath, rumHandler},
 		{IntakePath, backendHandler},
 	}
@@ -98,14 +98,6 @@ func NewMux(beaterConfig *config.Config, report publish.Reporter) (*http.ServeMu
 	return mux, nil
 }
 
-func apmMiddleware(m map[request.ResultID]*monitoring.Int) []middleware.Middleware {
-	return []middleware.Middleware{
-		middleware.LogMiddleware(),
-		middleware.RecoverPanicMiddleware(),
-		middleware.MonitoringMiddleware(m),
-	}
-}
-
 func backendHandler(cfg *config.Config, reporter publish.Reporter) (request.Handler, error) {
 	h := intake.Handler(systemMetadataDecoder(cfg, emptyDecoder),
 		&stream.Processor{
@@ -114,13 +106,7 @@ func backendHandler(cfg *config.Config, reporter publish.Reporter) (request.Hand
 			MaxEventSize: cfg.MaxEventSize,
 		},
 		reporter)
-	return middleware.Wrap(h, backendMiddleware(cfg)...)
-}
-
-func backendMiddleware(cfg *config.Config) []middleware.Middleware {
-	return append(apmMiddleware(intake.MonitoringMap),
-		middleware.RequestTimeMiddleware(),
-		middleware.RequireAuthorizationMiddleware(cfg.SecretToken))
+	return middleware.Wrap(h, backendMiddleware(cfg, intake.MonitoringMap)...)
 }
 
 func rumHandler(cfg *config.Config, reporter publish.Reporter) (request.Handler, error) {
@@ -135,15 +121,7 @@ func rumHandler(cfg *config.Config, reporter publish.Reporter) (request.Handler,
 			MaxEventSize: cfg.MaxEventSize,
 		},
 		reporter)
-	return middleware.Wrap(h, rumMiddleware(cfg)...)
-}
-
-func rumMiddleware(cfg *config.Config) []middleware.Middleware {
-	return append(apmMiddleware(intake.MonitoringMap),
-		middleware.KillSwitchMiddleware(cfg.RumConfig.IsEnabled()),
-		middleware.SetRateLimitMiddleware(cfg.RumConfig.EventRate),
-		middleware.RequestTimeMiddleware(),
-		middleware.CORSMiddleware(cfg.RumConfig.AllowOrigins))
+	return middleware.Wrap(h, rumMiddleware(cfg, intake.MonitoringMap)...)
 }
 
 func sourcemapHandler(cfg *config.Config, reporter publish.Reporter) (request.Handler, error) {
@@ -155,29 +133,49 @@ func sourcemapHandler(cfg *config.Config, reporter publish.Reporter) (request.Ha
 	return middleware.Wrap(h, sourcemapMiddleware(cfg)...)
 }
 
-func sourcemapMiddleware(cfg *config.Config) []middleware.Middleware {
-	return append(apmMiddleware(sourcemap.MonitoringMap),
-		middleware.KillSwitchMiddleware(cfg.RumConfig.IsEnabled() && cfg.RumConfig.SourceMapping.IsEnabled()),
-		middleware.RequireAuthorizationMiddleware(cfg.SecretToken))
+func backendAgentConfigHandler(cfg *config.Config, _ publish.Reporter) (request.Handler, error) {
+	return agentConfigHandler(cfg, backendMiddleware(cfg, agent.MonitoringMap))
 }
 
-func configAgentHandler(cfg *config.Config, _ publish.Reporter) (request.Handler, error) {
+func agentConfigHandler(cfg *config.Config, m []middleware.Middleware) (request.Handler, error) {
 	var kbClient kibana.Client
 	if cfg.Kibana.Enabled() {
 		kbClient = kibana.NewConnectingClient(cfg.Kibana)
 	}
 	h := agent.Handler(kbClient, cfg.AgentConfig)
-	return middleware.Wrap(h, agentConfigMiddleware(cfg)...)
-}
-
-func agentConfigMiddleware(cfg *config.Config) []middleware.Middleware {
-	return append(apmMiddleware(agent.MonitoringMap),
-		middleware.KillSwitchMiddleware(cfg.Kibana.Enabled()),
-		middleware.RequireAuthorizationMiddleware(cfg.SecretToken))
+	ks := middleware.KillSwitchMiddleware(cfg.Kibana.Enabled())
+	return middleware.Wrap(h, append(m, ks)...)
 }
 
 func rootHandler(cfg *config.Config, _ publish.Reporter) (request.Handler, error) {
 	return middleware.Wrap(root.Handler(), rootMiddleware(cfg)...)
+}
+
+func apmMiddleware(m map[request.ResultID]*monitoring.Int) []middleware.Middleware {
+	return []middleware.Middleware{
+		middleware.LogMiddleware(),
+		middleware.RecoverPanicMiddleware(),
+		middleware.MonitoringMiddleware(m),
+		middleware.RequestTimeMiddleware(),
+	}
+}
+
+func backendMiddleware(cfg *config.Config, m map[request.ResultID]*monitoring.Int) []middleware.Middleware {
+	return append(apmMiddleware(m),
+		middleware.RequireAuthorizationMiddleware(cfg.SecretToken))
+}
+
+func rumMiddleware(cfg *config.Config, m map[request.ResultID]*monitoring.Int) []middleware.Middleware {
+	return append(apmMiddleware(m),
+		middleware.SetRateLimitMiddleware(cfg.RumConfig.EventRate),
+		middleware.CORSMiddleware(cfg.RumConfig.AllowOrigins),
+		middleware.KillSwitchMiddleware(cfg.RumConfig.IsEnabled()))
+}
+
+func sourcemapMiddleware(cfg *config.Config) []middleware.Middleware {
+	enabled := cfg.RumConfig.IsEnabled() && cfg.RumConfig.SourceMapping.IsEnabled()
+	return append(backendMiddleware(cfg, sourcemap.MonitoringMap),
+		middleware.KillSwitchMiddleware(enabled))
 }
 
 func rootMiddleware(cfg *config.Config) []middleware.Middleware {

--- a/beater/middleware/rate_limit_middleware.go
+++ b/beater/middleware/rate_limit_middleware.go
@@ -27,11 +27,11 @@ const burstMultiplier = 3
 
 // SetRateLimitMiddleware sets a rate limiter
 func SetRateLimitMiddleware(cfg *config.EventRate) Middleware {
-	cache, err := ratelimit.NewLRUCache(cfg.LruSize, cfg.Limit, burstMultiplier)
+	store, err := ratelimit.NewStore(cfg.LruSize, cfg.Limit, burstMultiplier)
 
 	return func(h request.Handler) (request.Handler, error) {
 		return func(c *request.Context) {
-			c.RateLimitManager = cache
+			c.RateLimiter = store
 			h(c)
 		}, err
 	}

--- a/beater/request/context.go
+++ b/beater/request/context.go
@@ -40,14 +40,14 @@ var (
 
 // Context abstracts request and response information for http requests
 type Context struct {
-	Request          *http.Request
-	Logger           *logp.Logger
-	RateLimitManager ratelimit.Manager
-	TokenSet         bool
-	Authorized       bool
-	Result           Result
-	w                http.ResponseWriter
-	writeAttempts    int
+	Request       *http.Request
+	Logger        *logp.Logger
+	RateLimiter   *ratelimit.Store
+	TokenSet      bool
+	Authorized    bool
+	Result        Result
+	w             http.ResponseWriter
+	writeAttempts int
 }
 
 // Reset allows to reuse a context by removing all request specific information
@@ -56,7 +56,7 @@ func (c *Context) Reset(w http.ResponseWriter, r *http.Request) {
 	c.Logger = nil
 	c.TokenSet = false
 	c.Authorized = false
-	c.RateLimitManager = nil
+	c.RateLimiter = nil
 	c.Result.Reset()
 
 	c.w = w


### PR DESCRIPTION
This PR tries to exemplify and materialize some observations I brought up in discussions during https://github.com/elastic/apm-server/pull/2706 and before:

* Avoid interface pollution: This removes one interface not needed. Doing so, the code is easier to navigate, and we test the actual code and not a mock.

* Follow Go idiomatic naming conventions: avoid non obvious acronyms and vague names like "managers" and such, which are more of a Java thing.
 
* Remove complex stateful functions: `handler.rateLimit` was making a rate limit call, plus returning a rate limiter if that was ok. There was also some redundant nil checking going on. Calling the limiter is now separated from getting one.

Incidentally, this is also less code to do the same thing and less dependencies per package (imports), but I still need to double check that I didn't change behaviour involuntarily... 