### PR TITLE
[7.x] fix: ensure ES index names are lowercase for ILM (#4322)

### DIFF
--- a/changelogs/7.9.asciidoc
+++ b/changelogs/7.9.asciidoc
@@ -16,7 +16,7 @@ https://github.com/elastic/apm-server/compare/v7.9.2\...v7.9.3[View commits]
 
 [float]
 ==== Bug fixes
-* Ensure custom index names are lowercased {pull}4295[4295]
+* Ensure custom index names are lowercased {pull}4295[4295],{pull}4322[4322]
 
 [float]
 [[release-notes-7.9.2]]

--- a/idxmgmt/ilm/config.go
+++ b/idxmgmt/ilm/config.go
@@ -19,6 +19,7 @@ package ilm
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	libcommon "github.com/elastic/beats/v7/libbeat/common"
@@ -125,7 +126,7 @@ func (m *Mappings) Unpack(cfg *libcommon.Config) error {
 			mapping.Index = existing.Index
 		}
 		if mapping.IndexSuffix != "" {
-			mapping.Index = fmt.Sprintf("%s-%s", mapping.Index, mapping.IndexSuffix)
+			mapping.Index = fmt.Sprintf("%s-%s", mapping.Index, strings.ToLower(mapping.IndexSuffix))
 		}
 		(*m)[mapping.EventType] = mapping
 	}

--- a/idxmgmt/ilm/config_test.go
+++ b/idxmgmt/ilm/config_test.go
@@ -118,7 +118,7 @@ func TestConfig_Valid(t *testing.T) {
 		expected Config
 	}{
 		{name: "new policy and index suffix",
-			cfg: `{"setup":{"mapping":[{"event_type":"span","policy_name":"spanPolicy"},{"event_type":"metric","index_suffix":"production"},{"event_type":"error","index_suffix":"%{[observer.name]}"}],"policies":[{"name":"spanPolicy","policy":{"phases":{"foo":{}}}}]}}`,
+			cfg: `{"setup":{"mapping":[{"event_type":"span","policy_name":"spanPolicy"},{"event_type":"metric","index_suffix":"ProdUCtion"},{"event_type":"error","index_suffix":"%{[observer.name]}"}],"policies":[{"name":"spanPolicy","policy":{"phases":{"foo":{}}}}]}}`,
 			expected: Config{Mode: libilm.ModeAuto,
 				Setup: Setup{Enabled: true, Overwrite: false, RequirePolicy: true,
 					Mappings: map[string]Mapping{
@@ -129,7 +129,7 @@ func TestConfig_Valid(t *testing.T) {
 						"transaction": {EventType: "transaction", PolicyName: defaultPolicyName,
 							Index: "apm-9.9.9-transaction"},
 						"metric": {EventType: "metric", PolicyName: defaultPolicyName,
-							Index: "apm-9.9.9-metric-production", IndexSuffix: "production"},
+							Index: "apm-9.9.9-metric-production", IndexSuffix: "ProdUCtion"},
 						"profile": {EventType: "profile", PolicyName: defaultPolicyName,
 							Index: "apm-9.9.9-profile"},
 					},

--- a/tests/system/config/apm-server.yml.j2
+++ b/tests/system/config/apm-server.yml.j2
@@ -162,7 +162,7 @@ apm-server:
   {% if ilm_custom_suffix %}
   ilm.setup.mapping:
     - event_type: "error"
-      index_suffix: "custom"
+      index_suffix: "CUSTOM"
     - event_type: "transaction"
       index_suffix: "foo"
   {% endif %}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix: ensure ES index names are lowercase for ILM (#4322)