### PR TITLE
[7.x] all: add metadata directly to model types (#3573)

### DIFF
--- a/beater/api/asset/sourcemap/handler.go
+++ b/beater/api/asset/sourcemap/handler.go
@@ -69,17 +69,14 @@ func Handler(dec RequestDecoder, processor asset.Processor, cfg transform.Config
 			return
 		}
 
-		metadata, transformables, err := processor.Decode(data)
+		transformables, err := processor.Decode(data)
 		if err != nil {
 			c.Result.SetWithError(request.IDResponseErrorsDecode, err)
 			c.Write()
 			return
 		}
 
-		tctx := &transform.Context{
-			Config:   cfg,
-			Metadata: *metadata,
-		}
+		tctx := &transform.Context{Config: cfg}
 		req := publish.PendingReq{Transformables: transformables, Tcontext: tctx}
 		span, ctx := apm.StartSpan(c.Request.Context(), "Send", "Reporter")
 		defer span.End()

--- a/beater/api/asset/sourcemap/handler_test.go
+++ b/beater/api/asset/sourcemap/handler_test.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/elastic/apm-server/beater/beatertest"
 	"github.com/elastic/apm-server/beater/request"
-	"github.com/elastic/apm-server/model/metadata"
 	"github.com/elastic/apm-server/processor/asset"
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/apm-server/tests/loader"
@@ -150,11 +149,11 @@ func (p *mockProcessor) Validate(m map[string]interface{}) error {
 	}
 	return nil
 }
