### PR TITLE
sampling/pubsub: new package for coordination

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	go.elastic.co/apm/module/apmgrpc v1.7.0
 	go.elastic.co/apm/module/apmhttp v1.7.2
 	go.elastic.co/ecszap v0.2.0 // indirect
-	go.elastic.co/fastjson v1.1.0 // indirect
+	go.elastic.co/fastjson v1.1.0
 	go.uber.org/atomic v1.6.0
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect

--- a/log/selectors.go
+++ b/log/selectors.go
@@ -37,4 +37,5 @@ const (
 	TransactionMetrics = "txmetrics"
 	SpanMetrics        = "spanmetrics"
 	Transform          = "transform"
+	Sampling           = "sampling"
 )

--- a/x-pack/apm-server/sampling/pubsub/config.go
+++ b/x-pack/apm-server/sampling/pubsub/config.go
@@ -29,7 +29,9 @@ type Config struct {
 	// SearchInterval holds the time between searches initiated by the subscriber.
 	//
 	// This controls how long it takes for servers to become aware of each other's
-	// sampled trace IDs.
+	// sampled trace IDs, and so should be in the order of tens of seconds, or low
+	// minutes. In order not to lose sampled trace events, SearchInterval should be
+	// no greater than half of the TTL for events in local storage.
 	SearchInterval time.Duration
 
 	// FlushInterval holds the amount of time to wait before flushing the bulk indexer.
@@ -39,7 +41,7 @@ type Config struct {
 	FlushInterval time.Duration
 
 	// Logger is used for logging publish and subscribe operations -- particularly
-	// errors that occur asyncrhonously.
+	// errors that occur asynchronously.
 	//
 	// If Logger is nil, a new logger will be constructed.
 	Logger *logp.Logger

--- a/x-pack/apm-server/sampling/pubsub/config.go
+++ b/x-pack/apm-server/sampling/pubsub/config.go
@@ -1,0 +1,66 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package pubsub
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/go-elasticsearch/v7"
+)
+
+// Config holds configuration for Pubsub.
+type Config struct {
+	// Client holds an Elasticsearch client, for indexing and searching for
+	// trace ID observations.
+	Client *elasticsearch.Client
+
+	// Index holds the index name.
+	Index string
+
+	// BeatID holds the APM Server's unique ID, used for filtering out
+	// local observations in the subscriber.
+	BeatID string
+
+	// SearchInterval holds the time between searches initiated by the subscriber.
+	//
+	// This controls how long it takes for servers to become aware of each other's
+	// sampled trace IDs.
+	SearchInterval time.Duration
+
+	// FlushInterval holds the amount of time to wait before flushing the bulk indexer.
+	//
+	// This adds some delay to how long it takes for other servers to become aware
+	// of locally sampled trace IDs, and so should be in the order of seconds.
+	FlushInterval time.Duration
+
+	// Logger is used for logging publish and subscribe operations -- particularly
+	// errors that occur asyncrhonously.
+	//
+	// If Logger is nil, a new logger will be constructed.
+	Logger *logp.Logger
+}
+
+// Validate validates the configuration.
+func (config Config) Validate() error {
+	if config.Client == nil {
+		return errors.New("Client unspecified")
+	}
+	if config.Index == "" {
+		return errors.New("Index unspecified")
+	}
+	if config.BeatID == "" {
+		return errors.New("BeatID unspecified")
+	}
+	if config.SearchInterval <= 0 {
+		return errors.New("SearchInterval unspecified or negative")
+	}
+	if config.FlushInterval <= 0 {
+		return errors.New("FlushInterval unspecified or negative")
+	}
+	return nil
+}

--- a/x-pack/apm-server/sampling/pubsub/config_test.go
+++ b/x-pack/apm-server/sampling/pubsub/config_test.go
@@ -1,0 +1,60 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package pubsub_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/go-elasticsearch/v7"
+
+	"github.com/elastic/apm-server/x-pack/apm-server/sampling/pubsub"
+)
+
+func TestConfigInvalid(t *testing.T) {
+	type test struct {
+		config pubsub.Config
+		err    string
+	}
+
+	for _, test := range []test{{
+		config: pubsub.Config{},
+		err:    "Client unspecified",
+	}, {
+		config: pubsub.Config{
+			Client: &elasticsearch.Client{},
+		},
+		err: "Index unspecified",
+	}, {
+		config: pubsub.Config{
+			Client: &elasticsearch.Client{},
+			Index:  "index",
+		},
+		err: "BeatID unspecified",
+	}, {
+		config: pubsub.Config{
+			Client: &elasticsearch.Client{},
+			Index:  "index",
+			BeatID: "beat_id",
+		},
+		err: "SearchInterval unspecified or negative",
+	}, {
+		config: pubsub.Config{
+			Client:         &elasticsearch.Client{},
+			Index:          "index",
+			BeatID:         "beat_id",
+			SearchInterval: time.Second,
+		},
+		err: "FlushInterval unspecified or negative",
+	}} {
+		pubsub, err := pubsub.New(test.config)
+		require.Error(t, err)
+		require.Nil(t, pubsub)
+		assert.EqualError(t, err, "invalid pubsub config: "+test.err)
+	}
+}

