### PR TITLE
[7.x] [docs] Fix typos (#2690)

### DIFF
--- a/docs/guide/apm-doc-directory.asciidoc
+++ b/docs/guide/apm-doc-directory.asciidoc
@@ -34,12 +34,12 @@ which helps keep the agents light, prevents certain security risks, and improves
 After the APM Server has validated and processed events from the APM agents,
 the server transforms the data into Elasticsearch documents and stores them in corresponding
 {apm-server-ref-v}/exploring-es-data.html[Elasticsearch indices].
-In a matter of seconds you can start viewing your application performance data in the Kibana APM UI.
+In a matter of seconds you can start viewing your application performance data in the Kibana APM app.
 
 // Todo: Change these links to include APM Server on Cloud installation
 // The easiest way to get started with Elastic APM is by using our
 // https://www.elastic.co/cloud/elasticsearch-service[hosted {es} Service] on
-// Elastic Cloud 
+// Elastic Cloud
 The {apm-server-ref-v}/index.html[APM Server reference] provides everything you need when it comes to working with the server.
 Here you can learn about {apm-server-ref-v}/installing.html[installation],
 {apm-server-ref-v}/configuring-howto-apm-server.html[configuration],
@@ -49,12 +49,12 @@ Here you can learn about {apm-server-ref-v}/installing.html[installation],
 [float]
 === Elasticsearch
 
-{ref}/index.html[Elasticsearch] is a highly scalable open-source full-text search and analytics engine.
+{ref}/index.html[Elasticsearch] is a highly scalable open source full-text search and analytics engine.
 It allows you to store, search, and analyze large volumes of data quickly and in near real time.
 Elasticsearch is used to store APM performance metrics and make use of its aggregations.
 
 [float]
-=== APM Kibana UI
+=== APM Kibana app
 
 {kibana-ref}/index.html[Kibana] is an open source analytics and visualization platform designed to work with Elasticsearch.
 You use Kibana to search, view, and interact with data stored in Elasticsearch.
@@ -65,6 +65,6 @@ The following sections will help you get started:
 
 * {kibana-ref}/apm-getting-started.html[Getting Started]
 * {kibana-ref}/apm-bottlenecks.html[Visualizing application bottlenecks]
-* {kibana-ref}/apm-ui.html[Using the APM UI]
+* {kibana-ref}/apm-ui.html[Using the APM app]
 
-APM also has built-in integrations with Machine Learning. To learn more about this feature, refer to the Kibana UI documentation for {kibana-ref}/machine-learning-integration.html[Machine learning integration].
+APM also has built-in integrations with Machine Learning. To learn more about this feature, refer to the Kibana documentation for {kibana-ref}/machine-learning-integration.html[Machine learning integration].


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [docs] Fix typos (#2690)