### PR TITLE
[fleet] add quotes to special char default value

### DIFF
--- a/apmpackage/apm/0.1.0/manifest.yml
+++ b/apmpackage/apm/0.1.0/manifest.yml
@@ -85,7 +85,7 @@ policy_templates:
             multi: true
             required: false
             show_user: false
-            default: ["*"]
+            default: ['"*"']
           - name: rum_allow_headers
             type: string
             title: RUM - Access-Control-Allow-Headers


### PR DESCRIPTION

<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
https://github.com/elastic/kibana/pull/93585
Yaml parser gets confused when default value of package metadata starts with `*` without being put in quotes. The fix is to put all default values starting with an asterisk as `'"*"'`. 
<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

Note: I wasn't able to manually test as the elastic agent image is currently broken. It is a minor change though, so I suggest we move forward with this and test once the elastic agent is fixed. 

## How to test these changes
Start Elastic Agent and Fleet, and 
* install APM integration to an agent policy.
* edit policy and try to enter a string starting with `*` without quotes -> should lead to error
* edit policy and try to enter a string starting with `*` in  quotes -> should work
<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues
related to #https://github.com/elastic/kibana/pull/93585

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
