### PR TITLE
[7.x] Add changelog for 7.7 (#3547)

### DIFF
--- a/changelogs/7.7.asciidoc
+++ b/changelogs/7.7.asciidoc
@@ -8,17 +8,31 @@ https://github.com/elastic/apm-server/compare/7.6\...7.7[View commits]
 [[release-notes-7.7.0]]
 === APM Server version 7.7.0
 
-https://github.com/elastic/apm-server/compare/v7.6.0\...v7.7.0[View commits]
+https://github.com/elastic/apm-server/compare/v7.6.2\...v7.7.0[View commits]
 
 [float]
 ==== Breaking Changes
 * Remove enroll subcommand {pull}3270[3270].
 
 [float]
+==== Bug fixes
+* Merge default values with custom Elasticsearch config for API Keys and add `required` tag for `host` {pull}3342[3342]
+* Merge default values with custom Sourcemap Elasticsearch config {pull}3355[3355]
+
+[float]
 ==== Intake API Changes
+* Add `transfer_size`, `encoded_body_size`  and `decoded_body_size` to `transaction.context.http.response` {pull}3327[3327]
+* Add `transfer_size`, `encoded_body_size`, `decoded_body_size` and `headers` to `span.context.http.response` {pull}3327[3327]
+* Deprecate `span.context.http.status_code` in favor of newly introduced `span.context.http.response.status_code` {pull}3327[3327]
 
 [float]
 ==== Added
 * Instrumentation for go-elasticsearch {pull}3305[3305]
+* Make the list of Access-Control-Allow-Headers for RUM preflight requests configurable {pull}3299[3299]
+* Instrumentation for kibana client {pull}3359[3359]
 * Added support for Jaeger auth tags {pull}3394[3394]
+* Add pipeline for removing metadata fields from spans {pull}3408[3408]
+* Add gRPC sampling endpoint for Jaeger {pull}3490[3490]
+* Change default value for apm-server.ssl.client_authentication from optional to none {pull}3500[3500]
 * Enabled instrumentation of sourcemaps {pull}3515[3515]
+* Upgrade Go to 1.13.9 {pull}3539[3539]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add changelog for 7.7 (#3547)