### PR TITLE
Fix RUM agent name to js-base.

### DIFF
--- a/agentcfg/model.go
+++ b/agentcfg/model.go
@@ -33,7 +33,7 @@ const (
 
 var (
 	// RumAgent keywords (new and old)
-	RumAgent = []string{"rum-js", "base-js"}
+	RumAgent = []string{"rum-js", "js-base"}
 	// RumSettings are whitelisted applicable settings for RUM
 	RumSettings = []string{"transaction_sample_rate"}
 )

--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -296,6 +296,24 @@ class RumAgentConfigurationIntegrationTest(AgentConfigurationTest):
         assert r2.status_code == 304
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+    def test_rum_current_name(self):
+        service_name = "rum-service"
+        self.create_service_config({"transaction_sample_rate": 0.2}, service_name, agent="js-base")
+
+        r1 = requests.get(self.rum_agent_config_url,
+                          params={"service.name": service_name},
+                          headers={"Content-Type": "application/json"})
+
+        assert r1.status_code == 200
+        assert r1.json() == {'transaction_sample_rate': '0.2'}
+        etag = r1.headers["Etag"].replace('"', '')  # RUM will send it without double quotes
+
+        r2 = requests.get(self.rum_agent_config_url,
+                          params={"service.name": service_name, "ifnonematch": etag},
+                          headers={"Content-Type": "application/json"})
+        assert r2.status_code == 304
+
+    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_backend_after_rum(self):
         service_name = "backend-service"
         self.create_service_config({"transaction_sample_rate": 0.3}, service_name)


### PR DESCRIPTION
Change RUM agent name from `base-js` to `js-base` for server check
on agent config management via RUM endpoint.
