### PR TITLE
systemtest: fix missing error check

### DIFF
--- a/systemtest/fleet_test.go
+++ b/systemtest/fleet_test.go
@@ -131,6 +131,7 @@ func TestFleetIntegration(t *testing.T) {
 	waitFor.Port = "8200/tcp"
 	agent.WaitingFor = waitFor
 	err = agent.Start()
+	require.NoError(t, err)
 
 	// Elastic Agent has started apm-server. Connect to apm-server and send some data,
 	// and make sure it gets indexed into a data stream.


### PR DESCRIPTION
## Motivation/summary

Check error in test to avoid surprises later on.

## How to test these changes

`cd systemtest && go test -v -run Fleet`

## Related issues

None.