### PR TITLE
[7.12] docs: Update PHP agent manual distributed tracing docs (#4862)

### DIFF
--- a/docs/tab-widgets/distributed-trace-receive.asciidoc
+++ b/docs/tab-widgets/distributed-trace-receive.asciidoc
@@ -119,10 +119,10 @@ agent.startTransaction('my-service-b-transaction', { childOf: traceparent }) <2>
 
 // tag::php[]
 
-1. Receive the distributed tracing context on the server side and unserialize it back to a new `DistributedTracingData` object.
+1. Receive the distributed tracing data on the server side.
 
 2. Begin a new transaction using the agent's public API. For example, use {apm-php-ref-v}/public-api.html#api-elasticapm-class-begin-current-transaction[`ElasticApm::beginCurrentTransaction`]
-and pass the new `DistributedTracingData` object as a parameter.
+and pass the received distributed tracing data (serialized as string) as a parameter.
 This will create a new transaction as a child of the incoming trace context.
 
 3. Don't forget to eventually end the transaction on the server side.
@@ -135,11 +135,11 @@ $receiverTransaction = ElasticApm::beginCurrentTransaction( <1>
     'GET /data-api',
     'data-layer',
     /* timestamp */ null,
-    $distData <2>
+    $distDataAsString <2>
 );
 ----
 <1> Start a new transaction
-<2> Pass in the new `DistributedTracingData` object
+<2> Pass in the received distributed tracing data (serialized as string)
 
 Once this new transaction has been created in the receiving service,
 you can create child spans, or use any other agent API methods as you typically would.

--- a/docs/tab-widgets/distributed-trace-send.asciidoc
+++ b/docs/tab-widgets/distributed-trace-send.asciidoc
@@ -124,9 +124,9 @@ Example:
 
 [source,php]
 ----
-$distData = ElasticApm::getCurrentTransaction()->getDistributedTracingData(); <1>
+$distDataAsString = ElasticApm::getSerializedCurrentDistributedTracingData(); <1>
 ----
-<1> Get the current distributed tracing context
+<1> Get the current distributed tracing data serialized as string
 
 // end::php[]
 


### PR DESCRIPTION
Backports the following commits to 7.12:
 - docs: Update PHP agent manual distributed tracing docs (#4862)