### PR TITLE
ci: build apm-server before running systemtests

### DIFF
--- a/script/jenkins/linux-test.sh
+++ b/script/jenkins/linux-test.sh
@@ -11,7 +11,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-make update docker-system-tests
+make update apm-server docker-system-tests
 
 # TODO(axw) make this part of the "system-tests" target
 (cd systemtest && go test -v ./...)


### PR DESCRIPTION
## Motivation/summary

Build apm-server outside of the tests so that the build time isn't included in test timeout. This is particularly important on older branches, where the Docker image may not have cached the module dependencies.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
~- [ ] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)~
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

Backport this and create a PR on 7.x? :)

## Related issues

https://apm-ci.elastic.co/blue/organizations/jenkins/apm-server%2Fapm-server-mbp/detail/PR-4192/2/pipeline