### PR TITLE
[7.x] add logging to jaeger and otlp gRPC calls (#4934)

### DIFF
--- a/beater/interceptors/logging.go
+++ b/beater/interceptors/logging.go
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package interceptors
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+
+	"github.com/elastic/apm-server/utility"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+// Logging intercepts a gRPC request and provides logging processing. The
+// returned function implements grpc.UnaryServerInterceptor.
+func Logging(logger *logp.Logger) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		start := time.Now()
+		if p, ok := peer.FromContext(ctx); ok {
+			logger = logger.With("source.address", p.Addr)
+		}
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			headers := http.Header(md)
+			// Account for `forwarded`, `x-real-ip`, `x-forwarded-for` headers
+			if ip := utility.ExtractIPFromHeader(headers); ip != nil {
+				logger = logger.With("source.address", ip)
+			}
+		}
+
+		resp, err := handler(ctx, req)
+		res, _ := status.FromError(err)
+		logger = logger.With(
+			"grpc.request.method", info.FullMethod,
+			"event.duration", time.Since(start),
+			"grpc.response.status_code", res.Code(),
+		)
+
+		if err != nil {
+			logger.With("error.message", res.Message()).Error(logp.Error(err))
+		} else {
+			logger.Info(res.Message())
+		}
+		return resp, err
+	}
+}

--- a/beater/interceptors/logging_test.go
+++ b/beater/interceptors/logging_test.go
@@ -1,0 +1,122 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package interceptors
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/logp/configure"
+)
+
+func TestLogging(t *testing.T) {
+	addr := &net.TCPAddr{
+		IP:   net.ParseIP("1.2.3.4"),
+		Port: 56837,
+	}
+	p := &peer.Peer{
+		Addr: addr,
+	}
+
+	ctx := peer.NewContext(context.Background(), p)
+	methodName := "test_method_name"
+	info := &grpc.UnaryServerInfo{
+		FullMethod: methodName,
+	}
+
+	requiredKeys := []string{
+		"source.address",
+		"grpc.request.method",
+		"event.duration",
+		"grpc.response.status_code",
+	}
+
+	for _, tc := range []struct {
+		alternateIP string
+		statusCode  codes.Code
+		f           func(ctx context.Context, req interface{}) (interface{}, error)
+	}{
+		{
+			statusCode: codes.Internal,
+			f: func(ctx context.Context, req interface{}) (interface{}, error) {
+				return nil, status.New(codes.Internal, "internal server error").Err()
+			},
+		},
+		{
+			statusCode: codes.OK,
+			f: func(ctx context.Context, req interface{}) (interface{}, error) {
+				return nil, nil
+			},
+		},
+		{
+			alternateIP: "6.7.8.9",
+			statusCode:  codes.OK,
+			f: func(ctx context.Context, req interface{}) (interface{}, error) {
+				return nil, nil
+			},
+		},
+	} {
+		configure.Logging(
+			"APM Server test",
+			common.MustNewConfigFrom(`{"ecs":true}`),
+		)
+		require.NoError(t, logp.DevelopmentSetup(logp.ToObserverOutput()))
+		logger := logp.NewLogger("interceptor.logging.test")
+
+		wantAddr := addr.String()
+		if tc.alternateIP != "" {
+			wantAddr = tc.alternateIP
+			ctx = metadata.NewIncomingContext(ctx, metadata.Pairs("X-Real-IP", tc.alternateIP))
+		}
+
+		i := Logging(logger)
+		_, err := i(ctx, nil, info, tc.f)
+		entries := logp.ObserverLogs().TakeAll()
+		assert.Len(t, entries, 1)
+		entry := entries[0]
+
+		fields := entry.ContextMap()
+		if tc.statusCode != codes.OK {
+			assert.Error(t, err)
+			assert.Equal(t, zapcore.ErrorLevel, entry.Entry.Level)
+			assert.Equal(t, "internal server error", fields["error.message"])
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, zapcore.InfoLevel, entry.Entry.Level)
+			assert.NotContains(t, fields, "error.message")
+		}
+		for _, k := range requiredKeys {
+			assert.Contains(t, fields, k)
+		}
+		assert.Equal(t, methodName, fields["grpc.request.method"])
+		assert.Equal(t, wantAddr, fields["source.address"])
+		assert.Equal(t, tc.statusCode.String(), fields["grpc.response.status_code"])
+	}
+}

