### PR TITLE
Makefile: fix update-beats-module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ update-beats: update-beats-module update
 .PHONY: update-beats-module
 update-beats-module:
 	go get -d -u $(BEATS_MODULE)@$(BEATS_VERSION)
-	rsync -crv --delete $(shell go list -m -f {{.Dir}} $(BEATS_MODULE))/testing/environments testing/
+	rsync -crv --delete $$(go list -m -f {{.Dir}} $(BEATS_MODULE))/testing/environments testing/
 
 ##############################################################################
 # Kibana synchronisation.


### PR DESCRIPTION
## Motivation/summary

Update Make `update-beats-module` target to run `go list -m -f {{.Dir}} ...` in the shell command, rather than in Make as a [shell function](https://www.gnu.org/software/make/manual/html_node/Shell-Function.html), to avoid premature expansion.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
~- [ ] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)~
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

1. `make update-beats`
2. Check that testing/environments matches the new module

## Related issues

Fixes https://github.com/elastic/apm-server/issues/3784