### PR TITLE
Add failure handling to ingest pipelines.

### DIFF
--- a/ingest/pipeline/definition.json
+++ b/ingest/pipeline/definition.json
@@ -26,7 +26,8 @@
         "user_agent" : {
           "field": "user_agent.original",
           "target_field": "user_agent",
-          "ignore_missing": true
+          "ignore_missing": true,
+          "ignore_failure": true
         }
       }
     ]
@@ -42,7 +43,16 @@
           "database_file": "GeoLite2-City.mmdb",
           "field": "client.ip",
           "target_field": "client.geo",
-          "ignore_missing": true
+          "ignore_missing": true,
+          "on_failure": [
+            {
+              "remove": {
+                  "field": "client.ip",
+                  "ignore_missing": true,
+                  "ignore_failure": true
+              }
+            }
+          ]
         }
       }
     ]


### PR DESCRIPTION
Avoid unexpected infinite retries on pipeline failures due to internal callback handling, by defining failure handling on pipelines.

For the `geoip` pipeline the `client.ip` field will be removed on failure. The field has an `ip` mapping in Elasticsearch. Therefore ingesting the document in ES would fail, even if the pipeline error is ignored in case of a malformed IP address. Dropping the malformed field, ensures the document can be indexed. Information in `client.ip` is always duplicated from some other field, therefore no original information is lost. While there is some pre-processing in place to avoid malformed IP addresses, this is the only case that comes to my mind that could make the pipeline fail. 

For the `user_agent` pipeline failures are simply ignored. The `user_agent.original` field is indexed as a keyword and therefore less susceptible to ingestion failure on malformed user_agent information, and the failure handling only ensures edge cases are covered and unexpected ingestion issues avoided. 

closes elastic/apm-server#2880
