### PR TITLE
[7.x] docs: add missing breaking changes (#4405)

### DIFF
--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -4,6 +4,10 @@ APM Server is built on top of {beats-ref}/index.html[libbeat].
 As such, any breaking change in libbeat is also considered to be a breaking change in APM Server.
 
 [float]
+=== 7.10
+There are no breaking changes in APM Server.
+
+[float]
 === 7.9
 There are no breaking changes in APM Server.
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: add missing breaking changes (#4405)