### PR TITLE
fix: trigger on _beats changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,14 +64,14 @@ pipeline {
           dir("${BASE_DIR}"){
             env.GO_VERSION = readFile(".go-version").trim()
             def regexps =[
-              "^_beats",
+              "^_beats.*",
               "^apm-server.yml",
               "^apm-server.docker.yml",
               "^magefile.go",
-              "^ingest",
-              "^packaging",
-              "^tests/packaging",
-              "^vendor/github.com/elastic/beats"
+              "^ingest.*",
+              "^packaging.*",
+              "^tests/packaging.*",
+              "^vendor/github.com/elastic/beats.*"
             ]
             env.BEATS_UPDATED = isGitRegionMatch(patterns: regexps)
 


### PR DESCRIPTION
## What does this PR do?

It fixes some regular expressions to work with the new implementation of `isGitRegionMatch` step.

## Why is it important?

After merging, all PRs with changes in the regexp specified will trigger the release stage.

```
              "^_beats.*",
              "^apm-server.yml",
              "^apm-server.docker.yml",
              "^magefile.go",
              "^ingest.*",
              "^packaging.*",
              "^tests/packaging.*",
              "^vendor/github.com/elastic/beats.*"
```

## Related issues
closes https://github.com/elastic/apm-server/issues/3181
