### PR TITLE
[docs] Use shared docs file

### DIFF
--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -243,7 +243,7 @@ ifndef::no_dashboards[]
 ["source","sh",subs="attributes"]
 -----
 {beatname_lc} export config
-{beatname_lc} export template --es.version {stack-version} --index myindexname
+{beatname_lc} export template --es.version {version} --index myindexname
 {beatname_lc} export dashboard --id="a7b35890-8baa-11e8-9676-ef67484126fb" > dashboard.json
 -----
 endif::no_dashboards[]
@@ -252,7 +252,7 @@ ifdef::no_dashboards[]
 ["source","sh",subs="attributes"]
 -----
 {beatname_lc} export config
-{beatname_lc} export template --es.version {stack-version} --index myindexname
+{beatname_lc} export template --es.version {version} --index myindexname
 -----
 endif::no_dashboards[]
 

--- a/docs/copied-from-beats/outputs/output-logstash.asciidoc
+++ b/docs/copied-from-beats/outputs/output-logstash.asciidoc
@@ -82,7 +82,7 @@ ifndef::apm-server[]
     ...
     "@metadata": { <1>
       "beat": "{beat_default_index_prefix}", <2>
-      "version": "{stack-version}" <3>
+      "version": "{version}" <3>
     }
 }
 ------------------------------------------------------------------------------
@@ -102,7 +102,7 @@ ifdef::apm-server[]
     "@metadata": { <1>
       "beat": "{beat_default_index_prefix}", <2>
       "pipeline":"apm", <3>
-      "version": "{stack-version}" <4>
+      "version": "{version}" <4>
     }
 }
 ------------------------------------------------------------------------------

--- a/docs/copied-from-beats/repositories.asciidoc
+++ b/docs/copied-from-beats/repositories.asciidoc
@@ -27,7 +27,7 @@ to sign all our packages. It is available from https://pgp.mit.edu.
 
 ifeval::["{release-state}"=="unreleased"]
 
-Version {stack-version} of {repo} has not yet been released.
+Version {version} of {repo} has not yet been released.
 
 endif::[]
 
@@ -130,7 +130,7 @@ endif::[]
 
 ifeval::["{release-state}"=="unreleased"]
 
-Version {stack-version} of {repo} has not yet been released.
+Version {version} of {repo} has not yet been released.
 
 endif::[]
 

--- a/docs/copied-from-beats/shared-docker.asciidoc
+++ b/docs/copied-from-beats/shared-docker.asciidoc
@@ -21,7 +21,7 @@ against the Elastic Docker registry.
 
 ifeval::["{release-state}"=="unreleased"]
 
-However, version {stack-version} of {beatname_uc} has not yet been
+However, version {version} of {beatname_uc} has not yet been
 released, so no Docker image is currently available for this version.
 
 endif::[]

--- a/docs/copied-from-beats/shared-template-load.asciidoc
+++ b/docs/copied-from-beats/shared-template-load.asciidoc
@@ -304,7 +304,7 @@ endif::win_only[]
 
 ["source","sh",subs="attributes"]
 ----
-PS > .{backslash}{beatname_lc}.exe export template --es.version {stack-version} | Out-File -Encoding UTF8 {beatname_lc}.template.json
+PS > .{backslash}{beatname_lc}.exe export template --es.version {version} | Out-File -Encoding UTF8 {beatname_lc}.template.json
 ----
 endif::win_os[]
 
@@ -315,7 +315,7 @@ ifdef::deb_os,rpm_os[]
 
 ["source","sh",subs="attributes"]
 ----
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_template/{beatname_lc}-{stack-version} -d@{beatname_lc}.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_template/{beatname_lc}-{version} -d@{beatname_lc}.template.json
 ----
 endif::deb_os,rpm_os[]
 
@@ -324,7 +324,7 @@ ifdef::mac_os[]
 
 ["source","sh",subs="attributes"]
 ----
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_template/{beatname_lc}-{stack-version} -d@{beatname_lc}.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_template/{beatname_lc}-{version} -d@{beatname_lc}.template.json
 ----
 endif::mac_os[]
 
@@ -333,7 +333,7 @@ ifdef::linux_os[]
 
 ["source","sh",subs="attributes"]
 ----
-curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_template/{beatname_lc}-{stack-version} -d@{beatname_lc}.template.json
+curl -XPUT -H 'Content-Type: application/json' http://localhost:9200/_template/{beatname_lc}-{version} -d@{beatname_lc}.template.json
 ----
 endif::linux_os[]
 
