### PR TITLE
tests/system: fix system tests

### DIFF
--- a/docs/data/elasticsearch/generated/errors.json
+++ b/docs/data/elasticsearch/generated/errors.json
@@ -407,7 +407,8 @@
         },
         "user_agent": {
             "device": {
-                "name": "Other"
+                "name": "Other",
+                "type": "Other"
             },
             "name": "Other",
             "original": "Mozilla Chrome Edge"

--- a/docs/data/elasticsearch/generated/transactions.json
+++ b/docs/data/elasticsearch/generated/transactions.json
@@ -497,7 +497,8 @@
         },
         "user_agent": {
             "device": {
-                "name": "Other"
+                "name": "Other",
+                "type": "Other"
             },
             "name": "Other",
             "original": "Mozilla Chrome Edge"

--- a/systemtest/approvals/TestRUMErrorSourcemapping.approved.json
+++ b/systemtest/approvals/TestRUMErrorSourcemapping.approved.json
@@ -302,7 +302,8 @@
             },
             "user_agent": {
                 "device": {
-                    "name": "Other"
+                    "name": "Other",
+                    "type": "Other"
                 },
                 "name": "Go-http-client",
                 "original": "Go-http-client/1.1",

--- a/systemtest/approvals/TestRUMXForwardedFor.approved.json
+++ b/systemtest/approvals/TestRUMXForwardedFor.approved.json
@@ -65,7 +65,8 @@
             },
             "user_agent": {
                 "device": {
-                    "name": "Other"
+                    "name": "Other",
+                    "type": "Other"
                 },
                 "name": "Go-http-client",
                 "original": "Go-http-client/1.1",

--- a/tests/system/error.approved.json
+++ b/tests/system/error.approved.json
@@ -407,7 +407,8 @@
         },
         "user_agent": {
             "device": {
-                "name": "Other"
+                "name": "Other",
+                "type": "Other"
             },
             "name": "Other",
             "original": "Mozilla Chrome Edge"

--- a/tests/system/kibana.py
+++ b/tests/system/kibana.py
@@ -61,7 +61,7 @@ class Kibana(object):
             }
         )
         assert resp.status_code == 200, resp.status_code
-        return resp.json()
+        return resp.json()['configurations']
 
     def delete_agent_config(self, service, env=None):
         data = {

--- a/tests/system/transaction.approved.json
+++ b/tests/system/transaction.approved.json
@@ -497,7 +497,8 @@
         },
         "user_agent": {
             "device": {
-                "name": "Other"
+                "name": "Other",
+                "type": "Other"
             },
             "name": "Other",
             "original": "Mozilla Chrome Edge"


### PR DESCRIPTION
## Motivation/summary

Fix Python-based system tests due to several recent changes:
 - Kibana now has a different response structure for listing agent config (API only used in system tests, no backwards compatibility issue for APM Server)
 - Add `user_agent.device.type` to approvals, which is now added by the `user_agent` ingest processor

## How to test these changes

`make system-tests`

## Related issues

None.