### PR TITLE
[docs] 6.8.11 version bump

### DIFF
--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 6.8.10
+:stack-version: 6.8.11
 :major-version: 6.x
 :doc-branch: 6.8
 :branch: {doc-branch}


### PR DESCRIPTION
## Summary

This PR bumps the version from `6.8.10` --> `6.8.11`.

**Do not merge until release day.**