### PR TITLE
[7.3][docs] Updates to Agent compat and links

### DIFF
--- a/docs/guide/agent-server-compatibility.asciidoc
+++ b/docs/guide/agent-server-compatibility.asciidoc
@@ -33,6 +33,7 @@ The chart below outlines the compatibility between different versions of the APM
 .2+|**Ruby Agent**
 |`1.x` |`6.4`-`6.x`
 |`2.x` |>= `6.5`
+|`3.x` |>= `6.5`
 
 // RUM
 .3+|**JavaScript RUM Agent**

--- a/docs/guide/agent-server-compatibility.asciidoc
+++ b/docs/guide/agent-server-compatibility.asciidoc
@@ -22,7 +22,7 @@ The chart below outlines the compatibility between different versions of the APM
 .3+|**Node.js Agent**
 |`1.x` |`6.2`-`6.x`
 |`2.x` |>= `6.5`
-|`3.x` |>= `6.5`
+|`3.x` |>= `6.6`
 
 // Python
 .3+|**Python Agent**

--- a/docs/guide/agent-server-compatibility.asciidoc
+++ b/docs/guide/agent-server-compatibility.asciidoc
@@ -19,9 +19,10 @@ The chart below outlines the compatibility between different versions of the APM
 |`1.x` |>= `6.5`
 
 // Node
-.2+|**Node.js Agent**
+.3+|**Node.js Agent**
 |`1.x` |`6.2`-`6.x`
 |`2.x` |>= `6.5`
+|`3.x` |>= `6.5`
 
 // Python
 .3+|**Python Agent**
@@ -30,7 +31,7 @@ The chart below outlines the compatibility between different versions of the APM
 |`5.x` |>= `6.6`
 
 // Ruby
-.2+|**Ruby Agent**
+.3+|**Ruby Agent**
 |`1.x` |`6.4`-`6.x`
 |`2.x` |>= `6.5`
 |`3.x` |>= `6.5`

--- a/docs/guide/install-and-run.asciidoc
+++ b/docs/guide/install-and-run.asciidoc
@@ -115,7 +115,7 @@ and configuring it with the address of your APM Server, a secret token (if neces
 .2+|Node.js
 2+|The Node.js agent automatically instruments Express, hapi, Koa, and Restify out of the box.
 |{apm-node-ref-v}/supported-technologies.html[Supported technologies]
-|{apm-node-ref-v}/intro.html#get-started[Get started with the Node.js Agent]
+|{apm-node-ref-v}/set-up.html[Set up the Node.js Agent]
 
 .2+|Python
 2+|The Python agent automatically instruments Django and Flask out of the box.


### PR DESCRIPTION
* docs: update agent server compatibitly for node
* docs: update agent-server compat for ruby
* docs: new link to Node Agent

**MUST BE MERGED WITH https://github.com/elastic/apm-agent-nodejs/pull/1443**