### PR TITLE
systemtest: fix query for enrollment API Keys

### DIFF
--- a/systemtest/fleettest/client.go
+++ b/systemtest/fleettest/client.go
@@ -165,7 +165,7 @@ func (c *Client) CreateAgentPolicy(name, namespace, description string) (*AgentP
 }
 
 func (c *Client) getAgentPolicyEnrollmentAPIKey(policyID string) (*EnrollmentAPIKey, error) {
-	keys, err := c.enrollmentAPIKeys("fleet-enrollment-api-keys.policy_id:" + policyID)
+	keys, err := c.enrollmentAPIKeys("policy_id:" + policyID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Motivation/summary

Fleet has apparently changed how enrollment API Keys should be queried, I suppose because of the move to store them in dedicated indices for Fleet Server. Update system tests to match.

## How to test these changes

cd systemtest && go test -v -run FleetIntegration