### PR TITLE
[7.x] systemtest: retry deleting ILM policy (#4186)

### DIFF
--- a/systemtest/elasticsearch.go
+++ b/systemtest/elasticsearch.go
@@ -115,9 +115,13 @@ func CleanupElasticsearch(t testing.TB) {
 	}
 
 	// Delete the ILM policy last or we'll get an error due to it being in use.
-	err := doReq(esapi.ILMDeleteLifecycleRequest{Policy: "apm-rollover-30-days"})
-	if err != nil {
-		t.Fatal(err)
+	for {
+		err := doReq(esapi.ILMDeleteLifecycleRequest{Policy: "apm-rollover-30-days"})
+		if err == nil {
+			break
+		}
+		// Retry deleting, in case indices are still being deleted.
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - systemtest: retry deleting ILM policy (#4186)