### PR TITLE
Add API Key support

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -85,12 +85,6 @@ apm-server:
 
   #---------------------------- APM Server - Secure Communication with Agents ----------------------------
 
-  # Authorization token for sending data to the APM server. If a token is set, the
-  # agents must send it in the following format: Authorization: Bearer <secret-token>.
-  # It is recommended to use an authorization token in combination with SSL enabled,
-  # and save the token in the apm-server keystore. The token is not used for the RUM endpoint.
-  #secret_token:
-
   # Enable secure communication between APM agents and the server. By default ssl is disabled.
   #ssl:
     #enabled: false
@@ -130,9 +124,88 @@ apm-server:
     # susceptible to man-in-the-middle attacks. Use only for testing. Default is `full`.
     #ssl.verification_mode: full
 
+  # The APM Server endpoints can be secured by configuring a secret token or enabling the usage of API keys. Both
+  # options can be enabled in parallel, allowing Elastic APM agents to chose whichever mechanism they support.
+  # As soon as one of the options is enabled, requests without a valid token are denied by the server. An exception
+  # to this are requests to any enabled RUM endpoint. RUM endpoints are generally not secured by any token.
+  #
+  # Configure authorization via a common `secret_token`. By default it is disabled.
+  # Agents include the token in the following format: Authorization: Bearer <secret-token>.
+  # It is recommended to use an authorization token in combination with SSL enabled,
+  # and save the token in the apm-server keystore.
+  #secret_token:
+
+  # Enable API key authorization by setting enabled to true. By default API key support is disabled.
+  # Agents include a valid API key in the following format: Authorization: ApiKey <token>.
+  # The key must be the base64 encoded representation of the API key's "id:key".
+  #api_key:
+    #enabled: false
+
+    # Restrict how many unique API keys are allowed per minute. Should be set to at least the amount of different
+    # API keys configured in your monitored services. Every unique API key triggers one request to Elasticsearch.
+    #limit: 100
+
+    # API keys need to be fetched from Elasticsearch. If nothing is configured, configuration settings from the
+    # output section will be reused.
+    # Note that configuration needs to point to a secured Elasticsearch cluster that is able to serve API key requests.
+    #elasticsearch:
+      #hosts: ["localhost:9200"]
+
+      #protocol: "http"
+
+      # Optional HTTP Path.
+      #path: ""
+
+      # Proxy server url.
+      #proxy_url: ""
+      #proxy_disable: false
+
+      # Configure http request timeout before failing an request to Elasticsearch.
+      #timeout: 10s
+
+      # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
+      #ssl.enabled: true
+
+      # Optional SSL configuration options. SSL is off by default, change the `protocol` option if you want to enable `https`.
+      # Configure SSL verification mode. If `none` is configured, all server hosts
+      # and certificates will be accepted. In this mode, SSL based connections are
+      # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+      # `full`.
+      #ssl.verification_mode: full
+
+      # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+      # 1.2 are enabled.
+      #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+      # List of root certificates for HTTPS server verifications.
+      #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+      # Certificate for SSL client authentication.
+      #ssl.certificate: "/etc/pki/client/cert.pem"
+
+      # Client Certificate Key
+      #ssl.key: "/etc/pki/client/cert.key"
+
+      # Optional passphrase for decrypting the Certificate Key.
+      # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
+      #ssl.key_passphrase: ''
+
+      # Configure cipher suites to be used for SSL connections.
+      #ssl.cipher_suites: []
+
+      # Configure curve types for ECDHE based cipher suites.
+      #ssl.curve_types: []
+
+      # Configure what types of renegotiation are supported. Valid options are
+      # never, once, and freely. Default is never.
+      #ssl.renegotiation: never
+
+
   #---------------------------- APM Server - RUM Real User Monitoring ----------------------------
 
   # Enable Real User Monitoring (RUM) Support. By default RUM is disabled.
+  # RUM does not support token based authorization. Enabled RUM endpoints will not require any authorization
+  # token configured for other endpoints.
   #rum:
     #enabled: false
 

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -85,12 +85,6 @@ apm-server:
 
   #---------------------------- APM Server - Secure Communication with Agents ----------------------------
 
-  # Authorization token for sending data to the APM server. If a token is set, the
-  # agents must send it in the following format: Authorization: Bearer <secret-token>.
-  # It is recommended to use an authorization token in combination with SSL enabled,
-  # and save the token in the apm-server keystore. The token is not used for the RUM endpoint.
-  #secret_token:
-
   # Enable secure communication between APM agents and the server. By default ssl is disabled.
   #ssl:
     #enabled: false
@@ -130,9 +124,88 @@ apm-server:
     # susceptible to man-in-the-middle attacks. Use only for testing. Default is `full`.
     #ssl.verification_mode: full
 
+  # The APM Server endpoints can be secured by configuring a secret token or enabling the usage of API keys. Both
+  # options can be enabled in parallel, allowing Elastic APM agents to chose whichever mechanism they support.
+  # As soon as one of the options is enabled, requests without a valid token are denied by the server. An exception
+  # to this are requests to any enabled RUM endpoint. RUM endpoints are generally not secured by any token.
+  #
+  # Configure authorization via a common `secret_token`. By default it is disabled.
+  # Agents include the token in the following format: Authorization: Bearer <secret-token>.
+  # It is recommended to use an authorization token in combination with SSL enabled,
+  # and save the token in the apm-server keystore.
+  #secret_token:
+
+  # Enable API key authorization by setting enabled to true. By default API key support is disabled.
+  # Agents include a valid API key in the following format: Authorization: ApiKey <token>.
+  # The key must be the base64 encoded representation of the API key's "id:key".
+  #api_key:
+    #enabled: false
+
+    # Restrict how many unique API keys are allowed per minute. Should be set to at least the amount of different
+    # API keys configured in your monitored services. Every unique API key triggers one request to Elasticsearch.
+    #limit: 100
+
+    # API keys need to be fetched from Elasticsearch. If nothing is configured, configuration settings from the
+    # output section will be reused.
+    # Note that configuration needs to point to a secured Elasticsearch cluster that is able to serve API key requests.
+    #elasticsearch:
+      #hosts: ["localhost:9200"]
+
+      #protocol: "http"
+
+      # Optional HTTP Path.
+      #path: ""
+
+      # Proxy server url.
+      #proxy_url: ""
+      #proxy_disable: false
+
+      # Configure http request timeout before failing an request to Elasticsearch.
+      #timeout: 10s
+
+      # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
+      #ssl.enabled: true
+
+      # Optional SSL configuration options. SSL is off by default, change the `protocol` option if you want to enable `https`.
+      # Configure SSL verification mode. If `none` is configured, all server hosts
+      # and certificates will be accepted. In this mode, SSL based connections are
+      # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+      # `full`.
+      #ssl.verification_mode: full
+
+      # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+      # 1.2 are enabled.
+      #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+      # List of root certificates for HTTPS server verifications.
+      #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+      # Certificate for SSL client authentication.
+      #ssl.certificate: "/etc/pki/client/cert.pem"
+
+      # Client Certificate Key
+      #ssl.key: "/etc/pki/client/cert.key"
+
+      # Optional passphrase for decrypting the Certificate Key.
+      # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
+      #ssl.key_passphrase: ''
+
+      # Configure cipher suites to be used for SSL connections.
+      #ssl.cipher_suites: []
+
+      # Configure curve types for ECDHE based cipher suites.
+      #ssl.curve_types: []
+
+      # Configure what types of renegotiation are supported. Valid options are
+      # never, once, and freely. Default is never.
+      #ssl.renegotiation: never
+
+
   #---------------------------- APM Server - RUM Real User Monitoring ----------------------------
 
   # Enable Real User Monitoring (RUM) Support. By default RUM is disabled.
+  # RUM does not support token based authorization. Enabled RUM endpoints will not require any authorization
+  # token configured for other endpoints.
   #rum:
     #enabled: false
 

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -85,12 +85,6 @@ apm-server:
 
   #---------------------------- APM Server - Secure Communication with Agents ----------------------------
 
-  # Authorization token for sending data to the APM server. If a token is set, the
-  # agents must send it in the following format: Authorization: Bearer <secret-token>.
-  # It is recommended to use an authorization token in combination with SSL enabled,
-  # and save the token in the apm-server keystore. The token is not used for the RUM endpoint.
-  #secret_token:
-
   # Enable secure communication between APM agents and the server. By default ssl is disabled.
   #ssl:
     #enabled: false
@@ -130,9 +124,88 @@ apm-server:
     # susceptible to man-in-the-middle attacks. Use only for testing. Default is `full`.
     #ssl.verification_mode: full
 
