### PR TITLE
Format code, change tests/system to avoid breakage

### DIFF
--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -448,24 +448,24 @@ func TestTLSSettings(t *testing.T) {
 			"ConfiguredToRequired": {
 				config: map[string]interface{}{"ssl": map[string]interface{}{
 					"client_authentication": "required",
-					"key":         "../../testdata/tls/key.pem",
-					"certificate": "../../testdata/tls/certificate.pem",
+					"key":                   "../../testdata/tls/key.pem",
+					"certificate":           "../../testdata/tls/certificate.pem",
 				}},
 				tls: &tlscommon.ServerConfig{ClientAuth: 4, Certificate: testdataCertificateConfig},
 			},
 			"ConfiguredToOptional": {
 				config: map[string]interface{}{"ssl": map[string]interface{}{
 					"client_authentication": "optional",
-					"key":         "../../testdata/tls/key.pem",
-					"certificate": "../../testdata/tls/certificate.pem",
+					"key":                   "../../testdata/tls/key.pem",
+					"certificate":           "../../testdata/tls/certificate.pem",
 				}},
 				tls: &tlscommon.ServerConfig{ClientAuth: 3, Certificate: testdataCertificateConfig},
 			},
 			"DefaultRequiredByCA": {
 				config: map[string]interface{}{"ssl": map[string]interface{}{
 					"certificate_authorities": []string{"../../testdata/tls/ca.crt.pem"},
-					"key":         "../../testdata/tls/key.pem",
-					"certificate": "../../testdata/tls/certificate.pem",
+					"key":                     "../../testdata/tls/key.pem",
+					"certificate":             "../../testdata/tls/certificate.pem",
 				}},
 				tls: &tlscommon.ServerConfig{ClientAuth: 4, Certificate: testdataCertificateConfig},
 			},
@@ -473,8 +473,8 @@ func TestTLSSettings(t *testing.T) {
 				config: map[string]interface{}{"ssl": map[string]interface{}{
 					"client_authentication":   "none",
 					"certificate_authorities": []string{"../../testdata/tls/ca.crt.pem"},
-					"key":         "../../testdata/tls/key.pem",
-					"certificate": "../../testdata/tls/certificate.pem",
+					"key":                     "../../testdata/tls/key.pem",
+					"certificate":             "../../testdata/tls/certificate.pem",
 				}},
 				tls: &tlscommon.ServerConfig{ClientAuth: 0, Certificate: testdataCertificateConfig},
 			},

--- a/model/modeldecoder/generator/jsonschema_test.go
+++ b/model/modeldecoder/generator/jsonschema_test.go
@@ -23,10 +23,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/elastic/apm-server/model/modeldecoder/generator/generatortest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/xeipuuv/gojsonschema"
+
+	"github.com/elastic/apm-server/model/modeldecoder/generator/generatortest"
 )
 
 type testcase struct {

--- a/script/generate_notice.py
+++ b/script/generate_notice.py
@@ -19,12 +19,13 @@ COPYRIGHT_YEAR_BEGIN = "2017"
 
 # Additional third-party, non-source code dependencies, to add to the CSV output.
 additional_third_party_deps = [{
-      "name":      "Red Hat Universal Base Image minimal",
-      "version":   "8",
-      "url":       "https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8",
-      "license":   "Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf",
-      "sourceURL": "https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz",
+    "name":      "Red Hat Universal Base Image minimal",
+    "version":   "8",
+    "url":       "https://catalog.redhat.com/software/containers/ubi8/ubi-minimal/5c359a62bed8bd75a2c3fba8",
+    "license":   "Custom;https://www.redhat.com/licenses/EULA_Red_Hat_Universal_Base_Image_English_20190422.pdf",
+    "sourceURL": "https://oss-dependencies.elastic.co/redhat/ubi/ubi-minimal-8-source.tar.gz",
 }]
+
 
 def read_file(filename):
     if not os.path.isfile(filename):
@@ -206,7 +207,7 @@ def write_csv_file(f, modules):
                 module.get("Version", ""),
                 module.get("Revision", ""),
                 license["license_summary"],
-                "" # source URL
+                ""  # source URL
             ])
 
     for dep in additional_third_party_deps:

--- a/tests/system/apmserver.py
+++ b/tests/system/apmserver.py
@@ -13,12 +13,7 @@ from urllib.parse import urlparse
 from elasticsearch import Elasticsearch, NotFoundError
 import requests
 
-# Add libbeat/tests/system to the import path.
-output = subprocess.check_output(["go", "list", "-m", "-f", "{{.Path}} {{.Dir}}", "all"]).decode("utf-8")
-beats_line = [line for line in output.splitlines() if line.startswith("github.com/elastic/beats/")][0]
-beats_dir = beats_line.split(" ", 2)[1]
-sys.path.append(os.path.join(beats_dir, 'libbeat', 'tests', 'system'))
-
+import libbeat_paths
 from beat.beat import INTEGRATION_TESTS, TestCase, TimeoutError
 from helper import wait_until
 from es_helper import cleanup, default_pipelines

--- a/tests/system/libbeat_paths.py
+++ b/tests/system/libbeat_paths.py
@@ -1,0 +1,9 @@
+import os.path
+import subprocess
+import sys
+
+# Add libbeat/tests/system to the import path.
+output = subprocess.check_output(["go", "list", "-m", "-f", "{{.Path}} {{.Dir}}", "all"]).decode("utf-8")
+beats_line = [line for line in output.splitlines() if line.startswith("github.com/elastic/beats/")][0]
+beats_dir = beats_line.split(" ", 2)[1]
+sys.path.append(os.path.join(beats_dir, 'libbeat', 'tests', 'system'))

--- a/tests/system/test_tls.py
+++ b/tests/system/test_tls.py
@@ -6,13 +6,12 @@ import subprocess
 import socket
 import pytest
 from requests.packages.urllib3.exceptions import SubjectAltNameWarning
-requests.packages.urllib3.disable_warnings(SubjectAltNameWarning)
-
 from apmserver import ServerBaseTest
 from apmserver import TimeoutError, integration_test
 
 INTEGRATION_TESTS = os.environ.get('INTEGRATION_TESTS', False)
 
+requests.packages.urllib3.disable_warnings(SubjectAltNameWarning)
 
 @integration_test
 class TestSecureServerBaseTest(ServerBaseTest):

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
@@ -77,7 +77,7 @@ func TestProcessTransformablesOverflow(t *testing.T) {
 		MaxTransactionGroups:           2,
 		MetricsInterval:                time.Microsecond,
 		HDRHistogramSignificantFigures: 1,
-		Logger: logger,
+		Logger:                         logger,
 	})
 	require.NoError(t, err)
 
@@ -214,7 +214,7 @@ func TestAggregatorRunPublishErrors(t *testing.T) {
 		MaxTransactionGroups:           2,
 		MetricsInterval:                10 * time.Millisecond,
 		HDRHistogramSignificantFigures: 1,
-		Logger: logger,
+		Logger:                         logger,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Motivation/summary

autopep8 will move imports to the top of the file
if they come after statements. Move the sys.path
magic to another file so we can preserve import
ordering.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

- Run `make fmt`, should result in no changes.
- Run `make system-tests`, should run successfully

## Related issues

Closes https://github.com/elastic/apm-server/issues/4454