### PR TITLE
[7.x] Spec out transaction marks for RUM V3 (#3526)

### DIFF
--- a/docs/spec/transactions/rum_v3_mark.json
+++ b/docs/spec/transactions/rum_v3_mark.json
@@ -1,0 +1,107 @@
+{
+    "$id": "docs/spec/transactions/rum_v3_mark.json",
+    "type": ["object", "null"],
+    "description": "A mark captures the timing in milliseconds of a significant event during the lifetime of a transaction. Every mark is a simple key value pair, where the value has to be a number, and can be set by the user or the agent.",
+    "properties": {
+        "a": {
+            "type": ["object", "null"],
+            "description": "agent",
+            "properties": {
+                "dc": {
+                    "type": ["number", "null"],
+                    "description": "domComplete"
+                },
+                "di": {
+                    "type": ["number", "null"],
+                    "description": "domInteractive"
+                },
+                "ds": {
+                    "type": ["number", "null"],
+                    "description": "domContentLoadedEventStart"
+                },
+                "de": {
+                    "type": ["number", "null"],
+                    "description": "domContentLoadedEventEnd"
+                },
+                "fb": {
+                    "type": ["number", "null"],
+                    "description": "timeToFirstByte"
+                },
+                "fp": {
+                    "type": ["number", "null"],
+                    "description": "firstContentfulPaint"
+                },
+                "lp": {
+                    "type": ["number", "null"],
+                    "description": "largestContentfulPaint"
+                }
+            }
+        },
+        "nt": {
+            "type": ["object", "null"],
+            "description": "navigation-timing",
+            "properties": {
+                "fs": {
+                    "type": ["number", "null"],
+                    "description": "fetchStart"
+                },
+                "ls": {
+                    "type": ["number", "null"],
+                    "description": "domainLookupStart"
+                },
+                "le": {
+                    "type": ["number", "null"],
+                    "description": "domainLookupEnd"
+                },
+                "cs": {
+                    "type": ["number", "null"],
+                    "description": "connectStart"
+                },
+                "ce": {
+                    "type": ["number", "null"],
+                    "description": "connectEnd"
+                },
+                "qs": {
+                    "type": ["number", "null"],
+                    "description": "requestStart"
+                },
+                "rs": {
+                    "type": ["number", "null"],
+                    "description": "responseStart"
+                },
+                "re": {
+                    "type": ["number", "null"],
+                    "description": "responseEnd"
+                },
+                "dl": {
+                    "type": ["number", "null"],
+                    "description": "domLoading"
+                },
+                "di": {
+                    "type": ["number", "null"],
+                    "description": "domInteractive"
+                },
+                "ds": {
+                    "type": ["number", "null"],
+                    "description": "domContentLoadedEventStart"
+                },
+                "de": {
+                    "type": ["number", "null"],
+                    "description": "domContentLoadedEventEnd"
+                },
+                "dc": {
+                    "type": ["number", "null"],
+                    "description": "domComplete"
+                },
+                "es": {
+                    "type": ["number", "null"],
+                    "description": "loadEventStart"
+                },
+                "ee": {
+                    "type": ["number", "null"],
+                    "description": "loadEventEnd"
+                }
+            }
+        }
+    }
+}

--- a/docs/spec/transactions/rum_v3_transaction.json
+++ b/docs/spec/transactions/rum_v3_transaction.json
@@ -76,12 +76,7 @@
                         "null"
                     ],
                     "description": "A mark captures the timing of a significant event during the lifetime of a transaction. Marks are organized into groups and can be set by the user or the agent.",
