### PR TITLE
[7.x] Refactor decoder to take stuct as parameter instead of creating and returning map struct (#4072)

### DIFF
--- a/decoder/stream_decoder.go
+++ b/decoder/stream_decoder.go
@@ -24,18 +24,18 @@ import (
 	"io"
 )
 
-// NewNDJSONStreamReader returns a NDJSONStreamReader which reads
+// NewNDJSONStreamDecoder returns a new NDJSONStreamDecoder which decodes
 // ND-JSON lines from r, with a maximum line length of maxLineLength.
-func NewNDJSONStreamReader(r io.Reader, maxLineLength int) *NDJSONStreamReader {
-	var sr NDJSONStreamReader
-	sr.bufioReader = bufio.NewReaderSize(r, maxLineLength)
-	sr.lineReader = NewLineReader(sr.bufioReader, maxLineLength)
-	sr.resetDecoder()
-	return &sr
+func NewNDJSONStreamDecoder(r io.Reader, maxLineLength int) *NDJSONStreamDecoder {
+	var dec NDJSONStreamDecoder
+	dec.bufioReader = bufio.NewReaderSize(r, maxLineLength)
+	dec.lineReader = NewLineReader(dec.bufioReader, maxLineLength)
+	dec.resetDecoder()
+	return &dec
 }
 
-// NDJSONStreamReader reads and decodes a stream of ND-JSON lines from an io.Reader.
-type NDJSONStreamReader struct {
+// NDJSONStreamDecoder decodes a stream of ND-JSON lines from an io.Reader.
+type NDJSONStreamDecoder struct {
 	bufioReader *bufio.Reader
 	lineReader  *LineReader
 
@@ -46,43 +46,47 @@ type NDJSONStreamReader struct {
 }
 
 // Reset sets sr's underlying io.Reader to r, and resets any reading/decoding state.
-func (sr *NDJSONStreamReader) Reset(r io.Reader) {
-	sr.bufioReader.Reset(r)
-	sr.lineReader.Reset(sr.bufioReader)
-	sr.isEOF = false
-	sr.latestLine = nil
-	sr.latestLineReader.Reset(nil)
+func (dec *NDJSONStreamDecoder) Reset(r io.Reader) {
+	dec.bufioReader.Reset(r)
+	dec.lineReader.Reset(dec.bufioReader)
+	dec.isEOF = false
+	dec.latestLine = nil
+	dec.latestLineReader.Reset(nil)
 }
 
-func (sr *NDJSONStreamReader) resetDecoder() {
-	sr.decoder = NewJSONDecoder(&sr.latestLineReader)
+func (dec *NDJSONStreamDecoder) resetDecoder() {
+	dec.decoder = NewJSONDecoder(&dec.latestLineReader)
 }
 
-func (sr *NDJSONStreamReader) Read() (map[string]interface{}, error) {
-	buf, readErr := sr.readLine()
-	if len(buf) == 0 || (readErr != nil && !sr.isEOF) {
-		return nil, readErr
+// Decode decodes the next line into v.
+func (dec *NDJSONStreamDecoder) Decode(v interface{}) error {
+	buf, readErr := dec.readLine()
+	if len(buf) == 0 || (readErr != nil && !dec.isEOF) {
+		return readErr
 	}
-	decoded := make(map[string]interface{})
-	if err := sr.decoder.Decode(&decoded); err != nil {
-		sr.resetDecoder() // clear out decoding state
-		return nil, JSONDecodeError("data read error: " + err.Error())
+	if err := dec.decoder.Decode(v); err != nil {
+		dec.resetDecoder() // clear out decoding state
+		return JSONDecodeError("data read error: " + err.Error())
 	}
-	return decoded, readErr // this might be io.EOF
+	return readErr // this might be io.EOF
 }
 
-func (sr *NDJSONStreamReader) readLine() ([]byte, error) {
+func (dec *NDJSONStreamDecoder) readLine() ([]byte, error) {
 	// readLine can return valid data in `buf` _and_ also an io.EOF
-	line, readErr := sr.lineReader.ReadLine()
-	sr.latestLine = line
-	sr.latestLineReader.Reset(sr.latestLine)
-	sr.isEOF = readErr == io.EOF
+	line, readErr := dec.lineReader.ReadLine()
+	dec.latestLine = line
+	dec.latestLineReader.Reset(dec.latestLine)
+	dec.isEOF = readErr == io.EOF
 	return line, readErr
 }
 
-func (sr *NDJSONStreamReader) IsEOF() bool        { return sr.isEOF }
-func (sr *NDJSONStreamReader) LatestLine() []byte { return sr.latestLine }
+// IsEOF signals whether the underlying reader reached the end
+func (dec *NDJSONStreamDecoder) IsEOF() bool { return dec.isEOF }
 
+// LatestLine returns the latest line read as []byte
+func (dec *NDJSONStreamDecoder) LatestLine() []byte { return dec.latestLine }
+
+// JSONDecodeError is a custom error that can occur during JSON decoding
 type JSONDecodeError string
 
 func (s JSONDecodeError) Error() string { return string(s) }

--- a/decoder/stream_decoder_test.go
+++ b/decoder/stream_decoder_test.go
@@ -61,10 +61,11 @@ func TestNDStreamReader(t *testing.T) {
 		},
 	}
 	buf := bytes.NewBufferString(strings.Join(lines, "\n"))
-	n := NewNDJSONStreamReader(buf, 20)
+	n := NewNDJSONStreamDecoder(buf, 20)
 
 	for idx, test := range expected {
-		out, err := n.Read()
+		var out map[string]interface{}
+		err := n.Decode(&out)
 		assert.Equal(t, test.out, out, "Failed at idx %v", idx)
 		if test.errPattern == "" {
 			assert.Nil(t, err)

--- a/processor/stream/package_tests/metadata_attrs_test.go
+++ b/processor/stream/package_tests/metadata_attrs_test.go
@@ -36,7 +36,7 @@ type MetadataProcessor struct {
 }
 
 func (p *MetadataProcessor) LoadPayload(path string) (interface{}, error) {
-	ndjson, err := p.getReader(path)
+	ndjson, err := p.getDecoder(path)
 	if err != nil {
 		return nil, err
 	}
@@ -82,8 +82,8 @@ func getMetadataEventAttrs(t *testing.T, prefix string) *tests.Set {
 	payloadStream, err := loader.LoadDataAsStream("../testdata/intake-v2/only-metadata.ndjson")
 	require.NoError(t, err)
 
-	metadata, err := decoder.NewNDJSONStreamReader(payloadStream, lrSize).Read()
-	require.NoError(t, err)
+	var metadata map[string]interface{}
+	require.NoError(t, decoder.NewNDJSONStreamDecoder(payloadStream, lrSize).Decode(&metadata))
 
 	contextMetadata := metadata["metadata"]
 

--- a/processor/stream/processor.go
+++ b/processor/stream/processor.go
@@ -105,23 +105,24 @@ func RUMV3Processor(cfg *config.Config, tcfg *transform.Config) *Processor {
 	}
 }
 
-func (p *Processor) readMetadata(metadata *model.Metadata, reader *streamReader) (*model.Metadata, error) {
-	rawModel, err := reader.Read()
+func (p *Processor) readMetadata(metadata *model.Metadata, reader *streamReader) error {
+	var rawModel map[string]interface{}
+	err := reader.Read(&rawModel)
 	if err != nil {
 		if err == io.EOF {
-			return nil, &Error{
+			return &Error{
 				Type:     InvalidInputErrType,
 				Message:  "EOF while reading metadata",
 				Document: string(reader.LatestLine()),
 			}
 		}
-		return nil, err
+		return err
 	}
 
 	fieldName := field.Mapper(p.Mconfig.HasShortFieldNames)
 	rawMetadata, ok := rawModel[fieldName("metadata")].(map[string]interface{})
 	if !ok {
-		return nil, &Error{
+		return &Error{
 			Type:     InvalidInputErrType,
 			Message:  ErrUnrecognizedObject.Error(),
 			Document: string(reader.LatestLine()),
@@ -131,15 +132,15 @@ func (p *Processor) readMetadata(metadata *model.Metadata, reader *streamReader)
 	if err := p.decodeMetadata(rawMetadata, p.Mconfig.HasShortFieldNames, metadata); err != nil {
 		var ve *validation.Error
 		if errors.As(err, &ve) {
-			return nil, &Error{
+			return &Error{
 				Type:     InvalidInputErrType,
 				Message:  err.Error(),
 				Document: string(reader.LatestLine()),
 			}
 		}
-		return nil, err
+		return err
 	}
-	return metadata, nil
+	return nil
 }
 
 // HandleRawModel validates and decodes a single json object into its struct form
@@ -193,7 +194,8 @@ func (p *Processor) readBatch(
 
 	// input events are decoded and appended to the batch
 	for i := 0; i < batchSize && !reader.IsEOF(); i++ {
-		rawModel, err := reader.Read()
+		var rawModel map[string]interface{}
+		err := reader.Read(&rawModel)
 		if err != nil && err != io.EOF {
 			if e, ok := err.(*Error); ok && (e.Type == InvalidInputErrType || e.Type == InputTooLargeErrType) {
 				response.LimitedAdd(e)
@@ -227,7 +229,7 @@ func (p *Processor) HandleStream(ctx context.Context, ipRateLimiter *rate.Limite
 	defer sr.release()
 
 	// first item is the metadata object
-	metadata, err := p.readMetadata(meta, sr)
+	err := p.readMetadata(meta, sr)
 	if err != nil {
 		// no point in continuing if we couldn't read the metadata
 		res.Add(err)
@@ -243,7 +245,7 @@ func (p *Processor) HandleStream(ctx context.Context, ipRateLimiter *rate.Limite
 	var batch model.Batch
 	var done bool
 	for !done {
-		done = p.readBatch(ctx, ipRateLimiter, requestTime, metadata, batchSize, &batch, sr, res)
+		done = p.readBatch(ctx, ipRateLimiter, requestTime, meta, batchSize, &batch, sr, res)
 		if batch.Len() == 0 {
 			continue
 		}
@@ -285,15 +287,15 @@ func (p *Processor) getStreamReader(r io.Reader) *streamReader {
 		return sr
 	}
 	return &streamReader{
-		processor:          p,
-		NDJSONStreamReader: decoder.NewNDJSONStreamReader(r, p.MaxEventSize),
+		processor:           p,
+		NDJSONStreamDecoder: decoder.NewNDJSONStreamDecoder(r, p.MaxEventSize),
 	}
 }
 
 // streamReader wraps NDJSONStreamReader, converting errors to stream errors.
 type streamReader struct {
 	processor *Processor
-	*decoder.NDJSONStreamReader
+	*decoder.NDJSONStreamDecoder
 }
 
 // release releases the streamReader, adding it to its Processor's sync.Pool.
@@ -303,27 +305,27 @@ func (sr *streamReader) release() {
 	sr.processor.streamReaderPool.Put(sr)
 }
 
-func (sr *streamReader) Read() (map[string]interface{}, error) {
+func (sr *streamReader) Read(v *map[string]interface{}) error {
 	// TODO(axw) decode into a reused map, clearing out the
 	// map between reads. We would require that decoders copy
 	// any contents of rawModel that they wish to retain after
 	// the call, in order to safely reuse the map.
-	v, err := sr.NDJSONStreamReader.Read()
+	err := sr.NDJSONStreamDecoder.Decode(v)
 	if err != nil {
 		if _, ok := err.(decoder.JSONDecodeError); ok {
-			return nil, &Error{
+			return &Error{
 				Type:     InvalidInputErrType,
 				Message:  err.Error(),
 				Document: string(sr.LatestLine()),
 			}
 		}
 		if err == decoder.ErrLineTooLong {
-			return nil, &Error{
+			return &Error{
 				Type:     InputTooLargeErrType,
 				Message:  "event exceeded the permitted size.",
 				Document: string(sr.LatestLine()),
 			}
 		}
 	}
-	return v, err
+	return err
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Refactor decoder to take stuct as parameter instead of creating and returning map struct (#4072)