### PR TITLE
[7.x] Fix metadata.service.* fields requirements in json schema (#4142)

### DIFF
--- a/beater/api/profile/handler_test.go
+++ b/beater/api/profile/handler_test.go
@@ -137,7 +137,7 @@ func TestHandler(t *testing.T) {
 				part{
 					name:        "metadata",
 					contentType: "application/json",
-					body:        strings.NewReader(`{"service":{"name":"foo","agent":{}}}`),
+					body:        strings.NewReader(`{"service":{"name":"foo","agent":{"name":"go","version":"1.0"}}}`),
 				},
 			},
 			body:    prettyJSON(map[string]interface{}{"accepted": 2}),

--- a/beater/test_approved_es_documents/TestPublishIntegrationProfileCPUProfileMetadata.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationProfileCPUProfileMetadata.approved.json
@@ -3,7 +3,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -146,7 +147,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -235,7 +237,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -396,7 +399,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -485,7 +489,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -556,7 +561,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -663,7 +669,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -764,7 +771,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -859,7 +867,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -972,7 +981,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -1103,7 +1113,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -1168,7 +1179,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -1245,7 +1257,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -1358,7 +1371,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -1501,7 +1515,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -1572,7 +1587,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -1697,7 +1713,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -1810,7 +1827,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -1911,7 +1929,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -2012,7 +2031,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -2143,7 +2163,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -2208,7 +2229,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -2303,7 +2325,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -2374,7 +2397,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -2451,7 +2475,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -2588,7 +2613,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -2677,7 +2703,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -2742,7 +2769,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -2795,7 +2823,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -2884,7 +2913,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -3015,7 +3045,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -3134,7 +3165,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -3253,7 +3285,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -3336,7 +3369,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -3461,7 +3495,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -3532,7 +3567,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -3621,7 +3657,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -3698,7 +3735,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -3829,7 +3867,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -4008,7 +4047,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -4097,7 +4137,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -4204,7 +4245,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -4377,7 +4419,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -4442,7 +4485,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -4579,7 +4623,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -4704,7 +4749,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -4775,7 +4821,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -4870,7 +4917,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -4929,7 +4977,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -5012,7 +5061,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -5077,7 +5127,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -5214,7 +5265,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -5279,7 +5331,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -5332,7 +5385,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -5421,7 +5475,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -5540,7 +5595,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -5641,7 +5697,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -5724,7 +5781,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -5837,7 +5895,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -5950,7 +6009,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -6039,7 +6099,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -6170,7 +6231,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -6265,7 +6327,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -6366,7 +6429,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -6461,7 +6525,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -6544,7 +6609,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -6609,7 +6675,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -6728,7 +6795,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -6871,7 +6939,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -7026,7 +7095,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -7121,7 +7191,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -7186,7 +7257,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -7287,7 +7359,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -7448,7 +7521,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -7591,7 +7665,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -7722,7 +7797,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -7793,7 +7869,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -7870,7 +7947,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -7983,7 +8061,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -8030,7 +8109,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -8089,7 +8169,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -8166,7 +8247,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -8249,7 +8331,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -8332,7 +8415,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -8427,7 +8511,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -8546,7 +8631,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -8623,7 +8709,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -8706,7 +8793,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -8831,7 +8919,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -8908,7 +8997,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -9027,7 +9117,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -9128,7 +9219,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -9229,7 +9321,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -9288,7 +9381,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -9401,7 +9495,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -9484,7 +9579,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -9543,7 +9639,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"
@@ -9686,7 +9783,8 @@
         {
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
-                "name": "go"
+                "name": "go",
+                "version": "1.0.0"
             },
             "ecs": {
                 "version": "1.5.0"

--- a/docs/spec/cloud.json
+++ b/docs/spec/cloud.json
@@ -1,74 +1,108 @@
 {
     "$id": "docs/spec/cloud.json",
     "title": "Cloud",
-    "type": ["object", "null"],
+    "type": [
+        "object",
+        "null"
+    ],
     "properties": {
         "account": {
             "properties": {
-                "id" : {
+                "id": {
                     "description": "Cloud account ID",
-                    "type": ["string"],
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "maxLength": 1024
                 },
-                "name" : {
+                "name": {
                     "description": "Cloud account name",
-                    "type": ["string"],
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "maxLength": 1024
                 }
             }
         },
         "availability_zone": {
             "description": "Cloud availability zone name. e.g. us-east-1a",
-            "type": ["string", "null"],
+            "type": [
+                "string",
+                "null"
+            ],
             "maxLength": 1024
         },
         "instance": {
             "properties": {
-                "id" : {
+                "id": {
                     "description": "Cloud instance/machine ID",
-                    "type": ["string"],
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "maxLength": 1024
                 },
-                "name" : {
+                "name": {
                     "description": "Cloud instance/machine name",
-                    "type": ["string"],
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "maxLength": 1024
                 }
             }
         },
         "machine": {
             "properties": {
-                "type" : {
+                "type": {
                     "description": "Cloud instance/machine type",
-                    "type": ["string"],
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "maxLength": 1024
                 }
             }
         },
         "project": {
             "properties": {
-                "id" : {
+                "id": {
                     "description": "Cloud project ID",
-                    "type": ["string"],
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "maxLength": 1024
                 },
-                "name" : {
+                "name": {
                     "description": "Cloud project name",
-                    "type": ["string"],
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "maxLength": 1024
                 }
             }
         },
         "provider": {
             "description": "Cloud provider name. e.g. aws, azure, gcp, digitalocean.",
-            "type": ["string", "null"],
+            "type": [
+                "string"
+            ],
             "maxLength": 1024
         },
         "region": {
             "description": "Cloud region name. e.g. us-east-1",
-            "type": ["string", "null"],
+            "type": [
+                "string",
+                "null"
+            ],
             "maxLength": 1024
         }
     },
-    "required": ["provider"]
+    "required": [
+        "provider"
+    ]
 }

--- a/docs/spec/metadata.json
+++ b/docs/spec/metadata.json
@@ -2,22 +2,167 @@
     "$id": "docs/spec/metadata.json",
     "title": "Metadata",
     "description": "Metadata concerning the other objects in the stream.",
-    "type": ["object"],
+    "type": "object",
     "properties": {
         "service": {
-            "$ref": "service.json",
-            "type": "object",
-            "required": ["name", "agent"],
-            "properties.name.type": "string",
-            "properties.agent.type": "string",
-            "properties.agent.required": ["name", "version"],
-            "properties.agent.properties.name.type": "string",
-            "properties.agent.properties.version.type": "string",
-            "properties.runtime.required": ["name", "version"],
-            "properties.runtime.properties.name.type": "string",
-            "properties.runtime.properties.version.type": "string",
-            "properties.language.required": ["name"],
-            "properties.language.properties.name.type": "string"
+            "type": [
+                "object"
+            ],
+            "properties": {
+                "agent": {
+                    "description": "Name and version of the Elastic APM agent",
+                    "type": [
+                        "object"
+                    ],
+                    "properties": {
+                        "name": {
+                            "description": "Name of the Elastic APM agent, e.g. \"Python\"",
+                            "type": [
+                                "string"
+                            ],
+                            "maxLength": 1024,
+                            "minLength": 1
+                        },
+                        "version": {
+                            "description": "Version of the Elastic APM agent, e.g.\"1.0.0\"",
+                            "type": [
+                                "string"
+                            ],
+                            "maxLength": 1024
+                        },
+                        "ephemeral_id": {
+                            "description": "Free format ID used for metrics correlation by some agents",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 1024
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "version"
+                    ]
+                },
+                "framework": {
+                    "description": "Name and version of the web framework used",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 1024
+                        },
+                        "version": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 1024
+                        }
+                    }
+                },
+                "language": {
+                    "description": "Name and version of the programming language used",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": [
+                                "string"
+                            ],
+                            "maxLength": 1024
+                        },
+                        "version": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 1024
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                },
+                "name": {
+                    "description": "Immutable name of the service emitting this event",
+                    "type": [
+                        "string"
+                    ],
+                    "pattern": "^[a-zA-Z0-9 _-]+$",
+                    "maxLength": 1024,
+                    "minLength": 1
+                },
+                "environment": {
+                    "description": "Environment name of the service, e.g. \"production\" or \"staging\"",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "maxLength": 1024
+                },
+                "runtime": {
+                    "description": "Name and version of the language runtime running this service",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": [
+                                "string"
+                            ],
+                            "maxLength": 1024
+                        },
+                        "version": {
+                            "type": [
+                                "string"
+                            ],
+                            "maxLength": 1024
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "version"
+                    ]
+                },
+                "version": {
+                    "description": "Version of the service emitting this event",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "maxLength": 1024
+                },
+                "node": {
+                    "description": "Unique meaningful name of the service node.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "configured_name": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 1024
+                        }
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "agent"
+            ]
         },
         "process": {
             "$ref": "process.json"
@@ -29,12 +174,14 @@
             "description": "Describes the authenticated User for a request.",
             "$ref": "user.json"
         },
-	"cloud": {
+        "cloud": {
             "$ref": "cloud.json"
-	},
+        },
         "labels": {
             "$ref": "tags.json"
         }
     },
-    "required": ["service"]
+    "required": [
+        "service"
+    ]
 }

--- a/docs/spec/rum_v3_metadata.json
+++ b/docs/spec/rum_v3_metadata.json
@@ -7,36 +7,142 @@
     ],
     "properties": {
         "se": {
-            "$ref": "rum_v3_service.json",
-            "type": "object",
+            "$id": "docs/spec/rum_v3_service.json",
+            "title": "Service",
+            "type": [
+                "object"
+            ],
+            "properties": {
+                "a": {
+                    "description": "Name and version of the Elastic APM agent",
+                    "type": [
+                        "object"
+                    ],
+                    "properties": {
+                        "n": {
+                            "description": "Name of the Elastic APM agent, e.g. \"Python\"",
+                            "type": [
+                                "string"
+                            ],
+                            "minLength": 1,
+                            "maxLength": 1024
+                        },
+                        "ve": {
+                            "description": "Version of the Elastic APM agent, e.g.\"1.0.0\"",
+                            "type": [
+                                "string"
+                            ],
+                            "maxLength": 1024
+                        }
+                    },
+                    "required": [
+                        "n",
+                        "ve"
+                    ]
+                },
+                "fw": {
+                    "description": "Name and version of the web framework used",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "n": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 1024
+                        },
+                        "ve": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 1024
+                        }
+                    }
+                },
+                "la": {
+                    "description": "Name and version of the programming language used",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "n": {
+                            "type": [
+                                "string"
+                            ],
+                            "maxLength": 1024
+                        },
+                        "ve": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 1024
+                        }
+                    },
+                    "required": [
+                        "n"
+                    ]
+                },
+                "n": {
+                    "description": "Immutable name of the service emitting this event",
+                    "type": [
+                        "string"
+                    ],
+                    "pattern": "^[a-zA-Z0-9 _-]+$",
+                    "minLength": 1,
+                    "maxLength": 1024
+                },
+                "en": {
+                    "description": "Environment name of the service, e.g. \"production\" or \"staging\"",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "maxLength": 1024
+                },
+                "ru": {
+                    "description": "Name and version of the language runtime running this service",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "n": {
+                            "type": [
+                                "string"
+                            ],
+                            "maxLength": 1024
+                        },
+                        "ve": {
+                            "type": [
+                                "string"
+                            ],
+                            "maxLength": 1024
+                        }
+                    },
+                    "required": [
+                        "n",
+                        "ve"
+                    ]
+                },
+                "ve": {
+                    "description": "Version of the service emitting this event",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "maxLength": 1024
+                }
+            },
             "required": [
-                "n",
-                "a"
-            ],
-            "properties.n.type": "string",
-            "properties.a.type": "string",
-            "properties.a.required": [
-                "n",
-                "ve"
-            ],
-            "properties.a.properties.n.type": "string",
-            "properties.a.properties.ve.type": "string",
-            "properties.ru.required": [
-                "n",
-                "ve"
-            ],
-            "properties.ru.properties.n.type": "string",
-            "properties.ru.properties.ve.type": "string",
-            "properties.la.required": [
+                "a",
                 "n"
-            ],
-            "properties.la.properties.n.type": "string"
-        },
-        "u": {
-            "$ref": "rum_v3_user.json"
-        },
-        "l": {
-            "$ref": "tags.json"
+            ]
         }
     },
     "required": [

--- a/model/metadata/generated/schema/metadata.go
+++ b/model/metadata/generated/schema/metadata.go
@@ -21,115 +21,167 @@ const ModelSchema = `{
     "$id": "docs/spec/metadata.json",
     "title": "Metadata",
     "description": "Metadata concerning the other objects in the stream.",
-    "type": ["object"],
+    "type": "object",
     "properties": {
         "service": {
-                "$id": "docs/spec/service.json",
-    "title": "Service",
-    "type": ["object", "null"],
-    "properties": {
-        "agent": {
-            "description": "Name and version of the Elastic APM agent",
-            "type": ["object", "null"],
+            "type": [
+                "object"
+            ],
             "properties": {
+                "agent": {
+                    "description": "Name and version of the Elastic APM agent",
+                    "type": [
+                        "object"
+                    ],
+                    "properties": {
+                        "name": {
+                            "description": "Name of the Elastic APM agent, e.g. \"Python\"",
+                            "type": [
+                                "string"
+                            ],
+                            "maxLength": 1024,
+                            "minLength": 1
+                        },
+                        "version": {
+                            "description": "Version of the Elastic APM agent, e.g.\"1.0.0\"",
+                            "type": [
+                                "string"
+                            ],
+                            "maxLength": 1024
+                        },
+                        "ephemeral_id": {
+                            "description": "Free format ID used for metrics correlation by some agents",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 1024
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "version"
+                    ]
+                },
+                "framework": {
+                    "description": "Name and version of the web framework used",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 1024
+                        },
+                        "version": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 1024
+                        }
+                    }
+                },
+                "language": {
+                    "description": "Name and version of the programming language used",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": [
+                                "string"
+                            ],
+                            "maxLength": 1024
+                        },
+                        "version": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 1024
+                        }
+                    },
+                    "required": [
+                        "name"
+                    ]
+                },
                 "name": {
-                    "description": "Name of the Elastic APM agent, e.g. \"Python\"",
-                    "type": ["string", "null"],
+                    "description": "Immutable name of the service emitting this event",
+                    "type": [
+                        "string"
+                    ],
+                    "pattern": "^[a-zA-Z0-9 _-]+$",
+                    "maxLength": 1024,
+                    "minLength": 1
+                },
+                "environment": {
+                    "description": "Environment name of the service, e.g. \"production\" or \"staging\"",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "maxLength": 1024
+                },
+                "runtime": {
+                    "description": "Name and version of the language runtime running this service",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": [
+                                "string"
+                            ],
+                            "maxLength": 1024
+                        },
+                        "version": {
+                            "type": [
+                                "string"
+                            ],
+                            "maxLength": 1024
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "version"
+                    ]
                 },
                 "version": {
-                    "description": "Version of the Elastic APM agent, e.g.\"1.0.0\"",
-                    "type": ["string", "null"],
+                    "description": "Version of the service emitting this event",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "maxLength": 1024
                 },
-                "ephemeral_id": {
-                    "description": "Free format ID used for metrics correlation by some agents",
-                    "type": ["string", "null"],
-                    "maxLength": 1024
+                "node": {
+                    "description": "Unique meaningful name of the service node.",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "configured_name": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 1024
+                        }
+                    }
                 }
-            }
-        },
-        "framework": {
-            "description": "Name and version of the web framework used",
-            "type": ["object", "null"],
-            "properties": {
-                "name": {
-                    "type": ["string", "null"],
-                    "maxLength": 1024
-                },
-                "version": {
-                    "type": ["string", "null"],
-                    "maxLength": 1024
-                }
-            }
-        },
-        "language": {
-            "description": "Name and version of the programming language used",
-            "type": ["object", "null"],
-            "properties": {
-                "name": {
-                    "type": ["string", "null"],
-                    "maxLength": 1024
-                },
-                "version": {
-                    "type": ["string", "null"],
-                    "maxLength": 1024
-                }
-            }
-        },
-        "name": {
-            "description": "Immutable name of the service emitting this event",
-            "type": ["string", "null"],
-            "pattern": "^[a-zA-Z0-9 _-]+$",
-            "maxLength": 1024
-        },
-        "environment": {
-            "description": "Environment name of the service, e.g. \"production\" or \"staging\"",
-            "type": ["string", "null"],
-            "maxLength": 1024
-        },
-        "runtime": {
-            "description": "Name and version of the language runtime running this service",
-            "type": ["object", "null"],
-            "properties": {
-                "name": {
-                    "type": ["string", "null"],
-                    "maxLength": 1024
-                },
-                "version": {
-                    "type": ["string", "null"],
-                    "maxLength": 1024
-                }
-            }
-        },
-        "version": {
-            "description": "Version of the service emitting this event",
-            "type": ["string", "null"],
-            "maxLength": 1024
-        },
-        "node": {
-            "description": "Unique meaningful name of the service node.",
-            "type": ["object", "null"],
-            "properties": {
-                "configured_name": {
-                    "type": ["string", "null"],
-                    "maxLength": 1024
-                }
-            }
-        }
-    },
-            "type": "object",
-            "required": ["name", "agent"],
-            "properties.name.type": "string",
-            "properties.agent.type": "string",
-            "properties.agent.required": ["name", "version"],
-            "properties.agent.properties.name.type": "string",
-            "properties.agent.properties.version.type": "string",
-            "properties.runtime.required": ["name", "version"],
-            "properties.runtime.properties.name.type": "string",
-            "properties.runtime.properties.version.type": "string",
-            "properties.language.required": ["name"],
-            "properties.language.properties.name.type": "string"
+            },
+            "required": [
+                "name",
+                "agent"
+            ]
         },
         "process": {
               "$id": "docs/spec/process.json",
@@ -256,80 +308,114 @@ const ModelSchema = `{
         }
     }
         },
