### PR TITLE
modeldecoder/generator: enable additionalProperties subschema

### DIFF
--- a/docs/spec/v2/metricset.json
+++ b/docs/spec/v2/metricset.json
@@ -8,6 +8,10 @@
       "additionalProperties": false,
       "patternProperties": {
         "^[^*\"]*$": {
+          "type": [
+            "null",
+            "object"
+          ],
           "properties": {
             "value": {
               "description": "Value holds the value of a single metric sample.",

--- a/model/modeldecoder/generator/jsonschema.go
+++ b/model/modeldecoder/generator/jsonschema.go
@@ -121,10 +121,6 @@ func (g *JSONSchemaGenerator) generate(st structType, key string, prop *property
 		default:
 			switch t := f.Type().Underlying().(type) {
 			case *types.Map:
-				if _, ok := tags[tagPatternKeys]; !ok && name == "" {
-					// ignore the field in case no json name and no patternProperties are given
-					continue
-				}
 				nestedProp := property{Properties: make(map[string]*property)}
 				if err = generateJSONPropertyMap(&info, prop, &childProp, &nestedProp); err != nil {
 					break
@@ -240,7 +236,7 @@ type property struct {
 	Type        *propertyType `json:"type,omitempty"`
 	// AdditionalProperties should default to `true` and be set to `false`
 	// in case PatternProperties are set
-	AdditionalProperties *bool                `json:"additionalProperties,omitempty"`
+	AdditionalProperties interface{}          `json:"additionalProperties,omitempty"`
 	PatternProperties    map[string]*property `json:"patternProperties,omitempty"`
 	Properties           map[string]*property `json:"properties,omitempty"`
 	Items                *property            `json:"items,omitempty"`


### PR DESCRIPTION
## Motivation/summary

Handle map value rules without requiring patternProperties in
JSON Schema.

When value rules (e.g. inputTypesVals) are specified, but no
patternKeys rule is specified, then nest the generated schema
under additionalProperties.

This will enable us to remove the patternKeys rules from labels,
tags, etc. when moving label key sanitization into the server,
without dropping label value validation.

## Checklist

- [x] I have signed the [Contributor License Agreement](https://www.elastic.co/contributor-agreement/).
~- [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~

I have considered changes for:
~- [ ] documentation~
~- [ ] logging (add log lines, choose appropriate log selector, etc.)~
~- [ ] metrics and monitoring (create issue for Kibana team to add metrics to visualizations, e.g. [Kibana#44001](https://github.com/elastic/kibana/issues/44001))~
- [x] automated tests (add tests for the code changes, all [**unit** tests](https://github.com/elastic/apm-server/blob/master/TESTING.md) pass locally)
~- [ ] telemetry~
~- [ ] Elasticsearch Service (https://cloud.elastic.co)~
~- [ ] Elastic Cloud Enterprise (https://www.elastic.co/products/ece)~
~- [ ] Elastic Cloud on Kubernetes (https://www.elastic.co/elastic-cloud-kubernetes)~

## How to test these changes

`make test`

## Related issues

https://github.com/elastic/apm-server/issues/4225