### PR TITLE
[7.x] Add TLS 1.3 to input default protocols (#3464)

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -110,10 +110,11 @@ apm-server:
     # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
     #key_passphrase: ''
 
-    # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.2 are enabled.
-    #supported_protocols: [TLSv1.1, TLSv1.2]
+    # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.3 are enabled.
+    #supported_protocols: [TLSv1.1, TLSv1.2, TLSv1.3]
 
     # Configure cipher suites to be used for SSL connections.
+    # Note that cipher suites are not configurable for TLS 1.3.
     #cipher_suites: []
 
     # Configure curve types for ECDHE based cipher suites.

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -110,10 +110,11 @@ apm-server:
     # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
     #key_passphrase: ''
 
-    # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.2 are enabled.
-    #supported_protocols: [TLSv1.1, TLSv1.2]
+    # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.3 are enabled.
+    #supported_protocols: [TLSv1.1, TLSv1.2, TLSv1.3]
 
     # Configure cipher suites to be used for SSL connections.
+    # Note that cipher suites are not configurable for TLS 1.3.
     #cipher_suites: []
 
     # Configure curve types for ECDHE based cipher suites.

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -110,10 +110,11 @@ apm-server:
     # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
     #key_passphrase: ''
 
-    # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.2 are enabled.
-    #supported_protocols: [TLSv1.1, TLSv1.2]
+    # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.3 are enabled.
+    #supported_protocols: [TLSv1.1, TLSv1.2, TLSv1.3]
 
     # Configure cipher suites to be used for SSL connections.
+    # Note that cipher suites are not configurable for TLS 1.3.
     #cipher_suites: []
 
     # Configure curve types for ECDHE based cipher suites.

--- a/docs/ssl-input-settings.asciidoc
+++ b/docs/ssl-input-settings.asciidoc
@@ -38,8 +38,8 @@ We recommend saving the `key_passphrase` in the APM Server <<keystore>>.
 ==== `supported_protocols`
 
 This setting is a list of allowed protocol versions:
-`SSLv3`, `TLSv1.0`, `TLSv1.1` and `TLSv1.2`. We do not recommend using `SSLv3` or `TLSv1.0`.
-The default value is `[TLSv1.1, TLSv1.2]`.
+`SSLv3`, `TLSv1.0`, `TLSv1.1`, `TLSv1.2` and `TLSv1.3`. We do not recommend using `SSLv3` or `TLSv1.0`.
+The default value is `[TLSv1.1, TLSv1.2, TLSv1.3]`.
 
 [float]
 ==== `cipher_suites`

--- a/tests/system/test_tls.py
+++ b/tests/system/test_tls.py
@@ -72,8 +72,11 @@ class TestSecureServerBaseTest(ServerBaseTest):
         cfg.update(self.ssl_overrides())
         return cfg
 
-    def ssl_connect(self, protocol=ssl.PROTOCOL_TLSv1_2, ciphers=None, cert=None, key=None, ca_cert=None):
-        context = ssl.SSLContext(protocol)
+    def ssl_connect(self, min_version=ssl.TLSVersion.TLSv1_1, max_version=ssl.TLSVersion.TLSv1_2,
+                    ciphers=None, cert=None, key=None, ca_cert=None):
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+        context.minimum_version = min_version
+        context.maximum_version = max_version
         if ciphers:
             context.set_ciphers(ciphers)
         if not ca_cert:
@@ -114,7 +117,7 @@ class TestSSLEnabledNoClientVerificationTest(TestSecureServerBaseTest):
 
 
 @integration_test
-class TestSSLEnabledOptionalClientVerificationTest(TestSecureServerBaseTest):
+class TestSSLEnabledOptionalClientAuthenticationTest(TestSecureServerBaseTest):
     # no ssl_overrides necessary as `optional` is default
 
     def test_https_no_certificate_ok(self):
@@ -131,7 +134,7 @@ class TestSSLEnabledOptionalClientVerificationTest(TestSecureServerBaseTest):
 
 
 @integration_test
-class TestSSLEnabledOptionalClientVerificationWithCATest(TestSecureServerBaseTest):
+class TestSSLEnabledOptionalClientAuthenticationWithCATest(TestSecureServerBaseTest):
     def ssl_overrides(self):
         return {"ssl_certificate_authorities": self.ca_cert}
 
@@ -150,7 +153,7 @@ class TestSSLEnabledOptionalClientVerificationWithCATest(TestSecureServerBaseTes
 
 
 @integration_test
-class TestSSLEnabledRequiredClientVerificationTest(TestSecureServerBaseTest):
+class TestSSLEnabledRequiredClientAuthenticationTest(TestSecureServerBaseTest):
     def ssl_overrides(self):
         return {"ssl_client_authentication": "required",
                 "ssl_certificate_authorities": self.ca_cert}
@@ -174,13 +177,25 @@ class TestSSLDefaultSupportedProcotolsTest(TestSecureServerBaseTest):
 
     @raises(ssl.SSLError)
     def test_tls_v1_0(self):
-        self.ssl_connect(protocol=ssl.PROTOCOL_TLSv1, cert=self.server_cert, key=self.server_key)
+        self.ssl_connect(min_version=ssl.TLSVersion.TLSv1,
+                         max_version=ssl.TLSVersion.TLSv1,
+                         cert=self.server_cert, key=self.server_key)
 
     def test_tls_v1_1(self):
-        self.ssl_connect(protocol=ssl.PROTOCOL_TLSv1_1, cert=self.server_cert, key=self.server_key)
+        self.ssl_connect(min_version=ssl.TLSVersion.TLSv1_1,
+                         max_version=ssl.TLSVersion.TLSv1_1,
+                         cert=self.server_cert, key=self.server_key)
 
     def test_tls_v1_2(self):
-        self.ssl_connect(cert=self.server_cert, key=self.server_key)
+        self.ssl_connect(min_version=ssl.TLSVersion.TLSv1_2,
+                         max_version=ssl.TLSVersion.TLSv1_2,
+                         cert=self.server_cert, key=self.server_key)
+
+    def test_tls_v1_3(self):
+        if ssl.HAS_TLSv1_3:
+            self.ssl_connect(min_version=ssl.TLSVersion.TLSv1_3,
+                             max_version=ssl.TLSVersion.TLSv1_3,
+                             cert=self.server_cert, key=self.server_key)
 
 
 @integration_test
@@ -191,7 +206,16 @@ class TestSSLSupportedProcotolsTest(TestSecureServerBaseTest):
 
     @raises(ssl.SSLError)
     def test_tls_v1_1(self):
-        self.ssl_connect(protocol=ssl.PROTOCOL_TLSv1_1, cert=self.server_cert, key=self.server_key)
+        self.ssl_connect(min_version=ssl.TLSVersion.TLSv1_1,
+                         max_version=ssl.TLSVersion.TLSv1_1,
+                         cert=self.server_cert, key=self.server_key)
+
+    @raises(ssl.SSLError)
+    def test_tls_v1_3(self):
+        if ssl.HAS_TLSv1_3:
+            self.ssl_connect(min_version=ssl.TLSVersion.TLSv1_3,
+                             max_version=ssl.TLSVersion.TLSv1_3,
+                             cert=self.server_cert, key=self.server_key)
 
     def test_tls_v1_2(self):
         self.ssl_connect(cert=self.server_cert, key=self.server_key)


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add TLS 1.3 to input default protocols (#3464)