### PR TITLE
docs: Update documentation from Beats

### DIFF
--- a/docs/copied-from-beats/docs/command-reference.asciidoc
+++ b/docs/copied-from-beats/docs/command-reference.asciidoc
@@ -103,8 +103,11 @@ endif::[]
 ifdef::apm-server[]
 |<<apikey-command,`apikey`>> |{apikey-command-short-desc}.
 endif::[]
+|<<export-command,`export`>> |{export-command-short-desc}.
 |<<help-command,`help`>> |{help-command-short-desc}.
+ifndef::serverless[]
 |<<keystore-command,`keystore`>> |{keystore-command-short-desc}.
+endif::[]
 ifeval::["{beatname_lc}"=="functionbeat"]
 |<<package-command,`package`>> |{package-command-short-desc}.
 |<<remove-command,`remove`>> |{remove-command-short-desc}.
@@ -433,6 +436,7 @@ Specifies the name of the command to show help for.
 {beatname_lc} help export
 -----
 
+ifndef::serverless[]
 [[keystore-command]]
 ==== `keystore` command
 
@@ -488,6 +492,8 @@ Shows help for the `keystore` command.
 
 See <<keystore>> for more examples.
 
+endif::[]
+
 ifeval::["{beatname_lc}"=="functionbeat"]
 [[package-command]]
 ==== `package` command
@@ -507,7 +513,7 @@ ifeval::["{beatname_lc}"=="functionbeat"]
 Shows help for the `package` command.
 
 *`-o, --output`*::
-Specifies the full path to the zip file that will contain the package.
+Specifies the full path pattern to use when creating the packages. 
 
 {global-flags}
 
@@ -515,7 +521,7 @@ Specifies the full path to the zip file that will contain the package.
 
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} package /path/to/file.zip
+{beatname_lc} package --output /path/to/folder/package-{{.Provider}}.zip
 -----
 
 [[remove-command]]
@@ -787,11 +793,6 @@ endif::no_dashboards[]
 *`-h, --help`*::
 Shows help for the `setup` command.
 
-ifdef::has_ml_jobs[]
-*`--machine-learning`*::
-Sets up machine learning job configurations only.
-endif::[]
-
 ifeval::["{beatname_lc}"=="filebeat"]
 *`--modules MODULE_LIST`*::
 Specifies a comma-separated list of modules. Use this flag to avoid errors when
@@ -831,7 +832,6 @@ ifeval::["{beatname_lc}"=="filebeat"]
 ["source","sh",subs="attributes"]
 -----
 {beatname_lc} setup --dashboards
-{beatname_lc} setup --machine-learning
 {beatname_lc} setup --pipelines
 {beatname_lc} setup --pipelines --modules system,nginx,mysql <1>
 {beatname_lc} setup --index-management
@@ -847,7 +847,6 @@ ifndef::no_dashboards[]
 ["source","sh",subs="attributes"]
 -----
 {beatname_lc} setup --dashboards
-{beatname_lc} setup --machine-learning
 {beatname_lc} setup --index-management
 -----
 endif::no_dashboards[]
@@ -856,7 +855,6 @@ ifndef::apm-server[]
 ifdef::no_dashboards[]
 ["source","sh",subs="attributes"]
 -----
-{beatname_lc} setup --machine-learning
 {beatname_lc} setup --index-management
 -----
 endif::no_dashboards[]
@@ -1030,6 +1028,13 @@ messages.
 
 *`-e, --e`*::
 Logs to stderr and disables syslog/file output.
+
+*`-environment`*::
+For logging purposes, specifies the environment that {beatname_uc} is running in.
+This setting is used to select a default log output when no log output is configured.
+Supported values are: `systemd`, `container`, `macos_service`, and `windows_service`.
+If `systemd` or `container` is specified, {beatname_uc} will log to stdout and stderr
+by default.
 
 *`--path.config`*::
 Sets the path for configuration files. See the <<directory-layout>> section for

--- a/docs/copied-from-beats/docs/https.asciidoc
+++ b/docs/copied-from-beats/docs/https.asciidoc
@@ -31,8 +31,13 @@ output.elasticsearch:
 <3> This setting enables the HTTPS protocol.
 <4> The IP and port of the Elasticsearch nodes.
 
