### PR TITLE
[7.x] ci(jenkins): reuse top level agent (#2774) | [apm-ci] suppress the NativeCommandError in windows builds (#2890) | ci(jenkins): update argument (#2904) | [apm-ci] When asciidoc speedup skip some stages (#2891) | [jjbb] check_paths_for_

### DIFF
--- a/.ci/check-changelogs.groovy
+++ b/.ci/check-changelogs.groovy
@@ -1,0 +1,64 @@
+#!/usr/bin/env groovy
+@Library('apm@current') _
+
+pipeline {
+  agent { label 'linux && immutable' }
+  environment {
+    REPO = 'apm-server'
+    BASE_DIR = "src/github.com/elastic/${env.REPO}"
+    NOTIFY_TO = credentials('notify-to')
+    JOB_GCS_BUCKET = credentials('gcs-bucket')
+    JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
+    quietPeriod(10)
+  }
+  triggers {
+    cron 'H H(3-4) * * 1-5'
+  }
+  stages {
+    /**
+     Checkout the code and stash it, to use it on other stages.
+    */
+    stage('Checkout') {
+      options { skipDefaultCheckout() }
+      environment {
+        PATH = "${env.PATH}:${env.WORKSPACE}/bin"
+      }
+      steps {
+        deleteDir()
+        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
+        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+      }
+    }
+    /**
+      Validate changelog tests.
+    */
+    stage('Changelog Test') {
+      options { skipDefaultCheckout() }
+      environment {
+        PATH = "${env.PATH}:${env.WORKSPACE}/bin"
+        HOME = "${env.WORKSPACE}"
+      }
+      steps {
+        deleteDir()
+        unstash 'source'
+        dir("${BASE_DIR}"){
+          sh(label: 'Run check changelogs', script: './script/jenkins/check-changelogs.sh')
+        }
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult()
+    }
+  }
+}

--- a/.ci/check-changelogs.groovy
+++ b/.ci/check-changelogs.groovy
@@ -34,7 +34,8 @@ pipeline {
       }
       steps {
         deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
+        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true,
+                    depth: 3, reference: "/var/lib/jenkins/.git-references/${REPO}.git")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
       }
     }

