### PR TITLE
[7.x] processor/otel: translate OpenTelemetry exceptions (#4876)

### DIFF
--- a/processor/otel/exceptions.go
+++ b/processor/otel/exceptions.go
@@ -1,0 +1,217 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Portions copied from OpenTelemetry Collector (contrib), from the
+// elastic exporter.
+//
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otel
+
+import (
+	"bufio"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/elastic/apm-server/model"
+)
+
+var (
+	javaStacktraceAtRegexp   = regexp.MustCompile(`at (.*)\(([^:]*)(?::([0-9]+))?\)`)
+	javaStacktraceMoreRegexp = regexp.MustCompile(`\.\.\. ([0-9]+) more`)
+)
+
+func convertOpenTelemetryExceptionSpanEvent(
+	timestamp time.Time,
+	exceptionType, exceptionMessage, exceptionStacktrace string,
+	exceptionEscaped bool,
+	language string,
+) *model.Error {
+	if exceptionMessage == "" {
+		exceptionMessage = "[EMPTY]"
+	}
+	exceptionHandled := !exceptionEscaped
+	exceptionError := model.Error{
+		Timestamp: timestamp,
+		Exception: &model.Exception{
+			Message: exceptionMessage,
+			Type:    exceptionType,
+			Handled: &exceptionHandled,
+		},
+	}
+	if exceptionStacktrace != "" {
+		if err := setExceptionStacktrace(exceptionStacktrace, language, exceptionError.Exception); err != nil {
+			// Couldn't parse stacktrace, just add it as an attribute to the
+			// exception so the user can still access it.
+			exceptionError.Exception.Stacktrace = nil
+			exceptionError.Exception.Cause = nil
+			exceptionError.Exception.Attributes = map[string]interface{}{
+				"stacktrace": exceptionStacktrace,
+			}
+		}
+	}
+	return &exceptionError
+}
+
+func setExceptionStacktrace(s, language string, out *model.Exception) error {
+	switch language {
+	case "java":
+		return setJavaExceptionStacktrace(s, out)
+	}
+	return fmt.Errorf("parsing %q stacktraces not implemented", language)
+}
+
+// setJavaExceptionStacktrace parses a Java exception stack trace according to
+// https://docs.oracle.com/javase/7/docs/api/java/lang/Throwable.html#printStackTrace()
+func setJavaExceptionStacktrace(s string, out *model.Exception) error {
+	const (
+		causedByPrefix   = "Caused by: "
+		suppressedPrefix = "Suppressed: "
+	)
+
+	type Exception struct {
+		*model.Exception
+		enclosing *model.Exception
+		indent    int
+	}
+	first := true
+	current := Exception{out, nil, 0}
+	stack := []Exception{}
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	for scanner.Scan() {
+		if first {
+			// Ignore the first line, we only care about the locations.
+			first = false
+			continue
+		}
+		var indent int
+		line := scanner.Text()
+		if i := strings.IndexFunc(line, isNotTab); i > 0 {
+			line = line[i:]
+			indent = i
+		}
+		for indent < current.indent {
+			n := len(stack)
+			current, stack = stack[n-1], stack[:n-1]
+		}
+		switch {
+		case strings.HasPrefix(line, "at "):
+			if err := parseJavaStacktraceFrame(line, current.Exception); err != nil {
+				return err
+			}
+		case strings.HasPrefix(line, "..."):
+			// "... N more" lines indicate that the last N frames from the enclosing
+			// exception's stacktrace are common to this exception.
+			if current.enclosing == nil {
+				return fmt.Errorf("no enclosing exception preceding line %q", line)
+			}
+			submatch := javaStacktraceMoreRegexp.FindStringSubmatch(line)
+			if submatch == nil {
+				return fmt.Errorf("failed to parse stacktrace line %q", line)
+			}
+			if n, err := strconv.Atoi(submatch[1]); err == nil {
+				enclosing := current.enclosing
+				if len(enclosing.Stacktrace) < n {
+					return fmt.Errorf(
+						"enclosing exception stacktrace has %d frames, cannot satisfy %q",
+						len(enclosing.Stacktrace), line,
+					)
+				}
+				m := len(enclosing.Stacktrace)
+				current.Stacktrace = append(current.Stacktrace, enclosing.Stacktrace[m-n:]...)
+			}
+		case strings.HasPrefix(line, causedByPrefix):
+			// "Caused by:" lines are at the same level of indentation
+			// as the enclosing exception.
+			current.Cause = make([]model.Exception, 1)
+			current.enclosing = current.Exception
+			current.Exception = &current.Cause[0]
+			current.Exception.Handled = current.enclosing.Handled
+			current.Message = line[len(causedByPrefix):]
+		case strings.HasPrefix(line, suppressedPrefix):
+			// Suppressed exceptions have no place in the Elastic APM
+			// model, so they are ignored.
+			//
+			// Unlike "Caused by:", "Suppressed:" lines are indented within their
+			// enclosing exception; we just account for the indentation here.
+			stack = append(stack, current)
+			current.enclosing = current.Exception
+			current.Exception = &model.Exception{}
+			current.indent = indent
+		default:
+			return fmt.Errorf("unexpected line %q", line)
+		}
+	}
+	return scanner.Err()
+}
+
+func parseJavaStacktraceFrame(s string, out *model.Exception) error {
+	submatch := javaStacktraceAtRegexp.FindStringSubmatch(s)
+	if submatch == nil {
+		return fmt.Errorf("failed to parse stacktrace line %q", s)
+	}
+	var module string
+	function := submatch[1]
+	if slash := strings.IndexRune(function, '/'); slash >= 0 {
+		// We could have either:
+		//  - "class_loader/module/class.method"
+		//  - "module/class.method"
+		module, function = function[:slash], function[slash+1:]
+		if slash := strings.IndexRune(function, '/'); slash >= 0 {
+			module, function = function[:slash], function[slash+1:]
+		}
+	}
+	var classname string
+	if dot := strings.LastIndexByte(function, '.'); dot > 0 {
+		// Split into classname and method.
+		classname, function = function[:dot], function[dot+1:]
+	}
+	file := submatch[2]
+	var lineno *int
+	if submatch[3] != "" {
+		if n, err := strconv.Atoi(submatch[3]); err == nil {
+			lineno = &n
+		}
+	}
+	out.Stacktrace = append(out.Stacktrace, &model.StacktraceFrame{
+		Module:    module,
+		Classname: classname,
+		Function:  function,
+		Filename:  file,
+		Lineno:    lineno,
+	})
+	return nil
+}
+
+func isNotTab(r rune) bool {
+	return r != '\t'
+}

--- a/processor/otel/exceptions_test.go
+++ b/processor/otel/exceptions_test.go
@@ -1,0 +1,336 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Portions copied from OpenTelemetry Collector (contrib), from the
+// elastic exporter.
+//
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otel_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/translator/conventions"
+
+	"github.com/elastic/apm-server/model"
+)
+
+func TestEncodeSpanEventsNonExceptions(t *testing.T) {
+	nonExceptionEvent := pdata.NewSpanEvent()
+	nonExceptionEvent.SetName("not_exception")
+
+	incompleteExceptionEvent := pdata.NewSpanEvent()
+	incompleteExceptionEvent.SetName("exception")
+	incompleteExceptionEvent.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		// At least one of exception.message and exception.type is required.
+		conventions.AttributeExceptionStacktrace: pdata.NewAttributeValueString("stacktrace"),
+	})
+
+	_, errors := transformTransactionSpanEvents(t, "java", nonExceptionEvent, incompleteExceptionEvent)
+	require.Empty(t, errors)
+}
+
+func TestEncodeSpanEventsJavaExceptions(t *testing.T) {
+	timestamp := time.Unix(123, 0).UTC()
+
+	exceptionEvent1 := pdata.NewSpanEvent()
+	exceptionEvent1.SetTimestamp(pdata.TimestampUnixNano(timestamp.UnixNano()))
+	exceptionEvent1.SetName("exception")
+	exceptionEvent1.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"exception.type":    pdata.NewAttributeValueString("java.net.ConnectException.OSError"),
+		"exception.message": pdata.NewAttributeValueString("Division by zero"),
+		"exception.escaped": pdata.NewAttributeValueBool(true),
+		"exception.stacktrace": pdata.NewAttributeValueString(`
+Exception in thread "main" java.lang.RuntimeException: Test exception
+	at com.example.GenerateTrace.methodB(GenerateTrace.java:13)
+	at com.example.GenerateTrace.methodA(GenerateTrace.java:9)
+	at com.example.GenerateTrace.main(GenerateTrace.java:5)
+	at com.foo.loader/foo@9.0/com.foo.Main.run(Main.java)
+	at com.foo.loader//com.foo.bar.App.run(App.java:12)
+	at java.base/java.lang.Thread.run(Unknown Source)
+`[1:],
+		),
+	})
+	exceptionEvent2 := pdata.NewSpanEvent()
+	exceptionEvent2.SetTimestamp(pdata.TimestampUnixNano(timestamp.UnixNano()))
+	exceptionEvent2.SetName("exception")
+	exceptionEvent2.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"exception.type":    pdata.NewAttributeValueString("HighLevelException"),
+		"exception.message": pdata.NewAttributeValueString("MidLevelException: LowLevelException"),
+		"exception.stacktrace": pdata.NewAttributeValueString(`
+HighLevelException: MidLevelException: LowLevelException
+	at Junk.a(Junk.java:13)
+	at Junk.main(Junk.java:4)
+Caused by: MidLevelException: LowLevelException
+	at Junk.c(Junk.java:23)
+	at Junk.b(Junk.java:17)
+	at Junk.a(Junk.java:11)
+	... 1 more
+	Suppressed: java.lang.ArithmeticException: / by zero
+		at Junk.c(Junk.java:25)
+		... 3 more
+Caused by: LowLevelException
+	at Junk.e(Junk.java:37)
+	at Junk.d(Junk.java:34)
+	at Junk.c(Junk.java:21)
+	... 3 more`[1:],
+		),
+	})
+
+	expectedMetadata := languageOnlyMetadata("java")
+	transaction, errors := transformTransactionSpanEvents(t, "java", exceptionEvent1, exceptionEvent2)
+	assert.Equal(t, []*model.Error{{
+		Metadata:        expectedMetadata,
+		TraceID:         transaction.TraceID,
+		ParentID:        transaction.ID,
+		TransactionID:   transaction.ID,
+		TransactionType: transaction.Type,
+		Timestamp:       timestamp,
+		Exception: &model.Exception{
+			Type:    "java.net.ConnectException.OSError",
+			Message: "Division by zero",
+			Handled: newBool(false),
+			Stacktrace: []*model.StacktraceFrame{{
+				Classname: "com.example.GenerateTrace",
+				Function:  "methodB",
+				Filename:  "GenerateTrace.java",
+				Lineno:    newInt(13),
+			}, {
+				Classname: "com.example.GenerateTrace",
+				Function:  "methodA",
+				Filename:  "GenerateTrace.java",
+				Lineno:    newInt(9),
+			}, {
+				Classname: "com.example.GenerateTrace",
+				Function:  "main",
+				Filename:  "GenerateTrace.java",
+				Lineno:    newInt(5),
+			}, {
+				Module:    "foo@9.0",
+				Classname: "com.foo.Main",
+				Function:  "run",
+				Filename:  "Main.java",
+			}, {
+				Classname: "com.foo.bar.App",
+				Function:  "run",
+				Filename:  "App.java",
+				Lineno:    newInt(12),
+			}, {
+				Module:    "java.base",
+				Classname: "java.lang.Thread",
+				Function:  "run",
+				Filename:  "Unknown Source",
+			}},
+		},
+	}, {
+		Metadata:        expectedMetadata,
+		TraceID:         transaction.TraceID,
+		ParentID:        transaction.ID,
+		TransactionID:   transaction.ID,
+		TransactionType: transaction.Type,
+		Timestamp:       timestamp,
+		Exception: &model.Exception{
+			Type:    "HighLevelException",
+			Message: "MidLevelException: LowLevelException",
+			Handled: newBool(true),
+			Stacktrace: []*model.StacktraceFrame{{
+				Classname: "Junk",
+				Function:  "a",
+				Filename:  "Junk.java",
+				Lineno:    newInt(13),
+			}, {
+				Classname: "Junk",
+				Function:  "main",
+				Filename:  "Junk.java",
+				Lineno:    newInt(4),
+			}},
+			Cause: []model.Exception{{
+				Message: "MidLevelException: LowLevelException",
+				Handled: newBool(true),
+				Stacktrace: []*model.StacktraceFrame{{
+					Classname: "Junk",
+					Function:  "c",
+					Filename:  "Junk.java",
+					Lineno:    newInt(23),
+				}, {
+					Classname: "Junk",
+					Function:  "b",
+					Filename:  "Junk.java",
+					Lineno:    newInt(17),
+				}, {
+					Classname: "Junk",
+					Function:  "a",
+					Filename:  "Junk.java",
+					Lineno:    newInt(11),
+				}, {
+					Classname: "Junk",
+					Function:  "main",
+					Filename:  "Junk.java",
+					Lineno:    newInt(4),
+				}},
+				Cause: []model.Exception{{
+					Message: "LowLevelException",
+					Handled: newBool(true),
+					Stacktrace: []*model.StacktraceFrame{{
+						Classname: "Junk",
+						Function:  "e",
+						Filename:  "Junk.java",
+						Lineno:    newInt(37),
+					}, {
+						Classname: "Junk",
+						Function:  "d",
+						Filename:  "Junk.java",
+						Lineno:    newInt(34),
+					}, {
+						Classname: "Junk",
+						Function:  "c",
+						Filename:  "Junk.java",
+						Lineno:    newInt(21),
+					}, {
+						Classname: "Junk",
+						Function:  "b",
+						Filename:  "Junk.java",
+						Lineno:    newInt(17),
+					}, {
+						Classname: "Junk",
+						Function:  "a",
+						Filename:  "Junk.java",
+						Lineno:    newInt(11),
+					}, {
+						Classname: "Junk",
+						Function:  "main",
+						Filename:  "Junk.java",
+						Lineno:    newInt(4),
+					}},
+				}},
+			}},
+		},
+	}}, errors)
+}
+
+func TestEncodeSpanEventsJavaExceptionsUnparsedStacktrace(t *testing.T) {
+	stacktraces := []string{
+		// Unexpected prefix.
+		"abc\ndef",
+
+		// "... N more" with no preceding exception.
+		"abc\n... 1 more",
+
+		// "... N more" where N is greater than the number of stack
+		// frames in the enclosing exception.
+		`ignored message
+	at Class.method(Class.java:1)
+Caused by: something else
+	at Class.method(Class.java:2)
+	... 2 more`,
+
+		// "... N more" where N is not a sequence of digits.
+		`abc
+	at Class.method(Class.java:1)
+Caused by: whatever
+	at Class.method(Class.java:2)
+	... lots more`,
+
+		// "at <location>" where <location> is invalid.
+		`abc
+	at the movies`,
+	}
+
+	var events []pdata.SpanEvent
+	for _, stacktrace := range stacktraces {
+		event := pdata.NewSpanEvent()
+		event.SetName("exception")
+		event.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+			"exception.type":       pdata.NewAttributeValueString("ExceptionType"),
+			"exception.stacktrace": pdata.NewAttributeValueString(stacktrace),
+		})
+		events = append(events, event)
+	}
+
+	_, errors := transformTransactionSpanEvents(t, "java", events...)
+	require.Len(t, errors, len(stacktraces))
+
+	for i, e := range errors {
+		assert.Empty(t, e.Exception.Stacktrace)
+		assert.Equal(t, map[string]interface{}{"stacktrace": stacktraces[i]}, e.Exception.Attributes)
+	}
+}
+
+func TestEncodeSpanEventsNonJavaExceptions(t *testing.T) {
+	timestamp := time.Unix(123, 0).UTC()
+
+	exceptionEvent := pdata.NewSpanEvent()
+	exceptionEvent.SetTimestamp(pdata.TimestampUnixNano(timestamp.UnixNano()))
+	exceptionEvent.SetName("exception")
+	exceptionEvent.Attributes().InitFromMap(map[string]pdata.AttributeValue{
+		"exception.type":       pdata.NewAttributeValueString("the_type"),
+		"exception.message":    pdata.NewAttributeValueString("the_message"),
+		"exception.stacktrace": pdata.NewAttributeValueString("the_stacktrace"),
+	})
+
+	// For languages where we do not explicitly parse the stacktrace,
+	// the raw stacktrace is stored as an attribute on the exception.
+	transaction, errors := transformTransactionSpanEvents(t, "COBOL", exceptionEvent)
+	require.Len(t, errors, 1)
+
+	assert.Equal(t, &model.Error{
+		Metadata:        languageOnlyMetadata("COBOL"),
+		TraceID:         transaction.TraceID,
+		ParentID:        transaction.ID,
+		TransactionID:   transaction.ID,
+		TransactionType: transaction.Type,
+		Timestamp:       timestamp,
+		Exception: &model.Exception{
+			Type:    "the_type",
+			Message: "the_message",
+			Handled: newBool(true),
+			Attributes: map[string]interface{}{
+				"stacktrace": "the_stacktrace",
+			},
+		},
+	}, errors[0])
+}
+
+func languageOnlyMetadata(language string) model.Metadata {
+	return model.Metadata{
+		Service: model.Service{
+			Name:     "unknown",
+			Language: model.Language{Name: language},
+			Agent: model.Agent{
+				Name:    "otlp/" + language,
+				Version: "unknown",
+			},
+		},
+	}
+}

