### PR TITLE
[docs] Update apm-contrib link for dashboards

### DIFF
--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -244,4 +244,4 @@ Loading dashboards from APM Server is no longer supported. Please see the {kiban
 Loading Kibana dashboards from APM Server is no longer supported.
 Please use the {kibana-ref}/xpack-apm.html[Kibana APM UI] instead.
 As an alternative, a small number of dashboards and visualizations are available in the
-https://github.com/elastic/apm-contrib/tree/master/apm-ui[apm-contrib] repository.
+https://github.com/elastic/apm-contrib/tree/master/kibana[apm-contrib] repository.


### PR DESCRIPTION
Backport to `7.x`, `7.6`, `7.5`, `6.8`.