### PR TITLE
ci(jenkins): add the update beats stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -358,7 +358,7 @@ pipeline {
           post {
             always {
               catchError(buildResult: 'SUCCESS', message: 'Failed to grab test results tar files', stageResult: 'SUCCESS') {
-                tar(file: "update-betas-system-tests-linux-files.tgz", archive: true, dir: "system-tests", pathPrefix: "${BASE_DIR}/build")
+                tar(file: "update-beats-system-tests-linux-files.tgz", archive: true, dir: "system-tests", pathPrefix: "${BASE_DIR}/build")
               }
             }
           }


### PR DESCRIPTION
## What does this PR do?

Add a new stage that runs the update-beats script.

## Why is it important?

This would help to detect libbeat incompatibilities in early stages. It is part of the parallel test process so it should not add time to the build.

**Notes**
this step was enabled in the past, it was disabled because it never success until a week or so before the release and a few weeks after the release, so it would be marked as unstable when it fails and the build would still a success, the GitHub check will show that there is a problem.

<img width="876" alt="Screenshot 2019-11-29 at 13 14 42" src="https://user-images.githubusercontent.com/5400788/69876738-a20cf380-12c0-11ea-8ee7-e2745cbf755b.png">

<img width="686" alt="Screenshot 2019-11-29 at 15 55 26" src="https://user-images.githubusercontent.com/5400788/69876759-b0f3a600-12c0-11ea-903c-8acf8014e12f.png">

## Related issues
Closes #13371