### PR TITLE
docs: Update documentation copied from Beats

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -672,6 +672,28 @@ output.elasticsearch:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
+
+
 #----------------------------- Console output -----------------------------
 #output.console:
   # Boolean flag to enable or disable the output module.
@@ -926,6 +948,27 @@ output.elasticsearch:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/krb5kdc/kafka.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/path/config
+
+  # The service principal name.
+  #kerberos.service_name: HTTP/my-service@realm
+
+  # Name of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
+
 #================================= Paths ==================================
 
 # The home path for the apm-server installation. This is the default base path
@@ -1129,6 +1172,27 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
 
   #metrics.period: 10s
   #state.period: 1m

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -672,6 +672,28 @@ output.elasticsearch:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
+
+
 #----------------------------- Console output -----------------------------
 #output.console:
   # Boolean flag to enable or disable the output module.
@@ -926,6 +948,27 @@ output.elasticsearch:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/krb5kdc/kafka.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/path/config
+
+  # The service principal name.
+  #kerberos.service_name: HTTP/my-service@realm
+
+  # Name of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
+
 #================================= Paths ==================================
 
 # The home path for the apm-server installation. This is the default base path
@@ -1129,6 +1172,27 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
 
   #metrics.period: 10s
   #state.period: 1m

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -672,6 +672,28 @@ output.elasticsearch:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
+
+
 #----------------------------- Console output -----------------------------
 #output.console:
   # Boolean flag to enable or disable the output module.
@@ -926,6 +948,27 @@ output.elasticsearch:
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
 
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/krb5kdc/kafka.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/path/config
+
+  # The service principal name.
+  #kerberos.service_name: HTTP/my-service@realm
+
+  # Name of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
+
 #================================= Paths ==================================
 
 # The home path for the apm-server installation. This is the default base path
@@ -1129,6 +1172,27 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
+
+  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
+  #kerberos.enabled: true
+
+  # Authentication type to use with Kerberos. Available options: keytab, password.
+  #kerberos.auth_type: password
+
+  # Path to the keytab file. It is used when auth_type is set to keytab.
+  #kerberos.keytab: /etc/elastic.keytab
+
+  # Path to the Kerberos configuration.
+  #kerberos.config_path: /etc/krb5.conf
+
+  # Name of the Kerberos user.
+  #kerberos.username: elastic
+
+  # Password of the Kerberos user. It is used when auth_type is set to password.
+  #kerberos.password: changeme
+
+  # Kerberos realm.
+  #kerberos.realm: ELASTIC
 
   #metrics.period: 10s
   #state.period: 1m

--- a/docs/copied-from-beats/docs/loggingconfig.asciidoc
+++ b/docs/copied-from-beats/docs/loggingconfig.asciidoc
@@ -235,6 +235,12 @@ true.
 
 When true, logs messages in JSON format. The default is false.
 
+[float]
+==== `logging.ecs`
+
+When true, logs messages with minimal required Elastic Common Schema (ECS)
+information.
+
 ifndef::serverless[]
 [float]
 ==== `logging.files.redirect_stderr` experimental[]

