### PR TITLE
[ILM] Change default policies to 30day rollover

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -276,45 +276,29 @@ apm-server:
       # The configured event types and policies will be merged with the default policies.
       #mapping:
         #- event_type: "error"
-        #  policy_name: "rollover-1-day"
+        #  policy_name: "rollover-30-days"
         #- event_type: "span"
-        #  policy_name: "rollover-1-day"
+        #  policy_name: "rollover-30-days"
         #- event_type: "transaction"
-        #  policy_name: "rollover-7-days"
+        #  policy_name: "rollover-30-days"
         #- event_type: "metric"
-        #  policy_name: "rollover-7-days"
+        #  policy_name: "rollover-30-days"
 
       # Configured policies are added to all pre-defined default policies.
       # If a policy with the same name as a default policy is configured, the configured policy overwrites the default policy.
       #policies:
-        #- name: "rollover-7-days"
+        #- name: "rollover-30-days"
           #policy:
             #phases:
               #hot:
                 #actions:
                   #rollover:
                     #max_size: "50gb"
-                    #max_age: "7d"
+                    #max_age: "30d"
                   #set_priority:
                     #priority: 100
               #warm:
-                #min_age: "31d"
-                #actions:
-                  #set_priority:
-                    #priority: 50
-                  #readonly: {}
-        #- name: "rollover-1-day"
-          #policy:
-            #phases:
-              #hot:
-                #actions:
-                  #rollover:
-                    #max_size: "50gb"
-                    #max_age: "1d"
-                  #set_priority:
-                    #priority: 100
-              #warm:
-                #min_age: "7d"
+                #min_age: "30d"
                 #actions:
                   #set_priority:
                     #priority: 50

--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -276,18 +276,18 @@ apm-server:
       # The configured event types and policies will be merged with the default policies.
       #mapping:
         #- event_type: "error"
-        #  policy_name: "rollover-30-days"
+        #  policy_name: "apm-rollover-30-days"
         #- event_type: "span"
-        #  policy_name: "rollover-30-days"
+        #  policy_name: "apm-rollover-30-days"
         #- event_type: "transaction"
-        #  policy_name: "rollover-30-days"
+        #  policy_name: "apm-rollover-30-days"
         #- event_type: "metric"
-        #  policy_name: "rollover-30-days"
+        #  policy_name: "apm-rollover-30-days"
 
       # Configured policies are added to all pre-defined default policies.
       # If a policy with the same name as a default policy is configured, the configured policy overwrites the default policy.
       #policies:
-        #- name: "rollover-30-days"
+        #- name: "apm-rollover-30-days"
           #policy:
             #phases:
               #hot:

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -276,45 +276,29 @@ apm-server:
       # The configured event types and policies will be merged with the default policies.
       #mapping:
         #- event_type: "error"
-        #  policy_name: "rollover-1-day"
+        #  policy_name: "rollover-30-days"
         #- event_type: "span"
-        #  policy_name: "rollover-1-day"
+        #  policy_name: "rollover-30-days"
         #- event_type: "transaction"
-        #  policy_name: "rollover-7-days"
+        #  policy_name: "rollover-30-days"
         #- event_type: "metric"
-        #  policy_name: "rollover-7-days"
+        #  policy_name: "rollover-30-days"
 
       # Configured policies are added to all pre-defined default policies.
       # If a policy with the same name as a default policy is configured, the configured policy overwrites the default policy.
       #policies:
-        #- name: "rollover-7-days"
+        #- name: "rollover-30-days"
           #policy:
             #phases:
               #hot:
                 #actions:
                   #rollover:
                     #max_size: "50gb"
-                    #max_age: "7d"
+                    #max_age: "30d"
                   #set_priority:
                     #priority: 100
               #warm:
-                #min_age: "31d"
-                #actions:
-                  #set_priority:
-                    #priority: 50
-                  #readonly: {}
-        #- name: "rollover-1-day"
-          #policy:
-            #phases:
-              #hot:
-                #actions:
-                  #rollover:
-                    #max_size: "50gb"
-                    #max_age: "1d"
-                  #set_priority:
-                    #priority: 100
-              #warm:
-                #min_age: "7d"
+                #min_age: "30d"
                 #actions:
                   #set_priority:
                     #priority: 50

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -276,18 +276,18 @@ apm-server:
       # The configured event types and policies will be merged with the default policies.
       #mapping:
         #- event_type: "error"
