### PR TITLE
Add note about tags vs labels to json schemas

### DIFF
--- a/docs/spec/v2/error.json
+++ b/docs/spec/v2/error.json
@@ -507,7 +507,7 @@
           }
         },
         "tags": {
-          "description": "Tags are a flat mapping of user-defined tags. Allowed value types are string, boolean and number values. Tags are indexed and searchable.",
+          "description": "Tags are a flat mapping of user-defined tags. On the agent side, tags are called labels. Allowed value types are string, boolean and number values. Tags are indexed and searchable.",
           "type": [
             "null",
             "object"

--- a/docs/spec/v2/metricset.json
+++ b/docs/spec/v2/metricset.json
@@ -50,7 +50,7 @@
       }
     },
     "tags": {
-      "description": "Tags are a flat mapping of user-defined tags. Allowed value types are string, boolean and number values. Tags are indexed and searchable.",
+      "description": "Tags are a flat mapping of user-defined tags. On the agent side, tags are called labels. Allowed value types are string, boolean and number values. Tags are indexed and searchable.",
       "type": [
         "null",
         "object"

--- a/docs/spec/v2/span.json
+++ b/docs/spec/v2/span.json
@@ -454,7 +454,7 @@
           }
         },
         "tags": {
-          "description": "Tags are a flat mapping of user-defined tags. Allowed value types are string, boolean and number values. Tags are indexed and searchable.",
+          "description": "Tags are a flat mapping of user-defined tags. On the agent side, tags are called labels. Allowed value types are string, boolean and number values. Tags are indexed and searchable.",
           "type": [
             "null",
             "object"

--- a/docs/spec/v2/transaction.json
+++ b/docs/spec/v2/transaction.json
@@ -506,7 +506,7 @@
           }
         },
         "tags": {
-          "description": "Tags are a flat mapping of user-defined tags. Allowed value types are string, boolean and number values. Tags are indexed and searchable.",
+          "description": "Tags are a flat mapping of user-defined tags. On the agent side, tags are called labels. Allowed value types are string, boolean and number values. Tags are indexed and searchable.",
           "type": [
             "null",
             "object"

--- a/model/modeldecoder/v2/model.go
+++ b/model/modeldecoder/v2/model.go
@@ -86,8 +86,9 @@ type context struct {
 	// here will override the more generic information retrieved from metadata,
 	// missing service fields will be retrieved from the metadata information.
 	Service contextService `json:"service"`
-	// Tags are a flat mapping of user-defined tags. Allowed value types are
-	// string, boolean and number values. Tags are indexed and searchable.
+	// Tags are a flat mapping of user-defined tags. On the agent side, tags
+	// are called labels. Allowed value types are string, boolean and number
+	// values. Tags are indexed and searchable.
 	Tags common.MapStr `json:"tags" validate:"inputTypesVals=string;bool;number,maxLengthVals=1024"`
 	// User holds information about the correlated user for this event. If
 	// user data are provided here, all user related information from metadata
@@ -537,8 +538,9 @@ type metricset struct {
 	Samples map[string]metricsetSampleValue `json:"samples" validate:"required,patternKeys=patternNoAsteriskQuote"`
 	// Span holds selected information about the correlated transaction.
 	Span metricsetSpanRef `json:"span"`
-	// Tags are a flat mapping of user-defined tags. Allowed value types are
-	// string, boolean and number values. Tags are indexed and searchable.
+	// Tags are a flat mapping of user-defined tags. On the agent side, tags
+	// are called labels. Allowed value types are string, boolean and number
+	// values. Tags are indexed and searchable.
 	Tags common.MapStr `json:"tags" validate:"inputTypesVals=string;bool;number,maxLengthVals=1024"`
 	// Transaction holds selected information about the correlated transaction.
 	Transaction metricsetTransactionRef `json:"transaction"`
@@ -631,8 +633,9 @@ type spanContext struct {
 	// here will override the more generic information retrieved from metadata,
 	// missing service fields will be retrieved from the metadata information.
 	Service contextService `json:"service"`
-	// Tags are a flat mapping of user-defined tags. Allowed value types are
-	// string, boolean and number values. Tags are indexed and searchable.
+	// Tags are a flat mapping of user-defined tags. On the agent side, tags
+	// are called labels. Allowed value types are string, boolean and number
+	// values. Tags are indexed and searchable.
 	Tags common.MapStr `json:"tags" validate:"inputTypesVals=string;bool;number,maxLengthVals=1024"`
 }
 


### PR DESCRIPTION
Tags were renamed to Labels on the agent side years ago, but it's not super obvious that labels go to `"tags"` in the intake API.

I'm open to better ways to word this addition -- the important thing is that now if you do a Find for `labels`, something actually shows up. :)