### PR TITLE
[7.x] Backport Dockerised system tests improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,10 @@ system-tests: $(PYTHON_BIN) apm-server.test
 	INTEGRATION_TESTS=1 TZ=UTC $(PYTHON_BIN)/nosetests $(NOSETESTS_OPTIONS) $(SYSTEM_TEST_TARGET)
 
 .PHONY: docker-system-tests
+docker-system-tests: export SYSTEM_TEST_TARGET=$(SYSTEM_TEST_TARGET)
 docker-system-tests: docker-compose.override.yml
 	docker-compose build
-	SYSTEM_TEST_TARGET=$(SYSTEM_TEST_TARGET) docker-compose run --rm -T beat make system-tests
+	docker-compose run --rm -T beat make system-tests
 
 # docker-compose.override.yml holds overrides for docker-compose.yml.
 #

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ system-tests: $(PYTHON_BIN) apm-server.test
 .PHONY: docker-system-tests
 docker-system-tests: docker-compose.override.yml
 	docker-compose build
-	docker-compose run --rm -T beat make system-tests
+	SYSTEM_TEST_TARGET=$(SYSTEM_TEST_TARGET) docker-compose run --rm -T beat make system-tests
 
 # docker-compose.override.yml holds overrides for docker-compose.yml.
 #

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ system-tests: $(PYTHON_BIN) apm-server.test
 	INTEGRATION_TESTS=1 TZ=UTC $(PYTHON_BIN)/nosetests $(NOSETESTS_OPTIONS) $(SYSTEM_TEST_TARGET)
 
 .PHONY: docker-system-tests
-docker-system-tests: export SYSTEM_TEST_TARGET=$(SYSTEM_TEST_TARGET)
+docker-system-tests: export SYSTEM_TEST_TARGET:=$(SYSTEM_TEST_TARGET)
 docker-system-tests: docker-compose.override.yml
 	docker-compose build
 	docker-compose run --rm -T beat make system-tests

--- a/TESTING.md
+++ b/TESTING.md
@@ -33,6 +33,12 @@ example from within an editor, while still allowing all dependencies to run in c
 make system-tests SYSTEM_TEST_TARGET=./tests/system/test_integration.py:SourcemappingIntegrationTest.test_backend_error
 ```
 
+* Or run the dockerised version of thes tests with `make docker-system-tests`, e.g.:
+
+```
+make docker-system-tests SYSTEM_TEST_TARGET=./tests/system/test_integration.py:SourcemappingIntegrationTest.test_backend_error
+```
+
 Elasticsearch diagnostics may be enabled by setting `DIAGNOSTIC_INTERVAL`.
 `DIAGNOSTIC_INTERVAL=1` will dump hot threads and task lists every second while tests are running
 to `build/system-tests/run/$test_name/diagnostics/`.

--- a/TESTING.md
+++ b/TESTING.md
@@ -33,7 +33,7 @@ example from within an editor, while still allowing all dependencies to run in c
 make system-tests SYSTEM_TEST_TARGET=./tests/system/test_integration.py:SourcemappingIntegrationTest.test_backend_error
 ```
 
-* Or run the dockerised version of thes tests with `make docker-system-tests`, e.g.:
+* Or run the dockerised version of the tests with `make docker-system-tests`, e.g.:
 
 ```
 make docker-system-tests SYSTEM_TEST_TARGET=./tests/system/test_integration.py:SourcemappingIntegrationTest.test_backend_error

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       KIBANA_PORT: "5601"
       KIBANA_USER: "${BEAT_KIBANA_USER:-apm_user_ro}"
       KIBANA_PASS: "${BEAT_KIBANA_PASS:-changeme}"
+      SYSTEM_TEST_TARGET: "${SYSTEM_TEST_TARGET:-}"
 
   # This is a proxy used to block beats until all services are healthy.
   # See: https://github.com/docker/compose/issues/4369


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

<!--
Replace this comment with a description of what is being changed by this PR and why.

If this PR should close an issue, please add one of the magic keywords
(e.g. fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/

Most changes should include:

* unit tests
* integration tests
* documentation

Major changes require a number of considerations including impact on:

* logging selector(s)
* metrics
* telemetry
* Elasticsearch Service (https://cloud.elastic.co)
* Elastic Cloud Enterprise (https://www.elastic.co/products/ece)
-->

## Motivation/Summary
Backport #3427 and #3439 to 7.x