### PR TITLE
[7.x] ILM: restrict customization of alias to suffix. (#3905)

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -382,25 +382,27 @@ apm-server:
       # Default value is `true`.
       #require_policy: true
 
-      # The configured event types, policies and rollover_aliases will be merged with
-      # the default setup. Only configure the mappings that should be customized.
-      # NOTICE: when customizing `rollover_alias`, it is strongly recommended to keep
-      # the prefix "apm-%{[observer.version]}" unchanged;
-      # in case the prefix is changed, `setup.template.name` and `setup.template.pattern`
-      # need to be changed accordingly to match the created indices
+      # Customized mappings will be merged with the default setup, so you only need to configure mappings for the
+      # event types, policies, and index suffixes that you want to customize.
+      # Indices are named in this way: `apm-%{[observer.version]}-%{[event.type]}-{index_suffix}`,
+      # e.g., apm-7.9.0-span-custom*. The `index_suffix` is optional.
+      # NOTE: When configuring an `index_suffix`, ensure that no previously set up templates conflict with the
+      #       newly configured ones. If an index matches multiple templates with the same order, the settings of
+      #       the templates will override each other. Any conflicts need to be cleaned up manually.
+      # NOTE: When customizing `setup.template.name` and `setup.template.pattern`, ensure they still match the indices.
       #mapping:
         #- event_type: "error"
         #  policy_name: "apm-rollover-30-days"
-        #  rollover_alias: "apm-%{[observer.version]}-error"
+        #  index_suffix: ""
         #- event_type: "span"
         #  policy_name: "apm-rollover-30-days"
-        #  rollover_alias: "apm-%{[observer.version]}-span"
+        #  index_suffix: ""
         #- event_type: "transaction"
         #  policy_name: "apm-rollover-30-days"
-        #  rollover_alias: "apm-%{[observer.version]}-transaction"
+        #  index_suffix: ""
         #- event_type: "metric"
         #  policy_name: "apm-rollover-30-days"
-        #  rollover_alias: "apm-%{[observer.version]}-metric"
+        #  index_suffix: ""
 
       # Configured policies are added to pre-defined default policies.
       # If a policy with the same name as a default policy is configured, the configured policy overwrites the default policy.
@@ -493,14 +495,12 @@ apm-server:
 #setup.template.enabled: true
 
 # Template name. By default the template name is "apm-%{[observer.version]}"
-# The template name and pattern has to be set in case the elasticsearch index pattern is modified,
-# or the `apm-server.ilm.setup.mapping` rollover_aliases are changed.
+# The template name and pattern has to be set in case the elasticsearch index pattern is modified.
 #setup.template.name: "apm-%{[observer.version]}"
 
 # Template pattern. By default the template pattern is "apm-%{[observer.version]}-*" to apply to the default index settings.
 # The first part is the version of apm-server and then -* is used to match all daily indices.
-# The template name and pattern has to be set in case the elasticsearch index pattern is modified,
-# or the `apm-server.ilm.setup.mapping` rollover_aliases are changed.
+# The template name and pattern has to be set in case the elasticsearch index pattern is modified.
 #setup.template.pattern: "apm-%{[observer.version]}-*"
 
 # Path to fields.yml file to generate the template.

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -382,25 +382,27 @@ apm-server:
       # Default value is `true`.
       #require_policy: true
 
-      # The configured event types, policies and rollover_aliases will be merged with
-      # the default setup. Only configure the mappings that should be customized.
-      # NOTICE: when customizing `rollover_alias`, it is strongly recommended to keep
-      # the prefix "apm-%{[observer.version]}" unchanged;
-      # in case the prefix is changed, `setup.template.name` and `setup.template.pattern`
-      # need to be changed accordingly to match the created indices
+      # Customized mappings will be merged with the default setup, so you only need to configure mappings for the
+      # event types, policies, and index suffixes that you want to customize.
+      # Indices are named in this way: `apm-%{[observer.version]}-%{[event.type]}-{index_suffix}`,
+      # e.g., apm-7.9.0-span-custom*. The `index_suffix` is optional.
+      # NOTE: When configuring an `index_suffix`, ensure that no previously set up templates conflict with the
+      #       newly configured ones. If an index matches multiple templates with the same order, the settings of
+      #       the templates will override each other. Any conflicts need to be cleaned up manually.
+      # NOTE: When customizing `setup.template.name` and `setup.template.pattern`, ensure they still match the indices.
       #mapping:
         #- event_type: "error"
         #  policy_name: "apm-rollover-30-days"
-        #  rollover_alias: "apm-%{[observer.version]}-error"
+        #  index_suffix: ""
         #- event_type: "span"
         #  policy_name: "apm-rollover-30-days"
-        #  rollover_alias: "apm-%{[observer.version]}-span"
+        #  index_suffix: ""
         #- event_type: "transaction"
         #  policy_name: "apm-rollover-30-days"
-        #  rollover_alias: "apm-%{[observer.version]}-transaction"
+        #  index_suffix: ""
         #- event_type: "metric"
         #  policy_name: "apm-rollover-30-days"
-        #  rollover_alias: "apm-%{[observer.version]}-metric"
+        #  index_suffix: ""
 
       # Configured policies are added to pre-defined default policies.
       # If a policy with the same name as a default policy is configured, the configured policy overwrites the default policy.
@@ -493,14 +495,12 @@ apm-server:
 #setup.template.enabled: true
 
 # Template name. By default the template name is "apm-%{[observer.version]}"
-# The template name and pattern has to be set in case the elasticsearch index pattern is modified,
-# or the `apm-server.ilm.setup.mapping` rollover_aliases are changed.
+# The template name and pattern has to be set in case the elasticsearch index pattern is modified.
 #setup.template.name: "apm-%{[observer.version]}"
 
 # Template pattern. By default the template pattern is "apm-%{[observer.version]}-*" to apply to the default index settings.
 # The first part is the version of apm-server and then -* is used to match all daily indices.
-# The template name and pattern has to be set in case the elasticsearch index pattern is modified,
-# or the `apm-server.ilm.setup.mapping` rollover_aliases are changed.
+# The template name and pattern has to be set in case the elasticsearch index pattern is modified.
 #setup.template.pattern: "apm-%{[observer.version]}-*"
 
 # Path to fields.yml file to generate the template.

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -382,25 +382,27 @@ apm-server:
       # Default value is `true`.
       #require_policy: true
 
-      # The configured event types, policies and rollover_aliases will be merged with
-      # the default setup. Only configure the mappings that should be customized.
-      # NOTICE: when customizing `rollover_alias`, it is strongly recommended to keep
-      # the prefix "apm-%{[observer.version]}" unchanged;
-      # in case the prefix is changed, `setup.template.name` and `setup.template.pattern`
-      # need to be changed accordingly to match the created indices
+      # Customized mappings will be merged with the default setup, so you only need to configure mappings for the
+      # event types, policies, and index suffixes that you want to customize.
+      # Indices are named in this way: `apm-%{[observer.version]}-%{[event.type]}-{index_suffix}`,
+      # e.g., apm-7.9.0-span-custom*. The `index_suffix` is optional.
+      # NOTE: When configuring an `index_suffix`, ensure that no previously set up templates conflict with the
+      #       newly configured ones. If an index matches multiple templates with the same order, the settings of
+      #       the templates will override each other. Any conflicts need to be cleaned up manually.
+      # NOTE: When customizing `setup.template.name` and `setup.template.pattern`, ensure they still match the indices.
       #mapping:
         #- event_type: "error"
         #  policy_name: "apm-rollover-30-days"
-        #  rollover_alias: "apm-%{[observer.version]}-error"
+        #  index_suffix: ""
         #- event_type: "span"
         #  policy_name: "apm-rollover-30-days"
-        #  rollover_alias: "apm-%{[observer.version]}-span"
+        #  index_suffix: ""
         #- event_type: "transaction"
         #  policy_name: "apm-rollover-30-days"
-        #  rollover_alias: "apm-%{[observer.version]}-transaction"
+        #  index_suffix: ""
         #- event_type: "metric"
         #  policy_name: "apm-rollover-30-days"
-        #  rollover_alias: "apm-%{[observer.version]}-metric"
+        #  index_suffix: ""
 
       # Configured policies are added to pre-defined default policies.
       # If a policy with the same name as a default policy is configured, the configured policy overwrites the default policy.
@@ -493,14 +495,12 @@ apm-server:
 #setup.template.enabled: true
 
 # Template name. By default the template name is "apm-%{[observer.version]}"
-# The template name and pattern has to be set in case the elasticsearch index pattern is modified,
-# or the `apm-server.ilm.setup.mapping` rollover_aliases are changed.
+# The template name and pattern has to be set in case the elasticsearch index pattern is modified.
 #setup.template.name: "apm-%{[observer.version]}"
 
 # Template pattern. By default the template pattern is "apm-%{[observer.version]}-*" to apply to the default index settings.
 # The first part is the version of apm-server and then -* is used to match all daily indices.
-# The template name and pattern has to be set in case the elasticsearch index pattern is modified,
-# or the `apm-server.ilm.setup.mapping` rollover_aliases are changed.
+# The template name and pattern has to be set in case the elasticsearch index pattern is modified.
 #setup.template.pattern: "apm-%{[observer.version]}-*"
 
 # Path to fields.yml file to generate the template.

--- a/docs/ilm-reference.asciidoc
+++ b/docs/ilm-reference.asciidoc
@@ -51,16 +51,16 @@ apm-server:
       mapping:
         - event_type: "error"
           policy_name: "apm-rollover-30-days"
-          rollover_alias: "apm-%{[observer.version]}-error"
+          index_suffix: ""
         - event_type: "span"
           policy_name: "apm-rollover-30-days"
-          rollover_alias: "apm-%{[observer.version]}-span"
+          index_suffix: ""
         - event_type: "transaction"
           policy_name: "apm-rollover-30-days"
-          rollover_alias: "apm-%{[observer.version]}-transaction"
+          index_suffix: ""
         - event_type: "metric"
           policy_name: "apm-rollover-30-days"
-          rollover_alias: "apm-%{[observer.version]}-metric"
+          index_suffix: ""
       policies:
         - name: "apm-rollover-30-days"
           policy:
@@ -213,11 +213,12 @@ APM Server will still make use of ILM and connect your template with the defined
 [[ilm-setup-mapping-config]]
 ===== `apm-server.ilm.setup.mapping`
 
-Maps each event type to a corresponding `policy_name` and `rollover_alias`.
+Maps each event type to a corresponding `policy_name` and `index_suffix`.
 APM event types can only be `error`, `span`, `transaction`, and `metric`.
 If you attempt to map an index lifecycle policy to a different event type, APM Server will not start.
 If you only map a subset of APM event types, the default values will be used for omitted event types.
 If a policy is defined, it must be mapped to an event type to take effect.
-When customizing `rollover_alias`, it is strongly recommended to keep the prefix `apm-%{[observer.version]}` unchanged;
- if the prefix must be changed, `setup.template.name` and `setup.template.pattern` need to be changed accordingly,
-to match the created indices.
+
+By default, the APM Server creates a template without a custom index suffix per event type. When defining custom
+index suffixes, always ensure that templates, that might have been set up previously, are removed or do not conflict.
+See <<custom-ilm-index-suffix,customizing an index suffix>> for more information.

--- a/docs/ilm.asciidoc
+++ b/docs/ilm.asciidoc
@@ -14,7 +14,7 @@ All of this can be done directly from the `apm-server.yml` file.
 
 * <<ilm-enable>>
 * <<ilm-setup>>
-* <<custom-ilm-alias>>
+* <<custom-ilm-index-suffix>>
 * <<custom-ilm-policy>>
 * <<example-ilm-config>>
 * <<map-ilm-policy>>
@@ -61,29 +61,42 @@ apm-server:
 ILM can now be customized via the remaining `apm-server.ilm.setup.*` configuration options.
 
 [float]
-[[custom-ilm-alias]]
-==== Create a custom ILM `rollover_alias`
+[[custom-ilm-index-suffix]]
+==== Create a custom ILM `index_suffix`
 
-You can define a custom rollover alias per event type. The rollover alias can only contain a
-restricted set of variables, limited to variables concerning `observer.*`. In case other
-variables are configured, the server will refuse to start.
-The related ILM policy can specify a rollover action, e.g. when an index reaches a size of 50GB
-it should roll over to create a new index. The `rollover_alias` abstracts away the concrete write index, while
+You can define a custom index suffix for each event type. The index suffix is limited to variables
+concerning `observer.*`; if other variables are configured, the server will refuse to start.
+The resulting rollover alias and index name will be of type `apm-{version}-{event_type}-{custom_index_suffix},
+e.g., `apm-7.9.0-span-foo`.
+The mapped ILM policy can specify a rollover action, e.g., when an index reaches a size of 50GB,
+it should roll over to create a new index. The rollover alias abstracts away the concrete write index, while
 automatically being updated and keeping track of the current write index.
-This allows to use the `rollover_alias` instead of specific indices in queries.
+This allows you to use the rollover alias instead of specific indices in queries.
 
-For example when defining a rollover alias with name `apm-7.8.0-transaction`, an alias pointing to a write index
-`apm-7.8.0-transaction-000001` is created. When the index reaches the defined size or age it will roll over to
-a new index `apm-7.8.0-transaction-000002`. The rollover alias `apm-7.8.0-transaction` keeps
-track of which index is the write index when ingesting data.
+For example, the default rollover alias for event type `transaction` would be `apm-7.8.0-transaction`. This alias points
+to a write index named `apm-7.8.0-transaction-000001`. When this index reaches its defined size or age, it will roll over to
+a new index named `apm-7.8.0-transaction-000002`. The rollover alias of `apm-7.8.0-transaction` keeps
+track of which index is the current write index while ingesting data.
 
-NOTE: Ensure that the configured `rollover_alias` for all event types start with the same prefix,
-and that this prefix is also configured for `setup.template.name` and `setup.template.pattern`.
-If the template configuration is not accordingly changed, the Elasticsearch index template with
-the predefined mappings will not match against created indices, leading to indexing issues.
+NOTE: Manually ensure that templates containing customized index information do not conflict with each other
+or the default templates.
 
-The example below shows how to change the `rollover_alias` to a custom value,
-and set the template configuration to a matching name and pattern.
+By default, the APM Server creates a template without a custom index suffix per event type. When defining custom
+index suffixes, always ensure that templates, that might have been set up previously, are removed or do not conflict.
+A conflicting behavior could occur when an index matches multiple templates with the same `order`.
+For example, the APM Server was started without any customization, leading to a default index setup. Afterward, the
+Server configuration is customized to add the index suffix `production` for the event type `span`.
+When the Server restarts, it will set up a new index template based on the new custom index suffix.
+A newly created index named `apm-server-7.9.0-span-production` would now match the default template with the index pattern of
+`apm-server-7.9.0-span*`, but also the new template with the index pattern `apm-server-7.9.0-span-production*`.
+In this case, the old template needs to be manually deleted,
+or the `index_pattern` or `order` need to be changed to avoid conflicts.
+
+NOTE: If you customize `setup.template.pattern`, ensure that the configured pattern
+still matches the rollover aliases. If it doesn't, the Elasticsearch index template with the predefined mappings will
+not match against created indices, leading to indexing issues.
+
+The example below shows how to change the `index_suffix` to a custom value.
 
 [source,yml]
 ----
@@ -93,16 +106,13 @@ apm-server:
     setup:
       mapping:
         - event_type: "error"
-          rollover_alias: "apm-dev-error"
+          index_suffix: "dev"
         - event_type: "span"
-          rollover_alias: "apm-dev-span"
+          index_suffix: "dev"
         - event_type: "transaction"
-          rollover_alias: "apm-dev-transaction"
+          index_suffix: "dev"
         - event_type: "metric"
-          rollover_alias: "apm-dev-metric"
-
-setup.template.name: "apm-dev"
-setup.template.pattern: "apm-dev*"
+          index_suffix: "dev"
 ----
 
 [float]
@@ -253,16 +263,16 @@ Additionally this example shows how to set custom rollover aliases.
       mapping:
         - event_type: "error"
           policy_name: "apm-error-span-policy"
-          rollover_alias: "apm-%{[observer.version]}-development-error"
+          index_suffix: "development"
         - event_type: "span"
           policy_name: "apm-error-span-policy"
-          rollover_alias: "apm-%{[observer.version]}-development-span"
+          index_suffix: "development"
         - event_type: "transaction"
           policy_name: "apm-transaction-metric-policy"
-          rollover_alias: "apm-%{[observer.version]}-development-transaction"
+          index_suffix: "development"
         - event_type: "metric"
           policy_name: "apm-transaction-metric-policy"
-          rollover_alias: "apm-%{[observer.version]}-development-metric"
+          index_suffix: "development"
       enabled: true
       policies:
         - name: "apm-error-span-policy"

--- a/idxmgmt/ilm/config.go
+++ b/idxmgmt/ilm/config.go
@@ -56,9 +56,10 @@ type Policies map[string]Policy
 
 //Mapping binds together an ILM policy's name and body with an event type
 type Mapping struct {
-	EventType     string `config:"event_type"`
-	PolicyName    string `config:"policy_name"`
-	RolloverAlias string `config:"rollover_alias"`
+	EventType   string `config:"event_type"`
+	PolicyName  string `config:"policy_name"`
+	IndexSuffix string `config:"index_suffix"`
+	Index       string `config:"-"`
 }
 
 // Policy contains information about an ILM policy and the name
@@ -86,11 +87,11 @@ func NewConfig(info beat.Info, cfg *libcommon.Config) (Config, error) {
 	// replace variable rollover_alias parts with beat information if available
 	// otherwise fail as the full alias needs to be known during setup.
 	for et, m := range config.Setup.Mappings {
-		rolloverAlias, err := applyStaticFmtstr(info, m.RolloverAlias)
+		idx, err := applyStaticFmtstr(info, m.Index)
 		if err != nil {
-			return Config{}, errors.Wrap(err, "variable part of rollover_alias cannot be resolved")
+			return Config{}, errors.Wrap(err, "variable part of index suffix cannot be resolved")
 		}
-		m.RolloverAlias = rolloverAlias
+		m.Index = idx
 		config.Setup.Mappings[et] = m
 	}
 	if len(config.Setup.Policies) == 0 {
@@ -121,12 +122,12 @@ func (m *Mappings) Unpack(cfg *libcommon.Config) error {
 			if mapping.PolicyName == "" {
 				mapping.PolicyName = existing.PolicyName
 			}
-			if mapping.RolloverAlias == "" {
-				mapping.RolloverAlias = existing.RolloverAlias
-			}
+			mapping.Index = existing.Index
+		}
+		if mapping.IndexSuffix != "" {
+			mapping.Index = fmt.Sprintf("%s-%s", mapping.Index, mapping.IndexSuffix)
 		}
 		(*m)[mapping.EventType] = mapping
-
 	}
 	return nil
 }
@@ -157,9 +158,6 @@ func validate(c *Config) error {
 		}
 		if m.PolicyName == "" {
 			return errors.New("empty policy_name not supported for ILM setup")
-		}
-		if m.RolloverAlias == "" {
-			return errors.New("empty rollover_alias not supported for ILM setup")
 		}
 		if !c.Setup.RequirePolicy {
 			// `require_policy=false` indicates that policies are set up outside
@@ -214,7 +212,7 @@ func defaultMappings() map[string]Mapping {
 	m := map[string]Mapping{}
 	for _, et := range common.EventTypes {
 		m[et] = Mapping{EventType: et, PolicyName: defaultPolicyName,
-			RolloverAlias: fmt.Sprintf("%s-%s", common.APMPrefix, et)}
+			Index: fmt.Sprintf("%s-%s", common.APMPrefix, et)}
 	}
 	return m
 }
@@ -259,7 +257,7 @@ func (c *Config) conditionalIndices() []map[string]interface{} {
 		common.ConditionalSourcemapIndex(),
 	}
 	for _, m := range c.Setup.Mappings {
-		conditions = append(conditions, common.Condition(m.EventType, m.RolloverAlias))
+		conditions = append(conditions, common.Condition(m.EventType, m.Index))
 	}
 	return conditions
 }

--- a/idxmgmt/ilm/supporter_factory.go
+++ b/idxmgmt/ilm/supporter_factory.go
@@ -42,7 +42,7 @@ func MakeDefaultSupporter(
 
 	for _, m := range ilmConfig.Setup.Mappings {
 		policy := ilmConfig.Setup.Policies[m.PolicyName]
-		supporter := libilm.NewStdSupport(log, mode, libilm.Alias{Name: m.RolloverAlias, Pattern: pattern},
+		supporter := libilm.NewStdSupport(log, mode, libilm.Alias{Name: m.Index, Pattern: pattern},
 			libilm.Policy{Name: policy.Name, Body: policy.Body}, ilmConfig.Setup.Overwrite, true)
 		supporters = append(supporters, supporter)
 	}

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -159,12 +159,12 @@ apm-server:
   ilm.setup.enabled: {{ ilm_setup_enabled }}
   {% endif %}
 
-  {% if ilm_aliases %}
+  {% if ilm_custom_suffix %}
   ilm.setup.mapping:
     - event_type: "error"
-      rollover_alias: "apm-error-custom"
+      index_suffix: "custom"
     - event_type: "transaction"
-      rollover_alias: "apm-transaction-custom"
+      index_suffix: "foo"
   {% endif %}
 
   {% if ilm_policies %}

--- a/tests/system/test_setup_index_management.py
+++ b/tests/system/test_setup_index_management.py
@@ -304,7 +304,7 @@ class TestILMConfiguredPolicies(ElasticTest):
 
 @integration_test
 class TestILMCustomAlias(ElasticTest):
-    config_overrides = {"ilm_aliases": True}
+    config_overrides = {"ilm_custom_suffix": True}
 
     def setUp(self):
         super(TestILMCustomAlias, self).setUp()
@@ -312,7 +312,7 @@ class TestILMCustomAlias(ElasticTest):
 
     def test_ilm_loaded(self):
         # aliasnames configured in apm-server.yml.j2
-        aliases = ["apm-error-custom", "apm-transaction-custom",
+        aliases = [index_error + "-custom", index_transaction + "-foo",
                    index_metric, index_profile, index_span]
         self.idxmgmt.wait_until_created(templates=[index_name] + aliases, aliases=aliases)
         self.idxmgmt.assert_event_template(with_ilm=True, event_templates=aliases)


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ILM: restrict customization of alias to suffix. (#3905)