### PR TITLE
[DOCS] Update link to Logs app content

### DIFF
--- a/docs/guide/obs-integrations.asciidoc
+++ b/docs/guide/obs-integrations.asciidoc
@@ -12,7 +12,7 @@ Many applications use logging frameworks to help record, format, and append an a
 Elastic APM now offers a way to make your application logs even more useful,
 by integrating with the most popular logging frameworks in their respective languages.
 This means you can easily inject trace information into your logs,
-allowing you to explore logs in the {kibana-ref}/xpack-logs.html[Logs app],
+allowing you to explore logs in the {observability-guide}/monitor-logs.html[Logs app],
 then jump straight into the corresponding APM traces -- all while preserving the trace context.
 
 To get started:


### PR DESCRIPTION
Due to build failures on the [Kibana docs PR](https://github.com/elastic/kibana/pull/79978), this PR updates the link to the Logs app content. 

This update gives us the opportunity to link directly to the Logs app content in the Observability guide, rather than to the new content in the Kibana PR. 

### Related PRs

https://github.com/elastic/kibana/pull/79978