### PR TITLE
[7.x] all: propagate context through Transformables (#3515)

### DIFF
--- a/beater/jaeger/server_test.go
+++ b/beater/jaeger/server_test.go
@@ -355,7 +355,7 @@ type testcase struct {
 func (tc *testcase) setup(t *testing.T) {
 	reporter := func(ctx context.Context, req publish.PendingReq) error {
 		for _, transformable := range req.Transformables {
-			tc.events = append(tc.events, transformable.Transform(req.Tcontext)...)
+			tc.events = append(tc.events, transformable.Transform(ctx, req.Tcontext)...)
 		}
 		return nil
 	}

--- a/beater/onboarding.go
+++ b/beater/onboarding.go
@@ -43,7 +43,7 @@ type onboardingDoc struct {
 	listenAddr string
 }
 
-func (o onboardingDoc) Transform(tctx *transform.Context) []beat.Event {
+func (o onboardingDoc) Transform(ctx context.Context, tctx *transform.Context) []beat.Event {
 	return []beat.Event{{
 		Timestamp: tctx.RequestTime,
 		Fields: common.MapStr{

--- a/changelogs/7.7.asciidoc
+++ b/changelogs/7.7.asciidoc
@@ -21,3 +21,4 @@ https://github.com/elastic/apm-server/compare/v7.6.0\...v7.7.0[View commits]
 ==== Added
 * Instrumentation for go-elasticsearch {pull}3305[3305]
 * Added support for Jaeger auth tags {pull}3394[3394]
+* Enabled instrumentation of sourcemaps {pull}3515[3515]

--- a/model/error/event_test.go
+++ b/model/error/event_test.go
@@ -18,6 +18,7 @@
 package error
 
 import (
+	"context"
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/json"
@@ -542,7 +543,7 @@ func TestEventFields(t *testing.T) {
 				},
 			}
 
-			output := tc.Event.Transform(tctx)
+			output := tc.Event.Transform(context.Background(), tctx)
 			require.Len(t, output, 1)
 			fields := output[0].Fields["error"]
 			assert.Equal(t, tc.Output, fields)
@@ -689,7 +690,7 @@ func TestEvents(t *testing.T) {
 				RequestTime: timestamp,
 			}
 
-			outputEvents := tc.Transformable.Transform(tctx)
+			outputEvents := tc.Transformable.Transform(context.Background(), tctx)
 			require.Len(t, outputEvents, 1)
 			outputEvent := outputEvents[0]
 			assert.Equal(t, tc.Output, outputEvent.Fields)
@@ -1037,13 +1038,13 @@ func TestSourcemapping(t *testing.T) {
 		Config:   transform.Config{SourcemapStore: nil},
 		Metadata: metadata.Metadata{Service: &metadata.Service{Name: &str, Version: &str}},
 	}
-	transformedNoSourcemap := event1.fields(tctx)
+	transformedNoSourcemap := event1.fields(context.Background(), tctx)
 
 	// transform with sourcemap store
 	store, err := sourcemap.NewStore(test.ESClientWithValidSourcemap(t), "apm-*sourcemap*", time.Minute)
 	require.NoError(t, err)
 	tctx.Config = transform.Config{SourcemapStore: store}
-	transformedWithSourcemap := event2.fields(tctx)
+	transformedWithSourcemap := event2.fields(context.Background(), tctx)
 
 	// ensure events have different line number and grouping keys
 	assert.Equal(t, 1, *event1.Exception.Stacktrace[0].Lineno)

--- a/model/metricset/event.go
+++ b/model/metricset/event.go
@@ -18,6 +18,7 @@
 package metricset
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -202,7 +203,7 @@ func (t *Transaction) fields() common.MapStr {
 	return fields
 }
 
-func (me *Metricset) Transform(tctx *transform.Context) []beat.Event {
+func (me *Metricset) Transform(ctx context.Context, tctx *transform.Context) []beat.Event {
 	transformations.Inc()
 	if me == nil {
 		return nil

--- a/model/metricset/event_test.go
+++ b/model/metricset/event_test.go
@@ -18,6 +18,7 @@
 package metricset
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -245,7 +246,7 @@ func TestTransform(t *testing.T) {
 
 	tctx := &transform.Context{Config: transform.Config{}, Metadata: *md}
 	for idx, test := range tests {
-		outputEvents := test.Metricset.Transform(tctx)
+		outputEvents := test.Metricset.Transform(context.Background(), tctx)
 
 		for j, outputEvent := range outputEvents {
 			assert.Equal(t, test.Output[j], outputEvent.Fields, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
@@ -257,7 +258,7 @@ func TestTransform(t *testing.T) {
 func TestEventTransformUseReqTime(t *testing.T) {
 	reqTimestampParsed := time.Date(2017, 5, 30, 18, 53, 27, 154*1e6, time.UTC)
 	e := Metricset{}
-	beatEvent := e.Transform(&transform.Context{RequestTime: reqTimestampParsed})
+	beatEvent := e.Transform(context.Background(), &transform.Context{RequestTime: reqTimestampParsed})
 	require.Len(t, beatEvent, 1)
 	assert.Equal(t, reqTimestampParsed, beatEvent[0].Timestamp)
 }

--- a/model/profile/profile.go
+++ b/model/profile/profile.go
@@ -18,6 +18,7 @@
 package profile
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -46,7 +47,7 @@ type PprofProfile struct {
 }
 
 // Transform transforms a Profile into a sequence of beat.Events: one per profile sample.
-func (pp PprofProfile) Transform(tctx *transform.Context) []beat.Event {
+func (pp PprofProfile) Transform(ctx context.Context, tctx *transform.Context) []beat.Event {
 	// Precompute value field names for use in each event.
 	// TODO(axw) limit to well-known value names?
 	profileTimestamp := time.Unix(0, pp.Profile.TimeNanos)

--- a/model/profile/profile_test.go
+++ b/model/profile/profile_test.go
@@ -18,6 +18,7 @@
 package profile_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -27,7 +28,6 @@ import (
 
 	"github.com/elastic/apm-server/model/metadata"
 	"github.com/elastic/apm-server/model/profile"
-	"github.com/elastic/apm-server/sourcemap"
 	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -87,11 +87,11 @@ func TestPprofProfileTransform(t *testing.T) {
 	metadata := metadata.Metadata{Service: &service}
 
 	tctx := &transform.Context{
-		Config:      transform.Config{SourcemapStore: &sourcemap.Store{}},
+		Config:      transform.Config{}, // not used
 		Metadata:    metadata,
 		RequestTime: time.Time{}, // not used
 	}
-	output := pp.Transform(tctx)
+	output := pp.Transform(context.Background(), tctx)
 	require.Len(t, output, 2)
 	assert.Equal(t, output[0], output[1])
 

--- a/model/sourcemap/payload.go
+++ b/model/sourcemap/payload.go
@@ -18,6 +18,7 @@
 package sourcemap
 
 import (
+	"context"
 	"time"
 
 	"github.com/santhosh-tekuri/jsonschema"
@@ -59,7 +60,7 @@ type Sourcemap struct {
 	BundleFilepath string
 }
 
-func (pa *Sourcemap) Transform(tctx *transform.Context) []beat.Event {
+func (pa *Sourcemap) Transform(ctx context.Context, tctx *transform.Context) []beat.Event {
 	sourcemapCounter.Inc()
 	if pa == nil {
 		return nil
@@ -68,7 +69,7 @@ func (pa *Sourcemap) Transform(tctx *transform.Context) []beat.Event {
 	if tctx.Config.SourcemapStore == nil {
 		logp.NewLogger(logs.Sourcemap).Error("Sourcemap Accessor is nil, cache cannot be invalidated.")
 	} else {
-		tctx.Config.SourcemapStore.Added(pa.ServiceName, pa.ServiceVersion, pa.BundleFilepath)
+		tctx.Config.SourcemapStore.Added(ctx, pa.ServiceName, pa.ServiceVersion, pa.BundleFilepath)
 	}
 
 	ev := beat.Event{

--- a/model/sourcemap/payload_test.go
+++ b/model/sourcemap/payload_test.go
@@ -18,6 +18,7 @@
 package sourcemap
 
 import (
+	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -52,7 +53,7 @@ func TestDecode(t *testing.T) {
 	sourcemap, err := DecodeSourcemap(data)
 	assert.NoError(t, err)
 
-	rs := sourcemap.Transform(&transform.Context{})
+	rs := sourcemap.Transform(context.Background(), &transform.Context{})
 	assert.Len(t, rs, 1)
 	event := rs[0]
 	assert.WithinDuration(t, time.Now(), event.Timestamp, time.Second)
@@ -77,7 +78,7 @@ func TestTransform(t *testing.T) {
 	}
 
 	tctx := &transform.Context{}
-	events := p.Transform(tctx)
+	events := p.Transform(context.Background(), tctx)
 	assert.Len(t, events, 1)
 	event := events[0]
 
@@ -120,7 +121,7 @@ func TestInvalidateCache(t *testing.T) {
 		require.NoError(t, err)
 
 		// transform with sourcemap store
-		event.Transform(&transform.Context{Config: transform.Config{SourcemapStore: store}})
+		event.Transform(context.Background(), &transform.Context{Config: transform.Config{SourcemapStore: store}})
 
 		logCollection := logp.ObserverLogs().TakeAll()
 		assert.Equal(t, 2, len(logCollection))
@@ -143,7 +144,7 @@ func TestInvalidateCache(t *testing.T) {
 		require.NoError(t, logp.DevelopmentSetup(logp.ToObserverOutput()))
 
 		// transform with sourcemap store
-		event.Transform(&transform.Context{Config: transform.Config{SourcemapStore: nil}})
+		event.Transform(context.Background(), &transform.Context{Config: transform.Config{SourcemapStore: nil}})
 
 		logCollection := logp.ObserverLogs().TakeAll()
 		assert.Equal(t, 1, len(logCollection))

--- a/model/span/event.go
+++ b/model/span/event.go
@@ -18,6 +18,7 @@
 package span
 
 import (
+	"context"
 	"net"
 	"strings"
 	"time"
@@ -374,7 +375,7 @@ func DecodeEvent(input interface{}, cfg m.Config, err error) (transform.Transfor
 	return &event, nil
 }
 
-func (e *Event) Transform(tctx *transform.Context) []beat.Event {
+func (e *Event) Transform(ctx context.Context, tctx *transform.Context) []beat.Event {
 	transformations.Inc()
 	if frames := len(e.Stacktrace); frames > 0 {
 		stacktraceCounter.Inc()
@@ -383,7 +384,7 @@ func (e *Event) Transform(tctx *transform.Context) []beat.Event {
 
 	fields := common.MapStr{
 		"processor": processorEntry,
-		spanDocType: e.fields(tctx),
+		spanDocType: e.fields(ctx, tctx),
 	}
 
 	// first set the generic metadata
@@ -420,7 +421,7 @@ func (e *Event) Transform(tctx *transform.Context) []beat.Event {
 	}
 }
 
-func (e *Event) fields(tctx *transform.Context) common.MapStr {
+func (e *Event) fields(ctx context.Context, tctx *transform.Context) common.MapStr {
 	if e == nil {
 		return nil
 	}
@@ -448,7 +449,7 @@ func (e *Event) fields(tctx *transform.Context) common.MapStr {
 
 	utility.Set(fields, "message", e.Message.Fields())
 
-	st := e.Stacktrace.Transform(tctx)
+	st := e.Stacktrace.Transform(ctx, tctx)
 	utility.Set(fields, "stacktrace", st)
 	return fields
 }

--- a/model/span/event_test.go
+++ b/model/span/event_test.go
@@ -18,6 +18,7 @@
 package span
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -378,7 +379,7 @@ func TestSpanTransform(t *testing.T) {
 		RequestTime: timestamp,
 	}
 	for _, test := range tests {
-		output := test.Event.Transform(tctx)
+		output := test.Event.Transform(context.Background(), tctx)
 		fields := output[0].Fields
 		assert.Equal(t, test.Output, fields)
 	}
@@ -388,7 +389,7 @@ func TestEventTransformUseReqTimePlusStart(t *testing.T) {
 	reqTimestampParsed := time.Date(2017, 5, 30, 18, 53, 27, 154*1e6, time.UTC)
 	start := 1234.8
 	e := Event{Start: &start}
-	beatEvent := e.Transform(&transform.Context{RequestTime: reqTimestampParsed})
+	beatEvent := e.Transform(context.Background(), &transform.Context{RequestTime: reqTimestampParsed})
 	require.Len(t, beatEvent, 1)
 
 	adjustedParsed := time.Date(2017, 5, 30, 18, 53, 28, 388.8*1e6, time.UTC)

--- a/model/stacktrace.go
+++ b/model/stacktrace.go
@@ -51,7 +51,7 @@ func DecodeStacktrace(input interface{}, hasShortFieldNames bool, err error) (*S
 	return &st, err
 }
 
-func (st *Stacktrace) Transform(tctx *transform.Context) []common.MapStr {
+func (st *Stacktrace) Transform(ctx context.Context, tctx *transform.Context) []common.MapStr {
 	if st == nil {
 		return nil
 	}
@@ -85,7 +85,7 @@ func (st *Stacktrace) Transform(tctx *transform.Context) []common.MapStr {
 	logger := logp.NewLogger(logs.Stacktrace)
 	fct := "<anonymous>"
 	return st.transform(tctx, func(frame *StacktraceFrame) {
-		fct, errMsg = frame.applySourcemap(context.TODO(), tctx.Config.SourcemapStore, tctx.Metadata.Service, fct)
+		fct, errMsg = frame.applySourcemap(ctx, tctx.Config.SourcemapStore, tctx.Metadata.Service, fct)
 		if errMsg != "" {
 			if _, ok := sourcemapErrorSet[errMsg]; !ok {
 				logger.Warn(errMsg)

--- a/model/stacktrace_test.go
+++ b/model/stacktrace_test.go
@@ -18,6 +18,7 @@
 package model
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -145,7 +146,7 @@ func TestStacktraceTransform(t *testing.T) {
 		},
 	}
 	for idx, test := range tests {
-		output := test.Stacktrace.Transform(&tctx)
+		output := test.Stacktrace.Transform(context.Background(), &tctx)
 		assert.Equal(t, test.Output, output, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 	}
 }
@@ -293,8 +294,8 @@ func TestStacktraceTransformWithSourcemapping(t *testing.T) {
 			}
 
 			// run `Stacktrace.Transform` twice to ensure method is idempotent
-			tc.Stacktrace.Transform(tctx)
-			output := tc.Stacktrace.Transform(tctx)
+			tc.Stacktrace.Transform(context.Background(), tctx)
+			output := tc.Stacktrace.Transform(context.Background(), tctx)
 			assert.Equal(t, tc.Output, output)
 		})
 	}

--- a/model/transaction/event.go
+++ b/model/transaction/event.go
@@ -18,6 +18,7 @@
 package transaction
 
 import (
+	"context"
 	"time"
 
 	"github.com/elastic/apm-server/model/field"
@@ -176,7 +177,7 @@ func (e *Event) fields(tctx *transform.Context) common.MapStr {
 	return tx
 }
 
-func (e *Event) Transform(tctx *transform.Context) []beat.Event {
+func (e *Event) Transform(ctx context.Context, tctx *transform.Context) []beat.Event {
 	transformations.Inc()
 
 	if e.Timestamp.IsZero() {

--- a/model/transaction/event_test.go
+++ b/model/transaction/event_test.go
@@ -18,6 +18,7 @@
 package transaction
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -317,7 +318,7 @@ func TestEventTransform(t *testing.T) {
 	tctx := &transform.Context{}
 
 	for idx, test := range tests {
-		output := test.Event.Transform(tctx)
+		output := test.Event.Transform(context.Background(), tctx)
 		assert.Equal(t, test.Output, output[0].Fields["transaction"], fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 	}
 }
@@ -524,7 +525,7 @@ func TestEventsTransformWithMetadata(t *testing.T) {
 			Metadata:    *test.Metadata,
 			RequestTime: timestamp,
 		}
-		outputEvents := test.Event.Transform(tctx)
+		outputEvents := test.Event.Transform(context.Background(), tctx)
 
 		for j, outputEvent := range outputEvents {
 			assert.Equal(t, test.Output[j], outputEvent.Fields, fmt.Sprintf("Failed at idx %v (j: %v); %s", idx, j, test.Msg))
@@ -536,7 +537,7 @@ func TestEventsTransformWithMetadata(t *testing.T) {
 func TestEventTransformUseReqTime(t *testing.T) {
 	reqTimestampParsed := time.Date(2017, 5, 30, 18, 53, 27, 154*1e6, time.UTC)
 	e := Event{}
-	beatEvent := e.Transform(&transform.Context{RequestTime: reqTimestampParsed})
+	beatEvent := e.Transform(context.Background(), &transform.Context{RequestTime: reqTimestampParsed})
 	require.Len(t, beatEvent, 1)
 	assert.Equal(t, reqTimestampParsed, beatEvent[0].Timestamp)
 }

--- a/processor/asset/sourcemap/package_tests/processor_test.go
+++ b/processor/asset/sourcemap/package_tests/processor_test.go
@@ -18,6 +18,7 @@
 package package_tests
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -70,7 +71,7 @@ func TestSourcemapProcessorOK(t *testing.T) {
 		tctx.Metadata = *metadata
 		var events []beat.Event
 		for _, transformable := range payload {
-			events = append(events, transformable.Transform(&tctx)...)
+			events = append(events, transformable.Transform(context.Background(), &tctx)...)
 		}
 		verifyErr := approvals.ApproveEvents(events, info.Name, "@timestamp")
 		if verifyErr != nil {

--- a/processor/asset/sourcemap/package_tests/test_processor.go
+++ b/processor/asset/sourcemap/package_tests/test_processor.go
@@ -18,6 +18,7 @@
 package package_tests
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/elastic/apm-server/processor/asset"
@@ -61,7 +62,7 @@ func (p *TestProcessor) Process(buf []byte) ([]beat.Event, error) {
 
 	var events []beat.Event
 	for _, transformable := range transformables {
-		events = append(events, transformable.Transform(&transform.Context{Metadata: *metadata})...)
+		events = append(events, transformable.Transform(context.Background(), &transform.Context{Metadata: *metadata})...)
 	}
 	return events, nil
 }

--- a/processor/otel/consumer_test.go
+++ b/processor/otel/consumer_test.go
@@ -64,7 +64,7 @@ func TestConsumer_ConsumeTraceData(t *testing.T) {
 			reporter := func(ctx context.Context, p publish.PendingReq) error {
 				var events []beat.Event
 				for _, transformable := range p.Transformables {
-					events = append(events, transformable.Transform(p.Tcontext)...)
+					events = append(events, transformable.Transform(ctx, p.Tcontext)...)
 				}
 				assert.NoError(t, approvals.ApproveEvents(events, file("consume_"+tc.name)))
 				return nil

--- a/processor/stream/package_tests/intake_test_processor.go
+++ b/processor/stream/package_tests/intake_test_processor.go
@@ -111,7 +111,7 @@ func (p *intakeTestProcessor) Process(buf []byte) ([]beat.Event, error) {
 	for _, req := range reqs {
 		if req.Transformables != nil {
 			for _, transformable := range req.Transformables {
-				events = append(events, transformable.Transform(req.Tcontext)...)
+				events = append(events, transformable.Transform(context.Background(), req.Tcontext)...)
 			}
 		}
 	}

--- a/processor/stream/processor_test.go
+++ b/processor/stream/processor_test.go
@@ -96,7 +96,7 @@ func TestIntegrationESOutput(t *testing.T) {
 	report := func(ctx context.Context, p publish.PendingReq) error {
 		var events []beat.Event
 		for _, transformable := range p.Transformables {
-			events = append(events, transformable.Transform(p.Tcontext)...)
+			events = append(events, transformable.Transform(ctx, p.Tcontext)...)
 		}
 		name := ctx.Value("name").(string)
 		verifyErr := approvals.ApproveEvents(events, name)
@@ -152,7 +152,7 @@ func TestIntegrationRum(t *testing.T) {
 	report := func(ctx context.Context, p publish.PendingReq) error {
 		var events []beat.Event
 		for _, transformable := range p.Transformables {
-			events = append(events, transformable.Transform(p.Tcontext)...)
+			events = append(events, transformable.Transform(ctx, p.Tcontext)...)
 		}
 		name := ctx.Value("name").(string)
 		verifyErr := approvals.ApproveEvents(events, name)
@@ -196,10 +196,10 @@ func TestIntegrationRum(t *testing.T) {
 func TestRUMV3(t *testing.T) {
 
 	reporter := func(name string) publish.Reporter {
-		return func(_ context.Context, p publish.PendingReq) error {
+		return func(ctx context.Context, p publish.PendingReq) error {
 			var events []beat.Event
 			for _, transformable := range p.Transformables {
-				events = append(events, transformable.Transform(p.Tcontext)...)
+				events = append(events, transformable.Transform(ctx, p.Tcontext)...)
 			}
 			verifyErr := approvals.ApproveEvents(events, name)
 			if verifyErr != nil {

--- a/sourcemap/store.go
+++ b/sourcemap/store.go
@@ -97,8 +97,8 @@ func (s *Store) Fetch(ctx context.Context, name string, version string, path str
 }
 
 // Added ensures the internal cache is cleared for the given parameters. This should be called when a sourcemap is uploaded.
-func (s *Store) Added(name string, version string, path string) {
-	if sourcemap, err := s.Fetch(context.TODO(), name, version, path); err == nil && sourcemap != nil {
+func (s *Store) Added(ctx context.Context, name string, version string, path string) {
+	if sourcemap, err := s.Fetch(ctx, name, version, path); err == nil && sourcemap != nil {
 		s.logger.Warnf("Overriding sourcemap for service %s version %s and file %s",
 			name, version, path)
 	}

--- a/sourcemap/store_test.go
+++ b/sourcemap/store_test.go
@@ -157,7 +157,7 @@ func TestStore_Added(t *testing.T) {
 	assert.Equal(t, "", mapper.File())
 
 	// remove from cache, afterwards sourcemap should be fetched from ES
-	store.Added(name, version, path)
+	store.Added(context.Background(), name, version, path)
 	mapper, err = store.Fetch(context.Background(), name, version, path)
 	require.NoError(t, err)
 	assert.NotNil(t, &sourcemap.Consumer{}, mapper)

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -18,6 +18,7 @@
 package transform
 
 import (
+	"context"
 	"regexp"
 	"time"
 
@@ -28,7 +29,7 @@ import (
 )
 
 type Transformable interface {
-	Transform(*Context) []beat.Event
+	Transform(context.Context, *Context) []beat.Event
 }
 
 type Context struct {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - all: propagate context through Transformables (#3515)