### PR TITLE
Wait until agent config index is created 

### DIFF
--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -15,6 +15,12 @@ class AgentConfigurationTest(ElasticTest):
         "acm_cache_expiration": "1s",
     }
 
+    def setUp(self):
+        super(AgentConfigurationTest, self).setUp()
+        # with the Kibana platform, the agent config index will be created async
+        # we need to wait until it is ready
+        self.wait_until(lambda: self.es.indices.exists(".apm-agent-configuration"))
+
     def config(self):
         cfg = super(ElasticTest, self).config()
         cfg.update({


### PR DESCRIPTION
This is needed because with Kibana NP that index is created asyncrously.
