### PR TITLE
docs: link to max spans config

### DIFF
--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -14,43 +14,40 @@ Events can contain additional <<metadata,metadata>> which further enriches your 
 [[transaction-spans]]
 === Spans
 
-*Spans* contain information about a specific code path that has been executed.
-They measure from the start to end of an activity,
+*Spans* contain information about the execution of a specific code path.
+They measure from the start to the end of an activity,
 and they can have a parent/child relationship with other spans.
 
-Agents automatically instrument a variety of libraries to capture these spans from within your application.
-In addition, you can use the Agent API for ad hoc instrumentation of specific code paths.
+Agents automatically instrument a variety of libraries to capture these spans from within your application,
+but you can also use the Agent API for custom instrumentation of specific code paths.
 
-A span contains:
+Each span contains:
 
-* A `transaction.id` attribute that refers to their parent <<transactions,transaction>>.
-* A `parent.id` attribute that refers to their parent span, or their transaction.
-* start time and duration
-* name
-* type
+* A `transaction.id` attribute that refers to its parent <<transactions,transaction>>.
+* A `parent.id` attribute that refers to its parent span or transaction.
+* Its start time and duration
+* A `name`
+* A `type`
 * An optional `stack trace`. Stack traces consist of stack frames,
 which represent a function call on the call stack.
 They include attributes like function name, file name and path, line number, etc.
 
-TIP: Most agents limit keyword fields (e.g. `span.id`) to 1024 characters,
-and non-keyword fields (e.g. `span.start.us`) to 10,000 characters.
+TIP: Most agents limit keyword fields, like `span.id`, to 1024 characters,
+and non-keyword fields, like `span.start.us`, to 10,000 characters.
 
 Spans are stored in {apm-server-ref-v}/span-indices.html[span indices].
-Note that these indices are separate from {apm-server-ref-v}/transaction-indices.html[transaction indices] by default.
+This storage is separate from {apm-server-ref-v}/transaction-indices.html[transaction indices] by default.
 
 [float]
 [[dropped-spans]]
-==== Dropped Spans
+==== Dropped spans
 
-For performance reasons, some APM agents can choose to purposefully sample or omit spans.
-One example of this might be for long running transactions with over 100 spans.
-These edge cases can overload both the agent and the APM Server.
-To avoid this, agents will drop spans. When they do this,
-they notify the server of exactly how many spans were dropped.
-This note is then passed on to the user in the UI.
+For performance reasons, APM agents can choose to sample or omit spans purposefully.
+This can be useful in preventing edge cases, like long-running transactions with over 100 spans,
+that would otherwise overload both the Agent and the APM Server.
+When this occurs, the APM app will display the number of spans dropped.
 
-Settings affecting dropped spans, and more details on why they might occur,
-are available in the relevant agent documentation:
+To configure the number of spans recorded per transaction, see the relevant Agent documentation:
 
 * Go: {apm-go-ref-v}/configuration.html#config-transaction-max-spans[`ELASTIC_APM_TRANSACTION_MAX_SPANS`]
 * Java: {apm-java-ref-v}/config-core.html#config-transaction-max-spans[`transaction_max_spans`]
@@ -61,13 +58,13 @@ are available in the relevant agent documentation:
 
 [float]
 [[missing-spans]]
-==== Missing Spans
+==== Missing spans
 
-Similarly to dropped spans, transactions may have missing spans.
-This can happen because spans are streamed from the APM Agent to the APM Server separately from their transaction.
-Unforeseen errors may cause spans to go missing.
-Because the agent notifies the server about how many spans there should be,
-the number of missing spans is able to be calculated and shown in the UI.
+Agents stream spans to the APM Server separately from their transactions.
+Because of this, unforeseen errors may cause spans to go missing.
+Agents know how many spans a transaction should have;
+if the number of expected spans does not equal the number of spans received by the APM Server,
+the APM app will calculate the difference and display a message.
 
 [[transactions]]
 === Transactions

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -21,13 +21,13 @@ and they can have a parent/child relationship with other spans.
 Agents automatically instrument a variety of libraries to capture these spans from within your application,
 but you can also use the Agent API for custom instrumentation of specific code paths.
 
