### PR TITLE
model: de-pointer several integer fields

### DIFF
--- a/model/context.go
+++ b/model/context.go
@@ -52,7 +52,7 @@ type URL struct {
 	Scheme   string
 	Full     string
 	Domain   string
-	Port     *int
+	Port     int
 	Path     string
 	Query    string
 	Fragment string
@@ -84,7 +84,7 @@ func ParseURL(original, defaultHostname, defaultScheme string) *URL {
 	}
 	if port := url.Port(); port != "" {
 		if intv, err := strconv.Atoi(port); err == nil {
-			out.Port = &intv
+			out.Port = intv
 		}
 	}
 	return out
@@ -132,7 +132,7 @@ type Resp struct {
 }
 
 type MinimalResp struct {
-	StatusCode      *int
+	StatusCode      int
 	Headers         http.Header
 	TransferSize    *float64
 	EncodedBodySize *float64
@@ -149,7 +149,9 @@ func (url *URL) Fields() common.MapStr {
 	fields.maybeSetString("fragment", url.Fragment)
 	fields.maybeSetString("domain", url.Domain)
 	fields.maybeSetString("path", url.Path)
-	fields.maybeSetIntptr("port", url.Port)
+	if url.Port > 0 {
+		fields.set("port", url.Port)
+	}
 	fields.maybeSetString("original", url.Original)
 	fields.maybeSetString("scheme", url.Scheme)
 	fields.maybeSetString("query", url.Query)
@@ -221,8 +223,10 @@ func (m *MinimalResp) Fields() common.MapStr {
 		return nil
 	}
 	var fields mapStr
+	if m.StatusCode > 0 {
+		fields.set("status_code", m.StatusCode)
+	}
 	fields.maybeSetMapStr("headers", headerToFields(m.Headers))
-	fields.maybeSetIntptr("status_code", m.StatusCode)
 	fields.maybeSetFloat64ptr("transfer_size", m.TransferSize)
 	fields.maybeSetFloat64ptr("encoded_body_size", m.EncodedBodySize)
 	fields.maybeSetFloat64ptr("decoded_body_size", m.DecodedBodySize)

--- a/model/modeldecoder/rumv3/decoder.go
+++ b/model/modeldecoder/rumv3/decoder.go
@@ -439,8 +439,7 @@ func mapToResponseModel(from contextResponse, out *model.Resp) {
 		out.Headers = from.Headers.Val.Clone()
 	}
 	if from.StatusCode.IsSet() {
-		val := from.StatusCode.Val
-		out.StatusCode = &val
+		out.StatusCode = from.StatusCode.Val
 	}
 	if from.TransferSize.IsSet() {
 		val := from.TransferSize.Val
@@ -540,8 +539,7 @@ func mapToSpanModel(from *span, metadata *model.Metadata, reqTime time.Time, out
 			destination.Address = from.Context.Destination.Address.Val
 		}
 		if from.Context.Destination.Port.IsSet() {
-			val := from.Context.Destination.Port.Val
-			destination.Port = &val
+			destination.Port = from.Context.Destination.Port.Val
 		}
 		out.Destination = &destination
 	}
@@ -564,8 +562,7 @@ func mapToSpanModel(from *span, metadata *model.Metadata, reqTime time.Time, out
 			http.Method = from.Context.HTTP.Method.Val
 		}
 		if from.Context.HTTP.StatusCode.IsSet() {
-			val := from.Context.HTTP.StatusCode.Val
-			http.StatusCode = &val
+			http.StatusCode = from.Context.HTTP.StatusCode.Val
 		}
 		if from.Context.HTTP.URL.IsSet() {
 			http.URL = from.Context.HTTP.URL.Val

--- a/model/modeldecoder/rumv3/error_test.go
+++ b/model/modeldecoder/rumv3/error_test.go
@@ -176,7 +176,7 @@ func TestDecodeMapToErrorModel(t *testing.T) {
 		var out model.Error
 		mapToErrorModel(&input, initializedMetadata(), time.Now(), &out)
 		assert.Equal(t, "https://my.site.test:9201", out.Page.URL.Full)
-		assert.Equal(t, 9201, *out.Page.URL.Port)
+		assert.Equal(t, 9201, out.Page.URL.Port)
 		assert.Equal(t, "https", out.Page.URL.Scheme)
 	})
 

--- a/model/modeldecoder/rumv3/transaction_test.go
+++ b/model/modeldecoder/rumv3/transaction_test.go
@@ -334,7 +334,7 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 		var tr model.Transaction
 		mapToTransactionModel(&inputTr, initializedMetadata(), time.Now(), &tr)
 		assert.Equal(t, "https://my.site.test:9201", tr.Page.URL.Full)
-		assert.Equal(t, 9201, *tr.Page.URL.Port)
+		assert.Equal(t, 9201, tr.Page.URL.Port)
 		assert.Equal(t, "https", tr.Page.URL.Scheme)
 	})
 

--- a/model/modeldecoder/v2/decoder.go
+++ b/model/modeldecoder/v2/decoder.go
@@ -632,7 +632,7 @@ func mapToRequestURLModel(from contextRequestURL, out *model.URL) {
 		// should never result in an error, type is checked when decoding
 		port, err := strconv.Atoi(fmt.Sprint(from.Port.Val))
 		if err == nil {
-			out.Port = &port
+			out.Port = port
 		}
 	}
 }
