### PR TITLE
[7.x] Set metricset.name for breakdown metrics (#4910)

### DIFF
--- a/apmpackage/apm/0.1.0/docs/README.md
+++ b/apmpackage/apm/0.1.0/docs/README.md
@@ -521,6 +521,7 @@ Metrics are written to `metrics-apm.app.*`, `metrics-apm.internal.*`, and `metri
     "tag1": "one",
     "tag2": 2
   },
+  "metricset.name": "app",
   "observer": {
     "ephemeral_id": "8785cbe1-7f89-4279-84c2-6c33979531fb",
     "hostname": "ix.lan",

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -408,7 +408,10 @@ func (s *serverRunner) run() error {
 }
 
 func (s *serverRunner) wrapRunServerWithPreprocessors(runServer RunServerFunc) RunServerFunc {
-	var processors []model.BatchProcessor
+	processors := []model.BatchProcessor{
+		// Set metricset.name for well-known agent metrics.
+		modelprocessor.SetMetricsetName{},
+	}
 	if s.config.DefaultServiceEnvironment != "" {
 		processors = append(processors, &modelprocessor.SetDefaultServiceEnvironment{
 			DefaultServiceEnvironment: s.config.DefaultServiceEnvironment,

--- a/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
@@ -400,6 +400,7 @@
                 "success": true
             },
             "long_gauge": 3147483648,
+            "metricset.name": "span_breakdown",
             "negative": {
                 "d": {
                     "o": {

--- a/beater/test_approved_es_documents/TestPublishIntegrationMetricsets.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationMetricsets.approved.json
@@ -29,6 +29,7 @@
                 "tag2": 2
             },
             "long_gauge": 3147483648,
+            "metricset.name": "span_breakdown",
             "negative": {
                 "d": {
                     "o": {
@@ -127,6 +128,7 @@
                 "tag1": "one",
                 "tag2": 2
             },
+            "metricset.name": "app",
             "observer": {
                 "ephemeral_id": "00000000-0000-0000-0000-000000000000",
                 "hostname": "",
@@ -173,6 +175,7 @@
                 "tag1": "one",
                 "tag2": 2
             },
+            "metricset.name": "app",
             "observer": {
                 "ephemeral_id": "00000000-0000-0000-0000-000000000000",
                 "hostname": "",

--- a/beater/test_approved_es_documents/TestPublishIntegrationMinimalEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationMinimalEvents.approved.json
@@ -163,6 +163,7 @@
             "host": {
                 "ip": "127.0.0.1"
             },
+            "metricset.name": "app",
             "observer": {
                 "ephemeral_id": "00000000-0000-0000-0000-000000000000",
                 "hostname": "",

--- a/docs/data/elasticsearch/generated/metricsets.json
+++ b/docs/data/elasticsearch/generated/metricsets.json
@@ -27,6 +27,7 @@
             "tag1": "one",
             "tag2": 2
         },
+        "metricset.name": "app",
         "observer": {
             "ephemeral_id": "8785cbe1-7f89-4279-84c2-6c33979531fb",
             "hostname": "ix.lan",
@@ -76,6 +77,7 @@
             "tag1": "one",
             "tag2": 2
         },
+        "metricset.name": "app",
         "observer": {
             "ephemeral_id": "2f30050f-81e6-491a-a54f-e7d94eec17b5",
             "hostname": "simmac.net",
@@ -154,6 +156,7 @@
             "tag2": 2
         },
         "long_gauge": 3147483648.0,
+        "metricset.name": "span_breakdown",
         "negative": {
             "d": {
                 "o": {

--- a/model/modelprocessor/metricsetname.go
+++ b/model/modelprocessor/metricsetname.go
@@ -1,0 +1,68 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package modelprocessor
+
+import (
+	"context"
+	"strings"
+
+	"github.com/elastic/apm-server/model"
+)
+
+const (
+	spanBreakdownMetricsetName        = "span_breakdown"
+	transactionBreakdownMetricsetName = "transaction_breakdown"
+	appMetricsetName                  = "app"
+)
+
+// SetMetricsetName is a transform.Processor that sets a name for
+// metricsets containing well-known agent metrics, such as breakdown
+// metrics.
+type SetMetricsetName struct{}
+
+// ProcessBatch sets the name for metricsets. Well-defined metrics (breakdowns)
+// will be given a specific name, while all other metrics will be given the name
+// "app".
+func (SetMetricsetName) ProcessBatch(ctx context.Context, b *model.Batch) error {
+	for _, ms := range b.Metricsets {
+		if ms.Name != "" || len(ms.Samples) == 0 {
+			continue
+		}
+		ms.Name = appMetricsetName
+		if ms.Transaction.Type == "" {
+			// Not a breakdown metricset.
+			continue
+		}
+		if ms.Span.Type != "" {
+			for _, sample := range ms.Samples {
+				if strings.HasPrefix(sample.Name, "span.self_time.") {
+					ms.Name = spanBreakdownMetricsetName
+					break
+				}
+			}
+		} else {
+			for _, sample := range ms.Samples {
+				if strings.HasPrefix(sample.Name, "transaction.breakdown.") {
+					ms.Name = transactionBreakdownMetricsetName
+					break
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/model/modelprocessor/metricsetname_test.go
+++ b/model/modelprocessor/metricsetname_test.go
@@ -1,0 +1,79 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package modelprocessor_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-server/model"
+	"github.com/elastic/apm-server/model/modelprocessor"
+)
+
+func TestSetMetricsetName(t *testing.T) {
+	tests := []struct {
+		metricset model.Metricset
+		name      string
+	}{{
+		metricset: model.Metricset{},
+		name:      "",
+	}, {
+		metricset: model.Metricset{Name: "already_set"},
+		name:      "already_set",
+	}, {
+		metricset: model.Metricset{Transaction: model.MetricsetTransaction{Type: "request"}},
+		name:      "",
+	}, {
+		metricset: model.Metricset{
+			Samples: []model.Sample{{
+				Name: "transaction.breakdown.count",
+			}},
+		},
+		name: "app",
+	}, {
+		metricset: model.Metricset{
+			Transaction: model.MetricsetTransaction{Type: "request"},
+			Samples: []model.Sample{{
+				Name: "transaction.duration.count",
+			}, {
+				Name: "transaction.breakdown.count",
+			}},
+		},
+		name: "transaction_breakdown",
+	}, {
+		metricset: model.Metricset{
+			Transaction: model.MetricsetTransaction{Type: "request"},
+			Span:        model.MetricsetSpan{Type: "app"},
+			Samples: []model.Sample{{
+				Name: "span.self_time.count",
+			}},
+		},
+		name: "span_breakdown",
+	}}
+
+	for _, test := range tests {
+		batch := &model.Batch{Metricsets: []*model.Metricset{&test.metricset}}
+		processor := modelprocessor.SetMetricsetName{}
+		err := processor.ProcessBatch(context.Background(), batch)
+		assert.NoError(t, err)
+		assert.Equal(t, test.name, batch.Metricsets[0].Name)
+	}
+
+}

--- a/systemtest/approvals/TestApprovedMetrics.approved.json
+++ b/systemtest/approvals/TestApprovedMetrics.approved.json
@@ -1,0 +1,235 @@
+{
+    "events": [
+        {
+            "@timestamp": "2017-05-30T18:53:41.364Z",
+            "agent": {
+                "name": "elastic-node",
+                "version": "3.14.0"
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "ingested": "dynamic"
+            },
+            "go": {
+                "memstats": {
+                    "heap": {
+                        "sys": {
+                            "bytes": 6520832
+                        }
+                    }
+                }
+            },
+            "host": {
+                "ip": "127.0.0.1"
+            },
+            "labels": {
+                "tag1": "one",
+                "tag2": 2
+            },
+            "metricset.name": "app",
+            "observer": {
+                "ephemeral_id": "dynamic",
+                "hostname": "dynamic",
+                "id": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic",
+                "version_major": "dynamic"
+            },
+            "process": {
+                "pid": 1234
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "language": {
+                    "name": "ecmascript"
+                },
+                "name": "1234_service-12a3",
+                "node": {
+                    "name": "node-1"
+                }
+            },
+            "user": {
+                "email": "user@mail.com",
+                "id": "axb123hg",
+                "name": "logged-in-user"
+            }
+        },
+        {
+            "@timestamp": "2017-05-30T18:53:41.366Z",
+            "agent": {
+                "name": "elastic-node",
+                "version": "3.14.0"
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "ingested": "dynamic"
+            },
+            "host": {
+                "ip": "127.0.0.1"
+            },
+            "labels": {
+                "tag1": "one",
+                "tag2": 2
+            },
+            "metricset.name": "app",
+            "observer": {
+                "ephemeral_id": "dynamic",
+                "hostname": "dynamic",
+                "id": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic",
+                "version_major": "dynamic"
+            },
+            "process": {
+                "pid": 1234
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "language": {
+                    "name": "ecmascript"
+                },
+                "name": "1234_service-12a3",
+                "node": {
+                    "name": "node-1"
+                }
+            },
+            "system": {
+                "process": {
+                    "cgroup": {
+                        "memory": {
+                            "mem": {
+                                "limit": {
+                                    "bytes": 2048
+                                },
+                                "usage": {
+                                    "bytes": 1024
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "user": {
+                "email": "user@mail.com",
+                "id": "axb123hg",
+                "name": "logged-in-user"
+            }
+        },
+        {
+            "@timestamp": "2017-05-30T18:53:42.281Z",
+            "agent": {
+                "name": "elastic-node",
+                "version": "3.14.0"
+            },
+            "byte_counter": 1,
+            "dotted": {
+                "float": {
+                    "gauge": 6.12
+                }
+            },
+            "double_gauge": 3.141592653589793,
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "ingested": "dynamic"
+            },
+            "float_gauge": 9.16,
+            "host": {
+                "ip": "127.0.0.1"
+            },
+            "integer_gauge": 42767,
+            "labels": {
+                "code": 200,
+                "some": "abc",
+                "success": true,
+                "tag1": "one",
+                "tag2": 2
+            },
+            "long_gauge": 3147483648,
+            "metricset.name": "span_breakdown",
+            "negative": {
+                "d": {
+                    "o": {
+                        "t": {
+                            "t": {
+                                "e": {
+                                    "d": -1022
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "observer": {
+                "ephemeral_id": "dynamic",
+                "hostname": "dynamic",
+                "id": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic",
+                "version_major": "dynamic"
+            },
+            "process": {
+                "pid": 1234
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "language": {
+                    "name": "ecmascript"
+                },
+                "name": "1234_service-12a3",
+                "node": {
+                    "name": "node-1"
+                }
+            },
+            "short_counter": 227,
+            "span": {
+                "self_time": {
+                    "count": 1,
+                    "sum": {
+                        "us": 633.288
+                    }
+                },
+                "subtype": "mysql",
+                "type": "db"
+            },
+            "transaction": {
+                "breakdown": {
+                    "count": 12
+                },
+                "duration": {
+                    "count": 2,
+                    "sum": {
+                        "us": 12
+                    }
+                },
+                "name": "GET /",
+                "self_time": {
+                    "count": 2,
+                    "sum": {
+                        "us": 10
+                    }
+                },
+                "type": "request"
+            },
+            "user": {
+                "email": "user@mail.com",
+                "id": "axb123hg",
+                "name": "logged-in-user"
+            }
+        }
+    ]
+}

--- a/systemtest/approvals/TestOTLPGRPCMetrics.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCMetrics.approved.json
@@ -13,6 +13,7 @@
                 "ingested": "dynamic"
             },
             "float64_counter": 1,
+            "metricset.name": "app",
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",

--- a/systemtest/metrics_test.go
+++ b/systemtest/metrics_test.go
@@ -1,0 +1,211 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package systemtest_test
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+	"go.elastic.co/apm"
+
+	"github.com/elastic/apm-server/systemtest"
+	"github.com/elastic/apm-server/systemtest/apmservertest"
+	"github.com/elastic/apm-server/systemtest/estest"
+	"github.com/elastic/go-elasticsearch/v7/esapi"
+)
+
+func TestApprovedMetrics(t *testing.T) {
+	systemtest.CleanupElasticsearch(t)
+	srv := apmservertest.NewServer(t)
+
+	eventsPayload, err := ioutil.ReadFile("../testdata/intake-v2/metricsets.ndjson")
+	require.NoError(t, err)
+
+	req, _ := http.NewRequest("POST", srv.URL+"/intake/v2/events", bytes.NewReader(eventsPayload))
+	req.Header.Set("Content-Type", "application/x-ndjson")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+
+	// Check the metrics documents are exactly as we expect.
+	result := systemtest.Elasticsearch.ExpectMinDocs(t, 3, "apm-*", estest.TermQuery{
+		Field: "processor.event",
+		Value: "metric",
+	})
+	systemtest.ApproveEvents(t, t.Name(), result.Hits.Hits)
+}
+
+func TestBreakdownMetrics(t *testing.T) {
+	systemtest.CleanupElasticsearch(t)
+	srv := apmservertest.NewServer(t)
+
+	tracer := srv.Tracer()
+	tx := tracer.StartTransaction("tx_name", "tx_type")
+	span := tx.StartSpan("span_name", "span_type", nil)
+	span.Duration = 500 * time.Millisecond
+	span.End()
+	tx.Duration = time.Second
+	tx.End()
+	tracer.SendMetrics(nil)
+	tracer.Flush(nil)
+
+	result := systemtest.Elasticsearch.ExpectMinDocs(t, 3, "apm-*", estest.BoolQuery{
+		Filter: []interface{}{
+			estest.TermQuery{
+				Field: "processor.event",
+				Value: "metric",
+			},
+			estest.TermQuery{
+				Field: "transaction.type",
+				Value: "tx_type",
+			},
+		},
+	})
+
+	docs := unmarshalMetricsetDocs(t, result.Hits.Hits)
+	assert.ElementsMatch(t, []metricsetDoc{{
+		Trasaction:    metricsetTransaction{Type: "tx_type"},
+		MetricsetName: "transaction_breakdown",
+	}, {
+		Trasaction:    metricsetTransaction{Type: "tx_type"},
+		Span:          metricsetSpan{Type: "span_type"},
+		MetricsetName: "span_breakdown",
+	}, {
+		Trasaction:    metricsetTransaction{Type: "tx_type"},
+		Span:          metricsetSpan{Type: "app"},
+		MetricsetName: "span_breakdown",
+	}}, docs)
+}
+
+func TestApplicationMetrics(t *testing.T) {
+	systemtest.CleanupElasticsearch(t)
+	srv := apmservertest.NewServer(t)
+
+	tracer := srv.Tracer()
+	tracer.RegisterMetricsGatherer(apm.GatherMetricsFunc(func(ctx context.Context, metrics *apm.Metrics) error {
+		metrics.Add("a.b.c", nil, 123)
+		metrics.Add("x.y.z", nil, 123.456)
+		return nil
+	}))
+	tracer.SendMetrics(nil)
+	tracer.Flush(nil)
+
+	result := systemtest.Elasticsearch.ExpectDocs(t, "apm-*", estest.TermQuery{
+		Field: "metricset.name",
+		Value: "app",
+	})
+
+	// The Go agent sends all metrics with the same set of labels in one metricset.
+	// This includes custom metrics, Go runtime metrics, system and process metrics.
+	expectedFields := []string{
+		"golang.goroutines",
+		"system.memory.total",
+		"a.b.c",
+		"x.y.z",
+	}
+	for _, fieldName := range expectedFields {
+		var found bool
+		for _, hit := range result.Hits.Hits {
+			if gjson.GetBytes(hit.RawSource, fieldName).Exists() {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "field %q not found in 'app' metricset docs", fieldName)
+	}
+
+	// Check that the index mapping has been updated for the custom
+	// metrics, with the expected dynamically mapped field types.
+	var allMappings map[string]struct {
+		Mappings map[string]interface{}
+	}
+	_, err := systemtest.Elasticsearch.Do(context.Background(), &esapi.IndicesGetFieldMappingRequest{
+		Index:  []string{"apm-*"},
+		Fields: []string{"a.b.c", "x.y.z"},
+	}, &allMappings)
+	require.NoError(t, err)
+
+	var mappings map[string]interface{}
+	for _, index := range allMappings {
+		if len(index.Mappings) != 0 {
+			mappings = index.Mappings
+			break
+		}
+	}
+	require.NotEmpty(t, mappings)
+	assert.Equal(t, map[string]interface{}{
+		"a.b.c": map[string]interface{}{
+			"full_name": "a.b.c",
+			"mapping": map[string]interface{}{
+				"c": map[string]interface{}{
+					"type": "long",
+				},
+			},
+		},
+		"x.y.z": map[string]interface{}{
+			"full_name": "x.y.z",
+			"mapping": map[string]interface{}{
+				"z": map[string]interface{}{
+					"type": "float",
+				},
+			},
+		},
+	}, mappings)
+}
+
+type metricsetTransaction struct {
+	Type string `json:"type"`
+}
+
+type metricsetSpan struct {
+	Type string `json:"type"`
+}
+
+type metricsetSample struct {
+	Value float64 `json:"value"`
+}
+
+type metricsetDoc struct {
+	Trasaction    metricsetTransaction `json:"transaction"`
+	Span          metricsetSpan        `json:"span"`
+	MetricsetName string               `json:"metricset.name"`
+}
+
+func unmarshalMetricsetDocs(t testing.TB, hits []estest.SearchHit) []metricsetDoc {
+	var docs []metricsetDoc
+	for _, hit := range hits {
+		docs = append(docs, unmarshalMetricsetDoc(t, &hit))
+	}
+	return docs
+}
+
+func unmarshalMetricsetDoc(t testing.TB, hit *estest.SearchHit) metricsetDoc {
+	var doc metricsetDoc
+	if err := hit.UnmarshalSource(&doc); err != nil {
+		t.Fatal(err)
+	}
+	return doc
+}

--- a/tests/system/metricset.approved.json
+++ b/tests/system/metricset.approved.json
@@ -27,6 +27,7 @@
             "tag1": "one",
             "tag2": 2
         },
+        "metricset.name": "app",
         "observer": {
             "ephemeral_id": "8785cbe1-7f89-4279-84c2-6c33979531fb",
             "hostname": "ix.lan",
@@ -76,6 +77,7 @@
             "tag1": "one",
             "tag2": 2
         },
+        "metricset.name": "app",
         "observer": {
             "ephemeral_id": "2f30050f-81e6-491a-a54f-e7d94eec17b5",
             "hostname": "simmac.net",
@@ -154,6 +156,7 @@
             "tag2": 2
         },
         "long_gauge": 3147483648.0,
+        "metricset.name": "span_breakdown",
         "negative": {
             "d": {
                 "o": {

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -305,18 +305,6 @@ class ExpvarCustomUrlIntegrationTest(ExpvarBaseTest):
 
 
 @integration_test
-class MetricsIntegrationTest(ElasticTest):
-    def test_metric_doc(self):
-        self.load_docs_with_template(self.get_metricset_payload_path(), self.intake_url, 'metric', 3)
-        mappings = self.es.indices.get_field_mapping(
-            index=index_metric, fields="system.process.cpu.total.norm.pct")
-        expected_type = "scaled_float"
-        doc = mappings[self.ilm_index(index_metric)]["mappings"]
-        actual_type = doc["system.process.cpu.total.norm.pct"]["mapping"]["pct"]["type"]
-        assert expected_type == actual_type, "want: {}, got: {}".format(expected_type, actual_type)
-
-
-@integration_test
 class ExperimentalBaseTest(ElasticTest):
     def check_experimental_key_indexed(self, experimental):
         self.load_docs_with_template(self.get_payload_path("experimental.ndjson"),


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Set metricset.name for breakdown metrics (#4910)