### PR TITLE
[7.6] docs: improvements for APM fields (#3608)

### DIFF
--- a/docs/configuring-output-after.asciidoc
+++ b/docs/configuring-output-after.asciidoc
@@ -12,15 +12,19 @@ See <<config-sourcemapping-elasticsearch>> for more details.
 [float]
 === `fields`
 
-Fields are optional tags that can be added to any output.
+Fields are optional tags that can be added to the documents that APM Server outputs.
+They are defined at the top-level in your configuration file, and will apply to any configured output.
 Fields can be scalar values, arrays, dictionaries, or any nested combination of these.
 By default, the fields that you specify here will be grouped under a `fields` sub-dictionary in the output document.
 
-Example:
+Example using the Elasticsearch output:
 
 [source,yaml]
 ------------------------------------------------------------------------------
 fields: {project: "myproject", instance-id: "574734885120952459"}
+#-------------------------- Elasticsearch output --------------------------
+output.elasticsearch:
+  hosts: ["localhost:9200"]
 ------------------------------------------------------------------------------
 
 To store the custom fields as top-level fields, set the `fields_under_root` option to true.


### PR DESCRIPTION
Backports the following commits to 7.6:
 - docs: improvements for APM fields (#3608)