### PR TITLE
Revert "[DOCS] Bump docs to 6.8.4 release (#2838)"

### DIFF
--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 6.8.4
+:stack-version: 6.8.3
 :major-version: 6.x
 :doc-branch: 6.8
 :branch: {doc-branch}


### PR DESCRIPTION
This reverts commit 5cdfeef1e91d0ac4de10114e9fd22af10c40796e.