### PR TITLE
Refactor decoder to take stuct as parameter instead of creating and returning map struct

### DIFF
--- a/agentcfg/cache_test.go
+++ b/agentcfg/cache_test.go
@@ -18,6 +18,7 @@
 package agentcfg
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -119,7 +120,7 @@ func BenchmarkFetchAndAdd(b *testing.B) {
 		setup := newCacheSetup(b.Name(), exp, false)
 		q := Query{Service: Service{}}
 		for i := 0; i < b.N; i++ {
-			q.Service.Name = string(b.N)
+			q.Service.Name = fmt.Sprintf("%v", b.N)
 			setup.cache.fetch(q, testFn)
 		}
 	})

--- a/beater/authorization/privilege_test.go
+++ b/beater/authorization/privilege_test.go
@@ -18,6 +18,7 @@
 package authorization
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -31,7 +32,7 @@ func TestPrivilegesCache(t *testing.T) {
 	cache := newPrivilegesCache(time.Millisecond, n)
 	assert.False(t, cache.isFull())
 	for i := 0; i < n-1; i++ {
-		cache.add(string(i), elasticsearch.Permissions{})
+		cache.add(fmt.Sprintf("%v", i), elasticsearch.Permissions{})
 		assert.False(t, cache.isFull())
 	}
 	cache.add("oneMore", elasticsearch.Permissions{})

--- a/decoder/stream_decoder.go
+++ b/decoder/stream_decoder.go
@@ -24,7 +24,7 @@ import (
 	"io"
 )
 
-// NewNDJSONStreamDecoder returns a NewNDJSONStreamDecoder which decodes
+// NewNDJSONStreamDecoder returns a new NDJSONStreamDecoder which decodes
 // ND-JSON lines from r, with a maximum line length of maxLineLength.
 func NewNDJSONStreamDecoder(r io.Reader, maxLineLength int) *NDJSONStreamDecoder {
 	var dec NDJSONStreamDecoder
@@ -58,7 +58,7 @@ func (dec *NDJSONStreamDecoder) resetDecoder() {
 	dec.decoder = NewJSONDecoder(&dec.latestLineReader)
 }
 
-// Decode decodes the next line into the given interfacedec
+// Decode decodes the next line into v.
 func (dec *NDJSONStreamDecoder) Decode(v interface{}) error {
 	buf, readErr := dec.readLine()
 	if len(buf) == 0 || (readErr != nil && !dec.isEOF) {

--- a/decoder/stream_decoder_test.go
+++ b/decoder/stream_decoder_test.go
@@ -61,10 +61,11 @@ func TestNDStreamReader(t *testing.T) {
 		},
 	}
 	buf := bytes.NewBufferString(strings.Join(lines, "\n"))
-	n := NewNDJSONStreamReader(buf, 20)
+	n := NewNDJSONStreamDecoder(buf, 20)
 
 	for idx, test := range expected {
-		out, err := n.Read()
+		var out map[string]interface{}
+		err := n.Decode(&out)
 		assert.Equal(t, test.out, out, "Failed at idx %v", idx)
 		if test.errPattern == "" {
 			assert.Nil(t, err)

--- a/model/metadata_test.go
+++ b/model/metadata_test.go
@@ -18,16 +18,13 @@
 package model
 
 import (
-	"bytes"
 	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"go.elastic.co/apm/model"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 
-	"github.com/elastic/apm-server/decoder"
 	"github.com/elastic/apm-server/tests"
 )
 
@@ -170,26 +167,4 @@ func BenchmarkMetadataSet(b *testing.B) {
 		},
 		Labels: common.MapStr{"k": "v", "n": 1, "f": 1.5, "b": false},
 	})
-}
-
-func BenchmarkMetadataDecode(b *testing.B) {
-	maxEventSize := 307200
-	input := []byte(`{"metadata":{"process":{"pid":1234,"title":"/usr/lib/jvm/java-10-openjdk-amd64/bin/java","ppid":1,"argv":["-v"]},"system":{"architecture":"amd64","detected_hostname":"8ec7ceb99074","configured_hostname":"host1","platform":"Linux","container":{"id":"8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"},"kubernetes":{"namespace":"default","pod":{"uid":"b17f231da0ad128dc6c6c0b2e82f6f303d3893e3","name":"instrumented-java-service"},"node":{"name":"node-name"}}},"service":{"name":"1234_service-12a3","version":"4.3.0","node":{"configured_name":"8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"},"environment":"production","language":{"name":"Java","version":"10.0.2"},"agent":{"version":"1.10.0","name":"java","ephemeral_id":"e71be9ac-93b0-44b9-a997-5638f6ccfc36"},"framework":{"name":"spring","version":"5.0.0"},"runtime":{"name":"Java","version":"10.0.2"}},"labels":{"group":"experimental","ab_testing":true,"segment":5}}}`)
-
-	reader := bytes.NewReader(input)
-	var dec *decoder.NDJSONStreamDecoder
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		b.StopTimer()
-		reader.Reset(input)
-		dec = decoder.NewNDJSONStreamDecoder(reader, maxEventSize)
-		b.StartTimer()
-
-		for !dec.IsEOF() {
-			var span model.Span
-			if err := dec.Decode(&span); err != nil && !dec.IsEOF() {
-				panic(err.Error())
-			}
-		}
-	}
 }

--- a/model/metadata_test.go
+++ b/model/metadata_test.go
@@ -18,13 +18,16 @@
 package model
 
 import (
+	"bytes"
 	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.elastic.co/apm/model"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 
+	"github.com/elastic/apm-server/decoder"
 	"github.com/elastic/apm-server/tests"
 )
 
@@ -167,4 +170,26 @@ func BenchmarkMetadataSet(b *testing.B) {
 		},
 		Labels: common.MapStr{"k": "v", "n": 1, "f": 1.5, "b": false},
 	})
