### PR TITLE
support truncating sourcemap lines

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -240,6 +240,10 @@ apm-server:
       # Sourcemapping is enabled by default.
       #enabled: true
 
+      # Maximum allowed line length in characters. Default maximum line length
+      # is unlimited, indicated by `0`. Minimum allowed value is 16.
+      #max_line_length: 0
+
       # Source maps are always fetched from Elasticsearch, by default using the output.elasticsearch configuration.
       # A different instance must be configured when using any other output.
       # This setting only affects sourcemap reads - the output determines where sourcemaps are written.

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -240,6 +240,10 @@ apm-server:
       # Sourcemapping is enabled by default.
       #enabled: true
 
+      # Maximum allowed line length in characters. Default maximum line length
+      # is unlimited, indicated by `0`. Minimum allowed value is 16.
+      #max_line_length: 0
+
       # Source maps are always fetched from Elasticsearch, by default using the output.elasticsearch configuration.
       # A different instance must be configured when using any other output.
       # This setting only affects sourcemap reads - the output determines where sourcemaps are written.

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -240,6 +240,10 @@ apm-server:
       # Sourcemapping is enabled by default.
       #enabled: true
 
+      # Maximum allowed line length in characters. Default maximum line length
+      # is unlimited, indicated by `0`. Minimum allowed value is 16.
+      #max_line_length: 0
+
       # Source maps are always fetched from Elasticsearch, by default using the output.elasticsearch configuration.
       # A different instance must be configured when using any other output.
       # This setting only affects sourcemap reads - the output determines where sourcemaps are written.

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -603,6 +603,7 @@ func newTransformConfig(beatInfo beat.Info, cfg *config.Config) (*transform.Conf
 		RUM: transform.RUMConfig{
 			LibraryPattern:      regexp.MustCompile(cfg.RumConfig.LibraryPattern),
 			ExcludeFromGrouping: regexp.MustCompile(cfg.RumConfig.ExcludeFromGrouping),
+			MaxLineLength:       cfg.RumConfig.SourceMapping.MaxLineLength,
 		},
 	}
 

