### PR TITLE
[DOCS] Bump docs for 7.4.1 release

### DIFF
--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -3,7 +3,7 @@
 // doc-branch can be:       master, 8.0, 8.1, etc.
 // release-state is only:   released | prerelease | unreleased
 
-:stack-version: 7.4.0
+:stack-version: 7.4.1
 :major-version: 7.x
 :doc-branch: 7.4
 :branch: {doc-branch}


### PR DESCRIPTION
Bumps the stack version attribute for the 7.4.1 release.

**DO NOT MERGE UNTIL RELEASE DAY**