### PR TITLE
[7.x] ci: fix benchmark stage (#4672)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -336,9 +336,9 @@ pipeline {
               golang(){
                 dir("${BASE_DIR}"){
                   sh(label: 'Run benchmarks', script: './.ci/scripts/bench.sh')
-                  sendBenchmarks(file: 'bench.out', index: "benchmark-server")
                 }
               }
+              sendBenchmarks(file: "${BASE_DIR}/bench.out", index: "benchmark-server")
             }
           }
         }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ci: fix benchmark stage (#4672)