### PR TITLE
[7.8] docs: Fix broken .NET agent link

### DIFF
--- a/docs/guide/apm-release-notes.asciidoc
+++ b/docs/guide/apm-release-notes.asciidoc
@@ -92,7 +92,7 @@ Configure the {apm-rum-ref}/configuration.html#api-version[`api-version`] in you
 Auto instrumentation for `System.Data.SqlClient` is now available for both .NET Core and .NET Framework applications.
 This means you can get out-of-the-box visibility, including service maps and distributed traces, for the SqlClient calls made from your .NET applications.
 +
-Learn more in {apm-dotnet-ref}/setup.html#setup-sqlclient[set up SQLClient],
+Learn more in {apm-dotnet-ref}/setup-sqlclient.html[set up SQLClient],
 and upgrade to the latest version of the .NET agent to get started.
 
 // end::notable-v78-highlights[]


### PR DESCRIPTION
Had to rewind time for this fix. Fixes a broken link introduced in the `1.7` release of the .NET agent.

Related: https://github.com/elastic/apm-agent-dotnet/pull/1036