### PR TITLE
model: add system.network.{cpus,memory,network}

### DIFF
--- a/docs/spec/v2/metadata.json
+++ b/docs/spec/v2/metadata.json
@@ -394,6 +394,14 @@
             }
           }
         },
+        "cpus": {
+          "description": "CPUCores holds the number of CPU cores of the system on which the monitored service is running.",
+          "type": [
+            "null",
+            "integer"
+          ],
+          "minimum": 1
+        },
         "detected_hostname": {
           "description": "DetectedHostname is the hostname detected by the APM agent. It usually contains what the hostname command returns on the host machine. It will be used as the event's hostname if ConfiguredHostname is not present.",
           "type": [
@@ -466,6 +474,51 @@
                   "maxLength": 1024
                 }
               }
+            }
+          }
+        },
+        "memory": {
+          "description": "Memory holds the memory of the system on which the monitored service is running, in bytes.",
+          "type": [
+            "null",
+            "integer"
+          ],
+          "minimum": 1
+        },
+        "network": {
+          "description": "Network holds information about the network that the system is connected to. This is only relevant for browsers and mobile devices.  See https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation for more details on how these fields should be set and interpreted for browsers.",
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "downlink": {
+              "description": "Downlink holds the effective bandwidth estimate in megabits per second.",
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "effectivetype": {
+              "description": "EffectiveType describes the effective network type as one of a discrete set of network types, e.g. 'slow-2g', '2g', '3g', or '4g'.",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "rtt": {
+              "description": "RTT holds the estimated effective round-trip time of the current connection, in milliseconds.",
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "savedata": {
+              "description": "SaveData reports whether or not reduced data usage has been enabled on the client device.",
+              "type": [
+                "null",
+                "boolean"
+              ]
             }
           }
         },

--- a/model/modeldecoder/v2/decoder.go
+++ b/model/modeldecoder/v2/decoder.go
@@ -512,6 +512,12 @@ func mapToMetadataModel(from *metadata, out *model.Metadata) {
 	if from.System.Platform.IsSet() {
 		out.System.Platform = from.System.Platform.Val
 	}
+	if from.System.Memory.IsSet() {
+		out.System.Memory = from.System.Memory.Val
+	}
+	if from.System.CPUCores.IsSet() {
+		out.System.CPUCores = from.System.CPUCores.Val
+	}
 
 	// User
 	if from.User.ID.IsSet() {

--- a/model/modeldecoder/v2/model.go
+++ b/model/modeldecoder/v2/model.go
@@ -502,6 +502,18 @@ type metadataSystem struct {
 	Kubernetes metadataSystemKubernetes `json:"kubernetes"`
 	// Platform name of the system platform the monitored service is running on.
 	Platform nullable.String `json:"platform" validate:"maxLength=1024"`
+	// Memory holds the memory of the system on which the monitored service is
+	// running, in bytes.
+	Memory nullable.Int `json:"memory" validate:"min=1"`
+	// CPUCores holds the number of CPU cores of the system on which the monitored
+	// service is running.
+	CPUCores nullable.Int `json:"cpus" validate:"min=1"`
+	// Network holds information about the network that the system is connected to.
+	// This is only relevant for browsers and mobile devices.
+	//
+	// See https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation for
+	// more details on how these fields should be set and interpreted for browsers.
+	Network metadataSystemNetwork `json:"network"`
 }
 
 type metadataSystemContainer struct {
@@ -528,6 +540,23 @@ type metadataSystemKubernetesPod struct {
 	Name nullable.String `json:"name" validate:"maxLength=1024"`
 	// UID is the system-generated string uniquely identifying the Pod.
 	UID nullable.String `json:"uid" validate:"maxLength=1024"`
+}
+
+type metadataSystemNetwork struct {
+	// Downlink holds the effective bandwidth estimate in megabits per second.
+	Downlink nullable.Int
+
+	// EffectiveType describes the effective network type as one of a
+	// discrete set of network types, e.g. 'slow-2g', '2g', '3g', or '4g'.
+	EffectiveType nullable.String
+
+	// RTT holds the estimated effective round-trip time of the current
+	// connection, in milliseconds.
+	RTT nullable.Int
+
+	// SaveData reports whether or not reduced data usage has been enabled
+	// on the client device.
+	SaveData nullable.Bool
 }
 
 type metricset struct {

--- a/model/modeldecoder/v2/model_generated.go
+++ b/model/modeldecoder/v2/model_generated.go
@@ -467,7 +467,7 @@ func (val *metadataServiceRuntime) validate() error {
 }
 
 func (val *metadataSystem) IsSet() bool {
-	return val.Architecture.IsSet() || val.ConfiguredHostname.IsSet() || val.Container.IsSet() || val.DetectedHostname.IsSet() || val.DeprecatedHostname.IsSet() || val.Kubernetes.IsSet() || val.Platform.IsSet()
+	return val.Architecture.IsSet() || val.ConfiguredHostname.IsSet() || val.Container.IsSet() || val.DetectedHostname.IsSet() || val.DeprecatedHostname.IsSet() || val.Kubernetes.IsSet() || val.Platform.IsSet() || val.Memory.IsSet() || val.CPUCores.IsSet() || val.Network.IsSet()
 }
 
 func (val *metadataSystem) Reset() {
@@ -478,6 +478,9 @@ func (val *metadataSystem) Reset() {
 	val.DeprecatedHostname.Reset()
 	val.Kubernetes.Reset()
 	val.Platform.Reset()
+	val.Memory.Reset()
+	val.CPUCores.Reset()
+	val.Network.Reset()
 }
 
 func (val *metadataSystem) validate() error {
@@ -504,6 +507,15 @@ func (val *metadataSystem) validate() error {
 	}
 	if utf8.RuneCountInString(val.Platform.Val) > 1024 {
 		return fmt.Errorf("'platform': validation rule 'maxLength(1024)' violated")
+	}
+	if val.Memory.Val < 1 {
+		return fmt.Errorf("'memory': validation rule 'min(1)' violated")
+	}
+	if val.CPUCores.Val < 1 {
+		return fmt.Errorf("'cpus': validation rule 'min(1)' violated")
+	}
+	if err := val.Network.validate(); err != nil {
+		return errors.Wrapf(err, "network")
 	}
 	return nil
 }
@@ -588,6 +600,24 @@ func (val *metadataSystemKubernetesPod) validate() error {
 	}
 	if utf8.RuneCountInString(val.UID.Val) > 1024 {
 		return fmt.Errorf("'uid': validation rule 'maxLength(1024)' violated")
+	}
+	return nil
+}
+
+func (val *metadataSystemNetwork) IsSet() bool {
+	return val.Downlink.IsSet() || val.EffectiveType.IsSet() || val.RTT.IsSet() || val.SaveData.IsSet()
+}
+
+func (val *metadataSystemNetwork) Reset() {
+	val.Downlink.Reset()
+	val.EffectiveType.Reset()
+	val.RTT.Reset()
+	val.SaveData.Reset()
+}
+
+func (val *metadataSystemNetwork) validate() error {
+	if !val.IsSet() {
+		return nil
 	}
 	return nil
 }

--- a/model/system.go
+++ b/model/system.go
@@ -29,9 +29,24 @@ type System struct {
 	Architecture       string
 	Platform           string
 	IP                 net.IP
+	Container          Container
+	Kubernetes         Kubernetes
 
-	Container  Container
-	Kubernetes Kubernetes
+	// Memory holds the total system memory, in bytes.
+	//
+	// This may be recorded for short-lived operations,
+	// such as browser requests or serverless function
+	// invocations, where the amount of available memory
+	// may be pertinent to request performance.
+	Memory int
+
+	// CPUCores holds the total number of CPU cores.
+	//
+	// This may be recorded for short-lived operations,
+	// such as browser requests or serverless function
+	// invocations, where the number of CPUs may be
+	// pertinent to request performance.
+	CPUCores int
 }
 
 func (s *System) name() string {
@@ -75,6 +90,12 @@ func (s *System) fields() common.MapStr {
 	}
 	if s.IP != nil {
 		system.set("ip", s.IP.String())
+	}
+	if s.Memory > 0 {
+		system.set("memory.total", s.Memory)
+	}
+	if s.CPUCores > 0 {
+		system.set("cpu.cores", s.CPUCores)
 	}
 	return common.MapStr(system)
 }


### PR DESCRIPTION
## Motivation/summary

Extend the system metadata with properties for describing the number of CPU cores, amount of system memory, and network information for end-user devices.

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

## How to test these changes

TODO

## Related issues

#3657