### PR TITLE
Prep golang env for package build test

### DIFF
--- a/.ci/check-packages.groovy
+++ b/.ci/check-packages.groovy
@@ -60,12 +60,14 @@ pipeline {
               deleteDir()
               unstash 'source'
               dir("${BASE_DIR}"){
-                sh(label: 'make batch',
-                  script: """#!/bin/bash
-                    echo "beats_url_base: ${BEATS_URL_BASE}" > run-settings-jenkins.yml
-                    echo "apm_url_base: ${APM_URL_BASE}" >> run-settings-jenkins.yml
-                    echo "version: ${VERSION}" >> run-settings-jenkins.yml
-                    RUN_SETTINGS=jenkins make batch""")
+                withGoEnv(){
+                  sh(label: 'make batch',
+                    script: """#!/bin/bash
+                      echo "beats_url_base: ${BEATS_URL_BASE}" > run-settings-jenkins.yml
+                      echo "apm_url_base: ${APM_URL_BASE}" >> run-settings-jenkins.yml
+                      echo "version: ${VERSION}" >> run-settings-jenkins.yml
+                      RUN_SETTINGS=jenkins make batch""")
+                }
               }
             }
             post {


### PR DESCRIPTION
This corrects an error discovered in the newly provisioned pipeline to smoke test the package installation for apm-server:

https://apm-ci.elastic.co/job/apm-server/job/apm-server-check-packages/1/console