### PR TITLE
docs/spec: require duration >= 0

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -240,34 +240,6 @@ Contents of "NOTICE":
     Limitations under the License.
 
 --------------------------------------------------------------------
-Dependency: github.com/codahale/hdrhistogram
-Revision: 3a0bb77429bd
-License type (autodetected): MIT
-Contents of "LICENSE":
-
-    The MIT License (MIT)
-
-    Copyright (c) 2014 Coda Hale
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.
-
---------------------------------------------------------------------
 Dependency: github.com/containerd/containerd
 Version: v1.3.3
 License type (autodetected): Apache-2.0
@@ -574,6 +546,35 @@ Dependency: github.com/elastic/go-elasticsearch/v8
 Version: v8.0.0
 Revision: aff00e5adfde
 License type (autodetected): Apache-2.0
+
+--------------------------------------------------------------------
+Dependency: github.com/elastic/go-hdrhistogram
+Version: v0.1.0
+License type (autodetected): MIT
+Contents of "LICENSE":
+
+    The MIT License (MIT)
+
+    Copyright (c) 2014 Coda Hale
+    Copyright (c) 2020 Elasticsearch BV
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-lumber

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -9,6 +9,7 @@ https://github.com/elastic/apm-server/compare/7.7\...master[View commits]
 [float]
 ==== Bug fixes
 * Ensure applied flag can be set for agent configurations fetched for Jaeger {pull}3677[3677]
+* Negative transaction and span durations now cause a schema validation error {pull}3721[3721]
 
 [float]
 ==== Intake API Changes

--- a/docs/spec/spans/rum_v3_span.json
+++ b/docs/spec/spans/rum_v3_span.json
@@ -188,7 +188,8 @@
                 },
                 "d": {
                     "type": "number",
-                    "description": "Duration of the span in milliseconds"
+                    "description": "Duration of the span in milliseconds",
+                    "minimum": 0
                 },
                 "n": {
                     "type": "string",

--- a/docs/spec/spans/span.json
+++ b/docs/spec/spans/span.json
@@ -195,7 +195,8 @@
                 },
                 "duration": {
                     "type": "number",
-                    "description": "Duration of the span in milliseconds"
+                    "description": "Duration of the span in milliseconds",
+                    "minimum": 0
                 },
                 "name": {
                     "type": "string",

--- a/docs/spec/transactions/rum_v3_transaction.json
+++ b/docs/spec/transactions/rum_v3_transaction.json
@@ -64,7 +64,8 @@
                 },
                 "d": {
                     "type": "number",
-                    "description": "How long the transaction took to complete, in ms with 3 decimal points"
+                    "description": "How long the transaction took to complete, in ms with 3 decimal points",
+                    "minimum": 0
                 },
                 "rt": {
                     "type": [

--- a/docs/spec/transactions/transaction.json
+++ b/docs/spec/transactions/transaction.json
@@ -44,7 +44,8 @@
                 },
                 "duration": {
                     "type": "number",
-                    "description": "How long the transaction took to complete, in ms with 3 decimal points"
+                    "description": "How long the transaction took to complete, in ms with 3 decimal points",
+                    "minimum": 0
                 },
                 "result": {
                     "type": ["string", "null"],

--- a/model/modeldecoder/span_test.go
+++ b/model/modeldecoder/span_test.go
@@ -269,21 +269,31 @@ func TestDecodeSpanInvalid(t *testing.T) {
 
 	for name, test := range map[string]struct {
 		input map[string]interface{}
+		err   string
 	}{
 		"transaction id wrong type": {
 			input: map[string]interface{}{"transaction_id": 123},
+			err:   `type.*expected string or null, but got number`,
 		},
 		"no trace_id": {
 			input: map[string]interface{}{"trace_id": nil},
+			err:   `missing properties: "trace_id"`,
 		},
 		"no id": {
 			input: map[string]interface{}{"id": nil},
+			err:   `missing properties: "id"`,
 		},
 		"no parent_id": {
 			input: map[string]interface{}{"parent_id": nil},
+			err:   `missing properties: "parent_id"`,
 		},
 		"invalid stacktrace": {
 			input: map[string]interface{}{"stacktrace": []interface{}{"foo"}},
+			err:   `stacktrace.*expected object, but got string`,
+		},
+		"negative duration": {
+			input: map[string]interface{}{"duration": -1.0},
+			err:   "duration.*must be >= 0 but found -1",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -300,7 +310,7 @@ func TestDecodeSpanInvalid(t *testing.T) {
 			}
 			_, err := DecodeSpan(Input{Raw: input})
 			require.Error(t, err)
-			t.Logf("%s", err)
+			assert.Regexp(t, test.err, err.Error())
 		})
 	}
 }

--- a/model/modeldecoder/transaction_test.go
+++ b/model/modeldecoder/transaction_test.go
@@ -93,29 +93,49 @@ var fullTransactionInput = map[string]interface{}{
 	},
 }
 