+  # The APM Server endpoints can be secured by configuring a secret token or enabling the usage of API keys. Both
+  # options can be enabled in parallel, allowing Elastic APM agents to chose whichever mechanism they support.
+  # As soon as one of the options is enabled, requests without a valid token are denied by the server. An exception
+  # to this are requests to any enabled RUM endpoint. RUM endpoints are generally not secured by any token.
+  #
+  # Configure authorization via a common `secret_token`. By default it is disabled.
+  # Agents include the token in the following format: Authorization: Bearer <secret-token>.
+  # It is recommended to use an authorization token in combination with SSL enabled,
+  # and save the token in the apm-server keystore.
+  #secret_token:
+
+  # Enable API key authorization by setting enabled to true. By default API key support is disabled.
+  # Agents include a valid API key in the following format: Authorization: ApiKey <token>.
+  # The key must be the base64 encoded representation of the API key's "id:key".
+  #api_key:
+    #enabled: false
+
+    # Restrict how many unique API keys are allowed per minute. Should be set to at least the amount of different
+    # API keys configured in your monitored services. Every unique API key triggers one request to Elasticsearch.
+    #limit: 100
+
+    # API keys need to be fetched from Elasticsearch. If nothing is configured, configuration settings from the
+    # output section will be reused.
+    # Note that configuration needs to point to a secured Elasticsearch cluster that is able to serve API key requests.
+    #elasticsearch:
+      #hosts: ["localhost:9200"]
+
+      #protocol: "http"
+
+      # Optional HTTP Path.
+      #path: ""
+
+      # Proxy server url.
+      #proxy_url: ""
+      #proxy_disable: false
+
+      # Configure http request timeout before failing an request to Elasticsearch.
+      #timeout: 10s
+
+      # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
+      #ssl.enabled: true
+
+      # Optional SSL configuration options. SSL is off by default, change the `protocol` option if you want to enable `https`.
+      # Configure SSL verification mode. If `none` is configured, all server hosts
+      # and certificates will be accepted. In this mode, SSL based connections are
+      # susceptible to man-in-the-middle attacks. Use only for testing. Default is
+      # `full`.
+      #ssl.verification_mode: full
+
+      # List of supported/valid TLS versions. By default all TLS versions 1.0 up to
+      # 1.2 are enabled.
+      #ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+      # List of root certificates for HTTPS server verifications.
+      #ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+      # Certificate for SSL client authentication.
+      #ssl.certificate: "/etc/pki/client/cert.pem"
+
+      # Client Certificate Key
+      #ssl.key: "/etc/pki/client/cert.key"
+
+      # Optional passphrase for decrypting the Certificate Key.
+      # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
+      #ssl.key_passphrase: ''
+
+      # Configure cipher suites to be used for SSL connections.
+      #ssl.cipher_suites: []
+
+      # Configure curve types for ECDHE based cipher suites.
+      #ssl.curve_types: []
+
+      # Configure what types of renegotiation are supported. Valid options are
+      # never, once, and freely. Default is never.
+      #ssl.renegotiation: never
+
+
   #---------------------------- APM Server - RUM Real User Monitoring ----------------------------
 
   # Enable Real User Monitoring (RUM) Support. By default RUM is disabled.
+  # RUM does not support token based authorization. Enabled RUM endpoints will not require any authorization
+  # token configured for other endpoints.
   #rum:
     #enabled: false
 

--- a/beater/api/asset/sourcemap/test_approved/integration/TestSourcemapHandler_AuthorizationMiddleware/Unauthorized.approved.json
+++ b/beater/api/asset/sourcemap/test_approved/integration/TestSourcemapHandler_AuthorizationMiddleware/Unauthorized.approved.json
@@ -1,3 +1,3 @@
 {
-    "error": "invalid token"
+    "error": "unauthorized"
 }

--- a/beater/api/config/agent/handler.go
+++ b/beater/api/config/agent/handler.go
@@ -75,21 +75,21 @@ func Handler(client kibana.Client, config *config.AgentConfig) request.Handler {
 			return
 		}
 
