### PR TITLE
systemtest: increase max retries for Elasticsearch

### DIFF
--- a/systemtest/elasticsearch.go
+++ b/systemtest/elasticsearch.go
@@ -37,7 +37,7 @@ import (
 const (
 	adminElasticsearchUser  = "admin"
 	adminElasticsearchPass  = "changeme"
-	maxElasticsearchBackoff = time.Second
+	maxElasticsearchBackoff = 10 * time.Second
 )
 
 var (
@@ -75,9 +75,10 @@ func newElasticsearchConfig() elasticsearch.Config {
 		addresses = append(addresses, u.String())
 	}
 	return elasticsearch.Config{
-		Addresses: addresses,
+		Addresses:  addresses,
+		MaxRetries: 5,
 		RetryBackoff: func(attempt int) time.Duration {
-			backoff := time.Duration(attempt*100) * time.Millisecond
+			backoff := (500 * time.Millisecond) * (1 << (attempt - 1))
 			if backoff > maxElasticsearchBackoff {
 				backoff = maxElasticsearchBackoff
 			}

--- a/systemtest/estest/client.go
+++ b/systemtest/estest/client.go
@@ -39,7 +39,10 @@ func (es *Client) Do(
 	opts ...RequestOption,
 ) (*esapi.Response, error) {
 	requestOptions := requestOptions{
-		timeout:  10 * time.Second,
+		// Set the timeout to something high to account for Elasticsearch
+		// cluster and index/shard initialisation. Under normal conditions
+		// this timeout should never be reached.
+		timeout:  time.Minute,
 		interval: 100 * time.Millisecond,
 	}
 	for _, opt := range opts {

--- a/systemtest/estest/search.go
+++ b/systemtest/estest/search.go
@@ -30,6 +30,7 @@ import (
 //
 // ExpectDocs is equivalent to calling ExpectMinDocs with a minimum of 1.
 func (es *Client) ExpectDocs(t testing.TB, index string, query interface{}, opts ...RequestOption) SearchResult {
+	t.Helper()
 	return es.ExpectMinDocs(t, 1, index, query, opts...)
 }
 
@@ -46,7 +47,7 @@ func (es *Client) ExpectMinDocs(t testing.TB, min int, index string, query inter
 		req = req.WithQuery(query)
 	}
 	if _, err := req.Do(context.Background(), &result, opts...); err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	return result
 }


### PR DESCRIPTION
## Motivation/summary

- Increase the max retries and backoff for Elasticsearch request, to gracefully handle 503 errors due to cluster and index initialisation.
- Increase the default `estest.Client` request loop timeout from 10 seconds up to 1 minute.
- Declare `estest.Client.ExpectDocs` to be a test helper to make sure it is not indicated as the culprit in a test failure.
- Use `testing.TB.Fatal` instead of `testing.TB.Error` when search requests return an error in `ExpectMinDocs, so we don't continue on in the test with empty results

## How to test these changes

N/A, non-functional change.

## Related issues

Stabilising system tests.