### PR TITLE
fix: discard to check changelogs before 7.3

### DIFF
--- a/script/check_changelogs.py
+++ b/script/check_changelogs.py
@@ -28,7 +28,7 @@ def main():
     cl_dir = 'changelogs'
     for cl in sorted(os.listdir(cl_dir)):
         version, _ = os.path.splitext(cl)
-        if version == 'head':
+        if version in ['head', "6.0", "6.1", "6.2", "6.3", "6.4", "6.5", "6.6", "6.7", "6.8", "7.0", "7.1", "7.2"]:
             continue
         parsed_version = parse_version(version)
         with open(os.path.join(cl_dir, cl), mode='rb') as f:


### PR DESCRIPTION
## What does this PR do?

After this change, the check changelogs test would ignore every changelog before 7.3

## Why is it important?

We have a job that will never succeed if we do not fix the changelogs or ignore them.

## Related issues
Closes #2789