-		if valid := validateClient(c, client, c.TokenSet); !valid {
+		if valid := validateClient(c, client, c.Authorization.IsAuthorizationConfigured()); !valid {
 			c.Write()
 			return
 		}
 
 		query, queryErr := buildQuery(c)
 		if queryErr != nil {
-			extractQueryError(c, queryErr, c.TokenSet)
+			extractQueryError(c, queryErr, c.Authorization.IsAuthorizationConfigured())
 			c.Write()
 			return
 		}
 
 		result, err := fetcher.Fetch(query)
 		if err != nil {
-			extractInternalError(c, err, c.TokenSet)
+			extractInternalError(c, err, c.Authorization.IsAuthorizationConfigured())
 			c.Write()
 			return
 		}

--- a/beater/api/config/agent/handler_test.go
+++ b/beater/api/config/agent/handler_test.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/elastic/apm-server/agentcfg"
+	"github.com/elastic/apm-server/beater/authorization"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -166,7 +167,7 @@ func TestAgentConfigHandler(t *testing.T) {
 
 	for name, tc := range testcases {
 
-		runTest := func(t *testing.T, expectedBody map[string]string, tokenSet bool) {
+		runTest := func(t *testing.T, expectedBody map[string]string, auth authorization.Authorization) {
 			h := Handler(tc.kbClient, &cfg)
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(tc.method, target(tc.queryParams), nil)
@@ -175,7 +176,7 @@ func TestAgentConfigHandler(t *testing.T) {
 			}
 			ctx := &request.Context{}
 			ctx.Reset(w, r)
-			ctx.TokenSet = tokenSet
+			ctx.Authorization = auth
 			h(ctx)
 
 			require.Equal(t, tc.respStatus, w.Code)
@@ -189,11 +190,11 @@ func TestAgentConfigHandler(t *testing.T) {
 		}
 
 		t.Run(name+"NoSecretToken", func(t *testing.T) {
-			runTest(t, tc.respBody, false)
+			runTest(t, tc.respBody, authorization.AllowAuth{})
 		})
 
 		t.Run(name+"WithSecretToken", func(t *testing.T) {
-			runTest(t, tc.respBodyToken, true)
+			runTest(t, tc.respBodyToken, authorization.DenyAuth{})
 		})
 	}
 }

--- a/beater/api/config/agent/test_approved/integration/TestConfigAgentHandler_AuthorizationMiddleware/Unauthorized.approved.json
+++ b/beater/api/config/agent/test_approved/integration/TestConfigAgentHandler_AuthorizationMiddleware/Unauthorized.approved.json
@@ -1,3 +1,3 @@
 {
-    "error": "invalid token"
+    "error": "unauthorized"
 }

--- a/beater/api/config_agent_integration_test.go
+++ b/beater/api/config_agent_integration_test.go
@@ -39,57 +39,52 @@ func TestConfigAgentHandler_AuthorizationMiddleware(t *testing.T) {
 	t.Run("Unauthorized", func(t *testing.T) {
 		cfg := configEnabledConfigAgent()
 		cfg.SecretToken = "1234"
-		rec := requestToConfigAgentHandler(t, cfg)
-
-		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		rec, err := requestToMuxerWithPattern(cfg, AgentConfigPath)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
 		approvals.AssertApproveResult(t, approvalPathConfigAgent(t.Name()), rec.Body.Bytes())
 	})
 
 	t.Run("Authorized", func(t *testing.T) {
 		cfg := configEnabledConfigAgent()
 		cfg.SecretToken = "1234"
-		h, err := backendAgentConfigHandler(cfg, beatertest.NilReporter)
+		h := map[string]string{headers.Authorization: "Bearer 1234"}
+		rec, err := requestToMuxerWithHeader(cfg, AgentConfigPath, http.MethodGet, h)
 		require.NoError(t, err)
-		c, rec := beatertest.DefaultContextWithResponseRecorder()
-		c.Request.Header.Set(headers.Authorization, "Bearer 1234")
-		h(c)
-
-		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		require.NotEqual(t, http.StatusUnauthorized, rec.Code)
 		approvals.AssertApproveResult(t, approvalPathConfigAgent(t.Name()), rec.Body.Bytes())
 	})
 }
 
 func TestConfigAgentHandler_KillSwitchMiddleware(t *testing.T) {
 	t.Run("Off", func(t *testing.T) {
-		rec := requestToConfigAgentHandler(t, config.DefaultConfig(beatertest.MockBeatVersion()))
-
-		assert.Equal(t, http.StatusForbidden, rec.Code)
+		rec, err := requestToMuxerWithPattern(config.DefaultConfig(beatertest.MockBeatVersion()), AgentConfigPath)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusForbidden, rec.Code)
 		approvals.AssertApproveResult(t, approvalPathConfigAgent(t.Name()), rec.Body.Bytes())
 
 	})
 
 	t.Run("On", func(t *testing.T) {
-		rec := requestToConfigAgentHandler(t, configEnabledConfigAgent())
-
-		assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+		rec, err := requestToMuxerWithPattern(configEnabledConfigAgent(), AgentConfigPath)
+		require.NoError(t, err)
+		require.NotEqual(t, http.StatusForbidden, rec.Code)
 		approvals.AssertApproveResult(t, approvalPathConfigAgent(t.Name()), rec.Body.Bytes())
 	})
 }
 
 func TestConfigAgentHandler_PanicMiddleware(t *testing.T) {
-	h, err := backendAgentConfigHandler(config.DefaultConfig(beatertest.MockBeatVersion()), beatertest.NilReporter)
-	require.NoError(t, err)
+	h := testHandler(t, backendAgentConfigHandler)
 	rec := &beatertest.WriterPanicOnce{}
 	c := &request.Context{}
 	c.Reset(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 	h(c)
-	assert.Equal(t, http.StatusInternalServerError, rec.StatusCode)
+	require.Equal(t, http.StatusInternalServerError, rec.StatusCode)
 	approvals.AssertApproveResult(t, approvalPathConfigAgent(t.Name()), rec.Body.Bytes())
 }
 
 func TestConfigAgentHandler_MonitoringMiddleware(t *testing.T) {
-	h, err := backendAgentConfigHandler(config.DefaultConfig(beatertest.MockBeatVersion()), beatertest.NilReporter)
-	require.NoError(t, err)
+	h := testHandler(t, backendAgentConfigHandler)
 	c, _ := beatertest.ContextWithResponseRecorder(http.MethodPost, "/")
 
 	expected := map[request.ResultID]int{
@@ -100,14 +95,6 @@ func TestConfigAgentHandler_MonitoringMiddleware(t *testing.T) {
 	equal, result := beatertest.CompareMonitoringInt(h, c, expected, agent.MonitoringMap)
 	assert.True(t, equal, result)
 
-}
-
-func requestToConfigAgentHandler(t *testing.T, cfg *config.Config) *httptest.ResponseRecorder {
-	h, err := backendAgentConfigHandler(cfg, beatertest.NilReporter)
-	require.NoError(t, err)
-	c, rec := beatertest.DefaultContextWithResponseRecorder()
-	h(c)
-	return rec
 }
 
 func configEnabledConfigAgent() *config.Config {

--- a/beater/api/intake/test_approved/integration/backend/TestIntakeBackendHandler_AuthorizationMiddleware/Unauthorized.approved.json
+++ b/beater/api/intake/test_approved/integration/backend/TestIntakeBackendHandler_AuthorizationMiddleware/Unauthorized.approved.json
@@ -1,3 +1,3 @@
 {
-    "error": "invalid token"
+    "error": "unauthorized"
 }

--- a/beater/api/intake/test_approved/integration/rum/TestRUMHandler_NoAuthorizationRequired.approved.json
+++ b/beater/api/intake/test_approved/integration/rum/TestRUMHandler_NoAuthorizationRequired.approved.json
@@ -1,0 +1,8 @@
+{
+    "accepted": 0,
+    "errors": [
+        {
+            "message": "invalid content type: ''"
+        }
+    ]
+}

--- a/beater/api/mux_test.go
+++ b/beater/api/mux_test.go
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-server/beater/authorization"
+	"github.com/elastic/apm-server/beater/beatertest"
+	"github.com/elastic/apm-server/beater/config"
+	"github.com/elastic/apm-server/beater/request"
+	"github.com/elastic/apm-server/publish"
+)
+
+func requestToMuxerWithPattern(cfg *config.Config, pattern string) (*httptest.ResponseRecorder, error) {
+	r := httptest.NewRequest(http.MethodPost, pattern, nil)
+	return requestToMuxer(cfg, r)
+}
+func requestToMuxerWithHeader(cfg *config.Config, pattern string, method string, header map[string]string) (*httptest.ResponseRecorder, error) {
+	r := httptest.NewRequest(method, pattern, nil)
+	for k, v := range header {
+		r.Header.Set(k, v)
+	}
+	return requestToMuxer(cfg, r)
+}
+
+func requestToMuxer(cfg *config.Config, r *http.Request) (*httptest.ResponseRecorder, error) {
+	mux, err := NewMux(cfg, beatertest.NilReporter)
+	if err != nil {
+		return nil, err
+	}
+	w := httptest.NewRecorder()
+	h, _ := mux.Handler(r)
+	h.ServeHTTP(w, r)
+	return w, nil
+}
+
+func testHandler(t *testing.T, fn func(*config.Config, *authorization.Builder, publish.Reporter) (request.Handler, error)) request.Handler {
+	cfg := config.DefaultConfig(beatertest.MockBeatVersion())
+	builder, err := authorization.NewBuilder(cfg)
+	require.NoError(t, err)
+	h, err := fn(cfg, builder, beatertest.NilReporter)
+	require.NoError(t, err)
+	return h
+}

--- a/beater/api/root/handler.go
+++ b/beater/api/root/handler.go
@@ -46,12 +46,19 @@ func Handler() request.Handler {
 	return func(c *request.Context) {
 		if c.Request.URL.Path != "/" {
 			c.Result.SetDefault(request.IDResponseErrorsNotFound)
-		} else {
-			c.Result.SetDefault(request.IDResponseValidOK)
-			if c.Authorized {
-				c.Result.Body = serverInfo
-			}
+			c.Write()
+			return
 		}
+
+		c.Result.SetDefault(request.IDResponseValidOK)
+		authorized, err := c.Authorization.AuthorizedFor("")
+		if err != nil {
+			c.Result.Err = err
+		}
+		if authorized {
+			c.Result.Body = serverInfo
+		}
+
 		c.Write()
 	}
 }

--- a/beater/api/sourcemap_handler_integration_test.go
+++ b/beater/api/sourcemap_handler_integration_test.go
@@ -37,31 +37,28 @@ func TestSourcemapHandler_AuthorizationMiddleware(t *testing.T) {
 	t.Run("Unauthorized", func(t *testing.T) {
 		cfg := cfgEnabledRUM()
 		cfg.SecretToken = "1234"
-		rec := requestToSourcemapHandler(t, cfg)
-
-		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+		rec, err := requestToMuxerWithPattern(cfg, AssetSourcemapPath)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusUnauthorized, rec.Code)
 		approvals.AssertApproveResult(t, approvalPathAsset(t.Name()), rec.Body.Bytes())
 	})
 
 	t.Run("Authorized", func(t *testing.T) {
 		cfg := cfgEnabledRUM()
 		cfg.SecretToken = "1234"
-		h, err := sourcemapHandler(cfg, beatertest.NilReporter)
+		h := map[string]string{headers.Authorization: "Bearer 1234"}
+		rec, err := requestToMuxerWithHeader(cfg, AssetSourcemapPath, http.MethodPost, h)
 		require.NoError(t, err)
-		c, rec := beatertest.ContextWithResponseRecorder(http.MethodPost, "/")
-		c.Request.Header.Set(headers.Authorization, "Bearer 1234")
-		h(c)
-
-		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		require.NotEqual(t, http.StatusUnauthorized, rec.Code)
 		approvals.AssertApproveResult(t, approvalPathAsset(t.Name()), rec.Body.Bytes())
 	})
 }
 
 func TestSourcemapHandler_KillSwitchMiddleware(t *testing.T) {
 	t.Run("OffRum", func(t *testing.T) {
-		rec := requestToSourcemapHandler(t, config.DefaultConfig(beatertest.MockBeatVersion()))
-
-		assert.Equal(t, http.StatusForbidden, rec.Code)
+		rec, err := requestToMuxerWithPattern(config.DefaultConfig(beatertest.MockBeatVersion()), AssetSourcemapPath)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusForbidden, rec.Code)
 		approvals.AssertApproveResult(t, approvalPathAsset(t.Name()), rec.Body.Bytes())
 	})
 
@@ -70,34 +67,32 @@ func TestSourcemapHandler_KillSwitchMiddleware(t *testing.T) {
 		rum := true
 		cfg.RumConfig.Enabled = &rum
 		cfg.RumConfig.SourceMapping.Enabled = new(bool)
-		rec := requestToSourcemapHandler(t, cfg)
-
-		assert.Equal(t, http.StatusForbidden, rec.Code)
+		rec, err := requestToMuxerWithPattern(config.DefaultConfig(beatertest.MockBeatVersion()), AssetSourcemapPath)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusForbidden, rec.Code)
 		approvals.AssertApproveResult(t, approvalPathAsset(t.Name()), rec.Body.Bytes())
 	})
 
 	t.Run("On", func(t *testing.T) {
-		rec := requestToSourcemapHandler(t, cfgEnabledRUM())
-
-		assert.Equal(t, http.StatusBadRequest, rec.Code)
+		rec, err := requestToMuxerWithPattern(cfgEnabledRUM(), AssetSourcemapPath)
+		require.NoError(t, err)
+		require.NotEqual(t, http.StatusForbidden, rec.Code)
 		approvals.AssertApproveResult(t, approvalPathAsset(t.Name()), rec.Body.Bytes())
 	})
 }
 
 func TestSourcemapHandler_PanicMiddleware(t *testing.T) {
-	h, err := sourcemapHandler(config.DefaultConfig(beatertest.MockBeatVersion()), beatertest.NilReporter)
-	require.NoError(t, err)
+	h := testHandler(t, sourcemapHandler)
 	rec := &beatertest.WriterPanicOnce{}
 	c := &request.Context{}
 	c.Reset(rec, httptest.NewRequest(http.MethodGet, "/", nil))
 	h(c)
-	assert.Equal(t, http.StatusInternalServerError, rec.StatusCode)
+	require.Equal(t, http.StatusInternalServerError, rec.StatusCode)
 	approvals.AssertApproveResult(t, approvalPathAsset(t.Name()), rec.Body.Bytes())
 }
 
 func TestSourcemapHandler_MonitoringMiddleware(t *testing.T) {
-	h, err := sourcemapHandler(config.DefaultConfig(beatertest.MockBeatVersion()), beatertest.NilReporter)
-	require.NoError(t, err)
+	h := testHandler(t, sourcemapHandler)
 	c, _ := beatertest.ContextWithResponseRecorder(http.MethodPost, "/")
 
 	// send GET request resulting in 403 Forbidden error as RUM is disabled by default
@@ -109,14 +104,6 @@ func TestSourcemapHandler_MonitoringMiddleware(t *testing.T) {
 
 	equal, result := beatertest.CompareMonitoringInt(h, c, expected, sourcemap.MonitoringMap)
 	assert.True(t, equal, result)
-}
-
-func requestToSourcemapHandler(t *testing.T, cfg *config.Config) *httptest.ResponseRecorder {
-	h, err := sourcemapHandler(cfg, beatertest.NilReporter)
-	require.NoError(t, err)
-	c, rec := beatertest.ContextWithResponseRecorder(http.MethodPost, "/")
-	h(c)
-	return rec
 }
 
 func approvalPathAsset(f string) string { return "asset/sourcemap/test_approved/integration/" + f }

--- a/beater/authorization/allow.go
+++ b/beater/authorization/allow.go
@@ -1,0 +1,31 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package authorization
+
+// AllowAuth implements the Authorization interface. It allows all authorization requests.
+type AllowAuth struct{}
+
+// AuthorizedFor always returns true
+func (AllowAuth) AuthorizedFor(_ string) (bool, error) {
+	return true, nil
+}
+
+// IsAuthorizationConfigured always returns false.
+func (AllowAuth) IsAuthorizationConfigured() bool {
+	return false
+}

--- a/beater/authorization/allow_test.go
+++ b/beater/authorization/allow_test.go
@@ -1,0 +1,38 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package authorization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAllowAuth(t *testing.T) {
+	handler := AllowAuth{}
+
+	t.Run("IsAuthorizationConfigured", func(t *testing.T) {
+		assert.False(t, handler.IsAuthorizationConfigured())
+	})
+
+	t.Run("AuthorizedFor", func(t *testing.T) {
+		authorized, err := handler.AuthorizedFor("")
+		assert.True(t, authorized)
+		assert.NoError(t, err)
+	})
+}

--- a/beater/authorization/apikey.go
+++ b/beater/authorization/apikey.go
@@ -1,0 +1,149 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package authorization
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/apm-server/beater/headers"
+	"github.com/elastic/apm-server/elasticsearch"
+)
+
+const (
+	application = "apm"
+	sep         = `","`
+
+	cleanupInterval = 60 * time.Second
+)
+
+type apikeyBuilder struct {
+	esClient        elasticsearch.Client
+	cache           *privilegesCache
+	anyOfPrivileges []string
+}
+
+type apikeyAuth struct {
+	*apikeyBuilder
+	key string
+}
+
+type hasPrivilegesResponse struct {
+	Applications map[string]map[string]privileges `json:"application"`
+}
+
+func newApikeyBuilder(client elasticsearch.Client, cache *privilegesCache, anyOfPrivileges []string) *apikeyBuilder {
+	return &apikeyBuilder{client, cache, anyOfPrivileges}
+}
+
+func (a *apikeyBuilder) forKey(key string) *apikeyAuth {
+	return &apikeyAuth{a, key}
+}
+
+// IsAuthorizationConfigured will return true if a non-empty token is required.
+func (a *apikeyAuth) IsAuthorizationConfigured() bool {
+	return true
+}
+
+// AuthorizedFor checks if the configured api key is authorized.
+// An api key is considered to be authorized when the api key has the configured privileges for the requested resource.
+// Privileges are fetched from Elasticsearch and then cached in a global cache.
+func (a *apikeyAuth) AuthorizedFor(resource string) (bool, error) {
+	//fetch from cache
+	if allowed, found := a.fromCache(resource); found {
+		return allowed, nil
+	}
+
+	if a.cache.isFull() {
+		return false, errors.New("api_key limit reached, " +
+			"check your logs for failed authorization attempts " +
+			"or consider increasing config option `apm-server.api_key.limit`")
+	}
+
+	//fetch from ES
+	privileges, err := a.queryES(resource)
+	if err != nil {
+		return false, err
+	}
+	//add to cache
+	a.cache.add(id(a.key, resource), privileges)
+
+	allowed, _ := a.fromCache(resource)
+	return allowed, nil
+}
+
+func (a *apikeyAuth) fromCache(resource string) (allowed bool, found bool) {
+	privileges := a.cache.get(id(a.key, resource))
+	if privileges == nil {
+		return
+	}
+	found = true
+	allowed = false
+	for _, privilege := range a.anyOfPrivileges {
+		if privilegeAllowed, ok := privileges[privilege]; ok && privilegeAllowed {
+			allowed = true
+			return
+		}
+	}
+	return
+}
+
+func (a *apikeyAuth) queryES(resource string) (privileges, error) {
+	query := buildQuery(PrivilegesAll, resource)
+	statusCode, body, err := a.esClient.SecurityHasPrivilegesRequest(strings.NewReader(query),
+		http.Header{headers.Authorization: []string{headers.APIKey + " " + a.key}})
+	if err != nil {
+		return nil, err
+	}
+	defer body.Close()
+	if statusCode != http.StatusOK {
+		// return nil privileges for queried apps to ensure they are cached
+		return privileges{}, nil
+	}
+
+	var decodedResponse hasPrivilegesResponse
+	if err := json.NewDecoder(body).Decode(&decodedResponse); err != nil {
+		return nil, err
+	}
+	if resources, ok := decodedResponse.Applications[application]; ok {
+		if privileges, ok := resources[resource]; ok {
+			return privileges, nil
+		}
+	}
+	return privileges{}, nil
+}
+
+func buildQuery(privileges []string, resource string) string {
+	var b strings.Builder
+	b.WriteString(`{"application":[{"application":"`)
+	b.WriteString(application)
+	b.WriteString(`","privileges":["`)
+	b.WriteString(strings.Join(privileges, sep))
+	b.WriteString(`"],"resources":"`)
+	b.WriteString(resource)
+	b.WriteString(`"}]}`)
+	return b.String()
+}
+
+func id(apiKey, resource string) string {
+	return apiKey + "_" + resource
+}

--- a/beater/authorization/apikey_test.go
+++ b/beater/authorization/apikey_test.go
@@ -1,0 +1,192 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package authorization
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-server/elasticsearch"
+	"github.com/elastic/apm-server/elasticsearch/estest"
+)
+
+func TestApikeyBuilder(t *testing.T) {
+	// in case handler does not read from cache, but from ES an error is returned
+	tc := &apikeyTestcase{
+		cache:     newPrivilegesCache(time.Minute, 5),
+		transport: estest.NewTransport(t, http.StatusInternalServerError, nil)}
+
+	tc.setup(t)
+	key := "myApiKey"
+	handler1 := tc.builder.forKey(key)
+	handler2 := tc.builder.forKey(key)
+
+	// add existing privileges to shared cache
+	privilegesValid := privileges{}
+	for _, p := range PrivilegesAll {
+		privilegesValid[p] = true
+	}
+	resource := "service-go"
+	tc.cache.add(id(key, resource), privilegesValid)
+
+	// check that cache is actually shared between apiKeyHandlers
+	allowed, err := handler1.AuthorizedFor(resource)
+	assert.NoError(t, err)
+	assert.True(t, allowed)
+
+	allowed, err = handler2.AuthorizedFor(resource)
+	assert.NoError(t, err)
+	assert.True(t, allowed)
+}
+
+func TestApikeyAuth_IsAuthorizationConfigured(t *testing.T) {
+	tc := &apikeyTestcase{}
+	tc.setup(t)
+	assert.True(t, tc.builder.forKey("xyz").IsAuthorizationConfigured())
+}
+
+func TestAPIKey_AuthorizedFor(t *testing.T) {
+	t.Run("cache full", func(t *testing.T) {
+		tc := &apikeyTestcase{cache: newPrivilegesCache(time.Millisecond, 1)}
+		tc.setup(t)
+		handler := tc.builder.forKey("")
+
+		authorized, err := handler.AuthorizedFor("data:ingest")
+		assert.False(t, authorized)
+		assert.NoError(t, err)
+
+		authorized, err = handler.AuthorizedFor("apm:read")
+		assert.Error(t, err)
+		assert.False(t, authorized)
+	})
+
+	t.Run("from cache", func(t *testing.T) {
+		// in case handler does not read from cache, but from ES an error is returned
+		tc := &apikeyTestcase{transport: estest.NewTransport(t, http.StatusInternalServerError, nil)}
+		tc.setup(t)
+		key := ""
+		handler := tc.builder.forKey(key)
+		resourceValid := "foo"
+		resourceInvalid := "bar"
+		resourceMissing := "missing"
+
+		tc.cache.add(id(key, resourceValid), privileges{tc.anyOfPrivileges[0]: true})
+		tc.cache.add(id(key, resourceInvalid), privileges{tc.anyOfPrivileges[0]: false})
+
+		valid, err := handler.AuthorizedFor(resourceValid)
+		require.NoError(t, err)
+		assert.True(t, valid)
+
+		valid, err = handler.AuthorizedFor(resourceInvalid)
+		require.NoError(t, err)
+		assert.False(t, valid)
+
+		valid, err = handler.AuthorizedFor(resourceMissing)
+		require.Error(t, err)
+		assert.False(t, valid)
+	})
+
+	t.Run("from ES", func(t *testing.T) {
+		tc := &apikeyTestcase{}
+		tc.setup(t)
+		handler := tc.builder.forKey("key")
+
+		valid, err := handler.AuthorizedFor("foo")
+		require.NoError(t, err)
+		assert.True(t, valid)
+
+		valid, err = handler.AuthorizedFor("bar")
+		require.NoError(t, err)
+		assert.False(t, valid)
+
+		valid, err = handler.AuthorizedFor("missing")
+		require.NoError(t, err)
+		assert.False(t, valid)
+		assert.Equal(t, 3, tc.cache.cache.ItemCount())
+	})
+
+	t.Run("error from ES", func(t *testing.T) {
+		tc := &apikeyTestcase{
+			transport: estest.NewTransport(t, http.StatusInternalServerError, nil)}
+		tc.setup(t)
+		handler := tc.builder.forKey("12a3")
+
+		valid, err := handler.AuthorizedFor("xyz")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Internal server error")
+		assert.False(t, valid)
+		assert.Zero(t, tc.cache.cache.ItemCount())
+	})
+
+	t.Run("invalid status from ES", func(t *testing.T) {
+		tc := &apikeyTestcase{transport: estest.NewTransport(t, http.StatusNotFound, nil)}
+		tc.setup(t)
+		handler := tc.builder.forKey("12a3")
+
+		valid, err := handler.AuthorizedFor("xyz")
+		require.NoError(t, err)
+		assert.False(t, valid)
+		assert.Equal(t, 1, tc.cache.cache.ItemCount())
+	})
+
+	t.Run("decode error from ES", func(t *testing.T) {
+		tc := &apikeyTestcase{transport: estest.NewTransport(t, http.StatusOK, nil)}
+		tc.setup(t)
+		handler := tc.builder.forKey("123")
+		valid, err := handler.AuthorizedFor("foo")
+		require.Error(t, err)
+		assert.False(t, valid)
+		assert.Zero(t, tc.cache.cache.ItemCount())
+	})
+}
+
+type apikeyTestcase struct {
+	transport       *estest.Transport
+	client          elasticsearch.Client
+	cache           *privilegesCache
+	anyOfPrivileges []string
+
+	builder *apikeyBuilder
+}
+
+func (tc *apikeyTestcase) setup(t *testing.T) {
+	var err error
+	if tc.client == nil {
+		if tc.transport == nil {
+			tc.transport = estest.NewTransport(t, http.StatusOK, map[string]interface{}{
+				"application": map[string]interface{}{
+					application: map[string]privileges{
+						"foo": {PrivilegeAgentConfigRead: true, PrivilegeEventWrite: true, PrivilegeSourcemapWrite: false},
+						"bar": {PrivilegeAgentConfigRead: true, PrivilegeEventWrite: false},
+					}}})
+		}
+		tc.client, err = estest.NewElasticsearchClient(tc.transport)
+		require.NoError(t, err)
+	}
+	if tc.cache == nil {
+		tc.cache = newPrivilegesCache(time.Millisecond, 5)
+	}
+	if tc.anyOfPrivileges == nil {
+		tc.anyOfPrivileges = []string{PrivilegeEventWrite, PrivilegeSourcemapWrite}
+	}
+	tc.builder = newApikeyBuilder(tc.client, tc.cache, tc.anyOfPrivileges)
+}

