### PR TITLE
beater: stop relying on onboarding in tests

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -54,6 +54,11 @@ var (
 
 // CreatorParams holds parameters for creating beat.Beaters.
 type CreatorParams struct {
+	// Logger is a logger to use in Beaters created by the beat.Creator.
+	//
+	// If Logger is nil, logp.NewLogger will be used to create a new one.
+	Logger *logp.Logger
+
 	// WrapRunServer is used to wrap the RunServerFunc used to run the APM Server.
 	//
 	// WrapRunServer is optional. If provided, it must return a function that calls
@@ -65,7 +70,12 @@ type CreatorParams struct {
 // using the provided CreatorParams.
 func NewCreator(args CreatorParams) beat.Creator {
 	return func(b *beat.Beat, ucfg *common.Config) (beat.Beater, error) {
-		logger := logp.NewLogger(logs.Beater)
+		logger := args.Logger
+		if logger != nil {
+			logger = logger.Named(logs.Beater)
+		} else {
+			logger = logp.NewLogger(logs.Beater)
+		}
 		if err := checkConfig(logger); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Motivation/summary

In the beater tests when we start a server,
we have been relying on the onboarding doc
to be published which contains the listening
address. We use the listening address in
tests to send requests to the server.

When the server runs with data streams enabled
it does not publish an onboarding document.
In order to unit test this mode we need to
stop relying on onboarding docs. This change
switches over to extracting the listening
address from logs, similar to how it is done
in systemtest.

It is possible to configure logp such that the
root logger (and loggers derived from it) are
observable in tests, but this would not work
with parallel tests. Instead, we introduce a
means of injecting a logger into the beater.

## How to test these changes

`make test`

## Related issues

Required to unit test changes related to https://github.com/elastic/apm-server/issues/4376