### PR TITLE
model: enhancements to support transaction aggregations

### DIFF
--- a/beater/config/api_key.go
+++ b/beater/config/api_key.go
@@ -62,7 +62,7 @@ func defaultAPIKeyConfig() *APIKeyConfig {
 func (c *APIKeyConfig) Unpack(inp *common.Config) error {
 	cfg := tmpAPIKeyConfig(*defaultAPIKeyConfig())
 	if err := inp.Unpack(&cfg); err != nil {
-		return errors.Errorf("error unpacking api_key config: %w", err)
+		return errors.Wrap(err, "error unpacking api_key config")
 	}
 	*c = APIKeyConfig(cfg)
 	if inp.HasField("elasticsearch") {

--- a/beater/config/rum.go
+++ b/beater/config/rum.go
@@ -146,7 +146,7 @@ func (s *SourceMapping) Unpack(inp *common.Config) error {
 
 	cfg := tmpSourceMapping(*defaultSourcemapping())
 	if err := inp.Unpack(&cfg); err != nil {
-		return errors.Errorf("error unpacking sourcemapping config: %w", err)
+		return errors.Wrap(err, "error unpacking sourcemapping config")
 	}
 	*s = SourceMapping(cfg)
 	if inp.HasField("elasticsearch") {

--- a/model/metadata/system.go
+++ b/model/metadata/system.go
@@ -38,10 +38,11 @@ func (s *System) name() string {
 	if s.ConfiguredHostname != "" {
 		return s.ConfiguredHostname
 	}
-	return s.hostname()
+	return s.Hostname()
 }
 
-func (s *System) hostname() string {
+// Hostname returns the value to store in `host.hostname`.
+func (s *System) Hostname() string {
 	if s == nil {
 		return ""
 	}
@@ -66,7 +67,7 @@ func (s *System) fields() common.MapStr {
 		return nil
 	}
 	var system mapStr
-	system.maybeSetString("hostname", s.hostname())
+	system.maybeSetString("hostname", s.Hostname())
 	system.maybeSetString("name", s.name())
 	system.maybeSetString("architecture", s.Architecture)
 	if s.Platform != "" {

--- a/model/metricset/event.go
+++ b/model/metricset/event.go
@@ -45,50 +45,57 @@ var (
 	processorEntry  = common.MapStr{"name": processorName, "event": docType}
 )
 
+// Metricset describes a set of metrics and associated metadata.
+type Metricset struct {
+	// Timestamp holds the time at which the metrics were published.
+	Timestamp time.Time
+
+	// Metadata holds common metadata describing the entities with which
+	// the metrics are associated: service, system, etc.
+	Metadata metadata.Metadata
+
+	// Transaction holds information about the transaction group with
+	// which the metrics are associated.
+	Transaction Transaction
+
+	// Span holds information about the span types with which the
+	// metrics are associated.
+	Span Span
+
+	// Labels holds arbitrary labels to apply to the metrics.
+	//
+	// These labels override any with the same names in Metadata.Labels.
+	Labels common.MapStr
+
+	// Samples holds the metrics in the set.
+	Samples []Sample
+}
+
+// Sample represents a single named metric.
 type Sample struct {
-	Name  string
+	// Name holds the metric name.
+	Name string
+
+	// Value holds the metric value for single-value metrics.
 	Value float64
 }
 
-// Transaction provides enough information to connect a metricset to the related kind of transactions
+// Transaction provides enough information to connect a metricset to the related kind of transactions.
 type Transaction struct {
-	Name *string
-	Type *string
+	// Name holds the transaction name: "GET /foo", etc.
+	Name string
+
+	// Type holds the transaction type: "request", "message", etc.
+	Type string
 }
 
-// Span provides enough information to connect a metricset to the related kind of spans
+// Span provides enough information to connect a metricset to the related kind of spans.
 type Span struct {
-	Type    *string
-	Subtype *string
-}
+	// Type holds the span type: "external", "db", etc.
+	Type string
 
-type Metricset struct {
-	Metadata    metadata.Metadata
-	Samples     []*Sample
-	Labels      common.MapStr
-	Transaction *Transaction
-	Span        *Span
-	Timestamp   time.Time
-}
-
-func (s *Span) fields() common.MapStr {
-	if s == nil {
-		return nil
-	}
-	fields := common.MapStr{}
-	utility.Set(fields, "type", s.Type)
-	utility.Set(fields, "subtype", s.Subtype)
-	return fields
-}
-
-func (t *Transaction) fields() common.MapStr {
-	if t == nil {
-		return nil
-	}
-	fields := common.MapStr{}
-	utility.Set(fields, "type", t.Type)
-	utility.Set(fields, "name", t.Name)
-	return fields
+	// Subtype holds the span subtype: "http", "sql", etc.
+	Subtype string
 }
 
 func (me *Metricset) Transform(ctx context.Context, tctx *transform.Context) []beat.Event {
@@ -99,7 +106,7 @@ func (me *Metricset) Transform(ctx context.Context, tctx *transform.Context) []b
 
 	fields := common.MapStr{}
 	for _, sample := range me.Samples {
-		if _, err := fields.Put(sample.Name, sample.Value); err != nil {
+		if err := sample.set(fields); err != nil {
 			logp.NewLogger(logs.Transform).Warnf("failed to transform sample %#v", sample)
 			continue
 		}
@@ -107,16 +114,37 @@ func (me *Metricset) Transform(ctx context.Context, tctx *transform.Context) []b
 
 	fields["processor"] = processorEntry
 	me.Metadata.Set(fields)
+	if transactionFields := me.Transaction.fields(); transactionFields != nil {
+		utility.DeepUpdate(fields, transactionKey, transactionFields)
+	}
+	if spanFields := me.Span.fields(); spanFields != nil {
+		utility.DeepUpdate(fields, spanKey, spanFields)
+	}
 
 	// merges with metadata labels, overrides conflicting keys
 	utility.DeepUpdate(fields, "labels", me.Labels)
-	utility.DeepUpdate(fields, transactionKey, me.Transaction.fields())
-	utility.DeepUpdate(fields, spanKey, me.Span.fields())
 
-	return []beat.Event{
-		{
-			Fields:    fields,
-			Timestamp: me.Timestamp,
-		},
-	}
+	return []beat.Event{{
+		Fields:    fields,
+		Timestamp: me.Timestamp,
+	}}
+}
+
+func (t *Transaction) fields() common.MapStr {
+	var fields mapStr
+	fields.maybeSetString("type", t.Type)
+	fields.maybeSetString("name", t.Name)
+	return common.MapStr(fields)
+}
+
+func (s *Span) fields() common.MapStr {
+	var fields mapStr
+	fields.maybeSetString("type", s.Type)
+	fields.maybeSetString("subtype", s.Subtype)
+	return common.MapStr(fields)
+}
+
+func (s *Sample) set(fields common.MapStr) error {
+	_, err := fields.Put(s.Name, s.Value)
+	return err
 }

--- a/model/metricset/event_test.go
+++ b/model/metricset/event_test.go
@@ -36,7 +36,14 @@ func TestTransform(t *testing.T) {
 	metadata := metadata.Metadata{
 		Service: metadata.Service{Name: "myservice"},
 	}
-	spType, spSubtype, trType, trName := "db", "sql", "request", "GET /"
+
+	const (
+		trType = "request"
+		trName = "GET /"
+
+		spType    = "db"
+		spSubtype = "sql"
+	)
 
 	tests := []struct {
 		Metricset *Metricset
@@ -65,7 +72,7 @@ func TestTransform(t *testing.T) {
 				Metadata:  metadata,
 				Labels:    common.MapStr{"a.b": "a.b.value"},
 				Timestamp: timestamp,
-				Samples: []*Sample{
+				Samples: []Sample{
 					{
 						Name:  "a.counter",
 						Value: 612,
@@ -75,23 +82,19 @@ func TestTransform(t *testing.T) {
 						Value: 9.16,
 					},
 				},
-				Span:        &Span{Type: &spType, Subtype: &spSubtype},
-				Transaction: &Transaction{Type: &trType, Name: &trName},
+				Span:        Span{Type: spType, Subtype: spSubtype},
+				Transaction: Transaction{Type: trType, Name: trName},
 			},
 			Output: []common.MapStr{
 				{
-					"labels": common.MapStr{
-						"a.b": "a.b.value",
-					},
-					"service": common.MapStr{
-						"name": "myservice",
-					},
-
-					"a":           common.MapStr{"counter": float64(612)},
-					"some":        common.MapStr{"gauge": float64(9.16)},
 					"processor":   common.MapStr{"event": "metric", "name": "metric"},
+					"service":     common.MapStr{"name": "myservice"},
 					"transaction": common.MapStr{"name": trName, "type": trType},
 					"span":        common.MapStr{"type": spType, "subtype": spSubtype},
+					"labels":      common.MapStr{"a.b": "a.b.value"},
+
+					"a":    common.MapStr{"counter": float64(612)},
+					"some": common.MapStr{"gauge": float64(9.16)},
 				},
 			},
 			Msg: "Payload with valid metric.",

--- a/model/metricset/mapstr.go
+++ b/model/metricset/mapstr.go
@@ -15,41 +15,22 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package modeldecoder
+package metricset
 
-import "encoding/json"
+import "github.com/elastic/beats/v7/libbeat/common"
 
-func getObject(obj map[string]interface{}, key string) map[string]interface{} {
-	value, _ := obj[key].(map[string]interface{})
-	return value
-}
+type mapStr common.MapStr
 
-func decodeString(obj map[string]interface{}, key string, out *string) bool {
-	if value, ok := obj[key].(string); ok {
-		*out = value
-		return true
+func (m *mapStr) set(k string, v interface{}) {
+	if *m == nil {
+		*m = make(mapStr)
 	}
-	return false
+	(*m)[k] = v
 }
 
-func decodeInt(obj map[string]interface{}, key string, out *int) bool {
-	var f float64
-	if decodeFloat64(obj, key, &f) {
-		*out = int(f)
-		return true
-	}
-	return false
-}
-
-func decodeFloat64(obj map[string]interface{}, key string, out *float64) bool {
-	switch value := obj[key].(type) {
-	case json.Number:
-		if f, err := value.Float64(); err == nil {
-			*out = f
-		}
-		return true
-	case float64:
-		*out = value
+func (m *mapStr) maybeSetString(k, v string) bool {
+	if v != "" {
+		m.set(k, v)
 		return true
 	}
 	return false

--- a/model/modeldecoder/metricset_test.go
+++ b/model/modeldecoder/metricset_test.go
@@ -75,8 +75,6 @@ func TestDecode(t *testing.T) {
 			err: nil,
 			metricset: &metricset.Metricset{
 				Metadata:  metadata,
-				Samples:   []*metricset.Sample{},
-				Labels:    nil,
 				Timestamp: timestampParsed,
 			},
 		},
@@ -97,7 +95,6 @@ func TestDecode(t *testing.T) {
 			},
 			metricset: &metricset.Metricset{
 				Metadata:  metadata,
-				Samples:   []*metricset.Sample{},
 				Timestamp: requestTime,
 			},
 		},
@@ -119,7 +116,7 @@ func TestDecode(t *testing.T) {
 			err: nil,
 			metricset: &metricset.Metricset{
 				Metadata: metadata,
-				Samples: []*metricset.Sample{
+				Samples: []metricset.Sample{
 					{
 						Name:  "some.gauge",
 						Value: 9.16,
@@ -158,7 +155,7 @@ func TestDecode(t *testing.T) {
 			err: nil,
 			metricset: &metricset.Metricset{
 				Metadata: metadata,
-				Samples: []*metricset.Sample{
+				Samples: []metricset.Sample{
 					{
 						Name:  "a.counter",
 						Value: 612,
@@ -167,8 +164,8 @@ func TestDecode(t *testing.T) {
 				Labels: common.MapStr{
 					"atag": true,
 				},
-				Span:        &metricset.Span{Type: &spType, Subtype: &spSubtype},
-				Transaction: &metricset.Transaction{Type: &trType, Name: &trName},
+				Span:        metricset.Span{Type: spType, Subtype: spSubtype},
+				Transaction: metricset.Transaction{Type: trType, Name: trName},
 				Timestamp:   timestampParsed,
 			},
 		},


### PR DESCRIPTION
## Motivation/summary

There are a few smallish changes here bundled together, in support of transaction duration aggregations (https://github.com/elastic/apm-server/issues/3485).

Summary:
 - export `metadata.System.Hostname`, so its value can be used in aggregation keys
 - add `metricset.Transaction.{Result,Root}` fields, to use in aggregation keys
 - add `metricset.Sample.{Counts,Values}` fields, for indexing histogram metrics
 - use non-pointer fields for `metricset.Metricset` and related types to simplify usage, and reduce allocations

Note that the added fields are only added to the model types, and not the intake API. That will come later, as part of https://github.com/elastic/apm-server/issues/3195.

## Checklist
- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
~- [ ] I have made corresponding changes to the documentation~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

## How to test these changes

`make test`

## Related issues

https://github.com/elastic/apm-server/issues/3485