### PR TITLE
Introduce model.Input for decoding

### DIFF
--- a/beater/api/asset/sourcemap/handler.go
+++ b/beater/api/asset/sourcemap/handler.go
@@ -77,9 +77,8 @@ func Handler(dec RequestDecoder, processor asset.Processor, cfg transform.Config
 		}
 
 		tctx := &transform.Context{
-			RequestTime: utility.RequestTime(c.Request.Context()),
-			Config:      cfg,
-			Metadata:    *metadata,
+			Config:   cfg,
+			Metadata: *metadata,
 		}
 		req := publish.PendingReq{Transformables: transformables, Tcontext: tctx}
 		span, ctx := apm.StartSpan(c.Request.Context(), "Send", "Reporter")

--- a/beater/api/profile/handler.go
+++ b/beater/api/profile/handler.go
@@ -84,10 +84,7 @@ func Handler(
 			}
 		}
 
-		tctx := &transform.Context{
-			RequestTime: utility.RequestTime(c.Request.Context()),
-			Config:      transformConfig,
-		}
+		tctx := &transform.Context{Config: transformConfig}
 
 		var totalLimitRemaining int64 = profileContentLengthLimit
 		var profiles []*pprof_profile.Profile

--- a/beater/onboarding.go
+++ b/beater/onboarding.go
@@ -35,7 +35,7 @@ func notifyListening(ctx context.Context, config *config.Config, reporter publis
 	logp.NewLogger(logs.Onboarding).Info("Publishing onboarding document")
 	reporter(ctx, publish.PendingReq{
 		Transformables: []transform.Transformable{onboardingDoc{listenAddr: config.Host}},
-		Tcontext:       &transform.Context{RequestTime: time.Now()},
+		Tcontext:       &transform.Context{},
 	})
 }
 
@@ -45,7 +45,7 @@ type onboardingDoc struct {
 
 func (o onboardingDoc) Transform(ctx context.Context, tctx *transform.Context) []beat.Event {
 	return []beat.Event{{
-		Timestamp: tctx.RequestTime,
+		Timestamp: time.Now(),
 		Fields: common.MapStr{
 			"processor": common.MapStr{"name": "onboarding", "event": "onboarding"},
 			"observer":  common.MapStr{"listening": o.listenAddr},

--- a/model/config.go
+++ b/model/config.go
@@ -17,6 +17,28 @@
 
 package model
 
+import (
+	"time"
+)
+
+// Input holds the input required for decoding an event.
+type Input struct {
+	// Raw holds the raw input, decoded by encoding/json.
+	Raw interface{}
+
+	// RequestTime is the time at which the event was received
+	// by the server. This is used to set the timestamp for
+	// events sent by RUM.
+	RequestTime time.Time
+
+	// Config holds configuration for decoding.
+	//
+	// TODO(axw) define a Decoder type which encapsulates
+	// static configuration defined in one location, removing
+	// the possibility of inconsistent configuration.
+	Config Config
+}
+
 type Config struct {
 	Experimental bool
 	// RUM v3 support

--- a/model/error/event_test.go
+++ b/model/error/event_test.go
@@ -81,6 +81,7 @@ func (l *Log) withFrames(frames []*m.StacktraceFrame) *Log {
 func TestErrorEventDecode(t *testing.T) {
 	timestamp := json.Number("1496170407154000")
 	timestampParsed := time.Date(2017, 5, 30, 18, 53, 27, 154*1e6, time.UTC)
+	requestTime := time.Now()
 
 	id, culprit, lineno := "123", "foo()", 2
 	parentId, traceId, transactionId := "0123456789abcdef", "01234567890123456789abcdefabcdef", "abcdefabcdef0000"
@@ -155,6 +156,14 @@ func TestErrorEventDecode(t *testing.T) {
 				Id:        &id,
 				Culprit:   &culprit,
 				Timestamp: timestampParsed,
+			},
+		},
+		"minimal valid error with request time": {
+			input: map[string]interface{}{"id": id, "culprit": culprit, "context": map[string]interface{}{}},
+			e: &Event{
+				Id:        &id,
+				Culprit:   &culprit,
+				Timestamp: requestTime,
 			},
 		},
 		"minimal valid error with log and exception": {
@@ -282,7 +291,11 @@ func TestErrorEventDecode(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			transformable, err := DecodeEvent(test.input, test.cfg, test.inpErr)
+			transformable, err := DecodeEvent(m.Input{
+				Raw:         test.input,
+				RequestTime: requestTime,
+				Config:      test.cfg,
+			}, test.inpErr)
 			if test.e != nil && assert.NotNil(t, transformable) {
 				event := transformable.(*Event)
 				assert.Equal(t, test.e, event)
@@ -315,7 +328,7 @@ func TestHandleExceptionTree(t *testing.T) {
 			},
 		},
 	}
-	result, err := DecodeEvent(errorEvent, m.Config{}, nil)
+	result, err := DecodeEvent(m.Input{Raw: errorEvent}, nil)
 	require.NoError(t, err)
 
 	event := result.(*Event)
@@ -342,7 +355,7 @@ func TestDecodingAnomalies(t *testing.T) {
 				"type":    "type0",
 			},
 		}
-		result, err := DecodeEvent(badID, m.Config{}, nil)
+		result, err := DecodeEvent(m.Input{Raw: badID}, nil)
 		assert.Error(t, err)
 		assert.Nil(t, result)
 	})
@@ -358,7 +371,7 @@ func TestDecodingAnomalies(t *testing.T) {
 				},
 			},
 		}
-		result, err := DecodeEvent(badException, m.Config{}, nil)
+		result, err := DecodeEvent(m.Input{Raw: badException}, nil)
 		assert.Error(t, err)
 		assert.Nil(t, result)
 	})
@@ -372,7 +385,7 @@ func TestDecodingAnomalies(t *testing.T) {
 				"cause":   []interface{}{7.4},
 			},
 		}
