### PR TITLE
[7.x] create 7.13 changelog (3ec1c48b)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,3 +1,5 @@
+include::./changelogs/head.asciidoc[]
+include::./changelogs/7.13.asciidoc[]
 include::./changelogs/7.12.asciidoc[]
 include::./changelogs/7.11.asciidoc[]
 include::./changelogs/7.10.asciidoc[]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,4 +1,3 @@
-include::./changelogs/head.asciidoc[]
 include::./changelogs/7.13.asciidoc[]
 include::./changelogs/7.12.asciidoc[]
 include::./changelogs/7.11.asciidoc[]

--- a/changelogs/7.13.asciidoc
+++ b/changelogs/7.13.asciidoc
@@ -1,0 +1,44 @@
+[[release-notes-7.13]]
+== APM Server version 7.13
+
+https://github.com/elastic/apm-server/compare/7.12\...7.13[View commits]
+
+* <<release-notes-7.13.0>>
+
+[float]
+[[release-notes-7.13.0]]
+=== APM Server version 7.10.0
+
+https://github.com/elastic/apm-server/compare/v7.12.1\...v7.13.0[View commits]
+
+[float]
+==== Bug fixes
+* Fix `setup.template` config merging {pull}4950[4950]
+* The server now responds with 503 instead of 401 when failure is unrelated to API Key validity, e.g. if Elasticsearch is inaccessible {pull}5053[5053]
+
+[float]
+==== Added
+* Add support for Node.js wall time profiles {pull}4728[4728]
+* Add metricset.name field to metric docs {pull}4857[4857]
+* Add `apm-server.default_service_environment` config {pull}4861[4861]
+* Transaction histogram metrics are now recorded by default {pull}4882[4882]
+* Add `error.grouping_name` field to speed up error grouping aggregations {pull}4886[4886]
+* Add support for OpenTelemetry exception span events {pull}4876[4876]
+* Set metricset.name for breakdown metrics {pull}4910[4910]
+* Set log and http responses for server timeout {pull}4918[4918]
+* Define ES fields for cgroup.cpu and cgroup.cpuacct metrics {pull}4956[4956]
+* Log gRPC tracing requests {pull}4934[4934]
+* Improved coverage of translation of OpenTelemetry resource conventions {pull}4955[4955]
+* Set `client.ip` for events from the Elastic APM iOS agent {pull}4975[4975]
+* Calculate service destination metrics for OpenTelemetry spans {pull}4976[4976]
+* Add exponential retries to api key and tail sampling requests{pull}4991[4991]
+* Add `apm-server.rum.allow_service_names` config {pull}5030[5030]
+* Ingest pipeline for translating OpenTelemetry Java metrics to Elastic APM fields {pull}4986[4986]
+* Set `event.ingested` first in the ingest pipeline {pull}5048[5048]
+* The server now responds with a reason for some 401 Unauthorized requests {pull}5053[5053]
+* Add `session.id` and `session.sequence` fields for RUM session tracking {pull}5056[5056]
+* Support for ingesting `user.domain` {pull}5067[5067]
+* Add `"application": "apm"` metadata to API Keys created with `apm-server apikey create` {pull}5090[5090]
+* API Key auth is no longer considered experimental {pull}5091[5091]
+* Set gRPC status code to `DEADLINE_EXCEEDED` on request timeout {pull}5089[5089]
+* Add support for OpenTelemetry RPC semantic conventions {pull}5074[5074]

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -10,6 +10,7 @@
 --
 This following sections summarizes the changes in each release.
 
+* <<release-notes-7.13>>
 * <<release-notes-7.12>>
 * <<release-notes-7.11>>
 * <<release-notes-7.10>>


### PR DESCRIPTION
Backports the following commits to 7.x:
 - create 7.13 changelog (3ec1c48b)