### PR TITLE
Makefile: add "mage" back to $PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,8 +247,15 @@ autopep8: $(MAGE)
 # can just use "go build" and it'll resolve all dependencies using modules.
 export GOBIN=$(abspath $(GOOSBUILD))
 
-$(MAGE): magefile.go vendor/vendor.json
-	go run ./vendor/github.com/magefile/mage -compile=$@
+BIN_MAGE=$(GOOSBUILD)/bin/mage
+
+# BIN_MAGE is the standard "mage" binary.
+$(BIN_MAGE): vendor/vendor.json
+	go build -o $@ ./vendor/github.com/magefile/mage
+
+# MAGE is the compiled magefile.
+$(MAGE): magefile.go $(BIN_MAGE)
+	$(BIN_MAGE) -compile=$@
 
 $(STATICCHECK): vendor/vendor.json
 	go get ./vendor/honnef.co/go/tools/cmd/staticcheck
@@ -291,5 +298,6 @@ release-manager-release:
 	_beats/dev-tools/run_with_go_ver $(MAKE) release
 
 .PHONY: release
+release: export PATH:=$(dir $(BIN_MAGE)):$(PATH)
 release: $(MAGE)
 	$(MAGE) package


### PR DESCRIPTION
## Motivation/summary

Add the `mage` binary back into $PATH for release-manager. In the Makefile we use a compiled magefile, but now also build the mage binary and add it to $PATH just for the release target.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes~
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

## How to test these changes

- `rm $(which mage)`
- `make release`

## Related issues

Closes #3417 