### PR TITLE
[7.11] [docs] Fix typo in Node.js addLabels method name (#4556)

### DIFF
--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -208,7 +208,7 @@ Defining too many unique fields in an index is a condition that can lead to a
 * Go: {apm-go-ref-v}/api.html#context-set-label[`SetLabel`]
 * Java: {apm-java-ref-v}/public-api.html#api-transaction-add-tag[`addLabel`]
 * .NET: {apm-dotnet-ref-v}/public-api.html#api-transaction-tags[`Labels`]
-* Node.js: {apm-node-ref-v}/agent-api.html#apm-set-label[`setLabel`] | {apm-node-ref-v}/agent-api.html#apm-add-labels[`addLabel`]
+* Node.js: {apm-node-ref-v}/agent-api.html#apm-set-label[`setLabel`] | {apm-node-ref-v}/agent-api.html#apm-add-labels[`addLabels`]
 * Python: {apm-py-ref-v}/api.html#api-label[`elasticapm.label()`]
 * Ruby:  {apm-ruby-ref-v}/api.html#api-agent-set-label[`set_label`]
 * Rum: {apm-rum-ref-v}/agent-api.html#apm-add-labels[`addLabels`]


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [docs] Fix typo in Node.js addLabels method name (#4556)