### PR TITLE
Fix performance degradation

### DIFF
--- a/model/batch.go
+++ b/model/batch.go
@@ -22,10 +22,18 @@ import (
 )
 
 type Batch struct {
-	Transactions []Transaction
-	Spans        []Span
-	Metricsets   []Metricset
-	Errors       []Error
+	Transactions []*Transaction
+	Spans        []*Span
+	Metricsets   []*Metricset
+	Errors       []*Error
+}
+
+// Reset resets the batch to be empty, but it retains the underlying storage.
+func (b *Batch) Reset() {
+	b.Transactions = b.Transactions[:0]
+	b.Spans = b.Spans[:0]
+	b.Metricsets = b.Metricsets[:0]
+	b.Errors = b.Errors[:0]
 }
 
 func (b *Batch) Len() int {
@@ -37,17 +45,17 @@ func (b *Batch) Len() int {
 
 func (b *Batch) Transformables() []transform.Transformable {
 	transformables := make([]transform.Transformable, 0, b.Len())
-	for i := range b.Transactions {
-		transformables = append(transformables, &b.Transactions[i])
+	for _, tx := range b.Transactions {
+		transformables = append(transformables, tx)
 	}
-	for i := range b.Spans {
-		transformables = append(transformables, &b.Spans[i])
+	for _, span := range b.Spans {
+		transformables = append(transformables, span)
 	}
-	for i := range b.Metricsets {
-		transformables = append(transformables, &b.Metricsets[i])
+	for _, metricset := range b.Metricsets {
+		transformables = append(transformables, metricset)
 	}
-	for i := range b.Errors {
-		transformables = append(transformables, &b.Errors[i])
+	for _, err := range b.Errors {
+		transformables = append(transformables, err)
 	}
 	return transformables
 }

--- a/model/modeldecoder/error.go
+++ b/model/modeldecoder/error.go
@@ -39,7 +39,7 @@ func DecodeRUMV3Error(input Input, batch *m.Batch) error {
 	if err != nil {
 		return err
 	}
-	batch.Errors = append(batch.Errors, *apmError)
+	batch.Errors = append(batch.Errors, apmError)
 	return nil
 }
 
@@ -49,7 +49,7 @@ func DecodeError(input Input, batch *m.Batch) error {
 	if err != nil {
 		return err
 	}
-	batch.Errors = append(batch.Errors, *apmError)
+	batch.Errors = append(batch.Errors, apmError)
 	return nil
 }
 

--- a/model/modeldecoder/error_test.go
+++ b/model/modeldecoder/error_test.go
@@ -246,7 +246,7 @@ func TestErrorEventDecode(t *testing.T) {
 				Config:      test.cfg,
 			}, batch)
 			require.NoError(t, err)
-			assert.Equal(t, test.e, &batch.Errors[0])
+			assert.Equal(t, test.e, batch.Errors[0])
 		})
 	}
 }

--- a/model/modeldecoder/metricset.go
+++ b/model/modeldecoder/metricset.go
@@ -45,7 +45,7 @@ func DecodeMetricset(input Input, batch *model.Batch) error {
 	if err != nil {
 		return err
 	}
-	batch.Metricsets = append(batch.Metricsets, *metricset)
+	batch.Metricsets = append(batch.Metricsets, metricset)
 	return nil
 }
 
@@ -54,7 +54,7 @@ func DecodeRUMV3Metricset(input Input, batch *model.Batch) error {
 	if err != nil {
 		return err
 	}
-	batch.Metricsets = append(batch.Metricsets, *metricset)
+	batch.Metricsets = append(batch.Metricsets, metricset)
 	return nil
 }
 

--- a/model/modeldecoder/metricset_test.go
+++ b/model/modeldecoder/metricset_test.go
@@ -180,7 +180,7 @@ func TestDecode(t *testing.T) {
 		if test.metricset != nil {
 			want := test.metricset
 			got := batch.Metricsets[0]
-			assertMetricsetsMatch(t, want, &got)
+			assertMetricsetsMatch(t, want, got)
 		}
 	}
 }

