### PR TITLE
[7.x] docs: fix ilm copy pasta (#3088)

### DIFF
--- a/docs/ilm.asciidoc
+++ b/docs/ilm.asciidoc
@@ -165,7 +165,7 @@ apm-server:
       enabled: true
       overwrite: true
       require_policy: true
-      templates:
+      mapping:
         - event_type: "error"
           policy_name: "apm-rollover-30-days"
         - event_type: "span"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: fix ilm copy pasta (#3088)