### PR TITLE
aggregation/spanmetrics: add `event.outcome`

### DIFF
--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
@@ -167,6 +167,7 @@ func (a *Aggregator) processSpan(span *model.Span) {
 	key := aggregationKey{
 		serviceEnvironment: span.Metadata.Service.Environment,
 		serviceName:        span.Metadata.Service.Name,
+		outcome:            span.Outcome,
 		resource:           *span.DestinationService.Resource,
 	}
 	duration := time.Duration(span.Duration * float64(time.Millisecond))
@@ -202,6 +203,7 @@ type aggregationKey struct {
 	serviceEnvironment string
 	// destination
 	resource string
+	outcome  string
 }
 
 type spanMetrics struct {
@@ -217,6 +219,9 @@ func makeMetricset(timestamp time.Time, key aggregationKey, count, sum float64, 
 				Name:        key.serviceName,
 				Environment: key.serviceEnvironment,
 			},
+		},
+		Event: model.MetricsetEventCategorization{
+			Outcome: key.outcome,
 		},
 		Span: model.MetricsetSpan{
 			// TODO add span type/subtype?


### PR DESCRIPTION
## Motivation/summary

Add Span.Outcome to the aggregation key, and include
outcome in the metrics produced. This enables the UI
to calculate edge error rates.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

Send some exit spans with different `span.outcome` values set, and check that they are aggregated into multiple buckets, and the outcome is copied to `event.outcome` in the metrics docs.

## Related issues

#3985