### PR TITLE
[fleet] Fix apm package types

### DIFF
--- a/apmpackage/apm/0.1.0/manifest.yml
+++ b/apmpackage/apm/0.1.0/manifest.yml
@@ -42,13 +42,13 @@ policy_templates:
         description: Collect application traces
         vars:
           - name: host
-            type: string
+            type: text
             title: Host
             required: true
             show_user: true
             default: localhost:8200
           - name: secret_token
-            type: string
+            type: text
             title: Secret token for Agent authentication
             required: false
             show_user: true
@@ -60,7 +60,7 @@ policy_templates:
             show_user: true
             default: false
           - name: kibana_api_key
-            type: string
+            type: text
             title: API Key for Central Configuration
             required: false
             description: API Key for APM central configuration feature. Enter as <Id>:<API Key>
@@ -73,13 +73,13 @@ policy_templates:
             show_user: true
             default: false
           - name: default_service_environment
-            type: string
+            type: text
             title: Default Service Environment
             description: Default service environment to record in events which have no service environment defined.
             required: false
             show_user: false
           - name: rum_allow_origins
-            type: string
+            type: text
             title: RUM - Origin Headers
             description: Allowed Origin headers to be sent by User Agents.
             multi: true
@@ -87,7 +87,7 @@ policy_templates:
             show_user: false
             default: ['"*"']
           - name: rum_allow_headers
-            type: string
+            type: text
             title: RUM - Access-Control-Allow-Headers
             description: Supported Access-Control-Allow-Headers in addition to "Content-Type", "Content-Encoding" and "Accept".
             multi: true
@@ -100,34 +100,34 @@ policy_templates:
             required: false
             show_user: false
           - name: rum_event_rate_limit
-            type: int
+            type: integer
             title: RUM - Rate limit events per IP
             description: Maximum number of events allowed per IP per second.
             required: false
             show_user: false
             default: 300
           - name: rum_event_rate_lru_size
-            type: int
+            type: integer
             title: RUM - Rate limit cache size
             description: Number of unique IPs to be cached for the rate limiter.
             required: false
             show_user: false
             default: 1000
           - name: sourcemap_api_key
-            type: string
+            type: text
             title: RUM - API Key for Sourcemaps
             required: false
             description: API Key for sourcemap feature. Enter as <Id>:<API Key>
             show_user: false
           - name: api_key_limit
-            type: int
+            type: integer
             title: Maximum number of API Keys for Agent authentication
             description: Restrict number of unique API Keys per minute, used for auth between APM Agents and Server.
             required: false
             show_user: false
             default: 100
           - name: max_event_bytes
-            type: int
+            type: integer
             title: Maximum size per event (bytes)
             required: false
             show_user: false


### PR DESCRIPTION


<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Update apm package to use types supported by the [package-spec](https://github.com/elastic/package-spec/blob/master/versions/1/data_stream/manifest.spec.yml#L50-L55)
* `text` over `string` 
* `integer` over `int` 

## Related issues
fixes #https://github.com/elastic/package-storage/issues/1011
<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
