### PR TITLE
[intake] Fix reference to message json spec.

### DIFF
--- a/docs/spec/spans/span.json
+++ b/docs/spec/spans/span.json
@@ -176,7 +176,7 @@
                             }
                         },
                         "message": {
-                            "$ref": "message.json"
+                            "$ref": "../message.json"
                         }
                     }
                 },


### PR DESCRIPTION
The reference to the message json spec file from spans was invalid.

Thanks for pointing out the bug @mikker.