### PR TITLE
[7.x] Add a _doc_count field for single-histogram metricsets (#4647)

### DIFF
--- a/model/metricset_test.go
+++ b/model/metricset_test.go
@@ -171,6 +171,7 @@ func TestTransform(t *testing.T) {
 							},
 						},
 					},
+					"_doc_count": int64(6), // 1+2+3
 				},
 			},
 			Msg: "Payload with transaction duration.",

--- a/systemtest/approvals/TestTransactionAggregation.approved.json
+++ b/systemtest/approvals/TestTransactionAggregation.approved.json
@@ -2,6 +2,7 @@
     "events": [
         {
             "@timestamp": "dynamic",
+            "_doc_count": 5,
             "agent": {
                 "name": "go"
             },
@@ -35,20 +36,74 @@
                 }
             },
             "timeseries": {
-                "instance": "systemtest:name:865d6816622184cd"
+                "instance": "systemtest:abc:29d4be3fbd7f200f"
             },
             "transaction": {
                 "duration": {
                     "histogram": {
                         "counts": [
-                            1
+                            5
                         ],
                         "values": [
                             1003519
                         ]
                     }
                 },
-                "name": "name",
+                "name": "abc",
+                "root": true,
+                "type": "backend"
+            }
+        },
+        {
+            "@timestamp": "dynamic",
+            "_doc_count": 10,
+            "agent": {
+                "name": "go"
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "ingested": "dynamic",
+                "outcome": "unknown"
+            },
+            "host": {
+                "hostname": "beowulf",
+                "name": "beowulf"
+            },
+            "observer": {
+                "ephemeral_id": "dynamic",
+                "hostname": "dynamic",
+                "id": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic",
+                "version_major": "dynamic"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "name": "systemtest",
+                "node": {
+                    "name": "beowulf"
+                }
+            },
+            "timeseries": {
+                "instance": "systemtest:def:41b636ee77bc8c1c"
+            },
+            "transaction": {
+                "duration": {
+                    "histogram": {
+                        "counts": [
+                            10
+                        ],
+                        "values": [
+                            1003519
+                        ]
+                    }
+                },
+                "name": "def",
                 "root": true,
                 "type": "backend"
             }

--- a/systemtest/approvals/TestTransactionAggregationShutdown.approved.json
+++ b/systemtest/approvals/TestTransactionAggregationShutdown.approved.json
@@ -2,6 +2,7 @@
     "events": [
         {
             "@timestamp": "dynamic",
+            "_doc_count": 1,
             "agent": {
                 "name": "go"
             },

--- a/systemtest/estest/search.go
+++ b/systemtest/estest/search.go
@@ -81,7 +81,8 @@ func (r *SearchRequest) Do(ctx context.Context, out *SearchResult, opts ...Reque
 }
 
 type SearchResult struct {
-	Hits SearchHits `json:"hits"`
+	Hits         SearchHits                 `json:"hits"`
+	Aggregations map[string]json.RawMessage `json:"aggregations"`
 }
 
 type SearchHits struct {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add a _doc_count field for single-histogram metricsets (#4647)