--- a/x-pack/apm-server/sampling/pubsub/pubsub.go
+++ b/x-pack/apm-server/sampling/pubsub/pubsub.go
@@ -1,0 +1,219 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package pubsub
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+	"go.elastic.co/fastjson"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/go-elasticsearch/v7/esapi"
+	"github.com/elastic/go-elasticsearch/v7/esutil"
+
+	logs "github.com/elastic/apm-server/log"
+)
+
+// Pubsub provides a means of publishing and subscribing to sampled trace IDs,
+// using Elasticsearch for temporary storage.
+//
+// An independent process will periodically reap old documents in the index.
+type Pubsub struct {
+	config  Config
+	indexer esutil.BulkIndexer
+}
+
+// New returns a new Pubsub which can publish and subscribe sampled trace IDs,
+// using Elasticsearch for storage.
+//
+// Documents are expected to be indexed through a pipeline which sets the
+// `event.ingested` timestamp field. Another process will periodically reap
+// events older than a configured age.
+func New(config Config) (*Pubsub, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid pubsub config")
+	}
+	if config.Logger == nil {
+		config.Logger = logp.NewLogger(logs.Sampling)
+	}
+	indexer, err := esutil.NewBulkIndexer(esutil.BulkIndexerConfig{
+		Client:        config.Client,
+		Index:         config.Index,
+		FlushInterval: config.FlushInterval,
+		OnError: func(ctx context.Context, err error) {
+			config.Logger.With(logp.Error(err)).Debug("publishing sampled trace IDs failed")
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &Pubsub{config: config, indexer: indexer}, nil
+}
+
+// PublishSampledTraceIDs bulk indexes traceIDs into Elasticsearch.
+func (p *Pubsub) PublishSampledTraceIDs(ctx context.Context, traceID ...string) error {
+	for _, id := range traceID {
+		var doc traceIDDocument
+		doc.Observer.ID = p.config.BeatID
+		doc.Trace.ID = id
+
+		var json fastjson.Writer
+		if err := doc.MarshalFastJSON(&json); err != nil {
+			return err
+		}
+		if err := p.indexer.Add(ctx, esutil.BulkIndexerItem{
+			Action: "index",
+			Body:   bytes.NewReader(json.Bytes()),
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SubscribeSampledTraceIDs subscribes to new sampled trace IDs, sending them to the
+// traceIDs channel.
+func (p *Pubsub) SubscribeSampledTraceIDs(ctx context.Context, traceIDs chan<- string) error {
+	ticker := time.NewTicker(p.config.SearchInterval)
+	defer ticker.Stop()
+
+	// NOTE(axw) we should use the Changes API when it is implemented:
+	// https://github.com/elastic/elasticsearch/issues/1242
+
+	var lastSeqNo int64 = 0
+	var lastPrimaryTerm int64 = -1
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+		for {
+			// Keep searching until there are no more new trace IDs.
+			n, err := p.searchTraceIDs(ctx, traceIDs, &lastSeqNo, &lastPrimaryTerm)
+			if err != nil {
+				// Errors may occur due to rate limiting, or while the index is
+				// still being created, so just log and continue.
+				p.config.Logger.With(logp.Error(err)).Debug("error searching for trace IDs")
+				break
+			}
+			if n == 0 {
+				// No more results, go back to sleep.
+				break
+			}
+		}
+	}
+}
+
+// searchTraceIDs searches for new sampled trace IDs (after lastPrimaryTerm and lastSeqNo),
+// sending them to the out channel and returning the number of trace IDs sent.
+func (p *Pubsub) searchTraceIDs(ctx context.Context, out chan<- string, lastSeqNo, lastPrimaryTerm *int64) (int, error) {
+	searchBody := map[string]interface{}{
+		"size":                1000,
+		"seq_no_primary_term": true,
+		"sort":                []interface{}{map[string]interface{}{"_seq_no": "asc"}},
+		"search_after":        []interface{}{*lastSeqNo - 1},
+		"query": map[string]interface{}{
+			// Filter out local observations.
+			"bool": map[string]interface{}{
+				"must_not": map[string]interface{}{
+					"term": map[string]interface{}{
+						"observer.id": map[string]interface{}{
+							"value": p.config.BeatID,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	req := esapi.SearchRequest{
+		Index: []string{p.config.Index},
+		Body:  esutil.NewJSONReader(searchBody),
+	}
+	resp, err := req.Do(ctx, p.config.Client)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.IsError() {
+		switch resp.StatusCode {
+		case http.StatusNotFound:
+			return 0, nil
+		}
+		message, _ := ioutil.ReadAll(resp.Body)
+		return 0, fmt.Errorf("search request failed: %s", message)
+	}
+
+	var result struct {
+		Hits struct {
+			Hits []struct {
+				SeqNo       int64           `json:"_seq_no,omitempty"`
+				PrimaryTerm int64           `json:"_primary_term,omitempty"`
+				Source      traceIDDocument `json:"_source"`
+			}
+		}
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, err
+	}
+	if len(result.Hits.Hits) == 0 {
+		return 0, nil
+	}
+
+	var n int
+	maxPrimaryTerm := *lastPrimaryTerm
+	for _, hit := range result.Hits.Hits {
+		if hit.SeqNo < *lastSeqNo || (hit.SeqNo == *lastSeqNo && hit.PrimaryTerm <= *lastPrimaryTerm) {
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return n, ctx.Err()
+		case out <- hit.Source.Trace.ID:
+			n++
+		}
+		if hit.PrimaryTerm > maxPrimaryTerm {
+			maxPrimaryTerm = hit.PrimaryTerm
+		}
+	}
+	// we sort by hit.SeqNo, but not _primary_term (you can't?)
+	*lastSeqNo = result.Hits.Hits[len(result.Hits.Hits)-1].SeqNo
+	*lastPrimaryTerm = maxPrimaryTerm
+	return n, nil
+}
+
+type traceIDDocument struct {
+	// Observer identifies the entity (typically an APM Server) that observed
+	// and indexed the/ trace ID document. This can be used to filter out local
+	// observations.
+	Observer struct {
+		// ID holds the unique ID of the observer.
+		ID string `json:"id"`
+	} `json:"observer"`
+
+	// Trace identifies a trace.
+	Trace struct {
+		// ID holds the unique ID of the trace.
+		ID string `json:"id"`
+	} `json:"trace"`
+}
+
+func (d *traceIDDocument) MarshalFastJSON(w *fastjson.Writer) error {
+	w.RawString(`{"observer":{"id":`)
+	w.String(d.Observer.ID)
+	w.RawString(`},`)
+	w.RawString(`"trace":{"id":`)
+	w.String(d.Trace.ID)
+	w.RawString(`}}`)
+	return nil
+}

--- a/x-pack/apm-server/sampling/pubsub/pubsub_integration_test.go
+++ b/x-pack/apm-server/sampling/pubsub/pubsub_integration_test.go
@@ -1,0 +1,249 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package pubsub_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/elastic/go-elasticsearch/v7"
+
+	"github.com/elastic/apm-server/x-pack/apm-server/sampling/pubsub"
+)
+
+const (
+	defaultElasticsearchHost = "localhost"
+	defaultElasticsearchPort = "9200"
+	defaultElasticsearchUser = "apm_server_user"
+	defaultElasticsearchPass = "changeme"
+)
+
+func TestElasticsearchIntegration_PublishSampledTraceIDs(t *testing.T) {
+	const (
+		localBeatID = "local_beat_id"
+		indexName   = "apm-testing-sampled-traces"
+	)
+
+	client := newElasticsearchClient(t)
+	recreateIndex(t, client, indexName)
+
+	var input []string
+	for i := 0; i < 50; i++ {
+		input = append(input, uuid.Must(uuid.NewV4()).String())
+	}
+
+	es, err := pubsub.New(pubsub.Config{
+		Client:         client,
+		Index:          indexName,
+		BeatID:         localBeatID,
+		FlushInterval:  100 * time.Millisecond,
+		SearchInterval: time.Minute,
+	})
+	require.NoError(t, err)
+
+	err = es.PublishSampledTraceIDs(context.Background(), input...)
+	assert.NoError(t, err)
+
+	var result struct {
+		Hits struct {
+			Hits []struct {
+				Source struct {
+					Observer struct {
+						ID string
+					}
+					Trace struct {
+						ID string
+					}
+				} `json:"_source"`
+			}
+		}
+	}
+
+	for {
+		resp, err := client.Search(
+			client.Search.WithIndex(indexName),
+			client.Search.WithSize(len(input)+1),
+		)
+		require.NoError(t, err)
+		if resp.IsError() {
+			resp.Body.Close()
+			time.Sleep(100 * time.Millisecond)
+			continue
+		}
+		err = json.NewDecoder(resp.Body).Decode(&result)
+		assert.NoError(t, err)
+		resp.Body.Close()
+		if len(result.Hits.Hits) == len(input) {
+			break
+		}
+	}
+
+	output := make([]string, len(input))
+	for i, hit := range result.Hits.Hits {
+		assert.Equal(t, localBeatID, hit.Source.Observer.ID)
+		output[i] = hit.Source.Trace.ID
+	}
+	assert.ElementsMatch(t, input, output)
+}
+
+func TestElasticsearchIntegration_SubscribeSampledTraceIDs(t *testing.T) {
+	const (
+		localBeatID  = "local_observer_id"
+		remoteBeatID = "remote_observer_id"
+		indexName    = "apm-testing-sampled-traces"
+	)
+
+	client := newElasticsearchClient(t)
+	recreateIndex(t, client, indexName)
+
+	es, err := pubsub.New(pubsub.Config{
+		Client:         client,
+		Index:          indexName,
+		BeatID:         localBeatID,
+		FlushInterval:  time.Minute,
+		SearchInterval: 100 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	var g errgroup.Group
+	out := make(chan string)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g.Go(func() error {
+		return es.SubscribeSampledTraceIDs(ctx, out)
+	})
+	assert.NoError(t, err)
+
+	// Nothing should be sent until there's a document indexed.
+	expectNone(t, out)
+
+	type indexAction struct {
+		Index struct{} `json:"index"`
+	}
+	type doc struct {
+		Observer struct {
+			ID string `json:"id"`
+		} `json:"observer"`
+		Trace struct {
+			ID string `json:"id"`
+		} `json:"trace"`
+	}
+	indexTraceID := func(observerID string, traceID ...string) {
+		var body bytes.Buffer
+		enc := json.NewEncoder(&body)
+		for _, id := range traceID {
+			var doc doc
+			doc.Observer.ID = observerID
+			doc.Trace.ID = id
+			assert.NoError(t, enc.Encode(indexAction{}))
+			assert.NoError(t, enc.Encode(&doc))
+		}
+		resp, err := client.Bulk(&body, client.Bulk.WithIndex(indexName))
+		require.NoError(t, err)
+		assert.False(t, resp.IsError())
+		resp.Body.Close()
+	}
+
+	// Index some local observations. These should not be reported
+	// by the local subscriber.
+	var input []string
+	for i := 0; i < 500; i++ {
+		input = append(input, uuid.Must(uuid.NewV4()).String())
+	}
+	indexTraceID(localBeatID, input...)
+	expectNone(t, out)
+
+	// Index some remote observations. Repeat twice, to ensure that the
+	// subscriber does not report old trace IDs the second time around.
+	for i := 0; i < 2; i++ {
+		var input []string
+		for i := 0; i < 500; i++ {
+			input = append(input, uuid.Must(uuid.NewV4()).String())
+		}
+		indexTraceID(remoteBeatID, input...)
+
+		output := make([]string, len(input))
+		for i := range input {
+			output[i] = expectValue(t, out)
+		}
+		assert.Equal(t, input, output)
+	}
+}
+
+func recreateIndex(tb testing.TB, client *elasticsearch.Client, indexName string) {
+	body := strings.NewReader(`{
+  "mappings": {
+    "properties": {
+      "event.ingested": {"type": "date"},
+      "observer": {
+        "properties": {
+          "id": {"type": "keyword"}
+        }
+      },
+      "trace": {
+        "properties": {
+          "id": {"type": "keyword"}
+        }
+      }
+    }
+  }
+}`)
+	resp, err := client.Indices.Delete([]string{indexName})
+	require.NoError(tb, err)
+	resp.Body.Close()
+
+	resp, err = client.Indices.Create(indexName, client.Indices.Create.WithBody(body))
+	require.NoError(tb, err)
+	assert.False(tb, resp.IsError())
+	resp.Body.Close()
+}
+
+func newElasticsearchClient(tb testing.TB) *elasticsearch.Client {
+	switch strings.ToLower(os.Getenv("INTEGRATION_TESTS")) {
+	case "1", "true":
+	default:
+		tb.Skip("Skipping integration test, export INTEGRATION_TESTS=1 to run")
+	}
+
+	esURL := url.URL{Scheme: "http", Host: net.JoinHostPort(
+		getenvDefault("ES_HOST", defaultElasticsearchHost),
+		getenvDefault("ES_PORT", defaultElasticsearchPort),
+	)}
+	cfg := elasticsearch.Config{
+		Addresses: []string{esURL.String()},
+		RetryBackoff: func(attempt int) time.Duration {
+			backoff := time.Duration(attempt*100) * time.Millisecond
+			if backoff > time.Second {
+				backoff = time.Second
+			}
+			return backoff
+		},
+	}
+	cfg.Username = getenvDefault("ES_USER", defaultElasticsearchUser)
+	cfg.Password = getenvDefault("ES_PASS", defaultElasticsearchPass)
+	client, err := elasticsearch.NewClient(cfg)
+	require.NoError(tb, err)
+	return client
+}
+
+func getenvDefault(key, defaultValue string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		v = defaultValue
+	}
+	return v
+}

--- a/x-pack/apm-server/sampling/pubsub/pubsub_test.go
+++ b/x-pack/apm-server/sampling/pubsub/pubsub_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -63,7 +64,7 @@ func TestPublishSampledTraceIDs(t *testing.T) {
 
 	var ids []string
 	for i := 0; i < 20; i++ {
-		ids = append(ids, fmt.Sprintf("trace_%d", len(ids)))
+		ids = append(ids, uuid.Must(uuid.NewV4()).String())
 	}
 
 	// Publish in a separate goroutine, as it may get blocked if we don't

--- a/x-pack/apm-server/sampling/pubsub/pubsub_test.go
+++ b/x-pack/apm-server/sampling/pubsub/pubsub_test.go
@@ -1,0 +1,261 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package pubsub_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/elastic/go-elasticsearch/v7"
+
+	"github.com/elastic/apm-server/x-pack/apm-server/sampling/pubsub"
+)
+
+func TestPublishSampledTraceIDs(t *testing.T) {
+	const (
+		indexName = "trace-ids"
+		beatID    = "beat_id"
+	)
+
+	requests := make(chan *http.Request, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, r.Body); err != nil {
+			panic(err)
+		}
+		r.Body = ioutil.NopCloser(&buf)
+
+		select {
+		case <-r.Context().Done():
+		case requests <- r:
+		}
+	}))
+	defer srv.Close()
+
+	client, err := elasticsearch.NewClient(elasticsearch.Config{
+		Addresses: []string{srv.URL},
+	})
+	require.NoError(t, err)
+
+	pub, err := pubsub.New(pubsub.Config{
+		Client:         client,
+		Index:          indexName,
+		BeatID:         beatID,
+		FlushInterval:  time.Millisecond,
+		SearchInterval: time.Minute,
+	})
+	require.NoError(t, err)
+
+	var ids []string
+	for i := 0; i < 20; i++ {
+		ids = append(ids, fmt.Sprintf("trace_%d", len(ids)))
+	}
+
+	// Publish in a separate goroutine, as it may get blocked if we don't
+	// service bulk requests.
+	go func() {
+		for i := 0; i < len(ids); i += 2 {
+			err = pub.PublishSampledTraceIDs(context.Background(), ids[i], ids[i+1])
+			assert.NoError(t, err)
+			time.Sleep(10 * time.Millisecond) // sleep to force a new request
+		}
+	}()
+
+	var received []string
+	deadlineTimer := time.NewTimer(10 * time.Second)
+	for len(received) < len(ids) {
+		select {
+		case <-deadlineTimer.C:
+			t.Fatal("timed out waiting for events to be received by server")
+		case req := <-requests:
+			require.Equal(t, fmt.Sprintf("/%s/_bulk", indexName), req.URL.Path)
+
+			d := json.NewDecoder(req.Body)
+			for {
+				action := make(map[string]interface{})
+				err := d.Decode(&action)
+				if err == io.EOF {
+					break
+				}
+				assert.NoError(t, err)
+				assert.Equal(t, map[string]interface{}{"index": map[string]interface{}{}}, action)
+
+				doc := make(map[string]interface{})
+				assert.NoError(t, d.Decode(&doc))
+				assert.Equal(t, map[string]interface{}{"id": beatID}, doc["observer"])
+
+				trace := doc["trace"].(map[string]interface{})
+				traceID := trace["id"].(string)
+				received = append(received, traceID)
+				delete(trace, "id")
+				assert.Empty(t, trace) // no other fields in "trace"
+
+				delete(doc, "observer")
+				delete(doc, "trace")
+				assert.Empty(t, doc) // no other fields in doc
+			}
+		}
+	}
+
+	// The publisher uses an esutil.BulkIndexer, which may index items out
+	// of order due to having multiple goroutines picking items off a queue.
+	assert.ElementsMatch(t, ids, received)
+}
+
+func TestSubscribeSampledTraceIDs(t *testing.T) {
+	const (
+		indexName = "trace-ids"
+		beatID    = "beat_id"
+	)
+
+	var requests []*http.Request
+	responses := make(chan string)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, r.Body); err != nil {
+			panic(err)
+		}
+		r.Body = ioutil.NopCloser(&buf)
+		requests = append(requests, r)
+
+		select {
+		case <-r.Context().Done():
+		case resp := <-responses:
+			w.Write([]byte(resp))
+		}
+	}))
+	defer srv.Close()
+
+	client, err := elasticsearch.NewClient(elasticsearch.Config{
+		Addresses: []string{srv.URL},
+	})
+	require.NoError(t, err)
+
+	sub, err := pubsub.New(pubsub.Config{
+		Client:         client,
+		Index:          indexName,
+		BeatID:         beatID,
+		FlushInterval:  time.Minute,
+		SearchInterval: time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	ids := make(chan string)
+	ctx, cancel := context.WithCancel(context.Background())
+	g, ctx := errgroup.WithContext(ctx)
+	go g.Go(func() error {
+		return sub.SubscribeSampledTraceIDs(ctx, ids)
+	})
+	defer g.Wait()
+	defer cancel()
+
+	responses <- `{
+          "hits": {
+	    "hits": [
+	      {
+	        "_seq_no": 1,
+	        "_primary_term": 1,
+		"_source": {"trace": {"id": "trace_1"}, "observer": {"id": "another_beat_id"}}
+	      },
+	      {
+	        "_seq_no": 2,
+	        "_primary_term": 2,
+		"_source": {"trace": {"id": "trace_2"}, "observer": {"id": "another_beat_id"}}
+	      }
+	    ]
+	  }
+	}`
+
+	assert.Equal(t, "trace_1", expectValue(t, ids))
+	assert.Equal(t, "trace_2", expectValue(t, ids))
+
+	responses <- "nonsense" // bad response, subscriber continues
+
+	// trace_2 is repeated, since we search for >= the last
+	// _seq_no, in case there's a new _primary_term.
+	responses <- `{
+          "hits": {
+	    "hits": [
+	      {
+	        "_seq_no": 2,
+	        "_primary_term": 2,
+		"_source": {"trace": {"id": "trace_2"}, "observer": {"id": "another_beat_id"}}
+	      },
+	      {
+	        "_seq_no": 2,
+	        "_primary_term": 3,
+		"_source": {"trace": {"id": "trace_2b"}, "observer": {"id": "another_beat_id"}}
+	      },
+	      {
+	        "_seq_no": 99,
+	        "_primary_term": 3,
+		"_source": {"trace": {"id": "trace_99"}, "observer": {"id": "another_beat_id"}}
+	      }
+	    ]
+	  }
+	}`
+
+	assert.Equal(t, "trace_2b", expectValue(t, ids))
+	assert.Equal(t, "trace_99", expectValue(t, ids))
+
+	responses <- `{"hits":{"hits":[]}}` // no hits
+	expectNone(t, ids)
+
+	cancel() // stop subscriber
+	srv.Close()
+
+	var bodies []string
+	for _, r := range requests {
+		assert.Equal(t, fmt.Sprintf("/%s/_search", indexName), r.URL.Path)
+
+		var buf bytes.Buffer
+		io.Copy(&buf, r.Body)
+		bodies = append(bodies, strings.TrimSpace(buf.String()))
+	}
+
+	assert.Equal(t, []string{
+		`{"query":{"bool":{"must_not":{"term":{"observer.id":{"value":"beat_id"}}}}},"search_after":[-1],"seq_no_primary_term":true,"size":1000,"sort":[{"_seq_no":"asc"}]}`,
+
+		// Repeats because of the invalid response.
+		`{"query":{"bool":{"must_not":{"term":{"observer.id":{"value":"beat_id"}}}}},"search_after":[1],"seq_no_primary_term":true,"size":1000,"sort":[{"_seq_no":"asc"}]}`,
+		`{"query":{"bool":{"must_not":{"term":{"observer.id":{"value":"beat_id"}}}}},"search_after":[1],"seq_no_primary_term":true,"size":1000,"sort":[{"_seq_no":"asc"}]}`,
+
+		// Repeats because of the zero hits response.
+		`{"query":{"bool":{"must_not":{"term":{"observer.id":{"value":"beat_id"}}}}},"search_after":[98],"seq_no_primary_term":true,"size":1000,"sort":[{"_seq_no":"asc"}]}`,
+		`{"query":{"bool":{"must_not":{"term":{"observer.id":{"value":"beat_id"}}}}},"search_after":[98],"seq_no_primary_term":true,"size":1000,"sort":[{"_seq_no":"asc"}]}`,
+	}, bodies)
+}
+
+func expectValue(t testing.TB, ch <-chan string) string {
+	select {
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timed out waiting for trace ID to be sent")
+		panic("unreachable")
+	case v, ok := <-ch:
+		assert.True(t, ok)
+		return v
+	}
+}
+
+func expectNone(t testing.TB, ch <-chan string) {
+	select {
+	case <-time.After(500 * time.Millisecond):
+	case v := <-ch:
+		t.Errorf("unexpected send on channel: %q", v)
+	}
+}


### PR DESCRIPTION
## Motivation/summary

Introduce a new package which provides a type for
publishing and subscribing to sampled trace IDs.

This is currently implemented using an imperfect
method of search_after on _seq_no. In the future,
once it eventuates, we should use the [Changes API](https://github.com/elastic/elasticsearch/issues/1242).

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
- [x] logging (add log lines, choose appropriate log selector, etc.)
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

```
docker-compose up -d elasticsearch
INTEGRATION_TESTs=1 go test -v ./x-pack/apm-server/sampling/pubsub
```

## Related issues

None