### PR TITLE
tests/system: wait for Kibana in ACM tests

### DIFF
--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -18,7 +18,6 @@ class AgentConfigurationTest(ElasticTest):
 
     def setUp(self):
         super(AgentConfigurationTest, self).setUp()
-        self.wait_until(lambda: requests.get(self.kibana_url).status_code < 400)
         # with the Kibana platform, the agent config index will be created async
         # we need to wait until it is ready
         self.wait_until(lambda: self.es.indices.exists(".apm-agent-configuration"))

--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -19,6 +19,9 @@ class AgentConfigurationTest(ElasticTest):
     def setUp(self):
         super(AgentConfigurationTest, self).setUp()
         self.wait_until(lambda: requests.get(self.kibana_url).status_code < 400)
+        # with the Kibana platform, the agent config index will be created async
+        # we need to wait until it is ready
+        self.wait_until(lambda: self.es.indices.exists(".apm-agent-configuration"))
 
     def config(self):
         cfg = super(ElasticTest, self).config()

--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -16,6 +16,10 @@ class AgentConfigurationTest(ElasticTest):
         "acm_cache_expiration": "1s",
     }
 
+    def setUp(self):
+        super(AgentConfigurationTest, self).setUp()
+        self.wait_until(lambda: requests.get(self.kibana_url).status_code < 400)
+
     def config(self):
         cfg = super(ElasticTest, self).config()
         cfg.update({


### PR DESCRIPTION
In the ACM system tests that expect Kibana to be accessible, wait for it to respond with a non-error response code in setUp.

Closes #2978 