### PR TITLE
Change name for mark_as_applied_by_agent config option

### DIFF
--- a/agentcfg/model.go
+++ b/agentcfg/model.go
@@ -60,12 +60,12 @@ type Query struct {
 	// it indicates that the exact same query response has already been delivered.
 	Etag string `json:"etag"`
 
-	// AppliedByAgent can be used to signal to the receiver that the response to this
+	// MarkAsAppliedByAgent can be used to signal to the receiver that the response to this
 	// query can be considered to have been applied immediately. When building queries for Elastic APM
 	// agent requests the Etag should be set, instead of the AppliedByAgent setting.
 	// Use this flag when building queries for third party integrations,
 	// such as Jaeger, that do not send an Etag in their request.
-	AppliedByAgent *bool `json:"applied_by_agent,omitempty"`
+	MarkAsAppliedByAgent *bool `json:"mark_as_applied_by_agent,omitempty"`
 
 	// InsecureAgents holds a set of prefixes for restricting results to those whose
 	// agent name matches any of the specified prefixes.

--- a/agentcfg/model_test.go
+++ b/agentcfg/model_test.go
@@ -53,8 +53,8 @@ func TestQueryMarshaling(t *testing.T) {
 		out   string
 	}{
 		{name: "third_party",
-			input: `{"service":{"name":"auth-service","environment":"production"},"applied_by_agent":true}`,
-			out:   `{"service":{"name":"auth-service","environment":"production"},"applied_by_agent":true,"etag":""}`},
+			input: `{"service":{"name":"auth-service","environment":"production"},"mark_as_applied_by_agent":true}`,
+			out:   `{"service":{"name":"auth-service","environment":"production"},"mark_as_applied_by_agent":true,"etag":""}`},
 		{name: "elastic_apm",
 			input: `{"service":{"name":"auth-service","environment":"production"},"etag":"1234"}`,
 			out:   `{"service":{"name":"auth-service","environment":"production"},"etag":"1234"}`},

--- a/beater/jaeger/grpc.go
+++ b/beater/jaeger/grpc.go
@@ -118,7 +118,7 @@ func (s *grpcSampler) GetSamplingStrategy(
 
 func (s *grpcSampler) fetchSamplingRate(ctx context.Context, service string) (float64, error) {
 	query := agentcfg.Query{Service: agentcfg.Service{Name: service},
-		InsecureAgents: jaegerAgentPrefixes, AppliedByAgent: newBool(true)}
+		InsecureAgents: jaegerAgentPrefixes, MarkAsAppliedByAgent: newBool(true)}
 	result, err := s.fetcher.Fetch(ctx, query)
 	if err != nil {
 		gRPCSamplingMonitoringMap.inc(request.IDResponseErrorsServiceUnavailable)


### PR DESCRIPTION

<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

A few suggestions about filling out this PR:

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR instead of prefixing the title with WIP.
3. Please label this PR with at least one of the following labels, depending on the scope of your change:
- bug fix
- breaking change
- enhancement
4. Remove those recommended/optional sections if you don't need them.
5. Submit the pull request: Push your local changes to your forked copy of the repository and submit a pull request (https://help.github.com/articles/using-pull-requests).
6. Please be patient. We might not be able to review your code as fast as we would like to, but we'll do our best to dedicate to it the attention it deserves. Your effort is much appreciated!

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
Change agent configuration management query paramert from `applied_by_agent` to `mark_as_applied_by_agent` as suggested in https://github.com/elastic/kibana/pull/63967#discussion_r412963447
<!--
Please explain the motivation behind this PR, along with a summary of the major changes involved. Replace this comment with a description of what is being changed by this PR and why.

Major changes require a number of considerations including impact on:

* logging selector(s)
* metrics
* telemetry
* Elasticsearch Service (https://cloud.elastic.co)
* Elastic Cloud Enterprise (https://www.elastic.co/products/ece)
-->

## Checklist
<!--
Add a checklist of things that are required to be reviewed in order to have the PR approved
List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->
~- [ ] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).~
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest master branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-server/blob/master/TESTING.md for details.
-->
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

## How to test these changes
see https://github.com/elastic/apm-server/pull/3677
<!--
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues
related to https://github.com/elastic/kibana/pull/63967

<!--
If this PR should close an issue, please add one of the magic keywords
(e.g. fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/
Examples:
- Closes #ISSUE_ID
- Relates #ISSUE_ID
- Requires #ISSUE_ID
- Supersedes #ISSUE_ID
-->
