### PR TITLE
[7.x] fix make fmt (#4659)

### DIFF
--- a/script/autopep8_all.sh
+++ b/script/autopep8_all.sh
@@ -2,4 +2,4 @@
 
 AUTOPEP8FLAGS=--max-line-length=120
 
-exec find -name '*.py' -and -not -path '*build/*' -exec autopep8 $AUTOPEP8FLAGS $* '{}' +
+exec find . -name '*.py' -and -not -path '*build/*' -exec autopep8 $AUTOPEP8FLAGS $* '{}' +


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fix make fmt (#4659)