### PR TITLE
[7.6] beater: rewrite flaky test (#3204)

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -182,7 +182,7 @@ func (bt *beater) Run(b *beat.Beat) error {
 
 	bt.mutex.Lock()
 	if bt.stopped {
-		defer bt.mutex.Unlock()
+		bt.mutex.Unlock()
 		return nil
 	}
 
@@ -194,7 +194,7 @@ func (bt *beater) Run(b *beat.Beat) error {
 	bt.mutex.Unlock()
 
 	//blocking until shutdown
-	return bt.server.run(lis, tracerServer, pub)
+	return bt.server.run(lis, tracerServer)
 }
 
 func isElasticsearchOutput(b *beat.Beat) bool {
@@ -229,7 +229,7 @@ func (bt *beater) Stop() {
 	}
 	bt.logger.Infof("stopping apm-server... waiting maximum of %v seconds for queues to drain",
 		bt.config.ShutdownTimeout.Seconds())
-	bt.server.stop(bt.logger)
+	bt.server.stop()
 	close(bt.stopping)
 	bt.stopped = true
 }

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -481,8 +481,7 @@ func dummyPipeline(cfg *common.Config, info beat.Info, clients ...outputs.Client
 	return p
 }
 
-func setupServer(t *testing.T, cfg *common.Config, beatConfig *beat.BeatConfig,
-	events chan beat.Event) (*beater, func(), error) {
+func setupServer(t *testing.T, cfg *common.Config, beatConfig *beat.BeatConfig, events chan beat.Event) (*beater, func(), error) {
 	if testing.Short() {
 		t.Skip("skipping server test")
 	}


### PR DESCRIPTION
Backports the following commits to 7.6:
 - beater: rewrite flaky test  (#3204)