### PR TITLE
decoder v2: redact input information from decode error

### DIFF
--- a/beater/api/intake/test_approved/InvalidEvent.approved.json
+++ b/beater/api/intake/test_approved/InvalidEvent.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{ \"transaction\": { \"id\": 12345, \"trace_id\": \"0123456789abcdef0123456789abcdef\", \"parent_id\": \"abcdefabcdef01234567\", \"type\": \"request\", \"duration\": 32.592981, \"span_count\": { \"started\": 21 } } }   ",
-            "message": "decode error: data read error: v2.transactionRoot.Transaction: v2.transaction.ID: ReadString: expects \" or n, "
+            "message": "decode error: data read error: v2.transactionRoot.Transaction: v2.transaction.ID: ReadString: expects \" or n,"
         }
     ]
 }

--- a/beater/api/intake/test_approved/InvalidEvent.approved.json
+++ b/beater/api/intake/test_approved/InvalidEvent.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{ \"transaction\": { \"id\": 12345, \"trace_id\": \"0123456789abcdef0123456789abcdef\", \"parent_id\": \"abcdefabcdef01234567\", \"type\": \"request\", \"duration\": 32.592981, \"span_count\": { \"started\": 21 } } }   ",
-            "message": "decode error: data read error: v2.transactionRoot.Transaction: v2.transaction.ID: ReadString: expects \" or n, but found 1, error found in #10 byte of ...| { \"id\": 12345, \"tra|..., bigger context ...|{ \"transaction\": { \"id\": 12345, \"trace_id\": \"0123456789abcdef0123456789abcde|..."
+            "message": "decode error: data read error: v2.transactionRoot.Transaction: v2.transaction.ID: ReadString: invalid"
         }
     ]
 }

--- a/beater/api/intake/test_approved/InvalidEvent.approved.json
+++ b/beater/api/intake/test_approved/InvalidEvent.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{ \"transaction\": { \"id\": 12345, \"trace_id\": \"0123456789abcdef0123456789abcdef\", \"parent_id\": \"abcdefabcdef01234567\", \"type\": \"request\", \"duration\": 32.592981, \"span_count\": { \"started\": 21 } } }   ",
-            "message": "decode error: data read error: v2.transactionRoot.Transaction: v2.transaction.ID: ReadString: invalid"
+            "message": "decode error: data read error: v2.transactionRoot.Transaction: v2.transaction.ID: ReadString: expects \" or n, "
         }
     ]
 }

--- a/beater/api/intake/test_approved/InvalidJSONMetadata.approved.json
+++ b/beater/api/intake/test_approved/InvalidJSONMetadata.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{\"metadata\": {\"invalid-json\"}}",
-            "message": "decode error: data read error: v2.metadataRoot.Metadata: v2.metadata.readFieldHash: expect :, but found }, error found in #10 byte of ...|lid-json\"}}|..., bigger context ...|{\"metadata\": {\"invalid-json\"}}|..."
+            "message": "decode error: data read error: v2.metadataRoot.Metadata: v2.metadata.readFieldHash: invalid"
         }
     ]
 }

--- a/beater/api/intake/test_approved/InvalidJSONMetadata.approved.json
+++ b/beater/api/intake/test_approved/InvalidJSONMetadata.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{\"metadata\": {\"invalid-json\"}}",
-            "message": "decode error: data read error: v2.metadataRoot.Metadata: v2.metadata.readFieldHash: expect :, "
+            "message": "decode error: data read error: v2.metadataRoot.Metadata: v2.metadata.readFieldHash: expect :,"
         }
     ]
 }

--- a/beater/api/intake/test_approved/InvalidJSONMetadata.approved.json
+++ b/beater/api/intake/test_approved/InvalidJSONMetadata.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{\"metadata\": {\"invalid-json\"}}",
-            "message": "decode error: data read error: v2.metadataRoot.Metadata: v2.metadata.readFieldHash: invalid"
+            "message": "decode error: data read error: v2.metadataRoot.Metadata: v2.metadata.readFieldHash: expect :, "
         }
     ]
 }

