### PR TITLE
docs: Update pipeline and processor docs for 7.7

### DIFF
--- a/docs/configuration-process.asciidoc
+++ b/docs/configuration-process.asciidoc
@@ -134,7 +134,7 @@ Defaults to true.
 [float]
 ==== `register.ingest.pipeline.overwrite`
 Overwrites the existing APM pipeline definition in Elasticsearch.
-Defaults to true.
+Defaults to false.
 
 [float]
 === Configuration options: `queue.mem.*`

--- a/docs/configuration-rum.asciidoc
+++ b/docs/configuration-rum.asciidoc
@@ -113,17 +113,6 @@ If changed, a matching index pattern needs to be specified here.
 [float]
 === Ingest pipelines
 
-// For now, this content is copied from `configuration-rum.asciidoc`.
-// Once we've moved to asciidoctor, the following include statement can be used instead.
-// This will single-source the content and prevent duplication.
-// include::configuring-ingest.asciidoc[tag=default-pipeline]
-
-By default, <<register.ingest.pipeline.enabled,`register.ingest.pipeline.enabled`>> is set to `true`.
-This loads the default pipeline definition to Elasticsearch on APM Server startup.
-
-The default pipeline is `apm`. It adds user agent information to events and processes {ref}/geoip-processor.html[Geo-IP data],
-which is especially useful for Elastic's {apm-rum-ref-v}/index.html[JavaScript RUM Agent].
-You can view the pipeline configuration by navigating to the APM Server's home directory and then
-viewing `ingest/pipeline/definition.json`.
-
-To disable this, or any other pipeline, set `output.elasticsearch.pipeline: _none`.
+The default APM Server pipeline includes processors that enrich RUM data prior to indexing in {es}.
+See the <<default-pipeline,default ingest pipeline>> for details on how to locate,
+edit, or disable this pre-processing.

--- a/docs/configuring-ingest.asciidoc
+++ b/docs/configuring-ingest.asciidoc
@@ -37,10 +37,6 @@ and then viewing `ingest/pipeline/definition.json`.
 
 To disable this, or any other pipeline, set `output.elasticsearch.pipeline: _none`.
 
-// The content within the "default-pipeline" tag is reused elsewhere. Keep that in mind when editing it.
-// tag::default-pipeline[]
-// end::default-pipeline[]
-
 [[custom-pipelines]]
 [float]
 === Custom pipelines

--- a/docs/configuring-ingest.asciidoc
+++ b/docs/configuring-ingest.asciidoc
@@ -6,25 +6,39 @@
 
 You can configure APM Server to use an {ref}/ingest.html[ingest node]
 to pre-process documents before indexing them in Elasticsearch.
-
-A pipeline is a definition of a series of processors that operate on your data.
-For example, a pipeline can define one processor to remove a field, and another to rename a field.
+A pipeline definition specifies the series of processors that will transform each document in a specific way.
+For example, a pipeline might define one processor that removes a field, followed by another that renames a field.
 
 [[default-pipeline]]
 [float]
 === Default ingest pipeline
 
-// The content within the "default-pipeline" tag is reused elsewhere. Keep that in mind when editing it.
-// tag::default-pipeline[]
-By default, <<register.ingest.pipeline.enabled,`register.ingest.pipeline.enabled`>> is set to `true`.
-This loads the default pipeline definition to Elasticsearch on APM Server startup.
+By default, APM Server registers the `apm` pipeline definition to Elasticsearch on startup.
+The `apm` pipeline definition defines the following processors:
 
-The default pipeline is `apm`. It adds user agent information to events and processes {ref}/geoip-processor.html[Geo-IP data],
-which is especially useful for Elastic's {apm-rum-ref-v}/index.html[JavaScript RUM Agent].
-You can view the pipeline configuration by navigating to the APM Server's home directory and then
-viewing `ingest/pipeline/definition.json`.
+[horizontal]
+`apm_user_agent`::
+Adds `user_agent` information for APM events
+
+`apm_user_geo`::
+Enriches Elastic's {apm-rum-ref-v}/index.html[JavaScript RUM Agent] data by
+adding user {ref}/geoip-processor.html[Geo-IP data] to the `client.geo` field.
+
+`apm_ingest_timestamp`::
+Adds an ingest timestamp for APM events.
+
+`apm_remove_span_metadata`::
+added:[7.7,"Previously hardcoded. See <<upgrading-to-77,upgrading to 7.7>>"]
+To save storage, removes metadata fields (like `host`, `kubernetes`, and `container`)
+that are already available on the parent transaction.
+
+See the complete pipeline definition by navigating to the APM Server's home directory,
+and then viewing `ingest/pipeline/definition.json`.
 
 To disable this, or any other pipeline, set `output.elasticsearch.pipeline: _none`.
