### PR TITLE
[7.x] Fix CI Dockerfile paths for go get (#3454)

### DIFF
--- a/.ci/docker/golang-mage/Dockerfile
+++ b/.ci/docker/golang-mage/Dockerfile
@@ -9,14 +9,14 @@ RUN git clone https://github.com/magefile/mage \
   && go run bootstrap.go \
   && mage -version \
   && cd /tools \
-  && go get github.com/elastic/apm-server/vendor/golang.org/x/tools/cmd/benchcmp \
-  && go get github.com/elastic/apm-server/vendor/github.com/t-yuki/gocover-cobertura \
-  && go get github.com/elastic/apm-server/vendor/github.com/jstemmer/go-junit-report \
-  && go get github.com/elastic/apm-server/vendor/github.com/kardianos/govendor \
+  && go get golang.org/x/tools/cmd/benchcmp \
+  && go get github.com/t-yuki/gocover-cobertura \
+  && go get github.com/jstemmer/go-junit-report \
+  && go get github.com/kardianos/govendor \
   && go get github.com/elastic/go-licenser \
-  && go get github.com/elastic/apm-server/vendor/github.com/pierrre/gotestcover \
-  && go get github.com/elastic/apm-server/vendor/github.com/stretchr/testify/assert \
-  && go get github.com/elastic/apm-server/vendor/golang.org/x/tools/cmd/goimports
+  && go get github.com/pierrre/gotestcover \
+  && go get github.com/stretchr/testify/assert \
+  && go get golang.org/x/tools/cmd/goimports
 
 RUN apt-get update -y -qq \
   && apt-get install -y -qq python3 python3-pip python3-venv \


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix CI Dockerfile paths for go get (#3454)