--- a/docs/copied-from-beats/docs/shared-kerberos-config.asciidoc
+++ b/docs/copied-from-beats/docs/shared-kerberos-config.asciidoc
@@ -1,0 +1,85 @@
+[[configuration-kerberos]]
+== Configure Kerberos
+
+You can specify Kerberos options with any output or input that supports Kerberos, like {es} and Kafka.
+
+The following encryption types are supported:
+
+* aes128-cts-hmac-sha1-96
+* aes128-cts-hmac-sha256-128
+* aes256-cts-hmac-sha1-96
+* aes256-cts-hmac-sha384-192
+* des3-cbc-sha1-kd
+* rc4-hmac
+
+Example output config with Kerberos password based authentication:
+
+[source,yaml]
+----
+output.elasticsearch.hosts: ["http://my-elasticsearch.elastic.co:9200"]
+output.elasticsearch.kerberos.auth_type: password
+output.elasticsearch.kerberos.username: "elastic"
+output.elasticsearch.kerberos.password: "changeme"
+output.elasticsearch.kerberos.config_path: "/etc/krb5.conf"
+output.elasticsearch.kerberos.realm: "ELASTIC.CO"
+----
+
+The service principal name for the Elasticsearch instance is contructed from these options. Based on this configuration
+it is going to be `HTTP/my-elasticsearch.elastic.co@ELASTIC.CO`.
+
+[float]
+=== Configuration options
+
+You can specify the following options in the `kerberos` section of the +{beatname_lc}.yml+ config file:
+
+[float]
+==== `enabled`
+
+The `enabled` setting can be used to enable the kerberos configuration by setting
+it to `false`. The default value is `true`.
+
+NOTE: Kerberos settings are disabled if either `enabled` is set to `false` or the
+`kerberos` section is missing.
+
+[float]
+==== `auth_type`
+
+There are two options to authenticate with Kerberos KDC: `password` and `keytab`.
+
+`password` expects the principal name and its password. When choosing `keytab`, you
+have to specify a princial name and a path to a keytab. The keytab must contain
+the keys of the selected principal. Otherwise, authentication will fail.
+
+[float]
+==== `config_path`
+
+You need to set the path to the `krb5.conf`, so +{beatname_lc} can find the Kerberos KDC to
+retrieve a ticket.
+
+[float]
+==== `username`
+
+Name of the principal used to connect to the output.
+
+[float]
+==== `password`
+
+If you configured `password` for `auth_type`, you have to provide a password
+for the selected principal.
+
+[float]
+==== `keytab`
+
+If you configured `keytab` for `auth_type`, you have to provide the path to the
+keytab of the selected principal.
+
+[float]
+==== `service_name`
+
+This option can only be configured for Kafka. It is the name of the Kafka service, usually `kafka`.
+
+[float]
+==== `realm`
+
+Name of the realm where the output resides.
+

--- a/docs/copied-from-beats/docs/shared-ssl-config.asciidoc
+++ b/docs/copied-from-beats/docs/shared-ssl-config.asciidoc
@@ -239,12 +239,11 @@ are `never`, `once`, and `freely`. The default value is never.
 [float]
 ==== `ca_sha256`
 
-This configure a certificate pin can that ca be used to ensure that a specific certificate is used
-to as part of the verified chain.
+This configures a certificate pin that you can use to ensure that a specific certificate is part of the verified chain.
 
 The pin is a base64 encoded string of the SHA-256 of the certificate.
 
-NOTE: This check is not a replacement for the normal SSL validation but it add additional validation.
+NOTE: This check is not a replacement for the normal SSL validation, but it adds additional validation.
 If this option is used with  `verification_mode` set to `none`, the check will always fail because
 it will not receive any verified chains.
 

--- a/docs/copied-from-beats/docs/shared-systemd.asciidoc
+++ b/docs/copied-from-beats/docs/shared-systemd.asciidoc
@@ -6,7 +6,7 @@ systemd. On these systems, you can manage {beatname_uc} by using the usual
 systemd commands.
 
 ifdef::apm-server[]
-We recommend that the {beatname_lc} process is run as a non-root user.
+We recommend that the {beatname_pkg} process is run as a non-root user.
 Therefore, that is the default setup for {beatname_uc}'s DEB package and RPM installation.
 endif::apm-server[]
 
@@ -16,12 +16,12 @@ Use `systemctl` to start or stop {beatname_uc}:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-sudo systemctl start {beatname_lc}
+sudo systemctl start {beatname_pkg}
 ------------------------------------------------
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-sudo systemctl stop {beatname_lc}
+sudo systemctl stop {beatname_pkg}
 ------------------------------------------------
 
 By default, the {beatname_uc} service starts automatically when the system
@@ -29,12 +29,12 @@ boots. To enable or disable auto start use:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-sudo systemctl enable {beatname_lc}
+sudo systemctl enable {beatname_pkg}
 ------------------------------------------------
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-sudo systemctl disable {beatname_lc}
+sudo systemctl disable {beatname_pkg}
 ------------------------------------------------
 
 
@@ -44,14 +44,14 @@ To get the service status, use `systemctl`:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-systemctl status {beatname_lc}
+systemctl status {beatname_pkg}
 ------------------------------------------------
 
 Logs are stored by default in journald. To view the Logs, use `journalctl`:
 
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
-journalctl -u {beatname_lc}.service
+journalctl -u {beatname_pkg}.service
 ------------------------------------------------
 
 [float]