--- a/beater/interceptors/metrics.go
+++ b/beater/interceptors/metrics.go
@@ -1,0 +1,69 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package interceptors
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elastic/apm-server/beater/request"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/monitoring"
+)
+
+// Metrics returns a grpc.UnaryServerInterceptor that increments the metrics in
+// a supplied registry keyed to its gRPC full method name.
+func Metrics(
+	logger *logp.Logger,
+	registries map[string]map[request.ResultID]*monitoring.Int,
+) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		m, prs := registries[info.FullMethod]
+		if !prs {
+			logger.With(
+				"grpc.request.method", info.FullMethod,
+			).Error("metrics registry missing")
+			return handler(ctx, req)
+		}
+
+		m[request.IDRequestCount].Inc()
+		defer m[request.IDResponseCount].Inc()
+
+		resp, err := handler(ctx, req)
+
+		responseID := request.IDResponseValidCount
+		if err != nil {
+			responseID = request.IDResponseErrorsCount
+			if s, ok := status.FromError(err); ok && s.Code() == codes.Unauthenticated {
+				m[request.IDResponseErrorsUnauthorized].Inc()
+			}
+		}
+
+		m[responseID].Inc()
+
+		return resp, err
+	}
+}

--- a/beater/interceptors/metrics_test.go
+++ b/beater/interceptors/metrics_test.go
@@ -1,0 +1,113 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package interceptors
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/elastic/apm-server/beater/beatertest"
+	"github.com/elastic/apm-server/beater/request"
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/monitoring"
+)
+
+var monitoringKeys = append(request.DefaultResultIDs, request.IDResponseErrorsUnauthorized)
+
+func TestMetrics(t *testing.T) {
+	registry := monitoring.NewRegistry()
+
+	monitoringMap := request.MonitoringMapForRegistry(registry, monitoringKeys)
+	methodName := "test_method_name"
+	logger := logp.NewLogger("interceptor.metrics.test")
+
+	testMap := map[string]map[request.ResultID]*monitoring.Int{
+		methodName: monitoringMap,
+	}
+	i := Metrics(logger, testMap)
+
+	ctx := context.Background()
+	info := &grpc.UnaryServerInfo{
+		FullMethod: methodName,
+	}
+
+	for _, tc := range []struct {
+		f             func(ctx context.Context, req interface{}) (interface{}, error)
+		monitoringInt map[request.ResultID]int64
+	}{
+		{
+			f: func(ctx context.Context, req interface{}) (interface{}, error) {
+				return nil, errors.New("error")
+			},
+			monitoringInt: map[request.ResultID]int64{
+				request.IDRequestCount:               1,
+				request.IDResponseCount:              1,
+				request.IDResponseValidCount:         0,
+				request.IDResponseErrorsCount:        1,
+				request.IDResponseErrorsInternal:     1,
+				request.IDResponseErrorsUnauthorized: 0,
+			},
+		},
+		{
+			f: func(ctx context.Context, req interface{}) (interface{}, error) {
+				return nil, status.Error(codes.Unauthenticated, ("error"))
+			},
+			monitoringInt: map[request.ResultID]int64{
+				request.IDRequestCount:               1,
+				request.IDResponseCount:              1,
+				request.IDResponseValidCount:         0,
+				request.IDResponseErrorsCount:        1,
+				request.IDResponseErrorsInternal:     0,
+				request.IDResponseErrorsUnauthorized: 1,
+			},
+		},
+		{
+			f: func(ctx context.Context, req interface{}) (interface{}, error) {
+				return nil, nil
+			},
+			monitoringInt: map[request.ResultID]int64{
+				request.IDRequestCount:               1,
+				request.IDResponseCount:              1,
+				request.IDResponseValidCount:         1,
+				request.IDResponseErrorsCount:        0,
+				request.IDResponseErrorsInternal:     0,
+				request.IDResponseErrorsUnauthorized: 0,
+			},
+		},
+	} {
+		i(ctx, nil, info, tc.f)
+		assertMonitoring(t, tc.monitoringInt, monitoringMap)
+		beatertest.ClearRegistry(monitoringMap)
+	}
+}
+
+func assertMonitoring(t *testing.T, expected map[request.ResultID]int64, actual map[request.ResultID]*monitoring.Int) {
+	for _, k := range monitoringKeys {
+		if val, ok := expected[k]; ok {
+			assert.Equalf(t, val, actual[k].Get(), "%s mismatch", k)
+		} else {
+			assert.Zerof(t, actual[k].Get(), "%s mismatch", k)
+		}
+	}
+}

