### PR TITLE
Add experimental flag to Jaeger integration

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -393,8 +393,10 @@ apm-server:
 
 
 
-  #---------------------------- APM Server - Open Telemetry Collector integration ----------------------------
+  #---------------------------- APM Server - Experimental Jaeger integration ----------------------------
 
+  # When enabling Jaeger integration, APM Server acts as Jaeger collector. It supports jaeger.thrift over HTTP
+  # and gRPC. This is an experimental feature, use with care.
   #jaeger:
     #grpc:
       # Set to true to enable the Jaeger gRPC collector service.

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -393,8 +393,10 @@ apm-server:
 
 
 
-  #---------------------------- APM Server - Open Telemetry Collector integration ----------------------------
+  #---------------------------- APM Server - Experimental Jaeger integration ----------------------------
 
+  # When enabling Jaeger integration, APM Server acts as Jaeger collector. It supports jaeger.thrift over HTTP
+  # and gRPC. This is an experimental feature, use with care.
   #jaeger:
     #grpc:
       # Set to true to enable the Jaeger gRPC collector service.

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -393,8 +393,10 @@ apm-server:
 
 
 
-  #---------------------------- APM Server - Open Telemetry Collector integration ----------------------------
+  #---------------------------- APM Server - Experimental Jaeger integration ----------------------------
 
+  # When enabling Jaeger integration, APM Server acts as Jaeger collector. It supports jaeger.thrift over HTTP
+  # and gRPC. This is an experimental feature, use with care.
   #jaeger:
     #grpc:
       # Set to true to enable the Jaeger gRPC collector service.


### PR DESCRIPTION
Jaeger integration will be released as experimental feature, for following reasons:
* APM Server acting as Jaeger collector doesn't support probabilistic sampling. 
* No automated end-to-end system tests yet.
* Used [opentelemetry/opentelemetry-collector](https://github.com/open-telemetry/opentelemetry-collector) library is in alpha state.