### PR TITLE
docs: fix release note typo; add breaking changes

### DIFF
--- a/changelogs/7.13.asciidoc
+++ b/changelogs/7.13.asciidoc
@@ -7,7 +7,7 @@ https://github.com/elastic/apm-server/compare/7.12\...7.13[View commits]
 
 [float]
 [[release-notes-7.13.0]]
-=== APM Server version 7.10.0
+=== APM Server version 7.13.0
 
 https://github.com/elastic/apm-server/compare/v7.12.1\...v7.13.0[View commits]
 
@@ -19,14 +19,14 @@ https://github.com/elastic/apm-server/compare/v7.12.1\...v7.13.0[View commits]
 [float]
 ==== Added
 * Add support for Node.js wall time profiles {pull}4728[4728]
-* Add metricset.name field to metric docs {pull}4857[4857]
+* Add `metricset.name` field to metric docs {pull}4857[4857]
 * Add `apm-server.default_service_environment` config {pull}4861[4861]
 * Transaction histogram metrics are now recorded by default {pull}4882[4882]
 * Add `error.grouping_name` field to speed up error grouping aggregations {pull}4886[4886]
 * Add support for OpenTelemetry exception span events {pull}4876[4876]
-* Set metricset.name for breakdown metrics {pull}4910[4910]
+* Set `metricset.name` for breakdown metrics {pull}4910[4910]
 * Set log and http responses for server timeout {pull}4918[4918]
-* Define ES fields for cgroup.cpu and cgroup.cpuacct metrics {pull}4956[4956]
+* Define ES fields for `cgroup.cpu` and `cgroup.cpuacct` metrics {pull}4956[4956]
 * Log gRPC tracing requests {pull}4934[4934]
 * Improved coverage of translation of OpenTelemetry resource conventions {pull}4955[4955]
 * Set `client.ip` for events from the Elastic APM iOS agent {pull}4975[4975]

--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -4,6 +4,10 @@ APM Server is built on top of {beats-ref}/index.html[libbeat].
 As such, any breaking change in libbeat is also considered to be a breaking change in APM Server.
 
 [float]
+=== 7.13
+There are no breaking changes in APM Server.
+
+[float]
 === 7.12
 
 There are three breaking changes to be aware of;

--- a/docs/guide/apm-breaking-changes.asciidoc
+++ b/docs/guide/apm-breaking-changes.asciidoc
@@ -3,6 +3,7 @@
 
 This section discusses the changes that you need to be aware of when migrating your application from one version of APM to another.
 
+* <<breaking-7.13.0>>
 * <<breaking-7.12.0>>
 * <<breaking-7.11.0>>
 * <<breaking-7.10.0>>
@@ -29,7 +30,14 @@ Also see {observability-guide}/whats-new.html[What's new in Observability {minor
 
 // tag::notable-v8-breaking-changes[]
 // end::notable-v8-breaking-changes[]
+// tag::714-bc[]
+// end::714-bc[]
+
+[[breaking-7.13.0]]
+=== 7.13.0 APM Breaking changes
+
 // tag::713-bc[]
+No breaking changes.
 // end::713-bc[]
 
 [[breaking-7.12.0]]


### PR DESCRIPTION
* Fixes typo in the ~7.10~ 7.13 release notes
* Adds code highlighting for fields
* Adds empty breaking changes section