### PR TITLE
[7.12] apmpackage: disallow multiple "apm" integrations (#4694)

### DIFF
--- a/apmpackage/apm/0.1.0/manifest.yml
+++ b/apmpackage/apm/0.1.0/manifest.yml
@@ -19,6 +19,7 @@ policy_templates:
 - name: apmserver
   title: Elastic APM Integration
   description: Elastic APM Integration
+  multiple: false
   inputs:
   - type: apm
     title: Collect application traces

--- a/systemtest/fleettest/client.go
+++ b/systemtest/fleettest/client.go
@@ -223,6 +223,22 @@ func (c *Client) ListPackages() ([]Package, error) {
 	return result.Response, nil
 }
 
+// Package returns information about the package with the given name and version.
+func (c *Client) Package(name, version string) (*Package, error) {
+	resp, err := http.Get(c.fleetURL + "/epm/packages/" + name + "-" + version)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var result struct {
+		Response Package `json:"response"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return &result.Response, nil
+}
+
 // PackagePolicy returns information about the package policy with the given ID.
 func (c *Client) PackagePolicy(id string) (*PackagePolicy, error) {
 	resp, err := http.Get(c.fleetURL + "/package_policies/" + id)
@@ -240,9 +256,9 @@ func (c *Client) PackagePolicy(id string) (*PackagePolicy, error) {
 }
 
 // CreatePackagePolicy adds an integration to a policy.
-func (c *Client) CreatePackagePolicy(p PackagePolicy) error {
+func (c *Client) CreatePackagePolicy(p *PackagePolicy) error {
 	var body bytes.Buffer
-	if err := json.NewEncoder(&body).Encode(&p); err != nil {
+	if err := json.NewEncoder(&body).Encode(p); err != nil {
 		return err
 	}
 	req := c.newFleetRequest("POST", "/package_policies", &body)

--- a/systemtest/fleettest/helpers.go
+++ b/systemtest/fleettest/helpers.go
@@ -1,0 +1,33 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fleettest
+
+// NewPackagePolicy returns a new PackagePolicy for the package,
+// with the given name, namespace, and agent policy ID.
+func NewPackagePolicy(pkg *Package, name, namespace, agentPolicyID string) *PackagePolicy {
+	out := &PackagePolicy{
+		Name:          name,
+		Namespace:     namespace,
+		AgentPolicyID: agentPolicyID,
+		Enabled:       true,
+	}
+	out.Package.Name = pkg.Name
+	out.Package.Version = pkg.Version
+	out.Package.Title = pkg.Title
+	return out
+}

--- a/systemtest/fleettest/types.go
+++ b/systemtest/fleettest/types.go
@@ -74,15 +74,33 @@ type PackagePolicyInput struct {
 }
 
 type Package struct {
-	Name        string `json:"name"`
-	Version     string `json:"version"`
-	Release     string `json:"release"`
-	Type        string `json:"type"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	Download    string `json:"download"`
-	Path        string `json:"path"`
-	Status      string `json:"status"`
+	Name            string                  `json:"name"`
+	Version         string                  `json:"version"`
+	Release         string                  `json:"release"`
+	Type            string                  `json:"type"`
+	Title           string                  `json:"title"`
+	Description     string                  `json:"description"`
+	Download        string                  `json:"download"`
+	Path            string                  `json:"path"`
+	Status          string                  `json:"status"`
+	PolicyTemplates []PackagePolicyTemplate `json:"policy_templates"`
+}
+
+type PackagePolicyTemplate struct {
+	Inputs []PackagePolicyTemplateInput `json:"inputs"`
+}
+
+type PackagePolicyTemplateInput struct {
+	Type         string                          `json:"type"`
+	Title        string                          `json:"title"`
+	TemplatePath string                          `json:"template_path"`
+	Description  string                          `json:"description"`
+	Vars         []PackagePolicyTemplateInputVar `json:"vars"`
+}
+
+type PackagePolicyTemplateInputVar struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
 }
 
 type EnrollmentAPIKey struct {


### PR DESCRIPTION
Backports the following commits to 7.12:
 - apmpackage: disallow multiple "apm" integrations (#4694)