### PR TITLE
[7.x] docs: add append_fields to docs (#3190)

### DIFF
--- a/docs/copied-from-beats/docs/template-config.asciidoc
+++ b/docs/copied-from-beats/docs/template-config.asciidoc
@@ -83,7 +83,6 @@ setup.template.settings:
   _source.enabled: false
 ----------------------------------------------------------------------
 
-ifeval::["{beatname_lc}"!="apm-server"]
 *`setup.template.append_fields`* experimental[]:: A list of fields to be added
 to the template and {kib} index pattern. This setting adds new fields. It does
 not overwrite or change existing fields. 
@@ -129,5 +128,3 @@ setup.template.json.name: "template-name
 
 NOTE: If the JSON template is used, the `fields.yml` is skipped for the template
 generation.
-
-endif::[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: add append_fields to docs (#3190)