### PR TITLE
[7.x] Flush aggregator on shutdown (#3971)

### DIFF
--- a/publish/acker.go
+++ b/publish/acker.go
@@ -1,0 +1,79 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package publish
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+)
+
+// waitPublishedAcker is a beat.ACKer which keeps track of the number of
+// events published. waitPublishedAcker provides an interruptible Wait method
+// that blocks until all events published at the time the client is closed are
+// acknowledged.
+type waitPublishedAcker struct {
+	active int64 // atomic
+
+	mu     sync.RWMutex
+	closed bool
+	done   chan struct{}
+}
+
+func newWaitPublishedAcker() *waitPublishedAcker {
+	return &waitPublishedAcker{done: make(chan struct{})}
+}
+
+// AddEvent is called when an event has been published or dropped by the client,
+// and increments a counter for published events.
+func (w *waitPublishedAcker) AddEvent(event beat.Event, published bool) {
+	if !published {
+		return
+	}
+	atomic.AddInt64(&w.active, 1)
+}
+
+// ACKEvents is called when published events have been acknowledged.
+func (w *waitPublishedAcker) ACKEvents(n int) {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	if atomic.AddInt64(&w.active, int64(-n)) == 0 && w.closed {
+		close(w.done)
+	}
+}
+
+// Close closes w, unblocking Wait when all previously published events have
+// been acknowledged.
+func (w *waitPublishedAcker) Close() {
+	w.mu.Lock()
+	w.closed = true
+	w.mu.Unlock()
+}
+
+// Wait waits for w to be closed and all previously published events to be
+// acknowledged.
+func (w *waitPublishedAcker) Wait(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-w.done:
+		return nil
+	}
+}

