### PR TITLE
[docs] Server/Agent API key documentation

### DIFF
--- a/docs/copied-from-beats/docs/command-reference.asciidoc
+++ b/docs/copied-from-beats/docs/command-reference.asciidoc
@@ -135,7 +135,7 @@ Communication between APM agents and APM Server now supports sending an
 <<api-key,API Key in the Authorization header>>.
 APM Server provides an `apikey` command that can create, verify, invalidate,
 and show information about API Keys for agent/server communication.
-Most operations require the `manage_security` cluster privilege,
+Most operations require the `manage_api_key` cluster privilege,
 and you must ensure that `apm-server.api_key` or `output.elasticsearch` are configured appropriately.
 
 *SYNOPSIS*
@@ -186,6 +186,7 @@ When used with `verify`, asks for the `config_agent:read` privilege.
 
 *`--credentials CREDS`*::
 Required for the `verify` subcommand. Specifies the credentials for which to to check privileges.
+Credentials are the base64 encoded representation of the API key's `id:name`.
 
 *`--expiration TIME`*::
 When used with `create`, specifies the expiration for the key, e.g., "1d" (default never).
@@ -201,7 +202,8 @@ When used with `create`, gives the `event:write` privilege to the created key.
 When used with `verify`, asks for the `event:write` privilege.
 
 *`--json`*::
-Prints the output of the command as JSON
+Prints the output of the command as JSON.
+Valid with all `apikey` subcommands.
 
 *`--name NAME`*::
 Name of the API key(s). Valid with the `create`, `info`, and `invalidate` subcommands.
@@ -223,9 +225,9 @@ When used with `info`, only returns valid API Keys (not expired or invalidated).
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} apikey create --ingest --agent-config --name service-001
-{beatname_lc} apikey info --name service-001 --valid-only
-{beatname_lc} apikey invalidate --name service-001
+{beatname_lc} apikey create --ingest --agent-config --name example-001
+{beatname_lc} apikey info --name example-001 --valid-only
+{beatname_lc} apikey invalidate --name example-001
 -----
 
 For more information, see <<api-key>>.

--- a/docs/copied-from-beats/docs/command-reference.asciidoc
+++ b/docs/copied-from-beats/docs/command-reference.asciidoc
@@ -17,7 +17,7 @@
 
 :deploy-command-short-desc: Deploys the specified function to your serverless environment
 
-:apikey-command-short-desc: Manage API Keys for communication between APM agents and server
+:apikey-command-short-desc: Manage API Keys for communication between APM agents and server.
 
 ifndef::serverless[]
 ifndef::no_dashboards[]
@@ -131,11 +131,12 @@ ifdef::apm-server[]
 
 experimental::[]
 
-{apikey-command-short-desc}
+Communication between APM agents and APM Server now supports sending an
+<<api-key,API Key in the Authorization header>>.
+APM Server provides an `apikey` command that can create, verify, invalidate,
+and show information about API Keys for agent/server communication.
 Most operations require the `manage_security` cluster privilege,
 and you must ensure that `apm-server.api_key` or `output.elasticsearch` are configured appropriately.
-
-For more information, see <<api-key>>.
 
 *SYNOPSIS*
 
@@ -148,9 +149,22 @@ For more information, see <<api-key>>.
 
 // tag::apikey-subcommands[]
 *`create`*::
-Create an API Key with the specified privilege(s).
-The privileges must exist already for the API key to be created.
-No required flags.
+Create an API Key with the specified privilege(s). No required flags.
++
+The user requesting to create an API Key needs to have APM privileges used by the APM Server.
+A superuser, by default, has these privileges. For other users,
+you can create them. Create a role that is then assigned to the user:
++
+["source","sh",subs="attributes"]
+----
+PUT /_security/role/apm-privileges {
+	"applications": [{
+	  "application": "apm",
+	  "privileges": ["sourcemap:write", "event:write", "config_agent:read"],
+	  "resources": ["*"]
+	}]
+}
+----
 
 *`info`*::
 Query API Key(s). `--id` or `--name` required.

--- a/docs/copied-from-beats/docs/command-reference.asciidoc
+++ b/docs/copied-from-beats/docs/command-reference.asciidoc
@@ -17,6 +17,8 @@
 
 :deploy-command-short-desc: Deploys the specified function to your serverless environment
 
+:apikey-command-short-desc: Manage API Keys for communication between APM agents and server
+
 ifndef::serverless[]
 ifndef::no_dashboards[]
 :export-command-short-desc: Exports the configuration, index template, ILM policy, or a dashboard to stdout
@@ -98,7 +100,9 @@ more information, see https://www.elastic.co/subscriptions and
 ifeval::["{beatname_lc}"=="functionbeat"]
 |<<deploy-command,`deploy`>> | {deploy-command-short-desc}.
 endif::[]
-|<<export-command,`export`>> |{export-command-short-desc}.
+ifdef::apm-server[]
+|<<apikey-command,`apikey`>> |{apikey-command-short-desc}.
+endif::[]
 |<<help-command,`help`>> |{help-command-short-desc}.
 |<<keystore-command,`keystore`>> |{keystore-command-short-desc}.
 ifeval::["{beatname_lc}"=="functionbeat"]
@@ -120,6 +124,96 @@ endif::[]
 |=======================
 
 Also see <<global-flags,Global flags>>.
+
+// ********************************************************
+// apikey
+// ********************************************************
+
+ifdef::apm-server[]
+[[apikey-command]]
+==== `apikey` command
+
+{apikey-command-short-desc}
+
+*SYNOPSIS*
+
+["source","sh",subs="attributes"]
+----
+{beatname_lc} apikey SUBCOMMAND [FLAGS]
+----
+
+*SUBCOMMANDS*
+
+*`create`*::
+Create an API Key with the specified privilege(s).
+
+*`info`*::
+Query API Key(s) by Id or Name.
+
+*`invalidate`*::
+Invalidate API Key(s) by Id or Name.
+
+*`verify`*::
+Check if a "credentials" string has the given privilege(s).
+
+*FLAGS*
+
+*`--agent-config`*::
+Required for agents to read configuration remotely. Valid with the `create` and `verify` subcommands
+When used with `create`, gives the `config_agent:read` privilege to the created key.
+When used with `verify`, asks for the `config_agent:read` privilege.
+
+*`--credentials CREDS`*::
+Required for the `verify` subcommand. Specifies the credentials for which to to check privileges.
+
+*`--expiration TIME`*::
+When used with `create`, specifies the expiration for the key, e.g., "1d" (default never).
+
+*`--id ID`*::
+ID of the API key. Valid with the `info` and `invalidate` subcommands.
+When used with `info`, queries the specified ID.
+When used with `invalidate`, deletes the specified ID.
+
+*`--ingest`*::
+Required for ingesting events. Valid with the `create` and `verify` subcommands
+When used with `create`, gives the `event:write` privilege to the created key.
+When used with `verify`, asks for the `event:write` privilege.
+
+*`--json`*::
+Prints the output of the command as JSON
+
+*`--name NAME`*::
+Name of the API key(s). Valid with the `create`, `info`, and `invalidate` subcommands.
+When used with `create`, specifies the name of the API key to be created (default: "apm-key").
+When used with `info`, specifies the API key to query (multiple matches are possible).
+When used with `invalidate`, specifies the API key to delete (multiple matches are possible).
+
+*`--purge`*::
+When used with `invalidate`, removes all privileges created and used by APM Server.
+
+*`--sourcemap`*::
+Required for uploading sourcemaps. Valid with the `create` and `verify` subcommands
+When used with `create`, gives the `sourcemap:write` privilege to the created key.
+When used with `verify`, asks for the `sourcemap:write` privilege.
+
+*`--valid-only`*::
+When used with `info`, only returns valid API Keys (not expired or invalidated).
+
+{global-flags}
+
+*EXAMPLES*
+
+["source","sh",subs="attributes"]
+-----
+{beatname_lc} apikey create --ingest --agent-config --name service-001
+{beatname_lc} apikey info --name service-001 --valid-only
+{beatname_lc} apikey invalidate --name service-001
+-----
+
+endif::[]
+// ********************************************************
+// END apikey
+// ********************************************************
 
 ifeval::["{beatname_lc}"=="functionbeat"]
 [[deploy-command]]

