### PR TITLE
[7.x] fix typo in subtype (#3747)

### DIFF
--- a/model/modeldecoder/field/rum_v3_mapping.go
+++ b/model/modeldecoder/field/rum_v3_mapping.go
@@ -105,7 +105,7 @@ var rumV3Mapping = map[string]string{
 	"start":                       "s",
 	"started":                     "sd",
 	"status_code":                 "sc",
-	"subType":                     "su",
+	"subtype":                     "su",
 	"sync":                        "sy",
 	"tags":                        "g",
 	"timeToFirstByte":             "fb",

--- a/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
@@ -116,6 +116,7 @@
                 "start": {
                     "us": 4000
                 },
+                "subtype": "browser-timing",
                 "type": "hard-navigation"
             },
             "timestamp": {
@@ -160,6 +161,7 @@
                 "start": {
                     "us": 14000
                 },
+                "subtype": "browser-timing",
                 "type": "hard-navigation"
             },
             "timestamp": {
@@ -225,6 +227,7 @@
                 "start": {
                     "us": 22534
                 },
+                "subtype": "script",
                 "type": "rc"
             },
             "timestamp": {
@@ -333,6 +336,7 @@
                 "start": {
                     "us": 98940
                 },
+                "subtype": "h",
                 "sync": true,
                 "type": "external"
             },
@@ -398,6 +402,7 @@
                 "start": {
                     "us": 106520
                 },
+                "subtype": "h",
                 "sync": true,
                 "type": "external"
             },
@@ -463,6 +468,7 @@
                 "start": {
                     "us": 119935
                 },
+                "subtype": "h",
                 "sync": false,
                 "type": "external"
             },
@@ -530,6 +536,7 @@
                 "start": {
                     "us": 120000
                 },
+                "subtype": "browser-timing",
                 "type": "hard-navigation"
             },
             "timestamp": {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix typo in subtype (#3747)