### PR TITLE
beater/interceptors: don't reassign shared logger

### DIFF
--- a/beater/interceptors/logging.go
+++ b/beater/interceptors/logging.go
@@ -39,6 +39,11 @@ func Logging(logger *logp.Logger) grpc.UnaryServerInterceptor {
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (interface{}, error) {
+		// Shadow the logger param to ensure we don't update the
+		// closure variable, and interfere with logging of other
+		// requests.
+		logger := logger
+
 		start := time.Now()
 		if metadata, ok := ClientMetadataFromContext(ctx); ok {
 			if metadata.SourceIP != nil {


### PR DESCRIPTION
## Motivation/summary

Make sure we create a new shadowed "logger" variable,
rather than reassigning to the "logger" param passed
into the interceptor. Otherwise, each request will add
duplicate fields to an ever-growing list of fields.

## How to test these changes

Send multiple gRPC requests to APM Server, with logging enabled. Make sure there are no duplicate fields in any request's log entry. (If you run a load generator, it'll become apparent pretty quickly as the terminal fills up with logs!)

## Related issues

None.