### PR TITLE
[7.x] Clarify messages on 403 errors for each endpoint. (#2869)

### DIFF
--- a/beater/api/asset/sourcemap/test_approved/integration/TestSourcemapHandler_KillSwitchMiddleware/OffRum.approved.json
+++ b/beater/api/asset/sourcemap/test_approved/integration/TestSourcemapHandler_KillSwitchMiddleware/OffRum.approved.json
@@ -1,3 +1,3 @@
 {
-    "error": "forbidden request: endpoint is disabled"
+    "error": "forbidden request: Sourcemap upload endpoint is disabled. Configure the `apm-server.rum` section in apm-server.yml to enable sourcemap uploads. If you are not using the RUM agent, you can safely ignore this error."
 }

--- a/beater/api/asset/sourcemap/test_approved/integration/TestSourcemapHandler_KillSwitchMiddleware/OffSourcemap.approved.json
+++ b/beater/api/asset/sourcemap/test_approved/integration/TestSourcemapHandler_KillSwitchMiddleware/OffSourcemap.approved.json
@@ -1,3 +1,3 @@
 {
-    "error": "forbidden request: endpoint is disabled"
+    "error": "forbidden request: Sourcemap upload endpoint is disabled. Configure the `apm-server.rum` section in apm-server.yml to enable sourcemap uploads. If you are not using the RUM agent, you can safely ignore this error."
 }

--- a/beater/api/config/agent/test_approved/integration/TestConfigAgentHandler_KillSwitchMiddleware/Off.approved.json
+++ b/beater/api/config/agent/test_approved/integration/TestConfigAgentHandler_KillSwitchMiddleware/Off.approved.json
@@ -1,3 +1,3 @@
 {
-    "error": "forbidden request: endpoint is disabled"
+    "error": "forbidden request: Agent remote configuration is disabled. Configure the `apm-server.kibana` section in apm-server.yml to enable it. If you are using a RUM agent, you also need to configure the `apm-server.rum` section. If you are not using remote configuration, you can safely ignore this error."
 }

--- a/beater/api/intake/test_approved/integration/rum/TestRUMHandler_KillSwitchMiddleware/OffRum.approved.json
+++ b/beater/api/intake/test_approved/integration/rum/TestRUMHandler_KillSwitchMiddleware/OffRum.approved.json
@@ -1,3 +1,3 @@
 {
-    "error": "forbidden request: endpoint is disabled"
+    "error": "forbidden request: RUM endpoint is disabled. Configure the `apm-server.rum` section in apm-server.yml to enable ingestion of RUM events. If you are not using the RUM agent, you can safely ignore this error."
 }

--- a/beater/middleware/kill_switch_middleware.go
+++ b/beater/middleware/kill_switch_middleware.go
@@ -23,16 +23,14 @@ import (
 	"github.com/elastic/apm-server/beater/request"
 )
 
-const errDisabledMsg = "endpoint is disabled"
-
 // KillSwitchMiddleware returns a Middleware checking whether the path for the request is enabled
-func KillSwitchMiddleware(enabled bool) Middleware {
+func KillSwitchMiddleware(enabled bool, errorMessage string) Middleware {
 	return func(h request.Handler) (request.Handler, error) {
 		return func(c *request.Context) {
 			if enabled {
 				h(c)
 			} else {
-				c.Result.SetWithError(request.IDResponseErrorsForbidden, errors.New(errDisabledMsg))
+				c.Result.SetWithError(request.IDResponseErrorsForbidden, errors.New(errorMessage))
 				c.Write()
 			}
 		}, nil

--- a/beater/middleware/kill_switch_middleware_test.go
+++ b/beater/middleware/kill_switch_middleware_test.go
@@ -29,12 +29,12 @@ import (
 func TestKillSwitchMiddleware(t *testing.T) {
 	t.Run("On", func(t *testing.T) {
 		c, rec := beatertest.DefaultContextWithResponseRecorder()
-		Apply(KillSwitchMiddleware(true), beatertest.Handler202)(c)
+		Apply(KillSwitchMiddleware(true, "endpoint is disabled"), beatertest.Handler202)(c)
 		assert.Equal(t, http.StatusAccepted, rec.Code)
 	})
 	t.Run("Off", func(t *testing.T) {
 		c, rec := beatertest.DefaultContextWithResponseRecorder()
-		Apply(KillSwitchMiddleware(false), beatertest.Handler202)(c)
+		Apply(KillSwitchMiddleware(false, "endpoint is disabled"), beatertest.Handler202)(c)
 		assert.Equal(t, http.StatusForbidden, rec.Code)
 	})
 }

--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -209,7 +209,7 @@ class AgentConfigurationIntegrationTest(AgentConfigurationTest):
                          headers={"Content-Type": "application/json"}
                          )
         assert r.status_code == 403
-        assert r.json() == {'error': 'forbidden request: endpoint is disabled'}
+        assert "RUM endpoint is disabled" in r.json().get('error'), r.json()
 
 
 class AgentConfigurationKibanaDownIntegrationTest(ElasticTest):
@@ -268,7 +268,6 @@ class AgentConfigurationKibanaDisabledIntegrationTest(ElasticTest):
         self.assertDictContainsSubset({
             "level": "error",
             "message": "forbidden request",
-            "error": "forbidden request: endpoint is disabled",
             "response_code": 403,
         }, config_request_logs[0])
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Clarify messages on 403 errors for each endpoint.  (#2869)