### PR TITLE
[7.x] docs: Update kerberos and upgrading docs (#3810)

### DIFF
--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -1,20 +1,20 @@
 [[breaking-changes]]
-=== Breaking Changes
+== Breaking Changes
 APM Server is built on top of {beats-ref}/index.html[libbeat].
 As such, any breaking change in libbeat is also considered to be a breaking change in APM Server.
 
 [float]
-==== 7.7
+=== 7.7
 * There are no breaking changes in APM Server.
 However, a previously hardcoded feature is now configurable.
 Failing to follow these <<upgrading-to-77,upgrade steps>> will result in increased span metadata ingestion when upgrading to version 7.7.
 
 [float]
-==== 7.6
+=== 7.6
 * There are no breaking changes in APM Server.
 
 [float]
-==== 7.5
+=== 7.5
 * Introduced dedicated `apm-server.ilm.setup.*` flags.
 This means you can now customize ILM behavior from within the APM Server configuration.
 As a side effect, `setup.template.*` settings will be ignored for ILM related templates per event type.
@@ -28,7 +28,7 @@ See {apm-server-ref}/ilm.html[default policy] for more information.
 you must ensure you are using version 7.5+ of APM Server and version 7.5+ of Kibana.
 
 [float]
-==== 7.0
+=== 7.0
 * Removed deprecated Intake v1 API endpoints.
 Upgrade agents to a version that supports APM Server >= 6.5.
 {apm-overview-ref-v}/breaking-7.0.0.html#breaking-remove-v1[More information].
@@ -37,19 +37,19 @@ Upgrade agents to a version that supports APM Server >= 6.5.
 * {beats-ref}/breaking-changes-7.0.html[Breaking changes in libbeat]
 
 [float]
-==== 6.5
+=== 6.5
 * There are no breaking changes in APM Server.
 * Advanced users may find the <<upgrading-to-65,upgrading to 6.5 guide>> useful.
 
 [float]
-==== 6.4
+=== 6.4
 * Indexing the `onboarding` document in it's own index by default.
 
 [float]
-==== 6.3
+=== 6.3
 * Indexing events in separate indices by default.
 * {beats-ref-63}/breaking-changes-6.3.html[Breaking changes in libbeat]
 
 [float]
-==== 6.2
+=== 6.2
 * APM Server GA

--- a/docs/copied-from-beats/docs/outputs-list.asciidoc
+++ b/docs/copied-from-beats/docs/outputs-list.asciidoc
@@ -83,5 +83,8 @@ ifdef::requires_xpack[]
 endif::[]
 include::{libbeat-outputs-dir}/codec/docs/codec.asciidoc[]
 endif::[]
+ifndef::no_kerberos[]
+include::{libbeat-dir}/shared-kerberos-config.asciidoc[]
+endif::[]
 
 //# end::outputs-include[]

--- a/docs/copied-from-beats/docs/shared-kerberos-config.asciidoc
+++ b/docs/copied-from-beats/docs/shared-kerberos-config.asciidoc
@@ -1,6 +1,10 @@
 [[configuration-kerberos]]
 == Configure Kerberos
 
+++++
+<titleabbrev>Kerberos</titleabbrev>
+++++
+
 You can specify Kerberos options with any output or input that supports Kerberos, like {es} and Kafka.
 
 The following encryption types are supported:
@@ -82,4 +86,3 @@ This option can only be configured for Kafka. It is the name of the Kafka servic
 ==== `realm`
 
 Name of the realm where the output resides.
-

--- a/docs/copied-from-beats/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/docs/copied-from-beats/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -682,5 +682,3 @@ See <<configuration-ssl>> for more information.
 Configuration options for Kerberos authentication.
 
 See <<configuration-kerberos>> for more information.
-
-include::{libbeat-dir}/shared-kerberos-config.asciidoc[]

--- a/docs/upgrading-to-65.asciidoc
+++ b/docs/upgrading-to-65.asciidoc
@@ -1,5 +1,5 @@
 [[upgrading-to-65]]
-=== Upgrade to APM Server version 6.5
+== Upgrade to APM Server version 6.5
 
 ++++
 <titleabbrev>Upgrade to version 6.5</titleabbrev>
@@ -16,8 +16,9 @@ it's recommended you read about the changes below and update accordingly.
 If you'd like to continue using the deprecated Intake API and Elasticsearch Schema,
 you can view https://www.elastic.co/guide/en/apm/server/6.4/overview.html[previous documentation].
 
+[float]
 [[upgrade-steps-65]]
-==== Upgrade Steps
+=== Upgrade Steps
 
 . Upgrade the Elastic Stack: {ref}/setup-upgrade.html[Elasticsearch],
 {kibana-ref}/upgrade.html[Kibana],
@@ -31,7 +32,7 @@ New agents do not support APM Server <6.5 and will not work if you upgrade in th
 
 [float]
 [[intake-api-changes-65]]
-==== Intake API Changes
+=== Intake API Changes
 
 The Intake API is what we call the internal protocol that APM agents use to talk to the APM Server.
 This API has been redesigned in 6.5 to increase the memory efficiency and predictability of the APM Server and APM agents.
@@ -48,7 +49,7 @@ is available in the <<events-api,Events API>> documentation.
 
 [float]
 [[metadata-api-changes-65]]
-===== Metadata
+==== Metadata
 
 Metadata is now sent to the APM Server only once per request.
 APM Server will retain this information and apply it to the applicable documents when it writes to Elasticsearch.
@@ -58,7 +59,7 @@ See the <<metadata-api, metadata documentation>> for more information.
 
 [float]
 [[error-api-changes-65]]
-===== Error
+==== Error
 
 The error schema adds three new properties, and deprecates two others.
 
@@ -73,7 +74,7 @@ See the <<error-schema, error schema documentation>> for more information.
 
 [float]
 [[transaction-api-changes-65]]
-===== Transaction
+==== Transaction
 
 The transaction schema adds two new properties, and deprecates two others.
 
@@ -87,7 +88,7 @@ See the <<transaction-schema, transaction schema documentation>> for more inform
 
 [float]
 [[span-api-changes-65]]
-===== Span
+==== Span
 
 The span schema adds three new properties, removes two, and changes one.
 
@@ -103,14 +104,14 @@ See the <<span-schema, span schema documentation>> for more information.
 
 [float]
 [[healthcheck-api-changes-65]]
-===== Healthcheck Endpoint
+==== Healthcheck Endpoint
 
 The Healthcheck endpoint, previously `/healthcheck`, has been deprecated.
 The <<server-info,server information>> api has replaced it.
 
 [float]
 [[assets-api-changes-65]]
-===== Assets Endpoint
+==== Assets Endpoint
 
 The assets endpoint, `/v1/rum/sourcemaps` has been deprecated,
 and replaced with the endpoint: `/assets/v1/sourcemaps`.
@@ -118,7 +119,7 @@ The data format remains unchanged.
 
 [float]
 [[metrics-api-changes-65]]
-===== Metricsets Endpoint
+==== Metricsets Endpoint
 
 The Metricsets endpoint, previously `/v1/metrics`,
 has also integrated with the new intake endpoint at `/intake/v2/events`.
@@ -132,7 +133,7 @@ See the <<metricset-api, metricset schema>> for more information.
 
 [float]
 [[server-config-changes-65]]
-==== Server Configuration Changes
+=== Server Configuration Changes
 
 There are some configuration changes that are worth mentioning.
 
@@ -160,7 +161,7 @@ RUM configuration changes:
 
 [float]
 [[es-schema-changes-65]]
-==== Elasticsearch Schema Changes
+=== Elasticsearch Schema Changes
 
 The Elasticsearch schema defines how APM data is stored in Elasticsearch.
 There have been a number of changes to the Elasticsearch schema for 6.5.
@@ -172,7 +173,7 @@ These new keys are essential to taking advantage of APM's new {apm-overview-ref-
 
 [float]
 [[es-error-changes-65]]
-===== Error
+==== Error
 
 The Elasticsearch error schema adds two new keys:
 
@@ -183,7 +184,7 @@ View the sample Elasticsearch <<error-indices,error document>> for more informat
 
 [float]
 [[es-transaction-changes-65]]
-===== Transaction
+==== Transaction
 
 The Elasticsearch transaction schema adds two new keys:
 
@@ -194,7 +195,7 @@ View the sample Elasticsearch <<transaction-indices,transaction document>> for m
 
 [float]
 [[es-span-changes-65]]
-===== Span
+==== Span
 
 The Elasticsearch span schema adds three new keys, and deprecates two:
 

--- a/docs/upgrading-to-70.asciidoc
+++ b/docs/upgrading-to-70.asciidoc
@@ -1,5 +1,5 @@
 [[upgrading-to-70]]
-=== Upgrade to APM Server version 7.0
+== Upgrade to APM Server version 7.0
 
 ++++
 <titleabbrev>Upgrade to version 7.0</titleabbrev>
@@ -9,11 +9,12 @@ Before upgrading to APM Server v7.0,
 there are some {apm-overview-ref-v}/breaking-7.0.0.html[breaking changes]
 in the APM Server and the APM UI that you should be aware of.
 
+[float]
 [[upgrade-steps-70]]
-==== Upgrade Steps
+=== Upgrade Steps
 
 Check the https://www.elastic.co/support/matrix#matrix_compatibility[Product Compatibility matrix]
-to determine if you need to upgrade Elasticsearch and Kibana. 
+to determine if you need to upgrade Elasticsearch and Kibana.
 
 . Upgrade {ref}/setup-upgrade.html[Elasticsearch].
 . Upgrade {kibana-ref}/upgrade.html[Kibana].
@@ -22,9 +23,10 @@ The {apm-overview-ref-v}/agent-server-compatibility.html[agent/server compatibil
 will help determine compatibility.
 . Upgrade APM Server (see below if upgrading from an RPM or Deb install).
 . Use the Kibana migration assistant, found in the Kibana Management tab,
-to migrate 6.x data to the 7.x format. 
+to migrate 6.x data to the 7.x format.
 
-===== Upgrading from 6.x RPM or Deb install
+[float]
+==== Upgrading from 6.x RPM or Deb install
 
 When upgrading from an RPM or Deb install,
 you'll be prompted with a warning saying the install is going to overwrite `/etc/apm-server/apm-server.yml`.

--- a/docs/upgrading-to-77.asciidoc
+++ b/docs/upgrading-to-77.asciidoc
@@ -1,5 +1,5 @@
 [[upgrading-to-77]]
-=== Upgrade to APM Server version 7.7
+== Upgrade to APM Server version 7.7
 
 ++++
 <titleabbrev>Upgrade to version 7.7</titleabbrev>
@@ -16,8 +16,9 @@ Switching this metadata cleanup functionality to a processor allows you to defin
 
 Failing to follow the upgrade steps will result in increased span metadata ingestion when upgrading to version 7.7.
 
+[float]
 [[upgrade-steps-77]]
-==== Upgrade Steps
+=== Upgrade Steps
 
 . In order to avoid breaking custom pipeline definitions,
 pipelines are not overwritten when restarting APM Server.

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -1,5 +1,5 @@
 [[upgrading]]
-== Upgrade APM Server
+= Upgrade APM Server
 
 ++++
 <titleabbrev>Upgrade</titleabbrev>
@@ -32,8 +32,8 @@ and applies the correct template automatically.
 
 include::./breaking-changes.asciidoc[]
 
-include::./upgrading-to-65.asciidoc[]
+include::./upgrading-to-77.asciidoc[]
 
 include::./upgrading-to-70.asciidoc[]
 
-include::./upgrading-to-77.asciidoc[]
+include::./upgrading-to-65.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: Update kerberos and upgrading docs (#3810)