### PR TITLE
[7.9] Bump version to 7.9.4 (make update-beats)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -535,7 +535,7 @@ Contents of "LICENSE":
 --------------------------------------------------------------------
 Dependency: github.com/elastic/beats/v7
 Version: v7.9.3
-Revision: e8f1cef65256
+Revision: 37d39ca68305
 License type (autodetected): Apache-2.0
 
 --------------------------------------------------------------------
@@ -3765,7 +3765,7 @@ Contents of "LICENSE.txt":
 
 --------------------------------------------------------------------
 Dependency: golang.org/x/crypto
-Revision: 7f63de1d35b0
+Revision: 9e8e0b390897
 License type (autodetected): BSD-3-Clause
 Contents of "LICENSE":
 
@@ -3799,7 +3799,7 @@ Contents of "LICENSE":
 
 --------------------------------------------------------------------
 Dependency: golang.org/x/net
-Revision: 4f7140c49acb
+Revision: f5854403a974
 License type (autodetected): BSD-3-Clause
 Contents of "LICENSE":
 
@@ -3867,7 +3867,7 @@ Contents of "LICENSE":
 
 --------------------------------------------------------------------
 Dependency: golang.org/x/sync
-Revision: 6e8e738ad208
+Revision: 67f06af15bc9
 License type (autodetected): BSD-3-Clause
 Contents of "LICENSE":
 
@@ -3901,7 +3901,7 @@ Contents of "LICENSE":
 
 --------------------------------------------------------------------
 Dependency: golang.org/x/sys
-Revision: dfb3f7c4e634
+Revision: 6e5568b54d1a
 License type (autodetected): BSD-3-Clause
 Contents of "LICENSE":
 

--- a/beater/api/root/test_approved/integration/TestRootHandler_AuthorizationMiddleware/Authorized.approved.json
+++ b/beater/api/root/test_approved/integration/TestRootHandler_AuthorizationMiddleware/Authorized.approved.json
@@ -1,5 +1,5 @@
 {
     "build_date": "0001-01-01T00:00:00Z",
     "build_sha": "unknown",
-    "version": "7.9.3"
+    "version": "7.9.4"
 }

