### PR TITLE
Update system tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,11 +23,15 @@ services:
       kibana: { condition: service_healthy }
 
   elasticsearch:
+    ports:
+      - 9200:9200
     extends:
       file: ./_beats/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: elasticsearch
 
   kibana:
+    ports:
+      - 5601:5601
     extends:
       file: ./_beats/testing/environments/${TESTING_ENVIRONMENT}.yml
       service: kibana

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -105,6 +105,14 @@ class ServerSetUpBaseTest(BaseTest):
         self.apmserver_proc = self.start_beat(**self.start_args())
         self.wait_until_started()
 
+        # try make sure APM Server is fully up
+        cfg = self.config()
+        # pipeline registration is enabled by default and only happens if the output is elasticsearch
+        if not getattr(self, "register_pipeline_disabled", False) and \
+            cfg.get("elasticsearch_host") and \
+            cfg.get("register_pipeline_enabled") != "false" and cfg.get("register_pipeline_overwrite") != "false":
+            self.wait_until_pipelines_registered()
+
     def start_args(self):
         return {}
 

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -196,20 +196,28 @@ class ElasticTest(ServerBaseTest):
         self.kibana_url = self.get_kibana_url()
 
         # Cleanup index and template first
-        self.es.indices.delete(index="apm*", ignore=[400, 404])
-        for idx in self.indices:
-            self.wait_until(lambda: not self.es.indices.exists(idx))
+        if self.es.indices.get("apm*"):
+            self.es.indices.delete(index="apm*", ignore=[400, 404])
+            for idx in self.indices:
+                self.wait_until(lambda: not self.es.indices.exists(idx), name="index {} to be deleted".format(idx))
+        assert all(idx.startswith("apm") for idx in self.indices), "not all indices prefixed with apm, cleanup assumption broken"
 
-        self.es.indices.delete_template(name="apm*", ignore=[400, 404])
-        for idx in self.indices:
-            self.wait_until(lambda: not self.es.indices.exists_template(idx))
+        if self.es.indices.get_template(name="apm*", ignore=[400, 404]):
+            self.es.indices.delete_template(name="apm*", ignore=[400, 404])
+            for idx in self.indices:
+                self.wait_until(lambda: not self.es.indices.exists_template(idx),
+                                name="index template {} to be deleted".format(idx))
 
         # truncate, don't delete agent configuration index since it's only created when kibana starts up
-        self.es.delete_by_query(self.index_acm, {"query": {"match_all": {}}},
-                                ignore_unavailable=True, wait_for_completion=True)
-        self.wait_until(lambda: self.es.count(index=self.index_acm, ignore_unavailable=True)["count"] == 0)
+        if self.es.count(index=self.index_acm, ignore_unavailable=True)["count"] > 0:
+            self.es.delete_by_query(self.index_acm, {"query": {"match_all": {}}},
+                                    ignore_unavailable=True, wait_for_completion=True)
+            self.wait_until(lambda: self.es.count(index=self.index_acm, ignore_unavailable=True)["count"] == 0,
+                            max_timeout=30, name="acm index {} to be empty".format(self.index_acm))
+
         # Cleanup pipelines
-        self.es.ingest.delete_pipeline(id="*")
+        if self.es.ingest.get_pipeline(ignore=[400, 404]):
+            self.es.ingest.delete_pipeline(id="*")
 
         super(ElasticTest, self).setUp()
 

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import shutil
+import unittest
 from time import gmtime, strftime
 from urlparse import urlparse
 
@@ -14,8 +15,9 @@ import requests
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..',
                              '..', '_beats', 'libbeat', 'tests', 'system'))
-from beat.beat import TestCase, TimeoutError
+from beat.beat import INTEGRATION_TESTS, TestCase, TimeoutError
 
+integration_test = unittest.skipUnless(INTEGRATION_TESTS, "integration test")
 
 class BaseTest(TestCase):
     maxDiff = None

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -200,11 +200,11 @@ class ElasticTest(ServerBaseTest):
         self.kibana_url = self.get_kibana_url()
 
         # Cleanup index and template first
+        assert all(idx.startswith("apm") for idx in self.indices), "not all indices prefixed with apm, cleanup assumption broken"
         if self.es.indices.get("apm*"):
             self.es.indices.delete(index="apm*", ignore=[400, 404])
             for idx in self.indices:
                 self.wait_until(lambda: not self.es.indices.exists(idx), name="index {} to be deleted".format(idx))
-        assert all(idx.startswith("apm") for idx in self.indices), "not all indices prefixed with apm, cleanup assumption broken"
 
         if self.es.indices.get_template(name="apm*", ignore=[400, 404]):
             self.es.indices.delete_template(name="apm*", ignore=[400, 404])

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -147,11 +147,13 @@ class ServerSetUpBaseTest(BaseTest):
             log = re.sub(s, "", log)
         self.assertNotRegexpMatches(log, "ERR|WARN")
 
-    def request_intake(self, data="", url="", headers={'content-type': 'application/x-ndjson'}):
-        if url == "":
+    def request_intake(self, data=None, url=None, headers=None):
+        if not url:
             url = self.intake_url
-        if data == "":
+        if data is None:
             data = self.get_event_payload()
+        if headers is None:
+            headers = {'content-type': 'application/x-ndjson'}
         return requests.post(url, data=data, headers=headers)
 
 

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -226,7 +226,8 @@ class ElasticTest(ServerBaseTest):
             lambda: (self.es.count(index=query_index, body={
                 "query": {"term": {"processor.name": endpoint}}}
             )['count'] == expected_events_count),
-            max_timeout=max_timeout
+            max_timeout=max_timeout,
+            name="{} documents to reach {}".format(endpoint, expected_events_count),
         )
 
     def check_backend_error_sourcemap(self, index, count=1):
@@ -318,7 +319,8 @@ class ClientSideElasticTest(ClientSideBaseTest, ElasticTest):
         self.wait_until(
             lambda: (self.es.count(index=idx, body={
                 "query": {"term": {"processor.name": 'sourcemap'}}}
-            )['count'] == expected_ct)
+            )['count'] == expected_ct),
+            name="{} sourcemaps to ingest".format(expected_ct),
         )
 
     def check_rum_error_sourcemap(self, updated, expected_err=None, count=1):

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -109,7 +109,14 @@ class ServerSetUpBaseTest(BaseTest):
         return {}
 
     def wait_until_started(self):