--- a/model/modeldecoder/v2/decoder.go
+++ b/model/modeldecoder/v2/decoder.go
@@ -42,11 +42,11 @@ type DecodeError struct {
 	err error
 }
 
-var jsoniterErrRegexp = regexp.MustCompile(`expect.* but found .*error found in .* bigger context.*`)
+var jsoniterErrRegexp = regexp.MustCompile(`but found .*error found in .* bigger context.*`)
 
 func newDecodeErrFromJSONIter(err error) DecodeError {
 	if jsoniterErrRegexp.MatchString(err.Error()) {
-		err = errors.New(jsoniterErrRegexp.ReplaceAllString(err.Error(), "invalid"))
+		err = errors.New(jsoniterErrRegexp.ReplaceAllString(err.Error(), ""))
 	}
 	return DecodeError{err}
 }

--- a/model/modeldecoder/v2/decoder.go
+++ b/model/modeldecoder/v2/decoder.go
@@ -42,7 +42,7 @@ type DecodeError struct {
 	err error
 }
 
-var jsoniterErrRegexp = regexp.MustCompile(`but found .*error found in .* bigger context.*`)
+var jsoniterErrRegexp = regexp.MustCompile(` but found .*error found in .* bigger context.*`)
 
 func newDecodeErrFromJSONIter(err error) DecodeError {
 	if jsoniterErrRegexp.MatchString(err.Error()) {

--- a/processor/stream/test_approved_stream_result/testIntegrationResultInvalidEvent.approved.json
+++ b/processor/stream/test_approved_stream_result/testIntegrationResultInvalidEvent.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{ \"transaction\": { \"id\": 12345, \"trace_id\": \"0123456789abcdef0123456789abcdef\", \"parent_id\": \"abcdefabcdef01234567\", \"type\": \"request\", \"duration\": 32.592981, \"span_count\": { \"started\": 21 } } }   ",
-            "message": "decode error: data read error: v2.transactionRoot.Transaction: v2.transaction.ID: ReadString: expects \" or n, "
+            "message": "decode error: data read error: v2.transactionRoot.Transaction: v2.transaction.ID: ReadString: expects \" or n,"
         }
     ]
 }

--- a/processor/stream/test_approved_stream_result/testIntegrationResultInvalidEvent.approved.json
+++ b/processor/stream/test_approved_stream_result/testIntegrationResultInvalidEvent.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{ \"transaction\": { \"id\": 12345, \"trace_id\": \"0123456789abcdef0123456789abcdef\", \"parent_id\": \"abcdefabcdef01234567\", \"type\": \"request\", \"duration\": 32.592981, \"span_count\": { \"started\": 21 } } }   ",
-            "message": "decode error: data read error: v2.transactionRoot.Transaction: v2.transaction.ID: ReadString: expects \" or n, but found 1, error found in #10 byte of ...| { \"id\": 12345, \"tra|..., bigger context ...|{ \"transaction\": { \"id\": 12345, \"trace_id\": \"0123456789abcdef0123456789abcde|..."
+            "message": "decode error: data read error: v2.transactionRoot.Transaction: v2.transaction.ID: ReadString: invalid"
         }
     ]
 }

--- a/processor/stream/test_approved_stream_result/testIntegrationResultInvalidEvent.approved.json
+++ b/processor/stream/test_approved_stream_result/testIntegrationResultInvalidEvent.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{ \"transaction\": { \"id\": 12345, \"trace_id\": \"0123456789abcdef0123456789abcdef\", \"parent_id\": \"abcdefabcdef01234567\", \"type\": \"request\", \"duration\": 32.592981, \"span_count\": { \"started\": 21 } } }   ",
-            "message": "decode error: data read error: v2.transactionRoot.Transaction: v2.transaction.ID: ReadString: invalid"
+            "message": "decode error: data read error: v2.transactionRoot.Transaction: v2.transaction.ID: ReadString: expects \" or n, "
         }
     ]
 }

