### PR TITLE
[docs] Add jaeger sampling docs

### DIFF
--- a/docs/configure-kibana-endpoint.asciidoc
+++ b/docs/configure-kibana-endpoint.asciidoc
@@ -1,11 +1,8 @@
 [[setup-kibana-endpoint]]
 == Configure the Kibana endpoint
 
-Starting with {beatname_uc} 7.3.0, we've introduced a new Kibana API for APM Server.
-Configuring this endpoint is required for 
+Configuring the Kibana endpoint is required for 
 {kibana-ref}/agent-configuration.html[APM Agent configuration in Kibana].
-Once the endpoint is configured,
-you'll be able to fine-tune certain agent configurations directly in Kibana without having to redeploy your agents.
 You configure the endpoint in the `apm-server.kibana` section of the
 +{beatname_lc}.yml+ config file.
 
@@ -13,6 +10,7 @@ Here's a sample configuration:
 
 [source,yaml]
 ----
+apm-server.kibana.enabled: true
 apm-server.kibana.host: "http://localhost:5601"
 ----
 
@@ -38,6 +36,7 @@ You can specify the following options in the `apm-server.kibana` section of the
 Defaults to `false`. Must be `true` to use APM Agent configuration.
 
 [float]
+[[kibana-host]]
 ==== `apm-server.kibana.host`
 
 The Kibana host that APM Server will communicate with. The default is

--- a/docs/jaeger-support.asciidoc
+++ b/docs/jaeger-support.asciidoc
@@ -56,16 +56,13 @@ Based on the endpoint enabled in the previous step, configure the relevant host 
 [[jaeger-configure-sampling]]
 *Configure Sampling*
 
-The gRPC endpoint supports probabilistic sampling which can be used to reduce the amount of data that your agents collect and send.
-Probabilistic sampling makes a random sampling decision based on the value of `sampling.default`.
+The gRPC endpoint supports probabilistic sampling, which can be used to reduce the amount of data that your agents collect and send.
+Probabilistic sampling makes a random sampling decision based on the configured sampling value.
 For example, a value of `.2` means that 20% of traces will be sampled.
-Sampling ratios can also be adjusted, on a per service basis, via the Agent configuration page in the APM app.
 
-To enable sampling:
-
-* Set `apm-server.grpc.sampling.enabled` to `enabled`.
-* Set `apm-server.grpc.sampling.default` to the desired sampling rate (between `0` and `1.0`).
-The default value is `1.0`, which samples at 100%.
+Sampling is automatically enabled when `apm-server.jaeger.grpc.enabled` is set to `true`.
+The default sampling ratio, as well as per-service sampling rates,
+are are configured via the {kibana-ref}/agent-configuration.html[Agent configuration] page in the APM app.
 
 WARNING: If a sampling rate smaller than `1.0` (100%) is configured,
 transactions per minute will be incorrectly calculated in the APM app.
@@ -154,19 +151,6 @@ Defaults to the standard Jaeger gRPC collector port `14250`.
 ===== `grpc.auth_tag`
 Set to the name of the tag that should be used for authorizing Jaeger agents.
 By default, authorization does not apply to Jaeger agents.
-
-[float]
-===== `grpc.sampling.enabled`
-Enable the sampling rate to be fetched from the gRPC endpoint.
-Only probabilistic sampling is supported.
-No authorization token can be configured for this endpoint.
-Sampling is disabled by default.
-
-[float]
-===== `grpc.sampling.default`
-Set the default sampling rate used when no service specific sampling is configured.
-Valid range is from `0` to `1.0`, where `0` samples at 0% and `1.0` samples at 100%.
-Defaults to `1.0`.
 
 [float]
 ===== `http.enabled`

--- a/docs/jaeger-support.asciidoc
+++ b/docs/jaeger-support.asciidoc
@@ -60,9 +60,19 @@ The gRPC endpoint supports probabilistic sampling, which can be used to reduce t
 Probabilistic sampling makes a random sampling decision based on the configured sampling value.
 For example, a value of `.2` means that 20% of traces will be sampled.
 
