### PR TITLE
docker-compose: fix kibana config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,6 @@ services:
       XPACK_SECURITY_ENCRYPTIONKEY: "fhjskloppd678ehkdfdlliverpoolfcr"
       XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY: "fhjskloppd678ehkdfdlliverpoolfcr"
       XPACK_FLEET_AGENTS_ELASTICSEARCH_HOST: "http://elasticsearch:9200"
-      XPACK_FLEET_AGENTS_KIBANA_HOST: "http://kibana:5601"
       XPACK_FLEET_AGENTS_TLSCHECKDISABLED: "true"
       XPACK_FLEET_REGISTRYURL: "http://package-registry:8080"
     depends_on:


### PR DESCRIPTION
## Motivation/summary

Remove XPACK_FLEET_AGENTS_KIBANA_HOST, now that we're using Fleet Server in system tests.

## How to test these changes

N/A, non-functional change.

## Related issues

Closes #5114 