### PR TITLE
elasticsearch: honour "headers" config

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -798,7 +798,7 @@ License type (autodetected): Apache-2.0
 --------------------------------------------------------------------
 Dependency: github.com/elastic/go-elasticsearch/v8
 Version: v8.0.0
-Revision: aff00e5adfde
+Revision: 59b6a186f8dd
 License type (autodetected): Apache-2.0
 
 --------------------------------------------------------------------

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -10,6 +10,7 @@ https://github.com/elastic/apm-server/compare/7.9\...master[View commits]
 ==== Bug fixes
 
 * Transaction metrics aggregation now flushes on shutdown, respecting apm-server.shutdown_timeout {pull}3971[3971]
+* Honour output.elasticsearch.headers configuration in API Key auth and source mapping {pull}4090[4090]
 
 [float]
 ==== Intake API Changes

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -83,45 +83,47 @@ func NewClient(config *Config) (Client, error) {
 	if config == nil {
 		return nil, errConfigMissing
 	}
-	transport, addresses, err := connectionConfig(config)
+	transport, addresses, headers, err := connectionConfig(config)
 	if err != nil {
 		return nil, err
 	}
-	return NewVersionedClient(config.APIKey, config.Username, config.Password, addresses, transport)
+	return NewVersionedClient(config.APIKey, config.Username, config.Password, addresses, headers, transport)
 }
 
 // NewVersionedClient returns the right elasticsearch client for the current Stack version, as an interface
