### PR TITLE
docs: init 7.12 bcs and rns

### DIFF
--- a/changelogs/7.12.asciidoc
+++ b/changelogs/7.12.asciidoc
@@ -3,10 +3,11 @@
 
 https://github.com/elastic/apm-server/compare/7.11\...7.12[View commits]
 
+[float]
 [[release-notes-7.12.0]]
 == APM Server version 7.12.0
 
-https://github.com/elastic/apm-server/compare/v7.11.1\...v7.12.0[View commits]
+https://github.com/elastic/apm-server/compare/v7.11.2\...v7.12.0[View commits]
 
 [float]
 ==== Breaking Changes

--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -4,6 +4,38 @@ APM Server is built on top of {beats-ref}/index.html[libbeat].
 As such, any breaking change in libbeat is also considered to be a breaking change in APM Server.
 
 [float]
+=== 7.12
+
+There are three breaking changes to be aware of;
+these changes only impact users ingesting data with
+{apm-server-ref-v}/jaeger.html[Jaeger clients].
+
+* Leading 0s are no longer removed from Jaeger client trace/span ids.
++
+--
+This change ensures distributed tracing continues to work across platforms by creating
+consistent, full trace/span IDs from Jaeger clients, Elastic APM agents,
+and OpenTelemetry SDKs.
+--
+
+* Jaeger spans will now have a type of "app" where they previously were "custom".
++
+--
+If the Jaeger span type is not inferred, it will now be "app".
+This aligns with the OpenTelemetry Collector exporter
+and improves the functionality of the _time spent by span type_ charts in the APM app.
+--
+
+* Jaeger spans may now have a more accurate outcome of "unknown".
++
+--
+Previously, a "success" outcome was assumed when a span didn't fail.
+The new default assigns "unknown", and only sets an outcome of "success" or "failure" when
+the outcome is explicitly known.
+This change aligns with Elastic APM agents and the OpenTelemetry Collector exporter.
+--
+
+[float]
 === 7.11
 There are no breaking changes in APM Server.
 

--- a/docs/guide/apm-breaking-changes.asciidoc
+++ b/docs/guide/apm-breaking-changes.asciidoc
@@ -3,6 +3,7 @@
 
 This section discusses the changes that you need to be aware of when migrating your application from one version of APM to another.
 
+* <<breaking-7.12.0>>
 * <<breaking-7.11.0>>
 * <<breaking-7.10.0>>
 * <<breaking-7.9.0>>
@@ -25,9 +26,45 @@ Also see {observability-guide}/whats-new.html[What's new in Observability {minor
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
-// Remove this tag in a future PR
+
 // tag::notable-v8-breaking-changes[]
 // end::notable-v8-breaking-changes[]
+// tag::713-bc[]
+// end::713-bc[]
+
+[[breaking-7.12.0]]
+=== 7.12.0 APM Breaking changes
+
+// tag::712-bc[]
+There are three breaking changes to be aware of;
+these changes only impact users ingesting data with
+{apm-server-ref-v}/jaeger.html[Jaeger clients].
+
+* Leading 0s are no longer removed from Jaeger client trace/span ids.
++
+--
+This change ensures distributed tracing continues to work across platforms by creating
+consistent, full trace/span IDs from Jaeger clients, Elastic APM agents,
+and OpenTelemetry SDKs.
+--
+
+* Jaeger spans will now have a type of "app" where they previously were "custom".
++
+--
+If the Jaeger span type is not inferred, it will now be "app".
+This aligns with the OpenTelemetry Collector exporter
+and improves the functionality of the _time spent by span type_ charts in the APM app.
+--
+
+* Jaeger spans may now have a more accurate outcome of "unknown".
++
+--
+Previously, a "success" outcome was assumed when a span didn't fail.
+The new default assigns "unknown", and only sets an outcome of "success" or "failure" when
+the outcome is explicitly known.
+This change aligns with Elastic APM agents and the OpenTelemetry Collector exporter.
+--
+// end::712-bc[]
 
 [[breaking-7.11.0]]
 === 7.11.0 APM Breaking changes

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -10,6 +10,7 @@
 --
 This following sections summarizes the changes in each release.
 
+* <<release-notes-7.12>>
 * <<release-notes-7.11>>
 * <<release-notes-7.10>>
 * <<release-notes-7.9>>


### PR DESCRIPTION
## Motivation/summary

Inits 7.12 breaking changes plus a few small fixes for release notes.

Backport with https://github.com/elastic/apm-server/pull/4858/.
