### PR TITLE
docs: add 6.8.15 release notes (#4974)

### DIFF
--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -20,6 +20,7 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
 
+[float]
 [[release-notes-6.8.15]]
 === APM Server version 6.8.15
 
@@ -27,6 +28,7 @@ https://github.com/elastic/apm-server/compare/v6.8.14\...v6.8.15[View commits]
 
 No significant changes.
 
+[float]
 [[release-notes-6.8.14]]
 === APM Server version 6.8.14
 

--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,6 +3,7 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.15>>
 * <<release-notes-6.8.14>>
 * <<release-notes-6.8.13>>
 * <<release-notes-6.8.12>>
@@ -19,7 +20,13 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
 
-[float]
+[[release-notes-6.8.15]]
+=== APM Server version 6.8.15
+
+https://github.com/elastic/apm-server/compare/v6.8.14\...v6.8.15[View commits]
+
+No significant changes.
+
 [[release-notes-6.8.14]]
 === APM Server version 6.8.14
 


### PR DESCRIPTION
Backports the following commits to master:
 - docs: add 6.8.15 release notes (#4974)