### PR TITLE
[7.6] decrease API Key cache time to one minute (#3238)

### DIFF
--- a/beater/authorization/builder.go
+++ b/beater/authorization/builder.go
@@ -42,7 +42,7 @@ type Authorization interface {
 }
 
 const (
-	cacheTimeoutMinute = 5
+	cacheTimeoutMinute = 1 * time.Minute
 )
 
 // NewBuilder creates authorization builder based off of the given information
@@ -61,8 +61,7 @@ func NewBuilder(cfg *config.Config) (*Builder, error) {
 			return nil, err
 		}
 
-		size := cfg.APIKeyConfig.LimitMin * cacheTimeoutMinute
-		cache := newPrivilegesCache(cacheTimeoutMinute*time.Minute, size)
+		cache := newPrivilegesCache(cacheTimeoutMinute, cfg.APIKeyConfig.LimitPerMin)
 		b.apikey = newApikeyBuilder(client, cache, []elasticsearch.PrivilegeAction{})
 		b.fallback = DenyAuth{}
 	}

--- a/beater/authorization/builder_test.go
+++ b/beater/authorization/builder_test.go
@@ -48,7 +48,7 @@ func TestBuilder(t *testing.T) {
 			}
 			if tc.withApikey {
 				cfg.APIKeyConfig = &config.APIKeyConfig{
-					Enabled: true, LimitMin: 100, ESConfig: elasticsearch.DefaultConfig()}
+					Enabled: true, LimitPerMin: 100, ESConfig: elasticsearch.DefaultConfig()}
 			}
 
 			builder, err := NewBuilder(cfg)
@@ -61,7 +61,7 @@ func TestBuilder(t *testing.T) {
 			assert.Equal(t, tc.bearer, builder.bearer)
 			if tc.withApikey {
 				assert.NotNil(t, builder.apikey)
-				assert.Equal(t, 500, builder.apikey.cache.size)
+				assert.Equal(t, 100, builder.apikey.cache.size)
 				assert.NotNil(t, builder.apikey.esClient)
 			}
 		})

--- a/beater/config/api_key.go
+++ b/beater/config/api_key.go
@@ -31,9 +31,9 @@ const apiKeyLimit = 100
 
 // APIKeyConfig can be used for authorizing against the APM Server via API Keys.
 type APIKeyConfig struct {
-	Enabled  bool                  `config:"enabled"`
-	LimitMin int                   `config:"limit"`
-	ESConfig *elasticsearch.Config `config:"elasticsearch"`
+	Enabled     bool                  `config:"enabled"`
+	LimitPerMin int                   `config:"limit"`
+	ESConfig    *elasticsearch.Config `config:"elasticsearch"`
 }
 
 // IsEnabled returns whether or not API Key authorization is enabled
@@ -59,5 +59,5 @@ func (c *APIKeyConfig) setup(log *logp.Logger, outputESCfg *common.Config) error
 }
 
 func defaultAPIKeyConfig() *APIKeyConfig {
-	return &APIKeyConfig{Enabled: false, LimitMin: apiKeyLimit}
+	return &APIKeyConfig{Enabled: false, LimitPerMin: apiKeyLimit}
 }

