### PR TITLE
[7.10] decoder v2: redact input information from decode error (#4286)

### DIFF
--- a/beater/api/intake/test_approved/InvalidEvent.approved.json
+++ b/beater/api/intake/test_approved/InvalidEvent.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{ \"transaction\": { \"id\": 12345, \"trace_id\": \"0123456789abcdef0123456789abcdef\", \"parent_id\": \"abcdefabcdef01234567\", \"type\": \"request\", \"duration\": 32.592981, \"span_count\": { \"started\": 21 } } }   ",
-            "message": "decode error: data read error: v2.transactionRoot.Transaction: v2.transaction.ID: ReadString: expects \" or n, but found 1, error found in #10 byte of ...| { \"id\": 12345, \"tra|..., bigger context ...|{ \"transaction\": { \"id\": 12345, \"trace_id\": \"0123456789abcdef0123456789abcde|..."
+            "message": "decode error: data read error: v2.transactionRoot.Transaction: v2.transaction.ID: ReadString: expects \" or n,"
         }
     ]
 }

--- a/beater/api/intake/test_approved/InvalidJSONMetadata.approved.json
+++ b/beater/api/intake/test_approved/InvalidJSONMetadata.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{\"metadata\": {\"invalid-json\"}}",
-            "message": "decode error: data read error: v2.metadataRoot.Metadata: v2.metadata.readFieldHash: expect :, but found }, error found in #10 byte of ...|lid-json\"}}|..., bigger context ...|{\"metadata\": {\"invalid-json\"}}|..."
+            "message": "decode error: data read error: v2.metadataRoot.Metadata: v2.metadata.readFieldHash: expect :,"
         }
     ]
 }

--- a/model/modeldecoder/v2/decoder.go
+++ b/model/modeldecoder/v2/decoder.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"net/textproto"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -39,6 +40,15 @@ import (
 // DecodeError represents an error due to JSON decoding.
 type DecodeError struct {
 	err error
+}
+
+var jsoniterErrRegexp = regexp.MustCompile(` but found .*error found in .* bigger context.*`)
+
+func newDecodeErrFromJSONIter(err error) DecodeError {
+	if jsoniterErrRegexp.MatchString(err.Error()) {
+		err = errors.New(jsoniterErrRegexp.ReplaceAllString(err.Error(), ""))
+	}
+	return DecodeError{err}
 }
 
 func (e DecodeError) Error() string {
@@ -150,7 +160,7 @@ func DecodeNestedError(d decoder.Decoder, input *modeldecoder.Input, out *model.
 	defer releaseErrorRoot(root)
 	var err error
 	if err = d.Decode(&root); err != nil && err != io.EOF {
-		return DecodeError{err}
+		return newDecodeErrFromJSONIter(err)
 	}
 	if err := root.validate(); err != nil {
 		return ValidationError{err}
@@ -169,7 +179,7 @@ func DecodeNestedSpan(d decoder.Decoder, input *modeldecoder.Input, out *model.S
 	defer releaseSpanRoot(root)
 	var err error
 	if err = d.Decode(&root); err != nil && err != io.EOF {
-		return DecodeError{err}
+		return newDecodeErrFromJSONIter(err)
 	}
 	if err := root.validate(); err != nil {
 		return ValidationError{err}
@@ -188,7 +198,7 @@ func DecodeNestedTransaction(d decoder.Decoder, input *modeldecoder.Input, out *
 	defer releaseTransactionRoot(root)
 	var err error
 	if err = d.Decode(&root); err != nil && err != io.EOF {
-		return DecodeError{err}
+		return newDecodeErrFromJSONIter(err)
 	}
 	if err := root.validate(); err != nil {
 		return ValidationError{err}
@@ -202,7 +212,7 @@ func decodeMetadata(decFn func(d decoder.Decoder, m *metadataRoot) error, d deco
 	defer releaseMetadataRoot(m)
 	var err error
 	if err = decFn(d, m); err != nil && err != io.EOF {
-		return DecodeError{err}
+		return newDecodeErrFromJSONIter(err)
 	}
 	if err := m.validate(); err != nil {
 		return ValidationError{err}

--- a/processor/stream/test_approved_stream_result/testIntegrationResultInvalidEvent.approved.json
+++ b/processor/stream/test_approved_stream_result/testIntegrationResultInvalidEvent.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{ \"transaction\": { \"id\": 12345, \"trace_id\": \"0123456789abcdef0123456789abcdef\", \"parent_id\": \"abcdefabcdef01234567\", \"type\": \"request\", \"duration\": 32.592981, \"span_count\": { \"started\": 21 } } }   ",
-            "message": "decode error: data read error: v2.transactionRoot.Transaction: v2.transaction.ID: ReadString: expects \" or n, but found 1, error found in #10 byte of ...| { \"id\": 12345, \"tra|..., bigger context ...|{ \"transaction\": { \"id\": 12345, \"trace_id\": \"0123456789abcdef0123456789abcde|..."
+            "message": "decode error: data read error: v2.transactionRoot.Transaction: v2.transaction.ID: ReadString: expects \" or n,"
         }
     ]
 }

--- a/processor/stream/test_approved_stream_result/testIntegrationResultInvalidJSONMetadata.approved.json
+++ b/processor/stream/test_approved_stream_result/testIntegrationResultInvalidJSONMetadata.approved.json
@@ -3,7 +3,7 @@
     "errors": [
         {
             "document": "{\"metadata\": {\"invalid-json\"}}",
-            "message": "decode error: data read error: v2.metadataRoot.Metadata: v2.metadata.readFieldHash: expect :, but found }, error found in #10 byte of ...|lid-json\"}}|..., bigger context ...|{\"metadata\": {\"invalid-json\"}}|..."
+            "message": "decode error: data read error: v2.metadataRoot.Metadata: v2.metadata.readFieldHash: expect :,"
         }
     ]
 }


### PR DESCRIPTION
Backports the following commits to 7.10:
 - decoder v2: redact input information from decode error (#4286)