### PR TITLE
[7.x] Add decoder v2 test for memory reuse (#4314)

### DIFF
--- a/model/modeldecoder/rumv3/decoder.go
+++ b/model/modeldecoder/rumv3/decoder.go
@@ -78,7 +78,7 @@ func DecodeNestedTransaction(d decoder.Decoder, input *modeldecoder.Input, out *
 	if err := root.validate(); err != nil {
 		return fmt.Errorf("validation error %w", err)
 	}
-	mapToTransactionModel(&root.Transaction, &input.Metadata, input.RequestTime, input.Config.Experimental, out)
+	mapToTransactionModel(&root.Transaction, &input.Metadata, input.RequestTime, input.Config, out)
 	return nil
 }
 
@@ -152,7 +152,7 @@ func mapToMetadataModel(m *metadata, out *model.Metadata) {
 	}
 }
 
-func mapToTransactionModel(t *transaction, metadata *model.Metadata, reqTime time.Time, experimental bool, out *model.Transaction) {
+func mapToTransactionModel(t *transaction, metadata *model.Metadata, reqTime time.Time, config modeldecoder.Config, out *model.Transaction) {
 	if t == nil {
 		return
 	}
@@ -377,7 +377,7 @@ func mapToTransactionModel(t *transaction, metadata *model.Metadata, reqTime tim
 			out.Custom = &custom
 		}
 	}
-	if experimental {
+	if config.Experimental {
 		out.Experimental = t.Experimental.Val
 	}
 }

--- a/model/modeldecoder/rumv3/model_test.go
+++ b/model/modeldecoder/rumv3/model_test.go
@@ -175,6 +175,7 @@ func TestTransactionRequiredValidationRules(t *testing.T) {
 	// setup: create full metadata struct with arbitrary values set
 	var event transaction
 	modeldecodertest.InitStructValues(&event)
+	event.Outcome.Set("success")
 	// test vanilla struct is valid
 	require.NoError(t, event.validate())
 

--- a/model/modeldecoder/v2/decoder.go
+++ b/model/modeldecoder/v2/decoder.go
@@ -940,10 +940,12 @@ func mapToStracktraceModel(from []stacktraceFrame, out model.Stacktrace) {
 			fr.Module = &val
 		}
 		if len(eventFrame.PostContext) > 0 {
-			fr.PostContext = eventFrame.PostContext
+			fr.PostContext = make([]string, len(eventFrame.PostContext))
+			copy(fr.PostContext, eventFrame.PostContext)
 		}
 		if len(eventFrame.PreContext) > 0 {
-			fr.PreContext = eventFrame.PreContext
+			fr.PreContext = make([]string, len(eventFrame.PreContext))
+			copy(fr.PreContext, eventFrame.PreContext)
 		}
 		if len(eventFrame.Vars) > 0 {
 			fr.Vars = eventFrame.Vars.Clone()
@@ -974,7 +976,7 @@ func mapToTransactionModel(from *transaction, metadata *model.Metadata, reqTime 
 		if config.Experimental && from.Context.Experimental.IsSet() {
 			out.Experimental = from.Context.Experimental.Val
 		}
-		// metadata labels and context labels are merged only in the output model
+		// metadata labels and context labels are merged when transforming the output model
 		if len(from.Context.Tags) > 0 {
 			labels := model.Labels(from.Context.Tags.Clone())
 			out.Labels = &labels

--- a/model/modeldecoder/v2/metadata_test.go
+++ b/model/modeldecoder/v2/metadata_test.go
@@ -21,7 +21,6 @@ import (
 	"net"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,6 +30,18 @@ import (
 	"github.com/elastic/apm-server/model/modeldecoder/modeldecodertest"
 )
 
+// initializedMetadata returns a metadata model with
+func initializedMetadata() *model.Metadata {
+	var input metadata
+	var out model.Metadata
+	modeldecodertest.SetStructValues(&input, modeldecodertest.DefaultValues())
+	mapToMetadataModel(&input, &out)
+	// initialize values that are not set by input
+	out.UserAgent = model.UserAgent{Name: "init", Original: "init"}
+	out.Client.IP = net.ParseIP("127.0.0.1")
+	out.System.IP = net.ParseIP("127.0.0.1")
+	return &out
+}
 func TestResetMetadataOnRelease(t *testing.T) {
 	inp := `{"metadata":{"service":{"name":"service-a"}}}`
 	m := fetchMetadataRoot()
@@ -75,33 +86,69 @@ func TestDecodeMetadata(t *testing.T) {
 }
 
 func TestDecodeMapToMetadataModel(t *testing.T) {
-	// setup:
-	// create initialized modeldecoder and empty model metadata
-	// map modeldecoder to model metadata and manually set
-	// enhanced data that are never set by the modeldecoder
-	var m metadata
-	modeldecodertest.SetStructValues(&m, "init", 5000, false, time.Now())
-	var modelM model.Metadata
-	ip := net.ParseIP("127.0.0.1")
-	modelM.System.IP, modelM.Client.IP = ip, ip
-	mapToMetadataModel(&m, &modelM)
 
-	exceptions := func(key string) bool {
-		return strings.HasPrefix(key, "UserAgent")
-	}
+	t.Run("overwrite", func(t *testing.T) {
+		// setup:
+		// create initialized modeldecoder and empty model metadata
+		// map modeldecoder to model metadata and manually set
+		// enhanced data that are never set by the modeldecoder
+		var input metadata
+		var out model.Metadata
+		defaultVal := modeldecodertest.DefaultValues()
+		modeldecodertest.SetStructValues(&input, defaultVal)
+		out.System.IP, out.Client.IP = defaultVal.IP, defaultVal.IP
+		mapToMetadataModel(&input, &out)
 
-	// iterate through model and assert values are set
-	modeldecodertest.AssertStructValues(t, &modelM, exceptions, "init", 5000, false, ip, time.Now())
+		exceptions := func(key string) bool {
+			return strings.HasPrefix(key, "UserAgent")
+		}
+		// iterate through model and assert values are set
+		modeldecodertest.AssertStructValues(t, &out, exceptions, defaultVal)
 
-	// overwrite model metadata with specified Values
-	// then iterate through model and assert values are overwritten
-	modeldecodertest.SetStructValues(&m, "overwritten", 12, true, time.Now())
-	mapToMetadataModel(&m, &modelM)
-	modeldecodertest.AssertStructValues(t, &modelM, exceptions, "overwritten", 12, true, ip, time.Now())
+		// overwrite model metadata with specified Values
+		// then iterate through model and assert values are overwritten
+		otherVal := modeldecodertest.NonDefaultValues()
+		// System.IP and Client.IP are not set by decoder,
+		// therefore their values are not updated
+		otherVal.Update(defaultVal.IP)
+		input.Reset()
+		modeldecodertest.SetStructValues(&input, otherVal)
+		mapToMetadataModel(&input, &out)
+		modeldecodertest.AssertStructValues(t, &out, exceptions, otherVal)
 
-	// map an empty modeldecoder metadata to the model
-	// and assert values are unchanged
-	modeldecodertest.SetZeroStructValues(&m)
-	mapToMetadataModel(&m, &modelM)
-	modeldecodertest.AssertStructValues(t, &modelM, exceptions, "overwritten", 12, true, ip, time.Now())
+		// map an empty modeldecoder metadata to the model
+		// and assert values are unchanged
+		input.Reset()
+		modeldecodertest.SetZeroStructValues(&input)
+		mapToMetadataModel(&input, &out)
+		modeldecodertest.AssertStructValues(t, &out, exceptions, otherVal)
+	})
+
+	t.Run("reused-memory", func(t *testing.T) {
+		var input metadata
+		var out1, out2 model.Metadata
+		defaultVal := modeldecodertest.DefaultValues()
+		modeldecodertest.SetStructValues(&input, defaultVal)
+		mapToMetadataModel(&input, &out1)
+		out1.System.IP, out1.Client.IP = defaultVal.IP, defaultVal.IP //not set by decoder
+
+		exceptions := func(key string) bool {
+			return strings.HasPrefix(key, "UserAgent")
+		}
+		// iterate through model and assert values are set
+		modeldecodertest.AssertStructValues(t, &out1, exceptions, defaultVal)
+
+		// overwrite model metadata with specified Values
+		// then iterate through model and assert values are overwritten
+		otherVal := modeldecodertest.NonDefaultValues()
+		// System.IP and Client.IP are not set by decoder,
+		// therefore their values are not updated
+		otherVal.Update(defaultVal.IP)
+		input.Reset()
+		modeldecodertest.SetStructValues(&input, otherVal)
+		mapToMetadataModel(&input, &out2)
+		out2.System.IP, out2.Client.IP = defaultVal.IP, defaultVal.IP
+		modeldecodertest.AssertStructValues(t, &out2, exceptions, otherVal)
+		modeldecodertest.AssertStructValues(t, &out1, exceptions, defaultVal)
+	})
 }

--- a/model/modeldecoder/v2/model_test.go
+++ b/model/modeldecoder/v2/model_test.go
@@ -517,6 +517,7 @@ func TestSpanRequiredValidationRules(t *testing.T) {
 	// setup: create full struct with arbitrary values set
 	var event span
 	modeldecodertest.InitStructValues(&event)
+	event.Outcome.Set("failure")
 	// test vanilla struct is valid
 	require.NoError(t, event.validate())
 
@@ -551,6 +552,7 @@ func TestTransactionRequiredValidationRules(t *testing.T) {
 	// setup: create full struct with arbitrary values set
 	var event transaction
 	modeldecodertest.InitStructValues(&event)
+	event.Outcome.Set("success")
 	// test vanilla struct is valid
 	require.NoError(t, event.validate())
 

--- a/model/modeldecoder/v2/transaction_test.go
+++ b/model/modeldecoder/v2/transaction_test.go
@@ -79,55 +79,45 @@ func TestDecodeNestedTransaction(t *testing.T) {
 }
 
 func TestDecodeMapToTransactionModel(t *testing.T) {
-	localhostIP := net.ParseIP("127.0.0.1")
 	gatewayIP := net.ParseIP("192.168.0.1")
 	randomIP := net.ParseIP("71.0.54.1")
 	exceptions := func(key string) bool {
 		return key == "RepresentativeCount"
 	}
 
-	initializedMeta := func() *model.Metadata {
-		var inputMeta metadata
-		var meta model.Metadata
-		modeldecodertest.SetStructValues(&inputMeta, "meta", 1, false, time.Now())
-		mapToMetadataModel(&inputMeta, &meta)
-		// initialize values that are not set by input
-		meta.UserAgent = model.UserAgent{Name: "meta", Original: "meta"}
-		meta.Client.IP = localhostIP
-		meta.System.IP = localhostIP
-		return &meta
-	}
-
-	t.Run("set-metadata", func(t *testing.T) {
-		// do not overwrite metadata with zero transaction values
+	t.Run("metadata-set", func(t *testing.T) {
+		// do not overwrite metadata with zero event values
 		var input transaction
 		var out model.Transaction
-		mapToTransactionModel(&input, initializedMeta(), time.Now(), modeldecoder.Config{Experimental: true}, &out)
+		mapToTransactionModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{Experimental: true}, &out)
 		// iterate through metadata model and assert values are set
-		modeldecodertest.AssertStructValues(t, &out.Metadata, exceptions, "meta", 1, false, localhostIP, time.Now())
+		modeldecodertest.AssertStructValues(t, &out.Metadata, exceptions, modeldecodertest.DefaultValues())
 	})
 
-	t.Run("overwrite-metadata", func(t *testing.T) {
-		// overwrite defined metadata with transaction metadata values
+	t.Run("metadata-overwrite", func(t *testing.T) {
+		// overwrite defined metadata with event metadata values
 		var input transaction
 		var out model.Transaction
-		modeldecodertest.SetStructValues(&input, "overwritten", 5000, false, time.Now())
-		input.Context.Request.Headers.Val.Add("user-agent", "first")
-		input.Context.Request.Headers.Val.Add("user-agent", "second")
-		input.Context.Request.Headers.Val.Add("x-real-ip", gatewayIP.String())
-		mapToTransactionModel(&input, initializedMeta(), time.Now(), modeldecoder.Config{Experimental: true}, &out)
+		otherVal := modeldecodertest.NonDefaultValues()
+		modeldecodertest.SetStructValues(&input, otherVal)
+		mapToTransactionModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{Experimental: true}, &out)
+		input.Reset()
 
-		// user-agent should be set to context request header values
-		assert.Equal(t, "first, second", out.Metadata.UserAgent.Original)
+		// ensure event Metadata are updated where expected
+		otherVal = modeldecodertest.NonDefaultValues()
+		userAgent := strings.Join(otherVal.HTTPHeader.Values("User-Agent"), ", ")
+		assert.Equal(t, userAgent, out.Metadata.UserAgent.Original)
 		// do not overwrite client.ip if already set in metadata
-		assert.Equal(t, localhostIP, out.Metadata.Client.IP, out.Metadata.Client.IP.String())
-		// metadata labels and transaction labels should not be merged
-		assert.Equal(t, common.MapStr{"meta": "meta"}, out.Metadata.Labels)
-		assert.Equal(t, &model.Labels{"overwritten": "overwritten"}, out.Labels)
-		// service values should be set
-		modeldecodertest.AssertStructValues(t, &out.Metadata.Service, exceptions, "overwritten", 100, true, localhostIP, time.Now())
-		// user values should be set
-		modeldecodertest.AssertStructValues(t, &out.Metadata.User, exceptions, "overwritten", 100, true, localhostIP, time.Now())
+		ip := modeldecodertest.DefaultValues().IP
+		assert.Equal(t, ip, out.Metadata.Client.IP, out.Metadata.Client.IP.String())
+		// metadata labels and event labels should not be merged
+		mLabels := common.MapStr{"init0": "init", "init1": "init", "init2": "init"}
+		tLabels := model.Labels{"overwritten0": "overwritten", "overwritten1": "overwritten"}
+		assert.Equal(t, mLabels, out.Metadata.Labels)
+		assert.Equal(t, &tLabels, out.Labels)
+		// service and user values should be set
+		modeldecodertest.AssertStructValues(t, &out.Metadata.Service, exceptions, otherVal)
+		modeldecodertest.AssertStructValues(t, &out.Metadata.User, exceptions, otherVal)
 	})
 
 	t.Run("client-ip-header", func(t *testing.T) {
@@ -153,7 +143,7 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 		var input transaction
 		var out model.Transaction
 		input.Context.User.Email.Set("test@user.com")
-		mapToTransactionModel(&input, initializedMeta(), time.Now(), modeldecoder.Config{Experimental: false}, &out)
+		mapToTransactionModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{Experimental: false}, &out)
 		assert.Equal(t, "test@user.com", out.Metadata.User.Email)
 		assert.Zero(t, out.Metadata.User.ID)
 		assert.Zero(t, out.Metadata.User.Name)
@@ -162,38 +152,48 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 	t.Run("transaction-values", func(t *testing.T) {
 		exceptions := func(key string) bool {
 			// metadata are tested separately
-			// URL parts are derived from url (separately tested)
-			// experimental is tested separately
-			// RepresentativeCount is not set by decoder
-			if strings.HasPrefix(key, "Metadata") || strings.HasPrefix(key, "Page.URL") ||
-				key == "Experimental" || key == "RepresentativeCount" {
+			if strings.HasPrefix(key, "Metadata") ||
+				// URL parts are derived from url (separately tested)
+				strings.HasPrefix(key, "Page.URL") ||
+				// experimental is tested separately
+				key == "Experimental" ||
+				// RepresentativeCount is not set by decoder
+				key == "RepresentativeCount" {
 				return true
 			}
-
 			return false
 		}
 
 		var input transaction
-		var out model.Transaction
-		eventTime, reqTime := time.Now(), time.Now().Add(time.Second)
-		modeldecodertest.SetStructValues(&input, "overwritten", 5000, true, eventTime)
-		mapToTransactionModel(&input, initializedMeta(), reqTime, modeldecoder.Config{Experimental: true}, &out)
-		modeldecodertest.AssertStructValues(t, &out, exceptions, "overwritten", 5000, true, localhostIP, eventTime)
-
-		// set requestTime if eventTime is zero
-		modeldecodertest.SetStructValues(&input, "overwritten", 5000, true, time.Time{})
-		out = model.Transaction{}
-		mapToTransactionModel(&input, initializedMeta(), reqTime, modeldecoder.Config{Experimental: true}, &out)
+		var out1, out2 model.Transaction
+		reqTime := time.Now().Add(time.Second)
+		defaultVal := modeldecodertest.DefaultValues()
+		modeldecodertest.SetStructValues(&input, defaultVal)
+		mapToTransactionModel(&input, initializedMetadata(), reqTime, modeldecoder.Config{Experimental: true}, &out1)
 		input.Reset()
-		modeldecodertest.AssertStructValues(t, &out, exceptions, "overwritten", 5000, true, localhostIP, reqTime)
+		modeldecodertest.AssertStructValues(t, &out1, exceptions, defaultVal)
 
+		// set Timestamp to requestTime if eventTime is zero
+		defaultVal.Update(time.Time{})
+		modeldecodertest.SetStructValues(&input, defaultVal)
+		mapToTransactionModel(&input, initializedMetadata(), reqTime, modeldecoder.Config{Experimental: true}, &out1)
+		defaultVal.Update(reqTime)
+		input.Reset()
+		modeldecodertest.AssertStructValues(t, &out1, exceptions, defaultVal)
+
+		// ensure memory is not shared by reusing input model
+		otherVal := modeldecodertest.NonDefaultValues()
+		modeldecodertest.SetStructValues(&input, otherVal)
+		mapToTransactionModel(&input, initializedMetadata(), reqTime, modeldecoder.Config{Experimental: true}, &out2)
+		modeldecodertest.AssertStructValues(t, &out2, exceptions, otherVal)
+		modeldecodertest.AssertStructValues(t, &out1, exceptions, defaultVal)
 	})
 
 	t.Run("page.URL", func(t *testing.T) {
 		var input transaction
 		input.Context.Page.URL.Set("https://my.site.test:9201")
 		var out model.Transaction
-		mapToTransactionModel(&input, initializedMeta(), time.Now(), modeldecoder.Config{Experimental: false}, &out)
+		mapToTransactionModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{Experimental: false}, &out)
 		assert.Equal(t, "https://my.site.test:9201", *out.Page.URL.Full)
 		assert.Equal(t, 9201, *out.Page.URL.Port)
 		assert.Equal(t, "https", *out.Page.URL.Scheme)
@@ -202,20 +202,20 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 	t.Run("sample-rate", func(t *testing.T) {
 		var input transaction
 		var out model.Transaction
-		modeldecodertest.SetStructValues(&input, "init", 5000, true, time.Now())
+		modeldecodertest.SetStructValues(&input, modeldecodertest.DefaultValues())
 		// sample rate is set to > 0
 		input.SampleRate.Set(0.25)
-		mapToTransactionModel(&input, initializedMeta(), time.Now(), modeldecoder.Config{}, &out)
+		mapToTransactionModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{}, &out)
 		assert.Equal(t, 4.0, out.RepresentativeCount)
 		// sample rate is not set -> Representative Count should be 1 by default
 		out.RepresentativeCount = 0.0 //reset to zero value
 		input.SampleRate.Reset()
-		mapToTransactionModel(&input, initializedMeta(), time.Now(), modeldecoder.Config{}, &out)
+		mapToTransactionModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{}, &out)
 		assert.Equal(t, 1.0, out.RepresentativeCount)
 		// sample rate is set to 0
 		out.RepresentativeCount = 0.0 //reset to zero value
 		input.SampleRate.Set(0)
-		mapToTransactionModel(&input, initializedMeta(), time.Now(), modeldecoder.Config{}, &out)
+		mapToTransactionModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{}, &out)
 		assert.Equal(t, 0.0, out.RepresentativeCount)
 	})
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add decoder v2 test for memory reuse (#4314)