### PR TITLE
[7.x] Revert "Require a minimum version in the RUM V3 handler." (#3610)

### DIFF
--- a/beater/api/mux.go
+++ b/beater/api/mux.go
@@ -19,12 +19,8 @@ package api
 
 import (
 	"expvar"
-	"fmt"
 	"net/http"
 	"regexp"
-
-	"github.com/elastic/beats/v7/libbeat/common"
-	"github.com/elastic/beats/v7/libbeat/version"
 
 	"github.com/elastic/beats/v7/libbeat/monitoring"
 
@@ -151,12 +147,7 @@ func rumV3IntakeHandler(cfg *config.Config, _ *authorization.Builder, reporter p
 		return nil, err
 	}
 	h := intake.Handler(stream.RUMV3Processor(cfg, tcfg), reporter)
-	releaseVersion := common.Version{Major: 7, Minor: 8}
-	enabled := releaseVersion.LessThanOrEqual(false, common.MustNewVersion(version.GetDefaultVersion()))
-	m := append(rumMiddleware(cfg, nil, intake.MonitoringMap),
-		middleware.KillSwitchMiddleware(enabled,
-			fmt.Sprintf("RUM V3 endpoint is disabled in this version. Update to %s or higher", releaseVersion.String())))
-	return middleware.Wrap(h, m...)
+	return middleware.Wrap(h, rumMiddleware(cfg, nil, intake.MonitoringMap)...)
 }
 
 func sourcemapHandler(cfg *config.Config, builder *authorization.Builder, reporter publish.Reporter) (request.Handler, error) {

--- a/beater/api/mux_intake_rum_test.go
+++ b/beater/api/mux_intake_rum_test.go
@@ -18,14 +18,9 @@
 package api
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/elastic/apm-server/tests/loader"
-	"github.com/elastic/beats/v7/libbeat/common"
-	"github.com/elastic/beats/v7/libbeat/version"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -132,26 +127,6 @@ func TestRumHandler_MonitoringMiddleware(t *testing.T) {
 
 	equal, result := beatertest.CompareMonitoringInt(h, c, expected, intake.MonitoringMap)
 	assert.True(t, equal, result)
-}
-
-func TestRUMV3HandlerMinVersion(t *testing.T) {
-	cfg := cfgEnabledRUM()
-	body, err := loader.LoadDataAsStream("../testdata/intake-v3/rum_events.ndjson")
-	require.NoError(t, err)
-	h, err := rumV3IntakeHandler(cfg, nil, beatertest.NilReporter)
-	require.NoError(t, err)
-	c, w := beatertest.ContextWithResponseRecorder(http.MethodPost, IntakeRUMV3Path)
-	c.Request.Body = body
-	c.Request.Header.Set(headers.ContentType, "application/x-ndjson")
-	h(c)
-	content, err := ioutil.ReadAll(w.Body)
-	require.NoError(t, err)
-	current := common.MustNewVersion(version.GetDefaultVersion())
-	if current.Major > 7 || (current.Major == 7 && current.Minor > 7) {
-		assert.Equal(t, http.StatusAccepted, w.Code, string(content))
-	} else {
-		assert.Equal(t, http.StatusForbidden, w.Code, string(content))
-	}
 }
 
 func cfgEnabledRUM() *config.Config {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Revert "Require a minimum version in the RUM V3 handler." (#3610)