### PR TITLE
Fix flaky test for apikey info by id

### DIFF
--- a/tests/system/test_apikey_cmd.py
+++ b/tests/system/test_apikey_cmd.py
@@ -111,7 +111,7 @@ class APIKeyCommandBaseTest(BaseTest):
         return apikey
 
     def invalidate_by_id(self, id):
-        invalidated = self.subcommand_output("invalidate", "--id", id)
+        invalidated = self.subcommand_output("invalidate", "--id={}".format(id))
         self.apikey_helper.wait_until_invalidated(id=id)
         return invalidated
 
@@ -167,7 +167,7 @@ class APIKeyCommandTest(APIKeyCommandBaseTest):
     def test_info_by_id(self):
         self.create()
         apikey = self.create()
-        info = self.subcommand_output("info", "--id", apikey["id"])
+        info = self.subcommand_output("info",  "--id={}".format(apikey["id"]))
         assert len(info.get("api_keys")) == 1, info
         assert info["api_keys"][0].get("username") == self.user, info
         assert info["api_keys"][0].get("id") == apikey["id"], info
@@ -190,25 +190,26 @@ class APIKeyCommandTest(APIKeyCommandBaseTest):
 
     def test_verify_all(self):
         apikey = self.create()
-        result = self.subcommand_output("verify", "--credentials", apikey["credentials"])
+        result = self.subcommand_output("verify", "--credentials={}".format(apikey["credentials"]))
         assert result == {'event:write': True, 'config_agent:read': True, 'sourcemap:write': True}, result
 
         for privilege in ["ingest", "sourcemap", "agent-config"]:
-            result = self.subcommand_output("verify", "--credentials", apikey["credentials"], "--" + privilege)
+            result = self.subcommand_output(
+                "verify", "--credentials={}".format(apikey["credentials"]), "--" + privilege)
             assert len(result) == 1, result
             assert list(result.values())[0] is True
 
     def test_verify_each(self):
         apikey = self.create("--ingest")
-        result = self.subcommand_output("verify", "--credentials", apikey["credentials"])
+        result = self.subcommand_output("verify", "--credentials={}".format(apikey["credentials"]))
         assert result == {'event:write': True, 'config_agent:read': False, 'sourcemap:write': False}, result
 
         apikey = self.create("--sourcemap")
-        result = self.subcommand_output("verify", "--credentials", apikey["credentials"])
+        result = self.subcommand_output("verify", "--credentials={}".format(apikey["credentials"]))
         assert result == {'event:write': False, 'config_agent:read': False, 'sourcemap:write': True}, result
 
         apikey = self.create("--agent-config")
-        result = self.subcommand_output("verify", "--credentials", apikey["credentials"])
+        result = self.subcommand_output("verify", "--credentials={}".format(apikey["credentials"]))
         assert result == {'event:write': False, 'config_agent:read': True, 'sourcemap:write': False}, result
 
 


### PR DESCRIPTION


## Motivation/summary
When passing an argument value that starts with a dash to a CLI tool it will be interpreted as a flag instead of a string value, e.g. `-xyz` would be interpreted as `--xyz`, when passed in as e.g. 
`--id -xyz` instead of `--id=-xyz`.
Instead of running `./apm-server apikey info --id -DB06HAB0_bchW-gz4zt` it should be run as `./apm-server apikey info --id="-DB06HAB0_bchW-gz4zt"`.

This PR adapts the python system tests accordingly to avoid test flakyness wherever a value that might start with a dash is passed in to the apikey tests.

<!--
Please explain the motivation behind this PR, along with a summary of the major changes involved. Replace this comment with a description of what is being changed by this PR and why.

Major changes require a number of considerations including impact on:

* logging selector(s)
* metrics
* telemetry
* Elasticsearch Service (https://cloud.elastic.co)
* Elastic Cloud Enterprise (https://www.elastic.co/products/ece)
-->

## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved
List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->
~- [ ] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).~
~- [ ] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)~
- [x] I have rebased my changes on top of the latest master branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest master branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-server/blob/master/TESTING.md for details.
-->
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

## How to test these changes
<!--
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
fixes #3298
<!--
If this PR should close an issue, please add one of the magic keywords
(e.g. fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/
Examples:
- Closes #ISSUE_ID
- Relates #ISSUE_ID
- Requires #ISSUE_ID
- Supersedes #ISSUE_ID
-->
