### PR TITLE
[7.6] [DOCS] Fixes license management link (#3893)

### DIFF
--- a/docs/copied-from-beats/docs/command-reference.asciidoc
+++ b/docs/copied-from-beats/docs/command-reference.asciidoc
@@ -91,7 +91,7 @@ endif::[]
 
 Some of the features described here require an Elastic license. For
 more information, see https://www.elastic.co/subscriptions and
-{stack-ov}/license-management.html[License Management].
+{kibana-ref}/managing-licenses.html[License Management].
 
 
 [options="header"]

--- a/docs/copied-from-beats/docs/shared-docker.asciidoc
+++ b/docs/copied-from-beats/docs/shared-docker.asciidoc
@@ -9,7 +9,7 @@ https://www.docker.elastic.co[www.docker.elastic.co].
 
 These images are free to use under the Elastic license. They contain open source 
 and free commercial features and access to paid commercial features.  
-{xpack-ref}/license-management.html[Start a 30-day trial] to try out all of the 
+{kibana-ref}/managing-licenses.html[Start a 30-day trial] to try out all of the 
 paid commercial features. See the 
 https://www.elastic.co/subscriptions[Subscriptions] page for information about 
 Elastic license levels.


### PR DESCRIPTION
Backports the following commits to 7.6:
 - [DOCS] Fixes license management link (#3893)