### PR TITLE
docs: sync changelogs (take two)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,4 +1,5 @@
 include::./changelogs/head.asciidoc[]
+include::./changelogs/7.10.asciidoc[]
 include::./changelogs/7.9.asciidoc[]
 include::./changelogs/7.8.asciidoc[]
 include::./changelogs/7.7.asciidoc[]

--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -18,6 +18,7 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
 
+[float]
 [[release-notes-6.8.13]]
 === APM Server version 6.8.13
 
@@ -25,6 +26,7 @@ https://github.com/elastic/apm-server/compare/v6.8.12\...v6.8.13[View commits]
 
 No significant changes.
 
+[float]
 [[release-notes-6.8.12]]
 === APM Server version 6.8.12
 
@@ -32,6 +34,7 @@ https://github.com/elastic/apm-server/compare/v6.8.11\...v6.8.12[View commits]
 
 No significant changes.
 
+[float]
 [[release-notes-6.8.11]]
 === APM Server version 6.8.11
 

--- a/changelogs/7.10.asciidoc
+++ b/changelogs/7.10.asciidoc
@@ -1,0 +1,53 @@
+[[release-notes-7.10]]
+== APM Server version 7.10
+
+https://github.com/elastic/apm-server/compare/7.9\...7.10[View commits]
+
+* <<release-notes-7.10.0>>
+
+[float]
+[[release-notes-7.10.0]]
+=== APM Server version 7.10.0
+
+https://github.com/elastic/apm-server/compare/v7.9.2\...v7.10.0[View commits]
+
+
+[float]
+==== Breaking Changes
+
+[float]
+==== Bug fixes
+
+* Transaction metrics aggregation now flushes on shutdown, respecting apm-server.shutdown_timeout {pull}3971[3971]
+* De-dot Jaeger process tag keys, fixing indexing errors when using jaeger-php {pull}4191[4191]
+* Fix json schema validation on `metadata.service.*` fields {pull}4142[4142]
+
+[float]
+==== Intake API Changes
+* Changed error messages for invalid events due to internal changes of decoder logic {pull}4261[4261]
+
+[float]
+==== Added
+
+* Use peer.address for destinationService.Resource if peer.address is not given on Jaeger span {pull}3975[3975]
+* Add event.duration to API request logs {pull}4030[4030]
+* Set destination.service.* from http.url for Jaeger spans {pull}4046[4046]
+* Use service.version for Metadata.Service.Version when converting a Jaeger span {pull}4061[4061]
+* Report basic telemetry {pull}4055[4055]
+* Add transaction.experience fields {pull}4056[4056]
+* Upgrade Go to 1.14.7 {pull}4067[4067]
+* Aggregate service destination span metrics {pull}4077[4077]
+* Added apm-server.kibana.headers configuration {pull}4087[4087]
+* Add a new Docker image based on UBI minimal 8 to packaging. {pull}4105[4105]
+* Add event.outcome to transactions and spans {pull}4064[4064]
+* Add event.outcome to aggregated transaction metrics {pull}4110[4110]
+* Set event.outcome for Jaeger spans based on http.status_code {pull}4127[4127]
+* Set event.outcome for transactions and spans based on http.status_code {pull}4165[4165]
+* Add mapping for `system.process.cgroup.*` metrics {pull}4176[4176]
+* Use transaction.sample_rate to calculate transaction metrics {pull}4212[4212]
+* Add longtask metric fields to transaction.experience {pull}4230[4230]
+
+[float]
+==== Comments
+
+A big thank you to https://github.com/tobiasstadler[@tobiasstadler] for their contributions to this release!

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -18,8 +18,3 @@ https://github.com/elastic/apm-server/compare/7.10\...master[View commits]
 ==== Added
 * Monitoring for aggregation of transaction metrics {pull}4287[4287]
 * Log warnings in aggregation of transaction metrics when grouping limit is reached {pull}4313[4313]
-
-[float]
-==== Comments
-
-A big thank you to https://github.com/tobiasstadler[@tobiasstadler] for their contributions to this release!

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -10,6 +10,7 @@
 --
 This following sections summarizes the changes in each release.
 
+* <<release-notes-7.10>>
 * <<release-notes-7.9>>
 * <<release-notes-7.8>>
 * <<release-notes-7.7>>


### PR DESCRIPTION
I messed up on https://github.com/elastic/apm-server/pull/4337. Sorry! Fixing in this PR by adding `7.10` RNs to `master` and moving the thank you note from `HEAD` to `7.10`.