### PR TITLE
Report all libbeat/monitoring metrics in /debug/vars 

### DIFF
--- a/beater/api/asset/sourcemap/handler.go
+++ b/beater/api/asset/sourcemap/handler.go
@@ -37,7 +37,7 @@ import (
 var (
 	// MonitoringMap holds a mapping for request.IDs to monitoring counters
 	MonitoringMap = request.DefaultMonitoringMapForRegistry(registry)
-	registry      = monitoring.Default.NewRegistry("apm-server.sourcemap", monitoring.PublishExpvar)
+	registry      = monitoring.Default.NewRegistry("apm-server.sourcemap")
 )
 
 // RequestDecoder is the type for a function that decodes sourcemap data from an http.Request.

--- a/beater/api/config/agent/handler.go
+++ b/beater/api/config/agent/handler.go
@@ -51,7 +51,7 @@ const (
 var (
 	// MonitoringMap holds a mapping for request.IDs to monitoring counters
 	MonitoringMap = request.DefaultMonitoringMapForRegistry(registry)
-	registry      = monitoring.Default.NewRegistry("apm-server.acm", monitoring.PublishExpvar)
+	registry      = monitoring.Default.NewRegistry("apm-server.acm")
 
 	errMsgKibanaDisabled     = errors.New(msgKibanaDisabled)
 	errMsgNoKibanaConnection = errors.New(msgNoKibanaConnection)

--- a/beater/api/expvar.go
+++ b/beater/api/expvar.go
@@ -1,0 +1,55 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package api
+
+import (
+	"expvar"
+	"fmt"
+	"net/http"
+
+	"github.com/elastic/beats/v7/libbeat/monitoring"
+)
+
+// debugVarsHandler reports expvar and all libbeat/monitoring metrics.
+//
+// TODO(axw) this is copied from libbeat/service. We should move the
+// handler to libbeat/monitoring, and export it for libbeat/service and
+// apm-server to use.
+func debugVarsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+	first := true
+	report := func(key string, value interface{}) {
+		if !first {
+			fmt.Fprintf(w, ",\n")
+		}
+		first = false
+		if str, ok := value.(string); ok {
+			fmt.Fprintf(w, "%q: %q", key, str)
+		} else {
+			fmt.Fprintf(w, "%q: %v", key, value)
+		}
+	}
+
+	fmt.Fprintf(w, "{\n")
+	monitoring.Do(monitoring.Full, report)
+	expvar.Do(func(kv expvar.KeyValue) {
+		report(kv.Key, kv.Value)
+	})
+	fmt.Fprintf(w, "\n}\n")
+}

--- a/beater/api/intake/handler.go
+++ b/beater/api/intake/handler.go
@@ -37,7 +37,7 @@ import (
 var (
 	// MonitoringMap holds a mapping for request.IDs to monitoring counters
 	MonitoringMap = request.DefaultMonitoringMapForRegistry(registry)
-	registry      = monitoring.Default.NewRegistry("apm-server.server", monitoring.PublishExpvar)
+	registry      = monitoring.Default.NewRegistry("apm-server.server")
 )
 
 // Handler returns a request.Handler for managing intake requests for backend and rum events.

--- a/beater/api/mux.go
+++ b/beater/api/mux.go
@@ -18,7 +18,6 @@
 package api
 
 import (
-	"expvar"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -119,7 +118,7 @@ func NewMux(beaterConfig *config.Config, report publish.Reporter) (*http.ServeMu
 	if beaterConfig.Expvar.IsEnabled() {
 		path := beaterConfig.Expvar.URL
 		logger.Infof("Path %s added to request handler", path)
-		mux.Handle(path, expvar.Handler())
+		mux.Handle(path, http.HandlerFunc(debugVarsHandler))
 	}
 	return mux, nil
 }

--- a/beater/api/profile/handler.go
+++ b/beater/api/profile/handler.go
@@ -42,7 +42,7 @@ import (
 var (
 	// MonitoringMap holds a mapping for request.IDs to monitoring counters
 	MonitoringMap = request.DefaultMonitoringMapForRegistry(registry)
-	registry      = monitoring.Default.NewRegistry("apm-server.profile", monitoring.PublishExpvar)
+	registry      = monitoring.Default.NewRegistry("apm-server.profile")
 )
 
 const (

--- a/beater/api/root/handler.go
+++ b/beater/api/root/handler.go
@@ -32,7 +32,7 @@ import (
 var (
 	// MonitoringMap holds a mapping for request.IDs to monitoring counters
 	MonitoringMap = request.DefaultMonitoringMapForRegistry(registry)
-	registry      = monitoring.Default.NewRegistry("apm-server.root", monitoring.PublishExpvar)
+	registry      = monitoring.Default.NewRegistry("apm-server.root")
 )
 
 // Handler returns error if route does not exist,

--- a/beater/jaeger/grpc.go
+++ b/beater/jaeger/grpc.go
@@ -39,7 +39,7 @@ import (
 )
 
 var (
-	gRPCCollectorRegistry                    = monitoring.Default.NewRegistry("apm-server.jaeger.grpc.collect", monitoring.PublishExpvar)
+	gRPCCollectorRegistry                    = monitoring.Default.NewRegistry("apm-server.jaeger.grpc.collect")
 	gRPCCollectorMonitoringMap monitoringMap = request.MonitoringMapForRegistry(gRPCCollectorRegistry, monitoringKeys)
 )
 
@@ -76,7 +76,7 @@ func (c *grpcCollector) postSpans(ctx context.Context, batch model.Batch) error 
 }
 
 var (
-	gRPCSamplingRegistry                    = monitoring.Default.NewRegistry("apm-server.jaeger.grpc.sampling", monitoring.PublishExpvar)
+	gRPCSamplingRegistry                    = monitoring.Default.NewRegistry("apm-server.jaeger.grpc.sampling")
 	gRPCSamplingMonitoringMap monitoringMap = request.MonitoringMapForRegistry(gRPCSamplingRegistry, monitoringKeys)
 
 	jaegerAgentPrefixes = []string{otel.AgentNameJaeger}

--- a/beater/jaeger/http.go
+++ b/beater/jaeger/http.go
@@ -41,7 +41,7 @@ const (
 )
 
 var (
-	httpRegistry      = monitoring.Default.NewRegistry("apm-server.jaeger.http", monitoring.PublishExpvar)
+	httpRegistry      = monitoring.Default.NewRegistry("apm-server.jaeger.http")
 	httpMonitoringMap = request.MonitoringMapForRegistry(httpRegistry, monitoringKeys)
 )
 

--- a/beater/middleware/monitoring_middleware_test.go
+++ b/beater/middleware/monitoring_middleware_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	mockMonitoringRegistry = monitoring.Default.NewRegistry("mock.monitoring", monitoring.PublishExpvar)
+	mockMonitoringRegistry = monitoring.Default.NewRegistry("mock.monitoring")
 	mockMonitoringNil      = map[request.ResultID]*monitoring.Int{}
 	mockMonitoring         = request.DefaultMonitoringMapForRegistry(mockMonitoringRegistry)
 )

--- a/beater/request/result_test.go
+++ b/beater/request/result_test.go
@@ -190,7 +190,7 @@ func TestResult_Failure(t *testing.T) {
 }
 
 func TestDefaultMonitoringMapForRegistry(t *testing.T) {
-	mockRegistry := monitoring.Default.NewRegistry("mock-default", monitoring.PublishExpvar)
+	mockRegistry := monitoring.Default.NewRegistry("mock-default")
 	m := DefaultMonitoringMapForRegistry(mockRegistry)
 	assert.Equal(t, 21, len(m))
 	for id := range m {
@@ -200,7 +200,7 @@ func TestDefaultMonitoringMapForRegistry(t *testing.T) {
 
 func TestMonitoringMapForRegistry(t *testing.T) {
 	keys := []ResultID{IDEventDroppedCount, IDResponseErrorsServiceUnavailable}
-	mockRegistry := monitoring.Default.NewRegistry("mock-with-keys", monitoring.PublishExpvar)
+	mockRegistry := monitoring.Default.NewRegistry("mock-with-keys")
 	m := MonitoringMapForRegistry(mockRegistry, keys)
 	assert.Equal(t, 2, len(m))
 	for id := range m {

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -15,3 +15,4 @@ https://github.com/elastic/apm-server/compare/7.6\...master[View commits]
 [float]
 ==== Added
 * RUM V3 endpoint {pull}3328[3328], {pull}3414[3414], {pull}3512[3512]
+* We now publish libbeat metrics through the /debug/vars endpoint {pull}3550[3550]

--- a/decoder/req_decoder.go
+++ b/decoder/req_decoder.go
@@ -30,7 +30,7 @@ import (
 )
 
 var (
-	decoderMetrics                = monitoring.Default.NewRegistry("apm-server.decoder", monitoring.PublishExpvar)
+	decoderMetrics                = monitoring.Default.NewRegistry("apm-server.decoder")
 	missingContentLengthCounter   = monitoring.NewInt(decoderMetrics, "missing-content-length.count")
 	deflateLengthAccumulator      = monitoring.NewInt(decoderMetrics, "deflate.content-length")
 	deflateCounter                = monitoring.NewInt(decoderMetrics, "deflate.count")

--- a/model/error/event.go
+++ b/model/error/event.go
@@ -46,7 +46,7 @@ import (
 )
 
 var (
-	Metrics           = monitoring.Default.NewRegistry("apm-server.processor.error", monitoring.PublishExpvar)
+	Metrics           = monitoring.Default.NewRegistry("apm-server.processor.error")
 	transformations   = monitoring.NewInt(Metrics, "transformations")
 	stacktraceCounter = monitoring.NewInt(Metrics, "stacktraces")
 	frameCounter      = monitoring.NewInt(Metrics, "frames")

--- a/model/metricset/event.go
+++ b/model/metricset/event.go
@@ -46,7 +46,7 @@ const (
 )
 
 var (
-	Metrics         = monitoring.Default.NewRegistry("apm-server.processor.metric", monitoring.PublishExpvar)
+	Metrics         = monitoring.Default.NewRegistry("apm-server.processor.metric")
 	transformations = monitoring.NewInt(Metrics, "transformations")
 	processorEntry  = common.MapStr{"name": processorName, "event": docType}
 )

--- a/model/sourcemap/payload.go
+++ b/model/sourcemap/payload.go
@@ -41,7 +41,7 @@ const (
 )
 
 var (
-	Metrics          = monitoring.Default.NewRegistry("apm-server.processor.sourcemap", monitoring.PublishExpvar)
+	Metrics          = monitoring.Default.NewRegistry("apm-server.processor.sourcemap")
 	sourcemapCounter = monitoring.NewInt(Metrics, "counter")
 
 	processorEntry = common.MapStr{"name": processorName, "event": smapDocType}

--- a/model/span/event.go
+++ b/model/span/event.go
@@ -44,7 +44,7 @@ const (
 )
 
 var (
-	Metrics         = monitoring.Default.NewRegistry("apm-server.processor.span", monitoring.PublishExpvar)
+	Metrics         = monitoring.Default.NewRegistry("apm-server.processor.span")
 	transformations = monitoring.NewInt(Metrics, "transformations")
 
 	stacktraceCounter = monitoring.NewInt(Metrics, "stacktraces")

--- a/model/transaction/event.go
+++ b/model/transaction/event.go
@@ -45,7 +45,7 @@ const (
 )
 
 var (
-	Metrics           = monitoring.Default.NewRegistry("apm-server.processor.transaction", monitoring.PublishExpvar)
+	Metrics           = monitoring.Default.NewRegistry("apm-server.processor.transaction")
 	transformations   = monitoring.NewInt(Metrics, "transformations")
 	processorEntry    = common.MapStr{"name": processorName, "event": transactionDocType}
 	cachedModelSchema = validation.CreateSchema(schema.ModelSchema, "transaction")


### PR DESCRIPTION
## Motivation/summary

Extend the `/debug/vars` handler to publish all metrics from the default libbeat/monitoring registry, like libbeat does when you start the beat with `-httpprof`:

https://github.com/elastic/beats/blob/d5289fc39baf183ddc26a79f8ccef180a720c8b1/libbeat/service/service.go#L130-L153

The reason for doing this is so we can access pipeline metrics, e.g. to check if the server has events in its queue (https://github.com/elastic/apm-server/issues/3520#issuecomment-603110428).

## Checklist
- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

## How to test these changes

- `apm-server -E apm-server.expvar.enabled=true`
- `curl http://localhost:8200/debug/vars`
  - Make sure "libbeat.output.*" and "apm-server.*" metrics are reported, as well as "cmdline", "memstats", and others
  - Make sure there are no duplicate variables

## Related issues

Intending to use this in hey-apm, see https://github.com/elastic/apm-server/issues/3520#issuecomment-603110428