### PR TITLE
tests/system: fix agent config tests

### DIFF
--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -247,11 +247,14 @@ class ElasticTest(ServerBaseTest):
         return cfg
 
     def setUp(self):
+        admin_user = os.getenv("ES_SUPERUSER_USER", "admin")
+        admin_password = os.getenv("ES_SUPERUSER_PASS", "changeme")
+        self.admin_es = Elasticsearch([self.get_elasticsearch_url(admin_user, admin_password)])
         self.es = Elasticsearch([self.get_elasticsearch_url()])
         self.kibana_url = self.get_kibana_url()
 
         delete_pipelines = [] if self.skip_clean_pipelines else default_pipelines
-        cleanup(self.es, delete_pipelines=delete_pipelines)
+        cleanup(self.admin_es, delete_pipelines=delete_pipelines)
 
         super(ElasticTest, self).setUp()
 

--- a/tests/system/test_monitoring.py
+++ b/tests/system/test_monitoring.py
@@ -27,11 +27,8 @@ class Test(ElasticTest):
 
         # Set a password for the built-in apm_system user, and use that for monitoring.
         monitoring_password = "changeme"
-        admin_user = os.getenv("ES_SUPERUSER_USER", "admin")
-        admin_password = os.getenv("ES_SUPERUSER_PASS", "changeme")
-        admin_es = Elasticsearch([self.get_elasticsearch_url(admin_user, admin_password)])
-        admin_es.xpack.security.change_password(username="apm_system",
-                                                body='{"password":"%s"}' % monitoring_password)
+        self.admin_es.xpack.security.change_password(username="apm_system",
+                                                     body='{"password":"%s"}' % monitoring_password)
         cfg.update({
             "elasticsearch_host": urlunparse(url),
             "monitoring_enabled": "true",


### PR DESCRIPTION
## Motivation/summary

Fix agent config system tests:
- adjust to the new Kibana server API routes (https://github.com/elastic/kibana/pull/57767)
- use the admin user for cleaning up indices before tests. We recently changed to using "apm_server_user" by default, and attempts to clean up the ACM index were silently failing, leaving behind data between tests which would cause tests to fail

## Checklist
- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~ (no user facing changes)

## How to test these changes

`make system-tests`

## Related issues

Closes https://github.com/elastic/apm-server/issues/3396