### PR TITLE
[7.x] Fixes incorrect name for output.elasticsearch.worker (#2887)

### DIFF
--- a/docs/data-ingestion.asciidoc
+++ b/docs/data-ingestion.asciidoc
@@ -29,7 +29,7 @@ Check the {apm-overview-ref-v}/agent-server-compatibility.html[agent/server comp
 If your Elasticsearch cluster is not ingesting the amount of data you expect,
 you can tweak a few APM Server settings:
 
-* Adjust `output.elasticsearch.workers`.
+* Adjust `output.elasticsearch.worker`.
 See {ref}/tune-for-indexing-speed.html[tune for indexing speed] for an overview.
 * Ensure `output.elasticsearch.bulk_max_size` is set to a high value, for example 5120.
   The default of 50 is very conservative.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fixes incorrect name for output.elasticsearch.worker (#2887)