### PR TITLE
processor/otel: de-dot metadata labels

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -10,6 +10,7 @@ https://github.com/elastic/apm-server/compare/7.9\...master[View commits]
 ==== Bug fixes
 
 * Transaction metrics aggregation now flushes on shutdown, respecting apm-server.shutdown_timeout {pull}3971[3971]
+* De-dot Jaeger process tag keys, fixing indexing errors when using jaeger-php {pull}4191[4191]
 
 [float]
 ==== Intake API Changes

--- a/processor/otel/consumer.go
+++ b/processor/otel/consumer.go
@@ -201,13 +201,13 @@ func parseMetadata(td consumerdata.TraceData, md *model.Metadata) {
 
 	md.Labels = make(common.MapStr)
 	for key, val := range td.Node.GetAttributes() {
-		md.Labels[key] = truncate(val)
+		md.Labels[replaceDots(key)] = truncate(val)
 	}
 	if t := td.Resource.GetType(); t != "" {
 		md.Labels["resource"] = truncate(t)
 	}
 	for key, val := range td.Resource.GetLabels() {
-		md.Labels[key] = truncate(val)
+		md.Labels[replaceDots(key)] = truncate(val)
 	}
 }
 

--- a/processor/otel/consumer_test.go
+++ b/processor/otel/consumer_test.go
@@ -89,14 +89,20 @@ func TestConsumer_Metadata(t *testing.T) {
 				Identifier: &commonpb.ProcessIdentifier{
 					HostName:       "host-foo",
 					Pid:            107892,
-					StartTimestamp: testStartTime()},
+					StartTimestamp: testStartTime(),
+				},
 				LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "Jaeger-C++-3.2.1"},
 				ServiceInfo: &commonpb.ServiceInfo{Name: "foo"},
-				Attributes:  map[string]string{"client-uuid": "xxf0", "ip": "17.0.10.123", "foo": "bar"},
+				Attributes: map[string]string{
+					"client-uuid": "xxf0",
+					"ip":          "17.0.10.123",
+					"foo":         "bar",
+					"peer.port":   "80",
+				},
 			},
 			Resource: &resourcepb.Resource{
 				Type:   "request",
-				Labels: map[string]string{"a": "b", "c": "d"},
+				Labels: map[string]string{"a": "b", "c": "d", "e.f": "g"},
 			},
 		},
 	}, {

--- a/processor/otel/test_approved/metadata_jaeger.approved.json
+++ b/processor/otel/test_approved/metadata_jaeger.approved.json
@@ -18,7 +18,9 @@
             "labels": {
                 "a": "b",
                 "c": "d",
+                "e_f": "g",
                 "foo": "bar",
+                "peer_port": "80",
                 "resource": "request"
             },
             "process": {


### PR DESCRIPTION
## Motivation/summary

De-dot metadata labels, like we do for span attributes, to prevent indexing errors caused by our `labels_*` dynamic mapping rules.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

1. Enable Jaeger intake
2. Instrument an application with Jaeger, run it with `JAEGER_TAGS=abc.def=123` set (or however process tags are set for the relevant Jaeger client)
3. Check that the spans are indexed, and there are no errors or warnings in the server log

## Related issues

Closes #4190 