### PR TITLE
Correct apm-server.host in configuration process example

### DIFF
--- a/docs/configuration-process.asciidoc
+++ b/docs/configuration-process.asciidoc
@@ -6,7 +6,7 @@ Example config file:
 ["source","yaml"]
 ----
 apm-server:
-  hosts: ["localhost:8200"]
+  host: ["localhost:8200"]
   rum:
     enabled: true
 

--- a/docs/configuration-process.asciidoc
+++ b/docs/configuration-process.asciidoc
@@ -6,7 +6,7 @@ Example config file:
 ["source","yaml"]
 ----
 apm-server:
-  host: ["localhost:8200"]
+  host: "localhost:8200"
   rum:
     enabled: true
 


### PR DESCRIPTION
## Motivation/summary

Docs show "hosts" in configuration instead of correct "host".

* Customer in ticket 519251 noted when using "hosts" APM server only listened on localhost (the default) instead of the configured URL.
* I do find it odd that "host" would be the parameter when the value appears to be an array (in square brackets, that is.)
* I found example config lists "host"

[example config](Example in repo shows correct 'host' parameter: https://github.com/elastic/apm-server/blob/71a6cc116a344d7e89f46999ab0727028b517d21/apm-server.yml#L5-L7)

## Checklist
- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [ ] Configuration change of "hosts" to "host" is valid?
~~- [ ] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)~~
~~- [ ] I have rebased my changes on top of the latest master branch~~
- [x] I have made corresponding changes to the documentation
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~
~~- [ ] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes~~
~~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~~

## How to test these changes
<!--
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
