### PR TITLE
[7.x] beater/authorization: remove unnecessary code (#3306)

### DIFF
--- a/beater/authorization/builder.go
+++ b/beater/authorization/builder.go
@@ -69,7 +69,6 @@ func NewBuilder(cfg *config.Config) (*Builder, error) {
 		b.bearer = &bearerBuilder{cfg.SecretToken}
 		b.fallback = DenyAuth{}
 	}
-	b.fallback.IsAuthorizationConfigured()
 	return &b, nil
 }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - beater/authorization: remove unnecessary code  (#3306)