### PR TITLE
ci(jenkins): retry build docker image up to 3 times with some sleep

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -440,7 +440,11 @@ pipeline {
 }
 
 def golang(Closure body){
-  def golangDocker = docker.build("golang-mage", "--build-arg GO_VERSION=${GO_VERSION} ${BASE_DIR}/.ci/docker/golang-mage")
+  def golangDocker
+  retry(3) { // Retry in case there are any errors when building the docker images (to avoid temporary glitches)
+    sleep randomNumber(min: 2, max: 5)
+    golangDocker = docker.build('golang-mage', "--build-arg GO_VERSION=${GO_VERSION} ${BASE_DIR}/.ci/docker/golang-mage")
+  }
   withEnv(["HOME=${WORKSPACE}", "GOPATH=${WORKSPACE}", "SHELL=/bin/bash"]) {
      golangDocker.inside('-v /usr/bin/docker:/usr/bin/docker -v /var/run/docker.sock:/var/run/docker.sock'){
        body()


### PR DESCRIPTION
## Motivation/summary

A way to avoid glitches when there are issues to access the public docker registry.

```
docker build -t golang-mage --build-arg GO_VERSION=1.13.8 src/github.com/elastic/apm-server/.ci/docker/golang-mage
Sending build context to Docker daemon   2.56kB
Step 1/7 : ARG GO_VERSION=1.13.8
Step 2/7 : FROM golang:${GO_VERSION}
Get https://registry-1.docker.io/v2/: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
```

For such, it will retry to build the docker image up to 3 times with some sleep between 2 to 5 seconds.

##
- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch

## How to test these changes

Run the pipeline and cross fingers