### PR TITLE
[automation] update elastic stack version for testing 7.14.0-a9c3399b

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       kibana: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0-b278d172-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0-a9c3399b-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -61,7 +61,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.14.0-b278d172-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.14.0-a9c3399b-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -84,7 +84,7 @@ services:
       package-registry: { condition: service_healthy }
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:7.14.0-b278d172-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:7.14.0-a9c3399b-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Thu, 20 May 2021 05:22:15 GMT, release_branch:7.x, prefix:, end_time:Thu, 20 May 2021 10:05:12 GMT, manifest_version:2.0.0, version:7.14.0-SNAPSHOT, branch:7.x, build_id:7.14.0-a9c3399b, build_duration_seconds:16977]