### PR TITLE
[7.x] Extrapolate Jaeger transaction count from reported sampling rate (#3722)

### DIFF
--- a/docs/jaeger-reference.asciidoc
+++ b/docs/jaeger-reference.asciidoc
@@ -50,8 +50,7 @@ There are some limitations and differences between Elastic APM and Jaeger that y
 
 * Because Jaeger has its own trace context header, and does not currently support W3C trace context headers,
 it is not possible to mix and match the use of Elastic's APM Agents and Jaeger's Clients.
-* Elastic APM only supports probabilistic sampling. Because of differences in the Jaeger and Elastic data structures,
-sampling at a value below `1.0` (100%), will cause inaccuracies in the APM app. See <<jaeger-configure-sampling>> for more information.
+* Elastic APM only supports probabilistic sampling.
 * We currently only support exception logging. Span logs are not supported.
 
 *Differences between APM Agents and Jaeger Clients:*

--- a/docs/jaeger-support.asciidoc
+++ b/docs/jaeger-support.asciidoc
@@ -68,13 +68,6 @@ To enable the kibana endpoint, set <<kibana-enabled>> to `true`, and point <<kib
 The default sampling ratio, as well as per-service sampling rates,
 can then be configured via the {kibana-ref}/agent-configuration.html[Agent configuration] page in the APM app.
 
-WARNING: If a sampling rate smaller than `1.0` (100%) is configured,
-transactions per minute will be incorrectly calculated in the APM app.
-This is because Elastic APM data model is fundamentally different from the Jaeger data model.
-In the Elastic ecosystem, sampling only impacts spans; transactions are always sampled at 100%.
-The Jaeger data structure, however, does not have the concept of transactions.
-Because of this, sampling decisions will apply to both transactions and spans.
-
 [float]
 [[jaeger-configure-sampling-local]]
 ===== Local sampling

--- a/model/transaction.go
+++ b/model/transaction.go
@@ -49,10 +49,6 @@ type Transaction struct {
 
 	Timestamp time.Time
 
-	// TODO(axw) record the sampling rate in effect at the time the
-	// transaction was recorded, in order to extrapolate transaction
-	// count statistics. We would use this for Jaeger, OTel, etc.
-
 	Type      string
 	Name      string
 	Result    string
@@ -68,6 +64,12 @@ type Transaction struct {
 	Custom    *Custom
 
 	Experimental interface{}
+
+	// RepresentativeCount, if positive, holds the approximate number of
+	// transactions that this transaction represents for aggregation.
+	//
+	// This may be used for scaling metrics; it is not indexed.
+	RepresentativeCount float64
 }
 
 type SpanCount struct {

--- a/processor/otel/consumer.go
+++ b/processor/otel/consumer.go
@@ -115,7 +115,7 @@ func (c *Consumer) convert(td consumerdata.TraceData) *model.Batch {
 				Duration:  duration,
 				Name:      name,
 			}
-			parseTransaction(otelSpan, hostname, &transaction)
+			parseTransaction(otelSpan, td.SourceFormat, hostname, &transaction)
 			batch.Transactions = append(batch.Transactions, &transaction)
 			for _, err := range parseErrors(logger, td.SourceFormat, otelSpan) {
 				addTransactionCtxToErr(transaction, err)
@@ -209,7 +209,7 @@ func parseMetadata(td consumerdata.TraceData, md *model.Metadata) {
 	}
 }
 
-func parseTransaction(span *tracepb.Span, hostname string, event *model.Transaction) {
+func parseTransaction(span *tracepb.Span, sourceFormat string, hostname string, event *model.Transaction) {
 	labels := make(common.MapStr)
 	var http model.Http
 	var message model.Message
@@ -217,7 +217,19 @@ func parseTransaction(span *tracepb.Span, hostname string, event *model.Transact
 	var result string
 	var hasFailed bool
 	var isHTTP, isMessaging bool
+	var samplerType, samplerParam *tracepb.AttributeValue
 	for kDots, v := range span.Attributes.GetAttributeMap() {
+		if sourceFormat == sourceFormatJaeger {
+			switch kDots {
+			case "sampler.type":
+				samplerType = v
+				continue
+			case "sampler.param":
+				samplerParam = v
+				continue
+			}
+		}
+
 		k := replaceDots(kDots)
 		switch v := v.Value.(type) {
 		case *tracepb.AttributeValue_BoolValue:
@@ -306,6 +318,26 @@ func parseTransaction(span *tracepb.Span, hostname string, event *model.Transact
 		}
 	}
 	event.Result = result
+
+	if samplerType != nil && samplerParam != nil {
+		// The client has reported its sampling rate, so
+		// we can use it to extrapolate transaction metrics.
+		switch samplerType.GetStringValue().GetValue() {
+		case "probabilistic":
+			probability := samplerParam.GetDoubleValue()
+			if probability > 0 && probability < 1 {
+				event.RepresentativeCount = 1 / probability
+			}
+		default:
+			utility.DeepUpdate(labels, "sampler_type", samplerType.GetStringValue().GetValue())
+			switch v := samplerParam.Value.(type) {
+			case *tracepb.AttributeValue_BoolValue:
+				utility.DeepUpdate(labels, "sampler_param", v.BoolValue)
+			case *tracepb.AttributeValue_DoubleValue:
+				utility.DeepUpdate(labels, "sampler_param", v.DoubleValue)
+			}
+		}
+	}
 
 	if len(labels) == 0 {
 		return

--- a/processor/otel/consumer_test.go
+++ b/processor/otel/consumer_test.go
@@ -33,8 +33,10 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 
+	"github.com/elastic/apm-server/model"
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/apm-server/tests/approvals"
+	"github.com/elastic/apm-server/transform"
 )
 
 func TestConsumer_ConsumeTraceData(t *testing.T) {
@@ -253,6 +255,34 @@ func TestConsumer_Transaction(t *testing.T) {
 			require.NoError(t, (&Consumer{Reporter: reporter}).ConsumeTraceData(context.Background(), tc.td))
 		})
 	}
+}
+
+func TestConsumer_TransactionSampleRate(t *testing.T) {
+	var transformables []transform.Transformable
+	reporter := func(ctx context.Context, req publish.PendingReq) error {
+		transformables = append(transformables, req.Transformables...)
+		events := transformAll(ctx, req)
+		assert.NoError(t, approvals.ApproveEvents(events, file("transaction_jaeger_sampling_rate")))
+		return nil
+	}
+	require.NoError(t, (&Consumer{Reporter: reporter}).ConsumeTraceData(context.Background(), consumerdata.TraceData{
+		SourceFormat: "jaeger",
+		Node: &commonpb.Node{
+			Identifier: &commonpb.ProcessIdentifier{HostName: "host-abc"},
+		},
+		Spans: []*tracepb.Span{{
+			Kind:      tracepb.Span_SERVER,
+			StartTime: testStartTime(), EndTime: testEndTime(),
+			Attributes: &tracepb.Span_Attributes{AttributeMap: map[string]*tracepb.AttributeValue{
+				"sampler.type":  testAttributeStringValue("probabilistic"),
+				"sampler.param": testAttributeDoubleValue(0.8),
+			}},
+		}},
+	}))
+
+	require.Len(t, transformables, 1)
+	tx := transformables[0].(*model.Transaction)
+	assert.Equal(t, 1.25 /* 1/0.8 */, tx.RepresentativeCount)
 }
 
 func TestConsumer_Span(t *testing.T) {

--- a/processor/otel/test_approved/transaction_jaeger_sampling_rate.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_sampling_rate.approved.json
@@ -1,0 +1,40 @@
+{
+    "events": [
+        {
+            "@timestamp": "2019-12-16T12:46:58.000768068Z",
+            "agent": {
+                "name": "Jaeger",
+                "version": "unknown"
+            },
+            "host": {
+                "hostname": "host-abc",
+                "name": "host-abc"
+            },
+            "processor": {
+                "event": "transaction",
+                "name": "transaction"
+            },
+            "service": {
+                "language": {
+                    "name": "unknown"
+                },
+                "name": "unknown",
+                "node": {
+                    "name": "host-abc"
+                }
+            },
+            "timestamp": {
+                "us": 1576500418000768
+            },
+            "transaction": {
+                "duration": {
+                    "us": 79000000
+                },
+                "id": "",
+                "result": "Success",
+                "sampled": true,
+                "type": "custom"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Extrapolate Jaeger transaction count from reported sampling rate (#3722)