### PR TITLE
Use the apm-server version everywhere*

### DIFF
--- a/beater/api/root/handler.go
+++ b/beater/api/root/handler.go
@@ -35,14 +35,20 @@ var (
 	registry      = monitoring.Default.NewRegistry("apm-server.root")
 )
 
+// HandlerConfig holds configuration for Handler.
+type HandlerConfig struct {
+	// Version holds the APM Server version.
+	Version string
+}
+
 // Handler returns error if route does not exist,
 // otherwise returns information about the server. The detail level differs for authorized and non-authorized requests.
 //TODO: only allow GET, HEAD requests (breaking change)
-func Handler() request.Handler {
+func Handler(cfg HandlerConfig) request.Handler {
 	serverInfo := common.MapStr{
 		"build_date": version.BuildTime().Format(time.RFC3339),
 		"build_sha":  version.Commit(),
-		"version":    version.GetDefaultVersion(),
+		"version":    cfg.Version,
 	}
 
 	return func(c *request.Context) {

--- a/beater/api/root/handler_test.go
+++ b/beater/api/root/handler_test.go
@@ -36,7 +36,7 @@ import (
 func TestRootHandler(t *testing.T) {
 	t.Run("404", func(t *testing.T) {
 		c, w := beatertest.ContextWithResponseRecorder(http.MethodGet, "/abc/xyz")
-		Handler()(c)
+		Handler(HandlerConfig{Version: "1.2.3"})(c)
 
 		assert.Equal(t, http.StatusNotFound, w.Code)
 		assert.Equal(t, `{"error":"404 page not found"}`+"\n", w.Body.String())
@@ -45,7 +45,7 @@ func TestRootHandler(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		c, w := beatertest.ContextWithResponseRecorder(http.MethodGet, "/")
 		c.Authorization = &authorization.DenyAuth{}
-		Handler()(c)
+		Handler(HandlerConfig{Version: "1.2.3"})(c)
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, "", w.Body.String())
@@ -54,7 +54,7 @@ func TestRootHandler(t *testing.T) {
 	t.Run("unauthorized", func(t *testing.T) {
 		c, w := beatertest.ContextWithResponseRecorder(http.MethodGet, "/")
 		c.Authorization = authorization.DenyAuth{}
-		Handler()(c)
+		Handler(HandlerConfig{Version: "1.2.3"})(c)
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, "", w.Body.String())
@@ -65,11 +65,11 @@ func TestRootHandler(t *testing.T) {
 		builder, err := authorization.NewBuilder(&config.Config{SecretToken: "abc"})
 		require.NoError(t, err)
 		c.Authorization = builder.ForPrivilege("").AuthorizationFor("Bearer", "abc")
-		Handler()(c)
+		Handler(HandlerConfig{Version: "1.2.3"})(c)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		body := fmt.Sprintf("{\"build_date\":\"0001-01-01T00:00:00Z\",\"build_sha\":\"%s\",\"version\":\"%s\"}\n",
-			version.Commit(), version.GetDefaultVersion())
+		body := fmt.Sprintf("{\"build_date\":\"0001-01-01T00:00:00Z\",\"build_sha\":\"%s\",\"version\":\"1.2.3\"}\n",
+			version.Commit())
 		assert.Equal(t, body, w.Body.String())
 	})
 }

--- a/beater/api/root/test_approved/integration/TestRootHandler_AuthorizationMiddleware/Authorized.approved.json
+++ b/beater/api/root/test_approved/integration/TestRootHandler_AuthorizationMiddleware/Authorized.approved.json
@@ -1,5 +1,5 @@
 {
     "build_date": "0001-01-01T00:00:00Z",
     "build_sha": "unknown",
-    "version": "8.0.0"
+    "version": "1.2.3"
 }

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/instrumentation"
 	"github.com/elastic/beats/v7/libbeat/logp"
-	"github.com/elastic/beats/v7/libbeat/version"
 )
 
 type testBeater struct {
@@ -68,7 +67,7 @@ func newBeat(t *testing.T, cfg *common.Config, beatConfig *beat.BeatConfig, even
 	info := beat.Info{
 		Beat:        "test-apm-server",
 		IndexPrefix: "test-apm-server",
-		Version:     version.GetDefaultVersion(),
+		Version:     "1.2.3", // hard-coded to avoid changing approvals
 		ID:          uuid.Must(uuid.FromString("fbba762a-14dd-412c-b7e9-b79f903eb492")),
 	}
 

--- a/beater/beatertest/monitoring.go
+++ b/beater/beatertest/monitoring.go
@@ -26,17 +26,14 @@ import (
 )
 
 // CompareMonitoringInt matches expected with real monitoring counters and
-// returns false and an a string showind diffs if not matching
+// returns false and an a string showind diffs if not matching.
+//
+// The caller is expected to call ClearRegistry before invoking some code
+// path that should update monitoring counters.
 func CompareMonitoringInt(
-	handler func(c *request.Context),
-	c *request.Context,
 	expected map[request.ResultID]int,
 	m map[request.ResultID]*monitoring.Int,
 ) (bool, string) {
-
-	ClearRegistry(m)
-	handler(c)
-
 	var result string
 	for _, id := range AllRequestResultIDs() {
 		monitoringIntVal := int64(0)
@@ -52,7 +49,6 @@ func CompareMonitoringInt(
 			result += fmt.Sprintf("[%s] Expected: %d, Received: %d", id, expectedVal, monitoringIntVal)
 		}
 	}
-
 	return len(result) == 0, result
 }
 

--- a/beater/http.go
+++ b/beater/http.go
@@ -30,6 +30,7 @@ import (
 	"github.com/elastic/apm-server/beater/api"
 	"github.com/elastic/apm-server/beater/config"
 	"github.com/elastic/apm-server/publish"
+	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/gmux"
@@ -43,8 +44,8 @@ type httpServer struct {
 	grpcListener net.Listener
 }
 
-func newHTTPServer(logger *logp.Logger, cfg *config.Config, tracer *apm.Tracer, reporter publish.Reporter) (*httpServer, error) {
-	mux, err := api.NewMux(cfg, reporter)
+func newHTTPServer(logger *logp.Logger, info beat.Info, cfg *config.Config, tracer *apm.Tracer, reporter publish.Reporter) (*httpServer, error) {
+	mux, err := api.NewMux(info, cfg, reporter)
 	if err != nil {
 		return nil, err
 	}

--- a/beater/middleware/monitoring_middleware_test.go
+++ b/beater/middleware/monitoring_middleware_test.go
@@ -40,8 +40,10 @@ func TestMonitoringHandler(t *testing.T) {
 		expected map[request.ResultID]int,
 		m map[request.ResultID]*monitoring.Int,
 	) {
+		beatertest.ClearRegistry(m)
 		c, _ := beatertest.DefaultContextWithResponseRecorder()
-		equal, result := beatertest.CompareMonitoringInt(Apply(MonitoringMiddleware(m), h), c, expected, m)
+		Apply(MonitoringMiddleware(m), h)(c)
+		equal, result := beatertest.CompareMonitoringInt(expected, m)
 		assert.True(t, equal, result)
 	}
 

--- a/beater/server.go
+++ b/beater/server.go
@@ -72,7 +72,7 @@ type ServerParams struct {
 
 // runServer runs the APM Server until a fatal error occurs, or ctx is cancelled.
 func runServer(ctx context.Context, args ServerParams) error {
-	srv, err := newServer(args.Logger, args.Config, args.Tracer, args.Reporter)
+	srv, err := newServer(args.Logger, args.Info, args.Config, args.Tracer, args.Reporter)
 	if err != nil {
 		return err
 	}
@@ -98,8 +98,8 @@ type server struct {
 	reporter     publish.Reporter
 }
 
-func newServer(logger *logp.Logger, cfg *config.Config, tracer *apm.Tracer, reporter publish.Reporter) (server, error) {
-	httpServer, err := newHTTPServer(logger, cfg, tracer, reporter)
+func newServer(logger *logp.Logger, info beat.Info, cfg *config.Config, tracer *apm.Tracer, reporter publish.Reporter) (server, error) {
+	httpServer, err := newHTTPServer(logger, info, cfg, tracer, reporter)
 	if err != nil {
 		return server{}, err
 	}

--- a/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
@@ -299,8 +299,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "process": {
                 "args": [
@@ -432,8 +432,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "process": {
                 "args": [
@@ -546,8 +546,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "process": {
                 "args": [
@@ -660,8 +660,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "parent": {
                 "id": "9632587410abcdef"
@@ -779,8 +779,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "parent": {
                 "id": "9632587410abcdef"

--- a/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
@@ -105,8 +105,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "parent": {
                 "id": "abcdefabcdef01234567"
@@ -241,8 +241,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "parent": {
                 "id": "abcdef0123456789"
@@ -418,8 +418,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "process": {
                 "args": [
@@ -705,8 +705,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "parent": {
                 "id": "9632587410abcdef"

--- a/beater/test_approved_es_documents/TestPublishIntegrationMetricsets.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationMetricsets.approved.json
@@ -47,8 +47,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "process": {
                 "pid": 1234
@@ -132,8 +132,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "process": {
                 "pid": 1234
@@ -178,8 +178,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "process": {
                 "pid": 1234

--- a/beater/test_approved_es_documents/TestPublishIntegrationMinimalEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationMinimalEvents.approved.json
@@ -23,8 +23,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "transaction",
@@ -71,8 +71,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "parent": {
                 "id": "ab23456a89012345"
@@ -122,8 +122,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "parent": {
                 "id": "ab23456a89012345"
@@ -168,8 +168,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "metric",
@@ -203,8 +203,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "error",
@@ -243,8 +243,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "error",
@@ -283,8 +283,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "error",

--- a/beater/test_approved_es_documents/TestPublishIntegrationProfileCPUProfile.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationProfileCPUProfile.approved.json
@@ -10,8 +10,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -144,8 +144,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -224,8 +224,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -376,8 +376,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -456,8 +456,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -518,8 +518,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -616,8 +616,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -708,8 +708,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -794,8 +794,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -898,8 +898,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1020,8 +1020,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1076,8 +1076,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1144,8 +1144,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1248,8 +1248,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1382,8 +1382,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1444,8 +1444,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1560,8 +1560,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1664,8 +1664,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1756,8 +1756,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1848,8 +1848,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1970,8 +1970,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2026,8 +2026,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2112,8 +2112,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2174,8 +2174,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2242,8 +2242,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2370,8 +2370,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2450,8 +2450,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2506,8 +2506,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2550,8 +2550,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2630,8 +2630,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2752,8 +2752,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2862,8 +2862,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2972,8 +2972,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3046,8 +3046,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3162,8 +3162,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3224,8 +3224,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3304,8 +3304,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3372,8 +3372,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3494,8 +3494,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3664,8 +3664,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3744,8 +3744,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3842,8 +3842,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4006,8 +4006,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4062,8 +4062,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4190,8 +4190,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4306,8 +4306,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4368,8 +4368,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4454,8 +4454,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4504,8 +4504,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4578,8 +4578,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4634,8 +4634,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4762,8 +4762,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4818,8 +4818,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4862,8 +4862,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4942,8 +4942,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5052,8 +5052,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5144,8 +5144,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5218,8 +5218,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5322,8 +5322,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5426,8 +5426,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5506,8 +5506,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5628,8 +5628,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5714,8 +5714,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5806,8 +5806,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5892,8 +5892,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5966,8 +5966,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6022,8 +6022,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6132,8 +6132,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6266,8 +6266,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6412,8 +6412,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6498,8 +6498,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6554,8 +6554,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6646,8 +6646,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6798,8 +6798,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6932,8 +6932,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7054,8 +7054,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7116,8 +7116,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7184,8 +7184,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7288,8 +7288,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7326,8 +7326,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7376,8 +7376,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7444,8 +7444,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7518,8 +7518,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7592,8 +7592,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7678,8 +7678,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7788,8 +7788,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7856,8 +7856,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7930,8 +7930,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8046,8 +8046,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8114,8 +8114,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8224,8 +8224,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8316,8 +8316,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8408,8 +8408,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8458,8 +8458,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8562,8 +8562,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8636,8 +8636,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8686,8 +8686,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8820,8 +8820,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",

--- a/beater/test_approved_es_documents/TestPublishIntegrationProfileCPUProfileMetadata.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationProfileCPUProfileMetadata.approved.json
@@ -17,8 +17,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -161,8 +161,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -251,8 +251,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -413,8 +413,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -503,8 +503,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -575,8 +575,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -683,8 +683,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -785,8 +785,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -881,8 +881,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -995,8 +995,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1127,8 +1127,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1193,8 +1193,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1271,8 +1271,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1385,8 +1385,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1529,8 +1529,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1601,8 +1601,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1727,8 +1727,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1841,8 +1841,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1943,8 +1943,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2045,8 +2045,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2177,8 +2177,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2243,8 +2243,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2339,8 +2339,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2411,8 +2411,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2489,8 +2489,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2627,8 +2627,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2717,8 +2717,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2783,8 +2783,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2837,8 +2837,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2927,8 +2927,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3059,8 +3059,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3179,8 +3179,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3299,8 +3299,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3383,8 +3383,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3509,8 +3509,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3581,8 +3581,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3671,8 +3671,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3749,8 +3749,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3881,8 +3881,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4061,8 +4061,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4151,8 +4151,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4259,8 +4259,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4433,8 +4433,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4499,8 +4499,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4637,8 +4637,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4763,8 +4763,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4835,8 +4835,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4931,8 +4931,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -4991,8 +4991,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5075,8 +5075,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5141,8 +5141,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5279,8 +5279,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5345,8 +5345,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5399,8 +5399,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5489,8 +5489,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5609,8 +5609,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5711,8 +5711,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5795,8 +5795,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -5909,8 +5909,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6023,8 +6023,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6113,8 +6113,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6245,8 +6245,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6341,8 +6341,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6443,8 +6443,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6539,8 +6539,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6623,8 +6623,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6689,8 +6689,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6809,8 +6809,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -6953,8 +6953,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7109,8 +7109,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7205,8 +7205,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7271,8 +7271,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7373,8 +7373,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7535,8 +7535,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7679,8 +7679,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7811,8 +7811,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7883,8 +7883,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -7961,8 +7961,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8075,8 +8075,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8123,8 +8123,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8183,8 +8183,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8261,8 +8261,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8345,8 +8345,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8429,8 +8429,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8525,8 +8525,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8645,8 +8645,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8723,8 +8723,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8807,8 +8807,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -8933,8 +8933,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -9011,8 +9011,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -9131,8 +9131,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -9233,8 +9233,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -9335,8 +9335,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -9395,8 +9395,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -9509,8 +9509,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -9593,8 +9593,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -9653,8 +9653,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -9797,8 +9797,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",

--- a/beater/test_approved_es_documents/TestPublishIntegrationProfileHeapProfile.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationProfileHeapProfile.approved.json
@@ -10,8 +10,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -79,8 +79,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -190,8 +190,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -289,8 +289,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -388,8 +388,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -433,8 +433,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -526,8 +526,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -571,8 +571,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -640,8 +640,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -703,8 +703,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -820,8 +820,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -901,8 +901,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1012,8 +1012,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1093,8 +1093,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1162,8 +1162,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1207,8 +1207,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1252,8 +1252,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1327,8 +1327,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1372,8 +1372,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1585,8 +1585,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1636,8 +1636,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1699,8 +1699,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1834,8 +1834,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -1885,8 +1885,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2014,8 +2014,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2053,8 +2053,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2116,8 +2116,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2185,8 +2185,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2338,8 +2338,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2497,8 +2497,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2704,8 +2704,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2821,8 +2821,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -2908,8 +2908,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3043,8 +3043,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3166,8 +3166,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3271,8 +3271,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3466,8 +3466,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3583,8 +3583,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3700,8 +3700,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3781,8 +3781,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3862,8 +3862,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",
@@ -3967,8 +3967,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "processor": {
                 "event": "profile",

--- a/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json
@@ -70,8 +70,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "parent": {
                 "id": "abcdef0123456789"
@@ -199,8 +199,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "parent": {
                 "id": "0000000011111111"
@@ -332,8 +332,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "parent": {
                 "id": "abcdefabcdef7890"
@@ -463,8 +463,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "parent": {
                 "id": "ababcdcdefefabde"
@@ -599,8 +599,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "parent": {
                 "id": "abcdef0123456789"
@@ -811,8 +811,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "parent": {
                 "id": "abcdef0123456789"

--- a/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json
@@ -67,8 +67,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "parent": {
                 "id": "abcdefabcdef01234567"
@@ -263,8 +263,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "process": {
                 "args": [
@@ -430,8 +430,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "process": {
                 "args": [
@@ -577,8 +577,8 @@
                 "hostname": "",
                 "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
                 "type": "test-apm-server",
-                "version": "8.0.0",
-                "version_major": 8
+                "version": "1.2.3",
+                "version_major": 1
             },
             "parent": {
                 "id": "abcdefabcdef01234567"

--- a/beater/tracing.go
+++ b/beater/tracing.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/logp"
 
 	"github.com/elastic/apm-server/beater/api"
@@ -53,7 +54,7 @@ func newTracerServer(listener net.Listener, logger *logp.Logger) (*tracerServer,
 		}
 	}
 	cfg := config.DefaultConfig()
-	mux, err := api.NewMux(cfg, report)
+	mux, err := api.NewMux(beat.Info{}, cfg, report)
 	if err != nil {
 		return nil, err
 	}

--- a/publish/pub.go
+++ b/publish/pub.go
@@ -89,17 +89,19 @@ func NewPublisher(pipeline beat.Pipeline, tracer *apm.Tracer, cfg *PublisherConf
 		return nil, errors.Wrap(err, "invalid config")
 	}
 
+	observerFields := common.MapStr{
+		"type":         cfg.Info.Beat,
+		"hostname":     cfg.Info.Hostname,
+		"version":      cfg.Info.Version,
+		"id":           cfg.Info.ID.String(),
+		"ephemeral_id": cfg.Info.EphemeralID.String(),
+	}
+	if version, err := common.NewVersion(cfg.Info.Version); err == nil {
+		observerFields["version_major"] = version.Major
+	}
+
 	processingCfg := beat.ProcessingConfig{
-		Fields: common.MapStr{
-			"observer": common.MapStr{
-				"type":          cfg.Info.Beat,
-				"hostname":      cfg.Info.Hostname,
-				"version":       cfg.Info.Version,
-				"version_major": 8,
-				"id":            cfg.Info.ID.String(),
-				"ephemeral_id":  cfg.Info.EphemeralID.String(),
-			},
-		},
+		Fields:    common.MapStr{"observer": observerFields},
 		Processor: cfg.Processor,
 	}
 	if cfg.TransformConfig.DataStreams {


### PR DESCRIPTION
## Motivation/summary

We have been using the libbeat version in the root handler,
which may not be the same as the apm-server version since
we maintain our own version now. This PR injects the apm-server
version into the root handler so it can be returned.

In the publisher code, we had hard-coded the major version
number. Less problematic, but I have changed this to parse the
full version to extract the major version number.

In the Elasticsearch client we still use the libbeat version for
determining the major version number. I think this is OK because
we should never have different *major* version of libbeat in
APM Server, for the time being at least.

Finally: instead of using the libbeat version in integration tests,
use a hard-coded version of "1.2.3" so we don't have to change
approval files each time we bump the version. This should enable
us to automate the version bump.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~ should have no visible impact on users, as we have kept libbeat up to date.
~- [ ] Documentation has been updated~

## How to test these changes

1. Run apm-server
2. Query http://localhost:8200/
3. Check that it responds with the apm-server version

## Related issues

Fixes #4420 