### PR TITLE
processor/stream optimisations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 /apm-server.iml
 /apm-server.keystore
 /apm-server
-/apm-server.test
+**/*.test
 /apm-server.dev.yml
 /_meta/fields.generated.yml
 /_meta/kibana/*/index-pattern

--- a/decoder/line_reader.go
+++ b/decoder/line_reader.go
@@ -40,6 +40,12 @@ func NewLineReader(reader *bufio.Reader, maxLineLength int) *LineReader {
 	}
 }
 
+// Reset sets lr's underlying *bufio.Reader to br, and clears any state.
+func (lr *LineReader) Reset(br *bufio.Reader) {
+	lr.br = br
+	lr.skip = false
+}
+
 // ReadLine reads the next line from the given reader.
 // If it encounters a line that is longer than `maxLineLength` it will
 // return the first `maxLineLength` bytes with `ErrLineTooLong`. On the next

--- a/decoder/req_decoder.go
+++ b/decoder/req_decoder.go
@@ -88,11 +88,15 @@ func CompressedRequestReader(req *http.Request) (io.ReadCloser, error) {
 
 func DecodeJSONData(reader io.Reader) (map[string]interface{}, error) {
 	v := make(map[string]interface{})
-	d := json.NewDecoder(reader)
-	d.UseNumber()
+	d := NewJSONDecoder(reader)
 	if err := d.Decode(&v); err != nil {
-		// If we run out of memory, for example
-		return nil, errors.Wrap(err, "data read error")
+		return nil, err
 	}
 	return v, nil
+}
+
+func NewJSONDecoder(r io.Reader) *json.Decoder {
+	d := json.NewDecoder(r)
+	d.UseNumber()
+	return d
 }

--- a/decoder/stream_decoder_test.go
+++ b/decoder/stream_decoder_test.go
@@ -18,7 +18,6 @@
 package decoder
 
 import (
-	"bufio"
 	"bytes"
 	"strings"
 	"testing"
@@ -62,7 +61,7 @@ func TestNDStreamReader(t *testing.T) {
 		},
 	}
 	buf := bytes.NewBufferString(strings.Join(lines, "\n"))
-	n := NewNDJSONStreamReader(NewLineReader(bufio.NewReaderSize(buf, 20), 20))
+	n := NewNDJSONStreamReader(buf, 20)
 
 	for idx, test := range expected {
 		out, err := n.Read()

--- a/processor/stream/package_tests/intake_test_processor.go
+++ b/processor/stream/package_tests/intake_test_processor.go
@@ -18,7 +18,6 @@
 package package_tests
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -51,8 +50,7 @@ func (v *intakeTestProcessor) getReader(path string) (*decoder.NDJSONStreamReade
 	if err != nil {
 		return nil, err
 	}
-	lr := decoder.NewLineReader(bufio.NewReaderSize(reader, lrSize), lrSize)
-	return decoder.NewNDJSONStreamReader(lr), nil
+	return decoder.NewNDJSONStreamReader(reader, lrSize), nil
 }
 
 func (v *intakeTestProcessor) readEvents(reader *decoder.NDJSONStreamReader) ([]interface{}, error) {

--- a/processor/stream/package_tests/metadata_attrs_test.go
+++ b/processor/stream/package_tests/metadata_attrs_test.go
@@ -18,7 +18,6 @@
 package package_tests
 
 import (
-	"bufio"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -84,8 +83,7 @@ func getMetadataEventAttrs(t *testing.T, prefix string) *tests.Set {
 	payloadStream, err := loader.LoadDataAsStream("../testdata/intake-v2/only-metadata.ndjson")
 	require.NoError(t, err)
 
-	lr := decoder.NewLineReader(bufio.NewReader(payloadStream), lrSize)
-	metadata, err := decoder.NewNDJSONStreamReader(lr).Read()
+	metadata, err := decoder.NewNDJSONStreamReader(payloadStream, lrSize).Read()
 	require.NoError(t, err)
 
 	contextMetadata := metadata["metadata"]

--- a/processor/stream/processor.go
+++ b/processor/stream/processor.go
@@ -52,39 +52,9 @@ var (
 	ErrUnrecognizedObject = errors.New("did not recognize object type")
 )
 
-type StreamReader interface {
-	Read() (map[string]interface{}, error)
-	IsEOF() bool
-	LatestLine() []byte
-}
-
-// srErrorWrapper wraps stream decoders and converts errors to
-// something we know how to deal with
-type srErrorWrapper struct {
-	StreamReader
-}
-
-func (s *srErrorWrapper) Read() (map[string]interface{}, error) {
-	v, err := s.StreamReader.Read()
-	if err != nil {
-		if _, ok := err.(decoder.JSONDecodeError); ok {
-			return nil, &Error{
-				Type:     InvalidInputErrType,
-				Message:  err.Error(),
-				Document: string(s.StreamReader.LatestLine()),
-			}
-		}
-
-		if err == decoder.ErrLineTooLong {
-			return nil, &Error{
-				Type:     InputTooLargeErrType,
-				Message:  "event exceeded the permitted size.",
-				Document: string(s.StreamReader.LatestLine()),
-			}
-		}
-	}
-	return v, err
-}
+const (
+	batchSize = 10
+)
 
 type processorModel struct {
 	schema       *jsonschema.Schema
@@ -92,12 +62,12 @@ type processorModel struct {
 }
 
 type Processor struct {
-	Tconfig        transform.Config
-	Mconfig        model.Config
-	MaxEventSize   int
-	bufferPool     sync.Pool
-	models         map[string]processorModel
-	metadataSchema *jsonschema.Schema
+	Tconfig          transform.Config
+	Mconfig          model.Config
+	MaxEventSize     int
+	streamReaderPool sync.Pool
+	models           map[string]processorModel
+	metadataSchema   *jsonschema.Schema
 }
 
 func BackendProcessor(cfg *config.Config) *Processor {
@@ -177,10 +147,7 @@ func RUMV3Processor(cfg *config.Config, tcfg *transform.Config) *Processor {
 	}
 }
 
-const batchSize = 10
-
-func (p *Processor) readMetadata(reqMeta map[string]interface{}, reader StreamReader) (*metadata.Metadata, error) {
-	// first item is the metadata object
+func (p *Processor) readMetadata(reqMeta map[string]interface{}, reader *streamReader) (*metadata.Metadata, error) {
 	rawModel, err := reader.Read()
 	if err != nil {
 		if err == io.EOF {
@@ -202,28 +169,18 @@ func (p *Processor) readMetadata(reqMeta map[string]interface{}, reader StreamRe
 			Document: string(reader.LatestLine()),
 		}
 	}
-
 	for k, v := range reqMeta {
 		utility.InsertInMap(rawMetadata, k, v.(map[string]interface{}))
 	}
 
-	// validate the metadata object against our jsonschema
-	err = validation.Validate(rawMetadata, p.metadataSchema)
-	if err != nil {
+	if err := validation.Validate(rawMetadata, p.metadataSchema); err != nil {
 		return nil, &Error{
 			Type:     InvalidInputErrType,
 			Message:  err.Error(),
 			Document: string(reader.LatestLine()),
 		}
 	}
-
-	// create a metadata struct
-	metadata, err := metadata.DecodeMetadata(rawMetadata, p.Mconfig.HasShortFieldNames)
-	if err != nil {
-		return nil, err
-	}
-
-	return metadata, nil
+	return metadata.DecodeMetadata(rawMetadata, p.Mconfig.HasShortFieldNames)
 }
 
 // HandleRawModel validates and decodes a single json object into its struct form
@@ -245,44 +202,37 @@ func (p *Processor) HandleRawModel(rawModel map[string]interface{}) (transform.T
 	return nil, ErrUnrecognizedObject
 }
 
-// readBatch will read up to `batchSize` objects from the ndjson stream
-// it returns a slice of eventables and a bool that indicates if there might be more to read.
-func (p *Processor) readBatch(ctx context.Context, ipRateLimiter *rate.Limiter, batchSize int, reader StreamReader, response *Result) ([]transform.Transformable, bool) {
-	var (
-		err        error
-		rawModel   map[string]interface{}
-		eventables []transform.Transformable
-	)
-
+// readBatch will read up to `batchSize` objects from the ndjson stream,
+// returning a slice of Transformables and a boolean indicating that there
+// might be more to read.
+func (p *Processor) readBatch(ctx context.Context, ipRateLimiter *rate.Limiter, batchSize int, reader *streamReader, response *Result) ([]transform.Transformable, bool) {
 	if ipRateLimiter != nil {
 		// use provided rate limiter to throttle batch read
 		ctxT, cancel := context.WithTimeout(ctx, time.Second)
-		err = ipRateLimiter.WaitN(ctxT, batchSize)
+		err := ipRateLimiter.WaitN(ctxT, batchSize)
 		cancel()
 		if err != nil {
 			response.Add(&Error{
 				Type:    RateLimitErrType,
 				Message: "rate limit exceeded",
 			})
-			return eventables, true
+			return nil, true
 		}
 	}
 
-	for i := 0; i < batchSize && err == nil; i++ {
-
-		rawModel, err = reader.Read()
+	var out []transform.Transformable
+	for i := 0; i < batchSize && !reader.IsEOF(); i++ {
+		rawModel, err := reader.Read()
 		if err != nil && err != io.EOF {
-
 			if e, ok := err.(*Error); ok && (e.Type == InvalidInputErrType || e.Type == InputTooLargeErrType) {
 				response.LimitedAdd(e)
 				continue
 			}
 			// return early, we assume we can only recover from a input error types
 			response.Add(err)
-			return eventables, true
+			return out, true
 		}
-
-		if rawModel != nil {
+		if len(rawModel) > 0 {
 			tr, err := p.HandleRawModel(rawModel)
 			if err != nil {
 				response.LimitedAdd(&Error{
@@ -292,37 +242,33 @@ func (p *Processor) readBatch(ctx context.Context, ipRateLimiter *rate.Limiter, 
 				})
 				continue
 			}
-			eventables = append(eventables, tr)
+			out = append(out, tr)
 		}
 	}
-
-	return eventables, reader.IsEOF()
+	return out, reader.IsEOF()
 }
 
 // HandleStream processes a stream of events
 func (p *Processor) HandleStream(ctx context.Context, ipRateLimiter *rate.Limiter, meta map[string]interface{}, reader io.Reader, report publish.Reporter) *Result {
 	res := &Result{}
 
-	buf, ok := p.bufferPool.Get().(*bufio.Reader)
+	sr, ok := p.streamReaderPool.Get().(*streamReader)
 	if !ok {
-		buf = bufio.NewReaderSize(reader, p.MaxEventSize)
+		sr = &streamReader{buf: bufio.NewReaderSize(reader, p.MaxEventSize)}
+		sr.lineReader = decoder.NewLineReader(sr.buf, p.MaxEventSize)
+		sr.NDJSONStreamReader = decoder.NewNDJSONStreamReader(sr.lineReader)
 	} else {
-		buf.Reset(reader)
+		sr.Reset(reader)
 	}
 	defer func() {
-		buf.Reset(nil)
-		p.bufferPool.Put(buf)
+		sr.Reset(nil)
+		p.streamReaderPool.Put(sr)
 	}()
 
-	lineReader := decoder.NewLineReader(buf, p.MaxEventSize)
-	ndReader := decoder.NewNDJSONStreamReader(lineReader)
-
-	// our own wrapper converts json reader errors to errors that are useful to us
-	jsonReader := &srErrorWrapper{ndReader}
-
-	metadata, err := p.readMetadata(meta, jsonReader)
-	// no point in continuing if we couldn't read the metadata
+	// first item is the metadata object
+	metadata, err := p.readMetadata(meta, sr)
 	if err != nil {
+		// no point in continuing if we couldn't read the metadata
 		res.Add(err)
 		return res
 	}
@@ -336,41 +282,83 @@ func (p *Processor) HandleStream(ctx context.Context, ipRateLimiter *rate.Limite
 	sp, ctx := apm.StartSpan(ctx, "Stream", "Reporter")
 	defer sp.End()
 
-	for {
-
-		transformables, done := p.readBatch(ctx, ipRateLimiter, batchSize, jsonReader, res)
-		if transformables != nil {
-			err := report(ctx, publish.PendingReq{
-				Transformables: transformables,
-				Tcontext:       tctx,
-				Trace:          !sp.Dropped(),
-			})
-
-			if err != nil {
-				switch err {
-				case publish.ErrChannelClosed:
-					res.Add(&Error{
-						Type:    ShuttingDownErrType,
-						Message: "server is shutting down",
-					})
-				case publish.ErrFull:
-					res.Add(&Error{
-						Type:    QueueFullErrType,
-						Message: err.Error(),
-					})
-				default:
-					res.Add(err)
-				}
-
-				return res
+	var transformables []transform.Transformable
+	var done bool
+	for !done {
+		transformables, done = p.readBatch(ctx, ipRateLimiter, batchSize, sr, res)
+		if len(transformables) == 0 {
+			continue
+		}
+		// NOTE(axw) `report` takes ownership of transformables, which
+		// means we cannot reuse the slice memory. We should investigate
+		// alternative interfaces between the processor and publisher
+		// which would enable better memory reuse.
+		if err := report(ctx, publish.PendingReq{
+			Transformables: transformables,
+			Tcontext:       tctx,
+			Trace:          !sp.Dropped(),
+		}); err != nil {
+			switch err {
+			case publish.ErrChannelClosed:
+				res.Add(&Error{
+					Type:    ShuttingDownErrType,
+					Message: "server is shutting down",
+				})
+			case publish.ErrFull:
+				res.Add(&Error{
+					Type:    QueueFullErrType,
+					Message: err.Error(),
+				})
+			default:
+				res.Add(err)
 			}
-
-			res.AddAccepted(len(transformables))
+			return res
 		}
-
-		if done {
-			break
-		}
+		res.AddAccepted(len(transformables))
 	}
 	return res
+}
+
+// streamReader wraps NDJSONStreamReader, converting errors to stream errors.
+type streamReader struct {
+	buf        *bufio.Reader
+	lineReader *decoder.LineReader
+	*decoder.NDJSONStreamReader
+}
+
+func (sr *streamReader) Read() (map[string]interface{}, error) {
+	// TODO(axw) decode into a reused map, clearing out the
+	// map between reads. We would require that decoders copy
+	// any contents of rawModel that they wish to retain after
+	// the call, in order to safely reuse the map.
+	v, err := sr.NDJSONStreamReader.Read()
+	if err != nil {
+		if _, ok := err.(decoder.JSONDecodeError); ok {
+			return nil, &Error{
+				Type:     InvalidInputErrType,
+				Message:  err.Error(),
+				Document: string(sr.LatestLine()),
+			}
+		}
+		if err == decoder.ErrLineTooLong {
+			return nil, &Error{
+				Type:     InputTooLargeErrType,
+				Message:  "event exceeded the permitted size.",
+				Document: string(sr.LatestLine()),
+			}
+		}
+	}
+	return v, err
+}
+
+func (sr *streamReader) Reset(r io.Reader) {
+	if r == nil {
+		sr.buf.Reset(nil)
+		sr.lineReader.Reset(nil)
+		sr.NDJSONStreamReader.Reset(nil)
+	} else {
+		sr.buf.Reset(r)
+		sr.lineReader.Reset(sr.buf)
+		sr.NDJSONStreamReader.Reset(sr.lineReader)
+	}
 }

--- a/script/jenkins/package-docker-snapshot.sh
+++ b/script/jenkins/package-docker-snapshot.sh
@@ -17,7 +17,7 @@ export SNAPSHOT='true'
 export IMAGE="docker.elastic.co/apm/apm-server"
 
 echo 'INFO: Build docker images'
-mage package
+./build/linux/mage package
 
 echo 'INFO: Get the just built docker image'
 TAG=$(docker images ${IMAGE} --format "{{.Tag}}" | head -1)

--- a/script/jenkins/package-docker-snapshot.sh
+++ b/script/jenkins/package-docker-snapshot.sh
@@ -17,7 +17,7 @@ export SNAPSHOT='true'
 export IMAGE="docker.elastic.co/apm/apm-server"
 
 echo 'INFO: Build docker images'
-./build/linux/mage package
+make release
 
 echo 'INFO: Get the just built docker image'
 TAG=$(docker images ${IMAGE} --format "{{.Tag}}" | head -1)


### PR DESCRIPTION
## Motivation/summary

While investigating https://github.com/elastic/apm-server/issues/3520, I identified some relatively easy wins for reducing the number and size of allocations made by `processor/stream`.

- Update `decoder.NDJSONStreamReader` so it creates and reuses a single `json.Decoder`, to reduce allocations. If a decoding error occurs, then a new decoder is created for the next line, to clear out any invalid decoding state.

- Remove the `processor/stream.StreamReader` interface: there's no need for this interface, as in practice it only ever has one implementation: streamReader, formerly known as srErrorWrapper. Using the static type means we can avoid indirect interface method calls.

- Replace `processor/stream.srErrorWrapper` with `processor/stream.streamReader`, which bundles a `bufio.Reader`, `decoder.LineReader`, and `decoder.NDJSONStreamReader`. We now pool the   whole `streamReader`, rather than just the underlying `bufio.Reader`, allowing us to reuse more memory and avoid allocations.

## Checklist
- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

## How to test these changes

`make test`

## Related issues

Relates to #3520