### PR TITLE
fix: set default value for ONLY_DOCS env var

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@ pipeline {
     DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
     DOCKER_IMAGE = "${env.DOCKER_REGISTRY}/observability-ci/apm-server"
+    ONLY_DOCS = "false"
   }
   options {
     timeout(time: 2, unit: 'HOURS')


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Before creating the PR, ensure that:

1. Your branch is rebased on top of the latest master.
   Squash your initial commits into meaningful commits.
   After creating a PR, do not rebase of force push any longer.
2. Nothing is broken, by running the test suite (at least unit tests).
   See https://github.com/elastic/apm-server/blob/master/TESTING.md for details.
3. Your code follows the style guidelines of this project:
   run `make check-full` for static code checks and linting.

A few suggestions about filling out this PR:

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR.
3. Please label this PR with at least one of the following labels:
   - bug fix
   - breaking change
   - enhancement
4. Reference the related issue, and make use of magic keywords where it makes sense
   https://help.github.com/articles/closing-issues-using-keywords/.
5. Do not remove any checklist items, strike through the ones that don't apply
   (by using tildes, e.g. ~scratch this ~).
6. Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
7. Submit the pull request:
   Push your changes to your forked copy of the repository and submit a pull request
   (https://help.github.com/articles/using-pull-requests).
8. Please be patient. We might not be able to immediately review your code,
   but we'll do our best to dedicate to it the attention it deserves.
   Your effort is much appreciated!

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

There is no default value for ONLY_DOCS, so only on PR has a value, this makes no stage is run. This PR fix the issue by setting a default value for ONLY_DOCS
