### PR TITLE
Remove specific branch name from packaging job

### DIFF
--- a/.ci/check-packages.groovy
+++ b/.ci/check-packages.groovy
@@ -15,7 +15,7 @@ pipeline {
     // The build parameters
     BEATS_URL_BASE = 'https://storage.googleapis.com/beats-ci-artifacts/snapshots'
     APM_URL_BASE = 'https://storage.googleapis.com/apm-ci-artifacts/jobs/snapshots'
-    BRANCH_NAME = 'master'
+    // BRANCH_NAME = 'master'
   }
   options {
     timeout(time: 4, unit: 'HOURS')


### PR DESCRIPTION
Fix which applies only to the packaging pipeline