### PR TITLE
[7.x] beater/middleware: log event.duration (#4030)

### DIFF
--- a/beater/middleware/log_middleware.go
+++ b/beater/middleware/log_middleware.go
@@ -18,6 +18,8 @@
 package middleware
 
 import (
+	"time"
+
 	"github.com/gofrs/uuid"
 
 	"go.elastic.co/apm"
@@ -37,6 +39,7 @@ func LogMiddleware() Middleware {
 
 		return func(c *request.Context) {
 			var reqID, transactionID, traceID string
+			start := time.Now()
 			tx := apm.TransactionFromContext(c.Request.Context())
 			if tx != nil {
 				// This request is being traced, grab its IDs to add to logs.
@@ -73,6 +76,7 @@ func LogMiddleware() Middleware {
 
 			c.Logger = reqLogger
 			h(c)
+			reqLogger = reqLogger.With("event.duration", time.Since(start))
 
 			if c.MultipleWriteAttempts() {
 				reqLogger.Warn("multiple write attempts")

--- a/beater/middleware/log_middleware_test.go
+++ b/beater/middleware/log_middleware_test.go
@@ -114,10 +114,13 @@ func TestLogMiddleware(t *testing.T) {
 				assert.Equal(t, tc.message, entry.Message)
 
 				ec := entry.ContextMap()
+				t.Logf("context map: %v", ec)
+
 				assert.NotEmpty(t, ec["request_id"])
 				assert.NotEmpty(t, ec["method"])
 				assert.Equal(t, c.Request.URL.String(), ec["URL"])
 				assert.NotEmpty(t, ec["remote_address"])
+				assert.Contains(t, ec, "event.duration")
 				assert.Equal(t, c.Request.Header.Get(headers.UserAgent), ec["user-agent"])
 				// zap encoded type
 				assert.Equal(t, tc.code, int(ec["response_code"].(int64)))


### PR DESCRIPTION
Backports the following commits to 7.x:
 - beater/middleware: log event.duration (#4030)