### PR TITLE
[7.x] package_tests: remove validation tests (#4467)

### DIFF
--- a/processor/stream/package_tests/error_attrs_test.go
+++ b/processor/stream/package_tests/error_attrs_test.go
@@ -18,7 +18,6 @@
 package package_tests
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/elastic/apm-server/beater/config"
@@ -152,80 +151,4 @@ func TestErrorKeywordLimitationOnErrorAttributes(t *testing.T) {
 			{Template: "trace.id", Mapping: "trace_id"},
 		},
 	)
-}
-
-func TestPayloadDataForError(t *testing.T) {
-	//// add test data for testing
-	//// * specific edge cases
-	//// * multiple allowed data types
-	//// * regex pattern, time formats
-	//// * length restrictions, other than keyword length restrictions
-	errorProcSetup().DataValidation(t,
-		[]tests.SchemaTestData{
-			{Key: "error",
-				Invalid: []tests.Invalid{{Msg: `decode error`, Values: val{false}}}},
-			{Key: "error.exception.code", Valid: val{"success", ""},
-				Invalid: []tests.Invalid{{Msg: `validation error`, Values: val{false}}}},
-			{Key: "error.exception.attributes", Valid: val{map[string]interface{}{}},
-				Invalid: []tests.Invalid{{Msg: `decode error`, Values: val{123}}}},
-			{Key: "error.timestamp",
-				Valid: val{json.Number("1496170422281000")},
-				Invalid: []tests.Invalid{
-					{Msg: `decode error`, Values: val{"1496170422281000"}}}},
-			{Key: "error.log.stacktrace.post_context",
-				Valid: val{[]interface{}{}, []interface{}{"context"}},
-				Invalid: []tests.Invalid{
-					{Msg: `decode error`, Values: val{[]interface{}{123}}},
-					{Msg: `decode error`, Values: val{"test"}}}},
-			{Key: "error.log.stacktrace.pre_context",
-				Valid: val{[]interface{}{}, []interface{}{"context"}},
-				Invalid: []tests.Invalid{
-					{Msg: `decode error`, Values: val{[]interface{}{123}}},
-					{Msg: `decode error`, Values: val{"test"}}}},
-			{Key: "error.exception.stacktrace.post_context",
-				Valid: val{[]interface{}{}, []interface{}{"context"}},
-				Invalid: []tests.Invalid{
-					{Msg: `decode error`, Values: val{[]interface{}{123}}},
-					{Msg: `decode error`, Values: val{"test"}}}},
-			{Key: "error.exception.stacktrace.pre_context",
-				Valid: val{[]interface{}{}, []interface{}{"context"}},
-				Invalid: []tests.Invalid{
-					{Msg: `decode error`, Values: val{[]interface{}{123}}},
-					{Msg: `decode error`, Values: val{"test"}}}},
-			{Key: "error.context.custom",
-				Valid: val{obj{"whatever": obj{"comes": obj{"end": -45}}}, obj{"whatever": 123}},
-				Invalid: []tests.Invalid{
-					{Msg: `validation error`, Values: val{
-						obj{"what.ever": 123}, obj{"what*ever": 123}, obj{"what\"ever": 123}}},
-					{Msg: `decode error`, Values: val{"context"}}}},
-			{Key: "error.context.request.body", Valid: val{tests.Str1025, obj{}},
-				Invalid: []tests.Invalid{{Msg: `validation error`, Values: val{102}}}},
-			{Key: "error.context.request.headers", Valid: val{
-				obj{"User-Agent": "go-1.1"},
-				obj{"foo-bar": "a,b"},
-				obj{"foo": []interface{}{"a", "b"}}},
-				Invalid: []tests.Invalid{{Msg: `decode error`, Values: val{102, obj{"foo": obj{"bar": "a"}}}}}},
-			{Key: "error.context.response.headers", Valid: val{
-				obj{"User-Agent": "go-1.1"},
-				obj{"foo-bar": "a,b"},
-				obj{"foo": []interface{}{"a", "b"}}},
-				Invalid: []tests.Invalid{{Msg: `decode error`, Values: val{102, obj{"foo": obj{"bar": "a"}}}}}},
-			{Key: "error.context.request.env", Valid: val{obj{}},
-				Invalid: []tests.Invalid{{Msg: `decode error`, Values: val{102, "a"}}}},
-			{Key: "error.context.request.cookies", Valid: val{obj{}},
-				Invalid: []tests.Invalid{{Msg: `decode error`, Values: val{102, "a"}}}},
-			{Key: "error.context.tags",
-				Valid: val{obj{tests.Str1024Special: tests.Str1024Special}, obj{tests.Str1024: 123.45}, obj{tests.Str1024: true}},
-				Invalid: []tests.Invalid{
-					{Msg: `decode error`, Values: val{"tags"}},
-					{Msg: `validation error`, Values: val{
-						obj{"invalid": tests.Str1025},
-						obj{tests.Str1024: obj{}},
-						obj{"invali*d": "hello"},
-						obj{"invali\"d": "hello"},
-						obj{"invali.d": "hello"}}}}},
-			{Key: "error.context.user.id", Valid: val{123, tests.Str1024Special},
-				Invalid: []tests.Invalid{
-					{Msg: `validation error`, Values: val{obj{}, tests.Str1025}}}},
-		})
 }

