### PR TITLE
Update client cert auth tests to TLS 1.3

### DIFF
--- a/tests/system/test_tls.py
+++ b/tests/system/test_tls.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import ssl
 import subprocess
+import socket
 
 from nose.tools import raises
 
@@ -69,7 +70,7 @@ class TestSecureServerBaseTest(ServerBaseTest):
         cfg.update(self.ssl_overrides())
         return cfg
 
-    def ssl_connect(self, min_version=ssl.TLSVersion.TLSv1_1, max_version=ssl.TLSVersion.TLSv1_2,
+    def ssl_connect(self, min_version=ssl.TLSVersion.TLSv1_1, max_version=ssl.TLSVersion.TLSv1_3,
                     ciphers=None, cert=None, key=None, ca_cert=None):
         context = ssl.SSLContext(ssl.PROTOCOL_TLS)
         context.minimum_version = min_version
@@ -81,8 +82,21 @@ class TestSecureServerBaseTest(ServerBaseTest):
         context.load_verify_locations(ca_cert)
         if cert and key:
             context.load_cert_chain(certfile=cert, keyfile=key, password=self.password)
-        s = context.wrap_socket(ssl.socket())
-        s.connect((self.host, self.port))
+        with context.wrap_socket(ssl.socket()) as s:
+            # For TLS 1.3 the client certificate authentication happens after the handshake,
+            # leading to s.connect not failing for invalid or missing client certs.
+            # The authentication happens when the client performs the first read.
+            # Setting a timeout helps speed up the tests, as `s.recv` is blocking.
+            # Timeout errors only happen when the cient can read from the socket,
+            # otherwise a SSLError occurs.
+            s.connect((self.host, self.port))
+            s.sendall(str.encode("sending TLS data"))
+            s.settimeout(0.5)
+            try:
+                s.recv(8)
+            except socket.timeout:
+                pass
+            s.close()
 
 
 class TestSSLBadPassphraseTest(TestSecureServerBaseTest):
@@ -95,7 +109,7 @@ class TestSSLBadPassphraseTest(TestSecureServerBaseTest):
 
 
 @integration_test
-class TestSSLEnabledNoClientVerificationTest(TestSecureServerBaseTest):
+class TestSSLEnabledNoClientAuthenticationTest(TestSecureServerBaseTest):
     def ssl_overrides(self):
         return {"ssl_client_authentication": "none"}
 
@@ -118,6 +132,7 @@ class TestSSLEnabledOptionalClientAuthenticationTest(TestSecureServerBaseTest):
 
     @raises(ssl.SSLError)
     def test_https_verify_cert_if_given(self):
+        # invalid certificate
         self.ssl_connect(cert=self.simple_cert, key=self.simple_key)
 
     @raises(ssl.SSLError)
@@ -216,23 +231,31 @@ class TestSSLSupportedProcotolsTest(TestSecureServerBaseTest):
 
 @integration_test
 class TestSSLSupportedCiphersTest(TestSecureServerBaseTest):
+    # Tests explicitly set TLS 1.2 as cipher suites are not configurable for TLS 1.3
     def ssl_overrides(self):
         return {"ssl_cipher_suites": ['ECDHE-RSA-AES-128-GCM-SHA256'],
                 "ssl_certificate_authorities": self.ca_cert}
 
     def test_https_no_cipher_set(self):
-        self.ssl_connect(cert=self.server_cert, key=self.server_key)
+        self.ssl_connect(max_version=ssl.TLSVersion.TLSv1_2,
+                         cert=self.server_cert, key=self.server_key)
 
     def test_https_supports_cipher(self):
         # set the same cipher in the client as set in the server
-        self.ssl_connect(ciphers='ECDHE-RSA-AES128-GCM-SHA256', cert=self.server_cert, key=self.server_key)
+        self.ssl_connect(max_version=ssl.TLSVersion.TLSv1_2,
+                         ciphers='ECDHE-RSA-AES128-GCM-SHA256',
+                         cert=self.server_cert, key=self.server_key)
 
     def test_https_unsupported_cipher(self):
         # client only offers unsupported cipher
         with self.assertRaisesRegexp(ssl.SSLError, 'SSLV3_ALERT_HANDSHAKE_FAILURE'):
-            self.ssl_connect(ciphers='ECDHE-RSA-AES256-SHA384', cert=self.server_cert, key=self.server_key)
+            self.ssl_connect(max_version=ssl.TLSVersion.TLSv1_2,
+                             ciphers='ECDHE-RSA-AES256-SHA384',
+                             cert=self.server_cert, key=self.server_key)
 
     def test_https_no_cipher_selected(self):
         # client provides invalid cipher
         with self.assertRaisesRegexp(ssl.SSLError, 'No cipher can be selected'):
-            self.ssl_connect(ciphers='AES1sd28-CCM8', cert=self.server_cert, key=self.server_key)
+            self.ssl_connect(max_version=ssl.TLSVersion.TLSv1_2,
+                             ciphers='AES1sd28-CCM8',
+                             cert=self.server_cert, key=self.server_key)


### PR DESCRIPTION


<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

A few suggestions about filling out this PR:

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR instead of prefixing the title with WIP.
3. Please label this PR with at least one of the following labels, depending on the scope of your change:
- bug fix
- breaking change
- enhancement
4. Remove those recommended/optional sections if you don't need them.
5. Submit the pull request: Push your local changes to your forked copy of the repository and submit a pull request (https://help.github.com/articles/using-pull-requests).
6. Please be patient. We might not be able to review your code as fast as we would like to, but we'll do our best to dedicate to it the attention it deserves. Your effort is much appreciated!

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
Follow up on #3435 to also support TLS 1.3 in tests ensuring client cert auth is handled correctly.
<!--
Please explain the motivation behind this PR, along with a summary of the major changes involved. Replace this comment with a description of what is being changed by this PR and why.

Major changes require a number of considerations including impact on:

* logging selector(s)
* metrics
* telemetry
* Elasticsearch Service (https://cloud.elastic.co)
* Elastic Cloud Enterprise (https://www.elastic.co/products/ece)
-->

## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved
List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->
- ~[ ] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).~ 
- ~[ ] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)~ 
- ~[ ] I have rebased my changes on top of the latest master branch~ 
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest master branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
- ~[ ] I have made corresponding changes to the documentation~ 
- ~[ ] I have added tests that prove my fix is effective or that my feature works~ 
- ~[ ] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes~ 
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-server/blob/master/TESTING.md for details.
-->
- ~[ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

## How to test these changes
No manual testing, only updates system tests.
<!--
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
#3435
<!--
If this PR should close an issue, please add one of the magic keywords
(e.g. fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/
Examples:
- Closes #ISSUE_ID
- Relates #ISSUE_ID
- Requires #ISSUE_ID
- Supersedes #ISSUE_ID
-->
