### PR TITLE
aggregation/txmetrics: fix alignment for 32-bit

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -8,6 +8,7 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 
 [float]
 ==== Bug fixes
+* Fix panic due to misaligned 64-bit access on 32-bit architectures {pull}5277[5277]
 
 [float]
 ==== Intake API Changes

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -51,7 +51,7 @@ type Aggregator struct {
 	stopped  chan struct{}
 
 	config              AggregatorConfig
-	metrics             aggregatorMetrics
+	metrics             *aggregatorMetrics // heap-allocated for 64-bit alignment
 	tooManyGroupsLogger *logp.Logger
 
 	mu               sync.RWMutex
@@ -118,6 +118,7 @@ func NewAggregator(config AggregatorConfig) (*Aggregator, error) {
 		stopping:            make(chan struct{}),
 		stopped:             make(chan struct{}),
 		config:              config,
+		metrics:             &aggregatorMetrics{},
 		tooManyGroupsLogger: config.Logger.WithOptions(logs.WithRateLimit(tooManyGroupsLoggerRateLimit)),
 		active:              newMetrics(config.MaxTransactionGroups),
 		inactive:            newMetrics(config.MaxTransactionGroups),

--- a/x-pack/apm-server/sampling/processor.go
+++ b/x-pack/apm-server/sampling/processor.go
@@ -43,7 +43,7 @@ type Processor struct {
 	storageMu    sync.RWMutex
 	db           *badger.DB
 	storage      *eventstorage.ShardedReadWriter
-	eventMetrics eventMetrics
+	eventMetrics *eventMetrics // heap-allocated for 64-bit alignment
 
 	stopMu   sync.Mutex
 	stopping chan struct{}
@@ -85,6 +85,7 @@ func NewProcessor(config Config) (*Processor, error) {
 		groups:              newTraceGroups(config.Policies, config.MaxDynamicServices, config.IngestRateDecayFactor),
 		db:                  db,
 		storage:             readWriter,
+		eventMetrics:        &eventMetrics{},
 		stopping:            make(chan struct{}),
 		stopped:             make(chan struct{}),
 	}


### PR DESCRIPTION
## Motivation/summary

See https://github.com/elastic/apm-server/issues/5276

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

1. Run apm-server on a 32-bit system with `-E http.enabled=true`
2. Ingest data
3. curl http://localhost:5066/stats
4. Make sure it doesn't panic

## Related issues

Closes https://github.com/elastic/apm-server/issues/5276