### PR TITLE
tests/system: update user-agent pipline test

### DIFF
--- a/tests/system/test_pipelines.py
+++ b/tests/system/test_pipelines.py
@@ -86,7 +86,7 @@ class PipelineRegisterTest(ElasticTest):
                 assert ua["os"]["name"] == "Mac OS X"
                 assert ua["os"]["version"] == "10.10.5"
                 assert ua["os"]["full"] == "Mac OS X 10.10.5"
-                assert ua["device"]["name"] == "Other"
+                assert ua["device"]["name"] == "Mac"
         assert ua_found
 
 


### PR DESCRIPTION
## Motivation/summary

Since the uap-core regexes were updated in
https://github.com/elastic/elasticsearch/pull/59697,
MacOS user-agents are now parsed differently.
Update our test to match the change.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

`make docker-system-tests`

## Related issues

https://github.com/elastic/elasticsearch/pull/59697