### PR TITLE
[7.8] docs: Sync changelogs (#3844)

### DIFF
--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,6 +3,8 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.10>>
+* <<release-notes-6.8.9>>
 * <<release-notes-6.8.8>>
 * <<release-notes-6.8.7>>
 * <<release-notes-6.8.6>>
@@ -12,6 +14,20 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.2>>
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
+
+[[release-notes-6.8.10]]
+=== APM Server version 6.8.10
+
+https://github.com/elastic/apm-server/compare/v6.8.9\...v6.8.10[View commits]
+
+No significant changes.
+
+[[release-notes-6.8.9]]
+=== APM Server version 6.8.9
+
+https://github.com/elastic/apm-server/compare/v6.8.8\...v6.8.9[View commits]
+
+No significant changes.
 
 [[release-notes-6.8.8]]
 === APM Server version 6.8.8
@@ -24,6 +40,7 @@ No significant changes.
 === APM Server version 6.8.7
 
 https://github.com/elastic/apm-server/compare/v6.8.6\...v6.8.7[View commits]
+
 No significant changes.
 
 [[release-notes-6.8.6]]

--- a/changelogs/7.7.asciidoc
+++ b/changelogs/7.7.asciidoc
@@ -3,7 +3,15 @@
 
 https://github.com/elastic/apm-server/compare/7.6\...7.7[View commits]
 
+* <<release-notes-7.7.1>>
 * <<release-notes-7.7.0>>
+
+[[release-notes-7.7.1]]
+=== APM Server version 7.7.1
+
+https://github.com/elastic/apm-server/compare/v7.7.0\...v7.7.1[View commits]
+
+No significant changes.
 
 [[release-notes-7.7.0]]
 === APM Server version 7.7.0


### PR DESCRIPTION
Backports the following commits to 7.8:
 - docs: Sync changelogs (#3844)