### PR TITLE
fix: invalidating API Keys against ES master

### DIFF
--- a/cmd/apikey.go
+++ b/cmd/apikey.go
@@ -116,7 +116,7 @@ If neither of them are, an error will be returned.`,
 				// TODO(axw) this should trigger usage
 				return errors.New(`either "id" or "name" are required`)
 			}
-			return invalidateAPIKey(client, &id, &name, json)
+			return invalidateAPIKey(client, id, name, json)
 		}),
 	}
 	invalidate.Flags().StringVar(&id, "id", "", "id of the API Key to delete")
@@ -393,17 +393,12 @@ func getAPIKey(client es.Client, id, name *string, validOnly, asJSON bool) error
 	return nil
 }
 
-func invalidateAPIKey(client es.Client, id, name *string, asJSON bool) error {
-	if isSet(id) {
-		name = nil
-	} else if isSet(name) {
-		id = nil
-	}
-	invalidateKeysRequest := es.InvalidateAPIKeyRequest{
-		APIKeyQuery: es.APIKeyQuery{
-			ID:   id,
-			Name: name,
-		},
+func invalidateAPIKey(client es.Client, id string, name string, asJSON bool) error {
+	invalidateKeysRequest := es.InvalidateAPIKeyRequest{}
+	if id != "" {
+		invalidateKeysRequest.IDs = []string{id}
+	} else if name != "" {
+		invalidateKeysRequest.Name = &name
 	}
 	invalidation, err := es.InvalidateAPIKey(context.Background(), client, invalidateKeysRequest)
 	if err != nil {

--- a/elasticsearch/security_api.go
+++ b/elasticsearch/security_api.go
@@ -97,7 +97,9 @@ type HasPrivilegesResponse struct {
 }
 
 type InvalidateAPIKeyRequest struct {
-	APIKeyQuery
+	// normally the Elasticsearch API will require either Ids or Name, but not both
+	IDs  []string `json:"ids,omitempty"`
+	Name *string  `json:"name,omitempty"`
 }
 
 type InvalidateAPIKeyResponse struct {


### PR DESCRIPTION

<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
The ES InvalidateApiKey API does not support param `id` anymore. Switch to using `ids` instead.

Related https://github.com/elastic/elasticsearch/pull/66671

Do NOT backport this to `7.x` as ES only introduced the `ids` parameter in `7.10`.
Ideally we would derive the used Elasticsearch version and adapt the parameter accordingly. There exists already an issue to [ensure ES client 8.0 can work with 7.x ES](https://github.com/elastic/apm-server/issues/2975), which would be a bigger change and needs more discussion how to tackle this. For now this fixes functionality and system tests in master.

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~


## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

* Run `apm-server apikey invalidate --id "123"` cmd against an `>=7.10` or `8.0` ES -> expected to work
* Run `apm-server apikey invalidate --id "123"` cmd against an `<7.10` ES -> expected to throw an error

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
