### PR TITLE
[7.x] [docs] 7.9 release notes and breaking changes (#4033)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,3 +1,5 @@
+include::./changelogs/head.asciidoc[]
+include::./changelogs/7.9.asciidoc[]
 include::./changelogs/7.8.asciidoc[]
 include::./changelogs/7.7.asciidoc[]
 include::./changelogs/7.6.asciidoc[]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,4 +1,3 @@
-include::./changelogs/head.asciidoc[]
 include::./changelogs/7.9.asciidoc[]
 include::./changelogs/7.8.asciidoc[]
 include::./changelogs/7.7.asciidoc[]

--- a/changelogs/7.9.asciidoc
+++ b/changelogs/7.9.asciidoc
@@ -1,0 +1,32 @@
+[[release-notes-7.9]]
+== APM Server version 7.9
+
+https://github.com/elastic/apm-server/compare/7.8\...7.9[View commits]
+
+* <<release-notes-7.9.0>>
+
+[float]
+[[release-notes-7.9.0]]
+=== APM Server version 7.9.0
+
+https://github.com/elastic/apm-server/compare/v7.8.0\...v7.9.0[View commits]
+
+[float]
+==== Bug fixes
+* Ensure unique names in dynamic templates for fields {pull}3832[3832]
+* Process `user_agent` and `client.ip` for RUM Intake v3 requests {pull}3943[3943]
+
+[float]
+==== Added
+* Support configurable response headers for the RUM endpoints {pull}3820[3820]
+* Support custom ILM index suffix {pull}3826[3826],{pull}3905[3905]
+* Jaeger traceIds/spanIds are formatted without leading zeros {pull}3849[3849]
+* Index Page URL and referer as ECS fields {pull}3857[3857]
+* Map the Jaeger attribute message_bus.destination to the Elastic APM type messaging {pull}3884[3884]
+* Added user_agent.name to grouping key for page-load transaction metrics {pull}3886[3886]
+* Map the Jaeger attribute peer.service to span.destination.service.name {pull}3897[3897]
+* Add timeseries.instance to transaction.duration.histogram docs {pull}3904[3904]
+* Uses `instrumentation` config and APM tracer from libbeat, deprecating `apm-server.instrumentation` {pull}3836[3836]
+* Scale Jaeger transaction counts by inverse sampling rate in histogram metrics {pull}3722[3722]
+* Use peer.hostname for destination.address if peer.address is not given on Jaeger span {pull}3969[3969]
+* Upgrade Go to 1.14.4 {pull}3961[3961]

--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -4,6 +4,10 @@ APM Server is built on top of {beats-ref}/index.html[libbeat].
 As such, any breaking change in libbeat is also considered to be a breaking change in APM Server.
 
 [float]
+=== 7.9
+There are no breaking changes in APM Server.
+
+[float]
 === 7.8
 There are no breaking changes in APM Server.
 

--- a/docs/guide/apm-breaking-changes.asciidoc
+++ b/docs/guide/apm-breaking-changes.asciidoc
@@ -3,6 +3,7 @@
 
 This section discusses the changes that you need to be aware of when migrating your application from one version of APM to another.
 
+* <<breaking-7.9.0>>
 * <<breaking-7.8.0>>
 * <<breaking-7.7.0>>
 * <<breaking-7.6.0>>
@@ -25,6 +26,13 @@ Also see <<apm-release-notes>>.
 // tag::notable-v8-breaking-changes[]
 
 // end::notable-v8-breaking-changes[]
+
+[[breaking-7.9.0]]
+=== 7.9.0 APM Breaking changes
+
+// tag::notable-v79-breaking-changes[]
+No breaking changes.
+// end::notable-v79-breaking-changes[]
 
 [[breaking-7.8.0]]
 === 7.8.0 APM Breaking changes

--- a/docs/guide/apm-release-notes.asciidoc
+++ b/docs/guide/apm-release-notes.asciidoc
@@ -7,6 +7,7 @@ For a full list of changes, see the
 {apm-server-ref-v}/release-notes.html[APM Server Release Notes] or the
 {kibana-ref}/release-notes.html[Kibana Release Notes].
 
+* <<release-highlights-7.9.0>>
 * <<release-highlights-7.8.0>>
 * <<release-highlights-7.7.0>>
 * <<release-highlights-7.6.0>>
@@ -28,6 +29,13 @@ For a full list of changes, see the
 // tag::notable-v8-highlights[]
 
 // end::notable-v8-highlights[]
+
+[[release-highlights-7.9.0]]
+=== APM version 7.9.0
+
+// tag::notable-v79-highlights[]
+// Coming soon...
+// end::notable-v79-highlights[]
 
 [[release-highlights-7.8.0]]
 === APM version 7.8.0

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -10,6 +10,7 @@
 --
 This following sections summarizes the changes in each release.
 
+* <<release-notes-7.9>>
 * <<release-notes-7.8>>
 * <<release-notes-7.7>>
 * <<release-notes-7.6>>


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [docs] 7.9 release notes and breaking changes (#4033)