### PR TITLE
[7.x] remove enroll command (#3270)

### DIFF
--- a/changelogs/7.7.asciidoc
+++ b/changelogs/7.7.asciidoc
@@ -1,0 +1,21 @@
+[[release-notes-7.7]]
+== APM Server version 7.7
+
+https://github.com/elastic/apm-server/compare/7.6\...7.7[View commits]
+
+* <<release-notes-7.7.0>>
+
+[[release-notes-7.7.0]]
+=== APM Server version 7.7.0
+
+https://github.com/elastic/apm-server/compare/v7.6.0\...v7.7.0[View commits]
+
+[float]
+==== Breaking Changes
+* Remove enroll subcommand {pull}3270[3270].
+
+[float]
+==== Intake API Changes
+
+[float]
+==== Added

--- a/x-pack/apm-server/cmd/root.go
+++ b/x-pack/apm-server/cmd/root.go
@@ -15,4 +15,8 @@ var RootCmd = cmd.RootCmd
 
 func init() {
 	xpackcmd.AddXPack(RootCmd, cmd.Name)
+	if enrollCmd, _, err := RootCmd.Find([]string{"enroll"}); err == nil {
+		// error is ok => enroll has already been removed
+		RootCmd.RemoveCommand(enrollCmd)
+	}
 }

--- a/x-pack/apm-server/cmd/root_test.go
+++ b/x-pack/apm-server/cmd/root_test.go
@@ -1,0 +1,29 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package cmd
+
+import (
+	"testing"
+)
+
+func TestSubCommands(t *testing.T) {
+	validCommands := map[string]struct{}{
+		"apikey":     {},
+		"completion": {},
+		"export":     {},
+		"keystore":   {},
+		"run":        {},
+		"setup":      {},
+		"test":       {},
+		"version":    {},
+	}
+
+	for _, cmd := range RootCmd.Commands() {
+		name := cmd.Name()
+		if _, ok := validCommands[name]; !ok {
+			t.Errorf("unexpected command: %s", name)
+		}
+	}
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - remove enroll command (#3270)