### PR TITLE
[7.x] beater: add pprof-related config (#4954)

### DIFF
--- a/beater/api/mux.go
+++ b/beater/api/mux.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"net/http"
+	"net/http/pprof"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/logp"
@@ -112,6 +113,15 @@ func NewMux(beatInfo beat.Info, beaterConfig *config.Config, report publish.Repo
 		path := beaterConfig.Expvar.URL
 		logger.Infof("Path %s added to request handler", path)
 		mux.Handle(path, http.HandlerFunc(debugVarsHandler))
+	}
+	if beaterConfig.Pprof.IsEnabled() {
+		const path = "/debug/pprof"
+		logger.Infof("Path %s added to request handler", path)
+		mux.Handle(path+"/", http.HandlerFunc(pprof.Index))
+		mux.Handle(path+"/cmdline", http.HandlerFunc(pprof.Cmdline))
+		mux.Handle(path+"/profile", http.HandlerFunc(pprof.Profile))
+		mux.Handle(path+"/symbol", http.HandlerFunc(pprof.Symbol))
+		mux.Handle(path+"/trace", http.HandlerFunc(pprof.Trace))
 	}
 	return mux, nil
 }

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"net"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -100,6 +101,15 @@ func NewCreator(args CreatorParams) beat.Creator {
 		}
 		if err := recordRootConfig(b.Info, bt.rawConfig); err != nil {
 			bt.logger.Errorf("Error recording telemetry data", err)
+		}
+
+		if bt.config.Pprof.IsEnabled() {
+			// Profiling rates should be set once, early on in the program.
+			runtime.SetBlockProfileRate(bt.config.Pprof.BlockProfileRate)
+			runtime.SetMutexProfileFraction(bt.config.Pprof.MutexProfileRate)
+			if bt.config.Pprof.MemProfileRate > 0 {
+				runtime.MemProfileRate = bt.config.Pprof.MemProfileRate
+			}
 		}
 
 		if !bt.config.DataStreams.Enabled {

--- a/beater/config/config.go
+++ b/beater/config/config.go
@@ -75,6 +75,7 @@ type Config struct {
 	MaxConnections            int                     `config:"max_connections"`
 	ResponseHeaders           map[string][]string     `config:"response_headers"`
 	Expvar                    *ExpvarConfig           `config:"expvar"`
+	Pprof                     *PprofConfig            `config:"pprof"`
 	AugmentEnabled            bool                    `config:"capture_personal_data"`
 	SelfInstrumentation       *InstrumentationConfig  `config:"instrumentation"`
 	RumConfig                 *RumConfig              `config:"rum"`
@@ -97,6 +98,14 @@ type Config struct {
 type ExpvarConfig struct {
 	Enabled *bool  `config:"enabled"`
 	URL     string `config:"url"`
+}
+
+// PprofConfig holds config information about exposing pprof
+type PprofConfig struct {
+	Enabled          bool `config:"enabled"`
+	BlockProfileRate int  `config:"block_profile_rate"`
+	MemProfileRate   int  `config:"mem_profile_rate"`
+	MutexProfileRate int  `config:"mutex_profile_rate"`
 }
 
 // AgentConfig holds remote agent config information
@@ -167,6 +176,11 @@ func (c *ExpvarConfig) IsEnabled() bool {
 	return c != nil && (c.Enabled == nil || *c.Enabled)
 }
 
+// IsEnabled indicates whether pprof is enabled or not
+func (c *PprofConfig) IsEnabled() bool {
+	return c != nil && c.Enabled
+}
+
 // DefaultConfig returns a config with default settings for `apm-server` config options.
 func DefaultConfig() *Config {
 	return &Config{
@@ -183,6 +197,7 @@ func DefaultConfig() *Config {
 			Enabled: new(bool),
 			URL:     "/debug/vars",
 		},
+		Pprof:        &PprofConfig{Enabled: false},
 		RumConfig:    defaultRum(),
 		Register:     defaultRegisterConfig(true),
 		Mode:         ModeProduction,

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -158,6 +158,9 @@ func TestUnpackConfig(t *testing.T) {
 					Enabled: &truthy,
 					URL:     "/debug/vars",
 				},
+				Pprof: &PprofConfig{
+					Enabled: false,
+				},
 				RumConfig: &RumConfig{
 					Enabled: &truthy,
 					EventRate: &EventRate{
@@ -262,6 +265,9 @@ func TestUnpackConfig(t *testing.T) {
 					"enabled": true,
 					"url":     "/debug/vars",
 				},
+				"pprof": map[string]interface{}{
+					"enabled": true,
+				},
 				"rum": map[string]interface{}{
 					"enabled": true,
 					"source_mapping": map[string]interface{}{
@@ -308,6 +314,9 @@ func TestUnpackConfig(t *testing.T) {
 				Expvar: &ExpvarConfig{
 					Enabled: &truthy,
 					URL:     "/debug/vars",
+				},
+				Pprof: &PprofConfig{
+					Enabled: true,
 				},
 				RumConfig: &RumConfig{
 					Enabled: &truthy,


### PR DESCRIPTION
Backports the following commits to 7.x:
 - beater: add pprof-related config (#4954)