### PR TITLE
[7.x] Integrate tail-based sampling (#4300)

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -205,6 +205,7 @@ func (bt *beater) Run(b *beat.Beat) error {
 	bt.mutex.Unlock()
 
 	return runServer(ctx, ServerParams{
+		Info:     b.Info,
 		Config:   bt.config,
 		Logger:   bt.logger,
 		Tracer:   tracer,

--- a/beater/config/config.go
+++ b/beater/config/config.go
@@ -137,6 +137,12 @@ func NewConfig(ucfg *common.Config, outputESCfg *common.Config) (*Config, error)
 		return nil, err
 	}
 
+	if c.Sampling.Tail != nil {
+		if err := c.Sampling.Tail.setup(logger, outputESCfg); err != nil {
+			return nil, err
+		}
+	}
+
 	if !c.Sampling.KeepUnsampled && !c.Aggregation.Transactions.Enabled {
 		// Unsampled transactions should only be dropped
 		// when transaction aggregation is enabled in the

--- a/beater/config/sampling.go
+++ b/beater/config/sampling.go
@@ -17,17 +17,84 @@
 
 package config
 
+import (
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/apm-server/elasticsearch"
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
 // SamplingConfig holds configuration related to sampling.
 type SamplingConfig struct {
 	// KeepUnsampled controls whether unsampled
 	// transactions should be recorded.
 	KeepUnsampled bool `config:"keep_unsampled"`
+
+	// Tail holds tail-sampling configuration.
+	Tail *TailSamplingConfig `config:"tail"`
+}
+
+// TailSamplingConfig holds configuration related to tail-sampling.
+type TailSamplingConfig struct {
+	Enabled bool `config:"enabled"`
+
+	DefaultSampleRate     float64               `config:"default_sample_rate" validate:"min=0, max=1"`
+	ESConfig              *elasticsearch.Config `config:"elasticsearch"`
+	Interval              time.Duration         `config:"interval" validate:"min=1s"`
+	IngestRateDecayFactor float64               `config:"ingest_rate_decay" validate:"min=0, max=1"`
+	StorageDir            string                `config:"storage_dir"`
+	StorageGCInterval     time.Duration         `config:"storage_gc_interval" validate:"min=1s"`
+	TTL                   time.Duration         `config:"ttl" validate:"min=1s"`
+
+	esConfigured bool
+}
+
+func (c *TailSamplingConfig) Unpack(in *common.Config) error {
+	type tailSamplingConfig TailSamplingConfig
+	cfg := tailSamplingConfig(defaultTailSamplingConfig())
+	if err := in.Unpack(&cfg); err != nil {
+		return errors.Wrap(err, "error unpacking tail sampling config")
+	}
+	*c = TailSamplingConfig(cfg)
+	c.esConfigured = in.HasField("elasticsearch")
+	return nil
+}
+
+func (c *TailSamplingConfig) setup(log *logp.Logger, outputESCfg *common.Config) error {
+	if !c.Enabled {
+		return nil
+	}
+	if !c.esConfigured && outputESCfg != nil {
+		log.Info("Falling back to elasticsearch output for tail-sampling")
+		if err := outputESCfg.Unpack(&c.ESConfig); err != nil {
+			return errors.Wrap(err, "error unpacking output.elasticsearch config for tail sampling")
+		}
+	}
+	return nil
 }
 
 func defaultSamplingConfig() SamplingConfig {
+	tail := defaultTailSamplingConfig()
 	return SamplingConfig{
 		// In a future major release we will set this to
 		// false, and then later remove the option.
 		KeepUnsampled: true,
+		Tail:          &tail,
+	}
+}
+
+func defaultTailSamplingConfig() TailSamplingConfig {
+	return TailSamplingConfig{
+		Enabled:               false,
+		ESConfig:              elasticsearch.DefaultConfig(),
+		DefaultSampleRate:     0.5,
+		Interval:              1 * time.Minute,
+		IngestRateDecayFactor: 0.25,
+		StorageDir:            "tail_sampling",
+		StorageGCInterval:     5 * time.Minute,
+		TTL:                   30 * time.Minute,
 	}
 }

--- a/beater/server.go
+++ b/beater/server.go
@@ -24,6 +24,7 @@ import (
 	"go.elastic.co/apm"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/version"
 
@@ -38,6 +39,9 @@ type RunServerFunc func(context.Context, ServerParams) error
 
 // ServerParams holds parameters for running the APM Server.
 type ServerParams struct {
+	// Info holds metadata about the server, such as its UUID.
+	Info beat.Info
+
 	// Config is the configuration used for running the APM Server.
 	Config *config.Config
 

--- a/systemtest/apmservertest/config.go
+++ b/systemtest/apmservertest/config.go
@@ -104,7 +104,30 @@ type JaegerConfig struct {
 
 // SamplingConfig holds APM Server trace sampling configuration.
 type SamplingConfig struct {
-	KeepUnsampled bool `json:"keep_unsampled"`
+	KeepUnsampled bool                `json:"keep_unsampled"`
+	Tail          *TailSamplingConfig `json:"tail,omitempty"`
+}
+
+// TailSamplingConfig holds APM Server tail-based sampling configuration.
+type TailSamplingConfig struct {
+	Enabled           bool
+	Interval          time.Duration
+	DefaultSampleRate float64
+}
+
+func (t *TailSamplingConfig) MarshalJSON() ([]byte, error) {
+	// time.Duration is encoded as int64.
+	// Convert time.Durations to durations, to encode as duration strings.
+	type config struct {
+		Enabled           bool     `json:"enabled"`
+		Interval          duration `json:"interval"`
+		DefaultSampleRate float64  `json:"default_sample_rate"`
+	}
+	return json.Marshal(config{
+		Enabled:           t.Enabled,
+		Interval:          duration(t.Interval),
+		DefaultSampleRate: t.DefaultSampleRate,
+	})
 }
 
 // RUMConfig holds APM Server RUM configuration.

--- a/systemtest/estest/search.go
+++ b/systemtest/estest/search.go
@@ -67,6 +67,11 @@ func (r *SearchRequest) WithQuery(q interface{}) *SearchRequest {
 	return r
 }
 
+func (r *SearchRequest) WithSize(size int) *SearchRequest {
+	r.Size = &size
+	return r
+}
+
 func (r *SearchRequest) Do(ctx context.Context, out *SearchResult, opts ...RequestOption) (*esapi.Response, error) {
 	return r.es.Do(ctx, &r.SearchRequest, out, opts...)
 }

--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
@@ -173,7 +173,7 @@ func (a *Aggregator) publish(ctx context.Context) error {
 //
 // This method is expected to be used immediately prior to publishing
 // the events.
-func (a *Aggregator) ProcessTransformables(in []transform.Transformable) []transform.Transformable {
+func (a *Aggregator) ProcessTransformables(ctx context.Context, in []transform.Transformable) ([]transform.Transformable, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	out := in
@@ -184,7 +184,7 @@ func (a *Aggregator) ProcessTransformables(in []transform.Transformable) []trans
 			}
 		}
 	}
-	return out
+	return out, nil
 }
 
 func (a *Aggregator) processSpan(span *model.Span) *model.Metricset {

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -248,7 +248,7 @@ func (a *Aggregator) publish(ctx context.Context) error {
 // This method is expected to be used immediately prior to publishing
 // the events, so that the metricsets requiring immediate publication
 // can be included in the same batch.
-func (a *Aggregator) ProcessTransformables(in []transform.Transformable) []transform.Transformable {
+func (a *Aggregator) ProcessTransformables(ctx context.Context, in []transform.Transformable) ([]transform.Transformable, error) {
 	out := in
 	for _, tf := range in {
 		if tx, ok := tf.(*model.Transaction); ok {
@@ -257,7 +257,7 @@ func (a *Aggregator) ProcessTransformables(in []transform.Transformable) []trans
 			}
 		}
 	}
-	return out
+	return out, nil
 }
 
 // AggregateTransaction aggregates transaction metrics.

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
@@ -91,7 +91,8 @@ func TestProcessTransformablesOverflow(t *testing.T) {
 		input = append(input, &model.Transaction{Name: "foo", RepresentativeCount: 1})
 		input = append(input, &model.Transaction{Name: "bar", RepresentativeCount: 1})
 	}
-	output := agg.ProcessTransformables(input)
+	output, err := agg.ProcessTransformables(context.Background(), input)
+	require.NoError(t, err)
 	assert.Equal(t, input, output)
 
 	// The third transaction group will return a metricset for immediate publication.
@@ -102,7 +103,8 @@ func TestProcessTransformablesOverflow(t *testing.T) {
 			RepresentativeCount: 1,
 		})
 	}
-	output = agg.ProcessTransformables(input)
+	output, err = agg.ProcessTransformables(context.Background(), input)
+	require.NoError(t, err)
 	assert.Len(t, output, len(input)+2)
 	assert.Equal(t, input, output[:len(input)])
 

--- a/x-pack/apm-server/main.go
+++ b/x-pack/apm-server/main.go
@@ -13,13 +13,16 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/monitoring"
+	"github.com/elastic/beats/v7/libbeat/paths"
 
 	"github.com/elastic/apm-server/beater"
+	"github.com/elastic/apm-server/elasticsearch"
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/spanmetrics"
 	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/txmetrics"
 	"github.com/elastic/apm-server/x-pack/apm-server/cmd"
+	"github.com/elastic/apm-server/x-pack/apm-server/sampling"
 )
 
 var (
@@ -32,7 +35,7 @@ type namedProcessor struct {
 }
 
 type processor interface {
-	ProcessTransformables([]transform.Transformable) []transform.Transformable
+	ProcessTransformables(context.Context, []transform.Transformable) ([]transform.Transformable, error)
 	Run() error
 	Stop(context.Context) error
 }
@@ -70,7 +73,44 @@ func newProcessors(args beater.ServerParams) ([]namedProcessor, error) {
 		}
 		processors = append(processors, namedProcessor{name: name, processor: spanAggregator})
 	}
+	if args.Config.Sampling.Tail != nil && args.Config.Sampling.Tail.Enabled {
+		const name = "tail sampler"
+		sampler, err := newTailSamplingProcessor(args)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error creating %s", name)
+		}
+		processors = append(processors, namedProcessor{name: name, processor: sampler})
+	}
 	return processors, nil
+}
+
+func newTailSamplingProcessor(args beater.ServerParams) (*sampling.Processor, error) {
+	tailSamplingConfig := args.Config.Sampling.Tail
+	es, err := elasticsearch.NewClient(tailSamplingConfig.ESConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create Elasticsearch client for tail-sampling")
+	}
+	return sampling.NewProcessor(sampling.Config{
+		BeatID:   args.Info.ID.String(),
+		Reporter: args.Reporter,
+		LocalSamplingConfig: sampling.LocalSamplingConfig{
+			FlushInterval: tailSamplingConfig.Interval,
+			// TODO(axw) make MaxTraceGroups configurable?
+			MaxTraceGroups:        1000,
+			DefaultSampleRate:     tailSamplingConfig.DefaultSampleRate,
+			IngestRateDecayFactor: tailSamplingConfig.IngestRateDecayFactor,
+		},
+		RemoteSamplingConfig: sampling.RemoteSamplingConfig{
+			Elasticsearch: es,
+			// TODO(axw) make index name configurable?
+			SampledTracesIndex: "apm-sampled-traces",
+		},
+		StorageConfig: sampling.StorageConfig{
+			StorageDir:        paths.Resolve(paths.Data, tailSamplingConfig.StorageDir),
+			StorageGCInterval: tailSamplingConfig.StorageGCInterval,
+			TTL:               tailSamplingConfig.TTL,
+		},
+	})
 }
 
 // runServerWithProcessors runs the APM Server and the given list of processors.
@@ -84,8 +124,12 @@ func runServerWithProcessors(ctx context.Context, runServer beater.RunServerFunc
 
 	origReport := args.Reporter
 	args.Reporter = func(ctx context.Context, req publish.PendingReq) error {
+		var err error
 		for _, p := range processors {
-			req.Transformables = p.ProcessTransformables(req.Transformables)
+			req.Transformables, err = p.ProcessTransformables(ctx, req.Transformables)
+			if err != nil {
+				return err
+			}
 		}
 		return origReport(ctx, req)
 	}

--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -439,7 +439,7 @@ func newTempdirConfig(tb testing.TB) sampling.Config {
 		},
 		RemoteSamplingConfig: sampling.RemoteSamplingConfig{
 			Elasticsearch:      pubsubtest.Client(nil, nil),
-			SampledTracesIndex: ".apm-sampled-traces",
+			SampledTracesIndex: "apm-sampled-traces",
 		},
 		StorageConfig: sampling.StorageConfig{
 			StorageDir:        tempdir,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Integrate tail-based sampling (#4300)