-	"cloud": {
+        "cloud": {
                 "$id": "docs/spec/cloud.json",
     "title": "Cloud",
-    "type": ["object", "null"],
+    "type": [
+        "object",
+        "null"
+    ],
     "properties": {
         "account": {
             "properties": {
-                "id" : {
+                "id": {
                     "description": "Cloud account ID",
-                    "type": ["string"],
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "maxLength": 1024
                 },
-                "name" : {
+                "name": {
                     "description": "Cloud account name",
-                    "type": ["string"],
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "maxLength": 1024
                 }
             }
         },
         "availability_zone": {
             "description": "Cloud availability zone name. e.g. us-east-1a",
-            "type": ["string", "null"],
+            "type": [
+                "string",
+                "null"
+            ],
             "maxLength": 1024
         },
         "instance": {
             "properties": {
-                "id" : {
+                "id": {
                     "description": "Cloud instance/machine ID",
-                    "type": ["string"],
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "maxLength": 1024
                 },
-                "name" : {
+                "name": {
                     "description": "Cloud instance/machine name",
-                    "type": ["string"],
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "maxLength": 1024
                 }
             }
         },
         "machine": {
             "properties": {
-                "type" : {
+                "type": {
                     "description": "Cloud instance/machine type",
-                    "type": ["string"],
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "maxLength": 1024
                 }
             }
         },
         "project": {
             "properties": {
-                "id" : {
+                "id": {
                     "description": "Cloud project ID",
-                    "type": ["string"],
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "maxLength": 1024
                 },
-                "name" : {
+                "name": {
                     "description": "Cloud project name",
-                    "type": ["string"],
+                    "type": [
+                        "string",
+                        "null"
+                    ],
                     "maxLength": 1024
                 }
             }
         },
         "provider": {
             "description": "Cloud provider name. e.g. aws, azure, gcp, digitalocean.",
-            "type": ["string", "null"],
+            "type": [
+                "string"
+            ],
             "maxLength": 1024
         },
         "region": {
             "description": "Cloud region name. e.g. us-east-1",
-            "type": ["string", "null"],
+            "type": [
+                "string",
+                "null"
+            ],
             "maxLength": 1024
         }
     },
-    "required": ["provider"]
-	},
+    "required": [
+        "provider"
+    ]
+        },
         "labels": {
                 "$id": "docs/spec/tags.json",
     "title": "Tags",
@@ -344,6 +430,7 @@ const ModelSchema = `{
     "additionalProperties": false
         }
     },
-    "required": ["service"]
-}
-`
+    "required": [
+        "service"
+    ]
+}`

--- a/model/metadata/generated/schema/rum_v3_metadata.go
+++ b/model/metadata/generated/schema/rum_v3_metadata.go
@@ -26,208 +26,145 @@ const RUMV3Schema = `{
     ],
     "properties": {
         "se": {
-                "$id": "docs/spec/rum_v3_service.json",
-    "title": "Service",
-    "type": [
-        "object",
-        "null"
-    ],
-    "properties": {
-        "a": {
-            "description": "Name and version of the Elastic APM agent",
+            "$id": "docs/spec/rum_v3_service.json",
+            "title": "Service",
             "type": [
-                "object",
-                "null"
+                "object"
             ],
             "properties": {
+                "a": {
+                    "description": "Name and version of the Elastic APM agent",
+                    "type": [
+                        "object"
+                    ],
+                    "properties": {
+                        "n": {
+                            "description": "Name of the Elastic APM agent, e.g. \"Python\"",
+                            "type": [
+                                "string"
+                            ],
+                            "minLength": 1,
+                            "maxLength": 1024
+                        },
+                        "ve": {
+                            "description": "Version of the Elastic APM agent, e.g.\"1.0.0\"",
+                            "type": [
+                                "string"
+                            ],
+                            "maxLength": 1024
+                        }
+                    },
+                    "required": [
+                        "n",
+                        "ve"
+                    ]
+                },
+                "fw": {
+                    "description": "Name and version of the web framework used",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "n": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 1024
+                        },
+                        "ve": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 1024
+                        }
+                    }
+                },
+                "la": {
+                    "description": "Name and version of the programming language used",
+                    "type": [
+                        "object",
+                        "null"
+                    ],
+                    "properties": {
+                        "n": {
+                            "type": [
+                                "string"
+                            ],
+                            "maxLength": 1024
+                        },
+                        "ve": {
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "maxLength": 1024
+                        }
+                    },
+                    "required": [
+                        "n"
+                    ]
+                },
                 "n": {
-                    "description": "Name of the Elastic APM agent, e.g. \"Python\"",
+                    "description": "Immutable name of the service emitting this event",
+                    "type": [
+                        "string"
+                    ],
+                    "pattern": "^[a-zA-Z0-9 _-]+$",
+                    "minLength": 1,
+                    "maxLength": 1024
+                },
+                "en": {
+                    "description": "Environment name of the service, e.g. \"production\" or \"staging\"",
                     "type": [
                         "string",
                         "null"
                     ],
                     "maxLength": 1024
                 },
-                "ve": {
-                    "description": "Version of the Elastic APM agent, e.g.\"1.0.0\"",
+                "ru": {
+                    "description": "Name and version of the language runtime running this service",
                     "type": [
-                        "string",
+                        "object",
                         "null"
                     ],
-                    "maxLength": 1024
-                }
-            }
-        },
-        "fw": {
-            "description": "Name and version of the web framework used",
-            "type": [
-                "object",
-                "null"
-            ],
-            "properties": {
-                "n": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "maxLength": 1024
+                    "properties": {
+                        "n": {
+                            "type": [
+                                "string"
+                            ],
+                            "maxLength": 1024
+                        },
+                        "ve": {
+                            "type": [
+                                "string"
+                            ],
+                            "maxLength": 1024
+                        }
+                    },
+                    "required": [
+                        "n",
+                        "ve"
+                    ]
                 },
                 "ve": {
+                    "description": "Version of the service emitting this event",
                     "type": [
                         "string",
                         "null"
                     ],
                     "maxLength": 1024
                 }
-            }
-        },
-        "la": {
-            "description": "Name and version of the programming language used",
-            "type": [
-                "object",
-                "null"
-            ],
-            "properties": {
-                "n": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "maxLength": 1024
-                },
-                "ve": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "maxLength": 1024
-                }
-            }
-        },
-        "n": {
-            "description": "Immutable name of the service emitting this event",
-            "type": [
-                "string",
-                "null"
-            ],
-            "pattern": "^[a-zA-Z0-9 _-]+$",
-            "maxLength": 1024
-        },
-        "en": {
-            "description": "Environment name of the service, e.g. \"production\" or \"staging\"",
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "ru": {
-            "description": "Name and version of the language runtime running this service",
-            "type": [
-                "object",
-                "null"
-            ],
-            "properties": {
-                "n": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "maxLength": 1024
-                },
-                "ve": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "maxLength": 1024
-                }
-            }
-        },
-        "ve": {
-            "description": "Version of the service emitting this event",
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        }
-    },
-            "type": "object",
+            },
             "required": [
-                "n",
-                "a"
-            ],
-            "properties.n.type": "string",
-            "properties.a.type": "string",
-            "properties.a.required": [
-                "n",
-                "ve"
-            ],
-            "properties.a.properties.n.type": "string",
-            "properties.a.properties.ve.type": "string",
-            "properties.ru.required": [
-                "n",
-                "ve"
-            ],
-            "properties.ru.properties.n.type": "string",
-            "properties.ru.properties.ve.type": "string",
-            "properties.la.required": [
+                "a",
                 "n"
-            ],
-            "properties.la.properties.n.type": "string"
-        },
-        "u": {
-                "$id": "docs/spec/rum_v3_user.json",
-    "title": "User",
-    "type": [
-        "object",
-        "null"
-    ],
-    "properties": {
-        "id": {
-            "description": "Identifier of the logged in user, e.g. the primary key of the user",
-            "type": [
-                "string",
-                "integer",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "em": {
-            "description": "Email of the logged in user",
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        },
-        "un": {
-            "description": "The username of the logged in user",
-            "type": [
-                "string",
-                "null"
-            ],
-            "maxLength": 1024
-        }
-    }
-        },
-        "l": {
-                "$id": "docs/spec/tags.json",
-    "title": "Tags",
-    "type": ["object", "null"],
-    "description": "A flat mapping of user-defined tags with string, boolean or number values.",
-    "patternProperties": {
-        "^[^.*\"]*$": {
-            "type": ["string", "boolean", "number", "null"],
-            "maxLength": 1024
-        }
-    },
-    "additionalProperties": false
+            ]
         }
     },
     "required": [
         "se"
     ]
-}
-`
+}`

