### PR TITLE
ci: use the specs relative location

### DIFF
--- a/.ci/update-json-schema.groovy
+++ b/.ci/update-json-schema.groovy
@@ -185,7 +185,7 @@ def createPRDescription(commit) {
     def gitLog = sh(script: """
       git log --pretty=format:'* https://github.com/${env.ORG_NAME}/${env.REPO_NAME}/commit/%h %s' \
           ${commit}...HEAD \
-          --follow -- spec \
+          --follow -- docs/spec \
       | sed 's/#\\([0-9]\\+\\)/https:\\/\\/github.com\\/${env.ORG_NAME}\\/${env.REPO_NAME}\\/pull\\/\\1/g' || true""", returnStdout: true)
     message += "*Changeset*\n${gitLog}"
   }


### PR DESCRIPTION
## Motivation/summary

Folder to filter was not pointing to the right location. Therefore the automation to create PRs was not linking the original commit.

For instance:


```
git  --no-pager log --pretty=format:'* https://github.com/elastic/apm-server/commit/%h %s' \
          5c2e4cb387e14b8a4707c8f2a349f0452fae72c5...HEAD \
          --follow -- spec
```

produces nothing, while the new change produces:
```
git  --no-pager log --pretty=format:'* https://github.com/elastic/apm-server/commit/%h %s' \      
          5c2e4cb387e14b8a4707c8f2a349f0452fae72c5...HEAD \
          --follow -- docs/spec
* https://github.com/elastic/apm-server/commit/f787691a Support for ingesting user.domain (#5067)% 
```