### PR TITLE
Remove ssl.certificate_authorities from apm-server.yml

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -84,19 +84,6 @@ apm-server:
     # Configure curve types for ECDHE based cipher suites.
     #curve_types: []
 
-    # Following options only concern requiring and verifying client certificates provided by the agents.
-    # Providing a client certificate is currently only supported by the RUM agent through
-    # browser configured certificates and Jaeger agents connecting via gRPC.
-    #
-    # Configure a list of root certificate authorities for verifying client certificates.
-    #certificate_authorities: []
-    #
-    # Configure which type of client authentication is supported.
-    # Options are `none`, `optional`, and `required`.
-    # Default is `none`. If `certificate_authorities` are configured,
-    # the value for `client_authentication` is automatically changed to `required`.
-    #client_authentication: "none"
-
   # The APM Server endpoints can be secured by configuring a secret token or enabling the usage of API keys. Both
   # options can be enabled in parallel, allowing Elastic APM agents to chose whichever mechanism they support.
   # As soon as one of the options is enabled, requests without a valid token are denied by the server. An exception

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -84,19 +84,6 @@ apm-server:
     # Configure curve types for ECDHE based cipher suites.
     #curve_types: []
 
-    # Following options only concern requiring and verifying client certificates provided by the agents.
-    # Providing a client certificate is currently only supported by the RUM agent through
-    # browser configured certificates and Jaeger agents connecting via gRPC.
-    #
-    # Configure a list of root certificate authorities for verifying client certificates.
-    #certificate_authorities: []
-    #
-    # Configure which type of client authentication is supported.
-    # Options are `none`, `optional`, and `required`.
-    # Default is `none`. If `certificate_authorities` are configured,
-    # the value for `client_authentication` is automatically changed to `required`.
-    #client_authentication: "none"
-
   # The APM Server endpoints can be secured by configuring a secret token or enabling the usage of API keys. Both
   # options can be enabled in parallel, allowing Elastic APM agents to chose whichever mechanism they support.
   # As soon as one of the options is enabled, requests without a valid token are denied by the server. An exception

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -84,19 +84,6 @@ apm-server:
     # Configure curve types for ECDHE based cipher suites.
     #curve_types: []
 
-    # Following options only concern requiring and verifying client certificates provided by the agents.
-    # Providing a client certificate is currently only supported by the RUM agent through
-    # browser configured certificates and Jaeger agents connecting via gRPC.
-    #
-    # Configure a list of root certificate authorities for verifying client certificates.
-    #certificate_authorities: []
-    #
-    # Configure which type of client authentication is supported.
-    # Options are `none`, `optional`, and `required`.
-    # Default is `none`. If `certificate_authorities` are configured,
-    # the value for `client_authentication` is automatically changed to `required`.
-    #client_authentication: "none"
-
   # The APM Server endpoints can be secured by configuring a secret token or enabling the usage of API keys. Both
   # options can be enabled in parallel, allowing Elastic APM agents to chose whichever mechanism they support.
   # As soon as one of the options is enabled, requests without a valid token are denied by the server. An exception

--- a/docs/ssl-input-settings.asciidoc
+++ b/docs/ssl-input-settings.asciidoc
@@ -52,6 +52,7 @@ The list of curve types for ECDHE (Elliptic Curve Diffie-Hellman ephemeral key e
 
 The list of root certificates for verifying client certificates.
 If `certificate_authorities` is empty or not set, the trusted certificate authorities of the host system are used.
+If `certificate_authorities` is set, `client_authentication` will be automatically set to `required`.
 Sending client certificates is currently only supported by the RUM agent through the browser
 and by the Jaeger agent.
 


### PR DESCRIPTION
## Motivation/summary

Setting a TLS certificate/key pair in apm-server.yml is a
common exercise, as users want to secure communications between
agents and server.

Configuring TLS client certificate authentication (mTLS)
is an uncommon requirement, and unsupported by most agents.
Users occasionally set `ssl.certificate_authorities` without
understanding the impact (makes client cert auth required),
and without needing to.

Because `ssl.certificate_authorities` is mostly for edge cases,
let's remove it from apm-server.yml and just document it in the
elastic.co docs. This will hopefully minimise accidental
configuration.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
- [x] documentation
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
~- [ ] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)~
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

N/A

## Related issues

None.