### PR TITLE
Add dataset_is_prefix field to manifest files

### DIFF
--- a/apmpackage/apm/0.1.0/data_stream/app_metrics/manifest.yml
+++ b/apmpackage/apm/0.1.0/data_stream/app_metrics/manifest.yml
@@ -1,4 +1,5 @@
 title: APM application metrics
 type: metrics
 dataset: apm
+dataset_is_prefix: true
 ilm_policy: metrics-apm.app_metrics-default_policy

--- a/apmpackage/apm/0.1.0/data_stream/error_logs/manifest.yml
+++ b/apmpackage/apm/0.1.0/data_stream/error_logs/manifest.yml
@@ -1,4 +1,5 @@
 title: APM logs and errors
 type: logs
 dataset: apm.error
+dataset_is_prefix: true
 ilm_policy: logs-apm.error_logs-default_policy

--- a/apmpackage/apm/0.1.0/data_stream/internal_metrics/manifest.yml
+++ b/apmpackage/apm/0.1.0/data_stream/internal_metrics/manifest.yml
@@ -1,4 +1,5 @@
 title: APM internal metrics
 type: metrics
 dataset: apm.internal
+dataset_is_prefix: true
 ilm_policy: metrics-apm.internal_metrics-default_policy

--- a/apmpackage/apm/0.1.0/data_stream/profile_metrics/manifest.yml
+++ b/apmpackage/apm/0.1.0/data_stream/profile_metrics/manifest.yml
@@ -1,4 +1,5 @@
 title: APM profiles
 type: metrics
 dataset: apm.profiling
+dataset_is_prefix: true
 ilm_policy: metrics-apm.profile_metrics-default_policy

--- a/apmpackage/apm/0.1.0/data_stream/traces/manifest.yml
+++ b/apmpackage/apm/0.1.0/data_stream/traces/manifest.yml
@@ -1,4 +1,5 @@
 title: APM traces
 type: traces
 dataset: apm
+dataset_is_prefix: true
 ilm_policy: traces-apm.traces-default_policy


### PR DESCRIPTION
## Motivation/summary

This won't have any effect until we release a new registry version (soon), but we can get it merged in the meanwhile.

## Checklist

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## Related issues

Pre-requisite for https://github.com/elastic/apm-server/issues/4492
