### PR TITLE
[7.x] aggregation/txmetrics: set timeseries.instance (#3904)

### DIFF
--- a/model/metricset.go
+++ b/model/metricset.go
@@ -68,6 +68,11 @@ type Metricset struct {
 
 	// Samples holds the metrics in the set.
 	Samples []Sample
+
+	// TimeseriesInstanceID holds an optional identifier for the timeseries
+	// instance, such as a hash of the labels used for aggregating the
+	// metrics.
+	TimeseriesInstanceID string
 }
 
 // Sample represents a single named metric.
@@ -149,6 +154,10 @@ func (me *Metricset) Transform(ctx context.Context, tctx *transform.Context) []b
 
 	// merges with metadata labels, overrides conflicting keys
 	utility.DeepUpdate(fields, "labels", me.Labels)
+
+	if me.TimeseriesInstanceID != "" {
+		fields["timeseries"] = common.MapStr{"instance": me.TimeseriesInstanceID}
+	}
 
 	return []beat.Event{{
 		Fields:    fields,

--- a/model/metricset_test.go
+++ b/model/metricset_test.go
@@ -82,11 +82,13 @@ func TestTransform(t *testing.T) {
 					Result: trResult,
 					Root:   true,
 				},
+				TimeseriesInstanceID: "foo",
 			},
 			Output: []common.MapStr{
 				{
-					"processor": common.MapStr{"event": "metric", "name": "metric"},
-					"service":   common.MapStr{"name": "myservice"},
+					"processor":  common.MapStr{"event": "metric", "name": "metric"},
+					"service":    common.MapStr{"name": "myservice"},
+					"timeseries": common.MapStr{"instance": "foo"},
 					"transaction": common.MapStr{
 						"name":   trName,
 						"type":   trType,

--- a/tests/system/rum_transaction_histogram_metrics.approved.json
+++ b/tests/system/rum_transaction_histogram_metrics.approved.json
@@ -26,6 +26,9 @@
             "name": "apm-agent-js",
             "version": "1.0.0"
         },
+        "timeseries": {
+            "instance": "apm-agent-js::2ac4d2f17a65a386"
+        },
         "transaction": {
             "duration": {
                 "histogram": {

--- a/tests/system/transaction_histogram_metrics.approved.json
+++ b/tests/system/transaction_histogram_metrics.approved.json
@@ -38,6 +38,9 @@
             },
             "version": "5.1.3"
         },
+        "timeseries": {
+            "instance": "1234_service-12a3:GET /api/types:95818d7bc9580d28"
+        },
         "transaction": {
             "duration": {
                 "histogram": {
@@ -93,6 +96,9 @@
                 "name": "container-id"
             },
             "version": "5.1.3"
+        },
+        "timeseries": {
+            "instance": "1234_service-12a3:GET /api/types:2d9c304bd7ae1b2d"
         },
         "transaction": {
             "duration": {
@@ -150,6 +156,9 @@
             },
             "version": "5.1.3"
         },
+        "timeseries": {
+            "instance": "serviceabc:GET /api/types:eaedcae530dae5c2"
+        },
         "transaction": {
             "duration": {
                 "histogram": {
@@ -165,13 +174,6 @@
             "result": "success",
             "root": true,
             "type": "request"
-        },
-        "user_agent": {
-            "device": {
-                "name": "Other"
-            },
-            "name": "Other",
-            "original": "Mozilla Chrome Edge"
         }
     }
 ]

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -6,6 +6,8 @@ package txmetrics
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -148,7 +150,7 @@ func (a *Aggregator) publish(ctx context.Context) error {
 	for hash, entries := range a.inactive.m {
 		for _, entry := range entries {
 			counts, values := entry.transactionMetrics.histogramBuckets()
-			metricset := makeMetricset(entry.transactionAggregationKey, now, counts, values)
+			metricset := makeMetricset(entry.transactionAggregationKey, hash, now, counts, values)
 			metricsets = append(metricsets, &metricset)
 		}
 		delete(a.inactive.m, hash)
@@ -189,8 +191,9 @@ func (a *Aggregator) AggregateTransformables(in []transform.Transformable) []tra
 // transaction. Otherwise, the returned metricset will be nil.
 func (a *Aggregator) AggregateTransaction(tx *model.Transaction) *model.Metricset {
 	key := a.makeTransactionAggregationKey(tx)
+	hash := key.hash()
 	duration := time.Duration(tx.Duration * float64(time.Millisecond))
-	if a.updateTransactionMetrics(key, duration) {
+	if a.updateTransactionMetrics(key, hash, duration) {
 		return nil
 	}
 	// Too many aggregation keys: could not update metrics, so immediately
@@ -199,12 +202,11 @@ func (a *Aggregator) AggregateTransaction(tx *model.Transaction) *model.Metricse
 	// TODO(axw) log a warning with a rate-limit, increment a counter.
 	counts := []int64{1}
 	values := []float64{float64(durationMicros(duration))}
-	metricset := makeMetricset(key, time.Now(), counts, values)
+	metricset := makeMetricset(key, hash, time.Now(), counts, values)
 	return &metricset
 }
 
-func (a *Aggregator) updateTransactionMetrics(key transactionAggregationKey, duration time.Duration) bool {
-	hash := key.hash()
+func (a *Aggregator) updateTransactionMetrics(key transactionAggregationKey, hash uint64, duration time.Duration) bool {
 	if duration < minDuration {
 		duration = minDuration
 	} else if duration > maxDuration {
@@ -293,7 +295,7 @@ func (a *Aggregator) makeTransactionAggregationKey(tx *model.Transaction) transa
 }
 
 // makeMetricset makes a Metricset from key, counts, and values, with timestamp ts.
-func makeMetricset(key transactionAggregationKey, ts time.Time, counts []int64, values []float64) model.Metricset {
+func makeMetricset(key transactionAggregationKey, hash uint64, ts time.Time, counts []int64, values []float64) model.Metricset {
 	out := model.Metricset{
 		Timestamp: ts,
 		Metadata: model.Metadata{
@@ -325,6 +327,16 @@ func makeMetricset(key transactionAggregationKey, ts time.Time, counts []int64, 
 			Values: values,
 		}},
 	}
+
+	// Record an timeseries instance ID, which should be uniquely identify the aggregation key.
+	var timeseriesInstanceID strings.Builder
+	timeseriesInstanceID.WriteString(key.serviceName)
+	timeseriesInstanceID.WriteRune(':')
+	timeseriesInstanceID.WriteString(key.transactionName)
+	timeseriesInstanceID.WriteRune(':')
+	timeseriesInstanceID.WriteString(fmt.Sprintf("%x", hash))
+	out.TimeseriesInstanceID = timeseriesInstanceID.String()
+
 	return out
 }
 

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
@@ -122,6 +122,7 @@ func TestAggregateTransformablesOverflow(t *testing.T) {
 				Counts: []int64{1},
 				Values: []float64{float64(time.Minute / time.Microsecond)},
 			}},
+			TimeseriesInstanceID: ":baz:bc30224a3738a508",
 		}, m)
 	}
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - aggregation/txmetrics: set timeseries.instance (#3904)