### PR TITLE
[jjbb]: folder description is required

### DIFF
--- a/.ci/jobs/apm-server.yml
+++ b/.ci/jobs/apm-server.yml
@@ -1,4 +1,5 @@
 ---
 - job:
     name: apm-server
+    description: apm-server
     project-type: folder


### PR DESCRIPTION
Fix the issue with Jenkins folders without a description
