### PR TITLE
Add TLS 1.3 to input default protocols

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -110,10 +110,11 @@ apm-server:
     # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
     #key_passphrase: ''
 
-    # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.2 are enabled.
-    #supported_protocols: [TLSv1.1, TLSv1.2]
+    # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.3 are enabled.
+    #supported_protocols: [TLSv1.1, TLSv1.2, TLSv1.3]
 
     # Configure cipher suites to be used for SSL connections.
+    # Note that cipher suites are not configurable for TLS 1.3.
     #cipher_suites: []
 
     # Configure curve types for ECDHE based cipher suites.

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -110,10 +110,11 @@ apm-server:
     # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
     #key_passphrase: ''
 
-    # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.2 are enabled.
-    #supported_protocols: [TLSv1.1, TLSv1.2]
+    # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.3 are enabled.
+    #supported_protocols: [TLSv1.1, TLSv1.2, TLSv1.3]
 
     # Configure cipher suites to be used for SSL connections.
+    # Note that cipher suites are not configurable for TLS 1.3.
     #cipher_suites: []
 
     # Configure curve types for ECDHE based cipher suites.

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -110,10 +110,11 @@ apm-server:
     # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
     #key_passphrase: ''
 
-    # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.2 are enabled.
-    #supported_protocols: [TLSv1.1, TLSv1.2]
+    # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.3 are enabled.
+    #supported_protocols: [TLSv1.1, TLSv1.2, TLSv1.3]
 
     # Configure cipher suites to be used for SSL connections.
+    # Note that cipher suites are not configurable for TLS 1.3.
     #cipher_suites: []
 
     # Configure curve types for ECDHE based cipher suites.

--- a/docs/ssl-input-settings.asciidoc
+++ b/docs/ssl-input-settings.asciidoc
@@ -38,8 +38,8 @@ We recommend saving the `key_passphrase` in the APM Server <<keystore>>.
 ==== `supported_protocols`
 
 This setting is a list of allowed protocol versions:
-`SSLv3`, `TLSv1.0`, `TLSv1.1` and `TLSv1.2`. We do not recommend using `SSLv3` or `TLSv1.0`.
-The default value is `[TLSv1.1, TLSv1.2]`.
+`SSLv3`, `TLSv1.0`, `TLSv1.1`, `TLSv1.2` and `TLSv1.3`. We do not recommend using `SSLv3` or `TLSv1.0`.
+The default value is `[TLSv1.1, TLSv1.2, TLSv1.3]`.
 
 [float]
 ==== `cipher_suites`

--- a/tests/system/test_tls.py
+++ b/tests/system/test_tls.py
@@ -72,8 +72,11 @@ class TestSecureServerBaseTest(ServerBaseTest):
         cfg.update(self.ssl_overrides())
         return cfg
 
-    def ssl_connect(self, protocol=ssl.PROTOCOL_TLSv1_2, ciphers=None, cert=None, key=None, ca_cert=None):
-        context = ssl.SSLContext(protocol)
+    def ssl_connect(self, min_version=ssl.TLSVersion.TLSv1_1, max_version=ssl.TLSVersion.TLSv1_2,
+                    ciphers=None, cert=None, key=None, ca_cert=None):
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+        context.minimum_version = min_version
+        context.maximum_version = max_version
         if ciphers:
             context.set_ciphers(ciphers)
         if not ca_cert:
@@ -114,7 +117,7 @@ class TestSSLEnabledNoClientVerificationTest(TestSecureServerBaseTest):
 
 
 @integration_test
-class TestSSLEnabledOptionalClientVerificationTest(TestSecureServerBaseTest):
+class TestSSLEnabledOptionalClientAuthenticationTest(TestSecureServerBaseTest):
     # no ssl_overrides necessary as `optional` is default
 
     def test_https_no_certificate_ok(self):
@@ -131,7 +134,7 @@ class TestSSLEnabledOptionalClientVerificationTest(TestSecureServerBaseTest):
 
 
 @integration_test
-class TestSSLEnabledOptionalClientVerificationWithCATest(TestSecureServerBaseTest):
+class TestSSLEnabledOptionalClientAuthenticationWithCATest(TestSecureServerBaseTest):
     def ssl_overrides(self):
         return {"ssl_certificate_authorities": self.ca_cert}
 
