### PR TITLE
[7.x] ci: build apm-server before running systemtests (#4195)

### DIFF
--- a/script/jenkins/linux-test.sh
+++ b/script/jenkins/linux-test.sh
@@ -11,7 +11,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-make update docker-system-tests
+make update apm-server docker-system-tests
 
 # TODO(axw) make this part of the "system-tests" target
 (cd systemtest && go test -v ./...)


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ci: build apm-server before running systemtests (#4195)