### PR TITLE
fix: backport package-docker-snapshot.sh script

### DIFF
--- a/script/jenkins/package-docker-snapshot.sh
+++ b/script/jenkins/package-docker-snapshot.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Build the docker image for the apm-server, retag and push it to the given docker registry
+#
+# Arguments:
+# - NEW_TAG, this is the tag for the docker image to be pushed.
+# - NEW_IMAGE, this is the docker image name to be pushed.
+#
+set -euo pipefail
+
+NEW_TAG=${1:?Docker tag is not set}
+NEW_IMAGE=${2:?Docker image is not set}
+
+export PLATFORMS='linux/amd64'
+export TYPE='docker'
+export SNAPSHOT='true'
+export IMAGE="docker.elastic.co/apm/apm-server"
+
+echo 'INFO: Build docker images'
+make release
+
+echo 'INFO: Get the just built docker image'
+TAG=$(docker images ${IMAGE} --format "{{.Tag}}" | head -1)
+
+echo "INFO: Retag docker image (${IMAGE}:${TAG})"
+docker tag "${IMAGE}:${TAG}" "${NEW_IMAGE}:${NEW_TAG}"
+
+echo "INFO: Push docker image (${NEW_IMAGE}:${NEW_TAG})"
+docker push "${NEW_IMAGE}:${NEW_TAG}"


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Before creating the PR, ensure that:

1. Your branch is rebased on top of the latest master.
   Squash your initial commits into meaningful commits.
   After creating a PR, do not rebase of force push any longer.
2. Nothing is broken, by running the test suite (at least unit tests).
   See https://github.com/elastic/apm-server/blob/master/TESTING.md for details.
3. Your code follows the style guidelines of this project:
   run `make check-full` for static code checks and linting.

A few suggestions about filling out this PR:

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR.
3. Please label this PR with at least one of the following labels:
   - bug fix
   - breaking change
   - enhancement
4. Reference the related issue, and make use of magic keywords where it makes sense
   https://help.github.com/articles/closing-issues-using-keywords/.
5. Do not remove any checklist items, strike through the ones that don't apply
   (by using tildes, e.g. ~scratch this ~).
6. Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
7. Submit the pull request:
   Push your changes to your forked copy of the repository and submit a pull request
   (https://help.github.com/articles/using-pull-requests).
8. Please be patient. We might not be able to immediately review your code,
   but we'll do our best to dedicate to it the attention it deserves.
   Your effort is much appreciated!

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Backport a script to build and push the docker images.

```

[2020-11-12T11:46:39.152Z] + ./script/jenkins/package-docker-snapshot.sh e657ca888bd349ba144f67b6c7347c3b3be3fbea docker.elastic.co/observability-ci/apm-server

[2020-11-12T11:46:39.152Z] /var/lib/jenkins/workspace/apm-server_apm-server-mbp_7.10/src/github.com/elastic/apm-server@tmp/durable-6d65a9b0/script.sh: 1: /var/lib/jenkins/workspace/apm-server_apm-server-mbp_7.10/src/github.com/elastic/apm-server@tmp/durable-6d65a9b0/script.sh: ./script/jenkins/package-docker-snapshot.sh: not found

script returned exit code 127
```