### PR TITLE
[7.x] sampling: use apm-server/elasticsearch.Client (#4285)

### DIFF
--- a/elasticsearch/bulk.go
+++ b/elasticsearch/bulk.go
@@ -1,0 +1,146 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package elasticsearch
+
+import (
+	"context"
+	"io"
+	"time"
+
+	esutilv7 "github.com/elastic/go-elasticsearch/v7/esutil"
+	esutilv8 "github.com/elastic/go-elasticsearch/v8/esutil"
+)
+
+// BulkIndexer represents a parallel, asynchronous, efficient indexer for Elasticsearch.
+//
+// This is a subset of the go-elasticsearch/esutil.BulkIndexer interface, suitable for
+// use with either a v7 or v8 client.
+type BulkIndexer interface {
+	// Add adds an item to the indexer. It returns an error when the item cannot be added.
+	// Use the OnSuccess and OnFailure callbacks to get the operation result for the item.
+	//
+	// You must call the Close() method after you're done adding items.
+	//
+	// It is safe for concurrent use. When it's called from goroutines,
+	// they must finish before the call to Close, eg. using sync.WaitGroup.
+	Add(context.Context, BulkIndexerItem) error
+
+	// Close waits until all added items are flushed and closes the indexer.
+	Close(context.Context) error
+
+	// Stats returns indexer statistics.
+	Stats() BulkIndexerStats
+}
+
+// BulkIndexerConfig represents configuration of the indexer.
+//
+// This is a subset of the go-elasticsearch/esutil.BulkIndexerConfig type, suitable for use
+// with either a v7 or v8 client.
+type BulkIndexerConfig struct {
+	NumWorkers    int           // The number of workers. Defaults to runtime.NumCPU().
+	FlushBytes    int           // The flush threshold in bytes. Defaults to 5MB.
+	FlushInterval time.Duration // The flush threshold as duration. Defaults to 30sec.
+
+	OnError      func(context.Context, error)          // Called for indexer errors.
+	OnFlushStart func(context.Context) context.Context // Called when the flush starts.
+	OnFlushEnd   func(context.Context)                 // Called when the flush ends.
+
+	// Parameters of the Bulk API.
+	Index    string
+	Pipeline string
+	Timeout  time.Duration
+}
+
+// BulkIndexerItem represents an indexer item.
+//
+// This is a clone of the go-elasticsearch/esutil.BulkIndexerItem type, suitable for use
+// with either a v7 or v8 client.
+type BulkIndexerItem struct {
+	Index           string
+	Action          string
+	DocumentID      string
+	Body            io.Reader
+	RetryOnConflict *int
+
+	OnSuccess func(context.Context, BulkIndexerItem, BulkIndexerResponseItem)        // Per item
+	OnFailure func(context.Context, BulkIndexerItem, BulkIndexerResponseItem, error) // Per item
+}
+
+type (
+	BulkIndexerStats        esutilv7.BulkIndexerStats
+	BulkIndexerResponse     esutilv7.BulkIndexerResponse
+	BulkIndexerResponseItem esutilv7.BulkIndexerResponseItem
+)
+
+type v7BulkIndexer struct {
+	esutilv7.BulkIndexer
+}
+
+func (b v7BulkIndexer) Add(ctx context.Context, item BulkIndexerItem) error {
+	itemv7 := esutilv7.BulkIndexerItem{
+		Index:           item.Index,
+		Action:          item.Action,
+		DocumentID:      item.DocumentID,
+		Body:            item.Body,
+		RetryOnConflict: item.RetryOnConflict,
+	}
+	if item.OnSuccess != nil {
+		itemv7.OnSuccess = func(ctx context.Context, itemv7 esutilv7.BulkIndexerItem, resp esutilv7.BulkIndexerResponseItem) {
+			item.OnSuccess(ctx, item, BulkIndexerResponseItem(resp))
+		}
+	}
+	if item.OnFailure != nil {
+		itemv7.OnFailure = func(ctx context.Context, itemv8 esutilv7.BulkIndexerItem, resp esutilv7.BulkIndexerResponseItem, err error) {
+			item.OnFailure(ctx, item, BulkIndexerResponseItem(resp), err)
+		}
+	}
+	return b.BulkIndexer.Add(ctx, itemv7)
+}
+
+func (b v7BulkIndexer) Stats() BulkIndexerStats {
+	return BulkIndexerStats(b.BulkIndexer.Stats())
+}
+
+type v8BulkIndexer struct {
+	esutilv8.BulkIndexer
+}
+
+func (b v8BulkIndexer) Add(ctx context.Context, item BulkIndexerItem) error {
+	itemv8 := esutilv8.BulkIndexerItem{
+		Index:           item.Index,
+		Action:          item.Action,
+		DocumentID:      item.DocumentID,
+		Body:            item.Body,
+		RetryOnConflict: item.RetryOnConflict,
+	}
+	if item.OnSuccess != nil {
+		itemv8.OnSuccess = func(ctx context.Context, itemv8 esutilv8.BulkIndexerItem, resp esutilv8.BulkIndexerResponseItem) {
+			item.OnSuccess(ctx, item, BulkIndexerResponseItem(resp))
+		}
+	}
+	if item.OnFailure != nil {
+		itemv8.OnFailure = func(ctx context.Context, itemv8 esutilv8.BulkIndexerItem, resp esutilv8.BulkIndexerResponseItem, err error) {
+			item.OnFailure(ctx, item, BulkIndexerResponseItem(resp), err)
+		}
+	}
+	return b.BulkIndexer.Add(ctx, itemv8)
+}
+
+func (b v8BulkIndexer) Stats() BulkIndexerStats {
+	return BulkIndexerStats(b.BulkIndexer.Stats())
+}

--- a/x-pack/apm-server/sampling/config.go
+++ b/x-pack/apm-server/sampling/config.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/elastic/apm-server/elasticsearch"
 	"github.com/elastic/apm-server/publish"
-	"github.com/elastic/go-elasticsearch/v7"
 )
 
 // Config holds configuration for Processor.
