### PR TITLE
[7.x] docs: Add RUM allow_headers configuration (#3592)

### DIFF
--- a/docs/configuration-rum.asciidoc
+++ b/docs/configuration-rum.asciidoc
@@ -28,6 +28,7 @@ apm-server.rum.enabled: true
 apm-server.rum.event_rate.limit: 300
 apm-server.rum.event_rate.lru_size: 1000
 apm-server.rum.allow_origins: ['*']
+apm-server.rum.allow_headers: ["header1", "header2"]
 apm-server.rum.library_pattern: "node_modules|bower_components|~"
 apm-server.rum.exclude_from_grouping: "^/webpack"
 apm-server.rum.source_mapping.enabled: true
@@ -66,6 +67,15 @@ User-agents send an Origin header that will be validated against this list.
 This is done automatically by modern browsers as part of the https://www.w3.org/TR/cors/[CORS specification].
 An origin is made of a protocol scheme, host and port, without the URL path.
 Default value is set to `['*']`, which allows everything.
+
+[float]
+[[rum-allow-headers]]
+==== `allow_headers`
+By default, HTTP requests made from the RUM agent to the APM Server are limited in the HTTP headers they are allowed to have.
+If any other headers are added, the request will be rejected by the browser due to Cross-Origin Resource Sharing (CORS) restrictions.
+If you need to add extra headers to these requests, you can use this configuration to allow additional headers. 
+The default list of values includes "Content-Type", "Content-Encoding", and "Accept";
+custom values configured here are appended to the default list and used as the value for the `Access-Control-Allow-Headers` header.
 
 [float]
 [[rum-library-pattern]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: Add RUM allow_headers configuration (#3592)