### PR TITLE
[7.x] beater/otlp: fix panic in parallel tests (#4911)

### DIFF
--- a/beater/otlp/grpc.go
+++ b/beater/otlp/grpc.go
@@ -19,6 +19,7 @@ package otlp
 
 import (
 	"context"
+	"sync"
 
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/collector/consumer/pdata"
@@ -45,6 +46,10 @@ var (
 	gRPCTracesMonitoringMap  = request.MonitoringMapForRegistry(gRPCTracesRegistry, monitoringKeys)
 )
 
+func init() {
+	monitoring.NewFunc(gRPCMetricsRegistry, "consumer", collectMetricsMonitoring, monitoring.Report)
+}
+
 // RegisterGRPCServices registers OTLP consumer services with the given gRPC server.
 func RegisterGRPCServices(grpcServer *grpc.Server, reporter publish.Reporter, logger *logp.Logger) error {
 	consumer := &monitoredConsumer{
@@ -52,14 +57,10 @@ func RegisterGRPCServices(grpcServer *grpc.Server, reporter publish.Reporter, lo
 		logger:   logger,
 	}
 
-	// TODO(axw) rather than registering and unregistering monitoring callbacks
-	// each time a new consumer is created, we should register one callback and
-	// have it aggregate metrics from the dynamic consumers.
-	//
-	// For now, we take the easy way out: we only have one OTLP gRPC service
-	// running at any time, so just unregister/register a new one.
-	gRPCMetricsRegistry.Remove("consumer")
-	monitoring.NewFunc(gRPCMetricsRegistry, "consumer", consumer.collectMetricsMonitoring, monitoring.Report)
+	// TODO(axw) stop assuming we have only one OTLP gRPC service running
+	// at any time, and instead aggregate metrics from consumers that are
+	// dynamically registered and unregistered.
+	setCurrentMonitoredConsumer(consumer)
 
 	traceReceiver := trace.New("otlp", consumer)
 	metricsReceiver := metrics.New("otlp", consumer)
@@ -111,4 +112,24 @@ func (c *monitoredConsumer) collectMetricsMonitoring(_ monitoring.Mode, V monito
 	monitoring.ReportNamespace(V, "consumer", func() {
 		monitoring.ReportInt(V, "unsupported_dropped", stats.UnsupportedMetricsDropped)
 	})
+}
+
+var (
+	currentMonitoredConsumerMu sync.RWMutex
+	currentMonitoredConsumer   *monitoredConsumer
+)
+
+func setCurrentMonitoredConsumer(c *monitoredConsumer) {
+	currentMonitoredConsumerMu.Lock()
+	defer currentMonitoredConsumerMu.Unlock()
+	currentMonitoredConsumer = c
+}
+
+func collectMetricsMonitoring(mode monitoring.Mode, V monitoring.Visitor) {
+	currentMonitoredConsumerMu.RLock()
+	c := currentMonitoredConsumer
+	currentMonitoredConsumerMu.RUnlock()
+	if c != nil {
+		c.collectMetricsMonitoring(mode, V)
+	}
 }


### PR DESCRIPTION
Backports the following commits to 7.x:
 - beater/otlp: fix panic in parallel tests (#4911)