### PR TITLE
[7.8] docs: clean up upgrading content (#3979)

### DIFF
--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -5,20 +5,22 @@ As such, any breaking change in libbeat is also considered to be a breaking chan
 
 [float]
 === 7.8
-* There are no breaking changes in APM Server.
+There are no breaking changes in APM Server.
 
 [float]
 === 7.7
-* There are no breaking changes in APM Server.
+There are no breaking changes in APM Server.
 However, a previously hardcoded feature is now configurable.
 Failing to follow these <<upgrading-to-77,upgrade steps>> will result in increased span metadata ingestion when upgrading to version 7.7.
 
 [float]
 === 7.6
-* There are no breaking changes in APM Server.
+There are no breaking changes in APM Server.
 
 [float]
 === 7.5
+The following breaking changes have been introduced in 7.5:
+
 * Introduced dedicated `apm-server.ilm.setup.*` flags.
 This means you can now customize ILM behavior from within the APM Server configuration.
 As a side effect, `setup.template.*` settings will be ignored for ILM related templates per event type.
@@ -33,6 +35,8 @@ you must ensure you are using version 7.5+ of APM Server and version 7.5+ of Kib
 
 [float]
 === 7.0
+The following breaking changes have been introduced in 7.0:
+
 * Removed deprecated Intake v1 API endpoints.
 Upgrade agents to a version that supports APM Server ≥ 6.5.
 {apm-overview-ref-v}/breaking-7.0.0.html#breaking-remove-v1[More information].
@@ -42,18 +46,23 @@ Upgrade agents to a version that supports APM Server ≥ 6.5.
 
 [float]
 === 6.5
-* There are no breaking changes in APM Server.
-* Advanced users may find the <<upgrading-to-65,upgrading to 6.5 guide>> useful.
+There are no breaking changes in APM Server.
+Advanced users may find the <<upgrading-to-65,upgrading to 6.5 guide>> useful.
 
 [float]
 === 6.4
+The following breaking changes have been introduced in 6.4:
+
 * Indexing the `onboarding` document in it's own index by default.
 
 [float]
 === 6.3
+The following breaking changes have been introduced in 6.3:
+
 * Indexing events in separate indices by default.
 * {beats-ref-63}/breaking-changes-6.3.html[Breaking changes in libbeat]
 
 [float]
 === 6.2
-* APM Server GA
+
+APM Server is now GA (generally available).

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -6,32 +6,45 @@
 ++++
 
 We do our best to keep APM Server backward compatible between minor releases.
-However, check out the <<breaking-changes, breaking changes>> section for exceptions.
+Any exceptions will be explained in <<breaking-changes,breaking changes>>.
 
-Before upgrading:
+[discrete]
+[[before-upgrading]]
+=== Before upgrading
 
-* Review the APM Server <<release-notes,release notes>> and <<breaking-changes, breaking changes>>
+* Review the APM Server <<release-notes,release notes>> and <<breaking-changes,breaking changes>>
 for changes between your current APM Server version and the one you are upgrading to.
-* Visit the general APM {apm-overview-ref-v}/apm-release-notes.html[release highlights] and {apm-overview-ref-v}/apm-breaking-changes.html[breaking changes] for highlights and important changes.
-* Check the {stack-ref}/index.html[Elastic Stack Installation and Upgrade Guide] for guidance on how to upgrade your Elastic Stack.
+* Review the APM stack {apm-overview-ref-v}/apm-release-notes.html[release highlights] and {apm-overview-ref-v}/apm-breaking-changes.html[breaking changes] for highlights and important changes to other APM components.
 
-When you're ready to upgrade your APM Server between minor versions,
-simply install the new release.
+[discrete]
+[[upgrade-order]]
+=== Upgrade process
 
-You'll want to take a look at the `apm-server.yml` configuration file after installing a new release.
+. The Elastic Stack (Elasticsearch and Kibana) must be upgraded before APM Server.
+See the {stack-ref}/upgrading-elastic-stack.html[Elastic Stack Installation and Upgrade Guide] for guidance.
+
+. If applicable, read and understand the relevant APM Server upgrading guide.
+Guides exist for upgrades to versions
+<<upgrading-to-77,`7.7`>>, <<upgrading-to-70,`7.0`>>, and <<upgrading-to-65,`6.5`>>.
+
+. Install the new APM Server release.
+
+. Review the `apm-server.yml` configuration file.
 There may be newly added configuration options, and you'll want to be aware of their default settings.
-See <<configuring-howto-apm-server,Configuring APM Server>> for more information on available configuration options.
+See <<configuring-howto-apm-server,configuring>> for more information on available options.
 
-If you set up index patterns and dashboards manually by running `./apm-server setup`,
+. If you set up index patterns and dashboards manually by running `./apm-server setup`,
 rerun the command to update the index pattern and the dashboards.
 
-When everything is properly configured and updated, start the APM server.
-
+. Start the APM server.
++
 When you start the APM server after upgrading, it creates new indices that use the current version,
 and applies the correct template automatically.
 
 include::./breaking-changes.asciidoc[]
 
+// Adding a new upgrading guide?
+// Be sure to also add it to the jump list above (step 2).
 include::./upgrading-to-77.asciidoc[]
 
 include::./upgrading-to-70.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 7.8:
 - docs: clean up upgrading content (#3979)