### PR TITLE
[7.3] Sync changelog. (#2939)

### DIFF
--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,11 +3,19 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.5>>
 * <<release-notes-6.8.4>>
 * <<release-notes-6.8.3>>
 * <<release-notes-6.8.2>>
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
+
+[[release-notes-6.8.5]]
+=== APM Server version 6.8.5
+
+https://github.com/elastic/apm-server/compare/v6.8.4\...v6.8.5[View commits]
+
+No significant changes.
 
 [[release-notes-6.8.4]]
 === APM Server version 6.8.4

--- a/changelogs/7.0.asciidoc
+++ b/changelogs/7.0.asciidoc
@@ -23,7 +23,7 @@ https://github.com/elastic/apm-server/compare/v7.0.0\...v7.0.1[View commits]
 [[release-notes-7.0.0]]
 === APM Server version 7.0.0
 
-https://github.com/elastic/apm-server/compare/v6.8.4\...v7.0.0[View commits]
+https://github.com/elastic/apm-server/compare/v6.8.5\...v7.0.0[View commits]
 
 These release notes include all changes made in the alpha, beta, and RC releases of 7.0.0.
 


### PR DESCRIPTION
Backports the following commits to 7.3:
 - Sync changelog.  (#2939)