--- a/beater/jaeger/common.go
+++ b/beater/jaeger/common.go
@@ -31,14 +31,7 @@ import (
 	"github.com/elastic/apm-server/beater/request"
 )
 
-var (
-	monitoringKeys = []request.ResultID{
-		request.IDRequestCount, request.IDResponseCount, request.IDResponseErrorsCount,
-		request.IDResponseValidCount, request.IDEventReceivedCount, request.IDEventDroppedCount,
-	}
-
-	errNotAuthorized = errors.New("not authorized")
-)
+var errNotAuthorized = errors.New("not authorized")
 
 type monitoringMap map[request.ResultID]*monitoring.Int
 

--- a/beater/jaeger/grpc_test.go
+++ b/beater/jaeger/grpc_test.go
@@ -38,7 +38,6 @@ import (
 
 	"github.com/elastic/apm-server/agentcfg"
 	"github.com/elastic/apm-server/beater/beatertest"
-	"github.com/elastic/apm-server/beater/request"
 	"github.com/elastic/apm-server/tests"
 )
 
@@ -46,37 +45,13 @@ func TestGRPCCollector_PostSpans(t *testing.T) {
 	for name, tc := range map[string]testGRPCCollector{
 		"empty request": {
 			request: &api_v2.PostSpansRequest{},
-			monitoringInt: map[request.ResultID]int64{
-				request.IDRequestCount:       1,
-				request.IDResponseCount:      1,
-				request.IDResponseValidCount: 1,
-			},
 		},
-		"successful request": {
-			monitoringInt: map[request.ResultID]int64{
-				request.IDRequestCount:       1,
-				request.IDResponseCount:      1,
-				request.IDResponseValidCount: 1,
-				request.IDEventReceivedCount: 2,
-			},
-		},
+		"successful request": {},
 		"failing request": {
 			consumerErr: errors.New("consumer failed"),
-			monitoringInt: map[request.ResultID]int64{
-				request.IDRequestCount:        1,
-				request.IDResponseCount:       1,
-				request.IDResponseErrorsCount: 1,
-				request.IDEventReceivedCount:  2,
-			},
 		},
 		"auth fails": {
 			authError: errors.New("oh noes"),
-			monitoringInt: map[request.ResultID]int64{
-				request.IDRequestCount:               1,
-				request.IDResponseCount:              1,
-				request.IDResponseErrorsCount:        1,
-				request.IDResponseErrorsUnauthorized: 1,
-			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -97,7 +72,6 @@ func TestGRPCCollector_PostSpans(t *testing.T) {
 				require.NotNil(t, resp)
 				require.NoError(t, err)
 			}
-			assertMonitoring(t, tc.monitoringInt, gRPCCollectorMonitoringMap)
 		})
 	}
 }
@@ -107,8 +81,6 @@ type testGRPCCollector struct {
 	authError   error
 	consumerErr error
 	collector   *grpcCollector
-
-	monitoringInt map[request.ResultID]int64
 }
 
 func (tc *testGRPCCollector) setup(t *testing.T) {
@@ -134,21 +106,11 @@ func (tc *testGRPCCollector) setup(t *testing.T) {
 		tc.request = &api_v2.PostSpansRequest{Batch: *batches[0]}
 	}
 
-	tc.collector = &grpcCollector{logp.NewLogger("gRPC"), authFunc(func(context.Context, model.Batch) error {
+	tc.collector = &grpcCollector{authFunc(func(context.Context, model.Batch) error {
 		return tc.authError
 	}), tracesConsumerFunc(func(ctx context.Context, td pdata.Traces) error {
 		return tc.consumerErr
 	})}
-}
-
-func assertMonitoring(t *testing.T, expected map[request.ResultID]int64, actual monitoringMap) {
-	for _, k := range monitoringKeys {
-		if val, ok := expected[k]; ok {
-			assert.Equalf(t, val, actual[k].Get(), "%s mismatch", k)
-		} else {
-			assert.Zerof(t, actual[k].Get(), "%s mismatch", k)
-		}
-	}
 }
 
 type tracesConsumerFunc func(ctx context.Context, td pdata.Traces) error
@@ -172,11 +134,7 @@ func TestGRPCSampler_GetSamplingStrategy(t *testing.T) {
 					"settings": map[string]interface{}{}}},
 			expectedErrMsg: "no sampling rate available",
 			expectedLogMsg: "No valid sampling rate fetched",
-			monitoringInt: map[request.ResultID]int64{
-				request.IDRequestCount:           1,
-				request.IDResponseCount:          1,
-				request.IDResponseErrorsCount:    1,
-				request.IDResponseErrorsNotFound: 1}},
+		},
 		"invalidSamplingRate": {
 			kibanaBody: map[string]interface{}{
 				"_id": "1",
@@ -185,20 +143,12 @@ func TestGRPCSampler_GetSamplingStrategy(t *testing.T) {
 						agentcfg.TransactionSamplingRateKey: "foo"}}},
 			expectedErrMsg: "no sampling rate available",
 			expectedLogMsg: "No valid sampling rate fetched",
