### PR TITLE
docs: 7.8.1 release notes

### DIFF
--- a/changelogs/7.8.asciidoc
+++ b/changelogs/7.8.asciidoc
@@ -3,7 +3,16 @@
 
 https://github.com/elastic/apm-server/compare/7.7\...7.8[View commits]
 
+* <<release-notes-7.8.1>>
 * <<release-notes-7.8.0>>
+
+[float]
+[[release-notes-7.8.1]]
+=== APM Server version 7.8.1
+
+https://github.com/elastic/apm-server/compare/v7.8.0\...v7.8.1[View commits]
+
+No significant changes.
 
 [float]
 [[release-notes-7.8.0]]


### PR DESCRIPTION
This PR adds release notes for 7.8.1. The only commit of note is https://github.com/elastic/apm-server/pull/3917, but there's no changelog entry so it has been excluded.

A note about the service maps issue has been added to the [Kibana release notes](https://www.elastic.co/guide/en/kibana/current/release-notes-7.8.1.html).