@@ -56,7 +56,7 @@ type LocalSamplingConfig struct {
 type RemoteSamplingConfig struct {
 	// Elasticsearch holds the Elasticsearch client to use for publishing
 	// and subscribing to remote sampling decisions.
-	Elasticsearch *elasticsearch.Client
+	Elasticsearch elasticsearch.Client
 
 	// SampledTracesIndex holds the name of the Elasticsearch index for
 	// storing and searching sampled trace IDs.

--- a/x-pack/apm-server/sampling/config_test.go
+++ b/x-pack/apm-server/sampling/config_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/apm-server/elasticsearch"
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/apm-server/x-pack/apm-server/sampling"
-	"github.com/elastic/go-elasticsearch/v7"
 )
 
 func TestNewProcessorConfigInvalid(t *testing.T) {
@@ -50,7 +50,10 @@ func TestNewProcessorConfigInvalid(t *testing.T) {
 	config.IngestRateDecayFactor = 0.5
 
 	assertInvalidConfigError("invalid remote sampling config: Elasticsearch unspecified")
-	config.Elasticsearch = &elasticsearch.Client{}
+	var elasticsearchClient struct {
+		elasticsearch.Client
+	}
+	config.Elasticsearch = elasticsearchClient
 
 	assertInvalidConfigError("invalid remote sampling config: SampledTracesIndex unspecified")
 	config.SampledTracesIndex = "sampled-traces"

--- a/x-pack/apm-server/sampling/pubsub/config.go
+++ b/x-pack/apm-server/sampling/pubsub/config.go
@@ -10,14 +10,15 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
-	"github.com/elastic/go-elasticsearch/v7"
+
+	"github.com/elastic/apm-server/elasticsearch"
 )
 
 // Config holds configuration for Pubsub.
 type Config struct {
 	// Client holds an Elasticsearch client, for indexing and searching for
 	// trace ID observations.
-	Client *elasticsearch.Client
+	Client elasticsearch.Client
 
 	// Index holds the index name.
 	Index string

--- a/x-pack/apm-server/sampling/pubsub/config_test.go
+++ b/x-pack/apm-server/sampling/pubsub/config_test.go
@@ -11,12 +11,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/go-elasticsearch/v7"
-
+	"github.com/elastic/apm-server/elasticsearch"
 	"github.com/elastic/apm-server/x-pack/apm-server/sampling/pubsub"
 )
 
 func TestConfigInvalid(t *testing.T) {
+	var elasticsearchClient struct {
+		elasticsearch.Client
+	}
+
 	type test struct {
 		config pubsub.Config
 		err    string
@@ -27,25 +30,25 @@ func TestConfigInvalid(t *testing.T) {
 		err:    "Client unspecified",
 	}, {
 		config: pubsub.Config{
-			Client: &elasticsearch.Client{},
+			Client: elasticsearchClient,
 		},
 		err: "Index unspecified",
 	}, {
 		config: pubsub.Config{
-			Client: &elasticsearch.Client{},
+			Client: elasticsearchClient,
 			Index:  "index",
 		},
 		err: "BeatID unspecified",
 	}, {
 		config: pubsub.Config{
-			Client: &elasticsearch.Client{},
+			Client: elasticsearchClient,
 			Index:  "index",
 			BeatID: "beat_id",
 		},
 		err: "SearchInterval unspecified or negative",
 	}, {
 		config: pubsub.Config{
-			Client:         &elasticsearch.Client{},
+			Client:         elasticsearchClient,
 			Index:          "index",
 			BeatID:         "beat_id",
 			SearchInterval: time.Second,

--- a/x-pack/apm-server/sampling/pubsub/pubsub_test.go
+++ b/x-pack/apm-server/sampling/pubsub/pubsub_test.go
@@ -22,8 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/elastic/go-elasticsearch/v7"
-
+	"github.com/elastic/apm-server/elasticsearch"
 	"github.com/elastic/apm-server/x-pack/apm-server/sampling/pubsub"
 )
 
@@ -48,8 +47,8 @@ func TestPublishSampledTraceIDs(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client, err := elasticsearch.NewClient(elasticsearch.Config{
-		Addresses: []string{srv.URL},
+	client, err := elasticsearch.NewClient(&elasticsearch.Config{
+		Hosts: []string{srv.Listener.Addr().String()},
 	})
 	require.NoError(t, err)
 
@@ -142,8 +141,8 @@ func TestSubscribeSampledTraceIDs(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client, err := elasticsearch.NewClient(elasticsearch.Config{
-		Addresses: []string{srv.URL},
+	client, err := elasticsearch.NewClient(&elasticsearch.Config{
+		Hosts: []string{srv.Listener.Addr().String()},
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - sampling: use apm-server/elasticsearch.Client (#4285)