--- a/docs/copied-from-beats/docs/command-reference.asciidoc
+++ b/docs/copied-from-beats/docs/command-reference.asciidoc
@@ -134,6 +134,11 @@ ifdef::apm-server[]
 ==== `apikey` command
 
 {apikey-command-short-desc}
+Manage API Keys for communication between APM agents and server. 
+Most operations require the "manage_security" cluster privilege. Ensure to configure "apm-server.api_key.*" or 
+"output.elasticsearch.*" appropriately. APM Server will create security privileges for the "apm" application; 
+you can freely query them. If you modify or delete apm privileges, APM Server might reject all requests.
+Check the Elastic Security API documentation for details.
 
 *SYNOPSIS*
 

--- a/docs/copied-from-beats/docs/command-reference.asciidoc
+++ b/docs/copied-from-beats/docs/command-reference.asciidoc
@@ -125,20 +125,16 @@ endif::[]
 
 Also see <<global-flags,Global flags>>.
 
-// ********************************************************
-// apikey
-// ********************************************************
-
 ifdef::apm-server[]
 [[apikey-command]]
 ==== `apikey` command
 
 {apikey-command-short-desc}
-Manage API Keys for communication between APM agents and server. 
-Most operations require the "manage_security" cluster privilege. Ensure to configure "apm-server.api_key.*" or 
-"output.elasticsearch.*" appropriately. APM Server will create security privileges for the "apm" application; 
-you can freely query them. If you modify or delete apm privileges, APM Server might reject all requests.
-Check the Elastic Security API documentation for details.
+Most operations require the `manage_security` cluster privilege,
+and you must ensure that `apm-server.api_key` or `output.elasticsearch` are configured appropriately.
+If you modify or delete apm privileges, APM Server might reject all requests.
+
+For more information, see <<api-key>>.
 
 *SYNOPSIS*
 
@@ -149,6 +145,7 @@ Check the Elastic Security API documentation for details.
 
 *SUBCOMMANDS*
 
+// tag::api-key-subcommands[]
 *`create`*::
 Create an API Key with the specified privilege(s).
 
@@ -160,11 +157,12 @@ Invalidate API Key(s) by Id or Name.
 
 *`verify`*::
 Check if a "credentials" string has the given privilege(s).
+// end::api-key-subcommands[]
 
 *FLAGS*
 
 *`--agent-config`*::
-Required for agents to read configuration remotely. Valid with the `create` and `verify` subcommands
+Required for agents to read configuration remotely. Valid with the `create` and `verify` subcommands.
 When used with `create`, gives the `config_agent:read` privilege to the created key.
 When used with `verify`, asks for the `config_agent:read` privilege.
 
@@ -180,7 +178,7 @@ When used with `info`, queries the specified ID.
 When used with `invalidate`, deletes the specified ID.
 
 *`--ingest`*::
-Required for ingesting events. Valid with the `create` and `verify` subcommands
+Required for ingesting events. Valid with the `create` and `verify` subcommands.
 When used with `create`, gives the `event:write` privilege to the created key.
 When used with `verify`, asks for the `event:write` privilege.
 
