### PR TITLE
Enclose HTTP request into a Session for flaky test

### DIFF
--- a/tests/system/test_tls.py
+++ b/tests/system/test_tls.py
@@ -104,9 +104,13 @@ class TestSSLEnabledNoClientVerificationTest(TestSecureServerBaseTest):
 
     def test_http_fails(self):
         with self.assertRaises(Exception):
-            return requests.post("http://localhost:8200/intake/v2/events",
-                                 headers={'content-type': 'application/x-ndjson'},
-                                 data=self.get_event_payload())
+            with requests.Session() as session:
+                try:
+                    return session.post("https://localhost:8200/intake/v2/events",
+                                        headers={'content-type': 'application/x-ndjson'},
+                                        data=self.get_event_payload())
+                finally:
+                    session.close()
 
 
 @integration_test


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

A few suggestions about filling out this PR:

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR instead of prefixing the title with WIP.
3. Please label this PR with at least one of the following labels, depending on the scope of your change:
- bug fix
- breaking change
- enhancement
4. Remove those recommended/optional sections if you don't need them.
5. Submit the pull request: Push your local changes to your forked copy of the repository and submit a pull request (https://help.github.com/articles/using-pull-requests).
6. Please be patient. We might not be able to review your code as fast as we would like to, but we'll do our best to dedicate to it the attention it deserves. Your effort is much appreciated!

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
<!--
Please explain the motivation behind this PR, along with a summary of the major changes involved. Replace this comment with a description of what is being changed by this PR and why.

Major changes require a number of considerations including impact on:

* logging selector(s)
* metrics
* telemetry
* Elasticsearch Service (https://cloud.elastic.co)
* Elastic Cloud Enterprise (https://www.elastic.co/products/ece)
-->

There is a single test that checks that a non-HTTPS request throws an Exception (see TestSSLEnabledNoClientVerificationTest.test_http_fails), which started to fail in random manner after the upgrade to Python3.

To avoid that the `requests` library reuses connections, we want to encapsulate the requests for this tests in a specific HTTP Session object, so that they are treated as new requests, with their own configuration.

## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved
List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->
- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest master branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-server/blob/master/TESTING.md for details.
-->
- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

## How to test these changes
<!--
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Please run the dockerised version of the tests, which starts up the runtime dependencies (elasticsearch and kibana):
```shell
$ make docker-system-tests SYSTEM_TEST_TARGET=./tests/system/test_tls.py:TestSSLEnabledNoClientVerificationTest.test_http_fails
```

## Related issues
<!--
If this PR should close an issue, please add one of the magic keywords
(e.g. fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/
Examples:
- Closes #ISSUE_ID
- Relates #ISSUE_ID
- Requires #ISSUE_ID
- Supersedes #ISSUE_ID
-->
- Closes #3420