### PR TITLE
fix: check that docker is installed

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -19,8 +19,9 @@ docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-ppc
 docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-s390x
 golang:${GO_VERSION}
 "
-
-for image in ${DOCKER_IMAGES}
-do
-(retry 2 docker pull ${image}) || echo "Error pulling ${image} Docker image, we continue"
-done
+if [ -x "$(command -v docker)" ]; then
+  for image in ${DOCKER_IMAGES}
+  do
+  (retry 2 docker pull ${image}) || echo "Error pulling ${image} Docker image, we continue"
+  done
+fi


### PR DESCRIPTION
## What does this PR do?

It checks that Docker is installed before run it.

## Why is it important?

Some worker types do not have Docker installed this breaks the packer build.