### PR TITLE
model/field: avoid closures

### DIFF
--- a/model/field/rum_v3_mapping.go
+++ b/model/field/rum_v3_mapping.go
@@ -121,30 +121,42 @@ var rumV3Mapping = map[string]string{
 	"version":                     "ve",
 }
 
-func Mapper(shortFieldNames bool) func(string) string {
-	return func(s string) string {
-		shortField, ok := rumV3Mapping[s]
-		if ok && shortFieldNames {
-			return shortField
-		}
-		return s
+var rumV3InverseMapping = make(map[string]string)
+
+func init() {
+	for k, v := range rumV3Mapping {
+		rumV3InverseMapping[v] = k
 	}
 }
 
-var rumV3InverseMapping = func() map[string]string {
-	m := make(map[string]string)
-	for k, v := range rumV3Mapping {
-		m[v] = k
+func Mapper(shortFieldNames bool) func(string) string {
+	if shortFieldNames {
+		return rumV3Mapper
 	}
-	return m
-}()
+	return identityMapper
+}
 
 func InverseMapper(shortFieldNames bool) func(string) string {
-	return func(s string) string {
-		longField, ok := rumV3InverseMapping[s]
-		if ok && shortFieldNames {
-			return longField
-		}
-		return s
+	if shortFieldNames {
+		return rumV3InverseMapper
 	}
+	return identityMapper
+}
+
+func rumV3Mapper(long string) string {
+	if short, ok := rumV3Mapping[long]; ok {
+		return short
+	}
+	return long
+}
+
+func rumV3InverseMapper(short string) string {
+	if long, ok := rumV3InverseMapping[short]; ok {
+		return long
+	}
+	return short
+}
+
+func identityMapper(s string) string {
+	return s
 }


### PR DESCRIPTION
## Motivation/summary

Modify `model/field.Mapper` (and InverseMapper) to stop creating closures, which cause both allocation and CPU overhead. Instead, check `shortFieldNames` and return a different static function depending on its value. Because we call field mappers frequently, this has a noticeable impact on micro-benchmarks.

I've added a benchmark for DecodeMetadata in a separate branch (https://github.com/axw/apm-server/tree/benchmark-metadata-old), as part of https://github.com/elastic/apm-server/pull/3618. I pulled the commit into that branch to compare:


```
name              old time/op    new time/op    delta
DecodeMetadata-8    9.74µs ± 5%    8.93µs ± 2%  -8.40%  (p=0.008 n=5+5)

name              old alloc/op   new alloc/op   delta
DecodeMetadata-8    1.31kB ± 0%    1.26kB ± 0%  -3.66%  (p=0.008 n=5+5)

name              old allocs/op  new allocs/op  delta
DecodeMetadata-8      61.0 ± 0%      58.0 ± 0%  -4.92%  (p=0.008 n=5+5)
```

Also, use `func init` rather than an anonymous function "one-liner" for creating the inverse mapping. This is what it's made for.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

## How to test these changes

`make test`

## Related issues

None.