### PR TITLE
ci(jenkins): update argument

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
               "^tests/packaging",
               "^vendor/github.com/elastic/beats"
             ]
-            env.BEATS_UPDATED = isGitRegionMatch(regexps: regexps)
+            env.BEATS_UPDATED = isGitRegionMatch(patterns: regexps)
           }
         }
       }


### PR DESCRIPTION
The signature for isGitRegionMatch has been changed to support different comparators, such as glob or regexp. By default glob is the comparator.
This should be merged only once the library has been released. Likely sometime this week.