### PR TITLE
[apm-ci] suppress the NativeCommandError in windows builds

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -174,6 +174,7 @@ func Update() error {
 }
 
 func Fields() error {
+	panic(errors.Errorf("force error for testing purposes"))
 	return mage.GenerateFieldsYAML("model")
 }
 

--- a/magefile.go
+++ b/magefile.go
@@ -174,7 +174,6 @@ func Update() error {
 }
 
 func Fields() error {
-	panic(errors.Errorf("force error for testing purposes"))
 	return mage.GenerateFieldsYAML("model")
 }
 

--- a/script/jenkins/windows-build.ps1
+++ b/script/jenkins/windows-build.ps1
@@ -8,7 +8,7 @@ function Exec {
 
     try {
         $global:lastexitcode = 0
-        & $cmd
+        & $cmd 2>&1 | %{ "$_" }
         if ($lastexitcode -ne 0) {
             throw $errorMessage
         }

--- a/script/jenkins/windows-build.ps1
+++ b/script/jenkins/windows-build.ps1
@@ -48,7 +48,3 @@ exec { mage fields }
 
 echo "Building $env:beat"
 exec { mage build } "Build FAILURE"
-
-
-echo "Force exit 1"
-exit 1

--- a/script/jenkins/windows-build.ps1
+++ b/script/jenkins/windows-build.ps1
@@ -48,3 +48,7 @@ exec { mage fields }
 
 echo "Building $env:beat"
 exec { mage build } "Build FAILURE"
+
+
+echo "Force exit 1"
+exit 1

--- a/script/jenkins/windows-test.ps1
+++ b/script/jenkins/windows-test.ps1
@@ -8,7 +8,7 @@ function Exec {
 
     try {
         $global:lastexitcode = 0
-        & $cmd
+        & $cmd 2>&1 | %{ "$_" }
         if ($lastexitcode -ne 0) {
             throw $errorMessage
         }


### PR DESCRIPTION
Supersede #2864 and caused by https://github.com/elastic/apm-server/issues/2889

This is the implementation as stated in https://stackoverflow.com/a/20950421

## New log output

![image](https://user-images.githubusercontent.com/2871786/68603298-ee25fe80-049f-11ea-9f26-3bf51bcf83e7.png)

which is `too` verbose and with some NativeCommandError messages as shown below:

![image](https://user-images.githubusercontent.com/2871786/68603382-0f86ea80-04a0-11ea-8e70-11dbc99ff4ed.png)

