### PR TITLE
[automation] update elastic stack version for testing 7.13.0-683cb8f3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       kibana: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.13.0-e9675cbf-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.13.0-683cb8f3-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -61,7 +61,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.13.0-e9675cbf-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.13.0-683cb8f3-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -84,7 +84,7 @@ services:
       package-registry: { condition: service_healthy }
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:7.13.0-e9675cbf-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:7.13.0-683cb8f3-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Wed, 5 May 2021 12:13:10 GMT, release_branch:7.13, prefix:, end_time:Wed, 5 May 2021 18:02:53 GMT, manifest_version:2.0.0, version:7.13.0-SNAPSHOT, branch:7.13, build_id:7.13.0-683cb8f3, build_duration_seconds:20983]