--- a/beater/config/rum.go
+++ b/beater/config/rum.go
@@ -59,12 +59,12 @@ type EventRate struct {
 
 // SourceMapping holds sourecemap config information
 type SourceMapping struct {
-	Cache        *Cache `config:"cache"`
-	Enabled      *bool  `config:"enabled"`
-	IndexPattern string `config:"index_pattern"`
-	// TODO: uint? uint64? Or do we not care and just use an int?
-	MaxLineLength uint                  `config:"max_line_length"`
-	ESConfig      *elasticsearch.Config `config:"elasticsearch"`
+	Cache        *Cache                `config:"cache"`
+	Enabled      *bool                 `config:"enabled"`
+	IndexPattern string                `config:"index_pattern"`
+	ESConfig     *elasticsearch.Config `config:"elasticsearch"`
+	// MaxLineLength of 0 indicates no maximum length.
+	MaxLineLength int `config:"max_line_length"`
 	esConfigured  bool
 }
 

--- a/beater/config/rum.go
+++ b/beater/config/rum.go
@@ -59,11 +59,13 @@ type EventRate struct {
 
 // SourceMapping holds sourecemap config information
 type SourceMapping struct {
-	Cache        *Cache                `config:"cache"`
-	Enabled      *bool                 `config:"enabled"`
-	IndexPattern string                `config:"index_pattern"`
-	ESConfig     *elasticsearch.Config `config:"elasticsearch"`
-	esConfigured bool
+	Cache        *Cache `config:"cache"`
+	Enabled      *bool  `config:"enabled"`
+	IndexPattern string `config:"index_pattern"`
+	// TODO: uint? uint64? Or do we not care and just use an int?
+	MaxLineLength uint                  `config:"max_line_length"`
+	ESConfig      *elasticsearch.Config `config:"elasticsearch"`
+	esConfigured  bool
 }
 
 // IsEnabled indicates whether RUM endpoint is enabled or not
@@ -131,9 +133,10 @@ func (s *SourceMapping) Unpack(inp *common.Config) error {
 
 func defaultSourcemapping() *SourceMapping {
 	return &SourceMapping{
-		Cache:        &Cache{Expiration: defaultSourcemapCacheExpiration},
-		IndexPattern: defaultSourcemapIndexPattern,
-		ESConfig:     elasticsearch.DefaultConfig(),
+		Cache:         &Cache{Expiration: defaultSourcemapCacheExpiration},
+		IndexPattern:  defaultSourcemapIndexPattern,
+		ESConfig:      elasticsearch.DefaultConfig(),
+		MaxLineLength: 0,
 	}
 }
 

--- a/beater/config/rum_test.go
+++ b/beater/config/rum_test.go
@@ -39,7 +39,6 @@ func TestIsRumEnabled(t *testing.T) {
 		{c: &Config{RumConfig: &RumConfig{Enabled: &truthy}}, enabled: true},
 	} {
 		assert.Equal(t, td.enabled, td.c.RumConfig.IsEnabled())
-
 	}
 }
 
@@ -62,4 +61,18 @@ func TestRumSetup(t *testing.T) {
 func TestDefaultRum(t *testing.T) {
 	c := DefaultConfig()
 	assert.Equal(t, defaultRum(), c.RumConfig)
+}
+
+func TestSourceMapMaxLineLength(t *testing.T) {
+	maxLen := uint(512)
+	srcMapping := defaultSourcemapping()
+	srcMapping.MaxLineLength = maxLen
+
+	parsedSrcMapping := new(SourceMapping)
+
+	parsedSrcMapping.Unpack(common.MustNewConfigFrom(map[string]interface{}{
+		"max_line_length": maxLen,
+	}))
+
+	assert.Equal(t, srcMapping.MaxLineLength, parsedSrcMapping.MaxLineLength)
 }

--- a/beater/config/rum_test.go
+++ b/beater/config/rum_test.go
@@ -64,7 +64,7 @@ func TestDefaultRum(t *testing.T) {
 }
 
 func TestSourceMapMaxLineLength(t *testing.T) {
-	maxLen := uint(512)
+	maxLen := 512
 	srcMapping := defaultSourcemapping()
 	srcMapping.MaxLineLength = maxLen
 

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -29,6 +29,7 @@ https://github.com/elastic/apm-server/compare/7.12\...master[View commits]
 * Set `client.ip` for events from the Elastic APM iOS agent {pull}4975[4975]
 * Calculate service destination metrics for OpenTelemetry spans {pull}4976[4976]
 * Add exponential retries to api key and tail sampling requests{pull}4991[4991]
+* Make maximum line length when viewing sourcemaps configurable {pull}5033[5033]
 
 [float]
 ==== Deprecated

--- a/model/stacktrace.go
+++ b/model/stacktrace.go
@@ -63,7 +63,7 @@ func (st *Stacktrace) transform(ctx context.Context, cfg *transform.Config, rum 
 	logger := logp.NewLogger(logs.Stacktrace)
 	fct := "<anonymous>"
 	return st.transformFrames(cfg, rum, func(frame *StacktraceFrame) {
-		fct, errMsg = frame.applySourcemap(ctx, cfg.RUM.SourcemapStore, service, fct)
+		fct, errMsg = frame.applySourcemap(ctx, cfg.RUM.SourcemapStore, service, fct, cfg.RUM.MaxLineLength)
 		if errMsg == "" || !logger.IsDebug() {
 			return
 		}

--- a/model/stacktrace_frame.go
+++ b/model/stacktrace_frame.go
@@ -148,7 +148,7 @@ func (s *StacktraceFrame) applySourcemap(
 	store *sourcemap.Store,
 	service *Service,
 	prevFunction string,
-	maxLineLength uint,
+	maxLineLength int,
 ) (function, errMsg string) {
 	function = prevFunction
 

--- a/model/stacktrace_frame.go
+++ b/model/stacktrace_frame.go
@@ -143,7 +143,13 @@ func (s *StacktraceFrame) setLibraryFrame(pattern *regexp.Regexp) {
 	s.LibraryFrame = &libraryFrame
 }
 
-func (s *StacktraceFrame) applySourcemap(ctx context.Context, store *sourcemap.Store, service *Service, prevFunction string) (function string, errMsg string) {
+func (s *StacktraceFrame) applySourcemap(
+	ctx context.Context,
+	store *sourcemap.Store,
+	service *Service,
+	prevFunction string,
+	maxLineLength uint,
+) (function, errMsg string) {
 	function = prevFunction
 
 	var valid bool
@@ -167,7 +173,7 @@ func (s *StacktraceFrame) applySourcemap(ctx context.Context, store *sourcemap.S
 		return
 	}
 
-	file, fct, line, col, ctxLine, preCtx, postCtx, ok := sourcemap.Map(mapper, *s.Original.Lineno, *s.Original.Colno)
+	file, fct, line, col, ctxLine, preCtx, postCtx, ok := sourcemap.Map(mapper, *s.Original.Lineno, *s.Original.Colno, maxLineLength)
 	if !ok {
 		errMsg = fmt.Sprintf("No Sourcemap found for Lineno %v, Colno %v", *s.Original.Lineno, *s.Original.Colno)
 		s.updateError(errMsg)

--- a/model/stacktrace_frame_test.go
+++ b/model/stacktrace_frame_test.go
@@ -131,7 +131,7 @@ func TestSourcemap_Apply(t *testing.T) {
 			},
 		} {
 			t.Run(name, func(t *testing.T) {
-				function, msg := tc.frame.applySourcemap(context.Background(), &sourcemap.Store{}, validService(), "foo")
+				function, msg := tc.frame.applySourcemap(context.Background(), &sourcemap.Store{}, validService(), "foo", 0)
 				assert.Equal(t, "foo", function)
 				assert.Contains(t, msg, tc.expectedErrorMsg)
 				assert.Equal(t, new(bool), tc.frame.SourcemapUpdated)
@@ -155,7 +155,7 @@ func TestSourcemap_Apply(t *testing.T) {
 		} {
 			t.Run(name, func(t *testing.T) {
 				frame := validFrame()
-				function, msg := frame.applySourcemap(context.Background(), tc.store, validService(), "xyz")
+				function, msg := frame.applySourcemap(context.Background(), tc.store, validService(), "xyz", 0)
 				assert.Equal(t, "xyz", function)
 				require.Contains(t, msg, tc.expectedErrorMsg)
 				assert.NotZero(t, frame.SourcemapError)
@@ -178,7 +178,7 @@ func TestSourcemap_Apply(t *testing.T) {
 		} {
 			t.Run(name, func(t *testing.T) {
 				frame := validFrame()
-				function, msg := frame.applySourcemap(context.Background(), tc.store, validService(), "xyz")
+				function, msg := frame.applySourcemap(context.Background(), tc.store, validService(), "xyz", 0)
 				assert.Equal(t, "xyz", function)
 				require.Contains(t, msg, tc.expectedErrorMsg)
 				assert.NotZero(t, msg)
@@ -218,7 +218,7 @@ func TestSourcemap_Apply(t *testing.T) {
 				frame := &StacktraceFrame{Colno: &tc.origCol, Lineno: &tc.origLine, AbsPath: tc.origPath}
 
 				prevFunction := "xyz"
-				function, msg := frame.applySourcemap(context.Background(), testSourcemapStore(t, test.ESClientWithValidSourcemap(t)), validService(), prevFunction)
+				function, msg := frame.applySourcemap(context.Background(), testSourcemapStore(t, test.ESClientWithValidSourcemap(t)), validService(), prevFunction, 0)
 				require.Empty(t, msg)
 				assert.Zero(t, frame.SourcemapError)
 				updated := true

--- a/sourcemap/mapper_test.go
+++ b/sourcemap/mapper_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/go-sourcemap/sourcemap"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMapNilConsumer(t *testing.T) {
@@ -36,11 +37,11 @@ func TestMapNilConsumer(t *testing.T) {
 
 func TestMapNoMatch(t *testing.T) {
 	m, err := sourcemap.Parse("", []byte(test.ValidSourcemap))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// nothing found for lineno and colno
 	file, fc, line, col, ctxLine, _, _, ok := Map(m, 0, 0, 0)
-	assert.False(t, ok)
+	require.False(t, ok)
 	assert.Zero(t, file)
 	assert.Zero(t, fc)
 	assert.Zero(t, line)
@@ -54,7 +55,7 @@ func TestMapMatch(t *testing.T) {
 	// Re-encode the sourcemap, adding carriage returns to the
 	// line endings in the source content.
 	decoded := make(map[string]interface{})
-	assert.NoError(t, json.Unmarshal([]byte(validSourcemap), &decoded))
+	require.NoError(t, json.Unmarshal([]byte(validSourcemap), &decoded))
 	sourceContent := decoded["sourcesContent"].([]interface{})
 	for i := range sourceContent {
 		sourceContentFile := sourceContent[i].(string)
@@ -62,14 +63,14 @@ func TestMapMatch(t *testing.T) {
 		sourceContent[i] = sourceContentFile
 	}
 	crlfSourcemap, err := json.Marshal(decoded)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// mapping found in minified sourcemap
 	test := func(t *testing.T, source []byte) {
 		m, err := sourcemap.Parse("", source)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		file, fc, line, col, ctxLine, preCtx, postCtx, ok := Map(m, 1, 7, 0)
-		assert.True(t, ok)
+		require.True(t, ok)
 		assert.Equal(t, "webpack:///bundle.js", file)
 		assert.Equal(t, "", fc)
 		assert.Equal(t, 1, line)
@@ -87,9 +88,9 @@ func TestMapMaxLineLength(t *testing.T) {
 
 	// mapping found in minified sourcemap
 	m, err := sourcemap.Parse("", source)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	file, fc, line, col, ctxLine, preCtx, postCtx, ok := Map(m, 1, 7, 16)
-	assert.True(t, ok)
+	require.True(t, ok)
 	assert.Equal(t, "webpack:///bundle.js", file)
 	assert.Equal(t, "", fc)
 	assert.Equal(t, 1, line)

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -46,4 +46,5 @@ type RUMConfig struct {
 	LibraryPattern      *regexp.Regexp
 	ExcludeFromGrouping *regexp.Regexp
 	SourcemapStore      *sourcemap.Store
+	MaxLineLength       uint
 }

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -46,5 +46,6 @@ type RUMConfig struct {
 	LibraryPattern      *regexp.Regexp
 	ExcludeFromGrouping *regexp.Regexp
 	SourcemapStore      *sourcemap.Store
-	MaxLineLength       uint
+	// MaxLineLength of 0 indicates no maximum length.
+	MaxLineLength int
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

User-requested feature to limit the line length for returned sourcemaps, as excessively long lines were OOM'ing coordinating nodes.

closes https://github.com/elastic/apm-server/issues/4149

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

Start a copy of APM server with the `source_mapping.max_line_length` set to something small. Confirm that when viewing lines, they've been truncated.

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
