### PR TITLE
[7.x] [docs] Fix ambiguous *.output documentation (#3093)

### DIFF
--- a/docs/copied-from-beats/outputs/console/docs/console.asciidoc
+++ b/docs/copied-from-beats/outputs/console/docs/console.asciidoc
@@ -7,6 +7,11 @@
 
 The Console output writes events in JSON format to stdout.
 
+To use this output, edit the {beatname_uc} configuration file to disable the {es}
+output by commenting it out, and enable the console output by adding `output.console`.
+
+Example configuration:
+
 [source,yaml]
 ------------------------------------------------------------------------------
 output.console:
@@ -15,7 +20,14 @@ output.console:
 
 ==== Configuration options
 
-You can specify the following options in the `console` section of the +{beatname_lc}.yml+ config file:
+You can specify the following `output.console` options in the +{beatname_lc}.yml+ config file:
+
+===== `enabled`
+
+The enabled config is a boolean setting to enable or disable the output. If set
+to false, the output is disabled.
+
+The default value is `true`.
 
 ===== `pretty`
 
@@ -26,14 +38,6 @@ If `pretty` is set to true, events written to stdout will be nicely formatted. T
 Output codec configuration. If the `codec` section is missing, events will be json encoded using the `pretty` option.
 
 See <<configuration-output-codec>> for more information.
-
-
-===== `enabled`
-
-The enabled config is a boolean setting to enable or disable the output. If set
-to false, the output is disabled.
-
-The default value is true.
 
 ===== `bulk_max_size`
 

--- a/docs/copied-from-beats/outputs/fileout/docs/fileout.asciidoc
+++ b/docs/copied-from-beats/outputs/fileout/docs/fileout.asciidoc
@@ -9,6 +9,11 @@ The File output dumps the transactions into a file where each transaction is in 
 Currently, this output is used for testing, but it can be used as input for
 Logstash.
 
+To use this output, edit the {beatname_uc} configuration file to disable the {es}
+output by commenting it out, and enable the file output by adding `output.file`.
+
+Example configuration:
+
 ["source","yaml",subs="attributes"]
 ------------------------------------------------------------------------------
 output.file:
@@ -21,14 +26,14 @@ output.file:
 
 ==== Configuration options
 
-You can specify the following options in the `file` section of the +{beatname_lc}.yml+ config file:
+You can specify the following `output.file` options in the +{beatname_lc}.yml+ config file:
 
 ===== `enabled`
 
 The enabled config is a boolean setting to enable or disable the output. If set
 to false, the output is disabled.
 
-The default value is true.
+The default value is `true`.
 
 [[path]]
 ===== `path`

--- a/docs/copied-from-beats/outputs/kafka/docs/kafka.asciidoc
+++ b/docs/copied-from-beats/outputs/kafka/docs/kafka.asciidoc
@@ -5,7 +5,11 @@
 <titleabbrev>Kafka</titleabbrev>
 ++++
 
-The Kafka output sends the events to Apache Kafka.
+The Kafka output sends events to Apache Kafka.
+
+To use this output, edit the {beatname_uc} configuration file to disable the {es}
+output by commenting it out, and enable the Kafka output by uncommenting the
+Kafka section.
 
 Example configuration:
 
@@ -42,7 +46,12 @@ You can specify the following options in the `kafka` section of the +{beatname_l
 The `enabled` config is a boolean setting to enable or disable the output. If set
 to false, the output is disabled.
 
-The default value is true.
+ifndef::apm-server[]
+The default value is `true`.
+endif::[]
+ifdef::apm-server[]
+The default value is `false`.
+endif::[]
 
 ===== `hosts`
 

--- a/docs/copied-from-beats/outputs/logstash/docs/logstash.asciidoc
+++ b/docs/copied-from-beats/outputs/logstash/docs/logstash.asciidoc
@@ -24,7 +24,7 @@ the {stack} getting started tutorial. Also see the documentation for the
 If you want to use {ls} to perform additional processing on the data collected by
 {beatname_uc}, you need to configure {beatname_uc} to use {ls}.
 
-To do this, you edit the {beatname_uc} configuration file to disable the {es}
+To do this, edit the {beatname_uc} configuration file to disable the {es}
 output by commenting it out and enable the {ls} output by uncommenting the
 logstash section:
 
@@ -224,7 +224,12 @@ You can specify the following options in the `logstash` section of the
 The enabled config is a boolean setting to enable or disable the output. If set
 to false, the output is disabled.
 
+ifndef::apm-server[]
 The default value is `true`.
+endif::[]
+ifdef::apm-server[]
+The default value is `false`.
+endif::[]
 
 [[hosts]]
 ===== `hosts`

--- a/docs/copied-from-beats/outputs/redis/docs/redis.asciidoc
+++ b/docs/copied-from-beats/outputs/redis/docs/redis.asciidoc
@@ -11,6 +11,9 @@ The Redis output inserts the events into a Redis list or a Redis channel.
 This output plugin is compatible with
 the https://www.elastic.co/guide/en/logstash/current/plugins-inputs-redis.html[Redis input plugin] for Logstash.
 
+To use this output, edit the {beatname_uc} configuration file to disable the {es}
+output by commenting it out, and enable the Redis output by adding `output.redis`.
+
 Example configuration:
 
 ["source","yaml",subs="attributes"]
@@ -29,14 +32,14 @@ This output works with Redis 3.2.4.
 
 ==== Configuration options
 
-You can specify the following options in the `redis` section of the +{beatname_lc}.yml+ config file:
+You can specify the following `output.redis` options in the +{beatname_lc}.yml+ config file:
 
 ===== `enabled`
 
 The enabled config is a boolean setting to enable or disable the output. If set
 to false, the output is disabled.
 
-The default value is true.
+The default value is `true`.
 
 ===== `hosts`
 
@@ -142,24 +145,6 @@ The default value is `list`.
 Output codec configuration. If the `codec` section is missing, events will be json encoded.
 
 See <<configuration-output-codec>> for more information.
-
-===== `host_topology`
-
-deprecated:[5.0.0]
-
-The Redis host to connect to when using topology map support. Topology map support is disabled if this option is not set.
-
-===== `password_topology`
-
-deprecated:[5.0.0]
-
-The password to use for authenticating with the Redis topology server. The default is no authentication.
-
-===== `db_topology`
-
-deprecated:[5.0.0]
-
-The Redis database number where the topology information is stored. The default is 1.
 
 ===== `worker`
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [docs] Fix ambiguous *.output documentation (#3093)