### PR TITLE
aggregation/spanmetrics: add max_groups config

### DIFF
--- a/beater/config/aggregation.go
+++ b/beater/config/aggregation.go
@@ -22,10 +22,13 @@ import (
 )
 
 const (
-	defaultAggregationInterval                       = 1 * time.Minute
-	defaultAggregationMaxTransactionGroups           = 1000
-	defaultAggregationHDRHistogramSignificantFigures = 2
-	defaultAggregationRUMUserAgentLRUSize            = 5000
+	defaultTransactionAggregationInterval                       = time.Minute
+	defaultTransactionAggregationMaxGroups                      = 10000
+	defaultTransactionAggregationHDRHistogramSignificantFigures = 2
+	defaultTransactionAggregationRUMUserAgentLRUSize            = 5000
+
+	defaultServiceDestinationAggregationInterval  = time.Minute
+	defaultServiceDestinationAggregationMaxGroups = 10000
 )
 
 // AggregationConfig holds configuration related to various metrics aggregations.
@@ -45,21 +48,23 @@ type TransactionAggregationConfig struct {
 
 // ServiceDestinationAggregationConfig holds configuration related to span metrics aggregation for service maps.
 type ServiceDestinationAggregationConfig struct {
-	Enabled  bool          `config:"enabled"`
-	Interval time.Duration `config:"interval" validate:"min=1"`
+	Enabled   bool          `config:"enabled"`
+	Interval  time.Duration `config:"interval" validate:"min=1"`
+	MaxGroups int           `config:"max_groups" validate:"min=1"`
 }
 
 func defaultAggregationConfig() AggregationConfig {
 	return AggregationConfig{
 		Transactions: TransactionAggregationConfig{
-			Interval:                       defaultAggregationInterval,
-			MaxTransactionGroups:           defaultAggregationMaxTransactionGroups,
-			HDRHistogramSignificantFigures: defaultAggregationHDRHistogramSignificantFigures,
-			RUMUserAgentLRUSize:            defaultAggregationRUMUserAgentLRUSize,
+			Interval:                       defaultTransactionAggregationInterval,
+			MaxTransactionGroups:           defaultTransactionAggregationMaxGroups,
+			HDRHistogramSignificantFigures: defaultTransactionAggregationHDRHistogramSignificantFigures,
+			RUMUserAgentLRUSize:            defaultTransactionAggregationRUMUserAgentLRUSize,
 		},
 		ServiceDestinations: ServiceDestinationAggregationConfig{
-			Enabled:  true,
-			Interval: defaultAggregationInterval,
+			Enabled:   true,
+			Interval:  defaultServiceDestinationAggregationInterval,
+			MaxGroups: defaultServiceDestinationAggregationMaxGroups,
 		},
 	}
 }

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -128,6 +128,9 @@ func TestUnpackConfig(t *testing.T) {
 							},
 						},
 					},
+					"service_destinations": map[string]interface{}{
+						"max_groups": 456,
+					},
 				},
 			},
 			outCfg: &Config{
@@ -222,8 +225,9 @@ func TestUnpackConfig(t *testing.T) {
 						RUMUserAgentLRUSize:            123,
 					},
 					ServiceDestinations: ServiceDestinationAggregationConfig{
-						Enabled:  true,
-						Interval: time.Minute,
+						Enabled:   true,
+						Interval:  time.Minute,
+						MaxGroups: 456,
 					},
 				},
 				Sampling: SamplingConfig{
@@ -338,13 +342,14 @@ func TestUnpackConfig(t *testing.T) {
 					Transactions: TransactionAggregationConfig{
 						Enabled:                        true,
 						Interval:                       time.Minute,
-						MaxTransactionGroups:           1000,
+						MaxTransactionGroups:           10000,
 						HDRHistogramSignificantFigures: 2,
 						RUMUserAgentLRUSize:            123,
 					},
 					ServiceDestinations: ServiceDestinationAggregationConfig{
-						Enabled:  false,
-						Interval: time.Minute,
+						Enabled:   false,
+						Interval:  time.Minute,
+						MaxGroups: 10000,
 					},
 				},
 				Sampling: SamplingConfig{

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -61,10 +61,10 @@ type AggregatorConfig struct {
 	// If Logger is nil, a new logger will be constructed.
 	Logger *logp.Logger
 
-	// MaxBuckets is the maximum number of distinct transaction groups
-	// to store within an aggregation period. Once this number of groups
-	// has been reached, any new aggregation keys will cause individual
-	// metrics documents to be immediately published.
+	// MaxTransactionGroups is the maximum number of distinct transaction
+	// group metrics to store within an aggregation period. Once this number
+	// of groups has been reached, any new aggregation keys will cause
+	// individual metrics documents to be immediately published.
 	MaxTransactionGroups int
 
 	// MetricsInterval is the interval between publishing of aggregated

--- a/x-pack/apm-server/main.go
+++ b/x-pack/apm-server/main.go
@@ -55,8 +55,9 @@ func newProcessors(args beater.ServerParams) ([]namedProcessor, error) {
 		const name = "service destinations aggregation"
 		args.Logger.Infof("creating %s with config: %+v", name, args.Config.Aggregation.ServiceDestinations)
 		spanAggregator, err := spanmetrics.NewAggregator(spanmetrics.AggregatorConfig{
-			Report:   args.Reporter,
-			Interval: args.Config.Aggregation.ServiceDestinations.Interval,
+			Report:    args.Reporter,
+			Interval:  args.Config.Aggregation.ServiceDestinations.Interval,
+			MaxGroups: args.Config.Aggregation.ServiceDestinations.MaxGroups,
 		})
 		if err != nil {
 			return nil, errors.Wrapf(err, "error creating %s", name)


### PR DESCRIPTION
## Motivation/summary

Add `apm-server.aggregation.service_destinations.max_groups` config, controlling the maximum number of metric groups to recorded each interval. The default value of 10000 should be high enough that it won't be reached under typical circumstances; this control exists to guard against faulty or malicious agents.

I've also increased the default value of `apm-server.aggregation.transactions.max_groups` from 1000 to 10000, which should bring us to the low MBs in terms of max memory usage, while still working for large environments.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~ (no docs yet, should be done separately)
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

Instrument a service with many outgoing destinations, set `apm-server.aggregation.service_destinations.max_groups` to something low (e.g. 1) and observe that the metrics are still accurate.

## Related issues

#3985 