### PR TITLE
docs: correct apm-server.host in configuration process example (#3649)

### DIFF
--- a/docs/configuration-process.asciidoc
+++ b/docs/configuration-process.asciidoc
@@ -6,7 +6,7 @@ Example config file:
 ["source","yaml"]
 ----
 apm-server:
-  hosts: ["localhost:8200"]
+  host: "localhost:8200"
   rum:
     enabled: true
 


### PR DESCRIPTION
Cherry-picks https://github.com/elastic/apm-server/pull/3649 to `7.x`.