### PR TITLE
model/...: remove error parameter from decoders

### DIFF
--- a/model/error/event.go
+++ b/model/error/event.go
@@ -119,14 +119,11 @@ type Log struct {
 	Stacktrace   m.Stacktrace
 }
 
-func DecodeRUMV3Event(input interface{}, cfg m.Config, err error) (transform.Transformable, error) {
-	return DecodeEvent(input, cfg, err)
+func DecodeRUMV3Event(input interface{}, cfg m.Config) (transform.Transformable, error) {
+	return DecodeEvent(input, cfg)
 }
 
-func DecodeEvent(input interface{}, cfg m.Config, err error) (transform.Transformable, error) {
-	if err != nil {
-		return nil, err
-	}
+func DecodeEvent(input interface{}, cfg m.Config) (transform.Transformable, error) {
 	if input == nil {
 		return nil, errMissingInput
 	}

--- a/model/error/event_test.go
+++ b/model/error/event_test.go
@@ -101,14 +101,13 @@ func TestErrorEventDecode(t *testing.T) {
 	ctxUrl := m.Url{Original: &origUrl}
 
 	for name, test := range map[string]struct {
-		input       interface{}
-		cfg         m.Config
-		err, inpErr error
-		e           *Event
+		input interface{}
+		cfg   m.Config
+		err   error
+		e     *Event
 	}{
-		"no input":               {input: nil, err: errMissingInput, e: nil},
-		"an error passed as arg": {input: nil, inpErr: errors.New("a"), err: errors.New("a"), e: nil},
-		"invalid type":           {input: "", err: errInvalidType, e: nil},
+		"no input":     {input: nil, err: errMissingInput, e: nil},
+		"invalid type": {input: "", err: errInvalidType, e: nil},
 		"error decoding timestamp": {
 			input: map[string]interface{}{"timestamp": 123},
 			err:   utility.ErrFetch,
@@ -282,7 +281,7 @@ func TestErrorEventDecode(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			transformable, err := DecodeEvent(test.input, test.cfg, test.inpErr)
+			transformable, err := DecodeEvent(test.input, test.cfg)
 			if test.e != nil && assert.NotNil(t, transformable) {
 				event := transformable.(*Event)
 				assert.Equal(t, test.e, event)
@@ -315,7 +314,7 @@ func TestHandleExceptionTree(t *testing.T) {
 			},
 		},
 	}
-	result, err := DecodeEvent(errorEvent, m.Config{}, nil)
+	result, err := DecodeEvent(errorEvent, m.Config{})
 	require.NoError(t, err)
 
 	event := result.(*Event)
@@ -342,7 +341,7 @@ func TestDecodingAnomalies(t *testing.T) {
 				"type":    "type0",
 			},
 		}
-		result, err := DecodeEvent(badID, m.Config{}, nil)
+		result, err := DecodeEvent(badID, m.Config{})
 		assert.Error(t, err)
 		assert.Nil(t, result)
 	})
@@ -358,7 +357,7 @@ func TestDecodingAnomalies(t *testing.T) {
 				},
 			},
 		}
-		result, err := DecodeEvent(badException, m.Config{}, nil)
+		result, err := DecodeEvent(badException, m.Config{})
 		assert.Error(t, err)
 		assert.Nil(t, result)
 	})
@@ -372,7 +371,7 @@ func TestDecodingAnomalies(t *testing.T) {
 				"cause":   []interface{}{7.4},
 			},
 		}
-		result, err := DecodeEvent(badException, m.Config{}, nil)
+		result, err := DecodeEvent(badException, m.Config{})
 		assert.Error(t, err)
 		assert.EqualError(t, err, "cause must be an exception")
 		assert.Nil(t, result)
@@ -389,7 +388,7 @@ func TestDecodingAnomalies(t *testing.T) {
 				},
 			},
 		}
-		result, err := DecodeEvent(emptyCauses, m.Config{}, nil)
+		result, err := DecodeEvent(emptyCauses, m.Config{})
 		require.NoError(t, err)
 		assert.NotNil(t, result)
 

--- a/model/metricset/event.go
+++ b/model/metricset/event.go
@@ -86,10 +86,7 @@ type metricsetDecoder struct {
 	*utility.ManualDecoder
 }
 
