### PR TITLE
ci(jenkins): run hey-apm with github comment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?(?:performance\\W+)?tests(?:\\W+please)?.*')
+    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?(?:hey-apm\\W+)?tests(?:\\W+please)?.*')
   }
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
@@ -333,7 +333,7 @@ pipeline {
           agent none
           when {
             beforeAgent true
-            expression { return env.GITHUB_COMMENT?.contains('performance tests') }
+            expression { return env.GITHUB_COMMENT?.contains('hey-apm tests') }
           }
           steps {
             withGithubNotify(context: 'Hey-Apm') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -348,7 +348,7 @@ pipeline {
               golang(){
                 dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
                 dir("${BASE_DIR}"){
-                  sh "./script/jenkins/package-docker-snapshot.sh ${env.GIT_BASE_COMMIT} ${env.DOCKER_IMAGE}"
+                  sh(label: 'Package & Push', script: "./script/jenkins/package-docker-snapshot.sh ${env.GIT_BASE_COMMIT} ${env.DOCKER_IMAGE}")
                 }
               }
               build(job: 'apm-server/apm-hey-test-benchmark', propagate: true, wait: true,

--- a/script/jenkins/package-docker-snapshot.sh
+++ b/script/jenkins/package-docker-snapshot.sh
@@ -16,9 +16,14 @@ export TYPE='docker'
 export SNAPSHOT='true'
 export IMAGE="docker.elastic.co/apm/apm-server"
 
-mage -debug package
+echo 'INFO: Build docker images'
+mage package
 
+echo 'INFO: Get the just built docker image'
 TAG=$(docker images ${IMAGE} --format "{{.Tag}}" | head -1)
 
+echo "INFO: Retag docker image (${IMAGE}:${TAG})"
 docker tag "${IMAGE}:${TAG}" "${NEW_IMAGE}:${NEW_TAG}"
+
+echo "INFO: Push docker image (${NEW_IMAGE}:${NEW_TAG})"
 docker push "${NEW_IMAGE}:${NEW_TAG}"

--- a/script/jenkins/package-docker-snapshot.sh
+++ b/script/jenkins/package-docker-snapshot.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Build the docker image for the apm-server, retag and push it to the given docker registry
+#
+# Arguments:
+# - NEW_TAG
+# - NEW_IMAGE
+#
+set -euo pipefail
+
+NEW_TAG=${1:?Docker tag is not set}
+NEW_IMAGE=${1:?Docker image is not set}
+
+export PLATFORMS='linux/amd64'
+export TYPE='docker'
+export SNAPSHOT='true'
+export IMAGE="docker.elastic.co/apm/apm-server"
+
+mage -debug package
+
+TAG=$(docker images ${IMAGE} --format "{{.Tag}}" | head -1)
+
+docker tag "${IMAGE}:${TAG}" "${NEW_IMAGE}:${NEW_TAG}"
+docker push "${NEW_IMAGE}:${NEW_TAG}"

--- a/script/jenkins/package-docker-snapshot.sh
+++ b/script/jenkins/package-docker-snapshot.sh
@@ -3,13 +3,13 @@
 # Build the docker image for the apm-server, retag and push it to the given docker registry
 #
 # Arguments:
-# - NEW_TAG
-# - NEW_IMAGE
+# - NEW_TAG, this is the tag for the docker image to be pushed.
+# - NEW_IMAGE, this is the docker image name to be pushed.
 #
 set -euo pipefail
 
 NEW_TAG=${1:?Docker tag is not set}
-NEW_IMAGE=${1:?Docker image is not set}
+NEW_IMAGE=${2:?Docker image is not set}
 
 export PLATFORMS='linux/amd64'
 export TYPE='docker'


### PR DESCRIPTION
## Motivation/summary

Being able to run the hey apm for the given PR when using the commment `jenkins run hey-apm tests please`

## Checklist
- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
- [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

## How to test these changes

Use the GitHub comment and wait for the GitHub check `Hey-Apm` that will cause:
- A github check
![image](https://user-images.githubusercontent.com/2871786/76831471-4f2f5b80-681f-11ea-91c6-41111ad6eaee.png)
- Trigger a build
![image](https://user-images.githubusercontent.com/2871786/76831585-80a82700-681f-11ea-95bb-1c9bb50d0ae1.png)

- Docker image generated an used in the hey-apm pipeline: See [this](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-server%2Fapm-hey-test-benchmark/detail/apm-hey-test-benchmark/239/pipeline#step-137-log-27)

## Related issues

Caused by https://github.com/elastic/hey-apm/issues/146
Depends on https://github.com/elastic/hey-apm/pull/154 and https://github.com/elastic/hey-apm/pull/155


## Tasks

- [x] Generate docker image