### PR TITLE
[docs] Fix 7.5 merge conflict

### DIFF
--- a/docs/guide/install-and-run.asciidoc
+++ b/docs/guide/install-and-run.asciidoc
@@ -118,7 +118,6 @@ and configuring it with the address of your APM Server, a secret token (if neces
 2+|The .NET agent automatically instruments ASP.NET Core applications, and .NET Framework applications.
 |{apm-dotnet-ref-v}/supported-technologies.html[Supported technologies]
 |{apm-dotnet-ref-v}/setup.html[Set up the .NET Agent]
-|
 
 .2+|Node.js
 2+|The Node.js agent automatically instruments Express, hapi, Koa, and Restify out of the box.

--- a/docs/guide/install-and-run.asciidoc
+++ b/docs/guide/install-and-run.asciidoc
@@ -115,12 +115,8 @@ and configuring it with the address of your APM Server, a secret token (if neces
 |{apm-java-ref-v}/setup.html[Set up the Java Agent]
 
 .2+|.NET
-<<<<<<< HEAD
-2+|The .NET agent automatically instruments ASP.NET Core applications, while .NET Framework applications can be instrumented with the public API.
-=======
 2+|The .NET agent automatically instruments ASP.NET Core applications, and .NET Framework applications.
 |{apm-dotnet-ref-v}/supported-technologies.html[Supported technologies]
->>>>>>> d44db7aa... docs: Add quick start docker (#3106)
 |{apm-dotnet-ref-v}/setup.html[Set up the .NET Agent]
 |
 


### PR DESCRIPTION
Fixes a merge conflict that I accidentally committed to the 7.5 docs yesterday in  https://github.com/elastic/apm-server/pull/3152. Closes https://github.com/elastic/apm-server/issues/3168. Thanks again @feenst.