### PR TITLE
ci: fix benchmark stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -336,9 +336,9 @@ pipeline {
               golang(){
                 dir("${BASE_DIR}"){
                   sh(label: 'Run benchmarks', script: './.ci/scripts/bench.sh')
-                  sendBenchmarks(file: 'bench.out', index: "benchmark-server")
                 }
               }
+              sendBenchmarks(file: "${BASE_DIR}/bench.out", index: "benchmark-server")
             }
           }
         }


### PR DESCRIPTION
The sendBenchmarks step provides its own Go environment, this moves the step outside the Go Docker container.

closes https://github.com/elastic/apm-server/issues/4662