### PR TITLE
[7.x] feat: allow to set different test environments (#3054)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
     CODECOV_SECRET = 'secret/apm-team/ci/apm-server-codecov'
+    ES_LOG_LEVEL = "${params.ES_LOG_LEVEL}"
   }
   options {
     timeout(time: 2, unit: 'HOURS')
@@ -34,6 +35,7 @@ pipeline {
     booleanParam(name: 'doc_ci', defaultValue: true, description: 'Enable build documentation')
     booleanParam(name: 'release_ci', defaultValue: true, description: 'Enable build the release packages')
     booleanParam(name: 'kibana_update_ci', defaultValue: true, description: 'Enable build the Check kibana Obj. Updated')
+    string(name: 'ES_LOG_LEVEL', defaultValue: "error", description: 'Elasticsearch error level')
   }
   stages {
     /**

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ STATICCHECK_REPO=${BEAT_PATH}/vendor/honnef.co/go/tools/cmd/staticcheck
 
 ES_USER?=apm_user
 ES_PASS?=changeme
+ES_LOG_LEVEL?=debug
 KIBANA_ES_USER?=kibana_system_user
 KIBANA_ES_PASS?=changeme
 BEAT_KIBANA_USER?=apm_user_ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - "xpack.security.authc.realms.native.native1.order=1"
       - "xpack.security.enabled=true"
       - "xpack.license.self_generated.type=trial"
+      - "logger.org.elasticsearch=${ES_LOG_LEVEL}"
     volumes:
       - "./testing/docker/elasticsearch/roles.yml:/usr/share/elasticsearch/config/roles.yml"
       - "./testing/docker/elasticsearch/users:/usr/share/elasticsearch/config/users"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - feat: allow to set different test environments (#3054)