### PR TITLE
[7.x] model/...: remove error parameter from decoders (#3571)

### DIFF
--- a/model/error/event.go
+++ b/model/error/event.go
@@ -119,14 +119,11 @@ type Log struct {
 	Stacktrace   m.Stacktrace
 }
 
-func DecodeRUMV3Event(input m.Input, err error) (transform.Transformable, error) {
-	return DecodeEvent(input, err)
+func DecodeRUMV3Event(input m.Input) (transform.Transformable, error) {
+	return DecodeEvent(input)
 }
 
-func DecodeEvent(input m.Input, err error) (transform.Transformable, error) {
-	if err != nil {
-		return nil, err
-	}
+func DecodeEvent(input m.Input) (transform.Transformable, error) {
 	if input.Raw == nil {
 		return nil, errMissingInput
 	}

--- a/model/error/event_test.go
+++ b/model/error/event_test.go
@@ -102,14 +102,13 @@ func TestErrorEventDecode(t *testing.T) {
 	ctxUrl := m.Url{Original: &origUrl}
 
 	for name, test := range map[string]struct {
-		input       interface{}
-		cfg         m.Config
-		err, inpErr error
-		e           *Event
+		input interface{}
+		cfg   m.Config
+		err   error
+		e     *Event
 	}{
-		"no input":               {input: nil, err: errMissingInput, e: nil},
-		"an error passed as arg": {input: nil, inpErr: errors.New("a"), err: errors.New("a"), e: nil},
-		"invalid type":           {input: "", err: errInvalidType, e: nil},
+		"no input":     {input: nil, err: errMissingInput, e: nil},
+		"invalid type": {input: "", err: errInvalidType, e: nil},
 		"error decoding timestamp": {
 			input: map[string]interface{}{"timestamp": 123},
 			err:   utility.ErrFetch,
@@ -295,7 +294,7 @@ func TestErrorEventDecode(t *testing.T) {
 				Raw:         test.input,
 				RequestTime: requestTime,
 				Config:      test.cfg,
-			}, test.inpErr)
+			})
 			if test.e != nil && assert.NotNil(t, transformable) {
 				event := transformable.(*Event)
 				assert.Equal(t, test.e, event)
@@ -328,7 +327,7 @@ func TestHandleExceptionTree(t *testing.T) {
 			},
 		},
 	}
-	result, err := DecodeEvent(m.Input{Raw: errorEvent}, nil)
+	result, err := DecodeEvent(m.Input{Raw: errorEvent})
 	require.NoError(t, err)
 
 	event := result.(*Event)
@@ -355,7 +354,7 @@ func TestDecodingAnomalies(t *testing.T) {
 				"type":    "type0",
 			},
 		}
-		result, err := DecodeEvent(m.Input{Raw: badID}, nil)
+		result, err := DecodeEvent(m.Input{Raw: badID})
 		assert.Error(t, err)
 		assert.Nil(t, result)
 	})
@@ -371,7 +370,7 @@ func TestDecodingAnomalies(t *testing.T) {
 				},
 			},
 		}
-		result, err := DecodeEvent(m.Input{Raw: badException}, nil)
+		result, err := DecodeEvent(m.Input{Raw: badException})
 		assert.Error(t, err)
 		assert.Nil(t, result)
 	})
@@ -385,7 +384,7 @@ func TestDecodingAnomalies(t *testing.T) {
 				"cause":   []interface{}{7.4},
 			},
 		}
-		result, err := DecodeEvent(m.Input{Raw: badException}, nil)
+		result, err := DecodeEvent(m.Input{Raw: badException})
 		assert.Error(t, err)
 		assert.EqualError(t, err, "cause must be an exception")
 		assert.Nil(t, result)
@@ -402,7 +401,7 @@ func TestDecodingAnomalies(t *testing.T) {
 				},
 			},
 		}
-		result, err := DecodeEvent(m.Input{Raw: emptyCauses}, nil)
+		result, err := DecodeEvent(m.Input{Raw: emptyCauses})
 		require.NoError(t, err)
 		assert.NotNil(t, result)
 

--- a/model/metricset/event.go
+++ b/model/metricset/event.go
@@ -86,10 +86,7 @@ type metricsetDecoder struct {
 	*utility.ManualDecoder
 }
 
-func DecodeEvent(input model.Input, err error) (transform.Transformable, error) {
-	if err != nil {
-		return nil, err
-	}
+func DecodeEvent(input model.Input) (transform.Transformable, error) {
 	if input.Raw == nil {
 		return nil, errors.New("no data for metric event")
 	}

--- a/model/metricset/event_test.go
+++ b/model/metricset/event_test.go
@@ -168,11 +168,10 @@ func TestDecode(t *testing.T) {
 			},
 		},
 	} {
-		var err error
 		transformables, err := DecodeEvent(model.Input{
 			Raw:         test.input,
 			RequestTime: requestTime,
-		}, err)
+		})
 		if test.err != nil {
 			assert.Error(t, err)
 		}

