### PR TITLE
[7.x] [test] Use apm_server_user for API Key tests. (#3124)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ GOBUILD_FLAGS=-ldflags "-s -X $(BEAT_PATH)/vendor/github.com/elastic/beats/libbe
 MAGE_IMPORT_PATH=${BEAT_PATH}/vendor/github.com/magefile/mage
 STATICCHECK_REPO=${BEAT_PATH}/vendor/honnef.co/go/tools/cmd/staticcheck
 
-ES_USER?=apm_user
+ES_USER?=apm_server_user
 ES_PASS?=changeme
 ES_LOG_LEVEL?=debug
 KIBANA_ES_USER?=kibana_system_user

--- a/testing/docker/elasticsearch/roles.yml
+++ b/testing/docker/elasticsearch/roles.yml
@@ -1,8 +1,12 @@
 apm_server:
-  cluster: ["manage_ilm"]
+  cluster: ['manage_ilm','manage_security','manage_api_key']
   indices:
     - names: ['apm-*']
       privileges: ['write','create_index','manage','manage_ilm']
+  applications:
+    - application: 'apm'
+      privileges: ['sourcemap:write','event:write','config_agent:read']
+      resources: '*'
 beats:
   cluster: ['manage_index_templates','monitor','manage_ingest_pipelines','manage_ilm']
   indices:

--- a/testing/docker/elasticsearch/users
+++ b/testing/docker/elasticsearch/users
@@ -1,5 +1,5 @@
 admin:$2a$10$xiY0ZzOKmDDN1p3if4t4muUBwh2.bFHADoMRAWQgSClm4ZJ4132Y.
-apm_user:$2a$10$iTy29qZaCSVn4FXlIjertuO8YfYVLCbvoUAJ3idaXfLRclg9GXdGG
+apm_server_user:$2a$10$iTy29qZaCSVn4FXlIjertuO8YfYVLCbvoUAJ3idaXfLRclg9GXdGG
 apm_user_ro:$2a$10$hQfy2o2u33SapUClsx8NCuRMpQyHP9b2l4t3QqrBA.5xXN2S.nT4u
 beats_user:$2a$10$LRpKi4/Q3Qo4oIbiu26rH.FNIL4aOH4aj2Kwi58FkMo1z9FgJONn2
 filebeat_user:$2a$10$sFxIEX8tKyOYgsbJLbUhTup76ssvSD3L4T0H6Raaxg4ewuNr.lUFC

--- a/testing/docker/elasticsearch/users_roles
+++ b/testing/docker/elasticsearch/users_roles
@@ -1,11 +1,11 @@
-apm_server:apm_user
-apm_system:apm_user
-apm_user:apm_user,apm_user_ro
+apm_server:apm_server_user
+apm_system:apm_server_user
+apm_user:apm_server_user,apm_user_ro
 beats:beats_user
 beats_system:beats_user,filebeat_user,heartbeat_user,metricbeat_user
 filebeat:filebeat_user
 heartbeat:heartbeat_user
-ingest_admin:apm_user
+ingest_admin:apm_server_user
 kibana_system:kibana_system_user
 kibana_user:apm_user_ro,beats_user,filebeat_user,heartbeat_user,metricbeat_user
 metricbeat:metricbeat_user

--- a/tests/system/test_access.py
+++ b/tests/system/test_access.py
@@ -90,8 +90,8 @@ class BaseAPIKeySetup(ElasticTest):
         self.resource_any = ["*"]
         self.resource_backend = ["-"]
 
-        user = os.getenv("ES_SUPERUSER_USER", "admin")
-        password = os.getenv("ES_SUPERUSER_PASS", "changeme")
+        user = os.getenv("ES_USER", "apm_server_user")
+        password = os.getenv("ES_PASS", "changeme")
         self.admin_es_url = self.get_elasticsearch_url(user, password)
 
         self.api_key_url = "{}/_security/api_key".format(self.admin_es_url)


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [test] Use apm_server_user for API Key tests. (#3124)