--- a/beater/authorization/bearer.go
+++ b/beater/authorization/bearer.go
@@ -1,0 +1,49 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package authorization
+
+import (
+	"crypto/subtle"
+)
+
+type bearerBuilder struct {
+	required string
+}
+
+type bearerAuth struct {
+	authorized bool
+	configured bool
+}
+
+func (b bearerBuilder) forToken(token string) *bearerAuth {
+	if b.required == "" {
+		return &bearerAuth{authorized: true, configured: false}
+	}
+	return &bearerAuth{
+		authorized: subtle.ConstantTimeCompare([]byte(b.required), []byte(token)) == 1,
+		configured: true}
+}
+
+func (b *bearerAuth) AuthorizedFor(_ string) (bool, error) {
+	return b.authorized, nil
+}
+
+// IsAuthorizationConfigured will return true if a non-empty token is required.
+func (b bearerAuth) IsAuthorizationConfigured() bool {
+	return b.configured
+}

--- a/beater/authorization/bearer_test.go
+++ b/beater/authorization/bearer_test.go
@@ -1,0 +1,46 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package authorization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBearerAuth(t *testing.T) {
+	for name, tc := range map[string]struct {
+		builder                bearerBuilder
+		token                  string
+		authorized, configured bool
+	}{
+		"empty":           {builder: bearerBuilder{}, authorized: true, configured: false},
+		"empty for token": {builder: bearerBuilder{}, authorized: true, configured: false, token: "1"},
+		"no token":        {builder: bearerBuilder{"123"}, authorized: false, configured: true},
+		"invalid token":   {builder: bearerBuilder{"123"}, authorized: false, configured: true, token: "1"},
+		"valid token":     {builder: bearerBuilder{"123"}, authorized: true, configured: true, token: "123"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			bearer := tc.builder.forToken(tc.token)
+			authorized, err := bearer.AuthorizedFor("")
+			assert.NoError(t, err)
+			assert.Equal(t, tc.authorized, authorized)
+			assert.Equal(t, tc.configured, bearer.IsAuthorizationConfigured())
+		})
+	}
+}

