### PR TITLE
[7.9] fix: ensure ES index names are lowercase (#4295)

### DIFF
--- a/changelogs/7.9.asciidoc
+++ b/changelogs/7.9.asciidoc
@@ -3,9 +3,20 @@
 
 https://github.com/elastic/apm-server/compare/7.8\...7.9[View commits]
 
+* <<release-notes-7.9.3>>
 * <<release-notes-7.9.2>>
 * <<release-notes-7.9.1>>
 * <<release-notes-7.9.0>>
+
+[float]
+[[release-notes-7.9.3]]
+=== APM Server version 7.9.3
+
+https://github.com/elastic/apm-server/compare/v7.9.2\...v7.9.3[View commits]
+
+[float]
+==== Bug fixes
+* Ensure custom index names are lowercased {pull}4295[4295]
 
 [float]
 [[release-notes-7.9.2]]

--- a/idxmgmt/supporter.go
+++ b/idxmgmt/supporter.go
@@ -19,6 +19,7 @@ package idxmgmt
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	"go.uber.org/atomic"
@@ -176,6 +177,7 @@ func (s *supporter) buildSelector(cfg *common.Config, err error) (outil.Selector
 		MultiKey:         "indices",
 		EnableSingleOnly: true,
 		FailEmpty:        true,
+		Case:             outil.SelectorLowerCase,
 	}
 	return outil.BuildSelectorFromConfig(cfg, buildSettings)
 }
@@ -236,7 +238,7 @@ func getEventCustomIndex(evt *beat.Event) string {
 	// returns index from alias
 	if tmp := evt.Meta["alias"]; tmp != nil {
 		if alias, ok := tmp.(string); ok {
-			return alias
+			return strings.ToLower(alias)
 		}
 	}
 
@@ -245,7 +247,7 @@ func getEventCustomIndex(evt *beat.Event) string {
 		if idx, ok := tmp.(string); ok {
 			ts := evt.Timestamp.UTC()
 			return fmt.Sprintf("%s-%d.%02d.%02d",
-				idx, ts.Year(), ts.Month(), ts.Day())
+				strings.ToLower(idx), ts.Year(), ts.Month(), ts.Day())
 		}
 	}
 

--- a/idxmgmt/supporter_test.go
+++ b/idxmgmt/supporter_test.go
@@ -148,26 +148,26 @@ func TestIndexSupport_BuildSelector(t *testing.T) {
 			withIlm: "apm-7.0.0-sourcemap",
 			fields:  common.MapStr{"processor.event": "sourcemap"},
 		},
-		"MetaInformationAlias": {
+		"MetaInformationAlia-lowercased": {
 			noIlm:   "apm-7.0.0-meta",
 			withIlm: "apm-7.0.0-meta", //meta overwrites ilm
 			fields:  common.MapStr{"processor.event": "span"},
-			meta:    common.MapStr{"alias": "apm-7.0.0-meta", "index": "test-123"},
+			meta:    common.MapStr{"alias": "APM-7.0.0-meta", "index": "test-123"},
 			cfg:     common.MapStr{"output.elasticsearch.index": "apm-customized"},
 		},
 		"MetaInformationIndex": {
 			noIlm:   fmt.Sprintf("apm-7.0.0-%s", day),
 			withIlm: fmt.Sprintf("apm-7.0.0-%s", day), //meta overwrites ilm
 			fields:  common.MapStr{"processor.event": "span"},
-			meta:    common.MapStr{"index": "apm-7.0.0"},
+			meta:    common.MapStr{"index": "APM-7.0.0"},
 			cfg:     common.MapStr{"output.elasticsearch.index": "apm-customized"},
 		},
-		"CustomIndex": {
+		"CustomIndex-lowercased": {
 			noIlm:   "apm-customized",
 			withIlm: "apm-7.0.0-metric", //custom index ignored when ilm enabled
 			ilmAuto: "apm-customized",   //custom respected for ilm auto
 			fields:  common.MapStr{"processor.event": "metric"},
-			cfg:     common.MapStr{"output.elasticsearch.index": "apm-customized"},
+			cfg:     common.MapStr{"output.elasticsearch.index": "APM-customized"},
 		},
 		"DifferentCustomIndices": {
 			noIlm:   fmt.Sprintf("apm-7.0.0-%s", day),


### PR DESCRIPTION
Backports the following commits to 7.9:
 - fix: ensure ES index names are lowercase (#4295)