### PR TITLE
[7.5] Add failure handling to ingest pipelines. (#2896)

### DIFF
--- a/ingest/pipeline/definition.json
+++ b/ingest/pipeline/definition.json
@@ -26,7 +26,8 @@
         "user_agent" : {
           "field": "user_agent.original",
           "target_field": "user_agent",
-          "ignore_missing": true
+          "ignore_missing": true,
+          "ignore_failure": true
         }
       }
     ]
@@ -42,7 +43,16 @@
           "database_file": "GeoLite2-City.mmdb",
           "field": "client.ip",
           "target_field": "client.geo",
-          "ignore_missing": true
+          "ignore_missing": true,
+          "on_failure": [
+            {
+              "remove": {
+                  "field": "client.ip",
+                  "ignore_missing": true,
+                  "ignore_failure": true
+              }
+            }
+          ]
         }
       }
     ]


### PR DESCRIPTION
Backports the following commits to 7.5:
 - Add failure handling to ingest pipelines.  (#2896)