### PR TITLE
[7.9] docs: 7.8.1 release notes (#3980)

### DIFF
--- a/changelogs/7.8.asciidoc
+++ b/changelogs/7.8.asciidoc
@@ -3,7 +3,16 @@
 
 https://github.com/elastic/apm-server/compare/7.7\...7.8[View commits]
 
+* <<release-notes-7.8.1>>
 * <<release-notes-7.8.0>>
+
+[float]
+[[release-notes-7.8.1]]
+=== APM Server version 7.8.1
+
+https://github.com/elastic/apm-server/compare/v7.8.0\...v7.8.1[View commits]
+
+No significant changes.
 
 [float]
 [[release-notes-7.8.0]]


### PR DESCRIPTION
Backports the following commits to 7.9:
 - docs: 7.8.1 release notes (#3980)