### PR TITLE
Add appliedByAgent flag to agentcfg query.

### DIFF
--- a/agentcfg/model.go
+++ b/agentcfg/model.go
@@ -60,8 +60,8 @@ type Query struct {
 	// it indicates that the exact same query response has already been delivered.
 	Etag string `json:"etag"`
 
-	// AppliedByAgent can be used to signal the receiver that the response to this
-	// query can be considered being applied. When building queries for elastic APM
+	// AppliedByAgent can be used to signal to the receiver that the response to this
+	// query can be considered to have been applied immediately. When building queries for Elastic APM
 	// agent requests the Etag should be set, instead of the AppliedByAgent setting.
 	// Use this flag when building queries for third party integrations,
 	// such as Jaeger, that do not send an Etag in their request.

--- a/agentcfg/model.go
+++ b/agentcfg/model.go
@@ -65,7 +65,7 @@ type Query struct {
 	// agent requests the Etag should be set, instead of the AppliedByAgent setting.
 	// Use this flag when building queries for third party integrations,
 	// such as Jaeger, that do not send an Etag in their request.
-	AppliedByAgent *bool `json:"applied_by_agent",omitempty`
+	AppliedByAgent *bool `json:"applied_by_agent,omitempty"`
 
 	// InsecureAgents holds a set of prefixes for restricting results to those whose
 	// agent name matches any of the specified prefixes.

--- a/agentcfg/model.go
+++ b/agentcfg/model.go
@@ -53,7 +53,20 @@ type Source struct {
 // Query represents an URL body or query params for agent configuration
 type Query struct {
 	Service Service `json:"service"`
-	Etag    string  `json:"etag"`
+
+	// Etag should be set to the Etag of a previous agent config query result.
+	// When the query is processed by the receiver a new Etag is calculated
+	// for the query result. If Etags from the query and the query result match,
+	// it indicates that the exact same query response has already been delivered.
+	Etag string `json:"etag"`
+
+	// AppliedByAgent can be used to signal the receiver that the response to this
+	// query can be considered being applied. When building queries for elastic APM
+	// agent requests the Etag should be set, instead of the AppliedByAgent setting.
+	// Use this flag when building queries for third party integrations,
+	// such as Jaeger, that do not send an Etag in their request.
+	AppliedByAgent *bool `json:"applied_by_agent",omitempty`
+
 	// InsecureAgents holds a set of prefixes for restricting results to those whose
 	// agent name matches any of the specified prefixes.
 	//

--- a/agentcfg/model_test.go
+++ b/agentcfg/model_test.go
@@ -57,7 +57,7 @@ func TestQueryMarshaling(t *testing.T) {
 			out:   `{"service":{"name":"auth-service","environment":"production"},"applied_by_agent":true,"etag":""}`},
 		{name: "elastic_apm",
 			input: `{"service":{"name":"auth-service","environment":"production"},"etag":"1234"}`,
-			out:   `{"service":{"name":"auth-service","environment":"production"},"etag":"1234","applied_by_agent":null}`},
+			out:   `{"service":{"name":"auth-service","environment":"production"},"etag":"1234"}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var query Query

--- a/beater/jaeger/grpc.go
+++ b/beater/jaeger/grpc.go
@@ -118,7 +118,7 @@ func (s *grpcSampler) GetSamplingStrategy(
 
 func (s *grpcSampler) fetchSamplingRate(ctx context.Context, service string) (float64, error) {
 	query := agentcfg.Query{Service: agentcfg.Service{Name: service},
-		InsecureAgents: jaegerAgentPrefixes, AppliedByAgent: boolean(true)}
+		InsecureAgents: jaegerAgentPrefixes, AppliedByAgent: newBool(true)}
 	result, err := s.fetcher.Fetch(ctx, query)
 	if err != nil {
 		gRPCSamplingMonitoringMap.inc(request.IDResponseErrorsServiceUnavailable)
@@ -156,4 +156,4 @@ func (s *grpcSampler) validateKibanaClient(ctx context.Context) error {
 	return nil
 }
 
-func boolean(b bool) *bool { return &b }
+func newBool(b bool) *bool { return &b }

--- a/beater/jaeger/grpc.go
+++ b/beater/jaeger/grpc.go
@@ -117,7 +117,8 @@ func (s *grpcSampler) GetSamplingStrategy(
 }
 
 func (s *grpcSampler) fetchSamplingRate(ctx context.Context, service string) (float64, error) {
-	query := agentcfg.Query{Service: agentcfg.Service{Name: service}, InsecureAgents: jaegerAgentPrefixes}
+	query := agentcfg.Query{Service: agentcfg.Service{Name: service},
+		InsecureAgents: jaegerAgentPrefixes, AppliedByAgent: boolean(true)}
 	result, err := s.fetcher.Fetch(ctx, query)
 	if err != nil {
 		gRPCSamplingMonitoringMap.inc(request.IDResponseErrorsServiceUnavailable)
@@ -154,3 +155,5 @@ func (s *grpcSampler) validateKibanaClient(ctx context.Context) error {
 	}
 	return nil
 }
+
+func boolean(b bool) *bool { return &b }

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -8,6 +8,7 @@ https://github.com/elastic/apm-server/compare/7.6\...master[View commits]
 
 [float]
 ==== Bug fixes
+* Ensure applied flag can be set for agent configurations fetched for Jaeger {pull}3677[3677]
 
 [float]
 ==== Intake API Changes

--- a/model/error_test.go
+++ b/model/error_test.go
@@ -155,7 +155,7 @@ func TestEventFields(t *testing.T) {
 	baseLogHash := md5.New()
 	io.WriteString(baseLogHash, baseLog().Message)
 	baseLogGroupingKey := hex.EncodeToString(baseLogHash.Sum(nil))
-	trId := "945254c5-67a5-417e-8a4e-aa29efcbfb79"
+	trID := "945254c5-67a5-417e-8a4e-aa29efcbfb79"
 
 	tests := map[string]struct {
 		Error  Error
@@ -217,7 +217,7 @@ func TestEventFields(t *testing.T) {
 				Culprit:       &culprit,
 				Exception:     &exception,
 				Log:           &log,
-				TransactionID: &trId,
+				TransactionID: &trID,
 
 				// Service name and version are required for sourcemapping.
 				Metadata: Metadata{
@@ -276,11 +276,11 @@ func TestEvents(t *testing.T) {
 		time.FixedZone("+0100", 3600))
 	timestampUs := timestamp.UnixNano() / 1000
 	exMsg := "exception message"
-	trId := "945254c5-67a5-417e-8a4e-aa29efcbfb79"
+	trID := "945254c5-67a5-417e-8a4e-aa29efcbfb79"
 	sampledTrue, sampledFalse := true, false
 	transactionType := "request"
 
-	email, userIp, userAgent := "m@m.com", "127.0.0.1", "js-1.0"
+	email, userIP, userAgent := "m@m.com", "127.0.0.1", "js-1.0"
 	uid := "1234567889"
 	url, referer := "https://localhost", "http://localhost"
 	labels := Labels(common.MapStr{"key": true})
@@ -297,7 +297,7 @@ func TestEvents(t *testing.T) {
 
 	mdWithUser := md
 	mdWithUser.User = User{ID: uid, Email: email, UserAgent: userAgent}
-	mdWithUser.Client.IP = net.ParseIP(userIp)
+	mdWithUser.Client.IP = net.ParseIP(userIP)
 
 	for name, tc := range map[string]struct {
 		Transformable transform.Transformable
@@ -354,7 +354,7 @@ func TestEvents(t *testing.T) {
 					Message:    &exMsg,
 					Stacktrace: Stacktrace{&StacktraceFrame{Filename: tests.StringPtr("myFile")}},
 				},
-				TransactionID:      &trId,
+				TransactionID:      &trID,
 				TransactionSampled: &sampledTrue,
 				Labels:             &labels,
 				Page:               &Page{Url: &url, Referer: &referer},
@@ -366,8 +366,8 @@ func TestEvents(t *testing.T) {
 				"service":    common.MapStr{"name": "myservice", "version": "1.0"},
 				"agent":      common.MapStr{"name": "go", "version": "1.0"},
 				"user":       common.MapStr{"id": uid, "email": email},
-				"client":     common.MapStr{"ip": userIp},
-				"source":     common.MapStr{"ip": userIp},
+				"client":     common.MapStr{"ip": userIP},
+				"source":     common.MapStr{"ip": userIP},
 				"user_agent": common.MapStr{"original": userAgent},
 				"error": common.MapStr{
 					"custom": common.MapStr{

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -36,7 +36,7 @@ func TestSpanTransform(t *testing.T) {
 	start := 0.65
 	serviceName, serviceVersion, env := "myService", "1.2", "staging"
 	service := Service{Name: serviceName, Version: serviceVersion, Environment: env}
-	hexId, parentId, traceId := "0147258369012345", "abcdef0123456789", "01234567890123456789abcdefa"
+	hexID, parentID, traceID := "0147258369012345", "abcdef0123456789", "01234567890123456789abcdefa"
 	subtype := "amqp"
 	action := "publish"
 	timestamp := time.Date(2019, 1, 3, 15, 17, 4, 908.596*1e6,
@@ -72,9 +72,9 @@ func TestSpanTransform(t *testing.T) {
 		{
 			Span: Span{
 				Metadata:   metadata,
-				ID:         hexId,
-				TraceID:    &traceId,
-				ParentID:   &parentId,
+				ID:         hexID,
+				TraceID:    &traceID,
+				ParentID:   &parentID,
 				Name:       "myspan",
 				Type:       "myspantype",
 				Subtype:    &subtype,
@@ -101,7 +101,7 @@ func TestSpanTransform(t *testing.T) {
 			},
 			Output: common.MapStr{
 				"span": common.MapStr{
-					"id":       hexId,
+					"id":       hexID,
 					"duration": common.MapStr{"us": 1200},
 					"name":     "myspan",
 					"start":    common.MapStr{"us": 650},
@@ -140,8 +140,8 @@ func TestSpanTransform(t *testing.T) {
 				"processor":   common.MapStr{"event": "span", "name": "transaction"},
 				"service":     common.MapStr{"name": serviceName, "environment": env, "version": serviceVersion},
 				"timestamp":   common.MapStr{"us": timestampUs},
-				"trace":       common.MapStr{"id": traceId},
-				"parent":      common.MapStr{"id": parentId},
+				"trace":       common.MapStr{"id": traceID},
+				"parent":      common.MapStr{"id": parentID},
 				"destination": common.MapStr{"address": address, "ip": address, "port": port},
 			},
 			Msg: "Full Span",


### PR DESCRIPTION


<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

A few suggestions about filling out this PR:

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR instead of prefixing the title with WIP.
3. Please label this PR with at least one of the following labels, depending on the scope of your change:
- bug fix
- breaking change
- enhancement
4. Remove those recommended/optional sections if you don't need them.
5. Submit the pull request: Push your local changes to your forked copy of the repository and submit a pull request (https://help.github.com/articles/using-pull-requests).
6. Please be patient. We might not be able to review your code as fast as we would like to, but we'll do our best to dedicate to it the attention it deserves. Your effort is much appreciated!

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
When using central config in combination with Jaeger for sampling, the config never shows as having been applied in the Kibana UI. This PR adds a query option when sending a request to Kibana, allowing the APM Server to indicate that agent configuration is applied by the agent.
<!--
Please explain the motivation behind this PR, along with a summary of the major changes involved. Replace this comment with a description of what is being changed by this PR and why.

Major changes require a number of considerations including impact on:

* logging selector(s)
* metrics
* telemetry
* Elasticsearch Service (https://cloud.elastic.co)
* Elastic Cloud Enterprise (https://www.elastic.co/products/ece)
-->

## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved
List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->
~- [ ] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).~
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest master branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
~- [ ] I have made corresponding changes to the documentation~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-server/blob/master/TESTING.md for details.
-->
- [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

## How to test these changes
<!--
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->
* Test together with https://github.com/elastic/kibana/pull/63967; right now that means check out the PR branch and [start Kibana local](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#setting-up-your-development-environment)
* Create agent configuration in Kibana
* Run a jaeger agent pointing to the APM Server as collector e.g.`./jaeger-agent --reporter.grpc.host-port=localhost:14250`
* Start apm-server with kibana and jaeger grpc enabled: `./apm-server -e -E apm-server.kibana.enabled=true -E apm-server.jaeger.grpc.enabled=true`
* send a sampling request to the jaeger agent, e.g. `curl localhost:5778/sampling?service=myservice`
* ensure agent config in Kibana is shown as applied after making requests from the hotrod app

## Related issues
fixes #3579

<!--
If this PR should close an issue, please add one of the magic keywords
(e.g. fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/
Examples
- Closes #ISSUE_ID
- Relates #ISSUE_ID
- Requires #ISSUE_ID
- Supersedes #ISSUE_ID
-->