-Among other things, spans can contain:
+Each span contains:
 
 * A `transaction.id` attribute that refers to its parent <<transactions,transaction>>.
 * A `parent.id` attribute that refers to its parent span or transaction.
-* Its start time and duration.
-* A `name`.
-* A `type`, `subtype`, and `action`.
+* Its start time and duration
+* A `name`
+* A `type`
 * An optional `stack trace`. Stack traces consist of stack frames,
 which represent a function call on the call stack.
 They include attributes like function name, file name and path, line number, etc.
@@ -184,44 +184,46 @@ Let's explore the different types of metadata that Elastic APM offers.
 [[labels-fields]]
 ==== Labels
 
-Labels add *indexed* information to transactions, spans, and errors.
+Labels are used to add *indexed* information to transactions, spans, and errors.
 Indexed means the data is searchable and aggregatable in Elasticsearch.
-Add additional key-value pairs to define multiple labels.
+Multiple labels can be defined with different key-value pairs.
 
 * Indexed: Yes
 * Elasticsearch type: {ref}/object.html[object]
-* Elasticsearch field: `labels`
-* Applies to: <<transactions>> | <<transaction-spans>> | <<errors>>
+* Elasticsearch field: `labels` (`context.tags` in APM Server pre-7.0)
+* Applies to <<transactions>> | <<transaction-spans>> | <<errors>>
 
-Label values can be a string, boolean, or number, although some agents only support string values at this time.
+Label values can be a string, boolean, or number in APM Server 6.7+.
+Using this API in combination with an older APM Server version leads to validation errors.
+In addition, some agents only support string values at this time.
 Because labels for a given key, regardless of agent used, are stored in the same place in Elasticsearch,
 all label values of a given key must have the same data type.
-Multiple data types per key will throw an exception, for example: `{foo: bar}` and `{foo: 42}` is not allowed.
+Multiple data types per key will throw an exception, e.g. `{foo: bar}` and `{foo: 42}`
 
 IMPORTANT: Avoid defining too many user-specified labels.
 Defining too many unique fields in an index is a condition that can lead to a
 {ref}/mapping.html#mapping-limit-settings[mapping explosion].
 
-[float]
-===== Agent API reference
-
-* Go: {apm-go-ref-v}/api.html#context-set-label[`SetLabel`]
-* Java: {apm-java-ref-v}/public-api.html#api-transaction-add-tag[`addLabel`]
-* .NET: {apm-dotnet-ref-v}/public-api.html#api-transaction-tags[`Labels`]
-* Node.js: {apm-node-ref-v}/agent-api.html#apm-set-label[`setLabel`] | {apm-node-ref-v}/agent-api.html#apm-add-labels[`addLabel`]
-* Python: {apm-py-ref-v}/api.html#api-label[`elasticapm.label()`]
-* Ruby:  {apm-ruby-ref-v}/api.html#api-agent-set-label[`set_label`]
-* Rum: {apm-rum-ref-v}/agent-api.html#apm-add-labels[`addLabels`]
+|===
+|*Labels API links*
+v|*Go:* {apm-go-ref-v}/api.html#context-set-label[`SetLabel`]
+*Java:* {apm-java-ref-v}/public-api.html#api-transaction-add-tag[`addLabel`]
+*.NET:* {apm-dotnet-ref-v}/public-api.html#api-transaction-tags[`Labels`]
+*Node.js:* {apm-node-ref-v}/agent-api.html#apm-set-label[`setLabel`] \| {apm-node-ref-v}/agent-api.html#apm-add-labels[`addLabel`]
+*Python:* {apm-py-ref-v}/api.html#api-label[`elasticapm.label()`]
+*Ruby:* {apm-ruby-ref-v}/api.html#api-agent-set-label[`set_label`]
+*Rum:* {apm-rum-ref-v}/agent-api.html#apm-add-labels[`addLabels`]
+|===
 
 [float]
 [[custom-fields]]
 ==== Custom context
 
-Custom context adds *non-indexed*,
+Custom context is used to add *non-indexed*,
 custom contextual information to transactions and errors.
 Non-indexed means the data is not searchable or aggregatable in Elasticsearch,
 and you cannot build dashboards on top of the data.
