### PR TITLE
beater/authorization: remove unnecessary code

### DIFF
--- a/beater/authorization/builder.go
+++ b/beater/authorization/builder.go
@@ -69,7 +69,6 @@ func NewBuilder(cfg *config.Config) (*Builder, error) {
 		b.bearer = &bearerBuilder{cfg.SecretToken}
 		b.fallback = DenyAuth{}
 	}
-	b.fallback.IsAuthorizationConfigured()
 	return &b, nil
 }
 


### PR DESCRIPTION
IsAuthorizationConfigured has no side effects for any of the implementations, so there's no point in calling it.