### PR TITLE
[7.x] aggregation/spanmetrics: add max_groups config (#4131)

### DIFF
--- a/beater/config/aggregation.go
+++ b/beater/config/aggregation.go
@@ -22,10 +22,13 @@ import (
 )
 
 const (
-	defaultAggregationInterval                       = 1 * time.Minute
-	defaultAggregationMaxTransactionGroups           = 1000
-	defaultAggregationHDRHistogramSignificantFigures = 2
-	defaultAggregationRUMUserAgentLRUSize            = 5000
+	defaultTransactionAggregationInterval                       = time.Minute
+	defaultTransactionAggregationMaxGroups                      = 10000
+	defaultTransactionAggregationHDRHistogramSignificantFigures = 2
+	defaultTransactionAggregationRUMUserAgentLRUSize            = 5000
+
+	defaultServiceDestinationAggregationInterval  = time.Minute
+	defaultServiceDestinationAggregationMaxGroups = 10000
 )
 
 // AggregationConfig holds configuration related to various metrics aggregations.
@@ -45,21 +48,23 @@ type TransactionAggregationConfig struct {
 
 // ServiceDestinationAggregationConfig holds configuration related to span metrics aggregation for service maps.
 type ServiceDestinationAggregationConfig struct {
-	Enabled  bool          `config:"enabled"`
-	Interval time.Duration `config:"interval" validate:"min=1"`
+	Enabled   bool          `config:"enabled"`
+	Interval  time.Duration `config:"interval" validate:"min=1"`
+	MaxGroups int           `config:"max_groups" validate:"min=1"`
 }
 
 func defaultAggregationConfig() AggregationConfig {
 	return AggregationConfig{
 		Transactions: TransactionAggregationConfig{
-			Interval:                       defaultAggregationInterval,
-			MaxTransactionGroups:           defaultAggregationMaxTransactionGroups,
-			HDRHistogramSignificantFigures: defaultAggregationHDRHistogramSignificantFigures,
-			RUMUserAgentLRUSize:            defaultAggregationRUMUserAgentLRUSize,
+			Interval:                       defaultTransactionAggregationInterval,
+			MaxTransactionGroups:           defaultTransactionAggregationMaxGroups,
+			HDRHistogramSignificantFigures: defaultTransactionAggregationHDRHistogramSignificantFigures,
+			RUMUserAgentLRUSize:            defaultTransactionAggregationRUMUserAgentLRUSize,
 		},
 		ServiceDestinations: ServiceDestinationAggregationConfig{
-			Enabled:  true,
-			Interval: defaultAggregationInterval,
+			Enabled:   true,
+			Interval:  defaultServiceDestinationAggregationInterval,
+			MaxGroups: defaultServiceDestinationAggregationMaxGroups,
 		},
 	}
 }

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -128,6 +128,9 @@ func TestUnpackConfig(t *testing.T) {
 							},
 						},
 					},
