### PR TITLE
[7.x] Rename dataset to avoid ambiguous index pattern generation (#4669)

### DIFF
--- a/apmpackage/apm/0.1.0/data_stream/app_metrics/elasticsearch/ingest_pipeline/default.json
+++ b/apmpackage/apm/0.1.0/data_stream/app_metrics/elasticsearch/ingest_pipeline/default.json
@@ -3,22 +3,22 @@
   "processors": [
     {
       "pipeline": {
-        "name": "metrics-apm-0.1.0-apm_user_agent"
+        "name": "metrics-apm.app-0.1.0-apm_user_agent"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm-0.1.0-apm_user_geo"
+        "name": "metrics-apm.app-0.1.0-apm_user_geo"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm-0.1.0-apm_ingest_timestamp"
+        "name": "metrics-apm.app-0.1.0-apm_ingest_timestamp"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm-0.1.0-apm_remove_span_metadata"
+        "name": "metrics-apm.app-0.1.0-apm_remove_span_metadata"
       }
     }
   ]

--- a/apmpackage/apm/0.1.0/data_stream/app_metrics/manifest.yml
+++ b/apmpackage/apm/0.1.0/data_stream/app_metrics/manifest.yml
@@ -1,4 +1,5 @@
 title: APM application metrics
 type: metrics
-dataset: apm
+dataset: apm.app
+dataset_is_prefix: true
 ilm_policy: metrics-apm.app_metrics-default_policy

--- a/model/metricset.go
+++ b/model/metricset.go
@@ -38,7 +38,7 @@ const (
 	metricsetEventKey       = "event"
 	metricsetTransactionKey = "transaction"
 	metricsetSpanKey        = "span"
-	AppMetricsDataset       = "apm"
+	AppMetricsDataset       = "apm.app"
 	InternalMetricsDataset  = "apm.internal"
 )
 

--- a/model/metricset_test.go
+++ b/model/metricset_test.go
@@ -63,7 +63,7 @@ func TestTransform(t *testing.T) {
 			Output: []common.MapStr{
 				{
 					"data_stream.type":    "metrics",
-					"data_stream.dataset": "apm",
+					"data_stream.dataset": "apm.app",
 					"processor":           common.MapStr{"event": "metric", "name": "metric"},
 					"service": common.MapStr{
 						"name": "myservice",
@@ -91,7 +91,7 @@ func TestTransform(t *testing.T) {
 			Output: []common.MapStr{
 				{
 					"data_stream.type":    "metrics",
-					"data_stream.dataset": "apm",
+					"data_stream.dataset": "apm.app",
 					"processor":           common.MapStr{"event": "metric", "name": "metric"},
 					"service":             common.MapStr{"name": "myservice"},
 					"labels":              common.MapStr{"a_b": "a.b.value"},

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationMetricsets.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationMetricsets.approved.json
@@ -99,7 +99,7 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm",
+            "data_stream.dataset": "apm.app",
             "data_stream.type": "metrics",
             "go": {
                 "memstats": {
@@ -145,7 +145,7 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm",
+            "data_stream.dataset": "apm.app",
             "data_stream.type": "metrics",
             "host": {
                 "ip": "192.0.0.1"

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationMinimalService.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationMinimalService.approved.json
@@ -6,7 +6,7 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm",
+            "data_stream.dataset": "apm.app",
             "data_stream.type": "metrics",
             "go": {
                 "memstats": {

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationOptionalTimestamps.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationOptionalTimestamps.approved.json
@@ -165,7 +165,7 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm",
+            "data_stream.dataset": "apm.app",
             "data_stream.type": "metrics",
             "host": {
                 "architecture": "x64",


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Rename dataset to avoid ambiguous index pattern generation (#4669)