-This also means you don't have to worry about {ref}/mapping.html#mapping-limit-settings[mapping explosions],
+This also means you do not have to worry about {ref}/mapping.html#mapping-limit-settings[mapping explosions],
 as these fields are not added to the mapping.
 
 Non-indexed information is useful for providing contextual information to help you
@@ -230,41 +232,40 @@ quickly debug performance issues or errors.
 * Indexed: No
 * Elasticsearch type: {ref}/object.html[object]
 * Elasticsearch fields: `transaction.custom` | `error.custom`
-* Applies to: <<transactions>> | <<errors>>
+* Applies to <<transactions>> | <<errors>>
 
-IMPORTANT: Setting a circular object, a large object, or a non JSON serializable object can lead to errors.
+IMPORTANT: Setting a circular object, large object, or a non JSON serializable object can lead to errors.
 
-[float]
-===== Agent API reference
-
-* Go: {apm-go-ref-v}/api.html#context-set-custom[`SetCustom`]
-* Java: {apm-java-ref-v}/public-api.html#api-transaction-add-custom-context[`addCustomContext`]
-* .NET: _coming soon_
-* Node.js: {apm-node-ref-v}/agent-api.html#apm-set-custom-context[`setCustomContext`]
-* Python: {apm-py-ref-v}/api.html#api-set-custom-context[`set_custom_context`]
-* Ruby: {apm-ruby-ref-v}/api.html#api-agent-set-custom-context[`set_custom_context`]
-* Rum: {apm-rum-ref-v}/agent-api.html#apm-set-custom-context[`setCustomContext`]
+|===
+|*Custom context API links*
+v|*Go:* {apm-go-ref-v}/api.html#context-set-custom[`SetCustom`]
+*Java:* {apm-java-ref-v}/public-api.html#api-transaction-add-custom-context[`addCustomContext`]
+*.NET:* _coming soon_
+*Node.js:* {apm-node-ref-v}/agent-api.html#apm-set-custom-context[`setCustomContext`]
+*Python:* {apm-py-ref-v}/api.html#api-set-custom-context[`set_custom_context`]
+*Ruby:* {apm-ruby-ref-v}/api.html#api-agent-set-custom-context[`set_custom_context`]
+*Rum:* {apm-rum-ref-v}/agent-api.html#apm-set-custom-context[`setCustomContext`]
+|===
 
 [float]
 [[user-fields]]
 ==== User context
 
-User context adds *indexed* user information to transactions and errors.
+User context is used to add *indexed* user information to transactions and errors.
 Indexed means the data is searchable and aggregatable in Elasticsearch.
 
 * Indexed: Yes
-* Elasticsearch type: {ref}/keyword.html[keyword]
+* Elasticsearch type: {ref}/keyword.html[keywords]
 * Elasticsearch fields: `user.email` | `user.name` | `user.id`
-* Applies to: <<transactions>> | <<errors>>
+* Applies to <<transactions>> | <<errors>>
 
-[float]
-===== Agent API reference
-
-* Go: {apm-go-ref-v}/api.html#context-set-username[`SetUsername`] | {apm-go-ref-v}/api.html#context-set-user-id[`SetUserID`] |
-{apm-go-ref-v}/api.html#context-set-user-email[`SetUserEmail`]
-* Java: {apm-java-ref-v}/public-api.html#api-transaction-set-user[`setUser`]
-* .NET _coming soon_
-* Node.js: {apm-node-ref-v}/agent-api.html#apm-set-user-context[`setUserContext`]
-* Python: {apm-py-ref-v}/api.html#api-set-user-context[`set_user_context`]
-* Ruby: {apm-ruby-ref-v}/api.html#api-agent-set-user[`set_user`]
-* Rum: {apm-rum-ref-v}/agent-api.html#apm-set-user-context[`setUserContext`]
+|===
+|*User context API links*
+v|*Go:* {apm-go-ref-v}/api.html#context-set-username[`SetUsername`] \| {apm-go-ref-v}/api.html#context-set-user-id[`SetUserID`] \| {apm-go-ref-v}/api.html#context-set-user-email[`SetUserEmail`]
+*Java:* {apm-java-ref-v}/public-api.html#api-transaction-set-user[`setUser`]
+*.NET* _coming soon_
+*Node.js:* {apm-node-ref-v}/agent-api.html#apm-set-user-context[`setUserContext`]
+*Python:* {apm-py-ref-v}/api.html#api-set-user-context[`set_user_context`]
+*Ruby:* {apm-ruby-ref-v}/api.html#api-agent-set-user[`set_user`]
+*Rum:* {apm-rum-ref-v}/agent-api.html#apm-set-user-context[`setUserContext`]
+|===

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -21,13 +21,13 @@ and they can have a parent/child relationship with other spans.
 Agents automatically instrument a variety of libraries to capture these spans from within your application,
 but you can also use the Agent API for custom instrumentation of specific code paths.
 
