### PR TITLE
model/...: encapsulate schema validation

### DIFF
--- a/beater/api/intake/test_approved/InvalidEvent.approved.json
+++ b/beater/api/intake/test_approved/InvalidEvent.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{ \"transaction\": { \"id\": 12345, \"trace_id\": \"0123456789abcdef0123456789abcdef\", \"parent_id\": \"abcdefabcdef01234567\", \"type\": \"request\", \"duration\": 32.592981, \"span_count\": { \"started\": 21 } } }   ",
-            "message": "error validating JSON document against schema: I[#] S[#] doesn't validate with \"transaction#\"\n  I[#] S[#/allOf/3] allOf failed\n    I[#/id] S[#/allOf/3/properties/id/type] expected string, but got number"
+            "message": "failed to validate transaction: error validating JSON: I[#] S[#] doesn't validate with \"transaction#\"\n  I[#] S[#/allOf/3] allOf failed\n    I[#/id] S[#/allOf/3/properties/id/type] expected string, but got number"
         }
     ]
 }

--- a/beater/api/intake/test_approved/InvalidMetadata.approved.json
+++ b/beater/api/intake/test_approved/InvalidMetadata.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{\"metadata\": {\"user\": null}}",
-            "message": "error validating JSON document against schema: I[#] S[#] doesn't validate with \"metadata#\"\n  I[#] S[#/required] missing properties: \"service\""
+            "message": "failed to validate metadata: error validating JSON: I[#] S[#] doesn't validate with \"metadata#\"\n  I[#] S[#/required] missing properties: \"service\""
         }
     ]
 }