--- a/model/modeldecoder/span.go
+++ b/model/modeldecoder/span.go
@@ -48,7 +48,7 @@ func DecodeSpan(input Input, batch *model.Batch) error {
 	if err != nil {
 		return err
 	}
-	batch.Spans = append(batch.Spans, *span)
+	batch.Spans = append(batch.Spans, span)
 	return nil
 }
 

--- a/model/modeldecoder/span_test.go
+++ b/model/modeldecoder/span_test.go
@@ -246,7 +246,7 @@ func TestDecodeSpan(t *testing.T) {
 				Config:      test.cfg,
 			}, batch)
 			require.NoError(t, err)
-			assert.Equal(t, test.e, &batch.Spans[0])
+			assert.Equal(t, test.e, batch.Spans[0])
 		})
 	}
 }

--- a/model/modeldecoder/transaction.go
+++ b/model/modeldecoder/transaction.go
@@ -54,17 +54,17 @@ func DecodeRUMV3Transaction(input Input, batch *model.Batch) error {
 	if err != nil {
 		return nil
 	}
-	batch.Transactions = append(batch.Transactions, *transaction)
+	batch.Transactions = append(batch.Transactions, transaction)
 	batch.Spans = append(batch.Spans, spans...)
 	batch.Metricsets = append(batch.Metricsets, metricsets...)
 	return nil
 }
 
-func decodeRUMV3Metricsets(raw map[string]interface{}, input Input, tr *model.Transaction) ([]model.Metricset, error) {
+func decodeRUMV3Metricsets(raw map[string]interface{}, input Input, tr *model.Transaction) ([]*model.Metricset, error) {
 	decoder := &utility.ManualDecoder{}
 	fieldName := field.Mapper(input.Config.HasShortFieldNames)
 	rawMetricsets := decoder.InterfaceArr(raw, fieldName("metricset"))
-	var metricsets = make([]model.Metricset, len(rawMetricsets))
+	var metricsets = make([]*model.Metricset, len(rawMetricsets))
 	for idx, rawMetricset := range rawMetricsets {
 		metricset, err := decodeMetricset(Input{
 			Raw:         rawMetricset,
@@ -84,16 +84,16 @@ func decodeRUMV3Metricsets(raw map[string]interface{}, input Input, tr *model.Tr
 		if tr.Result != nil {
 			metricset.Transaction.Result = *tr.Result
 		}
-		metricsets[idx] = *metricset
+		metricsets[idx] = metricset
 	}
 	return metricsets, nil
 }
 
-func decodeRUMV3Spans(raw map[string]interface{}, input Input, tr *model.Transaction) ([]model.Span, error) {
+func decodeRUMV3Spans(raw map[string]interface{}, input Input, tr *model.Transaction) ([]*model.Span, error) {
 	decoder := &utility.ManualDecoder{}
 	fieldName := field.Mapper(input.Config.HasShortFieldNames)
 	rawSpans := decoder.InterfaceArr(raw, fieldName("span"))
-	var spans = make([]model.Span, len(rawSpans))
+	var spans = make([]*model.Span, len(rawSpans))
 	for idx, rawSpan := range rawSpans {
 		span, err := decodeRUMV3Span(Input{
 			Raw:         rawSpan,
@@ -111,7 +111,7 @@ func decodeRUMV3Spans(raw map[string]interface{}, input Input, tr *model.Transac
 		} else if *span.ParentIdx < idx {
 			span.ParentID = &spans[*span.ParentIdx].ID
 		}
-		spans[idx] = *span
+		spans[idx] = span
 	}
 	return spans, nil
 }
@@ -122,7 +122,7 @@ func DecodeTransaction(input Input, batch *model.Batch) error {
 	if err != nil {
 		return err
 	}
-	batch.Transactions = append(batch.Transactions, *transaction)
+	batch.Transactions = append(batch.Transactions, transaction)
 	return nil
 }
 

--- a/model/modeldecoder/transaction_test.go
+++ b/model/modeldecoder/transaction_test.go
@@ -362,7 +362,7 @@ func TestTransactionEventDecode(t *testing.T) {
 				Config:      test.cfg,
 			}, batch)
 			require.NoError(t, err)
-			assert.Equal(t, test.e, &batch.Transactions[0])
+			assert.Equal(t, test.e, batch.Transactions[0])
 		})
 	}
 }

--- a/processor/otel/consumer.go
+++ b/processor/otel/consumer.go
@@ -106,10 +106,10 @@ func (c *Consumer) convert(td consumerdata.TraceData) *model.Batch {
 				Name:      &name,
 			}
 			parseTransaction(otelSpan, hostname, &transaction)
-			batch.Transactions = append(batch.Transactions, transaction)
+			batch.Transactions = append(batch.Transactions, &transaction)
 			for _, err := range parseErrors(logger, td.SourceFormat, otelSpan) {
 				addTransactionCtxToErr(transaction, err)
-				batch.Errors = append(batch.Errors, *err)
+				batch.Errors = append(batch.Errors, err)
 			}
 
 		} else {
@@ -123,10 +123,10 @@ func (c *Consumer) convert(td consumerdata.TraceData) *model.Batch {
 				Name:      name,
 			}
 			parseSpan(otelSpan, &span)
-			batch.Spans = append(batch.Spans, span)
+			batch.Spans = append(batch.Spans, &span)
 			for _, err := range parseErrors(logger, td.SourceFormat, otelSpan) {
 				addSpanCtxToErr(span, hostname, err)
-				batch.Errors = append(batch.Errors, *err)
+				batch.Errors = append(batch.Errors, err)
 			}
 		}
 	}