-Each span contains:
+Among other things, spans can contain:
 
 * A `transaction.id` attribute that refers to its parent <<transactions,transaction>>.
 * A `parent.id` attribute that refers to its parent span or transaction.
-* Its start time and duration
-* A `name`
-* A `type`
+* Its start time and duration.
+* A `name`.
+* A `type`, `subtype`, and `action`.
 * An optional `stack trace`. Stack traces consist of stack frames,
 which represent a function call on the call stack.
 They include attributes like function name, file name and path, line number, etc.
@@ -184,46 +184,44 @@ Let's explore the different types of metadata that Elastic APM offers.
 [[labels-fields]]
 ==== Labels
 
-Labels are used to add *indexed* information to transactions, spans, and errors.
+Labels add *indexed* information to transactions, spans, and errors.
 Indexed means the data is searchable and aggregatable in Elasticsearch.
-Multiple labels can be defined with different key-value pairs.
+Add additional key-value pairs to define multiple labels.
 
 * Indexed: Yes
 * Elasticsearch type: {ref}/object.html[object]
-* Elasticsearch field: `labels` (`context.tags` in APM Server pre-7.0)
-* Applies to <<transactions>> | <<transaction-spans>> | <<errors>>
+* Elasticsearch field: `labels`
+* Applies to: <<transactions>> | <<transaction-spans>> | <<errors>>
 
-Label values can be a string, boolean, or number in APM Server 6.7+.
-Using this API in combination with an older APM Server version leads to validation errors.
-In addition, some agents only support string values at this time.
+Label values can be a string, boolean, or number, although some agents only support string values at this time.
 Because labels for a given key, regardless of agent used, are stored in the same place in Elasticsearch,
 all label values of a given key must have the same data type.
-Multiple data types per key will throw an exception, e.g. `{foo: bar}` and `{foo: 42}`
+Multiple data types per key will throw an exception, for example: `{foo: bar}` and `{foo: 42}` is not allowed.
 
 IMPORTANT: Avoid defining too many user-specified labels.
 Defining too many unique fields in an index is a condition that can lead to a
 {ref}/mapping.html#mapping-limit-settings[mapping explosion].
 
-|===
-|*Labels API links*
-v|*Go:* {apm-go-ref-v}/api.html#context-set-label[`SetLabel`]
-*Java:* {apm-java-ref-v}/public-api.html#api-transaction-add-tag[`addLabel`]
-*.NET:* {apm-dotnet-ref-v}/public-api.html#api-transaction-tags[`Labels`]
-*Node.js:* {apm-node-ref-v}/agent-api.html#apm-set-label[`setLabel`] \| {apm-node-ref-v}/agent-api.html#apm-add-labels[`addLabel`]
-*Python:* {apm-py-ref-v}/api.html#api-label[`elasticapm.label()`]
-*Ruby:* {apm-ruby-ref-v}/api.html#api-agent-set-label[`set_label`]
-*Rum:* {apm-rum-ref-v}/agent-api.html#apm-add-labels[`addLabels`]
-|===
+[float]
+===== Agent API reference
+
+* Go: {apm-go-ref-v}/api.html#context-set-label[`SetLabel`]
+* Java: {apm-java-ref-v}/public-api.html#api-transaction-add-tag[`addLabel`]
+* .NET: {apm-dotnet-ref-v}/public-api.html#api-transaction-tags[`Labels`]
+* Node.js: {apm-node-ref-v}/agent-api.html#apm-set-label[`setLabel`] | {apm-node-ref-v}/agent-api.html#apm-add-labels[`addLabel`]
+* Python: {apm-py-ref-v}/api.html#api-label[`elasticapm.label()`]
+* Ruby:  {apm-ruby-ref-v}/api.html#api-agent-set-label[`set_label`]
+* Rum: {apm-rum-ref-v}/agent-api.html#apm-add-labels[`addLabels`]
 
 [float]
 [[custom-fields]]
 ==== Custom context
 
