### PR TITLE
Add metadata to API Keys created by server

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -36,6 +36,7 @@ https://github.com/elastic/apm-server/compare/7.12\...master[View commits]
 * The server now responds with a reason for some 401 Unauthorized requests {pull}5053[5053]
 * Add `session.id` and `session.sequence` fields for RUM session tracking {pull}5056[5056]
 * Support for ingesting `user.domain` {pull}5067[5067]
+* Add `"application": "apm"` metadata to API Keys created with `apm-server apikey create` {pull}5090[5090]
 
 [float]
 ==== Deprecated

--- a/cmd/apikey.go
+++ b/cmd/apikey.go
@@ -320,6 +320,7 @@ PUT /_security/role/my_role {
 				},
 			},
 		},
+		Metadata: map[string]interface{}{"application": "apm"},
 	}
 	if expiry != "" {
 		apikeyRequest.Expiration = &expiry

--- a/elasticsearch/security_api.go
+++ b/elasticsearch/security_api.go
@@ -67,9 +67,10 @@ func HasPrivileges(ctx context.Context, client Client, privileges HasPrivilegesR
 }
 
 type CreateAPIKeyRequest struct {
-	Name            string         `json:"name"`
-	Expiration      *string        `json:"expiration,omitempty"`
-	RoleDescriptors RoleDescriptor `json:"role_descriptors"`
+	Name            string                 `json:"name"`
+	Expiration      *string                `json:"expiration,omitempty"`
+	RoleDescriptors RoleDescriptor         `json:"role_descriptors"`
+	Metadata        map[string]interface{} `json:"metadata,omitempty"`
 }
 
 type CreateAPIKeyResponse struct {
@@ -121,9 +122,10 @@ type Application struct {
 
 type APIKeyResponse struct {
 	APIKey
-	Creation    int64  `json:"creation"`
-	Invalidated bool   `json:"invalidated"`
-	Username    string `json:"username"`
+	Creation    int64                  `json:"creation"`
+	Invalidated bool                   `json:"invalidated"`
+	Username    string                 `json:"username"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
 }
 
 type APIKeyQuery struct {


### PR DESCRIPTION
## Motivation/summary

Add `application: "apm"` in the metadata of API Keys created by APM Server, so they can later be identified as having been created by/for APM. The metadata must not be used for auth; it is purely for informational purposes.

Metadata will be shown when running `apm-server apikey info` with the `--json` flag, but not in the default text format.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

## How to test these changes

1. Create an API Key with `apm-server apikey create`
2. Run `apm-server apikey info --json --id <id-from-step-1>`, check the metadata shows `{"application": "apm"}`

## Related issues

https://github.com/elastic/apm-server/issues/3461
https://github.com/elastic/kibana/issues/77966