-        self.wait_until(lambda: self.log_contains("Starting apm-server"))
+        self.wait_until(lambda: self.log_contains("Starting apm-server"), name="apm-server started")
+
+    def wait_until_ilm_setup(self):
+        self.wait_until(lambda: self.log_contains("Finished index management setup."), name="ILM setup")
+
+    def wait_until_pipelines_registered(self):
+        self.wait_until(lambda: self.log_contains("Registered Ingest Pipelines successfully"),
+                                                  name="pipelines registered")
 
     def assert_no_logged_warnings(self, suppress=None):
         """

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -70,7 +70,7 @@ apm-server:
   register.ingest.pipeline.enabled: {{ register_pipeline_enabled }}
   {% endif %}
   {% if register_pipeline_overwrite %}
-  register.ingest.pipeline.overwrite: {{ register_pipeline_overwrite  }}
+  register.ingest.pipeline.overwrite: {{ register_pipeline_overwrite }}
   {% endif %}
 
   {% if instrumentation_enabled %}

--- a/tests/system/test_access.py
+++ b/tests/system/test_access.py
@@ -9,7 +9,7 @@ import unittest
 
 from nose.tools import raises
 from requests.exceptions import SSLError, ChunkedEncodingError
-from beat.beat import INTEGRATION_TESTS, TimeoutError
+from apmserver import TimeoutError, integration_test
 from requests.packages.urllib3.exceptions import SubjectAltNameWarning
 requests.packages.urllib3.disable_warnings(SubjectAltNameWarning)
 
@@ -56,7 +56,7 @@ class TestAccessWithCredentials(ServerBaseTest):
         assert r.status_code == 401, r.status_code
 
 
-@unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+@integration_test
 class TestSecureServerBaseTest(ServerSetUpBaseTest):
     @classmethod
     def setUpClass(cls):
@@ -145,6 +145,7 @@ class TestSSLBadPassphraseTest(TestSecureServerBaseTest):
         super(TestSecureServerBaseTest, self).setUp()
 
 
+@integration_test
 class TestSSLEnabledNoClientVerificationTest(TestSecureServerBaseTest):
     def ssl_overrides(self):
         return {"ssl_client_authentication": "none"}
@@ -163,6 +164,7 @@ class TestSSLEnabledNoClientVerificationTest(TestSecureServerBaseTest):
         assert r.status_code == 202, r.status_code
 
 
+@integration_test
 class TestSSLEnabledOptionalClientVerificationTest(TestSecureServerBaseTest):
     # no ssl_overrides necessary as `optional` is default
 
@@ -183,6 +185,7 @@ class TestSSLEnabledOptionalClientVerificationTest(TestSecureServerBaseTest):
         assert r.status_code == 202, r.status_code
 
 
+@integration_test
 class TestSSLEnabledOptionalClientVerificationWithCATest(TestSecureServerBaseTest):
     def ssl_overrides(self):
         return {"ssl_certificate_authorities": self.ca_cert}
@@ -205,6 +208,7 @@ class TestSSLEnabledOptionalClientVerificationWithCATest(TestSecureServerBaseTes
         assert r.status_code == 202, r.status_code
 
 
+@integration_test
 class TestSSLEnabledRequiredClientVerificationTest(TestSecureServerBaseTest):
     def ssl_overrides(self):
         return {"ssl_client_authentication": "required",
@@ -225,6 +229,7 @@ class TestSSLEnabledRequiredClientVerificationTest(TestSecureServerBaseTest):
         assert r.status_code == 202, r.status_code
 
 
+@integration_test
 class TestSSLDefaultSupportedProcotolsTest(TestSecureServerBaseTest):
     def ssl_overrides(self):
         return {"ssl_certificate_authorities": self.ca_cert}
@@ -240,6 +245,7 @@ class TestSSLDefaultSupportedProcotolsTest(TestSecureServerBaseTest):
         self.ssl_connect()
 
 
+@integration_test
 class TestSSLSupportedProcotolsTest(TestSecureServerBaseTest):
     def ssl_overrides(self):
         return {"ssl_supported_protocols": ["TLSv1.2"],
@@ -253,6 +259,7 @@ class TestSSLSupportedProcotolsTest(TestSecureServerBaseTest):
         self.ssl_connect()
 
 
+@integration_test
 class TestSSLSupportedCiphersTest(TestSecureServerBaseTest):
     def ssl_overrides(self):
         return {"ssl_cipher_suites": ['ECDHE-RSA-AES-128-GCM-SHA256'],

--- a/tests/system/test_export.py
+++ b/tests/system/test_export.py
@@ -2,13 +2,14 @@ import yaml
 import os
 import json
 import shutil
-from apmserver import SubCommandTest
+from apmserver import SubCommandTest, integration_test
 
 
 class ExportCommandTest(SubCommandTest):
     register_pipeline_disabled = True
 
 
+@integration_test
 class ExportConfigDefaultTest(ExportCommandTest):
     """
     Test export config subcommand.
@@ -48,6 +49,7 @@ class ExportConfigDefaultTest(ExportCommandTest):
             }, config["setup"])
 
 
+@integration_test
 class ExportConfigTest(ExportCommandTest):
     """
     Test export config subcommand.
@@ -90,6 +92,7 @@ class ExportConfigTest(ExportCommandTest):
             }, config["setup"])
 
 
+@integration_test
 class TestExportTemplate(ExportCommandTest):
     """
     Test export template
@@ -122,6 +125,7 @@ class TestExportTemplate(ExportCommandTest):
         assert template['order'] == 1
 
 
+@integration_test
 class TestExportILMPolicy(ExportCommandTest):
     """
     Test export ilm-policy
@@ -157,6 +161,7 @@ class TestExportILMPolicy(ExportCommandTest):
                 assert "delete" not in policy["policy"]["phases"]
 
 
+@integration_test
 class TestExportILMPolicyILMDisabled(TestExportILMPolicy):
     """
     Test export ilm-policy independent of ILM enabled state

--- a/tests/system/test_export.py
+++ b/tests/system/test_export.py
@@ -5,7 +5,11 @@ import shutil
 from apmserver import SubCommandTest
 
 
-class ExportConfigDefaultTest(SubCommandTest):
+class ExportCommandTest(SubCommandTest):
+    register_pipeline_disabled = True
+
+
+class ExportConfigDefaultTest(ExportCommandTest):
     """
     Test export config subcommand.
     """
@@ -44,7 +48,7 @@ class ExportConfigDefaultTest(SubCommandTest):
             }, config["setup"])
 
 
-class ExportConfigTest(SubCommandTest):
+class ExportConfigTest(ExportCommandTest):
     """
     Test export config subcommand.
     """
@@ -86,7 +90,7 @@ class ExportConfigTest(SubCommandTest):
             }, config["setup"])
 
 
-class TestExportTemplate(SubCommandTest):
+class TestExportTemplate(ExportCommandTest):
     """
     Test export template
     """
@@ -118,7 +122,7 @@ class TestExportTemplate(SubCommandTest):
         assert template['order'] == 1
 
 
-class TestExportILMPolicy(SubCommandTest):
+class TestExportILMPolicy(ExportCommandTest):
     """
     Test export ilm-policy
     """

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -1,18 +1,16 @@
 import json
 import os
 import time
-import unittest
 
-from apmserver import ElasticTest, ExpvarBaseTest
-from apmserver import ClientSideElasticTest
+from apmserver import integration_test
+from apmserver import ClientSideElasticTest, ElasticTest, ExpvarBaseTest
 from apmserver import OverrideIndicesTest, OverrideIndicesFailureTest
-from beat.beat import INTEGRATION_TESTS
 from sets import Set
 
 
+@integration_test
 class Test(ElasticTest):
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_onboarding_doc(self):
         """
         This test starts the beat and checks that the onboarding doc has been published to ES
@@ -27,7 +25,6 @@ class Test(ElasticTest):
         # Makes sure no error or warnings were logged
         self.assert_no_logged_warnings()
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_template(self):
         """
         This test starts the beat and checks that the template has been loaded to ES
@@ -40,7 +37,6 @@ class Test(ElasticTest):
         total_fields_limit = t['settings']['index']['mapping']['total_fields']['limit']
         assert total_fields_limit == "2000", total_fields_limit
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_tags_type(self):
         self.load_docs_with_template(self.get_payload_path("transactions_spans.ndjson"),
                                      self.intake_url, 'transaction', 9)
