### PR TITLE
beater: rewrite flaky test

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -182,7 +182,7 @@ func (bt *beater) Run(b *beat.Beat) error {
 
 	bt.mutex.Lock()
 	if bt.stopped {
-		defer bt.mutex.Unlock()
+		bt.mutex.Unlock()
 		return nil
 	}
 
@@ -194,7 +194,7 @@ func (bt *beater) Run(b *beat.Beat) error {
 	bt.mutex.Unlock()
 
 	//blocking until shutdown
-	return bt.server.run(lis, tracerServer, pub)
+	return bt.server.run(lis, tracerServer)
 }
 
 func isElasticsearchOutput(b *beat.Beat) bool {
@@ -229,7 +229,7 @@ func (bt *beater) Stop() {
 	}
 	bt.logger.Infof("stopping apm-server... waiting maximum of %v seconds for queues to drain",
 		bt.config.ShutdownTimeout.Seconds())
-	bt.server.stop(bt.logger)
+	bt.server.stop()
 	close(bt.stopping)
 	bt.stopped = true
 }

--- a/beater/server.go
+++ b/beater/server.go
@@ -19,6 +19,7 @@ package beater
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -41,6 +42,7 @@ type server struct {
 
 	httpServer   *httpServer
 	jaegerServer *jaeger.Server
+	reporter     publish.Reporter
 }
 
 func newServer(logger *logp.Logger, cfg *config.Config, tracer *apm.Tracer, reporter publish.Reporter) (server, error) {
@@ -52,13 +54,18 @@ func newServer(logger *logp.Logger, cfg *config.Config, tracer *apm.Tracer, repo
 	if err != nil {
 		return server{}, err
 	}
-	return server{logger, cfg, httpServer, jaegerServer}, nil
+	return server{
+		logger:       logger,
+		cfg:          cfg,
+		httpServer:   httpServer,
+		jaegerServer: jaegerServer,
+		reporter:     reporter,
+	}, nil
 }
 
-func (s server) run(listener net.Listener, tracerServer *tracerServer, pub *publish.Publisher) error {
+func (s server) run(listener net.Listener, tracerServer *tracerServer) error {
 	s.logger.Infof("Starting apm-server [%s built %s]. Hit CTRL-C to stop it.", version.Commit(), version.BuildTime())
 	var g errgroup.Group
-
 	if s.jaegerServer != nil {
 		g.Go(s.jaegerServer.Serve)
 	}
@@ -66,28 +73,23 @@ func (s server) run(listener net.Listener, tracerServer *tracerServer, pub *publ
 		g.Go(func() error {
 			return s.httpServer.start(listener)
 		})
-
 		if s.isAvailable(s.cfg.ShutdownTimeout) {
-			go notifyListening(s.cfg, pub.Client().Publish)
+			notifyListening(context.Background(), s.cfg, s.reporter)
 		}
-
 		if tracerServer != nil {
 			g.Go(func() error {
-				return tracerServer.serve(pub.Send)
+				return tracerServer.serve(s.reporter)
 			})
 		}
-
-		if err := g.Wait(); err != http.ErrServerClosed {
-			return err
-		}
-
-		s.logger.Infof("Server stopped")
 	}
-
+	if err := g.Wait(); err != http.ErrServerClosed {
+		return err
+	}
+	s.logger.Infof("Server stopped")
 	return nil
 }
 
-func (s server) stop(logger *logp.Logger) {
+func (s server) stop() {
 	if s.jaegerServer != nil {
 		s.jaegerServer.Stop()
 	}

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -481,8 +481,7 @@ func dummyPipeline(cfg *common.Config, info beat.Info, clients ...outputs.Client
 	return p
 }
 
-func setupServer(t *testing.T, cfg *common.Config, beatConfig *beat.BeatConfig,
-	events chan beat.Event) (*beater, func(), error) {
+func setupServer(t *testing.T, cfg *common.Config, beatConfig *beat.BeatConfig, events chan beat.Event) (*beater, func(), error) {
 	if testing.Short() {
 		t.Skip("skipping server test")
 	}


### PR DESCRIPTION
- Rewrite TestNotifyUpServerDown to use "setupServer", simplifying the test and removing an intermittent panic.
- Rename to TestOnboarding. I have no idea what the old name was meant to indicate.
- Rewrite onboarding to use publisher.

Closes #3203 