### PR TITLE
[docs] Update RUM and GO Agent labels

### DIFF
--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -205,13 +205,13 @@ Defining too many unique fields in an index is a condition that can lead to a
 
 |===
 |*Labels API links*
-v|*Go:* {apm-go-ref-v}/api.html#context-set-tag[`SetTag`]
+v|*Go:* {apm-go-ref-v}/api.html#context-set-label[`SetLabel`]
 *Java:* {apm-java-ref-v}/public-api.html#api-transaction-add-tag[`addLabel`]
 *.NET:* {apm-dotnet-ref-v}/public-api.html#api-transaction-tags[`Labels`]
 *Node.js:* {apm-node-ref-v}/agent-api.html#apm-set-label[`setLabel`] \| {apm-node-ref-v}/agent-api.html#apm-add-labels[`addLabel`]
 *Python:* {apm-py-ref-v}/api.html#api-label[`elasticapm.label()`]
 *Ruby:* {apm-ruby-ref-v}/api.html#api-agent-set-label[`set_label`]
-*Rum:* {apm-rum-ref-v}/agent-api.html#apm-add-tags[`addTags`]
+*Rum:* {apm-rum-ref-v}/agent-api.html#apm-add-labels[`addLabels`]
 |===
 
 [float]


### PR DESCRIPTION
## Motivation/summary

This PR updates links from the APM Overview to the RUM JS agent. These links are broken in the 5.x release of the RUM agent, and need to be fixed before documentation can be built.

While at it, I also updated the Go Agent, so that we don't run into the same problem come release time.

## Backport

Because this fix is related to an Agent release, the fix needs to be backported further than normal: `7.x`, `7.6`, `7.5`, `7.4`.

## Related issues

For the 5.x release: https://github.com/elastic/docs/pull/1769.
