### PR TITLE
[test] Fix flaky self instrumentation system test

### DIFF
--- a/tests/system/test_instrumentation.py
+++ b/tests/system/test_instrumentation.py
@@ -48,7 +48,7 @@ class TestInMemoryTracingAPIKey(BaseAPIKey):
 class TestExternalTracingAPIKey(BaseAPIKey):
     def config(self):
         cfg = super(TestExternalTracingAPIKey, self).config()
-        api_key = self.create_api_key([self.privilege_event], self.resource_any).lstrip("ApiKey ")
+        api_key = self.create_api_key([self.privilege_event], self.resource_any)
         cfg.update({
             "api_key_enabled": True,
             "instrumentation_enabled": "true",


### PR DESCRIPTION
Get rid of using lstrip for removing trailing `ApiKey `. The matching does not consider character order, but strips away everything until the first non-matching character. This can lead to removing starting characters from the actual API Key.

Eg:
`"Key ApiApiKey foo".lstrip("ApiKey ")` -> `foo`
`"ApiKey eVY1MTAyOEJEZ".lstrip("ApiKey ")` -> `VY1MTAyOEJEZ`