### PR TITLE
aggregation/txmetrics: don't group on user-agent

### DIFF
--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -264,7 +264,7 @@ func makeMetricset(key transactionAggregationKey, ts time.Time, counts []int64, 
 				Container:        model.Container{ID: key.containerID},
 				Kubernetes:       model.Kubernetes{PodName: key.kubernetesPodName},
 			},
-			User: model.User{UserAgent: key.userAgent},
+			// TODO(axw) include browser name, by parsing the user agent
 			// TODO(axw) include client.geo.country_iso_code somewhere
 		},
 		Transaction: model.MetricsetTransaction{
@@ -304,6 +304,8 @@ type metricsMapEntry struct {
 type transactionAggregationKey struct {
 	traceRoot bool
 	agentName string
+	// TODO(axw) requires User-Agent parsing in apm-server.
+	//browserName string
 	// TODO(axw) requires geoIP lookup in apm-server.
 	//clientCountryISOCode string
 	containerID        string
@@ -315,7 +317,6 @@ type transactionAggregationKey struct {
 	transactionName    string
 	transactionResult  string
 	transactionType    string
-	userAgent          string
 }
 
 func makeTransactionAggregationKey(tx *model.Transaction) transactionAggregationKey {
@@ -339,8 +340,8 @@ func makeTransactionAggregationKey(tx *model.Transaction) transactionAggregation
 		hostname:          tx.Metadata.System.Hostname(),
 		containerID:       tx.Metadata.System.Container.ID,
 		kubernetesPodName: tx.Metadata.System.Kubernetes.PodName,
-		userAgent:         tx.Metadata.User.UserAgent,
 
+		// TODO(axw) browser name, requires parsing User-Agent in apm-server.
 		// TODO(axw) clientCountryISOCode, requires geoIP lookup in apm-server.
 	}
 }
@@ -352,6 +353,7 @@ func (k *transactionAggregationKey) hash() uint64 {
 		h.WriteString("1")
 	}
 	h.WriteString(k.agentName)
+	// TODO(axw) browserName
 	// TODO(axw) clientCountryISOCode
 	h.WriteString(k.containerID)
 	h.WriteString(k.hostname)
@@ -362,7 +364,6 @@ func (k *transactionAggregationKey) hash() uint64 {
 	h.WriteString(k.transactionName)
 	h.WriteString(k.transactionResult)
 	h.WriteString(k.transactionType)
-	h.WriteString(k.userAgent)
 	return h.Sum64()
 }
 


### PR DESCRIPTION
## Motivation/summary

Stop grouping metrics by the full User-Agent string. That was a terrible idea. We'll need to parse User-Agent and include the browser name, and any other things we want to group by in the UI.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

1. Enable aggregation in apm-integration-testing
2. Check that none of the metrics have user_agent.original set

## Related issues

Closes #3841 