### PR TITLE
[7.12] Add dataset_is_prefix field to manifest files (#4653)

### DIFF
--- a/apmpackage/apm/0.1.0/data_stream/app_metrics/manifest.yml
+++ b/apmpackage/apm/0.1.0/data_stream/app_metrics/manifest.yml
@@ -1,4 +1,5 @@
 title: APM application metrics
 type: metrics
 dataset: apm
+dataset_is_prefix: true
 ilm_policy: metrics-apm.app_metrics-default_policy

--- a/apmpackage/apm/0.1.0/data_stream/error_logs/manifest.yml
+++ b/apmpackage/apm/0.1.0/data_stream/error_logs/manifest.yml
@@ -1,4 +1,5 @@
 title: APM logs and errors
 type: logs
 dataset: apm.error
+dataset_is_prefix: true
 ilm_policy: logs-apm.error_logs-default_policy

--- a/apmpackage/apm/0.1.0/data_stream/internal_metrics/manifest.yml
+++ b/apmpackage/apm/0.1.0/data_stream/internal_metrics/manifest.yml
@@ -1,4 +1,5 @@
 title: APM internal metrics
 type: metrics
 dataset: apm.internal
+dataset_is_prefix: true
 ilm_policy: metrics-apm.internal_metrics-default_policy

--- a/apmpackage/apm/0.1.0/data_stream/profile_metrics/manifest.yml
+++ b/apmpackage/apm/0.1.0/data_stream/profile_metrics/manifest.yml
@@ -1,4 +1,5 @@
 title: APM profiles
 type: metrics
 dataset: apm.profiling
+dataset_is_prefix: true
 ilm_policy: metrics-apm.profile_metrics-default_policy

--- a/apmpackage/apm/0.1.0/data_stream/traces/manifest.yml
+++ b/apmpackage/apm/0.1.0/data_stream/traces/manifest.yml
@@ -1,4 +1,5 @@
 title: APM traces
 type: traces
 dataset: apm
+dataset_is_prefix: true
 ilm_policy: traces-apm.traces-default_policy


### PR DESCRIPTION
Backports the following commits to 7.12:
 - Add dataset_is_prefix field to manifest files (#4653)