### PR TITLE
docs: Update Jaeger auth

### DIFF
--- a/docs/jaeger-support.asciidoc
+++ b/docs/jaeger-support.asciidoc
@@ -97,11 +97,30 @@ As of this writing, the Jaeger Agent binary offers the `--reporter.grpc.host-por
 which can be used to set a static list of collectors for the Jaeger Agent to connect to.
 The `host:port` set here should correspond with the value set in `apm-server.jaeger.grpc.host`.
 
-Jaeger Agent also offers the `--agent.tags` CLI flag, which can be used to pass Process tags
-to the Collector. If APM Server has `apm-server.jaeger.grpc.auth_tag` set, it will look for a
-Process tag of that name in incoming events, and use it for authorizing the Jaeger Agent against
-the configured secret token or API Keys. The auth tag will be removed from the events after
-being verified.
+*Optional token-based authorization**
+
+A <<secret-token,secret token>> or <<api-key,API key>> can be used to ensure only authorized
+Jaeger Agents can send data to the APM Server.
+Authorization is off by default, but can be enabled by setting a value in `apm-server.jaeger.grpc.auth_tag`.
+When enabled, APM Server looks for a _Process tag_ in each incoming event,
+and uses it to authorize the Jaeger Agent against the configured `auth_tag` and secret token or API key.
+Auth tags will be removed from events after being verified.
+
+Here's an example that sets the `auth_tag` and `secret_token` in APM Server:
+
+[source,yaml]
+----
+apm-server.jaeger.grpc.enabled=true
+apm-server.jaeger.grpc.auth_tag=authorization
+apm-server.secret_token=qwerty1234
+----
+
+To authorize Jaeger Agent communication, use the `--agent.tags` CLI flag to pass the corresponding Process tag to the APM Server:
+
+[source,console]
+----
+--agent.tags "authorization=Bearer qwerty1234"
+----
 
 See the https://www.jaegertracing.io/docs/1.16/cli/[Jaeger CLI flags documentation] for more information.
 


### PR DESCRIPTION
## What does this pull request do?

This PR adds an example and updates the Jaeger `auth_tag` documentation. I have a couple of questions that I'll add as comments.

I tested this feature with apm-integration-testing:

**APM Server:**
```
./scripts/compose.py start 7.7 \
--apm-server-opt apm-server.jaeger.grpc.enabled=true \
--apm-server-opt apm-server.jaeger.grpc.auth_tag=authorization \
--apm-server-opt apm-server.secret_token=qwerty1234
```

**Jaeger Agent:**
```
docker run --rm -it --name jaeger-agent --network apm-integration-testing -p6831:6831/udp \
-e REPORTER_GRPC_HOST_PORT=apm-server:14250 \
-e AGENT_TAGS="authorization=Bearer qwerty1234" \
jaegertracing/jaeger-agent:latest
```

**Jaeger Hotrod demo:**
```
docker run --rm -it --network apm-integration-testing \
-e JAEGER_AGENT_HOST=jaeger-agent \
-e JAEGER_AGENT_PORT=6831 \
-p8080-8083:8080-8083 jaegertracing/example-hotrod:latest all
```

## Documentation preview

http://apm-server_3768.docs-preview.app.elstc.co/diff

## Related issues

Closes https://github.com/elastic/apm-server/issues/3423.