### PR TITLE
ci: aggregate downstream test results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
     CODECOV_SECRET = 'secret/apm-team/ci/apm-server-codecov'
-    GITHUB_CHECK_ITS_NAME = 'APM Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     DIAGNOSTIC_INTERVAL = "${params.DIAGNOSTIC_INTERVAL}"
     ES_LOG_LEVEL = "${params.ES_LOG_LEVEL}"
@@ -450,29 +449,34 @@ pipeline {
             }
           }
         }
-      }
-    }
-    stage('APM Integration Tests') {
-      agent none
-      when {
-        beforeAgent true
-        allOf {
-          anyOf {
-            changeRequest()
-            expression { return !params.Run_As_Master_Branch }
+        stage('APM Integration Tests') {
+          agent { label 'linux && immutable' }
+          options { skipDefaultCheckout() }
+          when {
+            beforeAgent true
+            allOf {
+              anyOf {
+                changeRequest()
+                expression { return !params.Run_As_Master_Branch }
+              }
+              expression { return params.its_ci }
+              expression { return env.ONLY_DOCS == "false" }
+            }
           }
-          expression { return params.its_ci }
-          expression { return env.ONLY_DOCS == "false" }
+          steps {
+            script {
+              def buildObject = build(job: env.ITS_PIPELINE, propagate: false, wait: true,
+                    parameters: [string(name: 'INTEGRATION_TEST', value: 'All'),
+                                string(name: 'BUILD_OPTS', value: "--apm-server-build https://github.com/elastic/${env.REPO}@${env.GIT_BASE_COMMIT}")])
+              copyArtifacts(projectName: env.ITS_PIPELINE, selector: specific(buildNumber: buildObject.number.toString()))
+            }
+          }
+          post {
+            always {
+              junit(testResults: "**/*-junit*.xml", allowEmptyResults: true, keepLongStdio: true)
+            }
+          }
         }
-      }
-      steps {
-        build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-              parameters: [string(name: 'INTEGRATION_TEST', value: 'All'),
-                           string(name: 'BUILD_OPTS', value: "--apm-server-build https://github.com/elastic/${env.REPO}@${env.GIT_BASE_COMMIT}"),
-                           string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
-                           string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                           string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
-        githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
     CODECOV_SECRET = 'secret/apm-team/ci/apm-server-codecov'
-    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/PR-835'
+    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     DIAGNOSTIC_INTERVAL = "${params.DIAGNOSTIC_INTERVAL}"
     ES_LOG_LEVEL = "${params.ES_LOG_LEVEL}"
     DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
     CODECOV_SECRET = 'secret/apm-team/ci/apm-server-codecov'
-    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
+    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/PR-835'
     DIAGNOSTIC_INTERVAL = "${params.DIAGNOSTIC_INTERVAL}"
     ES_LOG_LEVEL = "${params.ES_LOG_LEVEL}"
     DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -464,11 +464,13 @@ pipeline {
             }
           }
           steps {
-            script {
-              def buildObject = build(job: env.ITS_PIPELINE, propagate: false, wait: true,
-                    parameters: [string(name: 'INTEGRATION_TEST', value: 'All'),
-                                string(name: 'BUILD_OPTS', value: "--apm-server-build https://github.com/elastic/${env.REPO}@${env.GIT_BASE_COMMIT}")])
-              copyArtifacts(projectName: env.ITS_PIPELINE, selector: specific(buildNumber: buildObject.number.toString()))
+            withGithubNotify(context: 'APM Integration Tests') {
+              script {
+                def buildObject = build(job: env.ITS_PIPELINE, propagate: false, wait: true,
+                      parameters: [string(name: 'INTEGRATION_TEST', value: 'All'),
+                                  string(name: 'BUILD_OPTS', value: "--apm-server-build https://github.com/elastic/${env.REPO}@${env.GIT_BASE_COMMIT}")])
+                copyArtifacts(projectName: env.ITS_PIPELINE, selector: specific(buildNumber: buildObject.number.toString()))
+              }
             }
           }
           post {


### PR DESCRIPTION
## Motivation/summary

The GitHub PR comment has been enabled recently, so there is only one place now to get a highlevel view what the CI build looks like. In order to enhance the build status, let's see if we can aggregate the results from the APM-ITs within the main pipeline.

## What

Run the `apm-integration-testing` test selector pipeline in the parallel stage rather than asynchronous. What does it mean? Pipeline needs to wait for the outcome from the `apm-integration-testing` to be able to aggregate the results in the PR comment

## Related issues

Depends on https://github.com/elastic/apm-integration-testing/pull/835

## Tests

From 3150 tests (See [latest build](https://apm-ci.elastic.co/job/apm-server/job/apm-server-mbp/job/master/lastBuild/testReport/))

![image](https://user-images.githubusercontent.com/2871786/81069894-6cf17680-8eda-11ea-8154-fa7dd0a956c8.png)

To 3356 tests (See [this build](https://apm-ci.elastic.co/job/apm-server/job/apm-server-mbp/job/PR-3735/3/testReport/))

![image](https://user-images.githubusercontent.com/2871786/81069975-898dae80-8eda-11ea-939b-ed3af5a155d8.png)


Test agents reports:

![image](https://user-images.githubusercontent.com/2871786/81070044-a0340580-8eda-11ea-8836-9fe2bb6fb67c.png)

Test server reports:

![image](https://user-images.githubusercontent.com/2871786/81070129-bd68d400-8eda-11ea-8b6c-ba89d701b404.png)