+}
+
+func BenchmarkMetadataDecode(b *testing.B) {
+	maxEventSize := 307200
+	input := []byte(`{"metadata":{"process":{"pid":1234,"title":"/usr/lib/jvm/java-10-openjdk-amd64/bin/java","ppid":1,"argv":["-v"]},"system":{"architecture":"amd64","detected_hostname":"8ec7ceb99074","configured_hostname":"host1","platform":"Linux","container":{"id":"8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"},"kubernetes":{"namespace":"default","pod":{"uid":"b17f231da0ad128dc6c6c0b2e82f6f303d3893e3","name":"instrumented-java-service"},"node":{"name":"node-name"}}},"service":{"name":"1234_service-12a3","version":"4.3.0","node":{"configured_name":"8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"},"environment":"production","language":{"name":"Java","version":"10.0.2"},"agent":{"version":"1.10.0","name":"java","ephemeral_id":"e71be9ac-93b0-44b9-a997-5638f6ccfc36"},"framework":{"name":"spring","version":"5.0.0"},"runtime":{"name":"Java","version":"10.0.2"}},"labels":{"group":"experimental","ab_testing":true,"segment":5}}}`)
+
+	reader := bytes.NewReader(input)
+	var dec *decoder.NDJSONStreamDecoder
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		reader.Reset(input)
+		dec = decoder.NewNDJSONStreamDecoder(reader, maxEventSize)
+		b.StartTimer()
+
+		for !dec.IsEOF() {
+			var span model.Span
+			if err := dec.Decode(&span); err != nil && !dec.IsEOF() {
+				panic(err.Error())
+			}
+		}
+	}
 }

