### PR TITLE
[jjbb] avoid building the update stack branches

### DIFF
--- a/.ci/jobs/apm-server-check-changelogs-mbp.yml
+++ b/.ci/jobs/apm-server-check-changelogs-mbp.yml
@@ -12,6 +12,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: false
+        head-filter-regex: '^(?!update-stack-version).*$'
         notification-context: 'apm-ci'
         property-strategies:
           all-branches:

--- a/.ci/jobs/apm-server-mbp.yml
+++ b/.ci/jobs/apm-server-mbp.yml
@@ -13,6 +13,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
+        head-filter-regex: '^(?!update-stack-version).*$'
         notification-context: 'apm-ci'
         repo: apm-server
         repo-owner: elastic

--- a/.ci/jobs/update-json-schema.yml
+++ b/.ci/jobs/update-json-schema.yml
@@ -13,6 +13,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: false
+          head-filter-regex: '^(?!update-stack-version).*$'
           notification-context: 'update-json-schema'
           repo: apm-server
           repo-owner: elastic


### PR DESCRIPTION
## Motivation/summary

Avoid builds for the bump automation branches since there will be PR if there are new changes.
