### PR TITLE
[7.x] sampling: require a default policy (#4729)

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -196,14 +196,17 @@ func (bt *beater) start(ctx context.Context, cancelContext context.CancelFunc, b
 			return nil, err
 		}
 		bt.stopServer = func() {
-			defer close(done)
-			defer closeTracer()
 			if bt.config.ShutdownTimeout > 0 {
 				time.AfterFunc(bt.config.ShutdownTimeout, cancelContext)
 			}
 			s.Stop()
 		}
 		s.Start()
+		go func() {
+			defer close(done)
+			defer closeTracer()
+			s.Wait()
+		}()
 	}
 	return done, nil
 }
@@ -306,11 +309,18 @@ func (s *serverRunner) String() string {
 	return "APMServer"
 }
 
+// Stop stops the server.
 func (s *serverRunner) Stop() {
 	s.stopOnce.Do(s.cancelRunServerContext)
+	s.Wait()
+}
+
+// Wait waits for the server to stop.
+func (s *serverRunner) Wait() {
 	s.wg.Wait()
 }
 
+// Start starts the server.
 func (s *serverRunner) Start() {
 	s.wg.Add(1)
 	go func() {

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -283,6 +283,7 @@ func TestUnpackConfig(t *testing.T) {
 				"sampling.keep_unsampled":                  false,
 				"sampling.tail": map[string]interface{}{
 					"enabled":           true,
+					"policies":          []map[string]interface{}{{"sample_rate": 0.5}},
 					"interval":          "2m",
 					"ingest_rate_decay": 1.0,
 				},
@@ -371,6 +372,7 @@ func TestUnpackConfig(t *testing.T) {
 					KeepUnsampled: false,
 					Tail: &TailSamplingConfig{
 						Enabled:               true,
+						Policies:              []TailSamplingPolicy{{SampleRate: 0.5}},
 						ESConfig:              elasticsearch.DefaultConfig(),
 						Interval:              2 * time.Minute,
 						IngestRateDecayFactor: 1.0,
@@ -564,7 +566,7 @@ func TestAgentConfig(t *testing.T) {
 }
 
 func TestNewConfig_ESConfig(t *testing.T) {
-	ucfg, err := common.NewConfigFrom(`{"rum.enabled":true,"api_key.enabled":true,"sampling.tail.enabled":true}`)
+	ucfg, err := common.NewConfigFrom(`{"rum.enabled":true,"api_key.enabled":true,"sampling.tail.policies":[{"sample_rate": 0.5}]}`)
 	require.NoError(t, err)
 
 	// no es config given

--- a/beater/config/sampling_test.go
+++ b/beater/config/sampling_test.go
@@ -1,0 +1,52 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+func TestSamplingPoliciesValidation(t *testing.T) {
+	t.Run("MinimallyValid", func(t *testing.T) {
+		_, err := NewConfig(common.MustNewConfigFrom(map[string]interface{}{
+			"sampling.tail.policies": []map[string]interface{}{{
+				"sample_rate": 0.5,
+			}},
+		}), nil)
+		assert.NoError(t, err)
+	})
+	t.Run("NoPolicies", func(t *testing.T) {
+		_, err := NewConfig(common.MustNewConfigFrom(map[string]interface{}{
+			"sampling.tail.enabled": true,
+		}), nil)
+		assert.EqualError(t, err, "Error processing configuration: invalid tail sampling config: no policies specified accessing 'sampling.tail'")
+	})
+	t.Run("NoDefaultPolicies", func(t *testing.T) {
+		_, err := NewConfig(common.MustNewConfigFrom(map[string]interface{}{
+			"sampling.tail.policies": []map[string]interface{}{{
+				"service.name": "foo",
+				"sample_rate":  0.5,
+			}},
+		}), nil)
+		assert.EqualError(t, err, "Error processing configuration: invalid tail sampling config: no default (empty criteria) policy specified accessing 'sampling.tail'")
+	})
+}

--- a/x-pack/apm-server/sampling/config_test.go
+++ b/x-pack/apm-server/sampling/config_test.go
@@ -38,7 +38,11 @@ func TestNewProcessorConfigInvalid(t *testing.T) {
 	config.MaxDynamicServices = 1
 
 	assertInvalidConfigError("invalid local sampling config: Policies unspecified")
-	config.Policies = []sampling.Policy{{}}
+	config.Policies = []sampling.Policy{{
+		PolicyCriteria: sampling.PolicyCriteria{ServiceName: "foo"},
+	}}
+	assertInvalidConfigError("invalid local sampling config: Policies does not contain a default (empty criteria) policy")
+	config.Policies[0].PolicyCriteria = sampling.PolicyCriteria{}
 	for _, invalid := range []float64{-1, 1.0, 2.0} {
 		config.Policies[0].SampleRate = invalid
 		assertInvalidConfigError("invalid local sampling config: Policy 0 invalid: SampleRate unspecified or out of range [0,1)")

--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -292,6 +292,9 @@ func TestProcessLocalTailSamplingPolicyOrder(t *testing.T) {
 	}, {
 		PolicyCriteria: sampling.PolicyCriteria{ServiceName: "service_name"},
 		SampleRate:     0.1,
+	}, {
+		PolicyCriteria: sampling.PolicyCriteria{},
+		SampleRate:     0,
 	}}
 	config.FlushInterval = 10 * time.Millisecond
 	published := make(chan string)


### PR DESCRIPTION
Backports the following commits to 7.x:
 - sampling: require a default policy (#4729)