### PR TITLE
systemtest/estest: fix ExpectMinDocs

### DIFF
--- a/systemtest/estest/search.go
+++ b/systemtest/estest/search.go
@@ -40,7 +40,7 @@ func (es *Client) ExpectDocs(t testing.TB, index string, query interface{}, opts
 func (es *Client) ExpectMinDocs(t testing.TB, min int, index string, query interface{}, opts ...RequestOption) SearchResult {
 	t.Helper()
 	var result SearchResult
-	opts = append(opts, WithCondition(result.Hits.NonEmptyCondition()))
+	opts = append(opts, WithCondition(result.Hits.MinHitsCondition(min)))
 	if _, err := es.Search(index).WithQuery(query).Do(context.Background(), &result, opts...); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
## Motivation/summary

ExpectMinDocs should use MinHitsCondition with the supplied `min` parameter, rather than using NonEmptyCondition.
This should fix some of the flakiness in system tests.

This bug would explain failures such as in https://apm-ci.elastic.co/blue/organizations/jenkins/apm-server%2Fapm-server-mbp/detail/PR-4328/11/pipeline:

```
=== RUN   TestKeepUnsampled/true
[2020-10-27T04:02:19.341Z]     sampling_test.go:65: 
[2020-10-27T04:02:19.341Z]         	Error Trace:	sampling_test.go:65
[2020-10-27T04:02:19.342Z]         	Error:      	"[{apm-8.0.0-transaction-000001 0mU3aHUB96GvjGMlwl-W %!s(float64=0.2876821) map[@timestamp:2020-10-27T04:01:23.978Z agent:map[name:go version:0.0.0] ecs:map[version:1.6.0] event:map[ingested:2020-10-27T04:01:26.166263922Z outcome:unknown] host:map[architecture:i386 hostname:beowulf ip:127.0.0.1 name:beowulf os:map[platform:minix]] observer:map[ephemeral_id:159d1750-380b-4ec7-a381-21ccdec73835 hostname:apm-ci-immutable-ubuntu-1804-1603770060961733359 id:46b4a9c0-97f8-4bd9-8422-90ebbd7fd9e5 type:apm-server version:8.0.0 version_major:%!s(float64=8)] process:map[args:[/tmp/go-build739674032/b001/systemtest.test -test.testlogfile=/tmp/go-build739674032/b001/testlog.txt -test.timeout=10m0s -test.v=true] pid:%!s(float64=1) title:systemtest.test] processor:map[event:transaction name:transaction] service:map[language:map[name:go version:2.0] name:systemtest node:map[name:beowulf] runtime:map[name:gc version:2.0]] timestamp:map[us:%!s(float64=1.603771283978361e+15)] trace:map[id:b2bf84d8ff9abe84520f8a2d54d98074] transaction:map[duration:map[us:%!s(float64=0)] id:b2bf84d8ff9abe84 name:sampled sampled:%!s(bool=true) span_count:map[dropped:%!s(float64=0) started:%!s(float64=0)] type:TestKeepUnsampled]] {"process":{"args":["/tmp/go-build739674032/b001/systemtest.test","-test.testlogfile=/tmp/go-build739674032/b001/testlog.txt","-test.timeout=10m0s","-test.v=true"],"pid":1,"title":"systemtest.test"},"agent":{"name":"go","version":"0.0.0"},"processor":{"name":"transaction","event":"transaction"},"observer":{"hostname":"apm-ci-immutable-ubuntu-1804-1603770060961733359","id":"46b4a9c0-97f8-4bd9-8422-90ebbd7fd9e5","ephemeral_id":"159d1750-380b-4ec7-a381-21ccdec73835","type":"apm-server","version":"8.0.0","version_major":8},"trace":{"id":"b2bf84d8ff9abe84520f8a2d54d98074"},"@timestamp":"2020-10-27T04:01:23.978Z","ecs":{"version":"1.6.0"},"service":{"node":{"name":"beowulf"},"name":"systemtest","runtime":{"name":"gc","version":"2.0"},"language":{"name":"go","version":"2.0"}},"host":{"hostname":"beowulf","os":{"platform":"minix"},"ip":"127.0.0.1","name":"beowulf","architecture":"i386"},"event":{"ingested":"2020-10-27T04:01:26.166263922Z","outcome":"unknown"},"transaction":{"duration":{"us":0},"name":"sampled","id":"b2bf84d8ff9abe84","span_count":{"dropped":0,"started":0},"type":"TestKeepUnsampled","sampled":true},"timestamp":{"us":1603771283978361}}}]" should have 2 item(s), but has 1
[2020-10-27T04:02:19.342Z]         	Test:       	TestKeepUnsampled/true
```

That assertion should be impossible, and would be if ExpectMin did its job.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

`cd systemtest && go test -v`

## Related issues

None.