### PR TITLE
[7.6] Update changelog to 7.6.1 changes (#3397)

### DIFF
--- a/changelogs/7.6.asciidoc
+++ b/changelogs/7.6.asciidoc
@@ -3,7 +3,18 @@
 
 https://github.com/elastic/apm-server/compare/7.5\...7.6[View commits]
 
+* <<release-notes-7.6.1>>
 * <<release-notes-7.6.0>>
+
+[[release-notes-7.6.1]]
+=== APM Server version 7.6.1
+
+https://github.com/elastic/apm-server/compare/v7.6.0\...v7.6.1[View commits]
+
+[float]
+==== Added
+* Upgrade Go to 1.13.8 {pull}3326[3326]
+
 
 [[release-notes-7.6.0]]
 === APM Server version 7.6.0


### PR DESCRIPTION
Backports the following commits to 7.6:
 - Update changelog to 7.6.1 changes (#3397)