### PR TITLE
[docs] Link to ES Geo IP processor

### DIFF
--- a/docs/configuration-rum.asciidoc
+++ b/docs/configuration-rum.asciidoc
@@ -103,7 +103,7 @@ If changed, a matching index pattern needs to be specified here.
 By default, <<register.ingest.pipeline.enabled,`register.ingest.pipeline.enabled`>> is set to `true`.
 This loads the default pipeline definition to Elasticsearch on APM Server startup.
 
-The default pipeline is `apm`. It adds user agent information to events and processes Geo-IP data,
+The default pipeline is `apm`. It adds user agent information to events and processes {ref}/geoip-processor.html[Geo-IP data],
 which is especially useful for Elastic's {apm-rum-ref-v}/index.html[JavaScript RUM Agent].
 You can view the pipeline configuration by navigating to the APM Server's home directory and then
 viewing `ingest/pipeline/definition.json`.

--- a/docs/configuring-ingest.asciidoc
+++ b/docs/configuring-ingest.asciidoc
@@ -19,7 +19,7 @@ For example, a pipeline can define one processor to remove a field, and another 
 By default, <<register.ingest.pipeline.enabled,`register.ingest.pipeline.enabled`>> is set to `true`.
 This loads the default pipeline definition to Elasticsearch on APM Server startup.
 
-The default pipeline is `apm`. It adds user agent information to events and processes Geo-IP data,
+The default pipeline is `apm`. It adds user agent information to events and processes {ref}/geoip-processor.html[Geo-IP data],
 which is especially useful for Elastic's {apm-rum-ref-v}/index.html[JavaScript RUM Agent].
 You can view the pipeline configuration by navigating to the APM Server's home directory and then
 viewing `ingest/pipeline/definition.json`.

--- a/docs/guide/apm-release-notes.asciidoc
+++ b/docs/guide/apm-release-notes.asciidoc
@@ -262,7 +262,7 @@ image::images/apm-highlight-rum-maps.png[APM sample rate configuration in Kibana
 * Added support for {apm-server-ref-v}/ilm.html[index lifecycle management (ILM)]:
 ILM enables you to automate how you want to manage your indices over time,
 by automating rollovers to a new index when the existing index reaches a specified size or age.
-* Added Geo-IP processing to the default ingest pipeline:
+* Added {ref}/geoip-processor.html[Geo-IP] processing to the default ingest pipeline:
 Pipelines are still disabled by default, but activation now includes a new Geo-IP pipeline.
 The Geo-IP pipeline takes an extracted IP address from RUM events and stores it in the `client.geo` field.
 This makes it much easier to use location data in Kibana's Visualize maps and Maps app directly:


### PR DESCRIPTION
## Motivation/summary

This PR adds links to the [Elasticsearch Geo IP processor](https://www.elastic.co/guide/en/elasticsearch/reference/master/geoip-processor.html) when it's mentioned in the APM Server documentation.
