### PR TITLE
[7.x] docker-compose: run system tests as non-root user (#3373)

### DIFF
--- a/.ci/scripts/docker-get-logs.sh
+++ b/.ci/scripts/docker-get-logs.sh
@@ -5,7 +5,7 @@ STEP=${1:-""}
 
 DOCKER_INFO_DIR="docker-info/${STEP}"
 mkdir -p ${DOCKER_INFO_DIR}
-cp docker-compose.yml ${DOCKER_INFO_DIR}
+cp docker-compose*.yml ${DOCKER_INFO_DIR}
 cd ${DOCKER_INFO_DIR}
 
 docker ps -a &> docker-containers.txt

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 html_docs
 /x-pack/apm-server/apm-server
 /x-pack/apm-server/build
+/docker-compose.override.yml

--- a/Makefile
+++ b/Makefile
@@ -109,17 +109,6 @@ create-docs:
 	@cp processor/stream/test_approved_es_documents/testIntakeRUMV3Transactions.approved.json docs/data/elasticsearch/generated/rum_v3_transactions.json
 	@cp processor/stream/test_approved_es_documents/testIntakeRUMV3Errors.approved.json docs/data/elasticsearch/generated/rum_v3_spans.json
 
-# Start manual testing environment with agents
-.PHONY: start-env
-start-env:
-	@docker-compose -f tests/docker-compose.yml build
-	@docker-compose -f tests/docker-compose.yml up -d
-
-# Stop manual testing environment with agents
-.PHONY: stop-env
-stop-env:
-	@docker-compose -f tests/docker-compose.yml down -v
-
 .PHONY: golint-install
 golint-install:
 	go get $(GOLINT_REPO) $(REVIEWDOG_REPO)
@@ -211,3 +200,21 @@ run-system-test: python-env
 	INTEGRATION_TESTS=1 TZ=UTC \
 	ES_USER=$(ES_USER) ES_PASS=$(ES_PASS) KIBANA_USER=$(BEAT_KIBANA_USER) KIBANA_PASS=$(BEAT_KIBANA_PASS) \
 	$(PYTHON_ENV)/bin/nosetests --with-timer -x -v $(SYSTEM_TEST_TARGET)
+
+# docker-compose.override.yml holds overrides for docker-compose.yml.
+#
+# Create this to ensure the UID used inside docker-compose is the same
+# as the current user on the host, so files are created with the same
+# privileges.
+#
+# Note that this target is intentionally non-.PHONY, so that users can
+# modify the resulting file without it being overwritten. To recreate
+# the file, remove it.
+docker-compose.override.yml:
+	printf "version: '2.3'\nservices:\n beat:\n  build:\n   args: [UID=%d]" $(shell id -u) > $@
+system-tests-environment: docker-compose.override.yml
+build-image: docker-compose.override.yml
+
+# We override the DOCKER_COMPOSE variable to not explicitly specify "-f docker-compose.yml",
+# so that "docker-compose.override.yml" is also read if it exists.
+DOCKER_COMPOSE=TESTING_ENVIRONMENT=${TESTING_ENVIRONMENT} docker-compose -p ${DOCKER_COMPOSE_PROJECT_NAME}

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,22 +1,17 @@
 FROM golang:1.13.7
 MAINTAINER Nicolas Ruflin <ruflin@elastic.co>
 
-RUN set -x && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-         netcat python3 python3-pip python3-venv && \
-    apt-get clean
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends netcat python3 python3-pip python3-venv
+RUN apt-get clean
+
+ARG UID=1000
+RUN useradd -m -u $UID apm-server
+USER $UID
+ENV HOME=/home/apm-server
+ENV GOPATH=$HOME/go:/go
 
 ENV PYTHON_ENV=/tmp/python-env
-
-RUN pip3 install --upgrade pip
-RUN pip3 install --upgrade setuptools
-
-# Setup work environment
-ENV APMSERVER_PATH /go/src/github.com/elastic/apm-server
-
-RUN mkdir -p $APMSERVER_PATH/build/coverage
-WORKDIR $APMSERVER_PATH
 
 # Add healthcheck for docker/healthcheck metricset to check during testing
 HEALTHCHECK CMD exit 0


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docker-compose: run system tests as non-root user (#3373)