### PR TITLE
[7.x] [Jaeger] Add gRPC sampling endpoint (#3490)

### DIFF
--- a/agentcfg/cache_test.go
+++ b/agentcfg/cache_test.go
@@ -21,12 +21,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/beats/v7/libbeat/logp"
-
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pkg/errors"
+	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 var (

--- a/agentcfg/model.go
+++ b/agentcfg/model.go
@@ -34,10 +34,8 @@ const (
 )
 
 var (
-	// RumAgent keywords (new and old)
-	RumAgent = []string{"rum-js", "js-base"}
-	// RumSettings are whitelisted applicable settings for RUM
-	RumSettings = []string{"transaction_sample_rate"}
+	// WhitelistedSettings are settings considered safe to be returned to all requesters, including unauthenticated ones such as RUM.
+	WhitelistedSettings = []string{"transaction_sample_rate"}
 )
 
 // Result models a Kibana response
@@ -56,16 +54,18 @@ type Source struct {
 type Query struct {
 	Service Service `json:"service"`
 	Etag    string  `json:"etag"`
-	IsRum   bool    `json:"-"`
+	// InsecureAgents holds a set of prefixes for restricting results to those whose
+	// agent name matches any of the specified prefixes.
+	//
+	// If InsecureAgents is non-empty, and any of the prefixes matches the result,
+	// then the resulting settings will be restricted to those identified by
+	// WhitelistedSettings. Otherwise, if InsecureAgents is empty, the agent name
+	// is ignored and no restrictions are applied.
+	InsecureAgents []string `json:"-"`
 }
 
 func (q Query) id() string {
 	return q.Service.Name + q.Service.Environment
-}
-
-// NewQuery creates a Query struct
-func NewQuery(name, env string) Query {
-	return Query{Service: Service{name, env}}
 }
 
 // Service holds supported attributes for querying configuration

--- a/agentcfg/model_test.go
+++ b/agentcfg/model_test.go
@@ -20,9 +20,8 @@ package agentcfg
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewDoc(t *testing.T) {

--- a/beater/jaeger/common.go
+++ b/beater/jaeger/common.go
@@ -20,14 +20,15 @@ package jaeger
 import (
 	"context"
 
-	"github.com/elastic/apm-server/beater/authorization"
-	"github.com/elastic/apm-server/beater/request"
-	"github.com/elastic/beats/v7/libbeat/monitoring"
-
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/open-telemetry/opentelemetry-collector/consumer"
 	trjaeger "github.com/open-telemetry/opentelemetry-collector/translator/trace/jaeger"
 	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/v7/libbeat/monitoring"
+
+	"github.com/elastic/apm-server/beater/authorization"
+	"github.com/elastic/apm-server/beater/request"
 )
 
 const (

--- a/beater/jaeger/grpc.go
+++ b/beater/jaeger/grpc.go
@@ -19,6 +19,9 @@ package jaeger
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strconv"
 
 	"github.com/jaegertracing/jaeger/model"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
@@ -26,18 +29,23 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/monitoring"
 
+	"github.com/elastic/apm-server/agentcfg"
 	"github.com/elastic/apm-server/beater/request"
+	"github.com/elastic/apm-server/kibana"
+	"github.com/elastic/apm-server/processor/otel"
 )
 
 var (
-	gRPCRegistry                    = monitoring.Default.NewRegistry("apm-server.jaeger.grpc", monitoring.PublishExpvar)
-	gRPCMonitoringMap monitoringMap = request.MonitoringMapForRegistry(gRPCRegistry, monitoringKeys)
+	gRPCCollectorRegistry                    = monitoring.Default.NewRegistry("apm-server.jaeger.grpc.collect", monitoring.PublishExpvar)
+	gRPCCollectorMonitoringMap monitoringMap = request.MonitoringMapForRegistry(gRPCCollectorRegistry, monitoringKeys)
 )
 
 // grpcCollector implements Jaeger api_v2 protocol for receiving tracing data
 type grpcCollector struct {
+	log      *logp.Logger
 	auth     authFunc
 	consumer consumer.TraceConsumer
 }
@@ -46,22 +54,103 @@ type grpcCollector struct {
 // TraceData and passes them on to the internal Consumer taking care of converting into Elastic APM format.
 // The implementation of the protobuf contract is based on the open-telemetry implementation at
 // https://github.com/open-telemetry/opentelemetry-collector/tree/master/receiver/jaegerreceiver
-func (c grpcCollector) PostSpans(ctx context.Context, r *api_v2.PostSpansRequest) (*api_v2.PostSpansResponse, error) {
-	gRPCMonitoringMap.inc(request.IDRequestCount)
-	defer gRPCMonitoringMap.inc(request.IDResponseCount)
+func (c *grpcCollector) PostSpans(ctx context.Context, r *api_v2.PostSpansRequest) (*api_v2.PostSpansResponse, error) {
+	gRPCCollectorMonitoringMap.inc(request.IDRequestCount)
+	defer gRPCCollectorMonitoringMap.inc(request.IDResponseCount)
 
 	if err := c.postSpans(ctx, r.Batch); err != nil {
-		gRPCMonitoringMap.inc(request.IDResponseErrorsCount)
+		gRPCCollectorMonitoringMap.inc(request.IDResponseErrorsCount)
+		c.log.With(logp.Error(err)).Error("error gRPC PostSpans")
 		return nil, err
 	}
-	gRPCMonitoringMap.inc(request.IDResponseValidCount)
+	gRPCCollectorMonitoringMap.inc(request.IDResponseValidCount)
 	return &api_v2.PostSpansResponse{}, nil
 }
 
-func (c grpcCollector) postSpans(ctx context.Context, batch model.Batch) error {
+func (c *grpcCollector) postSpans(ctx context.Context, batch model.Batch) error {
 	if err := c.auth(ctx, batch); err != nil {
-		gRPCMonitoringMap.inc(request.IDResponseErrorsUnauthorized)
+		gRPCCollectorMonitoringMap.inc(request.IDResponseErrorsUnauthorized)
 		return status.Error(codes.Unauthenticated, err.Error())
 	}
-	return consumeBatch(ctx, batch, c.consumer, gRPCMonitoringMap)
+	return consumeBatch(ctx, batch, c.consumer, gRPCCollectorMonitoringMap)
+}
+
+var (
+	gRPCSamplingRegistry                    = monitoring.Default.NewRegistry("apm-server.jaeger.grpc.sampling", monitoring.PublishExpvar)
+	gRPCSamplingMonitoringMap monitoringMap = request.MonitoringMapForRegistry(gRPCSamplingRegistry, monitoringKeys)
+
+	jaegerAgentPrefixes = []string{otel.AgentNameJaeger}
+)
+
+type grpcSampler struct {
+	log     *logp.Logger
+	client  kibana.Client
+	fetcher *agentcfg.Fetcher
+}
+
+// GetSamplingStrategy implements the api_v2/sampling.proto.
+// Only probabilistic sampling is supported.
+// It fetches the sampling rate from the central configuration management and returns the sampling strategy.
+func (s *grpcSampler) GetSamplingStrategy(
+	ctx context.Context,
+	params *api_v2.SamplingStrategyParameters) (*api_v2.SamplingStrategyResponse, error) {
+
+	gRPCSamplingMonitoringMap.inc(request.IDRequestCount)
+	defer gRPCSamplingMonitoringMap.inc(request.IDResponseCount)
+	if err := s.validateKibanaClient(ctx); err != nil {
+		gRPCSamplingMonitoringMap.inc(request.IDResponseErrorsCount)
+		// do not return full error details since this is part of an unprotected endpoint response
+		s.log.With(logp.Error(err)).Error("Configured Kibana client does not support agent remote configuration")
+		return nil, errors.New("agent remote configuration not supported, check server logs for more details")
+	}
+	samplingRate, err := s.fetchSamplingRate(ctx, params.ServiceName)
+	if err != nil {
+		gRPCSamplingMonitoringMap.inc(request.IDResponseErrorsCount)
+		// do not return full error details since this is part of an unprotected endpoint response
+		s.log.With(logp.Error(err)).Error("No valid sampling rate fetched from Kibana.")
+		return nil, errors.New("no sampling rate available, check server logs for more details")
+	}
+	gRPCSamplingMonitoringMap.inc(request.IDResponseValidCount)
+	return &api_v2.SamplingStrategyResponse{
+		StrategyType:          api_v2.SamplingStrategyType_PROBABILISTIC,
+		ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{SamplingRate: samplingRate}}, nil
+}
+
+func (s *grpcSampler) fetchSamplingRate(ctx context.Context, service string) (float64, error) {
+	query := agentcfg.Query{Service: agentcfg.Service{Name: service}, InsecureAgents: jaegerAgentPrefixes}
+	result, err := s.fetcher.Fetch(ctx, query)
+	if err != nil {
+		gRPCSamplingMonitoringMap.inc(request.IDResponseErrorsServiceUnavailable)
+		return 0, fmt.Errorf("fetching sampling rate failed: %w", err)
+	}
+
+	if sr, ok := result.Source.Settings[agentcfg.TransactionSamplingRateKey]; ok {
+		srFloat64, err := strconv.ParseFloat(sr, 64)
+		if err != nil {
+			gRPCSamplingMonitoringMap.inc(request.IDResponseErrorsInternal)
+			return 0, fmt.Errorf("parsing error for sampling rate `%v`: %w", sr, err)
+		}
+		return srFloat64, nil
+	}
+	gRPCSamplingMonitoringMap.inc(request.IDResponseErrorsNotFound)
+	return 0, fmt.Errorf("no sampling rate found for %v", service)
+}
+
+func (s *grpcSampler) validateKibanaClient(ctx context.Context) error {
+	if s.client == nil {
+		gRPCSamplingMonitoringMap.inc(request.IDResponseErrorsServiceUnavailable)
+		return errors.New("jaeger remote sampling endpoint is disabled, " +
+			"configure the `apm-server.kibana` section in apm-server.yml to enable it")
+	}
+	supported, err := s.client.SupportsVersion(ctx, agentcfg.KibanaMinVersion, true)
+	if err != nil {
+		gRPCSamplingMonitoringMap.inc(request.IDResponseErrorsServiceUnavailable)
+		return fmt.Errorf("error checking kibana version: %w", err)
+	}
+	if !supported {
+		gRPCSamplingMonitoringMap.inc(request.IDResponseErrorsServiceUnavailable)
+		return fmt.Errorf("not supported by used Kibana version, min required Kibana version: %v",
+			agentcfg.KibanaMinVersion)
+	}
+	return nil
 }

--- a/processor/otel/consumer.go
+++ b/processor/otel/consumer.go
@@ -46,8 +46,9 @@ import (
 )
 
 const (
+	AgentNameJaeger = "Jaeger"
+
 	sourceFormatJaeger = "jaeger"
-	agentNameJaeger    = "Jaeger"
 	keywordLength      = 1024
 	dot                = "."
 	underscore         = "_"
@@ -177,7 +178,7 @@ func parseMetadata(td consumerdata.TraceData, md *metadata.Metadata) {
 			jaegerVersion := "unknown"
 			md.Service.Agent.Version = &jaegerVersion
 		}
-		agentName := agentNameJaeger
+		agentName := AgentNameJaeger
 		if md.Service.Language.Name != nil {
 			agentName = truncate(agentName + "/" + *md.Service.Language.Name)
 		}

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -15,6 +15,9 @@ apm-server:
   {% if jaeger_grpc_auth_tag %}
   jaeger.grpc.auth_tag: {{ jaeger_grpc_auth_tag }}
   {% endif %}
+  {% if jaeger_grpc_sampling_enabled %}
+  jaeger.grpc.sampling.enabled: {{ jaeger_grpc_sampling_enabled }}
+  {% endif %}
 
   {% if api_key_enabled %}
   api_key.enabled: {{ api_key_enabled }}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [Jaeger] Add gRPC sampling endpoint (#3490)