### PR TITLE
[7.x] docs: Sync changelog

### DIFF
--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,6 +3,7 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.8>>
 * <<release-notes-6.8.7>>
 * <<release-notes-6.8.6>>
 * <<release-notes-6.8.5>>
@@ -11,6 +12,13 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.2>>
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
+
+[[release-notes-6.8.8]]
+=== APM Server version 6.8.8
+
+https://github.com/elastic/apm-server/compare/v6.8.7\...v6.8.8[View commits]
+
+No significant changes.
 
 [[release-notes-6.8.7]]
 === APM Server version 6.8.7

--- a/changelogs/7.6.asciidoc
+++ b/changelogs/7.6.asciidoc
@@ -3,8 +3,16 @@
 
 https://github.com/elastic/apm-server/compare/7.5\...7.6[View commits]
 
+* <<release-notes-7.6.2>>
 * <<release-notes-7.6.1>>
 * <<release-notes-7.6.0>>
+
+[[release-notes-7.6.2]]
+=== APM Server version 7.6.2
+
+https://github.com/elastic/apm-server/compare/v7.6.1\...v7.6.2[View commits]
+
+No significant changes.
 
 [[release-notes-7.6.1]]
 === APM Server version 7.6.1


### PR DESCRIPTION
Backports the following commits to 7.x:

* docs: 6.8.8 release notes (#3529)
* docs: 7.6.2 changelog (#3530)