### PR TITLE
docs: remove apm_user limitation

### DIFF
--- a/docs/apm-package/apm-integration.asciidoc
+++ b/docs/apm-package/apm-integration.asciidoc
@@ -46,16 +46,6 @@ See {ref}/example-using-index-lifecycle-policy.html[Customize built-in ILM polic
 Onboarding::
 APM Server no longer writes an onboarding document when setting up.
 
-Incompatible with `apm_user` role::
-The built-in {ref}/built-in-roles.html[`apm_user`] role is not compatible with the APM integration
-as it only provides read access to `apm-*` indices.
-The new data stream naming scheme does not follow this pattern,
-so users with the `apm_user` role will not be able to view `apm` data.
-+
-To grant a user access to APM data in Kibana, provide read access to the relevant
-indices listed in <<apm-integration-data-streams>>. You may also wish to grant users
-{kibana-ref}/apm-app-users.html[additional privileges] for features like spaces and machine learning.
-
 Standalone mode::
 {fleet-guide}/run-elastic-agent-standalone.html[Standalone mode] is not currently supported.
 An {agent} with the APM integration enabled must be managed by fleet.


### PR DESCRIPTION
## Summary

The `apm_user` role has been updated to include `read` and `view_index_metadata` privileges on data stream indices. This PR removes a previous limitation that stated incompatibility between the `apm_user` role and data streams.

Additional changes have been opened to explain the deprecation of `apm_user` and workarounds for APM users. See https://github.com/elastic/observability-docs/issues/516 for more information.