-Sampling is automatically enabled when `apm-server.jaeger.grpc.enabled` is set to `true`.
-The default sampling ratio, as well as per-service sampling rates,
-are are configured via the {kibana-ref}/agent-configuration.html[Agent configuration] page in the APM app.
+By default, when using Jaeger Clients over gRPC, two things happen:
+
+* APM Server automatically enables the sampling endpoint when `apm-server.jaeger.grpc.enabled` is set to `true`.
+* Jaeger clients poll APM Server for the configured sampling rate.
+
+In this case, the default sampling ratio, as well as per-service sampling rates,
+can be configured via the {kibana-ref}/agent-configuration.html[Agent configuration] page in the APM app.
+
+If you don't have access to the APM app,
+you'll need to change the Jaeger Client's `sampler.type` and `sampler.param`,
+enabling you to set the sampling configuration locally in each Client.
+See the official https://www.jaegertracing.io/docs/1.17/sampling/[Jaeger sampling documentation]
+for more information.
 
 WARNING: If a sampling rate smaller than `1.0` (100%) is configured,
 transactions per minute will be incorrectly calculated in the APM app.

--- a/docs/jaeger-support.asciidoc
+++ b/docs/jaeger-support.asciidoc
@@ -56,20 +56,20 @@ Based on the endpoint enabled in the previous step, configure the relevant host 
 [[jaeger-configure-sampling]]
 *Configure Sampling*
 
-If you're using the gRPC endpoint,
-you can enable probabilistic sampling to reduce the amount of data that your agents collect and send.
-Probabilistic sampling makes a random sampling decision based on the `sampling.default` configuration.
+The gRPC endpoint supports probabilistic sampling which can be used to reduce the amount of data that your agents collect and send.
+Probabilistic sampling makes a random sampling decision based on the value of `sampling.default`.
 For example, a value of `.2` means that 20% of traces will be sampled.
-Sampling ratios can also be adjusted via the Agent configuration page in the APM app.
+Sampling ratios can also be adjusted, on a per service basis, via the Agent configuration page in the APM app.
 
 To enable sampling:
+
 * Set `apm-server.grpc.sampling.enabled` to `enabled`.
-* Set `apm-server.grpc.sampling.default` to your desired sampling rate, between `0` and `1.0`.
+* Set `apm-server.grpc.sampling.default` to the desired sampling rate (between `0` and `1.0`).
 The default value is `1.0`, which samples at 100%.
 
 WARNING: If a sampling rate smaller than `1.0` (100%) is configured,
 transactions per minute will be incorrectly calculated in the APM app.
-This is because Elastic APM sampling is fundamentally different from Jaeger sampling.
+This is because Elastic APM data model is fundamentally different from the Jaeger data model.
 In the Elastic ecosystem, sampling only impacts spans; transactions are always sampled at 100%.
 The Jaeger data structure, however, does not have the concept of transactions.
 Because of this, sampling decisions will apply to both transactions and spans.
@@ -118,7 +118,7 @@ There are some limitations and differences between Elastic APM and Jaeger that y
 
 * Because Jaeger has its own trace context header, and does not currently support W3C trace context headers,
 it is not possible to mix and match the use of Elastic's APM Agents and Jaeger's Clients.
-* Elastic APM only supports probabilistic sampling. Because of differences in Jaeger and Elastic's data structures, 
+* Elastic APM only supports probabilistic sampling. Because of differences in the Jaeger and Elastic data structures, 
 sampling at a value below `1.0` (100%), will cause inaccuracies in the APM app. See <<jaeger-configure-sampling>> for more information.
 * We currently only support exception logging. Span logs are not supported.
 

--- a/docs/jaeger-support.asciidoc
+++ b/docs/jaeger-support.asciidoc
@@ -53,6 +53,27 @@ Based on the endpoint enabled in the previous step, configure the relevant host 
 * `apm-server.jaeger.grpc.host` defaults to `localhost:14250`.
 * `apm-server.jaeger.http.host` defaults to `localhost:14268`.
 
