### PR TITLE
systemtest: add test for RUM & X-Forwarded-For

### DIFF
--- a/systemtest/aggregation_test.go
+++ b/systemtest/aggregation_test.go
@@ -18,7 +18,6 @@
 package systemtest_test
 
 import (
-	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -66,15 +65,9 @@ func TestTransactionAggregation(t *testing.T) {
 	}
 	tracer.Flush(nil)
 
-	var result estest.SearchResult
-	_, err = systemtest.Elasticsearch.Search("apm-*").WithQuery(estest.BoolQuery{
-		Filter: []interface{}{
-			estest.ExistsQuery{Field: "transaction.duration.histogram"},
-		},
-	}).Do(context.Background(), &result,
-		estest.WithCondition(result.Hits.NonEmptyCondition()),
+	result := systemtest.Elasticsearch.ExpectDocs(t, "apm-*",
+		estest.ExistsQuery{Field: "transaction.duration.histogram"},
 	)
-	require.NoError(t, err)
 	systemtest.ApproveEvents(t, t.Name(), result.Hits.Hits, "@timestamp")
 }
 
@@ -104,15 +97,9 @@ func TestTransactionAggregationShutdown(t *testing.T) {
 	// Stop server to ensure metrics are flushed on shutdown.
 	assert.NoError(t, srv.Close())
 
-	var result estest.SearchResult
-	_, err = systemtest.Elasticsearch.Search("apm-*").WithQuery(estest.BoolQuery{
-		Filter: []interface{}{
-			estest.ExistsQuery{Field: "transaction.duration.histogram"},
-		},
-	}).Do(context.Background(), &result,
-		estest.WithCondition(result.Hits.NonEmptyCondition()),
+	result := systemtest.Elasticsearch.ExpectDocs(t, "apm-*",
+		estest.ExistsQuery{Field: "transaction.duration.histogram"},
 	)
-	require.NoError(t, err)
 	systemtest.ApproveEvents(t, t.Name(), result.Hits.Hits, "@timestamp")
 }
 
@@ -143,14 +130,8 @@ func TestServiceDestinationAggregation(t *testing.T) {
 	tx.End()
 	tracer.Flush(nil)
 
-	var result estest.SearchResult
-	_, err = systemtest.Elasticsearch.Search("apm-*").WithQuery(estest.BoolQuery{
-		Filter: []interface{}{
-			estest.ExistsQuery{Field: "span.destination.service.response_time.count"},
-		},
-	}).Do(context.Background(), &result,
-		estest.WithCondition(result.Hits.NonEmptyCondition()),
+	result := systemtest.Elasticsearch.ExpectDocs(t, "apm-*",
+		estest.ExistsQuery{Field: "span.destination.service.response_time.count"},
 	)
-	require.NoError(t, err)
 	systemtest.ApproveEvents(t, t.Name(), result.Hits.Hits, "@timestamp")
 }

--- a/systemtest/apmservertest/config.go
+++ b/systemtest/apmservertest/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	Kibana      *KibanaConfig      `json:"apm-server.kibana,omitempty"`
 	Aggregation *AggregationConfig `json:"apm-server.aggregation,omitempty"`
 	Sampling    *SamplingConfig    `json:"apm-server.sampling,omitempty"`
+	RUM         *RUMConfig         `json:"apm-server.rum,omitempty"`
 
 	// Instrumentation holds configuration for libbeat and apm-server instrumentation.
 	Instrumentation *InstrumentationConfig `json:"instrumentation,omitempty"`
@@ -104,6 +105,11 @@ type JaegerConfig struct {
 // SamplingConfig holds APM Server trace sampling configuration.
 type SamplingConfig struct {
 	KeepUnsampled bool `json:"keep_unsampled"`
+}
+
+// RUMConfig holds APM Server RUM configuration.
+type RUMConfig struct {
+	Enabled bool `json:"enabled"`
 }
 
 // InstrumentationConfig holds APM Server instrumentation configuration.

--- a/systemtest/approvals/TestRUMXForwardedFor.approved.json
+++ b/systemtest/approvals/TestRUMXForwardedFor.approved.json
@@ -1,0 +1,75 @@
+{
+    "events": [
+        {
+            "@timestamp": "dynamic",
+            "agent": {
+                "name": "rum-js",
+                "version": "5.5.0"
+            },
+            "client": {
+                "geo": {
+                    "city_name": "Perth",
+                    "continent_name": "Oceania",
+                    "country_iso_code": "AU",
+                    "location": {
+                        "lat": -31.9674,
+                        "lon": 115.8621
+                    },
+                    "region_iso_code": "AU-WA",
+                    "region_name": "Western Australia"
+                },
+                "ip": "220.244.41.16"
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "ingested": "dynamic",
+                "outcome": "unknown"
+            },
+            "observer": {
+                "ephemeral_id": "dynamic",
+                "hostname": "dynamic",
+                "id": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic",
+                "version_major": "dynamic"
+            },
+            "processor": {
+                "event": "transaction",
+                "name": "transaction"
+            },
+            "service": {
+                "name": "rum-js-test"
+            },
+            "source": {
+                "ip": "220.244.41.16"
+            },
+            "timestamp": {
+                "us": "dynamic"
+            },
+            "trace": {
+                "id": "611f4fa950f04631aaaaaaaaaaaaaaaa"
+            },
+            "transaction": {
+                "duration": {
+                    "us": 643000
+                },
+                "id": "611f4fa950f04631",
+                "sampled": true,
+                "span_count": {
+                    "started": 0
+                },
+                "type": "page-load"
+            },
+            "user_agent": {
+                "device": {
+                    "name": "Other"
+                },
+                "name": "Go-http-client",
+                "original": "Go-http-client/1.1",
+                "version": "1.1"
+            }
+        }
+    ]
+}

--- a/systemtest/estest/search.go
+++ b/systemtest/estest/search.go
@@ -20,10 +20,28 @@ package estest
 import (
 	"context"
 	"encoding/json"
+	"testing"
 
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/elastic/go-elasticsearch/v7/esutil"
 )
+
+// ExpectDocs searches index with query, returning the results.
+//
+// If the search returns no results within 10 seconds (by default),
+// ExpectDocs will call t.Error().
+func (es *Client) ExpectDocs(t testing.TB, index string, query interface{}, opts ...RequestOption) SearchResult {
+	t.Helper()
+	var result SearchResult
+	_, err := es.Search(index).WithQuery(query).Do(
+		context.Background(), &result,
+		WithCondition(result.Hits.NonEmptyCondition()),
+	)
+	if err != nil {
+		t.Error(err)
+	}
+	return result
+}
 
 func (es *Client) Search(index string) *SearchRequest {
 	req := &SearchRequest{es: es}

--- a/systemtest/instrumentation_test.go
+++ b/systemtest/instrumentation_test.go
@@ -18,10 +18,8 @@
 package systemtest_test
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,8 +42,7 @@ func TestAPMServerInstrumentation(t *testing.T) {
 	tracer.StartTransaction("name", "type").End()
 	tracer.Flush(nil)
 
-	var result estest.SearchResult
-	_, err = systemtest.Elasticsearch.Search("apm-*").WithQuery(estest.BoolQuery{
+	result := systemtest.Elasticsearch.ExpectDocs(t, "apm-*", estest.BoolQuery{
 		Filter: []interface{}{
 			estest.TermQuery{
 				Field: "processor.event",
@@ -60,11 +57,7 @@ func TestAPMServerInstrumentation(t *testing.T) {
 				Value: "request",
 			},
 		},
-	}).Do(context.Background(), &result,
-		estest.WithTimeout(10*time.Second),
-		estest.WithCondition(result.Hits.NonEmptyCondition()),
-	)
-	require.NoError(t, err)
+	})
 
 	var transactionDoc struct {
 		Trace       struct{ ID string }

--- a/systemtest/jaeger_test.go
+++ b/systemtest/jaeger_test.go
@@ -54,16 +54,9 @@ func TestJaegerGRPC(t *testing.T) {
 	_, err = client.PostSpans(context.Background(), request)
 	require.NoError(t, err)
 
-	var result estest.SearchResult
-	_, err = systemtest.Elasticsearch.Search("apm-*").WithQuery(estest.BoolQuery{
-		Filter: []interface{}{
-			estest.TermQuery{
-				Field: "processor.event",
-				Value: "transaction",
-			},
-		},
-	}).Do(context.Background(), &result, estest.WithCondition(result.Hits.NonEmptyCondition()))
-	require.NoError(t, err)
+	systemtest.Elasticsearch.ExpectDocs(t, "apm-*", estest.BoolQuery{Filter: []interface{}{
+		estest.TermQuery{Field: "processor.event", Value: "transaction"},
+	}})
 
 	// TODO(axw) check document contents. We currently do this in beater/jaeger.
 }

--- a/systemtest/rum_test.go
+++ b/systemtest/rum_test.go
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package systemtest_test
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-server/systemtest"
+	"github.com/elastic/apm-server/systemtest/apmservertest"
+	"github.com/elastic/apm-server/systemtest/estest"
+)
+
+func TestRUMXForwardedFor(t *testing.T) {
+	systemtest.CleanupElasticsearch(t)
+	srv := apmservertest.NewUnstartedServer(t)
+	srv.Config.RUM = &apmservertest.RUMConfig{Enabled: true}
+	err := srv.Start()
+	require.NoError(t, err)
+
+	serverURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	serverURL.Path = "/intake/v2/rum/events"
+
+	const body = `{"metadata":{"service":{"name":"rum-js-test","agent":{"name":"rum-js","version":"5.5.0"}}}}
+{"transaction":{"trace_id":"611f4fa950f04631aaaaaaaaaaaaaaaa","id":"611f4fa950f04631","type":"page-load","duration":643,"span_count":{"started":0}}}`
+
+	req, _ := http.NewRequest("POST", serverURL.String(), strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-ndjson")
+	req.Header.Set("X-Forwarded-For", "220.244.41.16")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, resp.StatusCode)
+	io.Copy(ioutil.Discard, resp.Body)
+	resp.Body.Close()
+
+	result := systemtest.Elasticsearch.ExpectDocs(t, "apm-*", estest.TermQuery{Field: "processor.event", Value: "transaction"})
+	systemtest.ApproveEvents(
+		t, t.Name(), result.Hits.Hits,
+		// RUM timestamps are set by the server based on the time the payload is received.
+		"@timestamp", "timestamp.us",
+	)
+}

--- a/systemtest/sampling_test.go
+++ b/systemtest/sampling_test.go
@@ -18,7 +18,6 @@
 package systemtest_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -50,18 +49,10 @@ func TestKeepUnsampled(t *testing.T) {
 			tracer.StartTransaction("unsampled", transactionType).End()
 			tracer.Flush(nil)
 
-			var result estest.SearchResult
-			_, err = systemtest.Elasticsearch.Search("apm-*").WithQuery(estest.BoolQuery{
-				Filter: []interface{}{
-					estest.TermQuery{
-						Field: "transaction.type",
-						Value: transactionType,
-					},
-				},
-			}).Do(context.Background(), &result,
-				estest.WithCondition(result.Hits.NonEmptyCondition()),
-			)
-			require.NoError(t, err)
+			result := systemtest.Elasticsearch.ExpectDocs(t, "apm-*", estest.TermQuery{
+				Field: "transaction.type",
+				Value: transactionType,
+			})
 
 			expectedTransactionDocs := 1
 			if keepUnsampled {


### PR DESCRIPTION
## Motivation/summary

Add a system test to ensure X-Forwarded-For is parsed and used for `client.ip`, which is subsequently used for geoIP enrichment.

I've introduced an `estest.Client.ExpectDocs` method to reduce boilerplate around waiting for docs to be indexed, and updated existing tests to use it.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

`cd systemtest && go test -v`

## Related issues

None.