### PR TITLE
[7.x] ci(jenkins): cancel previous running builds (#2983)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,7 @@ pipeline {
       }
       options { skipDefaultCheckout() }
       steps {
+        pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ci(jenkins): cancel previous running builds (#2983)