### PR TITLE
[7.10] docs: add release notes for 6.8.14 (#4697)

### DIFF
--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,6 +3,7 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.14>>
 * <<release-notes-6.8.13>>
 * <<release-notes-6.8.12>>
 * <<release-notes-6.8.11>>
@@ -17,6 +18,14 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.2>>
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
+
+[float]
+[[release-notes-6.8.14]]
+=== APM Server version 6.8.14
+
+https://github.com/elastic/apm-server/compare/v6.8.13\...v6.8.14[View commits]
+
+No significant changes.
 
 [float]
 [[release-notes-6.8.13]]


### PR DESCRIPTION
Backports the following commits to 7.10:
 - docs: add release notes for 6.8.14 (#4697)