@@ -69,10 +69,10 @@ override to change the default options.
 |=======================================
 
 To override these variables, create a drop-in unit file in the
-+/etc/systemd/system/{beatname_lc}.service.d+ directory.
++/etc/systemd/system/{beatname_pkg}.service.d+ directory.
 
 For example a file with the following content placed in
-+/etc/systemd/system/{beatname_lc}.service.d/debug.conf+
++/etc/systemd/system/{beatname_pkg}.service.d/debug.conf+
 would override `BEAT_LOG_OPTS` to enable debug for Elasticsearch output.
 
 ["source", "systemd", subs="attributes"]
@@ -87,12 +87,12 @@ the service:
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
 systemctl daemon-reload
-systemctl restart {beatname_lc}
+systemctl restart {beatname_pkg}
 ------------------------------------------------
 
 NOTE: It is recommended that you use a configuration management tool to
 include drop-in unit files. If you need to add a drop-in manually, use
-+systemctl edit {beatname_lc}.service+.
++systemctl edit {beatname_pkg}.service+.
 
 ifdef::apm-server[]
 include::{docdir}/config-ownership.asciidoc[]

--- a/docs/copied-from-beats/docs/shared-template-load.asciidoc
+++ b/docs/copied-from-beats/docs/shared-template-load.asciidoc
@@ -85,6 +85,8 @@ output.elasticsearch.index: "customname-%{[{beat_version_key}]}-%{+yyyy.MM.dd}"
 setup.template.name: "customname"
 setup.template.pattern: "customname-*"
 -----
+WARNING: If <<ilm,index lifecycle management>> is enabled (which is typically the default), `setup.template.name` and `setup.template.pattern` are ignored.
+
 ifndef::no_dashboards[]
 +
 If you're using pre-built Kibana dashboards, also set the

--- a/docs/copied-from-beats/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/docs/copied-from-beats/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -676,3 +676,11 @@ for HTTPS-based connections. If the `ssl` section is missing, the host CAs are u
 Elasticsearch.
 
 See <<configuration-ssl>> for more information.
+
+===== `kebreros`
+
+Configuration options for Kerberos authentication.
+
+See <<configuration-kerberos>> for more information.
+
+include::{libbeat-dir}/shared-kerberos-config.asciidoc[]

--- a/docs/copied-from-beats/outputs/logstash/docs/logstash.asciidoc
+++ b/docs/copied-from-beats/outputs/logstash/docs/logstash.asciidoc
@@ -330,6 +330,9 @@ The index root name to write events to. The default is the Beat name. For
 example +"{beat_default_index_prefix}"+ generates +"[{beat_default_index_prefix}-]{version}-YYYY.MM.DD"+
 indices (for example, +"{beat_default_index_prefix}-{version}-2017.04.26"+).
 
+NOTE: This parameter's value will be assigned to the `metadata.beat` field. It
+can then be accessed in Logstash's output section as `%{[@metadata][beat]}`.
+
 ===== `ssl`
 
 Configuration options for SSL parameters like the root CA for Logstash connections. See

--- a/docs/copied-from-beats/outputs/redis/docs/redis.asciidoc
+++ b/docs/copied-from-beats/outputs/redis/docs/redis.asciidoc
@@ -26,7 +26,8 @@ output.redis:
 
 ==== Compatibility
 
-This output works with Redis 3.2.4.
+This output is expected to work with all Redis versions between 3.2.4 and 5.0.8. Other versions might work as well,
+but are not supported.
 
 ==== Configuration options
 


### PR DESCRIPTION
## Motivation/summary

This PR updates the shared Beats documentation. It also adds documentation for Kerberos, including proposed changes to APM Server's yml config files in 1cb76a6. Based on https://github.com/elastic/beats/pull/16871 and https://github.com/elastic/beats/pull/17927, kerberos settings have been added to the Elasticsearch output, Kafka output, and X-pack Monitoring sections of those files.

## Related issues

For https://github.com/elastic/observability-dev/issues/833.