### PR TITLE
[7.9] Backport release note sync #4342

### DIFF
--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,6 +3,7 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.12>>
 * <<release-notes-6.8.11>>
 * <<release-notes-6.8.10>>
 * <<release-notes-6.8.9>>
@@ -16,7 +17,13 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
 
-[float]
+[[release-notes-6.8.12]]
+=== APM Server version 6.8.12
+
+https://github.com/elastic/apm-server/compare/v6.8.11\...v6.8.12[View commits]
+
+No significant changes.
+
 [[release-notes-6.8.11]]
 === APM Server version 6.8.11
 

--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,6 +3,7 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.13>>
 * <<release-notes-6.8.12>>
 * <<release-notes-6.8.11>>
 * <<release-notes-6.8.10>>
@@ -16,6 +17,13 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.2>>
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
+
+[[release-notes-6.8.13]]
+=== APM Server version 6.8.13
+
+https://github.com/elastic/apm-server/compare/v6.8.12\...v6.8.13[View commits]
+
+No significant changes.
 
 [[release-notes-6.8.12]]
 === APM Server version 6.8.12

--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -18,6 +18,7 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
 
+[float]
 [[release-notes-6.8.13]]
 === APM Server version 6.8.13
 
@@ -25,6 +26,7 @@ https://github.com/elastic/apm-server/compare/v6.8.12\...v6.8.13[View commits]
 
 No significant changes.
 
+[float]
 [[release-notes-6.8.12]]
 === APM Server version 6.8.12
 
@@ -32,6 +34,7 @@ https://github.com/elastic/apm-server/compare/v6.8.11\...v6.8.12[View commits]
 
 No significant changes.
 
+[float]
 [[release-notes-6.8.11]]
 === APM Server version 6.8.11
 


### PR DESCRIPTION
Backports:

* docs: 6.8.12 release notes (#4080)
* docs: sync changelogs take two (#4341)