### PR TITLE
[7.x] docs: add 7.11.2 release notes (#4936)

### DIFF
--- a/changelogs/7.11.asciidoc
+++ b/changelogs/7.11.asciidoc
@@ -3,8 +3,17 @@
 
 https://github.com/elastic/apm-server/compare/7.10\...7.11[View commits]
 
+* <<release-notes-7.11.2>>
 * <<release-notes-7.11.1>>
 * <<release-notes-7.11.0>>
+
+[float]
+[[release-notes-7.11.2]]
+=== APM Server version 7.11.2
+
+https://github.com/elastic/apm-server/compare/v7.11.1\...v7.11.2[View commits]
+
+No significant changes.
 
 [float]
 [[release-notes-7.11.1]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: add 7.11.2 release notes (#4936)