--- a/beater/authorization/builder.go
+++ b/beater/authorization/builder.go
@@ -1,0 +1,104 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package authorization
+
+import (
+	"time"
+
+	"github.com/elastic/apm-server/beater/config"
+	"github.com/elastic/apm-server/beater/headers"
+	"github.com/elastic/apm-server/elasticsearch"
+)
+
+// Builder creates an authorization Handler depending on configuration options
+type Builder struct {
+	apikey   *apikeyBuilder
+	bearer   *bearerBuilder
+	fallback Authorization
+}
+
+// Handler returns the authorization method according to provided information
+type Handler Builder
+
+// Authorization interface to be implemented by different auth types
+type Authorization interface {
+	AuthorizedFor(_ string) (bool, error)
+	IsAuthorizationConfigured() bool
+}
+
+const (
+	cacheTimeoutMinute = 5
+)
+
+// NewBuilder creates authorization builder based off of the given information
+func NewBuilder(cfg *config.Config) (*Builder, error) {
+	b := Builder{}
+	b.fallback = AllowAuth{}
+	if cfg.APIKeyConfig.IsEnabled() {
+		client, err := elasticsearch.NewClient(cfg.APIKeyConfig.ESConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		size := cfg.APIKeyConfig.LimitMin / cacheTimeoutMinute
+		if size <= 0 {
+			size = 1
+		}
+		cache := newPrivilegesCache(cacheTimeoutMinute*time.Minute, size)
+		b.apikey = newApikeyBuilder(client, cache, []string{})
+		b.fallback = DenyAuth{}
+	}
+	if cfg.SecretToken != "" {
+		b.bearer = &bearerBuilder{cfg.SecretToken}
+		b.fallback = DenyAuth{}
+	}
+	b.fallback.IsAuthorizationConfigured()
+	return &b, nil
+}
+
+// ForPrivilege creates an authorization Handler checking for this privilege
+func (b *Builder) ForPrivilege(privilege string) *Handler {
+	return b.ForAnyOfPrivileges([]string{privilege})
+}
+
+// ForAnyOfPrivileges creates an authorization Handler checking for any of the provided privileges
+func (b *Builder) ForAnyOfPrivileges(privileges []string) *Handler {
+	handler := Handler{bearer: b.bearer, fallback: b.fallback}
+	if b.apikey != nil {
+		handler.apikey = newApikeyBuilder(b.apikey.esClient, b.apikey.cache, privileges)
+	}
+	return &handler
+}
+
+// AuthorizationFor returns proper authorization implementation depending on the given kind, configured with the token.
+func (h *Handler) AuthorizationFor(kind string, token string) Authorization {
+	switch kind {
+	case headers.APIKey:
+		if h.apikey == nil {
+			return h.fallback
+		}
+		return h.apikey.forKey(token)
+	case headers.Bearer:
+		if h.bearer == nil {
+			return h.fallback
+		}
+		return h.bearer.forToken(token)
+	default:
+		return h.fallback
+	}
+}

--- a/beater/authorization/builder_test.go
+++ b/beater/authorization/builder_test.go
@@ -1,0 +1,104 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package authorization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-server/beater/config"
+	"github.com/elastic/apm-server/elasticsearch"
+)
+
+func TestBuilder(t *testing.T) {
+	for name, tc := range map[string]struct {
+		withBearer, withApikey bool
+		bearer                 *bearerBuilder
+		fallback               Authorization
+	}{
+		"no auth": {fallback: AllowAuth{}},
+		"bearer":  {withBearer: true, fallback: DenyAuth{}, bearer: &bearerBuilder{"xvz"}},
+		"apikey":  {withApikey: true, fallback: DenyAuth{}},
+		"all":     {withApikey: true, withBearer: true, fallback: DenyAuth{}, bearer: &bearerBuilder{"xvz"}},
+	} {
+
+		setup := func() *Builder {
+			cfg := config.DefaultConfig("9.9.9")
+
+			if tc.withBearer {
+				cfg.SecretToken = "xvz"
+			}
+			if tc.withApikey {
+				cfg.APIKeyConfig = &config.APIKeyConfig{
+					Enabled: true, LimitMin: 100, ESConfig: elasticsearch.DefaultConfig()}
+			}
+
+			builder, err := NewBuilder(cfg)
+			require.NoError(t, err)
+			return builder
+		}
+		t.Run("NewBuilder"+name, func(t *testing.T) {
+			builder := setup()
+			assert.Equal(t, tc.fallback, builder.fallback)
+			assert.Equal(t, tc.bearer, builder.bearer)
+			if tc.withApikey {
+				assert.NotNil(t, builder.apikey)
+				assert.Equal(t, 20, builder.apikey.cache.size)
+				assert.NotNil(t, builder.apikey.esClient)
+			}
+		})
+
+		t.Run("ForPrivilege"+name, func(t *testing.T) {
+			builder := setup()
+			h := builder.ForPrivilege(PrivilegeSourcemapWrite)
+			assert.Equal(t, builder.bearer, h.bearer)
+			assert.Equal(t, builder.fallback, h.fallback)
+			if tc.withApikey {
+				assert.Equal(t, []string{}, builder.apikey.anyOfPrivileges)
+				assert.Equal(t, []string{PrivilegeSourcemapWrite}, h.apikey.anyOfPrivileges)
+				assert.Equal(t, builder.apikey.esClient, h.apikey.esClient)
+				assert.Equal(t, builder.apikey.cache, h.apikey.cache)
+			}
+		})
+
+		t.Run("AuthorizationFor"+name, func(t *testing.T) {
+			builder := setup()
+			h := builder.ForPrivilege(PrivilegeSourcemapWrite)
+			auth := h.AuthorizationFor("ApiKey", "")
+			if tc.withApikey {
+				assert.IsType(t, &apikeyAuth{}, auth)
+			} else {
+				assert.Equal(t, h.fallback, auth)
+			}
+
+			auth = h.AuthorizationFor("Bearer", "")
+			if tc.withBearer {
+				assert.IsType(t, &bearerAuth{}, auth)
+			} else {
+				assert.Equal(t, h.fallback, auth)
+			}
+
+			auth = h.AuthorizationFor("Anything", "")
+			assert.Equal(t, h.fallback, auth)
+		})
+	}
+
+}

