### PR TITLE
[7.x] Backport release note sync

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,3 +1,4 @@
+include::./changelogs/head.asciidoc[]
 include::./changelogs/7.10.asciidoc[]
 include::./changelogs/7.9.asciidoc[]
 include::./changelogs/7.8.asciidoc[]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,4 +1,3 @@
-include::./changelogs/head.asciidoc[]
 include::./changelogs/7.10.asciidoc[]
 include::./changelogs/7.9.asciidoc[]
 include::./changelogs/7.8.asciidoc[]

--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,6 +3,7 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.12>>
 * <<release-notes-6.8.11>>
 * <<release-notes-6.8.10>>
 * <<release-notes-6.8.9>>
@@ -16,7 +17,13 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
 
-[float]
+[[release-notes-6.8.12]]
+=== APM Server version 6.8.12
+
+https://github.com/elastic/apm-server/compare/v6.8.11\...v6.8.12[View commits]
+
+No significant changes.
+
 [[release-notes-6.8.11]]
 === APM Server version 6.8.11
 

--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,6 +3,7 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.13>>
 * <<release-notes-6.8.12>>
 * <<release-notes-6.8.11>>
 * <<release-notes-6.8.10>>
@@ -16,6 +17,13 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.2>>
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
+
+[[release-notes-6.8.13]]
+=== APM Server version 6.8.13
+
+https://github.com/elastic/apm-server/compare/v6.8.12\...v6.8.13[View commits]
+
+No significant changes.
 
 [[release-notes-6.8.12]]
 === APM Server version 6.8.12

--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -18,6 +18,7 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
 
+[float]
 [[release-notes-6.8.13]]
 === APM Server version 6.8.13
 
@@ -25,6 +26,7 @@ https://github.com/elastic/apm-server/compare/v6.8.12\...v6.8.13[View commits]
 
 No significant changes.
 
+[float]
 [[release-notes-6.8.12]]
 === APM Server version 6.8.12
 
@@ -32,6 +34,7 @@ https://github.com/elastic/apm-server/compare/v6.8.11\...v6.8.12[View commits]
 
 No significant changes.
 
+[float]
 [[release-notes-6.8.11]]
 === APM Server version 6.8.11
 

--- a/changelogs/7.10.asciidoc
+++ b/changelogs/7.10.asciidoc
@@ -46,11 +46,8 @@ https://github.com/elastic/apm-server/compare/v7.9.2\...v7.10.0[View commits]
 * Add mapping for `system.process.cgroup.*` metrics {pull}4176[4176]
 * Use transaction.sample_rate to calculate transaction metrics {pull}4212[4212]
 * Add longtask metric fields to transaction.experience {pull}4230[4230]
-<<<<<<< HEAD
-=======
 
 [float]
 ==== Comments
 
 A big thank you to https://github.com/tobiasstadler[@tobiasstadler] for their contributions to this release!
->>>>>>> e654a65cd... docs: sync changelogs take two (#4341)

--- a/changelogs/7.10.asciidoc
+++ b/changelogs/7.10.asciidoc
@@ -46,3 +46,8 @@ https://github.com/elastic/apm-server/compare/v7.9.2\...v7.10.0[View commits]
 * Add mapping for `system.process.cgroup.*` metrics {pull}4176[4176]
 * Use transaction.sample_rate to calculate transaction metrics {pull}4212[4212]
 * Add longtask metric fields to transaction.experience {pull}4230[4230]
+
+[float]
+==== Comments
+
+A big thank you to https://github.com/tobiasstadler[@tobiasstadler] for their contributions to this release!

--- a/changelogs/7.10.asciidoc
+++ b/changelogs/7.10.asciidoc
@@ -46,3 +46,11 @@ https://github.com/elastic/apm-server/compare/v7.9.2\...v7.10.0[View commits]
 * Add mapping for `system.process.cgroup.*` metrics {pull}4176[4176]
 * Use transaction.sample_rate to calculate transaction metrics {pull}4212[4212]
 * Add longtask metric fields to transaction.experience {pull}4230[4230]
+<<<<<<< HEAD
+=======
+
+[float]
+==== Comments
+
+A big thank you to https://github.com/tobiasstadler[@tobiasstadler] for their contributions to this release!
+>>>>>>> e654a65cd... docs: sync changelogs take two (#4341)

--- a/changelogs/7.10.asciidoc
+++ b/changelogs/7.10.asciidoc
@@ -46,8 +46,3 @@ https://github.com/elastic/apm-server/compare/v7.9.2\...v7.10.0[View commits]
 * Add mapping for `system.process.cgroup.*` metrics {pull}4176[4176]
 * Use transaction.sample_rate to calculate transaction metrics {pull}4212[4212]
 * Add longtask metric fields to transaction.experience {pull}4230[4230]
-
-[float]
-==== Comments
-
-A big thank you to https://github.com/tobiasstadler[@tobiasstadler] for their contributions to this release!


### PR DESCRIPTION
Backports:

* docs: 6.8.12 release notes (#4080)
* docs: sync changelogs take two (#4341)