### PR TITLE
[7.13] mergify: prefix PR title with target branch (#5103)

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,6 +24,7 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "7.x"
+        title: "[{{ base }}] {{ title }} (backport #{{ number }})"
   - name: backport patches to 7.12 branch
     conditions:
       - merged
@@ -35,3 +36,4 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "7.12"
+        title: "[{{ base }}] {{ title }} (backport #{{ number }})"


### PR DESCRIPTION
Backports the following commits to 7.13:
 - mergify: prefix PR title with target branch (#5103)