### PR TITLE
capture es diagnostics per DIAGNOSTIC_INTERVAL

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -28,6 +28,10 @@ example from within an editor, while still allowing all dependencies to run in c
  SYSTEM_TEST_TARGET=./tests/system/test_integration.py:SourcemappingIntegrationTest.test_backend_error make run-system-test
 ```
 
+Elasticsearch diagnostics may be enabled by setting `DIAGNOSTIC_INTERVAL`.
+`DIAGNOSTIC_INTERVAL=1` will dump hot threads and task lists every second while tests are running
+to `build/system-tests/run/$test_name/diagnostics/`.
+
 ## Coverage Report
 For insights about test-coverage, run `make coverage-report`. The test coverage is reported in the folder `./build/coverage/`
 

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import shutil
+import threading
 import unittest
 from time import gmtime, strftime
 from urlparse import urlparse
@@ -18,9 +19,28 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..',
 from beat.beat import INTEGRATION_TESTS, TestCase, TimeoutError
 
 integration_test = unittest.skipUnless(INTEGRATION_TESTS, "integration test")
+diagnostic_interval = float(os.environ.get('DIAGNOSTIC_INTERVAL', 0))
+
 
 class BaseTest(TestCase):
     maxDiff = None
+
+    def setUp(self):
+        super(BaseTest, self).setUp()
+        if diagnostic_interval > 0:
+            self.diagnostics_path = os.path.join(self.working_dir, "diagnostics")
+            os.makedirs(self.diagnostics_path)
+            self.running = True
+            self.diagnostic_thread = threading.Thread(
+                target=self.dump_diagnotics, kwargs=dict(interval=diagnostic_interval))
+            self.diagnostic_thread.daemon = True
+            self.diagnostic_thread.start()
+
+    def tearDown(self):
+        if diagnostic_interval > 0:
+            self.running = False
+            self.diagnostic_thread.join(timeout=30)
+        super(BaseTest, self).tearDown()
 
     @classmethod
     def setUpClass(cls):
@@ -115,6 +135,23 @@ class BaseTest(TestCase):
 
     def ilm_index(self, index):
         return "{}-000001".format(index)
+
+    def dump_diagnotics(self, interval=2):
+        while self.running:
+            time.sleep(interval)
+            with open(os.path.join(self.diagnostics_path,
+                                   datetime.now().strftime("%Y%m%d_%H%M%S") + ".hot_threads"), mode="w") as out:
+                try:
+                    out.write(self.es.nodes.hot_threads(threads=99999))
+                except Exception as e:
+                    out.write("failed to query hot threads: {}\n".format(e))
+
+            with open(os.path.join(self.diagnostics_path,
+                                   datetime.now().strftime("%Y%m%d_%H%M%S") + ".tasks"), mode="w") as out:
+                try:
+                    json.dump(self.es.tasks.list(), out, indent=True, sort_keys=True)
+                except Exception as e:
+                    out.write("failed to query tasks: {}\n".format(e))
 
 
 class ServerSetUpBaseTest(BaseTest):

--- a/tests/system/test_setup_index_management.py
+++ b/tests/system/test_setup_index_management.py
@@ -100,9 +100,6 @@ class TestCommandSetupIndexManagement(BaseTest):
         self.idxmgmt.delete()
         self.render_config()
 
-    def tearDown(self):
-        self.idxmgmt.delete()
-
     def render_config(self):
         cfg = {"elasticsearch_host": self.get_elasticsearch_url(),
                "file_enabled": "false"}


### PR DESCRIPTION
Extracted from experiments in #3003.  This disables idx mgmt setup teardown as a result of that investigation.