### PR TITLE
[7.5] [docs] systemd and config ownership improvements (#3027)

### DIFF
--- a/docs/config-ownership.asciidoc
+++ b/docs/config-ownership.asciidoc
@@ -1,0 +1,42 @@
+[[config-file-ownership]]
+==== Configuration file ownership
+
+On systems with POSIX file permissions,
+the {beatname_uc} configuration file is subject to ownership and file permission checks.
+These checks prevent unauthorized users from providing or modifying configurations that are run by {beatname_uc}.
+
+When installed via an RPM or DEB package,
+the configuration file at +/etc/{beatname_lc}/{beatname_lc}.yml+ will be owned by +{beatname_lc}+,
+and have file permissions of `0600` (`-rw-------`).
+
+{beatname_uc} will only start if the configuration file is owned by the user running the process,
+or by running as root with configuration ownership set to `root:root`
+
+You may encounter the following errors if your configuration file fails these checks:
+
+["source", "systemd", subs="attributes"]
+-----
+Exiting: error loading config file: config file ("/etc/{beatname_lc}/{beatname_lc}.yml")
+must be owned by the user identifier (uid=1000) or root
+-----
+
+To correct this problem you can change the ownership of the configuration file with:
++chown {beatname_lc}:{beatname_lc} /etc/{beatname_lc}/{beatname_lc}.yml+.
+
+You can also make root the config owner, although this is not recommended:
++sudo chown root:root /etc/{beatname_lc}/{beatname_lc}.yml+.
+
+["source", "systemd", subs="attributes"]
+-----
+Exiting: error loading config file: config file ("/etc/{beatname_lc}/{beatname_lc}.yml")
+can only be writable by the owner but the permissions are "-rw-rw-r--"
+(to fix the permissions use: 'chmod go-w /etc/{beatname_lc}/{beatname_lc}.yml')
+-----
+
+To correct this problem, use +chmod go-w /etc/{beatname_lc}/{beatname_lc}.yml+ to
+remove write privileges from anyone other than the owner.
+
+===== Disabling strict permission checks
+
+You can disable strict permission checks from the command line by using
+`--strict.perms=false`, but we strongly encourage you to leave the checks enabled.

--- a/docs/copied-from-beats/command-reference.asciidoc
+++ b/docs/copied-from-beats/command-reference.asciidoc
@@ -933,10 +933,14 @@ details.
 Sets the path for log files. See the <<directory-layout>> section for details.
 
 *`--strict.perms`*::
-Sets strict permission checking on configuration files. The default is
-`-strict.perms=true`. See
-{beats-ref}/config-file-permissions.html[Config file ownership and permissions] in
+Sets strict permission checking on configuration files. The default is `-strict.perms=true`.
+ifndef::apm-server[]
+See {beats-ref}/config-file-permissions.html[Config file ownership and permissions] in
 the _Beats Platform Reference_ for more information.
+endif::[]
+ifdef::apm-server[]
+See <<config-file-ownership>> for more information.
+endif::[]
 
 *`-v, --v`*::
 Logs INFO-level messages.

--- a/docs/copied-from-beats/shared-systemd.asciidoc
+++ b/docs/copied-from-beats/shared-systemd.asciidoc
@@ -5,18 +5,23 @@ The DEB and RPM packages include a service unit for Linux systems with
 systemd. On these systems, you can manage {beatname_uc} by using the usual
 systemd commands.
 
+ifdef::apm-server[]
+We recommend that the {beatname_lc} process is run as a non-root user.
+Therefore, that is the default setup for {beatname_uc}'s DEB package and RPM installation.
+endif::apm-server[]
+
 ==== Start and stop {beatname_uc}
 
 Use `systemctl` to start or stop {beatname_uc}:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-systemctl start {beatname_lc}
+sudo systemctl start {beatname_lc}
 ------------------------------------------------
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-systemctl stop {beatname_lc}
+sudo systemctl stop {beatname_lc}
 ------------------------------------------------
 
 By default, the {beatname_uc} service starts automatically when the system
@@ -24,14 +29,13 @@ boots. To enable or disable auto start use:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-systemctl enable {beatname_lc}
+sudo systemctl enable {beatname_lc}
 ------------------------------------------------
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-systemctl disable {beatname_lc}
+sudo systemctl disable {beatname_lc}
 ------------------------------------------------
-
 
 ==== {beatname_uc} status and logs
 
@@ -101,3 +105,7 @@ systemctl restart {beatname_lc}
 NOTE: It is recommended that you use a configuration management tool to
 include drop-in unit files. If you need to add a drop-in manually, use
 +systemctl edit {beatname_lc}.service+.
+
+ifdef::apm-server[]
+include::./../config-ownership.asciidoc[]
+endif::apm-server[]

--- a/docs/getting-started-apm-server.asciidoc
+++ b/docs/getting-started-apm-server.asciidoc
@@ -301,7 +301,11 @@ You can change the defaults in `apm-server.yml` or by supplying a different addr
 [[running-deb-rpm]]
 ==== Debian Package / RPM
 
-The Debian package and RPM installations of APM Server create an `apm-server` user.
+For Debian package and RPM installations, we recommend the apm-server process runs as a non-root user.
+Therefore, these installation methods create an `apm-server` user which you can use to start the process.
+In addition, {beatname_uc} will only start if the configuration file is
+<<config-file-ownership,owned by the user running the process>>.
+
 To start the APM Server in this case, run:
 
 [source,bash]


### PR DESCRIPTION
Backports the following commits to 7.5:
 - [docs] systemd and config ownership improvements (#3027)