### PR TITLE
[7.x] modeldecoder/generator: enable additionalProperties subschema (#4464)

### DIFF
--- a/docs/spec/v2/metricset.json
+++ b/docs/spec/v2/metricset.json
@@ -8,6 +8,10 @@
       "additionalProperties": false,
       "patternProperties": {
         "^[^*\"]*$": {
+          "type": [
+            "null",
+            "object"
+          ],
           "properties": {
             "value": {
               "description": "Value holds the value of a single metric sample.",

--- a/model/modeldecoder/generator/jsonschema.go
+++ b/model/modeldecoder/generator/jsonschema.go
@@ -121,10 +121,6 @@ func (g *JSONSchemaGenerator) generate(st structType, key string, prop *property
 		default:
 			switch t := f.Type().Underlying().(type) {
 			case *types.Map:
-				if _, ok := tags[tagPatternKeys]; !ok && name == "" {
-					// ignore the field in case no json name and no patternProperties are given
-					continue
-				}
 				nestedProp := property{Properties: make(map[string]*property)}
 				if err = generateJSONPropertyMap(&info, prop, &childProp, &nestedProp); err != nil {
 					break
@@ -240,7 +236,7 @@ type property struct {
 	Type        *propertyType `json:"type,omitempty"`
 	// AdditionalProperties should default to `true` and be set to `false`
 	// in case PatternProperties are set
-	AdditionalProperties *bool                `json:"additionalProperties,omitempty"`
+	AdditionalProperties interface{}          `json:"additionalProperties,omitempty"`
 	PatternProperties    map[string]*property `json:"patternProperties,omitempty"`
 	Properties           map[string]*property `json:"properties,omitempty"`
 	Items                *property            `json:"items,omitempty"`


### PR DESCRIPTION
Backports the following commits to 7.x:
 - modeldecoder/generator: enable additionalProperties subschema (#4464)