### PR TITLE
[6.8] docs: add release notes for 6.8.14 (#4697)

### DIFF
--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,6 +3,7 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.14>>
 * <<release-notes-6.8.13>>
 * <<release-notes-6.8.12>>
 * <<release-notes-6.8.11>>
@@ -18,6 +19,15 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
 
+[float]
+[[release-notes-6.8.14]]
+=== APM Server version 6.8.14
+
+https://github.com/elastic/apm-server/compare/v6.8.13\...v6.8.14[View commits]
+
+No significant changes.
+
+[float]
 [[release-notes-6.8.13]]
 === APM Server version 6.8.13
 

--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -19,7 +19,6 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
 
-[float]
 [[release-notes-6.8.14]]
 === APM Server version 6.8.14
 
@@ -27,7 +26,6 @@ https://github.com/elastic/apm-server/compare/v6.8.13\...v6.8.14[View commits]
 
 No significant changes.
 
-[float]
 [[release-notes-6.8.13]]
 === APM Server version 6.8.13
 


### PR DESCRIPTION
Backports the following commits to 6.8:
 - docs: add release notes for 6.8.14 (#4697)