### PR TITLE
[7.x] Use service.version for Metadata.Service.Version when converting a Jaeger span (#4061)

### DIFF
--- a/processor/otel/consumer.go
+++ b/processor/otel/consumer.go
@@ -277,6 +277,8 @@ func parseTransaction(span *tracepb.Span, sourceFormat string, hostname string, 
 				isMessaging = true
 			case "type":
 				event.Type = truncate(v.StringValue.Value)
+			case "service.version":
+				event.Metadata.Service.Version = truncate(v.StringValue.Value)
 			case "component":
 				component = truncate(v.StringValue.Value)
 				fallthrough

--- a/processor/otel/consumer_test.go
+++ b/processor/otel/consumer_test.go
@@ -191,6 +191,7 @@ func TestConsumer_Transaction(t *testing.T) {
 						"type":             testAttributeStringValue("http_request"),
 						"component":        testAttributeStringValue("foo"),
 						"string.a.b":       testAttributeStringValue("some note"),
+						"service.version":  testAttributeStringValue("1.0"),
 					}},
 					TimeEvents: testTimeEvents(),
 				}}}},

--- a/processor/otel/test_approved/transaction_jaeger_full.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_full.approved.json
@@ -41,7 +41,8 @@
                 "name": "unknown",
                 "node": {
                     "name": "host-abc"
-                }
+                },
+                "version": "1.0"
             },
             "timestamp": {
                 "us": 1576500418000768
@@ -111,7 +112,8 @@
                 "name": "unknown",
                 "node": {
                     "name": "host-abc"
-                }
+                },
+                "version": "1.0"
             },
             "timestamp": {
                 "us": 1576500418000768
@@ -170,7 +172,8 @@
                 "name": "unknown",
                 "node": {
                     "name": "host-abc"
-                }
+                },
+                "version": "1.0"
             },
             "timestamp": {
                 "us": 1576500418000768
@@ -231,7 +234,8 @@
                 "name": "unknown",
                 "node": {
                     "name": "host-abc"
-                }
+                },
+                "version": "1.0"
             },
             "timestamp": {
                 "us": 1576500418000768
@@ -292,7 +296,8 @@
                 "name": "unknown",
                 "node": {
                     "name": "host-abc"
-                }
+                },
+                "version": "1.0"
             },
             "timestamp": {
                 "us": 1576500418000768
@@ -353,7 +358,8 @@
                 "name": "unknown",
                 "node": {
                     "name": "host-abc"
-                }
+                },
+                "version": "1.0"
             },
             "timestamp": {
                 "us": 1576500418000768
@@ -412,7 +418,8 @@
                 "name": "unknown",
                 "node": {
                     "name": "host-abc"
-                }
+                },
+                "version": "1.0"
             },
             "timestamp": {
                 "us": 1576500418000768


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Use service.version for Metadata.Service.Version when converting a Jaeger span (#4061)