### PR TITLE
[7.x] [intake] Fix reference to message json spec. (#3112)

### DIFF
--- a/docs/spec/spans/span.json
+++ b/docs/spec/spans/span.json
@@ -176,7 +176,7 @@
                             }
                         },
                         "message": {
-                            "$ref": "message.json"
+                            "$ref": "../message.json"
                         }
                     }
                 },


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [intake] Fix reference to message json spec. (#3112)