### PR TITLE
tests: use approvals for system tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -21,8 +21,9 @@ make unit
 While developing new tests or troubleshooting test failures, it is handy to run tests from outside of docker, for
 example from within an editor, while still allowing all dependencies to run in containers.  To accomplish this:
 
-* Run `make start-environment` to start docker containers for the Elastic Stack.
+* Run `make build-image start-environment` to start docker containers for the Elastic Stack.
 * Run `PYTHON_EXE=python2.7 make python-env` to build a python virtualenv
+* Run `make apm-server.test` to (re)build the executable used to run the apm-server
 * Run tests using the `run-system-tests` target, eg:
  ```
  SYSTEM_TEST_TARGET=./tests/system/test_integration.py:SourcemappingIntegrationTest.test_backend_error make run-system-test

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -61,8 +61,8 @@ class BaseTest(TestCase):
         cls.index_smap = "apm-{}-sourcemap".format(cls.apm_version)
         cls.index_profile = "apm-{}-profile".format(cls.apm_version)
         cls.index_acm = ".apm-agent-configuration"
-        cls.indices = [cls.index_onboarding, cls.index_error,
-                       cls.index_transaction, cls.index_span, cls.index_metric, cls.index_smap]
+        cls.indices = [cls.index_onboarding, cls.index_error, cls.index_transaction,
+                       cls.index_span, cls.index_metric, cls.index_smap, cls.index_profile]
 
         super(BaseTest, cls).setUpClass()
 

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -189,8 +189,8 @@ class ServerSetUpBaseTest(BaseTest):
         cfg = self.config()
         # pipeline registration is enabled by default and only happens if the output is elasticsearch
         if not getattr(self, "register_pipeline_disabled", False) and \
-            cfg.get("elasticsearch_host") and \
-            cfg.get("register_pipeline_enabled") != "false" and cfg.get("register_pipeline_overwrite") != "false":
+                cfg.get("elasticsearch_host") and \
+                cfg.get("register_pipeline_enabled") != "false" and cfg.get("register_pipeline_overwrite") != "false":
             self.wait_until_pipelines_registered()
 
     def start_args(self):
@@ -204,7 +204,7 @@ class ServerSetUpBaseTest(BaseTest):
 
     def wait_until_pipelines_registered(self):
         self.wait_until(lambda: self.log_contains("Registered Ingest Pipelines successfully"),
-                                                  name="pipelines registered")
+                        name="pipelines registered")
 
     def assert_no_logged_warnings(self, suppress=None):
         """
@@ -278,7 +278,8 @@ class ElasticTest(ServerBaseTest):
         self.kibana_url = self.get_kibana_url()
 
         # Cleanup index and template first
-        assert all(idx.startswith("apm") for idx in self.indices), "not all indices prefixed with apm, cleanup assumption broken"
+        assert all(idx.startswith("apm")
+                   for idx in self.indices), "not all indices prefixed with apm, cleanup assumption broken"
         if self.es.indices.get("apm*"):
             self.es.indices.delete(index="apm*", ignore=[400, 404])
             for idx in self.indices:

--- a/tests/system/error.approved.json
+++ b/tests/system/error.approved.json
@@ -1,272 +1,203 @@
 [
     {
-        "_score": 0.2876821,
-        "_type": "_doc",
-        "_id": "YEUQC2IBWUGW2FxIuwuv",
-        "_source": {
-            "@timestamp": "2017-05-09T15:04:05.000Z",
-            "timestamp":{
-                "us": 1494342245000000
+        "container": {
+            "id": "container-id"
+        },
+        "observer": {
+            "ephemeral_id": "e48a9b6e-4abd-440e-b2da-1bfaa738051d",
+            "version_major": 8,
+            "hostname": "alloy",
+            "version": "8.0.0",
+            "type": "apm-server",
+            "id": "d1489414-7cce-4bb7-aacc-7ce48818de2f"
+        },
+        "kubernetes": {
+            "pod": {
+                "uid": "pod-uid",
+                "name": "pod-name"
             },
-            "ecs": {
-                "version": "1.2.0"
+            "namespace": "namespace1"
+        },
+        "process": {
+            "ppid": 7788,
+            "args": [
+                "node",
+                "server.js"
+            ],
+            "pid": 1234,
+            "title": "node"
+        },
+        "timestamp": {
+            "us": 1494342245999000
+        },
+        "@timestamp": "2017-05-09T15:04:05.999Z",
+        "labels": {
+            "tag1": "one",
+            "tag2": 2
+        },
+        "agent": {
+            "version": "3.14.0",
+            "name": "elastic-node"
+        },
+        "host": {
+            "ip": "127.0.0.1",
+            "os": {
+                "platform": "darwin"
             },
-            "observer": {
-                "type": "apm-server",
-                "ephemeral_id": "xxx",
-                "hostname": "xxx",
-                "version": "xxx",
-                "id": "xxx"
+            "architecture": "x64"
+        },
+        "service": {
+            "node": {
+                "name": "myservice-node"
             },
-            "container":{
-                "id":"container-id"
+            "name": "1234_service-12a3",
+            "language": {
+                "version": "8",
+                "name": "ecmascript"
             },
-            "kubernetes":{
-                "namespace":"namespace1",
-                "pod":{
-                    "uid":"pod-uid",
-                    "name":"pod-name"
-                }
+            "environment": "staging",
+            "framework": {
+                "version": "1.2.3",
+                "name": "Express"
             },
-            "host": {
-                "os": {
-                    "platform": "darwin"
-                },
-                "architecture": "x64",
-                "ip": "127.0.0.1"
-            },
-            "agent": {
-                "version": "3.14.0",
-                "name": "elastic-node"
-            },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
-            "process": {
-                "ppid": 7788,
-                "pid": 1234,
-                "args": [
-                    "node",
-                    "server.js"
-                ],
-                "title": "node"
-            },
-            "service": {
-                "name": "1234_service-12a3",
-                "node": {
-                    "name": "myservice-node"
-                },
-                "language": {
-                    "version": "8",
-                    "name": "ecmascript"
-                },
-                "environment": "staging",
-                "framework": {
-                    "version": "1.2.3",
-                    "name": "Express"
-                },
-                "version": "5.1.3",
-                "runtime": {
-                    "version": "8.0.0",
-                    "name": "node"
-                }
-            },
-            "error": {
-                "exception": [{
-                    "type": "connection error"
-                }],
-                "grouping_key": "18f82051862e494727fa20e0adc15711",
-                "id": "7f0e9d68c1854d21a6f44673ed561ec8"
-            },
-            "user": {
-                "name": "bar",
-                "id": 123,
-                "email": "bar@example.com"
-            },
-            "labels": {
-                "tag1": "one",
-                "tag2": 2
+            "version": "5.1.3",
+            "runtime": {
+                "version": "8.0.0",
+                "name": "node"
             }
         },
-        "_index": "test-apm-12-12-2017"
+        "ecs": {
+            "version": "1.2.0"
+        },
+        "error": {
+            "grouping_key": "d6b3f958dfea98dc9ed2b57d5f0c48bb",
+            "log": {
+                "message": "Cannot read property 'baz' of undefined",
+                "level": "custom log level"
+            },
+            "id": "0f0e9d67c1854d21a6f44673ed561ec8"
+        },
+        "processor": {
+            "name": "error",
+            "event": "error"
+        }
     },
     {
-        "_score": 0.13353139,
-        "_type": "_doc",
-        "_id": "XkUQC2IBWUGW2FxIuwuv",
-        "_source": {
-            "@timestamp": "2017-05-09T15:04:05.999Z",
-            "timestamp":{
-                "us": 1494342245999999
+        "user_agent": {
+            "device": {
+                "name": "Other"
             },
-            "ecs":{
-                "version":"1.2.0"
+            "original": "Mozilla Chrome Edge",
+            "name": "Other"
+        },
+        "container": {
+            "id": "container-id"
+        },
+        "observer": {
+            "ephemeral_id": "e48a9b6e-4abd-440e-b2da-1bfaa738051d",
+            "version_major": 8,
+            "hostname": "alloy",
+            "version": "8.0.0",
+            "type": "apm-server",
+            "id": "d1489414-7cce-4bb7-aacc-7ce48818de2f"
+        },
+        "kubernetes": {
+            "pod": {
+                "uid": "pod-uid",
+                "name": "pod-name"
             },
-            "observer": {
-                "type": "apm-server",
-                "ephemeral_id": "xxx",
-                "hostname": "xxx",
-                "version": "xxx",
-                "id": "xxx"
-            },
-            "container":{
-                "id":"container-id"
-            },
-            "kubernetes":{
-                "namespace":"namespace1",
-                "pod":{
-                    "name":"pod-name",
-                    "uid":"pod-uid"
+            "namespace": "namespace1"
+        },
+        "process": {
+            "ppid": 7788,
+            "args": [
+                "node",
+                "server.js"
+            ],
+            "pid": 1234,
+            "title": "node"
+        },
+        "timestamp": {
+            "us": 1494342245999999
+        },
+        "@timestamp": "2017-05-09T15:04:05.999Z",
+        "labels": {
+            "organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8",
+            "tag1": "one",
+            "tag2": 2
+        },
+        "agent": {
+            "version": "4.3",
+            "name": "python"
+        },
+        "client": {
+            "ip": "8.8.8.8",
+            "geo": {
+                "continent_name": "North America",
+                "country_iso_code": "US",
+                "location": {
+                    "lat": 37.751,
+                    "lon": -97.822
                 }
+            }
+        },
+        "source": {
+            "ip": "8.8.8.8"
+        },
+        "host": {
+            "ip": "127.0.0.1",
+            "os": {
+                "platform": "darwin"
             },
-            "agent": {
-                "version": "4.3",
-                "name": "python"
+            "architecture": "x64"
+        },
+        "service": {
+            "node": {
+                "name": "myservice-xz"
             },
-            "host": {
-                "os": {
-                    "platform": "darwin"
-                },
-                "architecture": "x64",
-                "ip": "127.0.0.1"
+            "name": "abc",
+            "language": {
+                "version": "8",
+                "name": "ecmascript"
             },
-            "process": {
-                "ppid": 7788,
-                "pid": 1234,
-                "args": [
-                    "node",
-                    "server.js"
-                ],
-                "title": "node"
+            "environment": "staging",
+            "framework": {
+                "version": "1.2.3",
+                "name": "Express"
             },
-            "service": {
-                "name": "abc",
-                "node": {
-                    "name": "myservice-xz"
-                },
-                "language": {
-                    "version": "8",
-                    "name": "ecmascript"
-                },
-                "environment": "staging",
-                "framework": {
-                    "version": "1.2.3",
-                    "name": "Express"
-                },
-                "version": "5.1.3",
-                "runtime": {
-                    "version": "1.2",
-                    "name": "node"
-                }
-            },
-            "http": {
-                "version": "1.1",
-                "request": {
-                    "body": {
-                        "original":"Hello World"
-                    },
-                    "env": {
-                        "GATEWAY_INTERFACE": "CGI/1.1",
-                        "SERVER_SOFTWARE": "nginx"
-                    },
-                    "headers": {
-                        "Some-Other-Header": ["foo"],
-                        "Cookie": ["c1=v1,c2=v2"],
-                        "Array": ["foo", "bar", "baz"],
-                        "Content-Type": ["text/html"],
-                        "User-Agent": ["Mozilla Chrome Edge"]
-                    },
-                    "cookies":{
-                        "c1":"v1",
-                        "c2":"v2"
-                    },
-                    "method": "post",
-                    "socket": {
-                        "encrypted": true,
-                        "remote_address": "8.8.8.8"
-                    }
-                },
-                "response": {
-                    "finished": true,
-                    "headers": {
-                        "Content-Type": ["application/json"]
-                    },
-                    "headers_sent": true,
-                    "status_code": 200
-                }
-            },
-            "client": {
-                "ip": "8.8.8.8",
-                "geo": {
-                    "country_iso_code": "US",
-                    "location": {
-                        "lat": 37.751,
-                        "lon": -97.822
-                    },
-                    "continent_name": "North America"
-                }
-            },
-            "source": {
-                "ip": "8.8.8.8"
-            },
-            "url": {
-                "domain": "www.example.com",
-                "fragment": "#hash",
-                "full": "https://www.example.com/p/a/t/h?query=string#hash",
-                "original": "/p/a/t/h?query=string#hash",
-                "path": "/p/a/t/h",
-                "port": 8080,
-                "query": "?query=string",
-                "scheme": "https"
-            },
-            "transaction": {
-                "id": "945254c5-67a5-417e-8a4e-aa29efcbfb79"
-            },
-            "user": {
-                "name": "foo",
-                "id": 99,
-                "email": "foo@example.com"
-            },
-            "user_agent": {
-                "original": "Mozilla Chrome Edge",
-                "name": "Other",
-                "device": {
-                    "name": "Other"
-                }
-            },
-            "labels": {
-                "organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8",
-                "tag1": "one",
-                "tag2": 2
-            },
-            "error": {
-                "page": {
-                    "referer": "http://localhost:8000/test/e2e/",
-                    "url": "http://localhost:8000/test/e2e/general-usecase/"
-                },
-                "custom": {
-                    "and_objects": {
-                        "foo": [
-                            "bar",
-                            "baz"
-                        ]
-                    },
-                    "my_key": 1,
-                    "some_other_value": "foo bar"
-                },
-                "exception": [{
+            "version": "5.1.3",
+            "runtime": {
+                "version": "1.2",
+                "name": "node"
+            }
+        },
+        "ecs": {
+            "version": "1.2.0"
+        },
+        "url": {
+            "domain": "www.example.com",
+            "full": "https://www.example.com/p/a/t/h?query=string#hash",
+            "fragment": "#hash",
+            "port": 8080,
+            "query": "?query=string",
+            "path": "/p/a/t/h",
+            "scheme": "https",
+            "original": "/p/a/t/h?query=string#hash"
+        },
+        "error": {
+            "exception": [
+                {
                     "stacktrace": [
                         {
                             "function": "foo",
                             "abs_path": "/real/file/name.py",
+                            "library_frame": true,
                             "vars": {
                                 "key": "value"
                             },
-                            "exclude_from_grouping": false,
                             "module": "App::MyModule",
                             "filename": "file/name.py",
-                            "library_frame": true,
+                            "exclude_from_grouping": false,
                             "context": {
                                 "pre": [
                                     "line1",
@@ -325,274 +256,320 @@
                     },
                     "message": "The username root is unknown",
                     "type": "DbError"
-                }],
-                "grouping_key": "50f62f37edffc4630c6655ba3ecfcf46",
-                "id": "5f0e9d64c1854d21a6f44673ed561ec8",
-                "culprit": "my.module.function_name",
-                "log": {
-                    "stacktrace": [
-                        {
-                            "function": "foo",
-                            "abs_path": "/real/file/name.py",
-                            "vars": {
-                                "key": "value"
-                            },
-                            "exclude_from_grouping": false,
-                            "module": "App::MyModule",
-                            "filename": "/webpack/file/name.py",
-                            "library_frame": false,
-                            "context": {
-                                "pre": [
-                                    "line1",
-                                    "line2"
-                                ],
-                                "post": [
-                                    "line4",
-                                    "line5"
-                                ]
-                            },
-                            "line": {
-                                "column": 4,
-                                "number": 3,
-                                "context": "line3"
-                            }
-                        },
-                        {
-                            "function": "instrumented",
-                            "abs_path": "/Users/watson/code/node_modules/elastic/lib/instrumentation/index.js",
-                            "vars": {
-                                "key": "value"
-                            },
-                            "exclude_from_grouping": false,
-                            "filename": "lib/instrumentation/index.js",
-                            "context": {
-                                "pre": [
-                                    "  var trans = this.currentTransaction",
-                                    "",
-                                    "  return instrumented",
-                                    "",
-                                    "  function instrumented () {",
-                                    "    var prev = ins.currentTransaction",
-                                    "    ins.currentTransaction = trans"
-                                ],
-                                "post": [
-                                    "    ins.currentTransaction = prev",
-                                    "    return result",
-                                    "}",
-                                    "}",
-                                    "",
-                                    "Instrumentation.prototype._recoverTransaction = function (trans) {",
-                                    "  if (this.currentTransaction === trans) return"
-                                ]
-                            },
-                            "line": {
-                                "number": 102,
-                                "context": "    var result = original.apply(this, arguments)"
-                            }
-                        }
-                    ],
-                    "message": "My service could not talk to the database named foobar",
-                    "logger_name": "my.logger.name",
-                    "param_message": "My service could not talk to the database named %s",
-                    "level": "warning"
                 }
+            ],
+            "log": {
+                "stacktrace": [
+                    {
+                        "function": "foo",
+                        "abs_path": "/real/file/name.py",
+                        "library_frame": false,
+                        "vars": {
+                            "key": "value"
+                        },
+                        "module": "App::MyModule",
+                        "filename": "/webpack/file/name.py",
+                        "exclude_from_grouping": false,
+                        "context": {
+                            "pre": [
+                                "line1",
+                                "line2"
+                            ],
+                            "post": [
+                                "line4",
+                                "line5"
+                            ]
+                        },
+                        "line": {
+                            "column": 4,
+                            "number": 3,
+                            "context": "line3"
+                        }
+                    },
+                    {
+                        "function": "instrumented",
+                        "abs_path": "/Users/watson/code/node_modules/elastic/lib/instrumentation/index.js",
+                        "vars": {
+                            "key": "value"
+                        },
+                        "exclude_from_grouping": false,
+                        "filename": "lib/instrumentation/index.js",
+                        "context": {
+                            "pre": [
+                                "  var trans = this.currentTransaction",
+                                "",
+                                "  return instrumented",
+                                "",
+                                "  function instrumented () {",
+                                "    var prev = ins.currentTransaction",
+                                "    ins.currentTransaction = trans"
+                            ],
+                            "post": [
+                                "    ins.currentTransaction = prev",
+                                "    return result",
+                                "}",
+                                "}",
+                                "",
+                                "Instrumentation.prototype._recoverTransaction = function (trans) {",
+                                "  if (this.currentTransaction === trans) return"
+                            ]
+                        },
+                        "line": {
+                            "number": 102,
+                            "context": "    var result = original.apply(this, arguments)"
+                        }
+                    }
+                ],
+                "message": "My service could not talk to the database named foobar",
+                "logger_name": "my.logger.name",
+                "param_message": "My service could not talk to the database named %s",
+                "level": "warning"
             },
-            "processor": {
-                "name": "error",
-                "event": "error"
+            "culprit": "my.module.function_name",
+            "grouping_key": "50f62f37edffc4630c6655ba3ecfcf46",
+            "page": {
+                "url": "http://localhost:8000/test/e2e/general-usecase/",
+                "referer": "http://localhost:8000/test/e2e/"
             },
-            "user": {
-                "name": "foo",
-                "id": "99",
-                "email": "foo@example.com"
+            "custom": {
+                "and_objects": {
+                    "foo": [
+                        "bar",
+                        "baz"
+                    ]
+                },
+                "my_key": 1,
+                "some_other_value": "foo bar"
+            },
+            "id": "5f0e9d64c1854d21a6f44673ed561ec8"
+        },
+        "http": {
+            "version": "1.1",
+            "request": {
+                "body": {
+                    "original": "Hello World"
+                },
+                "cookies": {
+                    "c2": "v2",
+                    "c1": "v1"
+                },
+                "socket": {
+                    "encrypted": true,
+                    "remote_address": "8.8.8.8"
+                },
+                "headers": {
+                    "Some-Other-Header": [
+                        "foo"
+                    ],
+                    "Content-Type": [
+                        "text/html"
+                    ],
+                    "Array": [
+                        "foo",
+                        "bar",
+                        "baz"
+                    ],
+                    "Cookie": [
+                        "c1=v1,c2=v2"
+                    ],
+                    "User-Agent": [
+                        "Mozilla Chrome Edge"
+                    ]
+                },
+                "env": {
+                    "SERVER_SOFTWARE": "nginx",
+                    "GATEWAY_INTERFACE": "CGI/1.1"
+                },
+                "method": "post"
+            },
+            "response": {
+                "headers": {
+                    "Content-Type": [
+                        "application/json"
+                    ]
+                },
+                "finished": true,
+                "headers_sent": true,
+                "status_code": 200
             }
         },
-        "_index": "test-apm-12-12-2017"
+        "processor": {
+            "name": "error",
+            "event": "error"
+        },
+        "user": {
+            "email": "foo@example.com",
+            "name": "foo",
+            "id": "99"
+        }
     },
     {
-        "_score": 0.13353139,
-        "_type": "_doc",
-        "_id": "X0UQC2IBWUGW2FxIuwuv",
-        "_source": {
-            "@timestamp": "2017-05-09T15:04:05.000Z",
-            "timestamp":{
-                "us": 1494342245000000
+        "container": {
+            "id": "container-id"
+        },
+        "observer": {
+            "ephemeral_id": "e48a9b6e-4abd-440e-b2da-1bfaa738051d",
+            "version_major": 8,
+            "hostname": "alloy",
+            "version": "8.0.0",
+            "type": "apm-server",
+            "id": "d1489414-7cce-4bb7-aacc-7ce48818de2f"
+        },
+        "kubernetes": {
+            "pod": {
+                "uid": "pod-uid",
+                "name": "pod-name"
             },
-            "ecs":{
-                "version":"1.2.0"
+            "namespace": "namespace1"
+        },
+        "process": {
+            "ppid": 7788,
+            "args": [
+                "node",
+                "server.js"
+            ],
+            "pid": 1234,
+            "title": "node"
+        },
+        "timestamp": {
+            "us": 1494342245000000
+        },
+        "@timestamp": "2017-05-09T15:04:05.000Z",
+        "labels": {
+            "tag1": "one",
+            "tag2": 2
+        },
+        "agent": {
+            "version": "3.14.0",
+            "name": "elastic-node"
+        },
+        "host": {
+            "ip": "127.0.0.1",
+            "os": {
+                "platform": "darwin"
             },
-            "observer": {
-                "type": "apm-server",
-                "ephemeral_id": "xxx",
-                "hostname": "xxx",
-                "version": "xxx",
-                "id": "xxx"
+            "architecture": "x64"
+        },
+        "service": {
+            "node": {
+                "name": "myservice-node"
             },
-            "container":{
-                "id":"container-id"
+            "name": "1234_service-12a3",
+            "language": {
+                "version": "8",
+                "name": "ecmascript"
             },
-            "kubernetes":{
-                "namespace":"namespace1",
-                "pod":{
-                    "uid":"pod-uid",
-                    "name":"pod-name"
+            "environment": "staging",
+            "framework": {
+                "version": "1.2.3",
+                "name": "Express"
+            },
+            "version": "5.1.3",
+            "runtime": {
+                "version": "8.0.0",
+                "name": "node"
+            }
+        },
+        "ecs": {
+            "version": "1.2.0"
+        },
+        "error": {
+            "exception": [
+                {
+                    "type": "connection error"
                 }
+            ],
+            "grouping_key": "18f82051862e494727fa20e0adc15711",
+            "id": "7f0e9d68c1854d21a6f44673ed561ec8"
+        },
+        "processor": {
+            "name": "error",
+            "event": "error"
+        }
+    },
+    {
+        "container": {
+            "id": "container-id"
+        },
+        "observer": {
+            "ephemeral_id": "e48a9b6e-4abd-440e-b2da-1bfaa738051d",
+            "version_major": 8,
+            "hostname": "alloy",
+            "version": "8.0.0",
+            "type": "apm-server",
+            "id": "d1489414-7cce-4bb7-aacc-7ce48818de2f"
+        },
+        "kubernetes": {
+            "pod": {
+                "uid": "pod-uid",
+                "name": "pod-name"
             },
-            "agent": {
-                "version": "3.14.0",
-                "name": "elastic-node"
+            "namespace": "namespace1"
+        },
+        "process": {
+            "ppid": 7788,
+            "args": [
+                "node",
+                "server.js"
+            ],
+            "pid": 1234,
+            "title": "node"
+        },
+        "timestamp": {
+            "us": 1494342245000000
+        },
+        "@timestamp": "2017-05-09T15:04:05.000Z",
+        "labels": {
+            "tag1": "one",
+            "tag2": 2
+        },
+        "agent": {
+            "version": "3.14.0",
+            "name": "elastic-node"
+        },
+        "host": {
+            "ip": "127.0.0.1",
+            "os": {
+                "platform": "darwin"
             },
-            "host": {
-                "os": {
-                    "platform": "darwin"
-                },
-                "architecture": "x64",
-                "ip": "127.0.0.1"
+            "architecture": "x64"
+        },
+        "service": {
+            "node": {
+                "name": "myservice-node"
             },
-            "processor": {
-                "name": "error",
-                "event": "error"
+            "name": "1234_service-12a3",
+            "language": {
+                "version": "8",
+                "name": "ecmascript"
             },
-            "process": {
-                "ppid": 7788,
-                "pid": 1234,
-                "args": [
-                    "node",
-                    "server.js"
-                ],
-                "title": "node"
+            "environment": "staging",
+            "framework": {
+                "version": "1.2.3",
+                "name": "Express"
             },
-            "service": {
-                "name": "1234_service-12a3",
-                "node": {
-                    "name": "myservice-node"
-                },
-                "language": {
-                    "version": "8",
-                    "name": "ecmascript"
-                },
-                "environment": "staging",
-                "framework": {
-                    "version": "1.2.3",
-                    "name": "Express"
-                },
-                "version": "5.1.3",
-                "runtime": {
-                    "version": "8.0.0",
-                    "name": "node"
-                }
-            },
-            "error": {
-                "exception": [{
+            "version": "5.1.3",
+            "runtime": {
+                "version": "8.0.0",
+                "name": "node"
+            }
+        },
+        "ecs": {
+            "version": "1.2.0"
+        },
+        "error": {
+            "exception": [
+                {
                     "message": "foo is not defined",
                     "code": "35"
-                }],
-                "grouping_key": "f6b5a2877d9b00d5b32b44c9db039f11",
-                "id": "8f0e9d68c1854d21a6f44673ed561ec8"
-            },
-            "user": {
-                "name": "bar",
-                "id": 123,
-                "email": "bar@example.com"
-            },
-            "labels": {
-                "tag1": "one",
-                "tag2": 2
-            }
+                }
+            ],
+            "grouping_key": "f6b5a2877d9b00d5b32b44c9db039f11",
+            "id": "8f0e9d68c1854d21a6f44673ed561ec8"
         },
-        "_index": "test-apm-12-12-2017"
-    },
-    {
-        "_score": 0.13353139,
-        "_type": "_doc",
-        "_id": "YUUQC2IBWUGW2FxIuwuv",
-        "_source": {
-            "@timestamp": "2017-05-09T15:04:05.999Z",
-            "timestamp":{
-                "us": 1494342245999000
-            },
-            "ecs":{
-                "version":"1.2.0"
-            },
-            "observer": {
-                "type": "apm-server",
-                "ephemeral_id": "xxx",
-                "hostname": "xxx",
-                "version": "xxx",
-                "id": "xxx"
-            },
-            "container":{
-                "id":"container-id"
-            },
-            "kubernetes": {
-                "namespace": "namespace1",
-                "pod":{
-                    "uid":"pod-uid",
-                    "name":"pod-name"
-                }
-            },
-            "agent": {
-                "version": "3.14.0",
-                "name": "elastic-node"
-            },
-            "host": {
-                "os": {
-                    "platform": "darwin"
-                },
-                "architecture": "x64",
-                "ip": "127.0.0.1"
-            },
-            "processor": {
-                "name": "error",
-                "event": "error"
-            },
-            "process": {
-                "ppid": 7788,
-                "pid": 1234,
-                "args": [
-                    "node",
-                    "server.js"
-                ],
-                "title": "node"
-            },
-            "service": {
-                "name": "1234_service-12a3",
-                "node": {
-                    "name": "myservice-node"
-                },
-                "language": {
-                    "version": "8",
-                    "name": "ecmascript"
-                },
-                "environment": "staging",
-                "framework": {
-                    "version": "1.2.3",
-                    "name": "Express"
-                },
-                "version": "5.1.3",
-                "runtime": {
-                    "version": "8.0.0",
-                    "name": "node"
-                }
-            },
-            "error": {
-                "grouping_key": "d6b3f958dfea98dc9ed2b57d5f0c48bb",
-                "id": "0f0e9d67c1854d21a6f44673ed561ec8",
-                "log": {
-                    "message": "Cannot read property 'baz' of undefined",
-                    "level": "custom log level"
-                }
-            },
-            "user": {
-                "name": "bar",
-                "id": 123,
-                "email": "bar@example.com"
-            },
-            "labels": {
-                "tag1": "one",
-                "tag2": 2
-            }
-        },
-        "_index": "test-apm-12-12-2017"
+        "processor": {
+            "name": "error",
+            "event": "error"
+        }
     }
 ]

--- a/tests/system/spans.approved.json
+++ b/tests/system/spans.approved.json
@@ -1,434 +1,319 @@
 [
     {
-        "_score": 0.9808292,
-        "_type": "_doc",
-        "_id": "IkU4C2IBWUGW2FxIExjw",
-        "_source": {
-            "@timestamp": "2017-05-30T18:53:27.154Z",
-            "timestamp":{
-                "us": 1496170407154000
-            },
-            "ecs": {
-                "version": "1.2.0"
-            },
-            "observer": {
-                "type": "apm-server",
-                "ephemeral_id": "xxx",
-                "hostname": "xxx",
-                "version": "xxx",
-                "id": "xxx"
-            },
-            "container":{
-                "id":"container-id"
-            },
-            "kubernetes":{
-                "namespace":"namespace1",
-                "pod":{
-                    "uid":"pod-uid",
-                    "name":"pod-name"
-                }
-            },
-            "host": {
-                "os": {
-                    "platform": "darwin"
-                },
-                "hostname": "prod1.example.com",
-                "architecture": "x64",
-                "ip": "127.0.0.1"
-            },
-            "agent": {
-                "version": "3.14.0",
-                "name": "elastic-node"
-            },
-            "processor": {
-                "event": "span",
-                "name": "transaction"
-            },
-            "service": {
-                "name": "1234_service-12a3",
-                "environment": "staging"
-            },
-            "span": {
-                "id": "2aaaaaaaaaaaaaaa",
-                "name": "GET /api/types",
-                "start": {
-                    "us": 1845
-                },
-                "duration": {
-                    "us": 3564
-                },
-                "type": "request",
-                "subtype": "http",
-                "action": "post"
-            },
-            "transaction": {
-                "id": "945254c567a5417e"
-            },
-            "parent": {
-                "id": "945254c567a5417e"
-            },
-            "trace": {
-                "id": "945254c567a5417eaaaaaaaaaaaaaaaa"
-            }
+        "parent": {
+            "id": "945254c567a5417e"
         },
-        "_index": "test-apm-12-12-2017"
-    },
-    {
-        "_score": 0.6931472,
-        "_type": "_doc",
-        "_id": "J0U4C2IBWUGW2FxIExjw",
-        "_source": {
-            "@timestamp": "2017-05-30T18:53:42.281Z",
-            "timestamp":{
-                "us": 1496170422281000
-            },
-            "ecs": {
-                "version": "1.2.0"
-            },
-            "observer": {
-                "type": "apm-server",
-                "ephemeral_id": "xxx",
-                "hostname": "xxx",
-                "version": "xxx",
-                "id": "xxx"
-            },
-            "container":{
-                "id":"container-id"
-            },
-            "kubernetes":{
-                "namespace":"namespace1",
-                "pod":{
-                    "uid":"pod-uid",
-                    "name":"pod-name"
-                }
-            },
-            "host": {
-                "os": {
-                    "platform": "darwin"
-                },
-                "hostname": "prod1.example.com",
-                "architecture": "x64",
-                "ip": "127.0.0.1"
-            },
-            "agent": {
-                "version": "1.3",
-                "name": "js-base"
-            },
-            "span": {
-                "id": "15aaaaaaaaaaaaaa",
-                "duration": {
-                    "us": 3781
-                },
-                "start": {
-                    "us": 2830
-                },
-                "type": "db.postgresql.query",
-                "subtype": "postgresql",
-                "action": "query.custom",
-                "name": "SELECT FROM product_types",
-                "db": {
-                    "instance": "customers",
-                    "type": "sql",
-                    "user": {
-                        "name": "readonly_user"
+        "transaction": {
+            "id": "945254c567a5417e"
+        },
+        "span": {
+            "stacktrace": [
+                {
+                    "function": "onread",
+                    "abs_path": "net.js",
+                    "vars": {
+                        "key": "value"
                     },
-                    "statement": "SELECT * FROM product_types WHERE user_id=?"
-                }
-            },
-            "service": {
-                "name": "serviceabc",
-                "environment": "staging"
-            },
-            "transaction": {
-                "id": "85925e55b43f4342"
-            },
-            "parent": {
-                "id": "85925e55b43f4342"
-            },
-            "trace": {
-                "id": "85925e55b43f4342aaaaaaaaaaaaaaaa"
-            },
-            "processor": {
-                "name": "transaction",
-                "event": "span"
-            }
-        },
-        "_index": "test-apm-12-12-2017"
-    },
-    {
-        "_score": 0.2876821,
-        "_type": "_doc",
-        "_id": "I0U4C2IBWUGW2FxIExjw",
-        "_source": {
-            "@timestamp": "2017-05-30T18:53:27.154Z",
-            "timestamp":{
-                "us": 1496170407154000
-            },
-            "ecs": {
-                "version": "1.2.0"
-            },
-            "observer": {
-                "type": "apm-server",
-                "ephemeral_id": "xxx",
-                "hostname": "xxx",
-                "version": "xxx",
-                "id": "xxx"
-            },
-            "container":{
-                "id":"container-id"
-            },
-            "kubernetes":{
-                "namespace":"namespace1",
-                "pod":{
-                    "uid":"pod-uid",
-                    "name":"pod-name"
-                }
-            },
-            "host": {
-                "os": {
-                    "platform": "darwin"
-                },
-                "hostname": "prod1.example.com",
-                "architecture": "x64",
-                "ip": "127.0.0.1"
-            },
-            "agent": {
-                "version": "3.14.0",
-                "name": "elastic-node"
-            },
-            "processor": {
-                "event": "span",
-                "name": "transaction"
-            },
-            "service": {
-                "name": "1234_service-12a3",
-                "environment": "staging"
-            },
-            "span": {
-                "id": "3aaaaaaaaaaaaaaa",
-                "name": "GET /api/types",
-                "start": {
-                    "us": 0
-                },
-                "duration": {
-                    "us": 13980
-                },
-                "type": "request"
-            },
-            "transaction": {
-                "id": "945254c567a5417e"
-            },
-            "parent": {
-                "id": "945254c567a5417e"
-            },
-            "trace": {
-                "id": "945254c567a5417eaaaaaaaaaaaaaaaa"
-            }
-        },
-        "_index": "test-apm-12-12-2017"
-    },
-    {
-        "_score": 0.18232156,
-        "_type": "_doc",
-        "_id": "IEU4C2IBWUGW2FxIExjw",
-        "_source": {
-            "@timestamp": "2017-05-30T18:53:27.154Z",
-            "timestamp":{
-                "us": 1496170407154000
-            },
-            "ecs": {
-                "version": "1.2.0"
-            },
-            "observer": {
-                "type": "apm-server",
-                "ephemeral_id": "xxx",
-                "hostname": "xxx",
-                "version": "xxx",
-                "id": "xxx"
-            },
-            "container":{
-                "id":"container-id"
-            },
-            "kubernetes":{
-                "namespace":"namespace1",
-                "pod":{
-                    "uid":"pod-uid",
-                    "name":"pod-name"
-                }
-            },
-            "host": {
-                "os": {
-                    "platform": "darwin"
-                },
-                "hostname": "prod1.example.com",
-                "architecture": "x64",
-                "ip": "127.0.0.1"
-            },
-            "agent": {
-                "version": "3.14.0",
-                "name": "elastic-node"
-            },
-            "processor": {
-                "event": "span",
-                "name": "transaction"
-            },
-            "service": {
-                "name": "1234_service-12a3",
-                "environment": "staging"
-            },
-            "span": {
-                "id": "0aaaaaaaaaaaaaaa",
-                "stacktrace": [
-                    {
-                        "function": "onread",
-                        "library_frame": true,
-                        "vars": {
-                            "key": "value"
-                        },
-                        "abs_path": "net.js",
-                        "module": "some module",
-                        "filename": "net.js",
-                        "exclude_from_grouping": false,
-                        "context": {
-                            "pre": [
-                                "  var trans = this.currentTransaction",
-                                ""
-                            ],
-                            "post": [
-                                "    ins.currentTransaction = prev",
-                                "    return result",
-                                "}"
-                            ]
-                        },
-                        "line": {
-                            "column": 4,
-                            "number": 547,
-                            "context": "line3"
-                        }
+                    "exclude_from_grouping": false,
+                    "module": "some module",
+                    "filename": "net.js",
+                    "library_frame": true,
+                    "context": {
+                        "pre": [
+                            "  var trans = this.currentTransaction",
+                            ""
+                        ],
+                        "post": [
+                            "    ins.currentTransaction = prev",
+                            "    return result",
+                            "}"
+                        ]
                     },
-                    {
-                        "line": {
-                            "number": 10
-                        },
-                        "exclude_from_grouping": false,
-                        "filename": "my2file.js"
+                    "line": {
+                        "column": 4,
+                        "number": 547,
+                        "context": "line3"
                     }
-                ],
-                "name": "SELECT FROM product_types",
-                "sync": false,
-                "start": {
-                    "us": 2830
                 },
-                "duration": {
-                    "us": 3781
+                {
+                    "line": {
+                        "number": 10
+                    },
+                    "exclude_from_grouping": false,
+                    "filename": "my2file.js"
+                }
+            ],
+            "http": {
+                "url": {
+                    "original": "http://localhost:8000"
                 },
-                "type": "db",
-                "subtype": "postgresql",
-                "action": "query",
-                "db": {
-                    "instance": "customers",
-                    "type": "sql",
-                    "user": {
-                        "name": "readonly_user"
-                    },
-                    "statement": "SELECT * FROM product_types WHERE user_id=?"
-                },
-                "http": {
-                    "url": {
-                        "original": "http://localhost:8000"
-                    },
-                    "response": {
-                        "status_code": 200
-                    },
-                    "method": "get"
+                "method": "get",
+                "response": {
+                    "status_code": 200
                 }
             },
-            "transaction": {
-                "id": "945254c567a5417e"
+            "name": "SELECT FROM product_types",
+            "subtype": "postgresql",
+            "db": {
+                "instance": "customers",
+                "type": "sql",
+                "user": {
+                    "name": "readonly_user"
+                },
+                "statement": "SELECT * FROM product_types WHERE user_id=?"
             },
-            "parent": {
-                "id": "945254c567a5417e"
+            "sync": false,
+            "id": "0aaaaaaaaaaaaaaa",
+            "start": {
+                "us": 2830
             },
-            "trace": {
-                "id": "945254c567a5417eaaaaaaaaaaaaaaaa"
+            "duration": {
+                "us": 3781
             },
-            "labels": {
-                "span_tag": "something"
-            }
+            "type": "db",
+            "action": "query"
         },
-        "_index": "test-apm-12-12-2017"
+        "trace": {
+            "id": "945254c567a5417eaaaaaaaaaaaaaaaa"
+        },
+        "observer": {
+            "ephemeral_id": "b0eca9b8-818a-40af-89d9-52ce62270ecf",
+            "version_major": 8,
+            "hostname": "alloy",
+            "version": "8.0.0",
+            "type": "apm-server",
+            "id": "6c887131-df07-4f05-a69d-e60897ccbb64"
+        },
+        "timestamp": {
+            "us": 1496170407154000
+        },
+        "@timestamp": "2017-05-30T18:53:27.154Z",
+        "labels": {
+            "span_tag": "something"
+        },
+        "agent": {
+            "version": "3.14.0",
+            "name": "elastic-node"
+        },
+        "service": {
+            "environment": "staging",
+            "name": "1234_service-12a3"
+        },
+        "ecs": {
+            "version": "1.2.0"
+        },
+        "processor": {
+            "name": "transaction",
+            "event": "span"
+        }
     },
     {
-        "_score": 0.18232156,
-        "_type": "_doc",
-        "_id": "IUU4C2IBWUGW2FxIExjw",
-        "_source": {
-            "@timestamp": "2017-05-30T18:53:27.154Z",
-            "timestamp":{
-                "us": 1496170407154000
-            },
-            "ecs": {
-                "version": "1.2.0"
-            },
-            "observer": {
-                "type": "apm-server",
-                "ephemeral_id": "xxx",
-                "hostname": "xxx",
-                "version": "xxx",
-                "id": "xxx"
-            },
-            "container":{
-                "id":"container-id"
-            },
-            "kubernetes":{
-                "namespace":"namespace1",
-                "pod":{
-                    "uid":"pod-uid",
-                    "name":"pod-name"
-                }
-            },
-            "host": {
-                "os": {
-                    "platform": "darwin"
-                },
-                "hostname": "prod1.example.com",
-                "architecture": "x64",
-                "ip": "127.0.0.1"
-            },
-            "agent": {
-                "version": "3.14.0",
-                "name": "elastic-node"
-            },
-            "processor": {
-                "name": "transaction",
-                "event": "span"
-            },
-            "service": {
-                "name": "1234_service-12a3",
-                "environment": "staging"
-            },
-            "span": {
-                "id": "1aaaaaaaaaaaaaaa",
-                "name": "GET /api/types",
-                "start": {
-                    "us": 0
-                },
-                "duration": {
-                    "us": 32592
-                },
-                "type": "request",
-                "subtype": "external"
-            },
-            "transaction": {
-                "id": "945254c567a5417e"
-            },
-            "parent": {
-                "id": "945254c567a5417e"
-            },
-            "trace": {
-                "id": "945254c567a5417eaaaaaaaaaaaaaaaa"
-            }
+        "parent": {
+            "id": "85925e55b43f4342"
         },
-        "_index": "test-apm-12-12-2017"
+        "transaction": {
+            "id": "85925e55b43f4342"
+        },
+        "span": {
+            "name": "SELECT FROM product_types",
+            "start": {
+                "us": 2830
+            },
+            "db": {
+                "instance": "customers",
+                "type": "sql",
+                "user": {
+                    "name": "readonly_user"
+                },
+                "statement": "SELECT * FROM product_types WHERE user_id=?"
+            },
+            "subtype": "postgresql",
+            "action": "query.custom",
+            "duration": {
+                "us": 3781
+            },
+            "type": "db.postgresql.query",
+            "id": "15aaaaaaaaaaaaaa"
+        },
+        "trace": {
+            "id": "85925e55b43f4342aaaaaaaaaaaaaaaa"
+        },
+        "observer": {
+            "ephemeral_id": "b0eca9b8-818a-40af-89d9-52ce62270ecf",
+            "version_major": 8,
+            "hostname": "alloy",
+            "version": "8.0.0",
+            "type": "apm-server",
+            "id": "6c887131-df07-4f05-a69d-e60897ccbb64"
+        },
+        "timestamp": {
+            "us": 1496170422281000
+        },
+        "@timestamp": "2017-05-30T18:53:42.281Z",
+        "agent": {
+            "version": "1.3",
+            "name": "js-base"
+        },
+        "service": {
+            "environment": "staging",
+            "name": "serviceabc"
+        },
+        "ecs": {
+            "version": "1.2.0"
+        },
+        "processor": {
+            "name": "transaction",
+            "event": "span"
+        }
+    },
+    {
+        "parent": {
+            "id": "945254c567a5417e"
+        },
+        "transaction": {
+            "id": "945254c567a5417e"
+        },
+        "span": {
+            "name": "GET /api/types",
+            "start": {
+                "us": 0
+            },
+            "subtype": "external",
+            "duration": {
+                "us": 32592
+            },
+            "type": "request",
+            "id": "1aaaaaaaaaaaaaaa"
+        },
+        "trace": {
+            "id": "945254c567a5417eaaaaaaaaaaaaaaaa"
+        },
+        "observer": {
+            "ephemeral_id": "b0eca9b8-818a-40af-89d9-52ce62270ecf",
+            "version_major": 8,
+            "hostname": "alloy",
+            "version": "8.0.0",
+            "type": "apm-server",
+            "id": "6c887131-df07-4f05-a69d-e60897ccbb64"
+        },
+        "timestamp": {
+            "us": 1496170407154000
+        },
+        "@timestamp": "2017-05-30T18:53:27.154Z",
+        "agent": {
+            "version": "3.14.0",
+            "name": "elastic-node"
+        },
+        "service": {
+            "environment": "staging",
+            "name": "1234_service-12a3"
+        },
+        "ecs": {
+            "version": "1.2.0"
+        },
+        "processor": {
+            "name": "transaction",
+            "event": "span"
+        }
+    },
+    {
+        "parent": {
+            "id": "945254c567a5417e"
+        },
+        "transaction": {
+            "id": "945254c567a5417e"
+        },
+        "span": {
+            "name": "GET /api/types",
+            "start": {
+                "us": 1845
+            },
+            "subtype": "http",
+            "action": "post",
+            "duration": {
+                "us": 3564
+            },
+            "type": "request",
+            "id": "2aaaaaaaaaaaaaaa"
+        },
+        "trace": {
+            "id": "945254c567a5417eaaaaaaaaaaaaaaaa"
+        },
+        "observer": {
+            "ephemeral_id": "b0eca9b8-818a-40af-89d9-52ce62270ecf",
+            "version_major": 8,
+            "hostname": "alloy",
+            "version": "8.0.0",
+            "type": "apm-server",
+            "id": "6c887131-df07-4f05-a69d-e60897ccbb64"
+        },
+        "timestamp": {
+            "us": 1496170407154000
+        },
+        "@timestamp": "2017-05-30T18:53:27.154Z",
+        "agent": {
+            "version": "3.14.0",
+            "name": "elastic-node"
+        },
+        "service": {
+            "environment": "staging",
+            "name": "1234_service-12a3"
+        },
+        "ecs": {
+            "version": "1.2.0"
+        },
+        "processor": {
+            "name": "transaction",
+            "event": "span"
+        }
+    },
+    {
+        "parent": {
+            "id": "945254c567a5417e"
+        },
+        "transaction": {
+            "id": "945254c567a5417e"
+        },
+        "span": {
+            "duration": {
+                "us": 13980
+            },
+            "start": {
+                "us": 0
+            },
+            "type": "request",
+            "name": "GET /api/types",
+            "id": "3aaaaaaaaaaaaaaa"
+        },
+        "trace": {
+            "id": "945254c567a5417eaaaaaaaaaaaaaaaa"
+        },
+        "observer": {
+            "ephemeral_id": "b0eca9b8-818a-40af-89d9-52ce62270ecf",
+            "version_major": 8,
+            "hostname": "alloy",
+            "version": "8.0.0",
+            "type": "apm-server",
+            "id": "6c887131-df07-4f05-a69d-e60897ccbb64"
+        },
+        "timestamp": {
+            "us": 1496170407154000
+        },
+        "@timestamp": "2017-05-30T18:53:27.154Z",
+        "agent": {
+            "version": "3.14.0",
+            "name": "elastic-node"
+        },
+        "service": {
+            "environment": "staging",
+            "name": "1234_service-12a3"
+        },
+        "ecs": {
+            "version": "1.2.0"
+        },
+        "processor": {
+            "name": "transaction",
+            "event": "span"
+        }
     }
 ]

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 import json
 import os
+import sys
 import time
 
 import requests
@@ -79,16 +80,12 @@ class Test(ElasticTest):
         # compare existing ES documents for transactions with new ones
         rs = self.es.search(index=self.index_transaction)
         assert rs['hits']['total']['value'] == 4, "found {} documents".format(rs['count'])
-        with open(self._beat_path_join(os.path.dirname(__file__), 'transaction.approved.json')) as f:
-            approved = json.load(f)
-        self.check_docs(approved, rs['hits']['hits'], 'transaction')
+        self.approve_docs('transaction', rs['hits']['hits'], 'transaction')
 
         # compare existing ES documents for spans with new ones
         rs = self.es.search(index=self.index_span)
         assert rs['hits']['total']['value'] == 5, "found {} documents".format(rs['count'])
-        with open(self._beat_path_join(os.path.dirname(__file__), 'spans.approved.json')) as f:
-            approved = json.load(f)
-        self.check_docs(approved, rs['hits']['hits'], 'span')
+        self.approve_docs('spans', rs['hits']['hits'], 'span')
 
     def test_load_docs_with_template_and_add_error(self):
         """
@@ -101,38 +98,64 @@ class Test(ElasticTest):
         # compare existing ES documents for errors with new ones
         rs = self.es.search(index=self.index_error)
         assert rs['hits']['total']['value'] == 4, "found {} documents".format(rs['count'])
-        with open(self._beat_path_join(os.path.dirname(__file__), 'error.approved.json')) as f:
-            approved = json.load(f)
-        self.check_docs(approved, rs['hits']['hits'], 'error')
+        self.approve_docs('error', rs['hits']['hits'], 'error')
 
         self.check_backend_error_sourcemap(self.index_error, count=4)
 
-    def check_docs(self, approved, received, doc_type):
-        assert len(received) == len(approved)
-        for rec_entry in received:
-            checked = False
-            rec = rec_entry['_source']
-            rec_id = rec[doc_type]['id']
-            for appr_entry in approved:
-                appr = appr_entry['_source']
-                if rec_id == appr[doc_type]['id']:
-                    checked = True
-                    for k, v in rec.items():
-                        if k == "observer":
-                            expected = Set(["hostname", "version", "id", "ephemeral_id", "type", "version_major"])
-                            rec_keys = Set(v.keys())
-                            assert len(expected.symmetric_difference(rec_keys)) == 0
-                            assert v["version"].startswith(str(v["version_major"]) + ".")
-                            continue
+    def approve_docs(self, base_path, received, doc_type):
+        base_path = self._beat_path_join(os.path.dirname(__file__), base_path)
+        approved_path = base_path + '.approved.json'
+        received_path = base_path + '.received.json'
 
-                        self.assert_docs(v, appr[k])
-            assert checked, "New entry with id {}".format(rec_id)
+        try:
+            with open(approved_path) as f:
+                approved = json.load(f)
+        except IOError:
+            approved = []
 
-    def assert_docs(self, received, approved):
-        assert approved == received, "expected:\n{}\nreceived:\n{}".format(self.dump(approved), self.dump(received))
+        received = [doc['_source'] for doc in received]
+        received.sort(key=lambda source: source[doc_type]['id'])
 
-    def dump(self, data):
-        return json.dumps(data, indent=4, separators=(',', ': '))
+        # NOTE(axw) this is temporary
+        approved = [doc['_source'] for doc in approved]
+        approved.sort(key=lambda source: source[doc_type]['id'])
+
+        try:
+            for rec in received:
+                # Overwrite received observer values with the approved ones,
+                # in order to avoid noise in the 'approvals' diff if there are
+                # any other changes.
+                #
+                # We don't compare the observer values between received/approved,
+                # as they are dependent on the environment.
+                rec_id = rec[doc_type]['id']
+                rec_observer = rec['observer']
+                self.assertEqual(Set(rec_observer.keys()), Set(["hostname", "version", "id", "ephemeral_id", "type", "version_major"]))
+                assert rec_observer["version"].startswith(str(rec_observer["version_major"]) + ".")
+                for appr in approved:
+                    if appr[doc_type]['id'] == rec_id:
+                        rec['observer'] = appr['observer']
+                        break
+            assert len(received) == len(approved)
+            for i, rec in enumerate(received):
+                appr = approved[i]
+                rec_id = rec[doc_type]['id']
+                assert rec_id == appr[doc_type]['id'], "New entry with id {}".format(rec_id)
+                for k, v in rec.items():
+                    self.assertEqual(v, appr[k])
+        except Exception as exc:
+            with open(received_path, 'w') as f:
+                json.dump(received, f, indent=4, separators=(',', ': '))
+
+            # Create a dynamic Exception subclass so we can fake its name to look like the original exception.
+            class ApprovalException(Exception):
+                def __init__(self, cause):
+                    super(ApprovalException, self).__init__(cause.message)
+                def __str__(self):
+                    return self.message + "\n\nReceived data differs from approved data. Run 'make update' and then 'approvals' to verify the diff."
+            ApprovalException.__name__ = type(exc).__name__
+
+            raise ApprovalException, exc, sys.exc_info()[2]
 
 
 @integration_test

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -116,10 +116,6 @@ class Test(ElasticTest):
         received = [doc['_source'] for doc in received]
         received.sort(key=lambda source: source[doc_type]['id'])
 
-        # NOTE(axw) this is temporary
-        approved = [doc['_source'] for doc in approved]
-        approved.sort(key=lambda source: source[doc_type]['id'])
-
         try:
             for rec in received:
                 # Overwrite received observer values with the approved ones,

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -126,7 +126,8 @@ class Test(ElasticTest):
                 # as they are dependent on the environment.
                 rec_id = rec[doc_type]['id']
                 rec_observer = rec['observer']
-                self.assertEqual(Set(rec_observer.keys()), Set(["hostname", "version", "id", "ephemeral_id", "type", "version_major"]))
+                self.assertEqual(Set(rec_observer.keys()), Set(
+                    ["hostname", "version", "id", "ephemeral_id", "type", "version_major"]))
                 assert rec_observer["version"].startswith(str(rec_observer["version_major"]) + ".")
                 for appr in approved:
                     if appr[doc_type]['id'] == rec_id:
@@ -147,6 +148,7 @@ class Test(ElasticTest):
             class ApprovalException(Exception):
                 def __init__(self, cause):
                     super(ApprovalException, self).__init__(cause.message)
+
                 def __str__(self):
                     return self.message + "\n\nReceived data differs from approved data. Run 'make update' and then 'approvals' to verify the diff."
             ApprovalException.__name__ = type(exc).__name__

--- a/tests/system/transaction.approved.json
+++ b/tests/system/transaction.approved.json
@@ -1,494 +1,488 @@
 [
     {
-        "_id": "XkTYCmIBWUGW2FxI4_kt",
-        "_score": 0.6931472,
-        "_type": "_doc",
-        "_source": {
-            "@timestamp": "2017-05-30T18:53:27.154Z",
-            "timestamp":{
-                "us": 1496170407154000
+        "transaction": {
+            "sampled": true,
+            "name": "GET /api/types",
+            "span_count": {
+                "started": 0
             },
-            "ecs": {
-                "version": "1.2.0"
+            "result": "failure",
+            "duration": {
+                "us": 13980
             },
-            "observer": {
-                "type": "apm-server",
-                "ephemeral_id": "xxx",
-                "hostname": "xxx",
-                "version": "xxx",
-                "id": "xxx"
+            "type": "request",
+            "id": "85925e55b43f4340"
+        },
+        "container": {
+            "id": "container-id"
+        },
+        "kubernetes": {
+            "pod": {
+                "uid": "pod-uid",
+                "name": "pod-name"
             },
-            "container":{
-                "id":"container-id"
+            "namespace": "namespace1"
+        },
+        "observer": {
+            "ephemeral_id": "a8dcdc38-86e5-4adf-8ba4-93b65be40bdf",
+            "version_major": 8,
+            "hostname": "alloy",
+            "version": "8.0.0",
+            "type": "apm-server",
+            "id": "d4d46875-dd50-465b-a5d7-8dd287e45144"
+        },
+        "process": {
+            "ppid": 6789,
+            "args": [
+                "node",
+                "server.js"
+            ],
+            "pid": 1234,
+            "title": "node"
+        },
+        "timestamp": {
+            "us": 1496170422281000
+        },
+        "@timestamp": "2017-05-30T18:53:42.281Z",
+        "agent": {
+            "version": "3.14.0",
+            "name": "elastic-node"
+        },
+        "host": {
+            "ip": "127.0.0.1",
+            "os": {
+                "platform": "darwin"
             },
-            "kubernetes":{
-                "namespace":"namespace1",
-                "pod":{
-                    "uid":"pod-uid",
-                    "name":"pod-name"
-                }
+            "architecture": "x64"
+        },
+        "service": {
+            "node": {
+                "name": "container-id"
             },
-            "host": {
-                "os": {
-                    "platform": "darwin"
-                },
-                "architecture": "x64",
-                "ip": "127.0.0.1"
+            "name": "1234_service-12a3",
+            "language": {
+                "version": "8",
+                "name": "ecmascript"
             },
-            "agent": {
-                "name": "js-base",
-                "version": "1.3"
+            "environment": "staging",
+            "framework": {
+                "version": "1.2.3",
+                "name": "Express"
             },
-            "processor": {
-                "name": "transaction",
-                "event": "transaction"
-            },
-            "process": {
-                "args": [
-                    "node",
-                    "server.js"
-                ],
-                "pid": 1234,
-                "title": "node",
-                "ppid": 6789
-            },
-            "service": {
-                "name": "serviceabc",
-                "node": {
-                    "name": "special-name"
-                },
-                "language": {
-                    "version": "8",
-                    "name": "ecmascript"
-                },
-                "environment": "staging",
-                "framework": {
-                    "version": "1.2.3",
-                    "name": "Express"
-                },
-                "version": "5.1.3",
-                "runtime": {
-                    "version": "8.0.0",
-                    "name": "javascript"
-                }
-            },
-            "user": {
-                "id": "99",
-                "email": "foo@example.com"
-            },
-            "user_agent": {
-                "original": "Mozilla Chrome Edge",
-                "name": "Other",
-                "device": {
-                    "name": "Other"
-                }
-            },
-            "url": {
-                "domain": "www.example.com",
-                "fragment": "#hash",
-                "full": "https://www.example.com/p/a/t/h?query=string#hash",
-                "original": "/p/a/t/h?query=string#hash",
-                "path": "/p/a/t/h",
-                "port": 8080,
-                "query": "?query=string",
-                "scheme": "https"
-            },
-            "http": {
-                "request": {
-                    "body": {
-                        "original": {
-                            "additional": {
-                                "bar": 123,
-                                "req": "additional information"
-                            },
-                            "str": "hello world"
-                        }
-                    },
-                    "env": {
-                        "GATEWAY_INTERFACE": "CGI/1.1",
-                        "SERVER_SOFTWARE": "nginx"
-                    },
-                    "headers": {
-                        "Some-Other-Header": ["foo"],
-                        "Cookie": ["c1=v1,c2=v2"],
-                        "Array": ["foo", "bar", "baz"],
-                        "Content-Type": ["text/html"],
-                        "User-Agent": ["Mozilla Chrome Edge"]
-                    },
-                    "cookies": {
-                        "c2": "v2",
-                        "c1": "v1"
-                    },
-                    "method": "post",
-                    "socket": {
-                        "encrypted": true,
-                        "remote_address": "8.8.8.8"
-                    }
-                },
-                "response": {
-                    "finished": true,
-                    "headers": {
-                        "Content-Type": ["application/json"]
-                    },
-                    "headers_sent": true,
-                    "status_code": 200
-                },
-                "version": "1.1"
-            },
-            "client": {
-                "ip": "8.8.8.8",
-                "geo": {
-                    "continent_name": "North America",
-                    "country_iso_code": "US",
-                    "location": {
-                        "lat": 37.751,
-                        "lon": -97.822
-                    }
-                }
-            },
-            "source": {
-                "ip": "8.8.8.8"
-            },
-            "labels": {
-                "number_code": 2,
-                "bool_error": false,
-                "organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8"
-            },
-            "transaction": {
-                "type": "request",
-                "span_count": {
-                    "dropped": 2,
-                    "started": 4
-                },
-                "marks": {
-                    "another_mark": {
-                        "some_long": 10,
-                        "some_float": 10
-                    },
-                    "navigationTiming": {
-                        "navigationStart": -21,
-                        "appBeforeBootstrap": 608.9300000000001
-                    }
-                },
-                "custom": {
-                    "some_other_value": "foo bar",
-                    "and_objects": {
-                        "foo": [
-                            "bar",
-                            "baz"
-                        ]
-                    },
-                    "my_key": 1,
-                    "(": "not a valid regex and that is fine"
-                },
-                "id": "945254c567a5417e",
-                "name": "GET /api/types",
-                "sampled": true,
-                "duration": {
-                    "us": 32592
-                },
-                "page": {
-                    "referer": "http://localhost:8000/test/e2e/",
-                    "url": "http://localhost:8000/test/e2e/general-usecase/"
-                },
-                "result": "success"
-            },
-            "trace": {
-                "id": "945254c567a5417eaaaaaaaaaaaaaaaa"
+            "version": "5.1.3",
+            "runtime": {
+                "version": "8.0.0",
+                "name": "node"
             }
         },
-        "_index": "test-apm-12-12-2017"
+        "ecs": {
+            "version": "1.2.0"
+        },
+        "user": {
+            "email": "foo@bar.com",
+            "name": "foo",
+            "id": "123user"
+        },
+        "trace": {
+            "id": "85925e55b43f4340aaaaaaaaaaaaaaaa"
+        },
+        "processor": {
+            "name": "transaction",
+            "event": "transaction"
+        }
     },
     {
-        "_id": "ZUTYCmIBWUGW2FxI4_kt",
-        "_score": 0.6931472,
-        "_type": "_doc",
-        "_source": {
-            "@timestamp": "2017-05-30T18:53:42.281Z",
-            "timestamp":{
-                "us": 1496170422281999
+        "transaction": {
+            "sampled": false,
+            "name": "GET /api/types",
+            "span_count": {
+                "started": 0
             },
-            "ecs": {
-                "version": "1.2.0"
+            "result": "200",
+            "duration": {
+                "us": 13980
             },
-            "observer": {
-                "type": "apm-server",
-                "ephemeral_id": "xxx",
-                "hostname": "xxx",
-                "version": "xxx",
-                "id": "xxx"
+            "type": "request",
+            "id": "85925e55b43f4341"
+        },
+        "container": {
+            "id": "container-id"
+        },
+        "kubernetes": {
+            "pod": {
+                "uid": "pod-uid",
+                "name": "pod-name"
             },
-            "container":{
-                "id":"container-id"
+            "namespace": "namespace1"
+        },
+        "observer": {
+            "ephemeral_id": "a8dcdc38-86e5-4adf-8ba4-93b65be40bdf",
+            "version_major": 8,
+            "hostname": "alloy",
+            "version": "8.0.0",
+            "type": "apm-server",
+            "id": "d4d46875-dd50-465b-a5d7-8dd287e45144"
+        },
+        "process": {
+            "ppid": 6789,
+            "args": [
+                "node",
+                "server.js"
+            ],
+            "pid": 1234,
+            "title": "node"
+        },
+        "timestamp": {
+            "us": 1496170422000000
+        },
+        "@timestamp": "2017-05-30T18:53:42.000Z",
+        "agent": {
+            "version": "3.14.0",
+            "name": "elastic-node"
+        },
+        "host": {
+            "ip": "127.0.0.1",
+            "os": {
+                "platform": "darwin"
             },
-            "kubernetes":{
-                "namespace":"namespace1",
-                "pod":{
-                    "uid":"pod-uid",
-                    "name":"pod-name"
-                }
+            "architecture": "x64"
+        },
+        "service": {
+            "node": {
+                "name": "container-id"
             },
-            "host": {
-                "os": {
-                    "platform": "darwin"
-                },
-                "architecture": "x64",
-                "ip": "127.0.0.1"
+            "name": "1234_service-12a3",
+            "language": {
+                "version": "8",
+                "name": "ecmascript"
             },
-            "agent": {
-                "name": "elastic-node",
-                "version": "3.14.0"
+            "environment": "staging",
+            "framework": {
+                "version": "1.2.3",
+                "name": "Express"
             },
-            "processor": {
-                "name": "transaction",
-                "event": "transaction"
-            },
-            "process": {
-                "args": [
-                    "node",
-                    "server.js"
-                ],
-                "pid": 1234,
-                "title": "node",
-                "ppid": 6789
-            },
-            "service": {
-                "runtime": {
-                    "name": "node",
-                    "version": "8.0.0"
-                },
-                "framework": {
-                    "name": "Express",
-                    "version": "1.2.3"
-                },
-                "version": "5.1.3",
-                "language": {
-                    "name": "ecmascript",
-                    "version": "8"
-                },
-                "name": "1234_service-12a3",
-                "node": {
-                    "name": "container-id"
-                },
-                "environment": "staging"
-            },
-            "transaction": {
-                "type": "request",
-                "span_count": {
-                    "dropped": 258,
-                    "started": 1
-                },
-                "id": "85925e55b43f4342",
-                "name": "GET /api/types",
-                "sampled": true,
-                "duration": {
-                    "us": 13980
-                },
-                "result": "200"
-            },
-            "trace": {
-                "id": "85925e55b43f4342aaaaaaaaaaaaaaaa"
-            },
-            "user": {
-                "email": "foo@bar.com",
-                "id": "123user",
-                "name": "foo"
+            "version": "5.1.3",
+            "runtime": {
+                "version": "8.0.0",
+                "name": "node"
             }
         },
-        "_index": "test-apm-12-12-2017"
+        "ecs": {
+            "version": "1.2.0"
+        },
+        "user": {
+            "email": "foo@bar.com",
+            "name": "foo",
+            "id": "123user"
+        },
+        "trace": {
+            "id": "85925e55b43f4341aaaaaaaaaaaaaaaa"
+        },
+        "processor": {
+            "name": "transaction",
+            "event": "transaction"
+        }
     },
     {
-        "_id": "ZETYCmIBWUGW2FxI4_kt",
-        "_score": 0.6931472,
-        "_type": "_doc",
-        "_source": {
-            "@timestamp": "2017-05-30T18:53:42.000Z",
-            "timestamp":{
-                "us": 1496170422000000
+        "transaction": {
+            "sampled": true,
+            "name": "GET /api/types",
+            "span_count": {
+                "started": 1,
+                "dropped": 258
             },
-            "ecs": {
-                "version": "1.2.0"
+            "result": "200",
+            "duration": {
+                "us": 13980
             },
-            "observer": {
-                "type": "apm-server",
-                "ephemeral_id": "xxx",
-                "hostname": "xxx",
-                "version": "xxx",
-                "id": "xxx"
+            "type": "request",
+            "id": "85925e55b43f4342"
+        },
+        "container": {
+            "id": "container-id"
+        },
+        "kubernetes": {
+            "pod": {
+                "uid": "pod-uid",
+                "name": "pod-name"
             },
-            "container":{
-                "id":"container-id"
+            "namespace": "namespace1"
+        },
+        "observer": {
+            "ephemeral_id": "a8dcdc38-86e5-4adf-8ba4-93b65be40bdf",
+            "version_major": 8,
+            "hostname": "alloy",
+            "version": "8.0.0",
+            "type": "apm-server",
+            "id": "d4d46875-dd50-465b-a5d7-8dd287e45144"
+        },
+        "process": {
+            "ppid": 6789,
+            "args": [
+                "node",
+                "server.js"
+            ],
+            "pid": 1234,
+            "title": "node"
+        },
+        "timestamp": {
+            "us": 1496170422281999
+        },
+        "@timestamp": "2017-05-30T18:53:42.281Z",
+        "agent": {
+            "version": "3.14.0",
+            "name": "elastic-node"
+        },
+        "host": {
+            "ip": "127.0.0.1",
+            "os": {
+                "platform": "darwin"
             },
-            "kubernetes":{
-                "namespace":"namespace1",
-                "pod":{
-                    "uid":"pod-uid",
-                    "name":"pod-name"
-                }
+            "architecture": "x64"
+        },
+        "service": {
+            "node": {
+                "name": "container-id"
             },
-            "host": {
-                "os": {
-                    "platform": "darwin"
-                },
-                "architecture": "x64",
-                "ip": "127.0.0.1"
+            "name": "1234_service-12a3",
+            "language": {
+                "version": "8",
+                "name": "ecmascript"
             },
-            "agent": {
-                "name": "elastic-node",
-                "version": "3.14.0"
+            "environment": "staging",
+            "framework": {
+                "version": "1.2.3",
+                "name": "Express"
             },
-            "processor": {
-                "name": "transaction",
-                "event": "transaction"
-            },
-            "process": {
-                "args": [
-                    "node",
-                    "server.js"
-                ],
-                "pid": 1234,
-                "title": "node",
-                "ppid": 6789
-            },
-            "service": {
-                "runtime": {
-                    "name": "node",
-                    "version": "8.0.0"
-                },
-                "framework": {
-                    "name": "Express",
-                    "version": "1.2.3"
-                },
-                "version": "5.1.3",
-                "language": {
-                    "name": "ecmascript",
-                    "version": "8"
-                },
-                "name": "1234_service-12a3",
-                "node": {
-                    "name": "container-id"
-                },
-                "environment": "staging"
-            },
-            "transaction": {
-                "type": "request",
-                "id": "85925e55b43f4341",
-                "name": "GET /api/types",
-                "sampled": false,
-                "span_count": {
-                    "started": 0
-                },
-                "duration": {
-                    "us": 13980
-                },
-                "result": "200"
-            },
-            "trace": {
-                "id": "85925e55b43f4341aaaaaaaaaaaaaaaa"
-            },
-            "user": {
-                "email": "foo@bar.com",
-                "id": "123user",
-                "name": "foo"
+            "version": "5.1.3",
+            "runtime": {
+                "version": "8.0.0",
+                "name": "node"
             }
         },
-        "_index": "test-apm-12-12-2017"
+        "ecs": {
+            "version": "1.2.0"
+        },
+        "user": {
+            "email": "foo@bar.com",
+            "name": "foo",
+            "id": "123user"
+        },
+        "trace": {
+            "id": "85925e55b43f4342aaaaaaaaaaaaaaaa"
+        },
+        "processor": {
+            "name": "transaction",
+            "event": "transaction"
+        }
     },
     {
-        "_id": "Y0TYCmIBWUGW2FxI4_kt",
-        "_score": 0.2876821,
-        "_type": "_doc",
-        "_source": {
-            "@timestamp": "2017-05-30T18:53:42.281Z",
-            "timestamp":{
-                "us": 1496170422281000
+        "user_agent": {
+            "device": {
+                "name": "Other"
             },
-            "ecs": {
-                "version": "1.2.0"
+            "original": "Mozilla Chrome Edge",
+            "name": "Other"
+        },
+        "container": {
+            "id": "container-id"
+        },
+        "observer": {
+            "ephemeral_id": "a8dcdc38-86e5-4adf-8ba4-93b65be40bdf",
+            "version_major": 8,
+            "hostname": "alloy",
+            "version": "8.0.0",
+            "type": "apm-server",
+            "id": "d4d46875-dd50-465b-a5d7-8dd287e45144"
+        },
+        "kubernetes": {
+            "pod": {
+                "uid": "pod-uid",
+                "name": "pod-name"
             },
-            "observer": {
-                "type": "apm-server",
-                "ephemeral_id": "xxx",
-                "hostname": "xxx",
-                "version": "xxx",
-                "id": "xxx"
-            },
-            "container":{
-                "id":"container-id"
-            },
-            "kubernetes":{
-                "namespace":"namespace1",
-                "pod":{
-                    "uid":"pod-uid",
-                    "name":"pod-name"
+            "namespace": "namespace1"
+        },
+        "process": {
+            "ppid": 6789,
+            "args": [
+                "node",
+                "server.js"
+            ],
+            "pid": 1234,
+            "title": "node"
+        },
+        "timestamp": {
+            "us": 1496170407154000
+        },
+        "@timestamp": "2017-05-30T18:53:27.154Z",
+        "labels": {
+            "organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8",
+            "bool_error": false,
+            "number_code": 2
+        },
+        "agent": {
+            "version": "1.3",
+            "name": "js-base"
+        },
+        "client": {
+            "ip": "8.8.8.8",
+            "geo": {
+                "continent_name": "North America",
+                "country_iso_code": "US",
+                "location": {
+                    "lat": 37.751,
+                    "lon": -97.822
                 }
-            },
-            "host": {
-                "os": {
-                    "platform": "darwin"
-                },
-                "architecture": "x64",
-                "ip": "127.0.0.1"
-            },
-            "agent": {
-                "name": "elastic-node",
-                "version": "3.14.0"
-            },
-            "processor": {
-                "name": "transaction",
-                "event": "transaction"
-            },
-            "process": {
-                "args": [
-                    "node",
-                    "server.js"
-                ],
-                "pid": 1234,
-                "title": "node",
-                "ppid": 6789
-            },
-            "service": {
-                "runtime": {
-                    "name": "node",
-                    "version": "8.0.0"
-                },
-                "framework": {
-                    "name": "Express",
-                    "version": "1.2.3"
-                },
-                "version": "5.1.3",
-                "language": {
-                    "name": "ecmascript",
-                    "version": "8"
-                },
-                "environment": "staging",
-                "name": "1234_service-12a3",
-                "node": {
-                    "name": "container-id"
-                }
-            },
-            "transaction": {
-                "type": "request",
-                "id": "85925e55b43f4340",
-                "duration": {
-                    "us": 13980
-                },
-                "sampled": true,
-                "span_count": {
-                    "started": 0
-                },
-                "name": "GET /api/types",
-                "result": "failure"
-            },
-            "trace": {
-                "id": "85925e55b43f4340aaaaaaaaaaaaaaaa"
-            },
-            "user": {
-                "email": "foo@bar.com",
-                "id": "123user",
-                "name": "foo"
             }
         },
-        "_index": "test-apm-12-12-2017"
+        "source": {
+            "ip": "8.8.8.8"
+        },
+        "host": {
+            "ip": "127.0.0.1",
+            "os": {
+                "platform": "darwin"
+            },
+            "architecture": "x64"
+        },
+        "service": {
+            "node": {
+                "name": "special-name"
+            },
+            "name": "serviceabc",
+            "language": {
+                "version": "8",
+                "name": "ecmascript"
+            },
+            "environment": "staging",
+            "framework": {
+                "version": "1.2.3",
+                "name": "Express"
+            },
+            "version": "5.1.3",
+            "runtime": {
+                "version": "8.0.0",
+                "name": "javascript"
+            }
+        },
+        "ecs": {
+            "version": "1.2.0"
+        },
+        "url": {
+            "domain": "www.example.com",
+            "full": "https://www.example.com/p/a/t/h?query=string#hash",
+            "fragment": "#hash",
+            "port": 8080,
+            "query": "?query=string",
+            "path": "/p/a/t/h",
+            "scheme": "https",
+            "original": "/p/a/t/h?query=string#hash"
+        },
+        "trace": {
+            "id": "945254c567a5417eaaaaaaaaaaaaaaaa"
+        },
+        "http": {
+            "version": "1.1",
+            "request": {
+                "body": {
+                    "original": {
+                        "additional": {
+                            "req": "additional information",
+                            "bar": 123
+                        },
+                        "str": "hello world"
+                    }
+                },
+                "cookies": {
+                    "c2": "v2",
+                    "c1": "v1"
+                },
+                "socket": {
+                    "encrypted": true,
+                    "remote_address": "8.8.8.8"
+                },
+                "headers": {
+                    "Some-Other-Header": [
+                        "foo"
+                    ],
+                    "Content-Type": [
+                        "text/html"
+                    ],
+                    "Array": [
+                        "foo",
+                        "bar",
+                        "baz"
+                    ],
+                    "Cookie": [
+                        "c1=v1,c2=v2"
+                    ],
+                    "User-Agent": [
+                        "Mozilla Chrome Edge"
+                    ]
+                },
+                "env": {
+                    "SERVER_SOFTWARE": "nginx",
+                    "GATEWAY_INTERFACE": "CGI/1.1"
+                },
+                "method": "post"
+            },
+            "response": {
+                "headers": {
+                    "Content-Type": [
+                        "application/json"
+                    ]
+                },
+                "finished": true,
+                "headers_sent": true,
+                "status_code": 200
+            }
+        },
+        "transaction": {
+            "sampled": true,
+            "name": "GET /api/types",
+            "span_count": {
+                "started": 4,
+                "dropped": 2
+            },
+            "page": {
+                "url": "http://localhost:8000/test/e2e/general-usecase/",
+                "referer": "http://localhost:8000/test/e2e/"
+            },
+            "result": "success",
+            "marks": {
+                "another_mark": {
+                    "some_long": 10,
+                    "some_float": 10
+                },
+                "navigationTiming": {
+                    "navigationStart": -21,
+                    "appBeforeBootstrap": 608.9300000000001
+                }
+            },
+            "duration": {
+                "us": 32592
+            },
+            "custom": {
+                "(": "not a valid regex and that is fine",
+                "my_key": 1,
+                "some_other_value": "foo bar",
+                "and_objects": {
+                    "foo": [
+                        "bar",
+                        "baz"
+                    ]
+                }
+            },
+            "type": "request",
+            "id": "945254c567a5417e"
+        },
+        "processor": {
+            "name": "transaction",
+            "event": "transaction"
+        },
+        "user": {
+            "id": "99",
+            "email": "foo@example.com"
+        }
     }
 ]


### PR DESCRIPTION
Update tests/system/test_integration.py to use the approved/received approach used in integration tests. We've been writing the complete ES responses, doc IDs and all, to disk. We now write only the _source of each, and sort them by event IDs first.

We change the logic in tests/system in one commit without regenerating the approved files, to prove that the changes do no affect the existing comparisons. The approved files are then regenerated in a second commit, storing only the _source contents, and sorting docs by event ID.

There are a couple of changes to tests/approvals to support the above, as well as cleaning up a bit of tech debt:
 - stop assuming that the received/approved files have a specific map structure, and just use `interface{}`
 - only write the received data to disk if the received/approved data differ

Also, a few drive-by fixes:
 - add some missing steps to TESTING.md
 - add the profile index to the list of indices to clean up in apmserver.py
 - `make fmt`

Closes https://github.com/elastic/apm-server/issues/1827