### PR TITLE
[7.8] docs: update links to logstash getting started (#3807)

### DIFF
--- a/docs/copied-from-beats/outputs/logstash/docs/logstash.asciidoc
+++ b/docs/copied-from-beats/outputs/logstash/docs/logstash.asciidoc
@@ -15,9 +15,9 @@ generated events.
 .Prerequisite
 To send events to {ls}, you also need to create a {ls} configuration pipeline
 that listens for incoming Beats connections and indexes the received events into
-{es}. For more information, see the section about
-{stack-gs}/get-started-elastic-stack.html#logstash-setup[configuring {ls}] in
-the {stack} getting started tutorial. Also see the documentation for the
+{es}. For more information, see
+{logstash-ref}/getting-started-with-logstash.html[Getting Started with {ls}].
+Also see the documentation for the
 {logstash-ref}/plugins-inputs-beats.html[{beats} input] and
 {logstash-ref}/plugins-outputs-elasticsearch.html[{es} output] plugins.
 


### PR DESCRIPTION
Backports the following commits to 7.8:
 - docs: update links to logstash getting started (#3807)