### PR TITLE
sampling: fix TestStorageGC

### DIFF
--- a/x-pack/apm-server/sampling/config.go
+++ b/x-pack/apm-server/sampling/config.go
@@ -76,6 +76,10 @@ type StorageConfig struct {
 	// TTL holds the amount of time before events and sampling decisions
 	// are expired from local storage.
 	TTL time.Duration
+
+	// ValueLogFileSize holds the size for Badger value log files.
+	// If unspecified, then the default value of 128MB will be used.
+	ValueLogFileSize int64
 }
 
 // Policy holds a tail-sampling policy: criteria for matching root transactions,

--- a/x-pack/apm-server/sampling/processor.go
+++ b/x-pack/apm-server/sampling/processor.go
@@ -66,7 +66,10 @@ func NewProcessor(config Config) (*Processor, error) {
 
 	logger := logp.NewLogger(logs.Sampling)
 	badgerOpts := badger.DefaultOptions(config.StorageDir)
-	badgerOpts.ValueLogFileSize = badgerValueLogFileSize
+	badgerOpts.ValueLogFileSize = config.ValueLogFileSize
+	if badgerOpts.ValueLogFileSize == 0 {
+		badgerOpts.ValueLogFileSize = badgerValueLogFileSize
+	}
 	badgerOpts.Logger = eventstorage.LogpAdaptor{Logger: logger}
 	db, err := badger.Open(badgerOpts)
 	if err != nil {


### PR DESCRIPTION
## Motivation/summary

Fix TestStorageGC by disabling GC (by setting a long interval) while storing events to drive up the vlog size. Enable it only after multiple vlog files have been written. This ensures that GC doesn't remove files while we're still writing, causing the test to never have multiple vlog files.

Also, make the Badger value log file size configurable, so tests can override it with a smaller size.

## How to test these changes

`go test -race ./x-pack/apm-server/sampling`

## Related issues

Closes #4651 