### PR TITLE
systemtest: fix flaky TestKeepUnsampled test

### DIFF
--- a/systemtest/sampling_test.go
+++ b/systemtest/sampling_test.go
@@ -49,15 +49,15 @@ func TestKeepUnsampled(t *testing.T) {
 			tracer.StartTransaction("unsampled", transactionType).End()
 			tracer.Flush(nil)
 
-			result := systemtest.Elasticsearch.ExpectDocs(t, "apm-*", estest.TermQuery{
-				Field: "transaction.type",
-				Value: transactionType,
-			})
-
 			expectedTransactionDocs := 1
 			if keepUnsampled {
 				expectedTransactionDocs++
 			}
+
+			result := systemtest.Elasticsearch.ExpectMinDocs(t, expectedTransactionDocs, "apm-*", estest.TermQuery{
+				Field: "transaction.type",
+				Value: transactionType,
+			})
 			assert.Len(t, result.Hits.Hits, expectedTransactionDocs)
 		})
 	}


### PR DESCRIPTION
## Motivation/summary

Wait for the expected number of docs to appear, rather than just waiting for a single one.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

`cd systemtest && go test -v`

## Related issues

Closes elastic/apm-server#4247 