### PR TITLE
systemtest: compensate for Fleet API bug

### DIFF
--- a/systemtest/fleettest/error.go
+++ b/systemtest/fleettest/error.go
@@ -1,0 +1,14 @@
+package fleettest
+
+// Error is an error type returned by Client methods on failed
+// requests to the Kibana Fleet API.
+type Error struct {
+	StatusCode int    `json:"statusCode"`
+	ErrorCode  string `json:"error"`
+	Message    string `json:"message"`
+}
+
+// Error returns the error message.
+func (e *Error) Error() string {
+	return e.Message
+}

--- a/systemtest/fleettest/error.go
+++ b/systemtest/fleettest/error.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package fleettest
 
 // Error is an error type returned by Client methods on failed


### PR DESCRIPTION
## Motivation/summary

https://github.com/elastic/kibana/issues/90544 is causing the system test to respond with 404 Not Found, despite the policy existing and being successfully deleted.

Update the test to temporarily expect a 404 response to avoid failing all our builds. Once the Kibana bug is resolved this will start failing, and we can again check that no error is returned.

## How to test these changes

`cd systemtest && go test -v -run Fleet`

## Related issues

Closes https://github.com/elastic/apm-server/issues/4692