+					"service_destinations": map[string]interface{}{
+						"max_groups": 456,
+					},
 				},
 			},
 			outCfg: &Config{
@@ -222,8 +225,9 @@ func TestUnpackConfig(t *testing.T) {
 						RUMUserAgentLRUSize:            123,
 					},
 					ServiceDestinations: ServiceDestinationAggregationConfig{
-						Enabled:  true,
-						Interval: time.Minute,
+						Enabled:   true,
+						Interval:  time.Minute,
+						MaxGroups: 456,
 					},
 				},
 				Sampling: SamplingConfig{
@@ -338,13 +342,14 @@ func TestUnpackConfig(t *testing.T) {
 					Transactions: TransactionAggregationConfig{
 						Enabled:                        true,
 						Interval:                       time.Minute,
-						MaxTransactionGroups:           1000,
+						MaxTransactionGroups:           10000,
 						HDRHistogramSignificantFigures: 2,
 						RUMUserAgentLRUSize:            123,
 					},
 					ServiceDestinations: ServiceDestinationAggregationConfig{
-						Enabled:  false,
-						Interval: time.Minute,
+						Enabled:   false,
+						Interval:  time.Minute,
+						MaxGroups: 10000,
 					},
 				},
 				Sampling: SamplingConfig{

--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+
 	logs "github.com/elastic/apm-server/log"
 	"github.com/elastic/apm-server/model"
 	"github.com/elastic/apm-server/publish"
@@ -19,9 +21,38 @@ import (
 
 // AggregatorConfig holds configuration for creating an Aggregator.
 type AggregatorConfig struct {
-	Report   publish.Reporter
-	Logger   *logp.Logger
+	// Report is a publish.Reporter for reporting metrics documents.
+	Report publish.Reporter
+
+	// MaxGroups is the maximum number of distinct service destination
+	// group metrics to store within an aggregation period. Once this
+	// number of groups is reached, any new aggregation keys will cause
+	// individual metrics documents to be immediately published.
+	MaxGroups int
+
+	// Interval is the interval between publishing of aggregated metrics.
+	// There may be additional metrics reported at arbitrary times if the
+	// aggregation groups fill up.
 	Interval time.Duration
+
+	// Logger is the logger for logging metrics aggregation/publishing.
+	//
+	// If Logger is nil, a new logger will be constructed.
+	Logger *logp.Logger
+}
+
+// Validate validates the aggregator config.
+func (config AggregatorConfig) Validate() error {
+	if config.Report == nil {
+		return errors.New("Report unspecified")
+	}
+	if config.MaxGroups <= 0 {
+		return errors.New("MaxGroups unspecified or negative")
+	}
+	if config.Interval <= 0 {
+		return errors.New("Interval unspecified or negative")
+	}
+	return nil
 }
 
 // Aggregator aggregates transaction durations, periodically publishing histogram spanMetrics.
@@ -38,6 +69,9 @@ type Aggregator struct {
 
 // NewAggregator returns a new Aggregator with the given config.
 func NewAggregator(config AggregatorConfig) (*Aggregator, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid aggregator config")
+	}
 	if config.Logger == nil {
 		config.Logger = logp.NewLogger(logs.SpanMetrics)
 	}
@@ -45,8 +79,8 @@ func NewAggregator(config AggregatorConfig) (*Aggregator, error) {
 		stopping: make(chan struct{}),
 		stopped:  make(chan struct{}),
 		config:   config,
-		active:   newMetricsBuffer(),
-		inactive: newMetricsBuffer(),
+		active:   newMetricsBuffer(config.MaxGroups),
+		inactive: newMetricsBuffer(config.MaxGroups),
 	}, nil
 }
 
@@ -123,7 +157,7 @@ func (a *Aggregator) publish(ctx context.Context) error {
 	now := time.Now()
 	metricsets := make([]transform.Transformable, 0, size)
 	for key, metrics := range a.inactive.m {
-		metricset := makeMetricset(now, key, metrics.count, metrics.sum, a.config.Interval.Milliseconds())
+		metricset := makeMetricset(now, key, metrics, a.config.Interval.Milliseconds())
 		metricsets = append(metricsets, &metricset)
 		delete(a.inactive.m, key)
 	}
@@ -144,24 +178,24 @@ func (a *Aggregator) ProcessTransformables(in []transform.Transformable) []trans
 	defer a.mu.RUnlock()
 	out := in
 	for _, tf := range in {
-		span, ok := tf.(*model.Span)
-		if !ok {
-			continue
+		if span, ok := tf.(*model.Span); ok {
+			if metricset := a.processSpan(span); metricset != nil {
+				out = append(out, metricset)
+			}
 		}
-		a.processSpan(span)
 	}
 	return out
 }
 
-func (a *Aggregator) processSpan(span *model.Span) {
+func (a *Aggregator) processSpan(span *model.Span) *model.Metricset {
 	if span.DestinationService == nil || span.DestinationService.Resource == nil {
-		return
+		return nil
 	}
 	if span.RepresentativeCount <= 0 {
 		// RepresentativeCount is zero when the sample rate is unknown.
 		// We cannot calculate accurate span metrics without the sample
 		// rate, so we don't calculate any at all in this case.
-		return
+		return nil
 	}
 
 	key := aggregationKey{
@@ -175,26 +209,36 @@ func (a *Aggregator) processSpan(span *model.Span) {
 		count: span.RepresentativeCount,
 		sum:   float64(duration.Microseconds()) * span.RepresentativeCount,
 	}
-	a.active.storeOrUpdate(key, metrics)
+	if a.active.storeOrUpdate(key, metrics) {
+		return nil
+	}
+	metricset := makeMetricset(time.Now(), key, metrics, 0)
+	return &metricset
 }
 
 type metricsBuffer struct {
-	// TODO might need a size cap
+	maxSize int
+
 	mu sync.RWMutex
 	m  map[aggregationKey]spanMetrics
 }
 
-func newMetricsBuffer() *metricsBuffer {
+func newMetricsBuffer(maxSize int) *metricsBuffer {
 	return &metricsBuffer{
-		m: make(map[aggregationKey]spanMetrics),
+		maxSize: maxSize,
+		m:       make(map[aggregationKey]spanMetrics),
 	}
 }
 
-func (mb *metricsBuffer) storeOrUpdate(key aggregationKey, value spanMetrics) {
+func (mb *metricsBuffer) storeOrUpdate(key aggregationKey, value spanMetrics) bool {
 	mb.mu.Lock()
 	defer mb.mu.Unlock()
-	old := mb.m[key]
+	old, ok := mb.m[key]
+	if !ok && len(mb.m) == mb.maxSize {
+		return false
+	}
 	mb.m[key] = spanMetrics{count: value.count + old.count, sum: value.sum + old.sum}
+	return true
 }
 
 type aggregationKey struct {
@@ -211,7 +255,7 @@ type spanMetrics struct {
 	sum   float64
 }
 
-func makeMetricset(timestamp time.Time, key aggregationKey, count, sum float64, interval int64) model.Metricset {
+func makeMetricset(timestamp time.Time, key aggregationKey, metrics spanMetrics, interval int64) model.Metricset {
 	out := model.Metricset{
 		Timestamp: timestamp,
 		Metadata: model.Metadata{
@@ -230,17 +274,24 @@ func makeMetricset(timestamp time.Time, key aggregationKey, count, sum float64, 
 		Samples: []model.Sample{
 			{
 				Name:  "destination.service.response_time.count",
-				Value: math.Round(count),
+				Value: math.Round(metrics.count),
 			},
 			{
 				Name:  "destination.service.response_time.sum.us",
-				Value: math.Round(sum),
-			},
-			{
-				Name:  "metricset.period",
-				Value: float64(interval),
+				Value: math.Round(metrics.sum),
 			},
 		},
+	}
+	if interval > 0 {
+		// Only set metricset.period for a positive interval.
+		//
+		// An interval of zero means the metricset is computed
+		// from an instantaneous value, meaning there is no
+		// aggregation period.
+		out.Samples = append(out.Samples, model.Sample{
+			Name:  "metricset.period",
+			Value: float64(interval),
+		})
 	}
 	return out
 }

--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator_test.go
@@ -20,8 +20,9 @@ import (
 
 func BenchmarkAggregateSpan(b *testing.B) {
 	agg, err := NewAggregator(AggregatorConfig{
-		Report:   makeErrReporter(nil),
-		Interval: time.Minute,
+		Report:    makeErrReporter(nil),
+		Interval:  time.Minute,
+		MaxGroups: 1000,
 	})
 	require.NoError(b, err)
 
@@ -33,16 +34,44 @@ func BenchmarkAggregateSpan(b *testing.B) {
 	})
 }
 
+func TestNewAggregatorConfigInvalid(t *testing.T) {
+	report := makeErrReporter(nil)
+
+	type test struct {
+		config AggregatorConfig
+		err    string
+	}
+
+	for _, test := range []test{{
+		config: AggregatorConfig{},
+		err:    "Report unspecified",
+	}, {
+		config: AggregatorConfig{
+			Report: report,
+		},
+		err: "MaxGroups unspecified or negative",
+	}, {
+		config: AggregatorConfig{
+			Report:    report,
+			MaxGroups: 1,
+		},
+		err: "Interval unspecified or negative",
+	}} {
+		agg, err := NewAggregator(test.config)
+		require.Error(t, err)
+		require.Nil(t, agg)
+		assert.EqualError(t, err, "invalid aggregator config: "+test.err)
+	}
+}
+
 func TestAggregatorRun(t *testing.T) {
 	reqs := make(chan publish.PendingReq, 1)
 	agg, err := NewAggregator(AggregatorConfig{
-		Report:   makeChanReporter(reqs),
-		Interval: 10 * time.Millisecond,
+		Report:    makeChanReporter(reqs),
+		Interval:  10 * time.Millisecond,
+		MaxGroups: 1000,
 	})
 	require.NoError(t, err)
-
-	go agg.Run()
-	defer agg.Stop(context.Background())
 
 	type input struct {
 		serviceName string
@@ -70,11 +99,15 @@ func TestAggregatorRun(t *testing.T) {
 			defer wg.Done()
 			span := makeSpan(in.serviceName, in.destination, in.outcome, 100*time.Millisecond, in.count)
 			for i := 0; i < 100; i++ {
-				agg.ProcessTransformables([]transform.Transformable{span})
+				assert.Len(t, agg.ProcessTransformables([]transform.Transformable{span}), 1)
 			}
 		}(in)
 	}
 	wg.Wait()
+
+	// Start the aggregator after processing to ensure metrics are aggregated deterministically.
+	go agg.Run()
+	defer agg.Stop(context.Background())
 
 	req := expectPublish(t, reqs)
 	metricsets := make([]*model.Metricset, len(req.Transformables))
@@ -154,6 +187,59 @@ func TestAggregatorRun(t *testing.T) {
 	}
 }
 
+func TestAggregatorOverflow(t *testing.T) {
+	reqs := make(chan publish.PendingReq, 1)
+	agg, err := NewAggregator(AggregatorConfig{
+		Report:    makeChanReporter(reqs),
+		Interval:  10 * time.Millisecond,
+		MaxGroups: 2,
+	})
+	require.NoError(t, err)
+
+	// The first two transaction groups will not require immediate publication,
+	// as we have configured the spanmetrics with a maximum of two buckets.
+	var input []transform.Transformable
+	for i := 0; i < 10; i++ {
+		input = append(input, makeSpan("service", "destination1", "success", 100*time.Millisecond, 1))
+		input = append(input, makeSpan("service", "destination2", "success", 100*time.Millisecond, 1))
+	}
+	output := agg.ProcessTransformables(input)
+	assert.Equal(t, input, output)
+
+	// The third group will return a metricset for immediate publication.
+	for i := 0; i < 2; i++ {
+		input = append(input, makeSpan("service", "destination3", "success", 100*time.Millisecond, 1))
+	}
+	output = agg.ProcessTransformables(input)
+	assert.Len(t, output, len(input)+2)
+	assert.Equal(t, input, output[:len(input)])
+
+	for _, tf := range output[len(input):] {
+		m, ok := tf.(*model.Metricset)
+		require.True(t, ok)
+		require.NotNil(t, m)
+		require.False(t, m.Timestamp.IsZero())
+
+		m.Timestamp = time.Time{}
+		assert.Equal(t, &model.Metricset{
+			Metadata: model.Metadata{
+				Service: model.Service{Name: "service"},
+			},
+			Event: model.MetricsetEventCategorization{
+				Outcome: "success",
+			},
+			Span: model.MetricsetSpan{
+				DestinationService: model.DestinationService{Resource: newString("destination3")},
+			},
+			Samples: []model.Sample{
+				{Name: "destination.service.response_time.count", Value: 1.0},
+				{Name: "destination.service.response_time.sum.us", Value: 100000.0},
+				// No metricset.period is recorded as these metrics are instantanous, not aggregated.
+			},
+		}, m)
+	}
+}
+
 func makeSpan(
 	serviceName string, destinationServiceResource, outcome string,
 	duration time.Duration,
@@ -198,4 +284,8 @@ func expectPublish(t *testing.T, ch <-chan publish.PendingReq) publish.PendingRe
 		t.Fatal("expected publish")
 	}
 	panic("unreachable")
+}
+
+func newString(s string) *string {
+	return &s
 }

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -61,10 +61,10 @@ type AggregatorConfig struct {
 	// If Logger is nil, a new logger will be constructed.
 	Logger *logp.Logger
 
-	// MaxBuckets is the maximum number of distinct transaction groups
-	// to store within an aggregation period. Once this number of groups
-	// has been reached, any new aggregation keys will cause individual
-	// metrics documents to be immediately published.
+	// MaxTransactionGroups is the maximum number of distinct transaction
+	// group metrics to store within an aggregation period. Once this number
+	// of groups has been reached, any new aggregation keys will cause
+	// individual metrics documents to be immediately published.
 	MaxTransactionGroups int
 
 	// MetricsInterval is the interval between publishing of aggregated

--- a/x-pack/apm-server/main.go
+++ b/x-pack/apm-server/main.go
@@ -55,8 +55,9 @@ func newProcessors(args beater.ServerParams) ([]namedProcessor, error) {
 		const name = "service destinations aggregation"
 		args.Logger.Infof("creating %s with config: %+v", name, args.Config.Aggregation.ServiceDestinations)
 		spanAggregator, err := spanmetrics.NewAggregator(spanmetrics.AggregatorConfig{
-			Report:   args.Reporter,
-			Interval: args.Config.Aggregation.ServiceDestinations.Interval,
+			Report:    args.Reporter,
+			Interval:  args.Config.Aggregation.ServiceDestinations.Interval,
+			MaxGroups: args.Config.Aggregation.ServiceDestinations.MaxGroups,
 		})
 		if err != nil {
 			return nil, errors.Wrapf(err, "error creating %s", name)


### PR DESCRIPTION
Backports the following commits to 7.x:
 - aggregation/spanmetrics: add max_groups config (#4131)