--- a/model/modeldecoder/metadata_test.go
+++ b/model/modeldecoder/metadata_test.go
@@ -236,7 +236,7 @@ func TestDecodeMetadataInvalid(t *testing.T) {
 	// baseInput holds the minimal valid input. Test-specific input is added to this.
 	baseInput := map[string]interface{}{
 		"service": map[string]interface{}{
-			"agent": map[string]interface{}{},
+			"agent": map[string]interface{}{"name": "go", "version": "1.0.0"},
 			"name":  "name",
 		},
 	}

--- a/processor/stream/package_tests/metadata_attrs_test.go
+++ b/processor/stream/package_tests/metadata_attrs_test.go
@@ -159,13 +159,36 @@ func TestKeywordLimitationOnMetadataAttrs(t *testing.T) {
 	)
 }
 
+func metadataRequiredKeys() *tests.Set {
+	return tests.NewSet(
+		"metadata",
+		"metadata.cloud.provider",
+		"metadata.service",
+		"metadata.service.name",
+		"metadata.service.agent",
+		"metadata.service.agent.name",
+		"metadata.service.agent.version",
+		"metadata.service.runtime.name",
+		"metadata.service.runtime.version",
+		"metadata.service.language.name",
+		"metadata.system.container.id",
+		"metadata.process.pid",
+	)
+}
+
+func TestAttrsPresenceInMetadata(t *testing.T) {
+	metadataProcSetup().AttrsPresence(t, metadataRequiredKeys(), nil)
+}
+
 func TestInvalidPayloadsForMetadata(t *testing.T) {
 	type val []interface{}
 
 	payloadData := []tests.SchemaTestData{
 		{Key: "metadata.service.name",
-			Valid:   val{"my-service"},
-			Invalid: []tests.Invalid{{Msg: "service/properties/name", Values: val{tests.Str1024Special}}},
+			Valid: val{"m"},
+			Invalid: []tests.Invalid{
+				{Msg: "service/properties/name", Values: val{tests.Str1024Special}},
+				{Msg: "service/properties/name", Values: val{""}}},
 		}}
 	metadataProcSetup().DataValidation(t, payloadData)
 }

--- a/testdata/profile/metadata.json
+++ b/testdata/profile/metadata.json
@@ -1,1 +1,2 @@
-{"service": {"name": "apm-server", "agent": {"name": "go"}}}
+{"service": {"name": "apm-server", "agent": {"name": "go","version":"1.0.0"}}}
+

--- a/tests/json_schema.go
+++ b/tests/json_schema.go
@@ -149,7 +149,8 @@ func (ps *ProcessorSetup) AttrsPresence(t *testing.T, requiredKeys *Set, condReq
 		//test sending nil value for key
 		ps.changePayload(t, key, nil, Condition{}, upsertFn,
 			func(k string) (bool, []string) {
-				return !required.ContainsStrPattern(k), []string{keyLast}
+				errMsgs := []string{keyLast, "did not recognize object type"}
+				return !required.ContainsStrPattern(k), errMsgs
 			},
 		)
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fix metadata.service.* fields requirements in json schema (#4142)