### PR TITLE
docker-compose.yml: allow wildard deletes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       - "xpack.security.authc.token.enabled=true"
       - "xpack.security.authc.api_key.enabled=true"
       - "logger.org.elasticsearch=${ES_LOG_LEVEL:-error}"
+      - "action.destructive_requires_name=false"
     volumes:
       - "./testing/docker/elasticsearch/roles.yml:/usr/share/elasticsearch/config/roles.yml"
       - "./testing/docker/elasticsearch/users:/usr/share/elasticsearch/config/users"

--- a/systemtest/elasticsearch.go
+++ b/systemtest/elasticsearch.go
@@ -118,7 +118,9 @@ func CleanupElasticsearch(t testing.TB) {
 	}
 
 	// Delete indices, data streams, and ingest pipelines.
-	doReq(esapi.IndicesDeleteRequest{Index: []string{legacyPrefix}})
+	if err := doReq(esapi.IndicesDeleteRequest{Index: []string{legacyPrefix}}); err != nil {
+		t.Fatal(err)
+	}
 	doParallel(
 		esapi.IndicesDeleteDataStreamRequest{Name: legacyPrefix},
 		esapi.IndicesDeleteDataStreamRequest{Name: apmTracesPrefix},


### PR DESCRIPTION
## Motivation/summary

Set `action.destructive_requires_name=false` in docker-compose.yml for Elastisearch, to allow wildcard deletions.

## How to test these changes

Non-functional change, check that system tests pass.

## Related issues

https://github.com/elastic/elasticsearch/issues/61074