-func TestTransactionEventDecodeFailure(t *testing.T) {
+func TestDecodeTransactionInvalid(t *testing.T) {
+	_, err := DecodeTransaction(Input{Raw: nil})
+	require.EqualError(t, err, "failed to validate transaction: error validating JSON: input missing")
+
+	_, err = DecodeTransaction(Input{Raw: ""})
+	require.EqualError(t, err, "failed to validate transaction: error validating JSON: invalid input type")
+
+	baseInput := map[string]interface{}{
+		"type":       "type",
+		"trace_id":   "trace_id",
+		"id":         "id",
+		"duration":   123,
+		"span_count": map[string]interface{}{"dropped": 1.0, "started": 2.0},
+	}
+
 	for name, test := range map[string]struct {
-		input interface{}
+		input map[string]interface{}
 		err   string
-		e     *model.Transaction
 	}{
-		"no input":           {input: nil, err: "failed to validate transaction: error validating JSON: input missing", e: nil},
-		"invalid type":       {input: "", err: "failed to validate transaction: error validating JSON: invalid input type", e: nil},
-		"cannot fetch field": {input: map[string]interface{}{}, err: "failed to validate transaction: error validating JSON: (.|\n)*missing properties:(.|\n)*", e: nil},
+		"missing trace_id": {
+			input: map[string]interface{}{"trace_id": nil},
+			err:   "missing properties: \"trace_id\"",
+		},
+		"negative duration": {
+			input: map[string]interface{}{"duration": -1.0},
+			err:   "duration.*must be >= 0 but found -1",
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			transformable, err := DecodeTransaction(Input{Raw: test.input})
-			if test.err != "" {
-				assert.Regexp(t, test.err, err.Error())
-			} else {
-				assert.NoError(t, err)
+			input := make(map[string]interface{})
+			for k, v := range baseInput {
+				input[k] = v
 			}
-			if test.e != nil {
-				event := transformable.(*model.Transaction)
-				assert.Equal(t, test.e, event)
-			} else {
-				assert.Nil(t, transformable)
+			for k, v := range test.input {
+				if v == nil {
+					delete(input, k)
+				} else {
+					input[k] = v
+				}
 			}
+			_, err := DecodeTransaction(Input{Raw: input})
+			assert.Error(t, err)
+			assert.Regexp(t, test.err, err.Error())
 		})
 	}
 }

--- a/model/span/generated/schema/rum_v3_span.go
+++ b/model/span/generated/schema/rum_v3_span.go
@@ -217,7 +217,8 @@ const RUMV3Schema = `{
                 },
                 "d": {
                     "type": "number",
-                    "description": "Duration of the span in milliseconds"
+                    "description": "Duration of the span in milliseconds",
+                    "minimum": 0
                 },
                 "n": {
                     "type": "string",

--- a/model/span/generated/schema/span.go
+++ b/model/span/generated/schema/span.go
@@ -323,7 +323,8 @@ const ModelSchema = `{
                 },
                 "duration": {
                     "type": "number",
-                    "description": "Duration of the span in milliseconds"
+                    "description": "Duration of the span in milliseconds",
+                    "minimum": 0
                 },
                 "name": {
                     "type": "string",

--- a/model/transaction/generated/schema/rum_v3_transaction.go
+++ b/model/transaction/generated/schema/rum_v3_transaction.go
@@ -256,7 +256,8 @@ const RUMV3Schema = `{
                 },
                 "d": {
                     "type": "number",
-                    "description": "Duration of the span in milliseconds"
+                    "description": "Duration of the span in milliseconds",
+                    "minimum": 0
                 },
                 "n": {
                     "type": "string",
@@ -740,7 +741,8 @@ const RUMV3Schema = `{
                 },
                 "d": {
                     "type": "number",
-                    "description": "How long the transaction took to complete, in ms with 3 decimal points"
+                    "description": "How long the transaction took to complete, in ms with 3 decimal points",
+                    "minimum": 0
                 },
                 "rt": {
                     "type": [

--- a/model/transaction/generated/schema/transaction.go
+++ b/model/transaction/generated/schema/transaction.go
@@ -451,7 +451,8 @@ const ModelSchema = `{
                 },
                 "duration": {
                     "type": "number",
-                    "description": "How long the transaction took to complete, in ms with 3 decimal points"
+                    "description": "How long the transaction took to complete, in ms with 3 decimal points",
+                    "minimum": 0
                 },
                 "result": {
                     "type": ["string", "null"],


### PR DESCRIPTION
## Motivation/summary

Until now the APM Server would accept negative transaction and span durations, which does not make sense. We should reject negative durations, so we don't record junk data.

Recording negative durations would impact our ability to use HDRHistogram in percentile aggregations: https://github.com/elastic/kibana/pull/64758.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
~- [ ] I have made corresponding changes to the documentation~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
- [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

## How to test these changes

I hacked the Go agent to allow it to send negative durations, set the duration to -1, and observed a schema validation error. Normally the Go agent does not allow this; it uses negative values as a sentinel for setting duration based on `now-start`.

## Related issues

Closes https://github.com/elastic/kibana/pull/64758