### PR TITLE
tests/system: use Kibana REST API to cleanup ACM

### DIFF
--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -24,6 +24,7 @@ from beat.beat import INTEGRATION_TESTS, TestCase, TimeoutError
 from helper import wait_until
 from es_helper import cleanup, default_pipelines
 from es_helper import index_smap, index_span, index_error, apm_prefix
+from kibana import Kibana
 
 integration_test = unittest.skipUnless(INTEGRATION_TESTS, "integration test")
 diagnostic_interval = float(os.environ.get('DIAGNOSTIC_INTERVAL', 0))
@@ -255,10 +256,11 @@ class ElasticTest(ServerBaseTest):
         admin_password = os.getenv("ES_SUPERUSER_PASS", "changeme")
         self.admin_es = Elasticsearch([self.get_elasticsearch_url(admin_user, admin_password)])
         self.es = Elasticsearch([self.get_elasticsearch_url()])
-        self.kibana_url = self.get_kibana_url()
+        self.kibana = Kibana(self.get_kibana_url())
 
         delete_pipelines = [] if self.skip_clean_pipelines else default_pipelines
         cleanup(self.admin_es, delete_pipelines=delete_pipelines)
+        self.kibana.delete_all_agent_config()
 
         super(ElasticTest, self).setUp()
 

--- a/tests/system/es_helper.py
+++ b/tests/system/es_helper.py
@@ -6,7 +6,6 @@ apm = "apm"
 apm_prefix = "{}*".format(apm)
 apm_version = "8.0.0"
 day = time.strftime("%Y.%m.%d", time.gmtime())
-agentcfg_index = ".apm-agent-configuration"
 default_policy = "apm-rollover-30-days"
 policy_url = "/_ilm/policy/"
 default_pipelines = ["apm_user_agent", "apm_user_geo", "apm"]
