### PR TITLE
[7.x] ci: add simper comment triggers (#4399)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
+    issueCommentTrigger('(?i)(.*(?:jenkins\\W+)?run\\W+(?:the\\W+)?(?:(hey-apm|package)\\W+)?tests(?:\\W+please)?.*|^\\/test|^\\/hey-apm|^\\/package)')
   }
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
@@ -390,7 +390,7 @@ pipeline {
             branch pattern: '\\d+\\.\\d+', comparator: 'REGEXP'
             tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: 'REGEXP'
             expression { return isPR() && env.BEATS_UPDATED != "false" }
-            expression { return env.GITHUB_COMMENT?.contains('package tests') }
+            expression { return env.GITHUB_COMMENT?.contains('package tests') || env.GITHUB_COMMENT?.contains('/package') }
             expression { return params.Run_As_Master_Branch }
           }
         }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ci: add simper comment triggers (#4399)