### PR TITLE
[7.8] [DOCS] Fixes Stack Overview links (#3925)

### DIFF
--- a/docs/copied-from-beats/docs/https.asciidoc
+++ b/docs/copied-from-beats/docs/https.asciidoc
@@ -17,7 +17,7 @@
 To secure the communication between {beatname_uc} and Elasticsearch, you can use
 HTTPS and basic authentication. Basic authentication for Elasticsearch is
 available when you enable {security} (see
-{stack-ov}/elasticsearch-security.html[Securing the {stack}] and configure {beatname_uc} to use {security-features}).
+{ref}/elasticsearch-security.html[Securing the {stack}] and configure {beatname_uc} to use {security-features}).
 If you aren't using {security}, you can use a web proxy instead.
 
 When sending data to a secured cluster through the `elasticsearch`

--- a/docs/copied-from-beats/docs/security/basic-auth.asciidoc
+++ b/docs/copied-from-beats/docs/security/basic-auth.asciidoc
@@ -64,5 +64,5 @@ output.elasticsearch:
 --------------------------------------------------
 
 To learn more about {stack} security features and other types of
-authentication, see {stack-ov}/elasticsearch-security.html[Securing the
+authentication, see {ref}/elasticsearch-security.html[Securing the
 {stack}].

--- a/docs/copied-from-beats/docs/security/users.asciidoc
+++ b/docs/copied-from-beats/docs/security/users.asciidoc
@@ -349,9 +349,9 @@ endif::apm-server[]
 ==== Learn more about users and roles
 
 Want to learn more about creating users and roles? See
-{stack-ov}/elasticsearch-security.html[Securing the {stack}]. Also see:
+{ref}/elasticsearch-security.html[Securing the {stack}]. Also see:
 
-* {stack-ov}/security-privileges.html[Security privileges] for a description of
+* {ref}/security-privileges.html[Security privileges] for a description of
 available privileges
-* {stack-ov}/built-in-roles.html[Built-in roles] for a description of roles that
+* {ref}/built-in-roles.html[Built-in roles] for a description of roles that
 you can assign to users


### PR DESCRIPTION
Backports the following commits to 7.8:
 - [DOCS] Fixes Stack Overview links (#3925)

Fixes the following broken links:
```
16:32:51 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/server/7.8/securing-communication-elasticsearch.html:
16:32:51 INFO:build_docs:   - en/elastic-stack-overview/7.8/elasticsearch-security.html
16:32:51 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/server/current/securing-communication-elasticsearch.html:
16:32:51 INFO:build_docs:   - en/elastic-stack-overview/7.8/elasticsearch-security.html
```