### PR TITLE
docs: sync changelogs and remove 7.5 from check_changelogs

### DIFF
--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,6 +3,7 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.7>>
 * <<release-notes-6.8.6>>
 * <<release-notes-6.8.5>>
 * <<release-notes-6.8.4>>
@@ -10,6 +11,12 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.2>>
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
+
+[[release-notes-6.8.7]]
+=== APM Server version 6.8.7
+
+https://github.com/elastic/apm-server/compare/v6.8.6\...v6.8.7[View commits]
+No significant changes.
 
 [[release-notes-6.8.6]]
 === APM Server version 6.8.6

--- a/script/check_changelogs.py
+++ b/script/check_changelogs.py
@@ -5,7 +5,7 @@ import hashlib
 import os
 import requests
 
-SUPPORTED_VERSIONS = ["6.8", "7.5", "7.6", "7.x"]
+SUPPORTED_VERSIONS = ["6.8", "7.6", "7.x"]
 
 
 def parse_version(version):


### PR DESCRIPTION
This PR syncs the 6.8.7 CL (https://github.com/elastic/apm-server/pull/3409) and removes `7.5` from the list of `SUPPORTED_VERSIONS` in `check_changelogs.py`.