### PR TITLE
systemtest: use Fleet Server

### DIFF
--- a/systemtest/apmservertest/config.go
+++ b/systemtest/apmservertest/config.go
@@ -453,7 +453,7 @@ func defaultOutputConfig() OutputConfig {
 			Enabled: true,
 			Hosts: []string{net.JoinHostPort(
 				getenvDefault("ES_HOST", defaultElasticsearchHost),
-				getenvDefault("ES_PORT", defaultElasticsearchPort),
+				ElasticsearchPort(),
 			)},
 			Username: getenvDefault("ES_USER", defaultElasticsearchUser),
 			Password: getenvDefault("ES_PASS", defaultElasticsearchPass),
@@ -468,6 +468,13 @@ func defaultOutputConfig() OutputConfig {
 // KIBANA_PORT, or otherwise returning the default of 5601.
 func KibanaPort() string {
 	return getenvDefault("KIBANA_PORT", defaultKibanaPort)
+}
+
+// ElasticsearchPort returns the Elasticsearch REST API port,
+// configured using ES_PORT, or otherwise returning the default
+// of 9200.
+func ElasticsearchPort() string {
+	return getenvDefault("ES_PORT", defaultElasticsearchPort)
 }
 
 func getenvDefault(k, defaultv string) string {

--- a/systemtest/fleet_test.go
+++ b/systemtest/fleet_test.go
@@ -223,7 +223,7 @@ func cleanupFleet(t testing.TB, fleet *fleettest.Client) {
 		err = fleet.DeleteAgentPolicy(p.ID)
 		var fleetError *fleettest.Error
 		if errors.As(err, &fleetError) {
-			assert.Equal(t, http.StatusNotFound, fleetError.StatusCode)
+			assert.Equal(t, http.StatusNotFound, fleetError.StatusCode, fleetError.Message)
 		}
 	}
 }

--- a/systemtest/fleettest/client.go
+++ b/systemtest/fleettest/client.go
@@ -70,13 +70,13 @@ func (c *Client) Agents() ([]Agent, error) {
 }
 
 // BulkUnenrollAgents bulk-unenrolls agents.
-func (c *Client) BulkUnenrollAgents(force bool, agentIDs ...string) error {
+func (c *Client) BulkUnenrollAgents(revoke bool, agentIDs ...string) error {
 	var body bytes.Buffer
 	type bulkUnenroll struct {
 		Agents []string `json:"agents"`
-		Force  bool     `json:"force"`
+		Revoke bool     `json:"revoke"`
 	}
-	if err := json.NewEncoder(&body).Encode(bulkUnenroll{agentIDs, force}); err != nil {
+	if err := json.NewEncoder(&body).Encode(bulkUnenroll{agentIDs, revoke}); err != nil {
 		return err
 	}
 	req := c.newFleetRequest("POST", "/agents/bulk_unenroll", &body)


### PR DESCRIPTION
## Motivation/summary

In the Fleet integration system test, bootstrap Fleet Server and then run the APM integration on a separate Elastci Agent that enrolls with the Fleet Server.

## Related issues

Closes #5075