### PR TITLE
[docs] Add missing 6.8.6 release notes

### DIFF
--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,12 +3,20 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.6>>
 * <<release-notes-6.8.5>>
 * <<release-notes-6.8.4>>
 * <<release-notes-6.8.3>>
 * <<release-notes-6.8.2>>
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
+
+[[release-notes-6.8.6]]
+=== APM Server version 6.8.6
+
+https://github.com/elastic/apm-server/compare/v6.8.5\...v6.8.6[View commits]
+
+No significant changes.
 
 [[release-notes-6.8.5]]
 === APM Server version 6.8.5


### PR DESCRIPTION
`check_changelogs.py` now checks `6.8` (https://github.com/elastic/apm-server/pull/3174). The check is failing because `6.8.6` rns don't exist outside of that branch.