### PR TITLE
[DOC] Fixing broken box for RUM

### DIFF
--- a/docs/guide/agent-server-compatibility.asciidoc
+++ b/docs/guide/agent-server-compatibility.asciidoc
@@ -35,7 +35,7 @@ The chart below outlines the compatibility between different versions of the APM
 |`5.x` |≥ `6.6`
 
 // Ruby
-.3+|**Ruby agent**
+.4+|**Ruby agent**
 |`1.x` |`6.4`-`6.x`
 |`2.x` |≥ `6.5`
 |`3.x` |≥ `6.5`


### PR DESCRIPTION
I'm not sure how to change RUM's first column background color to gray, but this will fix the broken box with the right columns' order from left to right