+
+// The content within the "default-pipeline" tag is reused elsewhere. Keep that in mind when editing it.
+// tag::default-pipeline[]
 // end::default-pipeline[]
 
 [[custom-pipelines]]
@@ -52,7 +66,7 @@ Navigate to APM Server's home directory and find the default pipeline configurat
 To add, change, or remove pipelines in Elasticsearch,
 change the definitions in this file and restart your APM Server or run `apm-server setup --pipelines`.
 
-By default, pipeline registration is <<register.ingest.pipeline.enabled,enabled>>. 
+By default, pipeline registration is <<register.ingest.pipeline.enabled,enabled>>.
 
 [[register-pipelines-manual]]
 [float]

--- a/docs/configuring-ingest.asciidoc
+++ b/docs/configuring-ingest.asciidoc
@@ -28,9 +28,12 @@ adding user {ref}/geoip-processor.html[Geo-IP data] to the `client.geo` field.
 Adds an ingest timestamp for APM events.
 
 `apm_remove_span_metadata`::
-added:[7.7,"Previously hardcoded. See <<upgrading-to-77,upgrading to 7.7>>"]
-To save storage, removes metadata fields (like `host`, `kubernetes`, and `container`)
+added:[7.7,"Upgrading? See <<upgrading-to-77,upgrading to 7.7>>"]
+To save storage, removes metadata fields, like `host`, `kubernetes`, and `container`,
 that are already available on the parent transaction.
++
+In previous versions of APM Server, this functionality was hardcoded internally.
+Switching metadata cleanup from an internal process to a processor allows you to keep any span metadata that is important in your architecture.
 
 See the complete pipeline definition by navigating to the APM Server's home directory,
 and then viewing `ingest/pipeline/definition.json`.

--- a/docs/upgrading-to-77.asciidoc
+++ b/docs/upgrading-to-77.asciidoc
@@ -31,8 +31,9 @@ to `true`.
 
 An alternate upgrade method is to use the <<setup-command,`setup` command>>.
 This upgrade method can be useful if you're using an output other than Elasticsearch.
-In this case, you'll need to disable the active output and point APM Server at your Elasticsearch cluster.
-You can then run the `setup --pipeline` command to register the pipeline definitions in `definition.json`.
+In this case, you can use the command line to disable the active output
+and point APM Server at your Elasticsearch cluster.
+Then, run the `setup --pipeline` command to register the pipeline definitions in `definition.json`.
 
 Here's an example of what this might look like, if you typically output to Logstash:
 
@@ -44,3 +45,5 @@ apm-server setup --pipelines \
     -E output.elasticsearch.enabled=true \
     -E output.elasticsearch.hosts=["http://username:password@elasticsearch:9200"]
 --------------------------------------------------
+
+After running `setup`, restart APM Server.

--- a/docs/upgrading-to-77.asciidoc
+++ b/docs/upgrading-to-77.asciidoc
@@ -24,15 +24,23 @@ pipelines are not overwritten when restarting APM Server.
 Enable pipeline overwriting by setting <<register.ingest.pipeline.overwrite,`register.ingest.pipeline.overwrite`>>
 to `true`.
 
-. Copy any custom pipelines you've created or altered to the pipeline definition file, located at
+. Copy any custom pipelines you've created or altered to the `apm` pipeline definition file, located at
 `ingest/pipeline/definition.json`.
 
 . Restart APM Server.
 
-Alternatively, you can use the <<setup-command,`setup`>>
-command to register the pipeline definitions in `definition.json`:
+An alternate upgrade method is to use the <<setup-command,`setup` command>>.
+This upgrade method can be useful if you're using an output other than Elasticsearch.
+In this case, you'll need to disable the active output and point APM Server at your Elasticsearch cluster.
+You can then run the `setup --pipeline` command to register the pipeline definitions in `definition.json`.
+
+Here's an example of what this might look like, if you typically output to Logstash:
 
 [source,sh]
 --------------------------------------------------
