### PR TITLE
fix: Run system tests in docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,10 @@ system-tests: $(PYTHON_BIN) apm-server.test
 	INTEGRATION_TESTS=1 TZ=UTC $(PYTHON_BIN)/nosetests $(NOSETESTS_OPTIONS) $(SYSTEM_TEST_TARGET)
 
 .PHONY: docker-system-tests
+docker-system-tests: export SYSTEM_TEST_TARGET=$(SYSTEM_TEST_TARGET)
 docker-system-tests: docker-compose.override.yml
 	docker-compose build
-	SYSTEM_TEST_TARGET=$(SYSTEM_TEST_TARGET) docker-compose run --rm -T beat make system-tests
+	docker-compose run --rm -T beat make system-tests
 
 # docker-compose.override.yml holds overrides for docker-compose.yml.
 #

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ system-tests: $(PYTHON_BIN) apm-server.test
 .PHONY: docker-system-tests
 docker-system-tests: docker-compose.override.yml
 	docker-compose build
-	docker-compose run --rm -T beat make system-tests
+	SYSTEM_TEST_TARGET=$(SYSTEM_TEST_TARGET) docker-compose run --rm -T beat make system-tests
 
 # docker-compose.override.yml holds overrides for docker-compose.yml.
 #

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ system-tests: $(PYTHON_BIN) apm-server.test
 	INTEGRATION_TESTS=1 TZ=UTC $(PYTHON_BIN)/nosetests $(NOSETESTS_OPTIONS) $(SYSTEM_TEST_TARGET)
 
 .PHONY: docker-system-tests
-docker-system-tests: export SYSTEM_TEST_TARGET=$(SYSTEM_TEST_TARGET)
+docker-system-tests: export SYSTEM_TEST_TARGET:=$(SYSTEM_TEST_TARGET)
 docker-system-tests: docker-compose.override.yml
 	docker-compose build
 	docker-compose run --rm -T beat make system-tests


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

A few suggestions about filling out this PR:

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR instead of prefixing the title with WIP.
3. Please label this PR with at least one of the following labels, depending on the scope of your change:
- bug fix
- breaking change
- enhancement
4. Remove those recommended/optional sections if you don't need them.
5. Submit the pull request: Push your local changes to your forked copy of the repository and submit a pull request (https://help.github.com/articles/using-pull-requests).
6. Please be patient. We might not be able to review your code as fast as we would like to, but we'll do our best to dedicate to it the attention it deserves. Your effort is much appreciated!

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
Bring back system tests in Docker execution, as because of #3427, the `SYSTEM_TEST_TARGET` environment variable was not populated in the Makefile causing the tests not to be run.

<!--
Please explain the motivation behind this PR, along with a summary of the major changes involved. Replace this comment with a description of what is being changed by this PR and why.

Major changes require a number of considerations including impact on:

* logging selector(s)
* metrics
* telemetry
* Elasticsearch Service (https://cloud.elastic.co)
* Elastic Cloud Enterprise (https://www.elastic.co/products/ece)
-->

## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved
List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->
- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest master branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-server/blob/master/TESTING.md for details.
-->
- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

## How to test these changes
<!--
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

Please run tests as in the CI with `make update docker-system-tests`

## Related issues
<!--
If this PR should close an issue, please add one of the magic keywords
(e.g. fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/
Examples:
- Closes #ISSUE_ID
- Relates #ISSUE_ID
- Requires #ISSUE_ID
- Supersedes #ISSUE_ID
-->
- Relates #3427
- Closes #3436