### PR TITLE
[7.5] [DOCS] Fixes Stack Overview links (#3925)

### DIFF
--- a/docs/copied-from-beats/docs/https.asciidoc
+++ b/docs/copied-from-beats/docs/https.asciidoc
@@ -13,7 +13,7 @@
 To secure the communication between {beatname_uc} and Elasticsearch, you can use
 HTTPS and basic authentication. Basic authentication for Elasticsearch is
 available when you enable {security} (see
-{stack-ov}/elasticsearch-security.html[Securing the {stack}] and <<securing-beats>>).
+{ref}/elasticsearch-security.html[Securing the {stack}] and configure {beatname_uc} to use {security-features}).
 If you aren't using {security}, you can use a web proxy instead.
 
 Here is a sample configuration:

--- a/docs/copied-from-beats/docs/monitoring/monitoring-beats.asciidoc
+++ b/docs/copied-from-beats/docs/monitoring/monitoring-beats.asciidoc
@@ -7,10 +7,10 @@
 
 You can use the {stack} {monitor-features} to gain insight into the health of
 ifndef::apm-server[]
-{beatname_uc} instances running in your environment. 
+{beatname_uc} instances running in your environment.
 endif::[]
 ifdef::apm-server[]
-{beatname_uc}. 
+{beatname_uc}.
 endif::[]
 
 To monitor {beatname_uc}, make sure monitoring is enabled on your {es} cluster,
@@ -27,8 +27,8 @@ ifndef::serverless[]
 * <<monitoring-metricbeat-collection, {metricbeat} collection>>
 endif::[]
 
-To learn about monitoring in general, see 
-{stack-ov}/xpack-monitoring.html[Monitoring the {stack}]. 
+To learn about monitoring in general, see
+{ref}/monitor-elasticsearch-cluster.html[Monitoring the {stack}].
 
 --
 

--- a/docs/copied-from-beats/docs/monitoring/monitoring-metricbeat.asciidoc
+++ b/docs/copied-from-beats/docs/monitoring/monitoring-metricbeat.asciidoc
@@ -6,8 +6,8 @@
 <titleabbrev>{metricbeat} collection</titleabbrev>
 ++++
 
-In 7.3 and later, you can use {metricbeat} to collect data about {beatname_uc} 
-and ship it to the monitoring cluster, rather than routing it through the 
+In 7.3 and later, you can use {metricbeat} to collect data about {beatname_uc}
+and ship it to the monitoring cluster, rather than routing it through the
 production cluster as described in <<monitoring-internal-collection>>.
 
 ifeval::["{beatname_lc}"=="metricbeat"]
@@ -25,8 +25,8 @@ concurrently. If you don't want to run two instances concurrently, use
 {metricbeat}.
 endif::[]
 
-To learn about monitoring in general, see 
-{stack-ov}/xpack-monitoring.html[Monitoring the {stack}].
+To learn about monitoring in general, see
+{ref}/monitor-elasticsearch-cluster.html[Monitoring the {stack}].
 
 //NOTE: The tagged regions are re-used in the Stack Overview.
 
@@ -68,7 +68,7 @@ http.port: 5067
 --
 // tag::disable-beat-collection[]
 Add the following setting in the {beatname_uc} configuration file
-(+{beatname_lc}.yml+): 
+(+{beatname_lc}.yml+):
 
 [source,yaml]
 ----------------------------------
@@ -76,7 +76,7 @@ monitoring.enabled: false
 ----------------------------------
 // end::disable-beat-collection[]
 
-For more information, see 
+For more information, see
 <<configuration-monitor,Monitoring configuration options>>.
 --
 
@@ -111,7 +111,7 @@ endif::[]
 +
 --
 // tag::enable-beat-module[]
-For example, to enable the default configuration in the `modules.d` directory, 
+For example, to enable the default configuration in the `modules.d` directory,
 run the following command, using the correct command syntax for your OS:
 
 ["source","sh",subs="attributes,callouts"]
@@ -119,9 +119,9 @@ run the following command, using the correct command syntax for your OS:
 metricbeat modules enable beat-xpack
 ----------------------------------------------------------------------
 
