### PR TITLE
mergify: prefix PR title with target branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,6 +24,7 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "7.x"
+        title: "[{{ base }}] {{ title }} (backport #{{ number }})"
   - name: backport patches to 7.12 branch
     conditions:
       - merged
@@ -35,3 +36,4 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "7.12"
+        title: "[{{ base }}] {{ title }} (backport #{{ number }})"


### PR DESCRIPTION
## Motivation/summary

Now that https://github.com/Mergifyio/mergify-engine/pull/2364 has been merged (thanks @v1v!), we can set a title template for backport PRs.

When using https://github.com/sqren/backport we would get PR titles prefixed with the target branch, which we all rather liked. Let's bring that back.