### PR TITLE
[DOCS] Bump docs for 6.8.4 release

### DIFF
--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 6.8.3
+:stack-version: 6.8.4
 :major-version: 6.x
 :doc-branch: 6.8
 :branch: {doc-branch}


### PR DESCRIPTION
Bumps the stack version attribute for the 6.8.4 release.

**DO NOT MERGE UNTIL RELEASE DAY**