### PR TITLE
aggregation/txmetrics: log warning when group limit is reached

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -15,4 +15,4 @@ https://github.com/elastic/apm-server/compare/7.10\...master[View commits]
 [float]
 ==== Added
 * Monitoring for aggregation of transaction metrics {pull}4287[4287]
-
+* Log warnings in aggregation of transaction metrics when grouping limit is reached {pull}4313[4313]

--- a/log/ratelimit.go
+++ b/log/ratelimit.go
@@ -1,0 +1,36 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package logs
+
+import (
+	"math"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+// WithRateLimit returns a logp.LogOption which rate limits messages
+// with approximately the given frequency.
+func WithRateLimit(interval time.Duration) logp.LogOption {
+	return zap.WrapCore(func(in zapcore.Core) zapcore.Core {
+		return zapcore.NewSamplerWithOptions(in, interval, 1, math.MaxInt32)
+	})
+}

--- a/log/ratelimit_test.go
+++ b/log/ratelimit_test.go
@@ -1,0 +1,45 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package logs_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+
+	logs "github.com/elastic/apm-server/log"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+func TestWithRateLimit(t *testing.T) {
+	core, observed := observer.New(zapcore.DebugLevel)
+	logger := logp.NewLogger("bo", zap.WrapCore(func(in zapcore.Core) zapcore.Core {
+		return zapcore.NewTee(in, core)
+	}))
+	limitedLogger := logger.WithOptions(logs.WithRateLimit(100 * time.Millisecond))
+
+	limitedLogger.Info("hello")
+	limitedLogger.Info("hello")
+	time.Sleep(200 * time.Millisecond)
+	limitedLogger.Info("hello")
+	assert.Equal(t, 2, observed.Len())
+}

--- a/systemtest/sampling_test.go
+++ b/systemtest/sampling_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.elastic.co/apm"
@@ -32,6 +31,7 @@ import (
 	"github.com/elastic/apm-server/systemtest"
 	"github.com/elastic/apm-server/systemtest/apmservertest"
 	"github.com/elastic/apm-server/systemtest/estest"
+	"github.com/elastic/go-elasticsearch/v7/esapi"
 )
 
 func TestKeepUnsampled(t *testing.T) {


### PR DESCRIPTION
## Motivation/summary

Log a warning when the transaction group limit is reached.
This logging is rate limited to once every minute, to avoid
flooding the logs due to high throughput of unique transaction
groups.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

I have considered changes for:
~- [ ] documentation~
- [x] logging (add log lines, choose appropriate log selector, etc.)
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
- [x] Elasticsearch Service (https://cloud.elastic.co)
- [x] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)
- [x] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)

## How to test these changes

- Run apm-server with `apm-server.aggregation.txmetrics.enabled=true`
- Send transactions with unique names in a loop
- Observe that the server will log a warning, but only once per minute

## Related issues

None.