### PR TITLE
[7.x] docs: jaeger auth (e7057e53)

### DIFF
--- a/docs/jaeger-support.asciidoc
+++ b/docs/jaeger-support.asciidoc
@@ -97,11 +97,30 @@ As of this writing, the Jaeger Agent binary offers the `--reporter.grpc.host-por
 which can be used to set a static list of collectors for the Jaeger Agent to connect to.
 The `host:port` set here should correspond with the value set in `apm-server.jaeger.grpc.host`.
 
-Jaeger Agent also offers the `--agent.tags` CLI flag, which can be used to pass Process tags
-to the Collector. If APM Server has `apm-server.jaeger.grpc.auth_tag` set, it will look for a
-Process tag of that name in incoming events, and use it for authorizing the Jaeger Agent against
-the configured secret token or API Keys. The auth tag will be removed from the events after
-being verified.
+*Optional token-based authorization**
+
+A <<secret-token,secret token>> or <<api-key,API key>> can be used to ensure only authorized
+Jaeger Agents can send data to the APM Server.
+Authorization is off by default, but can be enabled by setting a value in `apm-server.jaeger.grpc.auth_tag`.
+When enabled, APM Server looks for a _Process tag_ in each incoming event,
+and uses it to authorize the Jaeger Agent against the configured `auth_tag` and secret token or API key.
+Auth tags will be removed from events after being verified.
+
+Here's an example that sets the `auth_tag` and `secret_token` in APM Server:
+
+[source,yaml]
+----
+apm-server.jaeger.grpc.enabled=true
+apm-server.jaeger.grpc.auth_tag=authorization
+apm-server.secret_token=qwerty1234
+----
+
+To authorize Jaeger Agent communication, use the `--agent.tags` CLI flag to pass the corresponding Process tag to the APM Server:
+
+[source,console]
+----
+--agent.tags "authorization=Bearer qwerty1234"
+----
 
 See the https://www.jaegertracing.io/docs/1.16/cli/[Jaeger CLI flags documentation] for more information.
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: jaeger auth (e7057e53)