### PR TITLE
apmpackage: change secret_token to string

### DIFF
--- a/apmpackage/apm/0.1.0/manifest.yml
+++ b/apmpackage/apm/0.1.0/manifest.yml
@@ -31,7 +31,7 @@ policy_templates:
         show_user: true
         default: localhost:8200
       - name: secret_token
-        type: bool
+        type: string
         title: Secret token
         required: false
         show_user: true


### PR DESCRIPTION
## Motivation/summary

Fix the integration package `secret_token` setting, changing its type to "string" rather than "bool".

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

1. Install the package, and check that a text entry is shown for "Secret token" on the integration settings page in Fleet. Leave the setting empty.
2. Assign the package to a policy, add an agent
3. Observe that no secret token is required (e.g. via the healthcheck endpoint)
4. Set a non-empty value for the secret token
5. Restart elastic-agent
6. Observe that a secret token is now requied

## Related issues

Closes #4572 