### PR TITLE
systemtest: use ECS logging

### DIFF
--- a/systemtest/apmservertest/logs.go
+++ b/systemtest/apmservertest/logs.go
@@ -160,7 +160,8 @@ type LogEntry struct {
 	Timestamp time.Time
 	Level     zapcore.Level
 	Logger    string
-	Caller    string
+	File      string
+	Line      int
 	Message   string
 	Fields    map[string]interface{}
 }

--- a/systemtest/apmservertest/server.go
+++ b/systemtest/apmservertest/server.go
@@ -125,7 +125,9 @@ func (s *Server) Start() error {
 	cfgargs, err := configArgs(s.Config, map[string]interface{}{
 		// These are config attributes that we always specify,
 		// as the testing framework relies on them being set.
+		"logging.ecs":               true,
 		"logging.json":              true,
+		"logging.level":             "debug",
 		"logging.to_stderr":         true,
 		"apm-server.expvar.enabled": true,
 		"apm-server.host":           "127.0.0.1:0",
@@ -286,11 +288,14 @@ func (s *Server) consumeStderr(procStderr io.Reader) {
 	s.Stderr = stderrPipeReader
 
 	type logEntry struct {
-		Timestamp logpTimestamp
-		Level     zapcore.Level
-		Logger    string
-		Caller    string
-		Message   string
+		Timestamp logpTimestamp `json:"@timestamp"`
+		Message   string        `json:"message"`
+		Level     zapcore.Level `json:"log.level"`
+		Logger    string        `json:"log.logger"`
+		Origin    struct {
+			File string `json:"file.name"`
+			Line int    `json:"file.line"`
+		} `json:"log.origin"`
 	}
 
 	decoder := json.NewDecoder(procStderr)
@@ -307,16 +312,17 @@ func (s *Server) consumeStderr(procStderr io.Reader) {
 		if err := json.Unmarshal(raw, &fields); err != nil {
 			break
 		}
-		delete(fields, "timestamp")
-		delete(fields, "level")
-		delete(fields, "logger")
-		delete(fields, "caller")
+		delete(fields, "@timestamp")
+		delete(fields, "log.level")
+		delete(fields, "log.logger")
+		delete(fields, "log.origin")
 		delete(fields, "message")
 		s.Logs.add(LogEntry{
 			Timestamp: time.Time(entry.Timestamp),
 			Logger:    entry.Logger,
 			Level:     entry.Level,
-			Caller:    entry.Caller,
+			File:      entry.Origin.File,
+			Line:      entry.Origin.Line,
 			Message:   entry.Message,
 			Fields:    fields,
 		})


### PR DESCRIPTION
## Motivation/summary

Configure ECS logging, as it is the future of our logging.
Increase the log level to debug, for debugging test failures.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

`cd systemtest && go test -v`

## Related issues

None.