--- a/publish/pub.go
+++ b/publish/pub.go
@@ -41,11 +41,14 @@ type Reporter func(context.Context, PendingReq) error
 // number requests(events) active in the system can exceed the queue size. Only
 // the number of concurrent HTTP requests trying to publish at the same time is limited.
 type Publisher struct {
+	stopped       chan struct{}
+	tracer        *apm.Tracer
+	client        beat.Client
+	waitPublished *waitPublishedAcker
+
+	mu              sync.RWMutex
+	stopping        bool
 	pendingRequests chan PendingReq
-	tracer          *apm.Tracer
-	client          beat.Client
-	m               sync.RWMutex
-	stopped         bool
 }
 
 type PendingReq struct {
@@ -57,9 +60,8 @@ type PendingReq struct {
 // PublisherConfig is a struct holding configuration information for the publisher,
 // such as shutdown timeout, default pipeline name and beat info.
 type PublisherConfig struct {
-	Info            beat.Info
-	ShutdownTimeout time.Duration
-	Pipeline        string
+	Info     beat.Info
+	Pipeline string
 }
 
 var (
@@ -86,28 +88,39 @@ func NewPublisher(pipeline beat.Pipeline, tracer *apm.Tracer, cfg *PublisherConf
 	if cfg.Pipeline != "" {
 		processingCfg.Meta = map[string]interface{}{"pipeline": cfg.Pipeline}
 	}
-	client, err := pipeline.ConnectWith(beat.ClientConfig{
-		PublishMode: beat.GuaranteedSend,
-		// If set >0 `Close` will block for the duration or until pipeline is empty
-		WaitClose:  cfg.ShutdownTimeout,
-		Processing: processingCfg,
-	})
-	if err != nil {
-		return nil, err
-	}
 
 	p := &Publisher{
-		tracer: tracer,
-		client: client,
+		tracer:        tracer,
+		stopped:       make(chan struct{}),
+		waitPublished: newWaitPublishedAcker(),
 
 		// One request will be actively processed by the
 		// worker, while the other concurrent requests will be buffered in the queue.
 		pendingRequests: make(chan PendingReq, runtime.GOMAXPROCS(0)),
 	}
 
-	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
-		go p.run()
+	client, err := pipeline.ConnectWith(beat.ClientConfig{
+		PublishMode: beat.GuaranteedSend,
+		Processing:  processingCfg,
+		ACKHandler:  p.waitPublished,
+	})
+	if err != nil {
+		return nil, err
 	}
+	p.client = client
+
+	var wg sync.WaitGroup
+	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			p.run()
+		}()
+	}
+	go func() {
+		defer close(p.stopped)
+		wg.Wait()
+	}()
 
 	return p, nil
 }
@@ -117,28 +130,49 @@ func (p *Publisher) Client() beat.Client {
 	return p.client
 }
 
-// Stop closes all channels and waits for the the worker to stop.
-// The worker will drain the queue on shutdown, but no more pending requests
-// will be published.
-func (p *Publisher) Stop() {
-	p.m.Lock()
-	p.stopped = true
-	p.m.Unlock()
-	close(p.pendingRequests)
-	p.client.Close()
+// Stop closes all channels and waits for the the worker to stop, or for the
+// context to be signalled. If the context is never cancelled, Stop may block
+// indefinitely.
+//
+// The worker will drain the queue on shutdown, but no more requests will be
+// published after Stop returns.
+func (p *Publisher) Stop(ctx context.Context) error {
+	// Prevent additional requests from being enqueued.
+	p.mu.Lock()
+	if !p.stopping {
+		p.stopping = true
+		close(p.pendingRequests)
+	}
+	p.mu.Unlock()
+
+	// Wait for enqueued events to be published. Order of events is
+	// important here:
+	//   (1) wait for pendingRequests to be drained and published (p.stopped)
+	//   (2) close the beat.Client to prevent more events being published
+	//   (3) wait for published events to be acknowledged
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-p.stopped:
+	}
+	if err := p.client.Close(); err != nil {
+		return err
+	}
+	return p.waitPublished.Wait(ctx)
 }
 
 // Send tries to forward pendingReq to the publishers worker. If the queue is full,
 // an error is returned.
-// Calling send after Stop will return an error.
+//
+// Calling Send after Stop will return an error without enqueuing the request.
 func (p *Publisher) Send(ctx context.Context, req PendingReq) error {
 	if len(req.Transformables) == 0 {
 		return nil
 	}
 
-	p.m.RLock()
-	defer p.m.RUnlock()
-	if p.stopped {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if p.stopping {
 		return ErrChannelClosed
 	}
 
@@ -147,7 +181,10 @@ func (p *Publisher) Send(ctx context.Context, req PendingReq) error {
 		return ctx.Err()
 	case p.pendingRequests <- req:
 		return nil
-	case <-time.After(time.Second * 1): // this forces the go scheduler to try something else for a while
+	case <-time.After(time.Second * 1):
+		// TODO(axw) instead of having an arbitrary delay here,
+		// make it the caller's responsibility to use a context
+		// with a timeout.
 		return ErrFull
 	}
 }

--- a/publish/pub_test.go
+++ b/publish/pub_test.go
@@ -1,0 +1,119 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package publish_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/outputs"
+	"github.com/elastic/beats/v7/libbeat/publisher"
+	"github.com/elastic/beats/v7/libbeat/publisher/pipeline"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue"
+	"github.com/elastic/beats/v7/libbeat/publisher/queue/memqueue"
+	"go.elastic.co/apm/apmtest"
+
+	"github.com/elastic/apm-server/publish"
+	"github.com/elastic/apm-server/transform"
+)
+
+func TestPublisherStop(t *testing.T) {
+	// Create a pipeline with a limited queue size and no outputs,
+	// so we can simulate a pipeline that blocks indefinitely.
+	pipeline, err := pipeline.New(
+		beat.Info{},
+		pipeline.Monitors{},
+		func(lis queue.ACKListener) (queue.Queue, error) {
+			return memqueue.NewQueue(nil, memqueue.Settings{
+				ACKListener: lis,
+				Events:      1,
+			}), nil
+		},
+		outputs.Group{},
+		pipeline.Settings{},
+	)
+	require.NoError(t, err)
+
+	publisher, err := publish.NewPublisher(
+		pipeline, apmtest.DiscardTracer, &publish.PublisherConfig{},
+	)
+	require.NoError(t, err)
+	defer func() {
+		cancelledContext, cancel := context.WithCancel(context.Background())
+		cancel() // cancel immediately to avoid blocking Stop
+		publisher.Stop(cancelledContext)
+	}()
+
+	// Publish events until the publisher's channel fills up, meaning that
+	// the pipeline is full and there are still pending requests. The publisher
+	// waits for enqueued requests to be published, up until a configurable
+	// time has elapsed.
+	for {
+		err := publisher.Send(context.Background(), publish.PendingReq{
+			Transformables: []transform.Transformable{makeTransformable(
+				beat.Event{Fields: make(common.MapStr)},
+			)},
+		})
+		if err == publish.ErrFull {
+			break
+		}
+		assert.NoError(t, err)
+	}
+
+	// Stopping the publisher should block until the context is cancelled.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	assert.Equal(t, context.DeadlineExceeded, publisher.Stop(ctx))
+
+	// Set an output which acknowledges events immediately, unblocking publisher.Stop.
+	assert.NoError(t, pipeline.OutputReloader().Reload(nil,
+		func(outputs.Observer, common.ConfigNamespace) (outputs.Group, error) {
+			return outputs.Group{Clients: []outputs.Client{&mockClient{}}}, nil
+		},
+	))
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	assert.NoError(t, publisher.Stop(ctx))
+}
+
+func makeTransformable(events ...beat.Event) transform.Transformable {
+	return transformableFunc(func(ctx context.Context, tctx *transform.Context) []beat.Event {
+		return events
+	})
+}
+
+type transformableFunc func(context.Context, *transform.Context) []beat.Event
+
+func (f transformableFunc) Transform(ctx context.Context, tctx *transform.Context) []beat.Event {
+	return f(ctx, tctx)
+}
+
+type mockClient struct{}
+
+func (*mockClient) String() string { return "mock_client" }
+func (*mockClient) Close() error   { return nil }
+func (*mockClient) Publish(_ context.Context, batch publisher.Batch) error {
+	batch.ACK()
+	return nil
+}

--- a/tests/system/test_aggregation.py
+++ b/tests/system/test_aggregation.py
@@ -45,3 +45,25 @@ class Test(ElasticTest):
             # @timestamp is dynamic, so set it to something known.
             doc['_source']['@timestamp'] = '2020-04-14T08:56:03.100Z'
         self.approve_docs('rum_transaction_histogram_metrics', metric_docs)
+
+
+@integration_test
+class TestShutdown(ElasticTest):
+    def config(self):
+        cfg = super(TestShutdown, self).config()
+        cfg.update({
+            "aggregation_enabled": True,
+            # Set aggregation_interval to something that would cause
+            # a timeout if we were to wait that long. The server
+            # should flush metrics on shutdown without waiting for
+            # the configured interval.
+            "aggregation_interval": "180s",
+        })
+        return cfg
+
+    def test_transaction_metrics_flushed_shutdown(self):
+        self.load_docs_with_template(self.get_payload_path("transactions_spans.ndjson"),
+                                     self.intake_url, 'transaction', 9)
+        self.assert_no_logged_warnings()
+        self.apmserver_proc.kill() # Stop server to ensure metrics are flushed on shutdown
+        self.wait_for_events('metric', 3, index=index_metric)


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Flush aggregator on shutdown (#3971)