@@ -57,7 +53,6 @@ class Test(ElasticTest):
                 else:
                     assert mtype == "keyword", name + " mapped as " + mtype + ", not keyword"
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_mark_type(self):
         self.load_docs_with_template(self.get_payload_path("transactions_spans.ndjson"),
                                      self.intake_url, 'transaction', 9)
@@ -68,7 +63,6 @@ class Test(ElasticTest):
                 mtype = mapping["type"]
                 assert mtype == "scaled_float", name + " mapped as " + mtype + ", not scaled_float"
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_load_docs_with_template_and_add_transaction(self):
         """
         This test starts the beat with a loaded template and sends transaction data to elasticsearch.
@@ -93,7 +87,6 @@ class Test(ElasticTest):
             approved = json.load(f)
         self.check_docs(approved, rs['hits']['hits'], 'span')
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_load_docs_with_template_and_add_error(self):
         """
         This test starts the beat with a loaded template and sends error data to elasticsearch.
@@ -139,8 +132,8 @@ class Test(ElasticTest):
         return json.dumps(data, indent=4, separators=(',', ': '))
 
 
+@integration_test
 class EnrichEventIntegrationTest(ClientSideElasticTest):
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_backend_error(self):
         # for backend events library_frame information should not be changed,
         # as no regex pattern is defined.
@@ -150,7 +143,6 @@ class EnrichEventIntegrationTest(ClientSideElasticTest):
                                      4)
         self.check_library_frames({"true": 1, "false": 1, "empty": 2}, self.index_error)
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_rum_error(self):
         self.load_docs_with_template(self.get_error_payload_path(),
                                      self.intake_url,
@@ -158,7 +150,6 @@ class EnrichEventIntegrationTest(ClientSideElasticTest):
                                      1)
         self.check_library_frames({"true": 5, "false": 1, "empty": 0}, self.index_error)
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_backend_transaction(self):
         # for backend events library_frame information should not be changed,
         # as no regex pattern is defined.
@@ -168,7 +159,6 @@ class EnrichEventIntegrationTest(ClientSideElasticTest):
                                      9)
         self.check_library_frames({"true": 1, "false": 0, "empty": 1}, self.index_span)
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_rum_transaction(self):
         self.load_docs_with_template(self.get_transaction_payload_path(),
                                      self.intake_url,
@@ -176,7 +166,6 @@ class EnrichEventIntegrationTest(ClientSideElasticTest):
                                      2)
         self.check_library_frames({"true": 1, "false": 1, "empty": 0}, self.index_span)
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_enrich_backend_event(self):
         self.load_docs_with_template(self.get_backend_transaction_payload_path(),
                                      self.backend_intake_url, 'transaction', 9)
