### PR TITLE
ci(jenkins): reuse top level agent

### DIFF
--- a/.ci/check-changelogs.groovy
+++ b/.ci/check-changelogs.groovy
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent any
+  agent { label 'linux && immutable' }
   environment {
     REPO = 'apm-server'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -28,11 +28,10 @@ pipeline {
      Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout') {
-      agent { label 'immutable' }
+      options { skipDefaultCheckout() }
       environment {
         PATH = "${env.PATH}:${env.WORKSPACE}/bin"
       }
-      options { skipDefaultCheckout() }
       steps {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
@@ -43,7 +42,6 @@ pipeline {
       Validate changelog tests.
     */
     stage('Changelog Test') {
-      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       environment {
         PATH = "${env.PATH}:${env.WORKSPACE}/bin"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -350,20 +350,6 @@ pipeline {
         GOPATH = "${env.WORKSPACE}"
         SNAPSHOT="true"
       }
-      when {
-        beforeAgent true
-        allOf {
-          anyOf {
-            branch 'master'
-            branch "\\d+\\.\\d+"
-            branch "v\\d?"
-            tag "v\\d+\\.\\d+\\.\\d+*"
-            expression { return params.Run_As_Master_Branch }
-            expression { return env.BEATS_UPDATED != "false" }
-          }
-          expression { return params.release_ci }
-        }
-      }
       steps {
         withGithubNotify(context: 'Release') {
           deleteDir()
@@ -374,7 +360,6 @@ pipeline {
           golang(){
             dir("${BASE_DIR}"){
               sh(label: 'Build packages', script: './script/jenkins/package.sh')
-              sh(label: 'Test packages install', script: './script/jenkins/test-install-packages.sh')
             }
           }
         }
@@ -382,12 +367,6 @@ pipeline {
       post {
         success {
           echo "Archive packages"
-          googleStorageUpload(bucket: "gs://${JOB_GCS_BUCKET}/snapshots",
-            credentialsId: "${JOB_GCS_CREDENTIALS}",
-            pathPrefix: "${BASE_DIR}/build/distributions/",
-            pattern: "${BASE_DIR}/build/distributions/**/*",
-            sharedPublicly: true,
-            showInline: true)
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent any
+  agent { label 'linux && immutable' }
   environment {
     REPO = 'apm-server'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -43,7 +43,6 @@ pipeline {
      Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout') {
-      agent { label 'immutable' }
       environment {
         PATH = "${env.PATH}:${env.WORKSPACE}/bin"
         HOME = "${env.WORKSPACE}"
@@ -80,7 +79,6 @@ pipeline {
     Validate that all updates were committed.
     */
     stage('Intake') {
-      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       environment {
         PATH = "${env.PATH}:${env.WORKSPACE}/bin"
@@ -108,7 +106,6 @@ pipeline {
         Build on a linux environment.
         */
         stage('linux build') {
-          agent { label 'linux && immutable' }
           options { skipDefaultCheckout() }
           when {
             beforeAgent true
@@ -346,7 +343,6 @@ pipeline {
       build release packages.
     */
     stage('Release') {
-      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       environment {
         PATH = "${env.PATH}:${env.WORKSPACE}/bin"


### PR DESCRIPTION
### Highlights
- Let's reuse the top-level agent to reduce the number of fo requested agents and speed up just a bit the builds.
- Reset labels to be `linux && immutable` to help with what kind of OS is required to be used.
- Time improvements per Stage:
  - From the very beginning to the build Linux stage used to take 7 mnts approx and 3 workers and now less than 5 minutes and just one worker.

### Test Cases
- Release

<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

<!--
Replace this comment with a description of what is being changed by this PR and why.

If this PR should close an issue, please add one of the magic keywords
(e.g. fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/

Most changes should include:

* unit tests
* integration tests
* documentation

Major changes require a number of considerations including impact on:

* logging selector(s)
* metrics
* telemetry
* Elasticsearch Service (https://cloud.elastic.co)
* Elastic Cloud Enterprise (https://www.elastic.co/products/ece)
-->