-TIP: To obfuscate passwords and other sensitive settings, use the
-<<keystore,secrets keystore>>.
+TIP: To obfuscate passwords and other sensitive settings,
+ifndef::serverless[]
+use the <<keystore,secrets keystore>>.
+endif::[]
+ifdef::serverless[]
+use environment variables.
+endif::[]
 
 {beatname_uc} verifies the validity of the server certificates and only accepts trusted
 certificates. Creating a correct SSL/TLS infrastructure is outside the scope of

--- a/docs/copied-from-beats/docs/monitoring/monitoring-beats.asciidoc
+++ b/docs/copied-from-beats/docs/monitoring/monitoring-beats.asciidoc
@@ -14,21 +14,24 @@ ifdef::apm-server[]
 endif::[]
 
 To monitor {beatname_uc}, make sure monitoring is enabled on your {es} cluster,
-then configure the method used to collect {beatname_uc} metrics. You
-ifndef::serverless[]
-can use one of following methods:
-endif::[]
-ifdef::serverless[]
-can use the following method:
-endif::[]
+then configure the method used to collect {beatname_uc} metrics. You can use one
+of following methods:
 
-* <<monitoring-internal-collection,Internal collection>>
+* <<monitoring-internal-collection,Internal collection>> - Internal
+collectors send monitoring data directly to your monitoring cluster.
 ifndef::serverless[]
-* <<monitoring-metricbeat-collection, {metricbeat} collection>>
+* <<monitoring-metricbeat-collection, {metricbeat} collection>> - 
+{metricbeat} collects monitoring data from your {beatname_uc} instance
+and sends it directly to your monitoring cluster.
 endif::[]
+* <<monitoring-internal-collection-legacy,Legacy internal collection (deprecated)>> - 
+Legacy internal collectors send monitoring data to your production cluster.
 
-To learn about monitoring in general, see 
-{ref}/monitor-elasticsearch-cluster.html[Monitor a cluster]. 
+
+//Commenting out this link temporarily until the general monitoring docs can be
+//updated. 
+//To learn about monitoring in general, see 
+//{ref}/monitor-elasticsearch-cluster.html[Monitor a cluster]. 
 
 --
 
@@ -37,3 +40,5 @@ include::monitoring-internal-collection.asciidoc[]
 ifndef::serverless[]
 include::monitoring-metricbeat.asciidoc[]
 endif::[]
+
+include::monitoring-internal-collection-legacy.asciidoc[]

