### PR TITLE
docs: link to other troubleshooting guides

### DIFF
--- a/docs/guide/troubleshooting.asciidoc
+++ b/docs/guide/troubleshooting.asciidoc
@@ -6,9 +6,10 @@ If you run into trouble, there are three places you can look for help.
 [float]
 === Troubleshooting documentation
 
-The APM Server and each APM agent has a troubleshooting guide:
+The APM Server, APM app, and each APM agent has a troubleshooting guide:
 
 * {apm-server-ref-v}/troubleshooting.html[APM Server troubleshooting]
+* {kibana-ref}/troubleshooting.html[APM app troubleshooting]
 * {apm-dotnet-ref-v}/troubleshooting.html[.NET agent troubleshooting]
 * {apm-go-ref-v}/troubleshooting.html[Go agent troubleshooting]
 * {apm-java-ref-v}/trouble-shooting.html[Java agent troubleshooting]

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -1,13 +1,9 @@
-//////////////////////////////////////////////////////////////////////////
-//// This content is mainly copied from filebeat and adapted for apm-server
-//////////////////////////////////////////////////////////////////////////
-
 [[troubleshooting]]
 = Troubleshoot
 
 [partintro]
 --
-If you have issues installing or running APM Server, 
+If you have issues installing or running APM Server,
 read the following tips:
 
 * <<common-problems>>
@@ -21,6 +17,18 @@ Other sections in the documentation may also be helpful:
 * <<tune-apm-server, Tune APM Server>>
 * <<tune-es, Tune Elasticsearch>>
 * {apm-overview-ref-v}/agent-server-compatibility.html[Agent/Server compatibility matrix]
+
+If your issue is potentially related to other components of the APM ecosystem,
+don't forget to check the relevant troubleshooting guides:
+
+* {kibana-ref}/troubleshooting.html[APM app troubleshooting]
+* {apm-dotnet-ref-v}/troubleshooting.html[.NET agent troubleshooting]
+* {apm-go-ref-v}/troubleshooting.html[Go agent troubleshooting]
+* {apm-java-ref-v}/trouble-shooting.html[Java agent troubleshooting]
+* {apm-node-ref-v}/troubleshooting.html[Node.js agent troubleshooting]
+* {apm-py-ref-v}/troubleshooting.html[Python agent troubleshooting]
+* {apm-ruby-ref-v}/debugging.html[Ruby agent troubleshooting]
+* {apm-rum-ref-v}/troubleshooting.html[RUM troubleshooting]
 
 --
 


### PR DESCRIPTION
## Summary

Until we have a unified location for APM documentation, we maintain troubleshooting docs in a bunch of different places. This PR adds additional links to make it easier for users to find all of our troubleshooting guides, regardless of the page they google into.