### PR TITLE
tests/system: basic smoke-test for monitoring

### DIFF
--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -9,7 +9,7 @@ apm-server:
   api_key.limit: {{ api_key_limit | default(100) }}
   {% endif %}
   {% if api_key_es %}
-  api_key.elasticsearch.hosts: [{{ api_key_es}}]
+  api_key.elasticsearch.hosts: [{{ api_key_es }}]
   {% endif %}
 
   {% if max_event_size %}
@@ -185,6 +185,8 @@ output.file:
 {% if elasticsearch_host %}
 output.elasticsearch:
   hosts: ["{{ elasticsearch_host }}"]
+  username: {{ elasticsearch_username }}
+  password: {{ elasticsearch_password }}
 
   {% if override_index %}
   index: {{ override_index }}
@@ -257,3 +259,15 @@ logging:
     #keepfiles: 7
 
 queue.mem.flush.min_events: {{ queue_flush }}
+
+############################# X-pack Monitoring ###############################
+
+{% if monitoring_enabled %}
+monitoring.enabled: true
+{% if monitoring_elasticsearch_username %}
+monitoring.elasticsearch.username: {{ monitoring_elasticsearch_username  }}
+{% endif %}
+{% if monitoring_elasticsearch_password %}
+monitoring.elasticsearch.password: {{ monitoring_elasticsearch_password }}
+{% endif %}
+{% endif %}

--- a/tests/system/test_monitoring.py
+++ b/tests/system/test_monitoring.py
@@ -1,0 +1,40 @@
+from apmserver import integration_test
+from apmserver import ElasticTest
+
+import urlparse
+
+
+@integration_test
+class Test(ElasticTest):
+    def config(self):
+        cfg = super(Test, self).config()
+
+        # Extract username/password from the URL, and store
+        # separately from elasticsearch_host. This is necessary
+        # because Beats will use the userinfo from the URL in
+        # preference to specified values.
+        url = urlparse.urlparse(cfg["elasticsearch_host"])
+        if url.username:
+            cfg["elasticsearch_username"] = url.username
+        if url.password:
+            cfg["elasticsearch_password"] = url.password
+        bare_netloc = url.netloc.split('@')[-1]
+        url = list(url)
+        url[1] = bare_netloc
+
+        # Set a password for the built-in apm_system user, and use that for monitoring.
+        monitoring_password = "changeme"
+        self.es.xpack.security.change_password(username="apm_system",
+                                               body='{"password":"%s"}' % monitoring_password)
+        cfg.update({
+            "elasticsearch_host": urlparse.urlunparse(url),
+            "monitoring_enabled": "true",
+            "monitoring_elasticsearch_username": "apm_system",
+            "monitoring_elasticsearch_password": monitoring_password,
+        })
+        cfg.update(self.config_overrides)
+        return cfg
+
+    def test_connect(self):
+        goal_log = "Successfully connected to X-Pack Monitoring endpoint"
+        self.wait_until(lambda: self.log_contains(goal_log), name="apm-server connected to monitoring endpoint")

--- a/tests/system/test_monitoring.py
+++ b/tests/system/test_monitoring.py
@@ -1,6 +1,7 @@
 from apmserver import integration_test
 from apmserver import ElasticTest
 
+import os
 import urlparse
 
 from elasticsearch import Elasticsearch

--- a/tests/system/test_monitoring.py
+++ b/tests/system/test_monitoring.py
@@ -3,6 +3,8 @@ from apmserver import ElasticTest
 
 import urlparse
 
+from elasticsearch import Elasticsearch
+
 
 @integration_test
 class Test(ElasticTest):
@@ -24,8 +26,11 @@ class Test(ElasticTest):
 
         # Set a password for the built-in apm_system user, and use that for monitoring.
         monitoring_password = "changeme"
-        self.es.xpack.security.change_password(username="apm_system",
-                                               body='{"password":"%s"}' % monitoring_password)
+        admin_user = os.getenv("ES_SUPERUSER_USER", "admin")
+        admin_password = os.getenv("ES_SUPERUSER_PASS", "changeme")
+        admin_es = Elasticsearch([self.get_elasticsearch_url(admin_user, admin_password)])
+        admin_es.xpack.security.change_password(username="apm_system",
+                                                body='{"password":"%s"}' % monitoring_password)
         cfg.update({
             "elasticsearch_host": urlparse.urlunparse(url),
             "monitoring_enabled": "true",


### PR DESCRIPTION
Add a system test that verifies the server can connect to the X-Pack Monitoring endpoint using the built-in "apm_system" user.

See https://github.com/elastic/apm-server/issues/2708