### PR TITLE
[7.x] docs: fix changelog link (#2950)

### DIFF
--- a/changelogs/7.5.asciidoc
+++ b/changelogs/7.5.asciidoc
@@ -12,7 +12,7 @@ https://github.com/elastic/apm-server/compare/v7.4.1\...v7.5.0[View commits]
 
 [float]
 ==== Breaking Changes
-- Introduce dedicated ILM setup flags and ignore `setup.template.*` flags for ILM {pull}2764[2764],{pull}2877[2877].
+- Introduce dedicated ILM setup flags and ignore `setup.template.*` flags for ILM {pull}2764[2764], {pull}2877[2877].
 - Remove ILM specific templates from `apm-server export template` command {pull}2764[2764].
 
 [float]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: fix changelog link (#2950)