### PR TITLE
docs: add 6.8.16 release notes

### DIFF
--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,6 +3,7 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.16>>
 * <<release-notes-6.8.15>>
 * <<release-notes-6.8.14>>
 * <<release-notes-6.8.13>>
@@ -19,6 +20,14 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.2>>
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
+
+[float]
+[[release-notes-6.8.16]]
+=== APM Server version 6.8.16
+
+https://github.com/elastic/apm-server/compare/v6.8.15\...v6.8.16[View commits]
+
+No significant changes.
 
 [float]
 [[release-notes-6.8.15]]


### PR DESCRIPTION
Adds 6.8.16 release notes. No new commits since the last release.