### PR TITLE
[7.x] strip trailing slashes from kibana host configuration (#3277)

### DIFF
--- a/beater/api/mux.go
+++ b/beater/api/mux.go
@@ -179,15 +179,15 @@ type middlewareFunc func(*config.Config, *authorization.Handler, map[request.Res
 
 func agentConfigHandler(cfg *config.Config, authHandler *authorization.Handler, middlewareFunc middlewareFunc) (request.Handler, error) {
 	var client kibana.Client
-	if cfg.Kibana.Enabled() {
-		client = kibana.NewConnectingClient(cfg.Kibana)
+	if cfg.Kibana.Enabled {
+		client = kibana.NewConnectingClient(&cfg.Kibana.ClientConfig)
 	}
 	h := agent.Handler(client, cfg.AgentConfig)
 	msg := "Agent remote configuration is disabled. " +
 		"Configure the `apm-server.kibana` section in apm-server.yml to enable it. " +
 		"If you are using a RUM agent, you also need to configure the `apm-server.rum` section. " +
 		"If you are not using remote configuration, you can safely ignore this error."
-	ks := middleware.KillSwitchMiddleware(cfg.Kibana.Enabled(), msg)
+	ks := middleware.KillSwitchMiddleware(cfg.Kibana.Enabled, msg)
 	return middleware.Wrap(h, append(middlewareFunc(cfg, authHandler, agent.MonitoringMap), ks)...)
 }
 

--- a/beater/api/mux_config_agent_test.go
+++ b/beater/api/mux_config_agent_test.go
@@ -25,8 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/beats/libbeat/common"
-
 	"github.com/elastic/apm-server/beater/api/config/agent"
 	"github.com/elastic/apm-server/beater/beatertest"
 	"github.com/elastic/apm-server/beater/config"
@@ -99,7 +97,8 @@ func TestConfigAgentHandler_MonitoringMiddleware(t *testing.T) {
 
 func configEnabledConfigAgent() *config.Config {
 	cfg := config.DefaultConfig(beatertest.MockBeatVersion())
-	cfg.Kibana = common.MustNewConfigFrom(map[string]interface{}{"enabled": "true", "host": "localhost:foo"})
+	cfg.Kibana.Enabled = true
+	cfg.Kibana.Host = "localhost:foo"
 	return cfg
 }
 

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -25,12 +25,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/beats/libbeat/common/transport/tlscommon"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/libbeat/common"
+	"github.com/elastic/beats/libbeat/common/transport/tlscommon"
 	"github.com/elastic/beats/libbeat/outputs"
 
 	"github.com/elastic/apm-server/elasticsearch"
@@ -39,6 +38,10 @@ import (
 func Test_UnpackConfig(t *testing.T) {
 	falsy, truthy := false, true
 	version := "8.0.0"
+
+	kibanaNoSlashConfig := DefaultConfig(version)
+	kibanaNoSlashConfig.Kibana.Enabled = true
+	kibanaNoSlashConfig.Kibana.Host = "kibanahost:5601/proxy"
 
 	tests := map[string]struct {
 		inpCfg map[string]interface{}
@@ -152,7 +155,10 @@ func Test_UnpackConfig(t *testing.T) {
 						},
 					},
 				},
-				Kibana:      common.MustNewConfigFrom(map[string]interface{}{"enabled": "true"}),
+				Kibana: KibanaConfig{
+					Enabled:      true,
+					ClientConfig: defaultKibanaConfig().ClientConfig,
+				},
 				AgentConfig: &AgentConfig{Cache: &Cache{Expiration: 2 * time.Minute}},
 				Pipeline:    defaultAPMPipeline,
 				JaegerConfig: JaegerConfig{
@@ -257,7 +263,7 @@ func Test_UnpackConfig(t *testing.T) {
 						},
 					},
 				},
-				Kibana:      common.MustNewConfigFrom(map[string]interface{}{"enabled": "false"}),
+				Kibana:      defaultKibanaConfig(),
 				AgentConfig: &AgentConfig{Cache: &Cache{Expiration: 30 * time.Second}},
 				Pipeline:    defaultAPMPipeline,
 				JaegerConfig: JaegerConfig{
@@ -280,6 +286,15 @@ func Test_UnpackConfig(t *testing.T) {
 				},
 				APIKeyConfig: &APIKeyConfig{Enabled: true, LimitPerMin: 100, ESConfig: elasticsearch.DefaultConfig()},
 			},
+		},
+		"kibana trailing slash": {
+			inpCfg: map[string]interface{}{
+				"kibana": map[string]interface{}{
+					"enabled": "true",
+					"host":    "kibanahost:5601/proxy/",
+				},
+			},
+			outCfg: kibanaNoSlashConfig,
 		},
 	}
 

--- a/kibana/connecting_client_test.go
+++ b/kibana/connecting_client_test.go
@@ -113,7 +113,9 @@ type rt struct {
 }
 
 var (
-	mockCfg     = common.MustNewConfigFrom(`{"enabled": "false", "host": "non-existing"}`)
+	mockCfg = &kibana.ClientConfig{
+		Host: "non-existing",
+	}
 	mockBody    = ioutil.NopCloser(convert.ToReader(`{"response": "ok"}`))
 	mockStatus  = http.StatusOK
 	mockVersion = *common.MustNewVersion("7.3.0")


### PR DESCRIPTION
Backports the following commits to 7.x:
 - strip trailing slashes from kibana host configuration (#3277)