### PR TITLE
[7.3] Update documentation links to .NET agent

### DIFF
--- a/docs/guide/apm-release-notes.asciidoc
+++ b/docs/guide/apm-release-notes.asciidoc
@@ -35,7 +35,7 @@ For a full list of changes, see the
 https://github.com/elastic/apm-agent-dotnet/[Elastic APM agent for .NET] is now
 generally available! The .NET Agent adds automatic instrumentation for ASP.NET
 Core 2.x+ and Entity Framework Core 2.x+, while also providing a
-{apm-dotnet-ref}/public-api.html[Public API] for the .NET agent that will allow
+{apm-dotnet-ref-v}/public-api.html[Public API] for the .NET agent that will allow
 you to instrument any .NET custom application code.
 
 [discrete]
@@ -64,7 +64,7 @@ about this configuration, see
 image::images/apm-highlight-sample-rate.png[APM sample rate configuration in Kibana]
 
 [discrete]
-==== React support for Single Page Applications 
+==== React support for Single Page Applications
 
 The 7.3 release also brings a lot of exciting changes to the Real User
 Monitoring (RUM) agent. We have furthered our support of Single Page
@@ -187,7 +187,7 @@ Elastic APM now enables {apm-overview-ref-v}/distributed-tracing.html[distribute
 [float]
 ==== Bug Fixes
 Changes introduced in 6.4.0 potentially caused an empty APM Kibana UI.
-This happened in case the APM Server was using an outdated configuration file, not configured to index events into separate indices. 
+This happened in case the APM Server was using an outdated configuration file, not configured to index events into separate indices.
 To fix this, the APM Kibana UI now falls back to use `apm-*` as default indices to query.
 Users can still leverage separate indices for queries by overriding the default values described in {kibana-ref}/apm-settings-kb.html[Kibana APM settings].
 

--- a/docs/secure-communication-agents.asciidoc
+++ b/docs/secure-communication-agents.asciidoc
@@ -36,7 +36,7 @@ Each Agent has a configuration for setting the value of the secret token:
 
 * *Go Agent*: {apm-go-ref}/configuration.html#config-secret-token[`ELASTIC_APM_SECRET_TOKEN`]
 * *Java Agent*: {apm-java-ref}/config-reporter.html#config-secret-token[`secret_token`]
-* *.NET Agent*: {apm-dotnet-ref}/config-reporter.html#config-secret-token[`ELASTIC_APM_SECRET_TOKEN`]
+* *.NET Agent*: {apm-dotnet-ref-v}/config-reporter.html#config-secret-token[`ELASTIC_APM_SECRET_TOKEN`]
 * *Node.js Agent*: {apm-node-ref}/configuration.html#secret-token[`Secret Token`]
 * *Python Agent*: {apm-py-ref}/configuration.html#config-secret-token[`secret_token`]
 * *Ruby Agent*: {apm-ruby-ref}/configuration.html#config-secret-token[`secret_token`]
@@ -69,7 +69,7 @@ To enable secure communication in your Agents, you need to update the configured
 
 * *Go Agent*: {apm-go-ref}/configuration.html#config-server-url[`ELASTIC_APM_SERVER_URL`]
 * *Java Agent*: {apm-java-ref}/config-reporter.html#config-server-urls[`server_urls`]
-* *.NET Agent*: {apm-dotnet-ref}/config-reporter.html#config-server-url[`ServerUrl`]
+* *.NET Agent*: {apm-dotnet-ref-v}/config-reporter.html#config-server-url[`ServerUrl`]
 * *Node.js Agent*: {apm-node-ref}/configuration.html#server-url[`serverUrl`]
 * *Python Agent*: {apm-py-ref}/[`server_url`]
 * *Ruby Agent*: {apm-ruby-ref}/configuration.html#config-server-url[`server_url`]

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -21,7 +21,7 @@
 :node-branch: 2.x
 :py-branch: 5.x
 :ruby-branch: 2.x
-:dotnet-branch: 1.x
+:dotnet-branch: 1.8
 
 // Agent links
 :apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{py-branch}


### PR DESCRIPTION
For https://github.com/elastic/docs/pull/2072.