-        #  policy_name: "rollover-30-days"
+        #  policy_name: "apm-rollover-30-days"
         #- event_type: "span"
-        #  policy_name: "rollover-30-days"
+        #  policy_name: "apm-rollover-30-days"
         #- event_type: "transaction"
-        #  policy_name: "rollover-30-days"
+        #  policy_name: "apm-rollover-30-days"
         #- event_type: "metric"
-        #  policy_name: "rollover-30-days"
+        #  policy_name: "apm-rollover-30-days"
 
       # Configured policies are added to all pre-defined default policies.
       # If a policy with the same name as a default policy is configured, the configured policy overwrites the default policy.
       #policies:
-        #- name: "rollover-30-days"
+        #- name: "apm-rollover-30-days"
           #policy:
             #phases:
               #hot:

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -276,45 +276,29 @@ apm-server:
       # The configured event types and policies will be merged with the default policies.
       #mapping:
         #- event_type: "error"
-        #  policy_name: "rollover-1-day"
+        #  policy_name: "rollover-30-days"
         #- event_type: "span"
-        #  policy_name: "rollover-1-day"
+        #  policy_name: "rollover-30-days"
         #- event_type: "transaction"
-        #  policy_name: "rollover-7-days"
+        #  policy_name: "rollover-30-days"
         #- event_type: "metric"
-        #  policy_name: "rollover-7-days"
+        #  policy_name: "rollover-30-days"
 
       # Configured policies are added to all pre-defined default policies.
       # If a policy with the same name as a default policy is configured, the configured policy overwrites the default policy.
       #policies:
-        #- name: "rollover-7-days"
+        #- name: "rollover-30-days"
           #policy:
             #phases:
               #hot:
                 #actions:
                   #rollover:
                     #max_size: "50gb"
-                    #max_age: "7d"
+                    #max_age: "30d"
                   #set_priority:
                     #priority: 100
               #warm:
-                #min_age: "31d"
-                #actions:
-                  #set_priority:
-                    #priority: 50
-                  #readonly: {}
-        #- name: "rollover-1-day"
-          #policy:
-            #phases:
-              #hot:
-                #actions:
-                  #rollover:
-                    #max_size: "50gb"
-                    #max_age: "1d"
-                  #set_priority:
-                    #priority: 100
-              #warm:
-                #min_age: "7d"
+                #min_age: "30d"
                 #actions:
                   #set_priority:
                     #priority: 50

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -276,18 +276,18 @@ apm-server:
       # The configured event types and policies will be merged with the default policies.
       #mapping:
         #- event_type: "error"
-        #  policy_name: "rollover-30-days"
+        #  policy_name: "apm-rollover-30-days"
         #- event_type: "span"
-        #  policy_name: "rollover-30-days"
+        #  policy_name: "apm-rollover-30-days"
         #- event_type: "transaction"
-        #  policy_name: "rollover-30-days"
+        #  policy_name: "apm-rollover-30-days"
         #- event_type: "metric"
-        #  policy_name: "rollover-30-days"
+        #  policy_name: "apm-rollover-30-days"
 
       # Configured policies are added to all pre-defined default policies.
       # If a policy with the same name as a default policy is configured, the configured policy overwrites the default policy.
       #policies:
-        #- name: "rollover-30-days"
+        #- name: "apm-rollover-30-days"
           #policy:
             #phases:
               #hot:

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -10,5 +10,6 @@
 - Add `service.node.configured_name` to Intake API and transform to `service.node.name` for ES output {pull}2746[2746].
 - Index value from `client.ip` in `source.ip` for ECS compatibility {pull}2771[2771].
 - Make ILM policies configurable {pull}2764[2764].
+- Change ILM default policies to rollover after 30 days. {pull}[].
 
 https://github.com/elastic/apm-server/compare/7.4\...master[View commits]

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -10,6 +10,6 @@
 - Add `service.node.configured_name` to Intake API and transform to `service.node.name` for ES output {pull}2746[2746].
 - Index value from `client.ip` in `source.ip` for ECS compatibility {pull}2771[2771].
 - Make ILM policies configurable {pull}2764[2764].
