### PR TITLE
[7.x] docs: add jaeger cloud note (#3329)

### DIFF
--- a/docs/jaeger-support.asciidoc
+++ b/docs/jaeger-support.asciidoc
@@ -1,7 +1,7 @@
 [[jaeger]]
 == Jaeger integration
 
-experimental::[]
+experimental::["This feature is experimental and may be changed in a future release. It is not yet available on Elastic Cloud. For feature status on Elastic Cloud, see https://github.com/elastic/apm/issues/212[#212]."]
 
 Elastic APM integrates with https://www.jaegertracing.io/[Jaeger], an open-source, distributed tracing system.
 This integration allows users with an existing Jaeger setup to switch from the default Jaeger backend,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: add jaeger cloud note (#3329)