### PR TITLE
sampling: add logging and monitoring

### DIFF
--- a/x-pack/apm-server/main.go
+++ b/x-pack/apm-server/main.go
@@ -27,6 +27,10 @@ import (
 
 var (
 	aggregationMonitoringRegistry = monitoring.Default.NewRegistry("apm-server.aggregation")
+
+	// Note: this registry is created in github.com/elastic/apm-server/sampling. That package
+	// will hopefully disappear in the future, when agents no longer send unsampled transactions.
+	samplingMonitoringRegistry = monitoring.Default.GetRegistry("apm-server.sampling")
 )
 
 type namedProcessor struct {
@@ -79,6 +83,7 @@ func newProcessors(args beater.ServerParams) ([]namedProcessor, error) {
 		if err != nil {
 			return nil, errors.Wrapf(err, "error creating %s", name)
 		}
+		monitoring.NewFunc(samplingMonitoringRegistry, "tail", sampler.CollectMonitoring, monitoring.Report)
 		processors = append(processors, namedProcessor{name: name, processor: sampler})
 	}
 	return processors, nil


### PR DESCRIPTION
## Motivation/summary

Log rate-limited warnings when the maximum number of
dynamic services is reached, causing root transactions
(indirectly, related trace events) to be dropped as a result.

Also, add some monitoring: record the number of events
(transactions and spans) that the tail-sampler has processed,
stored (locally), or explicitly dropped. Report the current LSM
and value log size for Badger. Report the current number of
dynamic service groups.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
- [x] logging (add log lines, choose appropriate log selector, etc.)
- [x] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~ (config telemetry coming in a followup)
- [x] Elasticsearch Service (https://cloud.elastic.co)
- [x] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)
- [x] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)

## How to test these changes

- Run server with monitoring and tail-sampling enabled, with a simple catch-all policy (e.g. only `sample_rate` defined)
- Send 1002 transactions each with a unique service name
- Observe that a single warning is logged due to the hard-coded limit of 1000 services being reached
- Observe reported metrics (query the index) includes the metrics documented in the description. One of those should be `dynamic_service_groups`, which should be 1000. Bear in mind that this depends on timing, as the groups may be reset between monitoring intervals.

## Related issues

https://github.com/elastic/apm-server/issues/4185