### PR TITLE
ci: remove cron trigger from the check changelog job

### DIFF
--- a/.ci/check-changelogs.groovy
+++ b/.ci/check-changelogs.groovy
@@ -20,9 +20,6 @@ pipeline {
     rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
     quietPeriod(10)
   }
-  triggers {
-    cron 'H H(3-4) * * 1-5'
-  }
   stages {
     /**
      Checkout the code and stash it, to use it on other stages.


### PR DESCRIPTION
## What does this PR do?

<!-- Comment:
Here you can explain the changes made on the PR.
-->

It removes the corn trigger form the check changelogs job.

## Why is it important?

<!-- Comment:
Here you can explains how this changes will impact in users or in the application
-->

Currently,  check changelogs job runs on a daily basis, every day it fails, only 4-6 days a week it does not fail, and it is OK. This job should be pass only when the changelog is updated so on dates near to the release. Because of that, I've asked to disable the corn and move to use it manually when it is needed.