### PR TITLE
[7.6] docs: 7.6.2 release notes

### DIFF
--- a/changelogs/7.6.asciidoc
+++ b/changelogs/7.6.asciidoc
@@ -3,8 +3,16 @@
 
 https://github.com/elastic/apm-server/compare/7.5\...7.6[View commits]
 
+* <<release-notes-7.6.2>>
 * <<release-notes-7.6.1>>
 * <<release-notes-7.6.0>>
+
+[[release-notes-7.6.2]]
+=== APM Server version 7.6.2
+
+https://github.com/elastic/apm-server/compare/v7.6.1\...v7.6.2[View commits]
+
+No significant changes.
 
 [[release-notes-7.6.1]]
 === APM Server version 7.6.1


### PR DESCRIPTION
There are only two non-doc commits since 7.6.1. @simitt, they're both yours. Are either worth of a changelog entry?

* Fix CI Dockerfile paths for go get (#3454) (#3471) 
* [7.6] Add TLS 1.3 to input default protocols (#3464) (#3469)