### PR TITLE
docs: fix two remaining links

### DIFF
--- a/docs/copied-from-beats/docs/security/users.asciidoc
+++ b/docs/copied-from-beats/docs/security/users.asciidoc
@@ -145,9 +145,9 @@ ifndef::serverless[]
 ===== {metricbeat} collection
 
 For <<monitoring-metricbeat-collection,{metricbeat} collection>>, {security}
-provides the `remote_monitoring_user` {stack-ov}/built-in-users.html[built-in
+provides the `remote_monitoring_user` {ref}/built-in-users.html[built-in
 user], and the `remote_monitoring_collector` and `remote_monitoring_agent`
-{stack-ov}/built-in-roles.html[built-in roles] for collecting and sending
+{ref}/built-in-roles.html[built-in roles] for collecting and sending
 monitoring information. You can use the built-in user, or
 create a user who has the privileges needed to collect and send monitoring
 information.


### PR DESCRIPTION
For https://github.com/elastic/docs/pull/1870.

Fixes:
```
12:12:14 INFO:build_docs:Bad cross-document links:
12:12:14 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/server/7.5/feature-roles.html:
12:12:14 INFO:build_docs:   - en/elastic-stack-overview/7.5/built-in-roles.html
12:12:14 INFO:build_docs:   - en/elastic-stack-overview/7.5/built-in-users.html
```