### PR TITLE
processor/stream: fix panic in benchmarks

### DIFF
--- a/processor/stream/benchmark_test.go
+++ b/processor/stream/benchmark_test.go
@@ -29,6 +29,7 @@ import (
 
 	"golang.org/x/time/rate"
 
+	"github.com/elastic/apm-server/model/metadata"
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/apm-server/tests/loader"
 )
@@ -48,7 +49,7 @@ func BenchmarkStreamProcessor(b *testing.B) {
 	}
 	//ensure to not hit rate limit as blocking wait would be measured otherwise
 	rl := rate.NewLimiter(rate.Limit(math.MaxFloat64-1), math.MaxInt32)
-	sp := &Processor{MaxEventSize: 300 * 1024}
+	sp := &Processor{MaxEventSize: 300 * 1024, metadataSchema: metadata.ModelSchema()}
 
 	benchmark := func(filename string, rl *rate.Limiter) func(b *testing.B) {
 		return func(b *testing.B) {

--- a/processor/stream/benchmark_test.go
+++ b/processor/stream/benchmark_test.go
@@ -20,40 +20,41 @@ package stream
 import (
 	"bytes"
 	"context"
-	"errors"
 	"io/ioutil"
 	"math"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"golang.org/x/time/rate"
 
-	"github.com/elastic/apm-server/model/metadata"
+	"github.com/elastic/apm-server/beater/config"
 	"github.com/elastic/apm-server/publish"
-	"github.com/elastic/apm-server/tests/loader"
+	"github.com/elastic/apm-server/transform"
 )
 
-func BenchmarkStreamProcessor(b *testing.B) {
+func BenchmarkBackendProcessor(b *testing.B) {
+	processor := BackendProcessor(&config.Config{MaxEventSize: 300 * 1024})
+	files, _ := filepath.Glob(filepath.FromSlash("../../testdata/intake-v2/*.ndjson"))
+	benchmarkStreamProcessor(b, processor, files)
+}
+
+func BenchmarkRUMV3Processor(b *testing.B) {
+	tcfg := &transform.Config{}
+	processor := RUMV3Processor(&config.Config{MaxEventSize: 300 * 1024}, tcfg)
+	files, _ := filepath.Glob(filepath.FromSlash("../../testdata/intake-v3/rum_*.ndjson"))
+	benchmarkStreamProcessor(b, processor, files)
+}
+
+func benchmarkStreamProcessor(b *testing.B, processor *Processor, files []string) {
 	report := func(ctx context.Context, p publish.PendingReq) error {
 		return nil
 	}
-	dir := "../testdata/intake-v2"
-	_, cwd, _, ok := runtime.Caller(0)
-	if !ok {
-		b.Error(errors.New("Could not determine test dir"))
-	}
-	files, err := ioutil.ReadDir(filepath.Join(cwd, "../..", dir))
-	if err != nil {
-		b.Error(err)
-	}
 	//ensure to not hit rate limit as blocking wait would be measured otherwise
 	rl := rate.NewLimiter(rate.Limit(math.MaxFloat64-1), math.MaxInt32)
-	sp := &Processor{MaxEventSize: 300 * 1024, metadataSchema: metadata.ModelSchema()}
 
 	benchmark := func(filename string, rl *rate.Limiter) func(b *testing.B) {
 		return func(b *testing.B) {
-			data, err := loader.LoadDataAsBytes(filepath.Join(dir, filename))
+			data, err := ioutil.ReadFile(filename)
 			if err != nil {
 				b.Error(err)
 			}
@@ -65,15 +66,15 @@ func BenchmarkStreamProcessor(b *testing.B) {
 				b.StopTimer()
 				r.Reset(data)
 				b.StartTimer()
-				sp.HandleStream(context.Background(), rl, map[string]interface{}{}, r, report)
+				processor.HandleStream(context.Background(), rl, map[string]interface{}{}, r, report)
 			}
 		}
 	}
 
 	for _, f := range files {
-		b.Run(f.Name(), func(b *testing.B) {
-			b.Run("NoRateLimit", benchmark(f.Name(), nil))
-			b.Run("WithRateLimit", benchmark(f.Name(), rl))
+		b.Run(filepath.Base(f), func(b *testing.B) {
+			b.Run("NoRateLimit", benchmark(f, nil))
+			b.Run("WithRateLimit", benchmark(f, rl))
 		})
 	}
 }


### PR DESCRIPTION
## Motivation/summary

This fixes a panic in processor/stream benchmarks, by setting the recently introduced metadata schema field in the Processor type.

See https://apm-ci.elastic.co/blue/organizations/jenkins/apm-server%2Fapm-server-mbp/detail/master/401/pipeline/#step-208-log-470:

```
[2020-03-20T07:08:41.373Z] panic: runtime error: invalid memory address or nil pointer dereference [recovered]
[2020-03-20T07:08:41.373Z] 	panic: runtime error: invalid memory address or nil pointer dereference
[2020-03-20T07:08:41.373Z] [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xe91c8a]
[2020-03-20T07:08:41.373Z] 
[2020-03-20T07:08:41.373Z] goroutine 36 [running]:
[2020-03-20T07:08:41.373Z] github.com/santhosh-tekuri/jsonschema.(*Schema).ValidateInterface.func1(0xc0000f7920)
[2020-03-20T07:08:41.373Z] 	/var/lib/jenkins/workspace/apm-server_apm-server-mbp_master/pkg/mod/github.com/santhosh-tekuri/jsonschema@v1.2.4/schema.go:125 +0xa3
[2020-03-20T07:08:41.373Z] panic(0x1037640, 0x1b25c70)
[2020-03-20T07:08:41.373Z] 	/usr/local/go/src/runtime/panic.go:679 +0x1b2
[2020-03-20T07:08:41.373Z] github.com/santhosh-tekuri/jsonschema.(*Schema).validate(0x0, 0x1015f20, 0xc00055c1b0, 0x0, 0x0)
[2020-03-20T07:08:41.373Z] 	/var/lib/jenkins/workspace/apm-server_apm-server-mbp_master/pkg/mod/github.com/santhosh-tekuri/jsonschema@v1.2.4/schema.go:145 +0x3a
[2020-03-20T07:08:41.373Z] github.com/santhosh-tekuri/jsonschema.(*Schema).ValidateInterface(0x0, 0x1015f20, 0xc00055c1b0, 0x0, 0x0)
[2020-03-20T07:08:41.373Z] 	/var/lib/jenkins/workspace/apm-server_apm-server-mbp_master/pkg/mod/github.com/santhosh-tekuri/jsonschema@v1.2.4/schema.go:129 +0x9c
[2020-03-20T07:08:41.373Z] github.com/elastic/apm-server/validation.Validate(0x1015f20, 0xc00055c1b0, 0x0, 0x8, 0xc000463048)
[2020-03-20T07:08:41.373Z] 	/var/lib/jenkins/workspace/apm-server_apm-server-mbp_master/src/github.com/elastic/apm-server/validation/validator.go:41 +0x43
[2020-03-20T07:08:41.373Z] github.com/elastic/apm-server/processor/stream.(*Processor).readMetadata(0xc00044e120, 0xc0000f7db8, 0x12fc9c0, 0xc000556000, 0x0, 0x6c2, 0x8)
[2020-03-20T07:08:41.374Z] 	/var/lib/jenkins/workspace/apm-server_apm-server-mbp_master/src/github.com/elastic/apm-server/processor/stream/processor.go:211 +0x1aa
[2020-03-20T07:08:41.374Z] github.com/elastic/apm-server/processor/stream.(*Processor).HandleStream(0xc00044e120, 0x12fec00, 0xc000028158, 0x0, 0xc000057db8, 0x12f2360, 0xc00055c0f0, 0x11bdfe0, 0x0)
[2020-03-20T07:08:41.374Z] 	/var/lib/jenkins/workspace/apm-server_apm-server-mbp_master/src/github.com/elastic/apm-server/processor/stream/processor.go:323 +0x2a0
[2020-03-20T07:08:41.374Z] github.com/elastic/apm-server/processor/stream.BenchmarkStreamProcessor.func2.1(0xc000508540)
[2020-03-20T07:08:41.374Z] 	/var/lib/jenkins/workspace/apm-server_apm-server-mbp_master/src/github.com/elastic/apm-server/processor/stream/benchmark_test.go:67 +0x2bc
[2020-03-20T07:08:41.374Z] testing.(*B).runN(0xc000508540, 0x1)
[2020-03-20T07:08:41.374Z] 	/usr/local/go/src/testing/benchmark.go:190 +0xcc
[2020-03-20T07:08:41.374Z] testing.(*B).run1.func1(0xc000508540)
[2020-03-20T07:08:41.374Z] 	/usr/local/go/src/testing/benchmark.go:230 +0x64
[2020-03-20T07:08:41.374Z] created by testing.(*B).run1
[2020-03-20T07:08:41.374Z] 	/usr/local/go/src/testing/benchmark.go:223 +0x7d
[2020-03-20T07:08:41.374Z] exit status 2
[2020-03-20T07:08:41.374Z] FAIL	github.com/elastic/apm-server/processor/stream	0.030s
```

## Checklist
- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
~- [ ] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes~
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

## How to test these changes

`go test -run=NONE -bench=. github.com/elastic/apm-server/processor/stream`

## Related issues

None.