### PR TITLE
[7.x] fix: use a dedicated HTTP Session for the request (#3431)

### DIFF
--- a/tests/system/test_tls.py
+++ b/tests/system/test_tls.py
@@ -104,9 +104,13 @@ class TestSSLEnabledNoClientVerificationTest(TestSecureServerBaseTest):
 
     def test_http_fails(self):
         with self.assertRaises(Exception):
-            return requests.post("http://localhost:8200/intake/v2/events",
-                                 headers={'content-type': 'application/x-ndjson'},
-                                 data=self.get_event_payload())
+            with requests.Session() as session:
+                try:
+                    return session.post("http://localhost:8200/intake/v2/events",
+                                        headers={'content-type': 'application/x-ndjson'},
+                                        data=self.get_event_payload())
+                finally:
+                    session.close()
 
 
 @integration_test


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix: use a dedicated HTTP Session for the request (#3431)