### PR TITLE
[7.x] Enable transaction aggregation by default (#4882)

### DIFF
--- a/beater/config/aggregation.go
+++ b/beater/config/aggregation.go
@@ -54,6 +54,7 @@ type ServiceDestinationAggregationConfig struct {
 func defaultAggregationConfig() AggregationConfig {
 	return AggregationConfig{
 		Transactions: TransactionAggregationConfig{
+			Enabled:                        true,
 			Interval:                       defaultTransactionAggregationInterval,
 			MaxTransactionGroups:           defaultTransactionAggregationMaxGroups,
 			HDRHistogramSignificantFigures: defaultTransactionAggregationHDRHistogramSignificantFigures,

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -127,7 +127,7 @@ func TestUnpackConfig(t *testing.T) {
 				},
 				"aggregation": map[string]interface{}{
 					"transactions": map[string]interface{}{
-						"enabled":                          true,
+						"enabled":                          false,
 						"interval":                         "1s",
 						"max_groups":                       123,
 						"hdrhistogram_significant_figures": 1,
@@ -223,7 +223,7 @@ func TestUnpackConfig(t *testing.T) {
 				},
 				Aggregation: AggregationConfig{
 					Transactions: TransactionAggregationConfig{
-						Enabled:                        true,
+						Enabled:                        false,
 						Interval:                       time.Second,
 						MaxTransactionGroups:           123,
 						HDRHistogramSignificantFigures: 1,
@@ -280,7 +280,7 @@ func TestUnpackConfig(t *testing.T) {
 				},
 				"jaeger.grpc.enabled":                      true,
 				"api_key.enabled":                          true,
-				"aggregation.transactions.enabled":         true,
+				"aggregation.transactions.enabled":         false,
 				"aggregation.service_destinations.enabled": false,
 				"sampling.keep_unsampled":                  false,
 				"sampling.tail": map[string]interface{}{
@@ -359,7 +359,7 @@ func TestUnpackConfig(t *testing.T) {
 				APIKeyConfig: &APIKeyConfig{Enabled: true, LimitPerMin: 100, ESConfig: elasticsearch.DefaultConfig()},
 				Aggregation: AggregationConfig{
 					Transactions: TransactionAggregationConfig{
-						Enabled:                        true,
+						Enabled:                        false,
 						Interval:                       time.Minute,
 						MaxTransactionGroups:           10000,
 						HDRHistogramSignificantFigures: 2,

--- a/systemtest/sampling_test.go
+++ b/systemtest/sampling_test.go
@@ -73,6 +73,9 @@ func TestKeepUnsampledWarning(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
 	srv := apmservertest.NewUnstartedServer(t)
 	srv.Config.Sampling = &apmservertest.SamplingConfig{KeepUnsampled: false}
+	srv.Config.Aggregation = &apmservertest.AggregationConfig{
+		Transactions: &apmservertest.TransactionAggregationConfig{Enabled: false},
+	}
 	require.NoError(t, srv.Start())
 	require.NoError(t, srv.Close())
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Enable transaction aggregation by default (#4882)