### PR TITLE
docs: Update agent server compatibility for RUM Agent

### DIFF
--- a/docs/guide/agent-server-compatibility.asciidoc
+++ b/docs/guide/agent-server-compatibility.asciidoc
@@ -40,5 +40,5 @@ The chart below outlines the compatibility between different versions of the APM
 .3+|**JavaScript RUM Agent**
 |`0.x` |`6.3`-`6.4`
 |`1.x` |`6.4`
-|`2.x`, `3.x`, `4.x` |>= `6.5`
+|`2.x`, `3.x`, `4.x`, `5.x` |>= `6.5`
 |====

--- a/docs/guide/agent-server-compatibility.asciidoc
+++ b/docs/guide/agent-server-compatibility.asciidoc
@@ -37,8 +37,9 @@ The chart below outlines the compatibility between different versions of the APM
 |`3.x` |>= `6.5`
 
 // RUM
-.3+|**JavaScript RUM Agent**
+.4+|**JavaScript RUM Agent**
 |`0.x` |`6.3`-`6.4`
 |`1.x` |`6.4`
-|`2.x`, `3.x`, `4.x`, `5.x` |>= `6.5`
+|`2.x`, `3.x`, `4.x`, |>= `6.5`
+|`5.x` |>= `7.0`
 |====

--- a/docs/guide/agent-server-compatibility.asciidoc
+++ b/docs/guide/agent-server-compatibility.asciidoc
@@ -40,6 +40,6 @@ The chart below outlines the compatibility between different versions of the APM
 .4+|**JavaScript RUM Agent**
 |`0.x` |`6.3`-`6.4`
 |`1.x` |`6.4`
-|`2.x`, `3.x`, `4.x`, |>= `6.5`
+|`2.x`, `3.x`, `4.x` |>= `6.5`
 |`5.x` |>= `7.0`
 |====


### PR DESCRIPTION
##  Motivation/summary

Adds Agent Server compatibility for version 5.x of the APM RUM Agent

## Checklist

- [x] Do not merge until version 5.0.0 has been released.
- [x] Figure out how Agent/Server compatibility will change with `5.x` (@jahtalab / @vigneshshanmugam).

## Related issues

For https://github.com/elastic/apm-agent-rum-js/issues/501
