### PR TITLE
fix: respect configured policyname for ILM

### DIFF
--- a/changelogs/7.10.asciidoc
+++ b/changelogs/7.10.asciidoc
@@ -21,6 +21,7 @@ https://github.com/elastic/apm-server/compare/v7.9.2\...v7.10.0[View commits]
 * Transaction metrics aggregation now flushes on shutdown, respecting apm-server.shutdown_timeout {pull}3971[3971]
 * De-dot Jaeger process tag keys, fixing indexing errors when using jaeger-php {pull}4191[4191]
 * Fix json schema validation on `metadata.service.*` fields {pull}4142[4142]
+* Fix regression where policy_name was ignored in ILM setup {pull}4354[4354]
 
 [float]
 ==== Intake API Changes

--- a/idxmgmt/ilm/config.go
+++ b/idxmgmt/ilm/config.go
@@ -97,11 +97,11 @@ func NewConfig(info beat.Info, cfg *libcommon.Config) (Config, error) {
 		}
 		m.Index = idx
 		config.Setup.Mappings[et] = m
-		// if require_policy=false and policy does not exist, add it with an empty body
 		if config.Setup.RequirePolicy {
 			continue
 		}
 		if _, ok := config.Setup.Policies[m.PolicyName]; !ok {
+			// if require_policy=false and policy does not exist, add it with an empty body
 			config.Setup.Policies[m.PolicyName] = Policy{Name: m.PolicyName}
 		}
 	}

--- a/idxmgmt/ilm/config.go
+++ b/idxmgmt/ilm/config.go
@@ -85,6 +85,9 @@ func NewConfig(info beat.Info, cfg *libcommon.Config) (Config, error) {
 			return Config{}, err
 		}
 	}
+	if len(config.Setup.Policies) == 0 {
+		config.Setup.Policies = defaultPolicies()
+	}
 	// replace variable rollover_alias parts with beat information if available
 	// otherwise fail as the full alias needs to be known during setup.
 	for et, m := range config.Setup.Mappings {
@@ -94,9 +97,13 @@ func NewConfig(info beat.Info, cfg *libcommon.Config) (Config, error) {
 		}
 		m.Index = idx
 		config.Setup.Mappings[et] = m
-	}
-	if len(config.Setup.Policies) == 0 {
-		config.Setup.Policies = defaultPolicies()
+		// if require_policy=false and policy does not exist, add it with an empty body
+		if config.Setup.RequirePolicy {
+			continue
+		}
+		if _, ok := config.Setup.Policies[m.PolicyName]; !ok {
+			config.Setup.Policies[m.PolicyName] = Policy{Name: m.PolicyName}
+		}
 	}
 	return config, validate(&config)
 }

--- a/idxmgmt/ilm/config_test.go
+++ b/idxmgmt/ilm/config_test.go
@@ -163,7 +163,11 @@ func TestConfig_Valid(t *testing.T) {
 							Index: "apm-9.9.9-error"}
 						return m
 					}(),
-					Policies: defaultPolicies(),
+					Policies: func() map[string]Policy {
+						p := defaultPolicies()
+						p["errorPolicy"] = Policy{Name: "errorPolicy"}
+						return p
+					}(),
 				}},
 		},
 	} {


### PR DESCRIPTION
## Motivation/summary
When configuring `ilm.setup.require_policy:false` the customized policy name has been ignored. This fixes the issue
by ensuring the policy name is added to the ILM setup.
The regression was introduced with #3826

## Checklist

~- [ ] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).~
- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes
configure `apm-server.ilm.setup.require_policy: false`, set a custom `policy_name` for at least one event type and ensure that the `index.lifecycle.name` for this event is properly set up

## Related issues
fixes 4349

@elastic/apm-server I believe this should be backported to `7.10`. 