-./apm-server setup --pipelines -e -E apm-server.register.ingest.pipeline.overwrite=true
+apm-server setup --pipelines \
+    -E apm-server.register.ingest.pipeline.overwrite=true \
+    -E output.logstash.enabled=false \
+    -E output.elasticsearch.enabled=true \
+    -E output.elasticsearch.hosts=["http://username:password@elasticsearch:9200"]
 --------------------------------------------------

--- a/docs/upgrading-to-77.asciidoc
+++ b/docs/upgrading-to-77.asciidoc
@@ -1,0 +1,38 @@
+[[upgrading-to-77]]
+=== Upgrade to APM Server version 7.7
+
+++++
+<titleabbrev>Upgrade to version 7.7</titleabbrev>
+++++
+
+Version 7.7 adds a new `apm_remove_span_metadata` processor to the default <<default-pipeline,`apm` ingest pipeline>>.
+To save storage, this processor removes span metadata fields, like `host`, `kubernetes`, and `container`,
+that are already available on the parent transaction.
+
+While this processor is new, the functionality is not.
+In previous versions of APM Server, this functionality was hardcoded internally.
+However, there are use cases for including this metadata in span documents.
+Switching this metadata cleanup functionality to a processor allows you to define the span metadata that is important in your architecture.
+
+Failing to follow the upgrade steps will result in increased span metadata ingestion when upgrading to version 7.7.
+
+[[upgrade-steps-77]]
+==== Upgrade Steps
+
+. In order to avoid breaking custom pipeline definitions,
+pipelines are not overwritten when restarting APM Server.
+Enable pipeline overwriting by setting <<register.ingest.pipeline.overwrite,`register.ingest.pipeline.overwrite`>>
+to `true`.
+
+. Copy any custom pipelines you've created or altered to the pipeline definition file, located at
+`ingest/pipeline/definition.json`.
+
+. Restart APM Server.
+
+Alternatively, you can use the <<setup-command,`setup`>>
+command to register the pipeline definitions in `definition.json`:
+
+[source,sh]
+--------------------------------------------------
+./apm-server setup --pipelines -e -E apm-server.register.ingest.pipeline.overwrite=true
+--------------------------------------------------

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -10,12 +10,12 @@ However, check out the <<breaking-changes, breaking changes>> section for except
 
 Before upgrading:
 
-* Review the APM Server <<release-notes,release notes>> and <<breaking-changes, breaking changes>> 
+* Review the APM Server <<release-notes,release notes>> and <<breaking-changes, breaking changes>>
 for changes between your current APM Server version and the one you are upgrading to.
 * Visit the general APM {apm-overview-ref-v}/apm-release-notes.html[release highlights] and {apm-overview-ref-v}/apm-breaking-changes.html[breaking changes] for highlights and important changes.
-* Check the {stack-ref}/index.html[Elastic Stack Installation and Upgrade Guide] for guidance on how to upgrade your Elastic Stack. 
+* Check the {stack-ref}/index.html[Elastic Stack Installation and Upgrade Guide] for guidance on how to upgrade your Elastic Stack.
 
-When you're ready to upgrade your APM Server between minor versions, 
+When you're ready to upgrade your APM Server between minor versions,
 simply install the new release.
 
 You'll want to take a look at the `apm-server.yml` configuration file after installing a new release.
@@ -35,3 +35,5 @@ include::./breaking-changes.asciidoc[]
 include::./upgrading-to-65.asciidoc[]
 
 include::./upgrading-to-70.asciidoc[]
+
+include::./upgrading-to-77.asciidoc[]


### PR DESCRIPTION
## Motivation/summary

* Adds documentation for the new `apm_remove_span_metadata` processor
* Cleans up the original **Parse data using ingest node pipelines** documentation, and adds definitions for the four default processors in the `apm` pipeline
* Adds an **Upgrade to APM Server version 7.7** guide. This walks through the upgrade caveat that @simitt explains in https://github.com/elastic/apm-server/pull/3446#issuecomment-605875117.
* Cleans up the RUM configuration ingest pipeline information. Instead, users are directed to the updated `configuring-ingest` documentation.

## Questions

I don't quite understand [this](https://github.com/elastic/apm-server/issues/3441#issue-576922757) statement:

> One important caveat is that users with an output other than Elasticsearch need to run setup against Elasticsearch to load the new pipeline, otherwise span documents will start taking much more space.

## Docs preview

http://apm-server_3593.docs-preview.app.elstc.co/diff

## Related issues

Closes https://github.com/elastic/apm-server/issues/3441.