### PR TITLE
[7.x] tests/system: use Kibana REST API to cleanup ACM (#3690)

### DIFF
--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -24,6 +24,7 @@ from beat.beat import INTEGRATION_TESTS, TestCase, TimeoutError
 from helper import wait_until
 from es_helper import cleanup, default_pipelines
 from es_helper import index_smap, index_span, index_error, apm_prefix
+from kibana import Kibana
 
 integration_test = unittest.skipUnless(INTEGRATION_TESTS, "integration test")
 diagnostic_interval = float(os.environ.get('DIAGNOSTIC_INTERVAL', 0))
@@ -255,10 +256,11 @@ class ElasticTest(ServerBaseTest):
         admin_password = os.getenv("ES_SUPERUSER_PASS", "changeme")
         self.admin_es = Elasticsearch([self.get_elasticsearch_url(admin_user, admin_password)])
         self.es = Elasticsearch([self.get_elasticsearch_url()])
-        self.kibana_url = self.get_kibana_url()
+        self.kibana = Kibana(self.get_kibana_url())
 
         delete_pipelines = [] if self.skip_clean_pipelines else default_pipelines
         cleanup(self.admin_es, delete_pipelines=delete_pipelines)
+        self.kibana.delete_all_agent_config()
 
         super(ElasticTest, self).setUp()
 

--- a/tests/system/kibana.py
+++ b/tests/system/kibana.py
@@ -1,0 +1,82 @@
+#import json
+from urllib.parse import urljoin
+
+import requests
+
+class Kibana(object):
+    def __init__(self, url):
+        self.url = url
+
+    def create_agent_config(self, service, settings, agent=None, env=None):
+        resp = self._upsert_agent_config(service, settings, agent=agent, env=env)
+        result = resp.json()["result"]
+        assert result == "created", result
+        return resp
+
+    def create_or_update_agent_config(self, service, settings, agent=None, env=None):
+        resp = self._upsert_agent_config(service, settings, agent=agent, env=env, overwrite=True)
+        result = resp.json()["result"]
+        assert result in ("created", "updated"), result
+        return resp
+
+    def _upsert_agent_config(self, service, settings, agent=None, env=None, overwrite=False):
+        data = {
+            "service": {"name": service},
+            "settings": settings,
+        }
+        if agent is not None:
+            data["agent_name"] = agent
+        if env is not None:
+            data["service"]["environment"] = env
+
+        resp = requests.put(
+            urljoin(self.url, "/api/apm/settings/agent-configuration"),
+            headers={
+                "Accept": "*/*",
+                "Content-Type": "application/json",
+                "kbn-xsrf": "1",
+            },
+            params={"overwrite": "true" if overwrite else "false"},
+            json=data,
+        )
+        assert resp.status_code == 200, resp.status_code
+        resp.raise_for_status()
+        return resp
+
+    def delete_all_agent_config(self):
+        configs = self.list_agent_config()
+        for config in configs:
+            service = config["service"]
+            self.delete_agent_config(
+                service["name"], env=service.get("environment", None))
+
+    def list_agent_config(self):
+        resp = requests.get(
+            urljoin(self.url, "/api/apm/settings/agent-configuration"),
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+                "kbn-xsrf": "1",
+            }
+        )
+        assert resp.status_code == 200, resp.status_code
+        return resp.json()
+
+    def delete_agent_config(self, service, env=None):
+        data = {
+            "service": {"name": service},
+        }
+        if env is not None:
+            data["service"]["environment"] = env
+
+        resp = requests.delete(
+            urljoin(self.url, "/api/apm/settings/agent-configuration"),
+            headers={
+                "Accept": "*/*",
+                "Content-Type": "application/json",
+                "kbn-xsrf": "1",
+            },
+            json=data,
+        )
+        assert resp.status_code == 200, resp.status_code
+        return resp

--- a/tests/system/test_integration_acm.py
+++ b/tests/system/test_integration_acm.py
@@ -19,36 +19,12 @@ class AgentConfigurationTest(ElasticTest):
         cfg.update(self.config_overrides)
         return cfg
 
-    def _upsert_service_config(self, settings, name, agent="python", env=None, overwrite=False):
-        data = {
-            "agent_name": agent,
-            "service": {"name": name},
-            "settings": settings
-        }
-        if env is not None:
-            data["service"]["environment"] = env
-
-        return requests.put(
-            urljoin(self.kibana_url, "/api/apm/settings/agent-configuration"),
-            params={"overwrite": "true" if overwrite else "false"},
-            headers={
-                "Accept": "*/*",
-                "Content-Type": "application/json",
-                "kbn-xsrf": "1",
-            },
-            json=data,
-        )
-
     def create_service_config(self, settings, name, agent="python", env=None):
-        config = self._upsert_service_config(settings, name, agent=agent, env=env)
-        config.raise_for_status()
-        assert config.status_code == 200, config.status_code
-        assert config.json()["result"] == "created"
+        return self.kibana.create_agent_config(name, settings, agent=agent, env=env)
 
     def update_service_config(self, settings, name, env=None):
-        config = self._upsert_service_config(settings, name, env=env, overwrite=True)
-        assert config.status_code == 200, config.status_code
-        assert config.json()["result"] == "updated"
+        res = self.kibana.create_or_update_agent_config(name, settings, env=env)
+        assert res.json()["result"] == "updated"
 
 
 @integration_test

--- a/tests/system/test_jaeger.py
+++ b/tests/system/test_jaeger.py
@@ -144,21 +144,8 @@ class GRPCSamplingTest(JaegerBaseTest):
         return cfg
 
     def create_service_config(self, service, sampling_rate, agent=None):
-        data = {"service": {"name": service},
-                "settings": {"transaction_sample_rate": "{}".format(sampling_rate)}}
-        if agent:
-            data["agent_name"] = agent
-        resp = requests.put(
-            urljoin(self.kibana_url, "/api/apm/settings/agent-configuration"),
-            headers={
-                "Accept": "*/*",
-                "Content-Type": "application/json",
-                "kbn-xsrf": "1",
-            },
-            params={"overwrite": "true"},
-            json=data,
-        )
-        assert resp.status_code == 200, resp.status_code
+        return self.kibana.create_or_update_agent_config(
+            service, {"transaction_sample_rate": "{}".format(sampling_rate)}, agent=agent)
 
     def call_sampling_endpoint(self, service):
         client = os.path.join(os.path.dirname(__file__), 'jaegergrpc')


### PR DESCRIPTION
Backports the following commits to 7.x:
 - tests/system: use Kibana REST API to cleanup ACM (#3690)