### PR TITLE
[7.x] Make list of Access-Control-Allow-Headers configurable.

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -239,6 +239,10 @@ apm-server:
     # If an item in the list is a single '*', everything will be allowed.
     #allow_origins : ['*']
 
+    # A list of Access-Control-Allow-Headers to allow RUM requests, in addition to "Content-Type",
+    # "Content-Encoding", and "Accept"
+    #allow_headers : []
+
     # Regexp to be matched against a stacktrace frame's `file_name` and `abs_path` attributes.
     # If the regexp matches, the stacktrace frame is considered to be a library frame.
     #library_pattern: "node_modules|bower_components|~"

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -239,6 +239,10 @@ apm-server:
     # If an item in the list is a single '*', everything will be allowed.
     #allow_origins : ['*']
 
+    # A list of Access-Control-Allow-Headers to allow RUM requests, in addition to "Content-Type",
+    # "Content-Encoding", and "Accept"
+    #allow_headers : []
+
     # Regexp to be matched against a stacktrace frame's `file_name` and `abs_path` attributes.
     # If the regexp matches, the stacktrace frame is considered to be a library frame.
     #library_pattern: "node_modules|bower_components|~"

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -239,6 +239,10 @@ apm-server:
     # If an item in the list is a single '*', everything will be allowed.
     #allow_origins : ['*']
 
+    # A list of Access-Control-Allow-Headers to allow RUM requests, in addition to "Content-Type",
+    # "Content-Encoding", and "Accept"
+    #allow_headers : []
+
     # Regexp to be matched against a stacktrace frame's `file_name` and `abs_path` attributes.
     # If the regexp matches, the stacktrace frame is considered to be a library frame.
     #library_pattern: "node_modules|bower_components|~"

--- a/beater/api/mux.go
+++ b/beater/api/mux.go
@@ -217,7 +217,7 @@ func rumMiddleware(cfg *config.Config, _ *authorization.Handler, m map[request.R
 	return append(apmMiddleware(m),
 		middleware.SetRumFlagMiddleware(),
 		middleware.SetIPRateLimitMiddleware(cfg.RumConfig.EventRate),
-		middleware.CORSMiddleware(cfg.RumConfig.AllowOrigins),
+		middleware.CORSMiddleware(cfg.RumConfig.AllowOrigins, cfg.RumConfig.AllowHeaders),
 		middleware.KillSwitchMiddleware(cfg.RumConfig.IsEnabled(), msg))
 }
 

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -77,6 +77,7 @@ func Test_UnpackConfig(t *testing.T) {
 						"lru_size": 2000,
 					},
 					"allow_origins": []string{"example*"},
+					"allow_headers": []string{"Authorization"},
 					"source_mapping": map[string]interface{}{
 						"cache": map[string]interface{}{
 							"expiration": 8 * time.Minute,
@@ -135,6 +136,7 @@ func Test_UnpackConfig(t *testing.T) {
 						LruSize: 2000,
 					},
 					AllowOrigins: []string{"example*"},
+					AllowHeaders: []string{"Authorization"},
 					SourceMapping: &SourceMapping{
 						Cache:        &Cache{Expiration: 8 * time.Minute},
 						IndexPattern: "apm-test*",
@@ -239,6 +241,7 @@ func Test_UnpackConfig(t *testing.T) {
 						LruSize: 1000,
 					},
 					AllowOrigins: []string{"*"},
+					AllowHeaders: []string{},
 					SourceMapping: &SourceMapping{
 						Cache: &Cache{
 							Expiration: 7 * time.Second,

--- a/beater/config/rum.go
+++ b/beater/config/rum.go
@@ -45,6 +45,7 @@ type RumConfig struct {
 	Enabled             *bool          `config:"enabled"`
 	EventRate           *EventRate     `config:"event_rate"`
 	AllowOrigins        []string       `config:"allow_origins"`
+	AllowHeaders        []string       `config:"allow_headers"`
 	LibraryPattern      string         `config:"library_pattern"`
 	ExcludeFromGrouping string         `config:"exclude_from_grouping"`
 	SourceMapping       *SourceMapping `config:"source_mapping"`
@@ -146,6 +147,7 @@ func defaultRum(beatVersion string) *RumConfig {
 			LruSize: defaultEventRateLRUSize,
 		},
 		AllowOrigins: []string{allowAllOrigins},
+		AllowHeaders: []string{},
 		SourceMapping: &SourceMapping{
 			Cache: &Cache{
 				Expiration: defaultSourcemapCacheExpiration,

--- a/beater/middleware/cors_middleware.go
+++ b/beater/middleware/cors_middleware.go
@@ -29,13 +29,13 @@ import (
 )
 
 var (
-	supportedHeaders = strings.Join([]string{headers.ContentType, headers.ContentEncoding, headers.Accept}, ", ")
+	supportedHeaders = []string{headers.ContentType, headers.ContentEncoding, headers.Accept}
 	supportedMethods = strings.Join([]string{http.MethodPost, http.MethodOptions}, ", ")
 )
 
 // CORSMiddleware returns a middleware serving preflight OPTION requests and terminating requests if they do not
 // match the required valid origin.
-func CORSMiddleware(allowedOrigins []string) Middleware {
+func CORSMiddleware(allowedOrigins, allowedHeaders []string) Middleware {
 	var isAllowed = func(origin string) bool {
 		for _, allowed := range allowedOrigins {
 			if glob.Glob(allowed, origin) {
@@ -65,7 +65,8 @@ func CORSMiddleware(allowedOrigins []string) Middleware {
 
 				// required if Access-Control-Request-Method and Access-Control-Request-Headers are in the requestHeaders
 				c.Header().Set(headers.AccessControlAllowMethods, supportedMethods)
-				c.Header().Set(headers.AccessControlAllowHeaders, supportedHeaders)
+				h := append(allowedHeaders, supportedHeaders...)
+				c.Header().Set(headers.AccessControlAllowHeaders, strings.Join(h, ", "))
 
 				c.Header().Set(headers.AccessControlExposeHeaders, headers.Etag)
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Make list of Access-Control-Allow-Headers configurable. (#3299)