### PR TITLE
ci: enable verbose mage output in CI

### DIFF
--- a/script/common.bash
+++ b/script/common.bash
@@ -99,6 +99,10 @@ jenkins_setup() {
   # Write cached magefile binaries to workspace to ensure
   # each run starts from a clean slate.
   export MAGEFILE_CACHE="${WORKSPACE}/.magefile"
+
+  # Enable verbose output for Mage,
+  # to help diagnose build failures.
+  export MAGEFILE_VERBOSE=1
 }
 
 docker_setup() {


### PR DESCRIPTION
## Motivation/summary

Enable verbose Mage output, so we can more easily diagnose errors in CI. For example, in https://apm-ci.elastic.co/blue/organizations/jenkins/apm-server%2Fapm-server-mbp/detail/master/381/pipeline/86 we can see

> [2020-03-10T06:07:10.609Z] Error: some files are not up-to-date. Run 'mage fmt update' then review and commit the changes. Modified: [NOTICE.txt]

But we don't know what the diff is, which might help us understand what caused the problem. By enabling verbose output in Mage, we'll see the diff.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes~
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

## How to test these changes

N/A

## Related issues

None.