### PR TITLE
[7.x] ingest/pipeline: convert ingest pipeline to YAML (#4977)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ apm-server.yml apm-server.docker.yml: $(MAGE) magefile.go _meta/beat.yml
 
 .PHONY: go-generate
 go-generate:
-	@$(GO) generate
+	@$(GO) generate . ./ingest/pipeline
 
 notice: NOTICE.txt
 NOTICE.txt: $(PYTHON) go.mod

--- a/ingest/pipeline/definition.json
+++ b/ingest/pipeline/definition.json
@@ -87,7 +87,7 @@
           }
         }
       ]
-    }     
+    }
   },
   {
     "id": "apm_remove_span_metadata",
@@ -120,16 +120,16 @@
   {
     "id": "apm_error_grouping_name",
     "body": {
-      "description" : "Set error.grouping_name for APM error events",
-      "processors" : [
+      "description": "Set error.grouping_name for APM error events",
+      "processors": [
         {
-          "script" : {
+          "script": {
             "source": "ctx.error.grouping_name = ctx.error.exception[0].message",
             "if": "ctx.error?.exception?.length != null && ctx.error?.exception?.length > 0"
           }
         },
         {
-          "set" : {
+          "set": {
             "field": "error.grouping_name",
             "copy_from": "error.log.message",
             "if": "ctx.error?.log?.message != null"

--- a/ingest/pipeline/definition.yml
+++ b/ingest/pipeline/definition.yml
@@ -1,0 +1,76 @@
+apm:
+  description: Default enrichment for APM events
+  processors:
+  - pipeline:
+      name: apm_user_agent
+  - pipeline:
+      name: apm_user_geo
+  - pipeline:
+      name: apm_ingest_timestamp
+  - pipeline:
+      name: apm_remove_span_metadata
+  - pipeline:
+      name: apm_error_grouping_name
+      if: ctx.processor?.event == 'error'
+
+apm_user_agent:
+  description: Add user agent information for APM events
+  processors:
+  - user_agent:
+      field: user_agent.original
+      target_field: user_agent
+      ignore_missing: true
+      ignore_failure: true
+
+apm_user_geo:
+  description: Add user geo information for APM events
+  processors:
+  - geoip:
+      database_file: GeoLite2-City.mmdb
+      field: client.ip
+      target_field: client.geo
+      ignore_missing: true
+      on_failure:
+      - remove:
+          field: client.ip
+          ignore_missing: true
+          ignore_failure: true
+
+apm_ingest_timestamp:
+  description: Add an ingest timestamp for APM events
+  processors:
+  - set:
+      if: ctx.processor?.event != 'span'
+      field: event.ingested
+      value: "{{_ingest.timestamp}}"
+
+apm_remove_span_metadata:
+  description: Removes metadata fields available already on the parent transaction, to save storage
+  processors:
+  - remove:
+      if: ctx.processor?.event == 'span'
+      field:
+      - host
+      - process
+      - user
+      - user_agent
+      - container
+      - kubernetes
+      - service.node
+      - service.version
+      - service.language
+      - service.runtime
+      - service.framework
+      ignore_missing: true
+      ignore_failure: true
+
+apm_error_grouping_name:
+  description: Set error.grouping_name for APM error events
+  processors:
+  - script:
+      source: ctx.error.grouping_name = ctx.error.exception[0].message
+      if: ctx.error?.exception?.length != null && ctx.error?.exception?.length > 0
+  - set:
+      field: error.grouping_name
+      copy_from: error.log.message
+      if: ctx.error?.log?.message != null

--- a/ingest/pipeline/generate.go
+++ b/ingest/pipeline/generate.go
@@ -1,0 +1,131 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// +build ignore
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type pipelineDefinition struct {
+	ID   interface{} `json:"id"`
+	Body interface{} `json:"body"`
+}
+
+func main() {
+	var doc yaml.Node
+	fin, err := os.Open("definition.yml")
+	if err != nil {
+		log.Fatal(err)
+	}
+	yamlDecoder := yaml.NewDecoder(fin)
+	if err := yamlDecoder.Decode(&doc); err != nil {
+		log.Fatal(err)
+	}
+
+	// Convert the document structure into the one expected by libbeat.
+	// e.g. convert {a: 1, b: 2, ...} to [{id: a, body: 1}, {id: b, body: 2}, ...]
+	if n := len(doc.Content); n != 1 {
+		log.Fatalf("expected 1 document, got %d", n)
+	}
+	mappingNode := doc.Content[0]
+	sequenceNode := &yaml.Node{Kind: yaml.SequenceNode, Content: make([]*yaml.Node, len(mappingNode.Content)/2)}
+	for i := 0; i < len(mappingNode.Content); i += 2 {
+		idNode := mappingNode.Content[i]
+		bodyNode := mappingNode.Content[i+1]
+		sequenceNode.Content[i/2] = &yaml.Node{
+			Kind: yaml.MappingNode,
+			Content: []*yaml.Node{
+				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "id"},
+				idNode,
+				{Kind: yaml.ScalarNode, Tag: "!!str", Value: "body"},
+				bodyNode,
+			},
+		}
+	}
+	doc.Content[0] = sequenceNode
+
+	var buf bytes.Buffer
+	if err := encodeJSON(&buf, &doc); err != nil {
+		log.Fatal(err)
+	}
+	var indented bytes.Buffer
+	if err := json.Indent(&indented, buf.Bytes(), "", "  "); err != nil {
+		log.Fatal(err)
+	}
+	if err := ioutil.WriteFile("definition.json", indented.Bytes(), 0644); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func encodeJSON(buf *bytes.Buffer, node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.DocumentNode:
+		return encodeJSON(buf, node.Content[0])
+	case yaml.SequenceNode:
+		buf.WriteByte('[')
+		for i, node := range node.Content {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			if err := encodeJSON(buf, node); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte(']')
+		return nil
+	case yaml.MappingNode:
+		buf.WriteByte('{')
+		for i := 0; i < len(node.Content); i += 2 {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			if err := encodeJSON(buf, node.Content[i]); err != nil {
+				return err
+			}
+			buf.WriteByte(':')
+			if err := encodeJSON(buf, node.Content[i+1]); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte('}')
+		return nil
+	case yaml.ScalarNode:
+		switch node.Tag {
+		case "!!str":
+			enc := json.NewEncoder(buf)
+			enc.SetEscapeHTML(false)
+			return enc.Encode(node.Value)
+		case "!!bool", "!!int":
+			buf.WriteString(node.Value)
+			return nil
+		default:
+			return fmt.Errorf("unexpected tag %q at %d:%d", node.Tag, node.Line, node.Column)
+		}
+	default:
+		return fmt.Errorf("unexpected kind %d at %d:%d", node.Kind, node.Line, node.Column)
+	}
+}

--- a/ingest/pipeline/register.go
+++ b/ingest/pipeline/register.go
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//go:generate go run generate.go
+
 package pipeline
 
 import (


### PR DESCRIPTION
Backports the following commits to 7.x:
 - ingest/pipeline: convert ingest pipeline to YAML (#4977)