### PR TITLE
[7.2] [DOCS] Fixes URLs on Secure communication with APM Agents page (#4746)

### DIFF
--- a/docs/secure-communication-agents.asciidoc
+++ b/docs/secure-communication-agents.asciidoc
@@ -69,7 +69,7 @@ To enable secure communication in your Agents, you need to update the configured
 
 * *Go Agent*: {apm-go-ref}/configuration.html#config-server-url[`ELASTIC_APM_SERVER_URL`]
 * *Java Agent*: {apm-java-ref}/config-reporter.html#config-server-urls[`server_urls`]
-* *.NET Agent*: {apm-dotnet-ref}/config-reporter.html#config-server-urls[`ServerUrls`]
+// * *.NET Agent*: {apm-dotnet-ref}/config-reporter.html#config-server-url[`ServerUrls`]
 * *Node.js Agent*: {apm-node-ref}/configuration.html#server-url[`serverUrl`]
 * *Python Agent*: {apm-py-ref}/[`server_url`]
 * *Ruby Agent*: {apm-ruby-ref}/configuration.html#config-server-url[`server_url`]


### PR DESCRIPTION
Backports the following commits to 7.2:
 - [DOCS] Fixes URLs on Secure communication with APM Agents page (#4746)