-Custom context is used to add *non-indexed*,
+Custom context adds *non-indexed*,
 custom contextual information to transactions and errors.
 Non-indexed means the data is not searchable or aggregatable in Elasticsearch,
 and you cannot build dashboards on top of the data.
-This also means you do not have to worry about {ref}/mapping.html#mapping-limit-settings[mapping explosions],
+This also means you don't have to worry about {ref}/mapping.html#mapping-limit-settings[mapping explosions],
 as these fields are not added to the mapping.
 
 Non-indexed information is useful for providing contextual information to help you
@@ -232,40 +230,41 @@ quickly debug performance issues or errors.
 * Indexed: No
 * Elasticsearch type: {ref}/object.html[object]
 * Elasticsearch fields: `transaction.custom` | `error.custom`
-* Applies to <<transactions>> | <<errors>>
+* Applies to: <<transactions>> | <<errors>>
 
-IMPORTANT: Setting a circular object, large object, or a non JSON serializable object can lead to errors.
+IMPORTANT: Setting a circular object, a large object, or a non JSON serializable object can lead to errors.
 
-|===
-|*Custom context API links*
-v|*Go:* {apm-go-ref-v}/api.html#context-set-custom[`SetCustom`]
-*Java:* {apm-java-ref-v}/public-api.html#api-transaction-add-custom-context[`addCustomContext`]
-*.NET:* _coming soon_
-*Node.js:* {apm-node-ref-v}/agent-api.html#apm-set-custom-context[`setCustomContext`]
-*Python:* {apm-py-ref-v}/api.html#api-set-custom-context[`set_custom_context`]
-*Ruby:* {apm-ruby-ref-v}/api.html#api-agent-set-custom-context[`set_custom_context`]
-*Rum:* {apm-rum-ref-v}/agent-api.html#apm-set-custom-context[`setCustomContext`]
-|===
+[float]
+===== Agent API reference
+
+* Go: {apm-go-ref-v}/api.html#context-set-custom[`SetCustom`]
+* Java: {apm-java-ref-v}/public-api.html#api-transaction-add-custom-context[`addCustomContext`]
+* .NET: _coming soon_
+* Node.js: {apm-node-ref-v}/agent-api.html#apm-set-custom-context[`setCustomContext`]
+* Python: {apm-py-ref-v}/api.html#api-set-custom-context[`set_custom_context`]
+* Ruby: {apm-ruby-ref-v}/api.html#api-agent-set-custom-context[`set_custom_context`]
+* Rum: {apm-rum-ref-v}/agent-api.html#apm-set-custom-context[`setCustomContext`]
 
 [float]
 [[user-fields]]
 ==== User context
 
-User context is used to add *indexed* user information to transactions and errors.
+User context adds *indexed* user information to transactions and errors.
 Indexed means the data is searchable and aggregatable in Elasticsearch.
 
 * Indexed: Yes
-* Elasticsearch type: {ref}/keyword.html[keywords]
+* Elasticsearch type: {ref}/keyword.html[keyword]
 * Elasticsearch fields: `user.email` | `user.name` | `user.id`
-* Applies to <<transactions>> | <<errors>>
+* Applies to: <<transactions>> | <<errors>>
 