-func NewVersionedClient(apikey, user, pwd string, addresses []string, transport http.RoundTripper) (Client, error) {
+func NewVersionedClient(apikey, user, pwd string, addresses []string, headers http.Header, transport http.RoundTripper) (Client, error) {
 	if apikey != "" {
 		apikey = base64.StdEncoding.EncodeToString([]byte(apikey))
 	}
 	transport = apmelasticsearch.WrapRoundTripper(transport)
 	version := common.MustNewVersion(version.GetDefaultVersion())
 	if version.IsMajor(8) {
-		c, err := newV8Client(apikey, user, pwd, addresses, transport)
+		c, err := newV8Client(apikey, user, pwd, addresses, headers, transport)
 		return clientV8{c}, err
 	}
-	c, err := newV7Client(apikey, user, pwd, addresses, transport)
+	c, err := newV7Client(apikey, user, pwd, addresses, headers, transport)
 	return clientV7{c}, err
 }
 
-func newV7Client(apikey, user, pwd string, addresses []string, transport http.RoundTripper) (*esv7.Client, error) {
+func newV7Client(apikey, user, pwd string, addresses []string, headers http.Header, transport http.RoundTripper) (*esv7.Client, error) {
 	return esv7.NewClient(esv7.Config{
 		APIKey:    apikey,
 		Username:  user,
 		Password:  pwd,
 		Addresses: addresses,
 		Transport: transport,
+		Header:    headers,
 	})
 }
 
-func newV8Client(apikey, user, pwd string, addresses []string, transport http.RoundTripper) (*esv8.Client, error) {
+func newV8Client(apikey, user, pwd string, addresses []string, headers http.Header, transport http.RoundTripper) (*esv8.Client, error) {
 	return esv8.NewClient(esv8.Config{
 		APIKey:    apikey,
 		Username:  user,
 		Password:  pwd,
 		Addresses: addresses,
 		Transport: transport,
+		Header:    headers,
 	})
 }
 

--- a/elasticsearch/config.go
+++ b/elasticsearch/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	Username     string            `config:"username"`
 	Password     string            `config:"password"`
 	APIKey       string            `config:"api_key"`
+	Headers      map[string]string `config:"headers"`
 }
 
 // DefaultConfig returns a default config.
@@ -72,16 +73,23 @@ func (h Hosts) Validate() error {
 	return nil
 }
 
-func connectionConfig(config *Config) (http.RoundTripper, []string, error) {
+func connectionConfig(config *Config) (http.RoundTripper, []string, http.Header, error) {
 	addrs, err := addresses(config)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	transp, err := httpTransport(config)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return transp, addrs, nil
+	var headers http.Header
+	if len(config.Headers) > 0 {
+		headers = make(http.Header)
+		for k, v := range config.Headers {
+			headers.Set(k, v)
+		}
+	}
+	return transp, addrs, headers, nil
 }
 
 func httpProxyURL(cfg *Config) (func(*http.Request) (*url.URL, error), error) {

--- a/elasticsearch/config_test.go
+++ b/elasticsearch/config_test.go
@@ -34,6 +34,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func init() {
+	// Set HTTP_PROXY at package init time, because
+	// http.ProxyFromEnvironment is cached and changes
+	// to the environment will not affect it later.
+	os.Setenv("HTTP_PROXY", "proxy.invalid")
+}
+
 func TestHttpProxyUrl(t *testing.T) {
 	t.Run("proxy disabled", func(t *testing.T) {
 		proxy, err := httpProxyURL(&Config{ProxyDisable: true})
@@ -42,22 +49,16 @@ func TestHttpProxyUrl(t *testing.T) {
 	})
 
 	t.Run("proxy from ENV", func(t *testing.T) {
-		// set env var for http proxy
-		os.Setenv("HTTP_PROXY", "proxy")
-
 		// create proxy function
 		proxy, err := httpProxyURL(&Config{})
 		require.Nil(t, err)
 		// ensure proxy function is called and check url
 		url, err := proxy(httptest.NewRequest(http.MethodGet, "http://example.com", nil))
 		require.Nil(t, err)
-		assert.Equal(t, "http://proxy", url.String())
+		assert.Equal(t, "http://proxy.invalid", url.String())
 	})
 
 	t.Run("proxy from URL", func(t *testing.T) {
-		// set env var for http proxy
-		os.Setenv("HTTP_PROXY", "proxy")
-
 		// create proxy function from URL without `http` prefix
 		proxy, err := httpProxyURL(&Config{ProxyURL: "foo"})
 		require.Nil(t, err)
@@ -159,7 +160,6 @@ func TestBeatsConfigSynced(t *testing.T) {
 		"bulk_max_size",
 		"compression_level",
 		"escape_html",
-		"headers",
 		// TODO Kerberos auth (https://github.com/elastic/apm-server/issues/3794)
 		"kerberos",
 		"loadbalance",

--- a/elasticsearch/estest/client.go
+++ b/elasticsearch/estest/client.go
@@ -25,11 +25,10 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/apm-server/elasticsearch"
-
-	"github.com/pkg/errors"
 )
 
 // Transport can be used to pass to test Elasticsearch Client for more control over client behavior
@@ -67,5 +66,5 @@ func NewTransport(t *testing.T, statusCode int, esBody map[string]interface{}) *
 
 // NewElasticsearchClient creates ES client using the given transport instance
 func NewElasticsearchClient(transport *Transport) (elasticsearch.Client, error) {
-	return elasticsearch.NewVersionedClient("", "", "", []string{}, transport)
+	return elasticsearch.NewVersionedClient("", "", "", []string{}, nil, transport)
 }

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4
 	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20200820005814-38fc1ed06525
 	github.com/elastic/go-elasticsearch/v7 v7.8.0
-	github.com/elastic/go-elasticsearch/v8 v8.0.0-20200210103600-aff00e5adfde
+	github.com/elastic/go-elasticsearch/v8 v8.0.0-20200819071622-59b6a186f8dd
 	github.com/elastic/go-hdrhistogram v0.1.0
 	github.com/elastic/go-licenser v0.3.1
 	github.com/elastic/go-sysinfo v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/elastic/fsevents v0.0.0-20181029231046-e1d381a4d270/go.mod h1:Msl1pdb
 github.com/elastic/go-concert v0.0.4/go.mod h1:9MtFarjXroUgmm0m6HY3NSe1XiKhdktiNRRj9hWvIaM=
 github.com/elastic/go-elasticsearch/v7 v7.8.0 h1:M9D55OK13IEgg51Jb57mZgseag1AsncwAUn4C6j1vlc=
 github.com/elastic/go-elasticsearch/v7 v7.8.0/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
-github.com/elastic/go-elasticsearch/v8 v8.0.0-20200210103600-aff00e5adfde h1:Y9SZx8RQqFycLxi5W5eFmxMqnmijULVc3LMjBTtZQdM=
-github.com/elastic/go-elasticsearch/v8 v8.0.0-20200210103600-aff00e5adfde/go.mod h1:xe9a/L2aeOgFKKgrO3ibQTnMdpAeL0GC+5/HpGScSa4=
+github.com/elastic/go-elasticsearch/v8 v8.0.0-20200819071622-59b6a186f8dd h1:kVw29H2M+wai0NQ/W8FzngD80DnHTUfz/8kbfZl10hU=
+github.com/elastic/go-elasticsearch/v8 v8.0.0-20200819071622-59b6a186f8dd/go.mod h1:xe9a/L2aeOgFKKgrO3ibQTnMdpAeL0GC+5/HpGScSa4=
 github.com/elastic/go-hdrhistogram v0.1.0 h1:7UVeQ9MsO5c9h8RJeH2S2lXCGi9hQB/94W6Pjjqprc4=
 github.com/elastic/go-hdrhistogram v0.1.0/go.mod h1:NEl0wZTQXzwq7X2WBZGl5G3efcKbvv+r9mTZpXrIs78=
 github.com/elastic/go-libaudit/v2 v2.0.1/go.mod h1:u100Al3gXDlDelEutZ0CZ6BMM+LsRFqdi7kzdrn6g7o=


### PR DESCRIPTION
## Motivation/summary

Honour the `elasticsearch.headers` config for `api_key` and `source_mapping`. I haven't updated `apm-server.yml` for now because this config is for unusual use cases. I would defer updating the config file or docs until users request the feature.

Update the go-elasticsearch/v8 module to add support for passing "global headers".

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

I have considered changes for:
- [x] documentation
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
- [x] Elasticsearch Service (https://cloud.elastic.co)
- [x] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)
- [x] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)

## How to test these changes

See https://github.com/elastic/apm-server/issues/4089

## Related issues

Closes https://github.com/elastic/apm-server/issues/4089