### PR TITLE
ingest: make apm_ingest_timestamp first pipeline

### DIFF
--- a/apmpackage/apm/0.2.0/data_stream/app_metrics/elasticsearch/ingest_pipeline/default.json
+++ b/apmpackage/apm/0.2.0/data_stream/app_metrics/elasticsearch/ingest_pipeline/default.json
@@ -3,17 +3,17 @@
   "processors": [
     {
       "pipeline": {
+        "name": "metrics-apm.app-0.2.0-apm_ingest_timestamp"
+      }
+    },
+    {
+      "pipeline": {
         "name": "metrics-apm.app-0.2.0-apm_user_agent"
       }
     },
     {
       "pipeline": {
         "name": "metrics-apm.app-0.2.0-apm_user_geo"
-      }
-    },
-    {
-      "pipeline": {
-        "name": "metrics-apm.app-0.2.0-apm_ingest_timestamp"
       }
     },
     {

--- a/apmpackage/apm/0.2.0/data_stream/error_logs/elasticsearch/ingest_pipeline/default.json
+++ b/apmpackage/apm/0.2.0/data_stream/error_logs/elasticsearch/ingest_pipeline/default.json
@@ -3,17 +3,17 @@
   "processors": [
     {
       "pipeline": {
+        "name": "logs-apm.error-0.2.0-apm_ingest_timestamp"
+      }
+    },
+    {
+      "pipeline": {
         "name": "logs-apm.error-0.2.0-apm_user_agent"
       }
     },
     {
       "pipeline": {
         "name": "logs-apm.error-0.2.0-apm_user_geo"
-      }
-    },
-    {
-      "pipeline": {
-        "name": "logs-apm.error-0.2.0-apm_ingest_timestamp"
       }
     },
     {

--- a/apmpackage/apm/0.2.0/data_stream/internal_metrics/elasticsearch/ingest_pipeline/default.json
+++ b/apmpackage/apm/0.2.0/data_stream/internal_metrics/elasticsearch/ingest_pipeline/default.json
@@ -3,17 +3,17 @@
   "processors": [
     {
       "pipeline": {
+        "name": "metrics-apm.internal-0.2.0-apm_ingest_timestamp"
+      }
+    },
+    {
+      "pipeline": {
         "name": "metrics-apm.internal-0.2.0-apm_user_agent"
       }
     },
     {
       "pipeline": {
         "name": "metrics-apm.internal-0.2.0-apm_user_geo"
-      }
-    },
-    {
-      "pipeline": {
-        "name": "metrics-apm.internal-0.2.0-apm_ingest_timestamp"
       }
     },
     {

--- a/apmpackage/apm/0.2.0/data_stream/profile_metrics/elasticsearch/ingest_pipeline/default.json
+++ b/apmpackage/apm/0.2.0/data_stream/profile_metrics/elasticsearch/ingest_pipeline/default.json
@@ -3,17 +3,17 @@
   "processors": [
     {
       "pipeline": {
+        "name": "metrics-apm.profiling-0.2.0-apm_ingest_timestamp"
+      }
+    },
+    {
+      "pipeline": {
         "name": "metrics-apm.profiling-0.2.0-apm_user_agent"
       }
     },
     {
       "pipeline": {
         "name": "metrics-apm.profiling-0.2.0-apm_user_geo"
-      }
-    },
-    {
-      "pipeline": {
-        "name": "metrics-apm.profiling-0.2.0-apm_ingest_timestamp"
       }
     },
     {

--- a/apmpackage/apm/0.2.0/data_stream/traces/elasticsearch/ingest_pipeline/default.json
+++ b/apmpackage/apm/0.2.0/data_stream/traces/elasticsearch/ingest_pipeline/default.json
@@ -3,17 +3,17 @@
   "processors": [
     {
       "pipeline": {
+        "name": "traces-apm-0.2.0-apm_ingest_timestamp"
+      }
+    },
+    {
+      "pipeline": {
         "name": "traces-apm-0.2.0-apm_user_agent"
       }
     },
     {
       "pipeline": {
         "name": "traces-apm-0.2.0-apm_user_geo"
-      }
-    },
-    {
-      "pipeline": {
-        "name": "traces-apm-0.2.0-apm_ingest_timestamp"
       }
     },
     {

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -31,6 +31,7 @@ https://github.com/elastic/apm-server/compare/7.12\...master[View commits]
 * Add exponential retries to api key and tail sampling requests{pull}4991[4991]
 * Add `apm-server.rum.allow_service_names` config {pull}5030[5030]
 * Ingest pipeline for translating OpenTelemetry Java metrics to Elastic APM fields {pull}4986[4986]
+* Set `event.ingested` first in the ingest pipeline {pull}5048[5048]
 
 [float]
 ==== Deprecated

--- a/ingest/pipeline/definition.json
+++ b/ingest/pipeline/definition.json
@@ -6,17 +6,17 @@
       "processors": [
         {
           "pipeline": {
+            "name": "apm_ingest_timestamp"
+          }
+        },
+        {
+          "pipeline": {
             "name": "apm_user_agent"
           }
         },
         {
           "pipeline": {
             "name": "apm_user_geo"
-          }
-        },
-        {
-          "pipeline": {
-            "name": "apm_ingest_timestamp"
           }
         },
         {

--- a/ingest/pipeline/definition.yml
+++ b/ingest/pipeline/definition.yml
@@ -2,11 +2,14 @@ apm:
   description: Default enrichment for APM events
   processors:
   - pipeline:
+      # apm_ingest_timestamp should always come first,
+      # ensuring `event.ingested` is set as early as
+      # possible.
+      name: apm_ingest_timestamp
+  - pipeline:
       name: apm_user_agent
   - pipeline:
       name: apm_user_geo
-  - pipeline:
-      name: apm_ingest_timestamp
   - pipeline:
       name: apm_remove_span_metadata
   - pipeline:


### PR DESCRIPTION
## Motivation/summary

`apm_ingest_timestamp` should always come first, ensuring
`event.ingested` is set as early as possible in the ingest
pipeline. This is in line with beats modules, and the ECS
definition of `event.ingested`.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

## How to test these changes

1. Run APM Server with a clean Elasticsearch
2. Check that the "apm" pipeline installed by APM Server calls "apm_ingest_timestamp" first

## Related issues

None.