--- a/docs/copied-from-beats/docs/monitoring/shared-monitor-config-legacy.asciidoc
+++ b/docs/copied-from-beats/docs/monitoring/shared-monitor-config-legacy.asciidoc
@@ -1,0 +1,138 @@
+//////////////////////////////////////////////////////////////////////////
+//// This content is shared by all Elastic Beats. Make sure you keep the
+//// descriptions here generic enough to work for all Beats that include
+//// this file. When using cross references, make sure that the cross
+//// references resolve correctly for any files that include this one.
+//// Use the appropriate variables defined in the index.asciidoc file to
+//// resolve Beat names: beatname_uc and beatname_lc.
+//// Use the following include to pull this content into a doc file:
+//// include::../../libbeat/docs/monitoring/shared-monitor-config.asciidoc[]
+//// Make sure this content appears below a level 2 heading.
+//////////////////////////////////////////////////////////////////////////
+
+[role="xpack"]
+[[configuration-monitor-legacy]]
+=== Settings for legacy internal collection
+
+deprecated::[7.2.0,These settings are deprecated and will be removed in version 8.0.0. Instead of sending monitoring data to your production cluster it's recommended that you use the configuration described under <<monitoring-internal-collection>> to route monitoring data directly to your monitoring cluster.]
+
+[float]
+=== `xpack.monitoring.enabled` deprecated:[7.2]
+
+The `enabled` config is a boolean setting to enable or disable {monitoring}.
+If set to `true`, monitoring is enabled.
+
+The default value is `false`.
+
+[float]
+=== `xpack.monitoring.elasticsearch` deprecated:[7.2]
+
+The {es} instances that you want to ship your {beatname_uc} metrics to. This
+configuration option contains the following fields:
+
+[float]
+==== `bulk_max_size`
+
+The maximum number of metrics to bulk in a single {es} bulk API index request.
+The default is `50`. For more information, see <<elasticsearch-output>>.
+
+[float]
+==== `backoff.init`
+
+The number of seconds to wait before trying to reconnect to Elasticsearch after
+a network error. After waiting `backoff.init` seconds, {beatname_uc} tries to
+reconnect. If the attempt fails, the backoff timer is increased exponentially up
+to `backoff.max`. After a successful connection, the backoff timer is reset. The
+default is 1s.
+
+[float]
+===== `backoff.max`
+
+The maximum number of seconds to wait before attempting to connect to
+Elasticsearch after a network error. The default is 60s.
+
+[float]
+==== `compression_level`
+
+The gzip compression level. Setting this value to `0` disables compression. The
+compression level must be in the range of `1` (best speed) to `9` (best
+compression). The default value is `0`. Increasing the compression level
+reduces the network usage but increases the CPU usage.
+
+[float]
+==== `headers`
+
+Custom HTTP headers to add to each request. For more information, see
+<<elasticsearch-output>>.
+
+[float]
+==== `hosts`
+
+The list of {es} nodes to connect to. Monitoring metrics are distributed to
+these nodes in round-robin order. For more information, see
+<<elasticsearch-output>>.
+
+[float]
+==== `max_retries`
+
+The number of times to retry sending the monitoring metrics after a failure.
+After the specified number of retries, the metrics are typically dropped. The
+default value is `3`. For more information, see <<elasticsearch-output>>.
+
+[float]
+==== `parameters`
+
+Dictionary of HTTP parameters to pass within the url with index operations.
+
+[float]
+==== `password`
+
+The password that {beatname_uc} uses to authenticate with the {es} instances for
+shipping monitoring data.
+
+[float]
+==== `metrics.period`
+
+The time interval (in seconds) when metrics are sent to the {es} cluster. A new
+snapshot of {beatname_uc} metrics is generated and scheduled for publishing each
+period. The default value is 10 * time.Second.
+
+[float]
+==== `state.period`
+
+The time interval (in seconds) when state information are sent to the {es} cluster. A new
+snapshot of {beatname_uc} state is generated and scheduled for publishing each
+period. The default value is 60 * time.Second.
+
+[float]
+==== `protocol`
+
+The name of the protocol to use when connecting to the {es} cluster. The options
+are: `http` or `https`. The default is `http`. If you specify a URL for `hosts`,
+however, the value of protocol is overridden by the scheme you specify in the URL.
+
+[float]
+==== `proxy_url`
+
+The URL of the proxy to use when connecting to the {es} cluster. For more
+information, see <<elasticsearch-output>>.
+
+[float]
+==== `timeout`
+
+The HTTP request timeout in seconds for the {es} request. The default is `90`.
+
+[float]
+==== `ssl`
+
+Configuration options for Transport Layer Security (TLS) or Secure Sockets Layer
+(SSL) parameters like the certificate authority (CA) to use for HTTPS-based
+connections. If the `ssl` section is missing, the host CAs are used for
+HTTPS connections to {es}. For more information, see <<configuration-ssl>>.
+
+[float]
+==== `username`
+
+The user ID that {beatname_uc} uses to authenticate with the {es} instances for
+shipping monitoring data.
+

--- a/docs/copied-from-beats/docs/output-cloud.asciidoc
+++ b/docs/copied-from-beats/docs/output-cloud.asciidoc
@@ -41,6 +41,8 @@ The Cloud ID, which can be found in the {ecloud} web console, is used by
 {beatname_uc} to resolve the {es} and {kib} URLs. This setting
 overwrites the `output.elasticsearch.hosts` and `setup.kibana.host` settings.
 
+NOTE: The base64 encoded `cloud.id` found in the {ecloud} web console does not explicitly specify a port. This means that {beatname_uc} will default to using port 443 when using `cloud.id`, not the commonly configured cloud endpoint port 9243.
+
 ==== `cloud.auth`
 
 When specified, the `cloud.auth` overwrites the `output.elasticsearch.username` and

--- a/docs/copied-from-beats/docs/outputconfig.asciidoc
+++ b/docs/copied-from-beats/docs/outputconfig.asciidoc
@@ -10,7 +10,6 @@
 //// Make sure this content appears below a level 2 heading.
 //////////////////////////////////////////////////////////////////////////
 
-// tag::shared-outputconfig[]
 
 [[configuring-output]]
 == Configure the output
@@ -22,8 +21,6 @@ output may be defined.
 The following topics describe how to configure each supported output. If you've
 secured the {stack}, also read <<securing-{beatname_lc}>> for more about
 security-related configuration options.
-
-// end::shared-outputconfig[]
 
 include::outputs-list.asciidoc[tag=outputs-list]
 

--- a/docs/copied-from-beats/docs/outputs-list.asciidoc
+++ b/docs/copied-from-beats/docs/outputs-list.asciidoc
@@ -3,33 +3,85 @@
 
 //# tag::outputs-list[]
 
+ifndef::no_es_output[]
 * <<elasticsearch-output>>
+endif::[]
+ifndef::no_ls_output[]
 * <<logstash-output>>
+endif::[]
+ifndef::no_kafka_output[]
 * <<kafka-output>>
-ifndef::no-output-redis[]
+endif::[]
+ifndef::no_redis_output[]
 * <<redis-output>>
 endif::[]
+ifndef::no_file_output[]
 * <<file-output>>
+endif::[]
+ifndef::no_console_output[]
 * <<console-output>>
+endif::[]
+ifndef::no_cloud_id[]
 * <<configure-cloud-id>>
+endif::[]
 
 //# end::outputs-list[]
 
 //# tag::outputs-include[]
+ifndef::no_es_output[]
+ifdef::requires_xpack[]
+[role="xpack"]
+endif::[]
 include::{libbeat-outputs-dir}/elasticsearch/docs/elasticsearch.asciidoc[]
+endif::[]
 
+ifndef::no_ls_output[]
+ifdef::requires_xpack[]
+[role="xpack"]
+endif::[]
 include::{libbeat-outputs-dir}/logstash/docs/logstash.asciidoc[]
+endif::[]
 
+ifndef::no_kafka_output[]
+ifdef::requires_xpack[]
+[role="xpack"]
+endif::[]
 include::{libbeat-outputs-dir}/kafka/docs/kafka.asciidoc[]
+endif::[]
 
+ifndef::no_redis_output[]
+ifdef::requires_xpack[]
+[role="xpack"]
+endif::[]
 include::{libbeat-outputs-dir}/redis/docs/redis.asciidoc[]
+endif::[]
 
+ifndef::no_file_output[]
+ifdef::requires_xpack[]
+[role="xpack"]
+endif::[]
 include::{libbeat-outputs-dir}/fileout/docs/fileout.asciidoc[]
+endif::[]
 
+ifndef::no_console_output[]
+ifdef::requires_xpack[]
+[role="xpack"]
+endif::[]
 include::{libbeat-outputs-dir}/console/docs/console.asciidoc[]
+endif::[]
 
+ifndef::no_cloud_id[]
+ifdef::requires_xpack[]
+[role="xpack"]
+endif::[]
 include::output-cloud.asciidoc[]
+endif::[]
 
+ifndef::no_codec[]
+ifdef::requires_xpack[]
+[role="xpack"]
+endif::[]
 include::{libbeat-outputs-dir}/codec/docs/codec.asciidoc[]
+endif::[]
 
 //# end::outputs-include[]

--- a/docs/copied-from-beats/docs/repositories.asciidoc
+++ b/docs/copied-from-beats/docs/repositories.asciidoc
@@ -120,6 +120,13 @@ sudo apt-get update && sudo apt-get install {beatname_pkg}
 +
 ["source","sh",subs="attributes"]
 --------------------------------------------------
+sudo systemctl enable {beatname_pkg}
+--------------------------------------------------
+
+If your system does not use `systemd` then run:
++
+["source","sh",subs="attributes"]
+--------------------------------------------------
 sudo update-rc.d {beatname_pkg} defaults 95 10
 --------------------------------------------------
 
@@ -212,6 +219,13 @@ sudo yum install {beatname_pkg}
 --------------------------------------------------
 
 . To configure {beatname_uc} to start automatically during boot, run:
++
+["source","sh",subs="attributes"]
+--------------------------------------------------
+sudo systemctl enable {beatname_pkg}
+--------------------------------------------------
+
+If your system does not use `systemd` then run:
 +
 ["source","sh",subs="attributes"]
 --------------------------------------------------

--- a/docs/copied-from-beats/docs/security/api-keys.asciidoc
+++ b/docs/copied-from-beats/docs/security/api-keys.asciidoc
@@ -82,7 +82,7 @@ POST /_security/api_key
       "cluster": ["monitor"],
       "index": [
         {
-          "names": [".monitoring-{beatname_lc}-*"],
+          "names": [".monitoring-beats-*"],
           "privileges": ["create_index", "create"]
         }
       ]

--- a/docs/copied-from-beats/docs/security/basic-auth.asciidoc
+++ b/docs/copied-from-beats/docs/security/basic-auth.asciidoc
@@ -25,7 +25,13 @@ output.elasticsearch:
 <1> Let's assume this user has the privileges required to publish events to
 {es}.
 <2> The example shows a hard-coded password, but you should store sensitive
-values in the <<keystore,secrets keystore>>.
+values
+ifndef::serverless[]
+in the <<keystore,secrets keystore>>.
+endif::[]
+ifdef::serverless[]
+in environment variables.
+endif::[]
 --
 ifndef::apm-server[]
 +

--- a/docs/copied-from-beats/docs/security/users.asciidoc
+++ b/docs/copied-from-beats/docs/security/users.asciidoc
@@ -214,8 +214,9 @@ endif::serverless[]
 ==== Grant privileges and roles needed for publishing
 
 Users who publish events to {es} need to create and write to {beatname_uc}
-indices. To minimize the privileges required by the writer role, you can use the
-<<privileges-to-setup-beats,setup role>> to pre-load dependencies.
+indices. To minimize the privileges required by the writer role, use the
+<<privileges-to-setup-beats,setup role>> to pre-load dependencies. This section
+assumes that you've pre-loaded dependencies. 
 
 ifndef::no_ilm[]
 When using ILM, turn off the ILM setup check in the {beatname_uc} config file before

--- a/docs/copied-from-beats/docs/shared-ssl-config.asciidoc
+++ b/docs/copied-from-beats/docs/shared-ssl-config.asciidoc
@@ -129,9 +129,10 @@ The passphrase used to decrypt an encrypted key stored in the configured `key` f
 List of allowed SSL/TLS versions. If SSL/TLS server decides for protocol versions
 not configured, the connection will be dropped during or after the handshake. The
 setting is a list of allowed protocol versions:
-`SSLv3`, `TLSv1` for TLS version 1.0, `TLSv1.0`, `TLSv1.1` and `TLSv1.2`.
+`SSLv3`, `TLSv1` for TLS version 1.0, `TLSv1.0`, `TLSv1.1`, `TLSv1.2`, and
+`TLSv1.3`.
 
-The default value is `[TLSv1.1, TLSv1.2]`.
+The default value is `[TLSv1.1, TLSv1.2, TLSv1.3]`.
 
 [float]
 ==== `verification_mode`
@@ -149,7 +150,8 @@ The default is `full`.
 
 The list of cipher suites to use. The first entry has the highest priority.
 If this option is omitted, the Go crypto library's default
-suites are used (recommended).
+suites are used (recommended). Note that TLS 1.3 cipher suites are not
+individually configurable in Go, so they are not included in this list.
 
 The following cipher suites are available:
 
@@ -226,6 +228,20 @@ are `never`, `once`, and `freely`. The default value is never.
 * `never` - Disables renegotiation.
 * `once` - Allows a remote server to request renegotiation once per connection.
 * `freely` - Allows a remote server to repeatedly request renegotiation.
+
+
+[float]
+==== `ca_sha256`
+
+This configure a certificate pin can that ca be used to ensure that a specific certificate is used
+to as part of the verified chain.
+
+The pin is a base64 encoded string of the SHA-256 of the certificate.
+
+NOTE: This check is not a replacement for the normal SSL validation but it add additional validation.
+If this option is used with  `verification_mode` set to `none`, the check will always fail because
+it will not receive any verified chains.
+
 
 ifeval::["{beatname_lc}" == "filebeat"]
 [float]

--- a/docs/copied-from-beats/docs/shared-systemd.asciidoc
+++ b/docs/copied-from-beats/docs/shared-systemd.asciidoc
@@ -54,10 +54,6 @@ Logs are stored by default in journald. To view the Logs, use `journalctl`:
 journalctl -u {beatname_lc}.service
 ------------------------------------------------
 
-NOTE: The unit file included in the packages sets the `-e` flag by default.
-This flag makes {beatname_uc} log to stderr and disables other log outputs.
-Systemd stores all output sent to stderr in journald.
-
 [float]
 === Customize systemd unit for {beatname_uc}
 
@@ -67,7 +63,7 @@ override to change the default options.
 [cols="<h,<,<m",options="header",]
 |=======================================
 | Variable | Description | Default value
-| BEAT_LOG_OPTS | Log options | `-e`
+| BEAT_LOG_OPTS | Log options |
 | BEAT_CONFIG_OPTS | Flags for configuration file path | +-c /etc/{beatname_lc}/{beatname_lc}.yml+
 | BEAT_PATH_OPTS | Other paths | +-path.home /usr/share/{beatname_lc} -path.config /etc/{beatname_lc} -path.data /var/lib/{beatname_lc} -path.logs /var/log/{beatname_lc}+
 |=======================================
@@ -82,16 +78,7 @@ would override `BEAT_LOG_OPTS` to enable debug for Elasticsearch output.
 ["source", "systemd", subs="attributes"]
 ------------------------------------------------
 [Service]
-Environment="BEAT_LOG_OPTS=-e -d elasticsearch"
-------------------------------------------------
-
-To change the logging output from the {beatname_uc} configuration file, empty
-the environment variable. For example:
-
-["source", "systemd", subs="attributes"]
-------------------------------------------------
-[Service]
-Environment="BEAT_LOG_OPTS="
+Environment="BEAT_LOG_OPTS=-d elasticsearch"
 ------------------------------------------------
 
 To apply your changes, reload the systemd configuration and restart

--- a/docs/copied-from-beats/docs/template-config.asciidoc
+++ b/docs/copied-from-beats/docs/template-config.asciidoc
@@ -11,7 +11,7 @@ connecting to Elasticsearch.
 ifndef::no-output-logstash[]
 
 NOTE: A connection to Elasticsearch is required to load the index template. If
-the output is Logstash, you must <<load-template-manually,load the template
+the configured output is not Elasticsearch (or Elastic Cloud), you must <<load-template-manually,load the template
 manually>>.
 
 endif::[]
@@ -83,16 +83,16 @@ setup.template.settings:
   _source.enabled: false
 ----------------------------------------------------------------------
 
-*`setup.template.append_fields`* experimental[]:: A list of fields to be added
+*`setup.template.append_fields`*:: A list of fields to be added
 to the template and {kib} index pattern. This setting adds new fields. It does
-not overwrite or change existing fields. 
+not overwrite or change existing fields.
 +
 This setting is useful when your data contains fields that {beatname_uc} doesn't
-know about in advance. 
+know about in advance.
 ifeval::["{beatname_lc}"=="metricbeat"]
 For example, you might want to append fields to the template when you're using
 a metricset, such as the <<metricbeat-metricset-http-json>>, and the full data
-structure is not known in advance. 
+structure is not known in advance.
 endif::[]
 +
 If `append_fields` is specified along with `overwrite: true`, {beatname_uc}
@@ -117,7 +117,7 @@ setup.template.append_fields:
 
 *`setup.template.json.enabled`*:: Set to `true` to load a
 JSON-based template file. Specify the path to your {es} index template file and
-set the name of the template. 
+set the name of the template.
 +
 ["source","yaml",subs="attributes"]
 ----------------------------------------------------------------------

--- a/docs/copied-from-beats/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/docs/copied-from-beats/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -20,6 +20,12 @@ output.elasticsearch:
   ssl.key: "/etc/pki/client/cert.key"
 ------------------------------------------------------------------------------
 
+Notes about the previous example and client based PKI authentication:
+
+- The `ssl.certificate` and `ssl.key` settings are ONLY needed if {es} is configured to require client based PKI authentication (with `xpack.security.http.ssl.client_authentication: required` or `xpack.security.http.ssl.client_authentication: optional`).
+- The `ssl.certificate_authorities` setting needs to include the CA used to sign the remote server certificate, not the client cert.
+- If client PKI is used, the remote server ({es}) should include the CA used for signing the client cert in the `xpack.security.http.ssl.certificate_authorities: []` list.
+
 To enable SSL, just add `https` to all URLs defined under __hosts__.
 
 ["source","yaml",subs="attributes,callouts"]

--- a/docs/copied-from-beats/outputs/kafka/docs/kafka.asciidoc
+++ b/docs/copied-from-beats/outputs/kafka/docs/kafka.asciidoc
@@ -132,12 +132,12 @@ the specified string:
 ------------------------------------------------------------------------------
 output.kafka:
   hosts: ["localhost:9092"]
-  topic: "logs-%{[beat.version]}"
+  topic: "logs-%{[agent.version]}"
   topics:
-    - topic: "critical-%{[beat.version]}"
+    - topic: "critical-%{[agent.version]}"
       when.contains:
         message: "CRITICAL"
-    - topic: "error-%{[beat.version]}"
+    - topic: "error-%{[agent.version]}"
       when.contains:
         message: "ERR"
 ------------------------------------------------------------------------------

--- a/docs/copied-from-beats/outputs/logstash/docs/logstash.asciidoc
+++ b/docs/copied-from-beats/outputs/logstash/docs/logstash.asciidoc
@@ -293,7 +293,7 @@ NOTE: The "ttl" option is not yet supported on an async Logstash client (one wit
 
 Configures number of batches to be sent asynchronously to logstash while waiting
 for ACK from logstash. Output only becomes blocking once number of `pipelining`
-batches have been written. Pipelining is disabled if a values of 0 is
+batches have been written. Pipelining is disabled if a value of 0 is
 configured. The default value is 2.
 
 ===== `proxy_url`

--- a/docs/copied-from-beats/outputs/redis/docs/redis.asciidoc
+++ b/docs/copied-from-beats/outputs/redis/docs/redis.asciidoc
@@ -1,5 +1,3 @@
-//begin inner exclude for redis
-ifndef::no-output-redis[]
 [[redis-output]]
 === Configure the Redis output
 
@@ -48,6 +46,12 @@ distributed to the servers in the list. If one server becomes unreachable, the e
 distributed to the reachable servers only. You can define each Redis server by specifying
 `HOST` or `HOST:PORT`. For example: `"192.15.3.2"` or `"test.redis.io:12345"`. If you
 don't specify a port number, the value configured by `port` is used.
+Configure each Redis server with an `IP:PORT` pair or with a `URL`. For
+example: `redis://localhost:6379` or `rediss://localhost:6379`.
+URLs can include a server-specific password. For example: `redis://:password@localhost:6379`.
+The `redis` scheme will disable the `ssl` settings for the host, while `rediss`
+will enforce TLS.  If `rediss` is specified and no `ssl` settings are
+configured, the output uses the system certificate store.
 
 ===== `index`
 
@@ -231,6 +235,3 @@ client. You can change this behavior by setting the
 
 This option determines whether Redis hostnames are resolved locally when using a proxy.
 The default value is false, which means that name resolution occurs on the proxy server.
-
-//end inner exclude for redis
-endif::[]


### PR DESCRIPTION
## Motivation/summary

This PR pulls in documentation changes from the Beats repo, and adapts some of the changes for APM Server. A follow-up PR will be opened in the Beats repo to persist the necessary changes.

A lot of these changes aren't noteworthy -- this looks to be mostly small changes and some attribute refactoring.

## Related issues

For https://github.com/elastic/apm-server/issues/3458
