### PR TITLE
[7.x] beater: ensure Fleet config contains 'apm-server' (#4684)

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -214,7 +214,8 @@ type serverCreator struct {
 }
 
 func (s *serverCreator) CheckConfig(cfg *common.Config) error {
-	return nil
+	_, err := config.NewIntegrationConfig(cfg)
+	return err
 }
 
 func (s *serverCreator) Create(p beat.PipelineConnector, rawConfig *common.Config) (cfgfile.Runner, error) {

--- a/beater/config/integration.go
+++ b/beater/config/integration.go
@@ -18,6 +18,8 @@
 package config
 
 import (
+	"errors"
+
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
@@ -27,8 +29,13 @@ func NewIntegrationConfig(rootConfig *common.Config) (*IntegrationConfig, error)
 			Namespace: "default",
 		},
 	}
-	err := rootConfig.Unpack(config)
-	return config, err
+	if err := rootConfig.Unpack(config); err != nil {
+		return nil, err
+	}
+	if config.APMServer == nil {
+		return nil, errors.New("'apm-server' not found in integration config")
+	}
+	return config, nil
 }
 
 // IntegrationConfig that comes from Elastic Agent

--- a/beater/config/integration_test.go
+++ b/beater/config/integration_test.go
@@ -1,0 +1,44 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-server/beater/config"
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+func TestIntegrationConfigMissingAPMServer(t *testing.T) {
+	cfg, err := config.NewIntegrationConfig(common.NewConfig())
+	assert.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.EqualError(t, err, "'apm-server' not found in integration config")
+}
+
+func TestIntegrationConfigValid(t *testing.T) {
+	cfg, err := config.NewIntegrationConfig(common.MustNewConfigFrom(map[string]interface{}{
+		"apm-server": map[string]interface{}{},
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	assert.NotNil(t, cfg.APMServer)
+}

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -434,11 +434,6 @@ func TestServerConfigReload(t *testing.T) {
 	// Now that the beater is running, send config changes. The reloader
 	// is not registered until after the beater starts running, so we
 	// must loop until it is set.
-	inputConfig := common.MustNewConfigFrom(map[string]interface{}{
-		"apm-server": map[string]interface{}{
-			"host": "localhost:0",
-		},
-	})
 	var reloadable reload.ReloadableList
 	for {
 		// The Reloader is not registered until after the beat has started running.
@@ -448,6 +443,16 @@ func TestServerConfigReload(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+
+	// The config must contain an "apm-server" section, and will be rejected otherwise.
+	err = reloadable.Reload([]*reload.ConfigWithMeta{{Config: common.NewConfig()}})
+	assert.EqualError(t, err, "1 error: Error creating runner from config: 'apm-server' not found in integration config")
+
+	inputConfig := common.MustNewConfigFrom(map[string]interface{}{
+		"apm-server": map[string]interface{}{
+			"host": "localhost:0",
+		},
+	})
 	err = reloadable.Reload([]*reload.ConfigWithMeta{{Config: inputConfig}})
 	require.NoError(t, err)
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - beater: ensure Fleet config contains 'apm-server' (#4684)