### PR TITLE
beater/middleware: add trace/log correlation

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -26,4 +26,5 @@ https://github.com/elastic/apm-server/compare/7.5\...master[View commits]
 - Upgrade Go to 1.13.5 {pull}3069[3069].
 - Add experimental support for receiving Jaeger trace data {pull}3129[3129]
 - Upgrade APM Go agent to 1.7.0, and add support for API Key auth for self-instrumentation {pull}3134[3134]
+- Add correlation for server trace/log data {pull}3136[3136]
 

--- a/tests/system/test_integration_logging.py
+++ b/tests/system/test_integration_logging.py
@@ -68,3 +68,24 @@ class LoggingIntegrationEventSizeTest(ElasticTest):
             }, req)
             error = req.get("error")
             assert error.startswith("event exceeded the permitted size."), json.dumps(req)
+
+
+@integration_test
+class LoggingIntegrationTraceCorrelationTest(ElasticTest):
+    config_overrides = {
+        "logging_json": "true",
+        "instrumentation_enabled": "true",
+    }
+
+    def test_trace_ids(self):
+        with open(self.get_transaction_payload_path()) as f:
+            r = requests.post(self.intake_url,
+                              data=f,
+                              headers={'content-type': 'application/x-ndjson'})
+            assert r.status_code == 202, r.status_code
+            intake_request_logs = list(self.logged_requests())
+            assert len(intake_request_logs) == 1, "multiple requests found"
+            req = intake_request_logs[0]
+            self.assertIn("trace.id", req)
+            self.assertIn("transaction.id", req)
+            self.assertEqual(req["transaction.id"], req["request_id"])


### PR DESCRIPTION
In the logging middleware, add `trace.id` and `transaction.id` fields if the request is being traced. If traced, reuse the transaction ID for the existing `request_id` field, rather than generating another UUID.

I have manually tested this with apm-integration-testing (using `--with-filebeat`), checking that a user can jump between the APM and Logs app in both directions.

Closes #3075 