### PR TITLE
[ci] Set UTF-8 for package testing job

### DIFF
--- a/.ci/check-packages.groovy
+++ b/.ci/check-packages.groovy
@@ -16,6 +16,9 @@ pipeline {
     BEATS_URL_BASE = 'https://storage.googleapis.com/beats-ci-artifacts/snapshots'
     APM_URL_BASE = 'https://storage.googleapis.com/apm-ci-artifacts/jobs/snapshots'
     // BRANCH_NAME = 'master'
+    LANG = "C.UTF-8"
+    LC_ALL = "C.UTF-8"
+    PYTHONUTF8 = "1"
   }
   options {
     timeout(time: 4, unit: 'HOURS')


### PR DESCRIPTION
This should hopefully fix the errors with Unicode on the packaging tests: https://apm-ci.elastic.co/job/apm-server/job/apm-server-check-packages/23/console