+[[jaeger-configure-sampling]]
+*Configure Sampling*
+
+If you're using the gRPC endpoint,
+you can enable probabilistic sampling to reduce the amount of data that your agents collect and send.
+Probabilistic sampling makes a random sampling decision based on the `sampling.default` configuration.
+For example, a value of `.2` means that 20% of traces will be sampled.
+Sampling ratios can also be adjusted via the Agent configuration page in the APM app.
+
+To enable sampling:
+* Set `apm-server.grpc.sampling.enabled` to `enabled`.
+* Set `apm-server.grpc.sampling.default` to your desired sampling rate, between `0` and `1.0`.
+The default value is `1.0`, which samples at 100%.
+
+WARNING: If a sampling rate smaller than `1.0` (100%) is configured,
+transactions per minute will be incorrectly calculated in the APM app.
+This is because Elastic APM sampling is fundamentally different from Jaeger sampling.
+In the Elastic ecosystem, sampling only impacts spans; transactions are always sampled at 100%.
+The Jaeger data structure, however, does not have the concept of transactions.
+Because of this, sampling decisions will apply to both transactions and spans.
+
 *Configure Jaeger Agent communication with APM Server (gRPC)*
 
 As of this writing, the Jaeger Agent binary offers the `--reporter.grpc.host-port` CLI flag,
@@ -97,7 +118,8 @@ There are some limitations and differences between Elastic APM and Jaeger that y
 
 * Because Jaeger has its own trace context header, and does not currently support W3C trace context headers,
 it is not possible to mix and match the use of Elastic's APM Agents and Jaeger's Clients.
-* Sampling decisions cannot currently be pushed from the APM Server.
+* Elastic APM only supports probabilistic sampling. Because of differences in Jaeger and Elastic's data structures, 
+sampling at a value below `1.0` (100%), will cause inaccuracies in the APM app. See <<jaeger-configure-sampling>> for more information.
 * We currently only support exception logging. Span logs are not supported.
 
 *Differences between APM Agents and Jaeger Clients:*
@@ -132,6 +154,19 @@ Defaults to the standard Jaeger gRPC collector port `14250`.
 ===== `grpc.auth_tag`
 Set to the name of the tag that should be used for authorizing Jaeger agents.
 By default, authorization does not apply to Jaeger agents.
+
+[float]
+===== `grpc.sampling.enabled`
+Enable the sampling rate to be fetched from the gRPC endpoint.
+Only probabilistic sampling is supported.
+No authorization token can be configured for this endpoint.
+Sampling is disabled by default.
+
+[float]
+===== `grpc.sampling.default`
+Set the default sampling rate used when no service specific sampling is configured.
+Valid range is from `0` to `1.0`, where `0` samples at 0% and `1.0` samples at 100%.
+Defaults to `1.0`.
 
 [float]
 ===== `http.enabled`

--- a/docs/jaeger-support.asciidoc
+++ b/docs/jaeger-support.asciidoc
@@ -60,10 +60,10 @@ The gRPC endpoint supports probabilistic sampling, which can be used to reduce t
 Probabilistic sampling makes a random sampling decision based on the configured sampling value.
 For example, a value of `.2` means that 20% of traces will be sampled.
 
-By default, when using Jaeger Clients over gRPC, two things happen:
+By default, when using Jaeger over gRPC, two things happen:
 
 * APM Server automatically enables the sampling endpoint when `apm-server.jaeger.grpc.enabled` is set to `true`.
-* Jaeger clients poll APM Server for the configured sampling rate.
+* Jaeger agents poll APM Server for the configured sampling rate.
 
 In this case, the default sampling ratio, as well as per-service sampling rates,
 can be configured via the {kibana-ref}/agent-configuration.html[Agent configuration] page in the APM app.

--- a/docs/jaeger-support.asciidoc
+++ b/docs/jaeger-support.asciidoc
@@ -35,7 +35,9 @@ Connecting your preexisting Jaeger setup to Elastic APM is easy!
 First, configure APM Server to receive Jaeger data,
 then configure your Jaeger Agents or Jaeger Clients to start sending spans to APM Server.
 
-*Configure APM Server*
+[float]
+[[jaeger-configure-apm-server]]
+==== Configure APM Server
 
 . Enable the correct jaeger endpoint in the `apm-server.yml` configuration file.
 +
@@ -53,26 +55,31 @@ Based on the endpoint enabled in the previous step, configure the relevant host 
 * `apm-server.jaeger.grpc.host` defaults to `localhost:14250`.
 * `apm-server.jaeger.http.host` defaults to `localhost:14268`.
 
+[float]
 [[jaeger-configure-sampling]]
