### PR TITLE
[7.x] Add missing fields properties (#4611)

### DIFF
--- a/apmpackage/apm/0.1.0/data_stream/app_metrics/fields/ecs.yml
+++ b/apmpackage/apm/0.1.0/data_stream/app_metrics/fields/ecs.yml
@@ -109,6 +109,12 @@
   type: object
   description: |
     A flat mapping of user-defined labels with string, boolean or number values.
+  dynamic: true
+  object_type_params:
+  - object_type: keyword
+  - object_type: boolean
+  - object_type: scaled_float
+    scaling_factor: 1000000
 - name: observer.hostname
   type: keyword
   description: |

--- a/apmpackage/apm/0.1.0/data_stream/app_metrics/fields/fields.yml
+++ b/apmpackage/apm/0.1.0/data_stream/app_metrics/fields/fields.yml
@@ -1,6 +1,7 @@
 - name: experimental
   type: object
   description: Additional experimental data sent by the agents.
+  dynamic: true
 - name: kubernetes.namespace
   type: keyword
   description: |

--- a/apmpackage/apm/0.1.0/data_stream/error_logs/fields/ecs.yml
+++ b/apmpackage/apm/0.1.0/data_stream/error_logs/fields/ecs.yml
@@ -129,6 +129,12 @@
   type: object
   description: |
     A flat mapping of user-defined labels with string, boolean or number values.
+  dynamic: true
+  object_type_params:
+  - object_type: keyword
+  - object_type: boolean
+  - object_type: scaled_float
+    scaling_factor: 1000000
 - name: observer.hostname
   type: keyword
   description: |

--- a/apmpackage/apm/0.1.0/data_stream/error_logs/fields/fields.yml
+++ b/apmpackage/apm/0.1.0/data_stream/error_logs/fields/fields.yml
@@ -35,6 +35,7 @@
 - name: experimental
   type: object
   description: Additional experimental data sent by the agents.
+  dynamic: true
 - name: http.request.headers
   type: object
   description: |

--- a/apmpackage/apm/0.1.0/data_stream/internal_metrics/fields/ecs.yml
+++ b/apmpackage/apm/0.1.0/data_stream/internal_metrics/fields/ecs.yml
@@ -115,6 +115,12 @@
   type: object
   description: |
     A flat mapping of user-defined labels with string, boolean or number values.
+  dynamic: true
+  object_type_params:
+  - object_type: keyword
+  - object_type: boolean
+  - object_type: scaled_float
+    scaling_factor: 1000000
 - name: observer.hostname
   type: keyword
   description: |

--- a/apmpackage/apm/0.1.0/data_stream/internal_metrics/fields/fields.yml
+++ b/apmpackage/apm/0.1.0/data_stream/internal_metrics/fields/fields.yml
@@ -1,6 +1,7 @@
 - name: experimental
   type: object
   description: Additional experimental data sent by the agents.
+  dynamic: true
 - name: kubernetes.namespace
   type: keyword
   description: |

--- a/apmpackage/apm/0.1.0/data_stream/profile_metrics/fields/ecs.yml
+++ b/apmpackage/apm/0.1.0/data_stream/profile_metrics/fields/ecs.yml
@@ -109,6 +109,12 @@
   type: object
   description: |
     A flat mapping of user-defined labels with string, boolean or number values.
+  dynamic: true
+  object_type_params:
+  - object_type: keyword
+  - object_type: boolean
+  - object_type: scaled_float
+    scaling_factor: 1000000
 - name: observer.hostname
   type: keyword
   description: |

--- a/apmpackage/apm/0.1.0/data_stream/profile_metrics/fields/fields.yml
+++ b/apmpackage/apm/0.1.0/data_stream/profile_metrics/fields/fields.yml
@@ -1,6 +1,7 @@
 - name: experimental
   type: object
   description: Additional experimental data sent by the agents.
+  dynamic: true
 - name: kubernetes.namespace
   type: keyword
   description: |

--- a/apmpackage/apm/0.1.0/data_stream/traces/fields/ecs.yml
+++ b/apmpackage/apm/0.1.0/data_stream/traces/fields/ecs.yml
@@ -131,6 +131,12 @@
   type: object
   description: |
     A flat mapping of user-defined labels with string, boolean or number values.
+  dynamic: true
+  object_type_params:
+  - object_type: keyword
+  - object_type: boolean
+  - object_type: scaled_float
+    scaling_factor: 1000000
 - name: observer.hostname
   type: keyword
   description: |

--- a/apmpackage/apm/0.1.0/data_stream/traces/fields/fields.yml
+++ b/apmpackage/apm/0.1.0/data_stream/traces/fields/fields.yml
@@ -5,6 +5,7 @@
 - name: experimental
   type: object
   description: Additional experimental data sent by the agents.
+  dynamic: true
 - name: http.request.headers
   type: object
   description: |
@@ -175,8 +176,10 @@
   type: object
   description: |
     A user-defined mapping of groups of marks in milliseconds.
+  dynamic: true
 - name: transaction.marks.*.*
   type: object
+  dynamic: true
 - name: transaction.message.age.ms
   type: long
   description: |

--- a/apmpackage/cmd/gen-package/field.go
+++ b/apmpackage/cmd/gen-package/field.go
@@ -18,25 +18,27 @@
 package main
 
 type field struct {
-	Name        string                 `yaml:"name,omitempty"`
-	Key         string                 `yaml:"key,omitempty"`
-	Title       string                 `yaml:"title,omitempty"`
-	Group       *int                   `yaml:"group,omitempty"`
-	Level       string                 `yaml:"level,omitempty"`
-	Required    *bool                  `yaml:"required,omitempty"`
-	Type        string                 `yaml:"type,omitempty"`
-	Format      string                 `yaml:"format,omitempty"`
-	Description string                 `yaml:"description,omitempty"`
-	Release     string                 `yaml:"release,omitempty"`
-	Alias       string                 `yaml:"alias,omitempty"`
-	Path        string                 `yaml:"path,omitempty"`
-	Footnote    string                 `yaml:"footnote,omitempty"`
-	IgnoreAbove *int                   `yaml:"ignore_above,omitempty"`
-	MultiFields []multiFieldDefinition `yaml:"multi_fields,omitempty"`
-	Fields      []field                `yaml:"fields,omitempty"`
-	IsECS       bool                   `yaml:"-"`
-	HasECS      bool                   `yaml:"-"`
-	HasNonECS   bool                   `yaml:"-"`
+	Name             string                 `yaml:"name,omitempty"`
+	Key              string                 `yaml:"key,omitempty"`
+	Title            string                 `yaml:"title,omitempty"`
+	Group            *int                   `yaml:"group,omitempty"`
+	Level            string                 `yaml:"level,omitempty"`
+	Required         *bool                  `yaml:"required,omitempty"`
+	Type             string                 `yaml:"type,omitempty"`
+	Format           string                 `yaml:"format,omitempty"`
+	Description      string                 `yaml:"description,omitempty"`
+	Dynamic          bool                   `yaml:"dynamic,omitempty"`
+	ObjectTypeParams interface{}            `yaml:"object_type_params,omitempty"`
+	Release          string                 `yaml:"release,omitempty"`
+	Alias            string                 `yaml:"alias,omitempty"`
+	Path             string                 `yaml:"path,omitempty"`
+	Footnote         string                 `yaml:"footnote,omitempty"`
+	IgnoreAbove      *int                   `yaml:"ignore_above,omitempty"`
+	MultiFields      []multiFieldDefinition `yaml:"multi_fields,omitempty"`
+	Fields           []field                `yaml:"fields,omitempty"`
+	IsECS            bool                   `yaml:"-"`
+	HasECS           bool                   `yaml:"-"`
+	HasNonECS        bool                   `yaml:"-"`
 }
 
 func (f field) isNonECSLeaf() bool {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add missing fields properties (#4611)