### PR TITLE
[7.12] Disable sourcemap upload endpoint when data streams enabled (#4735)

### DIFF
--- a/beater/api/asset/sourcemap/test_approved/integration/TestSourcemapHandler_KillSwitchMiddleware/DataStreams.approved.json
+++ b/beater/api/asset/sourcemap/test_approved/integration/TestSourcemapHandler_KillSwitchMiddleware/DataStreams.approved.json
@@ -1,0 +1,3 @@
+{
+    "error": "forbidden request: When APM Server is managed by Fleet, Sourcemaps must be uploaded directly to Elasticsearch."
+}

--- a/beater/api/mux.go
+++ b/beater/api/mux.go
@@ -221,7 +221,10 @@ func sourcemapMiddleware(cfg *config.Config, auth *authorization.Handler) []midd
 	msg := "Sourcemap upload endpoint is disabled. " +
 		"Configure the `apm-server.rum` section in apm-server.yml to enable sourcemap uploads. " +
 		"If you are not using the RUM agent, you can safely ignore this error."
-	enabled := cfg.RumConfig.IsEnabled() && cfg.RumConfig.SourceMapping.IsEnabled()
+	if cfg.DataStreams.Enabled {
+		msg = "When APM Server is managed by Fleet, Sourcemaps must be uploaded directly to Elasticsearch."
+	}
+	enabled := cfg.RumConfig.IsEnabled() && cfg.RumConfig.SourceMapping.IsEnabled() && !cfg.DataStreams.Enabled
 	return append(backendMiddleware(cfg, auth, sourcemap.MonitoringMap),
 		middleware.KillSwitchMiddleware(enabled, msg))
 }

--- a/beater/api/mux_sourcemap_handler_test.go
+++ b/beater/api/mux_sourcemap_handler_test.go
@@ -70,6 +70,15 @@ func TestSourcemapHandler_KillSwitchMiddleware(t *testing.T) {
 		approvaltest.ApproveJSON(t, approvalPathAsset(t.Name()), rec.Body.Bytes())
 	})
 
+	t.Run("DataStreams", func(t *testing.T) {
+		cfg := cfgEnabledRUM()
+		cfg.DataStreams.Enabled = true
+		rec, err := requestToMuxerWithPattern(cfg, AssetSourcemapPath)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusForbidden, rec.Code)
+		approvaltest.ApproveJSON(t, approvalPathAsset(t.Name()), rec.Body.Bytes())
+	})
+
 	t.Run("On", func(t *testing.T) {
 		rec, err := requestToMuxerWithPattern(cfgEnabledRUM(), AssetSourcemapPath)
 		require.NoError(t, err)


### PR DESCRIPTION
Backports the following commits to 7.12:
 - Disable sourcemap upload endpoint when data streams enabled (#4735)