### PR TITLE
Stop syncing _beats/libbeat/tests/system/beat/ in beat updates.

### DIFF
--- a/script/update_beats.sh
+++ b/script/update_beats.sh
@@ -48,10 +48,10 @@ rsync -crpv --delete \
     --include="libbeat/processors/testing/***" \
     --include="libbeat/scripts/***" \
     --include="libbeat/testing/***" \
+    --exclude="libbeat/tests/system/beat/***" \
     --include="libbeat/tests/" \
     --include="libbeat/tests/system" \
     --include=libbeat/tests/system/requirements.txt \
-    --include="libbeat/tests/system/beat/***" \
     --exclude="libbeat/*" \
     --include=.go-version \
     --include=reviewdog.yml \


### PR DESCRIPTION
This will cause our tests to keep working when Beats migrates to Python 3.

Closes #3001 (following recommendation from https://github.com/elastic/apm-server/issues/3001#issuecomment-582459881) 

This expects #3318 to be taken on.