### PR TITLE
[7.x] Instrument kibana client with apm go agent (#3359)

### DIFF
--- a/agentcfg/fetch.go
+++ b/agentcfg/fetch.go
@@ -18,6 +18,7 @@
 package agentcfg
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -59,16 +60,16 @@ func NewFetcher(client kibana.Client, cacheExpiration time.Duration) *Fetcher {
 }
 
 // Fetch retrieves agent configuration, fetched from Kibana or a local temporary cache.
-func (f *Fetcher) Fetch(query Query) (Result, error) {
+func (f *Fetcher) Fetch(ctx context.Context, query Query) (Result, error) {
 	req := func() (Result, error) {
-		return newResult(f.request(convert.ToReader(query)))
+		return newResult(f.request(ctx, convert.ToReader(query)))
 	}
 	result, err := f.fetch(query, req)
 	return sanitize(query.IsRum, result), err
 }
 
-func (f *Fetcher) request(r io.Reader) ([]byte, error) {
-	resp, err := f.client.Send(http.MethodPost, endpoint, nil, nil, r)
+func (f *Fetcher) request(ctx context.Context, r io.Reader) ([]byte, error) {
+	resp, err := f.client.Send(ctx, http.MethodPost, endpoint, nil, nil, r)
 	if err != nil {
 		return nil, errors.Wrap(err, ErrMsgSendToKibanaFailed)
 	}

--- a/agentcfg/fetch_test.go
+++ b/agentcfg/fetch_test.go
@@ -18,6 +18,7 @@
 package agentcfg
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -43,14 +44,14 @@ func TestFetcher_Fetch(t *testing.T) {
 
 	t.Run("ExpectationFailed", func(t *testing.T) {
 		kb := tests.MockKibana(http.StatusExpectationFailed, m{"error": "an error"}, mockVersion, true)
-		_, err := NewFetcher(kb, testExpiration).Fetch(query(t.Name()))
+		_, err := NewFetcher(kb, testExpiration).Fetch(context.Background(), query(t.Name()))
 		require.Error(t, err)
 		assert.Equal(t, "{\"error\":\"an error\"}", err.Error())
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
 		kb := tests.MockKibana(http.StatusNotFound, m{}, mockVersion, true)
-		result, err := NewFetcher(kb, testExpiration).Fetch(query(t.Name()))
+		result, err := NewFetcher(kb, testExpiration).Fetch(context.Background(), query(t.Name()))
 		require.NoError(t, err)
 		assert.Equal(t, zeroResult(), result)
 	})
@@ -60,7 +61,7 @@ func TestFetcher_Fetch(t *testing.T) {
 		b, err := json.Marshal(mockDoc(0.5))
 		expectedResult, err := newResult(b, err)
 		require.NoError(t, err)
-		result, err := NewFetcher(kb, testExpiration).Fetch(query(t.Name()))
+		result, err := NewFetcher(kb, testExpiration).Fetch(context.Background(), query(t.Name()))
 		require.NoError(t, err)
 		assert.Equal(t, expectedResult, result)
 	})
@@ -79,7 +80,7 @@ func TestFetcher_Fetch(t *testing.T) {
 			expectedResult, err := newResult(b, err)
 			require.NoError(t, err)
 
-			result, err := f.Fetch(query(t.Name()))
+			result, err := f.Fetch(context.Background(), query(t.Name()))
 			require.NoError(t, err)
 			assert.Equal(t, expectedResult, result)
 		}

--- a/beater/api/config/agent/handler_test.go
+++ b/beater/api/config/agent/handler_test.go
@@ -18,6 +18,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -27,16 +28,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/apm-server/agentcfg"
-	"github.com/elastic/apm-server/beater/authorization"
-
-	"golang.org/x/time/rate"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.elastic.co/apm/apmtest"
+	"golang.org/x/time/rate"
 
 	"github.com/elastic/beats/libbeat/common"
+	libkibana "github.com/elastic/beats/libbeat/kibana"
 
+	"github.com/elastic/apm-server/agentcfg"
+	"github.com/elastic/apm-server/beater/authorization"
 	"github.com/elastic/apm-server/beater/config"
 	"github.com/elastic/apm-server/beater/headers"
 	"github.com/elastic/apm-server/beater/request"
@@ -339,6 +340,26 @@ func TestIfNoneMatch(t *testing.T) {
 	assert.Equal(t, "123", ifNoneMatch(fromHeader("123")))
 	assert.Equal(t, "123", ifNoneMatch(fromHeader(`"123"`)))
 	assert.Equal(t, "123", ifNoneMatch(fromQueryArg("123")))
+}
+
+func TestAgentConfigTraceContext(t *testing.T) {
+	kibanaCfg := libkibana.DefaultClientConfig()
+	kibanaCfg.Host = "testKibana:12345"
+	client := kibana.NewConnectingClient(&kibanaCfg)
+	handler := Handler(client, &config.AgentConfig{Cache: &config.Cache{Expiration: 5 * time.Minute}})
+	_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {
+		// When the handler is called with a context containing
+		// a transaction, the underlying Kibana query should create a span
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/backend", convert.ToReader(m{
+			"service": m{"name": "opbeans"}}))
+		r = r.WithContext(ctx)
+		c := request.NewContext()
+		c.Reset(w, r)
+		handler(c)
+	})
+	require.Len(t, spans, 1)
+	assert.Equal(t, "app", spans[0].Type)
 }
 
 func target(params map[string]string) string {

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -25,12 +25,13 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"go.elastic.co/apm/module/apmelasticsearch"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/version"
 	esv7 "github.com/elastic/go-elasticsearch/v7"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 	esv8 "github.com/elastic/go-elasticsearch/v8"
-	"go.elastic.co/apm/module/apmelasticsearch"
 )
 
 // Client is an interface designed to abstract away version differences between elasticsearch clients