-For more information, see 
-{metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and 
-{metricbeat-ref}/metricbeat-module-beat.html[beat module]. 
+For more information, see
+{metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and
+{metricbeat-ref}/metricbeat-module-beat.html[beat module].
 // end::enable-beat-module[]
 --
 
@@ -143,7 +143,7 @@ The `modules.d/beat-xpack.yml` file contains the following settings:
   #password: "secret"
   xpack.enabled: true
 ----------------------------------
- 
+
 Set the `hosts`, `username`, and `password` settings as required by your
 environment. For other module settings, it's recommended that you accept the
 defaults.
@@ -152,7 +152,7 @@ By default, the module collects {beatname_uc} monitoring data from
 `localhost:5066`. If you exposed the metrics on a different host or port when
 you enabled the HTTP endpoint, update the `hosts` setting.
 
-To monitor multiple 
+To monitor multiple
 ifndef::apm-server[]
 {beats} agents,
 endif::[]
@@ -171,15 +171,15 @@ it via HTTPS. For example, use a `hosts` setting like `https://localhost:5066`.
 // end::configure-beat-module[]
 
 // tag::remote-monitoring-user[]
-If the Elastic {security-features} are enabled, you must also provide a user 
-ID and password so that {metricbeat} can collect metrics successfully: 
+If the Elastic {security-features} are enabled, you must also provide a user
+ID and password so that {metricbeat} can collect metrics successfully:
 
-.. Create a user on the production cluster that has the 
-`remote_monitoring_collector` {ref}/built-in-roles.html[built-in role]. 
+.. Create a user on the production cluster that has the
+`remote_monitoring_collector` {ref}/built-in-roles.html[built-in role].
 Alternatively, if it's available in your environment, use the
 `remote_monitoring_user` {ref}/built-in-users.html[built-in user].
 
-.. Add the `username` and `password` settings to the beat module configuration 
+.. Add the `username` and `password` settings to the beat module configuration
 file.
 // end::remote-monitoring-user[]
 --
@@ -197,19 +197,19 @@ other purposes, run the following command:
 ----------------------------------------------------------------------
 metricbeat modules disable system
 ----------------------------------------------------------------------
-// end::disable-system-module[] 
+// end::disable-system-module[]
 --
 
 . Identify where to send the monitoring data. +
 +
 --
-TIP: In production environments, we strongly recommend using a separate cluster 
-(referred to as the _monitoring cluster_) to store the data. Using a separate 
-monitoring cluster prevents production cluster outages from impacting your 
-ability to access your monitoring data. It also prevents monitoring activities 
+TIP: In production environments, we strongly recommend using a separate cluster
+(referred to as the _monitoring cluster_) to store the data. Using a separate
+monitoring cluster prevents production cluster outages from impacting your
+ability to access your monitoring data. It also prevents monitoring activities
 from impacting the performance of your production cluster.
 
-For example, specify the {es} output information in the {metricbeat} 
+For example, specify the {es} output information in the {metricbeat}
 configuration file (`metricbeat.yml`):
 
 [source,yaml]
@@ -217,14 +217,14 @@ configuration file (`metricbeat.yml`):
 output.elasticsearch:
   # Array of hosts to connect to.
   hosts: ["http://es-mon-1:9200", "http://es-mon2:9200"] <1>
-  
+
   # Optional protocol and basic auth credentials.
   #protocol: "https"
   #api_key:  "id:api_key" <2>
   #username: "elastic"
   #password: "changeme"
 ----------------------------------
-<1> In this example, the data is stored on a monitoring cluster with nodes 
+<1> In this example, the data is stored on a monitoring cluster with nodes
 `es-mon-1` and `es-mon-2`.
 <2> Specify one of `api_key` or `username`/`password`.
 
@@ -235,27 +235,27 @@ must access it via HTTPS. For example, use a `hosts` setting like
 IMPORTANT: The {es} {monitor-features} use ingest pipelines, therefore the
 cluster that stores the monitoring data must have at least one ingest node.
 
-If the {es} {security-features} are enabled on the monitoring cluster, you 
-must provide a valid user ID and password so that {metricbeat} can send metrics 
-successfully: 
+If the {es} {security-features} are enabled on the monitoring cluster, you
+must provide a valid user ID and password so that {metricbeat} can send metrics
+successfully:
 
-.. Create a user on the monitoring cluster that has the 
-`remote_monitoring_agent` {ref}/built-in-roles.html[built-in role]. 
+.. Create a user on the monitoring cluster that has the
+`remote_monitoring_agent` {ref}/built-in-roles.html[built-in role].
 Alternatively, if it's available in your environment, use the
-`remote_monitoring_user` {ref}/built-in-users.html[built-in user]. 
+`remote_monitoring_user` {ref}/built-in-users.html[built-in user].
 +
 TIP: If you're using index lifecycle management, the remote monitoring user
 requires additional privileges to create and read indices. For more
 information, see <<feature-roles>>.
 
-.. Add the `username` and `password` settings to the {es} output information in 
+.. Add the `username` and `password` settings to the {es} output information in
 the {metricbeat} configuration file.
 
-For more information about these configuration options, see 
+For more information about these configuration options, see
 {metricbeat-ref}/elasticsearch-output.html[Configure the {es} output].
 --
 
 . {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}] to begin
-collecting monitoring data. 
+collecting monitoring data.
 
-. {kibana-ref}/monitoring-data.html[View the monitoring data in {kib}]. 
+. {kibana-ref}/monitoring-data.html[View the monitoring data in {kib}].

--- a/docs/copied-from-beats/docs/security/basic-auth.asciidoc
+++ b/docs/copied-from-beats/docs/security/basic-auth.asciidoc
@@ -58,5 +58,5 @@ output.elasticsearch:
 --------------------------------------------------
 
 To learn more about {stack} security features and other types of
-authentication, see {stack-ov}/elasticsearch-security.html[Securing the
+authentication, see {ref}/elasticsearch-security.html[Securing the
 {stack}].

--- a/docs/copied-from-beats/docs/security/users.asciidoc
+++ b/docs/copied-from-beats/docs/security/users.asciidoc
@@ -28,11 +28,11 @@ the affect of future changes on your security strategy.
 
 IMPORTANT: Setting up {beatname_uc} is an admin-level task that requires extra
 privileges. As a best practice, grant the setup role to administrators only, and
-use a less restrictive role for event publishing.  
+use a less restrictive role for event publishing.
 
 Administrators who set up {beatname_uc} typically need to load mappings,
 dashboards, and other objects used to index data into {es} and visualize it in
-{kib}. 
+{kib}.
 
 To grant users the required privileges:
 
@@ -58,7 +58,7 @@ endif::has_ml_jobs[]
 
 |`manage` on +{beat_default_index_prefix}-*+ indices
 |Set up aliases used by ILM
- 
+
 ifdef::has_ml_jobs[]
 |`read` on +{beat_default_index_prefix}-*+ indices
 |Read {beatname_uc} indices in order to set up machine learning jobs
@@ -72,7 +72,7 @@ NOTE: These instructions assume that you are using the default name for
 match your index naming pattern.
 
 . Assign the *setup role*, along with the following built-in roles, to users who
-need to set up {beatname_uc}: 
+need to set up {beatname_uc}:
 +
 [options="header"]
 |====
@@ -107,8 +107,8 @@ roles needed depend on the method used to collect monitoring data.
 
 For <<monitoring-internal-collection,internal collection>>, {security}
 provides the +{beat_default_index_prefix}_system+
-{stack-ov}/built-in-users.html[built-in user] and
-+{beat_default_index_prefix}_system+ {stack-ov}/built-in-roles.html[built-in
+{ref}/built-in-users.html[built-in user] and
++{beat_default_index_prefix}_system+ {ref}/built-in-roles.html[built-in
 role] for sending monitoring information. You can use the built-in user, or
 create a user who has the privileges needed to send monitoring information.
 
@@ -132,7 +132,7 @@ If you don't use the +{beat_default_index_prefix}_system+ user:
 |====
 
 . Assign the *monitoring role*, along with the following built-in role, to
-users who need to monitor {beatname_uc}: 
+users who need to monitor {beatname_uc}:
 +
 [options="header"]
 |====
@@ -160,7 +160,7 @@ If you don't use the `remote_monitoring_user` user:
 . Create a user on the production cluster who will collect and send monitoring
 information.
 
-. Assign the following roles to the user: 
+. Assign the following roles to the user:
 +
 [options="header"]
 |====
@@ -249,7 +249,7 @@ ifndef::apm-server[]
 Omit any privileges that aren't relevant in your environment.
 endif::apm-server[]
 
-. Assign the *writer role* to users who will index events into {es}. 
+. Assign the *writer role* to users who will index events into {es}.
 
 [[kibana-user-privileges]]
 ==== Grant privileges and roles needed to read {beatname_uc} data

--- a/docs/copied-from-beats/docs/security/users.asciidoc
+++ b/docs/copied-from-beats/docs/security/users.asciidoc
@@ -316,9 +316,9 @@ endif::apm-server[]
 ==== Learn more about users and roles
 
 Want to learn more about creating users and roles? See
-{stack-ov}/elasticsearch-security.html[Securing the {stack}]. Also see:
+{ref}/elasticsearch-security.html[Securing the {stack}]. Also see:
 
-* {stack-ov}/security-privileges.html[Security privileges] for a description of
+* {ref}/security-privileges.html[Security privileges] for a description of
 available privileges
-* {stack-ov}/built-in-roles.html[Built-in roles] for a description of roles that
+* {ref}/built-in-roles.html[Built-in roles] for a description of roles that
 you can assign to users


### PR DESCRIPTION
Backports the following commits to 7.5:
 - [DOCS] Fixes Stack Overview links (#3925)

Fixes the following broken links:
```
16:32:51 INFO:build_docs:Bad cross-document links:
16:32:51 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/server/7.5/beats-basic-auth.html:
16:32:51 INFO:build_docs:   - en/elastic-stack-overview/7.5/elasticsearch-security.html
16:32:51 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/server/7.5/feature-roles.html:
16:32:51 INFO:build_docs:   - en/elastic-stack-overview/7.5/built-in-roles.html
16:32:51 INFO:build_docs:   - en/elastic-stack-overview/7.5/built-in-users.html
16:32:51 INFO:build_docs:   - en/elastic-stack-overview/7.5/elasticsearch-security.html
16:32:51 INFO:build_docs:   - en/elastic-stack-overview/7.5/security-privileges.html
16:32:51 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/server/7.5/monitoring-metricbeat-collection.html:
16:32:51 INFO:build_docs:   - en/elastic-stack-overview/7.5/xpack-monitoring.html
16:32:51 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/server/7.5/monitoring.html:
16:32:51 INFO:build_docs:   - en/elastic-stack-overview/7.5/xpack-monitoring.html
16:32:51 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/server/7.5/securing-communication-elasticsearch.html:
16:32:51 INFO:build_docs:   - en/elastic-stack-overview/7.5/elasticsearch-security.html
```