### PR TITLE
[7.x] beater: add support for config reloading (#4623)

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -23,6 +23,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	"go.elastic.co/apm"
@@ -35,6 +36,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/esleg/eslegclient"
 	"github.com/elastic/beats/v7/libbeat/instrumentation"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/management"
 	esoutput "github.com/elastic/beats/v7/libbeat/outputs/elasticsearch"
 	"github.com/elastic/beats/v7/libbeat/publisher/pipetool"
 
@@ -87,12 +89,13 @@ func NewCreator(args CreatorParams) beat.Creator {
 			waitPublished: newWaitPublishedAcker(),
 		}
 
-		esOutputCfg := elasticsearchOutputConfig(b)
-
 		var err error
-		bt.config, err = config.NewConfig(bt.rawConfig, esOutputCfg)
+		bt.config, err = config.NewConfig(bt.rawConfig, elasticsearchOutputConfig(b))
 		if err != nil {
 			return nil, err
+		}
+		if err := recordRootConfig(b.Info, bt.rawConfig); err != nil {
+			bt.logger.Errorf("Error recording telemetry data", err)
 		}
 
 		if !bt.config.DataStreams.Enabled {
@@ -113,7 +116,6 @@ type beater struct {
 	rawConfig     *common.Config
 	config        *config.Config
 	logger        *logp.Logger
-	namespace     string
 	wrapRunServer func(RunServerFunc) RunServerFunc
 	waitPublished *waitPublishedAcker
 
@@ -125,133 +127,258 @@ type beater struct {
 // Run runs the APM Server, blocking until the beater's Stop method is called,
 // or a fatal error occurs.
 func (bt *beater) Run(b *beat.Beat) error {
-	done := make(chan struct{})
-
-	var reloadOnce sync.Once
-	var reloadable = reload.ReloadableFunc(func(ucfg *reload.ConfigWithMeta) error {
-		var err error
-		// Elastic Agent might call ReloadableFunc many times, but we only need to act upon the first call,
-		// during startup. This might change when APM Server is included in Fleet
-		reloadOnce.Do(func() {
-			defer close(done)
-
-			integrationConfig, err := config.NewIntegrationConfig(ucfg.Config)
-			if err != nil {
-				bt.logger.Error("Could not parse integration configuration from Elastic Agent", err)
-				return
-			}
-
-			var cfg *config.Config
-			apmServerCommonConfig := integrationConfig.APMServer
-			apmServerCommonConfig.Merge(common.MustNewConfigFrom(`{"data_streams.enabled": true}`))
-			cfg, err = config.NewConfig(apmServerCommonConfig, elasticsearchOutputConfig(b))
-			if err != nil {
-				bt.logger.Error("Could not parse apm-server configuration from Elastic Agent ", err)
-				return
-			}
-
-			bt.config = cfg
-			bt.rawConfig = apmServerCommonConfig
-			if integrationConfig.DataStream != nil {
-				bt.namespace = integrationConfig.DataStream.Namespace
-			}
-			bt.logger.Info("Applying configuration from Elastic Agent... ")
-		})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done, err := bt.start(ctx, cancel, b)
+	if err != nil {
 		return err
-	})
-	if b.Manager != nil && b.Manager.Enabled() {
-		bt.logger.Info("Running under Elastic Agent, waiting for configuration... ")
-		reload.Register.MustRegister("inputs", reloadable)
-		<-done
 	}
+	<-done
+	bt.waitPublished.Wait(ctx)
+	return nil
+}
 
-	// send configs to telemetry
-	if err := recordRootConfig(b.Info, bt.rawConfig); err != nil {
-		bt.logger.Errorf("Error recording telemetry data", err)
+func (bt *beater) start(ctx context.Context, cancelContext context.CancelFunc, b *beat.Beat) (<-chan struct{}, error) {
+	done := make(chan struct{})
+	bt.mutex.Lock()
+	defer bt.mutex.Unlock()
+	if bt.stopped {
+		close(done)
+		return done, nil
 	}
-	recordAPMServerConfig(bt.config)
 
 	tracer, tracerServer, err := initTracing(b, bt.config, bt.logger)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	closeTracer := func() error { return nil }
 	if tracer != nil {
-		defer tracer.Close()
-		if tracerServer != nil {
-			defer tracerServer.Close()
+		closeTracer = func() error {
+			tracer.Close()
+			if tracerServer != nil {
+				return tracerServer.Close()
+			}
+			return nil
 		}
 	}
 
-	runServer := runServer
-	if tracerServer != nil {
-		runServer = runServerWithTracerServer(runServer, tracerServer, tracer)
-	}
-	if bt.wrapRunServer != nil {
-		// Wrap runServer function, enabling injection of
-		// behaviour into the processing/reporting pipeline.
-		runServer = bt.wrapRunServer(runServer)
+	sharedArgs := sharedServerRunnerParams{
+		Beat:          b,
+		WrapRunServer: bt.wrapRunServer,
+		Logger:        bt.logger,
+		Tracer:        tracer,
+		TracerServer:  tracerServer,
+		Acker:         bt.waitPublished,
 	}
 
-	publisher, err := bt.newPublisher(b, tracer)
+	if b.Manager != nil && b.Manager.Enabled() {
+		// Management enabled, register reloadable inputs.
+		creator := &serverCreator{context: ctx, args: sharedArgs}
+		inputs := cfgfile.NewRunnerList(management.DebugK, creator, b.Publisher)
+		bt.stopServer = func() {
+			defer close(done)
+			defer closeTracer()
+			if bt.config.ShutdownTimeout > 0 {
+				time.AfterFunc(bt.config.ShutdownTimeout, cancelContext)
+			}
+			inputs.Stop()
+		}
+		reload.Register.MustRegisterList("inputs", inputs)
+	} else {
+		// Management disabled, use statically defined config.
+		s, err := newServerRunner(ctx, serverRunnerParams{
+			sharedServerRunnerParams: sharedArgs,
+			Pipeline:                 b.Publisher,
+			Namespace:                "default",
+			RawConfig:                bt.rawConfig,
+		})
+		if err != nil {
+			return nil, err
+		}
+		bt.stopServer = func() {
+			defer close(done)
+			defer closeTracer()
+			if bt.config.ShutdownTimeout > 0 {
+				time.AfterFunc(bt.config.ShutdownTimeout, cancelContext)
+			}
+			s.Stop()
+		}
+		s.Start()
+	}
+	return done, nil
+}
+
+type serverCreator struct {
+	context context.Context
+	args    sharedServerRunnerParams
+}
+
+func (s *serverCreator) CheckConfig(cfg *common.Config) error {
+	return nil
+}
+
+func (s *serverCreator) Create(p beat.PipelineConnector, rawConfig *common.Config) (cfgfile.Runner, error) {
+	integrationConfig, err := config.NewIntegrationConfig(rawConfig)
+	if err != nil {
+		return nil, err
+	}
+	var namespace string
+	if integrationConfig.DataStream != nil {
+		namespace = integrationConfig.DataStream.Namespace
+	}
+	apmServerCommonConfig := integrationConfig.APMServer
+	apmServerCommonConfig.Merge(common.MustNewConfigFrom(`{"data_streams.enabled": true}`))
+	return newServerRunner(s.context, serverRunnerParams{
+		sharedServerRunnerParams: s.args,
+		Namespace:                namespace,
+		Pipeline:                 p,
+		RawConfig:                apmServerCommonConfig,
+	})
+}
+
+type serverRunner struct {
+	// backgroundContext is used for operations that should block on Stop,
+	// up to the process shutdown timeout limit. This allows the publisher to
+	// drain its queue when the server is stopped, for example.
+	backgroundContext context.Context
+
+	// runServerContext is used for the runServer call, and will be cancelled
+	// immediately when the Stop method is invoked.
+	runServerContext       context.Context
+	cancelRunServerContext context.CancelFunc
+
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+
+	pipeline      beat.PipelineConnector
+	acker         *waitPublishedAcker
+	namespace     string
+	config        *config.Config
+	beat          *beat.Beat
+	logger        *logp.Logger
+	tracer        *apm.Tracer
+	tracerServer  *tracerServer
+	wrapRunServer func(RunServerFunc) RunServerFunc
+}
+
+type serverRunnerParams struct {
+	sharedServerRunnerParams
+
+	Namespace string
+	Pipeline  beat.PipelineConnector
+	RawConfig *common.Config
+}
+
+type sharedServerRunnerParams struct {
+	Beat          *beat.Beat
+	WrapRunServer func(RunServerFunc) RunServerFunc
+	Logger        *logp.Logger
+	Tracer        *apm.Tracer
+	TracerServer  *tracerServer
+	Acker         *waitPublishedAcker
+}
+
+func newServerRunner(ctx context.Context, args serverRunnerParams) (*serverRunner, error) {
+	cfg, err := config.NewConfig(args.RawConfig, elasticsearchOutputConfig(args.Beat))
+	if err != nil {
+		return nil, err
+	}
+	runServerContext, cancel := context.WithCancel(ctx)
+	return &serverRunner{
+		backgroundContext:      ctx,
+		runServerContext:       runServerContext,
+		cancelRunServerContext: cancel,
+
+		config:        cfg,
+		acker:         args.Acker,
+		pipeline:      args.Pipeline,
+		namespace:     args.Namespace,
+		beat:          args.Beat,
+		logger:        args.Logger,
+		tracer:        args.Tracer,
+		tracerServer:  args.TracerServer,
+		wrapRunServer: args.WrapRunServer,
+	}, nil
+}
+
+func (s *serverRunner) String() string {
+	return "APMServer"
+}
+
+func (s *serverRunner) Stop() {
+	s.stopOnce.Do(s.cancelRunServerContext)
+	s.wg.Wait()
+}
+
+func (s *serverRunner) Start() {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.run()
+	}()
+}
+
+func (s *serverRunner) run() error {
+	// Send config to telemetry.
+	recordAPMServerConfig(s.config)
+
+	runServer := runServer
+	if s.tracerServer != nil {
+		runServer = runServerWithTracerServer(runServer, s.tracerServer, s.tracer)
+	}
+	if s.wrapRunServer != nil {
+		// Wrap runServer function, enabling injection of
+		// behaviour into the processing/reporting pipeline.
+		runServer = s.wrapRunServer(runServer)
+	}
+
+	transformConfig, err := newTransformConfig(s.beat.Info, s.config)
 	if err != nil {
 		return err
 	}
+	publisherConfig := &publish.PublisherConfig{
+		Info:            s.beat.Info,
+		Pipeline:        s.config.Pipeline,
+		Namespace:       s.namespace,
+		TransformConfig: transformConfig,
+	}
 
-	// shutdownContext may be updated by stopServer below,
-	// to initiate the shutdown timeout.
-	shutdownContext := context.Background()
-	var cancelShutdownContext context.CancelFunc
-	defer func() {
-		if cancelShutdownContext != nil {
-			defer cancelShutdownContext()
-		}
-		publisher.Stop(shutdownContext)
-		bt.waitPublished.Wait(shutdownContext)
-	}()
+	// When the publisher stops cleanly it will close its pipeline client,
+	// calling the acker's Close method. We need to call Open for each new
+	// publisher to ensure we wait for all clients and enqueued events to
+	// be closed at shutdown time.
+	s.acker.Open()
+	pipeline := pipetool.WithACKer(s.pipeline, s.acker)
+
+	publisher, err := publish.NewPublisher(pipeline, s.tracer, publisherConfig)
+	if err != nil {
+		return err
+	}
+	defer publisher.Stop(s.backgroundContext)
 
 	reporter := publisher.Send
-	if !bt.config.Sampling.KeepUnsampled {
+	if !s.config.Sampling.KeepUnsampled {
 		// The server has been configured to discard unsampled
 		// transactions. Make sure this is done just before calling
 		// the publisher to avoid affecting aggregations.
 		reporter = sampling.NewDiscardUnsampledReporter(reporter)
 	}
 
-	stopped := make(chan struct{})
-	defer close(stopped)
-	ctx, cancelContext := context.WithCancel(context.Background())
-	defer cancelContext()
-	var stopOnce sync.Once
-	stopServer := func() {
-		stopOnce.Do(func() {
-			if bt.config.ShutdownTimeout > 0 {
-				shutdownContext, cancelShutdownContext = context.WithTimeout(
-					shutdownContext, bt.config.ShutdownTimeout,
-				)
-			}
-			cancelContext()
-			<-stopped
-		})
-	}
-
-	bt.mutex.Lock()
-	if bt.stopped {
-		bt.mutex.Unlock()
-		return nil
-	}
-	bt.stopServer = stopServer
-	bt.mutex.Unlock()
-
-	return runServer(ctx, ServerParams{
-		Info:     b.Info,
-		Config:   bt.config,
-		Logger:   bt.logger,
-		Tracer:   tracer,
+	if err := runServer(s.runServerContext, ServerParams{
+		Info:     s.beat.Info,
+		Config:   s.config,
+		Logger:   s.logger,
+		Tracer:   s.tracer,
 		Reporter: reporter,
-	})
+	}); err != nil {
+		return err
+	}
+	return publisher.Stop(s.backgroundContext)
 }
 
 // checkConfig verifies the global configuration doesn't use unsupported settings
+//
+// TODO(axw) remove this, nobody expects dashboard setup from apm-server.
 func checkConfig(logger *logp.Logger) error {
 	cfg, err := cfgfile.Load("", nil)
 	if err != nil {
@@ -330,11 +457,11 @@ func (bt *beater) registerPipelineCallback(b *beat.Beat) error {
 }
 
 func initTracing(b *beat.Beat, cfg *config.Config, logger *logp.Logger) (*apm.Tracer, *tracerServer, error) {
-	var err error
 	tracer := b.Instrumentation.Tracer()
 	listener := b.Instrumentation.Listener()
 
 	if !tracer.Active() && cfg != nil {
+		var err error
 		tracer, listener, err = initLegacyTracer(b.Info, cfg)
 		if err != nil {
 			return nil, nil, err
@@ -412,21 +539,6 @@ func runServerWithTracerServer(runServer RunServerFunc, tracerServer *tracerServ
 		})
 		return g.Wait()
 	}
-}
-
-func (bt *beater) newPublisher(b *beat.Beat, tracer *apm.Tracer) (*publish.Publisher, error) {
-	transformConfig, err := newTransformConfig(b.Info, bt.config)
-	if err != nil {
-		return nil, err
-	}
-	publisherConfig := &publish.PublisherConfig{
-		Info:            b.Info,
-		Pipeline:        bt.config.Pipeline,
-		Namespace:       bt.namespace,
-		TransformConfig: transformConfig,
-	}
-	pipeline := pipetool.WithACKer(b.Publisher, bt.waitPublished)
-	return publish.NewPublisher(pipeline, tracer, publisherConfig)
 }
 
 func newTransformConfig(beatInfo beat.Info, cfg *config.Config) (*transform.Config, error) {

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -39,18 +40,104 @@ import (
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/instrumentation"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/version"
 )
 
 type testBeater struct {
 	*beater
+	b     *beat.Beat
+	logs  *observer.ObservedLogs
+	runCh chan error
 
 	listenAddr string
 	baseURL    string
 	client     *http.Client
 }
 
+func setupServer(t *testing.T, cfg *common.Config, beatConfig *beat.BeatConfig, events chan beat.Event) (*testBeater, error) {
+	if testing.Short() {
+		t.Skip("skipping server test")
+	}
+	apmBeat, cfg := newBeat(t, cfg, beatConfig, events)
+	return setupBeater(t, apmBeat, cfg, beatConfig)
+}
+
+func newBeat(t *testing.T, cfg *common.Config, beatConfig *beat.BeatConfig, events chan beat.Event) (*beat.Beat, *common.Config) {
+	info := beat.Info{
+		Beat:        "test-apm-server",
+		IndexPrefix: "test-apm-server",
+		Version:     version.GetDefaultVersion(),
+		ID:          uuid.Must(uuid.FromString("fbba762a-14dd-412c-b7e9-b79f903eb492")),
+	}
+
+	combinedConfig := common.MustNewConfigFrom(map[string]interface{}{
+		"host": "localhost:0",
+
+		// Enable instrumentation so the profile endpoint is
+		// available, but set the profiling interval to something
+		// long enough that it won't kick in.
+		"instrumentation": map[string]interface{}{
+			"enabled": true,
+			"profiling": map[string]interface{}{
+				"cpu": map[string]interface{}{
+					"enabled":  true,
+					"interval": "360s",
+				},
+			},
+		},
+	})
+	if cfg != nil {
+		require.NoError(t, cfg.Unpack(combinedConfig))
+	}
+
+	var pub beat.Pipeline
+	if events != nil {
+		// capture events
+		pubClient := newChanClientWith(events)
+		pub = dummyPipeline(cfg, info, pubClient)
+	} else {
+		// don't capture events
+		pub = dummyPipeline(cfg, info)
+	}
+
+	instrumentation, err := instrumentation.New(combinedConfig, info.Beat, info.Version)
+	require.NoError(t, err)
+	return &beat.Beat{
+		Publisher:       pub,
+		Info:            info,
+		Config:          beatConfig,
+		Instrumentation: instrumentation,
+	}, combinedConfig
+}
+
 func setupBeater(
+	t *testing.T,
+	apmBeat *beat.Beat,
+	ucfg *common.Config,
+	beatConfig *beat.BeatConfig,
+) (*testBeater, error) {
+	tb, err := newTestBeater(t, apmBeat, ucfg, beatConfig)
+	if err != nil {
+		return nil, err
+	}
+	tb.start()
+
+	listenAddr, err := tb.waitListenAddr(10 * time.Second)
+	if err != nil {
+		return nil, err
+	}
+	tb.initClient(tb.config, listenAddr)
+
+	res, err := tb.client.Get(tb.baseURL)
+	require.NoError(t, err)
+	defer res.Body.Close()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	return tb, nil
+}
+
+func newTestBeater(
 	t *testing.T,
 	apmBeat *beat.Beat,
 	ucfg *common.Config,
@@ -88,56 +175,51 @@ func setupBeater(
 		},
 	})
 
-	// create our beater
 	beatBeater, err := createBeater(apmBeat, ucfg)
 	if err != nil {
 		return nil, err
 	}
 	require.NotNil(t, beatBeater)
+	t.Cleanup(func() {
+		beatBeater.Stop()
+	})
 
-	errCh := make(chan error)
+	return &testBeater{
+		beater: beatBeater.(*beater),
+		b:      apmBeat,
+		logs:   observedLogs,
+		runCh:  make(chan error),
+	}, nil
+}
+
+// start starts running a beater created with newTestBeater.
+func (tb *testBeater) start() {
 	go func() {
-		err := beatBeater.Run(apmBeat)
-		if err != nil {
-			errCh <- err
-		}
+		tb.runCh <- tb.beater.Run(tb.b)
 	}()
+}
 
-	tb := &testBeater{beater: beatBeater.(*beater)}
-
-	// Wait for the server to log its listening address.
-	deadline := time.After(time.Second * 10)
+func (tb *testBeater) waitListenAddr(timeout time.Duration) (string, error) {
+	deadline := time.After(timeout)
 	for {
-		if listenAddr, ok := getListenAddr(observedLogs); ok {
-			tb.initClient(tb.config, listenAddr)
-			break
+		for _, entry := range tb.logs.TakeAll() {
+			const prefix = "Listening on: "
+			if strings.HasPrefix(entry.Message, prefix) {
+				listenAddr := entry.Message[len(prefix):]
+				return listenAddr, nil
+			}
 		}
 		select {
-		case err := <-errCh:
-			return nil, err
+		case err := <-tb.runCh:
+			if err != nil {
+				return "", err
+			}
+			return "", errors.New("server exited cleanly without logging expected message")
 		case <-deadline:
-			return nil, errors.New("timeout waiting for server to start listening")
+			return "", errors.New("timeout waiting for server to start listening")
 		case <-time.After(10 * time.Millisecond):
 		}
 	}
-
-	res, err := tb.client.Get(tb.baseURL)
-	require.NoError(t, err)
-	defer res.Body.Close()
-	require.Equal(t, http.StatusOK, res.StatusCode)
-	return tb, nil
-}
-
-func getListenAddr(observedLogs *observer.ObservedLogs) (string, bool) {
-	logs := observedLogs.TakeAll()
-	for _, entry := range logs {
-		const prefix = "Listening on: "
-		if strings.HasPrefix(entry.Message, prefix) {
-			listenAddr := entry.Message[len(prefix):]
-			return listenAddr, true
-		}
-	}
-	return "", false
 }
 
 func (tb *testBeater) initClient(cfg *config.Config, listenAddr string) {

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -30,7 +30,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofrs/uuid"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,15 +37,15 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
-	"github.com/elastic/beats/v7/libbeat/instrumentation"
+	"github.com/elastic/beats/v7/libbeat/common/reload"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/management"
 	"github.com/elastic/beats/v7/libbeat/outputs"
 	pubs "github.com/elastic/beats/v7/libbeat/publisher"
 	"github.com/elastic/beats/v7/libbeat/publisher/pipeline"
 	"github.com/elastic/beats/v7/libbeat/publisher/processing"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue"
 	"github.com/elastic/beats/v7/libbeat/publisher/queue/memqueue"
-	"github.com/elastic/beats/v7/libbeat/version"
 
 	"github.com/elastic/apm-server/beater/api"
 	"github.com/elastic/apm-server/beater/config"
@@ -405,6 +404,81 @@ func TestServerJaegerGRPC(t *testing.T) {
 	assert.NotNil(t, result)
 }
 
+func TestServerConfigReload(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping server test")
+	}
+
+	// The beater has no way of unregistering itself from reload.Register,
+	// so we create a fresh registry and replace it after the test.
+	oldRegister := reload.Register
+	defer func() {
+		reload.Register = oldRegister
+	}()
+	reload.Register = reload.NewRegistry()
+
+	cfg := common.MustNewConfigFrom(map[string]interface{}{
+		// Set an invalid host to illustrate that the static config
+		// is not used for defining the listening address.
+		"host": "testing.invalid:123",
+
+		// Data streams must be enabled when the server is managed.
+		"data_streams.enabled": true,
+	})
+	apmBeat, cfg := newBeat(t, cfg, nil, nil)
+	apmBeat.Manager = &mockManager{enabled: true}
+	beater, err := newTestBeater(t, apmBeat, cfg, nil)
+	require.NoError(t, err)
+	beater.start()
+
+	// Now that the beater is running, send config changes. The reloader
+	// is not registered until after the beater starts running, so we
+	// must loop until it is set.
+	inputConfig := common.MustNewConfigFrom(map[string]interface{}{
+		"apm-server": map[string]interface{}{
+			"host": "localhost:0",
+		},
+	})
+	var reloadable reload.ReloadableList
+	for {
+		// The Reloader is not registered until after the beat has started running.
+		reloadable = reload.Register.GetReloadableList("inputs")
+		if reloadable != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	err = reloadable.Reload([]*reload.ConfigWithMeta{{Config: inputConfig}})
+	require.NoError(t, err)
+
+	healthcheck := func(addr string) string {
+		resp, err := http.Get("http://" + addr)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		return string(body)
+	}
+
+	addr1, err := beater.waitListenAddr(1 * time.Second)
+	require.NoError(t, err)
+	assert.NotEmpty(t, healthcheck(addr1)) // non-empty as there's no auth required
+
+	// Reload config, causing the HTTP server to be restarted.
+	require.NoError(t, inputConfig.SetString("apm-server.secret_token", -1, "secret"))
+	err = reloadable.Reload([]*reload.ConfigWithMeta{{Config: inputConfig}})
+	require.NoError(t, err)
+
+	addr2, err := beater.waitListenAddr(1 * time.Second)
+	require.NoError(t, err)
+	assert.Empty(t, healthcheck(addr2)) // empty as auth is required but not specified
+
+	// First HTTP server should have been stopped.
+	_, err = http.Get("http://" + addr1)
+	assert.Error(t, err)
+}
+
 type chanClient struct {
 	done    chan struct{}
 	Channel chan beat.Event
@@ -490,64 +564,6 @@ func dummyPipeline(cfg *common.Config, info beat.Info, clients ...outputs.Client
 	return p
 }
 
-func setupServer(t *testing.T, cfg *common.Config, beatConfig *beat.BeatConfig, events chan beat.Event) (*testBeater, error) {
-	if testing.Short() {
-		t.Skip("skipping server test")
-	}
-
-	baseConfig := common.MustNewConfigFrom(map[string]interface{}{
-		"host": "localhost:0",
-
-		// Enable instrumentation so the profile endpoint is
-		// available, but set the profiling interval to something
-		// long enough that it won't kick in.
-		"instrumentation": map[string]interface{}{
-			"enabled": true,
-			"profiling": map[string]interface{}{
-				"cpu": map[string]interface{}{
-					"enabled":  true,
-					"interval": "360s",
-				},
-			},
-		},
-	})
-	if cfg != nil {
-		err := cfg.Unpack(baseConfig)
-		require.NoError(t, err)
-	}
-
-	beatId, err := uuid.FromString("fbba762a-14dd-412c-b7e9-b79f903eb492")
-	require.NoError(t, err)
-	info := beat.Info{
-		Beat:        "test-apm-server",
-		IndexPrefix: "test-apm-server",
-		Version:     version.GetDefaultVersion(),
-		ID:          beatId,
-	}
-
-	var pub beat.Pipeline
-	if events != nil {
-		// capture events
-		pubClient := newChanClientWith(events)
-		pub = dummyPipeline(cfg, info, pubClient)
-	} else {
-		// don't capture events
-		pub = dummyPipeline(cfg, info)
-	}
-
-	instrumentation, err := instrumentation.New(baseConfig, info.Beat, info.Version)
-	require.NoError(t, err)
-
-	// create a beat
-	apmBeat := &beat.Beat{
-		Publisher:       pub,
-		Info:            info,
-		Config:          beatConfig,
-		Instrumentation: instrumentation,
-	}
-	return setupBeater(t, apmBeat, baseConfig, beatConfig)
-}
-
 var testData = func() []byte {
 	b, err := loader.LoadDataAsBytes("../testdata/intake-v2/transactions.ndjson")
 	if err != nil {
@@ -570,4 +586,13 @@ func body(t *testing.T, response *http.Response) string {
 	require.NoError(t, err)
 	require.NoError(t, response.Body.Close())
 	return string(body)
+}
+
+type mockManager struct {
+	management.Manager
+	enabled bool
+}
+
+func (m *mockManager) Enabled() bool {
+	return m.enabled
 }

--- a/systemtest/approvals/TestDataStreamsEnabled/true.approved.json
+++ b/systemtest/approvals/TestDataStreamsEnabled/true.approved.json
@@ -7,7 +7,7 @@
                 "version": "0.0.0"
             },
             "data_stream.dataset": "apm",
-            "data_stream.namespace": "",
+            "data_stream.namespace": "default",
             "data_stream.type": "traces",
             "ecs": {
                 "version": "dynamic"

--- a/systemtest/elasticsearch.go
+++ b/systemtest/elasticsearch.go
@@ -92,9 +92,9 @@ func newElasticsearchConfig() elasticsearch.Config {
 func CleanupElasticsearch(t testing.TB) {
 	const (
 		legacyPrefix     = "apm*"
-		apmTracesPrefix  = "traces-apm.*"
-		apmMetricsPrefix = "metrics-apm.*"
-		apmLogsPrefix    = "logs-apm.*"
+		apmTracesPrefix  = "traces-apm*"
+		apmMetricsPrefix = "metrics-apm*"
+		apmLogsPrefix    = "logs-apm*"
 	)
 	requests := []estest.Request{
 		esapi.IndicesDeleteRequest{Index: []string{legacyPrefix}},
@@ -119,6 +119,11 @@ func CleanupElasticsearch(t testing.TB) {
 		g.Go(func() error { return doReq(req) })
 	}
 	if err := g.Wait(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete index templates after deleting data streams.
+	if err := doReq(esapi.IndicesDeleteIndexTemplateRequest{Name: legacyPrefix}); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - beater: add support for config reloading (#4623)