### PR TITLE
[7.x] [docs] Adds APM app cross cluster search documentation (#3089)

### DIFF
--- a/docs/guide/cross-cluster-search.asciidoc
+++ b/docs/guide/cross-cluster-search.asciidoc
@@ -1,0 +1,42 @@
+[[apm-cross-cluster-search]]
+== Cross-cluster search
+
+Elastic APM utilizes Elasticsearch's cross-cluster search functionality.
+Cross-cluster search lets you run a single search request against one or more
+{ref}/modules-remote-clusters.html[remote clusters] --
+making it easy to search APM data across multiple sources.
+This means you can also have deployments per data type, making sizing and scaling more predictable,
+and allowing for better performance while managing multiple observability use cases.
+
+[float]
+[[set-up-ccs]]
+=== Set up cross-cluster search
+
+*Step 1. Set up remote clusters.*
+
+If you're using the Hosted Elasticsearch Service, see {cloud}/ec-enable-ccs.html[Enable cross-cluster search].
+
+You can add remote clusters directly in Kibana, under *Management* > *Elasticsearch* > *Remote clusters*.
+All you need is a name for the remote cluster and the seed node(s).
+Remember the names of your remote clusters, you'll need them in step two.
+See {kibana-ref}/working-remote-clusters.html#managing-remote-clusters[managing remote clusters] for detailed information on the setup process.
+
+Alternatively, you can {ref}/modules-remote-clusters.html#configuring-remote-clusters[configure remote clusters]
+in Elasticsearch's `elasticsearch.yml` file.
+
+*Step 2. Edit the default APM app index pattern.*
+
+The APM app index pattern determines from which clusters and indices to display data.
+Index patterns follow this convention: `<cluster-names>:<pattern>`.
+The default value is `apm-*`, which displays data from any index beginning with `apm-`.
+
+To display data from the local cluster, and all remote clusters,
+you'll need to update the index pattern to: `*:apm-*,apm-*`.
+You can also specify certain clusters to display data from, for example, `obs-1:apm-*,obs-2:apm-*`.
+
+There are two ways to edit the default index pattern:
+
+* In the APM app -- Navigate to *APM* > *Settings* > *Indices*, and change all `apm_oss.*Pattern` values to
+include the new index pattern, e.g., `*:apm-*,apm-*`.
+* In `kibana.yml` -- All of the {kibana-ref}/apm-settings-kb.html[`apm_oss.*Pattern`] configuration values must
+include the new index pattern, e.g., `*:apm-*,apm-*`.

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -25,6 +25,8 @@ include::./opentracing.asciidoc[]
 
 include::./obs-integrations.asciidoc[]
 
+include::./cross-cluster-search.asciidoc[]
+
 include::./agent-server-compatibility.asciidoc[]
 
 include::./troubleshooting.asciidoc[]

--- a/docs/guide/install-and-run.asciidoc
+++ b/docs/guide/install-and-run.asciidoc
@@ -62,7 +62,8 @@ Install Kibana, start it up, and open up the web interface:
 Install, set up, and run APM Server.
 
 . {apm-server-ref-v}/installing.html[Install APM Server].
-. {apm-server-ref-v}/setting-up-and-running.html[Set up and Run APM Server].
+. {apm-server-ref-v}/apm-server-configuration.html[Set up APM Server]
+. {apm-server-ref-v}/setting-up-and-running.html[Start APM Server].
 
 Next, use the config file if you need to change the default configuration that APM Server uses to connect to Elasticsearch,
 or if you need to specify credentials:
@@ -109,8 +110,8 @@ and configuring it with the address of your APM Server, a secret token (if neces
 
 .2+|.NET
 2+|The .NET agent automatically instruments ASP.NET Core applications, while .NET Framework applications can be instrumented with the public API.
+|{apm-dotnet-ref-v}/supported-technologies.html[Supported technologies]
 |{apm-dotnet-ref-v}/setup.html[Set up the .NET Agent]
-|
 
 .2+|Node.js
 2+|The Node.js agent automatically instruments Express, hapi, Koa, and Restify out of the box.
@@ -160,7 +161,6 @@ Luckily, there are many different ways to tweak and tune the Elastic ecosystem t
 [float]
 ==== Configure APM agents
 
-// Note about central config will go here
 APM agents have a number of configuration options that allow you to fine tune things like
 environment names, sampling rates, instrumentations, metrics, and more.
 
@@ -176,6 +176,9 @@ a|
 * {apm-ruby-ref-v}/configuration.html[Ruby Agent configuration]
 * {apm-rum-ref-v}/configuration.html[RUM Agent configuration]
 |===
+
+A select number of configuration options can be changed directly in Kibana, without needing to redeploy the Agent.
+See {apm-app-ref}/agent-configuration.html[Agent configuration in Kibana] for more information.
 
 [float]
 ==== Configure Elastic Cloud


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [docs] Adds APM app cross cluster search documentation (#3089)