### PR TITLE
[7.10] Backport release note sync (#4341)

### DIFF
--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,6 +3,8 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.13>>
+* <<release-notes-6.8.12>>
 * <<release-notes-6.8.11>>
 * <<release-notes-6.8.10>>
 * <<release-notes-6.8.9>>
@@ -15,6 +17,22 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.2>>
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
+
+[float]
+[[release-notes-6.8.13]]
+=== APM Server version 6.8.13
+
+https://github.com/elastic/apm-server/compare/v6.8.12\...v6.8.13[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-6.8.12]]
+=== APM Server version 6.8.12
+
+https://github.com/elastic/apm-server/compare/v6.8.11\...v6.8.12[View commits]
+
+No significant changes.
 
 [float]
 [[release-notes-6.8.11]]

--- a/changelogs/7.10.asciidoc
+++ b/changelogs/7.10.asciidoc
@@ -46,3 +46,8 @@ https://github.com/elastic/apm-server/compare/v7.9.2\...v7.10.0[View commits]
 * Add mapping for `system.process.cgroup.*` metrics {pull}4176[4176]
 * Use transaction.sample_rate to calculate transaction metrics {pull}4212[4212]
 * Add longtask metric fields to transaction.experience {pull}4230[4230]
+
+[float]
+==== Comments
+
+A big thank you to https://github.com/tobiasstadler[@tobiasstadler] for their contributions to this release!


### PR DESCRIPTION
Backports the following commits to 7.10:
 - docs: sync changelogs take two (#4341) 
 - [7.x] Backport release note sync (#4342)