### PR TITLE
[7.x] Makefile: add check-fmt target (#4654)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ check-approvals: $(APPROVALS)
 	@$(APPROVALS)
 
 .PHONY: check
-check: $(MAGE) check-headers
+check: $(MAGE) check-fmt check-headers
 	@$(MAGE) check
 
 .PHONY: gen-package
@@ -226,14 +226,20 @@ ifndef CHECK_HEADERS_DISABLED
 	@$(GOLICENSER) -d -exclude build -license Elastic x-pack
 endif
 
-# TODO(axw) once we move to modules, start using "mage fmt" instead.
-.PHONY: gofmt autopep8
+
+.PHONY: check-gofmt check-autopep8 gofmt autopep8
+check-fmt: check-gofmt check-autopep8
 fmt: gofmt autopep8
+check-gofmt: $(GOIMPORTS)
+	@PATH=$(GOOSBUILD):$(PATH) sh script/check_goimports.sh
 gofmt: $(GOIMPORTS) add-headers
 	@echo "fmt - goimports: Formatting Go code"
-	@$(GOIMPORTS) -local github.com/elastic -l -w $(shell find . -type f -name '*.go' 2>/dev/null)
-autopep8: $(MAGE)
-	@$(MAGE) pythonAutopep8
+	@PATH=$(GOOSBUILD):$(PATH) GOIMPORTSFLAGS=-w sh script/goimports.sh
+check-autopep8: $(PYTHON_BIN)
+	@PATH=$(PYTHON_BIN):$(PATH) sh script/autopep8_all.sh --diff --exit-code
+autopep8: $(PYTHON_BIN)
+	@echo "fmt - autopep8: Formatting Python code"
+	@PATH=$(PYTHON_BIN):$(PATH) sh script/autopep8_all.sh --in-place
 
 ##############################################################################
 # Rules for creating and installing build tools.

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -471,24 +471,24 @@ func TestTLSSettings(t *testing.T) {
 			"ConfiguredToRequired": {
 				config: map[string]interface{}{"ssl": map[string]interface{}{
 					"client_authentication": "required",
-					"key":         "../../testdata/tls/key.pem",
-					"certificate": "../../testdata/tls/certificate.pem",
+					"key":                   "../../testdata/tls/key.pem",
+					"certificate":           "../../testdata/tls/certificate.pem",
 				}},
 				tls: &tlscommon.ServerConfig{ClientAuth: 4, Certificate: testdataCertificateConfig},
 			},
 			"ConfiguredToOptional": {
 				config: map[string]interface{}{"ssl": map[string]interface{}{
 					"client_authentication": "optional",
-					"key":         "../../testdata/tls/key.pem",
-					"certificate": "../../testdata/tls/certificate.pem",
+					"key":                   "../../testdata/tls/key.pem",
+					"certificate":           "../../testdata/tls/certificate.pem",
 				}},
 				tls: &tlscommon.ServerConfig{ClientAuth: 3, Certificate: testdataCertificateConfig},
 			},
 			"DefaultRequiredByCA": {
 				config: map[string]interface{}{"ssl": map[string]interface{}{
 					"certificate_authorities": []string{"../../testdata/tls/ca.crt.pem"},
-					"key":         "../../testdata/tls/key.pem",
-					"certificate": "../../testdata/tls/certificate.pem",
+					"key":                     "../../testdata/tls/key.pem",
+					"certificate":             "../../testdata/tls/certificate.pem",
 				}},
 				tls: &tlscommon.ServerConfig{ClientAuth: 4, Certificate: testdataCertificateConfig},
 			},
@@ -496,8 +496,8 @@ func TestTLSSettings(t *testing.T) {
 				config: map[string]interface{}{"ssl": map[string]interface{}{
 					"client_authentication":   "none",
 					"certificate_authorities": []string{"../../testdata/tls/ca.crt.pem"},
-					"key":         "../../testdata/tls/key.pem",
-					"certificate": "../../testdata/tls/certificate.pem",
+					"key":                     "../../testdata/tls/key.pem",
+					"certificate":             "../../testdata/tls/certificate.pem",
 				}},
 				tls: &tlscommon.ServerConfig{ClientAuth: 0, Certificate: testdataCertificateConfig},
 			},

--- a/beater/http.go
+++ b/beater/http.go
@@ -35,7 +35,6 @@ import (
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
 	"github.com/elastic/beats/v7/libbeat/logp"
-	"github.com/elastic/gmux"
 )
 
 type httpServer struct {

--- a/beater/http.go
+++ b/beater/http.go
@@ -33,8 +33,6 @@ import (
 	"github.com/elastic/apm-server/beater/api"
 	"github.com/elastic/apm-server/beater/config"
 	"github.com/elastic/apm-server/publish"
-	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
-	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 type httpServer struct {

--- a/beater/http.go
+++ b/beater/http.go
@@ -33,6 +33,9 @@ import (
 	"github.com/elastic/apm-server/beater/api"
 	"github.com/elastic/apm-server/beater/config"
 	"github.com/elastic/apm-server/publish"
+	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/gmux"
 )
 
 type httpServer struct {

--- a/publish/pub_test.go
+++ b/publish/pub_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.elastic.co/apm/apmtest"
+
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/outputs"
@@ -32,7 +34,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/publisher/pipeline"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue/memqueue"
-	"go.elastic.co/apm/apmtest"
 
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/apm-server/transform"

--- a/script/autopep8_all.sh
+++ b/script/autopep8_all.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+AUTOPEP8FLAGS=--max-line-length=120
+
+exec find -name '*.py' -and -not -path '*build/*' -exec autopep8 $AUTOPEP8FLAGS $* '{}' +

--- a/script/check_goimports.sh
+++ b/script/check_goimports.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+out=$(GOIMPORTSFLAGS=-l ./script/goimports.sh)
+if [ -n "$out" ]; then
+  out=$(echo $out | sed 's/ /\n - /')
+  printf "goimports differs:\n - $out\n" >&2
+  exit 1
+fi

--- a/script/generate_notice.py
+++ b/script/generate_notice.py
@@ -19,11 +19,12 @@ DEFAULT_BUILD_TAGS = "darwin,linux,windows"
 
 # Get the beats repo root directory, making sure it's downloaded first.
 subprocess.run(["go", "mod", "download", "github.com/elastic/beats/..."], check=True)
-BEATS_DIR = subprocess.check_output(["go", "list", "-m", "-f", "{{.Dir}}", "github.com/elastic/beats/..."]).decode("utf-8").strip()
+BEATS_DIR = subprocess.check_output(
+    ["go", "list", "-m", "-f", "{{.Dir}}", "github.com/elastic/beats/..."]).decode("utf-8").strip()
 
 # notice_overrides holds additional overrides entries for go-licence-detector.
 notice_overrides = [
-  {"name": "github.com/elastic/beats/v7", "licenceType": "Elastic"}
+    {"name": "github.com/elastic/beats/v7", "licenceType": "Elastic"}
 ]
 
 # Additional third-party, non-source code dependencies, to add to the CSV output.
@@ -61,7 +62,7 @@ def read_go_deps(main_packages, build_tags):
         module = pkg['Module']
         if "Main" not in module:
             modules[module['Path']] = module
-    return sorted(modules.values(), key = lambda module: module['Path'])
+    return sorted(modules.values(), key=lambda module: module['Path'])
 
 
 def go_license_detector(notice_out, deps_out, modules):
@@ -101,7 +102,6 @@ def go_license_detector(notice_out, deps_out, modules):
             "-depsOut", deps_out,
         ]
         subprocess.run(args, check=True, input=modules_json.encode("utf-8"))
-
 
 
 def write_notice_file(notice_filename, modules):

--- a/script/goimports.sh
+++ b/script/goimports.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+dirs=$(find . -maxdepth 1 -type d \! \( -name '.*' -or -name build \))
+exec goimports $GOIMPORTSFLAGS -local github.com/elastic *.go $dirs

--- a/systemtest/apikeycmd_test.go
+++ b/systemtest/apikeycmd_test.go
@@ -25,9 +25,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/go-elasticsearch/v7/esapi"
 
 	"github.com/elastic/apm-server/systemtest"
 	"github.com/elastic/apm-server/systemtest/apmservertest"

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
@@ -77,7 +77,7 @@ func TestProcessTransformablesOverflow(t *testing.T) {
 		MaxTransactionGroups:           2,
 		MetricsInterval:                time.Microsecond,
 		HDRHistogramSignificantFigures: 1,
-		Logger: logger,
+		Logger:                         logger,
 	})
 	require.NoError(t, err)
 
@@ -214,7 +214,7 @@ func TestAggregatorRunPublishErrors(t *testing.T) {
 		MaxTransactionGroups:           2,
 		MetricsInterval:                10 * time.Millisecond,
 		HDRHistogramSignificantFigures: 1,
-		Logger: logger,
+		Logger:                         logger,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Makefile: add check-fmt target (#4654)