### PR TITLE
[7.x] sampling: match policies in the given order (#4685)

### DIFF
--- a/x-pack/apm-server/sampling/processor.go
+++ b/x-pack/apm-server/sampling/processor.go
@@ -110,7 +110,7 @@ func (p *Processor) CollectMonitoring(_ monitoring.Mode, V monitoring.Visitor) {
 	//     currently an option in libbeat/monitoring.
 
 	p.groups.mu.RLock()
-	numDynamicGroups := len(p.groups.dynamicGroups)
+	numDynamicGroups := p.groups.numDynamicServiceGroups
 	p.groups.mu.RUnlock()
 	monitoring.ReportInt(V, "dynamic_service_groups", int64(numDynamicGroups))
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - sampling: match policies in the given order (#4685)