--- a/beater/authorization/deny.go
+++ b/beater/authorization/deny.go
@@ -1,0 +1,31 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package authorization
+
+// DenyAuth implements the Authorization interface. It denies all authorization requests.
+type DenyAuth struct{}
+
+// AuthorizedFor always returns false
+func (DenyAuth) AuthorizedFor(_ string) (bool, error) {
+	return false, nil
+}
+
+// IsAuthorizationConfigured always returns true.
+func (DenyAuth) IsAuthorizationConfigured() bool {
+	return true
+}

--- a/beater/authorization/deny_test.go
+++ b/beater/authorization/deny_test.go
@@ -1,0 +1,38 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package authorization
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDenyAuth(t *testing.T) {
+	handler := DenyAuth{}
+
+	t.Run("IsAuthorizationConfigured", func(t *testing.T) {
+		assert.True(t, handler.IsAuthorizationConfigured())
+	})
+
+	t.Run("AuthorizedFor", func(t *testing.T) {
+		authorized, err := handler.AuthorizedFor("")
+		assert.False(t, authorized)
+		assert.NoError(t, err)
+	})
+}

--- a/beater/authorization/privilege.go
+++ b/beater/authorization/privilege.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package authorization
+
+import (
+	"time"
+
+	"github.com/patrickmn/go-cache"
+)
+
+//Privileges
+const (
+	PrivilegeAgentConfigRead = "config_agent:read"
+	PrivilegeEventWrite      = "event:write"
+	PrivilegeSourcemapWrite  = "sourcemap:write"
+)
+
+var (
+	//PrivilegesAll returns all available privileges
+	PrivilegesAll = []string{
+		PrivilegeAgentConfigRead,
+		PrivilegeEventWrite,
+		PrivilegeSourcemapWrite}
+)
+
+type privilegesCache struct {
+	cache *cache.Cache
+	size  int
+}
+
+type privileges map[string]bool
+
+func newPrivilegesCache(expiration time.Duration, size int) *privilegesCache {
+	return &privilegesCache{cache: cache.New(expiration, cleanupInterval), size: size}
+}
+
+func (c *privilegesCache) isFull() bool {
+	return c.cache.ItemCount() >= c.size
+}
+
+func (c *privilegesCache) get(id string) privileges {
+	if val, exists := c.cache.Get(id); exists {
+		return val.(privileges)
+	}
+	return nil
+}
+
+func (c *privilegesCache) add(id string, privileges privileges) {
+	c.cache.SetDefault(id, privileges)
+}

--- a/beater/authorization/privilege_test.go
+++ b/beater/authorization/privilege_test.go
@@ -1,0 +1,45 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package authorization
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrivilegesCache(t *testing.T) {
+	n := 10
+	cache := newPrivilegesCache(time.Millisecond, n)
+	assert.False(t, cache.isFull())
+	for i := 0; i < n-1; i++ {
+		cache.add(string(i), privileges{})
+		assert.False(t, cache.isFull())
+	}
+	cache.add("oneMore", privileges{})
+	assert.True(t, cache.isFull())
+	assert.NotNil(t, cache.get("oneMore"))
+	time.Sleep(time.Millisecond)
+	assert.Nil(t, cache.get("oneMore"))
+
+	p := privileges{"a": true, "b": false}
+	cache.add("id1", p)
+	assert.Equal(t, p, cache.get("id1"))
+	assert.Nil(t, cache.get("oneMore"))
+}

--- a/beater/config/api_key.go
+++ b/beater/config/api_key.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package config
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/libbeat/logp"
+
+	"github.com/elastic/beats/libbeat/common"
+
+	"github.com/elastic/apm-server/elasticsearch"
+)
+
+const apiKeyLimit = 100
+
+// APIKeyConfig can be used for authorizing against the APM Server via API Keys.
+type APIKeyConfig struct {
+	Enabled  bool                  `config:"enabled"`
+	LimitMin int                   `config:"limit"`
+	ESConfig *elasticsearch.Config `config:"elasticsearch"`
+}
+
+// IsEnabled returns whether or not API Key authorization is enabled
+func (c *APIKeyConfig) IsEnabled() bool {
+	return c != nil && c.Enabled
+}
+
+func (c *APIKeyConfig) setup(log *logp.Logger, outputESCfg *common.Config) error {
+	if c == nil || !c.Enabled || c.ESConfig != nil {
+		return nil
+	}
+	c.ESConfig = elasticsearch.DefaultConfig()
+	if outputESCfg == nil {
+		return nil
+	}
+	log.Info("Falling back to elasticsearch output for API Key usage")
+	if err := outputESCfg.Unpack(c.ESConfig); err != nil {
+		return errors.Wrap(err, "unpacking Elasticsearch config into API key config")
+	}
+	// do not use username+password for API Key requests
+	c.ESConfig.Username = ""
+	c.ESConfig.Password = ""
+	return nil
+
+}
+
+func defaultAPIKeyConfig() *APIKeyConfig {
+	return &APIKeyConfig{Enabled: false, LimitMin: apiKeyLimit}
+}

--- a/beater/config/api_key_test.go
+++ b/beater/config/api_key_test.go
@@ -1,0 +1,96 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/elastic/beats/libbeat/logp"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/libbeat/common"
+
+	"github.com/elastic/apm-server/elasticsearch"
+)
+
+func TestAPIKeyConfig_IsEnabled(t *testing.T) {
+	assert.False(t, (&APIKeyConfig{}).IsEnabled())
+	assert.False(t, defaultAPIKeyConfig().IsEnabled())
+	assert.True(t, (&APIKeyConfig{Enabled: true}).IsEnabled())
+}
+
+func TestAPIKeyConfig_ESConfig(t *testing.T) {
+	for name, tc := range map[string]struct {
+		cfg   *APIKeyConfig
+		esCfg *common.Config
+
+		expectedConfig *APIKeyConfig
+		expectedErr    error
+	}{
+		"default": {
+			cfg:            defaultAPIKeyConfig(),
+			expectedConfig: defaultAPIKeyConfig(),
+		},
+		"ES config missing": {
+			cfg: &APIKeyConfig{Enabled: true, LimitMin: apiKeyLimit},
+			expectedConfig: &APIKeyConfig{
+				Enabled:  true,
+				LimitMin: apiKeyLimit,
+				ESConfig: elasticsearch.DefaultConfig()},
+		},
+		"ES configured": {
+			cfg: &APIKeyConfig{
+				Enabled:  true,
+				ESConfig: &elasticsearch.Config{Hosts: elasticsearch.Hosts{"192.0.0.1:9200"}}},
+			esCfg: common.MustNewConfigFrom(`{"hosts":["186.0.0.168:9200"]}`),
+			expectedConfig: &APIKeyConfig{
+				Enabled:  true,
+				ESConfig: &elasticsearch.Config{Hosts: elasticsearch.Hosts{"192.0.0.1:9200"}}},
+		},
+		"disabled with ES from output": {
+			cfg:            defaultAPIKeyConfig(),
+			esCfg:          common.MustNewConfigFrom(`{"hosts":["192.0.0.168:9200"]}`),
+			expectedConfig: defaultAPIKeyConfig(),
+		},
+		"ES from output": {
+			cfg:   &APIKeyConfig{Enabled: true, LimitMin: 20},
+			esCfg: common.MustNewConfigFrom(`{"hosts":["192.0.0.168:9200"],"username":"foo","password":"bar"}`),
+			expectedConfig: &APIKeyConfig{
+				Enabled:  true,
+				LimitMin: 20,
+				ESConfig: &elasticsearch.Config{
+					Timeout:  5 * time.Second,
+					Protocol: "http",
+					Hosts:    elasticsearch.Hosts{"192.0.0.168:9200"}}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := tc.cfg.setup(logp.NewLogger("api_key"), tc.esCfg)
+			if tc.expectedErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+			assert.Equal(t, tc.expectedConfig, tc.cfg)
+
+		})
+	}
+
+}

--- a/beater/config/config.go
+++ b/beater/config/config.go
@@ -61,7 +61,9 @@ type Config struct {
 	Mode                Mode                    `config:"mode"`
 	Kibana              *common.Config          `config:"kibana"`
 	AgentConfig         *AgentConfig            `config:"agent.config"`
-	SecretToken         string                  `config:"secret_token"`
+
+	SecretToken  string        `config:"secret_token"`
+	APIKeyConfig *APIKeyConfig `config:"api_key"`
 
 	Pipeline string
 }
@@ -115,6 +117,10 @@ func NewConfig(version string, ucfg *common.Config, outputESCfg *common.Config) 
 		return nil, err
 	}
 
+	if err := c.APIKeyConfig.setup(logger, outputESCfg); err != nil {
+		return nil, err
+	}
+
 	if err := c.SelfInstrumentation.setup(logger); err != nil {
 		return nil, err
 	}
@@ -143,11 +149,12 @@ func DefaultConfig(beatVersion string) *Config {
 			Enabled: new(bool),
 			URL:     "/debug/vars",
 		},
-		RumConfig:   defaultRum(beatVersion),
-		Register:    defaultRegisterConfig(true),
-		Mode:        ModeProduction,
-		Kibana:      common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
-		AgentConfig: &AgentConfig{Cache: &Cache{Expiration: 30 * time.Second}},
-		Pipeline:    defaultAPMPipeline,
+		RumConfig:    defaultRum(beatVersion),
+		Register:     defaultRegisterConfig(true),
+		Mode:         ModeProduction,
+		Kibana:       common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
+		AgentConfig:  &AgentConfig{Cache: &Cache{Expiration: 30 * time.Second}},
+		Pipeline:     defaultAPMPipeline,
+		APIKeyConfig: defaultAPIKeyConfig(),
 	}
 }

