### PR TITLE
[7.8] [logging] avoid logging processing error documents (#3917)

### DIFF
--- a/processor/stream/result.go
+++ b/processor/stream/result.go
@@ -18,7 +18,6 @@
 package stream
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/elastic/beats/v7/libbeat/monitoring"
@@ -31,9 +30,6 @@ type Error struct {
 }
 
 func (s *Error) Error() string {
-	if s.Document != "" {
-		return fmt.Sprintf("%s [%s]", s.Message, string(s.Document))
-	}
 	return s.Message
 }
 

--- a/processor/stream/result_test.go
+++ b/processor/stream/result_test.go
@@ -44,7 +44,7 @@ func TestStreamResponseSimple(t *testing.T) {
 
 	assert.Len(t, sr.Errors, 6)
 
-	expectedStr := `err1 [buf1], transmogrifier error, err2 [buf2], err3 [buf3], err4, err6`
+	expectedStr := `err1, transmogrifier error, err2, err3, err4, err6`
 	assert.Equal(t, expectedStr, sr.Error())
 }
 


### PR DESCRIPTION
Backports the following commits to 7.8:
 - [logging] avoid logging processing error documents (#3917)