### PR TITLE
[DOCS] Remove outdated CCR note

### DIFF
--- a/docs/copied-from-beats/docs/template-config.asciidoc
+++ b/docs/copied-from-beats/docs/template-config.asciidoc
@@ -69,11 +69,6 @@ setup.template.settings:
   index.number_of_replicas: 1
 ----------------------------------------------------------------------
 
-NOTE: If you want to use {ref}/xpack-ccr.html[{ccr}] to replicate {beatname_uc}
-indices to another cluster, you will need to add additional template settings to
-{ref}/ccr-requirements.html#ccr-overview-beats[enable soft deletes] on the
-underlying indices.
-
 *`setup.template.settings._source`*:: A dictionary of settings for the `_source` field. For the available settings,
 please see the Elasticsearch {ref}/mapping-source-field.html[reference].
 +


### PR DESCRIPTION
Users no longer need to set up soft deletes in Elasticsearch to replicate a Beats/APM index using cross-cluster replication.

This removes a related note in the APM documentation.

Relates to elastic/elasticsearch#50859.

Should backport to master, 7.x, 7.5, and 6.8