### PR TITLE
ci(jenkins): workaround gitCheckout issues

### DIFF
--- a/.ci/jobs/apm-server-mbp.yml
+++ b/.ci/jobs/apm-server-mbp.yml
@@ -30,8 +30,8 @@
           after: true
           before: true
         prune: true
-        shallow-clone: true
-        depth: 3
+        shallow-clone: false
+        depth: 100
         do-not-fetch-tags: true
         submodule:
           disable: false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ pipeline {
     CODECOV_SECRET = 'secret/apm-team/ci/apm-server-codecov'
     GITHUB_CHECK_ITS_NAME = 'APM Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
+    PIPELINE_LOG_LEVEL = 'DEBUG'
   }
   options {
     timeout(time: 2, unit: 'HOURS')


### PR DESCRIPTION
## Current issue

As far as I see the shallow cloning is disabled in the Jenkinsfile but the logs are not saying so:

![image](https://user-images.githubusercontent.com/2871786/70437657-02035700-1a84-11ea-9b46-e5ca292e4620.png)

Likely the JJBB is forcing that particular behavior, what it seems awkward. 

## What does this PR do?

Workaround the current issues when cloning the repo, as the JJBB seems to get more precedence.

## Why is it important?

Fix the pipeline in the master branch.

