### PR TITLE
magefile: don't package _meta/kibana.generated

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -264,9 +264,8 @@ func customizePackaging() {
 	)
 	for idx := len(mage.Packages) - 1; idx >= 0; idx-- {
 		args := &mage.Packages[idx]
-		pkgType := args.Types[0]
-		switch pkgType {
 
+		switch pkgType := args.Types[0]; pkgType {
 		case mage.Zip, mage.TarGz:
 			// Remove the reference config file from packages.
 			delete(args.Spec.Files, "{{.BeatName}}.reference.yml")
@@ -300,11 +299,19 @@ func customizePackaging() {
 			}
 
 		case mage.DMG:
+			// We do not build macOS packages.
 			mage.Packages = append(mage.Packages[:idx], mage.Packages[idx+1:]...)
+			continue
 
 		default:
 			panic(errors.Errorf("unhandled package type: %v", pkgType))
+		}
 
+		// Remove Kibana dashboard files.
+		for filename, filespec := range args.Spec.Files {
+			if strings.HasPrefix(filespec.Source, "_meta/kibana") {
+				delete(args.Spec.Files, filename)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Motivation/summary

This is part of the Makefile rewrite.

We don't package any dashboards, and index patterns are generated. Removing `_meta/kibana*` from packaging allows us to stop building those bits unnecessarily.

## Checklist
- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes~
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~ (no user-facing impact)

## How to test these changes

`make release`

## Related issues

Pulled out of #3368