### PR TITLE
docs: add 7.10.2 release notes

### DIFF
--- a/changelogs/7.10.asciidoc
+++ b/changelogs/7.10.asciidoc
@@ -3,9 +3,17 @@
 
 https://github.com/elastic/apm-server/compare/7.9\...7.10[View commits]
 
+* <<release-notes-7.10.2>>
 * <<release-notes-7.10.1>>
 * <<release-notes-7.10.0>>
 
+[float]
+[[release-notes-7.10.2]]
+=== APM Server version 7.10.2
+
+https://github.com/elastic/apm-server/compare/v7.10.1\...v7.10.2[View commits]
+
+No significant changes.
 
 [float]
 [[release-notes-7.10.1]]
@@ -21,13 +29,11 @@ https://github.com/elastic/apm-server/compare/v7.10.0\...v7.10.1[View commits]
 ==== Bug fixes
 * Add maxLen=1024 requirement to `metadata.system.container.id` {pull}4429[4429]
 
-
 [float]
 [[release-notes-7.10.0]]
 === APM Server version 7.10.0
 
 https://github.com/elastic/apm-server/compare/v7.9.2\...v7.10.0[View commits]
-
 
 [float]
 ==== Breaking Changes

--- a/changelogs/7.11.asciidoc
+++ b/changelogs/7.11.asciidoc
@@ -9,6 +9,8 @@ https://github.com/elastic/apm-server/compare/7.10\...7.11[View commits]
 [[release-notes-7.11.0]]
 === APM Server version 7.11.0
 
+https://github.com/elastic/apm-server/compare/v7.10.2\...v7.11.0[View commits]
+
 [float]
 ==== Bug fixes
 * JSON schema metricset: nest type and subtype under span {pull}4329[4329]


### PR DESCRIPTION
## Summary

Creates the 7.10.2 release notes with "no significant changes" per https://github.com/elastic/apm-server/commits/7.10.