### PR TITLE
[7.6] Stop syncing _beats/libbeat/tests/system/beat/ in beat updates. (#3320)

### DIFF
--- a/script/update_beats.sh
+++ b/script/update_beats.sh
@@ -47,10 +47,10 @@ rsync -crpv --delete \
     --include="libbeat/processors/testing/***" \
     --include="libbeat/scripts/***" \
     --include="libbeat/testing/***" \
+    --exclude="libbeat/tests/system/beat/***" \
     --include="libbeat/tests/" \
     --include="libbeat/tests/system" \
     --include=libbeat/tests/system/requirements.txt \
-    --include="libbeat/tests/system/beat/***" \
     --exclude="libbeat/*" \
     --include=.go-version \
     --include=reviewdog.yml \


### PR DESCRIPTION
Backports the following commits to 7.6:
 - Stop syncing _beats/libbeat/tests/system/beat/ in beat updates.  (#3320)