### PR TITLE
[7.5] [DOCS] Remove outdated CCR note (#3147)

### DIFF
--- a/docs/copied-from-beats/docs/template-config.asciidoc
+++ b/docs/copied-from-beats/docs/template-config.asciidoc
@@ -69,11 +69,6 @@ setup.template.settings:
   index.number_of_replicas: 1
 ----------------------------------------------------------------------
 
-NOTE: If you want to use {stack-ov}/xpack-ccr.html[{ccr}] to replicate {beatname_uc}
-indices to another cluster, you will need to add additional template settings to
-{ref}/ccr-requirements.html#ccr-overview-beats[enable soft deletes] on the
-underlying indices.
-
 *`setup.template.settings._source`*:: A dictionary of settings for the `_source` field. For the available settings,
 please see the Elasticsearch {ref}/mapping-source-field.html[reference].
 +


### PR DESCRIPTION
Backports the following commits to 7.5:
 - [DOCS] Remove outdated CCR note (#3147)