--- a/kibana/connecting_client.go
+++ b/kibana/connecting_client.go
@@ -25,11 +25,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/backoff"
 	"github.com/elastic/beats/libbeat/kibana"
 	"github.com/elastic/beats/libbeat/logp"
-	"github.com/pkg/errors"
 
 	"go.elastic.co/apm"
 	"go.elastic.co/apm/module/apmhttp"

--- a/kibana/connecting_client.go
+++ b/kibana/connecting_client.go
@@ -18,18 +18,21 @@
 package kibana
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/elastic/beats/libbeat/common"
 	"github.com/elastic/beats/libbeat/common/backoff"
 	"github.com/elastic/beats/libbeat/kibana"
 	"github.com/elastic/beats/libbeat/logp"
+	"github.com/pkg/errors"
+
+	"go.elastic.co/apm"
+	"go.elastic.co/apm/module/apmhttp"
 
 	logs "github.com/elastic/apm-server/log"
 )
@@ -44,13 +47,11 @@ var errNotConnected = errors.New("unable to retrieve connection to Kibana")
 // Client provides an interface for Kibana Clients
 type Client interface {
 	// Send tries to send request to Kibana and returns unparsed response
-	Send(string, string, url.Values, http.Header, io.Reader) (*http.Response, error)
+	Send(context.Context, string, string, url.Values, http.Header, io.Reader) (*http.Response, error)
 	// GetVersion returns Kibana version or an error
-	GetVersion() (common.Version, error)
-	// Connected indicates whether or not a connection to Kibana has been established
-	Connected() bool
+	GetVersion(context.Context) (common.Version, error)
 	// SupportsVersion compares given version to version of connected Kibana instance
-	SupportsVersion(*common.Version, bool) (bool, error)
+	SupportsVersion(context.Context, *common.Version, bool) (bool, error)
 }
 
 // ConnectingClient implements Client interface
