### PR TITLE
[7.x] beater/jaeger: introduce "auth_tag" configuration (#3394)

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -418,12 +418,26 @@ apm-server:
     #grpc:
       # Set to true to enable the Jaeger gRPC collector service.
       #enabled: false
+
       # Defines the gRPC host and port the server is listening on.
       # Defaults to the standard Jaeger gRPC collector port 14250.
       #host: "{{ .jaeger_grpc_hostport }}"
+
+      # Set to the name of a process tag to use for authorizing
+      # Jaeger agents.
+      #
+      # The tag value should have the same format as an HTTP
+      # Authorization header, i.e. "Bearer <secret_token>" or
+      # "ApiKey <base64(id:key)>".
+      #
+      # By default (if the auth_tag value is empty), authorization
+      # does not apply to Jaeger agents.
+      #auth_tag: ""
+
     #http:
       # Set to true to enable the Jaeger HTTP collector endpoint.
       #enabled: false
+
       # Defines the HTTP host and port the server is listening on.
       # Defaults to the standard Jaeger HTTP collector port 14268.
       #host: "{{ .jaeger_http_hostport }}"

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -418,12 +418,26 @@ apm-server:
     #grpc:
       # Set to true to enable the Jaeger gRPC collector service.
       #enabled: false
+
       # Defines the gRPC host and port the server is listening on.
       # Defaults to the standard Jaeger gRPC collector port 14250.
       #host: "0.0.0.0:14250"
+
+      # Set to the name of a process tag to use for authorizing
+      # Jaeger agents.
+      #
+      # The tag value should have the same format as an HTTP
+      # Authorization header, i.e. "Bearer <secret_token>" or
+      # "ApiKey <base64(id:key)>".
+      #
+      # By default (if the auth_tag value is empty), authorization
+      # does not apply to Jaeger agents.
+      #auth_tag: ""
+
     #http:
       # Set to true to enable the Jaeger HTTP collector endpoint.
       #enabled: false
+
       # Defines the HTTP host and port the server is listening on.
       # Defaults to the standard Jaeger HTTP collector port 14268.
       #host: "0.0.0.0:14268"

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -418,12 +418,26 @@ apm-server:
     #grpc:
       # Set to true to enable the Jaeger gRPC collector service.
       #enabled: false
+
       # Defines the gRPC host and port the server is listening on.
       # Defaults to the standard Jaeger gRPC collector port 14250.
       #host: "localhost:14250"
+
+      # Set to the name of a process tag to use for authorizing
+      # Jaeger agents.
+      #
+      # The tag value should have the same format as an HTTP
+      # Authorization header, i.e. "Bearer <secret_token>" or
+      # "ApiKey <base64(id:key)>".
+      #
+      # By default (if the auth_tag value is empty), authorization
+      # does not apply to Jaeger agents.
+      #auth_tag: ""
+
     #http:
       # Set to true to enable the Jaeger HTTP collector endpoint.
       #enabled: false
+
       # Defines the HTTP host and port the server is listening on.
       # Defaults to the standard Jaeger HTTP collector port 14268.
       #host: "localhost:14268"

--- a/beater/authorization/header.go
+++ b/beater/authorization/header.go
@@ -1,0 +1,32 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package authorization
+
+import (
+	"strings"
+)
+
+// ParseAuthorizationHeader parses an HTTP Authorization header value,
+// which should have the format "<auth-kind> <auth-token>".
+func ParseAuthorizationHeader(v string) (kind, token string) {
+	space := strings.IndexRune(v, ' ')
+	if space <= 0 {
+		return "", ""
+	}
+	return v[:space], v[space+1:]
+}

--- a/beater/config/jaeger.go
+++ b/beater/config/jaeger.go
@@ -36,6 +36,7 @@ type JaegerConfig struct {
 
 // JaegerGRPCConfig holds configuration for the Jaeger gRPC server.
 type JaegerGRPCConfig struct {
+	AuthTag string      `config:"auth_tag"`
 	Enabled bool        `config:"enabled"`
 	Host    string      `config:"host"`
 	TLS     *tls.Config `config:"-"`

--- a/beater/jaeger/grpc.go
+++ b/beater/jaeger/grpc.go
@@ -20,8 +20,11 @@ package jaeger
 import (
 	"context"
 
+	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/elastic/beats/libbeat/monitoring"
 
@@ -35,6 +38,7 @@ var (
 
 // grpcCollector implements Jaeger api_v2 protocol for receiving tracing data
 type grpcCollector struct {
+	auth     authFunc
 	consumer consumer.TraceConsumer
 }
 
@@ -44,12 +48,20 @@ type grpcCollector struct {
 // https://github.com/open-telemetry/opentelemetry-collector/tree/master/receiver/jaegerreceiver
 func (c grpcCollector) PostSpans(ctx context.Context, r *api_v2.PostSpansRequest) (*api_v2.PostSpansResponse, error) {
 	gRPCMonitoringMap.inc(request.IDRequestCount)
-	err := consumeBatch(ctx, r.Batch, c.consumer, gRPCMonitoringMap)
-	gRPCMonitoringMap.inc(request.IDResponseCount)
-	if err != nil {
+	defer gRPCMonitoringMap.inc(request.IDResponseCount)
+
+	if err := c.postSpans(ctx, r.Batch); err != nil {
 		gRPCMonitoringMap.inc(request.IDResponseErrorsCount)
 		return nil, err
 	}
 	gRPCMonitoringMap.inc(request.IDResponseValidCount)
 	return &api_v2.PostSpansResponse{}, nil
+}
+
+func (c grpcCollector) postSpans(ctx context.Context, batch model.Batch) error {
+	if err := c.auth(ctx, batch); err != nil {
+		gRPCMonitoringMap.inc(request.IDResponseErrorsUnauthorized)
+		return status.Error(codes.Unauthenticated, err.Error())
+	}
+	return consumeBatch(ctx, batch, c.consumer, gRPCMonitoringMap)
 }

--- a/beater/jaeger/grpc_test.go
+++ b/beater/jaeger/grpc_test.go
@@ -23,11 +23,14 @@ import (
 	"testing"
 
 	v1 "github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1"
+	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/open-telemetry/opentelemetry-collector/consumer/consumerdata"
 	"github.com/open-telemetry/opentelemetry-collector/translator/trace/jaeger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/elastic/apm-server/beater/beatertest"
 	"github.com/elastic/apm-server/beater/request"
@@ -60,15 +63,30 @@ func TestGRPCCollector_PostSpans(t *testing.T) {
 				request.IDEventReceivedCount:  2,
 			},
 		},
+		"auth fails": {
+			authError: errors.New("oh noes"),
+			monitoringInt: map[request.ResultID]int64{
+				request.IDRequestCount:               1,
+				request.IDResponseCount:              1,
+				request.IDResponseErrorsCount:        1,
+				request.IDResponseErrorsUnauthorized: 1,
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			tc.setup(t)
 
+			var expectedErr error
+			if tc.authError != nil {
+				expectedErr = status.Error(codes.Unauthenticated, tc.authError.Error())
+			} else {
+				expectedErr = tc.consumerErr
+			}
 			resp, err := tc.collector.PostSpans(context.Background(), tc.request)
-			if tc.consumerErr != nil {
+			if expectedErr != nil {
 				require.Nil(t, resp)
 				require.Error(t, err)
-				assert.Equal(t, tc.consumerErr, err)
+				assert.Equal(t, expectedErr, err)
 			} else {
 				require.NotNil(t, resp)
 				require.NoError(t, err)
@@ -80,6 +98,7 @@ func TestGRPCCollector_PostSpans(t *testing.T) {
 
 type testGRPCCollector struct {
 	request     *api_v2.PostSpansRequest
+	authError   error
 	consumerErr error
 	collector   grpcCollector
 
@@ -100,7 +119,9 @@ func (tc *testGRPCCollector) setup(t *testing.T) {
 		tc.request = &api_v2.PostSpansRequest{Batch: *batch}
 	}
 
-	tc.collector = grpcCollector{traceConsumerFunc(func(ctx context.Context, td consumerdata.TraceData) error {
+	tc.collector = grpcCollector{authFunc(func(context.Context, model.Batch) error {
+		return tc.authError
+	}), traceConsumerFunc(func(ctx context.Context, td consumerdata.TraceData) error {
 		return tc.consumerErr
 	})}
 }

--- a/changelogs/7.7.asciidoc
+++ b/changelogs/7.7.asciidoc
@@ -20,3 +20,4 @@ https://github.com/elastic/apm-server/compare/v7.6.0\...v7.7.0[View commits]
 [float]
 ==== Added
 * Instrumentation for go-elasticsearch {pull}3305[3305]
+* Added support for Jaeger auth tags {pull}3394[3394]

--- a/docs/jaeger-support.asciidoc
+++ b/docs/jaeger-support.asciidoc
@@ -59,6 +59,12 @@ As of this writing, the Jaeger Agent binary offers the `--reporter.grpc.host-por
 which can be used to set a static list of collectors for the Jaeger Agent to connect to.
 The `host:port` set here should correspond with the value set in `apm-server.jaeger.grpc.host`.
 
+Jaeger Agent also offers the `--agent.tags` CLI flag, which can be used to pass Process tags
+to the Collector. If APM Server has `apm-server.jaeger.grpc.auth_tag` set, it will look for a
+Process tag of that name in incoming events, and use it for authorizing the Jaeger Agent against
+the configured secret token or API Keys. The auth tag will not be removed from the events after
+being verified.
+
 See the https://www.jaegertracing.io/docs/1.16/cli/[Jaeger CLI flags documentation] for more information.
 
 *Configure Jaeger Client communication with APM Server (HTTP)*
@@ -121,6 +127,11 @@ Set to true to enable the Jaeger gRPC collector service. Defaults to `false`.
 ===== `grpc.host`
 Define the gRPC host and port the server is listening on.
 Defaults to the standard Jaeger gRPC collector port `14250`.
+
+[float]
+===== `grpc.auth_tag`
+Set to the name of the tag that should be used for authorizing Jaeger agents.
+By default, authorization does not apply to Jaeger agents.
 
 [float]
 ===== `http.enabled`

--- a/testdata/jaeger/batch_0_authorization.json
+++ b/testdata/jaeger/batch_0_authorization.json
@@ -1,0 +1,193 @@
+{
+ "batch": {
+  "spans": [
+   {
+    "trace_id": "AAAAAAAAAAB74v2Y0Jc74w==",
+    "span_id": "e+L9mNCXO+M=",
+    "operation_name": "Driver::findNearest",
+    "references": null,
+    "flags": 1,
+    "start_time": "2019-12-20T07:41:44.953864Z",
+    "duration": 243417000,
+    "tags": [
+     {
+      "key": "sampler.type",
+      "v_str": "const"
+     },
+     {
+      "key": "sampler.param",
+      "v_type": 1,
+      "v_bool": true
+     },
+     {
+      "key": "span.kind",
+      "v_str": "server"
+     },
+     {
+      "key": "as",
+      "v_str": "thrift"
+     },
+     {
+      "key": "peer.service",
+      "v_str": "driver-client"
+     },
+     {
+      "key": "peer.ipv4",
+      "v_type": 2,
+      "v_int64": 2130706433
+     },
+     {
+      "key": "peer.port",
+      "v_type": 2,
+      "v_int64": 50535
+     }
+    ],
+    "logs": [
+     {
+      "timestamp": "2019-12-20T07:41:44.954043Z",
+      "fields": [
+       {
+        "key": "event",
+        "v_str": "baggage"
+       },
+       {
+        "key": "key",
+        "v_str": "customer"
+       },
+       {
+        "key": "value",
+        "v_str": "Japanese Desserts"
+       }
+      ]
+     },
+     {
+      "timestamp": "2019-12-20T07:41:44.95405Z",
+      "fields": [
+       {
+        "key": "event",
+        "v_str": "Searching for nearby drivers"
+       },
+       {
+        "key": "level",
+        "v_str": "info"
+       },
+       {
+        "key": "location",
+        "v_str": "728,326"
+       }
+      ]
+     },
+     {
+      "timestamp": "2019-12-20T07:41:45.007552Z",
+      "fields": [
+       {
+        "key": "event",
+        "v_str": "Retrying GetDriver after error"
+       },
+       {
+        "key": "level",
+        "v_str": "error"
+       },
+       {
+        "key": "retry_no",
+        "v_type": 2,
+        "v_int64": 1
+       },
+       {
+        "key": "error",
+        "v_str": "redis timeout"
+       }
+      ]
+     },
+     {
+      "timestamp": "2019-12-20T07:41:45.089431Z",
+      "fields": [
+       {
+        "key": "event",
+        "v_str": "Retrying GetDriver after error"
+       },
+       {
+        "key": "level",
+        "v_str": "error"
+       },
+       {
+        "key": "retry_no",
+        "v_type": 2,
+        "v_int64": 1
+       },
+       {
+        "key": "error",
+        "v_str": "redis timeout"
+       }
+      ]
+     },
+     {
+      "timestamp": "2019-12-20T07:41:45.17253Z",
+      "fields": [
+       {
+        "key": "event",
+        "v_str": "Retrying GetDriver after error"
+       },
+       {
+        "key": "level",
+        "v_str": "error"
+       },
+       {
+        "key": "retry_no",
+        "v_type": 2,
+        "v_int64": 1
+       },
+       {
+        "key": "error",
+        "v_str": "redis timeout"
+       }
+      ]
+     },
+     {
+      "timestamp": "2019-12-20T07:41:45.197117Z",
+      "fields": [
+       {
+        "key": "event",
+        "v_str": "Search successful"
+       },
+       {
+        "key": "level",
+        "v_str": "info"
+       },
+       {
+        "key": "num_drivers",
+        "v_type": 2,
+        "v_int64": 10
+       }
+      ]
+     }
+    ]
+   }
+  ],
+  "process": {
+   "service_name": "driver",
+   "tags": [
+    {
+     "key": "jaeger.version",
+     "v_str": "Go-2.20.1"
+    },
+    {
+     "key": "hostname",
+     "v_str": "host01"
+    },
+    {
+     "key": "ip",
+     "v_str": "10.0.0.13"
+    },
+    {
+     "key": "client-uuid",
+     "v_str": "624386e9c81d2980"
+    },
+    {
+     "key": "authorization",
+     "v_str": "Bearer 1234"
+    }
+   ]
+  }
+ }
+}

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -12,6 +12,9 @@ apm-server:
   jaeger.grpc.enabled: {{ jaeger_grpc_enabled }}
   jaeger.grpc.host: {{ jaeger_grpc_host }}
   {% endif %}
+  {% if jaeger_grpc_auth_tag %}
+  jaeger.grpc.auth_tag: {{ jaeger_grpc_auth_tag }}
+  {% endif %}
 
   {% if api_key_enabled %}
   api_key.enabled: {{ api_key_enabled }}

--- a/tests/system/jaeger_batch_0_auth_tag_removed.approved.json
+++ b/tests/system/jaeger_batch_0_auth_tag_removed.approved.json
@@ -1,0 +1,258 @@
+[
+    {
+        "agent": {
+            "name": "Jaeger/Go",
+            "ephemeral_id": "624386e9c81d2980",
+            "version": "2.20.1"
+        },
+        "processor": {
+            "name": "transaction",
+            "event": "transaction"
+        },
+        "labels": {
+            "peer_service": "driver-client",
+            "as": "thrift",
+            "peer_ipv4": 2130706433,
+            "sampler_type": "const",
+            "peer_port": 50535,
+            "sampler_param": true
+        },
+        "observer": {
+            "hostname": "alloy",
+            "id": "b220b72b-ff8d-4701-9504-f2b351fc1e1d",
+            "ephemeral_id": "ac12c30a-25c5-49d9-ae82-b80afb99b810",
+            "type": "apm-server",
+            "version": "8.0.0",
+            "version_major": 8
+        },
+        "trace": {
+            "id": "00000000000000007be2fd98d0973be3"
+        },
+        "@timestamp": "2019-12-20T07:41:44.953Z",
+        "ecs": {
+            "version": "1.4.0"
+        },
+        "service": {
+            "node": {
+                "name": "host01"
+            },
+            "name": "driver",
+            "language": {
+                "name": "Go"
+            }
+        },
+        "host": {
+            "hostname": "host01",
+            "ip": "10.0.0.13",
+            "name": "host01"
+        },
+        "event": {
+            "ingested": "2020-02-26T07:25:03.320773Z"
+        },
+        "transaction": {
+            "duration": {
+                "us": 243417
+            },
+            "result": "Success",
+            "name": "Driver::findNearest",
+            "id": "7be2fd98d0973be3",
+            "type": "custom",
+            "sampled": true
+        },
+        "timestamp": {
+            "us": 1576827704953864
+        }
+    },
+    {
+        "parent": {
+            "id": "7be2fd98d0973be3"
+        },
+        "agent": {
+            "name": "Jaeger/Go",
+            "ephemeral_id": "624386e9c81d2980",
+            "version": "2.20.1"
+        },
+        "error": {
+            "exception": [
+                {
+                    "message": "redis timeout"
+                }
+            ],
+            "log": {
+                "message": "Retrying GetDriver after error"
+            },
+            "grouping_key": "dd09a7d0d9dde0adfcd694967c5a88de"
+        },
+        "processor": {
+            "name": "error",
+            "event": "error"
+        },
+        "observer": {
+            "hostname": "alloy",
+            "id": "b220b72b-ff8d-4701-9504-f2b351fc1e1d",
+            "type": "apm-server",
+            "ephemeral_id": "ac12c30a-25c5-49d9-ae82-b80afb99b810",
+            "version": "8.0.0",
+            "version_major": 8
+        },
+        "trace": {
+            "id": "00000000000000007be2fd98d0973be3"
+        },
+        "@timestamp": "2019-12-20T07:41:45.007Z",
+        "ecs": {
+            "version": "1.4.0"
+        },
+        "service": {
+            "node": {
+                "name": "host01"
+            },
+            "name": "driver",
+            "language": {
+                "name": "Go"
+            }
+        },
+        "host": {
+            "hostname": "host01",
+            "ip": "10.0.0.13",
+            "name": "host01"
+        },
+        "event": {
+            "ingested": "2020-02-26T07:25:03.363110Z"
+        },
+        "transaction": {
+            "id": "7be2fd98d0973be3",
+            "type": "custom"
+        },
+        "timestamp": {
+            "us": 1576827705007552
+        }
+    },
+    {
+        "parent": {
+            "id": "7be2fd98d0973be3"
+        },
+        "agent": {
+            "name": "Jaeger/Go",
+            "ephemeral_id": "624386e9c81d2980",
+            "version": "2.20.1"
+        },
+        "error": {
+            "exception": [
+                {
+                    "message": "redis timeout"
+                }
+            ],
+            "log": {
+                "message": "Retrying GetDriver after error"
+            },
+            "grouping_key": "dd09a7d0d9dde0adfcd694967c5a88de"
+        },
+        "processor": {
+            "name": "error",
+            "event": "error"
+        },
+        "observer": {
+            "hostname": "alloy",
+            "id": "b220b72b-ff8d-4701-9504-f2b351fc1e1d",
+            "ephemeral_id": "ac12c30a-25c5-49d9-ae82-b80afb99b810",
+            "type": "apm-server",
+            "version": "8.0.0",
+            "version_major": 8
+        },
+        "trace": {
+            "id": "00000000000000007be2fd98d0973be3"
+        },
+        "@timestamp": "2019-12-20T07:41:45.089Z",
+        "ecs": {
+            "version": "1.4.0"
+        },
+        "service": {
+            "node": {
+                "name": "host01"
+            },
+            "name": "driver",
+            "language": {
+                "name": "Go"
+            }
+        },
+        "host": {
+            "hostname": "host01",
+            "ip": "10.0.0.13",
+            "name": "host01"
+        },
+        "event": {
+            "ingested": "2020-02-26T07:25:03.363378Z"
+        },
+        "transaction": {
+            "id": "7be2fd98d0973be3",
+            "type": "custom"
+        },
+        "timestamp": {
+            "us": 1576827705089431
+        }
+    },
+    {
+        "parent": {
+            "id": "7be2fd98d0973be3"
+        },
+        "agent": {
+            "name": "Jaeger/Go",
+            "ephemeral_id": "624386e9c81d2980",
+            "version": "2.20.1"
+        },
+        "error": {
+            "exception": [
+                {
+                    "message": "redis timeout"
+                }
+            ],
+            "log": {
+                "message": "Retrying GetDriver after error"
+            },
+            "grouping_key": "dd09a7d0d9dde0adfcd694967c5a88de"
+        },
+        "processor": {
+            "name": "error",
+            "event": "error"
+        },
+        "observer": {
+            "hostname": "alloy",
+            "id": "b220b72b-ff8d-4701-9504-f2b351fc1e1d",
+            "ephemeral_id": "ac12c30a-25c5-49d9-ae82-b80afb99b810",
+            "type": "apm-server",
+            "version": "8.0.0",
+            "version_major": 8
+        },
+        "trace": {
+            "id": "00000000000000007be2fd98d0973be3"
+        },
+        "@timestamp": "2019-12-20T07:41:45.172Z",
+        "ecs": {
+            "version": "1.4.0"
+        },
+        "service": {
+            "node": {
+                "name": "host01"
+            },
+            "name": "driver",
+            "language": {
+                "name": "Go"
+            }
+        },
+        "host": {
+            "hostname": "host01",
+            "ip": "10.0.0.13",
+            "name": "host01"
+        },
+        "event": {
+            "ingested": "2020-02-26T07:25:03.369642Z"
+        },
+        "transaction": {
+            "id": "7be2fd98d0973be3",
+            "type": "custom"
+        },
+        "timestamp": {
+            "us": 1576827705172530
+        }
+    }
+]

--- a/tests/system/jaeger_batch_0_authorization.approved.json
+++ b/tests/system/jaeger_batch_0_authorization.approved.json
@@ -1,0 +1,258 @@
+[
+    {
+        "agent": {
+            "name": "Jaeger/Go",
+            "ephemeral_id": "624386e9c81d2980",
+            "version": "2.20.1"
+        },
+        "processor": {
+            "name": "transaction",
+            "event": "transaction"
+        },
+        "labels": {
+            "peer_service": "driver-client",
+            "as": "thrift",
+            "peer_ipv4": 2130706433,
+            "sampler_type": "const",
+            "peer_port": 50535,
+            "sampler_param": true
+        },
+        "observer": {
+            "hostname": "alloy",
+            "id": "2d19ea22-7f09-4ea6-a31f-b7c82c8ddeb9",
+            "ephemeral_id": "c9c909d0-6ffe-4851-bc96-264b3d5df0dd",
+            "type": "apm-server",
+            "version": "8.0.0",
+            "version_major": 8
+        },
+        "trace": {
+            "id": "00000000000000007be2fd98d0973be3"
+        },
+        "@timestamp": "2019-12-20T07:41:44.953Z",
+        "ecs": {
+            "version": "1.4.0"
+        },
+        "service": {
+            "node": {
+                "name": "host01"
+            },
+            "name": "driver",
+            "language": {
+                "name": "Go"
+            }
+        },
+        "host": {
+            "hostname": "host01",
+            "ip": "10.0.0.13",
+            "name": "host01"
+        },
+        "event": {
+            "ingested": "2020-02-26T07:04:26.266378Z"
+        },
+        "transaction": {
+            "duration": {
+                "us": 243417
+            },
+            "result": "Success",
+            "name": "Driver::findNearest",
+            "id": "7be2fd98d0973be3",
+            "type": "custom",
+            "sampled": true
+        },
+        "timestamp": {
+            "us": 1576827704953864
+        }
+    },
+    {
+        "parent": {
+            "id": "7be2fd98d0973be3"
+        },
+        "agent": {
+            "name": "Jaeger/Go",
+            "ephemeral_id": "624386e9c81d2980",
+            "version": "2.20.1"
+        },
+        "error": {
+            "exception": [
+                {
+                    "message": "redis timeout"
+                }
+            ],
+            "log": {
+                "message": "Retrying GetDriver after error"
+            },
+            "grouping_key": "dd09a7d0d9dde0adfcd694967c5a88de"
+        },
+        "processor": {
+            "name": "error",
+            "event": "error"
+        },
+        "observer": {
+            "hostname": "alloy",
+            "id": "2d19ea22-7f09-4ea6-a31f-b7c82c8ddeb9",
+            "ephemeral_id": "c9c909d0-6ffe-4851-bc96-264b3d5df0dd",
+            "type": "apm-server",
+            "version": "8.0.0",
+            "version_major": 8
+        },
+        "trace": {
+            "id": "00000000000000007be2fd98d0973be3"
+        },
+        "@timestamp": "2019-12-20T07:41:45.007Z",
+        "ecs": {
+            "version": "1.4.0"
+        },
+        "service": {
+            "node": {
+                "name": "host01"
+            },
+            "name": "driver",
+            "language": {
+                "name": "Go"
+            }
+        },
+        "host": {
+            "hostname": "host01",
+            "ip": "10.0.0.13",
+            "name": "host01"
+        },
+        "event": {
+            "ingested": "2020-02-26T07:04:26.322235Z"
+        },
+        "transaction": {
+            "id": "7be2fd98d0973be3",
+            "type": "custom"
+        },
+        "timestamp": {
+            "us": 1576827705007552
+        }
+    },
+    {
+        "parent": {
+            "id": "7be2fd98d0973be3"
+        },
+        "agent": {
+            "name": "Jaeger/Go",
+            "ephemeral_id": "624386e9c81d2980",
+            "version": "2.20.1"
+        },
+        "error": {
+            "exception": [
+                {
+                    "message": "redis timeout"
+                }
+            ],
+            "log": {
+                "message": "Retrying GetDriver after error"
+            },
+            "grouping_key": "dd09a7d0d9dde0adfcd694967c5a88de"
+        },
+        "processor": {
+            "name": "error",
+            "event": "error"
+        },
+        "observer": {
+            "hostname": "alloy",
+            "id": "2d19ea22-7f09-4ea6-a31f-b7c82c8ddeb9",
+            "type": "apm-server",
+            "ephemeral_id": "c9c909d0-6ffe-4851-bc96-264b3d5df0dd",
+            "version": "8.0.0",
+            "version_major": 8
+        },
+        "trace": {
+            "id": "00000000000000007be2fd98d0973be3"
+        },
+        "@timestamp": "2019-12-20T07:41:45.089Z",
+        "ecs": {
+            "version": "1.4.0"
+        },
+        "service": {
+            "node": {
+                "name": "host01"
+            },
+            "name": "driver",
+            "language": {
+                "name": "Go"
+            }
+        },
+        "host": {
+            "hostname": "host01",
+            "ip": "10.0.0.13",
+            "name": "host01"
+        },
+        "event": {
+            "ingested": "2020-02-26T07:04:26.329572Z"
+        },
+        "transaction": {
+            "id": "7be2fd98d0973be3",
+            "type": "custom"
+        },
+        "timestamp": {
+            "us": 1576827705089431
+        }
+    },
+    {
+        "parent": {
+            "id": "7be2fd98d0973be3"
+        },
+        "agent": {
+            "name": "Jaeger/Go",
+            "ephemeral_id": "624386e9c81d2980",
+            "version": "2.20.1"
+        },
+        "error": {
+            "exception": [
+                {
+                    "message": "redis timeout"
+                }
+            ],
+            "log": {
+                "message": "Retrying GetDriver after error"
+            },
+            "grouping_key": "dd09a7d0d9dde0adfcd694967c5a88de"
+        },
+        "processor": {
+            "name": "error",
+            "event": "error"
+        },
+        "observer": {
+            "hostname": "alloy",
+            "id": "2d19ea22-7f09-4ea6-a31f-b7c82c8ddeb9",
+            "ephemeral_id": "c9c909d0-6ffe-4851-bc96-264b3d5df0dd",
+            "type": "apm-server",
+            "version": "8.0.0",
+            "version_major": 8
+        },
+        "trace": {
+            "id": "00000000000000007be2fd98d0973be3"
+        },
+        "@timestamp": "2019-12-20T07:41:45.172Z",
+        "ecs": {
+            "version": "1.4.0"
+        },
+        "service": {
+            "node": {
+                "name": "host01"
+            },
+            "name": "driver",
+            "language": {
+                "name": "Go"
+            }
+        },
+        "host": {
+            "hostname": "host01",
+            "ip": "10.0.0.13",
+            "name": "host01"
+        },
+        "event": {
+            "ingested": "2020-02-26T07:04:26.329957Z"
+        },
+        "transaction": {
+            "id": "7be2fd98d0973be3",
+            "type": "custom"
+        },
+        "timestamp": {
+            "us": 1576827705172530
+        }
+    }
+]

--- a/tests/system/test_jaeger.py
+++ b/tests/system/test_jaeger.py
@@ -6,10 +6,9 @@ from apmserver import integration_test, ElasticTest
 from helper import wait_until
 
 
-@integration_test
-class Test(ElasticTest):
+class JaegerBaseTest(ElasticTest):
     def setUp(self):
-        super(Test, self).setUp()
+        super(JaegerBaseTest, self).setUp()
         wait_until(lambda: self.log_contains("Listening for Jaeger HTTP"), name="Jaeger HTTP listener started")
         wait_until(lambda: self.log_contains("Listening for Jaeger gRPC"), name="Jaeger gRPC listener started")
 
@@ -21,16 +20,23 @@ class Test(ElasticTest):
         self.jaeger_grpc_addr = match.group(1)
 
     def config(self):
-        cfg = super(Test, self).config()
+        cfg = super(JaegerBaseTest, self).config()
         cfg.update({
             "jaeger_grpc_enabled": "true",
             "jaeger_http_enabled": "true",
             # Listen on dynamic ports
             "jaeger_grpc_host": "localhost:0",
             "jaeger_http_host": "localhost:0",
+            # jaeger_grpc_auth_tag is set in the base suite so we can
+            # check that the authorization tag is always removed,
+            # even if there's no secret token / API Key auth.
+            "jaeger_grpc_auth_tag": "authorization",
         })
         return cfg
 
+
+@integration_test
+class Test(JaegerBaseTest):
     def test_jaeger_http(self):
         """
         This test sends a Jaeger span in Thrift encoding over HTTP, and verifies that it is indexed.
@@ -61,3 +67,61 @@ class Test(ElasticTest):
         transaction_docs = self.wait_for_events('transaction', 1)
         error_docs = self.wait_for_events('error', 3)
         self.approve_docs('jaeger_batch_0', transaction_docs + error_docs)
+
+    def test_jaeger_auth_tag_removed(self):
+        """
+        This test sends a Jaeger batch over gRPC, with an "authorization" process tag,
+        and verifies that the spans are indexed without that process tag indexed as a label.
+        """
+        jaeger_request_data = self.get_testdata_path('jaeger', 'batch_0_authorization.json')
+
+        client = os.path.join(os.path.dirname(__file__), 'jaegergrpc')
+        subprocess.run(
+            ['go', 'run', client, '-addr', self.jaeger_grpc_addr, '-insecure', jaeger_request_data],
+            check=True,
+        )
+
+        transaction_docs = self.wait_for_events('transaction', 1)
+        error_docs = self.wait_for_events('error', 3)
+        self.approve_docs('jaeger_batch_0_auth_tag_removed', transaction_docs + error_docs)
+
+
+@integration_test
+class TestAuthTag(JaegerBaseTest):
+    def config(self):
+        cfg = super(TestAuthTag, self).config()
+        cfg.update({"secret_token": "1234"})
+        return cfg
+
+    def test_jaeger_unauthorized(self):
+        """
+        This test sends a Jaeger batch over gRPC, without an "authorization" process tag,
+        and verifies that the spans are indexed.
+        """
+        jaeger_request_data = self.get_testdata_path('jaeger', 'batch_0.json')
+
+        client = os.path.join(os.path.dirname(__file__), 'jaegergrpc')
+        proc = subprocess.Popen(
+            ['go', 'run', client, '-addr', self.jaeger_grpc_addr, '-insecure', jaeger_request_data],
+            stderr=subprocess.PIPE,
+        )
+        stdout, stderr = proc.communicate()
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertRegex(stderr.decode("utf-8"), "not authorized")
+
+    def test_jaeger_authorized(self):
+        """
+        This test sends a Jaeger batch over gRPC, with an "authorization" process tag,
+        and verifies that the spans are indexed without that tag indexed as a label.
+        """
+        jaeger_request_data = self.get_testdata_path('jaeger', 'batch_0_authorization.json')
+
+        client = os.path.join(os.path.dirname(__file__), 'jaegergrpc')
+        subprocess.run(
+            ['go', 'run', client, '-addr', self.jaeger_grpc_addr, '-insecure', jaeger_request_data],
+            check=True,
+        )
+
+        transaction_docs = self.wait_for_events('transaction', 1)
+        error_docs = self.wait_for_events('error', 3)
+        self.approve_docs('jaeger_batch_0_authorization', transaction_docs + error_docs)


### PR DESCRIPTION
Backports the following commits to 7.x:
 - beater/jaeger: introduce "auth_tag" configuration (#3394)