### PR TITLE
[7.x] feat: enable DIAGNOSTIC_INTERVAL env var (#3032)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,9 @@ pipeline {
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
     CODECOV_SECRET = 'secret/apm-team/ci/apm-server-codecov'
+    GITHUB_CHECK_ITS_NAME = 'APM Integration Tests'
+    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
+    DIAGNOSTIC_INTERVAL = "${params.DIAGNOSTIC_INTERVAL}"
   }
   options {
     timeout(time: 2, unit: 'HOURS')
@@ -34,6 +37,8 @@ pipeline {
     booleanParam(name: 'doc_ci', defaultValue: true, description: 'Enable build documentation')
     booleanParam(name: 'release_ci', defaultValue: true, description: 'Enable build the release packages')
     booleanParam(name: 'kibana_update_ci', defaultValue: true, description: 'Enable build the Check kibana Obj. Updated')
+    booleanParam(name: 'its_ci', defaultValue: true, description: 'Enable async ITs')
+    string(name: 'DIAGNOSTIC_INTERVAL', defaultValue: "0", description: 'Elasticsearch detailed logging every X seconds')
   }
   stages {
     /**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,8 +9,6 @@ pipeline {
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
     CODECOV_SECRET = 'secret/apm-team/ci/apm-server-codecov'
-    GITHUB_CHECK_ITS_NAME = 'APM Integration Tests'
-    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     DIAGNOSTIC_INTERVAL = "${params.DIAGNOSTIC_INTERVAL}"
   }
   options {
@@ -37,7 +35,6 @@ pipeline {
     booleanParam(name: 'doc_ci', defaultValue: true, description: 'Enable build documentation')
     booleanParam(name: 'release_ci', defaultValue: true, description: 'Enable build the release packages')
     booleanParam(name: 'kibana_update_ci', defaultValue: true, description: 'Enable build the Check kibana Obj. Updated')
-    booleanParam(name: 'its_ci', defaultValue: true, description: 'Enable async ITs')
     string(name: 'DIAGNOSTIC_INTERVAL', defaultValue: "0", description: 'Elasticsearch detailed logging every X seconds')
   }
   stages {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - feat: enable DIAGNOSTIC_INTERVAL env var (#3032)