--- a/model/span/event.go
+++ b/model/span/event.go
@@ -273,15 +273,12 @@ func (d *DestinationService) fields() common.MapStr {
 	return fields
 }
 
-func DecodeRUMV3Event(input m.Input, err error) (transform.Transformable, error) {
-	return DecodeEvent(input, err)
+func DecodeRUMV3Event(input m.Input) (transform.Transformable, error) {
+	return DecodeEvent(input)
 }
 
 // DecodeEvent decodes a span event.
-func DecodeEvent(input m.Input, err error) (transform.Transformable, error) {
-	if err != nil {
-		return nil, err
-	}
+func DecodeEvent(input m.Input) (transform.Transformable, error) {
 	if input.Raw == nil {
 		return nil, errMissingInput
 	}

--- a/model/span/event_test.go
+++ b/model/span/event_test.go
@@ -20,7 +20,6 @@ package span
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -80,12 +79,10 @@ func TestDecodeSpan(t *testing.T) {
 		input interface{}
 		cfg   m.Config
 		// we don't use a regular `error.New` here, because some errors are of a different type
-		err    string
-		inpErr error
-		e      transform.Transformable
+		err string
+		e   transform.Transformable
 	}{
 		"no input":     {input: nil, err: errMissingInput.Error()},
-		"input error":  {input: nil, inpErr: errors.New("a"), err: "a"},
 		"invalid type": {input: "", err: errInvalidType.Error()},
 		"missing required field": {
 			input: map[string]interface{}{},
@@ -268,7 +265,7 @@ func TestDecodeSpan(t *testing.T) {
 				Raw:         test.input,
 				RequestTime: requestTime,
 				Config:      test.cfg,
-			}, test.inpErr)
+			})
 			if test.err == "" {
 				require.Nil(t, err)
 				assert.Equal(t, test.e, span)

--- a/model/transaction/event.go
+++ b/model/transaction/event.go
@@ -91,8 +91,8 @@ type SpanCount struct {
 	Started *int
 }
 
-func DecodeRUMV3Event(input m.Input, err error) (transform.Transformable, error) {
-	transformable, err := DecodeEvent(input, err)
+func DecodeRUMV3Event(input m.Input) (transform.Transformable, error) {
+	transformable, err := DecodeEvent(input)
 	if err != nil {
 		return transformable, err
 	}
@@ -145,10 +145,7 @@ func decodeRUMV3Marks(event *Event, raw map[string]interface{}, cfg m.Config) (t
 	return event, decoder.Err
 }
 
-func DecodeEvent(input m.Input, err error) (transform.Transformable, error) {
-	if err != nil {
-		return nil, err
-	}
+func DecodeEvent(input m.Input) (transform.Transformable, error) {
 	if input.Raw == nil {
 		return nil, errMissingInput
 	}

--- a/model/transaction/event_test.go
+++ b/model/transaction/event_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -41,17 +40,16 @@ import (
 
 func TestTransactionEventDecodeFailure(t *testing.T) {
 	for name, test := range map[string]struct {
-		input       interface{}
-		err, inpErr error
-		e           *Event
+		input interface{}
+		err   error
+		e     *Event
 	}{
 		"no input":           {input: nil, err: errMissingInput, e: nil},
-		"input error":        {input: nil, inpErr: errors.New("a"), err: errors.New("a"), e: nil},
 		"invalid type":       {input: "", err: errInvalidType, e: nil},
 		"cannot fetch field": {input: map[string]interface{}{}, err: utility.ErrFetch, e: nil},
 	} {
 		t.Run(name, func(t *testing.T) {
-			transformable, err := DecodeEvent(model.Input{Raw: test.input}, test.inpErr)
+			transformable, err := DecodeEvent(model.Input{Raw: test.input})
 			assert.Equal(t, test.err, err)
 			if test.e != nil {
 				event := transformable.(*Event)
@@ -255,7 +253,7 @@ func TestTransactionEventDecode(t *testing.T) {
 				Raw:         test.input,
 				RequestTime: requestTime,
 				Config:      test.cfg,
-			}, nil)
+			})
 			if test.err != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), test.err)

--- a/processor/stream/processor.go
+++ b/processor/stream/processor.go
@@ -54,7 +54,7 @@ const (
 
 type processorModel struct {
 	schema       *jsonschema.Schema
-	modelDecoder func(model.Input, error) (transform.Transformable, error)
+	modelDecoder func(model.Input) (transform.Transformable, error)
 }
 
 type Processor struct {
@@ -187,12 +187,12 @@ func (p *Processor) HandleRawModel(rawModel map[string]interface{}, requestTime 
 			if err != nil {
 				return nil, err
 			}
-			input := model.Input{
+
+			tr, err := m.modelDecoder(model.Input{
 				Raw:         entry,
 				RequestTime: requestTime,
 				Config:      p.Mconfig,
-			}
-			tr, err := m.modelDecoder(input, err)
+			})
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - model/...: remove error parameter from decoders (#3571)