### PR TITLE
mergify: hardcode target branch name

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,7 +24,7 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "7.x"
-        title: "[{{ base }}] {{ title }} (backport #{{ number }})"
+        title: "[7.x] {{ title }} (backport #{{ number }})"
   - name: backport patches to 7.12 branch
     conditions:
       - merged
@@ -36,4 +36,4 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "7.12"
-        title: "[{{ base }}] {{ title }} (backport #{{ number }})"
+        title: "[7.12] {{ title }} (backport #{{ number }})"


### PR DESCRIPTION
`base` is the _source_ branch, and there doesn't seem to be an attribute for the target branch. Just hardcode target branch name for now.