### PR TITLE
[7.10] docs: Update field ref with ECS icon (#4272)

### DIFF
--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -82,6 +82,8 @@ The protocol of the request, e.g. "https:".
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`url.full`*::
@@ -91,6 +93,8 @@ The full, possibly agent-assembled URL of the request, e.g https://example.com:4
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -102,6 +106,8 @@ The hostname of the request, e.g. "example.com".
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`url.port`*::
@@ -111,6 +117,8 @@ The port of the request, e.g. 443.
 
 
 type: long
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -122,6 +130,8 @@ The path of the request, e.g. "/search".
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`url.query`*::
@@ -132,6 +142,8 @@ The query string of the request, e.g. "q=elasticsearch".
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`url.fragment`*::
@@ -141,6 +153,8 @@ A fragment specifying a location in a web page , e.g. "top".
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -153,6 +167,8 @@ The http version of the request leading to this event.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 
@@ -163,6 +179,8 @@ The http method of the request leading to this event.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -185,6 +203,8 @@ Referrer for this HTTP request.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 
@@ -196,6 +216,8 @@ The status code of the HTTP response.
 
 type: long
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`http.response.finished`*::
@@ -205,6 +227,8 @@ Used by the Node agent to indicate when in the response life cycle an error has 
 
 
 type: boolean
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -228,6 +252,8 @@ A flat mapping of user-defined labels with string, boolean or number values.
 
 type: object
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 [float]
@@ -245,6 +271,8 @@ Immutable name of the service emitting this event.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`service.version`*::
@@ -254,6 +282,8 @@ Version of the service emitting this event.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -275,6 +305,8 @@ Unique meaningful name of the service node.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -515,6 +547,8 @@ Name of the agent used.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`agent.version`*::
@@ -525,6 +559,8 @@ Version of the agent used.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`agent.ephemeral_id`*::
@@ -534,6 +570,8 @@ The Ephemeral ID identifies a running process.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -551,6 +589,8 @@ Unique container id.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -618,6 +658,8 @@ The architecture of the host the event was recorded on.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`host.hostname`*::
@@ -627,6 +669,8 @@ The hostname of the host the event was recorded on.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -638,6 +682,8 @@ Name of the host the event was recorded on. It can contain same information as h
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`host.ip`*::
@@ -647,6 +693,8 @@ IP of the host that records the event.
 
 
 type: ip
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -664,6 +712,8 @@ The platform of the host the event was recorded on.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -683,6 +733,8 @@ May be filtered to protect sensitive information.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`process.pid`*::
@@ -692,6 +744,8 @@ Numeric process ID of the service process.
 
 
 type: long
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -703,6 +757,8 @@ Numeric ID of the service's parent process.
 
 type: long
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`process.title`*::
@@ -712,6 +768,8 @@ Service process title.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -734,6 +792,8 @@ Hostname of the APM Server.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`observer.version`*::
@@ -743,6 +803,8 @@ APM Server version.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -764,6 +826,8 @@ The type will be set to `apm-server`.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 
@@ -775,6 +839,8 @@ The username of the logged in user.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user.id`*::
@@ -785,6 +851,8 @@ Identifier of the logged in user.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user.email`*::
@@ -794,6 +862,8 @@ Email of the logged in user.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -806,6 +876,8 @@ IP address of the client of a recorded event. This is typically obtained from a 
 
 type: ip
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 
@@ -816,6 +888,8 @@ IP address of the source of a recorded event. This is typically obtained from a 
 
 
 type: ip
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -834,6 +908,8 @@ Then it should be duplicated to `.ip` or `.domain`, depending on which one it is
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`destination.ip`*::
@@ -843,6 +919,8 @@ IP addess of the destination.
 Can be one of multiple IPv4 or IPv6 addresses.
 
 type: ip
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -854,6 +932,8 @@ Port of the destination.
 type: long
 
 format: string
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -874,6 +954,8 @@ type: keyword
 
 example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user_agent.original.text`*::
@@ -883,6 +965,8 @@ Software agent acting in behalf of a user, eg. a web browser / OS combination.
 
 
 type: text
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -896,6 +980,8 @@ type: keyword
 
 example: Safari
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user_agent.version`*::
@@ -907,6 +993,8 @@ Version of the user agent.
 type: keyword
 
 example: 12.0
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -927,6 +1015,8 @@ type: keyword
 
 example: iPhone
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 [float]
@@ -946,6 +1036,8 @@ type: keyword
 
 example: darwin
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user_agent.os.name`*::
@@ -957,6 +1049,8 @@ Operating system name, without the version.
 type: keyword
 
 example: Mac OS X
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -970,6 +1064,8 @@ type: keyword
 
 example: Mac OS Mojave
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user_agent.os.family`*::
@@ -981,6 +1077,8 @@ OS family (such as redhat, debian, freebsd, windows).
 type: keyword
 
 example: debian
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -994,6 +1092,8 @@ type: keyword
 
 example: 10.14.1
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user_agent.os.kernel`*::
@@ -1005,6 +1105,8 @@ Operating system kernel version as a raw string.
 type: keyword
 
 example: 4.4.0-112-generic
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -1032,6 +1134,8 @@ Cloud account ID
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`cloud.account.name`*::
@@ -1040,6 +1144,8 @@ type: keyword
 Cloud account name
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -1052,6 +1158,8 @@ type: keyword
 
 example: us-east1-a
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 
@@ -1062,6 +1170,8 @@ Cloud instance/machine ID
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`cloud.instance.name`*::
@@ -1070,6 +1180,8 @@ type: keyword
 Cloud instance/machine name
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -1083,6 +1195,8 @@ type: keyword
 
 example: t2.medium
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 
@@ -1093,6 +1207,8 @@ Cloud project ID
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`cloud.project.name`*::
@@ -1101,6 +1217,8 @@ type: keyword
 Cloud project name
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -1113,6 +1231,8 @@ type: keyword
 
 example: gcp
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`cloud.region`*::
@@ -1123,6 +1243,8 @@ Cloud region name
 type: keyword
 
 example: us-east1
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -1136,6 +1258,8 @@ example: us-east1
 type: keyword
 
 example: success
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -1159,6 +1283,8 @@ The ID of the error.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -2061,8 +2187,15 @@ type: object
 [[exported-fields-ecs]]
 == ECS fields
 
-ECS Fields.
 
+This section defines Elastic Common Schema (ECS) fields—a common set of fields
+to be used when storing event data in {es}.
+
+This is an exhaustive list, and fields listed here are not necessarily used by {beatname_uc}.
+The goal of ECS is to enable and encourage users of {es} to normalize their event data,
+so that they can better analyze, visualize, and correlate the data represented in their events.
+
+See the {ecs-ref}[ECS reference] for more information.
 
 *`@timestamp`*::
 +


### PR DESCRIPTION
Backports the following commits to 7.10:
 - docs: Update field ref with ECS icon (#4272)