-		result, err := DecodeEvent(badException, m.Config{}, nil)
+		result, err := DecodeEvent(m.Input{Raw: badException}, nil)
 		assert.Error(t, err)
 		assert.EqualError(t, err, "cause must be an exception")
 		assert.Nil(t, result)
@@ -389,7 +402,7 @@ func TestDecodingAnomalies(t *testing.T) {
 				},
 			},
 		}
-		result, err := DecodeEvent(emptyCauses, m.Config{}, nil)
+		result, err := DecodeEvent(m.Input{Raw: emptyCauses}, nil)
 		require.NoError(t, err)
 		assert.NotNil(t, result)
 
@@ -685,9 +698,8 @@ func TestEvents(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			me := metadata.NewMetadata(&service, nil, nil, &metadata.User{Id: &uid}, metadataLabels)
 			tctx := &transform.Context{
-				Metadata:    *me,
-				Config:      transform.Config{SourcemapStore: &sourcemap.Store{}},
-				RequestTime: timestamp,
+				Metadata: *me,
+				Config:   transform.Config{SourcemapStore: &sourcemap.Store{}},
 			}
 
 			outputEvents := tc.Transformable.Transform(context.Background(), tctx)

--- a/model/profile/profile_test.go
+++ b/model/profile/profile_test.go
@@ -87,9 +87,8 @@ func TestPprofProfileTransform(t *testing.T) {
 	metadata := metadata.Metadata{Service: &service}
 
 	tctx := &transform.Context{
-		Config:      transform.Config{}, // not used
-		Metadata:    metadata,
-		RequestTime: time.Time{}, // not used
+		Config:   transform.Config{}, // not used
+		Metadata: metadata,
 	}
 	output := pp.Transform(context.Background(), tctx)
 	require.Len(t, output, 2)

--- a/model/span/event.go
+++ b/model/span/event.go
@@ -273,23 +273,23 @@ func (d *DestinationService) fields() common.MapStr {
 	return fields
 }
 
-func DecodeRUMV3Event(input interface{}, cfg m.Config, err error) (transform.Transformable, error) {
-	return DecodeEvent(input, cfg, err)
+func DecodeRUMV3Event(input m.Input, err error) (transform.Transformable, error) {
+	return DecodeEvent(input, err)
 }
 
 // DecodeEvent decodes a span event.
-func DecodeEvent(input interface{}, cfg m.Config, err error) (transform.Transformable, error) {
+func DecodeEvent(input m.Input, err error) (transform.Transformable, error) {
 	if err != nil {
 		return nil, err
 	}
-	if input == nil {
+	if input.Raw == nil {
 		return nil, errMissingInput
 	}
-	raw, ok := input.(map[string]interface{})
+	raw, ok := input.Raw.(map[string]interface{})
 	if !ok {
 		return nil, errInvalidType
 	}
-	fieldName := field.Mapper(cfg.HasShortFieldNames)
+	fieldName := field.Mapper(input.Config.HasShortFieldNames)
 	decoder := utility.ManualDecoder{}
 	event := Event{
 		Name:          decoder.String(raw, fieldName("name")),
@@ -318,13 +318,13 @@ func DecodeEvent(input interface{}, cfg m.Config, err error) (transform.Transfor
 		}
 		event.DB = db
 
-		http, err := decodeHTTP(ctx, cfg.HasShortFieldNames, decoder.Err)
+		http, err := decodeHTTP(ctx, input.Config.HasShortFieldNames, decoder.Err)
 		if err != nil {
 			return nil, err
 		}
 		event.HTTP = http
 
-		dest, destService, err := decodeDestination(ctx, cfg.HasShortFieldNames, decoder.Err)
+		dest, destService, err := decodeDestination(ctx, input.Config.HasShortFieldNames, decoder.Err)
 		if err != nil {
 			return nil, err
 		}
@@ -332,7 +332,7 @@ func DecodeEvent(input interface{}, cfg m.Config, err error) (transform.Transfor
 		event.DestinationService = destService
 
 		if s, set := ctx["service"]; set {
-			service, err := metadata.DecodeService(s, cfg.HasShortFieldNames, decoder.Err)
+			service, err := metadata.DecodeService(s, input.Config.HasShortFieldNames, decoder.Err)
 			if err != nil {
 				return nil, err
 			}
@@ -343,7 +343,7 @@ func DecodeEvent(input interface{}, cfg m.Config, err error) (transform.Transfor
 			return nil, err
 		}
 
-		if cfg.Experimental {
+		if input.Config.Experimental {
 			if obj, set := ctx["experimental"]; set {
 				event.Experimental = obj
 			}
@@ -351,7 +351,7 @@ func DecodeEvent(input interface{}, cfg m.Config, err error) (transform.Transfor
 	}
 
 	var stacktr *m.Stacktrace
-	stacktr, decoder.Err = m.DecodeStacktrace(raw[fieldName("stacktrace")], cfg.HasShortFieldNames, decoder.Err)
+	stacktr, decoder.Err = m.DecodeStacktrace(raw[fieldName("stacktrace")], input.Config.HasShortFieldNames, decoder.Err)
 	if decoder.Err != nil {
 		return nil, decoder.Err
 	}
@@ -370,6 +370,15 @@ func DecodeEvent(input interface{}, cfg m.Config, err error) (transform.Transfor
 			action := strings.Join(t[2:], sep)
 			event.Action = &action
 		}
+	}
+
+	if event.Timestamp.IsZero() {
+		timestamp := input.RequestTime
+		if event.Start != nil {
+			// adjust timestamp to be reqTime + start
+			timestamp = timestamp.Add(time.Duration(float64(time.Millisecond) * *event.Start))
+		}
+		event.Timestamp = timestamp
 	}
 
 	return &event, nil
@@ -400,23 +409,12 @@ func (e *Event) Transform(ctx context.Context, tctx *transform.Context) []beat.E
 	utility.AddId(fields, "transaction", e.TransactionId)
 	utility.Set(fields, "experimental", e.Experimental)
 	utility.Set(fields, "destination", e.Destination.fields())
-
-	timestamp := e.Timestamp
-	if timestamp.IsZero() {
-		timestamp = tctx.RequestTime
-	}
-
-	// adjust timestamp to be reqTime + start
-	if e.Timestamp.IsZero() && e.Start != nil {
-		timestamp = tctx.RequestTime.Add(time.Duration(float64(time.Millisecond) * *e.Start))
-	}
-
-	utility.Set(fields, "timestamp", utility.TimeAsMicros(timestamp))
+	utility.Set(fields, "timestamp", utility.TimeAsMicros(e.Timestamp))
 
 	return []beat.Event{
 		{
 			Fields:    fields,
-			Timestamp: timestamp,
+			Timestamp: e.Timestamp,
 		},
 	}
 }

--- a/model/span/event_test.go
+++ b/model/span/event_test.go
@@ -39,6 +39,7 @@ import (
 )
 
 func TestDecodeSpan(t *testing.T) {
+	requestTime := time.Now()
 	spanTime := time.Date(2018, 5, 30, 19, 53, 17, 134*1e6, time.UTC)
 	timestampEpoch := json.Number(fmt.Sprintf("%d", spanTime.UnixNano()/1000))
 	id, parentId := "0000000000000000", "FFFFFFFFFFFFFFFF"
@@ -138,6 +139,22 @@ func TestDecodeSpan(t *testing.T) {
 				ParentId:  parentId,
 				Id:        id,
 				TraceId:   traceId,
+			},
+		},
+		"no timestamp specified, request time + start used": {
+			input: map[string]interface{}{
+				"name": name, "type": "db", "duration": duration, "parent_id": parentId, "trace_id": traceId, "id": id,
+				"start": start,
+			},
+			e: &Event{
+				Name:      name,
+				Type:      "db",
+				Duration:  duration,
+				ParentId:  parentId,
+				Id:        id,
+				TraceId:   traceId,
+				Start:     &start,
+				Timestamp: requestTime.Add(time.Duration(start * float64(time.Millisecond))),
 			},
 		},
 		"event experimental=false": {
@@ -247,7 +264,11 @@ func TestDecodeSpan(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			span, err := DecodeEvent(test.input, test.cfg, test.inpErr)
+			span, err := DecodeEvent(m.Input{
+				Raw:         test.input,
+				RequestTime: requestTime,
+				Config:      test.cfg,
+			}, test.inpErr)
 			if test.err == "" {
 				require.Nil(t, err)
 				assert.Equal(t, test.e, span)
@@ -305,6 +326,7 @@ func TestSpanTransform(t *testing.T) {
 				Type:       "myspantype",
 				Subtype:    &subtype,
 				Action:     &action,
+				Timestamp:  timestamp,
 				Start:      &start,
 				Duration:   1.20,
 				Stacktrace: m.Stacktrace{{AbsPath: &path}},
@@ -364,7 +386,7 @@ func TestSpanTransform(t *testing.T) {
 				"labels":      common.MapStr{"label.a": 12, "label.b": "b", "c": 1},
 				"processor":   common.MapStr{"event": "span", "name": "transaction"},
 				"service":     common.MapStr{"name": serviceName, "environment": env, "version": serviceVersion},
-				"timestamp":   common.MapStr{"us": int64(float64(timestampUs) + start*1000)},
+				"timestamp":   common.MapStr{"us": timestampUs},
 				"trace":       common.MapStr{"id": traceId},
 				"parent":      common.MapStr{"id": parentId},
 				"destination": common.MapStr{"address": address, "ip": address, "port": port},
@@ -374,24 +396,12 @@ func TestSpanTransform(t *testing.T) {
 	}
 
 	tctx := &transform.Context{
-		Config:      transform.Config{SourcemapStore: &sourcemap.Store{}},
-		Metadata:    metadata.Metadata{Service: &service, Labels: metadataLabels},
-		RequestTime: timestamp,
+		Config:   transform.Config{SourcemapStore: &sourcemap.Store{}},
+		Metadata: metadata.Metadata{Service: &service, Labels: metadataLabels},
 	}
 	for _, test := range tests {
 		output := test.Event.Transform(context.Background(), tctx)
 		fields := output[0].Fields
 		assert.Equal(t, test.Output, fields)
 	}
-}
-
-func TestEventTransformUseReqTimePlusStart(t *testing.T) {
-	reqTimestampParsed := time.Date(2017, 5, 30, 18, 53, 27, 154*1e6, time.UTC)
-	start := 1234.8
-	e := Event{Start: &start}
-	beatEvent := e.Transform(context.Background(), &transform.Context{RequestTime: reqTimestampParsed})
-	require.Len(t, beatEvent, 1)
-
-	adjustedParsed := time.Date(2017, 5, 30, 18, 53, 28, 388.8*1e6, time.UTC)
-	assert.Equal(t, adjustedParsed, beatEvent[0].Timestamp)
 }

--- a/model/transaction/event_test.go
+++ b/model/transaction/event_test.go
@@ -51,7 +51,7 @@ func TestTransactionEventDecodeFailure(t *testing.T) {
 		"cannot fetch field": {input: map[string]interface{}{}, err: utility.ErrFetch, e: nil},
 	} {
 		t.Run(name, func(t *testing.T) {
-			transformable, err := DecodeEvent(test.input, model.Config{}, test.inpErr)
+			transformable, err := DecodeEvent(model.Input{Raw: test.input}, test.inpErr)
 			assert.Equal(t, test.err, err)
 			if test.e != nil {
 				event := transformable.(*Event)
@@ -91,8 +91,10 @@ func TestTransactionDecodeRUMV3Marks(t *testing.T) {
 
 func TestTransactionEventDecode(t *testing.T) {
 	id, trType, name, result := "123", "type", "foo()", "555"
+	requestTime := time.Now()
 	timestampParsed := time.Date(2017, 5, 30, 18, 53, 27, 154*1e6, time.UTC)
 	timestampEpoch := json.Number(fmt.Sprintf("%d", timestampParsed.UnixNano()/1000))
+
 	traceId, parentId := "0147258369012345abcdef0123456789", "abcdef0123456789"
 	dropped, started, duration := 12, 6, 1.67
 	name, userId, email, userIp := "jane", "abc123", "j@d.com", "127.0.0.1"
@@ -115,6 +117,19 @@ func TestTransactionEventDecode(t *testing.T) {
 		err   string
 		e     *Event
 	}{
+		"no timestamp specified, request time used": {
+			input: map[string]interface{}{
+				"id": id, "type": trType, "name": name, "duration": duration, "trace_id": traceId,
+			},
+			e: &Event{
+				Id:        id,
+				Type:      trType,
+				Name:      &name,
+				TraceId:   traceId,
+				Duration:  duration,
+				Timestamp: requestTime,
+			},
+		},
 		"event experimental=true, no experimental payload": {
 			input: map[string]interface{}{
 				"id": id, "type": trType, "name": name, "duration": duration, "trace_id": traceId,
@@ -236,7 +251,11 @@ func TestTransactionEventDecode(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			transformable, err := DecodeEvent(test.input, test.cfg, nil)
+			transformable, err := DecodeEvent(model.Input{
+				Raw:         test.input,
+				RequestTime: requestTime,
+				Config:      test.cfg,
+			}, nil)
 			if test.err != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), test.err)
@@ -548,8 +567,7 @@ func TestEventsTransformWithMetadata(t *testing.T) {
 
 	for idx, test := range tests {
 		tctx := &transform.Context{
-			Metadata:    *test.Metadata,
-			RequestTime: timestamp,
+			Metadata: *test.Metadata,
 		}
 		outputEvents := test.Event.Transform(context.Background(), tctx)
 
@@ -558,12 +576,4 @@ func TestEventsTransformWithMetadata(t *testing.T) {
 			assert.Equal(t, timestamp, outputEvent.Timestamp, fmt.Sprintf("Failed at idx %v (j: %v); %s", idx, j, test.Msg))
 		}
 	}
-}
-
-func TestEventTransformUseReqTime(t *testing.T) {
-	reqTimestampParsed := time.Date(2017, 5, 30, 18, 53, 27, 154*1e6, time.UTC)
-	e := Event{}
-	beatEvent := e.Transform(context.Background(), &transform.Context{RequestTime: reqTimestampParsed})
-	require.Len(t, beatEvent, 1)
-	assert.Equal(t, reqTimestampParsed, beatEvent[0].Timestamp)
 }

--- a/processor/otel/consumer.go
+++ b/processor/otel/consumer.go
@@ -64,12 +64,10 @@ type Consumer struct {
 // ConsumeTraceData consumes OpenTelemetry trace data,
 // converting into Elastic APM events and reporting to the Elastic APM schema.
 func (c *Consumer) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
-	requestTime := time.Now()
 	metadata, transformables := c.convert(td)
 	transformContext := &transform.Context{
-		RequestTime: requestTime,
-		Config:      c.TransformConfig,
-		Metadata:    metadata,
+		Config:   c.TransformConfig,
+		Metadata: metadata,
 	}
 
 	return c.Reporter(ctx, publish.PendingReq{

--- a/processor/stream/package_tests/intake_test_processor.go
+++ b/processor/stream/package_tests/intake_test_processor.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"time"
 
 	"github.com/santhosh-tekuri/jsonschema"
 
@@ -87,7 +88,7 @@ func (p *intakeTestProcessor) LoadPayload(path string) (interface{}, error) {
 func (p *intakeTestProcessor) Decode(data interface{}) error {
 	events := data.([]interface{})
 	for _, e := range events {
-		_, err := p.Processor.HandleRawModel(e.(map[string]interface{}))
+		_, err := p.Processor.HandleRawModel(e.(map[string]interface{}), time.Now())
 		if err != nil {
 			return err
 		}

--- a/processor/stream/processor.go
+++ b/processor/stream/processor.go
@@ -24,19 +24,16 @@ import (
 	"sync"
 	"time"
 
-	"github.com/elastic/apm-server/model/field"
-
-	"github.com/elastic/apm-server/beater/config"
-
-	"github.com/elastic/apm-server/model"
-
 	"github.com/santhosh-tekuri/jsonschema"
 	"golang.org/x/time/rate"
 
 	"go.elastic.co/apm"
 
+	"github.com/elastic/apm-server/beater/config"
 	"github.com/elastic/apm-server/decoder"
+	"github.com/elastic/apm-server/model"
 	er "github.com/elastic/apm-server/model/error"
+	"github.com/elastic/apm-server/model/field"
 	"github.com/elastic/apm-server/model/metadata"
 	"github.com/elastic/apm-server/model/metricset"
 	"github.com/elastic/apm-server/model/span"
@@ -57,7 +54,7 @@ const (
 
 type processorModel struct {
 	schema       *jsonschema.Schema
-	modelDecoder func(input interface{}, cfg model.Config, err error) (transform.Transformable, error)
+	modelDecoder func(model.Input, error) (transform.Transformable, error)
 }
 
 type Processor struct {
@@ -183,15 +180,19 @@ func (p *Processor) readMetadata(reqMeta map[string]interface{}, reader *streamR
 }
 
 // HandleRawModel validates and decodes a single json object into its struct form
-func (p *Processor) HandleRawModel(rawModel map[string]interface{}) (transform.Transformable, error) {
-	for key, model := range p.models {
+func (p *Processor) HandleRawModel(rawModel map[string]interface{}, requestTime time.Time) (transform.Transformable, error) {
+	for key, m := range p.models {
 		if entry, ok := rawModel[key]; ok {
-			err := validation.Validate(entry, model.schema)
+			err := validation.Validate(entry, m.schema)
 			if err != nil {
 				return nil, err
 			}
-
-			tr, err := model.modelDecoder(entry, p.Mconfig, err)
+			input := model.Input{
+				Raw:         entry,
+				RequestTime: requestTime,
+				Config:      p.Mconfig,
+			}
+			tr, err := m.modelDecoder(input, err)
 			if err != nil {
 				return nil, err
 			}
@@ -204,7 +205,15 @@ func (p *Processor) HandleRawModel(rawModel map[string]interface{}) (transform.T
 // readBatch will read up to `batchSize` objects from the ndjson stream,
 // returning a slice of Transformables and a boolean indicating that there
 // might be more to read.
-func (p *Processor) readBatch(ctx context.Context, ipRateLimiter *rate.Limiter, batchSize int, reader *streamReader, response *Result) ([]transform.Transformable, bool) {
+func (p *Processor) readBatch(
+	ctx context.Context,
+	ipRateLimiter *rate.Limiter,
+	requestTime time.Time,
+	batchSize int,
+	reader *streamReader,
+	response *Result,
+) ([]transform.Transformable, bool) {
+
 	if ipRateLimiter != nil {
 		// use provided rate limiter to throttle batch read
 		ctxT, cancel := context.WithTimeout(ctx, time.Second)
@@ -232,7 +241,7 @@ func (p *Processor) readBatch(ctx context.Context, ipRateLimiter *rate.Limiter, 
 			return out, true
 		}
 		if len(rawModel) > 0 {
-			tr, err := p.HandleRawModel(rawModel)
+			tr, err := p.HandleRawModel(rawModel, requestTime)
 			if err != nil {
 				response.LimitedAdd(&Error{
 					Type:     InvalidInputErrType,
@@ -262,10 +271,11 @@ func (p *Processor) HandleStream(ctx context.Context, ipRateLimiter *rate.Limite
 		return res
 	}
 
+	requestTime := utility.RequestTime(ctx)
 	tctx := &transform.Context{
-		RequestTime: utility.RequestTime(ctx),
-		Config:      p.Tconfig,
-		Metadata:    *metadata,
+		Config: p.Tconfig,
+		// TODO(axw) pass metadata into the decoder instead
+		Metadata: *metadata,
 	}
 
 	sp, ctx := apm.StartSpan(ctx, "Stream", "Reporter")
@@ -274,7 +284,7 @@ func (p *Processor) HandleStream(ctx context.Context, ipRateLimiter *rate.Limite
 	var transformables []transform.Transformable
 	var done bool
 	for !done {
-		transformables, done = p.readBatch(ctx, ipRateLimiter, batchSize, sr, res)
+		transformables, done = p.readBatch(ctx, ipRateLimiter, requestTime, batchSize, sr, res)
 		if len(transformables) == 0 {
 			continue
 		}

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -20,7 +20,6 @@ package transform
 import (
 	"context"
 	"regexp"
-	"time"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 
@@ -33,9 +32,8 @@ type Transformable interface {
 }
 
 type Context struct {
-	RequestTime time.Time
-	Config      Config
-	Metadata    metadata.Metadata
+	Config   Config
+	Metadata metadata.Metadata
 }
 
 type Config struct {


### PR DESCRIPTION
## Motivation/summary

Introduce the model.Input type to pass additional context to decoders, containing:
 - the raw decoded JSON input
 - the "request time", i.e. the time at which the input was received
 - decoding configuration -- temporarily, until we have a configurable Decoder type

RequestTime has been removed from transform.Context, and the decoders are now responsible for setting the Timestamp on the model types according to the input semantics.

In a follow-up, I would do the same thing for Metadata: add a Metadata field to model.Input, which would be initialised to the stream metadata value, and remove transform.Context's Metadata field.

The motivation behind these changes is to make the model types complete and self contained, and creating a clear separation of logic between decoding and transformation:
 - after decoding (from Elastic APM agents, Jaeger, ...), the model types should be complete, with the exception of post-processing enrichment such as source mapping
 - transformation would only be responsible for translating to `beat.Events` (perhaps still performing enrichment inline)

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
~- [ ] I have made corresponding changes to the documentation~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

## Related issues

See https://github.com/elastic/apm-server/issues/3567