### PR TITLE
[7.12] sampling: use a data stream for sampled trace docs (#4707)

### DIFF
--- a/apmpackage/apm/0.1.0/data_stream/sampled_traces/elasticsearch/ilm/default_policy.json
+++ b/apmpackage/apm/0.1.0/data_stream/sampled_traces/elasticsearch/ilm/default_policy.json
@@ -1,0 +1,19 @@
+{
+    "policy": {
+        "phases": {
+            "hot": {
+                "actions": {
+                    "rollover": {
+                        "max_age": "1h"
+                    }
+                }
+            },
+            "delete": {
+                "min_age": "1h",
+                "actions": {
+                    "delete": {}
+                }
+            }
+        }
+    }
+}

--- a/apmpackage/apm/0.1.0/data_stream/sampled_traces/elasticsearch/ingest_pipeline/default.json
+++ b/apmpackage/apm/0.1.0/data_stream/sampled_traces/elasticsearch/ingest_pipeline/default.json
@@ -1,0 +1,11 @@
+{
+  "description": "Ingest pipeline for sampled trace documents",
+  "processors": [
+    {
+      "set": {
+        "field": "event.ingested",
+        "value": "{{_ingest.timestamp}}"
+      }
+    }
+  ]
+}

--- a/apmpackage/apm/0.1.0/data_stream/sampled_traces/fields/base-fields.yml
+++ b/apmpackage/apm/0.1.0/data_stream/sampled_traces/fields/base-fields.yml
@@ -1,0 +1,12 @@
+- name: '@timestamp'
+  type: date
+  description: Event timestamp.
+- name: data_stream.type
+  type: constant_keyword
+  description: Data stream type.
+- name: data_stream.dataset
+  type: constant_keyword
+  description: Data stream dataset.
+- name: data_stream.namespace
+  type: constant_keyword
+  description: Data stream namespace.

--- a/apmpackage/apm/0.1.0/data_stream/sampled_traces/fields/ecs.yml
+++ b/apmpackage/apm/0.1.0/data_stream/sampled_traces/fields/ecs.yml
@@ -1,0 +1,8 @@
+- name: event.ingested
+  type: date
+  description: |
+    Timestamp when an event arrived in the central data store.
+- name: trace.id
+  type: keyword
+  description: |
+    The ID of the sampled trace.

--- a/apmpackage/apm/0.1.0/data_stream/sampled_traces/fields/fields.yml
+++ b/apmpackage/apm/0.1.0/data_stream/sampled_traces/fields/fields.yml
@@ -1,0 +1,6 @@
+# When changing fields or ILM policy, make sure to update
+# x-pack/apm-server/sampling/pubsub/datastream.go.
+- name: observer.id
+  type: keyword
+  description: |
+    The ID of the APM Server that indexed the sampled trace ID.

--- a/apmpackage/apm/0.1.0/data_stream/sampled_traces/manifest.yml
+++ b/apmpackage/apm/0.1.0/data_stream/sampled_traces/manifest.yml
@@ -1,0 +1,4 @@
+title: APM tail-sampled traces
+type: traces
+dataset: sampled
+ilm_policy: traces-apm.sampled-default_policy

--- a/apmpackage/cmd/gen-package/genfields.go
+++ b/apmpackage/cmd/gen-package/genfields.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"io/ioutil"
+	"log"
 	"net/http"
 	"path/filepath"
 	"sort"
@@ -42,6 +43,7 @@ func generateFields(version string) map[string][]field {
 	inputFieldsFiles["app_metrics"] = filterInternalMetrics(inputFieldsFiles["internal_metrics"])
 
 	for streamType, inputFields := range inputFieldsFiles {
+		log.Printf("%s", streamType)
 		var ecsFields []field
 		var nonECSFields []field
 		for _, fields := range populateECSInfo(ecsFlatFields, inputFields) {

--- a/apmpackage/cmd/gen-package/main.go
+++ b/apmpackage/cmd/gen-package/main.go
@@ -34,6 +34,13 @@ var versionMapping = map[string]string{
 	"8.0":  "0.1.0",
 }
 
+// Some data streams may not have a counterpart template
+// in standalone apm-server, and so it does not make sense
+// to maintain a separate fields.yml.
+var handwritten = map[string]bool{
+	"sampled_traces": true,
+}
+
 func main() {
 	stackVersion := common.MustNewVersion(cmd.DefaultSettings().Version)
 	shortVersion := fmt.Sprintf("%d.%d", stackVersion.Major, stackVersion.Minor)
@@ -58,11 +65,28 @@ func clear(version string) {
 		panic(err)
 	}
 	for _, f := range fileInfo {
-		if f.IsDir() {
-			os.Remove(ecsFilePath(version, f.Name()))
-			os.Remove(fieldsFilePath(version, f.Name()))
-			os.RemoveAll(pipelinesPath(version, f.Name()))
+		if !f.IsDir() {
+			continue
 		}
+		name := f.Name()
+		if handwritten[name] {
+			continue
+		}
+		removeFile(ecsFilePath(version, name))
+		removeFile(fieldsFilePath(version, name))
+		removeDir(pipelinesPath(version, name))
 	}
 	ioutil.WriteFile(docsFilePath(version), nil, 0644)
+}
+
+func removeFile(path string) {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		log.Fatal(err)
+	}
+}
+
+func removeDir(path string) {
+	if err := os.RemoveAll(path); err != nil && !os.IsNotExist(err) {
+		log.Fatal(err)
+	}
 }

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -366,11 +366,13 @@ func (s *serverRunner) run() error {
 	}
 
 	if err := runServer(s.runServerContext, ServerParams{
-		Info:     s.beat.Info,
-		Config:   s.config,
-		Logger:   s.logger,
-		Tracer:   s.tracer,
-		Reporter: reporter,
+		Info:      s.beat.Info,
+		Config:    s.config,
+		Managed:   s.beat.Manager != nil && s.beat.Manager.Enabled(),
+		Namespace: s.namespace,
+		Logger:    s.logger,
+		Tracer:    s.tracer,
+		Reporter:  reporter,
 	}); err != nil {
 		return err
 	}

--- a/beater/server.go
+++ b/beater/server.go
@@ -52,6 +52,12 @@ type ServerParams struct {
 	// Config is the configuration used for running the APM Server.
 	Config *config.Config
 
+	// Managed indicates that the server is managed by Fleet.
+	Managed bool
+
+	// Namespace holds the data stream namespace for the server.
+	Namespace string
+
 	// Logger is the logger for the beater component.
 	Logger *logp.Logger
 

--- a/systemtest/elasticsearch.go
+++ b/systemtest/elasticsearch.go
@@ -91,19 +91,11 @@ func newElasticsearchConfig() elasticsearch.Config {
 // and deletes the default ILM policy "apm-rollover-30-days".
 func CleanupElasticsearch(t testing.TB) {
 	const (
-		legacyPrefix     = "apm*"
+		legacyPrefix     = "apm-*"
 		apmTracesPrefix  = "traces-apm*"
 		apmMetricsPrefix = "metrics-apm*"
 		apmLogsPrefix    = "logs-apm*"
 	)
-	requests := []estest.Request{
-		esapi.IndicesDeleteRequest{Index: []string{legacyPrefix}},
-		esapi.IndicesDeleteDataStreamRequest{Name: apmTracesPrefix},
-		esapi.IndicesDeleteDataStreamRequest{Name: apmMetricsPrefix},
-		esapi.IndicesDeleteDataStreamRequest{Name: apmLogsPrefix},
-		esapi.IngestDeletePipelineRequest{PipelineID: legacyPrefix},
-		esapi.IndicesDeleteTemplateRequest{Name: legacyPrefix},
-	}
 
 	doReq := func(req estest.Request) error {
 		_, err := Elasticsearch.Do(context.Background(), req, nil)
@@ -113,12 +105,38 @@ func CleanupElasticsearch(t testing.TB) {
 		return err
 	}
 
-	var g errgroup.Group
-	for _, req := range requests {
-		req := req // copy for closure
-		g.Go(func() error { return doReq(req) })
+	doParallel := func(requests ...estest.Request) {
+		t.Helper()
+		var g errgroup.Group
+		for _, req := range requests {
+			req := req // copy for closure
+			g.Go(func() error { return doReq(req) })
+		}
+		if err := g.Wait(); err != nil {
+			t.Fatal(err)
+		}
 	}
-	if err := g.Wait(); err != nil {
+
+	// Delete indices, data streams, and ingest pipelines.
+	doReq(esapi.IndicesDeleteRequest{Index: []string{legacyPrefix}})
+	doParallel(
+		esapi.IndicesDeleteDataStreamRequest{Name: legacyPrefix},
+		esapi.IndicesDeleteDataStreamRequest{Name: apmTracesPrefix},
+		esapi.IndicesDeleteDataStreamRequest{Name: apmMetricsPrefix},
+		esapi.IndicesDeleteDataStreamRequest{Name: apmLogsPrefix},
+		esapi.IngestDeletePipelineRequest{PipelineID: legacyPrefix},
+	)
+
+	// Delete index templates after deleting data streams.
+	doParallel(
+		esapi.IndicesDeleteTemplateRequest{Name: legacyPrefix},
+		esapi.IndicesDeleteIndexTemplateRequest{Name: apmTracesPrefix},
+		esapi.IndicesDeleteIndexTemplateRequest{Name: apmMetricsPrefix},
+		esapi.IndicesDeleteIndexTemplateRequest{Name: apmLogsPrefix},
+	)
+
+	// Refresh indices to ensure all recent changes are visible.
+	if err := doReq(esapi.IndicesRefreshRequest{}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/systemtest/estest/search.go
+++ b/systemtest/estest/search.go
@@ -71,6 +71,11 @@ func (r *SearchRequest) WithQuery(q interface{}) *SearchRequest {
 	return r
 }
 
+func (r *SearchRequest) WithSort(fieldDirection ...string) *SearchRequest {
+	r.Sort = fieldDirection
+	return r
+}
+
 func (r *SearchRequest) WithSize(size int) *SearchRequest {
 	r.Size = &size
 	return r

--- a/x-pack/apm-server/sampling/config.go
+++ b/x-pack/apm-server/sampling/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/elastic/apm-server/elasticsearch"
 	"github.com/elastic/apm-server/publish"
+	"github.com/elastic/apm-server/x-pack/apm-server/sampling/pubsub"
 )
 
 // Config holds configuration for Processor.
@@ -60,9 +61,21 @@ type RemoteSamplingConfig struct {
 	// and subscribing to remote sampling decisions.
 	Elasticsearch elasticsearch.Client
 
-	// SampledTracesIndex holds the name of the Elasticsearch index for
-	// storing and searching sampled trace IDs.
-	SampledTracesIndex string
+	// SampledTracesDataStream holds the identifiers for the Elasticsearch
+	// data stream for storing and searching sampled trace IDs.
+	SampledTracesDataStream DataStreamConfig
+}
+
+// DataStreamConfig holds configuration to identify a data stream.
+type DataStreamConfig struct {
+	// Type holds the data stream's type.
+	Type string
+
+	// Dataset holds the data stream's dataset.
+	Dataset string
+
+	// Namespace holds the data stream's namespace.
+	Namespace string
 }
 
 // StorageConfig holds Processor configuration related to event storage.
@@ -175,10 +188,14 @@ func (config RemoteSamplingConfig) validate() error {
 	if config.Elasticsearch == nil {
 		return errors.New("Elasticsearch unspecified")
 	}
-	if config.SampledTracesIndex == "" {
-		return errors.New("SampledTracesIndex unspecified")
+	if err := config.SampledTracesDataStream.validate(); err != nil {
+		return errors.New("SampledTracesDataStream unspecified or invalid")
 	}
 	return nil
+}
+
+func (config DataStreamConfig) validate() error {
+	return pubsub.DataStreamConfig(config).Validate()
 }
 
 func (config StorageConfig) validate() error {

--- a/x-pack/apm-server/sampling/config_test.go
+++ b/x-pack/apm-server/sampling/config_test.go
@@ -57,8 +57,12 @@ func TestNewProcessorConfigInvalid(t *testing.T) {
 	}
 	config.Elasticsearch = elasticsearchClient
 
-	assertInvalidConfigError("invalid remote sampling config: SampledTracesIndex unspecified")
-	config.SampledTracesIndex = "sampled-traces"
+	assertInvalidConfigError("invalid remote sampling config: SampledTracesDataStream unspecified or invalid")
+	config.SampledTracesDataStream = sampling.DataStreamConfig{
+		Type:      "traces",
+		Dataset:   "sampled",
+		Namespace: "testing",
+	}
 
 	assertInvalidConfigError("invalid storage config: StorageDir unspecified")
 	config.StorageDir = "tbs"

--- a/x-pack/apm-server/sampling/processor.go
+++ b/x-pack/apm-server/sampling/processor.go
@@ -329,10 +329,10 @@ func (p *Processor) Run() error {
 	}
 
 	pubsub, err := pubsub.New(pubsub.Config{
-		BeatID: p.config.BeatID,
-		Client: p.config.Elasticsearch,
-		Index:  p.config.SampledTracesIndex,
-		Logger: p.logger,
+		BeatID:     p.config.BeatID,
+		Client:     p.config.Elasticsearch,
+		DataStream: pubsub.DataStreamConfig(p.config.SampledTracesDataStream),
+		Logger:     p.logger,
 
 		// Issue pubsub subscriber search requests at twice the frequency
 		// of publishing, so each server observes each other's sampled

--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -597,8 +597,12 @@ func newTempdirConfig(tb testing.TB) sampling.Config {
 			},
 		},
 		RemoteSamplingConfig: sampling.RemoteSamplingConfig{
-			Elasticsearch:      pubsubtest.Client(nil, nil),
-			SampledTracesIndex: "apm-sampled-traces",
+			Elasticsearch: pubsubtest.Client(nil, nil),
+			SampledTracesDataStream: sampling.DataStreamConfig{
+				Type:      "traces",
+				Dataset:   "sampled",
+				Namespace: "testing",
+			},
 		},
 		StorageConfig: sampling.StorageConfig{
 			StorageDir:        tempdir,

--- a/x-pack/apm-server/sampling/pubsub/config.go
+++ b/x-pack/apm-server/sampling/pubsub/config.go
@@ -5,6 +5,7 @@
 package pubsub
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -20,8 +21,8 @@ type Config struct {
 	// trace ID observations.
 	Client elasticsearch.Client
 
-	// Index holds the index name.
-	Index string
+	// DataStream holds the data stream.
+	DataStream DataStreamConfig
 
 	// BeatID holds the APM Server's unique ID, used for filtering out
 	// local observations in the subscriber.
@@ -48,13 +49,25 @@ type Config struct {
 	Logger *logp.Logger
 }
 
+// DataStreamConfig holds data stream configuration for Pubsub.
+type DataStreamConfig struct {
+	// Type holds the data stream's type.
+	Type string
+
+	// Dataset holds the data stream's dataset.
+	Dataset string
+
+	// Namespace holds the data stream's namespace.
+	Namespace string
+}
+
 // Validate validates the configuration.
 func (config Config) Validate() error {
 	if config.Client == nil {
 		return errors.New("Client unspecified")
 	}
-	if config.Index == "" {
-		return errors.New("Index unspecified")
+	if err := config.DataStream.Validate(); err != nil {
+		return errors.Wrap(err, "DataStream unspecified or invalid")
 	}
 	if config.BeatID == "" {
 		return errors.New("BeatID unspecified")
@@ -66,4 +79,23 @@ func (config Config) Validate() error {
 		return errors.New("FlushInterval unspecified or negative")
 	}
 	return nil
+}
+
+// Validate validates the configuration.
+func (config DataStreamConfig) Validate() error {
+	if config.Type == "" {
+		return errors.New("Type unspecified")
+	}
+	if config.Dataset == "" {
+		return errors.New("Dataset unspecified")
+	}
+	if config.Namespace == "" {
+		return errors.New("Namespace unspecified")
+	}
+	return nil
+}
+
+// String returns the data stream as a combined string.
+func (config DataStreamConfig) String() string {
+	return fmt.Sprintf("%s-%s-%s", config.Type, config.Dataset, config.Namespace)
 }

--- a/x-pack/apm-server/sampling/pubsub/config_test.go
+++ b/x-pack/apm-server/sampling/pubsub/config_test.go
@@ -32,24 +32,53 @@ func TestConfigInvalid(t *testing.T) {
 		config: pubsub.Config{
 			Client: elasticsearchClient,
 		},
-		err: "Index unspecified",
+		err: "DataStream unspecified or invalid: Type unspecified",
 	}, {
 		config: pubsub.Config{
 			Client: elasticsearchClient,
-			Index:  "index",
+			DataStream: pubsub.DataStreamConfig{
+				Type: "type",
+			},
+		},
+		err: "DataStream unspecified or invalid: Dataset unspecified",
+	}, {
+		config: pubsub.Config{
+			Client: elasticsearchClient,
+			DataStream: pubsub.DataStreamConfig{
+				Type:    "type",
+				Dataset: "dataset",
+			},
+		},
+		err: "DataStream unspecified or invalid: Namespace unspecified",
+	}, {
+		config: pubsub.Config{
+			Client: elasticsearchClient,
+			DataStream: pubsub.DataStreamConfig{
+				Type:      "type",
+				Dataset:   "dataset",
+				Namespace: "namespace",
+			},
 		},
 		err: "BeatID unspecified",
 	}, {
 		config: pubsub.Config{
 			Client: elasticsearchClient,
-			Index:  "index",
+			DataStream: pubsub.DataStreamConfig{
+				Type:      "type",
+				Dataset:   "dataset",
+				Namespace: "namespace",
+			},
 			BeatID: "beat_id",
 		},
 		err: "SearchInterval unspecified or negative",
 	}, {
 		config: pubsub.Config{
-			Client:         elasticsearchClient,
-			Index:          "index",
+			Client: elasticsearchClient,
+			DataStream: pubsub.DataStreamConfig{
+				Type:      "type",
+				Dataset:   "dataset",
+				Namespace: "namespace",
+			},
 			BeatID:         "beat_id",
 			SearchInterval: time.Second,
 		},

--- a/x-pack/apm-server/sampling/pubsub/datastream.go
+++ b/x-pack/apm-server/sampling/pubsub/datastream.go
@@ -1,0 +1,113 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package pubsub
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/elastic/apm-server/elasticsearch"
+
+	"github.com/elastic/go-elasticsearch/v7/esapi"
+)
+
+// SetupDataStream ensures that the sampled traces data stream index template
+// exists with the given name, creating it and its associated ILM policy if it
+// does not.
+//
+// This should only be called when not running under Fleet.
+func SetupDataStream(
+	ctx context.Context,
+	client elasticsearch.Client,
+	indexTemplateName string,
+	ilmPolicyName string,
+	indexPattern string,
+) error {
+	// Create/replace ILM policy.
+	resp, err := esapi.ILMPutLifecycleRequest{
+		Policy: ilmPolicyName,
+		Body:   strings.NewReader(ilmPolicy),
+	}.Do(ctx, client)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.IsError() {
+		body, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("failed to create ILM policy (%d): %s", resp.StatusCode, body)
+	}
+
+	// Create/replace index template.
+	dataStreamIndexTemplate := fmt.Sprintf(dataStreamIndexTemplate, indexPattern, ilmPolicyName)
+	resp, err = esapi.IndicesPutIndexTemplateRequest{
+		Name: indexTemplateName,
+		Body: strings.NewReader(dataStreamIndexTemplate),
+	}.Do(ctx, client)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.IsError() {
+		body, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("failed to create index template (%d): %s", resp.StatusCode, body)
+	}
+	return nil
+}
+
+// NOTE(axw) these replicate the index template and ILM policy created by Fleet,
+// and should be kept in sync with apmpackage/apm/.../data_stream/sampled_traces.
+
+const ilmPolicy = `{
+  "policy": {
+    "phases": {
+      "hot": {
+        "actions": {
+          "rollover": {
+            "max_age": "1h"
+          }
+        }
+      },
+      "delete": {
+        "min_age": "1h",
+        "actions": {
+          "delete": {}
+        }
+      }
+    }
+  }
+}`
+
+const dataStreamIndexTemplate = `{
+  "index_patterns": [%q],
+  "priority": 1,
+  "data_stream": {},
+  "template": {
+    "settings": {
+      "index.lifecycle.name": %q
+    },
+    "mappings": {
+      "properties": {
+        "@timestamp": {"type": "date"},
+        "event": {
+          "properties": {
+            "ingested": {"type": "date"}
+          }
+        },
+        "observer": {
+          "properties": {
+            "id": {"type": "keyword"}
+          }
+        },
+        "trace": {
+          "properties": {
+            "id": {"type": "keyword"}
+          }
+        }
+      }
+    }
+  }
+}`


### PR DESCRIPTION
Backports the following commits to 7.12:
 - sampling: use a data stream for sampled trace docs (#4707)