--- a/processor/stream/package_tests/metadata_attrs_test.go
+++ b/processor/stream/package_tests/metadata_attrs_test.go
@@ -177,16 +177,3 @@ func metadataRequiredKeys() *tests.Set {
 func TestAttrsPresenceInMetadata(t *testing.T) {
 	metadataProcSetup().AttrsPresence(t, metadataRequiredKeys(), nil)
 }
-func TestInvalidPayloadsForMetadata(t *testing.T) {
-	type val []interface{}
-
-	payloadData := []tests.SchemaTestData{
-		{Key: "metadata.service.name",
-			Valid: val{"m"},
-			Invalid: []tests.Invalid{
-				{Msg: "validation error", Values: val{tests.Str1024Special}},
-				{Msg: "validation error", Values: val{""}},
-			},
-		}}
-	metadataProcSetup().DataValidation(t, payloadData)
-}

--- a/processor/stream/package_tests/metricset_attrs_test.go
+++ b/processor/stream/package_tests/metricset_attrs_test.go
@@ -18,7 +18,6 @@
 package package_tests
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/elastic/apm-server/beater/config"
@@ -46,43 +45,4 @@ func TestAttributesPresenceInMetric(t *testing.T) {
 		"metricset.samples",
 	)
 	metricsetProcSetup().AttrsPresence(t, requiredKeys, nil)
-}
-
-func TestInvalidPayloads(t *testing.T) {
-	type obj = map[string]interface{}
-	type val = []interface{}
-
-	validMetric := obj{"value": json.Number("1.0")}
-	payloadData := []tests.SchemaTestData{
-		{Key: "metricset.timestamp",
-			Valid:   val{json.Number("1496170422281000")},
-			Invalid: []tests.Invalid{{Msg: `decode error`, Values: val{"1496170422281000"}}}},
-		{Key: "metricset.tags",
-			Valid: val{obj{tests.Str1024Special: tests.Str1024Special}, obj{tests.Str1024: 123.45}, obj{tests.Str1024: true}},
-			Invalid: []tests.Invalid{
-				{Msg: `decode error`, Values: val{"tags"}},
-				{Msg: `validation error`, Values: val{obj{"invalid": tests.Str1025}, obj{tests.Str1024: obj{}}}},
-				{Msg: `validation error`, Values: val{obj{"invali*d": "hello"}, obj{"invali\"d": "hello"}}}},
-		},
-		{
-			Key:   "metricset.samples",
-			Valid: val{obj{"valid-metric": validMetric}},
-			Invalid: []tests.Invalid{
-				{
-					Msg: `validation error`,
-					Values: val{
-						obj{"metric\"key\"_quotes": validMetric},
-						obj{"metric-*-key-star": validMetric},
-					},
-				},
-				{
-					Msg: `decode error`,
-					Values: val{
-						obj{"string-value": obj{"value": "foo"}},
-					},
-				},
-			},
-		},
-	}
-	metricsetProcSetup().DataValidation(t, payloadData)
 }

