### PR TITLE
[7.x] Adds support for API Keys in the Elasticsearch client. (#2989)

### DIFF
--- a/beater/config/rum.go
+++ b/beater/config/rum.go
@@ -38,8 +38,6 @@ const (
 	defaultLibraryPattern           = "node_modules|bower_components|~"
 	defaultSourcemapCacheExpiration = 5 * time.Minute
 	defaultSourcemapIndexPattern    = "apm-*-sourcemap*"
-
-	esConnectionTimeout = 5 * time.Second
 )
 
 // RumConfig holds config information related to the RUM endpoint
@@ -125,7 +123,7 @@ func (c *RumConfig) setup(log *logp.Logger, outputESCfg *common.Config) error {
 		return nil
 	}
 	log.Info("Falling back to elasticsearch output for sourcemap storage")
-	esCfg := &elasticsearch.Config{Hosts: []string{"localhost:9200"}, Protocol: "http", Timeout: esConnectionTimeout}
+	esCfg := elasticsearch.DefaultConfig()
 	if err := outputESCfg.Unpack(esCfg); err != nil {
 		return errors.Wrap(err, "unpacking Elasticsearch config into Sourcemap config")
 	}

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -83,22 +83,23 @@ func NewClient(config *Config) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewVersionedClient(config.Username, config.Password, addresses, transport)
+	return NewVersionedClient(config.APIKey, config.Username, config.Password, addresses, transport)
 }
 
 // NewVersionedClient returns the right elasticsearch client for the current Stack version, as an interface
-func NewVersionedClient(user, pwd string, addresses []string, transport http.RoundTripper) (Client, error) {
+func NewVersionedClient(apikey, user, pwd string, addresses []string, transport http.RoundTripper) (Client, error) {
 	version := common.MustNewVersion(version.GetDefaultVersion())
 	if version.IsMajor(8) {
-		c, err := newV8Client(user, pwd, addresses, transport)
+		c, err := newV8Client(apikey, user, pwd, addresses, transport)
 		return clientV8{c}, err
 	}
-	c, err := newV7Client(user, pwd, addresses, transport)
+	c, err := newV7Client(apikey, user, pwd, addresses, transport)
 	return clientV7{c}, err
 }
 
-func newV7Client(user, pwd string, addresses []string, transport http.RoundTripper) (*v7.Client, error) {
+func newV7Client(apikey, user, pwd string, addresses []string, transport http.RoundTripper) (*v7.Client, error) {
 	return v7.NewClient(v7.Config{
+		APIKey:    apikey,
 		Username:  user,
 		Password:  pwd,
 		Addresses: addresses,
@@ -106,8 +107,9 @@ func newV7Client(user, pwd string, addresses []string, transport http.RoundTripp
 	})
 }
 
-func newV8Client(user, pwd string, addresses []string, transport http.RoundTripper) (*v8.Client, error) {
+func newV8Client(apikey, user, pwd string, addresses []string, transport http.RoundTripper) (*v8.Client, error) {
 	return v8.NewClient(v8.Config{
+		APIKey:    apikey,
 		Username:  user,
 		Password:  pwd,
 		Addresses: addresses,

--- a/elasticsearch/config.go
+++ b/elasticsearch/config.go
@@ -37,8 +37,9 @@ const (
 )
 
 var (
-	errInvalidHosts  = errors.New("`Hosts` must at least contain one hostname")
-	errConfigMissing = errors.New("config missing")
+	errInvalidHosts     = errors.New("`Hosts` must at least contain one hostname")
+	errConfigMissing    = errors.New("config missing")
+	esConnectionTimeout = 5 * time.Second
 )
 
 // Config holds all configurable fields that are used to create a Client
@@ -52,6 +53,12 @@ type Config struct {
 	TLS          *tlscommon.Config `config:"ssl"`
 	Username     string            `config:"username"`
 	Password     string            `config:"password"`
+	APIKey       string            `config:"api_key"`
+}
+
+// DefaultConfig returns a default config.
+func DefaultConfig() *Config {
+	return &Config{Hosts: []string{"localhost:9200"}, Protocol: "http", Timeout: esConnectionTimeout}
 }
 
 // Hosts is an array of host strings and needs to have at least one entry

--- a/elasticsearch/estest/client.go
+++ b/elasticsearch/estest/client.go
@@ -66,5 +66,5 @@ func NewTransport(t *testing.T, statusCode int, esBody map[string]interface{}) *
 
 // NewElasticsearchClient creates ES client using the given transport instance
 func NewElasticsearchClient(transport *Transport) (elasticsearch.Client, error) {
-	return elasticsearch.NewVersionedClient("", "", []string{}, transport)
+	return elasticsearch.NewVersionedClient("", "", "", []string{}, transport)
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Adds support for API Keys in the Elasticsearch client.  (#2989)