--- a/beater/headers/keys.go
+++ b/beater/headers/keys.go
@@ -26,6 +26,7 @@ const (
 	AccessControlExposeHeaders = "Access-Control-Expose-Headers"
 	AccessControlMaxAge        = "Access-Control-Max-Age"
 	Authorization              = "Authorization"
+	APIKey                     = "ApiKey"
 	Bearer                     = "Bearer"
 	CacheControl               = "Cache-Control"
 	Connection                 = "Connection"

--- a/beater/middleware/authorization_middleware.go
+++ b/beater/middleware/authorization_middleware.go
@@ -18,61 +18,40 @@
 package middleware
 
 import (
-	"crypto/subtle"
 	"net/http"
 	"strings"
 
+	"github.com/elastic/apm-server/beater/authorization"
 	"github.com/elastic/apm-server/beater/headers"
 	"github.com/elastic/apm-server/beater/request"
 )
 
-// RequireAuthorizationMiddleware returns a Middleware to only let authorized requests pass through
-func RequireAuthorizationMiddleware(token string) Middleware {
+// AuthorizationMiddleware returns a Middleware to only let authorized requests pass through
+func AuthorizationMiddleware(auth *authorization.Handler, apply bool) Middleware {
+	resource := "-"
 	return func(h request.Handler) (request.Handler, error) {
 		return func(c *request.Context) {
-			c.TokenSet = tokenSet(token)
+			c.Authorization = auth.AuthorizationFor(fetchAuthHeader(c.Request))
 
-			if !isAuthorized(c.Request, token) {
-				c.Authorized = false
-				c.Result.SetDefault(request.IDResponseErrorsUnauthorized)
-				c.Write()
-				return
+			if apply {
+				authorized, err := c.Authorization.AuthorizedFor(resource)
+				if !authorized {
+					c.Result.SetDeniedAuthorization(err)
+					c.Write()
+					return
+				}
 			}
 
-			c.Authorized = true
 			h(c)
 		}, nil
 	}
 }
 
-// SetAuthorizationMiddleware returns a middleware setting authorization information in the context without terminating the
-// request if it is not authorized
-func SetAuthorizationMiddleware(token string) Middleware {
-	return func(h request.Handler) (request.Handler, error) {
-		return func(c *request.Context) {
-			c.Authorized = isAuthorized(c.Request, token)
-			c.TokenSet = tokenSet(token)
-			h(c)
-		}, nil
-	}
-}
-
-// isAuthorized checks the Authorization header. It must be in the form of:
-//   Authorization: Bearer <secret-token>
-// Bearer must be part of it.
-func isAuthorized(req *http.Request, token string) bool {
-	// No token configured
-	if !tokenSet(token) {
-		return true
-	}
+func fetchAuthHeader(req *http.Request) (string, string) {
 	header := req.Header.Get(headers.Authorization)
 	parts := strings.Split(header, " ")
-	if len(parts) != 2 || parts[0] != headers.Bearer {
-		return false
+	if len(parts) != 2 {
+		return "", ""
 	}
-	return subtle.ConstantTimeCompare([]byte(parts[1]), []byte(token)) == 1
-}
-
-func tokenSet(token string) bool {
-	return token != ""
+	return parts[0], parts[1]
 }

--- a/beater/request/context.go
+++ b/beater/request/context.go
@@ -24,9 +24,11 @@ import (
 
 	"golang.org/x/time/rate"
 
+	"github.com/elastic/beats/libbeat/logp"
+
+	"github.com/elastic/apm-server/beater/authorization"
 	"github.com/elastic/apm-server/beater/headers"
 	logs "github.com/elastic/apm-server/log"
-	"github.com/elastic/beats/libbeat/logp"
 )
 
 const (
@@ -43,10 +45,10 @@ type Context struct {
 	Request       *http.Request
 	Logger        *logp.Logger
 	RateLimiter   *rate.Limiter
-	TokenSet      bool
-	Authorized    bool
+	Authorization authorization.Authorization
 	IsRum         bool
 	Result        Result
+
 	w             http.ResponseWriter
 	writeAttempts int
 }
@@ -55,11 +57,11 @@ type Context struct {
 func (c *Context) Reset(w http.ResponseWriter, r *http.Request) {
 	c.Request = r
 	c.Logger = nil
-	c.TokenSet = false
-	c.Authorized = false
-	c.IsRum = false
 	c.RateLimiter = nil
+	c.Authorization = &authorization.AllowAuth{}
+	c.IsRum = false
 	c.Result.Reset()
+
 	c.w = w
 	c.writeAttempts = 0
 }

--- a/beater/request/result.go
+++ b/beater/request/result.go
@@ -88,7 +88,7 @@ var (
 		IDResponseErrorsInvalidQuery:       {Code: http.StatusBadRequest, Keyword: "invalid query"},
 		IDResponseErrorsDecode:             {Code: http.StatusBadRequest, Keyword: "data decoding error"},
 		IDResponseErrorsValidate:           {Code: http.StatusBadRequest, Keyword: "data validation error"},
-		IDResponseErrorsMethodNotAllowed:   {Code: http.StatusMethodNotAllowed, Keyword: "only POST requests are supported"},
+		IDResponseErrorsMethodNotAllowed:   {Code: http.StatusMethodNotAllowed, Keyword: "method not supported"},
 		IDResponseErrorsRateLimit:          {Code: http.StatusTooManyRequests, Keyword: "too many requests"},
 		IDResponseErrorsFullQueue:          {Code: http.StatusServiceUnavailable, Keyword: "queue is full"},
 		IDResponseErrorsShuttingDown:       {Code: http.StatusServiceUnavailable, Keyword: "server is shutting down"},
@@ -165,6 +165,16 @@ func (r *Result) SetWithError(id ResultID, err error) {
 // SetWithBody derives information about the result from the given ID. The body is set to the passed value.
 func (r *Result) SetWithBody(id ResultID, body interface{}) {
 	r.set(id, body, nil)
+}
+
+// SetDeniedAuthorization sets the result when authorization is denied
+func (r *Result) SetDeniedAuthorization(err error) {
+	if err != nil {
+		id := IDResponseErrorsServiceUnavailable
+		status := MapResultIDToStatus[id]
+		r.Set(id, status.Code, status.Keyword, status.Keyword, err)
+	}
+	r.SetDefault(IDResponseErrorsUnauthorized)
 }
 
 // Set allows for the most flexibility in setting a result's properties.

--- a/beater/request/result.go
+++ b/beater/request/result.go
@@ -82,7 +82,7 @@ var (
 		IDResponseValidAccepted:            {Code: http.StatusAccepted, Keyword: "request accepted"},
 		IDResponseValidNotModified:         {Code: http.StatusNotModified, Keyword: "not modified"},
 		IDResponseErrorsForbidden:          {Code: http.StatusForbidden, Keyword: "forbidden request"},
-		IDResponseErrorsUnauthorized:       {Code: http.StatusUnauthorized, Keyword: "invalid token"},
+		IDResponseErrorsUnauthorized:       {Code: http.StatusUnauthorized, Keyword: "unauthorized"},
 		IDResponseErrorsNotFound:           {Code: http.StatusNotFound, Keyword: "404 page not found"},
 		IDResponseErrorsRequestTooLarge:    {Code: http.StatusRequestEntityTooLarge, Keyword: "request body too large"},
 		IDResponseErrorsInvalidQuery:       {Code: http.StatusBadRequest, Keyword: "invalid query"},

--- a/beater/request/result_test.go
+++ b/beater/request/result_test.go
@@ -19,6 +19,7 @@ package request
 
 import (
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/elastic/beats/libbeat/monitoring"
@@ -27,6 +28,22 @@ import (
 
 	"github.com/pkg/errors"
 )
+
+func assertResultIsEmpty(t *testing.T, r Result) {
+	cType := reflect.TypeOf(r)
+	cVal := reflect.ValueOf(r)
+	for i := 0; i < cVal.NumField(); i++ {
+		val := cVal.Field(i).Interface()
+		switch cType.Field(i).Name {
+		case "ID":
+			assert.Equal(t, IDUnset, val)
+		case "StatusCode":
+			assert.Equal(t, http.StatusOK, val)
+		default:
+			assert.Empty(t, val)
+		}
+	}
+}
 
 func TestResult_Reset(t *testing.T) {
 	r := Result{
@@ -38,11 +55,7 @@ func TestResult_Reset(t *testing.T) {
 		Stacktrace: "bar",
 	}
 	r.Reset()
-	assert.Equal(t, r.ID, IDUnset)
-	assert.Equal(t, http.StatusOK, r.StatusCode)
-	for _, prop := range []interface{}{r.Keyword, r.Body, r.Err, r.Stacktrace} {
-		assert.Empty(t, prop)
-	}
+	assertResultIsEmpty(t, r)
 }
 
 func TestResult_Set(t *testing.T) {

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -17,3 +17,4 @@ https://github.com/elastic/apm-server/compare/7.5\...master[View commits]
 - Added experimental support for continuous profiling of the server {pull}2839[2839]
 - Upgrade Go to 1.13.4 {pull}2984[2984].
 - Build UBI based images also {pull}2994[2994].
+- Adds support for API Key authorization for incoming requests {pull}3004[3004]

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -26,29 +26,40 @@ import (
 	"github.com/elastic/beats/libbeat/version"
 
 	v7 "github.com/elastic/go-elasticsearch/v7"
+	v7esapi "github.com/elastic/go-elasticsearch/v7/esapi"
 
 	v8 "github.com/elastic/go-elasticsearch/v8"
+	v8esapi "github.com/elastic/go-elasticsearch/v8/esapi"
 )
 
 // Client is an interface designed to abstract away version differences between elasticsearch clients
 type Client interface {
 	// Search performs a query against the given index with the given body
 	Search(index string, body io.Reader) (int, io.ReadCloser, error)
+	SecurityHasPrivilegesRequest(body io.Reader, header http.Header) (int, io.ReadCloser, error)
 }
 
 type clientV8 struct {
-	c *v8.Client
+	client *v8.Client
 }
 
 // Search satisfies the Client interface for version 8
-func (v8 clientV8) Search(index string, body io.Reader) (int, io.ReadCloser, error) {
-	response, err := v8.c.Search(
-		v8.c.Search.WithContext(context.Background()),
-		v8.c.Search.WithIndex(index),
-		v8.c.Search.WithBody(body),
-		v8.c.Search.WithTrackTotalHits(true),
-		v8.c.Search.WithPretty(),
-	)
+func (c clientV8) Search(index string, body io.Reader) (int, io.ReadCloser, error) {
+	return v8Response(c.client.Search(
+		c.client.Search.WithContext(context.Background()),
+		c.client.Search.WithIndex(index),
+		c.client.Search.WithBody(body),
+		c.client.Search.WithTrackTotalHits(true),
+		c.client.Search.WithPretty(),
+	))
+}
+
+func (c clientV8) SecurityHasPrivilegesRequest(body io.Reader, header http.Header) (int, io.ReadCloser, error) {
+	hasPrivileges := v8esapi.SecurityHasPrivilegesRequest{Body: body, Header: header}
+	return v8Response(hasPrivileges.Do(context.Background(), c.client))
+}
+
+func v8Response(response *v8esapi.Response, err error) (int, io.ReadCloser, error) {
 	if err != nil {
 		return 0, nil, err
 	}
@@ -56,18 +67,26 @@ func (v8 clientV8) Search(index string, body io.Reader) (int, io.ReadCloser, err
 }
 
 type clientV7 struct {
-	c *v7.Client
+	client *v7.Client
 }
 
 // Search satisfies the Client interface for version 7
-func (v7 clientV7) Search(index string, body io.Reader) (int, io.ReadCloser, error) {
-	response, err := v7.c.Search(
-		v7.c.Search.WithContext(context.Background()),
-		v7.c.Search.WithIndex(index),
-		v7.c.Search.WithBody(body),
-		v7.c.Search.WithTrackTotalHits(true),
-		v7.c.Search.WithPretty(),
-	)
+func (c clientV7) Search(index string, body io.Reader) (int, io.ReadCloser, error) {
+	return v7Response(c.client.Search(
+		c.client.Search.WithContext(context.Background()),
+		c.client.Search.WithIndex(index),
+		c.client.Search.WithBody(body),
+		c.client.Search.WithTrackTotalHits(true),
+		c.client.Search.WithPretty(),
+	))
+}
+
+func (c clientV7) SecurityHasPrivilegesRequest(body io.Reader, header http.Header) (int, io.ReadCloser, error) {
+	hasPrivileges := v7esapi.SecurityHasPrivilegesRequest{Body: body, Header: header}
+	return v7Response(hasPrivileges.Do(context.Background(), c.client))
+}
+
+func v7Response(response *v7esapi.Response, err error) (int, io.ReadCloser, error) {
 	if err != nil {
 		return 0, nil, err
 	}

--- a/elasticsearch/estest/client.go
+++ b/elasticsearch/estest/client.go
@@ -46,18 +46,19 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // NewTransport creates test transport instance returning status code and body according to input parameters when called.
 func NewTransport(t *testing.T, statusCode int, esBody map[string]interface{}) *Transport {
-	var body io.ReadCloser
-	if esBody == nil {
-		body = ioutil.NopCloser(bytes.NewReader([]byte{}))
-	} else {
-		resp, err := json.Marshal(esBody)
-		require.NoError(t, err)
-		body = ioutil.NopCloser(bytes.NewReader(resp))
-	}
+
 	return &Transport{
 		roundTripFn: func(_ *http.Request) (*http.Response, error) {
 			if statusCode == http.StatusInternalServerError {
 				return &http.Response{}, errors.New("Internal server error")
+			}
+			var body io.ReadCloser
+			if esBody == nil {
+				body = ioutil.NopCloser(bytes.NewReader([]byte{}))
+			} else {
+				resp, err := json.Marshal(esBody)
+				require.NoError(t, err)
+				body = ioutil.NopCloser(bytes.NewReader(resp))
 			}
 			return &http.Response{StatusCode: statusCode, Body: body}, nil
 		},

--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -237,8 +237,8 @@ class AgentConfigurationKibanaDownIntegrationTest(ElasticTest):
         assert len(config_request_logs) == 2, config_request_logs
         self.assertDictContainsSubset({
             "level": "error",
-            "message": "invalid token",
-            "error": "invalid token",
+            "message": "unauthorized",
+            "error": "unauthorized",
             "response_code": 401,
         }, config_request_logs[0])
         self.assertDictContainsSubset({


### PR DESCRIPTION
With this PR support is added for authorizing requests between APM
agents and the Server via API keys. The API keys need to have privileges
for the generic resource "_".

Used `privileges`:
* `/config/v1/agents`:  `config_agent:read`
* `/intake/v2/events`:  `event:write`
* `/assets/v1/sourcemaps`:  `sourcemap:write`
* `/intake/v2/profile`:  `event:write` (theoretical as not supported yet)
* `/`: any of the above

Used `application`: `apm`

Used `resource`: `-`

API Keys for this implementation phase should be of format:
```
application: "apm"
privileges: "*" OR "config_agent:read","event:write", "sourcemap:write"`
resources: "*"
```

closes elastic/apm-server#2338


---
The main purpose for opening the PR without having integration tests is to 
* provide information for #2987 for the `application`, `privileges` and `resources` as early as possible
* get a code review on time 

What will follow is 
* [ ] Integration tests (depending on https://github.com/elastic/apm-server/pull/2799)
* [x] Changelog entry
* [ ] more manual testing, once there is also a branch available for #2987 to test them together.

---

# Rough outline of Test scenarios

## Default (disabled API Key)
Requests are accepted, independent of auth header (test with Bearer, with API Key, with random Auth method and without Auth header) 

## Set Bearer token via `apm-server.secret_token`
* Requests to backend endpoints with valid Bearer auth header are accepted, all others are denied
* Requests to RUM endpoint do not need authorization, if an auth header is sent, it is not used

## Enable API Key via `apm-server.api_key.enabled`
### Secret token is not set
* Requests to backend endpoint with valid API Key auth header are accepted, all others are denied
* Requests to RUM endpoint do not need authorization, if an auth header is sent, it is not used

### Also set secret token 
* Requests to backend endpoint with valid API Key auth header or valid Bearer header are accepted, all others are denied
* Requests to RUM endpoint do not need authorization, if an auth header is sent, it is not used

### Change Limit `apm-server.api_key.limit`
Check that limit is respected: requests with new API Keys are not processed, requests with used API Keys are processed unless cached key expires and cache is filled up with other API Keys

### Test Elasticsearch
* test with configured `apm-server.api_key.elasticsearch`
* test with configured `output.elasticsearch`
* test when both ES config options are set, configuration from `apm-server.api_key.elasticsearch` should be used
* test that configured `username` and `password` is not used for actual request to ES (as the privileges need to be derived from the API Key)

### Listing of API Keys 
#### API Key valid for request to any of the backend endpoints
```
{
  "application":[
    {
      "application": "apm",
      "privileges": ["*"],
      "resources": ["*"]
    }
  ]
}
```

```
{
  "application":[
    {
      "application": "*",
      "privileges": ["*"],
      "resources": ["*"]
    }
  ]
}
```

```
{
  "application":[
    {
      "application": "apm",
      "privileges": ["config_agent:read","sourcemap:write","event:write"],
      "resources": ["*"]
    }
  ]
}
```

```
{
  "application":[
    {
      "application": "apm",
      "privileges": ["*"],
      "resources": ["-"]
    }
  ]
}
```

```
{
  "application":[
    {
      "application": "apm",
      "privileges": ["config_agent:read","sourcemap:write","event:write"],
      "resources": ["-"]
    }
  ]
}
```


#### API Key valid for request to agent config + root
(resource can be "*" or "-")

```
{
  "application":[
    {
      "application": "apm",
      "privileges": ["config_agent:read""],
      "resources": ["*"]
    }
  ]
}
```

#### API Key valid for request to intake API + root
(resource can be "*" or "-")
```
{
  "application":[
    {
      "application": "apm",
      "privileges": ["event:write"],
      "resources": ["*"]
    }
  ]
}
```

#### API Key valid for request to sourcemap + root
(resource can be "*" or "-")
```
{
  "application":[
    {
      "application": "apm",
      "privileges": ["sourcemap:write"],
      "resources": ["*"]
    }
  ]
}
```


#### API Key invalid for request to backend endpoints
```
{
  "application":[
    {
      "application": "apm",
      "privileges": ["*"],
      "resources": ["service_a"]
    }
  ]
}
```

```
{
  "application":[
    {
      "application": "apm",
      "privileges": ["config_agent:read","sourcemap:write","event:write"],
      "resources": ["service_a"]
    }
  ]
}
```

```
{
  "application":[
    {
      "application": "apm",
      "privileges": ["foo"],
      "resources": ["*"]
    }
  ]
}
```


```
{
  "application":[
    {
      "application": "foo",
      "privileges": ["*"],
      "resources": ["*"]
    }
  ]
}
```