### PR TITLE
[Doc] Improvements for APM fields

### DIFF
--- a/docs/configuring-output-after.asciidoc
+++ b/docs/configuring-output-after.asciidoc
@@ -12,7 +12,7 @@ See <<config-sourcemapping-elasticsearch>> for more details.
 [float]
 === `fields`
 
-Fields are optional tags that can be added to any output.
+Fields are optional tags that can be added to all outputs.
 Fields can be scalar values, arrays, dictionaries, or any nested combination of these.
 By default, the fields that you specify here will be grouped under a `fields` sub-dictionary in the output document.
 
@@ -21,6 +21,9 @@ Example:
 [source,yaml]
 ------------------------------------------------------------------------------
 fields: {project: "myproject", instance-id: "574734885120952459"}
+#-------------------------- Elasticsearch output --------------------------
+output.elasticsearch:
+  hosts: ["localhost:9200"]
 ------------------------------------------------------------------------------
 
 To store the custom fields as top-level fields, set the `fields_under_root` option to true.

--- a/docs/configuring-output-after.asciidoc
+++ b/docs/configuring-output-after.asciidoc
@@ -17,7 +17,7 @@ They are defined at the top-level in your configuration file, and will apply to 
 Fields can be scalar values, arrays, dictionaries, or any nested combination of these.
 By default, the fields that you specify here will be grouped under a `fields` sub-dictionary in the output document.
 
-Example:
+Example using the Elasticsearch output:
 
 [source,yaml]
 ------------------------------------------------------------------------------

--- a/docs/configuring-output-after.asciidoc
+++ b/docs/configuring-output-after.asciidoc
@@ -12,7 +12,8 @@ See <<config-sourcemapping-elasticsearch>> for more details.
 [float]
 === `fields`
 
-Fields are optional tags that can be added to all outputs.
+Fields are optional tags that can be added to the documents that APM Server outputs.
+They are defined at the top-level in your configuration file, and will apply to any configured output.
 Fields can be scalar values, arrays, dictionaries, or any nested combination of these.
 By default, the fields that you specify here will be grouped under a `fields` sub-dictionary in the output document.
 


### PR DESCRIPTION
## Motivation/summary

Docs says:
> Fields are optional tags that can be added to any output.

https://www.elastic.co/guide/en/apm/server/7.6/configuring-output.html#libbeat-configuration-fields

Which makes me expect an APM server configuration like the following:

```yml
#-------------------------- Elasticsearch output --------------------------
output.elasticsearch:
  hosts: ["localhost:9200"]
  fields: {project: "myproject", instance-id: "574734885120952459"}
```

But actually field cannot be placed under a specific output, otherwise `fields` don't get send to it.
Instead, it's necessary to define `fields` under the root configuration like the following:


```yml
fields: {project: "myproject", instance-id: "574734885120952459"}
#-------------------------- Elasticsearch output --------------------------
output.elasticsearch:
  hosts: ["localhost:9200"]
``` 

Which gives the expected output:

```json
"fields": {
      "instance-id": "574734885120952459",
      "project": "myproject"
    },
```

I'm open to suggestions for better wording as well.
Thanks.