-			monitoringInt: map[request.ResultID]int64{
-				request.IDRequestCount:           1,
-				request.IDResponseCount:          1,
-				request.IDResponseErrorsCount:    1,
-				request.IDResponseErrorsInternal: 1}},
+		},
 		"unsupportedVersion": {
 			kibanaVersion:  common.MustNewVersion("7.4.0"),
 			expectedErrMsg: "agent remote configuration not supported",
 			expectedLogMsg: "Kibana client does not support",
-			monitoringInt: map[request.ResultID]int64{
-				request.IDRequestCount:                     1,
-				request.IDResponseCount:                    1,
-				request.IDResponseErrorsCount:              1,
-				request.IDResponseErrorsServiceUnavailable: 1}},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			require.NoError(t, logp.DevelopmentSetup(logp.ToObserverOutput()))
@@ -226,9 +176,6 @@ func TestGRPCSampler_GetSamplingStrategy(t *testing.T) {
 				assert.Nil(t, resp.OperationSampling)
 				assert.Nil(t, resp.RateLimitingSampling)
 			}
-
-			// assert monitoring counters
-			assertMonitoring(t, tc.monitoringInt, gRPCSamplingMonitoringMap)
 		})
 	}
 }
@@ -242,7 +189,6 @@ type testGRPCSampler struct {
 	expectedErrMsg       string
 	expectedLogMsg       string
 	expectedSamplingRate float64
-	monitoringInt        map[request.ResultID]int64
 }
 
 func (tc *testGRPCSampler) setup() {
@@ -266,11 +212,4 @@ func (tc *testGRPCSampler) setup() {
 	fetcher := agentcfg.NewFetcher(client, time.Second)
 	tc.sampler = &grpcSampler{logp.L(), client, fetcher}
 	beatertest.ClearRegistry(gRPCSamplingMonitoringMap)
-	if tc.monitoringInt == nil {
-		tc.monitoringInt = map[request.ResultID]int64{
-			request.IDRequestCount:       1,
-			request.IDResponseCount:      1,
-			request.IDResponseValidCount: 1,
-		}
-	}
 }

--- a/beater/jaeger/http.go
+++ b/beater/jaeger/http.go
@@ -42,6 +42,7 @@ const (
 
 var (
 	httpRegistry      = monitoring.Default.NewRegistry("apm-server.jaeger.http")
+	monitoringKeys    = append(request.DefaultResultIDs, request.IDEventReceivedCount)
 	httpMonitoringMap = request.MonitoringMapForRegistry(httpRegistry, monitoringKeys)
 )
 

--- a/beater/jaeger/http_test.go
+++ b/beater/jaeger/http_test.go
@@ -106,6 +106,16 @@ func testHTTPMux(t *testing.T, test httpMuxTest) {
 	assertMonitoring(t, test.expectedMonitoringMap, httpMonitoringMap)
 }
 
+func assertMonitoring(t *testing.T, expected map[request.ResultID]int64, actual monitoringMap) {
+	for _, k := range monitoringKeys {
+		if val, ok := expected[k]; ok {
+			assert.Equalf(t, val, actual[k].Get(), "%s mismatch", k)
+		} else {
+			assert.Zerof(t, actual[k].Get(), "%s mismatch", k)
+		}
+	}
+}
+
 func TestHTTPHandler_UnknownRoute(t *testing.T) {
 	c, recorder := newRequestContext("POST", "/foo", nil)
 	newHTTPHandler(nopConsumer())(c)

--- a/beater/request/result.go
+++ b/beater/request/result.go
@@ -102,6 +102,9 @@ var (
 		IDResponseErrorsServiceUnavailable: {Code: http.StatusServiceUnavailable, Keyword: "service unavailable"},
 		IDResponseErrorsInternal:           {Code: http.StatusInternalServerError, Keyword: "internal error"},
 	}
+
+	// DefaultResultIDs is a list of the default result IDs used by the package.
+	DefaultResultIDs = []ResultID{IDRequestCount, IDResponseCount, IDResponseErrorsCount, IDResponseValidCount}
 )
 
 // ResultID unique string identifying a requests Result
@@ -125,7 +128,7 @@ type Result struct {
 
 // DefaultMonitoringMapForRegistry returns map matching resultIDs to monitoring counters for given registry.
 func DefaultMonitoringMapForRegistry(r *monitoring.Registry) map[ResultID]*monitoring.Int {
-	ids := []ResultID{IDUnset, IDRequestCount, IDResponseCount, IDResponseErrorsCount, IDResponseValidCount}
+	ids := append(DefaultResultIDs, IDUnset)
 	for id := range MapResultIDToStatus {
 		ids = append(ids, id)
 	}

--- a/systemtest/logging_test.go
+++ b/systemtest/logging_test.go
@@ -18,6 +18,7 @@
 package systemtest_test
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -25,14 +26,60 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.elastic.co/apm/apmtest"
 	"go.elastic.co/fastjson"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpgrpc"
 	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc"
 
+	"github.com/elastic/apm-server/systemtest"
 	"github.com/elastic/apm-server/systemtest/apmservertest"
 )
+
+func TestAPMServerGRPCRequestLoggingValid(t *testing.T) {
+	systemtest.CleanupElasticsearch(t)
+	srv := apmservertest.NewUnstartedServer(t)
+	srv.Config.Jaeger = &apmservertest.JaegerConfig{
+		GRPCEnabled: true,
+		GRPCHost:    "localhost:0",
+	}
+	err := srv.Start()
+	require.NoError(t, err)
+	addr := srv.JaegerGRPCAddr
+	conn, err := grpc.Dial(addr, grpc.WithInsecure())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	client := api_v2.NewCollectorServiceClient(conn)
+	request, err := decodeJaegerPostSpansRequest("../testdata/jaeger/batch_0.json")
+	require.NoError(t, err)
+	_, err = client.PostSpans(context.Background(), request)
+	require.NoError(t, err)
+
+	err = sendOTLPTrace(context.Background(), srv, otlpgrpc.WithHeaders(map[string]string{"Authorization": "Bearer abc123"}))
+	require.NoError(t, err)
+
+	srv.Close()
+
+	var foundGRPC, foundJaeger bool
+	for _, entry := range srv.Logs.All() {
+		if entry.Logger == "beater.grpc" {
+			require.Equal(t, "/opentelemetry.proto.collector.trace.v1.TraceService/Export", entry.Fields["grpc.request.method"])
+			require.Equal(t, "OK", entry.Fields["grpc.response.status_code"])
+			foundGRPC = true
+		}
+		if entry.Logger == "beater.jaeger" {
+			require.Equal(t, "/jaeger.api_v2.CollectorService/PostSpans", entry.Fields["grpc.request.method"])
+			require.Equal(t, "OK", entry.Fields["grpc.response.status_code"])
+			foundJaeger = true
+		}
+	}
+	require.True(t, foundGRPC)
+	require.True(t, foundJaeger)
+}
 
 func TestAPMServerRequestLoggingValid(t *testing.T) {
 	srv := apmservertest.NewServer(t)

--- a/utility/ip_test.go
+++ b/utility/ip_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/elastic/apm-server/utility"
 
@@ -56,6 +57,17 @@ func TestExtractIP(t *testing.T) {
 
 	req.Header.Set(headerForwarded, "for=[2001:db8:cafe::17]:4711")
 	assert.Equal(t, "2001:db8:cafe::17", utility.ExtractIP(req).String())
+}
+
+func TestExtractIPFromGRPCMetadata(t *testing.T) {
+	ip := "123.0.0.1"
+	// metadata.Pairs stores keys as lowercase; we want to test that
+	// ExtractIPFromHeader is accounting for that.
+	md := metadata.Pairs("x-real-ip", ip)
+	headers := http.Header(md)
+	extractedIP := utility.ExtractIPFromHeader(headers)
+	assert.NotNil(t, ip)
+	assert.Equal(t, ip, extractedIP.String())
 }
 
 func TestExtractIPFromHeader(t *testing.T) {


### PR DESCRIPTION
Backports the following commits to 7.x:
 - add logging to jaeger and otlp gRPC calls (#4934)