### PR TITLE
[DOCS] Fixes Stack Overview links

### DIFF
--- a/docs/copied-from-beats/docs/https.asciidoc
+++ b/docs/copied-from-beats/docs/https.asciidoc
@@ -17,7 +17,7 @@
 To secure the communication between {beatname_uc} and Elasticsearch, you can use
 HTTPS and basic authentication. Basic authentication for Elasticsearch is
 available when you enable {security} (see
-{stack-ov}/elasticsearch-security.html[Securing the {stack}] and configure {beatname_uc} to use {security-features}).
+{ref}/elasticsearch-security.html[Securing the {stack}] and configure {beatname_uc} to use {security-features}).
 If you aren't using {security}, you can use a web proxy instead.
 
 When sending data to a secured cluster through the `elasticsearch`

--- a/docs/copied-from-beats/docs/security/basic-auth.asciidoc
+++ b/docs/copied-from-beats/docs/security/basic-auth.asciidoc
@@ -64,5 +64,5 @@ output.elasticsearch:
 --------------------------------------------------
 
 To learn more about {stack} security features and other types of
-authentication, see {stack-ov}/elasticsearch-security.html[Securing the
+authentication, see {ref}/elasticsearch-security.html[Securing the
 {stack}].

--- a/docs/copied-from-beats/docs/security/users.asciidoc
+++ b/docs/copied-from-beats/docs/security/users.asciidoc
@@ -349,9 +349,9 @@ endif::apm-server[]
 ==== Learn more about users and roles
 
 Want to learn more about creating users and roles? See
-{stack-ov}/elasticsearch-security.html[Securing the {stack}]. Also see:
+{ref}/elasticsearch-security.html[Securing the {stack}]. Also see:
 
-* {stack-ov}/security-privileges.html[Security privileges] for a description of
+* {ref}/security-privileges.html[Security privileges] for a description of
 available privileges
-* {stack-ov}/built-in-roles.html[Built-in roles] for a description of roles that
+* {ref}/built-in-roles.html[Built-in roles] for a description of roles that
 you can assign to users


### PR DESCRIPTION
## Motivation/summary

Updates links to pages that have moved out of the Stack Overview, since that book will be retired after 7.4.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

I have considered changes for:
- [x] documentation
- [ ] logging (add log lines, choose appropriate log selector, etc.)
- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))
- [ ] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
- [ ] telemetry
- [ ] Elasticsearch Service (https://cloud.elastic.co)
- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)
- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)

## How to test these changes

## Related issues

https://github.com/elastic/apm-server/pull/3893
https://github.com/elastic/docs/pull/1870