### PR TITLE
Decouple event inputs from transformation

### DIFF
--- a/beater/api/asset/sourcemap/handler.go
+++ b/beater/api/asset/sourcemap/handler.go
@@ -30,7 +30,6 @@ import (
 	"github.com/elastic/apm-server/beater/request"
 	"github.com/elastic/apm-server/processor/asset"
 	"github.com/elastic/apm-server/publish"
-	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/apm-server/utility"
 )
 
@@ -44,7 +43,7 @@ var (
 type RequestDecoder func(req *http.Request) (map[string]interface{}, error)
 
 // Handler returns a request.Handler for managing asset requests.
-func Handler(dec RequestDecoder, processor asset.Processor, cfg transform.Config, report publish.Reporter) request.Handler {
+func Handler(dec RequestDecoder, processor asset.Processor, report publish.Reporter) request.Handler {
 	return func(c *request.Context) {
 		if c.Request.Method != "POST" {
 			c.Result.SetDefault(request.IDResponseErrorsMethodNotAllowed)
@@ -76,8 +75,7 @@ func Handler(dec RequestDecoder, processor asset.Processor, cfg transform.Config
 			return
 		}
 
-		tctx := &transform.Context{Config: cfg}
-		req := publish.PendingReq{Transformables: transformables, Tcontext: tctx}
+		req := publish.PendingReq{Transformables: transformables}
 		span, ctx := apm.StartSpan(c.Request.Context(), "Send", "Reporter")
 		defer span.End()
 		req.Trace = !span.Dropped()

--- a/beater/api/asset/sourcemap/handler_test.go
+++ b/beater/api/asset/sourcemap/handler_test.go
@@ -137,7 +137,7 @@ func (tc *testcaseT) setup() {
 	}
 	c := request.NewContext()
 	c.Reset(tc.w, tc.r)
-	h := Handler(tc.dec, tc.processor, transform.Config{}, tc.reporter)
+	h := Handler(tc.dec, tc.processor, tc.reporter)
 	h(c)
 }
 

--- a/beater/api/intake/handler_test.go
+++ b/beater/api/intake/handler_test.go
@@ -168,7 +168,7 @@ type testcaseIntakeHandler struct {
 
 func (tc *testcaseIntakeHandler) setup(t *testing.T) {
 	if tc.processor == nil {
-		cfg := config.DefaultConfig("7.0.0")
+		cfg := config.DefaultConfig()
 		tc.processor = stream.BackendProcessor(cfg)
 	}
 	if tc.reporter == nil {

--- a/beater/api/mux.go
+++ b/beater/api/mux.go
@@ -129,7 +129,7 @@ func rumIntakeHandler(cfg *config.Config, _ *authorization.Builder, reporter pub
 	if err != nil {
 		return nil, err
 	}
-	h := intake.Handler(stream.RUMProcessor(cfg, tcfg), reporter)
+	h := intake.Handler(stream.RUMV2Processor(cfg, tcfg), reporter)
 	return middleware.Wrap(h, rumMiddleware(cfg, nil, intake.MonitoringMap)...)
 }
 

--- a/beater/api/mux_config_agent_test.go
+++ b/beater/api/mux_config_agent_test.go
@@ -56,7 +56,7 @@ func TestConfigAgentHandler_AuthorizationMiddleware(t *testing.T) {
 
 func TestConfigAgentHandler_KillSwitchMiddleware(t *testing.T) {
 	t.Run("Off", func(t *testing.T) {
-		rec, err := requestToMuxerWithPattern(config.DefaultConfig(beatertest.MockBeatVersion()), AgentConfigPath)
+		rec, err := requestToMuxerWithPattern(config.DefaultConfig(), AgentConfigPath)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusForbidden, rec.Code)
 		approvals.AssertApproveResult(t, approvalPathConfigAgent(t.Name()), rec.Body.Bytes())
@@ -96,7 +96,7 @@ func TestConfigAgentHandler_MonitoringMiddleware(t *testing.T) {
 }
 
 func configEnabledConfigAgent() *config.Config {
-	cfg := config.DefaultConfig(beatertest.MockBeatVersion())
+	cfg := config.DefaultConfig()
 	cfg.Kibana.Enabled = true
 	cfg.Kibana.Host = "localhost:foo"
 	return cfg

--- a/beater/api/mux_intake_backend_test.go
+++ b/beater/api/mux_intake_backend_test.go
@@ -35,7 +35,7 @@ import (
 
 func TestIntakeBackendHandler_AuthorizationMiddleware(t *testing.T) {
 	t.Run("Unauthorized", func(t *testing.T) {
-		cfg := config.DefaultConfig(beatertest.MockBeatVersion())
+		cfg := config.DefaultConfig()
 		cfg.SecretToken = "1234"
 		rec, err := requestToMuxerWithPattern(cfg, IntakePath)
 		require.NoError(t, err)
@@ -45,7 +45,7 @@ func TestIntakeBackendHandler_AuthorizationMiddleware(t *testing.T) {
 	})
 
 	t.Run("Authorized", func(t *testing.T) {
-		cfg := config.DefaultConfig(beatertest.MockBeatVersion())
+		cfg := config.DefaultConfig()
 		cfg.SecretToken = "1234"
 		h := map[string]string{headers.Authorization: "Bearer 1234"}
 		rec, err := requestToMuxerWithHeader(cfg, IntakePath, http.MethodGet, h)

--- a/beater/api/mux_intake_rum_test.go
+++ b/beater/api/mux_intake_rum_test.go
@@ -77,7 +77,7 @@ func TestRUMHandler_NoAuthorizationRequired(t *testing.T) {
 
 func TestRUMHandler_KillSwitchMiddleware(t *testing.T) {
 	t.Run("OffRum", func(t *testing.T) {
-		rec, err := requestToMuxerWithPattern(config.DefaultConfig(beatertest.MockBeatVersion()), IntakeRUMPath)
+		rec, err := requestToMuxerWithPattern(config.DefaultConfig(), IntakeRUMPath)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusForbidden, rec.Code)
 		approvals.AssertApproveResult(t, approvalPathIntakeRUM(t.Name()), rec.Body.Bytes())
@@ -104,7 +104,7 @@ func TestRUMHandler_CORSMiddleware(t *testing.T) {
 }
 
 func TestIntakeRUMHandler_PanicMiddleware(t *testing.T) {
-	h, err := rumIntakeHandler(config.DefaultConfig(beatertest.MockBeatVersion()), nil, beatertest.NilReporter)
+	h, err := rumIntakeHandler(config.DefaultConfig(), nil, beatertest.NilReporter)
 	require.NoError(t, err)
 	rec := &beatertest.WriterPanicOnce{}
 	c := request.NewContext()
@@ -115,7 +115,7 @@ func TestIntakeRUMHandler_PanicMiddleware(t *testing.T) {
 }
 
 func TestRumHandler_MonitoringMiddleware(t *testing.T) {
-	h, err := rumIntakeHandler(config.DefaultConfig(beatertest.MockBeatVersion()), nil, beatertest.NilReporter)
+	h, err := rumIntakeHandler(config.DefaultConfig(), nil, beatertest.NilReporter)
 	require.NoError(t, err)
 	c, _ := beatertest.ContextWithResponseRecorder(http.MethodPost, "/")
 	// send GET request resulting in 403 Forbidden error
@@ -130,7 +130,7 @@ func TestRumHandler_MonitoringMiddleware(t *testing.T) {
 }
 
 func cfgEnabledRUM() *config.Config {
-	cfg := config.DefaultConfig(beatertest.MockBeatVersion())
+	cfg := config.DefaultConfig()
 	t := true
 	cfg.RumConfig.Enabled = &t
 	return cfg

--- a/beater/api/mux_root_test.go
+++ b/beater/api/mux_root_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestRootHandler_AuthorizationMiddleware(t *testing.T) {
-	cfg := config.DefaultConfig(beatertest.MockBeatVersion())
+	cfg := config.DefaultConfig()
 	cfg.SecretToken = "1234"
 
 	t.Run("No auth", func(t *testing.T) {

--- a/beater/api/mux_sourcemap_handler_test.go
+++ b/beater/api/mux_sourcemap_handler_test.go
@@ -56,18 +56,18 @@ func TestSourcemapHandler_AuthorizationMiddleware(t *testing.T) {
 
 func TestSourcemapHandler_KillSwitchMiddleware(t *testing.T) {
 	t.Run("OffRum", func(t *testing.T) {
-		rec, err := requestToMuxerWithPattern(config.DefaultConfig(beatertest.MockBeatVersion()), AssetSourcemapPath)
+		rec, err := requestToMuxerWithPattern(config.DefaultConfig(), AssetSourcemapPath)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusForbidden, rec.Code)
 		approvals.AssertApproveResult(t, approvalPathAsset(t.Name()), rec.Body.Bytes())
 	})
 
 	t.Run("OffSourcemap", func(t *testing.T) {
-		cfg := config.DefaultConfig(beatertest.MockBeatVersion())
+		cfg := config.DefaultConfig()
 		rum := true
 		cfg.RumConfig.Enabled = &rum
 		cfg.RumConfig.SourceMapping.Enabled = new(bool)
-		rec, err := requestToMuxerWithPattern(config.DefaultConfig(beatertest.MockBeatVersion()), AssetSourcemapPath)
+		rec, err := requestToMuxerWithPattern(config.DefaultConfig(), AssetSourcemapPath)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusForbidden, rec.Code)
 		approvals.AssertApproveResult(t, approvalPathAsset(t.Name()), rec.Body.Bytes())

--- a/beater/api/mux_test.go
+++ b/beater/api/mux_test.go
@@ -55,7 +55,7 @@ func requestToMuxer(cfg *config.Config, r *http.Request) (*httptest.ResponseReco
 }
 
 func testHandler(t *testing.T, fn func(*config.Config, *authorization.Builder, publish.Reporter) (request.Handler, error)) request.Handler {
-	cfg := config.DefaultConfig(beatertest.MockBeatVersion())
+	cfg := config.DefaultConfig()
 	builder, err := authorization.NewBuilder(cfg)
 	require.NoError(t, err)
 	h, err := fn(cfg, builder, beatertest.NilReporter)

--- a/beater/api/profile/handler.go
+++ b/beater/api/profile/handler.go
@@ -57,10 +57,7 @@ const (
 )
 
 // Handler returns a request.Handler for managing profile requests.
-func Handler(
-	transformConfig transform.Config,
-	report publish.Reporter,
-) request.Handler {
+func Handler(report publish.Reporter) request.Handler {
 	handle := func(c *request.Context) (*result, error) {
 		if c.Request.Method != http.MethodPost {
 			return nil, requestError{
@@ -82,8 +79,6 @@ func Handler(
 				err: errors.New("rate limit exceeded"),
 			}
 		}
-
-		tctx := &transform.Context{Config: transformConfig}
 
 		var totalLimitRemaining int64 = profileContentLengthLimit
 		var profiles []*pprof_profile.Profile
@@ -185,10 +180,7 @@ func Handler(
 			}
 		}
 
-		if err := report(c.Request.Context(), publish.PendingReq{
-			Transformables: transformables,
-			Tcontext:       tctx,
-		}); err != nil {
+		if err := report(c.Request.Context(), publish.PendingReq{Transformables: transformables}); err != nil {
 			switch err {
 			case publish.ErrChannelClosed:
 				return nil, requestError{

--- a/beater/api/profile/handler_test.go
+++ b/beater/api/profile/handler_test.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/elastic/apm-server/beater/api/ratelimit"
 	"github.com/elastic/apm-server/model"
-	"github.com/elastic/apm-server/transform"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -201,7 +200,7 @@ func TestHandler(t *testing.T) {
 			if tc.rateLimit != nil {
 				tc.c.RateLimiter = tc.rateLimit.ForIP(&http.Request{})
 			}
-			Handler(transform.Config{}, tc.reporter(t))(tc.c)
+			Handler(tc.reporter(t))(tc.c)
 
 			assert.Equal(t, string(tc.id), string(tc.c.Result.ID))
 			resultStatus := request.MapResultIDToStatus[tc.id]

--- a/beater/authorization/builder_test.go
+++ b/beater/authorization/builder_test.go
@@ -41,7 +41,7 @@ func TestBuilder(t *testing.T) {
 	} {
 
 		setup := func() *Builder {
-			cfg := config.DefaultConfig("9.9.9")
+			cfg := config.DefaultConfig()
 
 			if tc.withBearer {
 				cfg.SecretToken = "xvz"

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -20,9 +20,9 @@ package beater
 import (
 	"context"
 	"net"
+	"regexp"
+	"strings"
 	"sync"
-
-	"github.com/elastic/beats/v7/libbeat/instrumentation"
 
 	"github.com/pkg/errors"
 	"go.elastic.co/apm"
@@ -32,14 +32,18 @@ import (
 	"github.com/elastic/beats/v7/libbeat/cfgfile"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/esleg/eslegclient"
+	"github.com/elastic/beats/v7/libbeat/instrumentation"
 	"github.com/elastic/beats/v7/libbeat/logp"
-	"github.com/elastic/beats/v7/libbeat/outputs/elasticsearch"
+	esoutput "github.com/elastic/beats/v7/libbeat/outputs/elasticsearch"
 
 	"github.com/elastic/apm-server/beater/config"
+	"github.com/elastic/apm-server/elasticsearch"
 	"github.com/elastic/apm-server/ingest/pipeline"
 	logs "github.com/elastic/apm-server/log"
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/apm-server/sampling"
+	"github.com/elastic/apm-server/sourcemap"
+	"github.com/elastic/apm-server/transform"
 )
 
 var (
@@ -68,7 +72,7 @@ func NewCreator(args CreatorParams) beat.Creator {
 			esOutputCfg = b.Config.Output.Config()
 		}
 
-		beaterConfig, err := config.NewConfig(b.Info.Version, ucfg, esOutputCfg)
+		beaterConfig, err := config.NewConfig(ucfg, esOutputCfg)
 		if err != nil {
 			return nil, err
 		}
@@ -149,10 +153,7 @@ func (bt *beater) Run(b *beat.Beat) error {
 		runServer = bt.wrapRunServer(runServer)
 	}
 
-	publisher, err := publish.NewPublisher(b.Publisher, tracer, &publish.PublisherConfig{
-		Info:     b.Info,
-		Pipeline: bt.config.Pipeline,
-	})
+	publisher, err := newPublisher(b, bt.config, tracer)
 	if err != nil {
 		return err
 	}
@@ -226,7 +227,7 @@ func (bt *beater) registerPipelineCallback(b *beat.Beat) error {
 		return pipeline.RegisterPipelines(conn, overwrite, path)
 	}
 	// ensure pipelines are registered when new ES connection is established.
-	_, err := elasticsearch.RegisterConnectCallback(func(conn *eslegclient.Connection) error {
+	_, err := esoutput.RegisterConnectCallback(func(conn *eslegclient.Connection) error {
 		return pipeline.RegisterPipelines(conn, overwrite, path)
 	})
 	return err
@@ -317,4 +318,44 @@ func runServerWithTracerServer(runServer RunServerFunc, tracerServer *tracerServ
 		})
 		return g.Wait()
 	}
+}
+
+func newPublisher(b *beat.Beat, cfg *config.Config, tracer *apm.Tracer) (*publish.Publisher, error) {
+	transformConfig, err := newTransformConfig(b.Info, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return publish.NewPublisher(b.Publisher, tracer, &publish.PublisherConfig{
+		Info:            b.Info,
+		Pipeline:        cfg.Pipeline,
+		TransformConfig: transformConfig,
+	})
+}
+
+func newTransformConfig(beatInfo beat.Info, cfg *config.Config) (*transform.Config, error) {
+	transformConfig := &transform.Config{
+		RUM: transform.RUMConfig{
+			LibraryPattern:      regexp.MustCompile(cfg.RumConfig.LibraryPattern),
+			ExcludeFromGrouping: regexp.MustCompile(cfg.RumConfig.ExcludeFromGrouping),
+		},
+	}
+
+	if cfg.RumConfig.IsEnabled() && cfg.RumConfig.SourceMapping.IsEnabled() && cfg.RumConfig.SourceMapping.ESConfig != nil {
+		store, err := newSourcemapStore(beatInfo, cfg.RumConfig.SourceMapping)
+		if err != nil {
+			return nil, err
+		}
+		transformConfig.RUM.SourcemapStore = store
+	}
+
+	return transformConfig, nil
+}
+
+func newSourcemapStore(beatInfo beat.Info, cfg *config.SourceMapping) (*sourcemap.Store, error) {
+	esClient, err := elasticsearch.NewClient(cfg.ESConfig)
+	if err != nil {
+		return nil, err
+	}
+	index := strings.ReplaceAll(cfg.IndexPattern, "%{[observer.version]}", beatInfo.Version)
+	return sourcemap.NewStore(esClient, index, cfg.Cache.Expiration)
 }

--- a/beater/config/aggregation_test.go
+++ b/beater/config/aggregation_test.go
@@ -59,7 +59,7 @@ func TestAggregationConfigInvalid(t *testing.T) {
 		expect: "Error processing configuration: requires value > 5 accessing 'aggregation.hdrhistogram_significant_figures'",
 	}} {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := NewConfig("9.9.9", common.MustNewConfigFrom(map[string]interface{}{
+			_, err := NewConfig(common.MustNewConfigFrom(map[string]interface{}{
 				test.key: test.value,
 			}), nil)
 			require.Error(t, err)
@@ -69,7 +69,7 @@ func TestAggregationConfigInvalid(t *testing.T) {
 }
 
 func TestAggregationConfigDefault(t *testing.T) {
-	cfg, err := NewConfig("9.9.9", common.MustNewConfigFrom(map[string]interface{}{}), nil)
+	cfg, err := NewConfig(common.MustNewConfigFrom(map[string]interface{}{}), nil)
 	require.NoError(t, err)
 	assert.Equal(t, defaultAggregationConfig(), cfg.Aggregation)
 }

--- a/beater/config/config.go
+++ b/beater/config/config.go
@@ -19,7 +19,6 @@ package config
 
 import (
 	"net"
-	"regexp"
 	"strings"
 	"time"
 
@@ -38,10 +37,6 @@ const (
 	DefaultPort = "8200"
 
 	msgInvalidConfigAgentCfg = "invalid value for `apm-server.agent.config.cache.expiration`, only accepting full seconds"
-)
-
-var (
-	regexObserverVersion = regexp.MustCompile("%.*{.*observer.version.?}")
 )
 
 type KibanaConfig struct {
@@ -111,9 +106,9 @@ type Cache struct {
 }
 
 // NewConfig creates a Config struct based on the default config and the given input params
-func NewConfig(version string, ucfg *common.Config, outputESCfg *common.Config) (*Config, error) {
+func NewConfig(ucfg *common.Config, outputESCfg *common.Config) (*Config, error) {
 	logger := logp.NewLogger(logs.Config)
-	c := DefaultConfig(version)
+	c := DefaultConfig()
 	if err := ucfg.Unpack(c); err != nil {
 		return nil, errors.Wrap(err, "Error processing configuration")
 	}
@@ -163,7 +158,7 @@ func (c *ExpvarConfig) IsEnabled() bool {
 }
 
 // DefaultConfig returns a config with default settings for `apm-server` config options.
-func DefaultConfig(beatVersion string) *Config {
+func DefaultConfig() *Config {
 	return &Config{
 		Host:            net.JoinHostPort("localhost", DefaultPort),
 		MaxHeaderSize:   1 * 1024 * 1024, // 1mb
@@ -178,7 +173,7 @@ func DefaultConfig(beatVersion string) *Config {
 			Enabled: new(bool),
 			URL:     "/debug/vars",
 		},
-		RumConfig:    defaultRum(beatVersion),
+		RumConfig:    defaultRum(),
 		Register:     defaultRegisterConfig(true),
 		Mode:         ModeProduction,
 		Kibana:       defaultKibanaConfig(),

--- a/beater/config/instrumentation_test.go
+++ b/beater/config/instrumentation_test.go
@@ -30,17 +30,15 @@ import (
 
 func TestNonzeroHosts(t *testing.T) {
 	t.Run("ZeroHost", func(t *testing.T) {
-		cfg, err := NewConfig("9.9.9",
-			common.MustNewConfigFrom(map[string]interface{}{
-				"instrumentation.enabled": true, "instrumentation.hosts": []string{""}}), nil)
+		cfg, err := NewConfig(common.MustNewConfigFrom(map[string]interface{}{
+			"instrumentation.enabled": true, "instrumentation.hosts": []string{""}}), nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), ucfg.ErrZeroValue.Error())
 		assert.Nil(t, cfg)
 	})
 
 	t.Run("Valid", func(t *testing.T) {
-		cfg, err := NewConfig("9.9.9",
-			common.MustNewConfigFrom(map[string]interface{}{"instrumentation.enabled": true}), nil)
+		cfg, err := NewConfig(common.MustNewConfigFrom(map[string]interface{}{"instrumentation.enabled": true}), nil)
 		require.NoError(t, err)
 		assert.True(t, *cfg.SelfInstrumentation.Enabled)
 		assert.Empty(t, cfg.SelfInstrumentation.Hosts)

--- a/beater/config/rum_test.go
+++ b/beater/config/rum_test.go
@@ -18,13 +18,9 @@
 package config
 
 import (
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/elastic/apm-server/elasticsearch"
 )
 
 func TestIsRumEnabled(t *testing.T) {
@@ -42,48 +38,6 @@ func TestIsRumEnabled(t *testing.T) {
 }
 
 func TestDefaultRum(t *testing.T) {
-	c := DefaultConfig("7.0.0")
-	assert.Equal(t, defaultRum("7.0.0"), c.RumConfig)
-}
-
-func TestMemoizedSourcemapMapper(t *testing.T) {
-	truthy := true
-	esConfig := elasticsearch.Config{Hosts: []string{"localhost:0"}}
-	mapping := SourceMapping{
-		Cache:        &Cache{Expiration: 1 * time.Minute},
-		IndexPattern: "apm-rum-test*",
-		ESConfig:     &esConfig,
-	}
-
-	for idx, td := range []struct {
-		c      *Config
-		mapper bool
-		e      error
-	}{
-		{c: &Config{RumConfig: &RumConfig{}}, mapper: false, e: nil},
-		{c: &Config{RumConfig: &RumConfig{Enabled: new(bool)}}, mapper: false, e: nil},
-		{c: &Config{RumConfig: &RumConfig{Enabled: &truthy}}, mapper: false, e: nil},
-		{c: &Config{RumConfig: &RumConfig{SourceMapping: &mapping}}, mapper: false, e: nil},
-		{c: &Config{
-			RumConfig: &RumConfig{
-				Enabled: &truthy,
-				SourceMapping: &SourceMapping{
-					Cache:        &Cache{Expiration: 1 * time.Minute},
-					IndexPattern: "apm-rum-test*",
-				},
-			}},
-			mapper: false,
-			e:      nil},
-		{c: &Config{RumConfig: &RumConfig{Enabled: &truthy, SourceMapping: &mapping}},
-			mapper: true,
-			e:      nil},
-	} {
-		mapper, e := td.c.RumConfig.MemoizedSourcemapStore()
-		if td.mapper {
-			assert.NotNil(t, mapper, fmt.Sprintf("Test number <%v> failed", idx))
-		} else {
-			assert.Nil(t, mapper, fmt.Sprintf("Test number <%v> failed", idx))
-		}
-		assert.Equal(t, td.e, e)
-	}
+	c := DefaultConfig()
+	assert.Equal(t, defaultRum(), c.RumConfig)
 }

--- a/beater/jaeger/server.go
+++ b/beater/jaeger/server.go
@@ -38,7 +38,6 @@ import (
 	"github.com/elastic/apm-server/kibana"
 	processor "github.com/elastic/apm-server/processor/otel"
 	"github.com/elastic/apm-server/publish"
-	"github.com/elastic/apm-server/transform"
 )
 
 // Server manages Jaeger gRPC and HTTP servers, providing methods for starting and stopping them.
@@ -59,10 +58,7 @@ func NewServer(logger *logp.Logger, cfg *config.Config, tracer *apm.Tracer, repo
 	if !cfg.JaegerConfig.GRPC.Enabled && !cfg.JaegerConfig.HTTP.Enabled {
 		return nil, nil
 	}
-	traceConsumer := &processor.Consumer{
-		Reporter:        reporter,
-		TransformConfig: transform.Config{},
-	}
+	traceConsumer := &processor.Consumer{Reporter: reporter}
 
 	srv := &Server{logger: logger}
 	if cfg.JaegerConfig.GRPC.Enabled {

--- a/beater/jaeger/server_test.go
+++ b/beater/jaeger/server_test.go
@@ -47,10 +47,11 @@ import (
 	"github.com/elastic/apm-server/beater/config"
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/apm-server/tests/approvals"
+	"github.com/elastic/apm-server/transform"
 )
 
 func TestApprovals(t *testing.T) {
-	cfg := config.DefaultConfig("8.0.0")
+	cfg := config.DefaultConfig()
 	cfg.JaegerConfig.GRPC.Enabled = true
 	cfg.JaegerConfig.GRPC.Host = "localhost:0"
 	cfg.JaegerConfig.HTTP.Enabled = true
@@ -87,11 +88,11 @@ func TestApprovals(t *testing.T) {
 func TestServerIntegration(t *testing.T) {
 	for name, tc := range map[string]testcase{
 		"default config": {
-			cfg: config.DefaultConfig("9.9.9"),
+			cfg: config.DefaultConfig(),
 		},
 		"default config with Jaeger gRPC enabled": {
 			cfg: func() *config.Config {
-				cfg := config.DefaultConfig("8.0.0")
+				cfg := config.DefaultConfig()
 				cfg.JaegerConfig.GRPC.Enabled = true
 				cfg.JaegerConfig.GRPC.Host = "localhost:0"
 				return cfg
@@ -100,7 +101,7 @@ func TestServerIntegration(t *testing.T) {
 		},
 		"default config with Jaeger gRPC and Kibana enabled": {
 			cfg: func() *config.Config {
-				cfg := config.DefaultConfig("8.0.0")
+				cfg := config.DefaultConfig()
 				cfg.JaegerConfig.GRPC.Enabled = true
 				cfg.JaegerConfig.GRPC.Host = "localhost:0"
 				cfg.Kibana.Enabled = true
@@ -111,7 +112,7 @@ func TestServerIntegration(t *testing.T) {
 		},
 		"default config with Jaeger HTTP enabled": {
 			cfg: func() *config.Config {
-				cfg := config.DefaultConfig("8.0.0")
+				cfg := config.DefaultConfig()
 				cfg.JaegerConfig.HTTP.Enabled = true
 				cfg.JaegerConfig.HTTP.Host = "localhost:0"
 				return cfg
@@ -119,7 +120,7 @@ func TestServerIntegration(t *testing.T) {
 		},
 		"default config with Jaeger gRPC and HTTP enabled": {
 			cfg: func() *config.Config {
-				cfg := config.DefaultConfig("8.0.0")
+				cfg := config.DefaultConfig()
 				cfg.JaegerConfig.GRPC.Enabled = true
 				cfg.JaegerConfig.GRPC.Host = "localhost:0"
 				cfg.JaegerConfig.HTTP.Enabled = true
@@ -226,7 +227,7 @@ func TestServerIntegration(t *testing.T) {
 		},
 		"secret token set but no auth_tag": {
 			cfg: func() *config.Config {
-				cfg := config.DefaultConfig("8.0.0")
+				cfg := config.DefaultConfig()
 				cfg.SecretToken = "hunter2"
 				cfg.JaegerConfig.GRPC.Enabled = true
 				cfg.JaegerConfig.GRPC.Host = "localhost:0"
@@ -238,7 +239,7 @@ func TestServerIntegration(t *testing.T) {
 		},
 		"secret token and auth_tag set, but no auth_tag sent by agent": {
 			cfg: func() *config.Config {
-				cfg := config.DefaultConfig("8.0.0")
+				cfg := config.DefaultConfig()
 				cfg.SecretToken = "hunter2"
 				cfg.JaegerConfig.GRPC.Enabled = true
 				cfg.JaegerConfig.GRPC.Host = "localhost:0"
@@ -250,7 +251,7 @@ func TestServerIntegration(t *testing.T) {
 		},
 		"secret token and auth_tag set, auth_tag sent by agent": {
 			cfg: func() *config.Config {
-				cfg := config.DefaultConfig("8.0.0")
+				cfg := config.DefaultConfig()
 				cfg.SecretToken = "hunter2"
 				cfg.JaegerConfig.GRPC.Enabled = true
 				cfg.JaegerConfig.GRPC.Host = "localhost:0"
@@ -355,7 +356,7 @@ type testcase struct {
 func (tc *testcase) setup(t *testing.T) {
 	reporter := func(ctx context.Context, req publish.PendingReq) error {
 		for _, transformable := range req.Transformables {
-			tc.events = append(tc.events, transformable.Transform(ctx, req.Tcontext)...)
+			tc.events = append(tc.events, transformable.Transform(ctx, &transform.Config{})...)
 		}
 		return nil
 	}

--- a/beater/onboarding.go
+++ b/beater/onboarding.go
@@ -35,7 +35,6 @@ func notifyListening(ctx context.Context, listenAddr net.Addr, reporter publish.
 	logp.NewLogger(logs.Onboarding).Info("Publishing onboarding document")
 	reporter(ctx, publish.PendingReq{
 		Transformables: []transform.Transformable{onboardingDoc{listenAddr: listenAddr.String()}},
-		Tcontext:       &transform.Context{},
 	})
 }
 
@@ -43,7 +42,7 @@ type onboardingDoc struct {
 	listenAddr string
 }
 
-func (o onboardingDoc) Transform(ctx context.Context, tctx *transform.Context) []beat.Event {
+func (o onboardingDoc) Transform(ctx context.Context, cfg *transform.Config) []beat.Event {
 	return []beat.Event{{
 		Timestamp: time.Now(),
 		Fields: common.MapStr{

--- a/cmd/apikey.go
+++ b/cmd/apikey.go
@@ -240,7 +240,7 @@ func bootstrap(settings instance.Settings) (es.Client, *config.Config, error) {
 	if beat.Config.Output.Name() == "elasticsearch" {
 		esOutputCfg = beat.Config.Output.Config()
 	}
-	beaterConfig, err := config.NewConfig(beat.Info.Version, cfg, esOutputCfg)
+	beaterConfig, err := config.NewConfig(cfg, esOutputCfg)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,10 @@ cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6A
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
+cloud.google.com/go v0.51.0 h1:PvKAVQWCtlGUSlZkGW3QLelKaWq7KYv/MW1EboG8bfM=
 cloud.google.com/go v0.51.0/go.mod h1:hWtGJ6gnXH+KgDv+V0zFGDvpi07n3z8ZNj3T1RW0Gcw=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
+cloud.google.com/go/datastore v1.0.0 h1:Kt+gOPPp2LEPWp8CSfxhsM8ik9CcyE/gYu+0r+RnZvM=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
@@ -128,6 +130,7 @@ github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b h1:AP/Y7sqYicnjGDf
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
 github.com/bombsimon/wsl v1.2.5 h1:9gTOkIwVtoDZywvX802SDHokeX4kW1cKnV8ZTVAPkRs=
 github.com/bombsimon/wsl v1.2.5/go.mod h1:43lEF/i0kpXbLCeDXL9LMT8c92HyBywXb0AsgMHYngM=
+github.com/bradleyfalzon/ghinstallation v1.1.0 h1:mwazVinJU0mPyLxIcdtJzu4DhWXFO5lMsWhKyFRIwFk=
 github.com/bradleyfalzon/ghinstallation v1.1.0/go.mod h1:p7iD8KytOOKg2wCqbwvJlq4JGpYMjwjkiqdyUqOIHLI=
 github.com/bsm/sarama-cluster v2.1.14-0.20180625083203-7e67d87a6b3f+incompatible/go.mod h1:r7ao+4tTNXvWm+VRpRJchr2kQhqxgmAp2iEX5W96gMM=
 github.com/cavaliercoder/badio v0.0.0-20160213150051-ce5280129e9e/go.mod h1:V284PjgVwSk4ETmz84rpu9ehpGg7swlIH8npP9k2bGw=
@@ -196,6 +199,7 @@ github.com/denisenkom/go-mssqldb v0.0.0-20200206145737-bbfc9a55622e/go.mod h1:xb
 github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
 github.com/devigned/tab v0.1.2-0.20190607222403-0c15cf42f9a2/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgrijalva/jwt-go v3.2.1-0.20190620180102-5e25c22bd5d6+incompatible h1:4jGdduO4ceTJFKf0IhgaB8NJapGqKHwC2b4xQ/cXujM=
 github.com/dgrijalva/jwt-go v3.2.1-0.20190620180102-5e25c22bd5d6+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/go-sip13 v0.0.0-20190329191031-25c5027a8c7b/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -476,8 +480,11 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-github/v28 v28.1.1 h1:kORf5ekX5qwXO2mGzXXOjMe/g6ap8ahVe0sBEulhSxo=
 github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
+github.com/google/go-github/v29 v29.0.2 h1:opYN6Wc7DOz7Ku3Oh4l7prmkOMwEcQxpFtxdU8N8Pts=
 github.com/google/go-github/v29 v29.0.2/go.mod h1:CHKiKKPHJ0REzfwc14QMklvtHwCveD0PxlMjLlzAM5E=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -500,6 +507,7 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.2-0.20190416172445-c2e93f3ae59f h1:XXzyYlFbxK3kWfcmu3Wc+Tv8/QQl/VqwsWuSYF1Rj0s=
 github.com/google/uuid v1.1.2-0.20190416172445-c2e93f3ae59f/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
+github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.0.0-20170426233943-68f4ded48ba9/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
@@ -576,6 +584,7 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/memberlist v0.1.4/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.8.3/go.mod h1:UpNcs7fFbpKIyZaUuSW6EPiH+eZC7OuyFD+wc1oal+k=
+github.com/haya14busa/go-actions-toolkit v0.0.0-20200105081403-ca0307860f01 h1:HiJF8Mek+I7PY0Bm+SuhkwaAZSZP83sw6rrTMrgZ0io=
 github.com/haya14busa/go-actions-toolkit v0.0.0-20200105081403-ca0307860f01/go.mod h1:1DWDZmeYf0LX30zscWb7K9rUMeirNeBMd5Dum+seUhc=
 github.com/haya14busa/go-checkstyle v0.0.0-20170303121022-5e9d09f51fa1/go.mod h1:RsN5RGgVYeXpcXNtWyztD5VIe7VNSEqpJvF2iEH7QvI=
 github.com/haya14busa/secretbox v0.0.0-20180525171038-07c7ecf409f5/go.mod h1:FGO/dXIFZnan7KvvUSFk1hYMnoVNzB6NTMPrmke8SSI=
@@ -685,6 +694,7 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-shellwords v1.0.7 h1:KqhVjVZomx2puPACkj9vrGFqnp42Htvo9SEAWePHKOs=
 github.com/mattn/go-shellwords v1.0.7/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
@@ -967,6 +977,7 @@ github.com/valyala/quicktemplate v1.2.0/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOV
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/vbatts/tar-split v0.11.1/go.mod h1:LEuURwDEiWjRjwu46yU3KVGuUdVv/dcnpcEPSzR8z6g=
 github.com/vmware/govmomi v0.0.0-20170802214208-2cad15190b41/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
+github.com/xanzy/go-gitlab v0.22.3 h1:/rNlZ2hquUWNc6rJdntVM03tEOoTmnZ1lcNyJCl0WlU=
 github.com/xanzy/go-gitlab v0.22.3/go.mod h1:t4Bmvnxj7k37S4Y17lfLx+nLqkf/oQwT2HagfWKv5Og=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
@@ -1238,6 +1249,7 @@ google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
 google.golang.org/api v0.9.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
 google.golang.org/api v0.10.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
+google.golang.org/api v0.15.0 h1:yzlyyDW/J0w8yNFJIhiAJy4kq74S+1DOLdawELNxFMA=
 google.golang.org/api v0.15.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsbkAI=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/model/error.go
+++ b/model/error.go
@@ -99,7 +99,7 @@ type Log struct {
 	Stacktrace   Stacktrace
 }
 
-func (e *Error) Transform(ctx context.Context, tctx *transform.Context) []beat.Event {
+func (e *Error) Transform(ctx context.Context, cfg *transform.Config) []beat.Event {
 	errorTransformations.Inc()
 
 	if e.Exception != nil {
@@ -110,7 +110,7 @@ func (e *Error) Transform(ctx context.Context, tctx *transform.Context) []beat.E
 	}
 
 	fields := common.MapStr{
-		"error":     e.fields(ctx, tctx),
+		"error":     e.fields(ctx, cfg),
 		"processor": errorProcessorEntry,
 	}
 
@@ -157,16 +157,16 @@ func (e *Error) Transform(ctx context.Context, tctx *transform.Context) []beat.E
 	}
 }
 
-func (e *Error) fields(ctx context.Context, tctx *transform.Context) common.MapStr {
+func (e *Error) fields(ctx context.Context, cfg *transform.Config) common.MapStr {
 	e.data = common.MapStr{}
 	e.add("id", e.ID)
 	e.add("page", e.Page.Fields())
 
 	exceptionChain := flattenExceptionTree(e.Exception)
-	e.addException(ctx, tctx, exceptionChain)
-	e.addLog(ctx, tctx)
+	e.addException(ctx, cfg, exceptionChain)
+	e.addLog(ctx, cfg)
 
-	e.updateCulprit(tctx)
+	e.updateCulprit(cfg)
 	e.add("culprit", e.Culprit)
 	e.add("custom", e.Custom.Fields())
 
@@ -175,8 +175,8 @@ func (e *Error) fields(ctx context.Context, tctx *transform.Context) common.MapS
 	return e.data
 }
 
-func (e *Error) updateCulprit(tctx *transform.Context) {
-	if tctx.Config.SourcemapStore == nil {
+func (e *Error) updateCulprit(cfg *transform.Config) {
+	if cfg.RUM.SourcemapStore == nil {
 		return
 	}
 	var fr *StacktraceFrame
@@ -210,7 +210,7 @@ func findSmappedNonLibraryFrame(frames []*StacktraceFrame) *StacktraceFrame {
 	return nil
 }
 
-func (e *Error) addException(ctx context.Context, tctx *transform.Context, chain []Exception) {
+func (e *Error) addException(ctx context.Context, cfg *transform.Config, chain []Exception) {
 	var result []common.MapStr
 	for _, exception := range chain {
 		ex := common.MapStr{}
@@ -232,7 +232,7 @@ func (e *Error) addException(ctx context.Context, tctx *transform.Context, chain
 			utility.Set(ex, "code", code.String())
 		}
 
-		st := exception.Stacktrace.transform(ctx, tctx, &e.Metadata.Service)
+		st := exception.Stacktrace.transform(ctx, cfg, e.RUM, &e.Metadata.Service)
 		utility.Set(ex, "stacktrace", st)
 
 		result = append(result, ex)
@@ -241,7 +241,7 @@ func (e *Error) addException(ctx context.Context, tctx *transform.Context, chain
 	e.add("exception", result)
 }
 
-func (e *Error) addLog(ctx context.Context, tctx *transform.Context) {
+func (e *Error) addLog(ctx context.Context, cfg *transform.Config) {
 	if e.Log == nil {
 		return
 	}
@@ -250,7 +250,7 @@ func (e *Error) addLog(ctx context.Context, tctx *transform.Context) {
 	utility.Set(log, "param_message", e.Log.ParamMessage)
 	utility.Set(log, "logger_name", e.Log.LoggerName)
 	utility.Set(log, "level", e.Log.Level)
-	st := e.Log.Stacktrace.transform(ctx, tctx, &e.Metadata.Service)
+	st := e.Log.Stacktrace.transform(ctx, cfg, e.RUM, &e.Metadata.Service)
 	utility.Set(log, "stacktrace", st)
 
 	e.add("log", log)

--- a/model/error.go
+++ b/model/error.go
@@ -228,7 +228,7 @@ func (e *Error) addException(ctx context.Context, tctx *transform.Context, chain
 			utility.Set(ex, "code", code.String())
 		}
 
-		st := exception.Stacktrace.Transform(ctx, tctx, &e.Metadata.Service)
+		st := exception.Stacktrace.transform(ctx, tctx, &e.Metadata.Service)
 		utility.Set(ex, "stacktrace", st)
 
 		result = append(result, ex)
@@ -246,7 +246,7 @@ func (e *Error) addLog(ctx context.Context, tctx *transform.Context) {
 	utility.Set(log, "param_message", e.Log.ParamMessage)
 	utility.Set(log, "logger_name", e.Log.LoggerName)
 	utility.Set(log, "level", e.Log.Level)
-	st := e.Log.Stacktrace.Transform(ctx, tctx, &e.Metadata.Service)
+	st := e.Log.Stacktrace.transform(ctx, tctx, &e.Metadata.Service)
 	utility.Set(log, "stacktrace", st)
 
 	e.add("log", log)

--- a/model/error.go
+++ b/model/error.go
@@ -71,6 +71,10 @@ type Error struct {
 	TransactionSampled *bool
 	TransactionType    *string
 
+	// RUM records whether or not this is a RUM error,
+	// and should have its stack frames sourcemapped.
+	RUM bool
+
 	Experimental interface{}
 	data         common.MapStr
 }

--- a/model/metricset.go
+++ b/model/metricset.go
@@ -129,7 +129,7 @@ type MetricsetSpan struct {
 	Subtype string
 }
 
-func (me *Metricset) Transform(ctx context.Context, _ *transform.Context) []beat.Event {
+func (me *Metricset) Transform(ctx context.Context, _ *transform.Config) []beat.Event {
 	metricsetTransformations.Inc()
 	if me == nil {
 		return nil

--- a/model/metricset.go
+++ b/model/metricset.go
@@ -129,7 +129,7 @@ type MetricsetSpan struct {
 	Subtype string
 }
 
-func (me *Metricset) Transform(ctx context.Context, tctx *transform.Context) []beat.Event {
+func (me *Metricset) Transform(ctx context.Context, _ *transform.Context) []beat.Event {
 	metricsetTransformations.Inc()
 	if me == nil {
 		return nil

--- a/model/metricset_test.go
+++ b/model/metricset_test.go
@@ -151,9 +151,8 @@ func TestTransform(t *testing.T) {
 		},
 	}
 
-	tctx := &transform.Context{}
 	for idx, test := range tests {
-		outputEvents := test.Metricset.Transform(context.Background(), tctx)
+		outputEvents := test.Metricset.Transform(context.Background(), &transform.Config{})
 
 		for j, outputEvent := range outputEvents {
 			assert.Equal(t, test.Output[j], outputEvent.Fields, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))

--- a/model/modeldecoder/error.go
+++ b/model/modeldecoder/error.go
@@ -43,6 +43,17 @@ func DecodeRUMV3Error(input Input, batch *m.Batch) error {
 	return nil
 }
 
+// DecodeRUMV2Error decodes a v2 RUM error.
+func DecodeRUMV2Error(input Input, batch *m.Batch) error {
+	apmError, err := decodeError(input, errorSchema)
+	if err != nil {
+		return err
+	}
+	apmError.RUM = true
+	batch.Errors = append(batch.Errors, apmError)
+	return nil
+}
+
 // DecodeError decodes a v2 error.
 func DecodeError(input Input, batch *m.Batch) error {
 	apmError, err := decodeError(input, errorSchema)

--- a/model/modeldecoder/metricset.go
+++ b/model/modeldecoder/metricset.go
@@ -39,6 +39,12 @@ var (
 	rumV3Schema     = validation.CreateSchema(schema.RUMV3Schema, "metricset")
 )
 
+// DecodeRUMV2Metricset decodes a v2 RUM metricset.
+func DecodeRUMV2Metricset(input Input, batch *model.Batch) error {
+	// Identical to backend agent metricsets.
+	return DecodeMetricset(input, batch)
+}
+
 // DecodeMetricset decodes a v2 metricset.
 func DecodeMetricset(input Input, batch *model.Batch) error {
 	metricset, err := decodeMetricset(input, metricsetSchema)
@@ -49,7 +55,7 @@ func DecodeMetricset(input Input, batch *model.Batch) error {
 	return nil
 }
 
-// DecodeRUMV3Metricset decodes a v3 metricset.
+// DecodeRUMV3Metricset decodes a v3 RUM metricset.
 func DecodeRUMV3Metricset(input Input, batch *model.Batch) error {
 	metricset, err := decodeMetricset(input, rumV3Schema)
 	if err != nil {

--- a/model/modeldecoder/span.go
+++ b/model/modeldecoder/span.go
@@ -40,10 +40,26 @@ var (
 // decodeRUMV3Span decodes a v3 RUM span, and optional parent index.
 // If parent index wasn't specified, then the value will be negative.
 func decodeRUMV3Span(input Input) (_ *model.Span, parentIndex int, _ error) {
-	return decodeSpan(input, rumV3SpanSchema)
+	span, parentIndex, err := decodeSpan(input, rumV3SpanSchema)
+	if err != nil {
+		return nil, -1, err
+	}
+	span.RUM = true
+	return span, parentIndex, nil
 }
 
-// DecodeSpan decodes a span.
+// DecodeRUMV2Span decodes a v2 RUM span.
+func DecodeRUMV2Span(input Input, batch *model.Batch) error {
+	span, _, err := decodeSpan(input, spanSchema)
+	if err != nil {
+		return err
+	}
+	span.RUM = true
+	batch.Spans = append(batch.Spans, span)
+	return nil
+}
+
+// DecodeSpan decodes a v2 span.
 func DecodeSpan(input Input, batch *model.Batch) error {
 	span, _, err := decodeSpan(input, spanSchema)
 	if err != nil {

--- a/model/modeldecoder/transaction.go
+++ b/model/modeldecoder/transaction.go
@@ -110,6 +110,12 @@ func decodeRUMV3Spans(raw map[string]interface{}, input Input, tr *model.Transac
 	return spans, nil
 }
 
+// DecodeRUMV2Transaction decodes a v2 RUM transaction.
+func DecodeRUMV2Transaction(input Input, batch *model.Batch) error {
+	// Identical to backend agent transactions.
+	return DecodeTransaction(input, batch)
+}
+
 // DecodeTransaction decodes a v2 transaction.
 func DecodeTransaction(input Input, batch *model.Batch) error {
 	transaction, err := decodeTransaction(input, transactionSchema)

--- a/model/profile.go
+++ b/model/profile.go
@@ -49,7 +49,7 @@ type PprofProfile struct {
 }
 
 // Transform transforms a Profile into a sequence of beat.Events: one per profile sample.
-func (pp PprofProfile) Transform(ctx context.Context, _ *transform.Context) []beat.Event {
+func (pp PprofProfile) Transform(ctx context.Context, _ *transform.Config) []beat.Event {
 	// Precompute value field names for use in each event.
 	// TODO(axw) limit to well-known value names?
 	profileTimestamp := time.Unix(0, pp.Profile.TimeNanos)

--- a/model/profile_test.go
+++ b/model/profile_test.go
@@ -85,7 +85,7 @@ func TestPprofProfileTransform(t *testing.T) {
 		},
 	}
 
-	output := pp.Transform(context.Background(), &transform.Context{})
+	output := pp.Transform(context.Background(), &transform.Config{})
 	require.Len(t, output, 2)
 	assert.Equal(t, output[0], output[1])
 

--- a/model/sourcemap.go
+++ b/model/sourcemap.go
@@ -53,16 +53,16 @@ type Sourcemap struct {
 	BundleFilepath string
 }
 
-func (pa *Sourcemap) Transform(ctx context.Context, tctx *transform.Context) []beat.Event {
+func (pa *Sourcemap) Transform(ctx context.Context, cfg *transform.Config) []beat.Event {
 	sourcemapCounter.Inc()
 	if pa == nil {
 		return nil
 	}
 
-	if tctx.Config.SourcemapStore == nil {
+	if cfg.RUM.SourcemapStore == nil {
 		logp.NewLogger(logs.Sourcemap).Error("Sourcemap Accessor is nil, cache cannot be invalidated.")
 	} else {
-		tctx.Config.SourcemapStore.Added(ctx, pa.ServiceName, pa.ServiceVersion, pa.BundleFilepath)
+		cfg.RUM.SourcemapStore.Added(ctx, pa.ServiceName, pa.ServiceVersion, pa.BundleFilepath)
 	}
 
 	ev := beat.Event{

--- a/model/sourcemap_test.go
+++ b/model/sourcemap_test.go
@@ -54,8 +54,7 @@ func TestTransform(t *testing.T) {
 		Sourcemap:      "mysmap",
 	}
 
-	tctx := &transform.Context{}
-	events := p.Transform(context.Background(), tctx)
+	events := p.Transform(context.Background(), &transform.Config{})
 	assert.Len(t, events, 1)
 	event := events[0]
 
@@ -101,7 +100,7 @@ func TestInvalidateCache(t *testing.T) {
 		require.NoError(t, err)
 
 		// transform with sourcemap store
-		event.Transform(context.Background(), &transform.Context{Config: transform.Config{SourcemapStore: store}})
+		event.Transform(context.Background(), &transform.Config{RUM: transform.RUMConfig{SourcemapStore: store}})
 
 		logCollection := logp.ObserverLogs().TakeAll()
 		assert.Equal(t, 2, len(logCollection))
@@ -123,8 +122,8 @@ func TestInvalidateCache(t *testing.T) {
 		// collect logs
 		require.NoError(t, logp.DevelopmentSetup(logp.ToObserverOutput()))
 
-		// transform with sourcemap store
-		event.Transform(context.Background(), &transform.Context{Config: transform.Config{SourcemapStore: nil}})
+		// transform with no sourcemap store
+		event.Transform(context.Background(), &transform.Config{RUM: transform.RUMConfig{}})
 
 		logCollection := logp.ObserverLogs().TakeAll()
 		assert.Equal(t, 1, len(logCollection))

--- a/model/span.go
+++ b/model/span.go
@@ -238,7 +238,7 @@ func (e *Span) fields(ctx context.Context, tctx *transform.Context) common.MapSt
 
 	// TODO(axw) we should be using a merged service object, combining
 	// the stream metadata and event-specific service info.
-	st := e.Stacktrace.Transform(ctx, tctx, &e.Metadata.Service)
+	st := e.Stacktrace.transform(ctx, tctx, &e.Metadata.Service)
 	utility.Set(fields, "stacktrace", st)
 	return fields
 }

--- a/model/span.go
+++ b/model/span.go
@@ -70,6 +70,10 @@ type Span struct {
 	Destination        *Destination
 	DestinationService *DestinationService
 
+	// RUM records whether or not this is a RUM span,
+	// and should have its stack frames sourcemapped.
+	RUM bool
+
 	Experimental interface{}
 }
 

--- a/model/span.go
+++ b/model/span.go
@@ -174,7 +174,7 @@ func (d *DestinationService) fields() common.MapStr {
 	return fields
 }
 
-func (e *Span) Transform(ctx context.Context, tctx *transform.Context) []beat.Event {
+func (e *Span) Transform(ctx context.Context, cfg *transform.Config) []beat.Event {
 	spanTransformations.Inc()
 	if frames := len(e.Stacktrace); frames > 0 {
 		spanStacktraceCounter.Inc()
@@ -183,7 +183,7 @@ func (e *Span) Transform(ctx context.Context, tctx *transform.Context) []beat.Ev
 
 	fields := common.MapStr{
 		"processor": spanProcessorEntry,
-		spanDocType: e.fields(ctx, tctx),
+		spanDocType: e.fields(ctx, cfg),
 	}
 
 	// first set the generic metadata
@@ -212,7 +212,7 @@ func (e *Span) Transform(ctx context.Context, tctx *transform.Context) []beat.Ev
 	}
 }
 
-func (e *Span) fields(ctx context.Context, tctx *transform.Context) common.MapStr {
+func (e *Span) fields(ctx context.Context, cfg *transform.Config) common.MapStr {
 	if e == nil {
 		return nil
 	}
@@ -242,7 +242,7 @@ func (e *Span) fields(ctx context.Context, tctx *transform.Context) common.MapSt
 
 	// TODO(axw) we should be using a merged service object, combining
 	// the stream metadata and event-specific service info.
-	st := e.Stacktrace.transform(ctx, tctx, &e.Metadata.Service)
+	st := e.Stacktrace.transform(ctx, cfg, e.RUM, &e.Metadata.Service)
 	utility.Set(fields, "stacktrace", st)
 	return fields
 }

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -82,6 +82,7 @@ func TestSpanTransform(t *testing.T) {
 				Timestamp:  timestamp,
 				Start:      &start,
 				Duration:   1.20,
+				RUM:        true,
 				Stacktrace: Stacktrace{{AbsPath: &path}},
 				Labels:     common.MapStr{"label.a": 12},
 				HTTP:       &HTTP{Method: &method, StatusCode: &statusCode, URL: &url},
@@ -148,11 +149,10 @@ func TestSpanTransform(t *testing.T) {
 		},
 	}
 
-	tctx := &transform.Context{
-		Config: transform.Config{SourcemapStore: &sourcemap.Store{}},
-	}
 	for _, test := range tests {
-		output := test.Span.Transform(context.Background(), tctx)
+		output := test.Span.Transform(context.Background(), &transform.Config{
+			RUM: transform.RUMConfig{SourcemapStore: &sourcemap.Store{}},
+		})
 		fields := output[0].Fields
 		assert.Equal(t, test.Output, fields)
 	}

--- a/model/stacktrace_frame.go
+++ b/model/stacktrace_frame.go
@@ -68,7 +68,7 @@ type Original struct {
 	sourcemapCopied bool
 }
 
-func (s *StacktraceFrame) Transform(tctx *transform.Context) common.MapStr {
+func (s *StacktraceFrame) transform(tctx *transform.Context) common.MapStr {
 	m := common.MapStr{}
 	utility.Set(m, "filename", s.Filename)
 	utility.Set(m, "classname", s.Classname)

--- a/model/stacktrace_frame.go
+++ b/model/stacktrace_frame.go
@@ -68,7 +68,7 @@ type Original struct {
 	sourcemapCopied bool
 }
 
-func (s *StacktraceFrame) transform(tctx *transform.Context) common.MapStr {
+func (s *StacktraceFrame) transform(cfg *transform.Config, rum bool) common.MapStr {
 	m := common.MapStr{}
 	utility.Set(m, "filename", s.Filename)
 	utility.Set(m, "classname", s.Classname)
@@ -76,13 +76,13 @@ func (s *StacktraceFrame) transform(tctx *transform.Context) common.MapStr {
 	utility.Set(m, "module", s.Module)
 	utility.Set(m, "function", s.Function)
 	utility.Set(m, "vars", s.Vars)
-	if tctx.Config.LibraryPattern != nil {
-		s.setLibraryFrame(tctx.Config.LibraryPattern)
+	if rum && cfg.RUM.LibraryPattern != nil {
+		s.setLibraryFrame(cfg.RUM.LibraryPattern)
 	}
 	utility.Set(m, "library_frame", s.LibraryFrame)
 
-	if tctx.Config.ExcludeFromGrouping != nil {
-		s.setExcludeFromGrouping(tctx.Config.ExcludeFromGrouping)
+	if rum && cfg.RUM.ExcludeFromGrouping != nil {
+		s.setExcludeFromGrouping(cfg.RUM.ExcludeFromGrouping)
 	}
 	utility.Set(m, "exclude_from_grouping", s.ExcludeFromGrouping)
 

--- a/model/stacktrace_frame_test.go
+++ b/model/stacktrace_frame_test.go
@@ -97,10 +97,9 @@ func TestStacktraceFrameTransform(t *testing.T) {
 			Msg: "Full StacktraceFrame",
 		},
 	}
-	tctx := transform.Context{}
 
 	for idx, test := range tests {
-		output := test.StFrame.transform(&tctx)
+		output := test.StFrame.transform(&transform.Config{}, true)
 		assert.Equal(t, test.Output, output, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 	}
 }
@@ -320,11 +319,10 @@ func TestExcludeFromGroupingKey(t *testing.T) {
 		if test.pattern != "" {
 			excludePattern = regexp.MustCompile(test.pattern)
 		}
-		tctx := transform.Context{
-			Config: transform.Config{ExcludeFromGrouping: excludePattern},
-		}
 
-		out := test.fr.transform(&tctx)
+		out := test.fr.transform(&transform.Config{
+			RUM: transform.RUMConfig{ExcludeFromGrouping: excludePattern},
+		}, true)
 		exclude := out["exclude_from_grouping"]
 		assert.Equal(t, test.exclude, exclude,
 			fmt.Sprintf("(%v): Pattern: %v, Filename: %v, expected to be excluded: %v", idx, test.pattern, test.fr.Filename, test.exclude))
@@ -338,78 +336,78 @@ func TestLibraryFrame(t *testing.T) {
 	path := "/~/a/b"
 	tests := []struct {
 		fr               StacktraceFrame
-		conf             transform.Config
+		libraryPattern   *regexp.Regexp
 		libraryFrame     *bool
 		origLibraryFrame *bool
 		msg              string
 	}{
 		{fr: StacktraceFrame{},
-			conf:             transform.Config{},
 			libraryFrame:     nil,
 			origLibraryFrame: nil,
 			msg:              "Empty StacktraceFrame, empty config"},
 		{fr: StacktraceFrame{AbsPath: &path},
-			conf:             transform.Config{LibraryPattern: nil},
 			libraryFrame:     nil,
 			origLibraryFrame: nil,
 			msg:              "No pattern"},
 		{fr: StacktraceFrame{AbsPath: &path},
-			conf:             transform.Config{LibraryPattern: regexp.MustCompile("")},
+			libraryPattern:   regexp.MustCompile(""),
 			libraryFrame:     &truthy,
 			origLibraryFrame: nil,
 			msg:              "Empty pattern"},
 		{fr: StacktraceFrame{LibraryFrame: &falsy},
-			conf:             transform.Config{LibraryPattern: regexp.MustCompile("~")},
+			libraryPattern:   regexp.MustCompile("~"),
 			libraryFrame:     &falsy,
 			origLibraryFrame: &falsy,
 			msg:              "Empty StacktraceFrame"},
 		{fr: StacktraceFrame{AbsPath: &path, LibraryFrame: &truthy},
-			conf:             transform.Config{LibraryPattern: regexp.MustCompile("^~/")},
+			libraryPattern:   regexp.MustCompile("^~/"),
 			libraryFrame:     &falsy,
 			origLibraryFrame: &truthy,
 			msg:              "AbsPath given, no Match"},
 		{fr: StacktraceFrame{Filename: tests.StringPtr("myFile.js"), LibraryFrame: &truthy},
-			conf:             transform.Config{LibraryPattern: regexp.MustCompile("^~/")},
+			libraryPattern:   regexp.MustCompile("^~/"),
 			libraryFrame:     &falsy,
 			origLibraryFrame: &truthy,
 			msg:              "Filename given, no Match"},
 		{fr: StacktraceFrame{AbsPath: &path, Filename: tests.StringPtr("myFile.js")},
-			conf:             transform.Config{LibraryPattern: regexp.MustCompile("^~/")},
+			libraryPattern:   regexp.MustCompile("^~/"),
 			libraryFrame:     &falsy,
 			origLibraryFrame: nil,
 			msg:              "AbsPath and Filename given, no Match"},
 		{fr: StacktraceFrame{Filename: tests.StringPtr("/tmp")},
-			conf:             transform.Config{LibraryPattern: regexp.MustCompile("/tmp")},
+			libraryPattern:   regexp.MustCompile("/tmp"),
 			libraryFrame:     &truthy,
 			origLibraryFrame: nil,
 			msg:              "Filename matching"},
 		{fr: StacktraceFrame{AbsPath: &path, LibraryFrame: &falsy},
-			conf:             transform.Config{LibraryPattern: regexp.MustCompile("~/")},
+			libraryPattern:   regexp.MustCompile("~/"),
 			libraryFrame:     &truthy,
 			origLibraryFrame: &falsy,
 			msg:              "AbsPath matching"},
 		{fr: StacktraceFrame{AbsPath: &path, Filename: tests.StringPtr("/a/b/c")},
-			conf:             transform.Config{LibraryPattern: regexp.MustCompile("~/")},
+			libraryPattern:   regexp.MustCompile("~/"),
 			libraryFrame:     &truthy,
 			origLibraryFrame: nil,
 			msg:              "AbsPath matching, Filename not matching"},
 		{fr: StacktraceFrame{AbsPath: &path, Filename: tests.StringPtr("/a/b/c")},
-			conf:             transform.Config{LibraryPattern: regexp.MustCompile("/a/b/c")},
+			libraryPattern:   regexp.MustCompile("/a/b/c"),
 			libraryFrame:     &truthy,
 			origLibraryFrame: nil,
 			msg:              "AbsPath not matching, Filename matching"},
 		{fr: StacktraceFrame{AbsPath: &path, Filename: tests.StringPtr("~/a/b/c")},
-			conf:             transform.Config{LibraryPattern: regexp.MustCompile("~/")},
+			libraryPattern:   regexp.MustCompile("~/"),
 			libraryFrame:     &truthy,
 			origLibraryFrame: nil,
 			msg:              "AbsPath and Filename matching"},
 	}
 
 	for _, test := range tests {
-		tctx := transform.Context{
-			Config: test.conf,
+		cfg := transform.Config{
+			RUM: transform.RUMConfig{
+				LibraryPattern: test.libraryPattern,
+			},
 		}
-		out := test.fr.transform(&tctx)["library_frame"]
+		out := test.fr.transform(&cfg, true)["library_frame"]
 		libFrame := test.fr.LibraryFrame
 		origLibFrame := test.fr.Original.LibraryFrame
 		if test.libraryFrame == nil {

--- a/model/stacktrace_frame_test.go
+++ b/model/stacktrace_frame_test.go
@@ -100,7 +100,7 @@ func TestStacktraceFrameTransform(t *testing.T) {
 	tctx := transform.Context{}
 
 	for idx, test := range tests {
-		output := (&test.StFrame).Transform(&tctx)
+		output := test.StFrame.transform(&tctx)
 		assert.Equal(t, test.Output, output, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 	}
 }
@@ -324,7 +324,7 @@ func TestExcludeFromGroupingKey(t *testing.T) {
 			Config: transform.Config{ExcludeFromGrouping: excludePattern},
 		}
 
-		out := test.fr.Transform(&tctx)
+		out := test.fr.transform(&tctx)
 		exclude := out["exclude_from_grouping"]
 		assert.Equal(t, test.exclude, exclude,
 			fmt.Sprintf("(%v): Pattern: %v, Filename: %v, expected to be excluded: %v", idx, test.pattern, test.fr.Filename, test.exclude))
@@ -409,7 +409,7 @@ func TestLibraryFrame(t *testing.T) {
 		tctx := transform.Context{
 			Config: test.conf,
 		}
-		out := test.fr.Transform(&tctx)["library_frame"]
+		out := test.fr.transform(&tctx)["library_frame"]
 		libFrame := test.fr.LibraryFrame
 		origLibFrame := test.fr.Original.LibraryFrame
 		if test.libraryFrame == nil {

--- a/model/stacktrace_test.go
+++ b/model/stacktrace_test.go
@@ -110,7 +110,7 @@ func TestStacktraceTransform(t *testing.T) {
 	}
 
 	for idx, test := range tests {
-		output := test.Stacktrace.Transform(context.Background(), &transform.Context{}, &service)
+		output := test.Stacktrace.transform(context.Background(), &transform.Context{}, &service)
 		assert.Equal(t, test.Output, output, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 	}
 }
@@ -256,9 +256,9 @@ func TestStacktraceTransformWithSourcemapping(t *testing.T) {
 				Config: transform.Config{SourcemapStore: testSourcemapStore(t, test.ESClientWithValidSourcemap(t))},
 			}
 
-			// run `Stacktrace.Transform` twice to ensure method is idempotent
-			tc.Stacktrace.Transform(context.Background(), tctx, &service)
-			output := tc.Stacktrace.Transform(context.Background(), tctx, &service)
+			// run `Stacktrace.transform` twice to ensure method is idempotent
+			tc.Stacktrace.transform(context.Background(), tctx, &service)
+			output := tc.Stacktrace.transform(context.Background(), tctx, &service)
 			assert.Equal(t, tc.Output, output)
 		})
 	}

--- a/model/stacktrace_test.go
+++ b/model/stacktrace_test.go
@@ -110,7 +110,7 @@ func TestStacktraceTransform(t *testing.T) {
 	}
 
 	for idx, test := range tests {
-		output := test.Stacktrace.transform(context.Background(), &transform.Context{}, &service)
+		output := test.Stacktrace.transform(context.Background(), &transform.Config{}, false, &service)
 		assert.Equal(t, test.Output, output, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 	}
 }
@@ -252,13 +252,15 @@ func TestStacktraceTransformWithSourcemapping(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			tctx := &transform.Context{
-				Config: transform.Config{SourcemapStore: testSourcemapStore(t, test.ESClientWithValidSourcemap(t))},
+			cfg := &transform.Config{
+				RUM: transform.RUMConfig{
+					SourcemapStore: testSourcemapStore(t, test.ESClientWithValidSourcemap(t)),
+				},
 			}
 
 			// run `Stacktrace.transform` twice to ensure method is idempotent
-			tc.Stacktrace.transform(context.Background(), tctx, &service)
-			output := tc.Stacktrace.transform(context.Background(), tctx, &service)
+			tc.Stacktrace.transform(context.Background(), cfg, true, &service)
+			output := tc.Stacktrace.transform(context.Background(), cfg, true, &service)
 			assert.Equal(t, tc.Output, output)
 		})
 	}

--- a/model/transaction.go
+++ b/model/transaction.go
@@ -105,7 +105,7 @@ func (e *Transaction) fields() common.MapStr {
 	return common.MapStr(fields)
 }
 
-func (e *Transaction) Transform(_ context.Context, _ *transform.Context) []beat.Event {
+func (e *Transaction) Transform(_ context.Context, _ *transform.Config) []beat.Event {
 	transactionTransformations.Inc()
 
 	fields := common.MapStr{

--- a/model/transaction_test.go
+++ b/model/transaction_test.go
@@ -126,10 +126,8 @@ func TestTransactionTransform(t *testing.T) {
 		},
 	}
 
-	tctx := &transform.Context{}
-
 	for idx, test := range tests {
-		output := test.Transaction.Transform(context.Background(), tctx)
+		output := test.Transaction.Transform(context.Background(), &transform.Config{})
 		assert.Equal(t, test.Output, output[0].Fields["transaction"], fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 	}
 }
@@ -173,7 +171,7 @@ func TestEventsTransformWithMetadata(t *testing.T) {
 		Custom:    &Custom{"foo": "bar"},
 		Message:   &Message{QueueName: tests.StringPtr("routeUser")},
 	}
-	events := txWithContext.Transform(context.Background(), &transform.Context{})
+	events := txWithContext.Transform(context.Background(), &transform.Config{})
 	require.Len(t, events, 1)
 	assert.Equal(t, events[0].Fields, common.MapStr{
 		"user":       common.MapStr{"id": "123", "name": "jane"},
@@ -269,10 +267,8 @@ func TestTransactionTransformPage(t *testing.T) {
 		},
 	}
 
-	tctx := &transform.Context{}
-
 	for idx, test := range tests {
-		output := test.Transaction.Transform(context.Background(), tctx)
+		output := test.Transaction.Transform(context.Background(), &transform.Config{})
 		assert.Equal(t, test.Output, output[0].Fields["url"], fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 	}
 }

--- a/processor/asset/sourcemap/package_tests/processor_test.go
+++ b/processor/asset/sourcemap/package_tests/processor_test.go
@@ -57,7 +57,6 @@ func TestSourcemapProcessorOK(t *testing.T) {
 
 	for _, info := range data {
 		p := sourcemap.Processor
-		tctx := transform.Context{}
 
 		data, err := loader.LoadData(info.Path)
 		require.NoError(t, err)
@@ -70,7 +69,7 @@ func TestSourcemapProcessorOK(t *testing.T) {
 
 		var events []beat.Event
 		for _, transformable := range payload {
-			events = append(events, transformable.Transform(context.Background(), &tctx)...)
+			events = append(events, transformable.Transform(context.Background(), &transform.Config{})...)
 		}
 		verifyErr := approvals.ApproveEvents(events, info.Name, "@timestamp")
 		if verifyErr != nil {

--- a/processor/asset/sourcemap/package_tests/test_processor.go
+++ b/processor/asset/sourcemap/package_tests/test_processor.go
@@ -62,7 +62,7 @@ func (p *TestProcessor) Process(buf []byte) ([]beat.Event, error) {
 
 	var events []beat.Event
 	for _, transformable := range transformables {
-		events = append(events, transformable.Transform(context.Background(), &transform.Context{})...)
+		events = append(events, transformable.Transform(context.Background(), &transform.Config{})...)
 	}
 	return events, nil
 }

--- a/processor/otel/consumer.go
+++ b/processor/otel/consumer.go
@@ -38,7 +38,6 @@ import (
 	logs "github.com/elastic/apm-server/log"
 	"github.com/elastic/apm-server/model"
 	"github.com/elastic/apm-server/publish"
-	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/apm-server/utility"
 )
 
@@ -53,19 +52,15 @@ const (
 
 // Consumer transforms open-telemetry data to be compatible with elastic APM data
 type Consumer struct {
-	TransformConfig transform.Config
-	Reporter        publish.Reporter
+	Reporter publish.Reporter
 }
 
 // ConsumeTraceData consumes OpenTelemetry trace data,
 // converting into Elastic APM events and reporting to the Elastic APM schema.
 func (c *Consumer) ConsumeTraceData(ctx context.Context, td consumerdata.TraceData) error {
 	batch := c.convert(td)
-	transformContext := &transform.Context{Config: c.TransformConfig}
-
 	return c.Reporter(ctx, publish.PendingReq{
 		Transformables: batch.Transformables(),
-		Tcontext:       transformContext,
 		Trace:          true,
 	})
 }

--- a/processor/otel/consumer_test.go
+++ b/processor/otel/consumer_test.go
@@ -490,7 +490,7 @@ func testAttributeStringValue(s string) *tracepb.AttributeValue {
 func transformAll(ctx context.Context, p publish.PendingReq) []beat.Event {
 	var events []beat.Event
 	for _, transformable := range p.Transformables {
-		events = append(events, transformable.Transform(ctx, p.Tcontext)...)
+		events = append(events, transformable.Transform(ctx, &transform.Config{})...)
 	}
 	return events
 }

--- a/processor/stream/benchmark_test.go
+++ b/processor/stream/benchmark_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/elastic/apm-server/beater/config"
 	"github.com/elastic/apm-server/model"
 	"github.com/elastic/apm-server/publish"
-	"github.com/elastic/apm-server/transform"
 )
 
 func BenchmarkBackendProcessor(b *testing.B) {
@@ -40,8 +39,7 @@ func BenchmarkBackendProcessor(b *testing.B) {
 }
 
 func BenchmarkRUMV3Processor(b *testing.B) {
-	tcfg := &transform.Config{}
-	processor := RUMV3Processor(&config.Config{MaxEventSize: 300 * 1024}, tcfg)
+	processor := RUMV3Processor(&config.Config{MaxEventSize: 300 * 1024})
 	files, _ := filepath.Glob(filepath.FromSlash("../../testdata/intake-v3/rum_*.ndjson"))
 	benchmarkStreamProcessor(b, processor, files)
 }

--- a/processor/stream/package_tests/intake_test_processor.go
+++ b/processor/stream/package_tests/intake_test_processor.go
@@ -32,6 +32,7 @@ import (
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/apm-server/tests"
 	"github.com/elastic/apm-server/tests/loader"
+	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/beats/v7/libbeat/beat"
 )
 
@@ -111,7 +112,7 @@ func (p *intakeTestProcessor) Process(buf []byte) ([]beat.Event, error) {
 	for _, req := range reqs {
 		if req.Transformables != nil {
 			for _, transformable := range req.Transformables {
-				events = append(events, transformable.Transform(context.Background(), req.Tcontext)...)
+				events = append(events, transformable.Transform(context.Background(), &transform.Config{})...)
 			}
 		}
 	}

--- a/processor/stream/processor.go
+++ b/processor/stream/processor.go
@@ -34,7 +34,6 @@ import (
 	"github.com/elastic/apm-server/model/modeldecoder"
 	"github.com/elastic/apm-server/model/modeldecoder/field"
 	"github.com/elastic/apm-server/publish"
-	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/apm-server/utility"
 	"github.com/elastic/apm-server/validation"
 )
@@ -53,7 +52,6 @@ type decodeMetadataFunc func(interface{}, bool, *model.Metadata) error
 type decodeEventFunc func(modeldecoder.Input, *model.Batch) error
 
 type Processor struct {
-	Tconfig          transform.Config
 	Mconfig          modeldecoder.Config
 	MaxEventSize     int
 	streamReaderPool sync.Pool
@@ -63,7 +61,6 @@ type Processor struct {
 
 func BackendProcessor(cfg *config.Config) *Processor {
 	return &Processor{
-		Tconfig:        transform.Config{},
 		Mconfig:        modeldecoder.Config{Experimental: cfg.Mode == config.ModeExperimental},
 		MaxEventSize:   cfg.MaxEventSize,
 		decodeMetadata: modeldecoder.DecodeMetadata,
@@ -76,9 +73,8 @@ func BackendProcessor(cfg *config.Config) *Processor {
 	}
 }
 
-func RUMV2Processor(cfg *config.Config, tcfg *transform.Config) *Processor {
+func RUMV2Processor(cfg *config.Config) *Processor {
 	return &Processor{
-		Tconfig:        *tcfg,
 		Mconfig:        modeldecoder.Config{Experimental: cfg.Mode == config.ModeExperimental},
 		MaxEventSize:   cfg.MaxEventSize,
 		decodeMetadata: modeldecoder.DecodeMetadata,
@@ -91,9 +87,8 @@ func RUMV2Processor(cfg *config.Config, tcfg *transform.Config) *Processor {
 	}
 }
 
-func RUMV3Processor(cfg *config.Config, tcfg *transform.Config) *Processor {
+func RUMV3Processor(cfg *config.Config) *Processor {
 	return &Processor{
-		Tconfig:        *tcfg,
 		Mconfig:        modeldecoder.Config{Experimental: cfg.Mode == config.ModeExperimental, HasShortFieldNames: true},
 		MaxEventSize:   cfg.MaxEventSize,
 		decodeMetadata: modeldecoder.DecodeRUMV3Metadata,
@@ -235,7 +230,6 @@ func (p *Processor) HandleStream(ctx context.Context, ipRateLimiter *rate.Limite
 	}
 
 	requestTime := utility.RequestTime(ctx)
-	tctx := &transform.Context{Config: p.Tconfig}
 
 	sp, ctx := apm.StartSpan(ctx, "Stream", "Reporter")
 	defer sp.End()
@@ -253,7 +247,6 @@ func (p *Processor) HandleStream(ctx context.Context, ipRateLimiter *rate.Limite
 		// which would enable better memory reuse.
 		if err := report(ctx, publish.PendingReq{
 			Transformables: batch.Transformables(),
-			Tcontext:       tctx,
 			Trace:          !sp.Dropped(),
 		}); err != nil {
 			switch err {

--- a/processor/stream/processor.go
+++ b/processor/stream/processor.go
@@ -76,17 +76,17 @@ func BackendProcessor(cfg *config.Config) *Processor {
 	}
 }
 
-func RUMProcessor(cfg *config.Config, tcfg *transform.Config) *Processor {
+func RUMV2Processor(cfg *config.Config, tcfg *transform.Config) *Processor {
 	return &Processor{
 		Tconfig:        *tcfg,
 		Mconfig:        modeldecoder.Config{Experimental: cfg.Mode == config.ModeExperimental},
 		MaxEventSize:   cfg.MaxEventSize,
 		decodeMetadata: modeldecoder.DecodeMetadata,
 		models: map[string]decodeEventFunc{
-			"transaction": modeldecoder.DecodeTransaction,
-			"span":        modeldecoder.DecodeSpan,
-			"metricset":   modeldecoder.DecodeMetricset,
-			"error":       modeldecoder.DecodeError,
+			"transaction": modeldecoder.DecodeRUMV2Transaction,
+			"span":        modeldecoder.DecodeRUMV2Span,
+			"metricset":   modeldecoder.DecodeRUMV2Metricset,
+			"error":       modeldecoder.DecodeRUMV2Error,
 		},
 	}
 }

--- a/processor/stream/processor_test.go
+++ b/processor/stream/processor_test.go
@@ -181,7 +181,7 @@ func TestIntegrationRum(t *testing.T) {
 				UserAgent: model.UserAgent{Original: "rum-2.0"},
 				Client:    model.Client{IP: net.ParseIP("192.0.0.1")}}
 
-			p := RUMProcessor(&config.Config{MaxEventSize: 100 * 1024}, &transform.Config{})
+			p := RUMV2Processor(&config.Config{MaxEventSize: 100 * 1024}, &transform.Config{})
 			actualResult := p.HandleStream(ctx, nil, &reqDecoderMeta, bodyReader, report)
 			assertApproveResult(t, actualResult, test.name)
 		})

--- a/processor/stream/processor_test.go
+++ b/processor/stream/processor_test.go
@@ -98,7 +98,7 @@ func TestIntegrationESOutput(t *testing.T) {
 	report := func(ctx context.Context, p publish.PendingReq) error {
 		var events []beat.Event
 		for _, transformable := range p.Transformables {
-			events = append(events, transformable.Transform(ctx, p.Tcontext)...)
+			events = append(events, transformable.Transform(ctx, &transform.Config{})...)
 		}
 		name := ctx.Value("name").(string)
 		verifyErr := approvals.ApproveEvents(events, name)
@@ -150,7 +150,7 @@ func TestIntegrationRum(t *testing.T) {
 	report := func(ctx context.Context, p publish.PendingReq) error {
 		var events []beat.Event
 		for _, transformable := range p.Transformables {
-			events = append(events, transformable.Transform(ctx, p.Tcontext)...)
+			events = append(events, transformable.Transform(ctx, &transform.Config{})...)
 		}
 		name := ctx.Value("name").(string)
 		verifyErr := approvals.ApproveEvents(events, name)
@@ -181,7 +181,7 @@ func TestIntegrationRum(t *testing.T) {
 				UserAgent: model.UserAgent{Original: "rum-2.0"},
 				Client:    model.Client{IP: net.ParseIP("192.0.0.1")}}
 
-			p := RUMV2Processor(&config.Config{MaxEventSize: 100 * 1024}, &transform.Config{})
+			p := RUMV2Processor(&config.Config{MaxEventSize: 100 * 1024})
 			actualResult := p.HandleStream(ctx, nil, &reqDecoderMeta, bodyReader, report)
 			assertApproveResult(t, actualResult, test.name)
 		})
@@ -194,7 +194,7 @@ func TestRUMV3(t *testing.T) {
 	reporter := func(name string) publish.Reporter {
 		return func(ctx context.Context, p publish.PendingReq) error {
 			for _, transformable := range p.Transformables {
-				resultEvents = append(resultEvents, transformable.Transform(ctx, p.Tcontext)...)
+				resultEvents = append(resultEvents, transformable.Transform(ctx, &transform.Config{})...)
 			}
 			return nil
 		}
@@ -219,7 +219,7 @@ func TestRUMV3(t *testing.T) {
 				UserAgent: model.UserAgent{Original: "rum-2.0"},
 				Client:    model.Client{IP: net.ParseIP("192.0.0.1")}}
 
-			p := RUMV3Processor(&config.Config{MaxEventSize: 100 * 1024}, &transform.Config{})
+			p := RUMV3Processor(&config.Config{MaxEventSize: 100 * 1024})
 			actualResult := p.HandleStream(ctx, nil, &reqDecoderMeta, bodyReader, reporter(name))
 			assertApproveResult(t, actualResult, test.name)
 

--- a/publish/pub_test.go
+++ b/publish/pub_test.go
@@ -56,7 +56,9 @@ func TestPublisherStop(t *testing.T) {
 	require.NoError(t, err)
 
 	publisher, err := publish.NewPublisher(
-		pipeline, apmtest.DiscardTracer, &publish.PublisherConfig{},
+		pipeline, apmtest.DiscardTracer, &publish.PublisherConfig{
+			TransformConfig: &transform.Config{},
+		},
 	)
 	require.NoError(t, err)
 	defer func() {
@@ -98,15 +100,15 @@ func TestPublisherStop(t *testing.T) {
 }
 
 func makeTransformable(events ...beat.Event) transform.Transformable {
-	return transformableFunc(func(ctx context.Context, tctx *transform.Context) []beat.Event {
+	return transformableFunc(func(ctx context.Context, cfg *transform.Config) []beat.Event {
 		return events
 	})
 }
 
-type transformableFunc func(context.Context, *transform.Context) []beat.Event
+type transformableFunc func(context.Context, *transform.Config) []beat.Event
 
-func (f transformableFunc) Transform(ctx context.Context, tctx *transform.Context) []beat.Event {
-	return f(ctx, tctx)
+func (f transformableFunc) Transform(ctx context.Context, cfg *transform.Config) []beat.Event {
+	return f(ctx, cfg)
 }
 
 type mockClient struct{}

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -27,20 +27,16 @@ import (
 )
 
 type Transformable interface {
-	Transform(context.Context, *Context) []beat.Event
+	Transform(context.Context, *Config) []beat.Event
 }
 
-// Context holds event-specific transformation context.
-//
-// TODO(axw) get rid of transform.Context, since it now holds only
-// static configuration. Introduce a "Transformer" type which can
-// be configured; we would have separate Transformers for RUM and
-// non-RUM.
-type Context struct {
-	Config Config
-}
-
+// Config holds general transformation configuration.
 type Config struct {
+	RUM RUMConfig
+}
+
+// RUMConfig holds RUM-related transformation configuration.
+type RUMConfig struct {
 	LibraryPattern      *regexp.Regexp
 	ExcludeFromGrouping *regexp.Regexp
 	SourcemapStore      *sourcemap.Store


### PR DESCRIPTION
## Motivation/summary

Currently `processor/stream`, `processor/otel`, etc. are tightly coupled with transformation, due to the need to thread `transform.Context` through these event producers into the publisher. As we work towards features like tail-based sampling, we will need to add support for persisting events to disk and read them back again prior to publishing. Requiring events to carry transformation context prevents this.

This PR makes two main changes:
 - relevant events (spans and errors) now indicate whether or not they are RUM events
 - the publisher is configured with a single transform config, which includes RUM-specific config only applied to RUM events

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

`make test`

## Related issues

None.