--- a/processor/stream/package_tests/span_attrs_test.go
+++ b/processor/stream/package_tests/span_attrs_test.go
@@ -18,7 +18,6 @@
 package package_tests
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/elastic/apm-server/beater/config"
@@ -179,33 +178,4 @@ func TestKeywordLimitationOnSpanAttrs(t *testing.T) {
 			{Template: "span.message.queue.name", Mapping: "context.message.queue.name"},
 		},
 	)
-}
-
-func TestPayloadDataForSpans(t *testing.T) {
-	// add test data for testing
-	// * specific edge cases
-	// * multiple allowed dataypes
-	// * regex pattern, time formats
-	// * length restrictions, other than keyword length restrictions
-
-	spanProcSetup().DataValidation(t,
-		[]tests.SchemaTestData{
-			{Key: "span.context.tags",
-				Valid: val{obj{tests.Str1024Special: tests.Str1024Special}, obj{tests.Str1024: 123.45}, obj{tests.Str1024: true}},
-				Invalid: []tests.Invalid{
-					{Msg: `decode error`, Values: val{"tags"}},
-					{Msg: `validation error`, Values: val{
-						obj{"invalid": tests.Str1025}, obj{tests.Str1024: obj{}},
-						obj{"invali*d": "hello"}, obj{"invali\"d": "hello"}, obj{"invali.d": "hello"}}}}},
-			{Key: "span.timestamp",
-				Valid: val{json.Number("1496170422281000")},
-				Invalid: []tests.Invalid{
-					{Msg: `decode error`, Values: val{"1496170422281000"}}}},
-			{Key: "span.stacktrace.pre_context",
-				Valid:   val{[]interface{}{}, []interface{}{"context"}},
-				Invalid: []tests.Invalid{{Msg: `decode error`, Values: val{[]interface{}{123}, "test"}}}},
-			{Key: "span.stacktrace.post_context",
-				Valid:   val{[]interface{}{}, []interface{}{"context"}},
-				Invalid: []tests.Invalid{{Msg: `decode error`, Values: val{[]interface{}{123, "test"}}}}},
-		})
 }

--- a/processor/stream/package_tests/transaction_attrs_test.go
+++ b/processor/stream/package_tests/transaction_attrs_test.go
@@ -18,7 +18,6 @@
 package package_tests
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/elastic/apm-server/beater/config"
@@ -135,77 +134,4 @@ func TestKeywordLimitationOnTransactionAttrs(t *testing.T) {
 			{Template: "transaction."},
 		},
 	)
