### PR TITLE
systemtest: log ILM policy deletion errors

### DIFF
--- a/systemtest/elasticsearch.go
+++ b/systemtest/elasticsearch.go
@@ -121,7 +121,9 @@ func CleanupElasticsearch(t testing.TB) {
 			break
 		}
 		// Retry deleting, in case indices are still being deleted.
-		time.Sleep(100 * time.Millisecond)
+		const delay = 100 * time.Millisecond
+		t.Logf("failed to delete ILM policy (retrying in %s): %s", delay, err)
+		time.Sleep(delay)
 	}
 }
 


### PR DESCRIPTION
## Motivation/summary

In systemtest.CleanupElasticsearch we attempt to the delete ILM policy
in a loop, to account for delayed removal of dependants (template, etc.)

We've seen in some tests (TestTransactionAggregationShutdown) that this
function is causing test timeouts, with the culprit being the loop/`time.Sleep`.
Let's log the error message to see what it doesn't exit.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

N/A

## Related issues

https://github.com/elastic/apm-server/issues/4366