### PR TITLE
docs: Update agent links for API keys

### DIFF
--- a/docs/secure-communication-agents.asciidoc
+++ b/docs/secure-communication-agents.asciidoc
@@ -160,27 +160,13 @@ A full list of `apikey` subcommands and flags is available in the <<apikey-comma
 You can now apply your newly created API keys in the configuration of each of your APM Agents.
 See the relevant Agent documentation for additional information:
 
-// Agent meta: https://github.com/elastic/apm/issues/183
-
-// GOOD DOCS:
 * *Go Agent*: {apm-go-ref}/configuration.html#config-api-key[`ELASTIC_APM_API_KEY`]
-// MERGED: https://github.com/elastic/apm-agent-go/pull/698
-
 * *.NET Agent*: {apm-dotnet-ref}/config-reporter.html#config-api-key[`ApiKey`]
-
-// No issue or docs yet
-// * *Java Agent*: {apm-java-ref}/config-reporter.html#config-api-key[`api_key`]
-
+* *Java Agent*: {apm-java-ref}/config-reporter.html#config-api-key[`api_key`]
+* *Python Agent*: {apm-py-ref}/configuration.html#config-api-key[`api_key`]
+* *Ruby Agent*: {apm-ruby-ref}/configuration.html#config-api-key[`api_key`]
 // No issue or docs yet
 // * *Node.js Agent*: {apm-node-ref}/configuration.html[`api_key`]
-
-// No docs yet
-// * *Python Agent*: {apm-py-ref}/configuration.html#config-api-key[`api_key`]
-// WIP
-
-// No docs yet
-// * *Ruby Agent*: {apm-ruby-ref}/configuration.html#config-api-key[`api_key`]
-// MERGED: https://github.com/elastic/apm-agent-ruby/pull/655
 
 [[api-key-settings]]
 === `api_key.*` configuration options
@@ -189,8 +175,6 @@ You can specify the following options in the `apm-server.api_key.*` section of t
 +{beatname_lc}.yml+ configuration file.
 They apply to API key communication between the APM Server and APM Agents.
 
-// To do!
-// These will become links, but the relevant docs haven't been merged yet.
 These are different from the API key settings used for the Elasticsearch output and monitoring.
 
 [float]
@@ -385,7 +369,6 @@ To enable secure communication in your Agents, you need to update the configured
 Some Agents also allow you to specify a custom certificate authority for connecting to APM Server.
 
 * *Go Agent*: {apm-go-ref}/configuration.html#config-server-cert[`ELASTIC_APM_SERVER_CERT`]
-// * *.NET Agent*: {apm-dotnet-ref}/
 * *Python Agent*: {apm-py-ref}/configuration.html#config-server-cert[`ELASTIC_APM_SERVER_CERT`]
 * *Ruby Agent*: {apm-ruby-ref}/configuration.html#config-ssl-ca-cert[`server_ca_certedit`]
 


### PR DESCRIPTION
All Agents now have API key documentation. This PR updates the linking from APM Server --> APM Agent to make it easier for users to configure API keys.

Links still need to be added in the following Agent References:
- [ ] Python
- [ ] Go
- [ ] Ruby