### PR TITLE
[docs] add append_fields to docs

### DIFF
--- a/docs/copied-from-beats/docs/template-config.asciidoc
+++ b/docs/copied-from-beats/docs/template-config.asciidoc
@@ -83,7 +83,6 @@ setup.template.settings:
   _source.enabled: false
 ----------------------------------------------------------------------
 
-ifeval::["{beatname_lc}"!="apm-server"]
 *`setup.template.append_fields`* experimental[]:: A list of fields to be added
 to the template and {kib} index pattern. This setting adds new fields. It does
 not overwrite or change existing fields. 
@@ -129,5 +128,3 @@ setup.template.json.name: "template-name
 
 NOTE: If the JSON template is used, the `fields.yml` is skipped for the template
 generation.
-
-endif::[]


### PR DESCRIPTION
We've started recommending `append_fields` to help users customize their APM experience ([1](https://github.com/elastic/kibana/issues/48674#issuecomment-545342220)) ([2](https://discuss.elastic.co/t/searching-for-a-custom-made-header/200403/3)). This PR adds the experimental documentation to the APM Server Reference.

Needs a separate PR in beats. For(ish) https://github.com/elastic/kibana/issues/49070.
