### PR TITLE
[DOCS] Fixes security links

### DIFF
--- a/docs/copied-from-beats/https.asciidoc
+++ b/docs/copied-from-beats/https.asciidoc
@@ -13,7 +13,7 @@
 To secure the communication between {beatname_uc} and Elasticsearch, you can use
 HTTPS and basic authentication. Basic authentication for Elasticsearch is
 available when you enable {security} (see
-{ref}/secure-cluster.html[Secure a cluster] and <<securing-beats>>).
+{ref}/secure-cluster.html[Secure a cluster]).
 If you aren't using {security}, you can use a web proxy instead.
 
 Here is a sample configuration:

--- a/docs/copied-from-beats/https.asciidoc
+++ b/docs/copied-from-beats/https.asciidoc
@@ -13,7 +13,7 @@
 To secure the communication between {beatname_uc} and Elasticsearch, you can use
 HTTPS and basic authentication. Basic authentication for Elasticsearch is
 available when you enable {security} (see
-{ref}/secure-cluster.html[Secure a cluster]).
+{ref}/secure-cluster.html[Secure a cluster] and <<securing-beats>>).
 If you aren't using {security}, you can use a web proxy instead.
 
 Here is a sample configuration:

--- a/docs/copied-from-beats/monitoring/monitoring-internal-collection.asciidoc
+++ b/docs/copied-from-beats/monitoring/monitoring-internal-collection.asciidoc
@@ -32,8 +32,8 @@ To learn about monitoring in general, see
 data to {es}. For example, you can use the built-in +{beat_monitoring_user}+ user or
 assign the built-in +{beat_monitoring_user}+ role to another user. For more
 information, see
-{stack-ov}/setting-up-authentication.html[Setting Up User Authentication] and
-{stack-ov}/built-in-roles.html[Built-in Roles].
+{ref}/setting-up-authentication.html[User authentication] and
+{ref}/built-in-roles.html[Built-in roles].
 
 . Add the `monitoring` settings in the {beatname_uc} configuration file. If you
 configured the {es} output and want to send {beatname_uc} monitoring events to

--- a/docs/copied-from-beats/monitoring/monitoring-internal-collection.asciidoc
+++ b/docs/copied-from-beats/monitoring/monitoring-internal-collection.asciidoc
@@ -23,7 +23,7 @@ For an alternative method, see <<monitoring-metricbeat-collection>>.
 endif::[]
 
 To learn about monitoring in general, see 
-{stack-ov}/xpack-monitoring.html[Monitoring the {stack}]. 
+{ref}/monitor-elasticsearch-cluster.html[Monitoring a cluster]. 
 
 //TODO: Not sure if these docs need to be updated to be parallel with other
 //stack components since this is the old way of configuring monitoring. 

--- a/docs/copied-from-beats/security/beats-system.asciidoc
+++ b/docs/copied-from-beats/security/beats-system.asciidoc
@@ -19,6 +19,6 @@ have set a password for the +{beat_monitoring_user}+ user. A user with the
 For more
 information, see:
 
-* {xpack-ref}/setting-up-authentication.html[Setting Up User Authentication]
-* {xpack-ref}/built-in-roles.html[Built-in Roles]
+* {ref}/setting-up-authentication.html[User authentication]
+* {ref}/built-in-roles.html[Built-in roles]
 * <<monitoring>>

--- a/docs/copied-from-beats/security/securing-beats.asciidoc
+++ b/docs/copied-from-beats/security/securing-beats.asciidoc
@@ -8,7 +8,7 @@
 ++++
 
 If you want {beatname_uc} to connect to a cluster that has
-{stack-ov}/elasticsearch-security.html[{security}] enabled, there are extra
+{ref}/elasticsearch-security.html[{security-features}] enabled, there are extra
 configuration steps:
 
 . <<feature-roles>>.
@@ -33,7 +33,7 @@ you plan to monitor {beatname_uc} in {kib} and have not yet set up the
 password, set it up now.
 
 For more information about {security}, see
-{xpack-ref}/elasticsearch-security.html[Securing the {stack}].
+{ref}/elasticsearch-security.html[Security overview].
 
 include::users.asciidoc[]
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/46880

This PR fixes links to content that has moved from the Stack Overview to the Elasticsearch Reference.

In particular, it is related to the following broken links in https://github.com/elastic/stack-docs/pull/700

> 11:38:39 INFO:build_docs:Bad cross-document links:
11:38:39 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/server/master/beats-system-user.html:
11:38:39 INFO:build_docs:   - en/elastic-stack-overview/master/built-in-roles.html
11:38:39 INFO:build_docs:   - en/elastic-stack-overview/master/setting-up-authentication.html
11:38:39 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/server/master/monitoring-internal-collection.html:
11:38:39 INFO:build_docs:   - en/elastic-stack-overview/master/built-in-roles.html
11:38:39 INFO:build_docs:   - en/elastic-stack-overview/master/setting-up-authentication.html
11:38:39 INFO:build_docs:   - en/elastic-stack-overview/master/xpack-monitoring.html
11:38:39 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/server/master/securing-beats.html:
11:38:39 INFO:build_docs:   - en/elastic-stack-overview/master/elasticsearch-security.html


Preview:
http://apm-server_2966.docs-preview.app.elstc.co/guide/en/apm/server/master/monitoring-internal-collection.html
http://apm-server_2966.docs-preview.app.elstc.co/guide/en/apm/server/master/beats-system-user.html