### PR TITLE
Use commit id and pr subfolder in the bucket

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -437,17 +437,6 @@ pipeline {
               }
             }
             stage('Publish') {
-              when {
-                beforeAgent true
-                anyOf {
-                  branch 'master'
-                  branch pattern: '\\d+\\.\\d+', comparator: 'REGEXP'
-                  branch pattern: 'v\\d?', comparator: 'REGEXP'
-                  tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: 'REGEXP'
-                  expression { return params.Run_As_Master_Branch }
-                  expression { return env.BEATS_UPDATED != "false" }
-                }
-              }
               environment {
                 BUCKET_URI = """${isPR() ? "gs://${JOB_GCS_BUCKET}/pull-requests/pr-${env.CHANGE_ID}" : "gs://${JOB_GCS_BUCKET}/snapshots"}"""
               }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -444,8 +444,20 @@ pipeline {
                   expression { return env.BEATS_UPDATED != "false" }
                 }
               }
+              environment {
+                BUCKET_URI = """${isPR() ? "gs://${JOB_GCS_BUCKET}/pull-requests/pr-${env.CHANGE_ID}" : "gs://${JOB_GCS_BUCKET}/snapshots"}"""
+              }
               steps {
-                googleStorageUpload(bucket: "gs://${JOB_GCS_BUCKET}/snapshots",
+                // Upload files to the default location
+                googleStorageUpload(bucket: "${BUCKET_URI}",
+                  credentialsId: "${JOB_GCS_CREDENTIALS}",
+                  pathPrefix: "${BASE_DIR}/build/distributions/",
+                  pattern: "${BASE_DIR}/build/distributions/**/*",
+                  sharedPublicly: true,
+                  showInline: true)
+
+                // Copy those files to another location with the sha commit to test them afterward.
+                googleStorageUpload(bucket: "gs://${JOB_GCS_BUCKET}/commits/${env.GIT_BASE_COMMIT}",
                   credentialsId: "${JOB_GCS_CREDENTIALS}",
                   pathPrefix: "${BASE_DIR}/build/distributions/",
                   pattern: "${BASE_DIR}/build/distributions/**/*",


### PR DESCRIPTION
### What

Upload artifacts if PRs to another location.
Upload artifacts to the commit-id folder then the beats-tester pipeline can consume them in another follow up if required

### Why

This will allow us to solve the issue of consuming artifacts when there is an uploading process in another build

### Tests

I triggered manually the [build#2](https://apm-ci.elastic.co/job/apm-server/job/apm-server-mbp/job/PR-4400/2/) which caused the package generation as shown below (WIP)