### PR TITLE
[docs] systemd and config ownership improvements

### DIFF
--- a/docs/config-ownership.asciidoc
+++ b/docs/config-ownership.asciidoc
@@ -24,7 +24,7 @@ To correct this problem you can change the ownership of the configuration file w
 +chown {beatname_lc}:{beatname_lc} /etc/{beatname_lc}/{beatname_lc}.yml+.
 
 You can also make root the config owner, although this is not recommended:
-+sudo chown root:root /etc/{beatname_lc}/{beatname_lc}.yml`+.
++sudo chown root:root /etc/{beatname_lc}/{beatname_lc}.yml+.
 
 ["source", "systemd", subs="attributes"]
 -----

--- a/docs/config-ownership.asciidoc
+++ b/docs/config-ownership.asciidoc
@@ -23,7 +23,7 @@ must be owned by the user identifier (uid=1000) or root
 To correct this problem you can change the ownership of the configuration file with:
 +chown {beatname_lc}:{beatname_lc} /etc/{beatname_lc}/{beatname_lc}.yml+.
 
-You can also make the config ownership world readable, although this is not recommended:
+You can also make root the config owner, although this is not recommended:
 +sudo chown root:root /etc/{beatname_lc}/{beatname_lc}.yml`+.
 
 ["source", "systemd", subs="attributes"]

--- a/docs/config-ownership.asciidoc
+++ b/docs/config-ownership.asciidoc
@@ -33,7 +33,7 @@ can only be writable by the owner but the permissions are "-rw-rw-r--"
 (to fix the permissions use: 'chmod go-w /etc/{beatname_lc}/{beatname_lc}.yml')
 -----
 
-To correct this problem, use `chmod go-w /etc/{beatname_lc}/{beatname_lc}.yml` to
+To correct this problem, use +chmod go-w /etc/{beatname_lc}/{beatname_lc}.yml+ to
 remove write privileges from anyone other than the owner.
 
 ===== Disabling strict permission checks

--- a/docs/config-ownership.asciidoc
+++ b/docs/config-ownership.asciidoc
@@ -24,7 +24,7 @@ To correct this problem you can change the ownership of the configuration file w
 +chown {beatname_lc}:{beatname_lc} /etc/{beatname_lc}/{beatname_lc}.yml+.
 
 You can also make the config ownership world readable, although this is not recommended:
-+chown root:root /etc/{beatname_lc}/{beatname_lc}.yml`+.
++sudo chown root:root /etc/{beatname_lc}/{beatname_lc}.yml`+.
 
 ["source", "systemd", subs="attributes"]
 -----

