### PR TITLE
[7.x] processor/otel: set default RepresentativeCount (#4976)

### DIFF
--- a/processor/otel/consumer.go
+++ b/processor/otel/consumer.go
@@ -358,6 +358,8 @@ func translateTransaction(
 	if samplerType != (pdata.AttributeValue{}) {
 		// The client has reported its sampling rate, so we can use it to extrapolate span metrics.
 		parseSamplerAttributes(samplerType, samplerParam, &tx.RepresentativeCount, labels)
+	} else {
+		tx.RepresentativeCount = 1
 	}
 
 	if tx.Result == "" {
@@ -606,6 +608,8 @@ func translateSpan(span pdata.Span, metadata model.Metadata, event *model.Span) 
 	if samplerType != (pdata.AttributeValue{}) {
 		// The client has reported its sampling rate, so we can use it to extrapolate transaction metrics.
 		parseSamplerAttributes(samplerType, samplerParam, &event.RepresentativeCount, labels)
+	} else {
+		event.RepresentativeCount = 1
 	}
 
 	event.Labels = labels

--- a/processor/otel/consumer_test.go
+++ b/processor/otel/consumer_test.go
@@ -101,6 +101,26 @@ func TestOutcome(t *testing.T) {
 	test(t, "failure", "Error", pdata.StatusCodeError)
 }
 
+func TestRepresentativeCount(t *testing.T) {
+	traces, spans := newTracesSpans()
+	otelSpan1 := pdata.NewSpan()
+	otelSpan1.SetTraceID(pdata.NewTraceID([16]byte{1}))
+	otelSpan1.SetSpanID(pdata.NewSpanID([8]byte{2}))
+	otelSpan2 := pdata.NewSpan()
+	otelSpan2.SetTraceID(pdata.NewTraceID([16]byte{1}))
+	otelSpan2.SetSpanID(pdata.NewSpanID([8]byte{2}))
+	otelSpan2.SetParentSpanID(pdata.NewSpanID([8]byte{3}))
+
+	spans.Spans().Append(otelSpan1)
+	spans.Spans().Append(otelSpan2)
+	batch := transformTraces(t, traces)
+	require.Len(t, batch.Transactions, 1)
+	require.Len(t, batch.Spans, 1)
+
+	assert.Equal(t, 1.0, batch.Transactions[0].RepresentativeCount)
+	assert.Equal(t, 1.0, batch.Spans[0].RepresentativeCount)
+}
+
 func TestHTTPTransactionURL(t *testing.T) {
 	test := func(t *testing.T, expected *model.URL, attrs map[string]pdata.AttributeValue) {
 		t.Helper()


### PR DESCRIPTION
Backports the following commits to 7.x:
 - processor/otel: set default RepresentativeCount (#4976)