### PR TITLE
[7.4] docs: Update agent server compatibility for RUM Agent (#3451)

### DIFF
--- a/docs/guide/agent-server-compatibility.asciidoc
+++ b/docs/guide/agent-server-compatibility.asciidoc
@@ -37,8 +37,9 @@ The chart below outlines the compatibility between different versions of the APM
 |`3.x` |>= `6.5`
 
 // RUM
-.3+|**JavaScript RUM Agent**
+.4+|**JavaScript RUM Agent**
 |`0.x` |`6.3`-`6.4`
 |`1.x` |`6.4`
 |`2.x`, `3.x`, `4.x` |>= `6.5`
+|`5.x` |>= `7.0`
 |====


### PR DESCRIPTION
Backports the following commits to 7.4:
 - docs: Update agent server compatibility for RUM Agent (#3451)