-func DecodeEvent(input interface{}, _ model.Config, err error) (transform.Transformable, error) {
-	if err != nil {
-		return nil, err
-	}
+func DecodeEvent(input interface{}, _ model.Config) (transform.Transformable, error) {
 	if input == nil {
 		return nil, errors.New("no data for metric event")
 	}

--- a/model/metricset/event_test.go
+++ b/model/metricset/event_test.go
@@ -159,8 +159,7 @@ func TestDecode(t *testing.T) {
 			},
 		},
 	} {
-		var err error
-		transformables, err := DecodeEvent(test.input, model.Config{}, err)
+		transformables, err := DecodeEvent(test.input, model.Config{})
 		if test.err != nil {
 			assert.Error(t, err)
 		}

--- a/model/span/event.go
+++ b/model/span/event.go
@@ -273,15 +273,12 @@ func (d *DestinationService) fields() common.MapStr {
 	return fields
 }
 
-func DecodeRUMV3Event(input interface{}, cfg m.Config, err error) (transform.Transformable, error) {
-	return DecodeEvent(input, cfg, err)
+func DecodeRUMV3Event(input interface{}, cfg m.Config) (transform.Transformable, error) {
+	return DecodeEvent(input, cfg)
 }
 
 // DecodeEvent decodes a span event.
-func DecodeEvent(input interface{}, cfg m.Config, err error) (transform.Transformable, error) {
-	if err != nil {
-		return nil, err
-	}
+func DecodeEvent(input interface{}, cfg m.Config) (transform.Transformable, error) {
 	if input == nil {
 		return nil, errMissingInput
 	}

--- a/model/span/event_test.go
+++ b/model/span/event_test.go
@@ -20,7 +20,6 @@ package span
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -79,12 +78,10 @@ func TestDecodeSpan(t *testing.T) {
 		input interface{}
 		cfg   m.Config
 		// we don't use a regular `error.New` here, because some errors are of a different type
-		err    string
-		inpErr error
-		e      transform.Transformable
+		err string
+		e   transform.Transformable
 	}{
 		"no input":     {input: nil, err: errMissingInput.Error()},
-		"input error":  {input: nil, inpErr: errors.New("a"), err: "a"},
 		"invalid type": {input: "", err: errInvalidType.Error()},
 		"missing required field": {
 			input: map[string]interface{}{},
@@ -247,7 +244,7 @@ func TestDecodeSpan(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			span, err := DecodeEvent(test.input, test.cfg, test.inpErr)
+			span, err := DecodeEvent(test.input, test.cfg)
 			if test.err == "" {
 				require.Nil(t, err)
 				assert.Equal(t, test.e, span)

--- a/model/transaction/event.go
+++ b/model/transaction/event.go
@@ -91,8 +91,8 @@ type SpanCount struct {
 	Started *int
 }
 
-func DecodeRUMV3Event(input interface{}, cfg m.Config, err error) (transform.Transformable, error) {
-	transformable, err := DecodeEvent(input, cfg, err)
+func DecodeRUMV3Event(input interface{}, cfg m.Config) (transform.Transformable, error) {
+	transformable, err := DecodeEvent(input, cfg)
 	if err != nil {
 		return transformable, err
 	}
@@ -145,10 +145,7 @@ func decodeRUMV3Marks(event *Event, raw map[string]interface{}, cfg m.Config) (t
 	return event, decoder.Err
 }
 
-func DecodeEvent(input interface{}, cfg m.Config, err error) (transform.Transformable, error) {
-	if err != nil {
-		return nil, err
-	}
+func DecodeEvent(input interface{}, cfg m.Config) (transform.Transformable, error) {
 	if input == nil {
 		return nil, errMissingInput
 	}

--- a/model/transaction/event_test.go
+++ b/model/transaction/event_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -41,17 +40,16 @@ import (
 
 func TestTransactionEventDecodeFailure(t *testing.T) {
 	for name, test := range map[string]struct {
-		input       interface{}
-		err, inpErr error
-		e           *Event
+		input interface{}
+		err   error
+		e     *Event
 	}{
 		"no input":           {input: nil, err: errMissingInput, e: nil},
-		"input error":        {input: nil, inpErr: errors.New("a"), err: errors.New("a"), e: nil},
 		"invalid type":       {input: "", err: errInvalidType, e: nil},
 		"cannot fetch field": {input: map[string]interface{}{}, err: utility.ErrFetch, e: nil},
 	} {
 		t.Run(name, func(t *testing.T) {
-			transformable, err := DecodeEvent(test.input, model.Config{}, test.inpErr)
+			transformable, err := DecodeEvent(test.input, model.Config{})
 			assert.Equal(t, test.err, err)
 			if test.e != nil {
 				event := transformable.(*Event)
@@ -236,7 +234,7 @@ func TestTransactionEventDecode(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			transformable, err := DecodeEvent(test.input, test.cfg, nil)
+			transformable, err := DecodeEvent(test.input, test.cfg)
 			if test.err != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), test.err)

--- a/processor/stream/processor.go
+++ b/processor/stream/processor.go
@@ -57,7 +57,7 @@ const (
 
 type processorModel struct {
 	schema       *jsonschema.Schema
-	modelDecoder func(input interface{}, cfg model.Config, err error) (transform.Transformable, error)
+	modelDecoder func(input interface{}, cfg model.Config) (transform.Transformable, error)
 }
 
 type Processor struct {
@@ -191,7 +191,7 @@ func (p *Processor) HandleRawModel(rawModel map[string]interface{}) (transform.T
 				return nil, err
 			}
 
-			tr, err := model.modelDecoder(entry, p.Mconfig, err)
+			tr, err := model.modelDecoder(entry, p.Mconfig)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Motivation/summary

Remove the input error parameter from the top-level model types' Decode functions. This is a non-idiomatic pattern which leads to less than ideal performance due to repeatedly checking errors rather than the idiomatic approach of checking once and bailing out early. The input error is always nil in practice for the modified decoders.

I've left the other decoders alone for now, as that's a much bigger change. We should address those as part of https://github.com/elastic/apm-server/issues/3551.

## Checklist
- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

## How to test these changes

`make test`

## Related issues

None