### PR TITLE
[7.x] Add telemetry for apm-server configuration (#4055)

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -76,6 +76,8 @@ func NewCreator(args CreatorParams) beat.Creator {
 		if err != nil {
 			return nil, err
 		}
+		// send configs to telemetry
+		recordConfigs(b.Info, beaterConfig, ucfg, logger)
 
 		bt := &beater{
 			config:        beaterConfig,

--- a/beater/telemetry.go
+++ b/beater/telemetry.go
@@ -1,0 +1,90 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"github.com/elastic/apm-server/beater/config"
+	"github.com/elastic/apm-server/idxmgmt"
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/idxmgmt/ilm"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/monitoring"
+)
+
+var apmRegistry = monitoring.GetNamespace("state").GetRegistry().NewRegistry("apm-server")
+
+type configTelemetry struct {
+	rumEnabled                *monitoring.Bool
+	apiKeysEnabled            *monitoring.Bool
+	kibanaEnabled             *monitoring.Bool
+	pipelinesEnabled          *monitoring.Bool
+	pipelinesOverwrite        *monitoring.Bool
+	setupTemplateEnabled      *monitoring.Bool
+	setupTemplateOverwrite    *monitoring.Bool
+	setupTemplateAppendFields *monitoring.Bool
+	ilmEnabled                *monitoring.Bool
+	ilmSetupEnabled           *monitoring.Bool
+	ilmSetupOverwrite         *monitoring.Bool
+	ilmSetupRequirePolicy     *monitoring.Bool
+	jaegerGRPCEnabled         *monitoring.Bool
+	jaegerHTTPEnabled         *monitoring.Bool
+	sslEnabled                *monitoring.Bool
+}
+
+var configMonitors = &configTelemetry{
+	rumEnabled:                monitoring.NewBool(apmRegistry, "rum.enabled"),
+	apiKeysEnabled:            monitoring.NewBool(apmRegistry, "api_key.enabled"),
+	kibanaEnabled:             monitoring.NewBool(apmRegistry, "kibana.enabled"),
+	pipelinesEnabled:          monitoring.NewBool(apmRegistry, "register.ingest.pipeline.enabled"),
+	pipelinesOverwrite:        monitoring.NewBool(apmRegistry, "register.ingest.pipeline.overwrite"),
+	setupTemplateEnabled:      monitoring.NewBool(apmRegistry, "setup.template.enabled"),
+	setupTemplateOverwrite:    monitoring.NewBool(apmRegistry, "setup.template.overwrite"),
+	setupTemplateAppendFields: monitoring.NewBool(apmRegistry, "setup.template.append_fields"),
+	ilmEnabled:                monitoring.NewBool(apmRegistry, "ilm.enabled"),
+	ilmSetupEnabled:           monitoring.NewBool(apmRegistry, "ilm.setup.enabled"),
+	ilmSetupOverwrite:         monitoring.NewBool(apmRegistry, "ilm.setup.overwrite"),
+	ilmSetupRequirePolicy:     monitoring.NewBool(apmRegistry, "ilm.setup.require_policy"),
+	jaegerGRPCEnabled:         monitoring.NewBool(apmRegistry, "jaeger.grpc.enabled"),
+	jaegerHTTPEnabled:         monitoring.NewBool(apmRegistry, "jaeger.http.enabled"),
+	sslEnabled:                monitoring.NewBool(apmRegistry, "ssl.enabled"),
+}
+
+func recordConfigs(info beat.Info, apmCfg *config.Config, rootCfg *common.Config, logger *logp.Logger) {
+	indexManagementCfg, err := idxmgmt.NewIndexManagementConfig(info, rootCfg)
+	if err != nil {
+		logger.Errorf("Error recording telemetry data", err)
+		return
+	}
+	configMonitors.rumEnabled.Set(apmCfg.RumConfig.IsEnabled())
+	configMonitors.apiKeysEnabled.Set(apmCfg.APIKeyConfig.IsEnabled())
+	configMonitors.kibanaEnabled.Set(apmCfg.Kibana.Enabled)
+	configMonitors.jaegerHTTPEnabled.Set(apmCfg.JaegerConfig.HTTP.Enabled)
+	configMonitors.jaegerGRPCEnabled.Set(apmCfg.JaegerConfig.GRPC.Enabled)
+	configMonitors.sslEnabled.Set(apmCfg.TLS.IsEnabled())
+	configMonitors.pipelinesEnabled.Set(apmCfg.Register.Ingest.Pipeline.IsEnabled())
+	configMonitors.pipelinesOverwrite.Set(apmCfg.Register.Ingest.Pipeline.ShouldOverwrite())
+	configMonitors.setupTemplateEnabled.Set(indexManagementCfg.Template.Enabled)
+	configMonitors.setupTemplateOverwrite.Set(indexManagementCfg.Template.Overwrite)
+	configMonitors.setupTemplateAppendFields.Set(len(indexManagementCfg.Template.AppendFields.GetKeys()) > 0)
+	configMonitors.ilmSetupEnabled.Set(indexManagementCfg.ILM.Setup.Enabled)
+	configMonitors.ilmSetupOverwrite.Set(indexManagementCfg.ILM.Setup.Overwrite)
+	configMonitors.ilmSetupRequirePolicy.Set(indexManagementCfg.ILM.Setup.RequirePolicy)
+	mode := indexManagementCfg.ILM.Mode
+	configMonitors.ilmEnabled.Set(mode == ilm.ModeAuto || mode == ilm.ModeEnabled)
+}

--- a/beater/telemetry_test.go
+++ b/beater/telemetry_test.go
@@ -1,0 +1,94 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"testing"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-server/beater/config"
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+func TestRecordConfigs(t *testing.T) {
+	resetCounters()
+	defer resetCounters()
+
+	info := beat.Info{Name: "apm-server", Version: "7.x"}
+	apmCfg := config.DefaultConfig()
+	apmCfg.APIKeyConfig.Enabled = true
+	apmCfg.Kibana.Enabled = true
+	apmCfg.JaegerConfig.GRPC.Enabled = true
+	apmCfg.JaegerConfig.HTTP.Enabled = true
+	rootCfg := common.MustNewConfigFrom(map[string]interface{}{
+		"apm-server": map[string]interface{}{
+			"ilm": map[string]interface{}{
+				"setup": map[string]interface{}{
+					"enabled":        true,
+					"overwrite":      true,
+					"require_policy": false,
+				},
+			},
+		},
+		"setup": map[string]interface{}{
+			"template": map[string]interface{}{
+				"overwrite": true,
+			},
+		},
+	})
+	recordConfigs(info, apmCfg, rootCfg, logp.NewLogger("beater"))
+
+	assert.Equal(t, configMonitors.ilmSetupEnabled.Get(), true)
+	assert.Equal(t, configMonitors.rumEnabled.Get(), false)
+	assert.Equal(t, configMonitors.apiKeysEnabled.Get(), true)
+	assert.Equal(t, configMonitors.kibanaEnabled.Get(), true)
+	assert.Equal(t, configMonitors.pipelinesEnabled.Get(), true)
+	assert.Equal(t, configMonitors.pipelinesOverwrite.Get(), false)
+	assert.Equal(t, configMonitors.setupTemplateEnabled.Get(), true)
+	assert.Equal(t, configMonitors.setupTemplateOverwrite.Get(), true)
+	assert.Equal(t, configMonitors.setupTemplateAppendFields.Get(), false)
+	assert.Equal(t, configMonitors.ilmEnabled.Get(), true)
+	assert.Equal(t, configMonitors.ilmSetupEnabled.Get(), true)
+	assert.Equal(t, configMonitors.ilmSetupOverwrite.Get(), true)
+	assert.Equal(t, configMonitors.ilmSetupRequirePolicy.Get(), false)
+	assert.Equal(t, configMonitors.jaegerGRPCEnabled.Get(), true)
+	assert.Equal(t, configMonitors.jaegerHTTPEnabled.Get(), true)
+	assert.Equal(t, configMonitors.sslEnabled.Get(), false)
+}
+
+func resetCounters() {
+	configMonitors.rumEnabled.Set(false)
+	configMonitors.apiKeysEnabled.Set(false)
+	configMonitors.kibanaEnabled.Set(false)
+	configMonitors.jaegerHTTPEnabled.Set(false)
+	configMonitors.jaegerGRPCEnabled.Set(false)
+	configMonitors.sslEnabled.Set(false)
+	configMonitors.pipelinesEnabled.Set(false)
+	configMonitors.pipelinesOverwrite.Set(false)
+	configMonitors.setupTemplateEnabled.Set(false)
+	configMonitors.setupTemplateOverwrite.Set(false)
+	configMonitors.setupTemplateAppendFields.Set(false)
+	configMonitors.ilmSetupEnabled.Set(false)
+	configMonitors.ilmSetupOverwrite.Set(false)
+	configMonitors.ilmSetupRequirePolicy.Set(false)
+	configMonitors.ilmEnabled.Set(false)
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add telemetry for apm-server configuration (#4055)