### PR TITLE
[7.x] fix: avoid panic when sourcemap doc does not contain hit (#4619)

### DIFF
--- a/sourcemap/es_store.go
+++ b/sourcemap/es_store.go
@@ -103,7 +103,7 @@ func parse(body io.ReadCloser, name, version, path string, logger *logp.Logger) 
 		return "", err
 	}
 	hits := esSourcemapResponse.Hits.Total.Value
-	if hits == 0 {
+	if hits == 0 || len(esSourcemapResponse.Hits.Hits) == 0 {
 		return emptyResult, nil
 	}
 

--- a/sourcemap/es_store_test.go
+++ b/sourcemap/es_store_test.go
@@ -82,8 +82,9 @@ func Test_esFetcher_fetch(t *testing.T) {
 		client   elasticsearch.Client
 		filePath string
 	}{
-		"no sourcemap found":    {client: test.ESClientWithSourcemapNotFound(t)},
-		"valid sourcemap found": {client: test.ESClientWithValidSourcemap(t), filePath: "bundle.js"},
+		"no sourcemap found":                {client: test.ESClientWithSourcemapNotFound(t)},
+		"sourcemap indicated but not found": {client: test.ESClientWithSourcemapIndicatedNotFound(t)},
+		"valid sourcemap found":             {client: test.ESClientWithValidSourcemap(t), filePath: "bundle.js"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			sourcemapStr, err := testESStore(tc.client).fetch(context.Background(), "abc", "1.0", "/tmp")

--- a/sourcemap/test/es_client.go
+++ b/sourcemap/test/es_client.go
@@ -107,6 +107,14 @@ func ESClientWithSourcemapNotFound(t *testing.T) elasticsearch.Client {
 	return client
 }
 
+// ESClientWithSourcemapIndicatedNotFound returns an elasticsearch client that will always return a result indicating
+// a sourcemap exists but it actually doesn't contain it. This is an edge case that usually shouldn't happen.
+func ESClientWithSourcemapIndicatedNotFound(t *testing.T) elasticsearch.Client {
+	client, err := estest.NewElasticsearchClient(estest.NewTransport(t, http.StatusOK, sourcemapIndicatedNotFoundFromES()))
+	require.NoError(t, err)
+	return client
+}
+
 func validSourcemapFromES() map[string]interface{} {
 	return map[string]interface{}{
 		"hits": map[string]interface{}{
@@ -121,6 +129,13 @@ func sourcemapNotFoundFromES() map[string]interface{} {
 	return map[string]interface{}{
 		"hits": map[string]interface{}{
 			"total": map[string]interface{}{"value": 0}}}
+}
+
+func sourcemapIndicatedNotFoundFromES() map[string]interface{} {
+	return map[string]interface{}{
+		"hits": map[string]interface{}{
+			"total": map[string]interface{}{"value": 1},
+			"hits":  []map[string]interface{}{}}}
 }
 
 func invalidSourcemapFromES() map[string]interface{} {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix: avoid panic when sourcemap doc does not contain hit (#4619)