### PR TITLE
[DOCS] Fixes link to role mapping

### DIFF
--- a/docs/copied-from-beats/https.asciidoc
+++ b/docs/copied-from-beats/https.asciidoc
@@ -13,7 +13,7 @@
 To secure the communication between {beatname_uc} and Elasticsearch, you can use
 HTTPS and basic authentication. Basic authentication for Elasticsearch is
 available when you enable {security} (see
-{stack-ov}/elasticsearch-security.html[Securing the {stack}] and <<securing-beats>>).
+{ref}/secure-cluster.html[Secure a cluster] and <<securing-beats>>).
 If you aren't using {security}, you can use a web proxy instead.
 
 Here is a sample configuration:

--- a/docs/copied-from-beats/monitoring/monitoring-beats.asciidoc
+++ b/docs/copied-from-beats/monitoring/monitoring-beats.asciidoc
@@ -28,7 +28,7 @@ ifndef::serverless[]
 endif::[]
 
 To learn about monitoring in general, see 
-{stack-ov}/xpack-monitoring.html[Monitoring the {stack}]. 
+{ref}/monitor-elasticsearch-cluster.html[Monitor a cluster]. 
 
 --
 

--- a/docs/copied-from-beats/monitoring/monitoring-internal-collection.asciidoc
+++ b/docs/copied-from-beats/monitoring/monitoring-internal-collection.asciidoc
@@ -23,7 +23,7 @@ For an alternative method, see <<monitoring-metricbeat-collection>>.
 endif::[]
 
 To learn about monitoring in general, see 
-{stack-ov}/xpack-monitoring.html[Monitoring the {stack}]. 
+{ref}/monitor-elasticsearch-cluster.html[Monitor a cluster]. 
 
 //TODO: Not sure if these docs need to be updated to be parallel with other
 //stack components since this is the old way of configuring monitoring. 
@@ -32,8 +32,8 @@ To learn about monitoring in general, see
 data to {es}. For example, you can use the built-in +{beat_monitoring_user}+ user or
 assign the built-in +{beat_monitoring_user}+ role to another user. For more
 information, see
-{stack-ov}/setting-up-authentication.html[Setting Up User Authentication] and
-{stack-ov}/built-in-roles.html[Built-in Roles].
+{ref}/setting-up-authentication.html[User authentication] and
+{ref}/built-in-roles.html[Built-in roles].
 
 . Add the `monitoring` settings in the {beatname_uc} configuration file. If you
 configured the {es} output and want to send {beatname_uc} monitoring events to

--- a/docs/copied-from-beats/monitoring/monitoring-metricbeat.asciidoc
+++ b/docs/copied-from-beats/monitoring/monitoring-metricbeat.asciidoc
@@ -26,7 +26,7 @@ concurrently. If you don't want to run two instances concurrently, use
 endif::[]
 
 To learn about monitoring in general, see 
-{stack-ov}/xpack-monitoring.html[Monitoring the {stack}].
+{ref}/monitor-elasticsearch-cluster.html[Monitor a cluster].
 
 //NOTE: The tagged regions are re-used in the Stack Overview.
 
@@ -175,9 +175,9 @@ If the Elastic {security-features} are enabled, you must also provide a user
 ID and password so that {metricbeat} can collect metrics successfully: 
 
 .. Create a user on the production cluster that has the 
-`remote_monitoring_collector` {stack-ov}/built-in-roles.html[built-in role]. 
+`remote_monitoring_collector` {ref}/built-in-roles.html[built-in role]. 
 Alternatively, use the `remote_monitoring_user` 
-{stack-ov}/built-in-users.html[built-in user].
+{ref}/built-in-users.html[built-in user].
 
 .. Add the `username` and `password` settings to the beat module configuration 
 file.
@@ -238,9 +238,9 @@ must provide a valid user ID and password so that {metricbeat} can send metrics
 successfully: 
 
 .. Create a user on the monitoring cluster that has the 
-`remote_monitoring_agent` {stack-ov}/built-in-roles.html[built-in role]. 
+`remote_monitoring_agent` {ref}/built-in-roles.html[built-in role]. 
 Alternatively, use the `remote_monitoring_user` 
-{stack-ov}/built-in-users.html[built-in user]. 
+{ref}/built-in-users.html[built-in user]. 
 +
 TIP: If you're using index lifecycle management, the remote monitoring user
 requires additional privileges to create and read indices. For more

