### PR TITLE
[CI] Remove OSX-specific commands from packaging pipeline

### DIFF
--- a/.ci/check-packages.groovy
+++ b/.ci/check-packages.groovy
@@ -57,8 +57,6 @@ pipeline {
           stage('Test'){
             options { skipDefaultCheckout() }
             steps {
-              // See https://stackoverflow.com/questions/59269208/errorrootcode-for-hash-md5-was-not-found-when-using-any-hg-mercurial-command
-              sh(label: "Switching OpenSSL versions to fix Py2", script: "brew switch openssl 1.0.2s")
               deleteDir()
               unstash 'source'
               dir("${BASE_DIR}"){


### PR DESCRIPTION
This removes commands from the job now that we are using bare-metal workers.