--- a/processor/otel/test_approved/span_jaeger_http.approved.json
+++ b/processor/otel/test_approved/span_jaeger_http.approved.json
@@ -97,14 +97,6 @@
                 "hostname": "host-abc",
                 "name": "host-abc"
             },
-            "http": {
-                "request": {
-                    "method": "get"
-                },
-                "response": {
-                    "status_code": 400
-                }
-            },
             "parent": {
                 "id": "0000000041414646"
             },
@@ -126,13 +118,6 @@
             },
             "trace": {
                 "id": "00000000000000000000000046467830"
-            },
-            "url": {
-                "domain": "foo.bar.com",
-                "full": "http://foo.bar.com?a=12",
-                "original": "http://foo.bar.com?a=12",
-                "query": "a=12",
-                "scheme": "http"
             }
         },
         {
@@ -153,14 +138,6 @@
                 "hostname": "host-abc",
                 "name": "host-abc"
             },
-            "http": {
-                "request": {
-                    "method": "get"
-                },
-                "response": {
-                    "status_code": 400
-                }
-            },
             "parent": {
                 "id": "0000000041414646"
             },
@@ -182,13 +159,6 @@
             },
             "trace": {
                 "id": "00000000000000000000000046467830"
-            },
-            "url": {
-                "domain": "foo.bar.com",
-                "full": "http://foo.bar.com?a=12",
-                "original": "http://foo.bar.com?a=12",
-                "query": "a=12",
-                "scheme": "http"
             }
         },
         {
@@ -211,14 +181,6 @@
                 "hostname": "host-abc",
                 "name": "host-abc"
             },