--- a/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
@@ -5,7 +5,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2017-05-09T15:04:05.999Z",
             "agent": {
@@ -302,7 +302,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "process": {
@@ -367,7 +367,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2018-08-09T14:59:05.999Z",
             "agent": {
@@ -438,7 +438,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "process": {
@@ -488,7 +488,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2018-08-09T14:59:05.999Z",
             "agent": {
@@ -555,7 +555,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "process": {
@@ -605,7 +605,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-01-09T21:40:53.000Z",
             "agent": {
@@ -672,7 +672,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "parent": {
@@ -728,7 +728,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2018-08-09T15:04:05.999Z",
             "agent": {
@@ -794,7 +794,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "parent": {

--- a/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
@@ -5,7 +5,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-10-21T11:30:44.929Z",
             "agent": {
@@ -108,7 +108,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "parent": {
@@ -204,7 +204,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-10-21T11:30:44.929Z",
             "agent": {
@@ -247,7 +247,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "parent": {
@@ -362,7 +362,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-10-21T11:30:44.929Z",
             "agent": {
@@ -430,7 +430,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "process": {
@@ -501,7 +501,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-10-21T11:30:44.929Z",
             "agent": {
@@ -723,7 +723,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "parent": {

--- a/beater/test_approved_es_documents/TestPublishIntegrationMetricsets.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationMetricsets.approved.json
@@ -5,7 +5,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2017-05-30T18:53:42.281Z",
             "agent": {
@@ -53,7 +53,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "process": {
@@ -113,7 +113,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2017-05-30T18:53:41.364Z",
             "agent": {
@@ -144,7 +144,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "process": {

--- a/beater/test_approved_es_documents/TestPublishIntegrationMinimalEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationMinimalEvents.approved.json
@@ -5,7 +5,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-01-09T21:40:53.000Z",
             "agent": {
@@ -26,7 +26,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -59,7 +59,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-01-09T21:40:53.000Z",
             "agent": {
@@ -77,7 +77,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "parent": {
@@ -113,7 +113,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2018-08-30T18:53:27.154Z",
             "agent": {
@@ -131,7 +131,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "parent": {
@@ -164,7 +164,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2017-05-30T18:53:42.281Z",
             "agent": {
@@ -182,7 +182,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -198,7 +198,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-01-09T21:40:53.000Z",
             "agent": {
@@ -223,7 +223,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -242,7 +242,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-01-09T21:40:53.000Z",
             "agent": {
@@ -269,7 +269,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -288,7 +288,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-01-09T21:40:53.000Z",
             "agent": {
@@ -315,7 +315,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {

--- a/beater/test_approved_es_documents/TestPublishIntegrationProfileCPUProfile.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationProfileCPUProfile.approved.json
@@ -5,7 +5,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -16,7 +16,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -144,7 +144,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -155,7 +155,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -229,7 +229,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -240,7 +240,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -386,7 +386,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -397,7 +397,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -471,7 +471,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -482,7 +482,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -538,7 +538,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -549,7 +549,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -641,7 +641,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -652,7 +652,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -738,7 +738,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -749,7 +749,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -829,7 +829,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -840,7 +840,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -938,7 +938,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -949,7 +949,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1065,7 +1065,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -1076,7 +1076,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1126,7 +1126,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -1137,7 +1137,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1199,7 +1199,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -1210,7 +1210,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1308,7 +1308,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -1319,7 +1319,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1447,7 +1447,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -1458,7 +1458,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1514,7 +1514,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -1525,7 +1525,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1635,7 +1635,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -1646,7 +1646,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1744,7 +1744,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -1755,7 +1755,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1841,7 +1841,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -1852,7 +1852,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1938,7 +1938,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -1949,7 +1949,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2065,7 +2065,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -2076,7 +2076,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2126,7 +2126,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -2137,7 +2137,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2217,7 +2217,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -2228,7 +2228,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2284,7 +2284,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -2295,7 +2295,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2357,7 +2357,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -2368,7 +2368,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2490,7 +2490,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -2501,7 +2501,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2575,7 +2575,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -2586,7 +2586,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2636,7 +2636,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -2647,7 +2647,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2685,7 +2685,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -2696,7 +2696,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2770,7 +2770,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -2781,7 +2781,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2897,7 +2897,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -2908,7 +2908,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3012,7 +3012,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -3023,7 +3023,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3127,7 +3127,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -3138,7 +3138,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3206,7 +3206,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -3217,7 +3217,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3327,7 +3327,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -3338,7 +3338,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3394,7 +3394,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -3405,7 +3405,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3479,7 +3479,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -3490,7 +3490,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3552,7 +3552,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -3563,7 +3563,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3679,7 +3679,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -3690,7 +3690,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3854,7 +3854,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -3865,7 +3865,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3939,7 +3939,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -3950,7 +3950,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4042,7 +4042,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -4053,7 +4053,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4211,7 +4211,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -4222,7 +4222,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4272,7 +4272,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -4283,7 +4283,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4405,7 +4405,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -4416,7 +4416,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4526,7 +4526,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -4537,7 +4537,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4593,7 +4593,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -4604,7 +4604,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4684,7 +4684,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -4695,7 +4695,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4739,7 +4739,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -4750,7 +4750,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4818,7 +4818,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -4829,7 +4829,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4879,7 +4879,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -4890,7 +4890,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5012,7 +5012,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -5023,7 +5023,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5073,7 +5073,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -5084,7 +5084,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5122,7 +5122,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -5133,7 +5133,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5207,7 +5207,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -5218,7 +5218,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5322,7 +5322,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -5333,7 +5333,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5419,7 +5419,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -5430,7 +5430,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5498,7 +5498,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -5509,7 +5509,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5607,7 +5607,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -5618,7 +5618,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5716,7 +5716,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -5727,7 +5727,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5801,7 +5801,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -5812,7 +5812,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5928,7 +5928,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -5939,7 +5939,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6019,7 +6019,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -6030,7 +6030,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6116,7 +6116,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -6127,7 +6127,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6207,7 +6207,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -6218,7 +6218,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6286,7 +6286,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -6297,7 +6297,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6347,7 +6347,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -6358,7 +6358,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6462,7 +6462,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -6473,7 +6473,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6601,7 +6601,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -6612,7 +6612,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6752,7 +6752,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -6763,7 +6763,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6843,7 +6843,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -6854,7 +6854,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6904,7 +6904,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -6915,7 +6915,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7001,7 +7001,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -7012,7 +7012,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7158,7 +7158,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -7169,7 +7169,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7297,7 +7297,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -7308,7 +7308,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7424,7 +7424,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -7435,7 +7435,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7491,7 +7491,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -7502,7 +7502,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7564,7 +7564,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -7575,7 +7575,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7673,7 +7673,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -7684,7 +7684,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7716,7 +7716,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -7727,7 +7727,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7771,7 +7771,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -7782,7 +7782,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7844,7 +7844,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -7855,7 +7855,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7923,7 +7923,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -7934,7 +7934,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8002,7 +8002,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -8013,7 +8013,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8093,7 +8093,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -8104,7 +8104,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8208,7 +8208,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -8219,7 +8219,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8281,7 +8281,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -8292,7 +8292,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8360,7 +8360,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -8371,7 +8371,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8481,7 +8481,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -8492,7 +8492,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8554,7 +8554,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -8565,7 +8565,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8669,7 +8669,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -8680,7 +8680,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8766,7 +8766,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -8777,7 +8777,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8863,7 +8863,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -8874,7 +8874,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8918,7 +8918,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -8929,7 +8929,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -9027,7 +9027,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -9038,7 +9038,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -9106,7 +9106,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -9117,7 +9117,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -9161,7 +9161,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -9172,7 +9172,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -9300,7 +9300,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "ecs": {
@@ -9311,7 +9311,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {

--- a/beater/test_approved_es_documents/TestPublishIntegrationProfileCPUProfileMetadata.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationProfileCPUProfileMetadata.approved.json
@@ -5,7 +5,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -22,7 +22,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -153,7 +153,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -170,7 +170,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -247,7 +247,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -264,7 +264,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -413,7 +413,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -430,7 +430,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -507,7 +507,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -524,7 +524,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -583,7 +583,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -600,7 +600,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -695,7 +695,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -712,7 +712,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -801,7 +801,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -818,7 +818,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -901,7 +901,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -918,7 +918,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1019,7 +1019,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -1036,7 +1036,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1155,7 +1155,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -1172,7 +1172,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1225,7 +1225,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -1242,7 +1242,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1307,7 +1307,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -1324,7 +1324,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1425,7 +1425,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -1442,7 +1442,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1573,7 +1573,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -1590,7 +1590,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1649,7 +1649,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -1666,7 +1666,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1779,7 +1779,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -1796,7 +1796,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1897,7 +1897,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -1914,7 +1914,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2003,7 +2003,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -2020,7 +2020,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2109,7 +2109,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -2126,7 +2126,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2245,7 +2245,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -2262,7 +2262,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2315,7 +2315,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -2332,7 +2332,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2415,7 +2415,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -2432,7 +2432,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2491,7 +2491,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -2508,7 +2508,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2573,7 +2573,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -2590,7 +2590,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2715,7 +2715,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -2732,7 +2732,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2809,7 +2809,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -2826,7 +2826,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2879,7 +2879,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -2896,7 +2896,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2937,7 +2937,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -2954,7 +2954,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3031,7 +3031,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -3048,7 +3048,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3167,7 +3167,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -3184,7 +3184,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3291,7 +3291,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -3308,7 +3308,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3415,7 +3415,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -3432,7 +3432,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3503,7 +3503,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -3520,7 +3520,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3633,7 +3633,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -3650,7 +3650,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3709,7 +3709,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -3726,7 +3726,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3803,7 +3803,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -3820,7 +3820,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3885,7 +3885,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -3902,7 +3902,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4021,7 +4021,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -4038,7 +4038,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4205,7 +4205,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -4222,7 +4222,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4299,7 +4299,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -4316,7 +4316,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4411,7 +4411,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -4428,7 +4428,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4589,7 +4589,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -4606,7 +4606,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4659,7 +4659,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -4676,7 +4676,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4801,7 +4801,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -4818,7 +4818,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4931,7 +4931,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -4948,7 +4948,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5007,7 +5007,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -5024,7 +5024,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5107,7 +5107,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -5124,7 +5124,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5171,7 +5171,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -5188,7 +5188,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5259,7 +5259,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -5276,7 +5276,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5329,7 +5329,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -5346,7 +5346,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5471,7 +5471,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -5488,7 +5488,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5541,7 +5541,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -5558,7 +5558,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5599,7 +5599,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -5616,7 +5616,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5693,7 +5693,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -5710,7 +5710,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5817,7 +5817,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -5834,7 +5834,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -5923,7 +5923,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -5940,7 +5940,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6011,7 +6011,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -6028,7 +6028,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6129,7 +6129,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -6146,7 +6146,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6247,7 +6247,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -6264,7 +6264,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6341,7 +6341,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -6358,7 +6358,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6477,7 +6477,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -6494,7 +6494,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6577,7 +6577,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -6594,7 +6594,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6683,7 +6683,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -6700,7 +6700,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6783,7 +6783,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -6800,7 +6800,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6871,7 +6871,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -6888,7 +6888,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -6941,7 +6941,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -6958,7 +6958,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7065,7 +7065,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -7082,7 +7082,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7213,7 +7213,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -7230,7 +7230,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7373,7 +7373,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -7390,7 +7390,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7473,7 +7473,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -7490,7 +7490,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7543,7 +7543,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -7560,7 +7560,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7649,7 +7649,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -7666,7 +7666,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7815,7 +7815,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -7832,7 +7832,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -7963,7 +7963,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -7980,7 +7980,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8099,7 +8099,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -8116,7 +8116,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8175,7 +8175,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -8192,7 +8192,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8257,7 +8257,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -8274,7 +8274,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8375,7 +8375,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -8392,7 +8392,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8427,7 +8427,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -8444,7 +8444,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8491,7 +8491,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -8508,7 +8508,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8573,7 +8573,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -8590,7 +8590,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8661,7 +8661,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -8678,7 +8678,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8749,7 +8749,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -8766,7 +8766,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8849,7 +8849,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -8866,7 +8866,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -8973,7 +8973,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -8990,7 +8990,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -9055,7 +9055,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -9072,7 +9072,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -9143,7 +9143,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -9160,7 +9160,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -9273,7 +9273,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -9290,7 +9290,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -9355,7 +9355,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -9372,7 +9372,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -9479,7 +9479,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -9496,7 +9496,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -9585,7 +9585,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -9602,7 +9602,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -9691,7 +9691,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -9708,7 +9708,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -9755,7 +9755,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -9772,7 +9772,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -9873,7 +9873,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -9890,7 +9890,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -9961,7 +9961,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -9978,7 +9978,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -10025,7 +10025,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -10042,7 +10042,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -10173,7 +10173,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:36.305Z",
             "agent": {
@@ -10190,7 +10190,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {

--- a/beater/test_approved_es_documents/TestPublishIntegrationProfileHeapProfile.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationProfileHeapProfile.approved.json
@@ -5,7 +5,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -16,7 +16,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -79,7 +79,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -90,7 +90,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -195,7 +195,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -206,7 +206,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -299,7 +299,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -310,7 +310,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -403,7 +403,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -414,7 +414,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -453,7 +453,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -464,7 +464,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -551,7 +551,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -562,7 +562,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -601,7 +601,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -612,7 +612,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -675,7 +675,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -686,7 +686,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -743,7 +743,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -754,7 +754,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -865,7 +865,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -876,7 +876,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -951,7 +951,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -962,7 +962,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1067,7 +1067,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -1078,7 +1078,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1153,7 +1153,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -1164,7 +1164,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1227,7 +1227,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -1238,7 +1238,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1277,7 +1277,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -1288,7 +1288,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1327,7 +1327,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -1338,7 +1338,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1407,7 +1407,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -1418,7 +1418,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1457,7 +1457,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -1468,7 +1468,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1675,7 +1675,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -1686,7 +1686,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1731,7 +1731,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -1742,7 +1742,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1799,7 +1799,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -1810,7 +1810,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1939,7 +1939,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -1950,7 +1950,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -1995,7 +1995,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -2006,7 +2006,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2129,7 +2129,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -2140,7 +2140,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2173,7 +2173,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -2184,7 +2184,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2241,7 +2241,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -2252,7 +2252,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2315,7 +2315,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -2326,7 +2326,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2473,7 +2473,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -2484,7 +2484,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2637,7 +2637,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -2648,7 +2648,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2849,7 +2849,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -2860,7 +2860,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -2971,7 +2971,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -2982,7 +2982,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3063,7 +3063,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -3074,7 +3074,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3203,7 +3203,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -3214,7 +3214,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3331,7 +3331,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -3342,7 +3342,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3441,7 +3441,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -3452,7 +3452,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3641,7 +3641,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -3652,7 +3652,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3763,7 +3763,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -3774,7 +3774,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3885,7 +3885,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -3896,7 +3896,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -3971,7 +3971,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -3982,7 +3982,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4057,7 +4057,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -4068,7 +4068,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {
@@ -4167,7 +4167,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-11-22T10:30:54.440Z",
             "ecs": {
@@ -4178,7 +4178,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "processor": {

--- a/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json
@@ -5,7 +5,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2018-07-30T18:53:42.281Z",
             "agent": {
@@ -70,7 +70,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "parent": {
@@ -139,7 +139,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2018-07-30T18:53:42.281Z",
             "agent": {
@@ -199,7 +199,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "parent": {
@@ -269,7 +269,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-01-09T21:40:53.000Z",
             "agent": {
@@ -332,7 +332,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "parent": {
@@ -403,7 +403,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-01-09T21:40:53.000Z",
             "agent": {
@@ -463,7 +463,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "parent": {
@@ -533,7 +533,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-01-09T21:40:53.000Z",
             "agent": {
@@ -599,7 +599,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "parent": {
@@ -747,7 +747,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2018-07-30T18:53:42.281Z",
             "agent": {
@@ -807,7 +807,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "parent": {

--- a/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json
@@ -5,7 +5,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-01-09T21:40:53.000Z",
             "agent": {
@@ -67,7 +67,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "parent": {
@@ -134,7 +134,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2017-05-30T18:53:27.154Z",
             "agent": {
@@ -263,7 +263,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "process": {
@@ -359,7 +359,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2018-07-30T18:53:42.281Z",
             "agent": {
@@ -430,7 +430,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "process": {
@@ -505,7 +505,7 @@
                 "beat": "apm-test",
                 "pipeline": "apm",
                 "type": "_doc",
-                "version": "7.9.3"
+                "version": "7.9.4"
             },
             "@timestamp": "2019-01-09T21:40:53.000Z",
             "agent": {
@@ -567,7 +567,7 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "7.9.3",
+                "version": "7.9.4",
                 "version_major": 7
             },
             "parent": {

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -81,6 +81,8 @@ The protocol of the request, e.g. "https:".
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`url.full`*::
@@ -90,6 +92,8 @@ The full, possibly agent-assembled URL of the request, e.g https://example.com:4
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -101,6 +105,8 @@ The hostname of the request, e.g. "example.com".
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`url.port`*::
@@ -110,6 +116,8 @@ The port of the request, e.g. 443.
 
 
 type: long
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -121,6 +129,8 @@ The path of the request, e.g. "/search".
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`url.query`*::
@@ -131,6 +141,8 @@ The query string of the request, e.g. "q=elasticsearch".
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`url.fragment`*::
@@ -140,6 +152,8 @@ A fragment specifying a location in a web page , e.g. "top".
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -152,6 +166,8 @@ The http version of the request leading to this event.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 
@@ -162,6 +178,8 @@ The http method of the request leading to this event.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -195,6 +213,8 @@ The status code of the HTTP response.
 
 type: long
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`http.response.finished`*::
@@ -204,6 +224,8 @@ Used by the Node agent to indicate when in the response life cycle an error has 
 
 
 type: boolean
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -227,6 +249,8 @@ A flat mapping of user-defined labels with string, boolean or number values.
 
 type: object
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 [float]
@@ -244,6 +268,8 @@ Immutable name of the service emitting this event.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`service.version`*::
@@ -253,6 +279,8 @@ Version of the service emitting this event.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -274,6 +302,8 @@ Unique meaningful name of the service node.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -519,6 +549,8 @@ Name of the agent used.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`agent.version`*::
@@ -529,6 +561,8 @@ Version of the agent used.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`agent.ephemeral_id`*::
@@ -538,6 +572,8 @@ The Ephemeral ID identifies a running process.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -555,6 +591,8 @@ Unique container id.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -622,6 +660,8 @@ The architecture of the host the event was recorded on.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`host.hostname`*::
@@ -631,6 +671,8 @@ The hostname of the host the event was recorded on.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -642,6 +684,8 @@ Name of the host the event was recorded on. It can contain same information as h
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`host.ip`*::
@@ -651,6 +695,8 @@ IP of the host that records the event.
 
 
 type: ip
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -668,6 +714,8 @@ The platform of the host the event was recorded on.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -687,6 +735,8 @@ May be filtered to protect sensitive information.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`process.pid`*::
@@ -696,6 +746,8 @@ Numeric process ID of the service process.
 
 
 type: long
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -707,6 +759,8 @@ Numeric ID of the service's parent process.
 
 type: long
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`process.title`*::
@@ -716,6 +770,8 @@ Service process title.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -738,6 +794,8 @@ Hostname of the APM Server.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`observer.version`*::
@@ -747,6 +805,8 @@ APM Server version.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -768,6 +828,8 @@ The type will be set to `apm-server`.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 
@@ -779,6 +841,8 @@ The username of the logged in user.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user.id`*::
@@ -789,6 +853,8 @@ Identifier of the logged in user.
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user.email`*::
@@ -798,6 +864,8 @@ Email of the logged in user.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -810,6 +878,8 @@ IP address of the client of a recorded event. This is typically obtained from a 
 
 type: ip
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 
@@ -820,6 +890,8 @@ IP address of the source of a recorded event. This is typically obtained from a 
 
 
 type: ip
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -838,6 +910,8 @@ Then it should be duplicated to `.ip` or `.domain`, depending on which one it is
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`destination.ip`*::
@@ -847,6 +921,8 @@ IP addess of the destination.
 Can be one of multiple IPv4 or IPv6 addresses.
 
 type: ip
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -858,6 +934,8 @@ Port of the destination.
 type: long
 
 format: string
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -878,6 +956,8 @@ type: keyword
 
 example: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user_agent.original.text`*::
@@ -887,6 +967,8 @@ Software agent acting in behalf of a user, eg. a web browser / OS combination.
 
 
 type: text
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -900,6 +982,8 @@ type: keyword
 
 example: Safari
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user_agent.version`*::
@@ -911,6 +995,8 @@ Version of the user agent.
 type: keyword
 
 example: 12.0
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -931,6 +1017,8 @@ type: keyword
 
 example: iPhone
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 [float]
@@ -950,6 +1038,8 @@ type: keyword
 
 example: darwin
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user_agent.os.name`*::
@@ -961,6 +1051,8 @@ Operating system name, without the version.
 type: keyword
 
 example: Mac OS X
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -974,6 +1066,8 @@ type: keyword
 
 example: Mac OS Mojave
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user_agent.os.family`*::
@@ -985,6 +1079,8 @@ OS family (such as redhat, debian, freebsd, windows).
 type: keyword
 
 example: debian
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -998,6 +1094,8 @@ type: keyword
 
 example: 10.14.1
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`user_agent.os.kernel`*::
@@ -1009,6 +1107,8 @@ Operating system kernel version as a raw string.
 type: keyword
 
 example: 4.4.0-112-generic
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -1036,6 +1136,8 @@ Cloud account ID
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`cloud.account.name`*::
@@ -1044,6 +1146,8 @@ type: keyword
 Cloud account name
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -1056,6 +1160,8 @@ type: keyword
 
 example: us-east1-a
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 
@@ -1066,6 +1172,8 @@ Cloud instance/machine ID
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`cloud.instance.name`*::
@@ -1074,6 +1182,8 @@ type: keyword
 Cloud instance/machine name
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -1087,6 +1197,8 @@ type: keyword
 
 example: t2.medium
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 
@@ -1097,6 +1209,8 @@ Cloud project ID
 
 type: keyword
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`cloud.project.name`*::
@@ -1105,6 +1219,8 @@ type: keyword
 Cloud project name
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -1117,6 +1233,8 @@ type: keyword
 
 example: gcp
 
+{yes-icon} {ecs-ref}[ECS] field.
+
 --
 
 *`cloud.region`*::
@@ -1127,6 +1245,8 @@ Cloud region name
 type: keyword
 
 example: us-east1
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -1150,6 +1270,8 @@ The ID of the error.
 
 
 type: keyword
+
+{yes-icon} {ecs-ref}[ECS] field.
 
 --
 
@@ -1964,8 +2086,15 @@ type: object
 [[exported-fields-ecs]]
 == ECS fields
 
-ECS Fields.
 
+This section defines Elastic Common Schema (ECS) fields—a common set of fields
+to be used when storing event data in {es}.
+
+This is an exhaustive list, and fields listed here are not necessarily used by {beatname_uc}.
+The goal of ECS is to enable and encourage users of {es} to normalize their event data,
+so that they can better analyze, visualize, and correlate the data represented in their events.
+
+See the {ecs-ref}[ECS reference] for more information.
 
 *`@timestamp`*::
 +

--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,10 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.1
 	github.com/client9/misspell v0.3.5-0.20180309020325-c0b55c823952 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect
-	github.com/dop251/goja v0.0.0-20201008094107-f97e50db25ec // indirect
+	github.com/dop251/goja v0.0.0-20201021154221-bf9dcfbbe798 // indirect
 	github.com/dop251/goja_nodejs v0.0.0-20200811150831-9bc458b4bbeb // indirect
 	github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4
-	github.com/elastic/beats/v7 v7.9.3-0.20201008170650-e8f1cef65256
+	github.com/elastic/beats/v7 v7.9.3-0.20201022093802-37d39ca68305
 	github.com/elastic/go-elasticsearch/v7 v7.9.1-0.20200819074336-1421f3b7a67c
 	github.com/elastic/go-elasticsearch/v8 v8.0.0-20200819071622-59b6a186f8dd
 	github.com/elastic/go-hdrhistogram v0.1.0
@@ -63,13 +63,13 @@ require (
 	go.uber.org/atomic v1.7.0
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.16.0
-	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 // indirect
+	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
-	golang.org/x/net v0.0.0-20201010224723-4f7140c49acb
-	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
-	golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 // indirect
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+	golang.org/x/sys v0.0.0-20201020230747-6e5568b54d1a // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
-	golang.org/x/tools v0.0.0-20201011145850-ed2f50202694 // indirect
+	golang.org/x/tools v0.0.0-20201022035929-9cf592e881e9 // indirect
 	google.golang.org/grpc v1.29.1
 	gopkg.in/yaml.v2 v2.3.0
 	howett.net/plist v0.0.0-20200419221736-3b63eb3a43b5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,8 @@ github.com/elastic/beats/v7 v7.9.2-0.20200924130853-3d7989f6957d h1:fcJ+21gb/Fi/
 github.com/elastic/beats/v7 v7.9.2-0.20200924130853-3d7989f6957d/go.mod h1:drhCN8qJL1qr5gPC3djI1ap/dAeGxuuSm4KiWPI8xIk=
 github.com/elastic/beats/v7 v7.9.3-0.20201008170650-e8f1cef65256 h1:8DkA0dXhe4UxrvWNVsRRrVyj6Z4lptCZ7Ps+rFqzHU8=
 github.com/elastic/beats/v7 v7.9.3-0.20201008170650-e8f1cef65256/go.mod h1:drhCN8qJL1qr5gPC3djI1ap/dAeGxuuSm4KiWPI8xIk=
+github.com/elastic/beats/v7 v7.9.3-0.20201022093802-37d39ca68305 h1:IopUG1LOPHTS1yEdJSnjrWmPmvWfZpLID9SNc4vBTH8=
+github.com/elastic/beats/v7 v7.9.3-0.20201022093802-37d39ca68305/go.mod h1:drhCN8qJL1qr5gPC3djI1ap/dAeGxuuSm4KiWPI8xIk=
 github.com/elastic/ecs v1.5.0 h1:/VEIBsRU4ecq2+U3RPfKNc6bFyomP6qnthYEcQZu8GU=
 github.com/elastic/ecs v1.5.0/go.mod h1:pgiLbQsijLOJvFR8OTILLu0Ni/R/foUNg0L+T6mU9b4=
 github.com/elastic/elastic-agent-client/v7 v7.0.0-20200709172729-d43b7ad5833a h1:2NHgf1RUw+f240lpTnLrCp1aBNvq2wDi0E1A423/S1k=
@@ -1067,6 +1069,8 @@ golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rB
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 h1:hb9wdF1z5waM+dSIICn1l0DkLVDT3hqhhQsDNUmHPRE=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 h1:pLI5jrR7OSLijeIDcmRxNmw2api+jEfxLoykJVice/E=
+golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -1132,6 +1136,8 @@ golang.org/x/net v0.0.0-20200923182212-328152dc79b1 h1:Iu68XRPd67wN4aRGGWwwq6bZo
 golang.org/x/net v0.0.0-20200923182212-328152dc79b1/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201010224723-4f7140c49acb h1:mUVeFHoDKis5nxCAzoAi7E8Ghb86EXh/RK6wtvJIqRY=
 golang.org/x/net v0.0.0-20201010224723-4f7140c49acb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190130055435-99b60b757ec1/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1149,6 +1155,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170608164803-0b25a408a500/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1197,6 +1205,8 @@ golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634 h1:bNEHhJCnrwMKNMmOx3yAynp5vs5/gRy+XWFtZFu7NBM=
 golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201020230747-6e5568b54d1a h1:e3IU37lwO4aq3uoRKINC7JikojFmE5gO7xhfxs8VC34=
+golang.org/x/sys v0.0.0-20201020230747-6e5568b54d1a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180805044716-cb6730876b98/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1257,6 +1267,8 @@ golang.org/x/tools v0.0.0-20200923182640-463111b69878 h1:VUw1+Jf6KJPf82mbTQMia6H
 golang.org/x/tools v0.0.0-20200923182640-463111b69878/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20201011145850-ed2f50202694 h1:BANdcOVw3KTuUiyfDp7wrzCpkCe8UP3lowugJngxBTg=
 golang.org/x/tools v0.0.0-20201011145850-ed2f50202694/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
+golang.org/x/tools v0.0.0-20201022035929-9cf592e881e9 h1:sEvmEcJVKBNUvgCUClbUQeHOAa9U0I2Ce1BooMvVCY4=
+golang.org/x/tools v0.0.0-20201022035929-9cf592e881e9/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.2
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
       retries: 300
@@ -16,7 +16,7 @@ services:
       - "xpack.security.enabled=false"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:7.9.1
+    image: docker.elastic.co/logstash/logstash:7.9.2
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 300
@@ -26,7 +26,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.9.1
+    image: docker.elastic.co/kibana/kibana:7.9.2
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5601"]
       retries: 300

--- a/tests/system/es_helper.py
+++ b/tests/system/es_helper.py
@@ -4,7 +4,7 @@ import time
 
 apm = "apm"
 apm_prefix = "{}*".format(apm)
-apm_version = "7.9.3"
+apm_version = "7.9.4"
 day = time.strftime("%Y.%m.%d", time.gmtime())
 default_policy = "apm-rollover-30-days"
 policy_url = "/_ilm/policy/"


### PR DESCRIPTION
## Motivation/summary

Run `make update-beats` to bump the version to 7.9.4.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
~- [ ] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)~
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

`make`
`./apm-server version`

## Related issues

None.