--- a/beater/config/api_key_test.go
+++ b/beater/config/api_key_test.go
@@ -49,11 +49,11 @@ func TestAPIKeyConfig_ESConfig(t *testing.T) {
 			expectedConfig: defaultAPIKeyConfig(),
 		},
 		"ES config missing": {
-			cfg: &APIKeyConfig{Enabled: true, LimitMin: apiKeyLimit},
+			cfg: &APIKeyConfig{Enabled: true, LimitPerMin: apiKeyLimit},
 			expectedConfig: &APIKeyConfig{
-				Enabled:  true,
-				LimitMin: apiKeyLimit,
-				ESConfig: elasticsearch.DefaultConfig()},
+				Enabled:     true,
+				LimitPerMin: apiKeyLimit,
+				ESConfig:    elasticsearch.DefaultConfig()},
 		},
 		"ES configured": {
 			cfg: &APIKeyConfig{
@@ -70,11 +70,11 @@ func TestAPIKeyConfig_ESConfig(t *testing.T) {
 			expectedConfig: defaultAPIKeyConfig(),
 		},
 		"ES from output": {
-			cfg:   &APIKeyConfig{Enabled: true, LimitMin: 20},
+			cfg:   &APIKeyConfig{Enabled: true, LimitPerMin: 20},
 			esCfg: common.MustNewConfigFrom(`{"hosts":["192.0.0.168:9200"],"username":"foo","password":"bar"}`),
 			expectedConfig: &APIKeyConfig{
-				Enabled:  true,
-				LimitMin: 20,
+				Enabled:     true,
+				LimitPerMin: 20,
 				ESConfig: &elasticsearch.Config{
 					Timeout:  5 * time.Second,
 					Username: "foo",

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -155,10 +155,6 @@ func Test_UnpackConfig(t *testing.T) {
 				Kibana:      common.MustNewConfigFrom(map[string]interface{}{"enabled": "true"}),
 				AgentConfig: &AgentConfig{Cache: &Cache{Expiration: 2 * time.Minute}},
 				Pipeline:    defaultAPMPipeline,
-				APIKeyConfig: &APIKeyConfig{
-					Enabled:  true,
-					LimitMin: 200,
-					ESConfig: &elasticsearch.Config{Hosts: elasticsearch.Hosts{"localhost:9201", "localhost:9202"}}},
 				JaegerConfig: JaegerConfig{
 					GRPC: JaegerGRPCConfig{
 						Enabled: true,
@@ -179,6 +175,11 @@ func Test_UnpackConfig(t *testing.T) {
 						Enabled: true,
 						Host:    "localhost:6789",
 					},
+				},
+				APIKeyConfig: &APIKeyConfig{
+					Enabled:     true,
+					LimitPerMin: 200,
+					ESConfig:    &elasticsearch.Config{Hosts: elasticsearch.Hosts{"localhost:9201", "localhost:9202"}},
 				},
 			},
 		},
@@ -256,10 +257,9 @@ func Test_UnpackConfig(t *testing.T) {
 						},
 					},
 				},
-				Kibana:       common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
-				AgentConfig:  &AgentConfig{Cache: &Cache{Expiration: 30 * time.Second}},
-				Pipeline:     defaultAPMPipeline,
-				APIKeyConfig: &APIKeyConfig{Enabled: true, LimitMin: 100, ESConfig: elasticsearch.DefaultConfig()},
+				Kibana:      common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
+				AgentConfig: &AgentConfig{Cache: &Cache{Expiration: 30 * time.Second}},
+				Pipeline:    defaultAPMPipeline,
 				JaegerConfig: JaegerConfig{
 					GRPC: JaegerGRPCConfig{
 						Enabled: true,
@@ -278,6 +278,7 @@ func Test_UnpackConfig(t *testing.T) {
 						Host:    "localhost:14268",
 					},
 				},
+				APIKeyConfig: &APIKeyConfig{Enabled: true, LimitPerMin: 100, ESConfig: elasticsearch.DefaultConfig()},
 			},
 		},
 	}

--- a/tests/system/test_access.py
+++ b/tests/system/test_access.py
@@ -168,15 +168,13 @@ class BaseAPIKey(ElasticTest):
 class TestAPIKeyCache(BaseAPIKey):
     def config(self):
         cfg = super(TestAPIKeyCache, self).config()
-        cfg.update({"api_key_enabled": True, "api_key_limit": 1})
+        cfg.update({"api_key_enabled": True, "api_key_limit": 5})
         return cfg
 
     def test_cache_full(self):
         """
         Test that authorized API Key is not accepted when cache is full
-        api_key.limit: number of unique API Keys per minute
-        cache expires every 5 minutes
-        => cache size is api_key_limit*5
+        api_key.limit: number of unique API Keys per minute => cache size
         """
 
         key1 = self.create_api_key([self.privilege_event], self.resource_any)


### PR DESCRIPTION
Backports the following commits to 7.6:
 - decrease API Key cache time to one minute (#3238)