### PR TITLE
Only log error message instead of full document body when validation error occurs

### DIFF
--- a/processor/stream/result.go
+++ b/processor/stream/result.go
@@ -18,7 +18,6 @@
 package stream
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/elastic/beats/v7/libbeat/monitoring"
@@ -31,9 +30,6 @@ type Error struct {
 }
 
 func (s *Error) Error() string {
-	if s.Document != "" {
-		return fmt.Sprintf("%s [%s]", s.Message, string(s.Document))
-	}
 	return s.Message
 }
 

--- a/processor/stream/result_test.go
+++ b/processor/stream/result_test.go
@@ -44,7 +44,7 @@ func TestStreamResponseSimple(t *testing.T) {
 
 	assert.Len(t, sr.Errors, 6)
 
-	expectedStr := `err1 [buf1], transmogrifier error, err2 [buf2], err3 [buf3], err4, err6`
+	expectedStr := `err1, transmogrifier error, err2, err3, err4, err6`
 	assert.Equal(t, expectedStr, sr.Error())
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Before creating the PR, ensure that:

1. Your branch is rebased on top of the latest master.
   Squash your initial commits into meaningful commits.
   After creating a PR, do not rebase of force push any longer.
2. Nothing is broken, by running the test suite (at least unit tests).
   See https://github.com/elastic/apm-server/blob/master/TESTING.md for details.
3. Your code follows the style guidelines of this project:
   run `make check-full` for static code checks and linting.

A few suggestions about filling out this PR:

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR.
3. Please label this PR with at least one of the following labels:
   - bug fix
   - breaking change
   - enhancement
4. Reference the related issue, and make use of magic keywords where it makes sense
   https://help.github.com/articles/closing-issues-using-keywords/.
5. Do not remove any checklist items, strike through the ones that don't apply
   (by using tildes, e.g. ~scratch this ~).
6. Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
7. Submit the pull request:
   Push your changes to your forked copy of the repository and submit a pull request
   (https://help.github.com/articles/using-pull-requests).
8. Please be patient. We might not be able to immediately review your code,
   but we'll do our best to dedicate to it the attention it deserves.
   Your effort is much appreciated!

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
Instead of printing the full document, only print the message as error string when validation errors occur while processing streaming events. The full document is still returned to the calling agent in the response body. 

## Checklist

~- [ ] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).~
- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

I have considered changes for:
~- [ ] documentation~
- [x] logging (add log lines, choose appropriate log selector, etc.)
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
- [x] Elasticsearch Service (https://cloud.elastic.co)
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes
Start APM Server and send malformed document to the server, observe that malformed document is returned to the caller, but not logged as error message. 

## Related issues
closes #3916
