### PR TITLE
chore: fetch all remotes before to checkout the branch

### DIFF
--- a/script/update_beats.sh
+++ b/script/update_beats.sh
@@ -18,6 +18,7 @@ trap "{ set +e;popd 2>/dev/null;set -e;rm -rf ${BASEDIR}/${GIT_CLONE}; }" EXIT
 git clone https://github.com/elastic/beats.git ${GIT_CLONE}
 (
     cd ${GIT_CLONE}
+    git fetch --all
     git checkout ${BEATS_VERSION}
 )
 


### PR DESCRIPTION
## What does this PR do?

It adds a `git fetch --all` before to checkout the Beats branch.

## Why is it important?

It allows us to use commits for any branch or remote ref that we have configured in our `git` config as Beats version (e.g commit PRs using the git ref +refs/pull/*/head:refs/remotes/origin/pr/*)

## Related issues
related to https://github.com/elastic/beats/pull/15631 and https://github.com/elastic/beats/issues/13371