### PR TITLE
tests/packaging: run package tests on x86_64 only

### DIFF
--- a/tests/packaging/package_test.go
+++ b/tests/packaging/package_test.go
@@ -56,11 +56,12 @@ func testInstall(t *testing.T, ext string) {
 	}
 	for _, pkg := range pkgs {
 		t.Run(fmt.Sprintf("%s_%s", t.Name(), pkg.arch), func(t *testing.T) {
-			if pkg.arch == "aarch64" || pkg.arch == "arm64" {
+			switch pkg.arch {
+			case "amd64", "x86_64":
+				checkInstall(t, pkg.path, fmt.Sprintf("Dockerfile.%s.%s.install", pkg.arch, ext))
+			default:
 				t.Skipf("skipped package install test for %s on %s", ext, pkg.arch)
-				return
 			}
-			checkInstall(t, pkg.path, fmt.Sprintf("Dockerfile.%s.%s.install", pkg.arch, ext))
 		})
 	}
 }


### PR DESCRIPTION
## Motivation/summary

The "Package" CI stage is failing because we're trying to run 32-bit code on 64-bit systems, which libbeat no longer allows. Disable package tests for everything exception amd64/x86_64. Later we can remove these tests entirely, and rely on beats-tester for smoke testing packages.

## How to test these changes

N/A

## Related issues

https://github.com/elastic/apm-server/issues/5274