--- a/processor/stream/package_tests/intake_test_processor.go
+++ b/processor/stream/package_tests/intake_test_processor.go
@@ -48,24 +48,23 @@ type intakeTestProcessor struct {
 
 const lrSize = 100 * 1024
 
-func (v *intakeTestProcessor) getReader(path string) (*decoder.NDJSONStreamReader, error) {
+func (v *intakeTestProcessor) getDecoder(path string) (*decoder.NDJSONStreamDecoder, error) {
 	reader, err := loader.LoadDataAsStream(path)
 	if err != nil {
 		return nil, err
 	}
-	return decoder.NewNDJSONStreamReader(reader, lrSize), nil
+	return decoder.NewNDJSONStreamDecoder(reader, lrSize), nil
 }
 
-func (v *intakeTestProcessor) readEvents(reader *decoder.NDJSONStreamReader) ([]interface{}, error) {
+func (v *intakeTestProcessor) readEvents(dec *decoder.NDJSONStreamDecoder) ([]interface{}, error) {
 	var (
 		err    error
-		e      map[string]interface{}
 		events []interface{}
 	)
 
 	for err != io.EOF {
-		e, err = reader.Read()
-		if err != nil && err != io.EOF {
+		var e map[string]interface{}
+		if err = dec.Decode(&e); err != nil && err != io.EOF {
 			return events, err
 		}
 		if e != nil {
@@ -76,13 +75,14 @@ func (v *intakeTestProcessor) readEvents(reader *decoder.NDJSONStreamReader) ([]
 }
 
 func (p *intakeTestProcessor) LoadPayload(path string) (interface{}, error) {
-	ndjson, err := p.getReader(path)
+	ndjson, err := p.getDecoder(path)
 	if err != nil {
 		return nil, err
 	}
 
 	// read and discard metadata
-	ndjson.Read()
+	var m map[string]interface{}
+	ndjson.Decode(&m)
 
 	return p.readEvents(ndjson)
 }

--- a/processor/stream/package_tests/metadata_attrs_test.go
+++ b/processor/stream/package_tests/metadata_attrs_test.go
@@ -36,7 +36,7 @@ type MetadataProcessor struct {
 }
 
 func (p *MetadataProcessor) LoadPayload(path string) (interface{}, error) {
-	ndjson, err := p.getReader(path)
+	ndjson, err := p.getDecoder(path)
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +82,8 @@ func getMetadataEventAttrs(t *testing.T, prefix string) *tests.Set {
 	payloadStream, err := loader.LoadDataAsStream("../testdata/intake-v2/only-metadata.ndjson")
 	require.NoError(t, err)
 
-	metadata, err := decoder.NewNDJSONStreamReader(payloadStream, lrSize).Read()
-	require.NoError(t, err)
+	var metadata map[string]interface{}
+	require.NoError(t, decoder.NewNDJSONStreamDecoder(payloadStream, lrSize).Decode(&metadata))
 
 	contextMetadata := metadata["metadata"]
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Before creating the PR, ensure that:

1. Your branch is rebased on top of the latest master.
   Squash your initial commits into meaningful commits.
   After creating a PR, do not rebase of force push any longer.
2. Nothing is broken, by running the test suite (at least unit tests).
   See https://github.com/elastic/apm-server/blob/master/TESTING.md for details.
3. Your code follows the style guidelines of this project:
   run `make check-full` for static code checks and linting.

A few suggestions about filling out this PR:

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR.
3. Please label this PR with at least one of the following labels:
   - bug fix
   - breaking change
   - enhancement
4. Reference the related issue, and make use of magic keywords where it makes sense
   https://help.github.com/articles/closing-issues-using-keywords/.
5. Do not remove any checklist items, strike through the ones that don't apply
   (by using tildes, e.g. ~scratch this ~).
6. Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
7. Submit the pull request:
   Push your changes to your forked copy of the repository and submit a pull request
   (https://help.github.com/articles/using-pull-requests).
8. Please be patient. We might not be able to immediately review your code,
   but we'll do our best to dedicate to it the attention it deserves.
   Your effort is much appreciated!

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
Refactor `NDSJONStreamReader` to decode bytes from reader into any given struct instead of creating and returning a `map[string]interface{}`. This is a precondition for decoding directly into models instead of map structs and further on for reusing the structs.

## Checklist

~- [ ] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).~
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001]~(https://github.com/elastic/kibana/issues/44001))
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes
`make test`

## Related issues
https://github.com/elastic/apm-server/issues/3551
