### PR TITLE
[7.12] docs: update agent/server compat for ruby (#5036)

### DIFF
--- a/docs/guide/agent-server-compatibility.asciidoc
+++ b/docs/guide/agent-server-compatibility.asciidoc
@@ -39,6 +39,7 @@ The chart below outlines the compatibility between different versions of the APM
 |`1.x` |`6.4`-`6.x`
 |`2.x` |≥ `6.5`
 |`3.x` |≥ `6.5`
+|`4.x` |≥ `6.5`
 
 // RUM
 .4+|**JavaScript RUM agent**


### PR DESCRIPTION
Backports the following commits to 7.12:
 - docs: update agent/server compat for ruby (#5036)