@@ -197,7 +195,7 @@ When used with `invalidate`, specifies the API key to delete (multiple matches a
 When used with `invalidate`, removes all privileges created and used by APM Server.
 
 *`--sourcemap`*::
-Required for uploading sourcemaps. Valid with the `create` and `verify` subcommands
+Required for uploading sourcemaps. Valid with the `create` and `verify` subcommands.
 When used with `create`, gives the `sourcemap:write` privilege to the created key.
 When used with `verify`, asks for the `sourcemap:write` privilege.
 
@@ -215,10 +213,9 @@ When used with `info`, only returns valid API Keys (not expired or invalidated).
 {beatname_lc} apikey invalidate --name service-001
 -----
 
+For more information, see <<api-key>>.
+
 endif::[]
-// ********************************************************
-// END apikey
-// ********************************************************
 
 ifeval::["{beatname_lc}"=="functionbeat"]
 [[deploy-command]]

--- a/docs/copied-from-beats/docs/command-reference.asciidoc
+++ b/docs/copied-from-beats/docs/command-reference.asciidoc
@@ -129,10 +129,11 @@ ifdef::apm-server[]
 [[apikey-command]]
 ==== `apikey` command
 
+experimental::[]
+
 {apikey-command-short-desc}
 Most operations require the `manage_security` cluster privilege,
 and you must ensure that `apm-server.api_key` or `output.elasticsearch` are configured appropriately.
-If you modify or delete apm privileges, APM Server might reject all requests.
 
 For more information, see <<api-key>>.
 
@@ -145,19 +146,22 @@ For more information, see <<api-key>>.
 
 *SUBCOMMANDS*
 
-// tag::api-key-subcommands[]
+// tag::apikey-subcommands[]
 *`create`*::
 Create an API Key with the specified privilege(s).
+The privileges must exist already for the API key to be created.
+No required flags.
 
 *`info`*::
-Query API Key(s) by Id or Name.
+Query API Key(s). `--id` or `--name` required.
 
 *`invalidate`*::
-Invalidate API Key(s) by Id or Name.
+Invalidate API Key(s). `--id` or `--name` required.
 
 *`verify`*::
-Check if a "credentials" string has the given privilege(s).
-// end::api-key-subcommands[]
+Check if a credentials string has the given privilege(s).
+ `--credentials` required.
+// end::apikey-subcommands[]
 
 *FLAGS*
 
@@ -190,9 +194,6 @@ Name of the API key(s). Valid with the `create`, `info`, and `invalidate` subcom
 When used with `create`, specifies the name of the API key to be created (default: "apm-key").
 When used with `info`, specifies the API key to query (multiple matches are possible).
 When used with `invalidate`, specifies the API key to delete (multiple matches are possible).
-
-*`--purge`*::
-When used with `invalidate`, removes all privileges created and used by APM Server.
 
 *`--sourcemap`*::
 Required for uploading sourcemaps. Valid with the `create` and `verify` subcommands.

--- a/docs/secure-communication-agents.asciidoc
+++ b/docs/secure-communication-agents.asciidoc
@@ -14,18 +14,13 @@ As RUM endpoints cannot be secured, they are exempt from this rule.
 [[api-key]]
 === API keys
 
-// Most operations require the `manage_security` cluster privilege,
-// and you must ensure that `apm-server.api_key` or `output.elasticsearch` are configured appropriately.
-// If you modify or delete apm privileges, APM Server might reject all requests.
-// APM Server will create security privileges for the `apm` application; you can freely query them.
-// If you modify or delete apm privileges, APM Server might reject all requests.
-// Check the Elastic Security API documentation for details.
+experimental::[]
 
 You can configure an API key to authorize requests to the APM Server.
 API keys are sent as plain-text,
 so they only provide security when used in combination with SSL/TLS.
-When you set an API key in each of your agents,
-you ensure that only your agents are able to send data to your APM servers.
+By enabling `apm-server.api_key.enabled: true`, you ensure that only agents with a valid API Key
+are able to successfully use APM Server's API (except for RUM endpoints).
 
 To secure the communication between APM Agents and the APM Server with API keys:
 
@@ -52,7 +47,7 @@ API keys are disabled by default. You can change this, and additional settings,
 in the `apm-server.api_key` section of the +{beatname_lc}.yml+ configuration file.
 
 At a minimum, you must enable API keys,
-and should set a limit on the number of unique API keys {es} allows per minute.
+and should set a limit on the number of unique API keys APM Server allows per minute.
 Here's an example `apm-server.api_key` config using 50 unique API keys:
 
 [source,yaml]
@@ -72,18 +67,16 @@ All other configuration options are described in <<api-key-settings>>.
 
 APM Server provides a command line interface for creating API keys.
 Keys created using this method can only be used for Agent/Server communication.
+The user that creates the API key will need to have the privileges they wish to give to the API key.
 
-While it is possible to CURL {es} directly to create API keys,
+While it is also possible to CURL {es} directly to create API keys,
 using this method is not recommended.
-The command line tool has safeguards that ensure the required privileges exist before creating an API key.
-If they do not exist, the CLI tool will create the privileges.
-Regardless, the user that creates the API key will need to have the privileges they wish to give to the API key.
 
 [[create-api-key-subcommands]]
 [float]
 ==== `apikey` subcommands
 
-include::{libbeat-dir}/command-reference.asciidoc[tag=api-key-subcommands]
+include::{libbeat-dir}/command-reference.asciidoc[tag=apikey-subcommands]
 
 [[create-api-key-privileges]]
 [float]
@@ -193,7 +186,7 @@ See the relevant Agent documentation for additional information:
 // MERGED: https://github.com/elastic/apm-agent-ruby/pull/655
 
 [[api-key-settings]]
-=== API key configuration options
+=== `api_key.*` configuration options
 
 You can specify the following options in the `apm-server.api_key.*` section of the
 +{beatname_lc}.yml+ configuration file.
@@ -220,11 +213,17 @@ The minimum value for this setting should be the number of API keys configured i
 The default `limit` is `100`.
 
 [float]
+=== `api_key.elasticsearch.*` configuration options
+
+All of the `api_key.elasticsearch.*` configurations are optional.
+If none are set, configuration settings from the `apm-server.output` section will be reused.
+
+[float]
 ===== `elasticsearch.hosts`
 
 API keys are fetched from Elasticsearch.
 This configuration needs to point to a secured Elasticsearch cluster that is able to serve API key requests.
-If nothing is configured, configuration settings from the `output` section will be reused.
+
 
 [float]
 ===== `elasticsearch.protocol`
@@ -253,9 +252,9 @@ The http request timeout in seconds for the Elasticsearch request.
 If nothing is configured, configuration settings from the `output` section will be reused.
 
 [float]
-=== Optional SSL configuration options
+==== `api_key.elasticsearch.ssl.*` configuration options
 
-SSL is off by default. Set `protocol` to `https` if you want to enable `https`.
+SSL is off by default. Set `elasticsearch.protocol` to `https` if you want to enable `https`.
 
 [float]
 ===== `elasticsearch.ssl.enabled`

--- a/docs/secure-communication-agents.asciidoc
+++ b/docs/secure-communication-agents.asciidoc
@@ -5,14 +5,14 @@ There are two ways to secure the communication between APM Agents and the APM Se
 Both options can be enabled in parallel,
 allowing Elastic APM agents to chose whichever mechanism they support.
 
-As soon as secure communication is enabled, requests without a valid token will be denied by APM Server.
+As soon as secure communication is enabled, requests without a valid token or API key will be denied by APM Server.
 As RUM endpoints cannot be secured, they are exempt from this rule.
 
 * <<api-key,API keys>>
 * <<secret-token,Secret token>>
 
 [[api-key]]
-=== API Keys
+=== API keys
 
 // Most operations require the `manage_security` cluster privilege,
 // and you must ensure that `apm-server.api_key` or `output.elasticsearch` are configured appropriately.
@@ -48,7 +48,23 @@ include::./ssl-input-short.asciidoc[]
 [float]
 === Configure API keys
 
-// TO DO
+API keys are disabled by default. You can change this, and additional settings,
+in the `apm-server.api_key` section of the +{beatname_lc}.yml+ configuration file.
+
+At a minimum, you must enable API keys,
+and should set a limit on the number of unique API keys {es} allows per minute.
+Here's an example `apm-server.api_key` config using 50 unique API keys:
+
+[source,yaml]
+----
+apm-server.api_key.enabled: true <1>
+apm-server.api_key.limit: 50 <2>
+----
+<1> Enables API keys
+<2> Restricts the number of unique API keys that {es} allows each minute.
+This value should be the number of unique API keys configured in your monitored services.
+
+All other options are described in <<api-key-settings>>.
 
 [[create-api-key]]
 [float]
@@ -59,32 +75,39 @@ Keys created using this method can only be used for Agent/Server communication.
 
 While it is possible to CURL {es} directly to create API keys,
 using this method is not recommended.
-The command line tool uses safeguards, which ensure that the required privileges exist before creating an API key.
+The command line tool has safeguards that ensure the required privileges exist before creating an API key.
 If they do not exist, the CLI tool will create the privileges.
 Regardless, the user that creates the API key will need to have the privileges they wish to give to the API key.
 
-The available commands are:
+[[create-api-key-subcommands]]
+[float]
+==== API key subcommands
 
 include::{libbeat-dir}/command-reference.asciidoc[tag=api-key-subcommands]
 
-For API keys, we created dedicated privileges. There are three unique privileges.
-If no privileges are specified, the created key has all privileges. 
+[[create-api-key-privileges]]
+[float]
+==== API key privileges
 
-*Agent configuration*::
-Required for agents to read configuration remotely.
+There are three unique privileges you can assign to each API keys.
+If privileges are not specified at creation time, the created key will have all privileges. 
+
+* *Agent configuration* - Required for agents to read
+{kibana-ref}/agent-configuration.html[Agent configuration remotely].
 `--agent-config` gives the `config_agent:read` privilege to the created key.
-
-*Ingest*::
-Required for ingesting events.
+* *Ingest* - Required for ingesting Agent events.
 `--ingest` gives the `event:write` privilege to the created key.
-
-*Sourcemap*::
-Required for uploading sourcemaps.
+* *Sourcemap* - Required for <<sourcemaps,uploading sourcemaps>>.
 `--sourcemap` gives the `sourcemap:write` privilege to the created key.
 
+[[create-api-key-workflow]]
+[float]
+==== API key example workflow
+
 Create an API key with the `create` subcommand.
+
 The following example creates an API key with a `name` of `java-001`,
-and the Agent configuration and ingest privileges.
+and gives the "agent configuration" and "ingest" privileges.
 
 ["source","sh",subs="attributes"]
 -----
@@ -104,14 +127,15 @@ Credentials .... cVQ0dHoyOEIxZzVDZ3dnMzVWJia3hPQQ==
 
 You should always verify the privileges of an API key after creating it.
 Verification can be done using the `verify` subcommand.
-The following example verifies that the `java-001` API key has the request privileges.
+
+The following example verifies that the `java-001` API key has the "agent configuration" and "ingest" privileges.
 
 ["source","sh",subs="attributes"]
 -----
 {beatname_lc} apikey verify --agent-config --ingest --credentials cVQ0dHoyOEIxZzVDZ3dnMzVWJia3hPQQ==  
 -----
 
-If your API key has the right privileges, the response will look similar to this:
+If the API key has the requested privileges, the response will look similar to this:
 
 [source,console-result,subs="attributes,callouts"]
 --------------------------------------------------
@@ -120,6 +144,7 @@ Authorized for privilege "config_agent:read"...:    Yes
 --------------------------------------------------
 
 To invalidate an API key, use the `invalidate` subcommand.
+
 The following example invalidates the `java-001` API key.
 
 ["source","sh",subs="attributes"]
@@ -135,14 +160,13 @@ Invalidated keys ... qT4tz28B1g59zC3uAXfW
 Error count ........ 0
 --------------------------------------------------
 
-A full list of `apikey` subcommands, flags, and additional examples,
-is available in the <<apikey-command,API key command reference>>
+A full list of `apikey` subcommands and flags is available in the <<apikey-command,API key command reference>>.
 
 [[set-api-key]]
 [float]
 === Set the API key in your APM Agents
 
-You can now set your newly created API keys in the configuration of your APM Agents.
+You can now apply your newly created API keys in the configuration of each of your APM Agents.
 See the relevant Agent documentation for additional information:
 
 // Agent meta: https://github.com/elastic/apm/issues/183
@@ -168,12 +192,11 @@ See the relevant Agent documentation for additional information:
 // * *Ruby Agent*: {apm-ruby-ref}/configuration.html#config-api-key[`api_key`]
 // MERGED: https://github.com/elastic/apm-agent-ruby/pull/655
 
-
-[float]
 [[api-key-settings]]
-=== API key settings
+=== API key configuration options
 
-You can specify the following options in the `apm-server.api_key` section of the +{beatname_lc}.yml+ config file.
+You can specify the following options in the `apm-server.api_key.*` section of the
++{beatname_lc}.yml+ configuration file.
 They apply to API key communication between the APM Server and APM Agents.
 
 // To do!
@@ -181,97 +204,121 @@ They apply to API key communication between the APM Server and APM Agents.
 These are different from the API key settings used for the Elasticsearch output and monitoring.
 
 [float]
-==== api_key.enabled
-Enable API key authorization by setting enabled to true. By default API key support is disabled.
-Agents include a valid API key in the following format: Authorization: ApiKey <token>.
-The key must be the base64 encoded representation of the API key's "id:key".
-api_key.enabled: false
+===== `enabled`
+
+Enable API key authorization by setting `enabled` to `true`.
+Agents will include a valid API key in the following format: `Authorization: ApiKey <token>`.
+The key must be the base64 encoded representation of the API key's `id:key`.
+By default, `enabled` is set to `false`, and API key support is disabled.
 
 [float]
-==== api_key.limit
-Restrict how many unique API keys are allowed per minute. Should be set to at least the amount of different
-API keys configured in your monitored services. Every unique API key triggers one request to Elasticsearch.
-api_key.limit: 100
+===== `limit`
+
+Each unique API key triggers one request to Elasticsearch.
+This setting restricts the number of unique API keys are allowed per minute.
+The minimum value for this setting should be the number of API keys configured in your monitored services.
+The default `limit` is `100`.
 
 [float]
-==== api_key.elasticsearch.hosts
-API keys need to be fetched from Elasticsearch. If nothing is configured, configuration settings from the
-output section will be reused.
-Note that configuration needs to point to a secured Elasticsearch cluster that is able to serve API key requests.
-api_key.elasticsearch.hosts: ["localhost:9200"]
+===== `elasticsearch.hosts`
+
+API keys are fetched from Elasticsearch.
+This configuration needs to point to a secured Elasticsearch cluster that is able to serve API key requests.
+If nothing is configured, configuration settings from the `output` section will be reused.
 
 [float]
-==== api_key.elasticsearch.protocol
-api_key.elasticsearch.protocol: "http"
+===== `elasticsearch.protocol`
+
+The name of the protocol Elasticsearch is reachable on.
+The options are: `http` or `https`. The default is `http`.
+If nothing is configured, configuration settings from the `output` section will be reused.
 
 [float]
-==== api_key.elasticsearch.path
-Optional HTTP Path.
-api_key.elasticsearch.path: ""
+===== `elasticsearch.path`
+
+An optional HTTP path prefix that is prepended to the HTTP API calls.
+If nothing is configured, configuration settings from the `output` section will be reused.
 
 [float]
-==== api_key.elasticsearch.proxy_url
-Proxy server url.
-api_key.elasticsearch.proxy_url: ""
-api_key.elasticsearch.proxy_disable: false
+===== `elasticsearch.proxy_url`
+
+The URL of the proxy to use when connecting to the Elasticsearch servers.
+The value may be either a complete URL or a "host[:port]", in which case the "http"scheme is assumed.
+If nothing is configured, configuration settings from the `output` section will be reused.
 
 [float]
-==== api_key.elasticsearch.timeout
-Configure http request timeout before failing an request to Elasticsearch.
-api_key.elasticsearch.timeout: 10s
+===== `elasticsearch.timeout`
+
+The http request timeout in seconds for the Elasticsearch request.
+If nothing is configured, configuration settings from the `output` section will be reused.
 
 [float]
-==== api_key.elasticsearch.ssl.enabled
-Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
-api_key.elasticsearch.ssl.enabled: true
+=== Optional SSL configuration options
+
+SSL is off by default. Set `protocol` to `https` if you want to enable `https`.
 
 [float]
-==== api_key.elasticsearch.ssl.verification_mode
-Optional SSL configuration options. SSL is off by default, change the `protocol` option if you want to enable `https`.
-Configure SSL verification mode. If `none` is configured, all server hosts and certificates will be accepted.
-In this mode, SSL based connections are susceptible to man-in-the-middle attacks. Use only for testing. Default is `full`.
-api_key.elasticsearch.ssl.verification_mode: full
+===== `elasticsearch.ssl.enabled`
+
+Enable custom SSL settings.
+Set to false to ignore custom SSL settings for secure communication.
 
 [float]
-==== api_key.elasticsearch.ssl.supported_protocols
-List of supported/valid TLS versions. By default all TLS versions 1.0 up to 1.2 are enabled.
-api_key.elasticsearch.ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+===== `elasticsearch.ssl.verification_mode`
+
+Configure SSL verification mode.
+If `none` is configured, all server hosts and certificates will be accepted.
+In this mode, SSL based connections are susceptible to man-in-the-middle attacks.
+**Use only for testing**. Default is `full`.
 
 [float]
-==== api_key.elasticsearch.ssl.certificate_authorities
+===== `elasticsearch.ssl.supported_protocols`
+
+List of supported/valid TLS versions.
+By default, all TLS versions from 1.0 to 1.2 are enabled.
+
+[float]
+===== `elasticsearch.ssl.certificate_authorities`
+
 List of root certificates for HTTPS server verifications.
-api_key.elasticsearch.ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
 
 [float]
-==== api_key.elasticsearch.ssl.certificate
-Certificate for SSL client authentication.
-api_key.elasticsearch.ssl.certificate: "/etc/pki/client/cert.pem"
+===== `elasticsearch.ssl.certificate`
+
+The path to the certificate for SSL client authentication.
 
 [float]
-==== api_key.elasticsearch.ssl.key
-Client Certificate Key
-api_key.elasticsearch.ssl.key: "/etc/pki/client/cert.key"
+===== `elasticsearch.ssl.key`
+
+The client certificate key used for client authentication.
+This option is required if certificate is specified.
 
 [float]
-==== api_key.elasticsearch.ssl.key_passphrase
-Optional passphrase for decrypting the Certificate Key.
+===== `elasticsearch.ssl.key_passphrase`
+
+An optional passphrase used to decrypt an encrypted key stored in the configured key file.
 It is recommended to use the provided keystore instead of entering the passphrase in plain text.
-api_key.elasticsearch.ssl.key_passphrase: ''
 
 [float]
-==== api_key.elasticsearch.ssl.cipher_suites
-Configure cipher suites to be used for SSL connections.
-api_key.elasticsearch.ssl.cipher_suites: []
+===== `elasticsearch.ssl.cipher_suites`
+
+The list of cipher suites to use. The first entry has the highest priority.
+If this option is omitted, the Go crypto library’s default suites are used (recommended).
 
 [float]
-==== api_key.elasticsearch.ssl.curve_types
-Configure curve types for ECDHE based cipher suites.
-api_key.elasticsearch.ssl.curve_types: []
+===== `elasticsearch.ssl.curve_types`
+
+The list of curve types for ECDHE (Elliptic Curve Diffie-Hellman ephemeral key exchange).
 
 [float]
-==== api_key.elasticsearch.ssl.renegotiation
-Configure what types of renegotiation are supported. Valid options are `never`, `once`, and `freely`. Default is `never`.
-api_key.elasticsearch.ssl.renegotiation: never
+===== `elasticsearch.ssl.renegotiation`
+
+Configure what types of renegotiation are supported.
+Valid options are `never`, `once`, and `freely`. Default is `never`.
+
+* `never` - Disables renegotiation.
+* `once` - Allows a remote server to request renegotiation once per connection.
+* `freely` - Allows a remote server to repeatedly request renegotiation.
 
 [[secret-token]]
 === Secret token

--- a/docs/secure-communication-agents.asciidoc
+++ b/docs/secure-communication-agents.asciidoc
@@ -30,7 +30,7 @@ you ensure that only your agents are able to send data to your APM servers.
 To secure the communication between APM Agents and the APM Server with API keys:
 
 . <<ssl-setup-api,Enable SSL/TLS>>
-. <<configure-api-key,Configure API keys>>
+. <<configure-api-key,Enable and configure API keys>>
 . <<create-api-key,Create an API key with APM Server>>
 . <<set-api-key,Set the API key in your APM Agents>>
 
@@ -39,14 +39,14 @@ as there is no way to prevent them from being publicly exposed.
 
 [[ssl-setup-api]]
 [float]
-=== SSL/TLS communication in APM Server
+=== Enable SSL/TLS communication
 
 // Use the shared ssl short description
 include::./ssl-input-short.asciidoc[]
 
 [[configure-api-key]]
 [float]
-=== Configure API keys
+=== Enable and configure API keys
 
 API keys are disabled by default. You can change this, and additional settings,
 in the `apm-server.api_key` section of the +{beatname_lc}.yml+ configuration file.
@@ -64,11 +64,11 @@ apm-server.api_key.limit: 50 <2>
 <2> Restricts the number of unique API keys that {es} allows each minute.
 This value should be the number of unique API keys configured in your monitored services.
 
-All other options are described in <<api-key-settings>>.
+All other configuration options are described in <<api-key-settings>>.
 
 [[create-api-key]]
 [float]
-=== Create an API key
+=== Create and validate an API key
 
 APM Server provides a command line interface for creating API keys.
 Keys created using this method can only be used for Agent/Server communication.
@@ -81,13 +81,13 @@ Regardless, the user that creates the API key will need to have the privileges t
 
 [[create-api-key-subcommands]]
 [float]
-==== API key subcommands
+==== `apikey` subcommands
 
 include::{libbeat-dir}/command-reference.asciidoc[tag=api-key-subcommands]
 
 [[create-api-key-privileges]]
 [float]
-==== API key privileges
+==== Privileges
 
 There are three unique privileges you can assign to each API keys.
 If privileges are not specified at creation time, the created key will have all privileges. 

--- a/docs/secure-communication-agents.asciidoc
+++ b/docs/secure-communication-agents.asciidoc
@@ -1,20 +1,212 @@
 [[secure-communication-agents]]
 == Secure communication with APM Agents
 
-To secure the communication between APM Agents and the APM Server:
+There are two ways to secure the communication between APM Agents and the APM Server.
+Both options can be enabled in parallel,
+allowing Elastic APM agents to chose whichever mechanism they support.
 
-. <<secret-token,Set a secret token in your Agents and Server>>
-. <<ssl-setup,Enable SSL/TLS in APM Server>>
-. <<https-in-agents,Enable HTTPS in your APM Agents>>
+As soon as secure communication is enabled, requests without a valid token will be denied by APM Server.
+As RUM endpoints cannot be secured, they are exempt from this rule.
+
+* <<api-key,API keys>>
+* <<secret-token,Secret token>>
+
+[[api-key]]
+=== API Keys
+
+//**************************************************
+// NEW STUFF
+//**************************************************
+
+You can configure an API key to authorize requests to the APM Server.
+When both the agents and the APM servers are configured with the same API key,
+this ensures that only your agents are able to send data to your APM servers.
+
+IMPORTANT: Because API keys are sent as plain-text, you should also secure you communication with HTTPS.
+
+To secure the communication between APM Agents and the APM Server with API keys:
+
+. Enable SSL/TLS
+. Create a secret token with APM Server
+. Set the secret token in your APM Agents
+
+// We recommend saving the api key in the APM Server <<keystore>>.
+
+IMPORTANT: API Keys are not applicable for the RUM Agent,
+as there is no way to prevent them from being publicly exposed.
+
+// BEGIN SSL
+// ************
+
+// Can we use a shared include for this?
+
+[[ssl-setup]]
+[float]
+=== SSL/TLS communication in APM Server
+
+To enable SSL/TLS, you need to enable SSL and provide both a private key and a certificate
+issued by a certificate authority (CA).
+You can then specify the path to those files in your configuration properties.
+This will make APM Server serve HTTPS requests instead of HTTP.
+
+Here's a basic APM Server SSL config with secure communication enabled:
+
+[source,yaml]
+----
+apm-server.ssl.enabled: true
+apm-server.ssl.key: "/etc/pki/key.pem"
+apm-server.ssl.certificate: "/etc/pki/apm-server.pem"
+----
+
+A full list of configuration options is available in <<agent-server-ssl>>.
+
+// END SSL
+// ************
+
+**Agent specific configuration**
+
+// Agent meta: https://github.com/elastic/apm/issues/183
+
+Each Agent has a configuration for setting the value of the API Key:
+
+// GOOD DOCS:
+* *Go Agent*: {apm-go-ref}/configuration.html#config-api-key[`ELASTIC_APM_API_KEY`]
+// MERGED: https://github.com/elastic/apm-agent-go/pull/698
+
+// No issue or docs yet
+// * *Java Agent*: {apm-java-ref}/config-reporter.html#config-api-key[`api_key`]
+
+// No issue or docs yet
+// * *.NET Agent*: {apm-dotnet-ref}/config-reporter.html#[`API_KEY`]
+
+// No issue or docs yet
+// * *Node.js Agent*: {apm-node-ref}/configuration.html[`api_key`]
+
+// No docs yet
+// * *Python Agent*: {apm-py-ref}/configuration.html#config-api-key[`api_key`]
+// WIP
+
+// No docs yet
+// * *Ruby Agent*: {apm-ruby-ref}/configuration.html#config-api-key[`api_key`]
+// MERGED: https://github.com/elastic/apm-agent-ruby/pull/655
+
+
+CONFIG OPTIONS BELOW
+
+[float]
+==== api_key.enabled
+Enable API key authorization by setting enabled to true. By default API key support is disabled.
+Agents include a valid API key in the following format: Authorization: ApiKey <token>.
+The key must be the base64 encoded representation of the API key's "id:key".
+api_key.enabled: false
+
+[float]
+==== api_key.limit
+Restrict how many unique API keys are allowed per minute. Should be set to at least the amount of different
+API keys configured in your monitored services. Every unique API key triggers one request to Elasticsearch.
+api_key.limit: 100
+
+[float]
+==== api_key.elasticsearch.hosts
+API keys need to be fetched from Elasticsearch. If nothing is configured, configuration settings from the
+output section will be reused.
+Note that configuration needs to point to a secured Elasticsearch cluster that is able to serve API key requests.
+api_key.elasticsearch.hosts: ["localhost:9200"]
+
+[float]
+==== api_key.elasticsearch.protocol
+api_key.elasticsearch.protocol: "http"
+
+[float]
+==== api_key.elasticsearch.path
+Optional HTTP Path.
+api_key.elasticsearch.path: ""
+
+[float]
+==== api_key.elasticsearch.proxy_url
+Proxy server url.
+api_key.elasticsearch.proxy_url: ""
+api_key.elasticsearch.proxy_disable: false
+
+[float]
+==== api_key.elasticsearch.timeout
+Configure http request timeout before failing an request to Elasticsearch.
+api_key.elasticsearch.timeout: 10s
+
+[float]
+==== api_key.elasticsearch.ssl.enabled
+Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
+api_key.elasticsearch.ssl.enabled: true
+
+[float]
+==== api_key.elasticsearch.ssl.verification_mode
+Optional SSL configuration options. SSL is off by default, change the `protocol` option if you want to enable `https`.
+Configure SSL verification mode. If `none` is configured, all server hosts and certificates will be accepted.
+In this mode, SSL based connections are susceptible to man-in-the-middle attacks. Use only for testing. Default is `full`.
+api_key.elasticsearch.ssl.verification_mode: full
+
+[float]
+==== api_key.elasticsearch.ssl.supported_protocols
+List of supported/valid TLS versions. By default all TLS versions 1.0 up to 1.2 are enabled.
+api_key.elasticsearch.ssl.supported_protocols: [TLSv1.0, TLSv1.1, TLSv1.2]
+
+[float]
+==== api_key.elasticsearch.ssl.certificate_authorities
+List of root certificates for HTTPS server verifications.
+api_key.elasticsearch.ssl.certificate_authorities: ["/etc/pki/root/ca.pem"]
+
+[float]
+==== api_key.elasticsearch.ssl.certificate
+Certificate for SSL client authentication.
+api_key.elasticsearch.ssl.certificate: "/etc/pki/client/cert.pem"
+
+[float]
+==== api_key.elasticsearch.ssl.key
+Client Certificate Key
+api_key.elasticsearch.ssl.key: "/etc/pki/client/cert.key"
+
+[float]
+==== api_key.elasticsearch.ssl.key_passphrase
+Optional passphrase for decrypting the Certificate Key.
+It is recommended to use the provided keystore instead of entering the passphrase in plain text.
+api_key.elasticsearch.ssl.key_passphrase: ''
+
+[float]
+==== api_key.elasticsearch.ssl.cipher_suites
+Configure cipher suites to be used for SSL connections.
+api_key.elasticsearch.ssl.cipher_suites: []
+
+[float]
+==== api_key.elasticsearch.ssl.curve_types
+Configure curve types for ECDHE based cipher suites.
+api_key.elasticsearch.ssl.curve_types: []
+
+[float]
+==== api_key.elasticsearch.ssl.renegotiation
+Configure what types of renegotiation are supported. Valid options are `never`, `once`, and `freely`. Default is `never`.
+api_key.elasticsearch.ssl.renegotiation: never
+
+//**************************************************
+// END NEW STUFF
+//**************************************************
 
 [[secret-token]]
-[float]
 === Secret token
 
 You can configure a secret token to authorize requests to the APM Server.
 This ensures that only your agents are able to send data to your APM servers.
 Both the agents and the APM servers have to be configured with the same secret token,
 and secret tokens only provide security when used in combination with SSL/TLS.
+
+To secure the communication between APM Agents and the APM Server with a secret token:
+
+. <<set-secret-token,Set a secret token in your Agents and Server>>
+. <<ssl-setup,Enable SSL/TLS in APM Server>>
+. <<https-in-agents,Enable HTTPS in your APM Agents>>
+
+[[set-secret-token]]
+[float]
+=== Set a secret token
 
 **APM Server configuration**
 

--- a/docs/secure-communication-agents.asciidoc
+++ b/docs/secure-communication-agents.asciidoc
@@ -14,60 +14,138 @@ As RUM endpoints cannot be secured, they are exempt from this rule.
 [[api-key]]
 === API Keys
 
-//**************************************************
-// NEW STUFF
-//**************************************************
+// Most operations require the `manage_security` cluster privilege,
+// and you must ensure that `apm-server.api_key` or `output.elasticsearch` are configured appropriately.
+// If you modify or delete apm privileges, APM Server might reject all requests.
+// APM Server will create security privileges for the `apm` application; you can freely query them.
+// If you modify or delete apm privileges, APM Server might reject all requests.
+// Check the Elastic Security API documentation for details.
 
 You can configure an API key to authorize requests to the APM Server.
-When both the agents and the APM servers are configured with the same API key,
-this ensures that only your agents are able to send data to your APM servers.
-
-IMPORTANT: Because API keys are sent as plain-text, you should also secure you communication with HTTPS.
+API keys are sent as plain-text,
+so they only provide security when used in combination with SSL/TLS.
+When you set an API key in each of your agents,
+you ensure that only your agents are able to send data to your APM servers.
 
 To secure the communication between APM Agents and the APM Server with API keys:
 
-. Enable SSL/TLS
-. Create a secret token with APM Server
-. Set the secret token in your APM Agents
+. <<ssl-setup-api,Enable SSL/TLS>>
+. <<configure-api-key,Configure API keys>>
+. <<create-api-key,Create an API key with APM Server>>
+. <<set-api-key,Set the API key in your APM Agents>>
 
-// We recommend saving the api key in the APM Server <<keystore>>.
-
-IMPORTANT: API Keys are not applicable for the RUM Agent,
+NOTE: API Keys are not applicable for the RUM Agent,
 as there is no way to prevent them from being publicly exposed.
 
-// BEGIN SSL
-// ************
-
-// Can we use a shared include for this?
-
-[[ssl-setup]]
+[[ssl-setup-api]]
 [float]
 === SSL/TLS communication in APM Server
 
-To enable SSL/TLS, you need to enable SSL and provide both a private key and a certificate
-issued by a certificate authority (CA).
-You can then specify the path to those files in your configuration properties.
-This will make APM Server serve HTTPS requests instead of HTTP.
+// Use the shared ssl short description
+include::./ssl-input-short.asciidoc[]
 
-Here's a basic APM Server SSL config with secure communication enabled:
+[[configure-api-key]]
+[float]
+=== Configure API keys
 
-[source,yaml]
-----
-apm-server.ssl.enabled: true
-apm-server.ssl.key: "/etc/pki/key.pem"
-apm-server.ssl.certificate: "/etc/pki/apm-server.pem"
-----
+// TO DO
 
-A full list of configuration options is available in <<agent-server-ssl>>.
+[[create-api-key]]
+[float]
+=== Create an API key
 
-// END SSL
-// ************
+APM Server provides a command line interface for creating API keys.
+Keys created using this method can only be used for Agent/Server communication.
 
-**Agent specific configuration**
+While it is possible to CURL {es} directly to create API keys,
+using this method is not recommended.
+The command line tool uses safeguards, which ensure that the required privileges exist before creating an API key.
+If they do not exist, the CLI tool will create the privileges.
+Regardless, the user that creates the API key will need to have the privileges they wish to give to the API key.
+
+The available commands are:
+
+include::{libbeat-dir}/command-reference.asciidoc[tag=api-key-subcommands]
+
+For API keys, we created dedicated privileges. There are three unique privileges.
+If no privileges are specified, the created key has all privileges. 
+
+*Agent configuration*::
+Required for agents to read configuration remotely.
+`--agent-config` gives the `config_agent:read` privilege to the created key.
+
+*Ingest*::
+Required for ingesting events.
+`--ingest` gives the `event:write` privilege to the created key.
+
+*Sourcemap*::
+Required for uploading sourcemaps.
+`--sourcemap` gives the `sourcemap:write` privilege to the created key.
+
+Create an API key with the `create` subcommand.
+The following example creates an API key with a `name` of `java-001`,
+and the Agent configuration and ingest privileges.
+
+["source","sh",subs="attributes"]
+-----
+{beatname_lc} apikey create --ingest --agent-config --name java-001
+-----
+
+The response will look similar to this:
+
+[source,console-result,subs="attributes,callouts"]
+--------------------------------------------------
+Name ........... java-001
+Expiration ..... never
+Id ............. qT4tz28B1g59zC3uAXfW
+API Key ........ rH55zKd5QT6wvs3UbbkxOA (won't be shown again)
+Credentials .... cVQ0dHoyOEIxZzVDZ3dnMzVWJia3hPQQ==
+--------------------------------------------------
+
+You should always verify the privileges of an API key after creating it.
+Verification can be done using the `verify` subcommand.
+The following example verifies that the `java-001` API key has the request privileges.
+
+["source","sh",subs="attributes"]
+-----
+{beatname_lc} apikey verify --agent-config --ingest --credentials cVQ0dHoyOEIxZzVDZ3dnMzVWJia3hPQQ==  
+-----
+
+If your API key has the right privileges, the response will look similar to this:
+
+[source,console-result,subs="attributes,callouts"]
+--------------------------------------------------
+Authorized for privilege "event:write"...:          Yes
+Authorized for privilege "config_agent:read"...:    Yes
+--------------------------------------------------
+
+To invalidate an API key, use the `invalidate` subcommand.
+The following example invalidates the `java-001` API key.
+
+["source","sh",subs="attributes"]
+-----
+{beatname_lc} apikey invalidate --name java-001
+-----
+
+The response will look similar to this:
+
+[source,console-result,subs="attributes,callouts"]
+--------------------------------------------------
+Invalidated keys ... qT4tz28B1g59zC3uAXfW
+Error count ........ 0
+--------------------------------------------------
+
+A full list of `apikey` subcommands, flags, and additional examples,
+is available in the <<apikey-command,API key command reference>>
+
+[[set-api-key]]
+[float]
+=== Set the API key in your APM Agents
+
+You can now set your newly created API keys in the configuration of your APM Agents.
+See the relevant Agent documentation for additional information:
 
 // Agent meta: https://github.com/elastic/apm/issues/183
-
-Each Agent has a configuration for setting the value of the API Key:
 
 // GOOD DOCS:
 * *Go Agent*: {apm-go-ref}/configuration.html#config-api-key[`ELASTIC_APM_API_KEY`]
@@ -91,7 +169,16 @@ Each Agent has a configuration for setting the value of the API Key:
 // MERGED: https://github.com/elastic/apm-agent-ruby/pull/655
 
 
-CONFIG OPTIONS BELOW
+[float]
+[[api-key-settings]]
+=== API key settings
+
+You can specify the following options in the `apm-server.api_key` section of the +{beatname_lc}.yml+ config file.
+They apply to API key communication between the APM Server and APM Agents.
+
+// To do!
+// These will become links, but the relevant docs haven't been merged yet.
+These are different from the API key settings used for the Elasticsearch output and monitoring.
 
 [float]
 ==== api_key.enabled
@@ -186,10 +273,6 @@ api_key.elasticsearch.ssl.curve_types: []
 Configure what types of renegotiation are supported. Valid options are `never`, `once`, and `freely`. Default is `never`.
 api_key.elasticsearch.ssl.renegotiation: never
 
-//**************************************************
-// END NEW STUFF
-//**************************************************
-
 [[secret-token]]
 === Secret token
 
@@ -200,9 +283,19 @@ and secret tokens only provide security when used in combination with SSL/TLS.
 
 To secure the communication between APM Agents and the APM Server with a secret token:
 
+. <<ssl-setup-token,Enable SSL/TLS in APM Server>>
 . <<set-secret-token,Set a secret token in your Agents and Server>>
-. <<ssl-setup,Enable SSL/TLS in APM Server>>
 . <<https-in-agents,Enable HTTPS in your APM Agents>>
+
+NOTE: Secret tokens are not applicable for the RUM Agent,
+as there is no way to prevent them from being publicly exposed.
+
+[[ssl-setup-token]]
+[float]
+=== SSL/TLS communication in APM Server
+
+// Use the shared ssl short description
+include::./ssl-input-short.asciidoc[]
 
 [[set-secret-token]]
 [float]
@@ -232,26 +325,6 @@ Each Agent has a configuration for setting the value of the secret token:
 * *Node.js Agent*: {apm-node-ref}/configuration.html#secret-token[`Secret Token`]
 * *Python Agent*: {apm-py-ref}/configuration.html#config-secret-token[`secret_token`]
 * *Ruby Agent*: {apm-ruby-ref}/configuration.html#config-secret-token[`secret_token`]
-
-[[ssl-setup]]
-[float]
-=== SSL/TLS communication in APM Server
-
-To enable SSL/TLS, you need to enable SSL and provide both a private key and a certificate
-issued by a certificate authority (CA).
-You can then specify the path to those files in your configuration properties.
-This will make APM Server serve HTTPS requests instead of HTTP.
-
-Here's a basic APM Server SSL config with secure communication enabled:
-
-[source,yaml]
-----
-apm-server.ssl.enabled: true
-apm-server.ssl.key: "/etc/pki/key.pem"
-apm-server.ssl.certificate: "/etc/pki/apm-server.pem"
-----
-
-A full list of configuration options is available in <<agent-server-ssl>>.
 
 [[https-in-agents]]
 [float]

--- a/docs/secure-communication-agents.asciidoc
+++ b/docs/secure-communication-agents.asciidoc
@@ -2,7 +2,7 @@
 == Secure communication with APM Agents
 
 There are two ways to secure the communication between APM Agents and the APM Server.
-Both options can be enabled in parallel,
+Both options can be enabled at the same time,
 allowing Elastic APM agents to chose whichever mechanism they support.
 
 As soon as secure communication is enabled, requests without a valid token or API key will be denied by APM Server.
@@ -47,7 +47,7 @@ API keys are disabled by default. You can change this, and additional settings,
 in the `apm-server.api_key` section of the +{beatname_lc}.yml+ configuration file.
 
 At a minimum, you must enable API keys,
-and should set a limit on the number of unique API keys APM Server allows per minute.
+and should set a limit on the number of unique API keys that APM Server allows per minute.
 Here's an example `apm-server.api_key` config using 50 unique API keys:
 
 [source,yaml]
@@ -68,9 +68,6 @@ All other configuration options are described in <<api-key-settings>>.
 APM Server provides a command line interface for creating API keys.
 Keys created using this method can only be used for Agent/Server communication.
 The user that creates the API key will need to have the privileges they wish to give to the API key.
-
-While it is also possible to CURL {es} directly to create API keys,
-using this method is not recommended.
 
 [[create-api-key-subcommands]]
 [float]
@@ -115,7 +112,7 @@ Name ........... java-001
 Expiration ..... never
 Id ............. qT4tz28B1g59zC3uAXfW
 API Key ........ rH55zKd5QT6wvs3UbbkxOA (won't be shown again)
-Credentials .... cVQ0dHoyOEIxZzVDZ3dnMzVWJia3hPQQ==
+Credentials .... cVQ0dHoyOEIxZzVDZ3dnMzVWJia3hPQQ== (won't be shown again)
 --------------------------------------------------
 
 You should always verify the privileges of an API key after creating it.
@@ -137,6 +134,7 @@ Authorized for privilege "config_agent:read"...:    Yes
 --------------------------------------------------
 
 To invalidate an API key, use the `invalidate` subcommand.
+Due to {es} caching, there may be a delay between when this subcommand is executed and when it takes effect.
 
 The following example invalidates the `java-001` API key.
 
@@ -201,7 +199,7 @@ These are different from the API key settings used for the Elasticsearch output 
 
 Enable API key authorization by setting `enabled` to `true`.
 Agents will include a valid API key in the following format: `Authorization: ApiKey <token>`.
-The key must be the base64 encoded representation of the API key's `id:key`.
+The key must be the base64 encoded representation of the API key's `id:name`.
 By default, `enabled` is set to `false`, and API key support is disabled.
 
 [float]

--- a/docs/ssl-input-short.asciidoc
+++ b/docs/ssl-input-short.asciidoc
@@ -1,0 +1,15 @@
+To enable SSL/TLS, you need to enable SSL and provide both a private key and a certificate
+issued by a certificate authority (CA).
+You can then specify the path to those files in your configuration properties.
+This will make APM Server serve HTTPS requests instead of HTTP.
+
+Here's a basic APM Server SSL config with secure communication enabled:
+
+[source,yaml]
+----
+apm-server.ssl.enabled: true
+apm-server.ssl.key: "/etc/pki/key.pem"
+apm-server.ssl.certificate: "/etc/pki/apm-server.pem"
+----
+
+A full list of configuration options is available in <<agent-server-ssl>>.


### PR DESCRIPTION
Adds Agent/Server API key documentation:
* Updates the command reference to include the `apikey` command.
* Adds a configuration reference for the new `api_key` config options.
* Adds a walkthrough for enabling, configuring, and setting API keys.

**[An HTML preview is available here](http://apm-server_3212.docs-preview.app.elstc.co/guide/en/apm/server/master/secure-communication-agents.html)**.

To do:
* A PR is required in Beats to persist these changes.
* The links to Agent documentation will need to be updated closer to release time.

Closes https://github.com/elastic/apm-server/issues/3033.