### PR TITLE
ci(jenkins): support isGitRegionMatch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ pipeline {
       steps {
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true,
-                    depth: 3, reference: "/var/lib/jenkins/.git-references/${REPO}.git")
+                    shallow: false, reference: "/var/lib/jenkins/.git-references/${REPO}.git")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script {
           dir("${BASE_DIR}"){


### PR DESCRIPTION
## Description

Shallow cloning and isGitRegionMatch are not compatible when the versions to compare are older than 5...

## When does it happen?

Now