--- a/processor/stream/test_approved_stream_result/testIntegrationResultInvalidJSONMetadata.approved.json
+++ b/processor/stream/test_approved_stream_result/testIntegrationResultInvalidJSONMetadata.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{\"metadata\": {\"invalid-json\"}}",
-            "message": "decode error: data read error: v2.metadataRoot.Metadata: v2.metadata.readFieldHash: expect :, but found }, error found in #10 byte of ...|lid-json\"}}|..., bigger context ...|{\"metadata\": {\"invalid-json\"}}|..."
+            "message": "decode error: data read error: v2.metadataRoot.Metadata: v2.metadata.readFieldHash: invalid"
         }
     ]
 }

--- a/processor/stream/test_approved_stream_result/testIntegrationResultInvalidJSONMetadata.approved.json
+++ b/processor/stream/test_approved_stream_result/testIntegrationResultInvalidJSONMetadata.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{\"metadata\": {\"invalid-json\"}}",
-            "message": "decode error: data read error: v2.metadataRoot.Metadata: v2.metadata.readFieldHash: expect :, "
+            "message": "decode error: data read error: v2.metadataRoot.Metadata: v2.metadata.readFieldHash: expect :,"
         }
     ]
 }

--- a/processor/stream/test_approved_stream_result/testIntegrationResultInvalidJSONMetadata.approved.json
+++ b/processor/stream/test_approved_stream_result/testIntegrationResultInvalidJSONMetadata.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{\"metadata\": {\"invalid-json\"}}",
-            "message": "decode error: data read error: v2.metadataRoot.Metadata: v2.metadata.readFieldHash: invalid"
+            "message": "decode error: data read error: v2.metadataRoot.Metadata: v2.metadata.readFieldHash: expect :, "
         }
     ]
 }


### PR DESCRIPTION
Avoid logging any input information on decode error.

<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Before creating the PR, ensure that:

1. Your branch is rebased on top of the latest master.
   Squash your initial commits into meaningful commits.
   After creating a PR, do not rebase of force push any longer.
2. Nothing is broken, by running the test suite (at least unit tests).
   See https://github.com/elastic/apm-server/blob/master/TESTING.md for details.
3. Your code follows the style guidelines of this project:
   run `make check-full` for static code checks and linting.

A few suggestions about filling out this PR:

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR.
3. Please label this PR with at least one of the following labels:
   - bug fix
   - breaking change
   - enhancement
4. Reference the related issue, and make use of magic keywords where it makes sense
   https://help.github.com/articles/closing-issues-using-keywords/.
5. Do not remove any checklist items, strike through the ones that don't apply
   (by using tildes, e.g. ~scratch this ~).
6. Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
7. Submit the pull request:
   Push your changes to your forked copy of the repository and submit a pull request
   (https://help.github.com/articles/using-pull-requests).
8. Please be patient. We might not be able to immediately review your code,
   but we'll do our best to dedicate to it the attention it deserves.
   Your effort is much appreciated!

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

APM Server should not log APM agent data on decode errors, it should log as much information as possible to identify the root cause for the failure though. 

https://github.com/json-iterator/go adds input information as context to the error message, which should not be logged. Error information is added hierarchically, but errors are not wrapped, so there is no good way of unwrapping and only keeping the _outer part_ of the error message. 
A possibility I looked into was to use `jsoniter.RegisterTypeDecoderFunc(string, func(ptr unsafe.Pointer, iter *Iterator)` for registering a decoder wrapper for every custom struct, reusing the default json-iter struct decoder, while being able to access and manipulate the `iter.Error` after decoding. Unfortunately I did not find a good way to do that, as the default decoders are not exported.

Every error is registered via calling the `iterator.ReportError(operation string, msg string)` method, which always wraps the error information in a fixed error message format. This PR removes any input information by using a regexp to match against this error wrapper message. This is a bit fragile as it depends on some internas of the `json-iterator`, but at least it is only one place where the information is set. Changes in the `json-iterator` behavior should be covered by our approval tests containing error messages. 

## Checklist

~- [ ] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).~
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
`- [ ] documentation~
- [x] logging (add log lines, choose appropriate log selector, etc.)
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
- [x] Elasticsearch Service (https://cloud.elastic.co)
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes
start APM Server and send documents leading to a decoding error; check the server logs

## Related issues
#3551 
