### PR TITLE
[7.x] systemtest: log ILM deletion errors (#4419)

### DIFF
--- a/systemtest/elasticsearch.go
+++ b/systemtest/elasticsearch.go
@@ -121,7 +121,9 @@ func CleanupElasticsearch(t testing.TB) {
 			break
 		}
 		// Retry deleting, in case indices are still being deleted.
-		time.Sleep(100 * time.Millisecond)
+		const delay = 100 * time.Millisecond
+		t.Logf("failed to delete ILM policy (retrying in %s): %s", delay, err)
+		time.Sleep(delay)
 	}
 }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - systemtest: log ILM deletion errors (#4419)