### PR TITLE
[automation] update elastic stack version for testing 7.14.0-c4ef352d

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       kibana: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0-c3a960d1-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0-c4ef352d-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -61,7 +61,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.14.0-c3a960d1-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.14.0-c4ef352d-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -84,7 +84,7 @@ services:
       package-registry: { condition: service_healthy }
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:7.14.0-c3a960d1-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:7.14.0-c4ef352d-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Mon, 17 May 2021 05:23:52 GMT, release_branch:7.x, prefix:, end_time:Mon, 17 May 2021 11:43:17 GMT, manifest_version:2.0.0, version:7.14.0-SNAPSHOT, branch:7.x, build_id:7.14.0-c4ef352d, build_duration_seconds:22765]