### PR TITLE
model/modeldecoder: fix 32-bit timestamp decoding

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -9,6 +9,7 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 [float]
 ==== Bug fixes
 * Fix panic due to misaligned 64-bit access on 32-bit architectures {pull}5277[5277]
+* model/modeldecoder: fix 32-bit timestamp decoding {pull}5308[5308]
 
 [float]
 ==== Intake API Changes

--- a/model/modeldecoder/nullable/nullable.go
+++ b/model/modeldecoder/nullable/nullable.go
@@ -78,10 +78,10 @@ func init() {
 		case jsoniter.NilValue:
 			iter.ReadNil()
 		default:
-			us := iter.ReadInt()
+			us := iter.ReadInt64()
 			s := us / 1000000
 			ns := (us - (s * 1000000)) * 1000
-			(*((*TimeMicrosUnix)(ptr))).Val = time.Unix(int64(s), int64(ns)).UTC()
+			(*((*TimeMicrosUnix)(ptr))).Val = time.Unix(s, ns).UTC()
 			(*((*TimeMicrosUnix)(ptr))).isSet = true
 		}
 	})


### PR DESCRIPTION
## Motivation/summary

Fix decoding of timestamps on 32-bit systems. Rather than decoding as 32-bit or 64-bit depending on the host architecture, always decode as 64-bit.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

Lazy: `GOARCH=386 go test -v ./model/modeldecoder/v2/`
Better: install apm-server on a 32-bit VM and send it some data.

## Related issues

Closes https://github.com/elastic/apm-server/issues/5307