### PR TITLE
[CI] Use MacOS for x86_64

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -189,7 +189,7 @@ pipeline {
         Build on a mac environment.
         */
         stage('OSX build-test') {
-          agent { label 'macosx' }
+          agent { label 'macosx && x86_64' }
           options {
             skipDefaultCheckout()
             warnError('OSX execution failed')


### PR DESCRIPTION
### What

Filter on x86 arch


### Why

ARM64 arch will be enabled sooner than later so let's prepare the CI pipelines for that