### PR TITLE
[7.x] docs: update greater than equal to symbol (#3890)

### DIFF
--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -34,7 +34,7 @@ you must ensure you are using version 7.5+ of APM Server and version 7.5+ of Kib
 [float]
 === 7.0
 * Removed deprecated Intake v1 API endpoints.
-Upgrade agents to a version that supports APM Server >= 6.5.
+Upgrade agents to a version that supports APM Server ≥ 6.5.
 {apm-overview-ref-v}/breaking-7.0.0.html#breaking-remove-v1[More information].
 * Moved fields in Elasticsearch to be compliant with the Elastic Common Schema (ECS).
 {apm-overview-ref-v}/breaking-7.0.0.html#breaking-ecs[More information and changed fields].

--- a/docs/guide/agent-server-compatibility.asciidoc
+++ b/docs/guide/agent-server-compatibility.asciidoc
@@ -8,38 +8,38 @@ The chart below outlines the compatibility between different versions of the APM
 |Agent |Agent Version |APM Server Version
 // Go
 .1+|**Go Agent**
-|`1.x` |>= `6.5`
+|`1.x` |≥ `6.5`
 
 // Java
 .1+|**Java Agent**
-|`1.x`|>= `6.5`
+|`1.x`|≥ `6.5`
 
 // .NET
 .1+|**.NET Agent**
-|`1.x` |>= `6.5`
+|`1.x` |≥ `6.5`
 
 // Node
 .3+|**Node.js Agent**
 |`1.x` |`6.2`-`6.x`
-|`2.x` |>= `6.5`
-|`3.x` |>= `6.6`
+|`2.x` |≥ `6.5`
+|`3.x` |≥ `6.6`
 
 // Python
 .3+|**Python Agent**
 |`2.x`, `3.x` |`6.2`-`6.x`
-|`4.x` |>= `6.5`
-|`5.x` |>= `6.6`
+|`4.x` |≥ `6.5`
+|`5.x` |≥ `6.6`
 
 // Ruby
 .3+|**Ruby Agent**
 |`1.x` |`6.4`-`6.x`
-|`2.x` |>= `6.5`
-|`3.x` |>= `6.5`
+|`2.x` |≥ `6.5`
+|`3.x` |≥ `6.5`
 
 // RUM
 .4+|**JavaScript RUM Agent**
 |`0.x` |`6.3`-`6.4`
 |`1.x` |`6.4`
-|`2.x`, `3.x`, `4.x` |>= `6.5`
-|`5.x` |>= `7.0`
+|`2.x`, `3.x`, `4.x` |≥ `6.5`
+|`5.x` |≥ `7.0`
 |====

--- a/docs/guide/apm-breaking-changes.asciidoc
+++ b/docs/guide/apm-breaking-changes.asciidoc
@@ -101,7 +101,7 @@ APM Server::
 +
 [[breaking-remove-v1]]
 **Removed deprecated Intake v1 API endpoints.** Before upgrading APM Server,
-ensure all APM agents are upgraded to a version that supports APM Server >= 6.5.
+ensure all APM agents are upgraded to a version that supports APM Server ≥ 6.5.
 View the {apm-overview-ref-v}/agent-server-compatibility.html[agent/server compatibility matrix]
 to determine if your agent versions are compatible.
 +

--- a/docs/upgrading-to-70.asciidoc
+++ b/docs/upgrading-to-70.asciidoc
@@ -18,7 +18,7 @@ to determine if you need to upgrade Elasticsearch and Kibana.
 
 . Upgrade {ref}/setup-upgrade.html[Elasticsearch].
 . Upgrade {kibana-ref}/upgrade.html[Kibana].
-. Ensure all of your APM agents are upgraded to a version that supports APM Server >= 6.5.
+. Ensure all of your APM agents are upgraded to a version that supports APM Server ≥ 6.5.
 The {apm-overview-ref-v}/agent-server-compatibility.html[agent/server compatibility matrix]
 will help determine compatibility.
 . Upgrade APM Server (see below if upgrading from an RPM or Deb install).


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: update greater than equal to symbol (#3890)