### PR TITLE
[7.x] Set client.ip for iOS agent (#4975)

### DIFF
--- a/beater/interceptors/metadata.go
+++ b/beater/interceptors/metadata.go
@@ -1,0 +1,83 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package interceptors
+
+import (
+	"context"
+	"net"
+	"net/http"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+
+	"github.com/elastic/apm-server/utility"
+)
+
+// ClientMetadata returns an interceptor that intercepts unary gRPC requests,
+// extracts metadata relating to the gRPC client, and adds it to the context.
+//
+// Metadata can be extracted from context using ClientMetadataFromContext.
+func ClientMetadata() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		var values ClientMetadataValues
+		if p, ok := peer.FromContext(ctx); ok {
+			if addr, ok := p.Addr.(*net.TCPAddr); ok {
+				values.SourceIP = addr.IP
+			}
+		}
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			if ua := md["user-agent"]; len(ua) > 0 {
+				values.UserAgent = ua[0]
+			}
+			// Account for `forwarded`, `x-real-ip`, `x-forwarded-for` headers
+			if ip := utility.ExtractIPFromHeader(http.Header(md)); ip != nil {
+				values.SourceIP = ip
+			}
+		}
+		ctx = context.WithValue(ctx, clientMetadataKey{}, values)
+		return handler(ctx, req)
+	}
+}
+
+type clientMetadataKey struct{}
+
+// ContextWithClientMetadata returns a copy of ctx with values.
+func ContextWithClientMetadata(ctx context.Context, values ClientMetadataValues) context.Context {
+	return context.WithValue(ctx, clientMetadataKey{}, values)
+}
+
+// ClientMetadataFromContext returns client metadata extracted by the ClientMetadata interceptor.
+func ClientMetadataFromContext(ctx context.Context) (ClientMetadataValues, bool) {
+	values, ok := ctx.Value(clientMetadataKey{}).(ClientMetadataValues)
+	return values, ok
+}
+
+// ClientMetadataValues holds metadata relating to the gRPC client that initiated the request being handled.
+type ClientMetadataValues struct {
+	// SourceIP net.IP holds the IP address of the gRPC client, if known.
+	SourceIP net.IP
+
+	// UserAgent holds the User-Agent for the gRPC client, if known.
+	UserAgent string
+}

--- a/beater/interceptors/metadata_test.go
+++ b/beater/interceptors/metadata_test.go
@@ -1,0 +1,78 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package interceptors
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+)
+
+func TestClientMetadata(t *testing.T) {
+	tcpAddr := &net.TCPAddr{
+		IP:   net.ParseIP("1.2.3.4"),
+		Port: 56837,
+	}
+	udpAddr := &net.UDPAddr{
+		IP:   net.ParseIP("1.1.1.1"),
+		Port: 1111,
+	}
+
+	interceptor := ClientMetadata()
+
+	for _, test := range []struct {
+		peer     *peer.Peer
+		metadata metadata.MD
+		expected ClientMetadataValues
+	}{{
+		expected: ClientMetadataValues{},
+	}, {
+		peer:     &peer.Peer{Addr: udpAddr},
+		expected: ClientMetadataValues{},
+	}, {
+		peer:     &peer.Peer{Addr: tcpAddr},
+		expected: ClientMetadataValues{SourceIP: tcpAddr.IP},
+	}, {
+		peer:     &peer.Peer{Addr: tcpAddr},
+		metadata: metadata.Pairs("X-Real-Ip", "5.6.7.8"),
+		expected: ClientMetadataValues{SourceIP: net.ParseIP("5.6.7.8")},
+	}, {
+		metadata: metadata.Pairs("User-Agent", "User-Agent"),
+		expected: ClientMetadataValues{UserAgent: "User-Agent"},
+	}} {
+		ctx := context.Background()
+		if test.peer != nil {
+			ctx = peer.NewContext(ctx, test.peer)
+		}
+		if test.metadata != nil {
+			ctx = metadata.NewIncomingContext(ctx, test.metadata)
+		}
+		var got ClientMetadataValues
+		var ok bool
+		interceptor(ctx, nil, nil, func(ctx context.Context, req interface{}) (interface{}, error) {
+			got, ok = ClientMetadataFromContext(ctx)
+			return nil, nil
+		})
+		assert.True(t, ok)
+		assert.Equal(t, test.expected, got)
+	}
+}

