### PR TITLE
[7.x] feat: grab docker container logs after run tests (#2948)

### DIFF
--- a/.ci/scripts/docker-get-logs.sh
+++ b/.ci/scripts/docker-get-logs.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STEP=${1:-""}
+
+DOCKER_INFO_DIR="docker-info/${STEP}"
+mkdir -p ${DOCKER_INFO_DIR}
+cp docker-compose.yml ${DOCKER_INFO_DIR}
+cd ${DOCKER_INFO_DIR}
+
+docker ps -a &> docker-containers.txt
+
+DOCKER_IDS=$(docker ps -aq)
+
+for id in ${DOCKER_IDS}
+do
+  docker ps -af id=${id} --no-trunc &> ${id}-cmd.txt
+  docker logs ${id} &> ${id}.log || echo "It is not possible to grab the logs of ${id}"
+  docker inspect ${id} &> ${id}-inspect.json || echo "It is not possible to grab the inspect of ${id}"
+done

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -212,13 +212,18 @@ pipeline {
           post {
             always {
               coverageReport("${BASE_DIR}/build/coverage")
-              junit(allowEmptyResults: true,
-                keepLongStdio: true,
-                testResults: "${BASE_DIR}/build/junit-*.xml,${BASE_DIR}/build/TEST-*.xml")
-              //googleStorageUpload bucket: "gs://${JOB_GCS_BUCKET}/${JOB_NAME}/${BUILD_NUMBER}", credentialsId: "${JOB_GCS_CREDENTIALS}", pathPrefix: "${BASE_DIR}", pattern: '**/build/system-tests/run/**/*', sharedPublicly: true, showInline: true
-              //googleStorageUpload bucket: "gs://${JOB_GCS_BUCKET}/${JOB_NAME}/${BUILD_NUMBER}", credentialsId: "${JOB_GCS_CREDENTIALS}", pathPrefix: "${BASE_DIR}", pattern: '**/build/TEST-*.out', sharedPublicly: true, showInline: true
-              tar(file: "system-tests-linux-files.tgz", archive: true, dir: "system-tests", pathPrefix: "${BASE_DIR}/build")
-              tar(file: "coverage-files.tgz", archive: true, dir: "coverage", pathPrefix: "${BASE_DIR}/build")
+              dir("${BASE_DIR}"){
+                archiveArtifacts(allowEmptyArchive: true,
+                  artifacts: "docker-info/**",
+                  defaultExcludes: false)
+                  junit(allowEmptyResults: true,
+                    keepLongStdio: true,
+                    testResults: "**/build/TEST-*.xml"
+                  )
+              }
+              catchError(buildResult: 'SUCCESS', message: 'Failed to grab test results tar files', stageResult: 'SUCCESS') {
+                tar(file: "system-tests-linux-files.tgz", archive: true, dir: "system-tests", pathPrefix: "${BASE_DIR}/build")
+              }
               codecov(repo: 'apm-server', basedir: "${BASE_DIR}", secret: "${CODECOV_SECRET}")
             }
           }

--- a/script/jenkins/linux-test.sh
+++ b/script/jenkins/linux-test.sh
@@ -5,12 +5,12 @@ source ./_beats/dev-tools/common.bash
 
 jenkins_setup
 
-#cleanup() {
-#  rm -rf $TEMP_PYTHON_ENV
-#  make stop-environment fix-permissions
-#}
-#trap cleanup EXIT
+cleanup() {
+  rm -rf $TEMP_PYTHON_ENV
+  .ci/scripts/docker-get-logs.sh
+  make stop-environment fix-permissions
+}
+trap cleanup EXIT
 
 make update
 make system-tests-environment
-make stop-environment


### PR DESCRIPTION
Backports the following commits to 7.x:
 - feat: grab docker container logs after run tests  (#2948)