### PR TITLE
Separate event decoders.

### DIFF
--- a/beater/api/intake/handler_test.go
+++ b/beater/api/intake/handler_test.go
@@ -38,12 +38,10 @@ import (
 	"github.com/elastic/apm-server/beater/headers"
 	"github.com/elastic/apm-server/beater/request"
 	"github.com/elastic/apm-server/decoder"
-	"github.com/elastic/apm-server/model"
 	"github.com/elastic/apm-server/processor/stream"
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/apm-server/tests/approvals"
 	"github.com/elastic/apm-server/tests/loader"
-	"github.com/elastic/apm-server/transform"
 )
 
 func TestIntakeHandler(t *testing.T) {
@@ -184,11 +182,7 @@ func (tc *testcaseIntakeHandler) setup(t *testing.T) {
 	}
 	if tc.processor == nil {
 		cfg := config.DefaultConfig("7.0.0")
-		tc.processor = &stream.Processor{
-			Tconfig:      transform.Config{},
-			Mconfig:      model.Config{Experimental: cfg.Mode == config.ModeExperimental},
-			MaxEventSize: cfg.MaxEventSize,
-		}
+		tc.processor = stream.BackendProcessor(cfg)
 	}
 	if tc.reporter == nil {
 		tc.reporter = beatertest.NilReporter

--- a/beater/config/instrumentation_test.go
+++ b/beater/config/instrumentation_test.go
@@ -22,9 +22,10 @@ import (
 
 	"github.com/elastic/go-ucfg"
 
-	"github.com/elastic/beats/libbeat/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/libbeat/common"
 )
 
 func TestNonzeroHosts(t *testing.T) {

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -25,12 +25,13 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"go.elastic.co/apm/module/apmelasticsearch"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/version"
 	esv7 "github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 	esv8 "github.com/elastic/go-elasticsearch/v8"
-	"go.elastic.co/apm/module/apmelasticsearch"
 )
 
 // Client is an interface designed to abstract away version differences between elasticsearch clients

--- a/processor/stream/package_tests/error_attrs_test.go
+++ b/processor/stream/package_tests/error_attrs_test.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/elastic/apm-server/beater/config"
+
 	"github.com/elastic/apm-server/model/error/generated/schema"
 	"github.com/elastic/apm-server/processor/stream"
 	"github.com/elastic/apm-server/tests"
@@ -28,7 +30,9 @@ import (
 
 func errorProcSetup() *tests.ProcessorSetup {
 	return &tests.ProcessorSetup{
-		Proc:            &intakeTestProcessor{Processor: stream.Processor{MaxEventSize: lrSize}},
+		Proc: &intakeTestProcessor{
+			Processor: *stream.BackendProcessor(&config.Config{MaxEventSize: lrSize}),
+		},
 		FullPayloadPath: "../testdata/intake-v2/errors.ndjson",
 		TemplatePaths: []string{
 			"../../../model/error/_meta/fields.yml",

--- a/processor/stream/package_tests/error_attrs_test.go
+++ b/processor/stream/package_tests/error_attrs_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/elastic/apm-server/beater/config"
-
 	"github.com/elastic/apm-server/model/error/generated/schema"
 	"github.com/elastic/apm-server/processor/stream"
 	"github.com/elastic/apm-server/tests"

--- a/processor/stream/package_tests/metadata_attrs_test.go
+++ b/processor/stream/package_tests/metadata_attrs_test.go
@@ -24,12 +24,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/apm-server/decoder"
-	"github.com/elastic/apm-server/tests/loader"
-
 	"github.com/elastic/apm-server/model/metadata"
 	"github.com/elastic/apm-server/model/metadata/generated/schema"
 	"github.com/elastic/apm-server/processor/stream"
 	"github.com/elastic/apm-server/tests"
+	"github.com/elastic/apm-server/tests/loader"
 	"github.com/elastic/apm-server/validation"
 )
 

--- a/processor/stream/package_tests/metricset_attrs_test.go
+++ b/processor/stream/package_tests/metricset_attrs_test.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/elastic/apm-server/beater/config"
+
 	"github.com/elastic/apm-server/model/metricset/generated/schema"
 	"github.com/elastic/apm-server/processor/stream"
 	"github.com/elastic/apm-server/tests"
@@ -28,7 +30,9 @@ import (
 
 func metricsetProcSetup() *tests.ProcessorSetup {
 	return &tests.ProcessorSetup{
-		Proc:            &intakeTestProcessor{Processor: stream.Processor{MaxEventSize: lrSize}},
+		Proc: &intakeTestProcessor{
+			Processor: *stream.BackendProcessor(&config.Config{MaxEventSize: lrSize}),
+		},
 		FullPayloadPath: "../testdata/intake-v2/metricsets.ndjson",
 		TemplatePaths: []string{
 			"../../../model/metricset/_meta/fields.yml",

--- a/processor/stream/package_tests/metricset_attrs_test.go
+++ b/processor/stream/package_tests/metricset_attrs_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/elastic/apm-server/beater/config"
-
 	"github.com/elastic/apm-server/model/metricset/generated/schema"
 	"github.com/elastic/apm-server/processor/stream"
 	"github.com/elastic/apm-server/tests"

--- a/processor/stream/package_tests/span_attrs_test.go
+++ b/processor/stream/package_tests/span_attrs_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/elastic/apm-server/beater/config"
-
 	"github.com/elastic/apm-server/model/span/generated/schema"
 	"github.com/elastic/apm-server/processor/stream"
 	"github.com/elastic/apm-server/tests"

--- a/processor/stream/package_tests/span_attrs_test.go
+++ b/processor/stream/package_tests/span_attrs_test.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/elastic/apm-server/beater/config"
+
 	"github.com/elastic/apm-server/model/span/generated/schema"
 	"github.com/elastic/apm-server/processor/stream"
 	"github.com/elastic/apm-server/tests"
@@ -28,7 +30,9 @@ import (
 
 func spanProcSetup() *tests.ProcessorSetup {
 	return &tests.ProcessorSetup{
-		Proc:            &intakeTestProcessor{Processor: stream.Processor{MaxEventSize: lrSize}},
+		Proc: &intakeTestProcessor{
+			Processor: *stream.BackendProcessor(&config.Config{MaxEventSize: lrSize}),
+		},
 		FullPayloadPath: "../testdata/intake-v2/spans.ndjson",
 		Schema:          schema.ModelSchema,
 		SchemaPrefix:    "span",

--- a/processor/stream/package_tests/transaction_attrs_test.go
+++ b/processor/stream/package_tests/transaction_attrs_test.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/elastic/apm-server/beater/config"
+
 	"github.com/elastic/apm-server/model/transaction/generated/schema"
 	"github.com/elastic/apm-server/processor/stream"
 	"github.com/elastic/apm-server/tests"
@@ -28,7 +30,9 @@ import (
 
 func transactionProcSetup() *tests.ProcessorSetup {
 	return &tests.ProcessorSetup{
-		Proc:            &intakeTestProcessor{Processor: stream.Processor{MaxEventSize: lrSize}},
+		Proc: &intakeTestProcessor{
+			Processor: *stream.BackendProcessor(&config.Config{MaxEventSize: lrSize}),
+		},
 		FullPayloadPath: "../testdata/intake-v2/transactions.ndjson",
 		Schema:          schema.ModelSchema,
 		SchemaPrefix:    "transaction",

--- a/processor/stream/package_tests/transaction_attrs_test.go
+++ b/processor/stream/package_tests/transaction_attrs_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/elastic/apm-server/beater/config"
-
 	"github.com/elastic/apm-server/model/transaction/generated/schema"
 	"github.com/elastic/apm-server/processor/stream"
 	"github.com/elastic/apm-server/tests"


### PR DESCRIPTION
This contains the minimum set of changes for  https://github.com/elastic/apm-server/issues/2905.

Supersedes #3254