### PR TITLE
[7.6] docs: sync changelogs (#3531)

### DIFF
--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,6 +3,7 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.7>>
 * <<release-notes-6.8.6>>
 * <<release-notes-6.8.5>>
 * <<release-notes-6.8.4>>
@@ -10,6 +11,12 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.2>>
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
+
+[[release-notes-6.8.7]]
+=== APM Server version 6.8.7
+
+https://github.com/elastic/apm-server/compare/v6.8.6\...v6.8.7[View commits]
+No significant changes.
 
 [[release-notes-6.8.6]]
 === APM Server version 6.8.6


### PR DESCRIPTION
Backports the following commits to 7.6:
 - docs: sync changelogs and remove 7.5 from check_changelogs (#3531)