@@ -344,6 +344,6 @@ endif::win_only[]
 
 ["source","sh",subs="attributes"]
 ----
-PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile {beatname_lc}.template.json -Uri http://localhost:9200/_template/{beatname_lc}-{stack-version}
+PS > Invoke-RestMethod -Method Put -ContentType "application/json" -InFile {beatname_lc}.template.json -Uri http://localhost:9200/_template/{beatname_lc}-{version}
 ----
 endif::win_os[]

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -206,7 +206,7 @@ Defining too many unique fields in an index is a condition that can lead to a
 v|*Go:* {apm-go-ref-v}/api.html#context-set-tag[`SetTag`]
 *Java:* {apm-java-ref-v}/public-api.html#api-transaction-add-tag[`addLabel`]
 *.NET:* {apm-dotnet-ref-v}/public-api.html#api-transaction-tags[`Labels`]
-*Node.js:* {apm-node-ref-v}/agent-api.html#apm-set-tag[`setTag`] \| {apm-node-ref-v}/agent-api.html#apm-add-tags[`addTags`]
+*Node.js:* {apm-node-ref-v}/agent-api.html#apm-set-label[`setLabel`] \| {apm-node-ref-v}/agent-api.html#apm-add-labels[`addLabel`]
 *Python:* {apm-py-ref-v}/api.html#api-label[`elasticapm.label()`]
 *Ruby:* {apm-ruby-ref-v}/api.html#api-agent-set-tag[`set_tag`]
 *Rum:* {apm-rum-ref-v}/agent-api.html#apm-add-tags[`addTags`]

--- a/docs/ilm-setup.asciidoc
+++ b/docs/ilm-setup.asciidoc
@@ -67,42 +67,42 @@ PUT _ilm/policy/apm_span_policy
 +
 To use the index lifecycle management policy created in the previous step,
 you need to specify it in the index template used to create the indices.
-The following template associates `apm_span_policy` with indices created from the +apm-{stack-version}-span-ilm+ template.
+The following template associates `apm_span_policy` with indices created from the +apm-{version}-span-ilm+ template.
 +
-NOTE: Because we're utilizing the current stack-version ({stack-version}) in this step,
+NOTE: Because we're utilizing the current stack-version ({version}) in this step,
 this action will need to be performed as a part of each version upgrade.
 +
 --
 ["source","js",subs="attributes"]
 -----------------------
-PUT _template/apm-{stack-version}-span-ilm
+PUT _template/apm-{version}-span-ilm
 {
   "order": 2,
-  "index_patterns": ["apm-{stack-version}-span-*"], <1>
+  "index_patterns": ["apm-{version}-span-*"], <1>
   "settings": {
     "index.lifecycle.name": "apm_span_policy", <2>
-    "index.lifecycle.rollover_alias": "apm-{stack-version}-span"
+    "index.lifecycle.rollover_alias": "apm-{version}-span"
   }
 }
 -----------------------
 // CONSOLE
-<1> This template applies to all indices with the prefix +apm-{stack-version}-span-+
+<1> This template applies to all indices with the prefix +apm-{version}-span-+
 <2> Associates `apm_span_policy` with all indices created with this template
 --
 
 . *Create the index and alias.*
 +
-Now we can create the first index: +apm-{stack-version}-span-000001+.
+Now we can create the first index: +apm-{version}-span-000001+.
 +
 NOTE: This action will need to be performed as a part of each version upgrade.
 +
 --
 ["source","js",subs="attributes"]
 -----------------------
