### PR TITLE
[7.x] [CI] Use MacOS for x86_64 (#4923)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -188,7 +188,7 @@ pipeline {
         Build on a mac environment.
         */
         stage('OSX build-test') {
-          agent { label 'macosx' }
+          agent { label 'macosx && x86_64' }
           options {
             skipDefaultCheckout()
             warnError('OSX execution failed')


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [CI] Use MacOS for x86_64 (#4923)