@@ -650,8 +650,7 @@ func mapToResponseModel(from contextResponse, out *model.Resp) {
 		out.HeadersSent = &val
 	}
 	if from.StatusCode.IsSet() {
-		val := from.StatusCode.Val
-		out.StatusCode = &val
+		out.StatusCode = from.StatusCode.Val
 	}
 	if from.TransferSize.IsSet() {
 		val := from.TransferSize.Val
@@ -772,8 +771,7 @@ func mapToSpanModel(from *span, metadata *model.Metadata, reqTime time.Time, con
 			destination.Address = from.Context.Destination.Address.Val
 		}
 		if from.Context.Destination.Port.IsSet() {
-			val := from.Context.Destination.Port.Val
-			destination.Port = &val
+			destination.Port = from.Context.Destination.Port.Val
 		}
 		out.Destination = &destination
 	}
@@ -812,8 +810,7 @@ func mapToSpanModel(from *span, metadata *model.Metadata, reqTime time.Time, con
 				response.Headers = from.Context.HTTP.Response.Headers.Val.Clone()
 			}
 			if from.Context.HTTP.Response.StatusCode.IsSet() {
-				val := from.Context.HTTP.Response.StatusCode.Val
-				response.StatusCode = &val
+				response.StatusCode = from.Context.HTTP.Response.StatusCode.Val
 			}
 			if from.Context.HTTP.Response.TransferSize.IsSet() {
 				val := from.Context.HTTP.Response.TransferSize.Val
@@ -822,8 +819,7 @@ func mapToSpanModel(from *span, metadata *model.Metadata, reqTime time.Time, con
 			http.Response = &response
 		}
 		if from.Context.HTTP.StatusCode.IsSet() {
-			val := from.Context.HTTP.StatusCode.Val
-			http.StatusCode = &val
+			http.StatusCode = from.Context.HTTP.StatusCode.Val
 		}
 		if from.Context.HTTP.URL.IsSet() {
 			http.URL = from.Context.HTTP.URL.Val

--- a/model/modeldecoder/v2/error_test.go
+++ b/model/modeldecoder/v2/error_test.go
@@ -193,7 +193,7 @@ func TestDecodeMapToErrorModel(t *testing.T) {
 		var out model.Error
 		mapToErrorModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{}, &out)
 		assert.Equal(t, "https://my.site.test:9201", out.Page.URL.Full)
-		assert.Equal(t, 9201, *out.Page.URL.Port)
+		assert.Equal(t, 9201, out.Page.URL.Port)
 		assert.Equal(t, "https", out.Page.URL.Scheme)
 	})
 }

--- a/model/modeldecoder/v2/transaction_test.go
+++ b/model/modeldecoder/v2/transaction_test.go
@@ -205,7 +205,7 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 		var out model.Transaction
 		mapToTransactionModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{Experimental: false}, &out)
 		assert.Equal(t, "https://my.site.test:9201", out.Page.URL.Full)
-		assert.Equal(t, 9201, *out.Page.URL.Port)
+		assert.Equal(t, 9201, out.Page.URL.Port)
 		assert.Equal(t, "https", out.Page.URL.Scheme)
 	})
 

