### PR TITLE
Makefile: fix beats branch for 7.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ copy-docs:
 # Beats synchronisation.
 ##############################################################################
 
-BEATS_VERSION?=7.x
+BEATS_VERSION?=7.13
 BEATS_MODULE:=$(shell $(GO) list -m -f {{.Path}} all | grep github.com/elastic/beats)
 
 .PHONY: update-beats
@@ -209,7 +209,7 @@ build/index-pattern.json: $(PYTHON) apm-server
 ##############################################################################
 
 GOLINT_TARGETS?=$(shell $(GO) list ./...)
-GOLINT_UPSTREAM?=origin/7.x
+GOLINT_UPSTREAM?=origin/7.13
 REVIEWDOG_FLAGS?=-conf=reviewdog.yml -f=golint -diff="git diff $(GOLINT_UPSTREAM)"
 GOLINT_COMMAND=$(GOLINT) ${GOLINT_TARGETS} | grep -v "should have comment" | $(REVIEWDOG) $(REVIEWDOG_FLAGS)
 


### PR DESCRIPTION
Update BEATS_VERSION. Having it set to 7.x means the `check-docker-compose` target fails.