### PR TITLE
[7.x] docs/spec: require duration >= 0 (#3721)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -240,34 +240,6 @@ Contents of "NOTICE":
     Limitations under the License.
 
 --------------------------------------------------------------------
-Dependency: github.com/codahale/hdrhistogram
-Revision: 3a0bb77429bd
-License type (autodetected): MIT
-Contents of "LICENSE":
-
-    The MIT License (MIT)
-
-    Copyright (c) 2014 Coda Hale
-
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated documentation files (the "Software"), to deal
-    in the Software without restriction, including without limitation the rights
-    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-    copies of the Software, and to permit persons to whom the Software is
-    furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in
-    all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.
-
---------------------------------------------------------------------
 Dependency: github.com/containerd/containerd
 Version: v1.3.3
 License type (autodetected): Apache-2.0
@@ -574,6 +546,35 @@ Dependency: github.com/elastic/go-elasticsearch/v8
 Version: v8.0.0
 Revision: aff00e5adfde
 License type (autodetected): Apache-2.0
+
+--------------------------------------------------------------------
+Dependency: github.com/elastic/go-hdrhistogram
+Version: v0.1.0
+License type (autodetected): MIT
+Contents of "LICENSE":
+
+    The MIT License (MIT)
+
+    Copyright (c) 2014 Coda Hale
+    Copyright (c) 2020 Elasticsearch BV
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
 
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-lumber

--- a/docs/spec/spans/rum_v3_span.json
+++ b/docs/spec/spans/rum_v3_span.json
@@ -188,7 +188,8 @@
                 },
                 "d": {
                     "type": "number",
-                    "description": "Duration of the span in milliseconds"
+                    "description": "Duration of the span in milliseconds",
+                    "minimum": 0
                 },
                 "n": {
                     "type": "string",

--- a/docs/spec/spans/span.json
+++ b/docs/spec/spans/span.json
@@ -195,7 +195,8 @@
                 },
                 "duration": {
                     "type": "number",
-                    "description": "Duration of the span in milliseconds"
+                    "description": "Duration of the span in milliseconds",
+                    "minimum": 0
                 },
                 "name": {
                     "type": "string",

--- a/docs/spec/transactions/rum_v3_transaction.json
+++ b/docs/spec/transactions/rum_v3_transaction.json
@@ -68,7 +68,8 @@
                 },
                 "d": {
                     "type": "number",
-                    "description": "How long the transaction took to complete, in ms with 3 decimal points"
+                    "description": "How long the transaction took to complete, in ms with 3 decimal points",
+                    "minimum": 0
                 },
                 "rt": {
                     "type": [

--- a/docs/spec/transactions/transaction.json
+++ b/docs/spec/transactions/transaction.json
@@ -44,7 +44,8 @@
                 },
                 "duration": {
                     "type": "number",
-                    "description": "How long the transaction took to complete, in ms with 3 decimal points"
+                    "description": "How long the transaction took to complete, in ms with 3 decimal points",
+                    "minimum": 0
                 },
                 "result": {
                     "type": ["string", "null"],

--- a/model/modeldecoder/span_test.go
+++ b/model/modeldecoder/span_test.go
@@ -270,21 +270,31 @@ func TestDecodeSpanInvalid(t *testing.T) {
 
 	for name, test := range map[string]struct {
 		input map[string]interface{}
+		err   string
 	}{
 		"transaction id wrong type": {
 			input: map[string]interface{}{"transaction_id": 123},
+			err:   `type.*expected string or null, but got number`,
 		},
 		"no trace_id": {
 			input: map[string]interface{}{"trace_id": nil},
+			err:   `missing properties: "trace_id"`,
 		},
 		"no id": {
 			input: map[string]interface{}{"id": nil},
+			err:   `missing properties: "id"`,
 		},
 		"no parent_id": {
 			input: map[string]interface{}{"parent_id": nil},
+			err:   `missing properties: "parent_id"`,
 		},
 		"invalid stacktrace": {
 			input: map[string]interface{}{"stacktrace": []interface{}{"foo"}},
+			err:   `stacktrace.*expected object, but got string`,
+		},
+		"negative duration": {
+			input: map[string]interface{}{"duration": -1.0},
+			err:   "duration.*must be >= 0 but found -1",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -301,7 +311,7 @@ func TestDecodeSpanInvalid(t *testing.T) {
 			}
 			err := DecodeSpan(Input{Raw: input}, &model.Batch{})
 			require.Error(t, err)
-			t.Logf("%s", err)
+			assert.Regexp(t, test.err, err.Error())
 		})
 	}
 }

--- a/model/span/generated/schema/rum_v3_span.go
+++ b/model/span/generated/schema/rum_v3_span.go
@@ -217,7 +217,8 @@ const RUMV3Schema = `{
                 },
                 "d": {
                     "type": "number",
-                    "description": "Duration of the span in milliseconds"
+                    "description": "Duration of the span in milliseconds",
+                    "minimum": 0
                 },
                 "n": {
                     "type": "string",

--- a/model/span/generated/schema/span.go
+++ b/model/span/generated/schema/span.go
@@ -323,7 +323,8 @@ const ModelSchema = `{
                 },
                 "duration": {
                     "type": "number",
-                    "description": "Duration of the span in milliseconds"
+                    "description": "Duration of the span in milliseconds",
+                    "minimum": 0
                 },
                 "name": {
                     "type": "string",

--- a/model/transaction/generated/schema/rum_v3_transaction.go
+++ b/model/transaction/generated/schema/rum_v3_transaction.go
@@ -256,7 +256,8 @@ const RUMV3Schema = `{
                 },
                 "d": {
                     "type": "number",
-                    "description": "Duration of the span in milliseconds"
+                    "description": "Duration of the span in milliseconds",
+                    "minimum": 0
                 },
                 "n": {
                     "type": "string",
@@ -838,7 +839,8 @@ const RUMV3Schema = `{
                 },
                 "d": {
                     "type": "number",
-                    "description": "How long the transaction took to complete, in ms with 3 decimal points"
+                    "description": "How long the transaction took to complete, in ms with 3 decimal points",
+                    "minimum": 0
                 },
                 "rt": {
                     "type": [

--- a/model/transaction/generated/schema/transaction.go
+++ b/model/transaction/generated/schema/transaction.go
@@ -451,7 +451,8 @@ const ModelSchema = `{
                 },
                 "duration": {
                     "type": "number",
-                    "description": "How long the transaction took to complete, in ms with 3 decimal points"
+                    "description": "How long the transaction took to complete, in ms with 3 decimal points",
+                    "minimum": 0
                 },
                 "result": {
                     "type": ["string", "null"],


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs/spec: require duration >= 0 (#3721)