@@ -185,7 +174,6 @@ class EnrichEventIntegrationTest(ClientSideElasticTest):
 
         assert "ip" in rs['hits']['hits'][0]["_source"]["host"], rs['hits']
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_enrich_rum_event(self):
         self.load_docs_with_template(self.get_error_payload_path(),
                                      self.intake_url,
@@ -200,7 +188,6 @@ class EnrichEventIntegrationTest(ClientSideElasticTest):
             assert "original" in hit["_source"]["user_agent"], rs['hits']
             assert "ip" in hit["_source"]["client"], rs['hits']
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_grouping_key_for_error(self):
         # upload the same error, once via rum, once via backend endpoint
         # check they don't have the same grouping key, as the
@@ -248,10 +235,10 @@ class EnrichEventIntegrationTest(ClientSideElasticTest):
                 lf["empty"] += 1
 
 
+@integration_test
 class ILMDisabledIntegrationTest(ElasticTest):
     config_overrides = {"ilm_enabled": "false"}
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_override_indices_config(self):
         # load error and transaction document to ES
         self.load_docs_with_template(self.get_error_payload_path(),
@@ -261,10 +248,10 @@ class ILMDisabledIntegrationTest(ElasticTest):
                                      query_index="{}-2017.05.09".format(self.index_error))
 
 
+@integration_test
 class OverrideIndicesIntegrationTest(OverrideIndicesTest):
     # default ILM=auto disables ILM when custom indices given
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_override_indices_config(self):
         # load error and transaction document to ES
         self.load_docs_with_template(self.get_error_payload_path(),
@@ -282,10 +269,10 @@ class OverrideIndicesIntegrationTest(OverrideIndicesTest):
         assert 4+2+1 == self.es.count(index=self.index_name)['count']
 
 
+@integration_test
 class OverrideIndicesILMFalseIntegrationTest(OverrideIndicesTest):
     config_overrides = {"ilm_enabled": "false"}
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_override_indices_config(self):
         # load error and transaction document to ES
         self.load_docs_with_template(self.get_error_payload_path(),
@@ -296,10 +283,10 @@ class OverrideIndicesILMFalseIntegrationTest(OverrideIndicesTest):
         assert 4+1 == self.es.count(index=self.index_name)['count']
 
 
+@integration_test
 class OverrideIndicesILMTrueIntegrationTest(OverrideIndicesTest):
     config_overrides = {"ilm_enabled": "true"}
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_override_indices_config(self):
         # load error and transaction document to ES
         self.load_docs_with_template(self.get_error_payload_path(),
@@ -310,17 +297,17 @@ class OverrideIndicesILMTrueIntegrationTest(OverrideIndicesTest):
         assert 4 == self.es.count(index=self.ilm_index(self.index_error))['count']
 
 
+@integration_test
 class OverrideIndicesFailureIntegrationTest(OverrideIndicesFailureTest):
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_template_setup_error(self):
         loaded_msg = "Exiting: setup.template.name and setup.template.pattern have to be set"
         self.wait_until(lambda: self.log_contains(loaded_msg),
                         max_timeout=5)
 
 
+@integration_test
 class SourcemappingIntegrationTest(ClientSideElasticTest):
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_backend_error(self):
         # ensure source mapping is not applied to backend events
         # load event for which a sourcemap would be applied when sent to rum endpoint,
@@ -339,7 +326,6 @@ class SourcemappingIntegrationTest(ClientSideElasticTest):
         self.assert_no_logged_warnings()
         self.check_backend_error_sourcemap(self.index_error)
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_duplicated_sourcemap_warning(self):
         path = 'http://localhost:8000/test/e2e/general-usecase/bundle.js.map'
 
@@ -359,7 +345,6 @@ class SourcemappingIntegrationTest(ClientSideElasticTest):
         self.assert_no_logged_warnings(
             ["WARN.*Overriding sourcemap", "WARN.*2 sourcemaps found for service"])
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_rum_error(self):
         # use an uncleaned path to test that path is cleaned in upload
         path = 'http://localhost:8000/test/e2e/../e2e/general-usecase/bundle.js.map'
@@ -374,7 +359,6 @@ class SourcemappingIntegrationTest(ClientSideElasticTest):
         self.assert_no_logged_warnings()
         self.check_rum_error_sourcemap(True)
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_backend_span(self):
         # ensure source mapping is not applied to backend events
         # load event for which a sourcemap would be applied when sent to rum endpoint,
@@ -394,7 +378,6 @@ class SourcemappingIntegrationTest(ClientSideElasticTest):
         self.assert_no_logged_warnings()
         self.check_backend_span_sourcemap()
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_rum_transaction(self):
         path = 'http://localhost:8000/test/e2e/general-usecase/bundle.js.map'
         r = self.upload_sourcemap(file_name='bundle.js.map',
@@ -410,7 +393,6 @@ class SourcemappingIntegrationTest(ClientSideElasticTest):
         self.assert_no_logged_warnings()
         self.check_rum_transaction_sourcemap(True)
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_rum_transaction_different_subdomain(self):
         path = 'http://localhost:8000/test/e2e/general-usecase/bundle.js.map'
         r = self.upload_sourcemap(file_name='bundle.js.map',
@@ -426,7 +408,6 @@ class SourcemappingIntegrationTest(ClientSideElasticTest):
         self.assert_no_logged_warnings()
         self.check_rum_transaction_sourcemap(True)
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_no_sourcemap(self):
         self.load_docs_with_template(self.get_error_payload_path(),
                                      self.intake_url,
@@ -435,7 +416,6 @@ class SourcemappingIntegrationTest(ClientSideElasticTest):
         self.check_rum_error_sourcemap(
             False, expected_err="No Sourcemap available")
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_no_matching_sourcemap(self):
         r = self.upload_sourcemap('bundle_no_mapping.js.map')
         self.assert_no_logged_warnings()
@@ -443,7 +423,6 @@ class SourcemappingIntegrationTest(ClientSideElasticTest):
         self.wait_for_sourcemaps()
         self.test_no_sourcemap()
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_fetch_latest_of_multiple_sourcemaps(self):
         # upload sourcemap file that finds no matchings
         path = 'http://localhost:8000/test/e2e/general-usecase/bundle.js.map'
@@ -476,7 +455,6 @@ class SourcemappingIntegrationTest(ClientSideElasticTest):
                                      1)
         self.check_rum_error_sourcemap(True, count=1)
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_sourcemap_mapping_cache_usage(self):
         path = 'http://localhost:8000/test/e2e/general-usecase/bundle.js.map'
         r = self.upload_sourcemap(
@@ -506,7 +484,6 @@ class SourcemappingIntegrationTest(ClientSideElasticTest):
         self.assert_no_logged_warnings()
         self.check_rum_error_sourcemap(True)
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_rum_error_changed_index(self):
         # use an uncleaned path to test that path is cleaned in upload
         path = 'http://localhost:8000/test/e2e/../e2e/general-usecase/bundle.js.map'
@@ -523,10 +500,10 @@ class SourcemappingIntegrationTest(ClientSideElasticTest):
         self.check_rum_error_sourcemap(True)
 
 
+@integration_test
 class SourcemappingCacheIntegrationTest(ClientSideElasticTest):
     config_overrides = {"smap_cache_expiration": "1"}
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_sourcemap_cache_expiration(self):
         path = 'http://localhost:8000/test/e2e/general-usecase/bundle.js.map'
         r = self.upload_sourcemap(
@@ -557,12 +534,12 @@ class SourcemappingCacheIntegrationTest(ClientSideElasticTest):
         self.check_rum_error_sourcemap(False, expected_err="No Sourcemap available")
 
 
+@integration_test
 class SourcemappingDisabledIntegrationTest(ClientSideElasticTest):
     config_overrides = {
         "rum_sourcemapping_disabled": True,
     }
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_rum_transaction(self):
         path = 'http://localhost:8000/test/e2e/general-usecase/bundle.js.map'
         r = self.upload_sourcemap(file_name='bundle.js.map',
@@ -586,39 +563,39 @@ class SourcemappingDisabledIntegrationTest(ClientSideElasticTest):
         assert frames_checked > 0, "no frames checked"
 
 
+@integration_test
 class ExpvarDisabledIntegrationTest(ExpvarBaseTest):
     config_overrides = {"expvar_enabled": "false"}
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_expvar_exists(self):
         """expvar disabled, should 404"""
         r = self.get_debug_vars()
         assert r.status_code == 404, r.status_code
 
 
+@integration_test
 class ExpvarEnabledIntegrationTest(ExpvarBaseTest):
     config_overrides = {"expvar_enabled": "true"}
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_expvar_exists(self):
         """expvar enabled, should 200"""
         r = self.get_debug_vars()
         assert r.status_code == 200, r.status_code
 
 
+@integration_test
 class ExpvarCustomUrlIntegrationTest(ExpvarBaseTest):
     config_overrides = {"expvar_enabled": "true", "expvar_url": "/foo"}
     expvar_url = ExpvarBaseTest.expvar_url.replace("/debug/vars", "/foo")
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_expvar_exists(self):
         """expvar enabled, should 200"""
         r = self.get_debug_vars()
         assert r.status_code == 200, r.status_code
 
 
+@integration_test
 class MetricsIntegrationTest(ElasticTest):
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_metric_doc(self):
         self.load_docs_with_template(self.get_metricset_payload_payload_path(), self.intake_url, 'metric', 2)
         mappings = self.es.indices.get_field_mapping(
@@ -629,6 +606,7 @@ class MetricsIntegrationTest(ElasticTest):
         assert expected_type == actual_type, "want: {}, got: {}".format(expected_type, actual_type)
 
 
+@integration_test
 class ProfileIntegrationTest(ElasticTest):
     def metric_fields(self):
         metric_fields = set()
@@ -646,6 +624,7 @@ class ProfileIntegrationTest(ElasticTest):
         self.wait_until(cond, max_timeout=10, name="waiting for profile")
 
 
+@integration_test
 class CPUProfileIntegrationTest(ProfileIntegrationTest):
     config_overrides = {
         "instrumentation_enabled": "true",
@@ -654,7 +633,6 @@ class CPUProfileIntegrationTest(ProfileIntegrationTest):
         "profiling_cpu_duration": "5s",
     }
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_self_profiling(self):
         """CPU profiling enabled"""
 
@@ -679,6 +657,7 @@ class CPUProfileIntegrationTest(ProfileIntegrationTest):
         self.assertEqual(metric_fields, expected_metric_fields)
 
 
+@integration_test
 class HeapProfileIntegrationTest(ProfileIntegrationTest):
     config_overrides = {
         "instrumentation_enabled": "true",
@@ -686,7 +665,6 @@ class HeapProfileIntegrationTest(ProfileIntegrationTest):
         "profiling_heap_interval": "1s",
     }
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_self_profiling(self):
         """Heap profiling enabled"""
 
@@ -703,6 +681,7 @@ class HeapProfileIntegrationTest(ProfileIntegrationTest):
         self.assertEqual(metric_fields, expected_metric_fields)
 
 
+@integration_test
 class ExperimentalBaseTest(ElasticTest):
     def check_experimental_key_indexed(self, experimental):
         self.wait_until_pipelines_registered()
@@ -723,17 +702,17 @@ class ExperimentalBaseTest(ElasticTest):
             assert rs['hits']['total']['value'] == ct
 
 
+@integration_test
 class ProductionModeTest(ExperimentalBaseTest):
     config_overrides = {"mode": "production", "queue_flush": 2048}
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_experimental_key_indexed(self):
         self.check_experimental_key_indexed(False)
 
 
+@integration_test
 class ExperimentalModeTest(ExperimentalBaseTest):
     config_overrides = {"mode": "experimental", "queue_flush": 2048}
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_experimental_key_indexed(self):
         self.check_experimental_key_indexed(True)

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -142,7 +142,7 @@ class Test(ElasticTest):
 class EnrichEventIntegrationTest(ClientSideElasticTest):
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_backend_error(self):
-        # for backend events librar_frame information should not be changed,
+        # for backend events library_frame information should not be changed,
         # as no regex pattern is defined.
         self.load_docs_with_template(self.get_backend_error_payload_path(),
                                      self.backend_intake_url,
@@ -160,7 +160,7 @@ class EnrichEventIntegrationTest(ClientSideElasticTest):
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_backend_transaction(self):
-        # for backend events librar_frame information should not be changed,
+        # for backend events library_frame information should not be changed,
         # as no regex pattern is defined.
         self.load_docs_with_template(self.get_backend_transaction_payload_path(),
                                      self.backend_intake_url,

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -705,7 +705,7 @@ class HeapProfileIntegrationTest(ProfileIntegrationTest):
 
 class ExperimentalBaseTest(ElasticTest):
     def check_experimental_key_indexed(self, experimental):
-        self.wait_until(lambda: self.log_contains("Registered Ingest Pipelines successfully"), max_timeout=10)
+        self.wait_until_pipelines_registered()
         self.load_docs_with_template(self.get_payload_path("experimental.ndjson"),
                                      self.intake_url, 'transaction', 2)
         self.wait_until(lambda: self.log_contains("events have been published"), max_timeout=10)

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -1,6 +1,9 @@
+from datetime import datetime, timedelta
 import json
 import os
 import time
+
+import requests
 
 from apmserver import integration_test
 from apmserver import ClientSideElasticTest, ElasticTest, ExpvarBaseTest
@@ -636,8 +639,6 @@ class CPUProfileIntegrationTest(ProfileIntegrationTest):
     def test_self_profiling(self):
         """CPU profiling enabled"""
 
-        import requests
-
         def create_load():
             payload_path = self.get_payload_path("transactions_spans.ndjson")
             with open(payload_path) as f:
@@ -645,7 +646,7 @@ class CPUProfileIntegrationTest(ProfileIntegrationTest):
 
         # Wait for profiling to begin, and then start sending data
         # to the server to create some CPU load.
-        from datetime import datetime, timedelta
+
         time.sleep(1)
         start = datetime.now()
         while datetime.now()-start < timedelta(seconds=5):

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -17,7 +17,7 @@ class Test(ElasticTest):
         """
         This test starts the beat and checks that the onboarding doc has been published to ES
         """
-        self.wait_until(lambda: self.es.indices.exists(self.index_onboarding))
+        self.wait_until(lambda: self.es.indices.exists(self.index_onboarding), name="onboarding index created")
         self.es.indices.refresh(index=self.index_onboarding)
 
         self.wait_until(
@@ -643,7 +643,7 @@ class ProfileIntegrationTest(ElasticTest):
             self.es.indices.refresh(index=self.index_profile)
             response = self.es.count(index=self.index_profile, body={"query": {"term": {"processor.name": "profile"}}})
             return response['count'] != 0
-        self.wait_until(cond, max_timeout=10)
+        self.wait_until(cond, max_timeout=10, name="waiting for profile")
 
 
 class CPUProfileIntegrationTest(ProfileIntegrationTest):

--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -5,8 +5,7 @@ import uuid
 
 import requests
 
-from apmserver import ElasticTest
-from beat.beat import INTEGRATION_TESTS
+from apmserver import ElasticTest, integration_test
 
 
 class AgentConfigurationTest(ElasticTest):
@@ -57,9 +56,8 @@ class AgentConfigurationTest(ElasticTest):
         assert config.json()["result"] == "updated"
 
 
+@integration_test
 class AgentConfigurationIntegrationTest(AgentConfigurationTest):
-
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_config_requests(self):
         service_name = uuid.uuid4().hex
         service_env = "production"
@@ -200,7 +198,6 @@ class AgentConfigurationIntegrationTest(AgentConfigurationTest):
         for want, got in zip(expect_log, config_request_logs):
             self.assertDictContainsSubset(want, got)
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_rum_disabled(self):
         r = requests.get(self.rum_agent_config_url,
                          params={
@@ -212,6 +209,7 @@ class AgentConfigurationIntegrationTest(AgentConfigurationTest):
         assert "RUM endpoint is disabled" in r.json().get('error'), r.json()
 
 
+@integration_test
 class AgentConfigurationKibanaDownIntegrationTest(ElasticTest):
     config_overrides = {
         "logging_json": "true",
@@ -220,7 +218,6 @@ class AgentConfigurationKibanaDownIntegrationTest(ElasticTest):
         "kibana_host": "unreachablehost"
     }
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_config_requests(self):
         r1 = requests.get(self.agent_config_url,
                           headers={
@@ -251,13 +248,13 @@ class AgentConfigurationKibanaDownIntegrationTest(ElasticTest):
         }, config_request_logs[1])
 
 
+@integration_test
 class AgentConfigurationKibanaDisabledIntegrationTest(ElasticTest):
     config_overrides = {
         "logging_json": "true",
         "kibana_enabled": "false",
     }
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_log_kill_switch_active(self):
         r = requests.get(self.agent_config_url,
                          headers={
@@ -272,12 +269,12 @@ class AgentConfigurationKibanaDisabledIntegrationTest(ElasticTest):
         }, config_request_logs[0])
 
 
+@integration_test
 class RumAgentConfigurationIntegrationTest(AgentConfigurationTest):
     config_overrides = {
         "enable_rum": "true",
     }
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_rum(self):
         service_name = "rum-service"
         self.create_service_config({"transaction_sample_rate": 0.2}, service_name, agent="rum-js")
@@ -295,7 +292,6 @@ class RumAgentConfigurationIntegrationTest(AgentConfigurationTest):
                           headers={"Content-Type": "application/json"})
         assert r2.status_code == 304
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_rum_current_name(self):
         service_name = "rum-service"
         self.create_service_config({"transaction_sample_rate": 0.2}, service_name, agent="js-base")
@@ -313,7 +309,6 @@ class RumAgentConfigurationIntegrationTest(AgentConfigurationTest):
                           headers={"Content-Type": "application/json"})
         assert r2.status_code == 304
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_backend_after_rum(self):
         service_name = "backend-service"
         self.create_service_config({"transaction_sample_rate": 0.3}, service_name)
@@ -332,7 +327,6 @@ class RumAgentConfigurationIntegrationTest(AgentConfigurationTest):
         assert r2.status_code == 200, r2.status_code
         assert r2.json() == {"transaction_sample_rate": "0.3"}, r2.json()
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_rum_after_backend(self):
         service_name = "backend-service"
         self.create_service_config({"transaction_sample_rate": 0.3}, service_name)
@@ -351,7 +345,6 @@ class RumAgentConfigurationIntegrationTest(AgentConfigurationTest):
         assert r2.status_code == 200, r2.status_code
         assert r2.json() == {}, r2.json()
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_all_agents(self):
         service_name = "any-service"
         self.create_service_config(

--- a/tests/system/test_integration_logging.py
+++ b/tests/system/test_integration_logging.py
@@ -3,18 +3,15 @@ import unittest
 
 import requests
 
-from apmserver import ElasticTest
-from beat.beat import INTEGRATION_TESTS
-
-from apmserver import ElasticTest
+from apmserver import ElasticTest, integration_test
 
 
+@integration_test
 class LoggingIntegrationTest(ElasticTest):
     config_overrides = {
         "logging_json": "true",
     }
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_log_valid_event(self):
         with open(self.get_transaction_payload_path()) as f:
             r = requests.post(self.intake_url,
@@ -30,7 +27,6 @@ class LoggingIntegrationTest(ElasticTest):
                 "response_code": 202,
             }, req)
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_log_invalid_event(self):
         with open(self.get_payload_path("invalid-event.ndjson")) as f:
             r = requests.post(self.intake_url,
@@ -49,13 +45,13 @@ class LoggingIntegrationTest(ElasticTest):
             assert error.startswith("error validating JSON document against schema:"), json.dumps(req)
 
 
+@integration_test
 class LoggingIntegrationEventSizeTest(ElasticTest):
     config_overrides = {
         "logging_json": "true",
         "max_event_size": "100",
     }
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_log_event_size_exceeded(self):
         with open(self.get_transaction_payload_path()) as f:
             r = requests.post(self.intake_url,

--- a/tests/system/test_pipelines.py
+++ b/tests/system/test_pipelines.py
@@ -1,13 +1,12 @@
 import unittest
-from apmserver import ElasticTest, SubCommandTest
-from beat.beat import INTEGRATION_TESTS, TimeoutError
+from apmserver import ElasticTest, SubCommandTest, TimeoutError, integration_test
 from elasticsearch import Elasticsearch, NotFoundError
 from nose.tools import raises
 
 
 # APM Server `setup`
 
-@unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+@integration_test
 class SetupPipelinesDefaultTest(SubCommandTest):
     pipeline_name = "apm_user_agent"
 
@@ -40,7 +39,7 @@ class SetupPipelinesDefaultTest(SubCommandTest):
         assert self.log_contains("Registered Ingest Pipelines successfully.")
 
 
-@unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+@integration_test
 class SetupPipelinesDisabledTest(SetupPipelinesDefaultTest):
     def config(self):
         cfg = super(SetupPipelinesDisabledTest, self).config()
@@ -54,7 +53,7 @@ class SetupPipelinesDisabledTest(SetupPipelinesDefaultTest):
         assert self.log_contains("No pipeline callback registered")
 
 
-@unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+@integration_test
 class PipelineRegisterTest(ElasticTest):
     def test_default_pipelines_registered(self):
         pipelines = [
@@ -96,7 +95,7 @@ class PipelineRegisterTest(ElasticTest):
         assert ua_found
 
 
-@unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+@integration_test
 class PipelineDisabledTest(ElasticTest):
     config_overrides = {"disable_pipeline": True}
 
@@ -118,7 +117,7 @@ class PipelineDisabledTest(ElasticTest):
         assert uaFound
 
 
-@unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+@integration_test
 class PipelinesConfigurationNoneTest(ElasticTest):
     config_overrides = {"disable_pipelines": True}
 
@@ -141,7 +140,7 @@ class PipelinesConfigurationNoneTest(ElasticTest):
         assert uaFound
 
 
-@unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+@integration_test
 class MissingPipelineTest(ElasticTest):
     config_overrides = {"register_pipeline_enabled": "false"}
 
@@ -155,7 +154,7 @@ class MissingPipelineTest(ElasticTest):
                                      self.intake_url, 'transaction', 3)
 
 
-@unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+@integration_test
 class PipelineDefaultDisableRegisterOverwriteTest(ElasticTest):
 
     config_overrides = {
@@ -177,7 +176,7 @@ class PipelineDefaultDisableRegisterOverwriteTest(ElasticTest):
         self.wait_until(lambda: self.log_contains(loaded_msg), name=loaded_msg)
 
 
-@unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+@integration_test
 class PipelineEnableRegisterOverwriteTest(ElasticTest):
     config_overrides = {
         "register_pipeline_overwrite": "true",

--- a/tests/system/test_pipelines.py
+++ b/tests/system/test_pipelines.py
@@ -72,8 +72,8 @@ class PipelineRegisterTest(ElasticTest):
 
     def test_pipeline_applied(self):
         # setup
-        self.wait_until(lambda: self.log_contains("Registered Ingest Pipelines successfully"))
-        self.wait_until(lambda: self.log_contains("Finished index management setup."))
+        self.wait_until_pipelines_registered()
+        self.wait_until_ilm_setup()
         self.load_docs_with_template(self.get_payload_path("transactions.ndjson"),
                                      self.intake_url, 'transaction', 3)
 
@@ -101,7 +101,7 @@ class PipelineDisabledTest(ElasticTest):
     config_overrides = {"disable_pipeline": True}
 
     def test_pipeline_not_applied(self):
-        self.wait_until(lambda: self.log_contains("Finished index management setup."))
+        self.wait_until_ilm_setup()
         self.load_docs_with_template(self.get_payload_path("transactions.ndjson"),
                                      self.intake_url, 'transaction', 3)
         uaFound = False
@@ -123,7 +123,7 @@ class PipelinesConfigurationNoneTest(ElasticTest):
     config_overrides = {"disable_pipelines": True}
 
     def test_pipeline_not_applied(self):
-        self.wait_until(lambda: self.log_contains("Finished index management setup."))
+        self.wait_until_ilm_setup()
         self.load_docs_with_template(self.get_payload_path("transactions.ndjson"),
                                      self.intake_url, 'transaction', 3)
 
@@ -147,8 +147,9 @@ class MissingPipelineTest(ElasticTest):
 
     @raises(TimeoutError)
     def test_pipeline_not_registered(self):
-        self.wait_until(lambda: self.log_contains("No pipeline callback registered"))
-        self.wait_until(lambda: self.log_contains("Finished index management setup."))
+        self.wait_until(lambda: self.log_contains("No pipeline callback registered"),
+                        name="pipeline callback not registered")
+        self.wait_until_ilm_setup()
         # ensure events get stored properly nevertheless
         self.load_docs_with_template(self.get_payload_path("transactions.ndjson"),
                                      self.intake_url, 'transaction', 3)

--- a/tests/system/test_pipelines.py
+++ b/tests/system/test_pipelines.py
@@ -185,17 +185,15 @@ class PipelineEnableRegisterOverwriteTest(ElasticTest):
     }
 
     def setUp(self):
-        super(PipelineEnableRegisterOverwriteTest, self).setUp()
         es = Elasticsearch([self.get_elasticsearch_url()])
         # Write empty default pipeline
         es.ingest.put_pipeline(
             id="apm",
             body={"description": "empty apm test pipeline", "processors": []})
         self.wait_until(lambda: es.ingest.get_pipeline("apm"), name="apm ingest pipeline created")
+        super(PipelineEnableRegisterOverwriteTest, self).setUp()
 
     def test_pipeline_overwritten(self):
-        loaded_msg = "Registered Ingest Pipelines successfully"
-        self.wait_until(lambda: self.log_contains(loaded_msg))
         pipeline_id = "apm"
         desc = "Default enrichment for APM events"
         self.wait_until(lambda: self.es.ingest.get_pipeline(id=pipeline_id)[pipeline_id]['description'] == desc,

--- a/tests/system/test_pipelines.py
+++ b/tests/system/test_pipelines.py
@@ -63,7 +63,7 @@ class PipelineRegisterTest(ElasticTest):
             ("apm", "Default enrichment for APM events"),
         ]
         loaded_msg = "Pipeline successfully registered"
-        self.wait_until(lambda: self.log_contains(loaded_msg))
+        self.wait_until(lambda: self.log_contains(loaded_msg), name=loaded_msg)
 
         for pipeline_id, pipeline_desc in pipelines:
             pipeline = self.wait_until(lambda: self.es.ingest.get_pipeline(id=pipeline_id),
@@ -170,11 +170,11 @@ class PipelineDefaultDisableRegisterOverwriteTest(ElasticTest):
         es.ingest.put_pipeline(
             id="apm",
             body={"description": "empty apm test pipeline", "processors": []})
-        self.wait_until(lambda: es.ingest.get_pipeline("apm"))
+        self.wait_until(lambda: es.ingest.get_pipeline("apm"), name="apm ingest pipeline created")
 
     def test_pipeline_not_overwritten(self):
         loaded_msg = "Pipeline already registered"
-        self.wait_until(lambda: self.log_contains(loaded_msg))
+        self.wait_until(lambda: self.log_contains(loaded_msg), name=loaded_msg)
 
 
 @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
@@ -191,11 +191,12 @@ class PipelineEnableRegisterOverwriteTest(ElasticTest):
         es.ingest.put_pipeline(
             id="apm",
             body={"description": "empty apm test pipeline", "processors": []})
-        self.wait_until(lambda: es.ingest.get_pipeline("apm"))
+        self.wait_until(lambda: es.ingest.get_pipeline("apm"), name="apm ingest pipeline created")
 
     def test_pipeline_overwritten(self):
         loaded_msg = "Registered Ingest Pipelines successfully"
         self.wait_until(lambda: self.log_contains(loaded_msg))
         pipeline_id = "apm"
-        self.wait_until(lambda: self.es.ingest.get_pipeline(id=pipeline_id)[pipeline_id]['description'] == "Default enrichment for APM events",
+        desc = "Default enrichment for APM events"
+        self.wait_until(lambda: self.es.ingest.get_pipeline(id=pipeline_id)[pipeline_id]['description'] == desc,
                         name="fetching pipeline {}".format(pipeline_id))

--- a/tests/system/test_requests.py
+++ b/tests/system/test_requests.py
@@ -60,16 +60,10 @@ class Test(ServerBaseTest):
 
     def test_gzip(self):
         events = self.get_event_payload()
-        try:
-            out = StringIO()
-        except:
-            out = io.BytesIO()
+        out = StringIO()
 
         with gzip.GzipFile(fileobj=out, mode="w") as f:
-            try:
-                f.write(events)
-            except:
-                f.write(bytes(events, 'utf-8'))
+            f.write(events)
 
         r = requests.post(self.intake_url, data=out.getvalue(),
                           headers={'Content-Encoding': 'gzip', 'Content-Type': 'application/x-ndjson'})
@@ -77,10 +71,7 @@ class Test(ServerBaseTest):
 
     def test_deflate(self):
         events = self.get_event_payload()
-        try:
-            compressed_data = zlib.compress(events)
-        except:
-            compressed_data = zlib.compress(bytes(events, 'utf-8'))
+        compressed_data = zlib.compress(events)
 
         r = requests.post(self.intake_url, data=compressed_data,
                           headers={'Content-Encoding': 'deflate', 'Content-Type': 'application/x-ndjson'})

--- a/tests/system/test_requests.py
+++ b/tests/system/test_requests.py
@@ -5,7 +5,7 @@ import threading
 import time
 import zlib
 
-from apmserver import ServerBaseTest, ClientSideBaseTest, CorsBaseTest
+from apmserver import ServerBaseTest, ClientSideBaseTest, CorsBaseTest, integration_test
 
 
 try:
@@ -14,6 +14,7 @@ except ImportError:
     from io import StringIO
 
 
+@integration_test
 class Test(ServerBaseTest):
 
     def test_ok(self):
@@ -103,6 +104,7 @@ class Test(ServerBaseTest):
         assert r.status_code == 404, r.status_code
 
 
+@integration_test
 class ClientSideTest(ClientSideBaseTest):
 
     def test_ok(self):
@@ -120,6 +122,7 @@ class ClientSideTest(ClientSideBaseTest):
         assert r.status_code == 400, r.status_code
 
 
+@integration_test
 class CorsTest(CorsBaseTest):
 
     def test_ok(self):
@@ -161,6 +164,7 @@ class CorsTest(CorsBaseTest):
             assert r.headers['Access-Control-Allow-Methods'] == 'POST, OPTIONS', r.headers
 
 
+@integration_test
 class RateLimitTest(ClientSideBaseTest):
 
     def fire_events(self, data_file, iterations, split_ips=False):

--- a/tests/system/test_setup_index_management.py
+++ b/tests/system/test_setup_index_management.py
@@ -1,12 +1,9 @@
-import os
-from nose.plugins.attrib import attr
 import unittest
 import logging
 from elasticsearch import Elasticsearch, NotFoundError, RequestError
-from apmserver import BaseTest, ElasticTest
+from nose.plugins.attrib import attr
 from nose.tools import raises
-
-INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
+from apmserver import BaseTest, ElasticTest, integration_test
 
 EVENT_NAMES = ('error', 'span', 'transaction', 'metric', 'profile')
 
@@ -85,6 +82,7 @@ class IdxMgmt(object):
         assert len(a) == 0, a
 
 
+@integration_test
 class TestCommandSetupIndexManagement(BaseTest):
     """
     Test beat command `setup --index-management`
@@ -110,8 +108,6 @@ class TestCommandSetupIndexManagement(BaseTest):
                "file_enabled": "false"}
         self.render_config_template(**cfg)
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    @attr('integration')
     def test_setup_default_template_enabled_ilm_auto(self):
         """
         Test setup --index-management when template enabled and ilm auto
@@ -123,8 +119,6 @@ class TestCommandSetupIndexManagement(BaseTest):
         self.idxmgmt.assert_alias()
         self.idxmgmt.assert_default_policy()
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    @attr('integration')
     def test_setup_default_template_ilm_setup_disabled(self):
         """
         Test setup --index-management when ilm setup false
@@ -137,8 +131,6 @@ class TestCommandSetupIndexManagement(BaseTest):
         self.idxmgmt.assert_alias(loaded=0)
         self.idxmgmt.assert_default_policy(loaded=False)
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    @attr('integration')
     def test_setup_template_enabled_ilm_disabled(self):
         """
         Test setup --index-management when template enabled and ilm disabled
@@ -151,8 +143,6 @@ class TestCommandSetupIndexManagement(BaseTest):
         self.idxmgmt.assert_alias(loaded=0)
         self.idxmgmt.assert_default_policy(loaded=False)
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    @attr('integration')
     def test_setup_template_disabled_ilm_auto(self):
         """
         Test setup --index-management when template disabled and ilm enabled
@@ -165,8 +155,6 @@ class TestCommandSetupIndexManagement(BaseTest):
         self.idxmgmt.assert_alias()
         self.idxmgmt.assert_default_policy()
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    @attr('integration')
     def test_setup_template_disabled_ilm_disabled(self):
         """
         Test setup --index-management when template disabled and ilm disabled
@@ -180,8 +168,6 @@ class TestCommandSetupIndexManagement(BaseTest):
         self.idxmgmt.assert_alias(loaded=0)
         self.idxmgmt.assert_default_policy(loaded=False)
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    @attr('integration')
     def test_enable_ilm(self):
         """
         Test setup --index-management when ilm was enabled and gets disabled
@@ -214,8 +200,6 @@ class TestCommandSetupIndexManagement(BaseTest):
         self.idxmgmt.assert_alias()  # aliases do not get deleted
         self.idxmgmt.assert_default_policy()  # policies do not get deleted
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    @attr('integration')
     def test_disable(self):
         """
         Test setup --index-management when ilm was disabled and gets enabled
@@ -247,8 +231,6 @@ class TestCommandSetupIndexManagement(BaseTest):
         self.idxmgmt.assert_alias()
         self.idxmgmt.assert_default_policy()
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    @attr('integration')
     @raises(RequestError)
     def test_ensure_policy_is_used(self):
         """
@@ -264,6 +246,7 @@ class TestCommandSetupIndexManagement(BaseTest):
         self.idxmgmt.delete_policies()
 
 
+@integration_test
 class TestRunIndexManagementDefault(ElasticTest):
     register_pipeline_disabled = True
     config_overrides = {"queue_flush": 2048}
@@ -274,7 +257,6 @@ class TestRunIndexManagementDefault(ElasticTest):
         self.idxmgmt = IdxMgmt(self.es, self.index_name)
         self.idxmgmt.delete()
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_template_loaded(self):
         self.wait_until_ilm_setup()
         self.idxmgmt.assert_event_template()
@@ -282,6 +264,7 @@ class TestRunIndexManagementDefault(ElasticTest):
         self.idxmgmt.assert_default_policy()
 
 
+@integration_test
 class TestRunIndexManagementWithoutILM(ElasticTest):
     register_pipeline_disabled = True
     config_overrides = {"queue_flush": 2048}
@@ -295,7 +278,6 @@ class TestRunIndexManagementWithoutILM(ElasticTest):
     def start_args(self):
         return {"extra_args": ["-E", "apm-server.ilm.enabled=false"]}
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_template_and_ilm_loaded(self):
         self.wait_until_ilm_setup()
         self.idxmgmt.assert_event_template(with_ilm=False)
@@ -303,6 +285,7 @@ class TestRunIndexManagementWithoutILM(ElasticTest):
         self.idxmgmt.assert_default_policy(loaded=False)
 
 
+@integration_test
 class TestILMConfiguredPolicies(ElasticTest):
 
     config_overrides = {"queue_flush": 2048, "ilm_policies": True}
@@ -313,7 +296,6 @@ class TestILMConfiguredPolicies(ElasticTest):
         self.idxmgmt = IdxMgmt(self.es, self.index_name)
         self.idxmgmt.delete()
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_ilm_loaded(self):
         self.wait_until_ilm_setup()
         self.idxmgmt.assert_event_template(with_ilm=True)
@@ -336,6 +318,7 @@ class TestILMConfiguredPolicies(ElasticTest):
         assert "hot" in phases
 
 
+@integration_test
 class TestRunIndexManagementWithSetupDisabled(ElasticTest):
 
     config_overrides = {"queue_flush": 2048}
@@ -349,7 +332,6 @@ class TestRunIndexManagementWithSetupDisabled(ElasticTest):
     def start_args(self):
         return {"extra_args": ["-E", "apm-server.ilm.setup.enabled=false"]}
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_template_and_ilm_loaded(self):
         self.wait_until(lambda: self.log_contains("Manage ILM setup is disabled."),
                         max_timeout=5)
@@ -359,6 +341,7 @@ class TestRunIndexManagementWithSetupDisabled(ElasticTest):
         self.idxmgmt.assert_default_policy(loaded=False)
 
 
+@integration_test
 class TestCommandSetupTemplate(BaseTest):
     """
     Test beat command `setup --template`
@@ -381,8 +364,6 @@ class TestCommandSetupTemplate(BaseTest):
                "file_enabled": "false"}
         self.render_config_template(**cfg)
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    @attr('integration')
     def test_setup_default(self):
         """
         Test setup --template default
@@ -396,8 +377,6 @@ class TestCommandSetupTemplate(BaseTest):
         self.idxmgmt.assert_alias(loaded=0)
         self.idxmgmt.assert_default_policy(loaded=False)
 
-    @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
-    @attr('integration')
     def test_setup_template_disabled_ilm_enabled(self):
         """
         Test setup --template when template disabled and ilm enabled

--- a/tests/system/test_setup_index_management.py
+++ b/tests/system/test_setup_index_management.py
@@ -296,6 +296,7 @@ class TestILMConfiguredPolicies(ElasticTest):
         self.idxmgmt = IdxMgmt(self.es, self.index_name)
         self.idxmgmt.delete()
 
+    @unittest.skip("flaky")
     def test_ilm_loaded(self):
         self.wait_until_ilm_setup()
         self.idxmgmt.assert_event_template(with_ilm=True)

--- a/tests/system/test_setup_index_management.py
+++ b/tests/system/test_setup_index_management.py
@@ -265,7 +265,7 @@ class TestCommandSetupIndexManagement(BaseTest):
 
 
 class TestRunIndexManagementDefault(ElasticTest):
-
+    register_pipeline_disabled = True
     config_overrides = {"queue_flush": 2048}
 
     def setUp(self):
@@ -283,7 +283,7 @@ class TestRunIndexManagementDefault(ElasticTest):
 
 
 class TestRunIndexManagementWithoutILM(ElasticTest):
-
+    register_pipeline_disabled = True
     config_overrides = {"queue_flush": 2048}
 
     def setUp(self):

--- a/tests/system/test_setup_index_management.py
+++ b/tests/system/test_setup_index_management.py
@@ -276,9 +276,7 @@ class TestRunIndexManagementDefault(ElasticTest):
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_template_loaded(self):
-        self.wait_until(lambda: self.log_contains("Finished index management setup."),
-                        max_timeout=5)
-
+        self.wait_until_ilm_setup()
         self.idxmgmt.assert_event_template()
         self.idxmgmt.assert_alias()
         self.idxmgmt.assert_default_policy()
@@ -299,9 +297,7 @@ class TestRunIndexManagementWithoutILM(ElasticTest):
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_template_and_ilm_loaded(self):
-        self.wait_until(lambda: self.log_contains("Finished index management setup."),
-                        max_timeout=5)
-
+        self.wait_until_ilm_setup()
         self.idxmgmt.assert_event_template(with_ilm=False)
         self.idxmgmt.assert_alias(loaded=0)
         self.idxmgmt.assert_default_policy(loaded=False)
@@ -319,9 +315,7 @@ class TestILMConfiguredPolicies(ElasticTest):
 
     @unittest.skipUnless(INTEGRATION_TESTS, "integration test")
     def test_ilm_loaded(self):
-        self.wait_until(lambda: self.log_contains("Finished index management setup."),
-                        max_timeout=5)
-
+        self.wait_until_ilm_setup()
         self.idxmgmt.assert_event_template(with_ilm=True)
         self.idxmgmt.assert_alias()
         self.idxmgmt.assert_default_policy(loaded=True)


### PR DESCRIPTION
A collection of testing updates extracted from #2799.  The most substantial change introduced makes tests wait for pipelines to load before running.  This uncovered a race in one test that is skipped for now.