### PR TITLE
docs: update event intake API docs

### DIFF
--- a/docs/error-api.asciidoc
+++ b/docs/error-api.asciidoc
@@ -7,7 +7,8 @@ An error or a logged error message captured by an agent occurring in a monitored
 [[error-schema]]
 ==== Error Schema
 
-The APM Server uses JSON Schema for validating requests. The specification for errors is defined below:
+APM Server uses JSON Schema to validate requests. The specification for errors is defined on
+{github_repo_link}/docs/spec/errors/error.json[GitHub] and included below:
 
 [source,json]
 ----

--- a/docs/example-intake-events.asciidoc
+++ b/docs/example-intake-events.asciidoc
@@ -1,7 +1,7 @@
 [[example-intake-events]]
 === Example Request Body
 
-See a request body example containing one event for all currently supported event types. 
+A request body example containing one event for all currently supported event types.
 
 [source,json]
 ----

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -36,6 +36,11 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :win_os:
 :linux_os:
 
+:github_repo_link: https://github.com/elastic/apm-server/blob/{version}
+ifeval::["{version}" == "8.0.0"]
+:github_repo_link: https://github.com/elastic/apm-server/blob/master
+endif::[]
+
 :downloads: https://artifacts.elastic.co/downloads/apm-server
 
 ifdef::env-github[]

--- a/docs/metadata-api.asciidoc
+++ b/docs/metadata-api.asciidoc
@@ -7,7 +7,7 @@ This provides general metadata concerning the other objects in the stream.
 Rather than send this metadata information from the agent multiple times,
 the APM Server hangs on to this information and applies it to other objects in the stream as necessary.
 
-TIP: Metadata is stored under `context` when viewing documents in Elasticsearch. 
+TIP: Metadata is stored under `context` when viewing documents in Elasticsearch.
 
 * <<kubernetes-data>>
 * <<metadata-schema>>
@@ -61,7 +61,8 @@ The table below maps these environment variables to the APM metadata event field
 [float]
 ==== Metadata Schema
 
-The APM Server uses JSON Schema for validating requests. The specification for metadata is defined below:
+APM Server uses JSON Schema to validate requests. The specification for metadata is defined on
+{github_repo_link}/docs/spec/metadata.json[GitHub] and included below:
 
 [source,json]
 ----

--- a/docs/metricset-api.asciidoc
+++ b/docs/metricset-api.asciidoc
@@ -1,13 +1,14 @@
 [[metricset-api]]
 === Metrics
 
-Metrics contain application metric data captured by an APM agent. 
+Metrics contain application metric data captured by an APM agent.
 
 [[metricset-schema]]
 [float]
 ==== Metric Schema
 
-The APM Server uses JSON Schema for validating requests. The specification for metrics is defined below:
+APM Server uses JSON Schema to validate requests. The specification for metrics is defined on
+{github_repo_link}/docs/spec/metricsets/metricset.json[GitHub] and included below:
 
 [source,json]
 ----

--- a/docs/span-api.asciidoc
+++ b/docs/span-api.asciidoc
@@ -1,13 +1,14 @@
 [[span-api]]
 === Spans
 
-Spans are events captured by an agent occurring in a monitored service. 
+Spans are events captured by an agent occurring in a monitored service.
 
 [[span-schema]]
 [float]
 ==== Span Schema
 
-The APM Server uses JSON Schema for validating requests. The specification for spans is defined below:
+APM Server uses JSON Schema to validate requests. The specification for spans is defined on
+{github_repo_link}/docs/spec/spans/span.json[GitHub] and included below:
 
 [source,json]
 ----

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -1,13 +1,14 @@
 [[transaction-api]]
 === Transactions
 
-Transactions are events corresponding to an incoming request or similar task occurring in a monitored service. 
+Transactions are events corresponding to an incoming request or similar task occurring in a monitored service.
 
 [[transaction-schema]]
 [float]
 ==== Transaction Schema
 
-The APM Server uses JSON Schema for validating requests. The specification for transactions is defined below:
+APM Server uses JSON Schema to validate requests. The specification for transactions is defined on
+{github_repo_link}/docs/spec/transactions/transaction.json[GitHub] and included below:
 
 [source,json]
 ----


### PR DESCRIPTION
## Motivation/summary

This PR adds documentation links to GitHub schema files.

## Related issues

Closes https://github.com/elastic/apm-server/issues/3390.