### PR TITLE
[7.10] ci: fix benchmark stage (#4672)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -333,7 +333,7 @@ pipeline {
               unstash 'source'
               golang(){
                 dir("${BASE_DIR}"){
-                  sh(label: 'Run benchmarks', script: './.ci/scripts/bench.sh')
+                  sh(label: 'Run benchmarks', script: './script/jenkins/bench.sh')
                 }
               }
               sendBenchmarks(file: "${BASE_DIR}/bench.out", index: "benchmark-server")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -333,10 +333,10 @@ pipeline {
               unstash 'source'
               golang(){
                 dir("${BASE_DIR}"){
-                  sh(label: 'Run benchmarks', script: './script/jenkins/bench.sh')
-                  sendBenchmarks(file: 'bench.out', index: "benchmark-server")
+                  sh(label: 'Run benchmarks', script: './.ci/scripts/bench.sh')
                 }
               }
+              sendBenchmarks(file: "${BASE_DIR}/bench.out", index: "benchmark-server")
             }
           }
         }


### PR DESCRIPTION
Backports the following commits to 7.10:
 - ci: fix benchmark stage (#4672)