-- Change ILM default policies to rollover after 30 days. {pull}[].
+- Change ILM default policies to rollover after 30 days {pull}2798[2798].
 
 https://github.com/elastic/apm-server/compare/7.4\...master[View commits]

--- a/idxmgmt/ilm/config_test.go
+++ b/idxmgmt/ilm/config_test.go
@@ -104,13 +104,13 @@ func TestConfig_Policies(t *testing.T) {
 		"assign different default policy": {
 			"error",
 			map[string]interface{}{
-				"mapping": []map[string]interface{}{{"event_type": "error", "policy_name": rollover7Days}}},
-			policyPool()[rollover7Days]},
+				"mapping": []map[string]interface{}{{"event_type": "error", "policy_name": rollover30Days}}},
+			policyPool()[rollover30Days]},
 		"change default policy": {
 			"transaction",
 			map[string]interface{}{
 				"policies": []map[string]interface{}{{
-					"name":   rollover7Days,
+					"name":   rollover30Days,
 					"policy": map[string]interface{}{"phases": map[string]interface{}{"delete": nil}}}}},
 			map[string]interface{}{"policy": map[string]interface{}{"phases": map[string]interface{}{"delete": map[string]interface{}{}}}}},
 		"assign new policy": {
@@ -149,7 +149,7 @@ func TestConfig_Invalid(t *testing.T) {
 		cfg    map[string]interface{}
 		errMsg string
 	}{
-		"invalid event_type": {map[string]interface{}{"mapping": []map[string]interface{}{{"event_type": "xyz", "policy_name": rollover7Days}}}, "event_type 'xyz' not supported"},
+		"invalid event_type": {map[string]interface{}{"mapping": []map[string]interface{}{{"event_type": "xyz", "policy_name": rollover30Days}}}, "event_type 'xyz' not supported"},
 		"invalid policy":     {map[string]interface{}{"mapping": []map[string]interface{}{{"event_type": "span", "policy_name": "xyz"}}}, "policy 'xyz' not configured"},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -162,10 +162,9 @@ func TestConfig_Invalid(t *testing.T) {
 }
 
 func defaultPolicies() []EventPolicy {
-	return []EventPolicy{
-		{EventType: "error", Policy: policyPool()[rollover1Day], Name: rollover1Day},
-		{EventType: "span", Policy: policyPool()[rollover1Day], Name: rollover1Day},
-		{EventType: "transaction", Policy: policyPool()[rollover7Days], Name: rollover7Days},
-		{EventType: "metric", Policy: policyPool()[rollover7Days], Name: rollover7Days},
+	var policies []EventPolicy
+	for event, policyName := range policyMapping() {
+		policies = append(policies, EventPolicy{EventType: event, Policy: policyPool()[policyName], Name: policyName})
 	}
+	return policies
 }

--- a/idxmgmt/ilm/policy.go
+++ b/idxmgmt/ilm/policy.go
@@ -18,8 +18,7 @@
 package ilm
 
 const (
-	rollover1Day  = "rollover-1-day"
-	rollover7Days = "rollover-7-days"
+	rollover30Days = "apm-rollover-30-days"
 
 	policyStr      = "policy"
 	phasesStr      = "phases"
@@ -41,24 +40,23 @@ const (
 )
 
 func policyMapping() map[string]string {
-	return map[string]string{
-		errorEvent:       rollover1Day,
-		spanEvent:        rollover1Day,
-		transactionEvent: rollover7Days,
-		metricEvent:      rollover7Days,
+	m := map[string]string{}
+	for _, event := range []string{errorEvent, spanEvent, transactionEvent, metricEvent} {
+		m[event] = rollover30Days
 	}
+	return m
 }
 
 func policyPool() map[string]policyBody {
 	return map[string]policyBody{
-		rollover7Days: {
+		rollover30Days: {
 			policyStr: map[string]interface{}{
 				phasesStr: map[string]interface{}{
 					hotStr: map[string]interface{}{
 						actionsStr: map[string]interface{}{
 							rolloverStr: map[string]interface{}{
 								maxSizeStr: "50gb",
-								maxAgeStr:  "7d",
+								maxAgeStr:  "30d",
 							},
 							setPriorityStr: map[string]interface{}{
 								priorityStr: 100,
@@ -66,33 +64,7 @@ func policyPool() map[string]policyBody {
 						},
 					},
 					warmStr: map[string]interface{}{
-						minAgeStr: "31d",
-						actionsStr: map[string]interface{}{
-							setPriorityStr: map[string]interface{}{
-								priorityStr: 50,
-							},
-							readonlyStr: map[string]interface{}{},
-						},
-					},
-				},
-			},
-		},
-		rollover1Day: {
-			policyStr: map[string]interface{}{
-				phasesStr: map[string]interface{}{
-					hotStr: map[string]interface{}{
-						actionsStr: map[string]interface{}{
-							rolloverStr: map[string]interface{}{
-								maxSizeStr: "50gb",
-								maxAgeStr:  "1d",
-							},
-							setPriorityStr: map[string]interface{}{
-								priorityStr: 100,
-							},
-						},
-					},
-					warmStr: map[string]interface{}{
-						minAgeStr: "7d",
+						minAgeStr: "30d",
 						actionsStr: map[string]interface{}{
 							setPriorityStr: map[string]interface{}{
 								priorityStr: 50,

--- a/idxmgmt/manager_test.go
+++ b/idxmgmt/manager_test.go
@@ -212,7 +212,7 @@ func TestManager_SetupILM(t *testing.T) {
 	var testCasesSetupEnabled = map[string]testCase{
 		"Default": {
 			loadMode:            libidxmgmt.LoadModeEnabled,
-			templatesILMEnabled: 4, policiesLoaded: 4, aliasesLoaded: 3,
+			templatesILMEnabled: 4, policiesLoaded: 1, aliasesLoaded: 3,
 		},
 		"ILM disabled": {
 			cfg:                  common.MapStr{"apm-server.ilm.enabled": false},
@@ -221,11 +221,11 @@ func TestManager_SetupILM(t *testing.T) {
 		},
 		"LoadModeOverwrite": {
 			loadMode:            libidxmgmt.LoadModeOverwrite,
-			templatesILMEnabled: 4, policiesLoaded: 4, aliasesLoaded: 3,
+			templatesILMEnabled: 4, policiesLoaded: 1, aliasesLoaded: 3,
 		},
 		"LoadModeForce ILM enabled": {
 			loadMode:            libidxmgmt.LoadModeForce,
-			templatesILMEnabled: 4, policiesLoaded: 4, aliasesLoaded: 3,
+			templatesILMEnabled: 4, policiesLoaded: 1, aliasesLoaded: 3,
 		},
 		"LoadModeForce ILM disabled": {
 			cfg:                  common.MapStr{"apm-server.ilm.enabled": false},
@@ -253,7 +253,7 @@ func TestManager_SetupILM(t *testing.T) {
 		"SetupDisabled LoadModeForce ILM enabled": {
 			cfg:                 common.MapStr{"apm-server.ilm.setup.enabled": false},
 			loadMode:            libidxmgmt.LoadModeForce,
-			templatesILMEnabled: 4, policiesLoaded: 4, aliasesLoaded: 3,
+			templatesILMEnabled: 4, policiesLoaded: 1, aliasesLoaded: 3,
 		},
 		"SetupDisabled LoadModeForce ILM disabled": {
 			cfg:                  common.MapStr{"apm-server.ilm.setup.enabled": false, "apm-server.ilm.enabled": false},
@@ -344,8 +344,11 @@ func TestManager_SetupILM(t *testing.T) {
 						{"event_type": "error", "policy_name": "foo"},
 						{"event_type": "transaction", "policy_name": "bar"}},
 				}},
-			loadMode:            libidxmgmt.LoadModeEnabled,
-			templatesILMEnabled: 4, policiesLoaded: 2, aliasesLoaded: 3,
+			loadMode: libidxmgmt.LoadModeEnabled,
+			// templates for all event types are loaded
+			// span and metrics share the same default policy, one policy is loaded
+			// 1 alias already exists, 3 new ones are loaded
+			templatesILMEnabled: 4, policiesLoaded: 1, aliasesLoaded: 3,
 		},
 	}
 

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -86,7 +86,7 @@ apm-server:
     - event_type: "error"
       policy_name: "rollover-10-days"
     - event_type: "span"
-      policy_name: "rollover-30-days"
+      policy_name: "apm-rollover-30-days"
 
   ilm.setup.policies:
     - name: "rollover-10-days"
@@ -99,7 +99,7 @@ apm-server:
                 max_age: "10d"
               set_priority:
                 priority: 100
-    - name: "rollover-30-days"
+    - name: "apm-rollover-30-days"
       policy:
         phases:
           hot:

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -81,8 +81,37 @@ apm-server:
   ilm.enabled: {{ ilm_enabled }}
   {% endif %}
 
-  {% if ilm_setup_enabled %}
-  ilm.setup.managed: {{ ilm_setup_enabled }}
+  {% if ilm_policies %}
+  ilm.setup.mapping:
+    - event_type: "error"
+      policy_name: "rollover-10-days"
+    - event_type: "span"
+      policy_name: "rollover-30-days"
+
+  ilm.setup.policies:
+    - name: "rollover-10-days"
+      policy:
+        phases:
+          hot:
+            actions:
+              rollover:
+                max_size: "50gb"
+                max_age: "10d"
+              set_priority:
+                priority: 100
+    - name: "rollover-30-days"
+      policy:
+        phases:
+          hot:
+            actions:
+              rollover:
+                max_size: "50gb"
+                max_age: "30d"
+              set_priority:
+                priority: 100
+          delete:
+            actions:
+              delete: {}
   {% endif %}
 
   {% if kibana_enabled is not none or kibana_host is not none %}

--- a/tests/system/test_export.py
+++ b/tests/system/test_export.py
@@ -144,7 +144,7 @@ class TestExportILMPolicy(SubCommandTest):
         assert os.path.exists(self.dir)
         dir = os.path.join(self.dir, "policy")
         for subdir, dirs, files in os.walk(dir):
-            assert len(files) == 2, files
+            assert len(files) == 1, files
             for file in files:
                 with open(os.path.join(dir, file)) as f:
                     policy = json.load(f)

--- a/tests/system/test_setup_index_management.py
+++ b/tests/system/test_setup_index_management.py
@@ -308,8 +308,8 @@ class TestILMConfiguredPolicies(ElasticTest):
         # check out configured policy in apm-server.yml.j2
 
         # ensure default policy is changed
-        policy = self.idxmgmt.fetch_policy("rollover-30-days")
-        phases = policy["rollover-30-days"]["policy"]["phases"]
+        policy = self.idxmgmt.fetch_policy(self.idxmgmt.default_policy)
+        phases = policy[self.idxmgmt.default_policy]["policy"]["phases"]
         assert len(phases) == 2
         assert "hot" in phases
         assert "delete" in phases

--- a/tests/system/test_setup_index_management.py
+++ b/tests/system/test_setup_index_management.py
@@ -15,12 +15,7 @@ class IdxMgmt(object):
         self._client = client
         self._index = index
         self._event_indices = ["{}-{}".format(self._index, e) for e in ['error', 'span', 'transaction', 'metric']]
-        self.default_policies = {
-            "error": "rollover-1-day",
-            "span": "rollover-1-day",
-            "transaction": "rollover-7-days",
-            "metric": "rollover-7-days"
-        }
+        self.default_policy = "apm-rollover-30-days"
 
     def indices(self):
         return self._event_indices + [self._index]
@@ -31,11 +26,10 @@ class IdxMgmt(object):
         self.delete_policies()
 
     def delete_policies(self):
-        for ev, p in self.default_policies.items():
-            try:
-                self._client.transport.perform_request('DELETE', '/_ilm/policy/' + p)
-            except NotFoundError:
-                pass
+        try:
+            self._client.transport.perform_request('DELETE', '/_ilm/policy/' + self.default_policy)
+        except NotFoundError:
+            pass
 
     def assert_template(self, loaded=1):
         resp = self._client.indices.get_template(name=self._index, ignore=[404])
@@ -50,7 +44,7 @@ class IdxMgmt(object):
         resp = self._client.indices.get_template(name=self._index + '*', ignore=[404])
 
         if self._index in resp:
-            loaded +=1
+            loaded += 1
         assert loaded == len(resp), len(resp)
 
         if loaded == 1:
@@ -75,10 +69,12 @@ class IdxMgmt(object):
         for idx in self._event_indices:
             assert "{}-000001".format(idx) in resp, resp
 
-    def assert_policies(self, loaded=4):
+    def assert_default_policy(self, loaded=True):
         resp = self._client.transport.perform_request('GET', '/_ilm/policy')
-        for ev, p in self.default_policies.items():
-            assert p in resp if loaded > 0 else p not in resp
+        assert self.default_policy in resp if loaded else self.default_policy not in resp
+
+    def fetch_policy(self, name):
+        return self._client.transport.perform_request('GET', '/_ilm/policy/' + name)
 
     def assert_docs_written_to_alias(self, alias):
         assert 1 == 2
@@ -123,7 +119,7 @@ class TestCommandSetupIndexManagement(BaseTest):
         self.idxmgmt.assert_template()
         self.idxmgmt.assert_event_template()
         self.idxmgmt.assert_alias()
-        self.idxmgmt.assert_policies()
+        self.idxmgmt.assert_default_policy()
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     @attr('integration')
@@ -137,7 +133,7 @@ class TestCommandSetupIndexManagement(BaseTest):
         self.idxmgmt.assert_template()
         self.idxmgmt.assert_event_template(loaded=0)
         self.idxmgmt.assert_alias(loaded=0)
-        self.idxmgmt.assert_policies(loaded=0)
+        self.idxmgmt.assert_default_policy(loaded=False)
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     @attr('integration')
@@ -151,7 +147,7 @@ class TestCommandSetupIndexManagement(BaseTest):
         self.idxmgmt.assert_template()
         self.idxmgmt.assert_event_template(with_ilm=False)
         self.idxmgmt.assert_alias(loaded=0)
-        self.idxmgmt.assert_policies(loaded=0)
+        self.idxmgmt.assert_default_policy(loaded=False)
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     @attr('integration')
@@ -165,7 +161,7 @@ class TestCommandSetupIndexManagement(BaseTest):
         self.idxmgmt.assert_template(loaded=0)
         self.idxmgmt.assert_event_template()
         self.idxmgmt.assert_alias()
-        self.idxmgmt.assert_policies()
+        self.idxmgmt.assert_default_policy()
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     @attr('integration')
@@ -180,7 +176,7 @@ class TestCommandSetupIndexManagement(BaseTest):
         self.idxmgmt.assert_template(loaded=0)
         self.idxmgmt.assert_event_template(with_ilm=False)
         self.idxmgmt.assert_alias(loaded=0)
-        self.idxmgmt.assert_policies(loaded=0)
+        self.idxmgmt.assert_default_policy(loaded=False)
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     @attr('integration')
@@ -195,7 +191,7 @@ class TestCommandSetupIndexManagement(BaseTest):
         self.idxmgmt.assert_template()
         self.idxmgmt.assert_event_template()
         self.idxmgmt.assert_alias()
-        self.idxmgmt.assert_policies()
+        self.idxmgmt.assert_default_policy()
 
         # load with ilm disabled
         exit_code = self.run_beat(extra_args=["setup", self.cmd,
@@ -203,8 +199,8 @@ class TestCommandSetupIndexManagement(BaseTest):
         assert exit_code == 0
         self.idxmgmt.assert_template()
         self.idxmgmt.assert_event_template(with_ilm=False)
-        self.idxmgmt.assert_alias() # policies do not get deleted
-        self.idxmgmt.assert_policies()  # aliases do not get deleted
+        self.idxmgmt.assert_alias()  # aliases do not get deleted
+        self.idxmgmt.assert_default_policy()  # policies do not get deleted
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     @attr('integration')
@@ -219,7 +215,7 @@ class TestCommandSetupIndexManagement(BaseTest):
         self.idxmgmt.assert_template()
         self.idxmgmt.assert_event_template(with_ilm=False)
         self.idxmgmt.assert_alias(loaded=0)
-        self.idxmgmt.assert_policies(loaded=0)
+        self.idxmgmt.assert_default_policy(loaded=False)
 
         # load with ilm enabled
         exit_code = self.run_beat(extra_args=["setup", self.cmd,
@@ -228,7 +224,7 @@ class TestCommandSetupIndexManagement(BaseTest):
         self.idxmgmt.assert_template()
         self.idxmgmt.assert_event_template()
         self.idxmgmt.assert_alias()
-        self.idxmgmt.assert_policies()
+        self.idxmgmt.assert_default_policy()
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     @attr('integration')
@@ -242,7 +238,7 @@ class TestCommandSetupIndexManagement(BaseTest):
         self.idxmgmt.assert_template()
         self.idxmgmt.assert_event_template()
         self.idxmgmt.assert_alias()
-        self.idxmgmt.assert_policies()
+        self.idxmgmt.assert_default_policy()
         # try deleting policy needs to raise an error as it is in use
         self.idxmgmt.delete_policies()
 
@@ -264,7 +260,7 @@ class TestRunIndexManagementDefault(ElasticTest):
 
         self.idxmgmt.assert_event_template()
         self.idxmgmt.assert_alias()
-        self.idxmgmt.assert_policies()
+        self.idxmgmt.assert_default_policy()
 
 
 class TestRunIndexManagementWithoutILM(ElasticTest):
@@ -286,8 +282,43 @@ class TestRunIndexManagementWithoutILM(ElasticTest):
                         max_timeout=5)
 
         self.idxmgmt.assert_event_template(with_ilm=False)
-        self.idxmgmt.assert_alias(0)
-        self.idxmgmt.assert_policies(0)
+        self.idxmgmt.assert_alias(loaded=0)
+        self.idxmgmt.assert_default_policy(loaded=False)
+
+
+class TestILMConfiguredPolicies(ElasticTest):
+
+    config_overrides = {"queue_flush": 2048, "ilm_policies": True}
+
+    def setUp(self):
+        super(TestILMConfiguredPolicies, self).setUp()
+
+        self.idxmgmt = IdxMgmt(self.es, self.index_name)
+        self.idxmgmt.delete()
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_ilm_loaded(self):
+        self.wait_until(lambda: self.log_contains("Finished index management setup."),
+                        max_timeout=5)
+
+        self.idxmgmt.assert_event_template(with_ilm=True)
+        self.idxmgmt.assert_alias(loaded=4)
+        self.idxmgmt.assert_default_policy(loaded=True)
+
+        # check out configured policy in apm-server.yml.j2
+
+        # ensure default policy is changed
+        policy = self.idxmgmt.fetch_policy("rollover-30-days")
+        phases = policy["rollover-30-days"]["policy"]["phases"]
+        assert len(phases) == 2
+        assert "hot" in phases
+        assert "delete" in phases
+
+        # ensure newly configured policy is loaded
+        policy = self.idxmgmt.fetch_policy("rollover-10-days")
+        phases = policy["rollover-10-days"]["policy"]["phases"]
+        assert len(phases) == 1
+        assert "hot" in phases
 
 
 class TestRunIndexManagementWithSetupDisabled(ElasticTest):
@@ -308,9 +339,10 @@ class TestRunIndexManagementWithSetupDisabled(ElasticTest):
         self.wait_until(lambda: self.log_contains("Manage ILM setup is disabled."),
                         max_timeout=5)
 
-        self.idxmgmt.assert_event_template(0)
-        self.idxmgmt.assert_alias(0)
-        self.idxmgmt.assert_policies(0)
+        self.idxmgmt.assert_event_template(loaded=0)
+        self.idxmgmt.assert_alias(loaded=0)
+        self.idxmgmt.assert_default_policy(loaded=False)
+
 
 class TestCommandSetupTemplate(BaseTest):
     """
@@ -345,9 +377,9 @@ class TestCommandSetupTemplate(BaseTest):
         self.idxmgmt.assert_template()
 
         # do not setup ILM when running this command
-        self.idxmgmt.assert_event_template(0)
-        self.idxmgmt.assert_alias(0)
-        self.idxmgmt.assert_policies(0)
+        self.idxmgmt.assert_event_template(loaded=0)
+        self.idxmgmt.assert_alias(loaded=0)
+        self.idxmgmt.assert_default_policy(loaded=False)
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     @attr('integration')


### PR DESCRIPTION
Changes the default ILM policy for all APM event types to rollover after 30 days OR 50gb, whichever limit is first hit. 

closes elastic/apm-server#2788 