@@ -23,10 +22,9 @@ default_aliases = [index_error, index_transaction, index_span, index_metric, ind
 default_indices = [index_name, index_onboarding, index_smap] + default_aliases
 
 
-def cleanup(es, delete_indices=[apm_prefix], truncate_indices=[agentcfg_index], delete_templates=[apm_prefix],
+def cleanup(es, delete_indices=[apm_prefix], delete_templates=[apm_prefix],
             delete_policies=[default_policy], delete_pipelines=[default_pipelines]):
     wait_until_indices_deleted(es, delete_indices=delete_indices)
-    wait_until_indices_truncated(es, truncate_indices=truncate_indices)
     wait_until_templates_deleted(es, delete_templates=delete_templates)
     wait_until_policies_deleted(es, delete_policies=delete_policies)
     wait_until_pipelines_deleted(es, delete_pipelines=delete_pipelines)
@@ -55,18 +53,6 @@ def wait_until_indices_deleted(es, delete_indices=[apm_prefix]):
 
     for idx in delete_indices:
         wait_until(lambda: is_deleted(idx), name="index {} to be deleted".format(idx))
-
-
-def wait_until_indices_truncated(es, truncate_indices=[agentcfg_index]):
-    if not truncate_indices:
-        return
-    # truncate, don't delete agent configuration index since it's only created when kibana starts up
-    for index in truncate_indices:
-        if es.count(index=index, ignore_unavailable=True)["count"] > 0:
-            es.delete_by_query(index, {"query": {"match_all": {}}},
-                               ignore_unavailable=True, wait_for_completion=True)
-            wait_until(lambda: es.count(index=index, ignore_unavailable=True)["count"] == 0,
-                       max_timeout=30, name="acm index {} to be empty".format(index))
 
 
 def wait_until_templates_deleted(es, delete_templates=[apm_prefix]):

--- a/tests/system/kibana.py
+++ b/tests/system/kibana.py
@@ -1,0 +1,82 @@
+#import json
+from urllib.parse import urljoin
+
+import requests
+
+class Kibana(object):
+    def __init__(self, url):
+        self.url = url
+
+    def create_agent_config(self, service, settings, agent=None, env=None):
+        resp = self._upsert_agent_config(service, settings, agent=agent, env=env)
+        result = resp.json()["result"]
+        assert result == "created", result
+        return resp
+
+    def create_or_update_agent_config(self, service, settings, agent=None, env=None):
+        resp = self._upsert_agent_config(service, settings, agent=agent, env=env, overwrite=True)
+        result = resp.json()["result"]
+        assert result in ("created", "updated"), result
+        return resp
+
+    def _upsert_agent_config(self, service, settings, agent=None, env=None, overwrite=False):
+        data = {
+            "service": {"name": service},
+            "settings": settings,
+        }
+        if agent is not None:
+            data["agent_name"] = agent
+        if env is not None:
+            data["service"]["environment"] = env
+
+        resp = requests.put(
+            urljoin(self.url, "/api/apm/settings/agent-configuration"),
+            headers={
+                "Accept": "*/*",
+                "Content-Type": "application/json",
+                "kbn-xsrf": "1",
+            },
+            params={"overwrite": "true" if overwrite else "false"},
+            json=data,
+        )
+        assert resp.status_code == 200, resp.status_code
+        resp.raise_for_status()
+        return resp
+
+    def delete_all_agent_config(self):
+        configs = self.list_agent_config()
+        for config in configs:
+            service = config["service"]
+            self.delete_agent_config(
+                service["name"], env=service.get("environment", None))
+
+    def list_agent_config(self):
+        resp = requests.get(
+            urljoin(self.url, "/api/apm/settings/agent-configuration"),
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "kbn-xsrf": "1",
+            }
+        )
+        assert resp.status_code == 200, resp.status_code
+        return resp.json()
+
+    def delete_agent_config(self, service, env=None):
+        data = {
+            "service": {"name": service},
+        }
+        if env is not None:
+            data["service"]["environment"] = env
+
+        resp = requests.delete(
+            urljoin(self.url, "/api/apm/settings/agent-configuration"),
+            headers={
+                "Accept": "*/*",
+                "Content-Type": "application/json",
+                "kbn-xsrf": "1",
+            },
+            json=data,
+        )
+        assert resp.status_code == 200, resp.status_code
+        return resp

--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -19,36 +19,12 @@ class AgentConfigurationTest(ElasticTest):
         cfg.update(self.config_overrides)
         return cfg
 
-    def _upsert_service_config(self, settings, name, agent="python", env=None, overwrite=False):
-        data = {
-            "agent_name": agent,
-            "service": {"name": name},
-            "settings": settings
-        }
-        if env is not None:
-            data["service"]["environment"] = env
-
-        return requests.put(
-            urljoin(self.kibana_url, "/api/apm/settings/agent-configuration"),
-            params={"overwrite": "true" if overwrite else "false"},
-            headers={
-                "Accept": "*/*",
-                "Content-Type": "application/json",
-                "kbn-xsrf": "1",
-            },
-            json=data,
-        )
-
     def create_service_config(self, settings, name, agent="python", env=None):
-        config = self._upsert_service_config(settings, name, agent=agent, env=env)
-        config.raise_for_status()
-        assert config.status_code == 200, config.status_code
-        assert config.json()["result"] == "created"
+        return self.kibana.create_agent_config(name, settings, agent=agent, env=env)
 
     def update_service_config(self, settings, name, env=None):
-        config = self._upsert_service_config(settings, name, env=env, overwrite=True)
-        assert config.status_code == 200, config.status_code
-        assert config.json()["result"] == "updated"
+        res = self.kibana.create_or_update_agent_config(name, settings, env=env)
+        assert res.json()["result"] == "updated"
 
 
 @integration_test

--- a/tests/system/test_jaeger.py
+++ b/tests/system/test_jaeger.py
@@ -144,21 +144,8 @@ class GRPCSamplingTest(JaegerBaseTest):
         return cfg
 
     def create_service_config(self, service, sampling_rate, agent=None):
-        data = {"service": {"name": service},
-                "settings": {"transaction_sample_rate": "{}".format(sampling_rate)}}
-        if agent:
-            data["agent_name"] = agent
-        resp = requests.put(
-            urljoin(self.kibana_url, "/api/apm/settings/agent-configuration"),
-            headers={
-                "Accept": "*/*",
-                "Content-Type": "application/json",
-                "kbn-xsrf": "1",
-            },
-            params={"overwrite": "true"},
-            json=data,
-        )
-        assert resp.status_code == 200, resp.status_code
+        return self.kibana.create_or_update_agent_config(
+            service, {"transaction_sample_rate": "{}".format(sampling_rate)}, agent=agent)
 
     def call_sampling_endpoint(self, service):
         client = os.path.join(os.path.dirname(__file__), 'jaegergrpc')


### PR DESCRIPTION
## Motivation/summary

Use the Kibana APM app's [Agent Configuration API](https://www.elastic.co/guide/en/kibana/master/agent-config-api.html) to delete agent config instead of deleting documents in the Elasticsearch index directly.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

## How to test these changes

`make system-tests`

## Related issues

Fixes https://github.com/elastic/apm-server/issues/3688