### PR TITLE
[7.x] docs: 7.9.2 release notes (#4227) (#4244)

### DIFF
--- a/changelogs/7.9.asciidoc
+++ b/changelogs/7.9.asciidoc
@@ -3,8 +3,19 @@
 
 https://github.com/elastic/apm-server/compare/7.8\...7.9[View commits]
 
+* <<release-notes-7.9.2>>
 * <<release-notes-7.9.1>>
 * <<release-notes-7.9.0>>
+
+[float]
+[[release-notes-7.9.2]]
+=== APM Server version 7.9.2
+
+https://github.com/elastic/apm-server/compare/v7.9.1\...v7.9.2[View commits]
+
+[float]
+==== Bug fixes
+* De-dot metadata labels set from process and resource tags to prevent indexing errors {pull}4193[4193]
 
 [float]
 [[release-notes-7.9.1]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: 7.9.2 release notes (#4227) (#4244)