### PR TITLE
elasticsearch: add known unhandled libbeat config to test

### DIFF
--- a/elasticsearch/config_test.go
+++ b/elasticsearch/config_test.go
@@ -18,6 +18,7 @@
 package elasticsearch
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -143,6 +144,29 @@ func TestBeatsConfigSynced(t *testing.T) {
 		require.Contains(t, libbeatStructFields, name)
 		libbeatStructField := libbeatStructFields[name]
 		assert.Equal(t, localStructField.structTag, libbeatStructField.structTag)
-		assert.Equal(t, localStructField.Type(), libbeatStructField.Type())
+		assert.Equal(t,
+			localStructField.Type(),
+			libbeatStructField.Type(),
+			fmt.Sprintf("expected type %s for config field %q, got %s",
+				libbeatStructField.Type(), name, localStructField.Type(),
+			),
+		)
+		delete(libbeatStructFields, name)
+	}
+
+	knownUnhandled := []string{
+		"backoff",
+		"bulk_max_size",
+		"compression_level",
+		"escape_html",
+		"headers",
+		// TODO Kerberos auth (https://github.com/elastic/apm-server/issues/3794)
+		"kerberos",
+		"loadbalance",
+		"max_retries",
+		"parameters",
+	}
+	for name := range libbeatStructFields {
+		assert.Contains(t, knownUnhandled, name)
 	}
 }


### PR DESCRIPTION
## Motivation/summary

Additions to libbeat config are not checked. Beats added Kerberos auth support, which we should mirror in our client (#3794). To make sure we keep on top of libbeat config changes, we should update the test to add a list of known fields in libbeat's config that we explicitly don't mirror.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)

~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

`go test ./elasticsearch`

## Related issues

Closes #3795