@@ -84,19 +85,21 @@ func NewConnectingClient(cfg *kibana.ClientConfig) Client {
 
 // Send tries to send a request to Kibana via established connection and returns unparsed response
 // If no connection is established an error is returned
-func (c *ConnectingClient) Send(method, extraPath string, params url.Values,
+func (c *ConnectingClient) Send(ctx context.Context, method, extraPath string, params url.Values,
 	headers http.Header, body io.Reader) (*http.Response, error) {
 	c.m.RLock()
 	defer c.m.RUnlock()
 	if c.client == nil {
 		return nil, errNotConnected
 	}
-	return c.client.Send(method, extraPath, params, headers, body)
+	return c.client.SendWithContext(ctx, method, extraPath, params, headers, body)
 }
 
 // GetVersion returns Kibana version or an error
 // If no connection is established an error is returned
-func (c *ConnectingClient) GetVersion() (common.Version, error) {
+func (c *ConnectingClient) GetVersion(ctx context.Context) (common.Version, error) {
+	span, _ := apm.StartSpan(ctx, "GetVersion", "app")
+	defer span.End()
 	c.m.RLock()
 	defer c.m.RUnlock()
 	if c.client == nil {
@@ -105,16 +108,11 @@ func (c *ConnectingClient) GetVersion() (common.Version, error) {
 	return c.client.GetVersion(), nil
 }
 
-// Connected checks if a connection has been established
-func (c *ConnectingClient) Connected() bool {
-	c.m.RLock()
-	defer c.m.RUnlock()
-	return c.client != nil
-}
-
 // SupportsVersion checks if connected Kibana instance is compatible to given version
 // If no connection is established an error is returned
-func (c *ConnectingClient) SupportsVersion(v *common.Version, retry bool) (bool, error) {
+func (c *ConnectingClient) SupportsVersion(ctx context.Context, v *common.Version, retry bool) (bool, error) {
+	span, ctx := apm.StartSpan(ctx, "SupportsVersion", "app")
+	defer span.End()
 	log := logp.NewLogger(logs.Kibana)
 	c.m.RLock()
 	if c.client == nil && !retry {
@@ -131,10 +129,11 @@ func (c *ConnectingClient) SupportsVersion(v *common.Version, retry bool) (bool,
 		log.Errorf("failed to obtain connection to Kibana: %s", err.Error())
 		return upToDate, err
 	}
+	client.HTTP = apmhttp.WrapClient(client.HTTP)
 	c.m.Lock()
 	c.client = client
 	c.m.Unlock()
-	return c.SupportsVersion(v, false)
+	return c.SupportsVersion(ctx, v, false)
 }
 
 func (c *ConnectingClient) connect() error {
@@ -150,6 +149,7 @@ func (c *ConnectingClient) connect() error {
 	if err != nil {
 		return err
 	}
+	client.HTTP = apmhttp.WrapClient(client.HTTP)
 	c.client = client
 	return nil
 }

--- a/kibana/connecting_client_test.go
+++ b/kibana/connecting_client_test.go
@@ -18,6 +18,7 @@
 package kibana
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -41,7 +42,7 @@ func TestNewConnectingClientFrom(t *testing.T) {
 func TestConnectingClient_Send(t *testing.T) {
 	t.Run("Send", func(t *testing.T) {
 		c := mockClient()
-		r, err := c.Send(http.MethodGet, "", nil, nil, nil)
+		r, err := c.Send(context.Background(), http.MethodGet, "", nil, nil, nil)
 		require.NoError(t, err)
 		assert.Equal(t, mockBody, r.Body)
 		assert.Equal(t, mockStatus, r.StatusCode)
@@ -49,7 +50,7 @@ func TestConnectingClient_Send(t *testing.T) {
 
 	t.Run("SendError", func(t *testing.T) {
 		c := NewConnectingClient(mockCfg)
-		r, err := c.Send(http.MethodGet, "", nil, nil, nil)
+		r, err := c.Send(context.Background(), http.MethodGet, "", nil, nil, nil)
 		require.Error(t, err)
 		assert.Equal(t, err, errNotConnected)
 		assert.Nil(t, r)
@@ -59,14 +60,14 @@ func TestConnectingClient_Send(t *testing.T) {
 func TestConnectingClient_GetVersion(t *testing.T) {
 	t.Run("GetVersion", func(t *testing.T) {
 		c := mockClient()
-		v, err := c.GetVersion()
+		v, err := c.GetVersion(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, mockVersion, v)
 	})
 
 	t.Run("GetVersionError", func(t *testing.T) {
 		c := NewConnectingClient(mockCfg)
-		v, err := c.GetVersion()
+		v, err := c.GetVersion(context.Background())
 		require.Error(t, err)
 		assert.Equal(t, err, errNotConnected)
 		assert.Equal(t, common.Version{}, v)
@@ -76,35 +77,23 @@ func TestConnectingClient_GetVersion(t *testing.T) {
 func TestConnectingClient_SupportsVersion(t *testing.T) {
 	t.Run("SupportsVersionTrue", func(t *testing.T) {
 		c := mockClient()
-		s, err := c.SupportsVersion(common.MustNewVersion("7.3.0"), false)
+		s, err := c.SupportsVersion(context.Background(), common.MustNewVersion("7.3.0"), false)
 		require.NoError(t, err)
 		assert.True(t, s)
 	})
 	t.Run("SupportsVersionFalse", func(t *testing.T) {
 		c := mockClient()
-		s, err := c.SupportsVersion(common.MustNewVersion("7.4.0"), false)
+		s, err := c.SupportsVersion(context.Background(), common.MustNewVersion("7.4.0"), false)
 		require.NoError(t, err)
 		assert.False(t, s)
 	})
 
 	t.Run("SupportsVersionError", func(t *testing.T) {
 		c := NewConnectingClient(mockCfg)
-		s, err := c.SupportsVersion(common.MustNewVersion("7.3.0"), false)
+		s, err := c.SupportsVersion(context.Background(), common.MustNewVersion("7.3.0"), false)
 		require.Error(t, err)
 		assert.Equal(t, err, errNotConnected)
 		assert.False(t, s)
-	})
-}
-
-func TestConnectingClient_Connected(t *testing.T) {
-	t.Run("Connected", func(t *testing.T) {
-		c := mockClient()
-		require.True(t, c.Connected())
-	})
-
-	t.Run("NotConnected", func(t *testing.T) {
-		c := NewConnectingClient(mockCfg)
-		require.False(t, c.Connected())
 	})
 }
 

--- a/tests/kibana.go
+++ b/tests/kibana.go
@@ -18,6 +18,7 @@
 package tests
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -40,7 +41,7 @@ type MockKibanaClient struct {
 }
 
 // Send returns a mock http.Response based on parameters used to init the MockKibanaClient instance
-func (c *MockKibanaClient) Send(method, extraPath string, params url.Values,
+func (c *MockKibanaClient) Send(_ context.Context, method, extraPath string, params url.Values,
 	headers http.Header, body io.Reader) (*http.Response, error) {
 	resp := http.Response{StatusCode: c.code, Body: ioutil.NopCloser(convert.ToReader(c.body))}
 	if resp.StatusCode == http.StatusBadGateway {
@@ -50,15 +51,12 @@ func (c *MockKibanaClient) Send(method, extraPath string, params url.Values,
 }
 
 // GetVersion returns a mock version based on parameters used to init the MockKibanaClient instance
-func (c *MockKibanaClient) GetVersion() (common.Version, error) {
+func (c *MockKibanaClient) GetVersion(context.Context) (common.Version, error) {
 	return c.v, nil
 }
 
-// Connected returns whether or not mock client is connected
-func (c *MockKibanaClient) Connected() bool { return c.connected }
-
 // SupportsVersion returns whether or not mock client is compatible with given version
-func (c *MockKibanaClient) SupportsVersion(v *common.Version, _ bool) (bool, error) {
+func (c *MockKibanaClient) SupportsVersion(_ context.Context, v *common.Version, _ bool) (bool, error) {
 	if !c.connected {
 		return false, errors.New("unable to retrieve connection to Kibana")
 	}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Instrument kibana client with apm go agent (#3359)