### PR TITLE
[7.x] model: fix span.transformations metric name (#3674)

### DIFF
--- a/model/span.go
+++ b/model/span.go
@@ -36,7 +36,7 @@ const (
 
 var (
 	spanMetrics           = monitoring.Default.NewRegistry("apm-server.processor.span")
-	spanTransformations   = monitoring.NewInt(spanMetrics, "spanTransformations")
+	spanTransformations   = monitoring.NewInt(spanMetrics, "transformations")
 	spanStacktraceCounter = monitoring.NewInt(spanMetrics, "stacktraces")
 	spanFrameCounter      = monitoring.NewInt(spanMetrics, "frames")
 	spanProcessorEntry    = common.MapStr{"name": "transaction", "event": spanDocType}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - model: fix span.transformations metric name (#3674)