### PR TITLE
[CI][arm] build and unit tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -235,7 +235,7 @@ pipeline {
               expression { return env.GITHUB_COMMENT?.contains('arm tests') || env.GITHUB_COMMENT?.contains('/arm')}
               branch 'master'
               allOf {
-                changeRequest
+                changeRequest()
                 expression { return params.arm_ci }
               }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -255,6 +255,13 @@ pipeline {
               }
             }
           }
+          post {
+            always {
+              dir("${BASE_DIR}/build"){
+                junit(allowEmptyResults: true, keepLongStdio: true, testResults: "junit-*.xml")
+              }
+            }
+          }
         }
         /**
           Run unit tests and report junit results.


### PR DESCRIPTION
## Motivation/summary

Use an ARM worker in the CI to validate the build and UTs.

By default it runs only when merge to master.

It can be triggered on a PR basis:

* with the GitHub comment `/arm` or `jenkins run the arm tests`
* with the UI if enabling the `arm_ci` parameter.

## Checklist

- ~~[ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~~
- ~~[ ] Documentation has been updated~~

For functional changes, consider:
- ~~Is it observable through the addition of either **logging** or **metrics**?~~
- ~~Is its use being published in **telemetry** to enable product improvement?~~
- ~~Have system tests been added to avoid regression?~~

## How to test these changes

Within the CI


## Test


![image](https://user-images.githubusercontent.com/2871786/109025259-78569e00-76b6-11eb-85e9-e93c81f76e03.png)

