### PR TITLE
[7.x] Derive outcome from the HTTP status code when available (#4165)

### DIFF
--- a/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
@@ -17,7 +17,7 @@
                 "version": "1.5.0"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "architecture": "amd64",
@@ -210,7 +210,7 @@
                 "version": "1.5.0"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "architecture": "amd64",

--- a/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json
@@ -555,7 +555,7 @@
                 "version": "1.5.0"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "architecture": "x64",

--- a/model/modeldecoder/transaction_test.go
+++ b/model/modeldecoder/transaction_test.go
@@ -193,6 +193,7 @@ func TestTransactionEventDecode(t *testing.T) {
 	page := model.Page{URL: model.ParseURL(url, ""), Referer: &referer}
 	request := model.Req{Method: "post", Socket: &model.Socket{}, Headers: http.Header{"User-Agent": []string{ua}}}
 	response := model.Resp{Finished: new(bool), MinimalResp: model.MinimalResp{Headers: http.Header{"Content-Type": []string{"text/html"}}}}
+	badRequestResp, internalErrorResp := 400, 500
 	h := model.Http{Request: &request, Response: &response}
 	ctxURL := model.URL{Original: &origURL}
 	custom := model.Custom{"abc": 1}
@@ -374,6 +375,53 @@ func TestTransactionEventDecode(t *testing.T) {
 					FirstInputDelay:       2.3,
 					TotalBlockingTime:     -1, // undefined
 				},
+			},
+		},
+		"with derived success outcome": {
+			input: map[string]interface{}{
+				"context": map[string]interface{}{
+					"response": map[string]interface{}{
+						"status_code": json.Number("400"),
+					},
+				},
+			},
+			e: &model.Transaction{
+				Metadata: inputMetadata,
+				ID:       id,
+				Type:     trType,
+				Name:     name,
+				TraceID:  traceID,
+				Duration: duration,
+				HTTP: &model.Http{Response: &model.Resp{
+					MinimalResp: model.MinimalResp{StatusCode: &badRequestResp},
+				}},
+				Timestamp: requestTime,
+				SpanCount: model.SpanCount{Dropped: &dropped, Started: &started},
+				// a 4xx code is a success from the server perspective
+				Outcome: "success",
+			},
+		},
+		"with derived failure outcome": {
+			input: map[string]interface{}{
+				"context": map[string]interface{}{
+					"response": map[string]interface{}{
+						"status_code": json.Number("500"),
+					},
+				},
+			},
+			e: &model.Transaction{
+				Metadata:  inputMetadata,
+				ID:        id,
+				Type:      trType,
+				Name:      name,
+				TraceID:   traceID,
+				Duration:  duration,
+				Timestamp: requestTime,
+				HTTP: &model.Http{Response: &model.Resp{
+					MinimalResp: model.MinimalResp{StatusCode: &internalErrorResp},
+				}},
+				SpanCount: model.SpanCount{Dropped: &dropped, Started: &started},
+				Outcome:   "failure",
 			},
 		},
 	} {

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
@@ -14,7 +14,7 @@
                 "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "architecture": "amd64",
@@ -195,7 +195,7 @@
                 "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "architecture": "amd64",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationSpans.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationSpans.approved.json
@@ -508,7 +508,7 @@
                 "port": 5432
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "host": {
                 "architecture": "x64",

--- a/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
@@ -10,7 +10,7 @@
                 "ip": "192.0.0.1"
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "http": {
                 "request": {
@@ -451,7 +451,7 @@
                 "port": 8000
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "labels": {
                 "testTagKey": "testTagValue"
@@ -541,7 +541,7 @@
                 "port": 8003
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "labels": {
                 "testTagKey": "testTagValue"
@@ -631,7 +631,7 @@
                 "port": 8003
             },
             "event": {
-                "outcome": "unknown"
+                "outcome": "success"
             },
             "labels": {
                 "testTagKey": "testTagValue"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Derive outcome from the HTTP status code when available (#4165)