### PR TITLE
[7.x] docs: fix GitHub links (#4375)

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -36,7 +36,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :win_os:
 :linux_os:
 
-:github_repo_link: https://github.com/elastic/apm-server/blob/{version}
+:github_repo_link: https://github.com/elastic/apm-server/blob/v{version}
 ifeval::["{version}" == "8.0.0"]
 :github_repo_link: https://github.com/elastic/apm-server/blob/master
 endif::[]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: fix GitHub links (#4375)