### PR TITLE
ci: comment PRs with the build status

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -478,7 +478,7 @@ pipeline {
   }
   post {
     cleanup {
-      notifyBuildResult()
+      notifyBuildResult(prComment: true)
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('apm@current') _
+@Library('apm@test/tests-reporting') _
 
 pipeline {
   agent { label 'linux && immutable' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('apm@test/tests-reporting') _
+@Library('apm@current') _
 
 pipeline {
   agent { label 'linux && immutable' }


### PR DESCRIPTION
## Motivation/summary

Enhance the build reporting with a message in the PR that contains the build status for the last commit. It does reuse the message.