--- a/.ci/check-changelogs.groovy
+++ b/.ci/check-changelogs.groovy
@@ -12,7 +12,7 @@ pipeline {
   }
   options {
     timeout(time: 1, unit: 'HOURS')
-    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    buildDiscarder(logRotator(numToKeepStr: '100', artifactNumToKeepStr: '30', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')
     disableResume()

--- a/.ci/jobs/apm-server-check-changelogs-mbp.yml
+++ b/.ci/jobs/apm-server-check-changelogs-mbp.yml
@@ -1,0 +1,40 @@
+---
+- job:
+    name: apm-server/apm-server-check-changelogs-mbp
+    display-name: APM Server check changelogs MBP
+    description: APM Server check changelogs MBP
+    project-type: multibranch
+    script-path: .ci/check-changelogs.groovy
+    scm:
+    - github:
+        branch-discovery: no-pr
+        discover-pr-forks-strategy: merge-current
+        discover-pr-forks-trust: permission
+        discover-pr-origin: merge-current
+        discover-tags: false
+        notification-context: 'apm-ci'
+        property-strategies:
+          all-branches:
+          - suppress-scm-triggering: true
+        repo: apm-server
+        repo-owner: elastic
+        credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+        ssh-checkout:
+          credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+        clean:
+          after: true
+          before: true
+        prune: true
+        shallow-clone: true
+        depth: 3
+        do-not-fetch-tags: true
+        submodule:
+          disable: false
+          recursive: true
+          parent-credentials: true
+          timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-server.git
+        timeout: '15'
+        use-author: true
+        wipe-workspace: 'True'
+    periodic-folder-trigger: 1w

--- a/.ci/jobs/apm-server-mbp.yml
+++ b/.ci/jobs/apm-server-mbp.yml
@@ -1,0 +1,44 @@
+---
+- job:
+    name: apm-server/apm-server-mbp
+    display-name: APM Server
+    description: APM Server
+    project-type: multibranch
+    concurrent: true
+    script-path: Jenkinsfile
+    scm:
+    - github:
+        branch-discovery: no-pr
+        discover-pr-forks-strategy: merge-current
+        discover-pr-forks-trust: permission
+        discover-pr-origin: merge-current
+        discover-tags: true
+        notification-context: 'apm-ci'
+        repo: apm-server
+        repo-owner: elastic
+        credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+        ssh-checkout:
+          credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+        build-strategies:
+        - tags:
+            ignore-tags-older-than: -1
+            ignore-tags-newer-than: -1
+        - regular-branches: true
+        - change-request:
+            ignore-target-only-changes: false
+        clean:
+          after: true
+          before: true
+        prune: true
+        shallow-clone: true
+        depth: 3
+        do-not-fetch-tags: true
+        submodule:
+          disable: false
+          recursive: true
+          parent-credentials: true
+          timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-server.git
+        timeout: '15'
+        use-author: true
+        wipe-workspace: 'True'

--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -1,0 +1,19 @@
+---
+
+##### GLOBAL METADATA
+
+- meta:
+    cluster: apm-ci
+
+##### JOB DEFAULTS
+
+- job:
+    view: APM-CI
+    logrotate:
+      numToKeep: 100
+    node: linux
+    periodic-folder-trigger: 1d
+    prune-dead-branches: true
+    publishers:
+    - email:
+        recipients: infra-root+build@elastic.co

--- a/.ci/scripts/docker-get-logs.sh
+++ b/.ci/scripts/docker-get-logs.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STEP=${1:-""}
+
+DOCKER_INFO_DIR="docker-info/${STEP}"
+mkdir -p ${DOCKER_INFO_DIR}
+cp docker-compose.yml ${DOCKER_INFO_DIR}
+cd ${DOCKER_INFO_DIR}
+
+docker ps -a &> docker-containers.txt
+
+DOCKER_IDS=$(docker ps -aq)
+
+for id in ${DOCKER_IDS}
+do
+  docker ps -af id=${id} --no-trunc &> ${id}-cmd.txt
+  docker logs ${id} &> ${id}.log || echo "It is not possible to grab the logs of ${id}"
+  docker inspect ${id} &> ${id}-inspect.json || echo "It is not possible to grab the inspect of ${id}"
+done

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,8 @@ pipeline {
       steps {
         pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
-        gitCheckout(basedir: "${BASE_DIR}")
+        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true,
+                    depth: 3, reference: "/var/lib/jenkins/.git-references/${REPO}.git")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script {
           dir("${BASE_DIR}"){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
   }
   options {
     timeout(time: 2, unit: 'HOURS')
-    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    buildDiscarder(logRotator(numToKeepStr: '100', artifactNumToKeepStr: '30', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')
     disableResume()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -221,15 +221,18 @@ pipeline {
           }
           post {
             always {
-              coverageReport("${BASE_DIR}/build/coverage")
-              junit(allowEmptyResults: true,
-                keepLongStdio: true,
-                testResults: "${BASE_DIR}/build/junit-*.xml,${BASE_DIR}/build/TEST-*.xml")
-              //googleStorageUpload bucket: "gs://${JOB_GCS_BUCKET}/${JOB_NAME}/${BUILD_NUMBER}", credentialsId: "${JOB_GCS_CREDENTIALS}", pathPrefix: "${BASE_DIR}", pattern: '**/build/system-tests/run/**/*', sharedPublicly: true, showInline: true
-              //googleStorageUpload bucket: "gs://${JOB_GCS_BUCKET}/${JOB_NAME}/${BUILD_NUMBER}", credentialsId: "${JOB_GCS_CREDENTIALS}", pathPrefix: "${BASE_DIR}", pattern: '**/build/TEST-*.out', sharedPublicly: true, showInline: true
-              tar(file: "system-tests-linux-files.tgz", archive: true, dir: "system-tests", pathPrefix: "${BASE_DIR}/build")
-              tar(file: "coverage-files.tgz", archive: true, dir: "coverage", pathPrefix: "${BASE_DIR}/build")
-              codecov(repo: 'apm-server', basedir: "${BASE_DIR}", secret: "${CODECOV_SECRET}")
+              dir("${BASE_DIR}"){
+                archiveArtifacts(allowEmptyArchive: true,
+                  artifacts: "docker-info/**",
+                  defaultExcludes: false)
+                  junit(allowEmptyResults: true,
+                    keepLongStdio: true,
+                    testResults: "**/build/TEST-*.xml"
+                  )
+              }
+              catchError(buildResult: 'SUCCESS', message: 'Failed to grab test results tar files', stageResult: 'SUCCESS') {
+                tar(file: "system-tests-linux-files.tgz", archive: true, dir: "system-tests", pathPrefix: "${BASE_DIR}/build")
+              }
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
         pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true,
-                    depth: 3, reference: "/var/lib/jenkins/.git-references/${REPO}.git")
+                    shallow: false, reference: "/var/lib/jenkins/.git-references/${REPO}.git")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script {
           dir("${BASE_DIR}"){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,24 +57,18 @@ pipeline {
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script {
           dir("${BASE_DIR}"){
-            env.GO_VERSION = readFile(".go-version")
-            if(env.CHANGE_TARGET){
-              def regexps =[
-                "^_beats",
-                "^apm-server.yml",
-                "^apm-server.docker.yml",
-                "^magefile.go",
-                "^ingest",
-                "^packaging",
-                "^tests/packaging",
-                "^vendor/github.com/elastic/beats"
-              ]
-              def changes = sh(script: "git diff --name-only origin/${env.CHANGE_TARGET}...${env.GIT_SHA} > git-diff.txt",returnStdout: true)
-              def match = regexps.find{ regexp ->
-                  sh(script: "grep '${regexp}' git-diff.txt",returnStatus: true) == 0
-              }
-              env.BEATS_UPDATED = (match != null)
-            }
+            env.GO_VERSION = readFile(".go-version").trim()
+            def regexps =[
+              "^_beats",
+              "^apm-server.yml",
+              "^apm-server.docker.yml",
+              "^magefile.go",
+              "^ingest",
+              "^packaging",
+              "^tests/packaging",
+              "^vendor/github.com/elastic/beats"
+            ]
+            env.BEATS_UPDATED = isGitRegionMatch(patterns: regexps)
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent any
+  agent { label 'linux && immutable' }
   environment {
     BASE_DIR = "src/github.com/elastic/apm-server"
     NOTIFY_TO = credentials('notify-to')
@@ -44,7 +44,6 @@ pipeline {
      Checkout the code and stash it, to use it on other stages.
     */
     stage('Checkout') {
-      agent { label 'master || immutable' }
       environment {
         PATH = "${env.PATH}:${env.WORKSPACE}/bin"
         HOME = "${env.WORKSPACE}"
@@ -88,7 +87,6 @@ pipeline {
     Validate that all updates were committed.
     */
     stage('Intake') {
-      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       environment {
         PATH = "${env.PATH}:${env.WORKSPACE}/bin"
@@ -114,7 +112,6 @@ pipeline {
         Build on a linux environment.
         */
         stage('linux build') {
-          agent { label 'linux && immutable' }
           options { skipDefaultCheckout() }
           environment {
             PATH = "${env.PATH}:${env.WORKSPACE}/bin"
@@ -375,7 +372,6 @@ pipeline {
       build release packages.
     */
     stage('Release') {
-      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       environment {
         PATH = "${env.PATH}:${env.WORKSPACE}/bin"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,6 +69,9 @@ pipeline {
               "^vendor/github.com/elastic/beats"
             ]
             env.BEATS_UPDATED = isGitRegionMatch(patterns: regexps)
+
+            // Skip all the stages except docs for PR's with asciidoc changes only
+            env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.asciidoc' ], comparator: 'regexp', shouldMatchAll: true)
           }
         }
       }
@@ -89,7 +92,10 @@ pipeline {
       }
       when {
         beforeAgent true
-        expression { return params.intake_ci }
+        allOf {
+          expression { return params.intake_ci }
+          expression { return env.ONLY_DOCS == "false" }
+        }
       }
       steps {
         deleteDir()
@@ -114,7 +120,10 @@ pipeline {
           }
           when {
             beforeAgent true
-            expression { return params.linux_ci }
+            allOf {
+              expression { return params.linux_ci }
+              expression { return env.ONLY_DOCS == "false" }
+            }
           }
           steps {
             deleteDir()
@@ -132,7 +141,10 @@ pipeline {
           options { skipDefaultCheckout() }
           when {
             beforeAgent true
-            expression { return params.windows_ci }
+            allOf {
+              expression { return params.windows_ci }
+              expression { return env.ONLY_DOCS == "false" }
+            }
           }
           steps {
             deleteDir()
@@ -160,7 +172,10 @@ pipeline {
           }
           when {
             beforeAgent true
-            expression { return params.test_ci }
+            allOf {
+              expression { return params.test_ci }
+              expression { return env.ONLY_DOCS == "false" }
+            }
           }
           steps {
             deleteDir()
@@ -191,7 +206,10 @@ pipeline {
           }
           when {
             beforeAgent true
-            expression { return params.test_sys_env_ci }
+            allOf {
+              expression { return params.test_sys_env_ci }
+              expression { return env.ONLY_DOCS == "false" }
+            }
           }
           steps {
             deleteDir()
@@ -273,6 +291,7 @@ pipeline {
                 expression { return params.Run_As_Master_Branch }
               }
               expression { return params.bench_ci }
+              expression { return env.ONLY_DOCS == "false" }
             }
           }
           steps {
@@ -328,7 +347,8 @@ pipeline {
             branch 'master'
             expression { return params.Run_As_Master_Branch }
           }
-          expression { return params.doc_ci }
+          expression { return params.its_ci }
+          expression { return env.ONLY_DOCS == "false" }
         }
       }
       steps {
@@ -384,6 +404,7 @@ pipeline {
             expression { return env.BEATS_UPDATED != "0" }
           }
           expression { return params.release_ci }
+          expression { return env.ONLY_DOCS == "false" }
         }
       }
       steps {

--- a/script/jenkins/linux-test.sh
+++ b/script/jenkins/linux-test.sh
@@ -5,12 +5,12 @@ source ./_beats/dev-tools/common.bash
 
 jenkins_setup
 
-#cleanup() {
-#  rm -rf $TEMP_PYTHON_ENV
-#  make stop-environment fix-permissions
-#}
-#trap cleanup EXIT
+cleanup() {
+  rm -rf $TEMP_PYTHON_ENV
+  .ci/scripts/docker-get-logs.sh
+  make stop-environment fix-permissions
+}
+trap cleanup EXIT
 
 make update
 make system-tests-environment
-make stop-environment

--- a/script/jenkins/windows-build.ps1
+++ b/script/jenkins/windows-build.ps1
@@ -8,7 +8,7 @@ function Exec {
 
     try {
         $global:lastexitcode = 0
-        & $cmd
+        & $cmd 2>&1 | %{ "$_" }
         if ($lastexitcode -ne 0) {
             throw $errorMessage
         }

--- a/script/jenkins/windows-test.ps1
+++ b/script/jenkins/windows-test.ps1
@@ -8,7 +8,7 @@ function Exec {
 
     try {
         $global:lastexitcode = 0
-        & $cmd
+        & $cmd 2>&1 | %{ "$_" }
         if ($lastexitcode -ne 0) {
             throw $errorMessage
         }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ci(jenkins): reuse top level agent (#2774)
 - [apm-ci] suppress the NativeCommandError in windows builds (#2890)
 - ci(jenkins): update argument (#2904)
 - [apm-ci] When asciidoc speedup skip some stages (#2891)
 - [jjbb] check_paths_for_matches.py not required anymore (#2925)
 - ci(jenkins): change log rotation, use cached repo (#2970)
 - ci(jenkins): use git reference repo (#2971)
 - feat: grab docker container logs after run tests (#2948)
 - ci(jenkins): shallow cloning doesn't work with isGitRegionMatch (#2998)