### PR TITLE
chore: use testcontainers to control compose's life cycle in system tests

### DIFF
--- a/systemtest/containers.go
+++ b/systemtest/containers.go
@@ -72,6 +72,22 @@ func StartStackContainers() error {
 	return waitKibanaContainerHealthy(ctx)
 }
 
+// ShutdownStackContainers stops the stack if the "DESTROY_STACK"
+// environment variable is set
+func ShutdownStackContainers() {
+	if "" == os.Getenv("DESTROY_STACK") {
+		log.Println("We leave Elasticsearch and Kibana running, to avoid slowing down iterative development and testing. Use docker-compose to stop services as necessary")
+		return
+	}
+
+	execError := compose.Down()
+	err := execError.Error
+	if err != nil {
+		log.Fatalf("Could not destroy the stack: %v\n", err)
+	}
+	return
+}
+
 // NewUnstartedElasticsearchContainer returns a new ElasticsearchContainer.
 func NewUnstartedElasticsearchContainer() (*ElasticsearchContainer, error) {
 	// Create a testcontainer.ContainerRequest based on the "elasticsearch service

--- a/systemtest/main_test.go
+++ b/systemtest/main_test.go
@@ -24,8 +24,15 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	os.Exit(testMainWrapper(m))
+}
+
+// support defer in testMain
+func testMainWrapper(m *testing.M) int {
 	if err := StartStackContainers(); err != nil {
 		log.Fatal(err)
 	}
-	os.Exit(m.Run())
+	defer ShutdownStackContainers()
+
+	return m.Run()
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Before creating the PR, ensure that:

1. Your branch is rebased on top of the latest master.
   Squash your initial commits into meaningful commits.
   After creating a PR, do not rebase of force push any longer.
2. Nothing is broken, by running the test suite (at least unit tests).
   See https://github.com/elastic/apm-server/blob/master/TESTING.md for details.
3. Your code follows the style guidelines of this project:
   run `make check-full` for static code checks and linting.

A few suggestions about filling out this PR:

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR.
3. Please label this PR with at least one of the following labels:
   - bug fix
   - breaking change
   - enhancement
4. Reference the related issue, and make use of magic keywords where it makes sense
   https://help.github.com/articles/closing-issues-using-keywords/.
5. Do not remove any checklist items, strike through the ones that don't apply
   (by using tildes, e.g. ~scratch this ~).
6. Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
7. Submit the pull request:
   Push your changes to your forked copy of the repository and submit a pull request
   (https://help.github.com/articles/using-pull-requests).
8. Please be patient. We might not be able to immediately review your code,
   but we'll do our best to dedicate to it the attention it deserves.
   Your effort is much appreciated!

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
Let's use the library to start the compose file.

We are also adding support to destroy it if the `DESTROY_STACK` environment variable is set. Otherwise (default) will keep existing behaviour.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

I have considered changes for:
- [ ] documentation
- [ ] logging (add log lines, choose appropriate log selector, etc.)
- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
- [ ] telemetry
- [ ] Elasticsearch Service (https://cloud.elastic.co)
- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)
- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)

## How to test these changes

```shell
$ cd systemtest
# will destroy the stack after tests run
$ DESTROY_STACK=true go test ./...
# won't destroy the stack after tests run
$ DESTROY_STACK= go test ./...
```

## Follow-ups
I'm not adding the new variable to Jenkins (maybe in at `script/common.bash`) because it will cause the containers to be destroyed before the `post` section in the Jenkins pipeline catures it to archive them in Jenkins UI.