-|===
-|*User context API links*
-v|*Go:* {apm-go-ref-v}/api.html#context-set-username[`SetUsername`] \| {apm-go-ref-v}/api.html#context-set-user-id[`SetUserID`] \| {apm-go-ref-v}/api.html#context-set-user-email[`SetUserEmail`]
-*Java:* {apm-java-ref-v}/public-api.html#api-transaction-set-user[`setUser`]
-*.NET* _coming soon_
-*Node.js:* {apm-node-ref-v}/agent-api.html#apm-set-user-context[`setUserContext`]
-*Python:* {apm-py-ref-v}/api.html#api-set-user-context[`set_user_context`]
-*Ruby:* {apm-ruby-ref-v}/api.html#api-agent-set-user[`set_user`]
-*Rum:* {apm-rum-ref-v}/agent-api.html#apm-set-user-context[`setUserContext`]
-|===
+[float]
+===== Agent API reference
+
+* Go: {apm-go-ref-v}/api.html#context-set-username[`SetUsername`] | {apm-go-ref-v}/api.html#context-set-user-id[`SetUserID`] |
+{apm-go-ref-v}/api.html#context-set-user-email[`SetUserEmail`]
+* Java: {apm-java-ref-v}/public-api.html#api-transaction-set-user[`setUser`]
+* .NET _coming soon_
+* Node.js: {apm-node-ref-v}/agent-api.html#apm-set-user-context[`setUserContext`]
+* Python: {apm-py-ref-v}/api.html#api-set-user-context[`set_user_context`]
+* Ruby: {apm-ruby-ref-v}/api.html#api-agent-set-user[`set_user`]
+* Rum: {apm-rum-ref-v}/agent-api.html#apm-set-user-context[`setUserContext`]

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -21,13 +21,13 @@ and they can have a parent/child relationship with other spans.
 Agents automatically instrument a variety of libraries to capture these spans from within your application,
 but you can also use the Agent API for custom instrumentation of specific code paths.
 
-Each span contains:
+Among other things, spans can contain:
 
 * A `transaction.id` attribute that refers to its parent <<transactions,transaction>>.
 * A `parent.id` attribute that refers to its parent span or transaction.
-* Its start time and duration
-* A `name`
-* A `type`
+* Its start time and duration.
+* A `name`.
+* A `type`, `subtype`, and `action`.
 * An optional `stack trace`. Stack traces consist of stack frames,
 which represent a function call on the call stack.
 They include attributes like function name, file name and path, line number, etc.

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -52,8 +52,12 @@ This note is then passed on to the user in the UI.
 Settings affecting dropped spans, and more details on why they might occur,
 are available in the relevant agent documentation:
 
-* {apm-node-ref-v}/configuration.html#transaction-max-spans[Node.js Agent max spans]
-* {apm-py-ref-v}/configuration.html[Python Agent max spans]
+* Go: {apm-go-ref-v}/configuration.html#config-transaction-max-spans[`ELASTIC_APM_TRANSACTION_MAX_SPANS`]
+* Java: {apm-java-ref-v}/config-core.html#config-transaction-max-spans[`transaction_max_spans`]
+* .NET: {apm-dotnet-ref-v}/config-core.html#config-transaction-max-spans[`TransactionMaxSpans`]
+* Node.js: {apm-node-ref-v}/configuration.html#transaction-max-spans[`transactionMaxSpans`]
+* Python: {apm-py-ref-v}/configuration.html#config-transaction-max-spans[`transaction_max_spans`]
+* Ruby: {apm-ruby-ref-v}/configuration.html#config-transaction-max-spans[`transaction_max_spans`]
 
 [float]
 [[missing-spans]]


### PR DESCRIPTION
## What does this pull request do?

This PR links the APM Overview's [dropped span](https://www.elastic.co/guide/en/apm/get-started/current/transaction-spans.html#dropped-spans) documentation to each agent's `transaction_max_spans` configuration documentation (L52-L57).

I also decided to update the rest of the content on the page while I had the file open.

## Documentation preview

http://apm-server_3708.docs-preview.app.elstc.co/diff

## Screenshot

<img width="689" alt="Screen Shot 2020-04-28 at 1 48 46 PM" src="https://user-images.githubusercontent.com/5618806/80536293-0064fd80-8957-11ea-9599-45d4d8b1e2ac.png">

## Related issues

Closes https://github.com/elastic/apm/issues/126.