### PR TITLE
[DOCS] Add tagged regions for content reuse

### DIFF
--- a/docs/guide/install-and-run.asciidoc
+++ b/docs/guide/install-and-run.asciidoc
@@ -146,8 +146,6 @@ and configuring it with the address of your APM Server, a secret token (if neces
 
 TIP: Check the {apm-overview-ref-v}/agent-server-compatibility.html[Agent/Server compatibility matrix] to ensure you're using agents that are compatible with your version of Elasticsearch.
 
-
-
 [[choose-service-name]]
 [float]
 ==== Choose a service name
@@ -169,7 +167,6 @@ spaces, underscores, and dashes (must match `^[a-zA-Z0-9 _-]+$`).
 
 Now that you're up and running with Elastic APM, you may want to adjust some configuration settings.
 Luckily, there are many different ways to tweak and tune the Elastic ecosystem to adapt it to your needs.
-
 
 [float]
 ==== Configure APM agents
@@ -195,7 +192,6 @@ a|
 A select number of configuration options can be changed directly in Kibana, without needing to redeploy the Agent.
 See {apm-app-ref}/agent-configuration.html[Agent configuration in Kibana] for more information.
 
-
 [float]
 ==== Configure Elastic Cloud
 
@@ -203,7 +199,6 @@ If you're running APM Server in Elastic cloud, you can configure your own user s
 Any changes are automatically appended to the `apm-server.yml` configuration file for your instance.
 
 Full details are available in the {cloud}/ec-manage-apm-settings.html[APM user settings] documentation.
-
 
 [float]
 ==== Configure a self installation
@@ -215,7 +210,6 @@ Don't forget to also read about
 {apm-server-ref-v}/securing-apm-server.html[securing APM Server], and
 {apm-server-ref-v}/monitoring.html[monitoring APM Server].
 // end::configure-agents[]
-
 
 [[quick-start-overview]]
 === Quick start development environment

--- a/docs/guide/install-and-run.asciidoc
+++ b/docs/guide/install-and-run.asciidoc
@@ -96,6 +96,8 @@ please see the full {apm-server-ref-v}/index.html[APM Server documentation].
 [[agents]]
 === Step 4: Install APM agents
 
+// This tagged region is reused in the Observability docs.
+// tag::apm-agent[]
 Agents are written in the same language as your service.
 Monitoring a new service requires installing the agent
 and configuring it with the address of your APM Server, a secret token (if necessary), and a service name.
@@ -144,6 +146,8 @@ and configuring it with the address of your APM Server, a secret token (if neces
 
 TIP: Check the {apm-overview-ref-v}/agent-server-compatibility.html[Agent/Server compatibility matrix] to ensure you're using agents that are compatible with your version of Elasticsearch.
 
+
+
 [[choose-service-name]]
 [float]
 ==== Choose a service name
@@ -158,6 +162,8 @@ Make sure you choose a good service name before you get started.
 The service name can only contain alphanumeric characters,
 spaces, underscores, and dashes (must match `^[a-zA-Z0-9 _-]+$`).
 
+// end::apm-agent[]
+
 [[configure-apm]]
 === Step 5: Configure APM
 
@@ -168,6 +174,8 @@ Luckily, there are many different ways to tweak and tune the Elastic ecosystem t
 [float]
 ==== Configure APM agents
 
+// This tagged region is reused in the Observability docs.
+// tag::configure-agents[]
 APM agents have a number of configuration options that allow you to fine tune things like
 environment names, sampling rates, instrumentations, metrics, and more.
 
@@ -187,6 +195,7 @@ a|
 A select number of configuration options can be changed directly in Kibana, without needing to redeploy the Agent.
 See {apm-app-ref}/agent-configuration.html[Agent configuration in Kibana] for more information.
 
+
 [float]
 ==== Configure Elastic Cloud
 
@@ -194,6 +203,7 @@ If you're running APM Server in Elastic cloud, you can configure your own user s
 Any changes are automatically appended to the `apm-server.yml` configuration file for your instance.
 
 Full details are available in the {cloud}/ec-manage-apm-settings.html[APM user settings] documentation.
+
 
 [float]
 ==== Configure a self installation
@@ -204,10 +214,14 @@ More information is available in {apm-server-ref-v}/configuring-howto-apm-server
 Don't forget to also read about
 {apm-server-ref-v}/securing-apm-server.html[securing APM Server], and
 {apm-server-ref-v}/monitoring.html[monitoring APM Server].
+// end::configure-agents[]
+
 
 [[quick-start-overview]]
 === Quick start development environment
 
+// This tagged region is reused in the Observability docs.
+// tag::dev-environment[]
 ifeval::["{release-state}"=="unreleased"]
 
 Version {version} of APM Server has not yet been released.
@@ -258,3 +272,4 @@ or running the Elastic stack on Docker in a production environment, see the foll
 * {stack-gs}/get-started-docker.html[Running the Elastic Stack on Docker]
 
 endif::[]
+// end::dev-environment[]


### PR DESCRIPTION
This PR adds tagged regions to accommodate content reuse in the Observability docs. 