### PR TITLE
docs: index-docinfo.xml header test

### DIFF
--- a/docs/index-docinfo.xml
+++ b/docs/index-docinfo.xml
@@ -11,13 +11,13 @@
         APM Agent documentation:
     </simpara>
     <itemizedlist>
-        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/go/current/introduction.html"><citetitle>Go Agent</citetitle></ulink></simpara></listitem>
-        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/java/current/introduction.html"><citetitle>Java Agent</citetitle></ulink></simpara></listitem>
-        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/dotnet/current/introduction.html"><citetitle>.NET Agent</citetitle></ulink></simpara></listitem>
-        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/nodejs/current/introduction.html"><citetitle>Node.js Agent</citetitle></ulink></simpara></listitem>
-        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/python/current/introduction.html"><citetitle>Python Agent</citetitle></ulink></simpara></listitem>
-        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/ruby/current/introduction.html"><citetitle>Ruby Agent</citetitle></ulink></simpara></listitem>
-        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/rum-js/current/introduction.html"><citetitle>JavaScript RUM Agent</citetitle></ulink></simpara></listitem>
+        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/go/current/index.html"><citetitle>Go Agent</citetitle></ulink></simpara></listitem>
+        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/java/current/index.html"><citetitle>Java Agent</citetitle></ulink></simpara></listitem>
+        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/dotnet/current/index.html"><citetitle>.NET Agent</citetitle></ulink></simpara></listitem>
+        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/nodejs/current/index.html"><citetitle>Node.js Agent</citetitle></ulink></simpara></listitem>
+        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/python/current/index.html"><citetitle>Python Agent</citetitle></ulink></simpara></listitem>
+        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/ruby/current/index.html"><citetitle>Ruby Agent</citetitle></ulink></simpara></listitem>
+        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/rum-js/current/index.html"><citetitle>JavaScript RUM Agent</citetitle></ulink></simpara></listitem>
     </itemizedlist>
 
 </legalnotice>

--- a/docs/index-docinfo.xml
+++ b/docs/index-docinfo.xml
@@ -1,0 +1,23 @@
+<legalnotice>
+    <simpara>
+        Welcome to the official documentation for APM Server.
+        The following documentation will help you learn more about the components that make up Elastic APM:
+    </simpara>
+    <itemizedlist>
+        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/get-started/current/index.html"><citetitle>APM Overview</citetitle></ulink></simpara></listitem>
+        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/kibana/7.4/xpack-apm.html"><citetitle>APM app in Kibana</citetitle></ulink></simpara></listitem>
+    </itemizedlist>
+    <simpara>
+        APM Agent documentation:
+    </simpara>
+    <itemizedlist>
+        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/go/current/introduction.html"><citetitle>Go Agent</citetitle></ulink></simpara></listitem>
+        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/java/current/introduction.html"><citetitle>Java Agent</citetitle></ulink></simpara></listitem>
+        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/dotnet/current/introduction.html"><citetitle>.NET Agent</citetitle></ulink></simpara></listitem>
+        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/nodejs/current/introduction.html"><citetitle>Node.js Agent</citetitle></ulink></simpara></listitem>
+        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/python/current/introduction.html"><citetitle>Python Agent</citetitle></ulink></simpara></listitem>
+        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/ruby/current/introduction.html"><citetitle>Ruby Agent</citetitle></ulink></simpara></listitem>
+        <listitem><simpara><ulink url="https://www.elastic.co/guide/en/apm/agent/rum-js/current/introduction.html"><citetitle>JavaScript RUM Agent</citetitle></ulink></simpara></listitem>
+    </itemizedlist>
+
+</legalnotice>


### PR DESCRIPTION
**Do not merge this PR**. I need the doc build to run so I can steal the preview.

Here's how a `*-docinfo.xml` file renders. It's built with docbook attributes; see the [docbook reference](https://tdg.docbook.org/tdg/4.5/ref-elements.html) for a complete list.

<img width="1027" alt="Screen Shot 2019-11-20 at 3 11 43 PM" src="https://user-images.githubusercontent.com/5618806/69286592-8317ae80-0ba8-11ea-8073-0f2fb90546ce.png">