-PUT apm-{stack-version}-span-000001 <1>
+PUT apm-{version}-span-000001 <1>
 {
   "aliases": {
-    "apm-{stack-version}-span":{
+    "apm-{version}-span":{
       "is_write_index": true <2>
     }
   }
@@ -129,15 +129,15 @@ The response should be similar to this:
 ["source","js",subs="attributes"]
 -----------------------
 {
-  "apm-{stack-version}-span-000001" : {
+  "apm-{version}-span-000001" : {
     "settings" : {
       "index" : {
         "lifecycle" : {
           "name" : "apm_span_policy",
-          "rollover_alias" : "apm-{stack-version}-span"
+          "rollover_alias" : "apm-{version}-span"
         },
         "number_of_shards" : "1",
-        "provided_name" : "apm-{stack-version}-span-000001",
+        "provided_name" : "apm-{version}-span-000001",
         "creation_date" : "1553024227938",
         "number_of_replicas" : "1",
         "uuid" : "6b5l-H7QTRK95FAodAN-wg",
@@ -177,27 +177,27 @@ This means you'll need to configure all of your indices in the file, even if som
 -----------------------
 output.elasticsearch:
   indices:
-    - index: "apm-{stack-version}-sourcemap"
+    - index: "apm-{version}-sourcemap"
       when.contains:
         processor.event: "sourcemap"
     
-    - index: "apm-{stack-version}-error"
+    - index: "apm-{version}-error"
       when.contains:
         processor.event: "error"
     
-    - index: "apm-{stack-version}-transaction"
+    - index: "apm-{version}-transaction"
       when.contains:
         processor.event: "transaction"
 
-    - index: "apm-{stack-version}-span"
+    - index: "apm-{version}-span"
       when.contains:
         processor.event: "span"
     
-    - index: "apm-{stack-version}-metric"
+    - index: "apm-{version}-metric"
       when.contains:
         processor.event: "metric"
     
-    - index: "apm-{stack-version}-onboarding"
+    - index: "apm-{version}-onboarding"
       when.contains:
         processor.event: "onboarding"
 -----------------------

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -2,7 +2,6 @@ include::./version.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 :version: {apm_server_version}
-:doc-branch: {branch}
 :beatname_lc: apm-server
 :beatname_uc: APM Server
 :beatname_pkg: {beatname_lc}

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,7 +1,6 @@
 include::./version.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-:stack-version: {apm_server_version}
 :version: {apm_server_version}
 :doc-branch: {branch}
 :beatname_lc: apm-server

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,7 +1,10 @@
 include::./version.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-:version: {stack-version}
+:stack-version: {apm_server_version}
+:version: {apm_server_version}
+:doc-branch: {branch}
 :beatname_lc: apm-server
 :beatname_uc: APM Server
 :beatname_pkg: {beatname_lc}

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,5 +1,4 @@
 include::./version.asciidoc[]
-include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 :stack-version: {apm_server_version}

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -16,9 +16,9 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :dockerconfig: https://raw.githubusercontent.com/elastic/apm-server/{doc-branch}/apm-server.docker.yml
 :discuss_forum: apm
 :github_repo_name: apm-server
-:sample_date_0: 2019.03.10
-:sample_date_1: 2019.03.11
-:sample_date_2: 2019.03.12
+:sample_date_0: 2019.10.20
+:sample_date_1: 2019.10.21
+:sample_date_2: 2019.10.22
 :repo: apm-server
 :no_kibana:
 :no_ilm:

--- a/docs/storage-management.asciidoc
+++ b/docs/storage-management.asciidoc
@@ -176,27 +176,27 @@ With the curator command line interface you can, for instance, see all your exis
 ------------------------------------------------------------
 curator_cli --host localhost show_indices --filter_list '[{"filtertype":"pattern","kind":"prefix","value":"apm-"}]'
 
-apm-{stack-version}-error-{sample_date_0}
-apm-{stack-version}-error-{sample_date_1}
-apm-{stack-version}-error-{sample_date_2}
-apm-{stack-version}-sourcemap
-apm-{stack-version}-span-{sample_date_0}
-apm-{stack-version}-span-{sample_date_1}
-apm-{stack-version}-span-{sample_date_2}
-apm-{stack-version}-transaction-{sample_date_0}
-apm-{stack-version}-transaction-{sample_date_1}
-apm-{stack-version}-transaction-{sample_date_2}
+apm-{version}-error-{sample_date_0}
+apm-{version}-error-{sample_date_1}
+apm-{version}-error-{sample_date_2}
+apm-{version}-sourcemap
+apm-{version}-span-{sample_date_0}
+apm-{version}-span-{sample_date_1}
+apm-{version}-span-{sample_date_2}
+apm-{version}-transaction-{sample_date_0}
+apm-{version}-transaction-{sample_date_1}
+apm-{version}-transaction-{sample_date_2}
 ------------------------------------------------------------
 
 And then delete any span indices older than 1 day:
 
 ["source","sh",subs="attributes"]
 ------------------------------------------------------------
-curator_cli --host localhost delete_indices --filter_list '[{"filtertype":"pattern","kind":"prefix","value":"apm-{stack-version}-span-"}, {"filtertype":"age","source":"name","timestring":"%Y.%m.%d","unit":"days","unit_count":1,"direction":"older"}]'
+curator_cli --host localhost delete_indices --filter_list '[{"filtertype":"pattern","kind":"prefix","value":"apm-{version}-span-"}, {"filtertype":"age","source":"name","timestring":"%Y.%m.%d","unit":"days","unit_count":1,"direction":"older"}]'
 
-INFO      Deleting selected indices: [apm-{stack-version}-span-{sample_date_0}, apm-{stack-version}-span-{sample_date_1}]
-INFO      ---deleting index apm-{stack-version}-span-{sample_date_0}
-INFO      ---deleting index apm-{stack-version}-span-{sample_date_1}
+INFO      Deleting selected indices: [apm-{version}-span-{sample_date_0}, apm-{version}-span-{sample_date_1}]
+INFO      ---deleting index apm-{version}-span-{sample_date_0}
+INFO      ---deleting index apm-{version}-span-{sample_date_1}
 INFO      "delete_indices" action completed.
 ------------------------------------------------------------
 

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -8,10 +8,10 @@
 include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 
 // Agent links
-:apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
-:apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
-:apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/rum-js/{apm-rum-branch}
-:apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{apm-ruby-branch}
-:apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{apm-java-branch}
-:apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
-:apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
+:apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{py-branch}
+:apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{node-branch}
+:apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/rum-js/{rum-branch}
+:apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{ruby-branch}
+:apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{java-branch}
+:apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{go-branch}
+:apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{dotnet-branch}

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -4,3 +4,5 @@
 :python: 2.7.9
 :docker: 1.12
 :docker-compose: 1.11
+
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -8,10 +8,10 @@
 include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 
 // Agent links
-:apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{py-branch}
-:apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{node-branch}
-:apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/rum-js/{rum-branch}
-:apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{ruby-branch}
-:apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{java-branch}
-:apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{go-branch}
-:apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{dotnet-branch}
+:apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
+:apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
+:apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/rum-js/{apm-rum-branch}
+:apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{apm-ruby-branch}
+:apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{apm-java-branch}
+:apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
+:apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -6,3 +6,12 @@
 :docker-compose: 1.11
 
 include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
+
+// Agent links
+:apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
+:apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
+:apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/rum-js/{apm-rum-branch}
+:apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{apm-ruby-branch}
+:apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{apm-java-branch}
+:apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
+:apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,5 +1,5 @@
-// apm_server_version can be:    7.0.1, 8.0.0-alpha1, 8.1.0, etc.
-:apm_server_version: 8.0.0
+// doc-branch can be: master, 8.0, 8.1, etc.
+:doc-branch: master
 :go-version: 1.12.9
 :python: 2.7.9
 :docker: 1.12

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,33 +1,6 @@
-// stack-version can be:    7.0.1, 8.0.0-alpha1, 8.1.0, etc.
-// major-version can be:    8.x, 7.x, 6.x, etc.
-// doc-branch can be:       master, 8.0, 8.1, etc.
-// release-state is only:   released | prerelease | unreleased
-
-:stack-version: 8.0.0
-:major-version: 8.x
-:doc-branch: master
-:branch: {doc-branch}
+// apm_server_version can be:    7.0.1, 8.0.0-alpha1, 8.1.0, etc.
+:apm_server_version: 8.0.0
 :go-version: 1.12.9
-:release-state: unreleased
 :python: 2.7.9
 :docker: 1.12
 :docker-compose: 1.11
-
-// APM Agent versions
-:server-branch: {doc-branch}
-:go-branch: 1.x
-:java-branch: 1.x
-:rum-branch: 4.x
-:node-branch: 2.x
-:py-branch: 5.x
-:ruby-branch: 2.x
-:dotnet-branch: 1.x
-
-// Agent links
-:apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{py-branch}
-:apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{node-branch}
-:apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/rum-js/{rum-branch}
-:apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{ruby-branch}
-:apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{java-branch}
-:apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{go-branch}
-:apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{dotnet-branch}


### PR DESCRIPTION
Follow up to elastic/apm-server#2712 / elastic/apm-server#2735 

A second attempt at this as we need to include the shared version file in order to link to other areas of the stack. In this version, I've left an attribute in the `version.asciidoc` file named `doc-branch`. This attribute is **only** used to populate `beat_doc_branch`. All docs variables will come from shared versions file.

The following attributes are defined in the shared versions file:
```asciidoc
:version:                8.0.0
:bare_version:           8.0.0
:apm_server_version:     8.0.0
:branch:                 master
:major-version:          8.x
:prev-major-version:     7.x
:ecs_version:            1.2

:apm-go-branch:         1.x
:apm-java-branch:       1.x
:apm-rum-branch:        4.x
:apm-node-branch:       3.x
:apm-py-branch:         5.x
:apm-ruby-branch:       3.x
:apm-dotnet-branch:     1.x
```