### PR TITLE
[7.x] script: force UTF-8 encoding when reading licenses (#3470)

### DIFF
--- a/script/generate_notice.py
+++ b/script/generate_notice.py
@@ -22,13 +22,8 @@ def read_file(filename):
     if not os.path.isfile(filename):
         print("File not found {}".format(filename))
         return ""
-    try:
-        with open(filename, 'r') as f:
-            return f.read()
-    except UnicodeDecodeError:
-        # try latin-1
-        with open(filename, 'r', encoding="ISO-8859-1") as f:
-            return f.read()
+    with open(filename, 'r', encoding='utf-8') as f:
+        return f.read()
 
 
 def read_go_deps(main_packages, build_tags):


### PR DESCRIPTION
Backports the following commits to 7.x:
 - script: force UTF-8 encoding when reading licenses (#3470)