### PR TITLE
processor/stream: fix panic in benchmarks

### DIFF
--- a/processor/stream/benchmark_test.go
+++ b/processor/stream/benchmark_test.go
@@ -32,13 +32,13 @@ import (
 )
 
 func BenchmarkBackendProcessor(b *testing.B) {
-	processor := BackendProcessor(&config.Config{MaxEventSize: 300 * 1024})
+	processor := BackendProcessor(config.DefaultConfig())
 	files, _ := filepath.Glob(filepath.FromSlash("../../testdata/intake-v2/*.ndjson"))
 	benchmarkStreamProcessor(b, processor, files)
 }
 
 func BenchmarkRUMV3Processor(b *testing.B) {
-	processor := RUMV3Processor(&config.Config{MaxEventSize: 300 * 1024})
+	processor := RUMV3Processor(config.DefaultConfig())
 	files, _ := filepath.Glob(filepath.FromSlash("../../testdata/intake-v3/rum_*.ndjson"))
 	benchmarkStreamProcessor(b, processor, files)
 }


### PR DESCRIPTION
## Motivation/summary

Fix RUM event processor benchmarks in `processor/stream` which were panicking due to invalid config.

## How to test these changes

N/A, non-functional change.

## Related issues

None.