### PR TITLE
[7.x] sampling: fix keep_unsampled processor (#4215)

### DIFF
--- a/sampling/sampling.go
+++ b/sampling/sampling.go
@@ -45,7 +45,7 @@ func NewDiscardUnsampledReporter(reporter publish.Reporter) publish.Reporter {
 				i++
 				continue
 			}
-			n := len(req.Transformables)
+			n := len(events)
 			events[i], events[n-1] = events[n-1], events[i]
 			events = events[:n-1]
 			dropped++

--- a/sampling/sampling_test.go
+++ b/sampling/sampling_test.go
@@ -44,9 +44,10 @@ func TestNewDiscardUnsampledReporter(t *testing.T) {
 	t2 := &model.Transaction{Sampled: newBool(false)}
 	t3 := &model.Transaction{Sampled: newBool(true)}
 	span := &model.Span{}
+	t4 := &model.Transaction{Sampled: newBool(false)}
 
 	reporter(context.Background(), publish.PendingReq{
-		Transformables: []transform.Transformable{t1, t2, t3, span},
+		Transformables: []transform.Transformable{t1, t2, t3, span, t4},
 	})
 
 	// Note that t3 gets sent to the back of the slice;
@@ -57,7 +58,7 @@ func TestNewDiscardUnsampledReporter(t *testing.T) {
 	assert.Equal(t, t3, reported[2])
 
 	expectedMonitoring := monitoring.MakeFlatSnapshot()
-	expectedMonitoring.Ints["transactions_dropped"] = 1
+	expectedMonitoring.Ints["transactions_dropped"] = 2
 
 	snapshot := monitoring.CollectFlatSnapshot(
 		monitoring.GetRegistry("apm-server.sampling"),


### PR DESCRIPTION
Backports the following commits to 7.x:
 - sampling: fix keep_unsampled processor (#4215)