--- a/docs/copied-from-beats/security/basic-auth.asciidoc
+++ b/docs/copied-from-beats/security/basic-auth.asciidoc
@@ -46,8 +46,8 @@ endif::apm-server[]
 configure the `certificate` and `key` settings. These settings assume that the
 distinguished name (DN) in the certificate is mapped to the appropriate roles in
 the `role_mapping.yml` file on each node in the {es} cluster. For more
-information, see {xpack-ref}/mapping-roles.html#mapping-roles-file[Using Role
-Mapping Files].
+information, see {ref}/mapping-roles.html#mapping-roles-file[Using role
+mapping files].
 +
 ["source","yaml",subs="attributes,callouts"]
 --------------------------------------------------

--- a/docs/copied-from-beats/security/basic-auth.asciidoc
+++ b/docs/copied-from-beats/security/basic-auth.asciidoc
@@ -58,5 +58,4 @@ output.elasticsearch:
 --------------------------------------------------
 
 To learn more about {stack} security features and other types of
-authentication, see {stack-ov}/elasticsearch-security.html[Securing the
-{stack}].
+authentication, see {ref}/secure-cluster.html[Secure a cluster].

--- a/docs/copied-from-beats/security/securing-beats.asciidoc
+++ b/docs/copied-from-beats/security/securing-beats.asciidoc
@@ -7,9 +7,8 @@
 <titleabbrev>Use {security}</titleabbrev>
 ++++
 
-If you want {beatname_uc} to connect to a cluster that has
-{stack-ov}/elasticsearch-security.html[{security}] enabled, there are extra
-configuration steps:
+If you want {beatname_uc} to connect to a cluster that has {security} enabled,
+there are extra configuration steps:
 
 . <<feature-roles>>.
 +

--- a/docs/copied-from-beats/security/users.asciidoc
+++ b/docs/copied-from-beats/security/users.asciidoc
@@ -107,8 +107,8 @@ roles needed depend on the method used to collect monitoring data.
 
 For <<monitoring-internal-collection,internal collection>>, {security}
 provides the +{beat_default_index_prefix}_system+
-{stack-ov}/built-in-users.html[built-in user] and
-+{beat_default_index_prefix}_system+ {stack-ov}/built-in-roles.html[built-in
+{ref}/built-in-users.html[built-in user] and
++{beat_default_index_prefix}_system+ {ref}/built-in-roles.html[built-in
 role] for sending monitoring information. You can use the built-in user, or
 create a user who has the privileges needed to send monitoring information.
 
@@ -145,9 +145,9 @@ ifndef::serverless[]
 ===== {metricbeat} collection
 
 For <<monitoring-metricbeat-collection,{metricbeat} collection>>, {security}
-provides the `remote_monitoring_user` {stack-ov}/built-in-users.html[built-in
+provides the `remote_monitoring_user` {ref}/built-in-users.html[built-in
 user], and the `remote_monitoring_collector` and `remote_monitoring_agent`
-{stack-ov}/built-in-roles.html[built-in roles] for collecting and sending
+{ref}/built-in-roles.html[built-in roles] for collecting and sending
 monitoring information. You can use the built-in user, or
 create a user who has the privileges needed to collect and send monitoring
 information.
@@ -316,9 +316,9 @@ endif::apm-server[]
 ==== Learn more about users and roles
 
 Want to learn more about creating users and roles? See
-{stack-ov}/elasticsearch-security.html[Securing the {stack}]. Also see:
+{ref}/secure-cluster.html[Secure a cluster]. Also see:
 
-* {stack-ov}/security-privileges.html[Security privileges] for a description of
+* {ref}/security-privileges.html[Security privileges] for a description of
 available privileges
-* {stack-ov}/built-in-roles.html[Built-in roles] for a description of roles that
+* {ref}/built-in-roles.html[Built-in roles] for a description of roles that
 you can assign to users

--- a/docs/copied-from-beats/template-config.asciidoc
+++ b/docs/copied-from-beats/template-config.asciidoc
@@ -69,7 +69,7 @@ setup.template.settings:
   index.number_of_replicas: 1
 ----------------------------------------------------------------------
 
-NOTE: If you want to use {stack-ov}/xpack-ccr.html[{ccr}] to replicate {beatname_uc}
+NOTE: If you want to use {ref}/xpack-ccr.html[{ccr}] to replicate {beatname_uc}
 indices to another cluster, you will need to add additional template settings to
 {ref}/ccr-requirements.html#ccr-overview-beats[enable soft deletes] on the
 underlying indices.


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/46880

This PR fixes a broken link to the security content in the Stack Overview, which has moved here: 
https://www.elastic.co/guide/en/elasticsearch/reference/master/mapping-roles.html#mapping-roles-file