### PR TITLE
remove enroll command

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -6,6 +6,8 @@ https://github.com/elastic/apm-server/compare/7.6\...master[View commits]
 [float]
 ==== Breaking Changes
 
+* Remove enroll subcommand {pull}3270[3270].
+
 [float]
 ==== Intake API Changes
 

--- a/x-pack/apm-server/cmd/root.go
+++ b/x-pack/apm-server/cmd/root.go
@@ -15,4 +15,8 @@ var RootCmd = cmd.RootCmd
 
 func init() {
 	xpackcmd.AddXPack(RootCmd, cmd.Name)
+	if enrollCmd, _, err := RootCmd.Find([]string{"enroll"}); err == nil {
+		// error is ok => enroll has already been removed
+		RootCmd.RemoveCommand(enrollCmd)
+	}
 }

--- a/x-pack/apm-server/cmd/root_test.go
+++ b/x-pack/apm-server/cmd/root_test.go
@@ -1,3 +1,7 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
 package cmd
 
 import (

--- a/x-pack/apm-server/cmd/root_test.go
+++ b/x-pack/apm-server/cmd/root_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestSubCommands(t *testing.T) {
+	validCommands := map[string]struct{}{
+		"apikey":     {},
+		"completion": {},
+		"export":     {},
+		"keystore":   {},
+		"run":        {},
+		"setup":      {},
+		"test":       {},
+		"version":    {},
+	}
+
+	for _, cmd := range RootCmd.Commands() {
+		name := cmd.Name()
+		if _, ok := validCommands[name]; !ok {
+			t.Errorf("unexpected command: %s", name)
+		}
+	}
+}


### PR DESCRIPTION
`enroll` technically succeeded but had no use.  Removing it is considered a bug fix and less confusing than just deprecating it.

fixes #3230 