-}
-
-func TestPayloadDataForTransaction(t *testing.T) {
-	// add test data for testing
-	// * specific edge cases
-	// * multiple allowed dataypes
-	// * regex pattern, time formats
-	// * length restrictions, other than keyword length restrictions
-
-	transactionProcSetup().DataValidation(t,
-		[]tests.SchemaTestData{
-			{Key: "transaction.duration",
-				Valid:   []interface{}{12.4},
-				Invalid: []tests.Invalid{{Msg: `decode error`, Values: val{"123"}}}},
-			{Key: "transaction.timestamp",
-				Valid: val{json.Number("1496170422281000")},
-				Invalid: []tests.Invalid{
-					{Msg: `decode error`, Values: val{"1496170422281000"}}}},
-			{Key: "transaction.marks",
-				Valid: []interface{}{obj{}, obj{tests.Str1024: obj{tests.Str1024: 21.0, "end": -45}}},
-				Invalid: []tests.Invalid{
-					{Msg: `decode error`, Values: val{
-						"marks",
-						obj{"timing": obj{"start": "start"}},
-						obj{"timing": obj{"start": obj{}}},
-					}},
-					{Msg: `validation error`, Values: val{
-						obj{"timing": obj{"m*e": -45}},
-						obj{"timing": obj{"m\"": -45}},
-						obj{"timing": obj{"m.": -45}},
-						obj{"tim*ing": obj{"start": -45}},
-						obj{"tim\"ing": obj{"start": -45}},
-						obj{"tim.ing": obj{"start": -45}}}}}},
-			{Key: "transaction.context.custom",
-				Valid: val{obj{"whatever": obj{"comes": obj{"end": -45}}},
-					obj{"whatever": 123}},
-				Invalid: []tests.Invalid{
-					{Msg: `validation error`, Values: val{obj{"what.ever": 123}, obj{"what*ever": 123}, obj{"what\"ever": 123}}},
-					{Msg: `decode error`, Values: val{"context"}}}},
-			{Key: "transaction.context.request.body",
-				Valid:   []interface{}{obj{}, tests.Str1025},
-				Invalid: []tests.Invalid{{Msg: `validation error`, Values: val{102}}}},
-			{Key: "transaction.context.request.headers", Valid: val{
-				obj{"User-Agent": "go-1.1"},
-				obj{"foo-bar": "a,b"},
-				obj{"foo": []interface{}{"a", "b"}}},
-				Invalid: []tests.Invalid{
-					{Msg: `decode error`, Values: val{102, obj{"foo": obj{"bar": "a"}}}}}},
-			{Key: "transaction.context.request.env",
-				Valid:   []interface{}{obj{}},
-				Invalid: []tests.Invalid{{Msg: `decode error`, Values: val{102, "a"}}}},
-			{Key: "transaction.context.request.cookies",
-				Valid:   []interface{}{obj{}},
-				Invalid: []tests.Invalid{{Msg: `decode error`, Values: val{123, ""}}}},
-			{Key: "transaction.context.response.headers", Valid: val{
-				obj{"User-Agent": "go-1.1"},
-				obj{"foo-bar": "a,b"},
-				obj{"foo": []interface{}{"a", "b"}}},
-				Invalid: []tests.Invalid{{Msg: `decode error`, Values: val{102, obj{"foo": obj{"bar": "a"}}}}}},
-			{Key: "transaction.context.tags",
-				Valid: val{obj{tests.Str1024Special: tests.Str1024Special}, obj{tests.Str1024: 123.45}, obj{tests.Str1024: true}},
-				Invalid: []tests.Invalid{
-					{Msg: `decode error`, Values: val{"tags"}},
-					{Msg: `validation error`, Values: val{
-						obj{"invalid": tests.Str1025},
-						obj{tests.Str1024: obj{}},
-						obj{"invali*d": "hello"},
-						obj{"invali\"d": "hello"},
-						obj{"invali.d": "hello"}}}}},
-			{Key: "transaction.context.user.id",
-				Valid:   val{123, tests.Str1024Special},
-				Invalid: []tests.Invalid{{Msg: `validation error`, Values: val{obj{}, tests.Str1025}}}},
-		})
 }

--- a/tests/json_schema.go
+++ b/tests/json_schema.go
@@ -51,17 +51,6 @@ type ProcessorSetup struct {
 	SchemaPath string
 }
 
-type SchemaTestData struct {
-	Key       string
-	Valid     []interface{}
-	Invalid   []Invalid
-	Condition Condition
-}
-type Invalid struct {
-	Msg    string
-	Values []interface{}
-}
-
 type Condition struct {
 	// If requirements for a field apply in case of anothers key absence,
 	// add the key.
@@ -182,31 +171,6 @@ func (ps *ProcessorSetup) KeywordLimitation(t *testing.T, keywordExceptionKeys *
 		}
 
 		assert.True(t, schemaKeys.Contains(key), "Expected <%s> (original: <%s>) to have the MaxLength limit set because it gets indexed as 'keyword'", key, k.(string))
-	}
-}
-
-// Test that specified values for attributes fail or pass
-// the validation accordingly.
-// The configuration and testing of valid attributes here is intended
-// to ensure correct setup and configuration to avoid false negatives.
-func (ps *ProcessorSetup) DataValidation(t *testing.T, testData []SchemaTestData) {
-	for _, d := range testData {
-		testAttrs := func(val interface{}, valid bool, msg string) {
-			ps.changePayload(t, d.Key, val, d.Condition,
-				upsertFn, func(k string) (bool, []string) {
-					return valid, []string{msg}
-				})
-		}
-
-		for _, invalid := range d.Invalid {
-			for _, v := range invalid.Values {
-				testAttrs(v, false, invalid.Msg)
-			}
-		}
-		for _, v := range d.Valid {
-			testAttrs(v, true, "")
-		}
-
 	}
 }
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - package_tests: remove validation tests (#4467)