### PR TITLE
[DOCS] Adds placeholder for release notes

### DIFF
--- a/changelogs/7.5.asciidoc
+++ b/changelogs/7.5.asciidoc
@@ -5,6 +5,12 @@ https://github.com/elastic/apm-server/compare/7.4\...7.5[View commits]
 
 * <<release-notes-7.5.0>>
 * <<release-notes-7.5.1>>
+* <<release-notes-7.5.2>>
+
+[[release-notes-7.5.2]]
+=== APM Server version 7.5.2
+
+coming::[7.5.2]
 
 [[release-notes-7.5.1]]
 === APM Server version 7.5.1


### PR DESCRIPTION
This PR creates a placeholder for the release notes. It must also be backported to the 7.5 branch.