### PR TITLE
docker-compose: explicitly set kibana host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
       retries: 300
       interval: 1s
     environment:
+      SERVER_HOST: 0.0.0.0
       STATUS_ALLOWANONYMOUS: "true"
       ELASTICSEARCH_URL: elasticsearch:9200
       ELASTICSEARCH_USERNAME: "${KIBANA_ES_USER:-kibana_system_user}"


### PR DESCRIPTION
Set the SERVER_HOST environment variable for kibana in docker-compose to avoid being broken by issues like https://github.com/elastic/kibana/issues/100533