### PR TITLE
[7.6] Add TLS 1.3 to input default protocols (#3464)

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -110,10 +110,11 @@ apm-server:
     # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
     #key_passphrase: ''
 
-    # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.2 are enabled.
-    #supported_protocols: [TLSv1.1, TLSv1.2]
+    # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.3 are enabled.
+    #supported_protocols: [TLSv1.1, TLSv1.2, TLSv1.3]
 
     # Configure cipher suites to be used for SSL connections.
+    # Note that cipher suites are not configurable for TLS 1.3.
     #cipher_suites: []
 
     # Configure curve types for ECDHE based cipher suites.

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -110,10 +110,11 @@ apm-server:
     # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
     #key_passphrase: ''
 
-    # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.2 are enabled.
-    #supported_protocols: [TLSv1.1, TLSv1.2]
+    # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.3 are enabled.
+    #supported_protocols: [TLSv1.1, TLSv1.2, TLSv1.3]
 
     # Configure cipher suites to be used for SSL connections.
+    # Note that cipher suites are not configurable for TLS 1.3.
     #cipher_suites: []
 
     # Configure curve types for ECDHE based cipher suites.

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -110,10 +110,11 @@ apm-server:
     # It is recommended to use the provided keystore instead of entering the passphrase in plain text.
     #key_passphrase: ''
 
-    # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.2 are enabled.
-    #supported_protocols: [TLSv1.1, TLSv1.2]
+    # List of supported/valid protocol versions. By default TLS versions 1.1 up to 1.3 are enabled.
+    #supported_protocols: [TLSv1.1, TLSv1.2, TLSv1.3]
 
     # Configure cipher suites to be used for SSL connections.
+    # Note that cipher suites are not configurable for TLS 1.3.
     #cipher_suites: []
 
     # Configure curve types for ECDHE based cipher suites.

--- a/docs/ssl-input-settings.asciidoc
+++ b/docs/ssl-input-settings.asciidoc
@@ -38,8 +38,8 @@ We recommend saving the `key_passphrase` in the APM Server <<keystore>>.
 ==== `supported_protocols`
 
 This setting is a list of allowed protocol versions:
-`SSLv3`, `TLSv1.0`, `TLSv1.1` and `TLSv1.2`. We do not recommend using `SSLv3` or `TLSv1.0`.
-The default value is `[TLSv1.1, TLSv1.2]`.
+`SSLv3`, `TLSv1.0`, `TLSv1.1`, `TLSv1.2` and `TLSv1.3`. We do not recommend using `SSLv3` or `TLSv1.0`.
+The default value is `[TLSv1.1, TLSv1.2, TLSv1.3]`.
 
 [float]
 ==== `cipher_suites`

--- a/tests/system/test_access.py
+++ b/tests/system/test_access.py
@@ -424,7 +424,7 @@ class TestSecureServerBaseTest(ServerBaseTest):
                     max_version=ssl.TLSVersion.TLSv1_2, ciphers=None):
         context = ssl.SSLContext(ssl.PROTOCOL_TLS)
         context.minimum_version = min_version
-        context.maximum_version= max_version
+        context.maximum_version = max_version
         if ciphers:
             context.set_ciphers(ciphers)
         context.load_verify_locations(self.ca_cert)
@@ -548,6 +548,7 @@ class TestSSLDefaultSupportedProcotolsTest(TestSecureServerBaseTest):
         if ssl.HAS_TLSv1_3:
             self.ssl_connect(min_version=ssl.TLSVersion.TLSv1_3,
                              max_version=ssl.TLSVersion.TLSv1_3)
+
 
 @integration_test
 class TestSSLSupportedProcotolsTest(TestSecureServerBaseTest):

--- a/tests/system/test_access.py
+++ b/tests/system/test_access.py
@@ -563,7 +563,7 @@ class TestSSLSupportedCiphersTest(TestSecureServerBaseTest):
                 "ssl_certificate_authorities": self.ca_cert}
 
     def test_https_no_cipher_set(self):
-        self.ssl_connect(protocol=ssl.PROTOCOL_TLSv1_2, )
+        self.ssl_connect(protocol=ssl.PROTOCOL_TLSv1_2)
 
     def test_https_supports_cipher(self):
         # set the same cipher in the client as set in the server


### PR DESCRIPTION
Backports the following commits to 7.6:
 - Add TLS 1.3 to input default protocols (#3464)