### PR DESCRIPTION
## Motivation/summary

Change the model.Batch type to store slices of
pointers, rather than structs. This enables us
to reuse the model.Batch (with the new Reset
method), and also avoids some memory copying
in modeldecoder (i.e. where it was decoding to
a heap allocated object, and then copying to
slice element when dereferencing).

In the future we might want to revert to storing
slices of structs, but only when we can safely
reuse a batch. i.e. pool model.Batch objects,
recycling once the publisher has transformed the
model objects to beat.Events.

benchstat, comparing to master:

```
name                                          old time/op    new time/op    delta
BackendProcessor/heavy.ndjson/NoRateLimit-12    31.4ms ± 2%    28.9ms ± 4%   -7.98%  (p=0.008 n=5+5)

name                                          old speed      new speed      delta
BackendProcessor/heavy.ndjson/NoRateLimit-12  12.7MB/s ± 2%  13.8MB/s ± 4%   +8.69%  (p=0.008 n=5+5)

name                                          old alloc/op   new alloc/op   delta
BackendProcessor/heavy.ndjson/NoRateLimit-12    9.94MB ± 0%    6.33MB ± 0%  -36.30%  (p=0.002 n=6+6)

name                                          old allocs/op  new allocs/op  delta
BackendProcessor/heavy.ndjson/NoRateLimit-12      115k ± 0%      113k ± 0%   -1.83%  (p=0.002 n=6+6)
```

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] My code follows the style guidelines of this project (run `make check-full` for static code checks and linting)
- [x] I have rebased my changes on top of the latest master branch
~- [ ] I have made corresponding changes to the documentation~
~- [ ] I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally with my changes
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

## How to test these changes

`go test -count=6 -benchtime=10s -benchmem -bench=BenchmarkBackendProcessor/heavy.ndjson/NoRateLimit -run=NONE github.com/elastic/apm-server/processor/stream`

(Run with master and this branch, use benchstat to compare)

## Related issues

Closes #3754