### PR TITLE
[7.x] Makefile: fix update-beats-module (#3785)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ update-beats: update-beats-module update
 .PHONY: update-beats-module
 update-beats-module:
 	go get -d -u $(BEATS_MODULE)@$(BEATS_VERSION)
-	rsync -crv --delete $(shell go list -m -f {{.Dir}} $(BEATS_MODULE))/testing/environments testing/
+	rsync -crv --delete $$(go list -m -f {{.Dir}} $(BEATS_MODULE))/testing/environments testing/
 
 ##############################################################################
 # Kibana synchronisation.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Makefile: fix update-beats-module (#3785)