### PR TITLE
fix: Add maxLen=1024 requirement to metadata.system.container.id

### DIFF
--- a/changelogs/7.10.asciidoc
+++ b/changelogs/7.10.asciidoc
@@ -3,7 +3,19 @@
 
 https://github.com/elastic/apm-server/compare/7.9\...7.10[View commits]
 
+* <<release-notes-7.10.1>>
 * <<release-notes-7.10.0>>
+
+
+[float]
+[[release-notes-7.10.1]]
+=== APM Server version 7.10.1
+
+https://github.com/elastic/apm-server/compare/v7.10.0\...v7.10.1[View commits]
+
+[float]
+==== Bug fixes
+* Add maxLen=1024 requirement to `metadata.system.container.id` {pull}4429[4429]
 
 [float]
 [[release-notes-7.10.0]]

--- a/model/modeldecoder/v2/model.go
+++ b/model/modeldecoder/v2/model.go
@@ -295,7 +295,7 @@ type metadataSystemContainer struct {
 	// `id` is the only field in `system.container`,
 	// if `system.container:{}` is sent, it should be considered valid
 	// if additional attributes are defined in the future, add the required tag
-	ID nullable.String `json:"id"` //validate:"required"
+	ID nullable.String `json:"id" validate:"max=1024"`
 }
 
 type metadataSystemKubernetes struct {

--- a/model/modeldecoder/v2/model_generated.go
+++ b/model/modeldecoder/v2/model_generated.go
@@ -494,6 +494,9 @@ func (val *metadataSystemContainer) validate() error {
 	if !val.IsSet() {
 		return nil
 	}
+	if utf8.RuneCountInString(val.ID.Val) > 1024 {
+		return fmt.Errorf("'id': validation rule 'max(1024)' violated")
+	}
 	return nil
 }
 


### PR DESCRIPTION

## Motivation/summary
The max length requirement was removed when switching to the new decoder logic.

## Checklist

~- [ ] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).~
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
~- [ ] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)~
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes
The fix comes out of [apm-server pull#4427](https://github.com/elastic/apm-server/pull/4427/files#diff-e1fc2ee084f735532c843f42168cb9e4ec49ba1f76225c6bf28aa261737f28a1R500) where package tests checking for maxLen restrictions were switched to use the generated json schema. These changes cover the maxLen restrictions with automated tests, but won't be backported to `7.10`. 

## Related issues
