### PR TITLE
ci(jenkins): use current tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('apm@v1.0.6') _
+@Library('apm@current') _
 
 pipeline {
   agent any


### PR DESCRIPTION
Otherwise, the 1.0.6 is broken as some configuration was changed sometime ago.