### PR TITLE
beater: disable auth for self-instrumentation

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -24,12 +24,10 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"sync"
 	"time"
 
 	"go.elastic.co/apm"
-	"go.elastic.co/apm/transport"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/elastic/beats/libbeat/beat"
@@ -41,7 +39,6 @@ import (
 	"github.com/elastic/apm-server/beater/config"
 	"github.com/elastic/apm-server/ingest/pipeline"
 	logs "github.com/elastic/apm-server/log"
-	"github.com/elastic/apm-server/pipelistener"
 	"github.com/elastic/apm-server/publish"
 )
 
@@ -50,11 +47,12 @@ func init() {
 }
 
 type beater struct {
-	config  *config.Config
-	mutex   sync.Mutex // guards server and stopped
-	server  *http.Server
-	stopped bool
-	logger  *logp.Logger
+	config   *config.Config
+	mutex    sync.Mutex // guards server and stopped
+	server   *http.Server
+	stopping chan struct{}
+	stopped  bool
+	logger   *logp.Logger
 }
 
 var (
@@ -101,9 +99,10 @@ func New(b *beat.Beat, ucfg *common.Config) (beat.Beater, error) {
 	}
 
 	bt := &beater{
-		config:  beaterConfig,
-		stopped: false,
-		logger:  logger,
+		config:   beaterConfig,
+		stopping: make(chan struct{}),
+		stopped:  false,
+		logger:   logger,
 	}
 
 	// setup pipelines if explicitly directed to or setup --pipelines and config is not set at all
@@ -159,14 +158,17 @@ func (bt *beater) listen() (net.Listener, error) {
 }
 
 func (bt *beater) Run(b *beat.Beat) error {
-	tracer, traceListener, err := initTracer(b.Info, bt.config, bt.logger)
+	tracer, tracerServer, err := initTracer(b.Info, bt.config, bt.logger)
 	if err != nil {
 		return err
 	}
-	if traceListener != nil {
-		defer traceListener.Close()
+	if tracerServer != nil {
+		go func() {
+			defer tracerServer.stop()
+			defer tracer.Close()
+			<-bt.stopping
+		}()
 	}
-	defer tracer.Close()
 
 	pub, err := publish.NewPublisher(b.Publisher, tracer, &publish.PublisherConfig{
 		Info: b.Info, ShutdownTimeout: bt.config.ShutdownTimeout, Pipeline: bt.config.Pipeline,
@@ -204,9 +206,9 @@ func (bt *beater) Run(b *beat.Beat) error {
 		go notifyListening(bt.config, pub.Client().Publish)
 	}
 
-	if traceListener != nil {
+	if tracerServer != nil {
 		g.Go(func() error {
-			return bt.server.Serve(traceListener)
+			return tracerServer.serve(pub.Send)
 		})
 	}
 
@@ -240,87 +242,6 @@ func (bt *beater) isServerAvailable(timeout time.Duration) bool {
 	return err == nil
 }
 
-// initTracer configures and returns an apm.Tracer for tracing
-// the APM server's own execution.
-func initTracer(info beat.Info, cfg *config.Config, logger *logp.Logger) (*apm.Tracer, net.Listener, error) {
-	if !cfg.SelfInstrumentation.IsEnabled() {
-		os.Setenv("ELASTIC_APM_ACTIVE", "false")
-		logger.Infof("self instrumentation is disabled")
-	} else {
-		os.Setenv("ELASTIC_APM_ACTIVE", "true")
-		logger.Infof("self instrumentation is enabled")
-	}
-	if !cfg.SelfInstrumentation.IsEnabled() {
-		tracer, err := apm.NewTracer(info.Beat, info.Version)
-		return tracer, nil, err
-	}
-
-	if cfg.SelfInstrumentation.Profiling.CPU.IsEnabled() {
-		interval := cfg.SelfInstrumentation.Profiling.CPU.Interval
-		duration := cfg.SelfInstrumentation.Profiling.CPU.Duration
-		logger.Infof("CPU profiling: every %s for %s", interval, duration)
-		os.Setenv("ELASTIC_APM_CPU_PROFILE_INTERVAL", fmt.Sprintf("%dms", int(interval.Seconds()*1000)))
-		os.Setenv("ELASTIC_APM_CPU_PROFILE_DURATION", fmt.Sprintf("%dms", int(duration.Seconds()*1000)))
-	}
-	if cfg.SelfInstrumentation.Profiling.Heap.IsEnabled() {
-		interval := cfg.SelfInstrumentation.Profiling.Heap.Interval
-		logger.Infof("Heap profiling: every %s", interval)
-		os.Setenv("ELASTIC_APM_HEAP_PROFILE_INTERVAL", fmt.Sprintf("%dms", int(interval.Seconds()*1000)))
-	}
-
-	var tracerTransport transport.Transport
-	var lis net.Listener
-	if cfg.SelfInstrumentation.Hosts != nil {
-		// tracing destined for external host
-		t, err := transport.NewHTTPTransport()
-		if err != nil {
-			return nil, nil, err
-		}
-		t.SetServerURL(cfg.SelfInstrumentation.Hosts...)
-		t.SetSecretToken(cfg.SelfInstrumentation.SecretToken)
-		tracerTransport = t
-		logger.Infof("self instrumentation directed to %s", cfg.SelfInstrumentation.Hosts)
-	} else {
-		// Create an in-process net.Listener for the tracer. This enables us to:
-		// - avoid the network stack
-		// - avoid/ignore TLS for self-tracing
-		// - skip tracing when the requests come from the in-process transport
-		//   (i.e. to avoid recursive/repeated tracing.)
-		pipeListener := pipelistener.New()
-		selfTransport, err := transport.NewHTTPTransport()
-		if err != nil {
-			lis.Close()
-			return nil, nil, err
-		}
-		selfTransport.SetServerURL(&url.URL{Scheme: "http", Host: "localhost"})
-		selfTransport.SetSecretToken(cfg.SecretToken)
-		selfTransport.Client.Transport = &http.Transport{
-			DialContext:     pipeListener.DialContext,
-			MaxIdleConns:    100,
-			IdleConnTimeout: 90 * time.Second,
-		}
-		tracerTransport = selfTransport
-		lis = pipeListener
-	}
-
-	var environment string
-	if cfg.SelfInstrumentation.Environment != nil {
-		environment = *cfg.SelfInstrumentation.Environment
-	}
-	tracer, err := apm.NewTracerOptions(apm.TracerOptions{
-		ServiceName:        info.Beat,
-		ServiceVersion:     info.Version,
-		ServiceEnvironment: environment,
-		Transport:          tracerTransport,
-	})
-	if err != nil {
-		return nil, nil, err
-	}
-	tracer.SetLogger(logp.NewLogger(logs.Tracing))
-
-	return tracer, lis, nil
-}
-
 func isElasticsearchOutput(b *beat.Beat) bool {
 	return b.Config != nil && b.Config.Output.Name() == "elasticsearch"
 }
@@ -346,12 +267,16 @@ func (bt *beater) registerPipelineCallback(b *beat.Beat) error {
 
 // Graceful shutdown
 func (bt *beater) Stop() {
+	bt.mutex.Lock()
+	defer bt.mutex.Unlock()
+	if bt.stopped {
+		return
+	}
 	bt.logger.Infof("stopping apm-server... waiting maximum of %v seconds for queues to drain",
 		bt.config.ShutdownTimeout.Seconds())
-	bt.mutex.Lock()
 	if bt.server != nil {
 		stop(bt.logger, bt.server)
 	}
+	close(bt.stopping)
 	bt.stopped = true
-	bt.mutex.Unlock()
 }

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -165,10 +165,10 @@ func (bt *beater) Run(b *beat.Beat) error {
 	if tracerServer != nil {
 		go func() {
 			defer tracerServer.stop()
-			defer tracer.Close()
 			<-bt.stopping
 		}()
 	}
+	defer tracer.Close()
 
 	pub, err := publish.NewPublisher(b.Publisher, tracer, &publish.PublisherConfig{
 		Info: b.Info, ShutdownTimeout: bt.config.ShutdownTimeout, Pipeline: bt.config.Pipeline,

--- a/beater/server.go
+++ b/beater/server.go
@@ -63,11 +63,6 @@ func newServer(cfg *config.Config, tracer *apm.Tracer, report publish.Reporter) 
 }
 
 func doNotTrace(req *http.Request) bool {
-	if req.RemoteAddr == "pipe" {
-		// Don't trace requests coming from self,
-		// or we will go into a continuous cycle.
-		return true
-	}
 	if req.URL.Path == api.RootPath {
 		// Don't trace root url (healthcheck) requests.
 		return true

--- a/beater/server.go
+++ b/beater/server.go
@@ -63,11 +63,8 @@ func newServer(cfg *config.Config, tracer *apm.Tracer, report publish.Reporter) 
 }
 
 func doNotTrace(req *http.Request) bool {
-	if req.URL.Path == api.RootPath {
-		// Don't trace root url (healthcheck) requests.
-		return true
-	}
-	return false
+	// Don't trace root url (healthcheck) requests.
+	return req.URL.Path == api.RootPath
 }
 
 func run(logger *logp.Logger, server *http.Server, lis net.Listener, cfg *config.Config) error {

--- a/beater/tracing.go
+++ b/beater/tracing.go
@@ -1,0 +1,179 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"go.elastic.co/apm"
+	"go.elastic.co/apm/transport"
+
+	"github.com/elastic/beats/libbeat/beat"
+	"github.com/elastic/beats/libbeat/logp"
+
+	"github.com/elastic/apm-server/beater/api"
+	"github.com/elastic/apm-server/beater/config"
+	logs "github.com/elastic/apm-server/log"
+	"github.com/elastic/apm-server/pipelistener"
+	"github.com/elastic/apm-server/publish"
+)
+
+func init() {
+	apm.DefaultTracer.Close()
+}
+
+// initTracer configures and returns an apm.Tracer for tracing
+// the APM server's own execution. If the server is configured
+// to send tracing data to itself, it will return a tracerServer
+// that can be used for receiving trace data.
+func initTracer(info beat.Info, cfg *config.Config, logger *logp.Logger) (*apm.Tracer, *tracerServer, error) {
+	if !cfg.SelfInstrumentation.IsEnabled() {
+		os.Setenv("ELASTIC_APM_ACTIVE", "false")
+		logger.Infof("self instrumentation is disabled")
+	} else {
+		os.Setenv("ELASTIC_APM_ACTIVE", "true")
+		logger.Infof("self instrumentation is enabled")
+	}
+	if !cfg.SelfInstrumentation.IsEnabled() {
+		tracer, err := apm.NewTracer(info.Beat, info.Version)
+		return tracer, nil, err
+	}
+
+	if cfg.SelfInstrumentation.Profiling.CPU.IsEnabled() {
+		interval := cfg.SelfInstrumentation.Profiling.CPU.Interval
+		duration := cfg.SelfInstrumentation.Profiling.CPU.Duration
+		logger.Infof("CPU profiling: every %s for %s", interval, duration)
+		os.Setenv("ELASTIC_APM_CPU_PROFILE_INTERVAL", fmt.Sprintf("%dms", int(interval.Seconds()*1000)))
+		os.Setenv("ELASTIC_APM_CPU_PROFILE_DURATION", fmt.Sprintf("%dms", int(duration.Seconds()*1000)))
+	}
+	if cfg.SelfInstrumentation.Profiling.Heap.IsEnabled() {
+		interval := cfg.SelfInstrumentation.Profiling.Heap.Interval
+		logger.Infof("Heap profiling: every %s", interval)
+		os.Setenv("ELASTIC_APM_HEAP_PROFILE_INTERVAL", fmt.Sprintf("%dms", int(interval.Seconds()*1000)))
+	}
+
+	var tracerTransport transport.Transport
+	var tracerServer *tracerServer
+	if cfg.SelfInstrumentation.Hosts != nil {
+		// tracing destined for external host
+		t, err := transport.NewHTTPTransport()
+		if err != nil {
+			return nil, nil, err
+		}
+		t.SetServerURL(cfg.SelfInstrumentation.Hosts...)
+		t.SetSecretToken(cfg.SelfInstrumentation.SecretToken)
+		tracerTransport = t
+		logger.Infof("self instrumentation directed to %s", cfg.SelfInstrumentation.Hosts)
+	} else {
+		var err error
+		tracerServer, err = newTracerServer(cfg)
+		if err != nil {
+			return nil, nil, err
+		}
+		tracerTransport = tracerServer.transport
+	}
+
+	var environment string
+	if cfg.SelfInstrumentation.Environment != nil {
+		environment = *cfg.SelfInstrumentation.Environment
+	}
+	tracer, err := apm.NewTracerOptions(apm.TracerOptions{
+		ServiceName:        info.Beat,
+		ServiceVersion:     info.Version,
+		ServiceEnvironment: environment,
+		Transport:          tracerTransport,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	tracer.SetLogger(logp.NewLogger(logs.Tracing))
+
+	return tracer, tracerServer, nil
+}
+
+type tracerServer struct {
+	cfg       *config.Config
+	logger    *logp.Logger
+	server    *http.Server
+	listener  net.Listener
+	transport transport.Transport
+}
+
+func newTracerServer(cfg *config.Config) (*tracerServer, error) {
+	cfgCopy := *cfg // Copy cfg so we can disable auth
+	cfg = &cfgCopy
+	cfg.SecretToken = ""
+	cfg.APIKeyConfig = nil
+
+	server := &http.Server{
+		IdleTimeout:    cfg.IdleTimeout,
+		ReadTimeout:    cfg.ReadTimeout,
+		WriteTimeout:   cfg.WriteTimeout,
+		MaxHeaderBytes: cfg.MaxHeaderSize,
+	}
+
+	// Create an in-process net.Listener for the tracer. This enables us to:
+	// - avoid the network stack
+	// - avoid/ignore TLS for self-tracing
+	// - skip tracing when the requests come from the in-process transport
+	//   (i.e. to avoid recursive/repeated tracing.)
+	pipeListener := pipelistener.New()
+	pipeTransport, err := transport.NewHTTPTransport()
+	if err != nil {
+		return nil, err
+	}
+	pipeTransport.SetServerURL(&url.URL{Scheme: "http", Host: "localhost"})
+	pipeTransport.Client.Transport = &http.Transport{
+		DialContext:     pipeListener.DialContext,
+		MaxIdleConns:    100,
+		IdleConnTimeout: 90 * time.Second,
+	}
+
+	return &tracerServer{
+		cfg:       cfg,
+		logger:    logp.NewLogger(logs.Beater),
+		server:    server,
+		listener:  pipeListener,
+		transport: pipeTransport,
+	}, nil
+}
+
+func (s *tracerServer) serve(report publish.Reporter) error {
+	mux, err := api.NewMux(s.cfg, report)
+	if err != nil {
+		return err
+	}
+	s.server.Handler = mux
+	return s.server.Serve(s.listener)
+}
+
+func (s *tracerServer) stop() {
+	err := s.server.Shutdown(context.Background())
+	if err != nil {
+		s.logger.Error(err.Error())
+		if err := s.server.Close(); err != nil {
+			s.logger.Error(err.Error())
+		}
+	}
+}

--- a/beater/tracing_test.go
+++ b/beater/tracing_test.go
@@ -170,6 +170,7 @@ func setupTestServerInstrumentation(t *testing.T, enabled bool) (chan beat.Event
 	cfg := common.MustNewConfigFrom(m{
 		"instrumentation": m{"enabled": enabled},
 		"host":            "localhost:0",
+		"secret_token":    "foo",
 	})
 	beater, teardown, err := setupServer(t, cfg, nil, events)
 	require.NoError(t, err)
@@ -182,6 +183,7 @@ func setupTestServerInstrumentation(t *testing.T, enabled bool) (chan beat.Event
 	baseUrl, client := beater.client(false)
 	req := makeTransactionRequest(t, baseUrl)
 	req.Header.Add("Content-Type", "application/x-ndjson")
+	req.Header.Add("Authorization", "Bearer foo")
 	resp, err := client.Do(req)
 	assert.NoError(t, err)
 	resp.Body.Close()

--- a/tests/system/test_access.py
+++ b/tests/system/test_access.py
@@ -259,8 +259,7 @@ class TestAccessWithAuthorization(BaseAPIKeySetup):
     def config(self):
         cfg = super(TestAccessWithAuthorization, self).config()
         cfg.update({"secret_token": "1234", "api_key_enabled": True, "enable_rum": True,
-                    "kibana_enabled": "true", "kibana_host": self.get_kibana_url(),
-                    "instrumentation_enabled": "true"})
+                    "kibana_enabled": "true", "kibana_host": self.get_kibana_url()})
         return cfg
 
     def test_root(self):
@@ -369,9 +368,7 @@ class TestSelfInstrumentationWithAPIKeys(BaseAPIKeySetup):
 
     def config(self):
         cfg = super(TestSelfInstrumentationWithAPIKeys, self).config()
-        cfg.update({"api_key_enabled": True, "enable_rum": True,
-                    "kibana_enabled": "true", "kibana_host": self.get_kibana_url(),
-                    "instrumentation_enabled": "true"})
+        cfg.update({"api_key_enabled": True, "instrumentation_enabled": "true"})
         return cfg
 
     def test_self_instrumentation(self):


### PR DESCRIPTION
When the server is configured to send trace data
to itself, it will now create an entirely separate
muxer and HTTP server for the purpose.

This tracer muxer is configured to not require any
auth, and is not instrumented, so we can simplify
the "doNotTrace" request ignorer.

Closes #3051 