### PR TITLE
[7.x] systemtest/estest: fix ExpectMinDocs (#4353)

### DIFF
--- a/systemtest/estest/search.go
+++ b/systemtest/estest/search.go
@@ -40,7 +40,7 @@ func (es *Client) ExpectDocs(t testing.TB, index string, query interface{}, opts
 func (es *Client) ExpectMinDocs(t testing.TB, min int, index string, query interface{}, opts ...RequestOption) SearchResult {
 	t.Helper()
 	var result SearchResult
-	opts = append(opts, WithCondition(result.Hits.NonEmptyCondition()))
+	opts = append(opts, WithCondition(result.Hits.MinHitsCondition(min)))
 	if _, err := es.Search(index).WithQuery(query).Do(context.Background(), &result, opts...); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - systemtest/estest: fix ExpectMinDocs (#4353)