### PR TITLE
Instrument kibana client with apm go agent

### DIFF
--- a/agentcfg/fetch.go
+++ b/agentcfg/fetch.go
@@ -18,6 +18,7 @@
 package agentcfg
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -59,16 +60,16 @@ func NewFetcher(client kibana.Client, cacheExpiration time.Duration) *Fetcher {
 }
 
 // Fetch retrieves agent configuration, fetched from Kibana or a local temporary cache.
-func (f *Fetcher) Fetch(query Query) (Result, error) {
+func (f *Fetcher) Fetch(ctx context.Context, query Query) (Result, error) {
 	req := func() (Result, error) {
-		return newResult(f.request(convert.ToReader(query)))
+		return newResult(f.request(ctx, convert.ToReader(query)))
 	}
 	result, err := f.fetch(query, req)
 	return sanitize(query.IsRum, result), err
 }
 
-func (f *Fetcher) request(r io.Reader) ([]byte, error) {
-	resp, err := f.client.Send(http.MethodPost, endpoint, nil, nil, r)
+func (f *Fetcher) request(ctx context.Context, r io.Reader) ([]byte, error) {
+	resp, err := f.client.Send(ctx, http.MethodPost, endpoint, nil, nil, r)
 	if err != nil {
 		return nil, errors.Wrap(err, ErrMsgSendToKibanaFailed)
 	}

--- a/agentcfg/fetch_test.go
+++ b/agentcfg/fetch_test.go
@@ -18,6 +18,7 @@
 package agentcfg
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -43,14 +44,14 @@ func TestFetcher_Fetch(t *testing.T) {
 
 	t.Run("ExpectationFailed", func(t *testing.T) {
 		kb := tests.MockKibana(http.StatusExpectationFailed, m{"error": "an error"}, mockVersion, true)
-		_, err := NewFetcher(kb, testExpiration).Fetch(query(t.Name()))
+		_, err := NewFetcher(kb, testExpiration).Fetch(context.Background(), query(t.Name()))
 		require.Error(t, err)
 		assert.Equal(t, "{\"error\":\"an error\"}", err.Error())
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
 		kb := tests.MockKibana(http.StatusNotFound, m{}, mockVersion, true)
-		result, err := NewFetcher(kb, testExpiration).Fetch(query(t.Name()))
+		result, err := NewFetcher(kb, testExpiration).Fetch(context.Background(), query(t.Name()))
 		require.NoError(t, err)
 		assert.Equal(t, zeroResult(), result)
 	})
@@ -60,7 +61,7 @@ func TestFetcher_Fetch(t *testing.T) {
 		b, err := json.Marshal(mockDoc(0.5))
 		expectedResult, err := newResult(b, err)
 		require.NoError(t, err)
-		result, err := NewFetcher(kb, testExpiration).Fetch(query(t.Name()))
+		result, err := NewFetcher(kb, testExpiration).Fetch(context.Background(), query(t.Name()))
 		require.NoError(t, err)
 		assert.Equal(t, expectedResult, result)
 	})
@@ -79,7 +80,7 @@ func TestFetcher_Fetch(t *testing.T) {
 			expectedResult, err := newResult(b, err)
 			require.NoError(t, err)
 
-			result, err := f.Fetch(query(t.Name()))
+			result, err := f.Fetch(context.Background(), query(t.Name()))
 			require.NoError(t, err)
 			assert.Equal(t, expectedResult, result)
 		}

--- a/beater/api/config/agent/handler_test.go
+++ b/beater/api/config/agent/handler_test.go
@@ -344,14 +344,12 @@ func TestIfNoneMatch(t *testing.T) {
 
 func TestAgetCofigTraceContext(t *testing.T) {
 	kibanaCfg := libkibana.DefaultClientConfig()
+	kibanaCfg.Host = "testKibana:12345"
 	client := kibana.NewConnectingClient(&kibanaCfg)
 	handler := Handler(client, &config.AgentConfig{Cache: &config.Cache{Expiration: 5 * time.Minute}})
 	_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
 		// When the handler is called with a context containing
-		// a transaction, the underlying Kibana query should create
-		// a span for the `SupportsVersion` check and one for
-		// a span for the `Send` method
-
+		// a transaction, the underlying Kibana query should create a span
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPost, "/backend", convert.ToReader(m{
 			"service": m{"name": "opbeans"}}))
@@ -360,7 +358,7 @@ func TestAgetCofigTraceContext(t *testing.T) {
 		c.Reset(w, r)
 		handler(c)
 	})
-	require.Len(t, spans, 2)
+	require.Len(t, spans, 1)
 	assert.Equal(t, "custom", spans[0].Type)
 }
 

--- a/beater/api/config/agent/handler_test.go
+++ b/beater/api/config/agent/handler_test.go
@@ -342,7 +342,7 @@ func TestIfNoneMatch(t *testing.T) {
 	assert.Equal(t, "123", ifNoneMatch(fromQueryArg("123")))
 }
 
-func TestAgetCofigTraceContext(t *testing.T) {
+func TestAgentConfigTraceContext(t *testing.T) {
 	kibanaCfg := libkibana.DefaultClientConfig()
 	kibanaCfg.Host = "testKibana:12345"
 	client := kibana.NewConnectingClient(&kibanaCfg)

--- a/beater/api/config/agent/handler_test.go
+++ b/beater/api/config/agent/handler_test.go
@@ -359,7 +359,7 @@ func TestAgentConfigTraceContext(t *testing.T) {
 		handler(c)
 	})
 	require.Len(t, spans, 1)
-	assert.Equal(t, "custom", spans[0].Type)
+	assert.Equal(t, "app", spans[0].Type)
 }
 
 func target(params map[string]string) string {

--- a/beater/api/config/agent/handler_test.go
+++ b/beater/api/config/agent/handler_test.go
@@ -18,6 +18,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -27,17 +28,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/apm-server/agentcfg"
-
-	"golang.org/x/time/rate"
-
-	"github.com/elastic/apm-server/beater/authorization"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.elastic.co/apm/apmtest"
+	"golang.org/x/time/rate"
 
 	"github.com/elastic/beats/libbeat/common"
+	libkibana "github.com/elastic/beats/libbeat/kibana"
 
+	"github.com/elastic/apm-server/agentcfg"
+	"github.com/elastic/apm-server/beater/authorization"
 	"github.com/elastic/apm-server/beater/config"
 	"github.com/elastic/apm-server/beater/headers"
 	"github.com/elastic/apm-server/beater/request"
@@ -340,6 +340,28 @@ func TestIfNoneMatch(t *testing.T) {
 	assert.Equal(t, "123", ifNoneMatch(fromHeader("123")))
 	assert.Equal(t, "123", ifNoneMatch(fromHeader(`"123"`)))
 	assert.Equal(t, "123", ifNoneMatch(fromQueryArg("123")))
+}
+
+func TestAgetCofigTraceContext(t *testing.T) {
+	kibanaCfg := libkibana.DefaultClientConfig()
+	client := kibana.NewConnectingClient(&kibanaCfg)
+	handler := Handler(client, &config.AgentConfig{Cache: &config.Cache{Expiration: 5 * time.Minute}})
+	_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		// When the handler is called with a context containing
+		// a transaction, the underlying Kibana query should create
+		// a span for the `SupportsVersion` check and one for
+		// a span for the `Send` method
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/backend", convert.ToReader(m{
+			"service": m{"name": "opbeans"}}))
+		r = r.WithContext(ctx)
+		c := request.NewContext()
+		c.Reset(w, r)
+		handler(c)
+	})
+	require.Len(t, spans, 2)
+	assert.Equal(t, "custom", spans[0].Type)
 }
 
 func target(params map[string]string) string {

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -21,8 +21,8 @@ https://github.com/elastic/apm-server/compare/7.6\...master[View commits]
 
 [float]
 ==== Added
-
 * Instrumentation for go-elasticsearch {pull}3305[3305]
 * Make configurable the list of Access-Control-Allow-Headers for RUM preflight requests {pull}3299[3299]
 * Initial RUM V3 endpoint {pull}3328[3328]
 * Upgrade Go to 1.13.8 {pull}3326[3326]
+* Instrumentation for kibana client {pull}3359[3359]

--- a/kibana/connecting_client.go
+++ b/kibana/connecting_client.go
@@ -98,7 +98,7 @@ func (c *ConnectingClient) Send(ctx context.Context, method, extraPath string, p
 // GetVersion returns Kibana version or an error
 // If no connection is established an error is returned
 func (c *ConnectingClient) GetVersion(ctx context.Context) (common.Version, error) {
-	span, _ := apm.StartSpan(ctx, "GetVersion", "custom")
+	span, _ := apm.StartSpan(ctx, "GetVersion", "app")
 	defer span.End()
 	c.m.RLock()
 	defer c.m.RUnlock()
@@ -111,7 +111,7 @@ func (c *ConnectingClient) GetVersion(ctx context.Context) (common.Version, erro
 // SupportsVersion checks if connected Kibana instance is compatible to given version
 // If no connection is established an error is returned
 func (c *ConnectingClient) SupportsVersion(ctx context.Context, v *common.Version, retry bool) (bool, error) {
-	span, ctx := apm.StartSpan(ctx, "SupportsVersion", "custom")
+	span, ctx := apm.StartSpan(ctx, "SupportsVersion", "app")
 	defer span.End()
 	log := logp.NewLogger(logs.Kibana)
 	c.m.RLock()

--- a/kibana/connecting_client.go
+++ b/kibana/connecting_client.go
@@ -92,8 +92,7 @@ func (c *ConnectingClient) Send(ctx context.Context, method, extraPath string, p
 	if c.client == nil {
 		return nil, errNotConnected
 	}
-
-	return c.client.Send(ctx, method, extraPath, params, headers, body)
+	return c.client.SendWithContext(ctx, method, extraPath, params, headers, body)
 }
 
 // GetVersion returns Kibana version or an error

--- a/kibana/connecting_client_test.go
+++ b/kibana/connecting_client_test.go
@@ -18,6 +18,7 @@
 package kibana
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -41,7 +42,7 @@ func TestNewConnectingClientFrom(t *testing.T) {
 func TestConnectingClient_Send(t *testing.T) {
 	t.Run("Send", func(t *testing.T) {
 		c := mockClient()
-		r, err := c.Send(http.MethodGet, "", nil, nil, nil)
+		r, err := c.Send(context.Background(), http.MethodGet, "", nil, nil, nil)
 		require.NoError(t, err)
 		assert.Equal(t, mockBody, r.Body)
 		assert.Equal(t, mockStatus, r.StatusCode)
@@ -49,7 +50,7 @@ func TestConnectingClient_Send(t *testing.T) {
 
 	t.Run("SendError", func(t *testing.T) {
 		c := NewConnectingClient(mockCfg)
-		r, err := c.Send(http.MethodGet, "", nil, nil, nil)
+		r, err := c.Send(context.Background(), http.MethodGet, "", nil, nil, nil)
 		require.Error(t, err)
 		assert.Equal(t, err, errNotConnected)
 		assert.Nil(t, r)
@@ -59,14 +60,14 @@ func TestConnectingClient_Send(t *testing.T) {
 func TestConnectingClient_GetVersion(t *testing.T) {
 	t.Run("GetVersion", func(t *testing.T) {
 		c := mockClient()
-		v, err := c.GetVersion()
+		v, err := c.GetVersion(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, mockVersion, v)
 	})
 
 	t.Run("GetVersionError", func(t *testing.T) {
 		c := NewConnectingClient(mockCfg)
-		v, err := c.GetVersion()
+		v, err := c.GetVersion(context.Background())
 		require.Error(t, err)
 		assert.Equal(t, err, errNotConnected)
 		assert.Equal(t, common.Version{}, v)
@@ -76,35 +77,23 @@ func TestConnectingClient_GetVersion(t *testing.T) {
 func TestConnectingClient_SupportsVersion(t *testing.T) {
 	t.Run("SupportsVersionTrue", func(t *testing.T) {
 		c := mockClient()
-		s, err := c.SupportsVersion(common.MustNewVersion("7.3.0"), false)
+		s, err := c.SupportsVersion(context.Background(), common.MustNewVersion("7.3.0"), false)
 		require.NoError(t, err)
 		assert.True(t, s)
 	})
 	t.Run("SupportsVersionFalse", func(t *testing.T) {
 		c := mockClient()
-		s, err := c.SupportsVersion(common.MustNewVersion("7.4.0"), false)
+		s, err := c.SupportsVersion(context.Background(), common.MustNewVersion("7.4.0"), false)
 		require.NoError(t, err)
 		assert.False(t, s)
 	})
 
 	t.Run("SupportsVersionError", func(t *testing.T) {
 		c := NewConnectingClient(mockCfg)
-		s, err := c.SupportsVersion(common.MustNewVersion("7.3.0"), false)
+		s, err := c.SupportsVersion(context.Background(), common.MustNewVersion("7.3.0"), false)
 		require.Error(t, err)
 		assert.Equal(t, err, errNotConnected)
 		assert.False(t, s)
-	})
-}
-
-func TestConnectingClient_Connected(t *testing.T) {
-	t.Run("Connected", func(t *testing.T) {
-		c := mockClient()
-		require.True(t, c.Connected())
-	})
-
-	t.Run("NotConnected", func(t *testing.T) {
-		c := NewConnectingClient(mockCfg)
-		require.False(t, c.Connected())
 	})
 }
 

--- a/tests/kibana.go
+++ b/tests/kibana.go
@@ -18,6 +18,7 @@
 package tests
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -40,7 +41,7 @@ type MockKibanaClient struct {
 }
 
 // Send returns a mock http.Response based on parameters used to init the MockKibanaClient instance
-func (c *MockKibanaClient) Send(method, extraPath string, params url.Values,
+func (c *MockKibanaClient) Send(_ context.Context, method, extraPath string, params url.Values,
 	headers http.Header, body io.Reader) (*http.Response, error) {
 	resp := http.Response{StatusCode: c.code, Body: ioutil.NopCloser(convert.ToReader(c.body))}
 	if resp.StatusCode == http.StatusBadGateway {
@@ -50,15 +51,12 @@ func (c *MockKibanaClient) Send(method, extraPath string, params url.Values,
 }
 
 // GetVersion returns a mock version based on parameters used to init the MockKibanaClient instance
-func (c *MockKibanaClient) GetVersion() (common.Version, error) {
+func (c *MockKibanaClient) GetVersion(context.Context) (common.Version, error) {
 	return c.v, nil
 }
 
-// Connected returns whether or not mock client is connected
-func (c *MockKibanaClient) Connected() bool { return c.connected }
-
 // SupportsVersion returns whether or not mock client is compatible with given version
-func (c *MockKibanaClient) SupportsVersion(v *common.Version, _ bool) (bool, error) {
+func (c *MockKibanaClient) SupportsVersion(_ context.Context, v *common.Version, _ bool) (bool, error) {
 	if !c.connected {
 		return false, errors.New("unable to retrieve connection to Kibana")
 	}

--- a/vendor/github.com/elastic/beats/libbeat/kibana/client.go
+++ b/vendor/github.com/elastic/beats/libbeat/kibana/client.go
@@ -158,7 +158,7 @@ func NewClientWithConfig(config *ClientConfig) (*Client, error) {
 func (conn *Connection) Request(method, extraPath string,
 	params url.Values, headers http.Header, body io.Reader) (int, []byte, error) {
 
-	resp, err := conn.Send(context.TODO(), method, extraPath, params, headers, body)
+	resp, err := conn.Send(method, extraPath, params, headers, body)
 	if err != nil {
 		return 0, nil, fmt.Errorf("fail to execute the HTTP %s request: %v", method, err)
 	}
@@ -179,7 +179,7 @@ func (conn *Connection) Request(method, extraPath string,
 }
 
 // Sends an application/json request to Kibana with appropriate kbn headers
-func (conn *Connection) Send(ctx context.Context, method, extraPath string,
+func (conn *Connection) Send(method, extraPath string,
 	params url.Values, headers http.Header, body io.Reader) (*http.Response, error) {
 
 	return conn.SendWithContext(context.Background(), method, extraPath, params, headers, body)

--- a/vendor/github.com/elastic/beats/libbeat/kibana/client.go
+++ b/vendor/github.com/elastic/beats/libbeat/kibana/client.go
@@ -158,7 +158,7 @@ func NewClientWithConfig(config *ClientConfig) (*Client, error) {
 func (conn *Connection) Request(method, extraPath string,
 	params url.Values, headers http.Header, body io.Reader) (int, []byte, error) {
 
-	resp, err := conn.Send(method, extraPath, params, headers, body)
+	resp, err := conn.Send(context.TODO(), method, extraPath, params, headers, body)
 	if err != nil {
 		return 0, nil, fmt.Errorf("fail to execute the HTTP %s request: %v", method, err)
 	}
@@ -179,7 +179,7 @@ func (conn *Connection) Request(method, extraPath string,
 }
 
 // Sends an application/json request to Kibana with appropriate kbn headers
-func (conn *Connection) Send(method, extraPath string,
+func (conn *Connection) Send(ctx context.Context, method, extraPath string,
 	params url.Values, headers http.Header, body io.Reader) (*http.Response, error) {
 
 	return conn.SendWithContext(context.Background(), method, extraPath, params, headers, body)


### PR DESCRIPTION
## Motivation/summary
This adds elastic apm instrumentation to the kibana client, and adds context passing to all client methods.

This change allows to gain more insights into outgoing requests to Kibana, as part of the Agent Configuration endpoint. For the moment it adds instrumentation to the APM Server code only, but once [the instrumentation is also added to beats](https://github.com/elastic/beats/pull/16427), the `apmhttp` auto-instrumentation can be leveraged for outgoing calls. 

closes #3185


## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved
List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->
~- [ ] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).~
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest master branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
~- [ ] I have made corresponding changes to the documentation~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-server/blob/master/TESTING.md for details.
-->
- [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

## How to test these changes
<!--
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Start APM Server with `rum` and `kibana` enabled, and start the Elastic Stack. Make a request to the agent config endpoint, e.g. `curl -i "http://localhost:8200/config/v1/agents?service.name=123"` and ensure the outgoing request to Kibana is recorded. 

<img width="1614" alt="Screenshot 2020-02-19 at 17 14 28" src="https://user-images.githubusercontent.com/5555349/74851285-53a94700-533b-11ea-80e1-3e332a40f95d.png">

## Related issues

closes #3185 
<!--
If this PR should close an issue, please add one of the magic keywords
(e.g. fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/
Examples:
- Closes #ISSUE_ID
- Relates #ISSUE_ID
- Requires #ISSUE_ID
- Supersedes #ISSUE_ID
-->
