### PR TITLE
[7.x] Document api_key in apm-server.yml file (#3138)

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -264,8 +264,11 @@ apm-server:
         # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
         # hosts: ["localhost:9200"]
 
-        # Optional protocol and basic auth credentials.
+        # Protocol - either `http` (default) or `https`.
         #protocol: "https"
+
+        # Authentication credentials - either API key or username/password.
+        #api_key: "id:api_key"
         #username: "elastic"
         #password: "changeme"
 
@@ -513,8 +516,11 @@ output.elasticsearch:
   # Set gzip compression level.
   #compression_level: 0
 
-  # Optional protocol and basic auth credentials.
+  # Protocol - either `http` (default) or `https`.
   #protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  #api_key: "id:api_key"
   #username: "elastic"
   #password: "changeme"
 
@@ -1014,10 +1020,13 @@ output.elasticsearch:
 # you can simply uncomment the following line.
 #monitoring.elasticsearch:
 
-  # Optional protocol and basic auth credentials.
+  # Protocol - either `http` (default) or `https`.
   #protocol: "https"
-  #username: "apm_system"
-  #password: ""
+
+  # Authentication credentials - either API key or username/password.
+  #api_key: "id:api_key"
+  #username: "elastic"
+  #password: "changeme"
 
   # Array of hosts to connect to.
   # Scheme and port can be left out and will be set to the default (`http` and `9200`).

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -264,8 +264,11 @@ apm-server:
         # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
         # hosts: ["localhost:9200"]
 
-        # Optional protocol and basic auth credentials.
+        # Protocol - either `http` (default) or `https`.
         #protocol: "https"
+
+        # Authentication credentials - either API key or username/password.
+        #api_key: "id:api_key"
         #username: "elastic"
         #password: "changeme"
 
@@ -513,8 +516,11 @@ output.elasticsearch:
   # Set gzip compression level.
   #compression_level: 0
 
-  # Optional protocol and basic auth credentials.
+  # Protocol - either `http` (default) or `https`.
   #protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  #api_key: "id:api_key"
   #username: "elastic"
   #password: "changeme"
 
@@ -1014,10 +1020,13 @@ output.elasticsearch:
 # you can simply uncomment the following line.
 #monitoring.elasticsearch:
 
-  # Optional protocol and basic auth credentials.
+  # Protocol - either `http` (default) or `https`.
   #protocol: "https"
-  #username: "apm_system"
-  #password: ""
+
+  # Authentication credentials - either API key or username/password.
+  #api_key: "id:api_key"
+  #username: "elastic"
+  #password: "changeme"
 
   # Array of hosts to connect to.
   # Scheme and port can be left out and will be set to the default (`http` and `9200`).

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -264,8 +264,11 @@ apm-server:
         # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
         # hosts: ["localhost:9200"]
 
-        # Optional protocol and basic auth credentials.
+        # Protocol - either `http` (default) or `https`.
         #protocol: "https"
+
+        # Authentication credentials - either API key or username/password.
+        #api_key: "id:api_key"
         #username: "elastic"
         #password: "changeme"
 
@@ -513,8 +516,11 @@ output.elasticsearch:
   # Set gzip compression level.
   #compression_level: 0
 
-  # Optional protocol and basic auth credentials.
+  # Protocol - either `http` (default) or `https`.
   #protocol: "https"
+
+  # Authentication credentials - either API key or username/password.
+  #api_key: "id:api_key"
   #username: "elastic"
   #password: "changeme"
 
@@ -1014,10 +1020,13 @@ output.elasticsearch:
 # you can simply uncomment the following line.
 #monitoring.elasticsearch:
 
-  # Optional protocol and basic auth credentials.
+  # Protocol - either `http` (default) or `https`.
   #protocol: "https"
-  #username: "apm_system"
-  #password: ""
+
+  # Authentication credentials - either API key or username/password.
+  #api_key: "id:api_key"
+  #username: "elastic"
+  #password: "changeme"
 
   # Array of hosts to connect to.
   # Scheme and port can be left out and will be set to the default (`http` and `9200`).

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -19,6 +19,7 @@ package elasticsearch
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"io"
@@ -92,6 +93,9 @@ func NewClient(config *Config) (Client, error) {
 
 // NewVersionedClient returns the right elasticsearch client for the current Stack version, as an interface
 func NewVersionedClient(apikey, user, pwd string, addresses []string, transport http.RoundTripper) (Client, error) {
+	if apikey != "" {
+		apikey = base64.StdEncoding.EncodeToString([]byte(apikey))
+	}
 	version := common.MustNewVersion(version.GetDefaultVersion())
 	if version.IsMajor(8) {
 		c, err := newV8Client(apikey, user, pwd, addresses, transport)


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Document api_key in apm-server.yml file (#3138)