### PR TITLE
[7.8] Manual backport of UserAgent refactoring

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/spf13/pflag"
 
 	"github.com/elastic/beats/v7/libbeat/beat"

--- a/model/error_test.go
+++ b/model/error_test.go
@@ -295,9 +295,10 @@ func TestEvents(t *testing.T) {
 		Labels: common.MapStr{"label": 101},
 	}
 
-	mdWithUser := md
-	mdWithUser.User = User{ID: uid, Email: email, UserAgent: userAgent}
-	mdWithUser.Client.IP = net.ParseIP(userIP)
+	mdWithContext := md
+	mdWithContext.User = User{ID: uid, Email: email}
+	mdWithContext.Client.IP = net.ParseIP(userIP)
+	mdWithContext.UserAgent.Original = userAgent
 
 	for name, tc := range map[string]struct {
 		Transformable transform.Transformable
@@ -348,7 +349,7 @@ func TestEvents(t *testing.T) {
 		"withContext": {
 			Transformable: &Error{
 				Timestamp: timestamp,
-				Metadata:  mdWithUser,
+				Metadata:  mdWithContext,
 				Log:       baseLog(),
 				Exception: &Exception{
 					Message:    &exMsg,

--- a/model/metadata.go
+++ b/model/metadata.go
@@ -24,13 +24,14 @@ import (
 )
 
 type Metadata struct {
-	Service Service
-	Process Process
-	System  System
-	User    User
-	Client  Client
-	Cloud   Cloud
-	Labels  common.MapStr
+	Service   Service
+	Process   Process
+	System    System
+	User      User
+	UserAgent UserAgent
+	Client    Client
+	Cloud     Cloud
+	Labels    common.MapStr
 }
 
 func (m *Metadata) Set(out common.MapStr) common.MapStr {
@@ -41,7 +42,7 @@ func (m *Metadata) Set(out common.MapStr) common.MapStr {
 	fields.maybeSetMapStr("process", m.Process.fields())
 	fields.maybeSetMapStr("user", m.User.Fields())
 	fields.maybeSetMapStr("client", m.Client.fields())
-	fields.maybeSetMapStr("user_agent", m.User.UserAgentFields())
+	fields.maybeSetMapStr("user_agent", m.UserAgent.fields())
 	fields.maybeSetMapStr("container", m.System.containerFields())
 	fields.maybeSetMapStr("kubernetes", m.System.kubernetesFields())
 	fields.maybeSetMapStr("cloud", m.Cloud.fields())

--- a/model/metadata_test.go
+++ b/model/metadata_test.go
@@ -155,10 +155,12 @@ func BenchmarkMetadataSet(b *testing.B) {
 			},
 		},
 		User: User{
-			ID:        "123",
-			Email:     "me@example.com",
-			Name:      "bob",
-			UserAgent: "user-agent",
+			ID:    "123",
+			Email: "me@example.com",
+			Name:  "bob",
+		},
+		UserAgent: UserAgent{
+			Original: "user-agent",
 		},
 		Client: Client{
 			IP: net.ParseIP("10.1.1.2"),

--- a/model/modeldecoder/context.go
+++ b/model/modeldecoder/context.go
@@ -73,7 +73,7 @@ func decodeContext(input map[string]interface{}, cfg Config, meta *model.Metadat
 		decodeUser(userInp, cfg.HasShortFieldNames, &meta.User, &meta.Client)
 	}
 	if ua := http.UserAgent(); ua != "" {
-		meta.User.UserAgent = ua
+		meta.UserAgent.Original = ua
 	}
 	if meta.Client.IP == nil {
 		meta.Client.IP = getHTTPClientIP(http)

--- a/model/modeldecoder/context_test.go
+++ b/model/modeldecoder/context_test.go
@@ -157,11 +157,10 @@ func TestDecodeContext(t *testing.T) {
 					"cookies": map[string]interface{}{"c1": "b", "c2": "c"}},
 				"tags": map[string]interface{}{"ab": "c", "status": 200, "success": false},
 				"user": map[string]interface{}{
-					"username":   "john",
-					"email":      "doe",
-					"ip":         "192.158.0.1",
-					"id":         "12345678ab",
-					"user-agent": "go-1.1"},
+					"username": "john",
+					"email":    "doe",
+					"ip":       "192.158.0.1",
+					"id":       "12345678ab"},
 				"service": map[string]interface{}{
 					"name":        "myService",
 					"version":     "5.1.3",
@@ -234,19 +233,17 @@ func TestDecodeContextMetadata(t *testing.T) {
 		// ID is missing because per-event user metadata
 		// replaces stream user metadata. This is unlike
 		// service metadata above, which is merged.
-		Name:      "john",
-		Email:     "john.doe@testing.invalid",
-		UserAgent: "go-1.1",
+		Name:  "john",
+		Email: "john.doe@testing.invalid",
 	}
 	mergedMetadata.Client.IP = net.ParseIP("10.1.1.1")
 
 	input := map[string]interface{}{
 		"tags": map[string]interface{}{"ab": "c", "status": 200, "success": false},
 		"user": map[string]interface{}{
-			"username":   mergedMetadata.User.Name,
-			"email":      mergedMetadata.User.Email,
-			"ip":         mergedMetadata.Client.IP.String(),
-			"user-agent": mergedMetadata.User.UserAgent,
+			"username": mergedMetadata.User.Name,
+			"email":    mergedMetadata.User.Email,
+			"ip":       mergedMetadata.Client.IP.String(),
 		},
 		"service": map[string]interface{}{
 			"version":     mergedMetadata.Service.Version,

--- a/model/modeldecoder/error_test.go
+++ b/model/modeldecoder/error_test.go
@@ -58,7 +58,8 @@ func TestErrorEventDecode(t *testing.T) {
 	}
 
 	mergedMetadata := inputMetadata
-	mergedMetadata.User = m.User{Name: name, Email: email, ID: userID, UserAgent: ua}
+	mergedMetadata.User = m.User{Name: name, Email: email, ID: userID}
+	mergedMetadata.UserAgent.Original = ua
 	mergedMetadata.Client.IP = net.ParseIP(userIP)
 
 	// baseInput holds the minimal valid input. Test-specific input is added to this.

--- a/model/modeldecoder/metadata.go
+++ b/model/modeldecoder/metadata.go
@@ -59,7 +59,11 @@ func decodeMetadata(input interface{}, hasShortFieldNames bool, schema *jsonsche
 	decodeService(getObject(raw, fieldName("service")), hasShortFieldNames, &out.Service)
 	decodeSystem(getObject(raw, "system"), &out.System)
 	decodeProcess(getObject(raw, "process"), &out.Process)
-	decodeUser(getObject(raw, fieldName("user")), hasShortFieldNames, &out.User, &out.Client)
+	if userObj := getObject(raw, fieldName("user")); userObj != nil {
+		decodeUser(userObj, hasShortFieldNames, &out.User, &out.Client)
+		// TODO(axw) stop decoding user.user-agent here (see #3885)
+		decodeString(userObj, "user-agent", &out.UserAgent.Original)
+	}
 	decodeCloud(getObject(raw, "cloud"), &out.Cloud)
 	decodeLabels(getObject(raw, fieldName("labels")), &out.Labels)
 	return nil

--- a/model/modeldecoder/metadata_test.go
+++ b/model/modeldecoder/metadata_test.go
@@ -171,10 +171,12 @@ func TestDecodeMetadata(t *testing.T) {
 			},
 		},
 		User: model.User{
-			ID:        uid,
-			Email:     mail,
-			Name:      username,
-			UserAgent: userAgent,
+			ID:    uid,
+			Email: mail,
+			Name:  username,
+		},
+		UserAgent: model.UserAgent{
+			Original: userAgent,
 		},
 		Client: model.Client{
 			IP: net.ParseIP(userIP),

--- a/model/modeldecoder/transaction_test.go
+++ b/model/modeldecoder/transaction_test.go
@@ -194,7 +194,8 @@ func TestTransactionEventDecode(t *testing.T) {
 	inputMetadata := model.Metadata{Service: model.Service{Name: "foo"}}
 
 	mergedMetadata := inputMetadata
-	mergedMetadata.User = model.User{Name: name, Email: email, ID: userID, UserAgent: ua}
+	mergedMetadata.User = model.User{Name: name, Email: email, ID: userID}
+	mergedMetadata.UserAgent.Original = ua
 	mergedMetadata.Client.IP = net.ParseIP(userIP)
 
 	// baseInput holds the minimal valid input. Test-specific input is added to this.

--- a/model/modeldecoder/user.go
+++ b/model/modeldecoder/user.go
@@ -31,7 +31,6 @@ func decodeUser(input map[string]interface{}, hasShortFieldNames bool, out *mode
 	}
 
 	fieldName := field.Mapper(hasShortFieldNames)
-	decodeString(input, "user-agent", &out.UserAgent)
 	decodeString(input, fieldName("username"), &out.Name)
 	decodeString(input, fieldName("email"), &out.Email)
 

--- a/model/modeldecoder/user_test.go
+++ b/model/modeldecoder/user_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestUserDecode(t *testing.T) {
-	id, mail, name, ip, agent := "12", "m@g.dk", "foo", "127.0.0.1", "ruby"
+	id, mail, name, ip := "12", "m@g.dk", "foo", "127.0.0.1"
 	for _, test := range []struct {
 		input  map[string]interface{}
 		user   model.User
@@ -45,9 +45,9 @@ func TestUserDecode(t *testing.T) {
 		},
 		{
 			input: map[string]interface{}{
-				"id": id, "email": mail, "username": name, "ip": ip, "user-agent": agent,
+				"id": id, "email": mail, "username": name, "ip": ip,
 			},
-			user:   model.User{ID: id, Email: mail, Name: name, UserAgent: agent},
+			user:   model.User{ID: id, Email: mail, Name: name},
 			client: model.Client{IP: net.ParseIP(ip)},
 		},
 	} {

--- a/model/transaction_test.go
+++ b/model/transaction_test.go
@@ -155,9 +155,10 @@ func TestEventsTransformWithMetadata(t *testing.T) {
 			Architecture:       architecture,
 			Platform:           platform,
 		},
-		User:   User{ID: id, Name: name, UserAgent: userAgent},
-		Client: Client{IP: net.ParseIP(ip)},
-		Labels: common.MapStr{"a": true},
+		User:      User{ID: id, Name: name},
+		UserAgent: UserAgent{Original: userAgent},
+		Client:    Client{IP: net.ParseIP(ip)},
+		Labels:    common.MapStr{"a": true},
 	}
 
 	request := Req{Method: "post", Socket: &Socket{}, Headers: http.Header{}}

--- a/model/user.go
+++ b/model/user.go
@@ -22,10 +22,9 @@ import (
 )
 
 type User struct {
-	ID        string
-	Email     string
-	Name      string
-	UserAgent string
+	ID    string
+	Email string
+	Name  string
 }
 
 func (u *User) Fields() common.MapStr {
@@ -37,11 +36,4 @@ func (u *User) Fields() common.MapStr {
 	user.maybeSetString("email", u.Email)
 	user.maybeSetString("name", u.Name)
 	return common.MapStr(user)
-}
-
-func (u *User) UserAgentFields() common.MapStr {
-	if u == nil || u.UserAgent == "" {
-		return nil
-	}
-	return common.MapStr{"original": u.UserAgent}
 }

--- a/model/user_agent.go
+++ b/model/user_agent.go
@@ -14,6 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package model
 
 import (

--- a/model/user_agent.go
+++ b/model/user_agent.go
@@ -14,46 +14,25 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 package model
 
 import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
-func TestUserFields(t *testing.T) {
-	id := "1234"
-	email := "test@mail.co"
-	name := "user123"
+type UserAgent struct {
+	// Original holds the original, full, User-Agent string.
+	Original string
 
-	tests := []struct {
-		User   User
-		Output common.MapStr
-	}{
-		{
-			User:   User{},
-			Output: nil,
-		},
-		{
-			User: User{
-				ID:    id,
-				Email: email,
-				Name:  name,
-			},
-			Output: common.MapStr{
-				"id":    "1234",
-				"email": "test@mail.co",
-				"name":  "user123",
-			},
-		},
-	}
+	// Name holds the user_agent.name value from the parsed User-Agent string.
+	// If Original is set, then this should typically not be set, as the full
+	// User-Agent string can be parsed by ingest node.
+	Name string
+}
 
-	for _, test := range tests {
-		output := test.User.Fields()
-		assert.Equal(t, test.Output, output)
-	}
+func (u *UserAgent) fields() common.MapStr {
+	var fields mapStr
+	fields.maybeSetString("original", u.Original)
+	fields.maybeSetString("name", u.Name)
+	return common.MapStr(fields)
 }

--- a/model/user_agent_test.go
+++ b/model/user_agent_test.go
@@ -25,35 +25,23 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
-func TestUserFields(t *testing.T) {
-	id := "1234"
-	email := "test@mail.co"
-	name := "user123"
-
+func TestUserAgentFields(t *testing.T) {
 	tests := []struct {
-		User   User
-		Output common.MapStr
-	}{
-		{
-			User:   User{},
-			Output: nil,
-		},
-		{
-			User: User{
-				ID:    id,
-				Email: email,
-				Name:  name,
-			},
-			Output: common.MapStr{
-				"id":    "1234",
-				"email": "test@mail.co",
-				"name":  "user123",
-			},
-		},
-	}
+		UserAgent UserAgent
+		Output    common.MapStr
+	}{{
+		UserAgent: UserAgent{},
+		Output:    nil,
+	}, {
+		UserAgent: UserAgent{Original: "rum-1.0"},
+		Output:    common.MapStr{"original": "rum-1.0"},
+	}, {
+		UserAgent: UserAgent{Name: "mosaic"},
+		Output:    common.MapStr{"name": "mosaic"},
+	}}
 
 	for _, test := range tests {
-		output := test.User.Fields()
+		output := test.UserAgent.fields()
 		assert.Equal(t, test.Output, output)
 	}
 }

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -264,7 +264,7 @@ func makeMetricset(key transactionAggregationKey, ts time.Time, counts []int64, 
 				Container:        model.Container{ID: key.containerID},
 				Kubernetes:       model.Kubernetes{PodName: key.kubernetesPodName},
 			},
-			User: model.User{UserAgent: key.userAgent},
+			UserAgent: model.UserAgent{Original: key.userAgent},
 			// TODO(axw) include client.geo.country_iso_code somewhere
 		},
 		Transaction: model.MetricsetTransaction{
@@ -339,7 +339,7 @@ func makeTransactionAggregationKey(tx *model.Transaction) transactionAggregation
 		hostname:          tx.Metadata.System.Hostname(),
 		containerID:       tx.Metadata.System.Container.ID,
 		kubernetesPodName: tx.Metadata.System.Kubernetes.PodName,
-		userAgent:         tx.Metadata.User.UserAgent,
+		userAgent:         tx.Metadata.UserAgent.Original,
 
 		// TODO(axw) clientCountryISOCode, requires geoIP lookup in apm-server.
 	}


### PR DESCRIPTION

<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Before creating the PR, ensure that:

1. Your branch is rebased on top of the latest master.
   Squash your initial commits into meaningful commits.
   After creating a PR, do not rebase of force push any longer.
2. Nothing is broken, by running the test suite (at least unit tests).
   See https://github.com/elastic/apm-server/blob/master/TESTING.md for details.
3. Your code follows the style guidelines of this project:
   run `make check-full` for static code checks and linting.

A few suggestions about filling out this PR:

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR.
3. Please label this PR with at least one of the following labels:
   - bug fix
   - breaking change
   - enhancement
4. Reference the related issue, and make use of magic keywords where it makes sense
   https://help.github.com/articles/closing-issues-using-keywords/.
5. Do not remove any checklist items, strike through the ones that don't apply
   (by using tildes, e.g. ~scratch this ~).
6. Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
7. Submit the pull request:
   Push your changes to your forked copy of the repository and submit a pull request
   (https://help.github.com/articles/using-pull-requests).
8. Please be patient. We might not be able to immediately review your code,
   but we'll do our best to dedicate to it the attention it deserves.
   Your effort is much appreciated!

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
Pull out user-agent refactoring from https://github.com/elastic/apm-server/pull/3886
as a basis for fixing a user-agent bug in Intake v3 protocol.

This is a requirement before https://github.com/elastic/apm-server/pull/3946 can be backported to `7.8`. 

## Checklist

~- [ ] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).~
- [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
      -> no changelog entry as this is purely an internal refactoring

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes
run automated tests

## Related issues
https://github.com/elastic/apm-server/pull/3886
https://github.com/elastic/apm-server/pull/3946 