--- a/model/span.go
+++ b/model/span.go
@@ -102,7 +102,7 @@ type DB struct {
 // TODO(axw) combine this and "Http", which is used by transaction and error, into one type.
 type HTTP struct {
 	URL        string
-	StatusCode *int
+	StatusCode int
 	Method     string
 	Response   *MinimalResp
 }
@@ -110,7 +110,7 @@ type HTTP struct {
 // Destination contains contextual data about the destination of a span, such as address and port
 type Destination struct {
 	Address string
-	Port    *int
+	Port    int
 }
 
 // DestinationService contains information about the destination service of a span event
@@ -145,11 +145,11 @@ func (http *HTTP) fields() common.MapStr {
 		fields.set("url", common.MapStr(url))
 	}
 	response := http.Response.Fields()
-	if http.StatusCode != nil {
+	if http.StatusCode > 0 {
 		if response == nil {
-			response = common.MapStr{"status_code": *http.StatusCode}
-		} else if http.Response.StatusCode == nil {
-			response["status_code"] = *http.StatusCode
+			response = common.MapStr{"status_code": http.StatusCode}
+		} else if http.Response.StatusCode == 0 {
+			response["status_code"] = http.StatusCode
 		}
 	}
 	fields.maybeSetMapStr("response", response)
@@ -168,7 +168,9 @@ func (d *Destination) fields() common.MapStr {
 			fields.set("ip", d.Address)
 		}
 	}
-	fields.maybeSetIntptr("port", d.Port)
+	if d.Port > 0 {
+		fields.set("port", d.Port)
+	}
 	return common.MapStr(fields)
 }
 

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -108,14 +108,14 @@ func TestSpanTransform(t *testing.T) {
 				RUM:                 true,
 				Stacktrace:          Stacktrace{{AbsPath: path}},
 				Labels:              common.MapStr{"label_a": 12},
-				HTTP:                &HTTP{Method: method, StatusCode: &statusCode, URL: url},
+				HTTP:                &HTTP{Method: method, StatusCode: statusCode, URL: url},
 				DB: &DB{
 					Instance:     instance,
 					Statement:    statement,
 					Type:         dbType,
 					UserName:     user,
 					RowsAffected: &rowsAffected},
-				Destination: &Destination{Address: address, Port: &port},
+				Destination: &Destination{Address: address, Port: port},
 				DestinationService: &DestinationService{
 					Type:     destServiceType,
 					Name:     destServiceName,

--- a/processor/otel/builder.go
+++ b/processor/otel/builder.go
@@ -76,7 +76,7 @@ func (tx *transactionBuilder) setHTTPStatusCode(statusCode int) {
 	if tx.HTTP.Response == nil {
 		tx.HTTP.Response = &model.Resp{}
 	}
-	tx.HTTP.Response.MinimalResp.StatusCode = &statusCode
+	tx.HTTP.Response.MinimalResp.StatusCode = statusCode
 	if tx.Outcome == outcomeUnknown {
 		if statusCode >= 500 {
 			tx.Outcome = outcomeFailure

--- a/processor/otel/consumer.go
+++ b/processor/otel/consumer.go
@@ -412,8 +412,7 @@ func translateSpan(span pdata.Span, metadata model.Metadata, event *model.Span) 
 		case pdata.AttributeValueINT:
 			switch kDots {
 			case "http.status_code":
-				code := int(v.IntVal())
-				http.StatusCode = &code
+				http.StatusCode = int(v.IntVal())
 				isHTTPSpan = true
 			case conventions.AttributeNetPeerPort, "peer.port":
 				netPeerPort = int(v.IntVal())
@@ -564,9 +563,9 @@ func translateSpan(span pdata.Span, metadata model.Metadata, event *model.Span) 
 
 	switch {
 	case isHTTPSpan:
-		if http.StatusCode != nil {
+		if http.StatusCode > 0 {
 			if event.Outcome == outcomeUnknown {
-				event.Outcome = clientHTTPStatusCodeOutcome(*http.StatusCode)
+				event.Outcome = clientHTTPStatusCodeOutcome(http.StatusCode)
 			}
 		}
 		event.Type = "external"
@@ -594,10 +593,7 @@ func translateSpan(span pdata.Span, metadata model.Metadata, event *model.Span) 
 	}
 
 	if destAddr != "" {
-		event.Destination = &model.Destination{Address: destAddr}
-		if destPort > 0 {
-			event.Destination.Port = &destPort
-		}
+		event.Destination = &model.Destination{Address: destAddr, Port: destPort}
 	}
 	if destinationService != (model.DestinationService{}) {
 		if destinationService.Type == "" {
@@ -724,7 +720,7 @@ func addSpanCtxToErr(span *model.Span, hostname string, err *model.Error) {
 	err.ParentID = span.ID
 	if span.HTTP != nil {
 		err.HTTP = &model.Http{}
-		if span.HTTP.StatusCode != nil {
+		if span.HTTP.StatusCode > 0 {
 			err.HTTP.Response = &model.Resp{MinimalResp: model.MinimalResp{StatusCode: span.HTTP.StatusCode}}
 		}
 		if span.HTTP.Method != "" {

--- a/processor/otel/consumer_test.go
+++ b/processor/otel/consumer_test.go
@@ -115,7 +115,7 @@ func TestHTTPTransactionURL(t *testing.T) {
 			Path:     "/foo",
 			Query:    "bar",
 			Domain:   "testing.invalid",
-			Port:     newInt(80),
+			Port:     80,
 		}, map[string]pdata.AttributeValue{
 			"http.scheme": pdata.NewAttributeValueString("https"),
 			"http.host":   pdata.NewAttributeValueString("testing.invalid:80"),
@@ -130,7 +130,7 @@ func TestHTTPTransactionURL(t *testing.T) {
 			Path:     "/foo",
 			Query:    "bar",
 			Domain:   "testing.invalid",
-			Port:     newInt(80),
+			Port:     80,
 		}, map[string]pdata.AttributeValue{
 			"http.scheme":      pdata.NewAttributeValueString("https"),
 			"http.server_name": pdata.NewAttributeValueString("testing.invalid"),
@@ -146,7 +146,7 @@ func TestHTTPTransactionURL(t *testing.T) {
 			Path:     "/foo",
 			Query:    "bar",
 			Domain:   "testing.invalid",
-			Port:     newInt(80),
+			Port:     80,
 		}, map[string]pdata.AttributeValue{
 			"http.scheme":   pdata.NewAttributeValueString("https"),
 			"net.host.name": pdata.NewAttributeValueString("testing.invalid"),
@@ -162,7 +162,7 @@ func TestHTTPTransactionURL(t *testing.T) {
 			Path:     "/foo",
 			Query:    "bar",
 			Domain:   "testing.invalid",
-			Port:     newInt(80),
+			Port:     80,
 		}, map[string]pdata.AttributeValue{
 			"http.url": pdata.NewAttributeValueString("https://testing.invalid:80/foo?bar"),
 		})
@@ -266,7 +266,7 @@ func TestHTTPSpanDestination(t *testing.T) {
 	t.Run("url_default_port_specified", func(t *testing.T) {
 		test(t, &model.Destination{
 			Address: "testing.invalid",
-			Port:    newInt(443),
+			Port:    443,
 		}, &model.DestinationService{
 			Type:     "external",
 			Name:     "https://testing.invalid",
@@ -278,7 +278,7 @@ func TestHTTPSpanDestination(t *testing.T) {
 	t.Run("url_port_scheme", func(t *testing.T) {
 		test(t, &model.Destination{
 			Address: "testing.invalid",
-			Port:    newInt(443),
+			Port:    443,
 		}, &model.DestinationService{
 			Type:     "external",
 			Name:     "https://testing.invalid",
@@ -290,7 +290,7 @@ func TestHTTPSpanDestination(t *testing.T) {
 	t.Run("url_non_default_port", func(t *testing.T) {
 		test(t, &model.Destination{
 			Address: "testing.invalid",
-			Port:    newInt(444),
+			Port:    444,
 		}, &model.DestinationService{
 			Type:     "external",
 			Name:     "https://testing.invalid:444",
@@ -302,7 +302,7 @@ func TestHTTPSpanDestination(t *testing.T) {
 	t.Run("scheme_host_target", func(t *testing.T) {
 		test(t, &model.Destination{
 			Address: "testing.invalid",
-			Port:    newInt(444),
+			Port:    444,
 		}, &model.DestinationService{
 			Type:     "external",
 			Name:     "https://testing.invalid:444",
@@ -316,7 +316,7 @@ func TestHTTPSpanDestination(t *testing.T) {
 	t.Run("scheme_netpeername_nethostport_target", func(t *testing.T) {
 		test(t, &model.Destination{
 			Address: "::1",
-			Port:    newInt(444),
+			Port:    444,
 		}, &model.DestinationService{
 			Type:     "external",
 			Name:     "https://[::1]:444",
@@ -392,7 +392,7 @@ func TestHTTPTransactionStatusCode(t *testing.T) {
 	tx := transformTransactionWithAttributes(t, map[string]pdata.AttributeValue{
 		"http.status_code": pdata.NewAttributeValueInt(200),
 	})
-	assert.Equal(t, newInt(200), tx.HTTP.Response.StatusCode)
+	assert.Equal(t, 200, tx.HTTP.Response.StatusCode)
 }
 
 func TestDatabaseSpan(t *testing.T) {
@@ -428,7 +428,7 @@ func TestDatabaseSpan(t *testing.T) {
 
 	assert.Equal(t, &model.Destination{
 		Address: "shopdb.example.com",
-		Port:    newInt(3306),
+		Port:    3306,
 	}, span.Destination)
 
 	assert.Equal(t, &model.DestinationService{
@@ -1012,8 +1012,4 @@ func newTracesSpans() (pdata.Traces, pdata.InstrumentationLibrarySpans) {
 	resourceSpans.InstrumentationLibrarySpans().Append(librarySpans)
 	traces.ResourceSpans().Append(resourceSpans)
 	return traces, librarySpans
-}
-
-func newInt(v int) *int {
-	return &v
 }


### PR DESCRIPTION
## Motivation/summary

Ports and HTTP status codes should always be
positive, so use zero as a sentinel value to
indicate omission in order to remove a pointer.

## How to test these changes

Non-functional change, run the tests.

## Related issues

None.