--- a/beater/api/profile/handler.go
+++ b/beater/api/profile/handler.go
@@ -126,14 +126,15 @@ func Handler(
 				for k, v := range c.RequestMetadata {
 					utility.InsertInMap(raw, k, v.(map[string]interface{}))
 				}
-				if err := validation.Validate(raw, metadata.ModelSchema()); err != nil {
-					return nil, requestError{
-						id:  request.IDResponseErrorsValidate,
-						err: errors.Wrap(err, "invalid metadata"),
-					}
-				}
 				metadata, err := metadata.DecodeMetadata(raw, false)
 				if err != nil {
+					var ve *validation.Error
+					if errors.As(err, &ve) {
+						return nil, requestError{
+							id:  request.IDResponseErrorsValidate,
+							err: errors.Wrap(err, "invalid metadata"),
+						}
+					}
 					return nil, requestError{
 						id:  request.IDResponseErrorsDecode,
 						err: errors.Wrap(err, "failed to decode metadata"),

--- a/model/metadata/metadata_test.go
+++ b/model/metadata/metadata_test.go
@@ -18,7 +18,6 @@
 package metadata
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,36 +36,36 @@ func TestDecodeMetadata(t *testing.T) {
 
 	for _, test := range []struct {
 		input  interface{}
-		err    error
+		err    string
 		output Metadata
 	}{
 		{
 			input: nil,
-			err:   nil,
+			err:   "failed to validate metadata: input missing",
 		},
 		{
 			input: "it doesn't work on strings",
-			err:   errors.New("invalid type for metadata"),
+			err:   "failed to validate metadata: invalid input type",
 		},
 		{
 			input: map[string]interface{}{"service": 123},
-			err:   errors.New("invalid type for service"),
+			err:   "invalid type for service",
 		},
 		{
 			input: map[string]interface{}{"system": 123},
-			err:   errors.New("invalid type for system"),
+			err:   "invalid type for system",
 		},
 		{
 			input: map[string]interface{}{"process": 123},
-			err:   errors.New("invalid type for process"),
+			err:   "invalid type for process",
 		},
 		{
 			input: map[string]interface{}{"user": 123},
-			err:   errors.New("invalid type for user"),
+			err:   "invalid type for user",
 		},
 		{
 			input: map[string]interface{}{"user": 123},
-			err:   errors.New("invalid type for user"),
+			err:   "invalid type for user",
 		},
 		{
 			input: map[string]interface{}{
@@ -105,10 +104,11 @@ func TestDecodeMetadata(t *testing.T) {
 		},
 	} {
 		output, err := DecodeMetadata(test.input, false)
-		require.Equal(t, test.err, err)
-		if test.err != nil {
+		if test.err != "" {
+			assert.EqualError(t, err, test.err)
 			assert.Nil(t, output)
 		} else {
+			assert.NoError(t, err)
 			if test.input == nil {
 				assert.Nil(t, output)
 			} else {

--- a/processor/stream/package_tests/error_attrs_test.go
+++ b/processor/stream/package_tests/error_attrs_test.go
@@ -196,7 +196,7 @@ func TestPayloadDataForError(t *testing.T) {
 	errorProcSetup().DataValidation(t,
 		[]tests.SchemaTestData{
 			{Key: "error",
-				Invalid: []tests.Invalid{{Msg: `/type`, Values: val{false}}}},
+				Invalid: []tests.Invalid{{Msg: `invalid input type`, Values: val{false}}}},
 			{Key: "error.exception.code", Valid: val{"success", ""},
 				Invalid: []tests.Invalid{{Msg: `exception/properties/code/type`, Values: val{false}}}},
 			{Key: "error.exception.attributes", Valid: val{map[string]interface{}{}},

--- a/processor/stream/test_approved_stream_result/testIntegrationResultInvalidEvent.approved.json
+++ b/processor/stream/test_approved_stream_result/testIntegrationResultInvalidEvent.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{ \"transaction\": { \"id\": 12345, \"trace_id\": \"0123456789abcdef0123456789abcdef\", \"parent_id\": \"abcdefabcdef01234567\", \"type\": \"request\", \"duration\": 32.592981, \"span_count\": { \"started\": 21 } } }   ",
-            "message": "error validating JSON document against schema: I[#] S[#] doesn't validate with \"transaction#\"\n  I[#] S[#/allOf/3] allOf failed\n    I[#/id] S[#/allOf/3/properties/id/type] expected string, but got number"
+            "message": "failed to validate transaction: error validating JSON: I[#] S[#] doesn't validate with \"transaction#\"\n  I[#] S[#/allOf/3] allOf failed\n    I[#/id] S[#/allOf/3/properties/id/type] expected string, but got number"
         }
     ]
 }

--- a/processor/stream/test_approved_stream_result/testIntegrationResultInvalidMetadata.approved.json
+++ b/processor/stream/test_approved_stream_result/testIntegrationResultInvalidMetadata.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{\"metadata\": {\"user\": null}}",
-            "message": "error validating JSON document against schema: I[#] S[#] doesn't validate with \"metadata#\"\n  I[#] S[#/required] missing properties: \"service\""
+            "message": "failed to validate metadata: error validating JSON: I[#] S[#] doesn't validate with \"metadata#\"\n  I[#] S[#/required] missing properties: \"service\""
         }
     ]
 }

--- a/tests/system/test_integration_logging.py
+++ b/tests/system/test_integration_logging.py
@@ -40,7 +40,7 @@ class LoggingIntegrationTest(ElasticTest):
                 "response_code": 400,
             }, req)
             error = req.get("error")
-            assert error.startswith("error validating JSON document against schema:"), json.dumps(req)
+            assert error.startswith("failed to validate transaction: error validating JSON document against schema:"), json.dumps(req)
 
 
 @integration_test

--- a/tests/system/test_integration_logging.py
+++ b/tests/system/test_integration_logging.py
@@ -40,7 +40,7 @@ class LoggingIntegrationTest(ElasticTest):
                 "response_code": 400,
             }, req)
             error = req.get("error")
-            assert error.startswith("failed to validate transaction: error validating JSON document against schema:"), json.dumps(req)
+            assert error.startswith("failed to validate transaction: error validating JSON:"), json.dumps(req)
 
 
 @integration_test

--- a/tests/system/test_requests.py
+++ b/tests/system/test_requests.py
@@ -41,7 +41,7 @@ class Test(ServerBaseTest):
         data = self.get_event_payload(name="invalid-event.ndjson")
         r = self.request_intake(data=data)
         assert r.status_code == 400, r.status_code
-        assert "failed to validate transaction: error validating JSON document against schema" in r.text, r.text
+        assert "failed to validate transaction: error validating JSON" in r.text, r.text
 
     def test_rum_default_disabled(self):
         r = self.request_intake(url='http://localhost:8200/intake/v2/rum/events')

--- a/tests/system/test_requests.py
+++ b/tests/system/test_requests.py
@@ -41,7 +41,7 @@ class Test(ServerBaseTest):
         data = self.get_event_payload(name="invalid-event.ndjson")
         r = self.request_intake(data=data)
         assert r.status_code == 400, r.status_code
-        assert "error validating JSON document against schema" in r.text, r.text
+        assert "failed to validate transaction: error validating JSON document against schema" in r.text, r.text
 
     def test_rum_default_disabled(self):
         r = self.request_intake(url='http://localhost:8200/intake/v2/rum/events')


### PR DESCRIPTION
## Motivation/summary

Move JSON-Schema validation into the model decoders, and unexpose the compiled JSON Schema objects.

This started out as something much simpler, moving the common validation code in decoders up to processor/stream, in response to https://github.com/elastic/apm-server/pull/3570#discussion_r400187492. I ended up going this route instead because:
 - moving the validation into the decoder itself, moving us closer to more efficient [combined validation/decoding](https://github.com/elastic/apm-server/issues/3551)
 - processor/stream shouldn't really care that much about the event structure; when we implement the above point, we'll no longer be operating on a map anyway

This change also removes a source of possible skew between validation and decoders, by ensuring the decoder cannot operate on input that fails JSON Schema validation. This is evident in the changes I had to make in the decoder tests, many of which had input that did not pass the JSON Schema validation.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

## How to test these changes

`make check test`

## Related issues

Relates to https://github.com/elastic/apm-server/issues/3551