### PR TITLE
[CI] Fix flaky ILM setup system test

### DIFF
--- a/tests/system/test_setup_index_management.py
+++ b/tests/system/test_setup_index_management.py
@@ -47,7 +47,7 @@ class IdxMgmt(object):
             loaded += 1
         assert loaded == len(resp), len(resp)
 
-        if loaded == 1:
+        if loaded <= 1:
             return
 
         s, i, l = 'settings', 'index', 'lifecycle'


### PR DESCRIPTION
Testing disabled ILM setup should not assert apm template to be loaded
as the test does not wait until setup is finished.

needs backport to 7.x and 7.5