-                    "patternProperties": {
-                        "^[^.*\"]*$": {
-                            "$ref": "mark.json"
-                        }
-                    },
-                    "additionalProperties": false
+                    "$ref": "rum_v3_mark.json"
                 },
                 "sm": {
                     "type": [

--- a/model/transaction/event_test.go
+++ b/model/transaction/event_test.go
@@ -63,6 +63,32 @@ func TestTransactionEventDecodeFailure(t *testing.T) {
 	}
 }
 
+func TestTransactionDecodeRUMV3Marks(t *testing.T) {
+	// unknown fields are ignored
+	input := map[string]interface{}{
+		"k": map[string]interface{}{
+			"foo": 0,
+			"a": map[string]interface{}{
+				"foo": 0,
+				"dc":  1.2,
+			},
+			"nt": map[string]interface{}{
+				"foo": 0,
+				"dc":  1.2,
+			},
+		},
+	}
+	event := &Event{}
+	transformable, err := decodeRUMV3Marks(event, input, model.Config{HasShortFieldNames: true})
+	require.Nil(t, err)
+
+	var f = 1.2
+	assert.Equal(t, common.MapStr{
+		"agent":            common.MapStr{"domComplete": &f},
+		"navigationTiming": common.MapStr{"domComplete": &f},
+	}, transformable.(*Event).Marks)
+}
+
 func TestTransactionEventDecode(t *testing.T) {
 	id, trType, name, result := "123", "type", "foo()", "555"
 	timestampParsed := time.Date(2017, 5, 30, 18, 53, 27, 154*1e6, time.UTC)

--- a/model/transaction/generated/schema/rum_v3_transaction.go
+++ b/model/transaction/generated/schema/rum_v3_transaction.go
@@ -424,20 +424,111 @@ const RUMV3Schema = `{
                         "null"
                     ],
                     "description": "A mark captures the timing of a significant event during the lifetime of a transaction. Marks are organized into groups and can be set by the user or the agent.",
-                    "patternProperties": {
-                        "^[^.*\"]*$": {
-                                "$id": "docs/spec/transactions/mark.json",
+                        "$id": "docs/spec/transactions/rum_v3_mark.json",
     "type": ["object", "null"],
     "description": "A mark captures the timing in milliseconds of a significant event during the lifetime of a transaction. Every mark is a simple key value pair, where the value has to be a number, and can be set by the user or the agent.",
-    "patternProperties": {
-        "^[^.*\"]*$": {
-            "type": ["number", "null"]
+    "properties": {
+        "a": {
+            "type": ["object", "null"],
+            "description": "agent",
+            "properties": {
+                "dc": {
+                    "type": ["number", "null"],
+                    "description": "domComplete"
+                },
+                "di": {
+                    "type": ["number", "null"],
+                    "description": "domInteractive"
+                },
+                "ds": {
+                    "type": ["number", "null"],
+                    "description": "domContentLoadedEventStart"
+                },
+                "de": {
+                    "type": ["number", "null"],
+                    "description": "domContentLoadedEventEnd"
+                },
+                "fb": {
+                    "type": ["number", "null"],
+                    "description": "timeToFirstByte"
+                },
+                "fp": {
+                    "type": ["number", "null"],
+                    "description": "firstContentfulPaint"
+                },
+                "lp": {
+                    "type": ["number", "null"],
+                    "description": "largestContentfulPaint"
+                }
+            }
+        },
+        "nt": {
+            "type": ["object", "null"],
+            "description": "navigation-timing",
+            "properties": {
+                "fs": {
+                    "type": ["number", "null"],
+                    "description": "fetchStart"
+                },
+                "ls": {
+                    "type": ["number", "null"],
+                    "description": "domainLookupStart"
+                },
+                "le": {
+                    "type": ["number", "null"],
+                    "description": "domainLookupEnd"
+                },
+                "cs": {
+                    "type": ["number", "null"],
+                    "description": "connectStart"
+                },
+                "ce": {
+                    "type": ["number", "null"],
+                    "description": "connectEnd"
+                },
+                "qs": {
+                    "type": ["number", "null"],
+                    "description": "requestStart"
+                },
+                "rs": {
+                    "type": ["number", "null"],
+                    "description": "responseStart"
+                },
+                "re": {
+                    "type": ["number", "null"],
+                    "description": "responseEnd"
+                },
+                "dl": {
+                    "type": ["number", "null"],
+                    "description": "domLoading"
+                },
+                "di": {
+                    "type": ["number", "null"],
+                    "description": "domInteractive"
+                },
+                "ds": {
+                    "type": ["number", "null"],
+                    "description": "domContentLoadedEventStart"
+                },
+                "de": {
+                    "type": ["number", "null"],
+                    "description": "domContentLoadedEventEnd"
+                },
+                "dc": {
+                    "type": ["number", "null"],
+                    "description": "domComplete"
+                },
+                "es": {
+                    "type": ["number", "null"],
+                    "description": "loadEventStart"
+                },
+                "ee": {
+                    "type": ["number", "null"],
+                    "description": "loadEventEnd"
+                }
+            }
         }
-    },
-    "additionalProperties": false
-                        }
-                    },
-                    "additionalProperties": false
+    }
                 },
                 "sm": {
                     "type": [

--- a/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
@@ -42,29 +42,29 @@
                 },
                 "id": "ec2e280be8345240",
                 "marks": {
-                    "a": {
-                        "dc": 138,
-                        "di": 120,
-                        "fb": 5,
-                        "fp": 70.825,
-                        "lp": 131.03
+                    "agent": {
+                        "domComplete": 138,
+                        "domInteractive": 120,
+                        "firstContentfulPaint": 70.82500003930181,
+                        "largestContentfulPaint": 131.03000004775822,
+                        "timeToFirstByte": 5
                     },
-                    "nt": {
-                        "ce": 0,
-                        "cs": 0,
-                        "dc": 138,
-                        "de": 122,
-                        "di": 120,
-                        "dl": 14,
-                        "ds": 120,
-                        "ee": 138,
-                        "es": 138,
-                        "fs": 0,
-                        "le": 0,
-                        "ls": 0,
-                        "qs": 4,
-                        "re": 6,
-                        "rs": 5
+                    "navigationTiming": {
+                        "connectEnd": 0,
+                        "connectStart": 0,
+                        "domComplete": 138,
+                        "domContentLoadedEventEnd": 122,
+                        "domContentLoadedEventStart": 120,
+                        "domInteractive": 120,
+                        "domLoading": 14,
+                        "domainLookupEnd": 0,
+                        "domainLookupStart": 0,
+                        "fetchStart": 0,
+                        "loadEventEnd": 138,
+                        "loadEventStart": 138,
+                        "requestStart": 4,
+                        "responseEnd": 6,
+                        "responseStart": 5
                     }
                 },
                 "name": "general-usecase-initial-p-load",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Spec out transaction marks for RUM V3 (#3526)