### PR TITLE
[7.10] fix: respect configured policyname for ILM (#4354)

### DIFF
--- a/changelogs/7.10.asciidoc
+++ b/changelogs/7.10.asciidoc
@@ -22,6 +22,7 @@ https://github.com/elastic/apm-server/compare/v7.9.2\...v7.10.0[View commits]
 * De-dot Jaeger process tag keys, fixing indexing errors when using jaeger-php {pull}4191[4191]
 * Fix json schema validation on `metadata.service.*` fields {pull}4142[4142]
 * Carriage returns are now stripped from source-mapped context source lines {pull}4348[4348]
+* Fix regression where policy_name was ignored in ILM setup {pull}4354[4354]
 
 [float]
 ==== Intake API Changes

--- a/idxmgmt/ilm/config.go
+++ b/idxmgmt/ilm/config.go
@@ -85,6 +85,9 @@ func NewConfig(info beat.Info, cfg *libcommon.Config) (Config, error) {
 			return Config{}, err
 		}
 	}
+	if len(config.Setup.Policies) == 0 {
+		config.Setup.Policies = defaultPolicies()
+	}
 	// replace variable rollover_alias parts with beat information if available
 	// otherwise fail as the full alias needs to be known during setup.
 	for et, m := range config.Setup.Mappings {
@@ -94,9 +97,13 @@ func NewConfig(info beat.Info, cfg *libcommon.Config) (Config, error) {
 		}
 		m.Index = idx
 		config.Setup.Mappings[et] = m
-	}
-	if len(config.Setup.Policies) == 0 {
-		config.Setup.Policies = defaultPolicies()
+		if config.Setup.RequirePolicy {
+			continue
+		}
+		if _, ok := config.Setup.Policies[m.PolicyName]; !ok {
+			// if require_policy=false and policy does not exist, add it with an empty body
+			config.Setup.Policies[m.PolicyName] = Policy{Name: m.PolicyName}
+		}
 	}
 	return config, validate(&config)
 }

--- a/idxmgmt/ilm/config_test.go
+++ b/idxmgmt/ilm/config_test.go
@@ -163,7 +163,11 @@ func TestConfig_Valid(t *testing.T) {
 							Index: "apm-9.9.9-error"}
 						return m
 					}(),
-					Policies: defaultPolicies(),
+					Policies: func() map[string]Policy {
+						p := defaultPolicies()
+						p["errorPolicy"] = Policy{Name: "errorPolicy"}
+						return p
+					}(),
 				}},
 		},
 	} {


### PR DESCRIPTION
Backports the following commits to 7.10:
 - fix: respect configured policyname for ILM (#4354)