### PR TITLE
[7.x] ci(jenkins): support OSX build and tests (#3522)

### DIFF
--- a/.ci/scripts/build-darwin.sh
+++ b/.ci/scripts/build-darwin.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+# shellcheck disable=SC1091
+source ./script/common.bash
+
+jenkins_setup
+
+./script/jenkins/build.sh

--- a/.ci/scripts/test-darwin.sh
+++ b/.ci/scripts/test-darwin.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -eox pipefail
+
+# Setup python3
+pythonVersion=3.7.7
+curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+export PATH="${HOME}/.pyenv/bin:$PATH"
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"
+pyenv install ${pythonVersion}
+pyenv global ${pythonVersion}
+pythonInstallation=$(dirname "$(pyenv which pip)")
+export PATH="${pythonInstallation}:$PATH"
+
+# shellcheck disable=SC1091
+source ./script/common.bash
+
+jenkins_setup
+
+script/jenkins/unit-test.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,7 @@ pipeline {
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
     booleanParam(name: 'linux_ci', defaultValue: true, description: 'Enable Linux build')
+    booleanParam(name: 'osx_ci', defaultValue: true, description: 'Enable OSX CI')
     booleanParam(name: 'windows_ci', defaultValue: true, description: 'Enable Windows CI')
     booleanParam(name: 'intake_ci', defaultValue: true, description: 'Enable test')
     booleanParam(name: 'test_ci', defaultValue: true, description: 'Enable test')
@@ -172,6 +173,44 @@ pipeline {
               junit(allowEmptyResults: true,
                 keepLongStdio: true,
                 testResults: "${BASE_DIR}/build/junit-report.xml,${BASE_DIR}/build/TEST-*.xml")
+            }
+          }
+        }
+        /**
+        Build on a mac environment.
+        */
+        stage('OSX build-test') {
+          agent { label 'macosx' }
+          options {
+            skipDefaultCheckout()
+            warnError('OSX execution failed')
+          }
+          when {
+            beforeAgent true
+            allOf {
+              expression { return params.osx_ci }
+              expression { return env.ONLY_DOCS == "false" }
+            }
+          }
+          environment {
+            HOME = "${env.WORKSPACE}"
+          }
+          steps {
+            withGithubNotify(context: 'Build-Test - OSX') {
+              deleteDir()
+              unstash 'source'
+              dir(BASE_DIR){
+                retry(2) { // Retry in case there are any errors to avoid temporary glitches
+                  sleep randomNumber(min: 5, max: 10)
+                  sh(label: 'OSX build', script: '.ci/scripts/build-darwin.sh')
+                  sh(label: 'Run Unit tests', script: '.ci/scripts/test-darwin.sh')
+                }
+              }
+            }
+          }
+          post {
+            always {
+              junit(allowEmptyResults: true, keepLongStdio: true, testResults: "${BASE_DIR}/build/junit-*.xml")
             }
           }
         }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ci(jenkins): support OSX build and tests (#3522)