--- a/docs/config-ownership.asciidoc
+++ b/docs/config-ownership.asciidoc
@@ -1,0 +1,42 @@
+[[config-file-ownership]]
+==== Configuration file ownership
+
+On systems with POSIX file permissions,
+the {beatname_uc} configuration file is subject to ownership and file permission checks.
+These checks prevent unauthorized users from providing or modifying configurations that are run by {beatname_uc}.
+
+When installed via an RPM or DEB package,
+the configuration file at +/etc/{beatname_lc}/{beatname_lc}.yml+ will be owned by +{beatname_lc}+,
+and have file permissions of `0600` (`-rw-------`).
+
+{beatname_uc} will only start if the configuration file is owned by the user running the process,
+or by running as root with configuration ownership set to `root:root`
+
+You may encounter the following errors if your configuration file fails these checks:
+
+["source", "systemd", subs="attributes"]
+-----
+Exiting: error loading config file: config file ("/etc/{beatname_lc}/{beatname_lc}.yml")
+must be owned by the user identifier (uid=1000) or root
+-----
+
+To correct this problem you can change the ownership of the configuration file with:
++chown {beatname_lc}:{beatname_lc} /etc/{beatname_lc}/{beatname_lc}.yml+.
+
+You can also make the config ownership world readable, although this is not recommended:
++chown root:root /etc/{beatname_lc}/{beatname_lc}.yml`+.
+
+["source", "systemd", subs="attributes"]
+-----
+Exiting: error loading config file: config file ("/etc/{beatname_lc}/{beatname_lc}.yml")
+can only be writable by the owner but the permissions are "-rw-rw-r--"
+(to fix the permissions use: 'chmod go-w /etc/{beatname_lc}/{beatname_lc}.yml')
+-----
+
+To correct this problem, use `chmod go-w /etc/{beatname_lc}/{beatname_lc}.yml` to
+remove write privileges from anyone other than the owner.
+
+===== Disabling strict permission checks
+
+You can disable strict permission checks from the command line by using
+`--strict.perms=false`, but we strongly encourage you to leave the checks enabled.

--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -933,10 +933,14 @@ details.
 Sets the path for log files. See the <<directory-layout>> section for details.
 
 *`--strict.perms`*::
-Sets strict permission checking on configuration files. The default is
-`-strict.perms=true`. See
-{beats-ref}/config-file-permissions.html[Config file ownership and permissions] in
+Sets strict permission checking on configuration files. The default is `-strict.perms=true`.
+ifndef::apm-server[]
+See {beats-ref}/config-file-permissions.html[Config file ownership and permissions] in
 the _Beats Platform Reference_ for more information.
+endif::[]
+ifdef::apm-server[]
+See <<config-file-ownership>> for more information.
+endif::[]
 
 *`-v, --v`*::
 Logs INFO-level messages.

--- a/docs/copied-from-beats/shared-systemd.asciidoc
+++ b/docs/copied-from-beats/shared-systemd.asciidoc
@@ -16,12 +16,12 @@ Use `systemctl` to start or stop {beatname_uc}:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-systemctl start {beatname_lc}
+sudo systemctl start {beatname_lc}
 ------------------------------------------------
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-systemctl stop {beatname_lc}
+sudo systemctl stop {beatname_lc}
 ------------------------------------------------
 
 By default, the {beatname_uc} service starts automatically when the system
@@ -29,12 +29,12 @@ boots. To enable or disable auto start use:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-systemctl enable {beatname_lc}
+sudo systemctl enable {beatname_lc}
 ------------------------------------------------
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-systemctl disable {beatname_lc}
+sudo systemctl disable {beatname_lc}
 ------------------------------------------------
 
 ==== {beatname_uc} status and logs

--- a/docs/copied-from-beats/shared-systemd.asciidoc
+++ b/docs/copied-from-beats/shared-systemd.asciidoc
@@ -7,7 +7,7 @@ systemd commands.
 
 ifdef::apm-server[]
 We recommend that the {beatname_lc} process is run as a non-root user.
-Therefor, that is the default setup for {beatname_uc}'s DEB package and RPM installation.
+Therefore, that is the default setup for {beatname_uc}'s DEB package and RPM installation.
 endif::apm-server[]
 
 ==== Start and stop {beatname_uc}

--- a/docs/copied-from-beats/shared-systemd.asciidoc
+++ b/docs/copied-from-beats/shared-systemd.asciidoc
@@ -5,6 +5,11 @@ The DEB and RPM packages include a service unit for Linux systems with
 systemd. On these systems, you can manage {beatname_uc} by using the usual
 systemd commands.
 
+ifdef::apm-server[]
+We recommend that the {beatname_lc} process is run as a non-root user.
+Therefor, that is the default setup for {beatname_uc}'s DEB package and RPM installation.
+endif::apm-server[]
+
 ==== Start and stop {beatname_uc}
 
 Use `systemctl` to start or stop {beatname_uc}:
@@ -31,7 +36,6 @@ systemctl enable {beatname_lc}
 ------------------------------------------------
 systemctl disable {beatname_lc}
 ------------------------------------------------
-
 
 ==== {beatname_uc} status and logs
 
@@ -101,3 +105,7 @@ systemctl restart {beatname_lc}
 NOTE: It is recommended that you use a configuration management tool to
 include drop-in unit files. If you need to add a drop-in manually, use
 +systemctl edit {beatname_lc}.service+.
+
+ifdef::apm-server[]
+include::./../config-ownership.asciidoc[]
+endif::apm-server[]

--- a/docs/getting-started-apm-server.asciidoc
+++ b/docs/getting-started-apm-server.asciidoc
@@ -301,7 +301,11 @@ You can change the defaults in `apm-server.yml` or by supplying a different addr
 [[running-deb-rpm]]
 ==== Debian Package / RPM
 
-The Debian package and RPM installations of APM Server create an `apm-server` user.
+For Debian package and RPM installations, we recommend the apm-server process runs as a non-root user.
+Therefor, these installation methods create an `apm-server` user which you can use to start the process.
+In addition, {beatname_uc} will only start if the configuration file is
+<<config-file-ownership,owned by the user running the process>>.
+
 To start the APM Server in this case, run:
 
 [source,bash]

--- a/docs/getting-started-apm-server.asciidoc
+++ b/docs/getting-started-apm-server.asciidoc
@@ -302,7 +302,7 @@ You can change the defaults in `apm-server.yml` or by supplying a different addr
 ==== Debian Package / RPM
 
 For Debian package and RPM installations, we recommend the apm-server process runs as a non-root user.
-Therefor, these installation methods create an `apm-server` user which you can use to start the process.
+Therefore, these installation methods create an `apm-server` user which you can use to start the process.
 In addition, {beatname_uc} will only start if the configuration file is
 <<config-file-ownership,owned by the user running the process>>.
 


### PR DESCRIPTION
**A preview of the documenation changes in this PR is available [here](http://apm-server_3027.docs-preview.app.elstc.co/diff)**.
Closes https://github.com/elastic/apm-server/issues/2865.

Still some "build" work that needs to be done before this can be merged, mostly in the beats repo.

This PR updates:

* [**Step 3: Start**](https://www.elastic.co/guide/en/apm/server/current/apm-server-starting.html)
<img width="686" alt="Screen Shot 2019-12-10 at 11 12 20 AM" src="https://user-images.githubusercontent.com/5618806/70560752-01c79200-1b3e-11ea-83b6-84e60e887e8d.png">

* [**APM Serever and systemd**](https://www.elastic.co/guide/en/apm/server/current/running-with-systemd.html)
<img width="698" alt="Screen Shot 2019-12-10 at 11 16 09 AM" src="https://user-images.githubusercontent.com/5618806/70560989-7c90ad00-1b3e-11ea-930a-3b53be0685b3.png">

* The command reference documentation, which was linking to the incorrect Beats information.