### PR TITLE
[7.x] Change name for mark_as_applied_by_agent config option (#3681)

### DIFF
--- a/agentcfg/model.go
+++ b/agentcfg/model.go
@@ -60,12 +60,12 @@ type Query struct {
 	// it indicates that the exact same query response has already been delivered.
 	Etag string `json:"etag"`
 
-	// AppliedByAgent can be used to signal to the receiver that the response to this
+	// MarkAsAppliedByAgent can be used to signal to the receiver that the response to this
 	// query can be considered to have been applied immediately. When building queries for Elastic APM
 	// agent requests the Etag should be set, instead of the AppliedByAgent setting.
 	// Use this flag when building queries for third party integrations,
 	// such as Jaeger, that do not send an Etag in their request.
-	AppliedByAgent *bool `json:"applied_by_agent,omitempty"`
+	MarkAsAppliedByAgent *bool `json:"mark_as_applied_by_agent,omitempty"`
 
 	// InsecureAgents holds a set of prefixes for restricting results to those whose
 	// agent name matches any of the specified prefixes.

--- a/agentcfg/model_test.go
+++ b/agentcfg/model_test.go
@@ -53,8 +53,8 @@ func TestQueryMarshaling(t *testing.T) {
 		out   string
 	}{
 		{name: "third_party",
-			input: `{"service":{"name":"auth-service","environment":"production"},"applied_by_agent":true}`,
-			out:   `{"service":{"name":"auth-service","environment":"production"},"applied_by_agent":true,"etag":""}`},
+			input: `{"service":{"name":"auth-service","environment":"production"},"mark_as_applied_by_agent":true}`,
+			out:   `{"service":{"name":"auth-service","environment":"production"},"mark_as_applied_by_agent":true,"etag":""}`},
 		{name: "elastic_apm",
 			input: `{"service":{"name":"auth-service","environment":"production"},"etag":"1234"}`,
 			out:   `{"service":{"name":"auth-service","environment":"production"},"etag":"1234"}`},

--- a/beater/jaeger/grpc.go
+++ b/beater/jaeger/grpc.go
@@ -118,7 +118,7 @@ func (s *grpcSampler) GetSamplingStrategy(
 
 func (s *grpcSampler) fetchSamplingRate(ctx context.Context, service string) (float64, error) {
 	query := agentcfg.Query{Service: agentcfg.Service{Name: service},
-		InsecureAgents: jaegerAgentPrefixes, AppliedByAgent: newBool(true)}
+		InsecureAgents: jaegerAgentPrefixes, MarkAsAppliedByAgent: newBool(true)}
 	result, err := s.fetcher.Fetch(ctx, query)
 	if err != nil {
 		gRPCSamplingMonitoringMap.inc(request.IDResponseErrorsServiceUnavailable)


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Change name for mark_as_applied_by_agent config option (#3681)