### PR TITLE
[7.x] Install modules into build directory for CI (#3456)

### DIFF
--- a/.ci/docker/golang-mage/Dockerfile
+++ b/.ci/docker/golang-mage/Dockerfile
@@ -1,25 +1,11 @@
 ARG GO_VERSION=1.12.4
 FROM golang:${GO_VERSION}
 
-WORKDIR /tools
-
-RUN echo "Building from golang:${GO_VERSION}"
-RUN git clone https://github.com/magefile/mage \
-  && cd mage \
-  && go run bootstrap.go \
-  && mage -version \
-  && cd /tools \
-  && go get golang.org/x/tools/cmd/benchcmp \
-  && go get github.com/t-yuki/gocover-cobertura \
-  && go get github.com/jstemmer/go-junit-report \
-  && go get github.com/kardianos/govendor \
-  && go get github.com/elastic/go-licenser \
-  && go get github.com/pierrre/gotestcover \
-  && go get github.com/stretchr/testify/assert \
-  && go get golang.org/x/tools/cmd/goimports
+ENV TOOLS=/tools
+WORKDIR $TOOLS
+COPY go.mod .
+RUN go mod download
 
 RUN apt-get update -y -qq \
   && apt-get install -y -qq python3 python3-pip python3-venv \
   && rm -rf /var/lib/apt/lists/*
-
-WORKDIR /go

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -392,7 +392,7 @@ def golang(Closure body){
   def golangDocker
   retry(3) { // Retry in case there are any errors when building the docker images (to avoid temporary glitches)
     sleep randomNumber(min: 2, max: 5)
-    golangDocker = docker.build('golang-mage', "--build-arg GO_VERSION=${GO_VERSION} ${BASE_DIR}/.ci/docker/golang-mage")
+    golangDocker = docker.build('golang-mage', "--build-arg GO_VERSION=${GO_VERSION} -f  ${BASE_DIR}/.ci/docker/golang-mage/Dockerfile ${BASE_DIR}")
   }
   withEnv(["HOME=${WORKSPACE}", "GOPATH=${WORKSPACE}", "SHELL=/bin/bash"]) {
      golangDocker.inside('-v /usr/bin/docker:/usr/bin/docker -v /var/run/docker.sock:/var/run/docker.sock'){

--- a/script/jenkins/build.sh
+++ b/script/jenkins/build.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-mage -debug build
+make apm-server

--- a/script/jenkins/package.sh
+++ b/script/jenkins/package.sh
@@ -5,4 +5,4 @@ set -euox pipefail
 # to prevent jenkins_release.sh from adding more PLATFORMS
 export PLATFORMS="${PLATFORMS:-+linux/amd64}"
 
-mage -debug package
+make release

--- a/script/jenkins/test-install-packages.sh
+++ b/script/jenkins/test-install-packages.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-mage -v -debug testPackagesInstall
+./build/linux/mage -v testPackagesInstall


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Install modules into build directory for CI (#3456)