--- a/beater/otlp/clientmetadata_test.go
+++ b/beater/otlp/clientmetadata_test.go
@@ -1,0 +1,68 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package otlp_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-server/beater/interceptors"
+	"github.com/elastic/apm-server/beater/otlp"
+	"github.com/elastic/apm-server/model"
+)
+
+func TestSetClientMetadata(t *testing.T) {
+	ip1234 := net.ParseIP("1.2.3.4")
+	ip5678 := net.ParseIP("5.6.7.8")
+
+	for _, test := range []struct {
+		ctx        context.Context
+		meta       model.Metadata
+		expectedIP net.IP
+	}{{
+		ctx:        context.Background(),
+		meta:       model.Metadata{Client: model.Client{IP: ip1234}},
+		expectedIP: ip1234,
+	}, {
+		ctx: context.Background(),
+		meta: model.Metadata{
+			Service: model.Service{Agent: model.Agent{Name: "iOS/swift"}},
+			Client:  model.Client{IP: ip1234},
+		},
+		expectedIP: ip1234,
+	}, {
+		ctx:  context.Background(),
+		meta: model.Metadata{Service: model.Service{Agent: model.Agent{Name: "iOS/swift"}}},
+	}, {
+		ctx: interceptors.ContextWithClientMetadata(context.Background(), interceptors.ClientMetadataValues{
+			SourceIP: ip5678,
+		}),
+		meta:       model.Metadata{Service: model.Service{Agent: model.Agent{Name: "iOS/swift"}}},
+		expectedIP: ip5678,
+	}} {
+		metaCopy := test.meta
+		err := otlp.SetClientMetadata(test.ctx, &metaCopy)
+		assert.NoError(t, err)
+
+		test.meta.Client.IP = test.expectedIP
+		assert.Equal(t, test.meta, metaCopy)
+	}
+}

--- a/model/modelprocessor/hostname.go
+++ b/model/modelprocessor/hostname.go
@@ -30,7 +30,7 @@ type SetSystemHostname struct{}
 
 // ProcessBatch sets or overrides the host.name and host.hostname fields for events.
 func (SetSystemHostname) ProcessBatch(ctx context.Context, b *model.Batch) error {
-	return foreachEventMetadata(ctx, b, setSystemHostname)
+	return MetadataProcessorFunc(setSystemHostname).ProcessBatch(ctx, b)
 }
 
 func setSystemHostname(ctx context.Context, meta *model.Metadata) error {

--- a/model/modelprocessor/metadata.go
+++ b/model/modelprocessor/metadata.go
@@ -23,7 +23,12 @@ import (
 	"github.com/elastic/apm-server/model"
 )
 
-func foreachEventMetadata(ctx context.Context, b *model.Batch, f func(ctx context.Context, meta *model.Metadata) error) error {
+// MetadataProcessorFunc is a function type which implements model.BatchProcessor
+// by processing the metadata in each event in the batch.
+type MetadataProcessorFunc func(ctx context.Context, meta *model.Metadata) error
+
+// ProcessBatch calls f with the metadata of each event in b.
+func (f MetadataProcessorFunc) ProcessBatch(ctx context.Context, b *model.Batch) error {
 	for _, event := range b.Transactions {
 		if err := f(ctx, &event.Metadata); err != nil {
 			return err

--- a/model/modelprocessor/nodename.go
+++ b/model/modelprocessor/nodename.go
@@ -32,7 +32,7 @@ type SetServiceNodeName struct{}
 
 // ProcessBatch sets a default service.node.name for events without one already set.
 func (SetServiceNodeName) ProcessBatch(ctx context.Context, b *model.Batch) error {
-	return foreachEventMetadata(ctx, b, setServiceNodeName)
+	return MetadataProcessorFunc(setServiceNodeName).ProcessBatch(ctx, b)
 }
 
 func setServiceNodeName(ctx context.Context, meta *model.Metadata) error {

--- a/systemtest/logging_test.go
+++ b/systemtest/logging_test.go
@@ -32,6 +32,7 @@ import (
 	"go.elastic.co/apm/apmtest"
 	"go.elastic.co/fastjson"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpgrpc"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 
@@ -59,7 +60,7 @@ func TestAPMServerGRPCRequestLoggingValid(t *testing.T) {
 	_, err = client.PostSpans(context.Background(), request)
 	require.NoError(t, err)
 
-	err = sendOTLPTrace(context.Background(), srv, otlpgrpc.WithHeaders(map[string]string{"Authorization": "Bearer abc123"}))
+	err = sendOTLPTrace(context.Background(), srv, sdktrace.Config{}, otlpgrpc.WithHeaders(map[string]string{"Authorization": "Bearer abc123"}))
 	require.NoError(t, err)
 
 	srv.Close()


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Set client.ip for iOS agent (#4975)