-*Configure Sampling*
+==== Configure Sampling
 
 The gRPC endpoint supports probabilistic sampling, which can be used to reduce the amount of data that your agents collect and send.
 Probabilistic sampling makes a random sampling decision based on the configured sampling value.
 For example, a value of `.2` means that 20% of traces will be sampled.
 
-By default, when using Jaeger over gRPC, two things happen:
+APM Server automatically enables the sampling endpoint when `grpc.enabled` is set to `true`.
+There are two different ways to configure the sampling rate of your Jaeger Agents:
 
-* APM Server automatically enables the sampling endpoint when `apm-server.jaeger.grpc.enabled` is set to `true`.
-* Jaeger agents poll APM Server for the configured sampling rate.
+* <<jaeger-configure-sampling-central,Centrally>>, with APM Agent configuration (default).
+* <<jaeger-configure-sampling-local,Locally>>, in each Jaeger client.
 
-In this case, the default sampling ratio, as well as per-service sampling rates,
-can be configured via the {kibana-ref}/agent-configuration.html[Agent configuration] page in the APM app.
+[float]
+[[jaeger-configure-sampling-central]]
+===== Central sampling
 
-If you don't have access to the APM app,
-you'll need to change the Jaeger Client's `sampler.type` and `sampler.param`,
-enabling you to set the sampling configuration locally in each Client.
-See the official https://www.jaegertracing.io/docs/1.17/sampling/[Jaeger sampling documentation]
-for more information.
+Central sampling, with APM Agent configuration,
+requires the <<setup-kibana-endpoint,Kibana endpoint>> to be enabled.
+This allows Jaeger clients to poll APM Server for the sampling rate.
+To enable the kibana endpoint, set <<kibana-enabled>> to `true`, and point <<kibana-host>> at the Kibana host that APM Server will communicate with.
+
+The default sampling ratio, as well as per-service sampling rates,
+can then be configured via the {kibana-ref}/agent-configuration.html[Agent configuration] page in the APM app.
 
 WARNING: If a sampling rate smaller than `1.0` (100%) is configured,
 transactions per minute will be incorrectly calculated in the APM app.
@@ -81,7 +88,19 @@ In the Elastic ecosystem, sampling only impacts spans; transactions are always s
 The Jaeger data structure, however, does not have the concept of transactions.
 Because of this, sampling decisions will apply to both transactions and spans.
 
-*Configure Jaeger Agent communication with APM Server (gRPC)*
+[float]
+[[jaeger-configure-sampling-local]]
+===== Local sampling
+
+If you don't have access to the APM app,
+you'll need to change the Jaeger Client's `sampler.type` and `sampler.param`,
+enabling you to set the sampling configuration locally in each Client.
+See the official https://www.jaegertracing.io/docs/1.17/sampling/[Jaeger sampling documentation]
+for more information.
+
+[float]
+[[jaeger-configure-grpc]]
+==== Configure Jaeger Agent communication with APM Server (gRPC)
 
 As of this writing, the Jaeger Agent binary offers the `--reporter.grpc.host-port` CLI flag,
 which can be used to set a static list of collectors for the Jaeger Agent to connect to.
@@ -95,7 +114,9 @@ being verified.
 
 See the https://www.jaegertracing.io/docs/1.16/cli/[Jaeger CLI flags documentation] for more information.
 
-*Configure Jaeger Client communication with APM Server (HTTP)*
+[float]
+[[jaeger-configure-http]]
+==== Configure Jaeger Client communication with APM Server (HTTP)
 
 If you're using an officially supported Jaeger Client library and want to connect directly to APM Server,
 you need to update the `JAEGER_ENDPOINT` configuration property.
@@ -111,7 +132,9 @@ See the relevant supported Jaeger library for more information.
 * https://github.com/jaegertracing/jaeger-client-cpp[C++]
 * https://github.com/jaegertracing/jaeger-client-csharp[C#]
 
-*Start sending span data*
+[float]
+[[jaeger-configure-start]]
+==== Start sending span data
 
 Data sent from Jaeger Agents or Clients to APM Server should now be visible in the APM app!
 


### PR DESCRIPTION
## Motivation/summary

Adds documentation for Jaeger sampling, including limitations and caveats.

## Related issues

For https://github.com/elastic/apm-server/issues/3487.
PR: https://github.com/elastic/apm-server/pull/3490.
