### PR TITLE
[7.x] fix: add type information to span.context.service (#4331)

### DIFF
--- a/docs/spec/spans/span.json
+++ b/docs/spec/spans/span.json
@@ -154,6 +154,10 @@
                         },
                         "service": {
                             "description": "Service related information can be sent per event. Provided information will override the more generic information from metadata, non provided fields will be set according to the metadata information.",
+                            "type": [
+                                "object",
+                                "null"
+                            ],
                             "properties": {
                                 "agent": {
                                     "description": "Name and version of the Elastic APM agent",

--- a/model/span/generated/schema/span.go
+++ b/model/span/generated/schema/span.go
@@ -246,6 +246,10 @@ const ModelSchema = `{
                         },
                         "service": {
                             "description": "Service related information can be sent per event. Provided information will override the more generic information from metadata, non provided fields will be set according to the metadata information.",
+                            "type": [
+                                "object",
+                                "null"
+                            ],
                             "properties": {
                                 "agent": {
                                     "description": "Name and version of the Elastic APM agent",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix: add type information to span.context.service (#4331)