### PR TITLE
[7.8] docs: Add agent troubleshooting links (#4024)

### DIFF
--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -184,46 +184,44 @@ Let's explore the different types of metadata that Elastic APM offers.
 [[labels-fields]]
 ==== Labels
 
-Labels are used to add *indexed* information to transactions, spans, and errors.
+Labels add *indexed* information to transactions, spans, and errors.
 Indexed means the data is searchable and aggregatable in Elasticsearch.
-Multiple labels can be defined with different key-value pairs.
+Add additional key-value pairs to define multiple labels.
 
 * Indexed: Yes
 * Elasticsearch type: {ref}/object.html[object]
-* Elasticsearch field: `labels` (`context.tags` in APM Server pre-7.0)
-* Applies to <<transactions>> | <<transaction-spans>> | <<errors>>
+* Elasticsearch field: `labels`
+* Applies to: <<transactions>> | <<transaction-spans>> | <<errors>>
 
-Label values can be a string, boolean, or number in APM Server 6.7+.
-Using this API in combination with an older APM Server version leads to validation errors.
-In addition, some agents only support string values at this time.
+Label values can be a string, boolean, or number, although some agents only support string values at this time.
 Because labels for a given key, regardless of agent used, are stored in the same place in Elasticsearch,
 all label values of a given key must have the same data type.
-Multiple data types per key will throw an exception, e.g. `{foo: bar}` and `{foo: 42}`
+Multiple data types per key will throw an exception, for example: `{foo: bar}` and `{foo: 42}` is not allowed.
 
 IMPORTANT: Avoid defining too many user-specified labels.
 Defining too many unique fields in an index is a condition that can lead to a
 {ref}/mapping.html#mapping-limit-settings[mapping explosion].
 
-|===
-|*Labels API links*
-v|*Go:* {apm-go-ref-v}/api.html#context-set-label[`SetLabel`]
-*Java:* {apm-java-ref-v}/public-api.html#api-transaction-add-tag[`addLabel`]
-*.NET:* {apm-dotnet-ref-v}/public-api.html#api-transaction-tags[`Labels`]
-*Node.js:* {apm-node-ref-v}/agent-api.html#apm-set-label[`setLabel`] \| {apm-node-ref-v}/agent-api.html#apm-add-labels[`addLabel`]
-*Python:* {apm-py-ref-v}/api.html#api-label[`elasticapm.label()`]
-*Ruby:* {apm-ruby-ref-v}/api.html#api-agent-set-label[`set_label`]
-*Rum:* {apm-rum-ref-v}/agent-api.html#apm-add-labels[`addLabels`]
-|===
+[float]
+===== Agent API reference
+
+* Go: {apm-go-ref-v}/api.html#context-set-label[`SetLabel`]
+* Java: {apm-java-ref-v}/public-api.html#api-transaction-add-tag[`addLabel`]
+* .NET: {apm-dotnet-ref-v}/public-api.html#api-transaction-tags[`Labels`]
+* Node.js: {apm-node-ref-v}/agent-api.html#apm-set-label[`setLabel`] | {apm-node-ref-v}/agent-api.html#apm-add-labels[`addLabel`]
+* Python: {apm-py-ref-v}/api.html#api-label[`elasticapm.label()`]
+* Ruby:  {apm-ruby-ref-v}/api.html#api-agent-set-label[`set_label`]
+* Rum: {apm-rum-ref-v}/agent-api.html#apm-add-labels[`addLabels`]
 
 [float]
 [[custom-fields]]
 ==== Custom context
 
-Custom context is used to add *non-indexed*,
+Custom context adds *non-indexed*,
 custom contextual information to transactions and errors.
 Non-indexed means the data is not searchable or aggregatable in Elasticsearch,
 and you cannot build dashboards on top of the data.
-This also means you do not have to worry about {ref}/mapping.html#mapping-limit-settings[mapping explosions],
+This also means you don't have to worry about {ref}/mapping.html#mapping-limit-settings[mapping explosions],
 as these fields are not added to the mapping.
 
 Non-indexed information is useful for providing contextual information to help you
@@ -232,40 +230,41 @@ quickly debug performance issues or errors.
 * Indexed: No
 * Elasticsearch type: {ref}/object.html[object]
 * Elasticsearch fields: `transaction.custom` | `error.custom`
-* Applies to <<transactions>> | <<errors>>
+* Applies to: <<transactions>> | <<errors>>
 
-IMPORTANT: Setting a circular object, large object, or a non JSON serializable object can lead to errors.
+IMPORTANT: Setting a circular object, a large object, or a non JSON serializable object can lead to errors.
 
-|===
-|*Custom context API links*
-v|*Go:* {apm-go-ref-v}/api.html#context-set-custom[`SetCustom`]
-*Java:* {apm-java-ref-v}/public-api.html#api-transaction-add-custom-context[`addCustomContext`]
-*.NET:* _coming soon_
-*Node.js:* {apm-node-ref-v}/agent-api.html#apm-set-custom-context[`setCustomContext`]
-*Python:* {apm-py-ref-v}/api.html#api-set-custom-context[`set_custom_context`]
-*Ruby:* {apm-ruby-ref-v}/api.html#api-agent-set-custom-context[`set_custom_context`]
-*Rum:* {apm-rum-ref-v}/agent-api.html#apm-set-custom-context[`setCustomContext`]
-|===
+[float]
+===== Agent API reference
+
+* Go: {apm-go-ref-v}/api.html#context-set-custom[`SetCustom`]
+* Java: {apm-java-ref-v}/public-api.html#api-transaction-add-custom-context[`addCustomContext`]
+* .NET: _coming soon_
+* Node.js: {apm-node-ref-v}/agent-api.html#apm-set-custom-context[`setCustomContext`]
+* Python: {apm-py-ref-v}/api.html#api-set-custom-context[`set_custom_context`]
+* Ruby: {apm-ruby-ref-v}/api.html#api-agent-set-custom-context[`set_custom_context`]
+* Rum: {apm-rum-ref-v}/agent-api.html#apm-set-custom-context[`setCustomContext`]
 
 [float]
 [[user-fields]]
 ==== User context
 
-User context is used to add *indexed* user information to transactions and errors.
+User context adds *indexed* user information to transactions and errors.
 Indexed means the data is searchable and aggregatable in Elasticsearch.
 
 * Indexed: Yes
-* Elasticsearch type: {ref}/keyword.html[keywords]
+* Elasticsearch type: {ref}/keyword.html[keyword]
 * Elasticsearch fields: `user.email` | `user.name` | `user.id`
-* Applies to <<transactions>> | <<errors>>
+* Applies to: <<transactions>> | <<errors>>
 
-|===
-|*User context API links*
-v|*Go:* {apm-go-ref-v}/api.html#context-set-username[`SetUsername`] \| {apm-go-ref-v}/api.html#context-set-user-id[`SetUserID`] \| {apm-go-ref-v}/api.html#context-set-user-email[`SetUserEmail`]
-*Java:* {apm-java-ref-v}/public-api.html#api-transaction-set-user[`setUser`]
-*.NET* _coming soon_
-*Node.js:* {apm-node-ref-v}/agent-api.html#apm-set-user-context[`setUserContext`]
-*Python:* {apm-py-ref-v}/api.html#api-set-user-context[`set_user_context`]
-*Ruby:* {apm-ruby-ref-v}/api.html#api-agent-set-user[`set_user`]
-*Rum:* {apm-rum-ref-v}/agent-api.html#apm-set-user-context[`setUserContext`]
-|===
+[float]
+===== Agent API reference
+
+* Go: {apm-go-ref-v}/api.html#context-set-username[`SetUsername`] | {apm-go-ref-v}/api.html#context-set-user-id[`SetUserID`] |
+{apm-go-ref-v}/api.html#context-set-user-email[`SetUserEmail`]
+* Java: {apm-java-ref-v}/public-api.html#api-transaction-set-user[`setUser`]
+* .NET _coming soon_
+* Node.js: {apm-node-ref-v}/agent-api.html#apm-set-user-context[`setUserContext`]
+* Python: {apm-py-ref-v}/api.html#api-set-user-context[`set_user_context`]
+* Ruby: {apm-ruby-ref-v}/api.html#api-agent-set-user[`set_user`]
+* Rum: {apm-rum-ref-v}/agent-api.html#apm-set-user-context[`setUserContext`]

--- a/docs/guide/distributed-tracing.asciidoc
+++ b/docs/guide/distributed-tracing.asciidoc
@@ -10,7 +10,7 @@ This is accomplished by tracing all of the requests - from the initial web reque
 This makes finding possible bottlenecks throughout your application much easier and faster.
 Best of all, there's no additional configuration needed for distributed tracing, just ensure you're using the latest version of the applicable {apm-agents-ref}/index.html[agent].
 
-The APM UI in Kibana also supports distributed tracing.
+The APM app in Kibana also supports distributed tracing.
 The Timeline visualization has been redesigned to show all of the transactions from individual services that are connected in a trace:
 
 [role="screenshot"]

--- a/docs/guide/opentracing.asciidoc
+++ b/docs/guide/opentracing.asciidoc
@@ -1,7 +1,7 @@
 [[opentracing]]
 == OpenTracing bridge
 
-All Elastic APM agents have https://opentracing.io/[OpenTracing] compatible bridges.
+Most Elastic APM agents have https://opentracing.io/[OpenTracing] compatible bridges.
 
 The OpenTracing bridge allows you to create Elastic APM <<transactions,transactions>> and <<transaction-spans,spans>> using the OpenTracing API.
 This means you can reuse your existing OpenTracing instrumentation to quickly and easily begin using Elastic APM.

--- a/docs/guide/troubleshooting.asciidoc
+++ b/docs/guide/troubleshooting.asciidoc
@@ -6,11 +6,15 @@ If you run into trouble, there are three places you can look for help.
 [float]
 === Troubleshooting documentation
 
-The APM Server and some of the APM agents have troubleshooting guides:
+The APM Server and each APM agent has a troubleshooting guide:
 
-* {apm-server-ref-v}/troubleshooting.html[Server troubleshooting]
+* {apm-server-ref-v}/troubleshooting.html[APM Server troubleshooting]
+* {apm-dotnet-ref-v}/troubleshooting.html[.NET agent troubleshooting]
+* {apm-go-ref-v}/troubleshooting.html[Go agent troubleshooting]
 * {apm-java-ref-v}/trouble-shooting.html[Java agent troubleshooting]
 * {apm-node-ref-v}/troubleshooting.html[Node.js agent troubleshooting]
+* {apm-py-ref-v}/troubleshooting.html[Python agent troubleshooting]
+* {apm-ruby-ref-v}/debugging.html[Ruby agent troubleshooting]
 * {apm-rum-ref-v}/troubleshooting.html[RUM troubleshooting]
 
 [float]


### PR DESCRIPTION
Backports the following commits to 7.9:
 - docs: Add agent troubleshooting links (#4024)
 - docs: fix bug in metadata docs (#3728)