### PR TITLE
[7.x] docs: Link to .NET ServerCert docs (#5078)

### DIFF
--- a/docs/secure-communication-agents.asciidoc
+++ b/docs/secure-communication-agents.asciidoc
@@ -494,6 +494,7 @@ Some agents also allow you to specify a custom certificate authority for connect
 * *Go agent*: certificate pinning through {apm-go-ref}/configuration.html#config-server-cert[`ELASTIC_APM_SERVER_CERT`]
 * *Python agent*: certificate pinning through {apm-py-ref}/configuration.html#config-server-cert[`server_cert`]
 * *Ruby agent*: certificate pinning through {apm-ruby-ref}/configuration.html#config-ssl-ca-cert[`server_ca_cert`]
+* *.NET agent*: {apm-dotnet-ref}/config-reporter.html#config-server-cert[`ServerCert`]
 * *NodeJS agent*: custom CA setting through {apm-node-ref}/configuration.html#server-ca-cert-file[`serverCaCertFile`]
 * *Java agent*: adding the certificate to the JVM `trustStore`.
 See {apm-java-ref}/ssl-configuration.html#ssl-server-authentication[APM Server authentication] for more details.

--- a/docs/ssl-input.asciidoc
+++ b/docs/ssl-input.asciidoc
@@ -43,6 +43,7 @@ When the APM server uses a certificate that is not chained to a publicly-trusted
 * *Go agent*: certificate pinning through {apm-go-ref}/configuration.html#config-server-cert[`ELASTIC_APM_SERVER_CERT`]
 * *Python agent*: certificate pinning through {apm-py-ref}/configuration.html#config-server-cert[`server_cert`]
 * *Ruby agent*: certificate pinning through {apm-ruby-ref}/configuration.html#config-ssl-ca-cert[`server_ca_cert`]
+* *.NET agent*: {apm-dotnet-ref}/config-reporter.html#config-server-cert[`ServerCert`]
 * *NodeJS agent*: custom CA setting through {apm-node-ref}/configuration.html#server-ca-cert-file[`serverCaCertFile`]
 * *Java agent*: adding the certificate to the JVM `trustStore`.
 See {apm-java-ref}/ssl-configuration.html#ssl-server-authentication[APM Server authentication] for more details.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: Link to .NET ServerCert docs (#5078)