-func (p *mockProcessor) Decode(m map[string]interface{}) (*metadata.Metadata, []transform.Transformable, error) {
+func (p *mockProcessor) Decode(m map[string]interface{}) ([]transform.Transformable, error) {
 	if _, ok := m["mockProcessor"]; ok {
-		return nil, nil, errors.New("processor decode error")
+		return nil, errors.New("processor decode error")
 	}
-	return &metadata.Metadata{}, nil, nil
+	return nil, nil
 }
 func (p *mockProcessor) Name() string {
 	return "mockProcessor"

--- a/beater/api/profile/handler.go
+++ b/beater/api/profile/handler.go
@@ -88,6 +88,7 @@ func Handler(
 
 		var totalLimitRemaining int64 = profileContentLengthLimit
 		var profiles []*pprof_profile.Profile
+		var profileMetadata metadata.Metadata
 		mr, err := c.Request.MultipartReader()
 		if err != nil {
 			return nil, err
@@ -138,7 +139,7 @@ func Handler(
 						err: errors.Wrap(err, "failed to decode metadata"),
 					}
 				}
-				tctx.Metadata = *metadata
+				profileMetadata = *metadata
 
 			case "profile":
 				params, err := validateContentType(http.Header(part.Header), pprofMediaType)
@@ -178,7 +179,10 @@ func Handler(
 
 		transformables := make([]transform.Transformable, len(profiles))
 		for i, p := range profiles {
-			transformables[i] = profile.PprofProfile{Profile: p}
+			transformables[i] = profile.PprofProfile{
+				Metadata: profileMetadata,
+				Profile:  p,
+			}
 		}
 
 		if err := report(c.Request.Context(), publish.PendingReq{

--- a/beater/api/profile/handler_test.go
+++ b/beater/api/profile/handler_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 
 	"github.com/elastic/apm-server/beater/api/ratelimit"
+	"github.com/elastic/apm-server/model/profile"
 	"github.com/elastic/apm-server/transform"
 
 	"github.com/stretchr/testify/assert"
@@ -145,7 +146,10 @@ func TestHandler(t *testing.T) {
 			reporter: func(t *testing.T) publish.Reporter {
 				return func(ctx context.Context, req publish.PendingReq) error {
 					require.Len(t, req.Transformables, 2)
-					assert.Equal(t, "foo", *req.Tcontext.Metadata.Service.Name)
+					for _, tr := range req.Transformables {
+						profile := tr.(profile.PprofProfile)
+						assert.Equal(t, "foo", *profile.Metadata.Service.Name)
+					}
 					return nil
 				}
 			},

--- a/model/input.go
+++ b/model/input.go
@@ -19,6 +19,8 @@ package model
 
 import (
 	"time"
+
+	"github.com/elastic/apm-server/model/metadata"
 )
 
 // Input holds the input required for decoding an event.
@@ -30,6 +32,9 @@ type Input struct {
 	// by the server. This is used to set the timestamp for
 	// events sent by RUM.
 	RequestTime time.Time
+
+	// Metadata holds metadata that may be added to the event.
+	Metadata metadata.Metadata
 
 	// Config holds configuration for decoding.
 	//

--- a/model/metadata/metadata.go
+++ b/model/metadata/metadata.go
@@ -77,17 +77,13 @@ func DecodeMetadata(input interface{}, hasShortFieldNames bool) (*Metadata, erro
 	if err != nil {
 		return nil, err
 	}
-	return NewMetadata(service, system, process, user, labels), nil
-}
-
-func NewMetadata(service *Service, system *System, process *Process, user *User, labels common.MapStr) *Metadata {
 	return &Metadata{
 		Service: service,
 		System:  system,
 		Process: process,
 		User:    user,
 		Labels:  labels,
-	}
+	}, nil
 }
 
 func (m *Metadata) Set(fields common.MapStr) common.MapStr {

--- a/model/metadata/service.go
+++ b/model/metadata/service.go
@@ -36,7 +36,7 @@ type Service struct {
 	Runtime     Runtime
 	Framework   Framework
 	Agent       Agent
-	node        node
+	Node        ServiceNode
 }
 
 //Language has an optional version and name
@@ -64,8 +64,8 @@ type Agent struct {
 	EphemeralId *string
 }
 
-type node struct {
-	name *string
+type ServiceNode struct {
+	Name *string
 }
 
 //DecodeService decodes a given input into a Service instance
@@ -100,8 +100,8 @@ func DecodeService(input interface{}, hasShortFieldNames bool, err error) (*Serv
 			Name:    decoder.StringPtr(raw, fieldName("name"), fieldName("runtime")),
 			Version: decoder.StringPtr(raw, fieldName("version"), fieldName("runtime")),
 		},
-		node: node{
-			name: decoder.StringPtr(raw, "configured_name", "node"),
+		Node: ServiceNode{
+			Name: decoder.StringPtr(raw, "configured_name", "node"),
 		},
 	}
 	return &service, decoder.Err
@@ -115,7 +115,7 @@ func (s *Service) Fields(containerID, hostName string) common.MapStr {
 	svc := common.MapStr{}
 	utility.Set(svc, "name", s.Name)
 	utility.Set(svc, "environment", s.Environment)
-	utility.Set(svc, "node", s.node.fields(containerID, hostName))
+	utility.Set(svc, "node", s.Node.fields(containerID, hostName))
 	utility.Set(svc, "version", s.Version)
 
 	lang := common.MapStr{}
@@ -144,9 +144,9 @@ func (s *Service) AgentFields() common.MapStr {
 	return s.Agent.fields()
 }
 
-func (n *node) fields(containerID, hostName string) common.MapStr {
-	if n.name != nil && *n.name != "" {
-		return common.MapStr{"name": *n.name}
+func (n *ServiceNode) fields(containerID, hostName string) common.MapStr {
+	if n.Name != nil && *n.Name != "" {
+		return common.MapStr{"name": *n.Name}
 	}
 	if containerID != "" {
 		return common.MapStr{"name": containerID}

--- a/model/metadata/service_test.go
+++ b/model/metadata/service_test.go
@@ -82,7 +82,7 @@ func TestServiceTransform(t *testing.T) {
 					Name:    &agentName,
 					Version: &agentVersion,
 				},
-				node: node{name: &serviceNodeName},
+				Node: ServiceNode{Name: &serviceNodeName},
 			},
 			ContainerID: "foo",
 			HostName:    "bar",

--- a/model/metricset/event.go
+++ b/model/metricset/event.go
@@ -32,6 +32,7 @@ import (
 
 	logs "github.com/elastic/apm-server/log"
 	"github.com/elastic/apm-server/model"
+	"github.com/elastic/apm-server/model/metadata"
 	"github.com/elastic/apm-server/model/metricset/generated/schema"
 	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/apm-server/utility"
@@ -75,6 +76,7 @@ type Span struct {
 }
 
 type Metricset struct {
+	Metadata    metadata.Metadata
 	Samples     []*Sample
 	Labels      common.MapStr
 	Transaction *Transaction
@@ -101,6 +103,7 @@ func DecodeEvent(input model.Input) (transform.Transformable, error) {
 		Transaction: md.decodeTransaction(raw[transactionKey]),
 		Span:        md.decodeSpan(raw[spanKey]),
 		Timestamp:   md.TimeEpochMicro(raw, "timestamp"),
+		Metadata:    input.Metadata,
 	}
 
 	if md.Err != nil {
@@ -218,7 +221,7 @@ func (me *Metricset) Transform(ctx context.Context, tctx *transform.Context) []b
 	}
 
 	fields["processor"] = processorEntry
-	tctx.Metadata.Set(fields)
+	me.Metadata.Set(fields)
 
 	// merges with metadata labels, overrides conflicting keys
 	utility.DeepUpdate(fields, "labels", me.Labels)

--- a/model/profile/profile.go
+++ b/model/profile/profile.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cespare/xxhash/v2"
 	"github.com/google/pprof/profile"
 
+	"github.com/elastic/apm-server/model/metadata"
 	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -43,11 +44,12 @@ var processorEntry = common.MapStr{
 
 // PprofProfile represents a resource profile.
 type PprofProfile struct {
-	Profile *profile.Profile
+	Metadata metadata.Metadata
+	Profile  *profile.Profile
 }
 
 // Transform transforms a Profile into a sequence of beat.Events: one per profile sample.
-func (pp PprofProfile) Transform(ctx context.Context, tctx *transform.Context) []beat.Event {
+func (pp PprofProfile) Transform(ctx context.Context, _ *transform.Context) []beat.Event {
 	// Precompute value field names for use in each event.
 	// TODO(axw) limit to well-known value names?
 	profileTimestamp := time.Unix(0, pp.Profile.TimeNanos)
@@ -108,7 +110,7 @@ func (pp PprofProfile) Transform(ctx context.Context, tctx *transform.Context) [
 				profileDocType: profileFields,
 			},
 		}
-		tctx.Metadata.Set(event.Fields)
+		pp.Metadata.Set(event.Fields)
 		if len(sample.Label) > 0 {
 			labels := make(common.MapStr)
 			for k, v := range sample.Label {

--- a/model/profile/profile_test.go
+++ b/model/profile/profile_test.go
@@ -34,8 +34,15 @@ import (
 )
 
 func TestPprofProfileTransform(t *testing.T) {
+	serviceName, env := "myService", "staging"
+	service := metadata.Service{
+		Name:        &serviceName,
+		Environment: &env,
+	}
+
 	timestamp := time.Unix(123, 456)
 	pp := profile.PprofProfile{
+		Metadata: metadata.Metadata{Service: &service},
 		Profile: &pprof_profile.Profile{
 			TimeNanos:     timestamp.UnixNano(),
 			DurationNanos: int64(10 * time.Second),
@@ -79,18 +86,7 @@ func TestPprofProfileTransform(t *testing.T) {
 		},
 	}
 
-	serviceName, env := "myService", "staging"
-	service := metadata.Service{
-		Name:        &serviceName,
-		Environment: &env,
-	}
-	metadata := metadata.Metadata{Service: &service}
-
-	tctx := &transform.Context{
-		Config:   transform.Config{}, // not used
-		Metadata: metadata,
-	}
-	output := pp.Transform(context.Background(), tctx)
+	output := pp.Transform(context.Background(), &transform.Context{})
 	require.Len(t, output, 2)
 	assert.Equal(t, output[0], output[1])
 

--- a/model/stacktrace_test.go
+++ b/model/stacktrace_test.go
@@ -140,13 +140,8 @@ func TestStacktraceTransform(t *testing.T) {
 		},
 	}
 
-	tctx := transform.Context{
-		Metadata: metadata.Metadata{
-			Service: &service,
-		},
-	}
 	for idx, test := range tests {
-		output := test.Stacktrace.Transform(context.Background(), &tctx)
+		output := test.Stacktrace.Transform(context.Background(), &transform.Context{}, &service)
 		assert.Equal(t, test.Output, output, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 	}
 }
@@ -289,13 +284,12 @@ func TestStacktraceTransformWithSourcemapping(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			tctx := &transform.Context{
-				Config:   transform.Config{SourcemapStore: testSourcemapStore(t, test.ESClientWithValidSourcemap(t))},
-				Metadata: metadata.Metadata{Service: &service},
+				Config: transform.Config{SourcemapStore: testSourcemapStore(t, test.ESClientWithValidSourcemap(t))},
 			}
 
 			// run `Stacktrace.Transform` twice to ensure method is idempotent
-			tc.Stacktrace.Transform(context.Background(), tctx)
-			output := tc.Stacktrace.Transform(context.Background(), tctx)
+			tc.Stacktrace.Transform(context.Background(), tctx, &service)
+			output := tc.Stacktrace.Transform(context.Background(), tctx, &service)
 			assert.Equal(t, tc.Output, output)
 		})
 	}

--- a/model/test_approved_model/context_full_event with experimental=true.approved.json
+++ b/model/test_approved_model/context_full_event with experimental=true.approved.json
@@ -82,6 +82,9 @@
             "Version": "8"
         },
         "Name": "myService",
+        "Node": {
+            "Name": null
+        },
         "Runtime": {
             "Name": "node",
             "Version": "8.0.0"

--- a/model/transaction/event.go
+++ b/model/transaction/event.go
@@ -60,6 +60,8 @@ func ModelSchema() *jsonschema.Schema {
 }
 
 type Event struct {
+	Metadata metadata.Metadata
+
 	Id       string
 	ParentId *string
 	TraceId  string
@@ -161,6 +163,7 @@ func DecodeEvent(input m.Input) (transform.Transformable, error) {
 	decoder := utility.ManualDecoder{}
 	fieldName := field.Mapper(input.Config.HasShortFieldNames)
 	e := Event{
+		Metadata:     input.Metadata,
 		Id:           decoder.String(raw, "id"),
 		Type:         decoder.String(raw, fieldName("type")),
 		Name:         decoder.StringPtr(raw, fieldName("name")),
@@ -236,7 +239,7 @@ func (e *Event) Transform(ctx context.Context, tctx *transform.Context) []beat.E
 	}
 
 	// first set generic metadata (order is relevant)
-	tctx.Metadata.Set(fields)
+	e.Metadata.Set(fields)
 
 	// then merge event specific information
 	utility.Update(fields, "user", e.User.Fields())

--- a/processor/asset/processor.go
+++ b/processor/asset/processor.go
@@ -18,12 +18,11 @@
 package asset
 
 import (
-	"github.com/elastic/apm-server/model/metadata"
 	"github.com/elastic/apm-server/transform"
 )
 
 type Processor interface {
 	Validate(map[string]interface{}) error
-	Decode(map[string]interface{}) (*metadata.Metadata, []transform.Transformable, error)
+	Decode(map[string]interface{}) ([]transform.Transformable, error)
 	Name() string
 }

--- a/processor/asset/sourcemap/package_tests/processor_test.go
+++ b/processor/asset/sourcemap/package_tests/processor_test.go
@@ -65,10 +65,9 @@ func TestSourcemapProcessorOK(t *testing.T) {
 		err = p.Validate(data)
 		require.NoError(t, err)
 
-		metadata, payload, err := p.Decode(data)
+		payload, err := p.Decode(data)
 		require.NoError(t, err)
 
-		tctx.Metadata = *metadata
 		var events []beat.Event
 		for _, transformable := range payload {
 			events = append(events, transformable.Transform(context.Background(), &tctx)...)

--- a/processor/asset/sourcemap/package_tests/test_processor.go
+++ b/processor/asset/sourcemap/package_tests/test_processor.go
@@ -36,7 +36,7 @@ func (p *TestProcessor) LoadPayload(path string) (interface{}, error) {
 }
 
 func (p *TestProcessor) Decode(input interface{}) error {
-	_, _, err := p.Processor.Decode(input.(map[string]interface{}))
+	_, err := p.Processor.Decode(input.(map[string]interface{}))
 	return err
 }
 
@@ -55,14 +55,14 @@ func (p *TestProcessor) Process(buf []byte) ([]beat.Event, error) {
 	if err != nil {
 		return nil, err
 	}
-	metadata, transformables, err := p.Processor.Decode(pl)
+	transformables, err := p.Processor.Decode(pl)
 	if err != nil {
 		return nil, err
 	}
 
 	var events []beat.Event
 	for _, transformable := range transformables {
-		events = append(events, transformable.Transform(context.Background(), &transform.Context{Metadata: *metadata})...)
+		events = append(events, transformable.Transform(context.Background(), &transform.Context{})...)
 	}
 	return events, nil
 }

--- a/processor/asset/sourcemap/sourcemap.go
+++ b/processor/asset/sourcemap/sourcemap.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/monitoring"
 
-	"github.com/elastic/apm-server/model/metadata"
 	sm "github.com/elastic/apm-server/model/sourcemap"
 	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/apm-server/validation"
@@ -55,15 +54,15 @@ func (p *sourcemapProcessor) Name() string {
 	return eventName
 }
 
-func (p *sourcemapProcessor) Decode(raw map[string]interface{}) (*metadata.Metadata, []transform.Transformable, error) {
+func (p *sourcemapProcessor) Decode(raw map[string]interface{}) ([]transform.Transformable, error) {
 	p.DecodingCount.Inc()
 	transformable, err := sm.DecodeSourcemap(raw)
 	if err != nil {
 		p.DecodingError.Inc()
-		return nil, nil, err
+		return nil, err
 	}
 
-	return &metadata.Metadata{}, []transform.Transformable{transformable}, err
+	return []transform.Transformable{transformable}, err
 }
 
 func (p *sourcemapProcessor) Validate(raw map[string]interface{}) error {

--- a/processor/otel/test_approved/metadata_jaeger-no-language.approved.json
+++ b/processor/otel/test_approved/metadata_jaeger-no-language.approved.json
@@ -17,6 +17,9 @@
             "Version": null
         },
         "Name": "unknown",
+        "Node": {
+            "Name": null
+        },
         "Runtime": {
             "Name": null,
             "Version": null

--- a/processor/otel/test_approved/metadata_jaeger-version.approved.json
+++ b/processor/otel/test_approved/metadata_jaeger-version.approved.json
@@ -17,6 +17,9 @@
             "Version": null
         },
         "Name": "unknown",
+        "Node": {
+            "Name": null
+        },
         "Runtime": {
             "Name": null,
             "Version": null

--- a/processor/otel/test_approved/metadata_jaeger.approved.json
+++ b/processor/otel/test_approved/metadata_jaeger.approved.json
@@ -27,6 +27,9 @@
             "Version": null
         },
         "Name": "foo",
+        "Node": {
+            "Name": null
+        },
         "Runtime": {
             "Name": null,
             "Version": null

--- a/processor/otel/test_approved/metadata_jaeger_minimal.approved.json
+++ b/processor/otel/test_approved/metadata_jaeger_minimal.approved.json
@@ -17,6 +17,9 @@
             "Version": null
         },
         "Name": "unknown",
+        "Node": {
+            "Name": null
+        },
         "Runtime": {
             "Name": null,
             "Version": null

--- a/processor/otel/test_approved/metadata_minimal.approved.json
+++ b/processor/otel/test_approved/metadata_minimal.approved.json
@@ -17,6 +17,9 @@
             "Version": null
         },
         "Name": "unknown",
+        "Node": {
+            "Name": null
+        },
         "Runtime": {
             "Name": null,
             "Version": null

--- a/processor/otel/test_approved/span_error_jaeger_http_1.approved.json
+++ b/processor/otel/test_approved/span_error_jaeger_http_1.approved.json
@@ -43,6 +43,45 @@
         "ParamMessage": null,
         "Stacktrace": null
     },
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Page": null,
     "ParentId": "41414646",
     "Service": null,

--- a/processor/otel/test_approved/span_error_jaeger_http_2.approved.json
+++ b/processor/otel/test_approved/span_error_jaeger_http_2.approved.json
@@ -33,6 +33,45 @@
         "ParamMessage": null,
         "Stacktrace": null
     },
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Page": null,
     "ParentId": "41414646",
     "Service": null,

--- a/processor/otel/test_approved/span_error_jaeger_http_3.approved.json
+++ b/processor/otel/test_approved/span_error_jaeger_http_3.approved.json
@@ -37,6 +37,45 @@
     "Id": null,
     "Labels": null,
     "Log": null,
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Page": null,
     "ParentId": "41414646",
     "Service": null,

--- a/processor/otel/test_approved/span_error_jaeger_http_4.approved.json
+++ b/processor/otel/test_approved/span_error_jaeger_http_4.approved.json
@@ -37,6 +37,45 @@
     "Id": null,
     "Labels": null,
     "Log": null,
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Page": null,
     "ParentId": "41414646",
     "Service": null,

--- a/processor/otel/test_approved/span_error_jaeger_http_5.approved.json
+++ b/processor/otel/test_approved/span_error_jaeger_http_5.approved.json
@@ -37,6 +37,45 @@
     "Id": null,
     "Labels": null,
     "Log": null,
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Page": null,
     "ParentId": "41414646",
     "Service": null,

--- a/processor/otel/test_approved/span_error_jaeger_http_6.approved.json
+++ b/processor/otel/test_approved/span_error_jaeger_http_6.approved.json
@@ -33,6 +33,45 @@
         "ParamMessage": null,
         "Stacktrace": null
     },
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Page": null,
     "ParentId": "41414646",
     "Service": null,

--- a/processor/otel/test_approved/span_jaeger_custom_0.approved.json
+++ b/processor/otel/test_approved/span_jaeger_custom_0.approved.json
@@ -9,6 +9,45 @@
     "Id": "",
     "Labels": null,
     "Message": null,
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Name": "",
     "ParentId": "61626364",
     "Service": null,

--- a/processor/otel/test_approved/span_jaeger_db_0.approved.json
+++ b/processor/otel/test_approved/span_jaeger_db_0.approved.json
@@ -18,6 +18,45 @@
         "component": "foo"
     },
     "Message": null,
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Name": "",
     "ParentId": "61626364",
     "Service": null,

--- a/processor/otel/test_approved/span_jaeger_http_0.approved.json
+++ b/processor/otel/test_approved/span_jaeger_http_0.approved.json
@@ -26,6 +26,45 @@
         "type": "db_request"
     },
     "Message": null,
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Name": "HTTP GET",
     "ParentId": "58585858",
     "Service": null,

--- a/processor/otel/test_approved/span_jaeger_http_status_code_0.approved.json
+++ b/processor/otel/test_approved/span_jaeger_http_status_code_0.approved.json
@@ -14,6 +14,45 @@
     "Id": "41414646",
     "Labels": null,
     "Message": null,
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Name": "HTTP GET",
     "ParentId": "58585858",
     "Service": null,

--- a/processor/otel/test_approved/transaction_error_jaeger_full_1.approved.json
+++ b/processor/otel/test_approved/transaction_error_jaeger_full_1.approved.json
@@ -43,6 +43,45 @@
         "ParamMessage": null,
         "Stacktrace": null
     },
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Page": null,
     "ParentId": "41414646",
     "Service": null,

--- a/processor/otel/test_approved/transaction_error_jaeger_full_2.approved.json
+++ b/processor/otel/test_approved/transaction_error_jaeger_full_2.approved.json
@@ -33,6 +33,45 @@
         "ParamMessage": null,
         "Stacktrace": null
     },
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Page": null,
     "ParentId": "41414646",
     "Service": null,

--- a/processor/otel/test_approved/transaction_error_jaeger_full_3.approved.json
+++ b/processor/otel/test_approved/transaction_error_jaeger_full_3.approved.json
@@ -37,6 +37,45 @@
     "Id": null,
     "Labels": null,
     "Log": null,
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Page": null,
     "ParentId": "41414646",
     "Service": null,

--- a/processor/otel/test_approved/transaction_error_jaeger_full_4.approved.json
+++ b/processor/otel/test_approved/transaction_error_jaeger_full_4.approved.json
@@ -37,6 +37,45 @@
     "Id": null,
     "Labels": null,
     "Log": null,
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Page": null,
     "ParentId": "41414646",
     "Service": null,

--- a/processor/otel/test_approved/transaction_error_jaeger_full_5.approved.json
+++ b/processor/otel/test_approved/transaction_error_jaeger_full_5.approved.json
@@ -37,6 +37,45 @@
     "Id": null,
     "Labels": null,
     "Log": null,
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Page": null,
     "ParentId": "41414646",
     "Service": null,

--- a/processor/otel/test_approved/transaction_error_jaeger_full_6.approved.json
+++ b/processor/otel/test_approved/transaction_error_jaeger_full_6.approved.json
@@ -33,6 +33,45 @@
         "ParamMessage": null,
         "Stacktrace": null
     },
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Page": null,
     "ParentId": "41414646",
     "Service": null,

--- a/processor/otel/test_approved/transaction_jaeger_custom_0.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_custom_0.approved.json
@@ -10,6 +10,37 @@
     },
     "Marks": null,
     "Message": null,
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": null,
+        "User": null
+    },
     "Name": "",
     "Page": null,
     "ParentId": null,

--- a/processor/otel/test_approved/transaction_jaeger_full_0.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_full_0.approved.json
@@ -34,6 +34,45 @@
     },
     "Marks": null,
     "Message": null,
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Name": "HTTP GET",
     "Page": null,
     "ParentId": null,

--- a/processor/otel/test_approved/transaction_jaeger_no_attrs_0.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_no_attrs_0.approved.json
@@ -10,6 +10,45 @@
     },
     "Marks": null,
     "Message": null,
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Name": "",
     "Page": null,
     "ParentId": null,

--- a/processor/otel/test_approved/transaction_jaeger_type_component_0.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_type_component_0.approved.json
@@ -10,6 +10,45 @@
     },
     "Marks": null,
     "Message": null,
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Name": "",
     "Page": null,
     "ParentId": null,

--- a/processor/otel/test_approved/transaction_jaeger_type_request_0.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_type_request_0.approved.json
@@ -22,6 +22,45 @@
     },
     "Marks": null,
     "Message": null,
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Name": "",
     "Page": null,
     "ParentId": "61626364",

--- a/processor/otel/test_approved/transaction_jaeger_type_request_result_0.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_type_request_result_0.approved.json
@@ -20,6 +20,45 @@
     "Labels": null,
     "Marks": null,
     "Message": null,
+    "Metadata": {
+        "Labels": {},
+        "Process": null,
+        "Service": {
+            "Agent": {
+                "EphemeralId": null,
+                "Name": "Jaeger",
+                "Version": "unknown"
+            },
+            "Environment": null,
+            "Framework": {
+                "Name": null,
+                "Version": null
+            },
+            "Language": {
+                "Name": "unknown",
+                "Version": null
+            },
+            "Name": "unknown",
+            "Node": {
+                "Name": null
+            },
+            "Runtime": {
+                "Name": null,
+                "Version": null
+            },
+            "Version": null
+        },
+        "System": {
+            "Architecture": null,
+            "ConfiguredHostname": null,
+            "Container": null,
+            "DetectedHostname": "host-abc",
+            "IP": "",
+            "Kubernetes": null,
+            "Platform": null
+        },
+        "User": null
+    },
     "Name": "",
     "Page": null,
     "ParentId": "61626364",

--- a/processor/stream/package_tests/intake_test_processor.go
+++ b/processor/stream/package_tests/intake_test_processor.go
@@ -27,6 +27,7 @@ import (
 	"github.com/santhosh-tekuri/jsonschema"
 
 	"github.com/elastic/apm-server/decoder"
+	"github.com/elastic/apm-server/model/metadata"
 	"github.com/elastic/apm-server/processor/stream"
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/apm-server/tests"
@@ -88,7 +89,7 @@ func (p *intakeTestProcessor) LoadPayload(path string) (interface{}, error) {
 func (p *intakeTestProcessor) Decode(data interface{}) error {
 	events := data.([]interface{})
 	for _, e := range events {
-		_, err := p.Processor.HandleRawModel(e.(map[string]interface{}), time.Now())
+		_, err := p.Processor.HandleRawModel(e.(map[string]interface{}), time.Now(), metadata.Metadata{})
 		if err != nil {
 			return err
 		}

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 
-	"github.com/elastic/apm-server/model/metadata"
 	"github.com/elastic/apm-server/sourcemap"
 )
 
@@ -31,9 +30,14 @@ type Transformable interface {
 	Transform(context.Context, *Context) []beat.Event
 }
 
+// Context holds event-specific transformation context.
+//
+// TODO(axw) get rid of transform.Context, since it now holds only
+// static configuration. Introduce a "Transformer" type which can
+// be configured; we would have separate Transformers for RUM and
+// non-RUM.
 type Context struct {
-	Config   Config
-	Metadata metadata.Metadata
+	Config Config
 }
 
 type Config struct {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - all: add metadata directly to model types (#3573)