### PR TITLE
Merge default values with custom API Key Elasticsearch settings

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -171,7 +171,7 @@ apm-server:
       #proxy_disable: false
 
       # Configure http request timeout before failing an request to Elasticsearch.
-      #timeout: 10s
+      #timeout: 5s
 
       # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
       #ssl.enabled: true

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -171,7 +171,7 @@ apm-server:
       #proxy_disable: false
 
       # Configure http request timeout before failing an request to Elasticsearch.
-      #timeout: 10s
+      #timeout: 5s
 
       # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
       #ssl.enabled: true

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -171,7 +171,7 @@ apm-server:
       #proxy_disable: false
 
       # Configure http request timeout before failing an request to Elasticsearch.
-      #timeout: 10s
+      #timeout: 5s
 
       # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
       #ssl.enabled: true

--- a/beater/config/api_key.go
+++ b/beater/config/api_key.go
@@ -60,7 +60,7 @@ func defaultAPIKeyConfig() *APIKeyConfig {
 }
 
 func (c *APIKeyConfig) Unpack(inp *common.Config) error {
-	cfg := tmpApiKeyConfig(*defaultAPIKeyConfig())
+	cfg := tmpAPIKeyConfig(*defaultAPIKeyConfig())
 	if err := inp.Unpack(&cfg); err != nil {
 		return errors.Errorf("error unpacking api_key config: %w", err)
 	}
@@ -71,4 +71,4 @@ func (c *APIKeyConfig) Unpack(inp *common.Config) error {
 	return nil
 }
 
-type tmpApiKeyConfig APIKeyConfig
+type tmpAPIKeyConfig APIKeyConfig

--- a/beater/config/api_key.go
+++ b/beater/config/api_key.go
@@ -34,6 +34,8 @@ type APIKeyConfig struct {
 	Enabled     bool                  `config:"enabled"`
 	LimitPerMin int                   `config:"limit"`
 	ESConfig    *elasticsearch.Config `config:"elasticsearch"`
+
+	esConfigured bool
 }
 
 // IsEnabled returns whether or not API Key authorization is enabled
@@ -42,22 +44,31 @@ func (c *APIKeyConfig) IsEnabled() bool {
 }
 
 func (c *APIKeyConfig) setup(log *logp.Logger, outputESCfg *common.Config) error {
-	if c == nil || !c.Enabled || c.ESConfig != nil {
-		return nil
-	}
-	c.ESConfig = elasticsearch.DefaultConfig()
-	if outputESCfg == nil {
+	if c == nil || !c.Enabled || c.esConfigured || outputESCfg == nil {
 		return nil
 	}
 	log.Info("Falling back to elasticsearch output for API Key usage")
 	if err := outputESCfg.Unpack(c.ESConfig); err != nil {
 		return errors.Wrap(err, "unpacking Elasticsearch config into API key config")
 	}
-
 	return nil
 
 }
 
 func defaultAPIKeyConfig() *APIKeyConfig {
-	return &APIKeyConfig{Enabled: false, LimitPerMin: apiKeyLimit}
+	return &APIKeyConfig{Enabled: false, LimitPerMin: apiKeyLimit, ESConfig: elasticsearch.DefaultConfig()}
 }
+
+func (c *APIKeyConfig) Unpack(inp *common.Config) error {
+	cfg := tmpApiKeyConfig(*defaultAPIKeyConfig())
+	if err := inp.Unpack(&cfg); err != nil {
+		return errors.Errorf("error unpacking api_key config: %w", err)
+	}
+	*c = APIKeyConfig(cfg)
+	if inp.HasField("elasticsearch") {
+		c.esConfigured = true
+	}
+	return nil
+}
+
+type tmpApiKeyConfig APIKeyConfig

--- a/beater/config/api_key_test.go
+++ b/beater/config/api_key_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/libbeat/logp"
 
 	"github.com/stretchr/testify/assert"
@@ -38,39 +40,42 @@ func TestAPIKeyConfig_IsEnabled(t *testing.T) {
 
 func TestAPIKeyConfig_ESConfig(t *testing.T) {
 	for name, tc := range map[string]struct {
-		cfg   *APIKeyConfig
+		cfg   *common.Config
 		esCfg *common.Config
 
 		expectedConfig *APIKeyConfig
 		expectedErr    error
 	}{
 		"default": {
-			cfg:            defaultAPIKeyConfig(),
+			cfg:            common.NewConfig(),
 			expectedConfig: defaultAPIKeyConfig(),
 		},
 		"ES config missing": {
-			cfg: &APIKeyConfig{Enabled: true, LimitPerMin: apiKeyLimit},
+			cfg: common.MustNewConfigFrom(`{"enabled": true}`),
 			expectedConfig: &APIKeyConfig{
 				Enabled:     true,
 				LimitPerMin: apiKeyLimit,
 				ESConfig:    elasticsearch.DefaultConfig()},
 		},
 		"ES configured": {
-			cfg: &APIKeyConfig{
-				Enabled:  true,
-				ESConfig: &elasticsearch.Config{Hosts: elasticsearch.Hosts{"192.0.0.1:9200"}}},
+			cfg:   common.MustNewConfigFrom(`{"enabled": true, "elasticsearch.timeout":"7s"}`),
 			esCfg: common.MustNewConfigFrom(`{"hosts":["186.0.0.168:9200"]}`),
 			expectedConfig: &APIKeyConfig{
-				Enabled:  true,
-				ESConfig: &elasticsearch.Config{Hosts: elasticsearch.Hosts{"192.0.0.1:9200"}}},
+				Enabled:     true,
+				LimitPerMin: apiKeyLimit,
+				ESConfig: &elasticsearch.Config{
+					Hosts:    elasticsearch.Hosts{"localhost:9200"},
+					Protocol: "http",
+					Timeout:  7 * time.Second},
+				esConfigured: true},
 		},
 		"disabled with ES from output": {
-			cfg:            defaultAPIKeyConfig(),
+			cfg:            common.NewConfig(),
 			esCfg:          common.MustNewConfigFrom(`{"hosts":["192.0.0.168:9200"]}`),
 			expectedConfig: defaultAPIKeyConfig(),
 		},
 		"ES from output": {
-			cfg:   &APIKeyConfig{Enabled: true, LimitPerMin: 20},
+			cfg:   common.MustNewConfigFrom(`{"enabled": true, "limit": 20}`),
 			esCfg: common.MustNewConfigFrom(`{"hosts":["192.0.0.168:9200"],"username":"foo","password":"bar"}`),
 			expectedConfig: &APIKeyConfig{
 				Enabled:     true,
@@ -84,13 +89,15 @@ func TestAPIKeyConfig_ESConfig(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			err := tc.cfg.setup(logp.NewLogger("api_key"), tc.esCfg)
+			var apiKeyConfig APIKeyConfig
+			require.NoError(t, tc.cfg.Unpack(&apiKeyConfig))
+			err := apiKeyConfig.setup(logp.NewLogger("api_key"), tc.esCfg)
 			if tc.expectedErr == nil {
 				assert.NoError(t, err)
 			} else {
 				assert.Error(t, err)
 			}
-			assert.Equal(t, tc.expectedConfig, tc.cfg)
+			assert.Equal(t, tc.expectedConfig, &apiKeyConfig)
 
 		})
 	}

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -187,7 +187,11 @@ func Test_UnpackConfig(t *testing.T) {
 				APIKeyConfig: &APIKeyConfig{
 					Enabled:     true,
 					LimitPerMin: 200,
-					ESConfig:    &elasticsearch.Config{Hosts: elasticsearch.Hosts{"localhost:9201", "localhost:9202"}},
+					ESConfig: &elasticsearch.Config{
+						Hosts:    elasticsearch.Hosts{"localhost:9201", "localhost:9202"},
+						Protocol: "http",
+						Timeout:  5 * time.Second},
+					esConfigured: true,
 				},
 			},
 		},

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -9,6 +9,10 @@ https://github.com/elastic/apm-server/compare/7.6\...master[View commits]
 * Remove enroll subcommand {pull}3270[3270].
 
 [float]
+==== Bugfixes
+* Merge default values with custom Elasticsearch config for API Keys and add `required` tag for `host` {pull}3342[3342]
+
+[float]
 ==== Intake API Changes
 * Add `transfer_size`, `encoded_body_size`  and `decoded_body_size` to `transaction.context.http.response` {pull}3327[3327]
 * Add `transfer_size`, `encoded_body_size`, `decoded_body_size` and `headers` to `span.context.http.response` {pull}3327[3327]

--- a/elasticsearch/config.go
+++ b/elasticsearch/config.go
@@ -44,7 +44,7 @@ var (
 
 // Config holds all configurable fields that are used to create a Client
 type Config struct {
-	Hosts        Hosts             `config:"hosts"`
+	Hosts        Hosts             `config:"hosts" validate:"required"`
 	Protocol     string            `config:"protocol"`
 	Path         string            `config:"path"`
 	ProxyURL     string            `config:"proxy_url"`


### PR DESCRIPTION
## Motivation/summary
When configuring an Elasticsearch instance for API Key usage, Elasticsearch default values should be merged with the custom configuration.

At the moment default values are not merged as soon as any of the `apm-server.api_key.elasticsearch.*` options is configured, which is unexpected behavior and not aligned with how other configuration options are merged with default values. 

This PR changes the behavior to use default options where no dedicated configuration option is provided. This change also allows to add the `required` flag for the Elasticsearch `host` option again, as now the host is always set by default. 

## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved
List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->
~- [ ] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).~
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest master branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
~- [ ] I have made corresponding changes to the documentation~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-server/blob/master/TESTING.md for details.
-->
- [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

## How to test these changes
<!--
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
Configure some option of `apm-server.api_key.elasticsearch.*` and ensure default values are applied for missing configuration options.
Default values are `hosts: []string{"localhost:9200"}, protocol: "http", timeout: 5s`. 

E.g. ensure to have a locally running Elasticsearch instance with security enabled and run `./apm-server apikey create -e -E apm-server.api_key.enabled=true -E apm-server.api_key.elasticsearch.username=foo -E apm-server.api_key.elasticsearch.password=bar` 
When providing proper username+password this should create an API Key, by using the default `host` configuration of `localhost:9200`. 

## Related issues

fixes #3341

<!--
If this PR should close an issue, please add one of the magic keywords
(e.g. fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/
Examples:
- Closes #ISSUE_ID
- Relates #ISSUE_ID
- Requires #ISSUE_ID
- Supersedes #ISSUE_ID
-->
