### PR TITLE
[7.x] mergify: add backports for 7.13/7.14

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -17,7 +17,7 @@ pull_request_rules:
     conditions:
       - merged
       - base=master
-      - label=v7.13.0
+      - label=v7.14.0
     actions:
       backport:
         assignees:
@@ -25,6 +25,18 @@ pull_request_rules:
         branches:
           - "7.x"
         title: "[7.x] {{ title }} (backport #{{ number }})"
+  - name: backport patches to 7.13 branch
+    conditions:
+      - merged
+      - base=master
+      - label=v7.13.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "7.13"
+        title: "[7.13] {{ title }} (backport #{{ number }})"
   - name: backport patches to 7.12 branch
     conditions:
       - merged


### PR DESCRIPTION
Backport the mergify changes in https://github.com/elastic/apm-server/commit/0d0885df08d45c51b3a496e4ec5c6e0d4cd60b53#diff-6a30e47dd51449847422017b16878889b848f6602ac56d5a2e67ce8a19afade2