### PR TITLE
beater: CreatorParams.RunServer -> WrapRunServer

### DIFF
--- a/beater/server.go
+++ b/beater/server.go
@@ -53,8 +53,8 @@ type ServerParams struct {
 	Reporter publish.Reporter
 }
 
-// RunServer runs the APM Server until a fatal error occurs, or ctx is cancelled.
-func RunServer(ctx context.Context, args ServerParams) error {
+// runServer runs the APM Server until a fatal error occurs, or ctx is cancelled.
+func runServer(ctx context.Context, args ServerParams) error {
 	srv, err := newServer(args.Logger, args.Config, args.Tracer, args.Reporter)
 	if err != nil {
 		return err

--- a/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
@@ -100,7 +100,8 @@
                 "ab_testing": true,
                 "group": "experimental",
                 "organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8",
-                "segment": 5
+                "segment": 5,
+                "wrapped_reporter": true
             },
             "observer": {
                 "ephemeral_id": "00000000-0000-0000-0000-000000000000",

--- a/beater/test_approved_es_documents/TestPublishIntegrationMinimalEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationMinimalEvents.approved.json
@@ -18,6 +18,9 @@
             "host": {
                 "ip": "127.0.0.1"
             },
+            "labels": {
+                "wrapped_reporter": true
+            },
             "observer": {
                 "ephemeral_id": "00000000-0000-0000-0000-000000000000",
                 "hostname": "",

--- a/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json
@@ -59,7 +59,8 @@
             },
             "labels": {
                 "tag1": "one",
-                "tag2": 2
+                "tag2": 2,
+                "wrapped_reporter": true
             },
             "observer": {
                 "ephemeral_id": "00000000-0000-0000-0000-000000000000",
@@ -253,7 +254,8 @@
                 "tag1": "one",
                 "tag2": 12,
                 "tag3": 12.45,
-                "tag4": false
+                "tag4": false,
+                "wrapped_reporter": true
             },
             "observer": {
                 "ephemeral_id": "00000000-0000-0000-0000-000000000000",
@@ -419,7 +421,8 @@
             },
             "labels": {
                 "tag1": "one",
-                "tag2": 2
+                "tag2": 2,
+                "wrapped_reporter": true
             },
             "observer": {
                 "ephemeral_id": "00000000-0000-0000-0000-000000000000",
@@ -555,7 +558,8 @@
             },
             "labels": {
                 "tag1": "one",
-                "tag2": 2
+                "tag2": 2,
+                "wrapped_reporter": true
             },
             "observer": {
                 "ephemeral_id": "00000000-0000-0000-0000-000000000000",

--- a/beater/tracing_test.go
+++ b/beater/tracing_test.go
@@ -54,6 +54,12 @@ func TestServerTracingEnabled(t *testing.T) {
 			if testTransactionIds.Contains(eventTransactionId(e)) {
 				continue
 			}
+
+			// Check that self-instrumentation goes through the
+			// reporter wrapped by setupBeater.
+			wrapped, _ := e.GetValue("labels.wrapped_reporter")
+			assert.Equal(t, true, wrapped)
+
 			selfTransactions = append(selfTransactions, eventTransactionName(e))
 		case <-time.After(5 * time.Second):
 			assert.FailNow(t, "timed out waiting for transaction")

--- a/main.go
+++ b/main.go
@@ -26,9 +26,7 @@ import (
 	"github.com/elastic/apm-server/cmd"
 )
 
-var rootCmd = cmd.NewRootCommand(beater.NewCreator(beater.CreatorParams{
-	RunServer: beater.RunServer,
-}))
+var rootCmd = cmd.NewRootCommand(beater.NewCreator(beater.CreatorParams{}))
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {

--- a/x-pack/apm-server/cmd/root_test.go
+++ b/x-pack/apm-server/cmd/root_test.go
@@ -22,9 +22,7 @@ func TestSubCommands(t *testing.T) {
 		"version":    {},
 	}
 
-	rootCmd := NewXPackRootCommand(beater.NewCreator(beater.CreatorParams{
-		RunServer: beater.RunServer,
-	}))
+	rootCmd := NewXPackRootCommand(beater.NewCreator(beater.CreatorParams{}))
 	for _, cmd := range rootCmd.Commands() {
 		name := cmd.Name()
 		if _, ok := validCommands[name]; !ok {


### PR DESCRIPTION
## Motivation/summary

Rather than passing in a RunServerFunc to CreatorParams,
pass in a function that can wrap a RunServerFunc. This
enables us to run the tracer server with an overridden reporter,
such as the one provided by the transaction histogram
aggregator.

We unexport beater.RunServer to ensure wrappers do not
mistakenly call it directly, rather than going through the
RunServerFunc provided to them.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

- Enable self-instrumentation
- Enable aggregation
- Send some traces to the server
- Wait for the server to record `transaction.duration.histogram` metrics docs for the API requests

## Related issues

Fixes #3801