### PR TITLE
[7.x] Use peer.hostname for destination.address if peer.address is not given (#3969)

### DIFF
--- a/processor/otel/consumer.go
+++ b/processor/otel/consumer.go
@@ -408,6 +408,11 @@ func parseSpan(span *tracepb.Span, event *model.Span) {
 			case "peer.address":
 				val := truncate(v.StringValue.Value)
 				destination.Address = &val
+			case "peer.hostname":
+				if destination.Address == nil {
+					val := truncate(v.StringValue.Value)
+					destination.Address = &val
+				}
 			case "peer.service":
 				destinationService.Name = &v.StringValue.Value
 			case "message_bus.destination":

--- a/processor/otel/consumer_test.go
+++ b/processor/otel/consumer_test.go
@@ -309,6 +309,7 @@ func TestConsumer_Span(t *testing.T) {
 						"type":             testAttributeStringValue("db_request"),
 						"component":        testAttributeStringValue("foo"),
 						"string.a.b":       testAttributeStringValue("some note"),
+						"peer.hostname":    testAttributeStringValue("db"),
 						"peer.port":        testAttributeIntValue(3306),
 						"peer.address":     testAttributeStringValue("mysql://db:3306"),
 						"peer.service":     testAttributeStringValue("sql"),
@@ -349,6 +350,8 @@ func TestConsumer_Span(t *testing.T) {
 					StartTime: testStartTime(), EndTime: testEndTime(),
 					Name: testTruncatableString("Message receive"),
 					Attributes: &tracepb.Span_Attributes{AttributeMap: map[string]*tracepb.AttributeValue{
+						"peer.hostname":           testAttributeStringValue("mq"),
+						"peer.port":               testAttributeIntValue(1234),
 						"message_bus.destination": testAttributeStringValue("queue-abc"),
 					}},
 					Status: &tracepb.Status{Code: 202},

--- a/processor/otel/test_approved/span_jaeger_messaging.approved.json
+++ b/processor/otel/test_approved/span_jaeger_messaging.approved.json
@@ -6,6 +6,10 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
+            "destination": {
+                "address": "mq",
+                "port": 1234
+            },
             "host": {
                 "hostname": "host-abc",
                 "name": "host-abc"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Use peer.hostname for destination.address if peer.address is not given (#3969)