### PR TITLE
[7.9] processor/otel: de-dot metadata labels (#4191)

### DIFF
--- a/processor/otel/consumer.go
+++ b/processor/otel/consumer.go
@@ -199,13 +199,13 @@ func parseMetadata(td consumerdata.TraceData, md *model.Metadata) {
 
 	md.Labels = make(common.MapStr)
 	for key, val := range td.Node.GetAttributes() {
-		md.Labels[key] = truncate(val)
+		md.Labels[replaceDots(key)] = truncate(val)
 	}
 	if t := td.Resource.GetType(); t != "" {
 		md.Labels["resource"] = truncate(t)
 	}
 	for key, val := range td.Resource.GetLabels() {
-		md.Labels[key] = truncate(val)
+		md.Labels[replaceDots(key)] = truncate(val)
 	}
 }
 

--- a/processor/otel/consumer_test.go
+++ b/processor/otel/consumer_test.go
@@ -88,14 +88,20 @@ func TestConsumer_Metadata(t *testing.T) {
 				Identifier: &commonpb.ProcessIdentifier{
 					HostName:       "host-foo",
 					Pid:            107892,
-					StartTimestamp: testStartTime()},
+					StartTimestamp: testStartTime(),
+				},
 				LibraryInfo: &commonpb.LibraryInfo{ExporterVersion: "Jaeger-C++-3.2.1"},
 				ServiceInfo: &commonpb.ServiceInfo{Name: "foo"},
-				Attributes:  map[string]string{"client-uuid": "xxf0", "ip": "17.0.10.123", "foo": "bar"},
+				Attributes: map[string]string{
+					"client-uuid": "xxf0",
+					"ip":          "17.0.10.123",
+					"foo":         "bar",
+					"peer.port":   "80",
+				},
 			},
 			Resource: &resourcepb.Resource{
 				Type:   "request",
-				Labels: map[string]string{"a": "b", "c": "d"},
+				Labels: map[string]string{"a": "b", "c": "d", "e.f": "g"},
 			},
 		},
 	}, {

--- a/processor/otel/test_approved/metadata_jaeger.approved.json
+++ b/processor/otel/test_approved/metadata_jaeger.approved.json
@@ -15,7 +15,9 @@
             "labels": {
                 "a": "b",
                 "c": "d",
+                "e_f": "g",
                 "foo": "bar",
+                "peer_port": "80",
                 "resource": "request"
             },
             "process": {


### PR DESCRIPTION
Backports the following commits to 7.9:
 - processor/otel: de-dot metadata labels (#4191)