### PR TITLE
[7.9] docs: Add agent troubleshooting links (#4024)

### DIFF
--- a/docs/guide/distributed-tracing.asciidoc
+++ b/docs/guide/distributed-tracing.asciidoc
@@ -10,7 +10,7 @@ This is accomplished by tracing all of the requests - from the initial web reque
 This makes finding possible bottlenecks throughout your application much easier and faster.
 Best of all, there's no additional configuration needed for distributed tracing, just ensure you're using the latest version of the applicable {apm-agents-ref}/index.html[agent].
 
-The APM UI in Kibana also supports distributed tracing.
+The APM app in Kibana also supports distributed tracing.
 The Timeline visualization has been redesigned to show all of the transactions from individual services that are connected in a trace:
 
 [role="screenshot"]

--- a/docs/guide/opentracing.asciidoc
+++ b/docs/guide/opentracing.asciidoc
@@ -1,7 +1,7 @@
 [[opentracing]]
 == OpenTracing bridge
 
-All Elastic APM agents have https://opentracing.io/[OpenTracing] compatible bridges.
+Most Elastic APM agents have https://opentracing.io/[OpenTracing] compatible bridges.
 
 The OpenTracing bridge allows you to create Elastic APM <<transactions,transactions>> and <<transaction-spans,spans>> using the OpenTracing API.
 This means you can reuse your existing OpenTracing instrumentation to quickly and easily begin using Elastic APM.

--- a/docs/guide/troubleshooting.asciidoc
+++ b/docs/guide/troubleshooting.asciidoc
@@ -6,11 +6,15 @@ If you run into trouble, there are three places you can look for help.
 [float]
 === Troubleshooting documentation
 
-The APM Server and some of the APM agents have troubleshooting guides:
+The APM Server and each APM agent has a troubleshooting guide:
 
-* {apm-server-ref-v}/troubleshooting.html[Server troubleshooting]
+* {apm-server-ref-v}/troubleshooting.html[APM Server troubleshooting]
+* {apm-dotnet-ref-v}/troubleshooting.html[.NET agent troubleshooting]
+* {apm-go-ref-v}/troubleshooting.html[Go agent troubleshooting]
 * {apm-java-ref-v}/trouble-shooting.html[Java agent troubleshooting]
 * {apm-node-ref-v}/troubleshooting.html[Node.js agent troubleshooting]
+* {apm-py-ref-v}/troubleshooting.html[Python agent troubleshooting]
+* {apm-ruby-ref-v}/debugging.html[Ruby agent troubleshooting]
 * {apm-rum-ref-v}/troubleshooting.html[RUM troubleshooting]
 
 [float]


### PR DESCRIPTION
Backports the following commits to 7.9:
 - docs: Add agent troubleshooting links (#4024)