### PR TITLE
[7.6] Add experimental flag to API Key feature (#3240)

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -142,6 +142,7 @@ apm-server:
   # Enable API key authorization by setting enabled to true. By default API key support is disabled.
   # Agents include a valid API key in the following format: Authorization: ApiKey <token>.
   # The key must be the base64 encoded representation of the API key's "id:key".
+  # This is an experimental feature, use with care.
   #api_key:
     #enabled: false
 

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -142,6 +142,7 @@ apm-server:
   # Enable API key authorization by setting enabled to true. By default API key support is disabled.
   # Agents include a valid API key in the following format: Authorization: ApiKey <token>.
   # The key must be the base64 encoded representation of the API key's "id:key".
+  # This is an experimental feature, use with care.
   #api_key:
     #enabled: false
 

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -142,6 +142,7 @@ apm-server:
   # Enable API key authorization by setting enabled to true. By default API key support is disabled.
   # Agents include a valid API key in the following format: Authorization: ApiKey <token>.
   # The key must be the base64 encoded representation of the API key's "id:key".
+  # This is an experimental feature, use with care.
   #api_key:
     #enabled: false
 


### PR DESCRIPTION
Backports the following commits to 7.6:
 - Add experimental flag to API Key feature (#3240)