### PR TITLE
docs: fix bad GitHub links

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -36,7 +36,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :win_os:
 :linux_os:
 
-:github_repo_link: https://github.com/elastic/apm-server/blob/{version}
+:github_repo_link: https://github.com/elastic/apm-server/blob/v{version}
 ifeval::["{version}" == "8.0.0"]
 :github_repo_link: https://github.com/elastic/apm-server/blob/master
 endif::[]


### PR DESCRIPTION
## Summary

Fixes four links in the Events API intake docs by adding a missing "v".

## Related issues

Closes https://github.com/elastic/apm-server/issues/4372