### PR TITLE
Revert "[DOCS] Bump docs to 7.4.1 release (#2837)"

### DIFF
--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -3,7 +3,7 @@
 // doc-branch can be:       master, 8.0, 8.1, etc.
 // release-state is only:   released | prerelease | unreleased
 
-:stack-version: 7.4.1
+:stack-version: 7.4.0
 :major-version: 7.x
 :doc-branch: 7.4
 :branch: {doc-branch}


### PR DESCRIPTION
This reverts commit 5e3feeba0080d3fa8b7c3777bf0262fa89e34d44.