### PR TITLE
systemtest: retry deleting ILM policy

### DIFF
--- a/systemtest/elasticsearch.go
+++ b/systemtest/elasticsearch.go
@@ -115,9 +115,13 @@ func CleanupElasticsearch(t testing.TB) {
 	}
 
 	// Delete the ILM policy last or we'll get an error due to it being in use.
-	err := doReq(esapi.ILMDeleteLifecycleRequest{Policy: "apm-rollover-30-days"})
-	if err != nil {
-		t.Fatal(err)
+	for {
+		err := doReq(esapi.ILMDeleteLifecycleRequest{Policy: "apm-rollover-30-days"})
+		if err == nil {
+			break
+		}
+		// Retry deleting, in case indices are still being deleted.
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
## Motivation/summary

Fix intermittent CI issues like the following, by retrying ILM policy deletion.

```
[2020-09-10T09:24:20.117Z] === RUN   TestTransactionAggregationShutdown
[2020-09-10T09:24:20.117Z]     elasticsearch.go:120: [400 Bad Request] {"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"Cannot delete policy [apm-rollover-30-days]. It is in use by one or more indices: [apm-8.0.0-error-000001]"}],"type":"illegal_argument_exception","reason":"Cannot delete policy [apm-rollover-30-days]. It is in use by one or more indices: [apm-8.0.0-error-000001]"},"status":400}
```

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

`cd systemtest && go test -v`

## Related issues

https://apm-ci.elastic.co/blue/organizations/jenkins/apm-server%2Fapm-server-mbp/detail/PR-4183/3/pipeline/130