### PR TITLE
[7.6] docs: Sync changelog

### DIFF
--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,6 +3,7 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.8>>
 * <<release-notes-6.8.7>>
 * <<release-notes-6.8.6>>
 * <<release-notes-6.8.5>>
@@ -11,6 +12,13 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.2>>
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
+
+[[release-notes-6.8.8]]
+=== APM Server version 6.8.8
+
+https://github.com/elastic/apm-server/compare/v6.8.7\...v6.8.8[View commits]
+
+No significant changes.
 
 [[release-notes-6.8.7]]
 === APM Server version 6.8.7


### PR DESCRIPTION
Backports the following commits to 7.6:

* docs: 6.8.8 release notes (#3529)