### PR TITLE
[7.10] docs: remove apm whats new (#4385)

### DIFF
--- a/docs/guide/apm-breaking-changes.asciidoc
+++ b/docs/guide/apm-breaking-changes.asciidoc
@@ -3,6 +3,7 @@
 
 This section discusses the changes that you need to be aware of when migrating your application from one version of APM to another.
 
+* <<breaking-7.10.0>>
 * <<breaking-7.9.0>>
 * <<breaking-7.8.0>>
 * <<breaking-7.7.0>>
@@ -19,13 +20,20 @@ This section discusses the changes that you need to be aware of when migrating y
 * <<breaking-6.5.0>>
 * <<breaking-6.4.0>>
 
-Also see <<whats-new>>.
+Also see {observability-guide}/whats-new.html[What's new in Observability {minor-version}].
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
+// Remove this tag in a future PR
 // tag::notable-v8-breaking-changes[]
-
 // end::notable-v8-breaking-changes[]
+
+[[breaking-7.10.0]]
+=== 7.10.0 APM Breaking changes
+
+// tag::notable-breaking-changes[]
+No breaking changes.
+// end::notable-breaking-changes[]
 
 [[breaking-7.9.0]]
 === 7.9.0 APM Breaking changes

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -15,8 +15,6 @@ include::./overview.asciidoc[]
 
 include::./apm-doc-directory.asciidoc[]
 
-include::./whats-new.asciidoc[]
-
 include::./install-and-run.asciidoc[]
 
 include::./quick-start-overview.asciidoc[]

--- a/docs/guide/redirects.asciidoc
+++ b/docs/guide/redirects.asciidoc
@@ -41,4 +41,13 @@ This page has moved. Please see <<agent-server-compatibility>>.
 [role="exclude",id="apm-release-notes"]
 === APM release highlights
 
-This page has moved. Please see <<whats-new>>.
+This page has moved.
+Please see {observability-guide}/whats-new.html[What's new in Observability {minor-version}].
+
+Please see <<whats-new>>.
+
+[role="exclude",id="whats-new"]
+=== What's new in APM {minor-version}
+
+This page has moved.
+Please see {observability-guide}/whats-new.html[What's new in Observability {minor-version}].

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -14,7 +14,8 @@ Any exceptions will be explained in <<breaking-changes,breaking changes>>.
 
 * Review the APM Server <<release-notes,release notes>> and <<breaking-changes,breaking changes>>
 for changes between your current APM Server version and the one you are upgrading to.
-* Review the APM stack {apm-overview-ref-v}/whats-new.html[release highlights] and {apm-overview-ref-v}/apm-breaking-changes.html[breaking changes] for highlights and important changes to other APM components.
+* Review the APM stack {apm-overview-ref-v}/apm-breaking-changes.html[breaking changes] and Observability
+{observability-guide}/whats-new.html[What's new in {minor-version}] for important changes to other APM components.
 
 [discrete]
 [[upgrade-order]]


### PR DESCRIPTION
Backports the following commits to 7.10:
 - docs: remove apm whats new (#4385)