### PR TITLE
[7.x] docs: 7.11 breaking changes (#4600)

### DIFF
--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -4,6 +4,10 @@ APM Server is built on top of {beats-ref}/index.html[libbeat].
 As such, any breaking change in libbeat is also considered to be a breaking change in APM Server.
 
 [float]
+=== 7.11
+There are no breaking changes in APM Server.
+
+[float]
 === 7.10
 There are no breaking changes in APM Server.
 

--- a/docs/guide/apm-breaking-changes.asciidoc
+++ b/docs/guide/apm-breaking-changes.asciidoc
@@ -3,6 +3,7 @@
 
 This section discusses the changes that you need to be aware of when migrating your application from one version of APM to another.
 
+* <<breaking-7.11.0>>
 * <<breaking-7.10.0>>
 * <<breaking-7.9.0>>
 * <<breaking-7.8.0>>
@@ -27,6 +28,13 @@ Also see {observability-guide}/whats-new.html[What's new in Observability {minor
 // Remove this tag in a future PR
 // tag::notable-v8-breaking-changes[]
 // end::notable-v8-breaking-changes[]
+
+[[breaking-7.11.0]]
+=== 7.11.0 APM Breaking changes
+
+// tag::notable-breaking-changes[]
+No breaking changes.
+// end::notable-breaking-changes[]
 
 [[breaking-7.10.0]]
 === 7.10.0 APM Breaking changes


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: 7.11 breaking changes (#4600)