### PR TITLE
[7.x] beater: separate recording static/dynamic config (#4609)

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -153,9 +153,10 @@ func (bt *beater) Run(b *beat.Beat) error {
 	}
 
 	// send configs to telemetry
-	if err := recordConfigs(b.Info, bt.config, bt.rawConfig); err != nil {
+	if err := recordRootConfig(b.Info, bt.rawConfig); err != nil {
 		bt.logger.Errorf("Error recording telemetry data", err)
 	}
+	recordAPMServerConfig(bt.config)
 
 	tracer, tracerServer, err := bt.initTracing(b)
 	if err != nil {

--- a/beater/telemetry_test.go
+++ b/beater/telemetry_test.go
@@ -54,7 +54,8 @@ func TestRecordConfigs(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, recordConfigs(info, apmCfg, rootCfg))
+	require.NoError(t, recordRootConfig(info, rootCfg))
+	recordAPMServerConfig(apmCfg)
 
 	assert.Equal(t, configMonitors.ilmSetupEnabled.Get(), true)
 	assert.Equal(t, configMonitors.rumEnabled.Get(), false)


### PR DESCRIPTION
Backports the following commits to 7.x:
 - beater: separate recording static/dynamic config (#4609)