### PR TITLE
docs: remove experimental label from API Key auth

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -107,7 +107,6 @@ apm-server:
   # Enable API key authorization by setting enabled to true. By default API key support is disabled.
   # Agents include a valid API key in the following format: Authorization: ApiKey <token>.
   # The key must be the base64 encoded representation of the API key's "id:key".
-  # This is an experimental feature, use with care.
   #api_key:
     #enabled: false
 

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -107,7 +107,6 @@ apm-server:
   # Enable API key authorization by setting enabled to true. By default API key support is disabled.
   # Agents include a valid API key in the following format: Authorization: ApiKey <token>.
   # The key must be the base64 encoded representation of the API key's "id:key".
-  # This is an experimental feature, use with care.
   #api_key:
     #enabled: false
 

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -107,7 +107,6 @@ apm-server:
   # Enable API key authorization by setting enabled to true. By default API key support is disabled.
   # Agents include a valid API key in the following format: Authorization: ApiKey <token>.
   # The key must be the base64 encoded representation of the API key's "id:key".
-  # This is an experimental feature, use with care.
   #api_key:
     #enabled: false
 

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -36,6 +36,7 @@ https://github.com/elastic/apm-server/compare/7.12\...master[View commits]
 * The server now responds with a reason for some 401 Unauthorized requests {pull}5053[5053]
 * Add `session.id` and `session.sequence` fields for RUM session tracking {pull}5056[5056]
 * Support for ingesting `user.domain` {pull}5067[5067]
+* API Key auth is no longer considered experimental {pull}5091[5091]
 
 [float]
 ==== Deprecated

--- a/docs/secure-communication-agents.asciidoc
+++ b/docs/secure-communication-agents.asciidoc
@@ -30,8 +30,6 @@ include::./ssl-input.asciidoc[]
 [[api-key]]
 === API keys
 
-experimental::[]
-
 You can configure API keys to authorize requests to the APM Server.
 
 NOTE: API keys are sent as plain-text,


### PR DESCRIPTION
## Motivation/summary

Remove the experimental label from API Key auth.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
- [x] Documentation has been updated

## How to test these changes

N/A

## Related issues

#3461