### PR TITLE
Makefile: ignore testing/environments source perms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ update-beats: update-beats-module update
 .PHONY: update-beats-module
 update-beats-module:
 	go get -d -u $(BEATS_MODULE)@$(BEATS_VERSION)
-	rsync -crpv --delete $(shell go list -m -f {{.Dir}} $(BEATS_MODULE))/testing/environments testing/
+	rsync -crv --delete $(shell go list -m -f {{.Dir}} $(BEATS_MODULE))/testing/environments testing/
 
 ##############################################################################
 # Kibana synchronisation.


### PR DESCRIPTION
## Motivation/summary

When rsync'ing testing/environments from libbeat,
ignore the source permissions. Files in the module
cache are read-only, leading the files added to our
tree to be read-only, causing pain when updating beats.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes~
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

## How to test these changes

`make update-beats`

## Related issues

None.