### PR TITLE
[7.x] Decoder v2: add errors and spans (#4260)

### DIFF
--- a/model/modeldecoder/generator/cmd/main.go
+++ b/model/modeldecoder/generator/cmd/main.go
@@ -47,7 +47,7 @@ func main() {
 }
 
 func genV2() {
-	rootObjs := []string{"metadataRoot", "transactionRoot"}
+	rootObjs := []string{"metadataRoot", "transactionRoot", "errorRoot", "spanRoot"}
 	out := filepath.Join(filepath.FromSlash(modeldecoderPath), pkgV2, "model_generated.go")
 	gen, err := generator.NewGenerator(importPath, pkgV2, typPath, rootObjs)
 	if err != nil {

--- a/model/modeldecoder/generator/generator.go
+++ b/model/modeldecoder/generator/generator.go
@@ -264,6 +264,8 @@ val.%s.Reset()
 	return nil
 }
 
+// generateValidation creates `validate` methods for struct fields
+// it only considers exported and anonymous fields
 func (g *Generator) generateValidation(structTyp structType, key string) error {
 	fmt.Fprintf(&g.buf, `
 func (val *%s) validate() error {
@@ -285,8 +287,14 @@ if !val.IsSet() {
 
 	var validation validationGenerator
 	for i := 0; i < len(structTyp.fields); i++ {
-		var custom bool
 		f := structTyp.fields[i]
+		// according to https://golang.org/pkg/go/types/#Var.Anonymous
+		// f.Anonymous() actually checks if f is embedded, not anonymous,
+		// so we need to do a name check instead
+		if !f.Exported() && f.Name() != "_" {
+			continue
+		}
+		var custom bool
 		switch f.Type() {
 		case g.nullableString:
 			validation = generateNullableStringValidation

--- a/model/modeldecoder/generator/struct.go
+++ b/model/modeldecoder/generator/struct.go
@@ -22,7 +22,7 @@ import (
 	"io"
 )
 
-func generateStructValidation(w io.Writer, _ []structField, f structField, isCustomStruct bool) error {
+func generateStructValidation(w io.Writer, fields []structField, f structField, isCustomStruct bool) error {
 	// if field is a custom struct, call its validation function
 	if isCustomStruct {
 		fmt.Fprintf(w, `
@@ -43,6 +43,8 @@ func generateStructValidation(w io.Writer, _ []structField, f structField, isCus
 		switch rule.name {
 		case tagRequired:
 			ruleNullableRequired(w, f)
+		case tagRequiredOneOf:
+			ruleRequiredOneOf(w, fields, rule.value)
 		default:
 			return fmt.Errorf("unhandled tag rule '%s'", rule)
 		}

--- a/model/modeldecoder/v2/error_test.go
+++ b/model/modeldecoder/v2/error_test.go
@@ -1,0 +1,190 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package v2
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-server/decoder"
+	"github.com/elastic/apm-server/model"
+	"github.com/elastic/apm-server/model/modeldecoder"
+	"github.com/elastic/apm-server/model/modeldecoder/modeldecodertest"
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+func TestResetErrorOnRelease(t *testing.T) {
+	inp := `{"error":{"id":"tr-a"}}`
+	root := fetchErrorRoot()
+	require.NoError(t, decoder.NewJSONIteratorDecoder(strings.NewReader(inp)).Decode(root))
+	require.True(t, root.IsSet())
+	releaseErrorRoot(root)
+	assert.False(t, root.IsSet())
+}
+
+func TestDecodeNestedError(t *testing.T) {
+	t.Run("decode", func(t *testing.T) {
+		now := time.Now()
+		input := modeldecoder.Input{Metadata: model.Metadata{}, RequestTime: now, Config: modeldecoder.Config{Experimental: true}}
+		str := `{"error":{"id":"a-b-c","timestamp":1599996822281000,"log":{"message":"abc"},"experimental":"exp"}}`
+		dec := decoder.NewJSONIteratorDecoder(strings.NewReader(str))
+		var out model.Error
+		require.NoError(t, DecodeNestedError(dec, &input, &out))
+		assert.Equal(t, "exp", out.Experimental)
+		assert.Equal(t, "2020-09-13 11:33:42.281 +0000 UTC", out.Timestamp.String())
+
+		input = modeldecoder.Input{Metadata: model.Metadata{}, RequestTime: now, Config: modeldecoder.Config{Experimental: false}}
+		str = `{"error":{"id":"a-b-c","log":{"message":"abc"},"experimental":"exp"}}`
+		dec = decoder.NewJSONIteratorDecoder(strings.NewReader(str))
+		out = model.Error{}
+		require.NoError(t, DecodeNestedError(dec, &input, &out))
+		// experimental should only be set if allowed by configuration
+		assert.Nil(t, out.Experimental)
+		// if no timestamp is provided, fall back to request time
+		assert.Equal(t, now, out.Timestamp)
+
+		err := DecodeNestedError(decoder.NewJSONIteratorDecoder(strings.NewReader(`malformed`)), &input, &out)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode")
+	})
+
+	t.Run("validate", func(t *testing.T) {
+		var out model.Error
+		err := DecodeNestedError(decoder.NewJSONIteratorDecoder(strings.NewReader(`{}`)), &modeldecoder.Input{}, &out)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "validation")
+	})
+}
+
+func TestDecodeMapToErrorModel(t *testing.T) {
+	localhostIP := net.ParseIP("127.0.0.1")
+	gatewayIP := net.ParseIP("192.168.0.1")
+	randomIP := net.ParseIP("71.0.54.1")
+	exceptions := func(key string) bool { return false }
+
+	initializedMeta := func() *model.Metadata {
+		var inputMeta metadata
+		var meta model.Metadata
+		modeldecodertest.SetStructValues(&inputMeta, "meta", 1, false, time.Now())
+		mapToMetadataModel(&inputMeta, &meta)
+		// initialize values that are not set by input
+		meta.UserAgent = model.UserAgent{Name: "meta", Original: "meta"}
+		meta.Client.IP = localhostIP
+		meta.System.IP = localhostIP
+		return &meta
+	}
+
+	t.Run("set-metadata", func(t *testing.T) {
+		// do not overwrite metadata with zero transaction values
+		var input errorEvent
+		var out model.Error
+		mapToErrorModel(&input, initializedMeta(), time.Now(), true, &out)
+		// iterate through metadata model and assert values are set
+		modeldecodertest.AssertStructValues(t, &out.Metadata, exceptions, "meta", 1, false, localhostIP, time.Now())
+	})
+
+	t.Run("overwrite-metadata", func(t *testing.T) {
+		// overwrite defined metadata with transaction metadata values
+		var input errorEvent
+		var out model.Error
+		modeldecodertest.SetStructValues(&input, "overwritten", 5000, false, time.Now())
+		input.Context.Request.Headers.Val.Add("user-agent", "first")
+		input.Context.Request.Headers.Val.Add("user-agent", "second")
+		input.Context.Request.Headers.Val.Add("x-real-ip", gatewayIP.String())
+		mapToErrorModel(&input, initializedMeta(), time.Now(), true, &out)
+
+		// user-agent should be set to context request header values
+		assert.Equal(t, "first, second", out.Metadata.UserAgent.Original)
+		// do not overwrite client.ip if already set in metadata
+		assert.Equal(t, localhostIP, out.Metadata.Client.IP, out.Metadata.Client.IP.String())
+		// metadata labels and transaction labels should not be merged
+		assert.Equal(t, common.MapStr{"meta": "meta"}, out.Metadata.Labels)
+		assert.Equal(t, &model.Labels{"overwritten": "overwritten"}, out.Labels)
+		// service values should be set
+		modeldecodertest.AssertStructValues(t, &out.Metadata.Service, exceptions, "overwritten", 100, true, localhostIP, time.Now())
+		// user values should be set
+		modeldecodertest.AssertStructValues(t, &out.Metadata.User, exceptions, "overwritten", 100, true, localhostIP, time.Now())
+	})
+
+	t.Run("client-ip-header", func(t *testing.T) {
+		var input errorEvent
+		var out model.Error
+		input.Context.Request.Headers.Set(http.Header{})
+		input.Context.Request.Headers.Val.Add("x-real-ip", gatewayIP.String())
+		input.Context.Request.Socket.RemoteAddress.Set(randomIP.String())
+		mapToErrorModel(&input, &model.Metadata{}, time.Now(), false, &out)
+		assert.Equal(t, gatewayIP, out.Metadata.Client.IP, out.Metadata.Client.IP.String())
+	})
+
+	t.Run("client-ip-socket", func(t *testing.T) {
+		var input errorEvent
+		var out model.Error
+		input.Context.Request.Socket.RemoteAddress.Set(randomIP.String())
+		mapToErrorModel(&input, &model.Metadata{}, time.Now(), false, &out)
+		assert.Equal(t, randomIP, out.Metadata.Client.IP, out.Metadata.Client.IP.String())
+	})
+
+	t.Run("error-values", func(t *testing.T) {
+		exceptions := func(key string) bool {
+			// metadata are tested separately
+			// URL parts are derived from url (separately tested)
+			// exception.parent is only set after calling `flattenExceptionTree` (not part of decoding)
+			// experimental is tested separately
+			// stacktrace original values are set when sourcemapping is applied, not in the decoder
+			// ExcludeFromGrouping is set when processing the event, not in the decoder
+			for _, s := range []string{"Metadata", "Page.URL", "Exception.Parent", "RUM",
+				"Exception.Stacktrace.Original", "Exception.Stacktrace.Sourcemap", "Exception.Stacktrace.ExcludeFromGrouping",
+				"Log.Stacktrace.Original", "Log.Stacktrace.Sourcemap", "Log.Stacktrace.ExcludeFromGrouping"} {
+				if strings.HasPrefix(key, s) {
+					return true
+				}
+			}
+			return false
+		}
+		var input errorEvent
+		var out model.Error
+		eventTime, reqTime := time.Now(), time.Now().Add(time.Second)
+		modeldecodertest.SetStructValues(&input, "overwritten", 5000, true, eventTime)
+		mapToErrorModel(&input, initializedMeta(), reqTime, true, &out)
+		fmt.Println(len(out.Log.Stacktrace))
+		fmt.Println(out.Log.Stacktrace[0].Vars)
+		input.Reset()
+		fmt.Println(len(out.Log.Stacktrace))
+		fmt.Println(out.Log.Stacktrace[0].Vars)
+		modeldecodertest.AssertStructValues(t, &out, exceptions, "overwritten", 5000, true, localhostIP, eventTime)
+		assert.False(t, out.RUM)
+	})
+
+	t.Run("page.URL", func(t *testing.T) {
+		var input errorEvent
+		input.Context.Page.URL.Set("https://my.site.test:9201")
+		var out model.Error
+		mapToErrorModel(&input, initializedMeta(), time.Now(), false, &out)
+		assert.Equal(t, "https://my.site.test:9201", *out.Page.URL.Full)
+		assert.Equal(t, 9201, *out.Page.URL.Port)
+		assert.Equal(t, "https", *out.Page.URL.Scheme)
+	})
+
+}

--- a/model/modeldecoder/v2/model.go
+++ b/model/modeldecoder/v2/model.go
@@ -35,8 +35,16 @@ var (
 
 // entry points
 
+type errorRoot struct {
+	Error errorEvent `json:"error" validate:"required"`
+}
+
 type metadataRoot struct {
 	Metadata metadata `json:"metadata" validate:"required"`
+}
+
+type spanRoot struct {
+	Span span `json:"span" validate:"required"`
 }
 
 type transactionRoot struct {
@@ -152,6 +160,46 @@ type contextServiceRuntime struct {
 	Version nullable.String `json:"version" validate:"max=1024"`
 }
 
+type errorEvent struct {
+	Context       context                 `json:"context"`
+	Culprit       nullable.String         `json:"culprit" validate:"max=1024"`
+	Exception     errorException          `json:"exception"`
+	Experimental  nullable.Interface      `json:"experimental"`
+	ID            nullable.String         `json:"id" validate:"required,max=1024"`
+	Log           errorLog                `json:"log"`
+	ParentID      nullable.String         `json:"parent_id" validate:"requiredIfAny=transaction_id;trace_id,max=1024"`
+	Timestamp     nullable.TimeMicrosUnix `json:"timestamp"`
+	TraceID       nullable.String         `json:"trace_id" validate:"requiredIfAny=transaction_id;parent_id,max=1024"`
+	Transaction   errorTransactionRef     `json:"transaction"`
+	TransactionID nullable.String         `json:"transaction_id" validate:"max=1024"`
+	_             struct{}                `validate:"requiredOneOf=exception;log"`
+}
+
+type errorException struct {
+	Attributes common.MapStr      `json:"attributes"`
+	Code       nullable.Interface `json:"code" validate:"types=string;int,max=1024"`
+	Cause      []errorException   `json:"cause"`
+	Handled    nullable.Bool      `json:"handled"`
+	Message    nullable.String    `json:"message"`
+	Module     nullable.String    `json:"module" validate:"max=1024"`
+	Stacktrace []stacktraceFrame  `json:"stacktrace"`
+	Type       nullable.String    `json:"type" validate:"max=1024"`
+	_          struct{}           `validate:"requiredOneOf=message;type"`
+}
+
+type errorLog struct {
+	Level        nullable.String   `json:"level" validate:"max=1024"`
+	LoggerName   nullable.String   `json:"logger_name" validate:"max=1024"`
+	Message      nullable.String   `json:"message" validate:"required"`
+	ParamMessage nullable.String   `json:"param_message" validate:"max=1024"`
+	Stacktrace   []stacktraceFrame `json:"stacktrace"`
+}
+
+type errorTransactionRef struct {
+	Sampled nullable.Bool   `json:"sampled"`
+	Type    nullable.String `json:"type" validate:"max=1024"`
+}
+
 type metadata struct {
 	Cloud   metadataCloud   `json:"cloud"`
 	Labels  common.MapStr   `json:"labels" validate:"patternKeys=regexpNoDotAsteriskQuote,typesVals=string;bool;number,maxVals=1024"`
@@ -263,6 +311,89 @@ type metadataSystemKubernetesNode struct {
 type metadataSystemKubernetesPod struct {
 	Name nullable.String `json:"name" validate:"max=1024"`
 	UID  nullable.String `json:"uid" validate:"max=1024"`
+}
+
+type span struct {
+	Action        nullable.String         `json:"action" validate:"max=1024"`
+	ChildIDs      []string                `json:"child_ids" validate:"max=1024"`
+	Context       spanContext             `json:"context"`
+	Duration      nullable.Float64        `json:"duration" validate:"required,min=0"`
+	Experimental  nullable.Interface      `json:"experimental"`
+	ID            nullable.String         `json:"id" validate:"required,max=1024"`
+	Name          nullable.String         `json:"name" validate:"required,max=1024"`
+	Outcome       nullable.String         `json:"outcome" validate:"enum=enumOutcome"`
+	ParentID      nullable.String         `json:"parent_id" validate:"required,max=1024"`
+	SampleRate    nullable.Float64        `json:"sample_rate"`
+	Stacktrace    []stacktraceFrame       `json:"stacktrace"`
+	Start         nullable.Float64        `json:"start"`
+	Subtype       nullable.String         `json:"subtype" validate:"max=1024"`
+	Sync          nullable.Bool           `json:"sync"`
+	Timestamp     nullable.TimeMicrosUnix `json:"timestamp"`
+	TraceID       nullable.String         `json:"trace_id" validate:"required,max=1024"`
+	TransactionID nullable.String         `json:"transaction_id" validate:"max=1024"`
+	Type          nullable.String         `json:"type" validate:"required,max=1024"`
+	_             struct{}                `validate:"requiredOneOf=start;timestamp"`
+}
+
+type spanContext struct {
+	Database    spanContextDatabase    `json:"db"`
+	Destination spanContextDestination `json:"destination"`
+	HTTP        spanContextHTTP        `json:"http"`
+	Message     contextMessage         `json:"message"`
+	Service     contextService         `json:"service"`
+	Tags        common.MapStr          `json:"tags" validate:"patternKeys=regexpNoDotAsteriskQuote,typesVals=string;bool;number,maxVals=1024"`
+}
+
+type spanContextDatabase struct {
+	Instance     nullable.String `json:"instance"`
+	Link         nullable.String `json:"link" validate:"max=1024"`
+	RowsAffected nullable.Int    `json:"rows_affected"`
+	Statement    nullable.String `json:"statement"`
+	Type         nullable.String `json:"type"`
+	User         nullable.String `json:"user"`
+}
+
+type spanContextDestination struct {
+	Address nullable.String               `json:"address" validate:"max=1024"`
+	Port    nullable.Int                  `json:"port"`
+	Service spanContextDestinationService `json:"service"`
+}
+
+type spanContextDestinationService struct {
+	Name     nullable.String `json:"name" validate:"required,max=1024"`
+	Resource nullable.String `json:"resource" validate:"required,max=1024"`
+	Type     nullable.String `json:"type" validate:"required,max=1024"`
+}
+
+type spanContextHTTP struct {
+	Method     nullable.String         `json:"method" validate:"max=1024"`
+	Response   spanContextHTTPResponse `json:"response"`
+	StatusCode nullable.Int            `json:"status_code"`
+	URL        nullable.String         `json:"url"`
+}
+
+type spanContextHTTPResponse struct {
+	DecodedBodySize nullable.Float64    `json:"decoded_body_size"`
+	EncodedBodySize nullable.Float64    `json:"encoded_body_size"`
+	Headers         nullable.HTTPHeader `json:"headers"`
+	StatusCode      nullable.Int        `json:"status_code"`
+	TransferSize    nullable.Float64    `json:"transfer_size"`
+}
+
+type stacktraceFrame struct {
+	AbsPath      nullable.String `json:"abs_path"`
+	Classname    nullable.String `json:"classname"`
+	ColumnNumber nullable.Int    `json:"colno"`
+	ContextLine  nullable.String `json:"context_line"`
+	Filename     nullable.String `json:"filename"`
+	Function     nullable.String `json:"function"`
+	LibraryFrame nullable.Bool   `json:"library_frame"`
+	LineNumber   nullable.Int    `json:"lineno"`
+	Module       nullable.String `json:"module"`
+	PostContext  []string        `json:"post_context"`
+	PreContext   []string        `json:"pre_context"`
+	Vars         common.MapStr   `json:"vars"`
+	_            struct{}        `validate:"requiredOneOf=classname;filename"`
 }
 
 type transaction struct {

--- a/model/modeldecoder/v2/model_generated.go
+++ b/model/modeldecoder/v2/model_generated.go
@@ -1277,3 +1277,550 @@ func (val *longtaskMetrics) validate() error {
 	}
 	return nil
 }
+
+func (val *errorRoot) IsSet() bool {
+	return val.Error.IsSet()
+}
+
+func (val *errorRoot) Reset() {
+	val.Error.Reset()
+}
+
+func (val *errorRoot) validate() error {
+	if err := val.Error.validate(); err != nil {
+		return errors.Wrapf(err, "error")
+	}
+	if !val.Error.IsSet() {
+		return fmt.Errorf("'error' required")
+	}
+	return nil
+}
+
+func (val *errorEvent) IsSet() bool {
+	return val.Context.IsSet() || val.Culprit.IsSet() || val.Exception.IsSet() || val.Experimental.IsSet() || val.ID.IsSet() || val.Log.IsSet() || val.ParentID.IsSet() || val.Timestamp.IsSet() || val.TraceID.IsSet() || val.Transaction.IsSet() || val.TransactionID.IsSet()
+}
+
+func (val *errorEvent) Reset() {
+	val.Context.Reset()
+	val.Culprit.Reset()
+	val.Exception.Reset()
+	val.Experimental.Reset()
+	val.ID.Reset()
+	val.Log.Reset()
+	val.ParentID.Reset()
+	val.Timestamp.Reset()
+	val.TraceID.Reset()
+	val.Transaction.Reset()
+	val.TransactionID.Reset()
+}
+
+func (val *errorEvent) validate() error {
+	if !val.IsSet() {
+		return nil
+	}
+	if err := val.Context.validate(); err != nil {
+		return errors.Wrapf(err, "context")
+	}
+	if utf8.RuneCountInString(val.Culprit.Val) > 1024 {
+		return fmt.Errorf("'culprit': validation rule 'max(1024)' violated")
+	}
+	if err := val.Exception.validate(); err != nil {
+		return errors.Wrapf(err, "exception")
+	}
+	if utf8.RuneCountInString(val.ID.Val) > 1024 {
+		return fmt.Errorf("'id': validation rule 'max(1024)' violated")
+	}
+	if !val.ID.IsSet() {
+		return fmt.Errorf("'id' required")
+	}
+	if err := val.Log.validate(); err != nil {
+		return errors.Wrapf(err, "log")
+	}
+	if utf8.RuneCountInString(val.ParentID.Val) > 1024 {
+		return fmt.Errorf("'parent_id': validation rule 'max(1024)' violated")
+	}
+	if !val.ParentID.IsSet() {
+		if val.TraceID.IsSet() {
+			return fmt.Errorf("'parent_id' required when 'trace_id' is set")
+		}
+		if val.TransactionID.IsSet() {
+			return fmt.Errorf("'parent_id' required when 'transaction_id' is set")
+		}
+	}
+	if utf8.RuneCountInString(val.TraceID.Val) > 1024 {
+		return fmt.Errorf("'trace_id': validation rule 'max(1024)' violated")
+	}
+	if !val.TraceID.IsSet() {
+		if val.ParentID.IsSet() {
+			return fmt.Errorf("'trace_id' required when 'parent_id' is set")
+		}
+		if val.TransactionID.IsSet() {
+			return fmt.Errorf("'trace_id' required when 'transaction_id' is set")
+		}
+	}
+	if err := val.Transaction.validate(); err != nil {
+		return errors.Wrapf(err, "transaction")
+	}
+	if utf8.RuneCountInString(val.TransactionID.Val) > 1024 {
+		return fmt.Errorf("'transaction_id': validation rule 'max(1024)' violated")
+	}
+	if !val.Exception.IsSet() && !val.Log.IsSet() {
+		return fmt.Errorf("requires at least one of the fields 'exception;log'")
+	}
+	return nil
+}
+
+func (val *errorException) IsSet() bool {
+	return len(val.Attributes) > 0 || val.Code.IsSet() || len(val.Cause) > 0 || val.Handled.IsSet() || val.Message.IsSet() || val.Module.IsSet() || len(val.Stacktrace) > 0 || val.Type.IsSet()
+}
+
+func (val *errorException) Reset() {
+	for k := range val.Attributes {
+		delete(val.Attributes, k)
+	}
+	val.Code.Reset()
+	for i := range val.Cause {
+		val.Cause[i].Reset()
+	}
+	val.Cause = val.Cause[:0]
+	val.Handled.Reset()
+	val.Message.Reset()
+	val.Module.Reset()
+	for i := range val.Stacktrace {
+		val.Stacktrace[i].Reset()
+	}
+	val.Stacktrace = val.Stacktrace[:0]
+	val.Type.Reset()
+}
+
+func (val *errorException) validate() error {
+	if !val.IsSet() {
+		return nil
+	}
+	switch t := val.Code.Val.(type) {
+	case string:
+		if utf8.RuneCountInString(t) > 1024 {
+			return fmt.Errorf("'code': validation rule 'max(1024)' violated")
+		}
+	case int:
+	case json.Number:
+		if _, err := t.Int64(); err != nil {
+			return fmt.Errorf("'code': validation rule 'types(string;int)' violated")
+		}
+	case nil:
+	default:
+		return fmt.Errorf("'code': validation rule 'types(string;int)' violated ")
+	}
+	for _, elem := range val.Cause {
+		if err := elem.validate(); err != nil {
+			return errors.Wrapf(err, "cause")
+		}
+	}
+	if utf8.RuneCountInString(val.Module.Val) > 1024 {
+		return fmt.Errorf("'module': validation rule 'max(1024)' violated")
+	}
+	for _, elem := range val.Stacktrace {
+		if err := elem.validate(); err != nil {
+			return errors.Wrapf(err, "stacktrace")
+		}
+	}
+	if utf8.RuneCountInString(val.Type.Val) > 1024 {
+		return fmt.Errorf("'type': validation rule 'max(1024)' violated")
+	}
+	if !val.Message.IsSet() && !val.Type.IsSet() {
+		return fmt.Errorf("requires at least one of the fields 'message;type'")
+	}
+	return nil
+}
+
+func (val *stacktraceFrame) IsSet() bool {
+	return val.AbsPath.IsSet() || val.Classname.IsSet() || val.ColumnNumber.IsSet() || val.ContextLine.IsSet() || val.Filename.IsSet() || val.Function.IsSet() || val.LibraryFrame.IsSet() || val.LineNumber.IsSet() || val.Module.IsSet() || len(val.PostContext) > 0 || len(val.PreContext) > 0 || len(val.Vars) > 0
+}
+
+func (val *stacktraceFrame) Reset() {
+	val.AbsPath.Reset()
+	val.Classname.Reset()
+	val.ColumnNumber.Reset()
+	val.ContextLine.Reset()
+	val.Filename.Reset()
+	val.Function.Reset()
+	val.LibraryFrame.Reset()
+	val.LineNumber.Reset()
+	val.Module.Reset()
+	val.PostContext = val.PostContext[:0]
+	val.PreContext = val.PreContext[:0]
+	for k := range val.Vars {
+		delete(val.Vars, k)
+	}
+}
+
+func (val *stacktraceFrame) validate() error {
+	if !val.IsSet() {
+		return nil
+	}
+	if !val.Classname.IsSet() && !val.Filename.IsSet() {
+		return fmt.Errorf("requires at least one of the fields 'classname;filename'")
+	}
+	return nil
+}
+
+func (val *errorLog) IsSet() bool {
+	return val.Level.IsSet() || val.LoggerName.IsSet() || val.Message.IsSet() || val.ParamMessage.IsSet() || len(val.Stacktrace) > 0
+}
+
+func (val *errorLog) Reset() {
+	val.Level.Reset()
+	val.LoggerName.Reset()
+	val.Message.Reset()
+	val.ParamMessage.Reset()
+	for i := range val.Stacktrace {
+		val.Stacktrace[i].Reset()
+	}
+	val.Stacktrace = val.Stacktrace[:0]
+}
+
+func (val *errorLog) validate() error {
+	if !val.IsSet() {
+		return nil
+	}
+	if utf8.RuneCountInString(val.Level.Val) > 1024 {
+		return fmt.Errorf("'level': validation rule 'max(1024)' violated")
+	}
+	if utf8.RuneCountInString(val.LoggerName.Val) > 1024 {
+		return fmt.Errorf("'logger_name': validation rule 'max(1024)' violated")
+	}
+	if !val.Message.IsSet() {
+		return fmt.Errorf("'message' required")
+	}
+	if utf8.RuneCountInString(val.ParamMessage.Val) > 1024 {
+		return fmt.Errorf("'param_message': validation rule 'max(1024)' violated")
+	}
+	for _, elem := range val.Stacktrace {
+		if err := elem.validate(); err != nil {
+			return errors.Wrapf(err, "stacktrace")
+		}
+	}
+	return nil
+}
+
+func (val *errorTransactionRef) IsSet() bool {
+	return val.Sampled.IsSet() || val.Type.IsSet()
+}
+
+func (val *errorTransactionRef) Reset() {
+	val.Sampled.Reset()
+	val.Type.Reset()
+}
+
+func (val *errorTransactionRef) validate() error {
+	if !val.IsSet() {
+		return nil
+	}
+	if utf8.RuneCountInString(val.Type.Val) > 1024 {
+		return fmt.Errorf("'type': validation rule 'max(1024)' violated")
+	}
+	return nil
+}
+
+func (val *spanRoot) IsSet() bool {
+	return val.Span.IsSet()
+}
+
+func (val *spanRoot) Reset() {
+	val.Span.Reset()
+}
+
+func (val *spanRoot) validate() error {
+	if err := val.Span.validate(); err != nil {
+		return errors.Wrapf(err, "span")
+	}
+	if !val.Span.IsSet() {
+		return fmt.Errorf("'span' required")
+	}
+	return nil
+}
+
+func (val *span) IsSet() bool {
+	return val.Action.IsSet() || len(val.ChildIDs) > 0 || val.Context.IsSet() || val.Duration.IsSet() || val.Experimental.IsSet() || val.ID.IsSet() || val.Name.IsSet() || val.Outcome.IsSet() || val.ParentID.IsSet() || val.SampleRate.IsSet() || len(val.Stacktrace) > 0 || val.Start.IsSet() || val.Subtype.IsSet() || val.Sync.IsSet() || val.Timestamp.IsSet() || val.TraceID.IsSet() || val.TransactionID.IsSet() || val.Type.IsSet()
+}
+
+func (val *span) Reset() {
+	val.Action.Reset()
+	val.ChildIDs = val.ChildIDs[:0]
+	val.Context.Reset()
+	val.Duration.Reset()
+	val.Experimental.Reset()
+	val.ID.Reset()
+	val.Name.Reset()
+	val.Outcome.Reset()
+	val.ParentID.Reset()
+	val.SampleRate.Reset()
+	for i := range val.Stacktrace {
+		val.Stacktrace[i].Reset()
+	}
+	val.Stacktrace = val.Stacktrace[:0]
+	val.Start.Reset()
+	val.Subtype.Reset()
+	val.Sync.Reset()
+	val.Timestamp.Reset()
+	val.TraceID.Reset()
+	val.TransactionID.Reset()
+	val.Type.Reset()
+}
+
+func (val *span) validate() error {
+	if !val.IsSet() {
+		return nil
+	}
+	if utf8.RuneCountInString(val.Action.Val) > 1024 {
+		return fmt.Errorf("'action': validation rule 'max(1024)' violated")
+	}
+	for _, elem := range val.ChildIDs {
+		if utf8.RuneCountInString(elem) > 1024 {
+			return fmt.Errorf("'child_ids': validation rule 'max(1024)' violated")
+		}
+	}
+	if err := val.Context.validate(); err != nil {
+		return errors.Wrapf(err, "context")
+	}
+	if val.Duration.Val < 0 {
+		return fmt.Errorf("'duration': validation rule 'min(0)' violated")
+	}
+	if !val.Duration.IsSet() {
+		return fmt.Errorf("'duration' required")
+	}
+	if utf8.RuneCountInString(val.ID.Val) > 1024 {
+		return fmt.Errorf("'id': validation rule 'max(1024)' violated")
+	}
+	if !val.ID.IsSet() {
+		return fmt.Errorf("'id' required")
+	}
+	if utf8.RuneCountInString(val.Name.Val) > 1024 {
+		return fmt.Errorf("'name': validation rule 'max(1024)' violated")
+	}
+	if !val.Name.IsSet() {
+		return fmt.Errorf("'name' required")
+	}
+	if val.Outcome.Val != "" {
+		var matchEnum bool
+		for _, s := range enumOutcome {
+			if val.Outcome.Val == s {
+				matchEnum = true
+				break
+			}
+		}
+		if !matchEnum {
+			return fmt.Errorf("'outcome': validation rule 'enum(enumOutcome)' violated")
+		}
+	}
+	if utf8.RuneCountInString(val.ParentID.Val) > 1024 {
+		return fmt.Errorf("'parent_id': validation rule 'max(1024)' violated")
+	}
+	if !val.ParentID.IsSet() {
+		return fmt.Errorf("'parent_id' required")
+	}
+	for _, elem := range val.Stacktrace {
+		if err := elem.validate(); err != nil {
+			return errors.Wrapf(err, "stacktrace")
+		}
+	}
+	if utf8.RuneCountInString(val.Subtype.Val) > 1024 {
+		return fmt.Errorf("'subtype': validation rule 'max(1024)' violated")
+	}
+	if utf8.RuneCountInString(val.TraceID.Val) > 1024 {
+		return fmt.Errorf("'trace_id': validation rule 'max(1024)' violated")
+	}
+	if !val.TraceID.IsSet() {
+		return fmt.Errorf("'trace_id' required")
+	}
+	if utf8.RuneCountInString(val.TransactionID.Val) > 1024 {
+		return fmt.Errorf("'transaction_id': validation rule 'max(1024)' violated")
+	}
+	if utf8.RuneCountInString(val.Type.Val) > 1024 {
+		return fmt.Errorf("'type': validation rule 'max(1024)' violated")
+	}
+	if !val.Type.IsSet() {
+		return fmt.Errorf("'type' required")
+	}
+	if !val.Start.IsSet() && !val.Timestamp.IsSet() {
+		return fmt.Errorf("requires at least one of the fields 'start;timestamp'")
+	}
+	return nil
+}
+
+func (val *spanContext) IsSet() bool {
+	return val.Database.IsSet() || val.Destination.IsSet() || val.HTTP.IsSet() || val.Message.IsSet() || val.Service.IsSet() || len(val.Tags) > 0
+}
+
+func (val *spanContext) Reset() {
+	val.Database.Reset()
+	val.Destination.Reset()
+	val.HTTP.Reset()
+	val.Message.Reset()
+	val.Service.Reset()
+	for k := range val.Tags {
+		delete(val.Tags, k)
+	}
+}
+
+func (val *spanContext) validate() error {
+	if !val.IsSet() {
+		return nil
+	}
+	if err := val.Database.validate(); err != nil {
+		return errors.Wrapf(err, "db")
+	}
+	if err := val.Destination.validate(); err != nil {
+		return errors.Wrapf(err, "destination")
+	}
+	if err := val.HTTP.validate(); err != nil {
+		return errors.Wrapf(err, "http")
+	}
+	if err := val.Message.validate(); err != nil {
+		return errors.Wrapf(err, "message")
+	}
+	if err := val.Service.validate(); err != nil {
+		return errors.Wrapf(err, "service")
+	}
+	for k, v := range val.Tags {
+		if k != "" && !regexpNoDotAsteriskQuote.MatchString(k) {
+			return fmt.Errorf("'tags': validation rule 'patternKeys(regexpNoDotAsteriskQuote)' violated")
+		}
+		switch t := v.(type) {
+		case nil:
+		case string:
+			if utf8.RuneCountInString(t) > 1024 {
+				return fmt.Errorf("'tags': validation rule 'maxVals(1024)' violated")
+			}
+		case bool:
+		case json.Number:
+		default:
+			return fmt.Errorf("'tags': validation rule 'typesVals(string;bool;number)' violated for key %s", k)
+		}
+	}
+	return nil
+}
+
+func (val *spanContextDatabase) IsSet() bool {
+	return val.Instance.IsSet() || val.Link.IsSet() || val.RowsAffected.IsSet() || val.Statement.IsSet() || val.Type.IsSet() || val.User.IsSet()
+}
+
+func (val *spanContextDatabase) Reset() {
+	val.Instance.Reset()
+	val.Link.Reset()
+	val.RowsAffected.Reset()
+	val.Statement.Reset()
+	val.Type.Reset()
+	val.User.Reset()
+}
+
+func (val *spanContextDatabase) validate() error {
+	if !val.IsSet() {
+		return nil
+	}
+	if utf8.RuneCountInString(val.Link.Val) > 1024 {
+		return fmt.Errorf("'link': validation rule 'max(1024)' violated")
+	}
+	return nil
+}
+
+func (val *spanContextDestination) IsSet() bool {
+	return val.Address.IsSet() || val.Port.IsSet() || val.Service.IsSet()
+}
+
+func (val *spanContextDestination) Reset() {
+	val.Address.Reset()
+	val.Port.Reset()
+	val.Service.Reset()
+}
+
+func (val *spanContextDestination) validate() error {
+	if !val.IsSet() {
+		return nil
+	}
+	if utf8.RuneCountInString(val.Address.Val) > 1024 {
+		return fmt.Errorf("'address': validation rule 'max(1024)' violated")
+	}
+	if err := val.Service.validate(); err != nil {
+		return errors.Wrapf(err, "service")
+	}
+	return nil
+}
+
+func (val *spanContextDestinationService) IsSet() bool {
+	return val.Name.IsSet() || val.Resource.IsSet() || val.Type.IsSet()
+}
+
+func (val *spanContextDestinationService) Reset() {
+	val.Name.Reset()
+	val.Resource.Reset()
+	val.Type.Reset()
+}
+
+func (val *spanContextDestinationService) validate() error {
+	if !val.IsSet() {
+		return nil
+	}
+	if utf8.RuneCountInString(val.Name.Val) > 1024 {
+		return fmt.Errorf("'name': validation rule 'max(1024)' violated")
+	}
+	if !val.Name.IsSet() {
+		return fmt.Errorf("'name' required")
+	}
+	if utf8.RuneCountInString(val.Resource.Val) > 1024 {
+		return fmt.Errorf("'resource': validation rule 'max(1024)' violated")
+	}
+	if !val.Resource.IsSet() {
+		return fmt.Errorf("'resource' required")
+	}
+	if utf8.RuneCountInString(val.Type.Val) > 1024 {
+		return fmt.Errorf("'type': validation rule 'max(1024)' violated")
+	}
+	if !val.Type.IsSet() {
+		return fmt.Errorf("'type' required")
+	}
+	return nil
+}
+
+func (val *spanContextHTTP) IsSet() bool {
+	return val.Method.IsSet() || val.Response.IsSet() || val.StatusCode.IsSet() || val.URL.IsSet()
+}
+
+func (val *spanContextHTTP) Reset() {
+	val.Method.Reset()
+	val.Response.Reset()
+	val.StatusCode.Reset()
+	val.URL.Reset()
+}
+
+func (val *spanContextHTTP) validate() error {
+	if !val.IsSet() {
+		return nil
+	}
+	if utf8.RuneCountInString(val.Method.Val) > 1024 {
+		return fmt.Errorf("'method': validation rule 'max(1024)' violated")
+	}
+	if err := val.Response.validate(); err != nil {
+		return errors.Wrapf(err, "response")
+	}
+	return nil
+}
+
+func (val *spanContextHTTPResponse) IsSet() bool {
+	return val.DecodedBodySize.IsSet() || val.EncodedBodySize.IsSet() || val.Headers.IsSet() || val.StatusCode.IsSet() || val.TransferSize.IsSet()
+}
+
+func (val *spanContextHTTPResponse) Reset() {
+	val.DecodedBodySize.Reset()
+	val.EncodedBodySize.Reset()
+	val.Headers.Reset()
+	val.StatusCode.Reset()
+	val.TransferSize.Reset()
+}
+
+func (val *spanContextHTTPResponse) validate() error {
+	if !val.IsSet() {
+		return nil
+	}
+	return nil
+}

--- a/model/modeldecoder/v2/span_test.go
+++ b/model/modeldecoder/v2/span_test.go
@@ -1,0 +1,229 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package v2
+
+import (
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-server/decoder"
+	"github.com/elastic/apm-server/model"
+	"github.com/elastic/apm-server/model/modeldecoder"
+	"github.com/elastic/apm-server/model/modeldecoder/modeldecodertest"
+)
+
+func TestResetSpanOnRelease(t *testing.T) {
+	inp := `{"span":{"name":"tr-a"}}`
+	root := fetchSpanRoot()
+	require.NoError(t, decoder.NewJSONIteratorDecoder(strings.NewReader(inp)).Decode(root))
+	require.True(t, root.IsSet())
+	releaseSpanRoot(root)
+	assert.False(t, root.IsSet())
+}
+
+func TestDecodeNestedSpan(t *testing.T) {
+	t.Run("decode", func(t *testing.T) {
+		input := modeldecoder.Input{Metadata: model.Metadata{}, RequestTime: time.Now(), Config: modeldecoder.Config{}}
+		str := `{"span":{"duration":100,"id":"a-b-c","name":"s","parent_id":"parent-123","trace_id":"trace-ab","type":"db","start":143}}`
+		dec := decoder.NewJSONIteratorDecoder(strings.NewReader(str))
+		var out model.Span
+		require.NoError(t, DecodeNestedSpan(dec, &input, &out))
+
+		err := DecodeNestedSpan(decoder.NewJSONIteratorDecoder(strings.NewReader(`malformed`)), &input, &out)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode")
+	})
+
+	t.Run("validate", func(t *testing.T) {
+		var out model.Span
+		err := DecodeNestedSpan(decoder.NewJSONIteratorDecoder(strings.NewReader(`{}`)), &modeldecoder.Input{}, &out)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "validation")
+	})
+}
+
+func TestDecodeMapToSpanModel(t *testing.T) {
+	ip := net.ParseIP("127.0.0.1")
+
+	initializedMeta := func() *model.Metadata {
+		var inputMeta metadata
+		var meta model.Metadata
+		modeldecodertest.SetStructValues(&inputMeta, "meta", 1, false, time.Now())
+		mapToMetadataModel(&inputMeta, &meta)
+		// initialize values that are not set by input
+		meta.UserAgent = model.UserAgent{Name: "meta", Original: "meta"}
+		meta.Client.IP = ip
+		meta.System.IP = ip
+		return &meta
+	}
+
+	t.Run("metadata", func(t *testing.T) {
+		// do not overwrite metadata with zero span values
+		exceptions := func(key string) bool { return false }
+		var input span
+		var out model.Span
+		modeldecodertest.SetStructValues(&input, "overwritten", 5000, true, time.Now().Add(time.Hour))
+		mapToSpanModel(&input, initializedMeta(), time.Now(), true, &out)
+		// iterate through metadata model and assert values are set
+		modeldecodertest.AssertStructValues(t, &out.Metadata, exceptions, "meta", 1, false, ip, time.Now())
+	})
+
+	t.Run("experimental", func(t *testing.T) {
+		// experimental enabled
+		input := modeldecoder.Input{Metadata: model.Metadata{}, RequestTime: time.Now(), Config: modeldecoder.Config{Experimental: true}}
+		str := `{"span":{"experimental":"exp","duration":100,"id":"a-b-c","name":"s","parent_id":"parent-123","trace_id":"trace-ab","type":"db","start":143}}`
+		dec := decoder.NewJSONIteratorDecoder(strings.NewReader(str))
+		var out model.Span
+		require.NoError(t, DecodeNestedSpan(dec, &input, &out))
+		assert.Equal(t, "exp", out.Experimental)
+
+		// experimental disabled
+		input = modeldecoder.Input{Metadata: model.Metadata{}, RequestTime: time.Now(), Config: modeldecoder.Config{Experimental: false}}
+		str = `{"span":{"experimental":"exp","duration":100,"id":"a-b-c","name":"s","parent_id":"parent-123","trace_id":"trace-ab","type":"db","start":143}}`
+		dec = decoder.NewJSONIteratorDecoder(strings.NewReader(str))
+		out = model.Span{}
+		require.NoError(t, DecodeNestedSpan(dec, &input, &out))
+		// experimental should only be set if allowed by configuration
+		assert.Nil(t, out.Experimental)
+	})
+
+	t.Run("span-values", func(t *testing.T) {
+		exceptions := func(key string) bool {
+			// metadata are tested in the 'metadata' test
+			// experimental is tested in test 'experimental'
+			// RUM is tested in test 'span-values'
+			// RepresentativeCount is tested further down in test 'sample-rate'
+			for _, s := range []string{"Experimental", "RUM", "RepresentativeCount"} {
+				if key == s {
+					return true
+				}
+			}
+			for _, s := range []string{"Metadata",
+				"Stacktrace.Original", "Stacktrace.Sourcemap", "Stacktrace.ExcludeFromGrouping"} {
+				if strings.HasPrefix(key, s) {
+					return true
+				}
+			}
+			return false
+		}
+		var input span
+		var out model.Span
+		eventTime, reqTime := time.Now(), time.Now().Add(time.Second)
+		modeldecodertest.SetStructValues(&input, "overwritten", 5000, true, eventTime)
+		mapToSpanModel(&input, initializedMeta(), reqTime, true, &out)
+		input.Reset()
+		modeldecodertest.AssertStructValues(t, &out, exceptions, "overwritten", 5000, true, ip, eventTime)
+		assert.False(t, out.RUM)
+	})
+
+	t.Run("timestamp", func(t *testing.T) {
+		var input span
+		var out model.Span
+		i := 5000
+		reqTime := time.Now().Add(time.Hour)
+		// add start to requestTime if eventTime is zero and start is given
+		modeldecodertest.SetStructValues(&input, "init", i, true, time.Time{})
+		mapToSpanModel(&input, initializedMeta(), reqTime, true, &out)
+		timestamp := reqTime.Add(time.Duration((float64(i) + 0.5) * float64(time.Millisecond)))
+		assert.Equal(t, timestamp, out.Timestamp)
+		// set requestTime if eventTime is zero and start is not set
+		out = model.Span{}
+		modeldecodertest.SetStructValues(&input, "init", i, true, time.Time{})
+		input.Start.Reset()
+		mapToSpanModel(&input, initializedMeta(), reqTime, true, &out)
+		require.Nil(t, out.Start)
+		assert.Equal(t, reqTime, out.Timestamp)
+	})
+
+	t.Run("sample-rate", func(t *testing.T) {
+		var input span
+		var out model.Span
+		modeldecodertest.SetStructValues(&input, "init", 5000, true, time.Now())
+		// sample rate is set to > 0
+		input.SampleRate.Set(0.25)
+		mapToSpanModel(&input, initializedMeta(), time.Now(), true, &out)
+		assert.Equal(t, 4.0, out.RepresentativeCount)
+		// sample rate is not set
+		out.RepresentativeCount = 0.0
+		input.SampleRate.Reset()
+		mapToSpanModel(&input, initializedMeta(), time.Now(), true, &out)
+		assert.Equal(t, 0.0, out.RepresentativeCount)
+		// sample rate is set to 0
+		input.SampleRate.Set(0)
+		mapToSpanModel(&input, initializedMeta(), time.Now(), true, &out)
+		assert.Equal(t, 0.0, out.RepresentativeCount)
+	})
+
+	t.Run("type-subtype-action", func(t *testing.T) {
+		for _, tc := range []struct {
+			name                                 string
+			inputType, inputSubtype, inputAction string
+			typ, subtype, action                 string
+		}{
+			{name: "only-type", inputType: "xyz",
+				typ: "xyz"},
+			{name: "derive-subtype", inputType: "x.y",
+				typ: "x", subtype: "y"},
+			{name: "derive-subtype-action", inputType: "x.y.z.a",
+				typ: "x", subtype: "y", action: "z.a"},
+			{name: "type-subtype", inputType: "x.y.z", inputSubtype: "a",
+				typ: "x.y.z", subtype: "a"},
+			{name: "type-action", inputType: "x.y.z", inputAction: "b",
+				typ: "x.y.z", action: "b"},
+			{name: "type-subtype-action", inputType: "x.y", inputSubtype: "a", inputAction: "b",
+				typ: "x.y", subtype: "a", action: "b"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				var input span
+				modeldecodertest.SetStructValues(&input, "init", 5000, true, time.Now())
+				input.Type.Set(tc.inputType)
+				if tc.inputSubtype != "" {
+					input.Subtype.Set(tc.inputSubtype)
+				} else {
+					input.Subtype.Reset()
+				}
+				if tc.inputAction != "" {
+					input.Action.Set(tc.inputAction)
+				} else {
+					input.Action.Reset()
+				}
+				var out model.Span
+				mapToSpanModel(&input, initializedMeta(), time.Now(), true, &out)
+				assert.Equal(t, tc.typ, out.Type)
+				if tc.subtype == "" {
+					assert.Nil(t, out.Subtype)
+				} else {
+					require.NotNil(t, out.Subtype)
+					assert.Equal(t, tc.subtype, *out.Subtype)
+				}
+				if tc.action == "" {
+					assert.Nil(t, out.Action)
+				} else {
+					require.NotNil(t, out.Action)
+					assert.Equal(t, tc.action, *out.Action)
+				}
+			})
+		}
+	})
+
+}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Decoder v2: add errors and spans (#4260)