### PR TITLE
sampling: fix flaky TestProcessLocalTailSampling

### DIFF
--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -136,8 +136,6 @@ func TestProcessLocalTailSampling(t *testing.T) {
 
 	processor, err := sampling.NewProcessor(config)
 	require.NoError(t, err)
-	go processor.Run()
-	defer processor.Stop(context.Background())
 
 	traceID1 := "0102030405060708090a0b0c0d0e0f10"
 	traceID2 := "0102030405060708090a0b0c0d0e0f11"
@@ -170,6 +168,13 @@ func TestProcessLocalTailSampling(t *testing.T) {
 	out, err := processor.ProcessTransformables(context.Background(), in)
 	require.NoError(t, err)
 	assert.Empty(t, out)
+
+	// Start periodic tail-sampling. We start the processor after processing
+	// events to ensure all events are processed before any local sampling
+	// decisions are made, such that we have a single tail-sampling decision
+	// to check.
+	go processor.Run()
+	defer processor.Stop(context.Background())
 
 	// We have configured 50% tail-sampling, so we expect a single trace ID
 	// to be published. Sampling is non-deterministic (weighted random), so


### PR DESCRIPTION
## Motivation/summary

TestProcessLocalTailSampling would sometimes fail due to a timing issue, where a sampling decision may be made part way through processing a batch of events. This is fixed by starting the processor after processing events (i.e. adding events to reservoirs, and storing in local storage).

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

`make test`

## Related issues

Closes #4436