### PR TITLE
[ilm] Apply lowercasing after resolving variables

### DIFF
--- a/idxmgmt/ilm/config.go
+++ b/idxmgmt/ilm/config.go
@@ -95,7 +95,7 @@ func NewConfig(info beat.Info, cfg *libcommon.Config) (Config, error) {
 		if err != nil {
 			return Config{}, errors.Wrap(err, "variable part of index suffix cannot be resolved")
 		}
-		m.Index = idx
+		m.Index = strings.ToLower(idx)
 		config.Setup.Mappings[et] = m
 		if config.Setup.RequirePolicy {
 			continue
@@ -133,7 +133,7 @@ func (m *Mappings) Unpack(cfg *libcommon.Config) error {
 			mapping.Index = existing.Index
 		}
 		if mapping.IndexSuffix != "" {
-			mapping.Index = fmt.Sprintf("%s-%s", mapping.Index, strings.ToLower(mapping.IndexSuffix))
+			mapping.Index = fmt.Sprintf("%s-%s", mapping.Index, mapping.IndexSuffix)
 		}
 		(*m)[mapping.EventType] = mapping
 	}

--- a/idxmgmt/ilm/config_test.go
+++ b/idxmgmt/ilm/config_test.go
@@ -20,6 +20,7 @@ package ilm
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -111,6 +112,7 @@ func TestConfig_RequirePolicy(t *testing.T) {
 }
 
 func TestConfig_Valid(t *testing.T) {
+	now := time.Now()
 	for _, tc := range []struct {
 		name string
 		cfg  string
@@ -118,12 +120,12 @@ func TestConfig_Valid(t *testing.T) {
 		expected Config
 	}{
 		{name: "new policy and index suffix",
-			cfg: `{"setup":{"mapping":[{"event_type":"span","policy_name":"spanPolicy"},{"event_type":"metric","index_suffix":"ProdUCtion"},{"event_type":"error","index_suffix":"%{[observer.name]}"}],"policies":[{"name":"spanPolicy","policy":{"phases":{"foo":{}}}}]}}`,
+			cfg: `{"setup":{"mapping":[{"event_type":"span","policy_name":"spanPolicy"},{"event_type":"metric","index_suffix":"ProdUCtion"},{"event_type":"error","index_suffix":"%{[observer.name]}-%{+yyyy-MM-dd}"}],"policies":[{"name":"spanPolicy","policy":{"phases":{"foo":{}}}}]}}`,
 			expected: Config{Mode: libilm.ModeAuto,
 				Setup: Setup{Enabled: true, Overwrite: false, RequirePolicy: true,
 					Mappings: map[string]Mapping{
 						"error": {EventType: "error", PolicyName: defaultPolicyName,
-							Index: "apm-9.9.9-error-mockapm", IndexSuffix: "%{[observer.name]}"},
+							Index: fmt.Sprintf("apm-9.9.9-error-mockapm-%d-%02d-%02d", now.Year(), now.Month(), now.Day()), IndexSuffix: "%{[observer.name]}-%{+yyyy-MM-dd}"},
 						"span": {EventType: "span", PolicyName: "spanPolicy",
 							Index: "apm-9.9.9-span"},
 						"transaction": {EventType: "transaction", PolicyName: defaultPolicyName,


### PR DESCRIPTION
## Motivation/summary
ES index names need to be lowercased, but the lowercasing happens too early at the moment. This PR moves it until after variable parts have been resolved. This is especially important when users want to configure dates and times in their index names. 

## How to test these changes
Configure a `apm-server.ilm.setup.mapping` section that contains a `index_suffix` with a variable part and some uppercase string, and ensure that the lowercasing happens after the variable has been resolved, for example:
```
apm-server.ilm.setup.mapping:
  - event_type: "error"
    policy_name: "apm-error"
    index_suffix: "MyTest-%{+yyyy.MM.dd}"
```
should result in an index called `apm-8.0.0-error-mytest-2021.04.14-000001` in ES. 

## Related issuesfixes #5095