### PR TITLE
[7.x] Changing TLS client_authentication default and cleaning up docs (#3500)

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -93,9 +93,6 @@ apm-server:
   #ssl:
     #enabled: false
 
-    # Configure a list of root certificate authorities for verifying client certificates.
-    #certificate_authorities: []
-
     # Path to file containing the certificate for server authentication.
     # Needs to be configured when ssl is enabled.
     #certificate: ''
@@ -120,14 +117,18 @@ apm-server:
     # Configure curve types for ECDHE based cipher suites.
     #curve_types: []
 
+    # Following options only concern requiring and verifying client certificates provided by the agents.
+    # Providing a client certificate is currently only supported by the RUM agent through
+    # browser configured certificates and Jaeger agents connecting via gRPC.
+    #
+    # Configure a list of root certificate authorities for verifying client certificates.
+    #certificate_authorities: []
+    #
     # Configure which type of client authentication is supported.
-    # Options are `none`, `optional`, and `required`. Default is `optional`.
-    #client_authentication: "optional"
-
-    # Configure SSL verification mode. If `none` is configured, all hosts and
-    # certificates will be accepted. In this mode, SSL-based connections are
-    # susceptible to man-in-the-middle attacks. Use only for testing. Default is `full`.
-    #ssl.verification_mode: full
+    # Options are `none`, `optional`, and `required`.
+    # Default is `none`. If `certificate_authorities` are configured,
+    # the value for `client_authentication` is automatically changed to `required`.
+    #client_authentication: "none"
 
   # The APM Server endpoints can be secured by configuring a secret token or enabling the usage of API keys. Both
   # options can be enabled in parallel, allowing Elastic APM agents to chose whichever mechanism they support.

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -93,9 +93,6 @@ apm-server:
   #ssl:
     #enabled: false
 
-    # Configure a list of root certificate authorities for verifying client certificates.
-    #certificate_authorities: []
-
     # Path to file containing the certificate for server authentication.
     # Needs to be configured when ssl is enabled.
     #certificate: ''
@@ -120,14 +117,18 @@ apm-server:
     # Configure curve types for ECDHE based cipher suites.
     #curve_types: []
 
+    # Following options only concern requiring and verifying client certificates provided by the agents.
+    # Providing a client certificate is currently only supported by the RUM agent through
+    # browser configured certificates and Jaeger agents connecting via gRPC.
+    #
+    # Configure a list of root certificate authorities for verifying client certificates.
+    #certificate_authorities: []
+    #
     # Configure which type of client authentication is supported.
-    # Options are `none`, `optional`, and `required`. Default is `optional`.
-    #client_authentication: "optional"
-
-    # Configure SSL verification mode. If `none` is configured, all hosts and
-    # certificates will be accepted. In this mode, SSL-based connections are
-    # susceptible to man-in-the-middle attacks. Use only for testing. Default is `full`.
-    #ssl.verification_mode: full
+    # Options are `none`, `optional`, and `required`.
+    # Default is `none`. If `certificate_authorities` are configured,
+    # the value for `client_authentication` is automatically changed to `required`.
+    #client_authentication: "none"
 
   # The APM Server endpoints can be secured by configuring a secret token or enabling the usage of API keys. Both
   # options can be enabled in parallel, allowing Elastic APM agents to chose whichever mechanism they support.

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -93,9 +93,6 @@ apm-server:
   #ssl:
     #enabled: false
 
-    # Configure a list of root certificate authorities for verifying client certificates.
-    #certificate_authorities: []
-
     # Path to file containing the certificate for server authentication.
     # Needs to be configured when ssl is enabled.
     #certificate: ''
@@ -120,14 +117,18 @@ apm-server:
     # Configure curve types for ECDHE based cipher suites.
     #curve_types: []
 
+    # Following options only concern requiring and verifying client certificates provided by the agents.
+    # Providing a client certificate is currently only supported by the RUM agent through
+    # browser configured certificates and Jaeger agents connecting via gRPC.
+    #
+    # Configure a list of root certificate authorities for verifying client certificates.
+    #certificate_authorities: []
+    #
     # Configure which type of client authentication is supported.
-    # Options are `none`, `optional`, and `required`. Default is `optional`.
-    #client_authentication: "optional"
-
-    # Configure SSL verification mode. If `none` is configured, all hosts and
-    # certificates will be accepted. In this mode, SSL-based connections are
-    # susceptible to man-in-the-middle attacks. Use only for testing. Default is `full`.
-    #ssl.verification_mode: full
+    # Options are `none`, `optional`, and `required`.
+    # Default is `none`. If `certificate_authorities` are configured,
+    # the value for `client_authentication` is automatically changed to `required`.
+    #client_authentication: "none"
 
   # The APM Server endpoints can be secured by configuring a secret token or enabling the usage of API keys. Both
   # options can be enabled in parallel, allowing Elastic APM agents to chose whichever mechanism they support.

--- a/beater/config/config.go
+++ b/beater/config/config.go
@@ -112,19 +112,6 @@ type Cache struct {
 func NewConfig(version string, ucfg *common.Config, outputESCfg *common.Config) (*Config, error) {
 	logger := logp.NewLogger(logs.Config)
 	c := DefaultConfig(version)
-
-	if ucfg.HasField("ssl") {
-		ssl, err := ucfg.Child("ssl", -1)
-		if err != nil {
-			return nil, err
-		}
-		if !ssl.HasField("certificate_authorities") && !ssl.HasField("client_authentication") {
-			if err := ucfg.SetString("ssl.client_authentication", -1, "optional"); err != nil {
-				return nil, err
-			}
-		}
-	}
-
 	if err := ucfg.Unpack(c); err != nil {
 		return nil, errors.Wrap(err, "Error processing configuration")
 	}

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -66,7 +66,7 @@ func Test_UnpackConfig(t *testing.T) {
 					"key":                     path.Join("../..", "testdata", "tls", "key.pem"),
 					"certificate":             path.Join("../..", "testdata", "tls", "certificate.pem"),
 					"certificate_authorities": []string{path.Join("../..", "testdata", "tls", "./ca.crt.pem")},
-					"client_authentication":   "none",
+					"client_authentication":   "required",
 				},
 				"expvar": map[string]interface{}{
 					"enabled": true,
@@ -124,7 +124,7 @@ func Test_UnpackConfig(t *testing.T) {
 					Certificate: tlscommon.CertificateConfig{
 						Certificate: path.Join("../..", "testdata", "tls", "certificate.pem"),
 						Key:         path.Join("../..", "testdata", "tls", "key.pem")},
-					ClientAuth: 0,
+					ClientAuth: 4,
 					CAs:        []string{path.Join("../..", "testdata", "tls", "./ca.crt.pem")},
 				},
 				AugmentEnabled: true,
@@ -178,7 +178,7 @@ func Test_UnpackConfig(t *testing.T) {
 								Certificate: tlscommon.CertificateConfig{
 									Certificate: path.Join("../..", "testdata", "tls", "certificate.pem"),
 									Key:         path.Join("../..", "testdata", "tls", "key.pem")},
-								ClientAuth: 0,
+								ClientAuth: 4,
 								CAs:        []string{path.Join("../..", "testdata", "tls", "./ca.crt.pem")}})
 							require.NoError(t, err)
 							return tlsServerConfig.BuildModuleConfig("localhost:12345")
@@ -243,7 +243,7 @@ func Test_UnpackConfig(t *testing.T) {
 				TLS: &tlscommon.ServerConfig{
 					Enabled:     &truthy,
 					Certificate: tlscommon.CertificateConfig{Certificate: "", Key: ""},
-					ClientAuth:  3},
+					ClientAuth:  0},
 				AugmentEnabled: true,
 				Expvar: &ExpvarConfig{
 					Enabled: &truthy,
@@ -287,7 +287,7 @@ func Test_UnpackConfig(t *testing.T) {
 							tlsServerConfig, err := tlscommon.LoadTLSServerConfig(&tlscommon.ServerConfig{
 								Enabled:     &truthy,
 								Certificate: tlscommon.CertificateConfig{Certificate: "", Key: ""},
-								ClientAuth:  3})
+								ClientAuth:  0})
 							require.NoError(t, err)
 							return tlsServerConfig.BuildModuleConfig("localhost:14250")
 						}(),
@@ -312,7 +312,7 @@ func Test_UnpackConfig(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		t.Run(name+"no outputESCfg", func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			inpCfg, err := common.NewConfigFrom(test.inpCfg)
 			assert.NoError(t, err)
 
@@ -371,16 +371,16 @@ func TestTLSSettings(t *testing.T) {
 			tls *tlscommon.ServerConfig
 		}{
 			"Defaults": {
-				config: map[string]interface{}{"ssl": nil},
-				tls:    &tlscommon.ServerConfig{ClientAuth: 3},
+				config: map[string]interface{}{"ssl.enabled": true},
+				tls:    &tlscommon.ServerConfig{ClientAuth: 0},
 			},
 			"ConfiguredToRequired": {
 				config: map[string]interface{}{"ssl": map[string]interface{}{"client_authentication": "required"}},
 				tls:    &tlscommon.ServerConfig{ClientAuth: 4},
 			},
-			"ConfiguredToNone": {
-				config: map[string]interface{}{"ssl": map[string]interface{}{"client_authentication": "none"}},
-				tls:    &tlscommon.ServerConfig{ClientAuth: 0},
+			"ConfiguredToOptional": {
+				config: map[string]interface{}{"ssl": map[string]interface{}{"client_authentication": "optional"}},
+				tls:    &tlscommon.ServerConfig{ClientAuth: 3},
 			},
 			"DefaultRequiredByCA": {
 				config: map[string]interface{}{"ssl": map[string]interface{}{
@@ -401,32 +401,6 @@ func TestTLSSettings(t *testing.T) {
 				cfg, err := NewConfig("9.9.9", ucfgCfg, nil)
 				require.NoError(t, err)
 				assert.Equal(t, tc.tls.ClientAuth, cfg.TLS.ClientAuth)
-			})
-		}
-	})
-
-	t.Run("VerificationMode", func(t *testing.T) {
-		for name, tc := range map[string]struct {
-			config map[string]interface{}
-			tls    *tlscommon.ServerConfig
-		}{
-			"Default": {
-				config: map[string]interface{}{"ssl": nil},
-				tls:    &tlscommon.ServerConfig{VerificationMode: tlscommon.VerifyFull}},
-			"ConfiguredToFull": {
-				config: map[string]interface{}{"ssl": map[string]interface{}{"verification_mode": "full"}},
-				tls:    &tlscommon.ServerConfig{VerificationMode: tlscommon.VerifyFull}},
-			"ConfiguredToNone": {
-				config: map[string]interface{}{"ssl": map[string]interface{}{"verification_mode": "none"}},
-				tls:    &tlscommon.ServerConfig{VerificationMode: tlscommon.VerifyNone}},
-		} {
-			t.Run(name, func(t *testing.T) {
-				ucfgCfg, err := common.NewConfigFrom(tc.config)
-				require.NoError(t, err)
-
-				cfg, err := NewConfig("9.9.9", ucfgCfg, nil)
-				require.NoError(t, err)
-				assert.Equal(t, tc.tls.VerificationMode, cfg.TLS.VerificationMode)
 			})
 		}
 	})

--- a/docs/ssl-input-settings.asciidoc
+++ b/docs/ssl-input-settings.asciidoc
@@ -23,12 +23,6 @@ The path to the file containing the Server certificate key.
 Required if `apm-server.ssl.enabled` is `true`.
 
 [float]
-==== `certificate_authorities`
-
-The list of root certificates for verifying client certificates.
-If `certificate_authorities` is empty or not set, the trusted certificate authorities of the host system are used.
-
-[float]
 ==== `key_passphrase`
 
 The passphrase used to decrypt an encrypted key stored in the configured `key` file.
@@ -54,22 +48,23 @@ suites are used (recommended).
 The list of curve types for ECDHE (Elliptic Curve Diffie-Hellman ephemeral key exchange).
 
 [float]
+==== `certificate_authorities`
+
+The list of root certificates for verifying client certificates.
+If `certificate_authorities` is empty or not set, the trusted certificate authorities of the host system are used.
+Sending client certificates is currently only supported by the RUM agent through the browser
+and by the Jaeger agent.
+
+[float]
 ==== `client_authentication`
 
 This configures what types of client authentication are supported. The valid options
-are `none`, `optional`, and `required`. The default is `optional`.
+are `none`, `optional`, and `required`. The default is `none`.
 If `certificate_authorities` has been specified, this setting will automatically change to `required`.
+This option only needs to be configured when the agent is expected to provide a client certificate.
+Sending client certificates is currently only supported by the RUM agent through the browser
+and by the Jaeger agent.
 
 * `none` - Disables client authentication.
 * `optional` - When a client certificate is given, the server will verify it.
 * `required` - Requires clients to provide a valid certificate.
-
-[float]
-==== `verification_mode`
-
-This option controls whether the client verifies server certificates and host
-names. Valid values are `none` and `full`. If `none` is used,
-SSL-based connections are susceptible to man-in-the-middle attacks. Use this
-option for testing only.
-
-The default is `full`.

--- a/tests/system/test_tls.py
+++ b/tests/system/test_tls.py
@@ -113,8 +113,7 @@ class TestSSLBadPassphraseTest(TestSecureServerBaseTest):
 
 @integration_test
 class TestSSLEnabledNoClientAuthenticationTest(TestSecureServerBaseTest):
-    def ssl_overrides(self):
-        return {"ssl_client_authentication": "none"}
+    # no ssl_overrides necessary as `none` is default
 
     def test_https_no_cert_ok(self):
         self.ssl_connect()
@@ -132,7 +131,8 @@ class TestSSLEnabledNoClientAuthenticationTest(TestSecureServerBaseTest):
 
 @integration_test
 class TestSSLEnabledOptionalClientAuthenticationTest(TestSecureServerBaseTest):
-    # no ssl_overrides necessary as `optional` is default
+    def ssl_overrides(self):
+        return {"ssl_client_authentication": "optional"}
 
     def test_https_no_certificate_ok(self):
         self.ssl_connect()


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Changing TLS client_authentication default and cleaning up docs (#3500)