### PR TITLE
[docs] Updates doc build script

### DIFF
--- a/script/build_apm_docs.sh
+++ b/script/build_apm_docs.sh
@@ -28,5 +28,5 @@ do
   dest_dir="$html_dir/${name}/${index_path}"
   mkdir -p "$dest_dir"
   params="--chunk=1"
-  $docs_dir/build_docs --asciidoctor $params --doc "$index" --out "$dest_dir"
+  $docs_dir/build_docs --direct_html $params --doc "$index" --out "$dest_dir"
 done


### PR DESCRIPTION
Replaces the no longer needed `--asciidoctor` flag (on by default) with the new and shiny `--direct_html`. This removes docbook from our documentation builds. For https://github.com/elastic/docs/pull/1643.