### PR TITLE
[7.x] display timeouts to user as "server timeout" (506311f0)

### DIFF
--- a/beater/api/intake/handler.go
+++ b/beater/api/intake/handler.go
@@ -95,6 +95,8 @@ L:
 			set(request.MapResultIDToStatus[request.IDResponseErrorsValidate].Code, request.IDResponseErrorsValidate)
 		case stream.RateLimitErrType:
 			set(request.MapResultIDToStatus[request.IDResponseErrorsRateLimit].Code, request.IDResponseErrorsRateLimit)
+		case stream.TimeoutErrType:
+			set(request.MapResultIDToStatus[request.IDResponseErrorsTimeout].Code, request.IDResponseErrorsTimeout)
 		case stream.QueueFullErrType:
 			set(request.MapResultIDToStatus[request.IDResponseErrorsFullQueue].Code, request.IDResponseErrorsFullQueue)
 			break L

--- a/beater/request/result.go
+++ b/beater/request/result.go
@@ -66,6 +66,8 @@ const (
 	IDResponseErrorsValidate ResultID = "response.errors.validate"
 	// IDResponseErrorsRateLimit identifies responses for rate limited requests
 	IDResponseErrorsRateLimit ResultID = "response.errors.ratelimit"
+	// IDResponseErrorsTimeout identifies responses for timed out requests
+	IDResponseErrorsTimeout ResultID = "response.errors.timeout"
 	// IDResponseErrorsMethodNotAllowed identifies responses for requests using a forbidden method
 	IDResponseErrorsMethodNotAllowed ResultID = "response.errors.method"
 	// IDResponseErrorsFullQueue identifies responses when internal queue was full

--- a/processor/stream/result.go
+++ b/processor/stream/result.go
@@ -21,8 +21,9 @@ import (
 	"context"
 	"strings"
 
-	"github.com/elastic/beats/v7/libbeat/monitoring"
 	"github.com/pkg/errors"
+
+	"github.com/elastic/beats/v7/libbeat/monitoring"
 )
 
 type Error struct {

--- a/processor/stream/result_test.go
+++ b/processor/stream/result_test.go
@@ -18,6 +18,7 @@
 package stream
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -58,6 +59,7 @@ func TestMonitoring(t *testing.T) {
 		{monitoringMap[InputTooLargeErrType], 1},
 		{monitoringMap[ShuttingDownErrType], 1},
 		{monitoringMap[ServerErrType], 2},
+		{monitoringMap[TimeoutErrType], 2},
 		{mAccepted, 12},
 	} {
 		// get current value for counter
@@ -73,6 +75,8 @@ func TestMonitoring(t *testing.T) {
 		sr.LimitedAdd(&Error{Type: ServerErrType})
 		sr.LimitedAdd(&Error{Type: InputTooLargeErrType, Message: "err3", Document: "buf3"})
 		sr.Add(&Error{Type: InvalidInputErrType})
+		sr.Add(context.Canceled)
+		sr.Add(context.Canceled)
 
 		assert.Equal(t, ct+test.expected, test.counter.Get())
 	}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - display timeouts to user as "server timeout" (506311f0)