### PR TITLE
Use installed version of openssl in packaging tests

### DIFF
--- a/.ci/check-packages.groovy
+++ b/.ci/check-packages.groovy
@@ -58,7 +58,7 @@ pipeline {
             options { skipDefaultCheckout() }
             steps {
               // See https://stackoverflow.com/questions/59269208/errorrootcode-for-hash-md5-was-not-found-when-using-any-hg-mercurial-command
-              sh(label: "Switching OpenSSL versions to fix Py2", script: "brew switch openssl 1.0.2t")
+              sh(label: "Switching OpenSSL versions to fix Py2", script: "brew switch openssl 1.0.2s")
               deleteDir()
               unstash 'source'
               dir("${BASE_DIR}"){


### PR DESCRIPTION
This is a minor fix for the packaging pipeline. It aligns the Jenkins pipeline with the correct version of OpenSSL on the OS X workers:

```
worker-c07yx0vrjyvy:openssl mp$ ls -l /usr/local/Cellar/openssl
total 0
drwxr-xr-x  13 elastic  staff  416 Aug 30  2019 1.0.2s
```