### PR TITLE
[7.x] sampling: fix TestStorageGC (#4656)

### DIFF
--- a/x-pack/apm-server/sampling/config.go
+++ b/x-pack/apm-server/sampling/config.go
@@ -76,6 +76,10 @@ type StorageConfig struct {
 	// TTL holds the amount of time before events and sampling decisions
 	// are expired from local storage.
 	TTL time.Duration
+
+	// ValueLogFileSize holds the size for Badger value log files.
+	// If unspecified, then the default value of 128MB will be used.
+	ValueLogFileSize int64
 }
 
 // Policy holds a tail-sampling policy: criteria for matching root transactions,

--- a/x-pack/apm-server/sampling/processor.go
+++ b/x-pack/apm-server/sampling/processor.go
@@ -66,7 +66,10 @@ func NewProcessor(config Config) (*Processor, error) {
 
 	logger := logp.NewLogger(logs.Sampling)
 	badgerOpts := badger.DefaultOptions(config.StorageDir)
-	badgerOpts.ValueLogFileSize = badgerValueLogFileSize
+	badgerOpts.ValueLogFileSize = config.ValueLogFileSize
+	if badgerOpts.ValueLogFileSize == 0 {
+		badgerOpts.ValueLogFileSize = badgerValueLogFileSize
+	}
 	badgerOpts.Logger = eventstorage.LogpAdaptor{Logger: logger}
 	db, err := badger.Open(badgerOpts)
 	if err != nil {

--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -452,8 +452,10 @@ func TestStorageGC(t *testing.T) {
 	config := newTempdirConfig(t)
 	config.TTL = 10 * time.Millisecond
 	config.FlushInterval = 10 * time.Millisecond
+	config.ValueLogFileSize = 1024 * 1024
 
 	writeBatch := func(n int) {
+		config.StorageGCInterval = time.Minute // effectively disable
 		processor, err := sampling.NewProcessor(config)
 		require.NoError(t, err)
 		go processor.Run()


### PR DESCRIPTION
Backports the following commits to 7.x:
 - sampling: fix TestStorageGC (#4656)