### PR TITLE
[7.x] beater: telemetry for tail-based sampling config (#4360)

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -145,7 +145,9 @@ func (bt *beater) Run(b *beat.Beat) error {
 	}
 
 	// send configs to telemetry
-	recordConfigs(b.Info, bt.config, bt.rawConfig, bt.logger)
+	if err := recordConfigs(b.Info, bt.config, bt.rawConfig); err != nil {
+		bt.logger.Errorf("Error recording telemetry data", err)
+	}
 
 	tracer, tracerServer, err := bt.initTracing(b)
 	if err != nil {

--- a/beater/telemetry_test.go
+++ b/beater/telemetry_test.go
@@ -20,9 +20,8 @@ package beater
 import (
 	"testing"
 
-	"github.com/elastic/beats/v7/libbeat/logp"
-
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/apm-server/beater/config"
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -55,7 +54,7 @@ func TestRecordConfigs(t *testing.T) {
 			},
 		},
 	})
-	recordConfigs(info, apmCfg, rootCfg, logp.NewLogger("beater"))
+	require.NoError(t, recordConfigs(info, apmCfg, rootCfg))
 
 	assert.Equal(t, configMonitors.ilmSetupEnabled.Get(), true)
 	assert.Equal(t, configMonitors.rumEnabled.Get(), false)

--- a/systemtest/sampling_test.go
+++ b/systemtest/sampling_test.go
@@ -147,6 +147,21 @@ func TestTailSampling(t *testing.T) {
 	// Make sure apm-server.sampling.tail metrics are published. Metric values are unit tested.
 	doc := getBeatsMonitoringStats(t, srv1, nil)
 	assert.True(t, gjson.GetBytes(doc.RawSource, "beats_stats.metrics.apm-server.sampling.tail").Exists())
+
+	// Check tail-sampling config is reported in telemetry.
+	var state struct {
+		APMServer struct {
+			Sampling struct {
+				Tail struct {
+					Enabled  bool
+					Policies int
+				}
+			}
+		} `mapstructure:"apm-server"`
+	}
+	getBeatsMonitoringState(t, srv1, &state)
+	assert.True(t, state.APMServer.Sampling.Tail.Enabled)
+	assert.Equal(t, 1, state.APMServer.Sampling.Tail.Policies)
 }
 
 func TestTailSamplingUnlicensed(t *testing.T) {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - beater: telemetry for tail-based sampling config (#4360)