### PR TITLE
[7.x] processor/otel: set Span.RepresentativeCount (#4116)

### DIFF
--- a/processor/otel/consumer.go
+++ b/processor/otel/consumer.go
@@ -131,7 +131,7 @@ func (c *Consumer) convert(td consumerdata.TraceData) *model.Batch {
 				Name:      name,
 				Outcome:   "unknown",
 			}
-			parseSpan(otelSpan, &span)
+			parseSpan(otelSpan, td.SourceFormat, &span)
 			batch.Spans = append(batch.Spans, &span)
 			for _, err := range parseErrors(logger, td.SourceFormat, otelSpan) {
 				addSpanCtxToErr(span, hostname, err)
@@ -320,22 +320,8 @@ func parseTransaction(span *tracepb.Span, sourceFormat string, hostname string, 
 
 	if samplerType != nil && samplerParam != nil {
 		// The client has reported its sampling rate, so
-		// we can use it to extrapolate transaction metrics.
-		switch samplerType.GetStringValue().GetValue() {
-		case "probabilistic":
-			probability := samplerParam.GetDoubleValue()
-			if probability > 0 && probability < 1 {
-				event.RepresentativeCount = 1 / probability
-			}
-		default:
-			utility.DeepUpdate(labels, "sampler_type", samplerType.GetStringValue().GetValue())
-			switch v := samplerParam.Value.(type) {
-			case *tracepb.AttributeValue_BoolValue:
-				utility.DeepUpdate(labels, "sampler_param", v.BoolValue)
-			case *tracepb.AttributeValue_DoubleValue:
-				utility.DeepUpdate(labels, "sampler_param", v.DoubleValue)
-			}
-		}
+		// we can use it to extrapolate span metrics.
+		parseSamplerAttributes(samplerType, samplerParam, &event.RepresentativeCount, labels)
 	}
 
 	if len(labels) == 0 {
@@ -345,7 +331,7 @@ func parseTransaction(span *tracepb.Span, sourceFormat string, hostname string, 
 	event.Labels = &l
 }
 
-func parseSpan(span *tracepb.Span, event *model.Span) {
+func parseSpan(span *tracepb.Span, sourceFormat string, event *model.Span) {
 	labels := make(common.MapStr)
 
 	var http model.HTTP
@@ -355,7 +341,19 @@ func parseSpan(span *tracepb.Span, event *model.Span) {
 	var destinationService model.DestinationService
 	var isDBSpan, isHTTPSpan, isMessagingSpan bool
 	var component string
+	var samplerType, samplerParam *tracepb.AttributeValue
 	for kDots, v := range span.Attributes.GetAttributeMap() {
+		if sourceFormat == sourceFormatJaeger {
+			switch kDots {
+			case "sampler.type":
+				samplerType = v
+				continue
+			case "sampler.param":
+				samplerParam = v
+				continue
+			}
+		}
+
 		k := replaceDots(kDots)
 		switch v := v.Value.(type) {
 		case *tracepb.AttributeValue_BoolValue:
@@ -519,10 +517,34 @@ func parseSpan(span *tracepb.Span, event *model.Span) {
 		event.DestinationService = &destinationService
 	}
 
+	if samplerType != nil && samplerParam != nil {
+		// The client has reported its sampling rate, so
+		// we can use it to extrapolate transaction metrics.
+		parseSamplerAttributes(samplerType, samplerParam, &event.RepresentativeCount, labels)
+	}
+
 	if len(labels) == 0 {
 		return
 	}
 	event.Labels = labels
+}
+
+func parseSamplerAttributes(samplerType, samplerParam *tracepb.AttributeValue, representativeCount *float64, labels common.MapStr) {
+	switch samplerType.GetStringValue().GetValue() {
+	case "probabilistic":
+		probability := samplerParam.GetDoubleValue()
+		if probability > 0 && probability <= 1 {
+			*representativeCount = 1 / probability
+		}
+	default:
+		utility.DeepUpdate(labels, "sampler_type", samplerType.GetStringValue().GetValue())
+		switch v := samplerParam.Value.(type) {
+		case *tracepb.AttributeValue_BoolValue:
+			utility.DeepUpdate(labels, "sampler_param", v.BoolValue)
+		case *tracepb.AttributeValue_DoubleValue:
+			utility.DeepUpdate(labels, "sampler_param", v.DoubleValue)
+		}
+	}
 }
 
 func parseErrors(logger *logp.Logger, source string, otelSpan *tracepb.Span) []*model.Error {

--- a/processor/otel/consumer_test.go
+++ b/processor/otel/consumer_test.go
@@ -258,12 +258,12 @@ func TestConsumer_Transaction(t *testing.T) {
 	}
 }
 
-func TestConsumer_TransactionSampleRate(t *testing.T) {
+func TestConsumer_SampleRate(t *testing.T) {
 	var transformables []transform.Transformable
 	reporter := func(ctx context.Context, req publish.PendingReq) error {
 		transformables = append(transformables, req.Transformables...)
 		events := transformAll(ctx, req)
-		approveEvents(t, "transaction_jaeger_sampling_rate", events)
+		approveEvents(t, "jaeger_sampling_rate", events)
 		return nil
 	}
 	require.NoError(t, (&Consumer{Reporter: reporter}).ConsumeTraceData(context.Background(), consumerdata.TraceData{
@@ -278,12 +278,22 @@ func TestConsumer_TransactionSampleRate(t *testing.T) {
 				"sampler.type":  testAttributeStringValue("probabilistic"),
 				"sampler.param": testAttributeDoubleValue(0.8),
 			}},
+		}, {
+			Kind:      tracepb.Span_CLIENT,
+			StartTime: testStartTime(), EndTime: testEndTime(),
+			ParentSpanId: []byte{1},
+			Attributes: &tracepb.Span_Attributes{AttributeMap: map[string]*tracepb.AttributeValue{
+				"sampler.type":  testAttributeStringValue("probabilistic"),
+				"sampler.param": testAttributeDoubleValue(0.4),
+			}},
 		}},
 	}))
 
-	require.Len(t, transformables, 1)
+	require.Len(t, transformables, 2)
 	tx := transformables[0].(*model.Transaction)
+	span := transformables[1].(*model.Span)
 	assert.Equal(t, 1.25 /* 1/0.8 */, tx.RepresentativeCount)
+	assert.Equal(t, 2.5 /* 1/0.4 */, span.RepresentativeCount)
 }
 
 func TestConsumer_Span(t *testing.T) {

--- a/processor/otel/test_approved/jaeger_sampling_rate.approved.json
+++ b/processor/otel/test_approved/jaeger_sampling_rate.approved.json
@@ -38,6 +38,46 @@
                 "sampled": true,
                 "type": "custom"
             }
+        },
+        {
+            "@timestamp": "2019-12-16T12:46:58.000Z",
+            "agent": {
+                "name": "Jaeger",
+                "version": "unknown"
+            },
+            "event": {
+                "outcome": "unknown"
+            },
+            "host": {
+                "hostname": "host-abc",
+                "name": "host-abc"
+            },
+            "parent": {
+                "id": "01"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "service": {
+                "language": {
+                    "name": "unknown"
+                },
+                "name": "unknown",
+                "node": {
+                    "name": "host-abc"
+                }
+            },
+            "span": {
+                "duration": {
+                    "us": 79000000
+                },
+                "name": "",
+                "type": "custom"
+            },
+            "timestamp": {
+                "us": 1576500418000768
+            }
         }
     ]
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - processor/otel: set Span.RepresentativeCount (#4116)