### PR TITLE
feat: limit sourcemap line length

### DIFF
--- a/sourcemap/mapper.go
+++ b/sourcemap/mapper.go
@@ -24,6 +24,7 @@ import (
 )
 
 const sourcemapContentSnippetSize = 5
+const sourcemapLineLimit = 256
 
 // Map sourcemapping for given line and column and return values after sourcemapping
 func Map(mapper *sourcemap.Consumer, lineno, colno int) (
@@ -57,5 +58,13 @@ func subSlice(from, to int, content []string) []string {
 	if to > len(content) {
 		to = len(content)
 	}
-	return content[from:to]
+	var slice = make([]string, to - from)
+	for i, line := range content[from:to] {
+		if len(line) <= sourcemapLineLimit {
+			slice[i] = line
+		} else {
+			slice[i] = line[:sourcemapLineLimit-3] + "..."
+		}
+	}
+	return slice
 }

--- a/sourcemap/mapper_test.go
+++ b/sourcemap/mapper_test.go
@@ -19,6 +19,7 @@ package sourcemap
 
 import (
 	"testing"
+	"strings"
 
 	"github.com/stretchr/testify/require"
 
@@ -86,4 +87,6 @@ func TestSubSlice(t *testing.T) {
 	} {
 		assert.Equal(t, []string{}, subSlice(test.start, test.end, []string{}))
 	}
+
+	assert.Equal(t, []string{strings.Repeat("x", 253) + "..."}, subSlice(0, 1, []string{strings.Repeat("x", 257)}))
 }

--- a/sourcemap/mapper_test.go
+++ b/sourcemap/mapper_test.go
@@ -88,5 +88,6 @@ func TestSubSlice(t *testing.T) {
 		assert.Equal(t, []string{}, subSlice(test.start, test.end, []string{}))
 	}
 
-	assert.Equal(t, []string{strings.Repeat("x", 253) + "..."}, subSlice(0, 1, []string{strings.Repeat("x", 257)}))
+	assert.Equal(t, []string{strings.Repeat("x", sourcemapLineLimit - 3) + "..."},
+		subSlice(0, 1, []string{strings.Repeat("x", sourcemapLineLimit + 1)}))
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Before creating the PR, ensure that:

1. Your branch is rebased on top of the latest master.
   Squash your initial commits into meaningful commits.
   After creating a PR, do not rebase of force push any longer.
2. Nothing is broken, by running the test suite (at least unit tests).
   See https://github.com/elastic/apm-server/blob/master/TESTING.md for details.
3. Your code follows the style guidelines of this project:
   run `make check-full` for static code checks and linting.

A few suggestions about filling out this PR:

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR.
3. Please label this PR with at least one of the following labels:
   - bug fix
   - breaking change
   - enhancement
4. Reference the related issue, and make use of magic keywords where it makes sense
   https://help.github.com/articles/closing-issues-using-keywords/.
5. Do not remove any checklist items, strike through the ones that don't apply
   (by using tildes, e.g. ~scratch this ~).
6. Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
7. Submit the pull request:
   Push your changes to your forked copy of the repository and submit a pull request
   (https://help.github.com/articles/using-pull-requests).
8. Please be patient. We might not be able to immediately review your code,
   but we'll do our best to dedicate to it the attention it deserves.
   Your effort is much appreciated!

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

My coordinating node got OOM when query documents with huge lone lines in the sourcemap, so I want limit the line length of the sourcemap.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

I have considered changes for:
- [ ] documentation
- [ ] logging (add log lines, choose appropriate log selector, etc.)
- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
- [ ] telemetry
- [ ] Elasticsearch Service (https://cloud.elastic.co)
- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)
- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)

## How to test these changes

## Related issues
