### PR TITLE
Integrate tail-based sampling

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -212,6 +212,7 @@ func (bt *beater) Run(b *beat.Beat) error {
 	bt.mutex.Unlock()
 
 	return runServer(ctx, ServerParams{
+		Info:     b.Info,
 		Config:   bt.config,
 		Logger:   bt.logger,
 		Tracer:   tracer,

--- a/beater/config/config.go
+++ b/beater/config/config.go
@@ -137,6 +137,12 @@ func NewConfig(ucfg *common.Config, outputESCfg *common.Config) (*Config, error)
 		return nil, err
 	}
 
+	if c.Sampling.Tail != nil {
+		if err := c.Sampling.Tail.setup(logger, outputESCfg); err != nil {
+			return nil, err
+		}
+	}
+
 	if !c.Sampling.KeepUnsampled && !c.Aggregation.Transactions.Enabled {
 		// Unsampled transactions should only be dropped
 		// when transaction aggregation is enabled in the

--- a/beater/config/sampling.go
+++ b/beater/config/sampling.go
@@ -43,11 +43,11 @@ type TailSamplingConfig struct {
 
 	DefaultSampleRate     float64               `config:"default_sample_rate" validate:"min=0, max=1"`
 	ESConfig              *elasticsearch.Config `config:"elasticsearch"`
-	Interval              time.Duration         `config:"interval" validate:"min=1"`
+	Interval              time.Duration         `config:"interval" validate:"min=1s"`
 	IngestRateDecayFactor float64               `config:"ingest_rate_decay" validate:"min=0, max=1"`
 	StorageDir            string                `config:"storage_dir"`
-	StorageGCInterval     time.Duration         `config:"storage_gc_interval" validate:"min=1"`
-	TTL                   time.Duration         `config:"ttl" validate:"min=1"`
+	StorageGCInterval     time.Duration         `config:"storage_gc_interval" validate:"min=1s"`
+	TTL                   time.Duration         `config:"ttl" validate:"min=1s"`
 
 	esConfigured bool
 }

--- a/beater/config/sampling.go
+++ b/beater/config/sampling.go
@@ -17,17 +17,84 @@
 
 package config
 
+import (
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/apm-server/elasticsearch"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
 // SamplingConfig holds configuration related to sampling.
 type SamplingConfig struct {
 	// KeepUnsampled controls whether unsampled
 	// transactions should be recorded.
 	KeepUnsampled bool `config:"keep_unsampled"`
+
+	// Tail holds tail-sampling configuration.
+	Tail *TailSamplingConfig `config:"tail"`
+}
+
+// TailSamplingConfig holds configuration related to tail-sampling.
+type TailSamplingConfig struct {
+	Enabled bool `config:"enabled"`
+
+	DefaultSampleRate     float64               `config:"default_sample_rate" validate:"min=0, max=1"`
+	ESConfig              *elasticsearch.Config `config:"elasticsearch"`
+	Interval              time.Duration         `config:"interval" validate:"min=1"`
+	IngestRateDecayFactor float64               `config:"ingest_rate_decay" validate:"min=0, max=1"`
+	StorageDir            string                `config:"storage_dir"`
+	StorageGCInterval     time.Duration         `config:"storage_gc_interval" validate:"min=1"`
+	TTL                   time.Duration         `config:"ttl" validate:"min=1"`
+
+	esConfigured bool
+}
+
+func (c *TailSamplingConfig) Unpack(in *common.Config) error {
+	type tailSamplingConfig TailSamplingConfig
+	cfg := tailSamplingConfig(defaultTailSamplingConfig())
+	if err := in.Unpack(&cfg); err != nil {
+		return errors.Wrap(err, "error unpacking tail sampling config")
+	}
+	*c = TailSamplingConfig(cfg)
+	c.esConfigured = in.HasField("elasticsearch")
+	return nil
+}
+
+func (c *TailSamplingConfig) setup(log *logp.Logger, outputESCfg *common.Config) error {
+	if !c.Enabled {
+		return nil
+	}
+	if !c.esConfigured && outputESCfg != nil {
+		log.Info("Falling back to elasticsearch output for tail-sampling")
+		if err := outputESCfg.Unpack(&c.ESConfig); err != nil {
+			return errors.Wrap(err, "error unpacking output.elasticsearch config for tail sampling")
+		}
+	}
+	return nil
 }
 
 func defaultSamplingConfig() SamplingConfig {
+	tail := defaultTailSamplingConfig()
 	return SamplingConfig{
 		// In a future major release we will set this to
 		// false, and then later remove the option.
 		KeepUnsampled: true,
+		Tail:          &tail,
+	}
+}
+
+func defaultTailSamplingConfig() TailSamplingConfig {
+	return TailSamplingConfig{
+		Enabled:               false,
+		ESConfig:              elasticsearch.DefaultConfig(),
+		DefaultSampleRate:     0.5,
+		Interval:              1 * time.Minute,
+		IngestRateDecayFactor: 0.25,
+		StorageDir:            "tail_sampling",
+		StorageGCInterval:     5 * time.Minute,
+		TTL:                   30 * time.Minute,
 	}
 }

--- a/beater/server.go
+++ b/beater/server.go
@@ -24,6 +24,7 @@ import (
 	"go.elastic.co/apm"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/version"
 
@@ -38,6 +39,9 @@ type RunServerFunc func(context.Context, ServerParams) error
 
 // ServerParams holds parameters for running the APM Server.
 type ServerParams struct {
+	// Info holds metadata about the server, such as its UUID.
+	Info beat.Info
+
 	// Config is the configuration used for running the APM Server.
 	Config *config.Config
 

--- a/systemtest/apmservertest/config.go
+++ b/systemtest/apmservertest/config.go
@@ -104,7 +104,30 @@ type JaegerConfig struct {
 
 // SamplingConfig holds APM Server trace sampling configuration.
 type SamplingConfig struct {
-	KeepUnsampled bool `json:"keep_unsampled"`
+	KeepUnsampled bool                `json:"keep_unsampled"`
+	Tail          *TailSamplingConfig `json:"tail,omitempty"`
+}
+
+// TailSamplingConfig holds APM Server tail-based sampling configuration.
+type TailSamplingConfig struct {
+	Enabled           bool
+	Interval          time.Duration
+	DefaultSampleRate float64
+}
+
+func (t *TailSamplingConfig) MarshalJSON() ([]byte, error) {
+	// time.Duration is encoded as int64.
+	// Convert time.Durations to durations, to encode as duration strings.
+	type config struct {
+		Enabled           bool     `json:"enabled"`
+		Interval          duration `json:"interval"`
+		DefaultSampleRate float64  `json:"default_sample_rate"`
+	}
+	return json.Marshal(config{
+		Enabled:           t.Enabled,
+		Interval:          duration(t.Interval),
+		DefaultSampleRate: t.DefaultSampleRate,
+	})
 }
 
 // RUMConfig holds APM Server RUM configuration.

--- a/systemtest/estest/search.go
+++ b/systemtest/estest/search.go
@@ -67,6 +67,11 @@ func (r *SearchRequest) WithQuery(q interface{}) *SearchRequest {
 	return r
 }
 
+func (r *SearchRequest) WithSize(size int) *SearchRequest {
+	r.Size = &size
+	return r
+}
+
 func (r *SearchRequest) Do(ctx context.Context, out *SearchResult, opts ...RequestOption) (*esapi.Response, error) {
 	return r.es.Do(ctx, &r.SearchRequest, out, opts...)
 }

--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
@@ -173,7 +173,7 @@ func (a *Aggregator) publish(ctx context.Context) error {
 //
 // This method is expected to be used immediately prior to publishing
 // the events.
-func (a *Aggregator) ProcessTransformables(in []transform.Transformable) []transform.Transformable {
+func (a *Aggregator) ProcessTransformables(ctx context.Context, in []transform.Transformable) ([]transform.Transformable, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	out := in
@@ -184,7 +184,7 @@ func (a *Aggregator) ProcessTransformables(in []transform.Transformable) []trans
 			}
 		}
 	}
-	return out
+	return out, nil
 }
 
 func (a *Aggregator) processSpan(span *model.Span) *model.Metricset {

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -222,7 +222,7 @@ func (a *Aggregator) publish(ctx context.Context) error {
 // This method is expected to be used immediately prior to publishing
 // the events, so that the metricsets requiring immediate publication
 // can be included in the same batch.
-func (a *Aggregator) ProcessTransformables(in []transform.Transformable) []transform.Transformable {
+func (a *Aggregator) ProcessTransformables(ctx context.Context, in []transform.Transformable) ([]transform.Transformable, error) {
 	out := in
 	for _, tf := range in {
 		if tx, ok := tf.(*model.Transaction); ok {
@@ -231,7 +231,7 @@ func (a *Aggregator) ProcessTransformables(in []transform.Transformable) []trans
 			}
 		}
 	}
-	return out
+	return out, nil
 }
 
 // AggregateTransaction aggregates transaction metrics.

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
@@ -90,7 +90,8 @@ func TestProcessTransformablesOverflow(t *testing.T) {
 		input = append(input, &model.Transaction{Name: "foo", RepresentativeCount: 1})
 		input = append(input, &model.Transaction{Name: "bar", RepresentativeCount: 1})
 	}
-	output := agg.ProcessTransformables(input)
+	output, err := agg.ProcessTransformables(context.Background(), input)
+	require.NoError(t, err)
 	assert.Equal(t, input, output)
 
 	// The third transaction group will return a metricset for immediate publication.
@@ -101,7 +102,8 @@ func TestProcessTransformablesOverflow(t *testing.T) {
 			RepresentativeCount: 1,
 		})
 	}
-	output = agg.ProcessTransformables(input)
+	output, err = agg.ProcessTransformables(context.Background(), input)
+	require.NoError(t, err)
 	assert.Len(t, output, len(input)+2)
 	assert.Equal(t, input, output[:len(input)])
 

--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -439,7 +439,7 @@ func newTempdirConfig(tb testing.TB) sampling.Config {
 		},
 		RemoteSamplingConfig: sampling.RemoteSamplingConfig{
 			Elasticsearch:      pubsubtest.Client(nil, nil),
-			SampledTracesIndex: ".apm-sampled-traces",
+			SampledTracesIndex: "apm-sampled-traces",
 		},
 		StorageConfig: sampling.StorageConfig{
 			StorageDir:        tempdir,


### PR DESCRIPTION
## Motivation/summary

Introduce configuration for tail-based sampling, and switch it on. Added a system test which runs two apm-server instances, and shows that tail-sampling works across them.

The configuration is only for testing/development, and is almost certainly going to change before we release anything. Documentation will come later once we've finalised things.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
- [x] logging (add log lines, choose appropriate log selector, etc.)
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~ (later)
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~ (later)
- [x] Elasticsearch Service (https://cloud.elastic.co)
- [x] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)
- [x] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)

## How to test these changes

Run apm-server with `-E apm-server.sampling.tail.enabled`. If multiple servers are in use, make sure the `apm-sampled-traces` index is pre-created with the appropriate mapping (see system tests).

## Related issues

Part of #4185 