### PR TITLE
ci(codecov): resolve PR coverage measures errors

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+comment:
+  layout: "header, changes, diff, files"
+  behavior: default
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1
+        if_not_found: success  # if parent is not found report status as success, error, or failure
+        if_ci_failed: error    # if ci fails report status as success, error, or failure
+        base: parent           # will always use the parent commit to compare against.
+      patch: off #https://docs.codecov.io/docs/commit-status#section-patch-status


### PR DESCRIPTION
## What does this PR do?

We detected that Codecov does not always return accurate coverage measures on PRs, so after digging a little in the Codecov issues we found a configuration that works better for us.

## Why is it important?

After applying this configuration, we'd not see wrong coverage measures in the PRs.

