### PR TITLE
script: force UTF-8 encoding when reading licenses

### DIFF
--- a/script/generate_notice.py
+++ b/script/generate_notice.py
@@ -22,13 +22,8 @@ def read_file(filename):
     if not os.path.isfile(filename):
         print("File not found {}".format(filename))
         return ""
-    try:
-        with open(filename, 'r') as f:
-            return f.read()
-    except UnicodeDecodeError:
-        # try latin-1
-        with open(filename, 'r', encoding="ISO-8859-1") as f:
-            return f.read()
+    with open(filename, 'r', encoding='utf-8') as f:
+        return f.read()
 
 
 def read_go_deps(main_packages, build_tags):


### PR DESCRIPTION
## Motivation/summary

In case the locale is something other than UTF-8,
force the encoding to "utf-8" when reading license
and notice files, in generate_notice.py.

## Checklist
- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes~
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

## How to test these changes

- `rm -f NOTICE.txt && make notice`
- `rm -f NOTICE.txt && LANG=C make notice`

## Related issues

None.