### PR TITLE
docs: readds .NET link

### DIFF
--- a/docs/secure-communication-agents.asciidoc
+++ b/docs/secure-communication-agents.asciidoc
@@ -482,7 +482,7 @@ To enable secure communication in your Agents, you need to update the configured
 
 * *Go Agent*: {apm-go-ref}/configuration.html#config-server-url[`ELASTIC_APM_SERVER_URL`]
 * *Java Agent*: {apm-java-ref}/config-reporter.html#config-server-urls[`server_urls`]
-// * *.NET Agent*: {apm-dotnet-ref}/config-reporter.html#config-server-url[`ServerUrls`]
+* *.NET Agent*: {apm-dotnet-ref}/config-reporter.html#config-server-url[`ServerUrl`]
 * *Node.js Agent*: {apm-node-ref}/configuration.html#server-url[`serverUrl`]
 * *Python Agent*: {apm-py-ref}/[`server_url`]
 * *Ruby Agent*: {apm-ruby-ref}/configuration.html#config-server-url[`server_url`]


### PR DESCRIPTION
Readds the .NET `ServerUrl` link that was removed in https://github.com/elastic/apm-server/pull/4746. Backport to `7.2`.