### PR TITLE
Add warnings to setup.template.overwrite

### DIFF
--- a/docs/copied-from-beats/docs/template-config.asciidoc
+++ b/docs/copied-from-beats/docs/template-config.asciidoc
@@ -55,7 +55,7 @@ relative path is set, it is considered relative to the config path. See the <<di
 section for details.
 
 *`setup.template.overwrite`*:: A boolean that specifies whether to overwrite the existing template. The default
-is false.
+is false. Do not enable this option for more than one instance of APM as it might overload your Elasticsearch with too many update requests.
 
 *`setup.template.settings`*:: A dictionary of settings to place into the `settings.index` dictionary of the
 Elasticsearch template. For more details about the available Elasticsearch mapping options, please


### PR DESCRIPTION
## Motivation/summary

Similar to https://github.com/elastic/beats/pull/22357, setup.template.overwrite could potentially overload Elasticsearch with too many update requests. 
On Elasticsearch side, it will be addressed in newer versions by introducing no-op updates which will be available from 7.11+ https://github.com/elastic/elasticsearch/pull/64493

See also https://github.com/elastic/elasticsearch/issues/57662

Thought having some warnings in the APM setting here should prevent users unwittingly leave template auto-creation on across large number of APM.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

I have considered changes for:
- [x] documentation
- [ ] logging (add log lines, choose appropriate log selector, etc.)
- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))
- [ ] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
- [ ] telemetry
- [ ] Elasticsearch Service (https://cloud.elastic.co)
- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)
- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)
