### PR TITLE
tests: fix docker-system-tests

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -23,9 +23,13 @@ RUN $PYTHON_ENV/build/ve/linux/bin/pip install wheel
 RUN touch -d "Yesterday" $PYTHON_ENV/build/ve/linux/bin/activate
 
 # Download module dependencies.
-COPY go.mod $HOME
 WORKDIR $HOME
+COPY go.mod go.sum ./
+COPY approvaltest/go.mod approvaltest/go.sum ./approvaltest/
+COPY systemtest/go.mod systemtest/go.sum ./systemtest/
 RUN go mod download
+RUN cd approvaltest && go mod download
+RUN cd systemtest && go mod download
 
 # Add healthcheck for docker/healthcheck metricset to check during testing
 HEALTHCHECK CMD exit 0


### PR DESCRIPTION
## Motivation/summary

Copy in approvaltest/go.mod (and systemtest/go.mod for good measure)
to fix `go mod download` at the top level. Also run `go mod download`
for the sub-modules, to speed up repeat runs of docker-system-tests.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

`make docker-system-tests`

## Related issues

None.