### PR TITLE
[7.x] docs: switch to standard ess trial links (#3514)

### DIFF
--- a/docs/getting-started-apm-server.asciidoc
+++ b/docs/getting-started-apm-server.asciidoc
@@ -17,7 +17,7 @@ Elastic Cloud.
 
 image::images/apm-architecture-cloud.png[Install Elastic APM on cloud]
 
-https://www.elastic.co/cloud/elasticsearch-service/signup[Try out the {es} Service for free],
+{ess-trial}[Try out the {es} Service for free],
 and then begin configuring your own user settings right in the Elasticsearch Service Console.
 Any changes are automatically appended to the `apm-server.yml` configuration file for your instance.
 A full list of configuration options is available in Elastic Cloud's

--- a/docs/guide/install-and-run.asciidoc
+++ b/docs/guide/install-and-run.asciidoc
@@ -15,7 +15,7 @@ Skip managing your own {es}, {kib}, and APM Server by using our
 https://www.elastic.co/cloud/elasticsearch-service[hosted {es} Service] on
 Elastic Cloud.
 
-https://www.elastic.co/cloud/elasticsearch-service/signup[Try out the {es} Service for free],
+{ess-trial}[Try out the {es} Service for free],
 then jump straight to <<agents>>.
 
 [float]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: switch to standard ess trial links (#3514)