### PR TITLE
[7.6] [docs][7.5] 7.5.2 release notes #3219 (#3223)

### DIFF
--- a/changelogs/7.5.asciidoc
+++ b/changelogs/7.5.asciidoc
@@ -3,8 +3,16 @@
 
 https://github.com/elastic/apm-server/compare/7.4\...7.5[View commits]
 
-* <<release-notes-7.5.0>>
+* <<release-notes-7.5.2>>
 * <<release-notes-7.5.1>>
+* <<release-notes-7.5.0>>
+
+[[release-notes-7.5.2]]
+=== APM Server version 7.5.2
+
+https://github.com/elastic/apm-server/compare/v7.5.1\...v7.5.2[View commits]
+
+No significant changes.
 
 [[release-notes-7.5.1]]
 === APM Server version 7.5.1


### PR DESCRIPTION
Backports the following commits to 7.6:
 - [docs][7.5] 7.5.2 release notes #3219 (#3223)