### PR TITLE
[7.x] Remove a duplicated call to close the default tracer (#3703)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /apm-server.iml
 /apm-server.keystore
 /apm-server
+/apm-server-oss
 **/*.test
 /apm-server.dev.yml
 /_meta/fields.generated.yml

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
-	"go.elastic.co/apm"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -37,10 +36,6 @@ import (
 	logs "github.com/elastic/apm-server/log"
 	"github.com/elastic/apm-server/publish"
 )
-
-func init() {
-	apm.DefaultTracer.Close()
-}
 
 var (
 	errSetupDashboardRemoved = errors.New("setting 'setup.dashboards' has been removed")

--- a/tests/system/kibana.py
+++ b/tests/system/kibana.py
@@ -3,6 +3,7 @@ from urllib.parse import urljoin
 
 import requests
 
+
 class Kibana(object):
     def __init__(self, url):
         self.url = url


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Remove a duplicated call to close the default tracer (#3703)