### PR TITLE
[docs] Add note about Jaeger availability on Cloud

### DIFF
--- a/docs/jaeger-support.asciidoc
+++ b/docs/jaeger-support.asciidoc
@@ -1,7 +1,7 @@
 [[jaeger]]
 == Jaeger integration
 
-experimental::[]
+experimental::["This feature is experimental and may be changed in a future release. It is not yet available on Elastic Cloud. For feature status on Elastic Cloud, see https://github.com/elastic/apm/issues/212[#212]."]
 
 Elastic APM integrates with https://www.jaegertracing.io/[Jaeger], an open-source, distributed tracing system.
 This integration allows users with an existing Jaeger setup to switch from the default Jaeger backend,


### PR DESCRIPTION
## Motivation/summary

Adds a warning explaining that Jaeger is not yet available on Cloud.

## Checklist
~~- [ ] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).~~
~~- [ ] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)~~
- [x] I have rebased my changes on top of the latest master branch
- [x] I have made corresponding changes to the documentation
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes~~
~~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~~

## How to test these changes

N/A

## Related issues

N/A

## Screenshots

<img width="677" alt="Screen Shot 2020-02-13 at 1 24 05 PM" src="https://user-images.githubusercontent.com/5618806/74479830-bba3ed00-4e64-11ea-81b0-846a52262c13.png">
