### PR TITLE
[7.9] docs: Update field ref with ECS icon (#4272)

### DIFF
--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -81,6 +81,8 @@ The protocol of the request, e.g. "https:".
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`url.full`*::
@@ -90,6 +92,8 @@ The full, possibly agent-assembled URL of the request, e.g https://example.com:4
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -101,6 +105,8 @@ The hostname of the request, e.g. "example.com".
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`url.port`*::
@@ -110,6 +116,8 @@ The port of the request, e.g. 443.
 
 
 type: long
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -121,6 +129,8 @@ The path of the request, e.g. "/search".
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`url.query`*::
@@ -131,6 +141,8 @@ The query string of the request, e.g. "q=elasticsearch".
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`url.fragment`*::
@@ -140,6 +152,8 @@ A fragment specifying a location in a web page , e.g. "top".
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -152,6 +166,8 @@ The http version of the request leading to this event.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 
@@ -162,6 +178,8 @@ The http method of the request leading to this event.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -184,6 +202,8 @@ Referrer for this HTTP request.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 
@@ -195,6 +215,8 @@ The status code of the HTTP response.
 
 type: long
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`http.response.finished`*::
@@ -204,6 +226,8 @@ Used by the Node agent to indicate when in the response life cycle an error has 
 
 
 type: boolean
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -227,6 +251,8 @@ A flat mapping of user-defined labels with string, boolean or number values.
 
 type: object
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 [float]
@@ -244,6 +270,8 @@ Immutable name of the service emitting this event.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`service.version`*::
@@ -253,6 +281,8 @@ Version of the service emitting this event.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -274,6 +304,8 @@ Unique meaningful name of the service node.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -519,6 +551,8 @@ Name of the agent used.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`agent.version`*::
@@ -529,6 +563,8 @@ Version of the agent used.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`agent.ephemeral_id`*::
@@ -538,6 +574,8 @@ The Ephemeral ID identifies a running process.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -555,6 +593,8 @@ Unique container id.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -622,6 +662,8 @@ The architecture of the host the event was recorded on.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`host.hostname`*::
@@ -631,6 +673,8 @@ The hostname of the host the event was recorded on.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -642,6 +686,8 @@ Name of the host the event was recorded on. It can contain same information as h
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`host.ip`*::
@@ -651,6 +697,8 @@ IP of the host that records the event.
 
 
 type: ip
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -668,6 +716,8 @@ The platform of the host the event was recorded on.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -687,6 +737,8 @@ May be filtered to protect sensitive information.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`process.pid`*::
@@ -696,6 +748,8 @@ Numeric process ID of the service process.
 
 
 type: long
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -707,6 +761,8 @@ Numeric ID of the service's parent process.
 
 type: long
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`process.title`*::
@@ -716,6 +772,8 @@ Service process title.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -738,6 +796,8 @@ Hostname of the APM Server.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`observer.version`*::
@@ -747,6 +807,8 @@ APM Server version.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -768,6 +830,8 @@ The type will be set to `apm-server`.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 
@@ -779,6 +843,8 @@ The username of the logged in user.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user.id`*::
@@ -789,6 +855,8 @@ Identifier of the logged in user.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user.email`*::
@@ -798,6 +866,8 @@ Email of the logged in user.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -810,6 +880,8 @@ IP address of the client of a recorded event. This is typically obtained from a 
 
 type: ip
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 
@@ -820,6 +892,8 @@ IP address of the source of a recorded event. This is typically obtained from a 
 
 
 type: ip
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -838,6 +912,8 @@ Then it should be duplicated to `.ip` or `.domain`, depending on which one it is
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`destination.ip`*::
@@ -847,6 +923,8 @@ IP addess of the destination.
 Can be one of multiple IPv4 or IPv6 addresses.
 
 type: ip
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -858,6 +936,8 @@ Port of the destination.
 type: long
 
 format: string
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -878,6 +958,8 @@ type: keyword
 
 example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user_agent.original.text`*::
@@ -887,6 +969,8 @@ Software agent acting in behalf of a user, eg. a web browser / OS combination.
 
 
 type: text
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -900,6 +984,8 @@ type: keyword
 
 example: Safari
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user_agent.version`*::
@@ -911,6 +997,8 @@ Version of the user agent.
 type: keyword
 
 example: 12.0
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -931,6 +1019,8 @@ type: keyword
 
 example: iPhone
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 [float]
@@ -950,6 +1040,8 @@ type: keyword
 
 example: darwin
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user_agent.os.name`*::
@@ -961,6 +1053,8 @@ Operating system name, without the version.
 type: keyword
 
 example: Mac OS X
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -974,6 +1068,8 @@ type: keyword
 
 example: Mac OS Mojave
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user_agent.os.family`*::
@@ -985,6 +1081,8 @@ OS family (such as redhat, debian, freebsd, windows).
 type: keyword
 
 example: debian
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -998,6 +1096,8 @@ type: keyword
 
 example: 10.14.1
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user_agent.os.kernel`*::
@@ -1009,6 +1109,8 @@ Operating system kernel version as a raw string.
 type: keyword
 
 example: 4.4.0-112-generic
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -1036,6 +1138,8 @@ Cloud account ID
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`cloud.account.name`*::
@@ -1044,6 +1148,8 @@ type: keyword
 Cloud account name
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -1056,6 +1162,8 @@ type: keyword
 
 example: us-east1-a
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 
@@ -1066,6 +1174,8 @@ Cloud instance/machine ID
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`cloud.instance.name`*::
@@ -1074,6 +1184,8 @@ type: keyword
 Cloud instance/machine name
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -1087,6 +1199,8 @@ type: keyword
 
 example: t2.medium
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 
@@ -1097,6 +1211,8 @@ Cloud project ID
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`cloud.project.name`*::
@@ -1105,6 +1221,8 @@ type: keyword
 Cloud project name
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -1117,6 +1235,8 @@ type: keyword
 
 example: gcp
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`cloud.region`*::
@@ -1127,6 +1247,8 @@ Cloud region name
 type: keyword
 
 example: us-east1
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -1150,6 +1272,8 @@ The ID of the error.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -1964,8 +2088,15 @@ type: object
 [[exported-fields-ecs]]
 == ECS fields
 
-ECS Fields.
 
+This section defines Elastic Common Schema (ECS) fields—a common set of fields
+to be used when storing event data in {es}.
+
+This is an exhaustive list, and fields listed here are not necessarily used by {beatname_uc}.
+The goal of ECS is to enable and encourage users of {es} to normalize their event data,
+so that they can better analyze, visualize, and correlate the data represented in their events.
+
+See the {ecs-ref}[ECS reference] for more information.
 
 *`@timestamp`*::
 +
@@ -9090,4 +9221,3 @@ type: long
 format: bytes
 
 --
-


### PR DESCRIPTION
Backports the following commits to 7.9:
 - docs: Update field ref with ECS icon (#4272)