### PR TITLE
Fix typo in spec ids

### DIFF
--- a/docs/spec/context.json
+++ b/docs/spec/context.json
@@ -1,5 +1,5 @@
 {
-    "$id": "doc/spec/context.json",
+    "$id": "docs/spec/context.json",
     "title": "Context",
     "description": "Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user",
     "type": ["object", "null"],

--- a/docs/spec/http_response.json
+++ b/docs/spec/http_response.json
@@ -1,5 +1,5 @@
 {
-    "$id": "doc/spec/http_response.json",
+    "$id": "docs/spec/http_response.json",
     "title": "HTTP response object",
     "description": "HTTP response object, used by error, span and transction documents",
     "type": ["object", "null"],

--- a/docs/spec/message.json
+++ b/docs/spec/message.json
@@ -1,5 +1,5 @@
 {
-    "$id": "doc/spec/message.json",
+    "$id": "docs/spec/message.json",
     "title": "Message",
     "description": "Details related to message receiving and publishing if the captured event integrates with a messaging system",
     "type": ["object", "null"],

--- a/docs/spec/metadata.json
+++ b/docs/spec/metadata.json
@@ -1,5 +1,5 @@
 {
-    "$id": "doc/spec/metadata.json",
+    "$id": "docs/spec/metadata.json",
     "title": "Metadata",
     "description": "Metadata concerning the other objects in the stream.",
     "type": ["object"],

--- a/docs/spec/process.json
+++ b/docs/spec/process.json
@@ -1,5 +1,5 @@
 {
-  "$id": "doc/spec/process.json",
+  "$id": "docs/spec/process.json",
   "title": "Process",
   "type": ["object", "null"],
   "properties": {

--- a/docs/spec/request.json
+++ b/docs/spec/request.json
@@ -1,5 +1,5 @@
 {
-    "$id": "docs/spec/http.json",
+    "$id": "docs/spec/request.json",
     "title": "Request",
     "description": "If a log record was generated as a result of a http request, the http interface can be used to collect this information.",
     "type": ["object", "null"],

--- a/docs/spec/rum_v3_context.json
+++ b/docs/spec/rum_v3_context.json
@@ -1,5 +1,5 @@
 {
-    "$id": "doc/spec/rum_v3_context.json",
+    "$id": "docs/spec/rum_v3_context.json",
     "title": "Context",
     "description": "Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user",
     "type": [

--- a/docs/spec/rum_v3_metadata.json
+++ b/docs/spec/rum_v3_metadata.json
@@ -1,5 +1,5 @@
 {
-    "$id": "doc/spec/rum_v3_metadata.json",
+    "$id": "docs/spec/rum_v3_metadata.json",
     "title": "Metadata",
     "description": "Metadata concerning the other objects in the stream.",
     "type": [

--- a/docs/spec/rum_v3_service.json
+++ b/docs/spec/rum_v3_service.json
@@ -1,5 +1,5 @@
 {
-    "$id": "doc/spec/rum_v3_service.json",
+    "$id": "docs/spec/rum_v3_service.json",
     "title": "Service",
     "type": [
         "object",

--- a/docs/spec/service.json
+++ b/docs/spec/service.json
@@ -1,5 +1,5 @@
 {
-    "$id": "doc/spec/service.json",
+    "$id": "docs/spec/service.json",
     "title": "Service",
     "type": ["object", "null"],
     "properties": {

--- a/docs/spec/system.json
+++ b/docs/spec/system.json
@@ -1,5 +1,5 @@
 {
-    "$id": "doc/spec/system.json",
+    "$id": "docs/spec/system.json",
     "title": "System",
     "type": ["object", "null"],
     "properties": {

--- a/docs/spec/tags.json
+++ b/docs/spec/tags.json
@@ -1,5 +1,5 @@
 {
-    "$id": "doc/spec/tags.json",
+    "$id": "docs/spec/tags.json",
     "title": "Tags",
     "type": ["object", "null"],
     "description": "A flat mapping of user-defined tags with string, boolean or number values.",

--- a/docs/spec/timestamp_epoch.json
+++ b/docs/spec/timestamp_epoch.json
@@ -1,9 +1,9 @@
 {
-    "$id": "doc/spec/timestamp_epoch.json",
+    "$id": "docs/spec/timestamp_epoch.json",
     "title": "Timestamp Epoch",
     "description": "Object with 'timestamp' property.",
     "type": ["object"],
-    "properties": {  
+    "properties": {
         "timestamp": {
             "description": "Recorded time of the event, UTC based and formatted as microseconds since Unix epoch",
             "type": ["integer", "null"]

--- a/docs/spec/timestamp_rfc3339.json
+++ b/docs/spec/timestamp_rfc3339.json
@@ -1,5 +1,5 @@
 {
-    "$id": "doc/spec/timestamp_rfc3339.json",
+    "$id": "docs/spec/timestamp_rfc3339.json",
     "title": "Timestamp",
     "description": "Used for '@timestamp' property.",
     "type": ["object"],

--- a/docs/spec/transactions/rum_v3_transaction.json
+++ b/docs/spec/transactions/rum_v3_transaction.json
@@ -1,5 +1,5 @@
 {
-    "$id": "docs/spec/transactions/rumv3_transaction.json",
+    "$id": "docs/spec/transactions/rum_v3_transaction.json",
     "type": "object",
     "description": "An event corresponding to an incoming request or similar task occurring in a monitored service",
     "allOf": [

--- a/model/error/generated/schema/error.go
+++ b/model/error/generated/schema/error.go
@@ -22,11 +22,11 @@ const ModelSchema = `{
     "type": "object",
     "description": "An error or a logged error message captured by an agent occurring in a monitored service",
     "allOf": [
-        {     "$id": "doc/spec/timestamp_epoch.json",
+        {     "$id": "docs/spec/timestamp_epoch.json",
     "title": "Timestamp Epoch",
     "description": "Object with 'timestamp' property.",
     "type": ["object"],
-    "properties": {  
+    "properties": {
         "timestamp": {
             "description": "Recorded time of the event, UTC based and formatted as microseconds since Unix epoch",
             "type": ["integer", "null"]
@@ -70,7 +70,7 @@ const ModelSchema = `{
                     }
                 },
                 "context": {
-                        "$id": "doc/spec/context.json",
+                        "$id": "docs/spec/context.json",
     "title": "Context",
     "description": "Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user",
     "type": ["object", "null"],
@@ -86,7 +86,7 @@ const ModelSchema = `{
         "response": {
             "type": ["object", "null"],
             "allOf": [
-                {     "$id": "doc/spec/http_response.json",
+                {     "$id": "docs/spec/http_response.json",
     "title": "HTTP response object",
     "description": "HTTP response object, used by error, span and transction documents",
     "type": ["object", "null"],
@@ -242,7 +242,7 @@ const ModelSchema = `{
     "required": ["url", "method"]
         },
         "tags": {
-                "$id": "doc/spec/tags.json",
+                "$id": "docs/spec/tags.json",
     "title": "Tags",
     "type": ["object", "null"],
     "description": "A flat mapping of user-defined tags with string, boolean or number values.",
@@ -293,7 +293,7 @@ const ModelSchema = `{
         },
         "service": {
             "description": "Service related information can be sent per event. Provided information will override the more generic information from metadata, non provided fields will be set according to the metadata information.",
-                "$id": "doc/spec/service.json",
+                "$id": "docs/spec/service.json",
     "title": "Service",
     "type": ["object", "null"],
     "properties": {
@@ -389,7 +389,7 @@ const ModelSchema = `{
     }
         },
         "message": {
-                "$id": "doc/spec/message.json",
+                "$id": "docs/spec/message.json",
     "title": "Message",
     "description": "Details related to message receiving and publishing if the captured event integrates with a messaging system",
     "type": ["object", "null"],

--- a/model/error/generated/schema/error.go
+++ b/model/error/generated/schema/error.go
@@ -139,7 +139,7 @@ const ModelSchema = `{
             ]
         },
         "request": {
-                "$id": "docs/spec/http.json",
+                "$id": "docs/spec/request.json",
     "title": "Request",
     "description": "If a log record was generated as a result of a http request, the http interface can be used to collect this information.",
     "type": ["object", "null"],

--- a/model/error/generated/schema/rum_v3_error.go
+++ b/model/error/generated/schema/rum_v3_error.go
@@ -22,11 +22,11 @@ const RUMV3Schema = `{
     "type": "object",
     "description": "An error or a logged error message captured by an agent occurring in a monitored service",
     "allOf": [
-        {     "$id": "doc/spec/timestamp_epoch.json",
+        {     "$id": "docs/spec/timestamp_epoch.json",
     "title": "Timestamp Epoch",
     "description": "Object with 'timestamp' property.",
     "type": ["object"],
-    "properties": {  
+    "properties": {
         "timestamp": {
             "description": "Recorded time of the event, UTC based and formatted as microseconds since Unix epoch",
             "type": ["integer", "null"]
@@ -70,7 +70,7 @@ const RUMV3Schema = `{
                     }
                 },
                 "c": {
-                        "$id": "doc/spec/rum_v3_context.json",
+                        "$id": "docs/spec/rum_v3_context.json",
     "title": "Context",
     "description": "Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user",
     "type": [
@@ -199,7 +199,7 @@ const RUMV3Schema = `{
             ]
         },
         "g": {
-                "$id": "doc/spec/tags.json",
+                "$id": "docs/spec/tags.json",
     "title": "Tags",
     "type": ["object", "null"],
     "description": "A flat mapping of user-defined tags with string, boolean or number values.",
@@ -271,7 +271,7 @@ const RUMV3Schema = `{
         },
         "se": {
             "description": "Service related information can be sent per event. Provided information will override the more generic information from metadata, non provided fields will be set according to the metadata information.",
-                "$id": "doc/spec/rum_v3_service.json",
+                "$id": "docs/spec/rum_v3_service.json",
     "title": "Service",
     "type": [
         "object",

--- a/model/metadata/generated/schema/metadata.go
+++ b/model/metadata/generated/schema/metadata.go
@@ -18,13 +18,13 @@
 package schema
 
 const ModelSchema = `{
-    "$id": "doc/spec/metadata.json",
+    "$id": "docs/spec/metadata.json",
     "title": "Metadata",
     "description": "Metadata concerning the other objects in the stream.",
     "type": ["object"],
     "properties": {
         "service": {
-                "$id": "doc/spec/service.json",
+                "$id": "docs/spec/service.json",
     "title": "Service",
     "type": ["object", "null"],
     "properties": {
@@ -132,7 +132,7 @@ const ModelSchema = `{
             "properties.language.properties.name.type": "string"
         },
         "process": {
-              "$id": "doc/spec/process.json",
+              "$id": "docs/spec/process.json",
   "title": "Process",
   "type": ["object", "null"],
   "properties": {
@@ -160,7 +160,7 @@ const ModelSchema = `{
   "required": ["pid"]
         },
         "system": {
-                "$id": "doc/spec/system.json",
+                "$id": "docs/spec/system.json",
     "title": "System",
     "type": ["object", "null"],
     "properties": {
@@ -257,7 +257,7 @@ const ModelSchema = `{
     }
         },
         "labels": {
-                "$id": "doc/spec/tags.json",
+                "$id": "docs/spec/tags.json",
     "title": "Tags",
     "type": ["object", "null"],
     "description": "A flat mapping of user-defined tags with string, boolean or number values.",

--- a/model/metadata/generated/schema/rum_v3_metadata.go
+++ b/model/metadata/generated/schema/rum_v3_metadata.go
@@ -18,7 +18,7 @@
 package schema
 
 const RUMV3Schema = `{
-    "$id": "doc/spec/rum_v3_metadata.json",
+    "$id": "docs/spec/rum_v3_metadata.json",
     "title": "Metadata",
     "description": "Metadata concerning the other objects in the stream.",
     "type": [
@@ -26,7 +26,7 @@ const RUMV3Schema = `{
     ],
     "properties": {
         "se": {
-                "$id": "doc/spec/rum_v3_service.json",
+                "$id": "docs/spec/rum_v3_service.json",
     "title": "Service",
     "type": [
         "object",
@@ -213,7 +213,7 @@ const RUMV3Schema = `{
     }
         },
         "l": {
-                "$id": "doc/spec/tags.json",
+                "$id": "docs/spec/tags.json",
     "title": "Tags",
     "type": ["object", "null"],
     "description": "A flat mapping of user-defined tags with string, boolean or number values.",

--- a/model/metricset/generated/schema/metricset.go
+++ b/model/metricset/generated/schema/metricset.go
@@ -22,11 +22,11 @@ const ModelSchema = `{
     "type": "object",
     "description": "Data captured by an agent representing an event occurring in a monitored service",
     "allOf": [
-        {     "$id": "doc/spec/timestamp_epoch.json",
+        {     "$id": "docs/spec/timestamp_epoch.json",
     "title": "Timestamp Epoch",
     "description": "Object with 'timestamp' property.",
     "type": ["object"],
-    "properties": {  
+    "properties": {
         "timestamp": {
             "description": "Recorded time of the event, UTC based and formatted as microseconds since Unix epoch",
             "type": ["integer", "null"]
@@ -94,7 +94,7 @@ const ModelSchema = `{
                     "additionalProperties": false
                 },
                 "tags": {
-                        "$id": "doc/spec/tags.json",
+                        "$id": "docs/spec/tags.json",
     "title": "Tags",
     "type": ["object", "null"],
     "description": "A flat mapping of user-defined tags with string, boolean or number values.",

--- a/model/metricset/generated/schema/rum_v3_metricset.go
+++ b/model/metricset/generated/schema/rum_v3_metricset.go
@@ -116,7 +116,7 @@ const RUMV3Schema = `{
             }
         },
         "tags": {
-                "$id": "doc/spec/tags.json",
+                "$id": "docs/spec/tags.json",
     "title": "Tags",
     "type": ["object", "null"],
     "description": "A flat mapping of user-defined tags with string, boolean or number values.",

--- a/model/span/generated/schema/rum_v3_span.go
+++ b/model/span/generated/schema/rum_v3_span.go
@@ -162,7 +162,7 @@ const RUMV3Schema = `{
                             }
                         },
                         "g": {
-                                "$id": "doc/spec/tags.json",
+                                "$id": "docs/spec/tags.json",
     "title": "Tags",
     "type": ["object", "null"],
     "description": "A flat mapping of user-defined tags with string, boolean or number values.",

--- a/model/span/generated/schema/span.go
+++ b/model/span/generated/schema/span.go
@@ -22,11 +22,11 @@ const ModelSchema = `{
     "type": "object",
     "description": "An event captured by an agent occurring in a monitored service",
     "allOf": [
-        {     "$id": "doc/spec/timestamp_epoch.json",
+        {     "$id": "docs/spec/timestamp_epoch.json",
     "title": "Timestamp Epoch",
     "description": "Object with 'timestamp' property.",
     "type": ["object"],
-    "properties": {  
+    "properties": {
         "timestamp": {
             "description": "Recorded time of the event, UTC based and formatted as microseconds since Unix epoch",
             "type": ["integer", "null"]
@@ -183,7 +183,7 @@ const ModelSchema = `{
                                     "description": "The method of the http request."
                                 },
                                 "response": {
-                                        "$id": "doc/spec/http_response.json",
+                                        "$id": "docs/spec/http_response.json",
     "title": "HTTP response object",
     "description": "HTTP response object, used by error, span and transction documents",
     "type": ["object", "null"],
@@ -220,7 +220,7 @@ const ModelSchema = `{
                             }
                         },
                         "tags": {
-                                "$id": "doc/spec/tags.json",
+                                "$id": "docs/spec/tags.json",
     "title": "Tags",
     "type": ["object", "null"],
     "description": "A flat mapping of user-defined tags with string, boolean or number values.",
@@ -277,7 +277,7 @@ const ModelSchema = `{
                             }
                         },
                         "message": {
-                                "$id": "doc/spec/message.json",
+                                "$id": "docs/spec/message.json",
     "title": "Message",
     "description": "Details related to message receiving and publishing if the captured event integrates with a messaging system",
     "type": ["object", "null"],

--- a/model/transaction/generated/schema/rum_v3_transaction.go
+++ b/model/transaction/generated/schema/rum_v3_transaction.go
@@ -18,7 +18,7 @@
 package schema
 
 const RUMV3Schema = `{
-    "$id": "docs/spec/transactions/rumv3_transaction.json",
+    "$id": "docs/spec/transactions/rum_v3_transaction.json",
     "type": "object",
     "description": "An event corresponding to an incoming request or similar task occurring in a monitored service",
     "allOf": [

--- a/model/transaction/generated/schema/rum_v3_transaction.go
+++ b/model/transaction/generated/schema/rum_v3_transaction.go
@@ -201,7 +201,7 @@ const RUMV3Schema = `{
                             }
                         },
                         "g": {
-                                "$id": "doc/spec/tags.json",
+                                "$id": "docs/spec/tags.json",
     "title": "Tags",
     "type": ["object", "null"],
     "description": "A flat mapping of user-defined tags with string, boolean or number values.",
@@ -407,7 +407,7 @@ const RUMV3Schema = `{
                     ]
                 },
                 "c": {
-                        "$id": "doc/spec/rum_v3_context.json",
+                        "$id": "docs/spec/rum_v3_context.json",
     "title": "Context",
     "description": "Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user",
     "type": [
@@ -536,7 +536,7 @@ const RUMV3Schema = `{
             ]
         },
         "g": {
-                "$id": "doc/spec/tags.json",
+                "$id": "docs/spec/tags.json",
     "title": "Tags",
     "type": ["object", "null"],
     "description": "A flat mapping of user-defined tags with string, boolean or number values.",
@@ -608,7 +608,7 @@ const RUMV3Schema = `{
         },
         "se": {
             "description": "Service related information can be sent per event. Provided information will override the more generic information from metadata, non provided fields will be set according to the metadata information.",
-                "$id": "doc/spec/rum_v3_service.json",
+                "$id": "docs/spec/rum_v3_service.json",
     "title": "Service",
     "type": [
         "object",

--- a/model/transaction/generated/schema/transaction.go
+++ b/model/transaction/generated/schema/transaction.go
@@ -22,11 +22,11 @@ const ModelSchema = `{
     "type": "object",
     "description": "An event corresponding to an incoming request or similar task occurring in a monitored service",
     "allOf": [
-        {     "$id": "doc/spec/timestamp_epoch.json",
+        {     "$id": "docs/spec/timestamp_epoch.json",
     "title": "Timestamp Epoch",
     "description": "Object with 'timestamp' property.",
     "type": ["object"],
-    "properties": {  
+    "properties": {
         "timestamp": {
             "description": "Recorded time of the event, UTC based and formatted as microseconds since Unix epoch",
             "type": ["integer", "null"]
@@ -86,7 +86,7 @@ const ModelSchema = `{
                     "required": ["started"]
                 },
                 "context": {
-                        "$id": "doc/spec/context.json",
+                        "$id": "docs/spec/context.json",
     "title": "Context",
     "description": "Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user",
     "type": ["object", "null"],
@@ -102,7 +102,7 @@ const ModelSchema = `{
         "response": {
             "type": ["object", "null"],
             "allOf": [
-                {     "$id": "doc/spec/http_response.json",
+                {     "$id": "docs/spec/http_response.json",
     "title": "HTTP response object",
     "description": "HTTP response object, used by error, span and transction documents",
     "type": ["object", "null"],
@@ -258,7 +258,7 @@ const ModelSchema = `{
     "required": ["url", "method"]
         },
         "tags": {
-                "$id": "doc/spec/tags.json",
+                "$id": "docs/spec/tags.json",
     "title": "Tags",
     "type": ["object", "null"],
     "description": "A flat mapping of user-defined tags with string, boolean or number values.",
@@ -309,7 +309,7 @@ const ModelSchema = `{
         },
         "service": {
             "description": "Service related information can be sent per event. Provided information will override the more generic information from metadata, non provided fields will be set according to the metadata information.",
-                "$id": "doc/spec/service.json",
+                "$id": "docs/spec/service.json",
     "title": "Service",
     "type": ["object", "null"],
     "properties": {
@@ -405,7 +405,7 @@ const ModelSchema = `{
     }
         },
         "message": {
-                "$id": "doc/spec/message.json",
+                "$id": "docs/spec/message.json",
     "title": "Message",
     "description": "Details related to message receiving and publishing if the captured event integrates with a messaging system",
     "type": ["object", "null"],

--- a/model/transaction/generated/schema/transaction.go
+++ b/model/transaction/generated/schema/transaction.go
@@ -155,7 +155,7 @@ const ModelSchema = `{
             ]
         },
         "request": {
-                "$id": "docs/spec/http.json",
+                "$id": "docs/spec/request.json",
     "title": "Request",
     "description": "If a log record was generated as a result of a http request, the http interface can be used to collect this information.",
     "type": ["object", "null"],


### PR DESCRIPTION
Bad ids are confusing the PHP schema validator: https://github.com/swaggest/php-json-schema

This fixes it.