### PR TITLE
Apply Py2 fix for OS X for packaging tests

### DIFF
--- a/.ci/check-packages.groovy
+++ b/.ci/check-packages.groovy
@@ -57,6 +57,8 @@ pipeline {
           stage('Test'){
             options { skipDefaultCheckout() }
             steps {
+              // See https://stackoverflow.com/questions/59269208/errorrootcode-for-hash-md5-was-not-found-when-using-any-hg-mercurial-command
+              sh(label: "Switching OpenSSL versions to fix Py2", script: "brew switch openssl 1.0.2t")
               deleteDir()
               unstash 'source'
               dir("${BASE_DIR}"){


### PR DESCRIPTION
This attempts to work around cases where the Py2 installation with Brew is not functional.

