### PR TITLE
[7.x] model/field: rewrite to avoid closure allocation (#3619)

### DIFF
--- a/model/field/rum_v3_mapping.go
+++ b/model/field/rum_v3_mapping.go
@@ -122,11 +122,19 @@ var rumV3Mapping = map[string]string{
 }
 
 func Mapper(shortFieldNames bool) func(string) string {
-	return func(s string) string {
-		shortField, ok := rumV3Mapping[s]
-		if ok && shortFieldNames {
-			return shortField
-		}
-		return s
+	if shortFieldNames {
+		return rumV3Mapper
 	}
+	return identityMapper
+}
+
+func rumV3Mapper(long string) string {
+	if short, ok := rumV3Mapping[long]; ok {
+		return short
+	}
+	return long
+}
+
+func identityMapper(s string) string {
+	return s
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - model/field: rewrite to avoid closure allocation (#3619)