-            "http": {
-                "request": {
-                    "method": "get"
-                },
-                "response": {
-                    "status_code": 400
-                }
-            },
             "parent": {
                 "id": "0000000041414646"
             },
@@ -240,13 +202,6 @@
             },
             "trace": {
                 "id": "00000000000000000000000046467830"
-            },
-            "url": {
-                "domain": "foo.bar.com",
-                "full": "http://foo.bar.com?a=12",
-                "original": "http://foo.bar.com?a=12",
-                "query": "a=12",
-                "scheme": "http"
             }
         },
         {
@@ -269,14 +224,6 @@
                 "hostname": "host-abc",
                 "name": "host-abc"
             },
-            "http": {
-                "request": {
-                    "method": "get"
-                },
-                "response": {
-                    "status_code": 400
-                }
-            },
             "parent": {
                 "id": "0000000041414646"
             },
@@ -298,13 +245,6 @@
             },
             "trace": {
                 "id": "00000000000000000000000046467830"
-            },
-            "url": {
-                "domain": "foo.bar.com",
-                "full": "http://foo.bar.com?a=12",
-                "original": "http://foo.bar.com?a=12",
-                "query": "a=12",
-                "scheme": "http"
             }
         },
         {
@@ -327,14 +267,6 @@
                 "hostname": "host-abc",
                 "name": "host-abc"
             },
