### PR TITLE
[7.x] Returns a sentinel value as Etag when there is no config in Kibana. (#2926)

### DIFF
--- a/agentcfg/cache_test.go
+++ b/agentcfg/cache_test.go
@@ -63,7 +63,7 @@ func TestCache_fetchAndAdd(t *testing.T) {
 		"DocFromCache":         {fetchFunc: testFn, init: true, doc: defaultResult},
 		"DocFromFunctionFails": {fetchFunc: testFnErr, shouldFail: true},
 		"DocFromFunction":      {fetchFunc: testFn, doc: externalResult},
-		"EmptyDocFromFunction": {fetchFunc: testFnSettingsNil, doc: Result{Source{Settings: Settings{}}}},
+		"EmptyDocFromFunction": {fetchFunc: testFnSettingsNil, doc: zeroResult()},
 		"NilDocFromFunction":   {fetchFunc: testFnNil},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/agentcfg/fetch_test.go
+++ b/agentcfg/fetch_test.go
@@ -52,7 +52,7 @@ func TestFetcher_Fetch(t *testing.T) {
 		kb := tests.MockKibana(http.StatusNotFound, m{}, mockVersion, true)
 		result, err := NewFetcher(kb, testExpiration).Fetch(query(t.Name()))
 		require.NoError(t, err)
-		assert.Equal(t, Result{Source: Source{Settings: Settings{}}}, result)
+		assert.Equal(t, zeroResult(), result)
 	})
 
 	t.Run("Success", func(t *testing.T) {

--- a/agentcfg/model.go
+++ b/agentcfg/model.go
@@ -29,6 +29,8 @@ const (
 	ServiceEnv = "service.environment"
 	// Etag / If-None-Match keyword
 	Etag = "ifnonematch"
+	// EtagSentinel is a value to return back to agents when Kibana doesn't have any configuration
+	EtagSentinel = "-"
 )
 
 var (
@@ -86,7 +88,7 @@ func (s Settings) UnmarshalJSON(b []byte) error {
 }
 
 func zeroResult() Result {
-	return Result{Source: Source{Settings: Settings{}}}
+	return Result{Source: Source{Settings: Settings{}, Etag: EtagSentinel}}
 }
 
 func newResult(b []byte, err error) (Result, error) {

--- a/agentcfg/model_test.go
+++ b/agentcfg/model_test.go
@@ -38,10 +38,10 @@ func TestNewDoc(t *testing.T) {
 	})
 
 	t.Run("ValidInput", func(t *testing.T) {
-		inp := []byte(`{"_id": "1234", "_source": {"settings":{"sample_rate":0.5}}}`)
+		inp := []byte(`{"_id": "1234", "_source": {"etag":"123", "settings":{"sample_rate":0.5}}}`)
 
 		d, err := newResult(inp, nil)
 		require.NoError(t, err)
-		assert.Equal(t, Result{Source{Settings: Settings{"sample_rate": "0.5"}}}, d)
+		assert.Equal(t, Result{Source{Etag: "123", Settings: Settings{"sample_rate": "0.5"}}}, d)
 	})
 }

--- a/beater/api/config/agent/handler.go
+++ b/beater/api/config/agent/handler.go
@@ -99,7 +99,7 @@ func Handler(client kibana.Client, config *config.AgentConfig) request.Handler {
 		c.Header().Set(headers.Etag, fmt.Sprintf("\"%s\"", result.Source.Etag))
 		c.Header().Set(headers.AccessControlExposeHeaders, headers.Etag)
 
-		if result.Source.Etag != "" && result.Source.Etag == ifNoneMatch(c) {
+		if result.Source.Etag == ifNoneMatch(c) {
 			c.Result.SetDefault(request.IDResponseValidNotModified)
 		} else {
 			c.Result.SetWithBody(request.IDResponseValidOK, result.Source.Settings)

--- a/beater/api/config/agent/handler_test.go
+++ b/beater/api/config/agent/handler_test.go
@@ -106,7 +106,7 @@ var (
 			queryParams:            map[string]string{"service.name": "opbeans-python"},
 			respStatus:             http.StatusOK,
 			respCacheControlHeader: "max-age=4, must-revalidate",
-			respEtagHeader:         `""`,
+			respEtagHeader:         fmt.Sprintf("\"%s\"", agentcfg.EtagSentinel),
 			respBody:               emptyBody,
 			respBodyToken:          emptyBody,
 		},


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Returns a sentinel value as Etag when there is no config in Kibana.  (#2926)