### PR TITLE
Makefile: add check-fmt target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,11 +230,11 @@ endif
 .PHONY: check-gofmt check-autopep8 gofmt autopep8
 check-fmt: check-gofmt check-autopep8
 fmt: gofmt autopep8
-check-gofmt:
-	@sh script/check_goimports.sh
+check-gofmt: $(GOIMPORTS)
+	@PATH=$(GOOSBUILD):$(PATH) sh script/check_goimports.sh
 gofmt: $(GOIMPORTS) add-headers
 	@echo "fmt - goimports: Formatting Go code"
-	@GOIMPORTSFLAGS=-w sh script/goimports.sh
+	@PATH=$(GOOSBUILD):$(PATH) GOIMPORTSFLAGS=-w sh script/goimports.sh
 check-autopep8: $(PYTHON_BIN)
 	@PATH=$(PYTHON_BIN):$(PATH) sh script/autopep8_all.sh --diff --exit-code
 autopep8: $(PYTHON_BIN)

--- a/beater/http.go
+++ b/beater/http.go
@@ -23,9 +23,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
-	"github.com/elastic/beats/v7/libbeat/logp"
-	"github.com/elastic/gmux"
 	"go.elastic.co/apm"
 	"go.elastic.co/apm/module/apmhttp"
 	"golang.org/x/net/netutil"
@@ -33,6 +30,9 @@ import (
 	"github.com/elastic/apm-server/beater/api"
 	"github.com/elastic/apm-server/beater/config"
 	"github.com/elastic/apm-server/publish"
+	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/gmux"
 )
 
 type httpServer struct {

--- a/script/autopep8_all.sh
+++ b/script/autopep8_all.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+AUTOPEP8FLAGS=--max-line-length=120
+
+exec find -name '*.py' -and -not -path '*build/*' -exec autopep8 $AUTOPEP8FLAGS $* '{}' +

--- a/script/check_goimports.sh
+++ b/script/check_goimports.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+out=$(GOIMPORTSFLAGS=-l ./script/goimports.sh)
+if [ -n "$out" ]; then
+  out=$(echo $out | sed 's/ /\n - /')
+  printf "goimports differs:\n - $out\n" >&2
+  exit 1
+fi

--- a/script/generate_notice.py
+++ b/script/generate_notice.py
@@ -19,11 +19,12 @@ DEFAULT_BUILD_TAGS = "darwin,linux,windows"
 
 # Get the beats repo root directory, making sure it's downloaded first.
 subprocess.run(["go", "mod", "download", "github.com/elastic/beats/..."], check=True)
-BEATS_DIR = subprocess.check_output(["go", "list", "-m", "-f", "{{.Dir}}", "github.com/elastic/beats/..."]).decode("utf-8").strip()
+BEATS_DIR = subprocess.check_output(
+    ["go", "list", "-m", "-f", "{{.Dir}}", "github.com/elastic/beats/..."]).decode("utf-8").strip()
 
 # notice_overrides holds additional overrides entries for go-licence-detector.
 notice_overrides = [
-  {"name": "github.com/elastic/beats/v7", "licenceType": "Elastic"}
+    {"name": "github.com/elastic/beats/v7", "licenceType": "Elastic"}
 ]
 
 # Additional third-party, non-source code dependencies, to add to the CSV output.
@@ -61,7 +62,7 @@ def read_go_deps(main_packages, build_tags):
         module = pkg['Module']
         if "Main" not in module:
             modules[module['Path']] = module
-    return sorted(modules.values(), key = lambda module: module['Path'])
+    return sorted(modules.values(), key=lambda module: module['Path'])
 
 
 def go_license_detector(notice_out, deps_out, modules):
@@ -101,7 +102,6 @@ def go_license_detector(notice_out, deps_out, modules):
             "-depsOut", deps_out,
         ]
         subprocess.run(args, check=True, input=modules_json.encode("utf-8"))
-
 
 
 def write_notice_file(notice_filename, modules):

--- a/script/goimports.sh
+++ b/script/goimports.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+dirs=$(find . -maxdepth 1 -type d \! \( -name '.*' -or -name build \))
+exec goimports $GOIMPORTSFLAGS -local github.com/elastic *.go $dirs


### PR DESCRIPTION
## Motivation/summary

Introduce Makefile targets to check formatting without making changes, and add those targets to the `make check` target. This should simplify checking formatting prior to pushing changes, could be run as a pre-push hook, and avoid reliance on CI for picking up such errors.

## How to test these changes

1. Modify some Go code to be improperly formatted
2. Run `make check`, it should fail
3. Run `make fmt`, it should fix the formatting
4. Run `make check`, it should no longer fail
5. Modify some Python code to be improperly formatted, repeat steps 2-4

## Related issues

Replaces https://github.com/elastic/apm-server/pull/4456