### PR TITLE
[7.6] Merge default values with custom API Key Elasticsearch settings (#3342)

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -171,7 +171,7 @@ apm-server:
       #proxy_disable: false
 
       # Configure http request timeout before failing an request to Elasticsearch.
-      #timeout: 10s
+      #timeout: 5s
 
       # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
       #ssl.enabled: true

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -171,7 +171,7 @@ apm-server:
       #proxy_disable: false
 
       # Configure http request timeout before failing an request to Elasticsearch.
-      #timeout: 10s
+      #timeout: 5s
 
       # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
       #ssl.enabled: true

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -171,7 +171,7 @@ apm-server:
       #proxy_disable: false
 
       # Configure http request timeout before failing an request to Elasticsearch.
-      #timeout: 10s
+      #timeout: 5s
 
       # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
       #ssl.enabled: true

--- a/beater/config/api_key_test.go
+++ b/beater/config/api_key_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/elastic/beats/libbeat/logp"
 
 	"github.com/stretchr/testify/assert"
@@ -38,39 +40,42 @@ func TestAPIKeyConfig_IsEnabled(t *testing.T) {
 
 func TestAPIKeyConfig_ESConfig(t *testing.T) {
 	for name, tc := range map[string]struct {
-		cfg   *APIKeyConfig
+		cfg   *common.Config
 		esCfg *common.Config
 
 		expectedConfig *APIKeyConfig
 		expectedErr    error
 	}{
 		"default": {
-			cfg:            defaultAPIKeyConfig(),
+			cfg:            common.NewConfig(),
 			expectedConfig: defaultAPIKeyConfig(),
 		},
 		"ES config missing": {
-			cfg: &APIKeyConfig{Enabled: true, LimitPerMin: apiKeyLimit},
+			cfg: common.MustNewConfigFrom(`{"enabled": true}`),
 			expectedConfig: &APIKeyConfig{
 				Enabled:     true,
 				LimitPerMin: apiKeyLimit,
 				ESConfig:    elasticsearch.DefaultConfig()},
 		},
 		"ES configured": {
-			cfg: &APIKeyConfig{
-				Enabled:  true,
-				ESConfig: &elasticsearch.Config{Hosts: elasticsearch.Hosts{"192.0.0.1:9200"}}},
+			cfg:   common.MustNewConfigFrom(`{"enabled": true, "elasticsearch.timeout":"7s"}`),
 			esCfg: common.MustNewConfigFrom(`{"hosts":["186.0.0.168:9200"]}`),
 			expectedConfig: &APIKeyConfig{
-				Enabled:  true,
-				ESConfig: &elasticsearch.Config{Hosts: elasticsearch.Hosts{"192.0.0.1:9200"}}},
+				Enabled:     true,
+				LimitPerMin: apiKeyLimit,
+				ESConfig: &elasticsearch.Config{
+					Hosts:    elasticsearch.Hosts{"localhost:9200"},
+					Protocol: "http",
+					Timeout:  7 * time.Second},
+				esConfigured: true},
 		},
 		"disabled with ES from output": {
-			cfg:            defaultAPIKeyConfig(),
+			cfg:            common.NewConfig(),
 			esCfg:          common.MustNewConfigFrom(`{"hosts":["192.0.0.168:9200"]}`),
 			expectedConfig: defaultAPIKeyConfig(),
 		},
 		"ES from output": {
-			cfg:   &APIKeyConfig{Enabled: true, LimitPerMin: 20},
+			cfg:   common.MustNewConfigFrom(`{"enabled": true, "limit": 20}`),
 			esCfg: common.MustNewConfigFrom(`{"hosts":["192.0.0.168:9200"],"username":"foo","password":"bar"}`),
 			expectedConfig: &APIKeyConfig{
 				Enabled:     true,
@@ -84,13 +89,15 @@ func TestAPIKeyConfig_ESConfig(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			err := tc.cfg.setup(logp.NewLogger("api_key"), tc.esCfg)
+			var apiKeyConfig APIKeyConfig
+			require.NoError(t, tc.cfg.Unpack(&apiKeyConfig))
+			err := apiKeyConfig.setup(logp.NewLogger("api_key"), tc.esCfg)
 			if tc.expectedErr == nil {
 				assert.NoError(t, err)
 			} else {
 				assert.Error(t, err)
 			}
-			assert.Equal(t, tc.expectedConfig, tc.cfg)
+			assert.Equal(t, tc.expectedConfig, &apiKeyConfig)
 
 		})
 	}

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -179,7 +179,11 @@ func Test_UnpackConfig(t *testing.T) {
 				APIKeyConfig: &APIKeyConfig{
 					Enabled:     true,
 					LimitPerMin: 200,
-					ESConfig:    &elasticsearch.Config{Hosts: elasticsearch.Hosts{"localhost:9201", "localhost:9202"}},
+					ESConfig: &elasticsearch.Config{
+						Hosts:    elasticsearch.Hosts{"localhost:9201", "localhost:9202"},
+						Protocol: "http",
+						Timeout:  5 * time.Second},
+					esConfigured: true,
 				},
 			},
 		},

--- a/changelogs/7.6.asciidoc
+++ b/changelogs/7.6.asciidoc
@@ -3,7 +3,17 @@
 
 https://github.com/elastic/apm-server/compare/7.5\...7.6[View commits]
 
+* <<release-notes-7.6.1>>
 * <<release-notes-7.6.0>>
+
+[[release-notes-7.6.1]]
+=== APM Server version 7.6.1
+
+https://github.com/elastic/apm-server/compare/v7.6.0\...v7.6.1[View commits]
+
+[float]
+==== Bug fixes
+* Merge default values with custom Elasticsearch config for API Keys and add `required` tag for `host` {pull}3342[3342]
 
 [[release-notes-7.6.0]]
 === APM Server version 7.6.0

--- a/elasticsearch/config.go
+++ b/elasticsearch/config.go
@@ -44,7 +44,7 @@ var (
 
 // Config holds all configurable fields that are used to create a Client
 type Config struct {
-	Hosts        Hosts             `config:"hosts"`
+	Hosts        Hosts             `config:"hosts" validate:"required"`
 	Protocol     string            `config:"protocol"`
 	Path         string            `config:"path"`
 	ProxyURL     string            `config:"proxy_url"`


### PR DESCRIPTION
Backports the following commits to 7.6:
 - Merge default values with custom API Key Elasticsearch settings (#3342)