### PR TITLE
[7.x] [ILM] Add ilm.setup.overwrite config option. (#2877)

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -241,39 +241,39 @@ apm-server:
 
   #---------------------------- APM Server - ILM Index Lifecycle Management ----------------------------
 
-  # Index Lifecycle Mangement (ILM)
   #ilm:
-    # `enabled: "auto"`
-    # If a different output than Elasticsearch is configured, ILM will be disabled.
-    # If Elasticsearch output is configured, but specific `index` or `indices` settings are configured, ILM will be
-    # disabled, as it only works with default index settings.
-    # If the configured Elasticsearch instance is not eligible for ILM, ILM will also be disabled.
-    # If all preconditions are met, ILM will be enabled.
-    #
-    # `enabled: "true"`
-    # APM Server ignores any configured index settings. The configured output must be set to Elasticsearch and the
-    # instance needs to support ILM. Otherwise APM Server cannot apply ILM and creates unmanaged indices.
-    #
-    # `enabled: "false"`
-    # ILM is disabled and the server creates unmanaged indices.
-    #
+    # Supported values are `auto`, `true` and `false`.
+    # `true`: Make use of Elasticsearch's Index Lifecycle Management for APM indices. If no Elasticsearch output is
+    # configured or the configured instance does not support ILM, APM Server cannot apply ILM and must create
+    # unmanaged indices instead.
+    # `false`: APM Server does not make use of Index Lifecycle Management in Elasticsearch.
+    # `auto`: If an Elasticsearch output is configured with default index and indices settings, and the configured
+    # Elasticsearch instance supports ILM, `auto` will resolve to `true`. Otherwise `auto` will resolve to `false`.
     # Default value is `auto`.
     #enabled: "auto"
 
     #setup:
-      # Do only disable setup if you want to setup everything related to managed indices on your own.
-      # When setup is enabled, the APM Server creates aliases, event type specific settings and policies.
-      # This is also important when ILM itself is disabled, as the templates need to be changed accordingly.
+      # Do only disable setup if you want to set up everything related to index management on your own.
+      # When setup is enabled, the APM Server creates
+      # - aliases and ILM policies if `apm-server.ilm.enabled` resolves to `true`.
+      # - ILM specific template per event type. This is required to map ILM aliases and policies to indices. In case
+      #   ILM is disabled, the templates will be created without any lifecycle management settings.
       # Be aware that if you turn off setup, you need to manually manage event type specific templates on your own.
-      # If you simply want to disable ILM, use the above setting `ilm.enabled`.
+      # If you simply want to disable ILM, use the above setting `apm-server.ilm.enabled`.
       # Defaults to true.
       #enabled: true
+
+      # Configure whether or not existing policies and ILM related templates should be updated. This needs to be
+      # set to true when customizing your policies.
+      # Defaults to false.
+      #overwrite: false
 
       # Set `require_policy` to `false` when policies are set up outside of APM Server but referenced here.
       # Default value is `true`.
       #require_policy: true
 
-      # The configured event types and policies will be merged with the default policies.
+      # The configured event types and policies will be merged with the default setup. You only need to configure
+      # the mappings that you want to customize.
       #mapping:
         #- event_type: "error"
         #  policy_name: "apm-rollover-30-days"
@@ -284,7 +284,7 @@ apm-server:
         #- event_type: "metric"
         #  policy_name: "apm-rollover-30-days"
 
-      # Configured policies are added to all pre-defined default policies.
+      # Configured policies are added to pre-defined default policies.
       # If a policy with the same name as a default policy is configured, the configured policy overwrites the default policy.
       #policies:
         #- name: "apm-rollover-30-days"

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -241,39 +241,39 @@ apm-server:
 
   #---------------------------- APM Server - ILM Index Lifecycle Management ----------------------------
 
-  # Index Lifecycle Mangement (ILM)
   #ilm:
-    # `enabled: "auto"`
-    # If a different output than Elasticsearch is configured, ILM will be disabled.
-    # If Elasticsearch output is configured, but specific `index` or `indices` settings are configured, ILM will be
-    # disabled, as it only works with default index settings.
-    # If the configured Elasticsearch instance is not eligible for ILM, ILM will also be disabled.
-    # If all preconditions are met, ILM will be enabled.
-    #
-    # `enabled: "true"`
-    # APM Server ignores any configured index settings. The configured output must be set to Elasticsearch and the
-    # instance needs to support ILM. Otherwise APM Server cannot apply ILM and creates unmanaged indices.
-    #
-    # `enabled: "false"`
-    # ILM is disabled and the server creates unmanaged indices.
-    #
+    # Supported values are `auto`, `true` and `false`.
+    # `true`: Make use of Elasticsearch's Index Lifecycle Management for APM indices. If no Elasticsearch output is
+    # configured or the configured instance does not support ILM, APM Server cannot apply ILM and must create
+    # unmanaged indices instead.
+    # `false`: APM Server does not make use of Index Lifecycle Management in Elasticsearch.
+    # `auto`: If an Elasticsearch output is configured with default index and indices settings, and the configured
+    # Elasticsearch instance supports ILM, `auto` will resolve to `true`. Otherwise `auto` will resolve to `false`.
     # Default value is `auto`.
     #enabled: "auto"
 
     #setup:
-      # Do only disable setup if you want to setup everything related to managed indices on your own.
-      # When setup is enabled, the APM Server creates aliases, event type specific settings and policies.
-      # This is also important when ILM itself is disabled, as the templates need to be changed accordingly.
+      # Do only disable setup if you want to set up everything related to index management on your own.
+      # When setup is enabled, the APM Server creates
+      # - aliases and ILM policies if `apm-server.ilm.enabled` resolves to `true`.
+      # - ILM specific template per event type. This is required to map ILM aliases and policies to indices. In case
+      #   ILM is disabled, the templates will be created without any lifecycle management settings.
       # Be aware that if you turn off setup, you need to manually manage event type specific templates on your own.
-      # If you simply want to disable ILM, use the above setting `ilm.enabled`.
+      # If you simply want to disable ILM, use the above setting `apm-server.ilm.enabled`.
       # Defaults to true.
       #enabled: true
+
+      # Configure whether or not existing policies and ILM related templates should be updated. This needs to be
+      # set to true when customizing your policies.
+      # Defaults to false.
+      #overwrite: false
 
       # Set `require_policy` to `false` when policies are set up outside of APM Server but referenced here.
       # Default value is `true`.
       #require_policy: true
 
-      # The configured event types and policies will be merged with the default policies.
+      # The configured event types and policies will be merged with the default setup. You only need to configure
+      # the mappings that you want to customize.
       #mapping:
         #- event_type: "error"
         #  policy_name: "apm-rollover-30-days"
@@ -284,7 +284,7 @@ apm-server:
         #- event_type: "metric"
         #  policy_name: "apm-rollover-30-days"
 
-      # Configured policies are added to all pre-defined default policies.
+      # Configured policies are added to pre-defined default policies.
       # If a policy with the same name as a default policy is configured, the configured policy overwrites the default policy.
       #policies:
         #- name: "apm-rollover-30-days"

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -241,39 +241,39 @@ apm-server:
 
   #---------------------------- APM Server - ILM Index Lifecycle Management ----------------------------
 
-  # Index Lifecycle Mangement (ILM)
   #ilm:
-    # `enabled: "auto"`
-    # If a different output than Elasticsearch is configured, ILM will be disabled.
-    # If Elasticsearch output is configured, but specific `index` or `indices` settings are configured, ILM will be
-    # disabled, as it only works with default index settings.
-    # If the configured Elasticsearch instance is not eligible for ILM, ILM will also be disabled.
-    # If all preconditions are met, ILM will be enabled.
-    #
-    # `enabled: "true"`
-    # APM Server ignores any configured index settings. The configured output must be set to Elasticsearch and the
-    # instance needs to support ILM. Otherwise APM Server cannot apply ILM and creates unmanaged indices.
-    #
-    # `enabled: "false"`
-    # ILM is disabled and the server creates unmanaged indices.
-    #
+    # Supported values are `auto`, `true` and `false`.
+    # `true`: Make use of Elasticsearch's Index Lifecycle Management for APM indices. If no Elasticsearch output is
+    # configured or the configured instance does not support ILM, APM Server cannot apply ILM and must create
+    # unmanaged indices instead.
+    # `false`: APM Server does not make use of Index Lifecycle Management in Elasticsearch.
+    # `auto`: If an Elasticsearch output is configured with default index and indices settings, and the configured
+    # Elasticsearch instance supports ILM, `auto` will resolve to `true`. Otherwise `auto` will resolve to `false`.
     # Default value is `auto`.
     #enabled: "auto"
 
     #setup:
-      # Do only disable setup if you want to setup everything related to managed indices on your own.
-      # When setup is enabled, the APM Server creates aliases, event type specific settings and policies.
-      # This is also important when ILM itself is disabled, as the templates need to be changed accordingly.
+      # Do only disable setup if you want to set up everything related to index management on your own.
+      # When setup is enabled, the APM Server creates
+      # - aliases and ILM policies if `apm-server.ilm.enabled` resolves to `true`.
+      # - ILM specific template per event type. This is required to map ILM aliases and policies to indices. In case
+      #   ILM is disabled, the templates will be created without any lifecycle management settings.
       # Be aware that if you turn off setup, you need to manually manage event type specific templates on your own.
-      # If you simply want to disable ILM, use the above setting `ilm.enabled`.
+      # If you simply want to disable ILM, use the above setting `apm-server.ilm.enabled`.
       # Defaults to true.
       #enabled: true
+
+      # Configure whether or not existing policies and ILM related templates should be updated. This needs to be
+      # set to true when customizing your policies.
+      # Defaults to false.
+      #overwrite: false
 
       # Set `require_policy` to `false` when policies are set up outside of APM Server but referenced here.
       # Default value is `true`.
       #require_policy: true
 
-      # The configured event types and policies will be merged with the default policies.
+      # The configured event types and policies will be merged with the default setup. You only need to configure
+      # the mappings that you want to customize.
       #mapping:
         #- event_type: "error"
         #  policy_name: "apm-rollover-30-days"
@@ -284,7 +284,7 @@ apm-server:
         #- event_type: "metric"
         #  policy_name: "apm-rollover-30-days"
 
-      # Configured policies are added to all pre-defined default policies.
+      # Configured policies are added to pre-defined default policies.
       # If a policy with the same name as a default policy is configured, the configured policy overwrites the default policy.
       #policies:
         #- name: "apm-rollover-30-days"

--- a/changelogs/7.5.asciidoc
+++ b/changelogs/7.5.asciidoc
@@ -12,7 +12,7 @@ https://github.com/elastic/apm-server/compare/v7.4.1\...v7.5.0[View commits]
 
 [float]
 ==== Breaking Changes
-- Introduce `apm-server.ilm.setup.enabled` flag and ignore `setup.template.*` flags for ILM setup {pull}2764[2764].
+- Introduce dedicated ILM setup flags and ignore `setup.template.*` flags for ILM {pull}2764[2764],{pull}2877[2877].
 - Remove ILM specific templates from `apm-server export template` command {pull}2764[2764].
 
 [float]
@@ -22,3 +22,4 @@ https://github.com/elastic/apm-server/compare/v7.4.1\...v7.5.0[View commits]
 - Make ILM policies configurable {pull}2764[2764].
 - Add support for agent config GA {pull}2747[2747].
 - Change ILM default policies to rollover after 30 days {pull}2798[2798].
+- Introduce `apm-server.ilm.setup.overwrite` config option and stop overwriting by default {pull}2877[2877].

--- a/idxmgmt/feature.go
+++ b/idxmgmt/feature.go
@@ -25,6 +25,7 @@ type feature struct {
 	enabled, overwrite, load, supported bool
 
 	warn string
+	info string
 	err  error
 }
 
@@ -51,6 +52,10 @@ func newFeature(enabled, overwrite, load, supported bool, mode libidxmgmt.LoadMo
 
 func (f *feature) warning() string {
 	return f.warn
+}
+
+func (f *feature) information() string {
+	return f.info
 }
 
 func (f *feature) error() error {

--- a/idxmgmt/ilm/config.go
+++ b/idxmgmt/ilm/config.go
@@ -38,6 +38,7 @@ type Config struct {
 //Setup holds information about how to setup ILM
 type Setup struct {
 	Enabled       bool `config:"enabled"`
+	Overwrite     bool `config:"overwrite"`
 	RequirePolicy bool `config:"require_policy"`
 	Policies      []EventPolicy
 }

--- a/idxmgmt/ilm/config_test.go
+++ b/idxmgmt/ilm/config_test.go
@@ -32,6 +32,7 @@ func TestConfig_Default(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, libilm.ModeAuto, c.Mode)
 	assert.True(t, c.Setup.Enabled)
+	assert.False(t, c.Setup.Overwrite)
 	assert.True(t, c.Setup.RequirePolicy)
 	assert.ObjectsAreEqual(defaultPolicies(), c.Setup.Policies)
 }
@@ -58,13 +59,29 @@ func TestConfig_SetupEnabled(t *testing.T) {
 		cfg     map[string]interface{}
 		enabled bool
 	}{
-		"default":  {map[string]interface{}{}, true},
+		"enabled":  {map[string]interface{}{"enabled": true}, true},
 		"disabled": {map[string]interface{}{"enabled": false}, false},
 	} {
 		t.Run(name, func(t *testing.T) {
 			c, err := NewConfig(common.MustNewConfigFrom(map[string]interface{}{"setup": tc.cfg}))
 			require.NoError(t, err)
 			assert.Equal(t, tc.enabled, c.Setup.Enabled)
+		})
+	}
+}
+
+func TestConfig_SetupOverwrite(t *testing.T) {
+	for name, tc := range map[string]struct {
+		cfg       map[string]interface{}
+		overwrite bool
+	}{
+		"overwrite":        {map[string]interface{}{"overwrite": true}, true},
+		"do not overwrite": {map[string]interface{}{"overwrite": false}, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c, err := NewConfig(common.MustNewConfigFrom(map[string]interface{}{"setup": tc.cfg}))
+			require.NoError(t, err)
+			assert.Equal(t, tc.overwrite, c.Setup.Overwrite)
 		})
 	}
 }

--- a/idxmgmt/manager_test.go
+++ b/idxmgmt/manager_test.go
@@ -34,9 +34,10 @@ import (
 )
 
 func TestManager_VerifySetup(t *testing.T) {
-	for name, setup := range map[string]struct {
+	for name, tc := range map[string]struct {
 		templateEnabled       bool
 		ilmSetupEnabled       bool
+		ilmSetupOverwrite     bool
 		ilmEnabled            string
 		loadTemplate, loadILM libidxmgmt.LoadMode
 		version               string
@@ -55,8 +56,9 @@ func TestManager_VerifySetup(t *testing.T) {
 			warn:            "Manage ILM setup is disabled.",
 		},
 		"LoadILMDisabled": {
-			loadILM: libidxmgmt.LoadModeDisabled,
-			warn:    "Manage ILM setup is disabled.",
+			loadILM:           libidxmgmt.LoadModeDisabled,
+			ilmSetupOverwrite: true,
+			warn:              "Manage ILM setup is disabled.",
 		},
 		"LoadTemplateDisabled": {
 			templateEnabled: true, loadTemplate: libidxmgmt.LoadModeDisabled,
@@ -99,30 +101,31 @@ func TestManager_VerifySetup(t *testing.T) {
 		},
 		"EverythingEnabled": {
 			templateEnabled: true, loadTemplate: libidxmgmt.LoadModeEnabled,
-			ilmSetupEnabled: true, loadILM: libidxmgmt.LoadModeEnabled,
+			ilmSetupEnabled: true, ilmSetupOverwrite: true, loadILM: libidxmgmt.LoadModeEnabled,
 			ok: true,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			c := common.MapStr{
-				"setup.template.enabled":       setup.templateEnabled,
-				"apm-server.ilm.setup.enabled": setup.ilmSetupEnabled,
+				"setup.template.enabled":         tc.templateEnabled,
+				"apm-server.ilm.setup.enabled":   tc.ilmSetupEnabled,
+				"apm-server.ilm.setup.overwrite": tc.ilmSetupOverwrite,
 			}
-			if setup.ilmEnabled != "" {
-				c["apm-server.ilm.enabled"] = setup.ilmEnabled
+			if tc.ilmEnabled != "" {
+				c["apm-server.ilm.enabled"] = tc.ilmEnabled
 			}
-			if setup.esCfg != nil {
-				c.DeepUpdate(setup.esCfg)
+			if tc.esCfg != nil {
+				c.DeepUpdate(tc.esCfg)
 			}
 			support := defaultSupporter(t, c)
-			version := setup.version
+			version := tc.version
 			if version == "" {
 				version = "7.0.0"
 			}
 			manager := support.Manager(newMockClientHandler(version), nil)
-			ok, warn := manager.VerifySetup(setup.loadTemplate, setup.loadILM)
-			require.Equal(t, setup.ok, ok, warn)
-			assert.Contains(t, warn, setup.warn)
+			ok, warn := manager.VerifySetup(tc.loadTemplate, tc.loadILM)
+			require.Equal(t, tc.ok, ok, warn)
+			assert.Contains(t, warn, tc.warn)
 		})
 	}
 }
@@ -212,12 +215,17 @@ func TestManager_SetupILM(t *testing.T) {
 	var testCasesSetupEnabled = map[string]testCase{
 		"Default": {
 			loadMode:            libidxmgmt.LoadModeEnabled,
-			templatesILMEnabled: 4, policiesLoaded: 1, aliasesLoaded: 3,
+			templatesILMEnabled: 3, policiesLoaded: 1, aliasesLoaded: 3,
 		},
 		"ILM disabled": {
 			cfg:                  common.MapStr{"apm-server.ilm.enabled": false},
 			loadMode:             libidxmgmt.LoadModeEnabled,
-			templatesILMDisabled: 4,
+			templatesILMDisabled: 3,
+		},
+		"ILM overwrite": {
+			cfg:                 common.MapStr{"apm-server.ilm.setup.overwrite": true},
+			loadMode:            libidxmgmt.LoadModeEnabled,
+			templatesILMEnabled: 4, policiesLoaded: 1, aliasesLoaded: 3,
 		},
 		"LoadModeOverwrite": {
 			loadMode:            libidxmgmt.LoadModeOverwrite,
@@ -232,6 +240,11 @@ func TestManager_SetupILM(t *testing.T) {
 			loadMode:             libidxmgmt.LoadModeForce,
 			templatesILMDisabled: 4,
 		},
+		"ILM overwrite LoadModeDisabled": {
+			cfg:                 common.MapStr{"apm-server.ilm.setup.overwrite": true},
+			loadMode:            libidxmgmt.LoadModeDisabled,
+			templatesILMEnabled: 0, templatesILMDisabled: 0,
+		},
 		"LoadModeUnset": {
 			templatesILMEnabled: 0, templatesILMDisabled: 0,
 		},
@@ -239,15 +252,15 @@ func TestManager_SetupILM(t *testing.T) {
 
 	var testCasesSetupDisabled = map[string]testCase{
 		"SetupDisabled": {
-			cfg:      common.MapStr{"apm-server.ilm.setup.enabled": false},
+			cfg:      common.MapStr{"apm-server.ilm.setup.enabled": false, "apm-server.ilm.setup.overwrite": true},
 			loadMode: libidxmgmt.LoadModeEnabled,
 		},
 		"SetupDisabled ILM disabled": {
-			cfg:      common.MapStr{"apm-server.ilm.setup.enabled": false, "apm-server.ilm.enabled": false},
+			cfg:      common.MapStr{"apm-server.ilm.setup.enabled": false, "apm-server.ilm.setup.overwrite": true, "apm-server.ilm.enabled": false},
 			loadMode: libidxmgmt.LoadModeEnabled,
 		},
 		"SetupDisabled LoadModeOverwrite": {
-			cfg:      common.MapStr{"apm-server.ilm.setup.enabled": false},
+			cfg:      common.MapStr{"apm-server.ilm.setup.enabled": false, "apm-server.ilm.setup.overwrite": true},
 			loadMode: libidxmgmt.LoadModeOverwrite,
 		},
 		"SetupDisabled LoadModeForce ILM enabled": {
@@ -269,13 +282,19 @@ func TestManager_SetupILM(t *testing.T) {
 		"Default ES Unsupported ILM": {
 			version:              "6.2.0",
 			loadMode:             libidxmgmt.LoadModeEnabled,
+			templatesILMDisabled: 3,
+		},
+		"SetupOverwrite Default ES Unsupported ILM": {
+			cfg:                  common.MapStr{"apm-server.ilm.setup.overwrite": "true"},
+			version:              "6.2.0",
+			loadMode:             libidxmgmt.LoadModeEnabled,
 			templatesILMDisabled: 4,
 		},
 		"ILM True ES Unsupported ILM": {
 			cfg:                  common.MapStr{"apm-server.ilm.enabled": "true"},
 			loadMode:             libidxmgmt.LoadModeEnabled,
 			version:              "6.2.0",
-			templatesILMDisabled: 4,
+			templatesILMDisabled: 3,
 		},
 		"Default ES Unsupported ILM Setup disabled": {
 			cfg:      common.MapStr{"apm-server.ilm.setup.enabled": false},
@@ -297,7 +316,7 @@ func TestManager_SetupILM(t *testing.T) {
 				"setup.template.pattern":       "custom",
 				"output.elasticsearch.index":   "custom"},
 			loadMode:             libidxmgmt.LoadModeEnabled,
-			templatesILMDisabled: 4,
+			templatesILMDisabled: 3,
 		},
 		"ESIndicesConfigured": {
 			cfg: common.MapStr{
@@ -310,7 +329,7 @@ func TestManager_SetupILM(t *testing.T) {
 					"when": map[string]interface{}{
 						"contains": map[string]interface{}{"processor.event": "metric"}}}}},
 			loadMode:             libidxmgmt.LoadModeEnabled,
-			templatesILMDisabled: 4,
+			templatesILMDisabled: 3,
 		},
 		"ESIndexConfigured Setup disabled": {
 			cfg: common.MapStr{
@@ -348,7 +367,7 @@ func TestManager_SetupILM(t *testing.T) {
 			// templates for all event types are loaded
 			// span and metrics share the same default policy, one policy is loaded
 			// 1 alias already exists, 3 new ones are loaded
-			templatesILMEnabled: 4, policiesLoaded: 1, aliasesLoaded: 3,
+			templatesILMEnabled: 3, policiesLoaded: 1, aliasesLoaded: 3,
 		},
 	}
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [ILM] Add ilm.setup.overwrite config option.  (#2877)