### PR TITLE
Add description to Intake API for remote_address

### DIFF
--- a/docs/spec/request.json
+++ b/docs/spec/request.json
@@ -43,7 +43,7 @@
                     "type": ["boolean", "null"]
                 },
                 "remote_address": {
-                    "description": "The network address sending the request. Should not be parsed from any headers like 'Forwarded'.",
+                    "description": "The network address sending the request. Should be obtained through standard APIs and not parsed from any headers like 'Forwarded'.",
                     "type": ["string", "null"]
                 }
             }

--- a/docs/spec/request.json
+++ b/docs/spec/request.json
@@ -43,6 +43,7 @@
                     "type": ["boolean", "null"]
                 },
                 "remote_address": {
+                    "description": "The network address sending the request. Should not be parsed from any headers like 'Forwarded'.",
                     "type": ["string", "null"]
                 }
             }

--- a/model/error/generated/schema/error.go
+++ b/model/error/generated/schema/error.go
@@ -156,6 +156,7 @@ const ModelSchema = `{
                     "type": ["boolean", "null"]
                 },
                 "remote_address": {
+                    "description": "The network address sending the request. Should not be parsed from any headers like 'Forwarded'.",
                     "type": ["string", "null"]
                 }
             }

--- a/model/error/generated/schema/error.go
+++ b/model/error/generated/schema/error.go
@@ -156,7 +156,7 @@ const ModelSchema = `{
                     "type": ["boolean", "null"]
                 },
                 "remote_address": {
-                    "description": "The network address sending the request. Should not be parsed from any headers like 'Forwarded'.",
+                    "description": "The network address sending the request. Should be obtained through standard APIs and not parsed from any headers like 'Forwarded'.",
                     "type": ["string", "null"]
                 }
             }

--- a/model/transaction/generated/schema/transaction.go
+++ b/model/transaction/generated/schema/transaction.go
@@ -172,7 +172,7 @@ const ModelSchema = `{
                     "type": ["boolean", "null"]
                 },
                 "remote_address": {
-                    "description": "The network address sending the request. Should not be parsed from any headers like 'Forwarded'.",
+                    "description": "The network address sending the request. Should be obtained through standard APIs and not parsed from any headers like 'Forwarded'.",
                     "type": ["string", "null"]
                 }
             }

--- a/model/transaction/generated/schema/transaction.go
+++ b/model/transaction/generated/schema/transaction.go
@@ -172,6 +172,7 @@ const ModelSchema = `{
                     "type": ["boolean", "null"]
                 },
                 "remote_address": {
+                    "description": "The network address sending the request. Should not be parsed from any headers like 'Forwarded'.",
                     "type": ["string", "null"]
                 }
             }


### PR DESCRIPTION
Help defining how the `context.request.socket.remote_address` should be populated.