@@ -150,7 +153,7 @@ class TestSSLEnabledOptionalClientVerificationWithCATest(TestSecureServerBaseTes
 
 
 @integration_test
-class TestSSLEnabledRequiredClientVerificationTest(TestSecureServerBaseTest):
+class TestSSLEnabledRequiredClientAuthenticationTest(TestSecureServerBaseTest):
     def ssl_overrides(self):
         return {"ssl_client_authentication": "required",
                 "ssl_certificate_authorities": self.ca_cert}
@@ -174,13 +177,25 @@ class TestSSLDefaultSupportedProcotolsTest(TestSecureServerBaseTest):
 
     @raises(ssl.SSLError)
     def test_tls_v1_0(self):
-        self.ssl_connect(protocol=ssl.PROTOCOL_TLSv1, cert=self.server_cert, key=self.server_key)
+        self.ssl_connect(min_version=ssl.TLSVersion.TLSv1,
+                         max_version=ssl.TLSVersion.TLSv1,
+                         cert=self.server_cert, key=self.server_key)
 
     def test_tls_v1_1(self):
-        self.ssl_connect(protocol=ssl.PROTOCOL_TLSv1_1, cert=self.server_cert, key=self.server_key)
+        self.ssl_connect(min_version=ssl.TLSVersion.TLSv1_1,
+                         max_version=ssl.TLSVersion.TLSv1_1,
+                         cert=self.server_cert, key=self.server_key)
 
     def test_tls_v1_2(self):
-        self.ssl_connect(cert=self.server_cert, key=self.server_key)
+        self.ssl_connect(min_version=ssl.TLSVersion.TLSv1_2,
+                         max_version=ssl.TLSVersion.TLSv1_2,
+                         cert=self.server_cert, key=self.server_key)
+
+    def test_tls_v1_3(self):
+        if ssl.HAS_TLSv1_3:
+            self.ssl_connect(min_version=ssl.TLSVersion.TLSv1_3,
+                             max_version=ssl.TLSVersion.TLSv1_3,
+                             cert=self.server_cert, key=self.server_key)
 
 
 @integration_test
@@ -191,7 +206,16 @@ class TestSSLSupportedProcotolsTest(TestSecureServerBaseTest):
 
     @raises(ssl.SSLError)
     def test_tls_v1_1(self):
-        self.ssl_connect(protocol=ssl.PROTOCOL_TLSv1_1, cert=self.server_cert, key=self.server_key)
+        self.ssl_connect(min_version=ssl.TLSVersion.TLSv1_1,
+                         max_version=ssl.TLSVersion.TLSv1_1,
+                         cert=self.server_cert, key=self.server_key)
+
+    @raises(ssl.SSLError)
+    def test_tls_v1_3(self):
+        if ssl.HAS_TLSv1_3:
+            self.ssl_connect(min_version=ssl.TLSVersion.TLSv1_3,
+                             max_version=ssl.TLSVersion.TLSv1_3,
+                             cert=self.server_cert, key=self.server_key)
 
     def test_tls_v1_2(self):
         self.ssl_connect(cert=self.server_cert, key=self.server_key)


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

A few suggestions about filling out this PR:

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR instead of prefixing the title with WIP.
3. Please label this PR with at least one of the following labels, depending on the scope of your change:
- bug fix
- breaking change
- enhancement
4. Remove those recommended/optional sections if you don't need them.
5. Submit the pull request: Push your local changes to your forked copy of the repository and submit a pull request (https://help.github.com/articles/using-pull-requests).
6. Please be patient. We might not be able to review your code as fast as we would like to, but we'll do our best to dedicate to it the attention it deserves. Your effort is much appreciated!

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
Update docs and tests to reflect TLS 1.3 as one of the defaults for APM Server SSL input settings.
<!--
Please explain the motivation behind this PR, along with a summary of the major changes involved. Replace this comment with a description of what is being changed by this PR and why.

Major changes require a number of considerations including impact on:

* logging selector(s)
* metrics
* telemetry
* Elasticsearch Service (https://cloud.elastic.co)
* Elastic Cloud Enterprise (https://www.elastic.co/products/ece)
-->

## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved
List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->
- ~[ ] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).~
- ~[ ] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)~
- ~[ ] I have rebased my changes on top of the latest master branch~
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest master branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
- ~[ ] I have made corresponding changes to the documentation~
- ~[ ] I have added tests that prove my fix is effective or that my feature works~
- ~[ ] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes~
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-server/blob/master/TESTING.md for details.
-->
-~[ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
- [ ] Should be backported to `7.x` and `7.6`. 

## How to test these changes
This only adds TLS 1.3 tests to automated tests and updates docs. Therefore no manual testing required. 
<!--
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

closes #3453
<!--
If this PR should close an issue, please add one of the magic keywords
(e.g. fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/
Examples:
- Closes #ISSUE_ID
- Relates #ISSUE_ID
- Requires #ISSUE_ID
- Supersedes #ISSUE_ID
-->