-            "http": {
-                "request": {
-                    "method": "get"
-                },
-                "response": {
-                    "status_code": 400
-                }
-            },
             "parent": {
                 "id": "0000000041414646"
             },
@@ -356,13 +288,6 @@
             },
             "trace": {
                 "id": "00000000000000000000000046467830"
-            },
-            "url": {
-                "domain": "foo.bar.com",
-                "full": "http://foo.bar.com?a=12",
-                "original": "http://foo.bar.com?a=12",
-                "query": "a=12",
-                "scheme": "http"
             }
         },
         {
@@ -383,14 +308,6 @@
                 "hostname": "host-abc",
                 "name": "host-abc"
             },
-            "http": {
-                "request": {
-                    "method": "get"
-                },
-                "response": {
-                    "status_code": 400
-                }
-            },
             "parent": {
                 "id": "0000000041414646"
             },
@@ -412,13 +329,6 @@
             },
             "trace": {
                 "id": "00000000000000000000000046467830"
-            },
-            "url": {
-                "domain": "foo.bar.com",
-                "full": "http://foo.bar.com?a=12",
-                "original": "http://foo.bar.com?a=12",
-                "query": "a=12",
-                "scheme": "http"
             }
         }
     ]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - processor/otel: translate OpenTelemetry exceptions (#4876)