### PR TITLE
beater: move event ACKer from publisher to beater

### DIFF
--- a/beater/acker.go
+++ b/beater/acker.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package publish
+package beater
 
 import (
 	"context"
@@ -29,6 +29,8 @@ import (
 // events published. waitPublishedAcker provides an interruptible Wait method
 // that blocks until all events published at the time the client is closed are
 // acknowledged.
+//
+// TODO(axw) move this to libbeat/common/acker.
 type waitPublishedAcker struct {
 	active int64 // atomic
 
@@ -37,6 +39,7 @@ type waitPublishedAcker struct {
 	done   chan struct{}
 }
 
+// newWaitPublishedAcker returns a new waitPublishedAcker.
 func newWaitPublishedAcker() *waitPublishedAcker {
 	return &waitPublishedAcker{done: make(chan struct{})}
 }


### PR DESCRIPTION
## Motivation/summary

In the future we will start and stop multiple publishers.
To avoid blocking the publisher.Stop method unnecessarily
during a config reload, move event ACKing to beater.

## How to test these changes

1. Run APM Server with a shutdown timeout configured
2. Stop Elasticsearch
3. Send some events
4. Shutdown APM Server, check that the shutdown timeout is honoured

## Related issues

Preparation for https://github.com/elastic/apm-server/issues/4376