### PR TITLE
[7.x] [mergify] assign the original author (#5069)

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,6 +20,8 @@ pull_request_rules:
       - label=v7.13.0
     actions:
       backport:
+        assignees:
+          - "{{ author }}"
         branches:
           - "7.x"
   - name: backport patches to 7.12 branch
@@ -29,5 +31,7 @@ pull_request_rules:
       - label=v7.12.0
     actions:
       backport:
+        assignees:
+          - "{{ author }}"
         branches:
           - "7.12"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [mergify] assign the original author (#5069)