### PR TITLE
[7.6] Introduce elasticsearch.Error (#3218)

### DIFF
--- a/elasticsearch/client_test.go
+++ b/elasticsearch/client_test.go
@@ -54,6 +54,5 @@ func TestClient(t *testing.T) {
 		} else {
 			assert.Fail(t, "unknown version ", version.GetDefaultVersion())
 		}
-
 	})
 }

--- a/elasticsearch/estest/client.go
+++ b/elasticsearch/estest/client.go
@@ -49,8 +49,8 @@ func NewTransport(t *testing.T, statusCode int, esBody map[string]interface{}) *
 
 	return &Transport{
 		roundTripFn: func(_ *http.Request) (*http.Response, error) {
-			if statusCode == http.StatusInternalServerError {
-				return &http.Response{}, errors.New("Internal server error")
+			if statusCode == -1 {
+				return nil, errors.New("client error")
 			}
 			var body io.ReadCloser
 			if esBody == nil {

--- a/elasticsearch/security_api_test.go
+++ b/elasticsearch/security_api_test.go
@@ -1,0 +1,49 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package elasticsearch
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasPrivilegesError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		fmt.Fprint(w, "oh noes")
+	}))
+	defer server.Close()
+
+	client, err := NewClient(&Config{Hosts: Hosts{server.Listener.Addr().String()}})
+	require.NoError(t, err)
+
+	resp, err := HasPrivileges(client, HasPrivilegesRequest{}, "foo")
+	require.Error(t, err)
+	assert.Zero(t, resp)
+
+	var eserr *Error
+	require.True(t, errors.As(err, &eserr))
+	assert.Equal(t, 401, eserr.StatusCode)
+	assert.Equal(t, "oh noes", eserr.Error())
+}

--- a/model/stacktrace_frame_test.go
+++ b/model/stacktrace_frame_test.go
@@ -232,7 +232,7 @@ func TestSourcemap_Apply(t *testing.T) {
 			expectedErrorMsg string
 		}{
 			"ESUnavailable": {store: testSourcemapStore(t, test.ESClientUnavailable(t)),
-				expectedErrorMsg: "Internal server error"},
+				expectedErrorMsg: "client error"},
 			"invalidSourcemap": {store: testSourcemapStore(t, test.ESClientWithInvalidSourcemap(t)),
 				expectedErrorMsg: "Could not parse Sourcemap."},
 			"unsupportedSourcemap": {store: testSourcemapStore(t, test.ESClientWithUnsupportedSourcemap(t)),

--- a/sourcemap/es_store_test.go
+++ b/sourcemap/es_store_test.go
@@ -19,7 +19,6 @@ package sourcemap
 
 import (
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/go-sourcemap/sourcemap"
@@ -43,7 +42,7 @@ func Test_esFetcher_fetchError(t *testing.T) {
 		temporary  bool
 	}{
 		"es not reachable": {
-			statusCode: http.StatusInternalServerError, temporary: true,
+			statusCode: -1, temporary: true,
 		},
 		"es bad request": {
 			statusCode: http.StatusBadRequest,
@@ -67,7 +66,11 @@ func Test_esFetcher_fetchError(t *testing.T) {
 			require.NoError(t, err)
 			consumer, err := testESStore(client).fetch("abc", "1.0", "/tmp")
 			require.Error(t, err)
-			assert.Equal(t, tc.temporary, strings.Contains(err.Error(), errMsgESFailure))
+			if tc.temporary {
+				assert.Contains(t, err.Error(), errMsgESFailure)
+			} else {
+				assert.NotContains(t, err.Error(), errMsgESFailure)
+			}
 			assert.Empty(t, consumer)
 		})
 	}

--- a/sourcemap/test/es_client.go
+++ b/sourcemap/test/es_client.go
@@ -76,9 +76,10 @@ func ESClientWithValidSourcemap(t *testing.T) elasticsearch.Client {
 	return client
 }
 
-// ESClientUnavailable returns an elasticsearch client that will always return an internal server error
+// ESClientUnavailable returns an elasticsearch client that will always return a client error, mimicking an
+// unavailable Elasticsearch server.
 func ESClientUnavailable(t *testing.T) elasticsearch.Client {
-	client, err := estest.NewElasticsearchClient(estest.NewTransport(t, http.StatusInternalServerError, nil))
+	client, err := estest.NewElasticsearchClient(estest.NewTransport(t, -1, nil))
 	require.NoError(t, err)
 	return client
 }


### PR DESCRIPTION
Backports the following commits to 7.6:
 - Introduce elasticsearch.Error  (#3218)