### PR TITLE
[7.x] Retry connection when Kibana version is not compatible. (#3031)

### DIFF
--- a/beater/api/config/agent/handler.go
+++ b/beater/api/config/agent/handler.go
@@ -117,15 +117,17 @@ func validateClient(c *request.Context, client kibana.Client, withAuth bool) boo
 			errMsgKibanaDisabled)
 		return false
 	}
-	if !client.Connected() {
-		c.Result.Set(request.IDResponseErrorsServiceUnavailable,
-			http.StatusServiceUnavailable,
-			msgNoKibanaConnection,
-			msgNoKibanaConnection,
-			errMsgNoKibanaConnection)
-		return false
-	}
-	if supported, _ := client.SupportsVersion(minKibanaVersion); !supported {
+
+	if supported, err := client.SupportsVersion(minKibanaVersion, true); !supported {
+		if err != nil {
+			c.Result.Set(request.IDResponseErrorsServiceUnavailable,
+				http.StatusServiceUnavailable,
+				msgNoKibanaConnection,
+				msgNoKibanaConnection,
+				errMsgNoKibanaConnection)
+			return false
+		}
+
 		version, _ := client.GetVersion()
 
 		errMsg := fmt.Sprintf("%s: min version %+v, configured version %+v",

--- a/beater/api/config/agent/handler_test.go
+++ b/beater/api/config/agent/handler_test.go
@@ -27,9 +27,9 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/time/rate"
-
 	"github.com/elastic/apm-server/agentcfg"
+
+	"golang.org/x/time/rate"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/changelogs/7.5.asciidoc
+++ b/changelogs/7.5.asciidoc
@@ -4,6 +4,16 @@
 https://github.com/elastic/apm-server/compare/7.4\...7.5[View commits]
 
 * <<release-notes-7.5.0>>
+* <<release-notes-7.5.1>>
+
+[[release-notes-7.5.1]]
+=== APM Server version 7.5.1
+
+https://github.com/elastic/apm-server/compare/v7.5.0\...v7.5.1[View commits]
+
+[float]
+==== Bug fixes
+- Update Kibana client when its version becomes stale {pull}3031[3031].
 
 [[release-notes-7.5.0]]
 === APM Server version 7.5.0

--- a/kibana/connecting_client_test.go
+++ b/kibana/connecting_client_test.go
@@ -76,20 +76,20 @@ func TestConnectingClient_GetVersion(t *testing.T) {
 func TestConnectingClient_SupportsVersion(t *testing.T) {
 	t.Run("SupportsVersionTrue", func(t *testing.T) {
 		c := mockClient()
-		s, err := c.SupportsVersion(common.MustNewVersion("7.3.0"))
+		s, err := c.SupportsVersion(common.MustNewVersion("7.3.0"), false)
 		require.NoError(t, err)
 		assert.True(t, s)
 	})
 	t.Run("SupportsVersionFalse", func(t *testing.T) {
 		c := mockClient()
-		s, err := c.SupportsVersion(common.MustNewVersion("7.4.0"))
+		s, err := c.SupportsVersion(common.MustNewVersion("7.4.0"), false)
 		require.NoError(t, err)
 		assert.False(t, s)
 	})
 
 	t.Run("SupportsVersionError", func(t *testing.T) {
 		c := NewConnectingClient(mockCfg)
-		s, err := c.SupportsVersion(common.MustNewVersion("7.3.0"))
+		s, err := c.SupportsVersion(common.MustNewVersion("7.3.0"), false)
 		require.Error(t, err)
 		assert.Equal(t, err, errNotConnected)
 		assert.False(t, s)

--- a/tests/kibana.go
+++ b/tests/kibana.go
@@ -58,7 +58,10 @@ func (c *MockKibanaClient) GetVersion() (common.Version, error) {
 func (c *MockKibanaClient) Connected() bool { return c.connected }
 
 // SupportsVersion returns whether or not mock client is compatible with given version
-func (c *MockKibanaClient) SupportsVersion(v *common.Version) (bool, error) {
+func (c *MockKibanaClient) SupportsVersion(v *common.Version, _ bool) (bool, error) {
+	if !c.connected {
+		return false, errors.New("unable to retrieve connection to Kibana")
+	}
 	return v.LessThanOrEqual(true, &c.v), nil
 }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Retry connection when Kibana version is not compatible.  (#3031)