### PR TITLE
[7.x] processor/otel: set outcome from status code (#4127)

### DIFF
--- a/processor/otel/consumer.go
+++ b/processor/otel/consumer.go
@@ -48,6 +48,10 @@ const (
 	keywordLength      = 1024
 	dot                = "."
 	underscore         = "_"
+
+	outcomeSuccess = "success"
+	outcomeFailure = "failure"
+	outcomeUnknown = "unknown"
 )
 
 // Consumer transforms open-telemetry data to be compatible with elastic APM data
@@ -111,7 +115,6 @@ func (c *Consumer) convert(td consumerdata.TraceData) *model.Batch {
 				Timestamp: startTime,
 				Duration:  duration,
 				Name:      name,
-				Outcome:   "unknown",
 			}
 			parseTransaction(otelSpan, td.SourceFormat, hostname, &transaction)
 			batch.Transactions = append(batch.Transactions, &transaction)
@@ -129,7 +132,7 @@ func (c *Consumer) convert(td consumerdata.TraceData) *model.Batch {
 				Timestamp: startTime,
 				Duration:  duration,
 				Name:      name,
-				Outcome:   "unknown",
+				Outcome:   outcomeUnknown,
 			}
 			parseSpan(otelSpan, td.SourceFormat, &span)
 			batch.Spans = append(batch.Spans, &span)
@@ -211,9 +214,10 @@ func parseMetadata(td consumerdata.TraceData, md *model.Metadata) {
 func parseTransaction(span *tracepb.Span, sourceFormat string, hostname string, event *model.Transaction) {
 	labels := make(common.MapStr)
 	var http model.Http
+	var httpStatusCode int
 	var message model.Message
 	var component string
-	var result string
+	var outcome, result string
 	var hasFailed bool
 	var isHTTP, isMessaging bool
 	var samplerType, samplerParam *tracepb.AttributeValue
@@ -241,9 +245,7 @@ func parseTransaction(span *tracepb.Span, sourceFormat string, hostname string, 
 		case *tracepb.AttributeValue_IntValue:
 			switch kDots {
 			case "http.status_code":
-				intv := int(v.IntValue)
-				http.Response = &model.Resp{MinimalResp: model.MinimalResp{StatusCode: &intv}}
-				result = statusCodeResult(intv)
+				httpStatusCode = int(v.IntValue)
 				isHTTP = true
 			default:
 				utility.DeepUpdate(labels, k, v.IntValue)
@@ -259,8 +261,7 @@ func parseTransaction(span *tracepb.Span, sourceFormat string, hostname string, 
 				isHTTP = true
 			case "http.status_code":
 				if intv, err := strconv.Atoi(v.StringValue.Value); err == nil {
-					http.Response = &model.Resp{MinimalResp: model.MinimalResp{StatusCode: &intv}}
-					result = statusCodeResult(intv)
+					httpStatusCode = intv
 				}
 				isHTTP = true
 			case "http.protocol":
@@ -298,11 +299,13 @@ func parseTransaction(span *tracepb.Span, sourceFormat string, hostname string, 
 	}
 
 	if isHTTP {
-		if code := int(span.GetStatus().GetCode()); code != 0 {
-			result = statusCodeResult(code)
-			if http.Response == nil {
-				http.Response = &model.Resp{MinimalResp: model.MinimalResp{StatusCode: &code}}
-			}
+		if httpStatusCode == 0 {
+			httpStatusCode = int(span.GetStatus().GetCode())
+		}
+		if httpStatusCode > 0 {
+			http.Response = &model.Resp{MinimalResp: model.MinimalResp{StatusCode: &httpStatusCode}}
+			result = statusCodeResult(httpStatusCode)
+			outcome = serverStatusCodeOutcome(httpStatusCode)
 		}
 		event.HTTP = &http
 	} else if isMessaging {
@@ -312,11 +315,14 @@ func parseTransaction(span *tracepb.Span, sourceFormat string, hostname string, 
 	if result == "" {
 		if hasFailed {
 			result = "Error"
+			outcome = outcomeFailure
 		} else {
 			result = "Success"
+			outcome = outcomeSuccess
 		}
 	}
 	event.Result = result
+	event.Outcome = outcome
 
 	if samplerType != nil && samplerParam != nil {
 		// The client has reported its sampling rate, so
@@ -488,6 +494,9 @@ func parseSpan(span *tracepb.Span, sourceFormat string, event *model.Span) {
 			if code := int(span.GetStatus().GetCode()); code != 0 {
 				http.StatusCode = &code
 			}
+		}
+		if http.StatusCode != nil {
+			event.Outcome = clientStatusCodeOutcome(*http.StatusCode)
 		}
 		event.Type = "external"
 		subtype := "http"
@@ -683,6 +692,22 @@ func statusCodeResult(statusCode int) string {
 		return standardStatusCodeResults[i-1]
 	}
 	return fmt.Sprintf("HTTP %d", statusCode)
+}
+
+// serverStatusCodeOutcome returns the transaction outcome value to use for the given status code.
+func serverStatusCodeOutcome(statusCode int) string {
+	if statusCode >= 500 {
+		return outcomeFailure
+	}
+	return outcomeSuccess
+}
+
+// clientStatusCodeOutcome returns the span outcome value to use for the given status code.
+func clientStatusCodeOutcome(statusCode int) string {
+	if statusCode >= 400 {
+		return outcomeFailure
+	}
+	return outcomeSuccess
 }
 
 // truncate returns s truncated at n runes, and the number of runes in the resulting string (<= n).

--- a/processor/otel/consumer_test.go
+++ b/processor/otel/consumer_test.go
@@ -195,7 +195,7 @@ func TestConsumer_Transaction(t *testing.T) {
 					ParentSpanId: []byte{0, 0, 0, 0, 97, 98, 99, 100}, Kind: tracepb.Span_SERVER,
 					StartTime: testStartTime(),
 					Attributes: &tracepb.Span_Attributes{AttributeMap: map[string]*tracepb.AttributeValue{
-						"http.status_code": testAttributeIntValue(200),
+						"http.status_code": testAttributeIntValue(500),
 						"http.protocol":    testAttributeStringValue("HTTP"),
 						"http.path":        testAttributeStringValue("http://foo.bar.com?a=12"),
 					}}}}}},
@@ -312,7 +312,7 @@ func TestConsumer_Span(t *testing.T) {
 						"error":            testAttributeBoolValue(true),
 						"hasErrors":        testAttributeBoolValue(true),
 						"double.a":         testAttributeDoubleValue(14.65),
-						"http.status_code": testAttributeIntValue(200),
+						"http.status_code": testAttributeIntValue(400),
 						"int.a":            testAttributeIntValue(148),
 						"span.kind":        testAttributeStringValue("filtered"),
 						"http.url":         testAttributeStringValue("http://foo.bar.com?a=12"),

--- a/processor/otel/test_approved/consume_span.approved.json
+++ b/processor/otel/test_approved/consume_span.approved.json
@@ -7,7 +7,7 @@
                 "version": "unknown"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "processor": {
                 "event": "transaction",

--- a/processor/otel/test_approved/jaeger_sampling_rate.approved.json
+++ b/processor/otel/test_approved/jaeger_sampling_rate.approved.json
@@ -7,7 +7,7 @@
                 "version": "unknown"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-abc",

--- a/processor/otel/test_approved/metadata_jaeger-no-language.approved.json
+++ b/processor/otel/test_approved/metadata_jaeger-no-language.approved.json
@@ -7,7 +7,7 @@
                 "version": "3.4.12"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "processor": {
                 "event": "transaction",

--- a/processor/otel/test_approved/metadata_jaeger-version.approved.json
+++ b/processor/otel/test_approved/metadata_jaeger-version.approved.json
@@ -7,7 +7,7 @@
                 "version": "3.4.12"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "processor": {
                 "event": "transaction",

--- a/processor/otel/test_approved/metadata_jaeger.approved.json
+++ b/processor/otel/test_approved/metadata_jaeger.approved.json
@@ -8,7 +8,7 @@
                 "version": "3.2.1"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-foo",

--- a/processor/otel/test_approved/metadata_jaeger_full-traceid.approved.json
+++ b/processor/otel/test_approved/metadata_jaeger_full-traceid.approved.json
@@ -7,7 +7,7 @@
                 "version": "unknown"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "processor": {
                 "event": "transaction",

--- a/processor/otel/test_approved/metadata_jaeger_minimal.approved.json
+++ b/processor/otel/test_approved/metadata_jaeger_minimal.approved.json
@@ -7,7 +7,7 @@
                 "version": "unknown"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "processor": {
                 "event": "transaction",

--- a/processor/otel/test_approved/metadata_minimal.approved.json
+++ b/processor/otel/test_approved/metadata_minimal.approved.json
@@ -7,7 +7,7 @@
                 "version": "unknown"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "processor": {
                 "event": "transaction",

--- a/processor/otel/test_approved/span_jaeger_http.approved.json
+++ b/processor/otel/test_approved/span_jaeger_http.approved.json
@@ -11,7 +11,7 @@
                 "port": 80
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "failure"
             },
             "host": {
                 "hostname": "host-abc",
@@ -55,7 +55,7 @@
                 "http": {
                     "method": "get",
                     "response": {
-                        "status_code": 200
+                        "status_code": 400
                     },
                     "url": {
                         "original": "http://foo.bar.com?a=12"
@@ -99,7 +99,7 @@
                     "method": "get"
                 },
                 "response": {
-                    "status_code": 200
+                    "status_code": 400
                 }
             },
             "parent": {
@@ -153,7 +153,7 @@
                     "method": "get"
                 },
                 "response": {
-                    "status_code": 200
+                    "status_code": 400
                 }
             },
             "parent": {
@@ -209,7 +209,7 @@
                     "method": "get"
                 },
                 "response": {
-                    "status_code": 200
+                    "status_code": 400
                 }
             },
             "parent": {
@@ -265,7 +265,7 @@
                     "method": "get"
                 },
                 "response": {
-                    "status_code": 200
+                    "status_code": 400
                 }
             },
             "parent": {
@@ -321,7 +321,7 @@
                     "method": "get"
                 },
                 "response": {
-                    "status_code": 200
+                    "status_code": 400
                 }
             },
             "parent": {
@@ -375,7 +375,7 @@
                     "method": "get"
                 },
                 "response": {
-                    "status_code": 200
+                    "status_code": 400
                 }
             },
             "parent": {

--- a/processor/otel/test_approved/span_jaeger_http_status_code.approved.json
+++ b/processor/otel/test_approved/span_jaeger_http_status_code.approved.json
@@ -11,7 +11,7 @@
                 "port": 80
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-abc",

--- a/processor/otel/test_approved/transaction_jaeger_custom.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_custom.approved.json
@@ -7,7 +7,7 @@
                 "version": "unknown"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "labels": {
                 "a_b": "foo"

--- a/processor/otel/test_approved/transaction_jaeger_full.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_full.approved.json
@@ -7,7 +7,7 @@
                 "version": "unknown"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-abc",

--- a/processor/otel/test_approved/transaction_jaeger_no_attrs.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_no_attrs.approved.json
@@ -7,7 +7,7 @@
                 "version": "unknown"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "failure"
             },
             "host": {
                 "hostname": "host-abc",

--- a/processor/otel/test_approved/transaction_jaeger_type_component.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_type_component.approved.json
@@ -7,7 +7,7 @@
                 "version": "unknown"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-abc",

--- a/processor/otel/test_approved/transaction_jaeger_type_messaging.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_type_messaging.approved.json
@@ -7,7 +7,7 @@
                 "version": "unknown"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-abc",

--- a/processor/otel/test_approved/transaction_jaeger_type_request.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_type_request.approved.json
@@ -7,7 +7,7 @@
                 "version": "unknown"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "failure"
             },
             "host": {
                 "hostname": "host-abc",
@@ -15,7 +15,7 @@
             },
             "http": {
                 "response": {
-                    "status_code": 200
+                    "status_code": 500
                 }
             },
             "labels": {
@@ -45,7 +45,7 @@
                     "us": 0
                 },
                 "id": "",
-                "result": "HTTP 2xx",
+                "result": "HTTP 5xx",
                 "sampled": true,
                 "type": "request"
             },

--- a/processor/otel/test_approved/transaction_jaeger_type_request_result.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_type_request_result.approved.json
@@ -7,7 +7,7 @@
                 "version": "unknown"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host-abc",

--- a/testdata/jaeger/batch_0.approved.json
+++ b/testdata/jaeger/batch_0.approved.json
@@ -8,7 +8,7 @@
                 "version": "2.20.1"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "hostname": "host01",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - processor/otel: set outcome from status code (#4127)