### PR TITLE
ci(jenkins): change log rotation, use cached repo

### DIFF
--- a/.ci/check-changelogs.groovy
+++ b/.ci/check-changelogs.groovy
@@ -12,7 +12,7 @@ pipeline {
   }
   options {
     timeout(time: 1, unit: 'HOURS')
-    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    buildDiscarder(logRotator(numToKeepStr: '100', artifactNumToKeepStr: '30', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')
     disableResume()

--- a/.ci/jobs/apm-server-check-changelogs-mbp.yml
+++ b/.ci/jobs/apm-server-check-changelogs-mbp.yml
@@ -4,9 +4,6 @@
     display-name: APM Server check changelogs MBP
     description: APM Server check changelogs MBP
     project-type: multibranch
-    view: APM-CI
-    number-to-keep: '5'
-    days-to-keep: '1'
     script-path: .ci/check-changelogs.groovy
     scm:
     - github:
@@ -36,8 +33,8 @@
           recursive: true
           parent-credentials: true
           timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-server.git
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'
     periodic-folder-trigger: 1w
-    prune-dead-branches: true

--- a/.ci/jobs/apm-server-mbp.yml
+++ b/.ci/jobs/apm-server-mbp.yml
@@ -4,14 +4,11 @@
     display-name: APM Server
     description: APM Server
     project-type: multibranch
-    view: APM-CI
-    number-to-keep: '5'
-    days-to-keep: '1'
     concurrent: true
     script-path: Jenkinsfile
     scm:
     - github:
-        branch-discovery: all
+        branch-discovery: no-pr
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
@@ -41,8 +38,7 @@
           recursive: true
           parent-credentials: true
           timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-server.git
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'
-    periodic-folder-trigger: 1d
-    prune-dead-branches: true

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -8,10 +8,12 @@
 ##### JOB DEFAULTS
 
 - job:
+    view: APM-CI
     logrotate:
-      daysToKeep: 30
       numToKeep: 100
     node: linux
+    periodic-folder-trigger: 1d
+    prune-dead-branches: true
     publishers:
     - email:
         recipients: infra-root+build@elastic.co

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
   }
   options {
     timeout(time: 2, unit: 'HOURS')
-    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    buildDiscarder(logRotator(numToKeepStr: '100', artifactNumToKeepStr: '30', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')
     disableResume()


### PR DESCRIPTION
Refactor the JJBB to:
- Store more builds
- Use git reference repo