### PR TITLE
ci(jenkins): support OSX builds

### DIFF
--- a/.ci/scripts/build-darwin.sh
+++ b/.ci/scripts/build-darwin.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+# shellcheck disable=SC1091
+source ./script/common.bash
+
+jenkins_setup
+
+./script/jenkins/build.sh

--- a/.ci/scripts/test-darwin.sh
+++ b/.ci/scripts/test-darwin.sh
@@ -2,11 +2,15 @@
 set -eox pipefail
 
 # Setup python3
+pythonVersion=3.7.7
 curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
 export PATH="${HOME}/.pyenv/bin:$PATH"
 eval "$(pyenv init -)"
 eval "$(pyenv virtualenv-init -)"
-pyenv install 3.7.7
+pyenv install ${pythonVersion}
+pyenv global ${pythonVersion}
+pythonInstallation=$(dirname "$(pyenv which pip)")
+export PATH="${pythonInstallation}:$PATH"
 
 # shellcheck disable=SC1091
 source ./script/common.bash

--- a/.ci/scripts/test-darwin.sh
+++ b/.ci/scripts/test-darwin.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euox pipefail
+set -eox pipefail
 
 # Setup python3
 curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash

--- a/.ci/scripts/test-darwin.sh
+++ b/.ci/scripts/test-darwin.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euox pipefail
 
+# Setup python3
+curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+pyenv install 3.7.7
+
 # shellcheck disable=SC1091
 source ./script/common.bash
 

--- a/.ci/scripts/test-darwin.sh
+++ b/.ci/scripts/test-darwin.sh
@@ -3,6 +3,9 @@ set -euox pipefail
 
 # Setup python3
 curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+export PATH="${HOME}/.pyenv/bin:$PATH"
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"
 pyenv install 3.7.7
 
 # shellcheck disable=SC1091

--- a/.ci/scripts/test-darwin.sh
+++ b/.ci/scripts/test-darwin.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+# shellcheck disable=SC1091
+source ./script/common.bash
+
+jenkins_setup
+
+script/jenkins/unit-test.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -180,6 +180,36 @@ pipeline {
           }
         }
         /**
+        Build on a mac environment.
+        */
+        stage('OSX build') {
+          agent { label 'macosx' }
+          options {
+            skipDefaultCheckout()
+            warnError('OSX execution failed')
+          }
+          when {
+            beforeAgent true
+            allOf {
+              expression { return env.ONLY_DOCS == "false" }
+            }
+          }
+          steps {
+            withGithubNotify(context: 'Build - OSX') {
+              deleteDir()
+              unstash 'source'
+              golang(){
+                dir(BASE_DIR){
+                  retry(2) { // Retry in case there are any errors to avoid temporary glitches
+                    sleep randomNumber(min: 5, max: 10)
+                    sh(label: 'OSX build', script: './script/jenkins/build.sh')
+                  }
+                }
+              }
+            }
+          }
+        }
+        /**
           Run unit tests and report junit results.
         */
         stage('Unit Test') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -201,7 +201,7 @@ pipeline {
               dir(BASE_DIR){
                 retry(2) { // Retry in case there are any errors to avoid temporary glitches
                   sleep randomNumber(min: 5, max: 10)
-                  sh(label: 'OSX build', script: './script/jenkins/build-darwin.sh')
+                  sh(label: 'OSX build', script: '.ci/scripts/build-darwin.sh')
                 }
               }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,7 +182,7 @@ pipeline {
         /**
         Build on a mac environment.
         */
-        stage('OSX build') {
+        stage('OSX build-test') {
           agent { label 'macosx' }
           options {
             skipDefaultCheckout()
@@ -195,15 +195,21 @@ pipeline {
             }
           }
           steps {
-            withGithubNotify(context: 'Build - OSX') {
+            withGithubNotify(context: 'Build-Test - OSX') {
               deleteDir()
               unstash 'source'
               dir(BASE_DIR){
                 retry(2) { // Retry in case there are any errors to avoid temporary glitches
                   sleep randomNumber(min: 5, max: 10)
                   sh(label: 'OSX build', script: '.ci/scripts/build-darwin.sh')
+                  sh(label: 'Run Unit tests', script: '.ci/scripts/test-darwin.sh')
                 }
               }
+            }
+          }
+          post {
+            always {
+              junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/build/junit-*.xml")
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -196,6 +196,9 @@ pipeline {
               expression { return env.ONLY_DOCS == "false" }
             }
           }
+          environment {
+            HOME = "${env.WORKSPACE}"
+          }
           steps {
             withGithubNotify(context: 'Build-Test - OSX') {
               deleteDir()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,7 @@ pipeline {
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
     booleanParam(name: 'linux_ci', defaultValue: true, description: 'Enable Linux build')
+    booleanParam(name: 'osx_ci', defaultValue: true, description: 'Enable OSX CI')
     booleanParam(name: 'windows_ci', defaultValue: true, description: 'Enable Windows CI')
     booleanParam(name: 'intake_ci', defaultValue: true, description: 'Enable test')
     booleanParam(name: 'test_ci', defaultValue: true, description: 'Enable test')
@@ -191,6 +192,7 @@ pipeline {
           when {
             beforeAgent true
             allOf {
+              expression { return params.osx_ci }
               expression { return env.ONLY_DOCS == "false" }
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,12 +198,10 @@ pipeline {
             withGithubNotify(context: 'Build - OSX') {
               deleteDir()
               unstash 'source'
-              golang(){
-                dir(BASE_DIR){
-                  retry(2) { // Retry in case there are any errors to avoid temporary glitches
-                    sleep randomNumber(min: 5, max: 10)
-                    sh(label: 'OSX build', script: './script/jenkins/build.sh')
-                  }
+              dir(BASE_DIR){
+                retry(2) { // Retry in case there are any errors to avoid temporary glitches
+                  sleep randomNumber(min: 5, max: 10)
+                  sh(label: 'OSX build', script: './script/jenkins/build-darwin.sh')
                 }
               }
             }


### PR DESCRIPTION
## Motivation/summary

Build and test the APM Server on Mac since it is a supported platform.

## How to test these changes

Within the CI

## Tasks
- Enable pyenv to install python3 in the CI Workers.
- Use wrapper to install the go version in the OSX CI Worker, this is a requirement, then call the build and test scripts for Linux.