### PR TITLE
[7.x] docs: 7.12 release notes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,3 +1,4 @@
+include::./changelogs/7.12.asciidoc[]
 include::./changelogs/7.11.asciidoc[]
 include::./changelogs/7.10.asciidoc[]
 include::./changelogs/7.9.asciidoc[]

--- a/changelogs/7.12.asciidoc
+++ b/changelogs/7.12.asciidoc
@@ -3,10 +3,11 @@
 
 https://github.com/elastic/apm-server/compare/7.11\...7.12[View commits]
 
+[float]
 [[release-notes-7.12.0]]
 == APM Server version 7.12.0
 
-https://github.com/elastic/apm-server/compare/v7.11.1\...v7.12.0[View commits]
+https://github.com/elastic/apm-server/compare/v7.11.2\...v7.12.0[View commits]
 
 [float]
 ==== Breaking Changes

--- a/changelogs/7.12.asciidoc
+++ b/changelogs/7.12.asciidoc
@@ -1,0 +1,41 @@
+[[release-notes-7.12]]
+== APM Server version 7.12
+
+https://github.com/elastic/apm-server/compare/7.11\...7.12[View commits]
+
+[[release-notes-7.12.0]]
+== APM Server version 7.12.0
+
+https://github.com/elastic/apm-server/compare/v7.11.1\...v7.12.0[View commits]
+
+[float]
+==== Breaking Changes
+* Leading 0s are no longer removed from trace/span ids if they are created by Jaeger {pull}4671[4671]
+* Jaeger spans will now have a type of "app" where they previously were "custom" {pull}4711[4711]
+* Jaeger spans may now have a (more accurate) outcome of "unknown" where they previously were "success" {pull}4711[4711]
+
+[float]
+==== Bug fixes
+* Dynamic templates for labels are no longer repeated {pull}4695[4695]
+* Tail-based sampling policies are now always matched in the order given {pull}4685[4685]
+
+[float]
+==== Intake API Changes
+* Add `cloud.service.name` support for metadata {pull}4626[4626]
+
+[float]
+==== Added
+* Jaeger gRPC is now served over the same port as the Elastic APM agent protocol {pull}4618[4618]
+* Support for reloading config in Fleet mode, gracefully stopping the HTTP server and starting a new one {pull}4623[4623]
+* Add a `_doc_count` field to transaction histogram docs {pull}4647[4647]
+* OpenTelemetry Protocol (OTLP) over gRPC is now supported on the standard endpoint (8200) {pull}4677[4677] {pull}4722[4722]
+* Add initial support for APM central config and sourcemaps when running under Fleet {pull}4670[4670]
+* Data stream and ILM policy for tail-based sampling {pull}4707[4707]
+* Add service name to index dataset {pull}4674[4674]
+* When tail-sampling is enabled, a default policy must be defined {pull}4729[4729]
+* Support additional config options when running under Fleet {pull}4690[4690]
+* Upgrade Go to 1.15.8 {pull}4733[4733]
+
+[float]
+==== Deprecated
+* `apm-server.jaeger` config is deprecated and will be removed in 8.0. Jaeger is now served on 8200 {pull}4618[4618]

--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -4,6 +4,38 @@ APM Server is built on top of {beats-ref}/index.html[libbeat].
 As such, any breaking change in libbeat is also considered to be a breaking change in APM Server.
 
 [float]
+=== 7.12
+
+There are three breaking changes to be aware of;
+these changes only impact users ingesting data with
+{apm-server-ref-v}/jaeger.html[Jaeger clients].
+
+* Leading 0s are no longer removed from Jaeger client trace/span ids.
++
+--
+This change ensures distributed tracing continues to work across platforms by creating
+consistent, full trace/span IDs from Jaeger clients, Elastic APM agents,
+and OpenTelemetry SDKs.
+--
+
+* Jaeger spans will now have a type of "app" where they previously were "custom".
++
+--
+If the Jaeger span type is not inferred, it will now be "app".
+This aligns with the OpenTelemetry Collector exporter
+and improves the functionality of the _time spent by span type_ charts in the APM app.
+--
+
+* Jaeger spans may now have a more accurate outcome of "unknown".
++
+--
+Previously, a "success" outcome was assumed when a span didn't fail.
+The new default assigns "unknown", and only sets an outcome of "success" or "failure" when
+the outcome is explicitly known.
+This change aligns with Elastic APM agents and the OpenTelemetry Collector exporter.
+--
+
+[float]
 === 7.11
 There are no breaking changes in APM Server.
 

--- a/docs/guide/apm-breaking-changes.asciidoc
+++ b/docs/guide/apm-breaking-changes.asciidoc
@@ -3,6 +3,7 @@
 
 This section discusses the changes that you need to be aware of when migrating your application from one version of APM to another.
 
+* <<breaking-7.12.0>>
 * <<breaking-7.11.0>>
 * <<breaking-7.10.0>>
 * <<breaking-7.9.0>>
@@ -25,9 +26,45 @@ Also see {observability-guide}/whats-new.html[What's new in Observability {minor
 
 //NOTE: The notable-breaking-changes tagged regions are re-used in the
 //Installation and Upgrade Guide
-// Remove this tag in a future PR
+
 // tag::notable-v8-breaking-changes[]
 // end::notable-v8-breaking-changes[]
+// tag::713-bc[]
+// end::713-bc[]
+
+[[breaking-7.12.0]]
+=== 7.12.0 APM Breaking changes
+
+// tag::712-bc[]
+There are three breaking changes to be aware of;
+these changes only impact users ingesting data with
+{apm-server-ref-v}/jaeger.html[Jaeger clients].
+
+* Leading 0s are no longer removed from Jaeger client trace/span ids.
++
+--
+This change ensures distributed tracing continues to work across platforms by creating
+consistent, full trace/span IDs from Jaeger clients, Elastic APM agents,
+and OpenTelemetry SDKs.
+--
+
+* Jaeger spans will now have a type of "app" where they previously were "custom".
++
+--
+If the Jaeger span type is not inferred, it will now be "app".
+This aligns with the OpenTelemetry Collector exporter
+and improves the functionality of the _time spent by span type_ charts in the APM app.
+--
+
+* Jaeger spans may now have a more accurate outcome of "unknown".
++
+--
+Previously, a "success" outcome was assumed when a span didn't fail.
+The new default assigns "unknown", and only sets an outcome of "success" or "failure" when
+the outcome is explicitly known.
+This change aligns with Elastic APM agents and the OpenTelemetry Collector exporter.
+--
+// end::712-bc[]
 
 [[breaking-7.11.0]]
 === 7.11.0 APM Breaking changes

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -10,6 +10,7 @@
 --
 This following sections summarizes the changes in each release.
 
+* <<release-notes-7.12>>
 * <<release-notes-7.11>>
 * <<release-notes-7.10>>
 * <<release-notes-7.9>>


### PR DESCRIPTION
This PR backports https://github.com/elastic/apm-server/pull/4858 and https://github.com/elastic/apm-server/pull/4959.