### PR TITLE
systemtest: fix exposed port mapping

### DIFF
--- a/systemtest/fleet_test.go
+++ b/systemtest/fleet_test.go
@@ -118,10 +118,9 @@ func TestFleetIntegration(t *testing.T) {
 
 	// Elastic Agent has started apm-server. Connect to apm-server and send some data,
 	// and make sure it gets indexed into a data stream.
-	require.Len(t, agent.Addrs, 1)
 	transport, err := transport.NewHTTPTransport()
 	require.NoError(t, err)
-	transport.SetServerURL(&url.URL{Scheme: "http", Host: agent.Addrs[0]})
+	transport.SetServerURL(&url.URL{Scheme: "http", Host: agent.Addrs["8200"]})
 	tracer, err := apm.NewTracerOptions(apm.TracerOptions{Transport: transport})
 	require.NoError(t, err)
 	defer tracer.Close()

--- a/systemtest/go.mod
+++ b/systemtest/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible
+	github.com/docker/go-connections v0.4.0
 	github.com/elastic/apm-server/approvaltest v0.0.0-00010101000000-000000000000
 	github.com/elastic/go-elasticsearch/v7 v7.8.0
 	github.com/elastic/go-sysinfo v1.4.0 // indirect


### PR DESCRIPTION
## Motivation/summary

Fix the recording of mapped ports for Elastic Agent containers. Instead of iterating the mapped ports, which may have multiple addresses (IPv4, IPv6), record a map of exposed to mapped ports using the host IP.

## How to test these changes

N/A