### PR TITLE
[mergify] run the check after the PR gets merged

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,6 +15,7 @@ pull_request_rules:
             ```
   - name: backport patches to 7.x branch
     conditions:
+      - merged
       - base=master
       - label=v7.13.0
     actions:
@@ -23,6 +24,7 @@ pull_request_rules:
           - "7.x"
   - name: backport patches to 7.12 branch
     conditions:
+      - merged
       - base=master
       - label=v7.12.0
     actions:


### PR DESCRIPTION
## Motivation/summary

The Mergify check on PRs never goes green in the GitHub UI, which makes it difficult to tell whether a PR is ready to merge.

Add the `merged` attribute -> https://docs.mergify.io/conditions/#attributes 