### PR TITLE
[DOCS] [7.4] Change Ruby APM `set_tags` link to `set_label`

### DIFF
--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -208,7 +208,7 @@ v|*Go:* {apm-go-ref-v}/api.html#context-set-tag[`SetTag`]
 *.NET:* {apm-dotnet-ref-v}/public-api.html#api-transaction-tags[`Labels`]
 *Node.js:* {apm-node-ref-v}/agent-api.html#apm-set-label[`setLabel`] \| {apm-node-ref-v}/agent-api.html#apm-add-labels[`addLabel`]
 *Python:* {apm-py-ref-v}/api.html#api-label[`elasticapm.label()`]
-*Ruby:* {apm-ruby-ref-v}/api.html#api-agent-set-tag[`set_tag`]
+*Ruby:* {apm-ruby-ref-v}/api.html#api-agent-set-label[`set_label`]
 *Rum:* {apm-rum-ref-v}/agent-api.html#apm-add-tags[`addTags`]
 |===
 


### PR DESCRIPTION
This fixes a broken link, which is causing the docs build to fail.

`set_tag` and it's anchor was removed from the APM Ruby docs with
https://github.com/elastic/apm-agent-ruby/pull/645.

7.4 backport of #3015