### PR TITLE
feat: add support for auto-backports

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,31 @@
+pull_request_rules:
+  - name: ask to resolve conflict
+    conditions:
+      - conflict
+    actions:
+        comment:
+          message: |
+            This pull request is now in conflicts. Could you fix it @{{author}}? 🙏
+            To fixup this pull request, you can check out it locally. See documentation: https://help.github.com/articles/checking-out-pull-requests-locally/
+            ```
+            git fetch upstream
+            git checkout -b {{head}} upstream/{{head}}
+            git merge upstream/{{base}}
+            git push upstream {{head}}
+            ```
+  - name: backport patches to 7.x branch
+    conditions:
+      - base=master
+      - label=v7.13.0
+    actions:
+      backport:
+        branches:
+          - "7.x"
+  - name: backport patches to 7.12 branch
+    conditions:
+      - base=master
+      - label=v7.12.0
+    actions:
+      backport:
+        branches:
+          - "7.12"


### PR DESCRIPTION
## What does this PR do?

Enable [backports](https://docs.mergify.io/actions/backport.html) with [mergify](https://docs.mergify.io/index.html) for:
- 7.x branch with the label `v7.13.0`
- 7.12 branch with the label `v7.12.0`

If any conflicts the PRs are created with the label `conflict` in addition a comment will be added with the actions to be done in order to fix the conflicts locally and push to the branch.

## Why is it important?

`Mergify` provides different mechanism to interact with PRs and automate certain process.

### Some examples

Backports to 7.x -> https://github.com/elastic/apm-pipeline-library/pull/995
Merges to master -> https://github.com/elastic/apm-pipeline-library/pull/994

## Issues

* There is an initiative to automate the GitHub labels creation in each obs11 repo -> https://github.com/elastic/apm-pipeline-library/pull/886
* Closes https://github.com/elastic/apm-server/issues/4881

## Actions

- [x] Ask Infra to enable the `mergify` app in this project.
- [x] Agree with the team
