### PR TITLE
[7.x] Move tests.MockKibanaClient to its own package (#5273)

### DIFF
--- a/agentcfg/fetch_test.go
+++ b/agentcfg/fetch_test.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/elastic/apm-server/beater/config"
 	"github.com/elastic/apm-server/kibana"
-	"github.com/elastic/apm-server/tests"
+	"github.com/elastic/apm-server/kibana/kibanatest"
 )
 
 type m map[string]interface{}
@@ -44,21 +44,21 @@ var (
 func TestFetcher_Fetch(t *testing.T) {
 
 	t.Run("ExpectationFailed", func(t *testing.T) {
-		kb := tests.MockKibana(http.StatusExpectationFailed, m{"error": "an error"}, mockVersion, true)
+		kb := kibanatest.MockKibana(http.StatusExpectationFailed, m{"error": "an error"}, mockVersion, true)
 		_, err := NewKibanaFetcher(kb, testExpiration).Fetch(context.Background(), query(t.Name()))
 		require.Error(t, err)
 		assert.Equal(t, "{\"error\":\"an error\"}", err.Error())
 	})
 
 	t.Run("NotFound", func(t *testing.T) {
-		kb := tests.MockKibana(http.StatusNotFound, m{}, mockVersion, true)
+		kb := kibanatest.MockKibana(http.StatusNotFound, m{}, mockVersion, true)
 		result, err := NewKibanaFetcher(kb, testExpiration).Fetch(context.Background(), query(t.Name()))
 		require.NoError(t, err)
 		assert.Equal(t, zeroResult(), result)
 	})
 
 	t.Run("Success", func(t *testing.T) {
-		kb := tests.MockKibana(http.StatusOK, mockDoc(0.5), mockVersion, true)
+		kb := kibanatest.MockKibana(http.StatusOK, mockDoc(0.5), mockVersion, true)
 		b, err := json.Marshal(mockDoc(0.5))
 		expectedResult, err := newResult(b, err)
 		require.NoError(t, err)
@@ -72,7 +72,7 @@ func TestFetcher_Fetch(t *testing.T) {
 		fetch := func(f *KibanaFetcher, kibanaSamplingRate, expectedSamplingRate float64) {
 
 			client := func(samplingRate float64) kibana.Client {
-				return tests.MockKibana(http.StatusOK, mockDoc(samplingRate), mockVersion, true)
+				return kibanatest.MockKibana(http.StatusOK, mockDoc(samplingRate), mockVersion, true)
 			}
 			f.client = client(kibanaSamplingRate)
 

--- a/beater/api/config/agent/handler_test.go
+++ b/beater/api/config/agent/handler_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/elastic/apm-server/beater/request"
 	"github.com/elastic/apm-server/convert"
 	"github.com/elastic/apm-server/kibana"
-	"github.com/elastic/apm-server/tests"
+	"github.com/elastic/apm-server/kibana/kibanatest"
 )
 
 type m map[string]interface{}
@@ -65,7 +65,7 @@ var (
 		respEtagHeader, respCacheControlHeader string
 	}{
 		"NotModified": {
-			kbClient: tests.MockKibana(http.StatusOK, m{
+			kbClient: kibanatest.MockKibana(http.StatusOK, m{
 				"_id": "1",
 				"_source": m{
 					"settings": m{
@@ -83,7 +83,7 @@ var (
 		},
 
 		"ModifiedWithEtag": {
-			kbClient: tests.MockKibana(http.StatusOK, m{
+			kbClient: kibanatest.MockKibana(http.StatusOK, m{
 				"_id": "1",
 				"_source": m{
 					"settings": m{
@@ -103,7 +103,7 @@ var (
 		},
 
 		"NoConfigFound": {
-			kbClient:               tests.MockKibana(http.StatusNotFound, m{}, mockVersion, true),
+			kbClient:               kibanatest.MockKibana(http.StatusNotFound, m{}, mockVersion, true),
 			method:                 http.MethodGet,
 			queryParams:            map[string]string{"service.name": "opbeans-python"},
 			respStatus:             http.StatusOK,
@@ -114,7 +114,7 @@ var (
 		},
 
 		"SendToKibanaFailed": {
-			kbClient:               tests.MockKibana(http.StatusBadGateway, m{}, mockVersion, true),
+			kbClient:               kibanatest.MockKibana(http.StatusBadGateway, m{}, mockVersion, true),
 			method:                 http.MethodGet,
 			queryParams:            map[string]string{"service.name": "opbeans-ruby"},
 			respStatus:             http.StatusServiceUnavailable,
@@ -124,7 +124,7 @@ var (
 		},
 
 		"NoConnection": {
-			kbClient:               tests.MockKibana(http.StatusServiceUnavailable, m{}, mockVersion, false),
+			kbClient:               kibanatest.MockKibana(http.StatusServiceUnavailable, m{}, mockVersion, false),
 			method:                 http.MethodGet,
 			queryParams:            map[string]string{"service.name": "opbeans-node"},
 			respStatus:             http.StatusServiceUnavailable,
@@ -134,7 +134,7 @@ var (
 		},
 
 		"InvalidVersion": {
-			kbClient: tests.MockKibana(http.StatusServiceUnavailable, m{},
+			kbClient: kibanatest.MockKibana(http.StatusServiceUnavailable, m{},
 				*common.MustNewVersion("7.2.0"), true),
 			method:                 http.MethodGet,
 			queryParams:            map[string]string{"service.name": "opbeans-node"},
@@ -146,7 +146,7 @@ var (
 		},
 
 		"NoService": {
-			kbClient:               tests.MockKibana(http.StatusOK, m{}, mockVersion, true),
+			kbClient:               kibanatest.MockKibana(http.StatusOK, m{}, mockVersion, true),
 			method:                 http.MethodGet,
 			respStatus:             http.StatusBadRequest,
 			respBody:               map[string]string{"error": msgInvalidQuery},
@@ -155,7 +155,7 @@ var (
 		},
 
 		"MethodNotAllowed": {
-			kbClient:               tests.MockKibana(http.StatusOK, m{}, mockVersion, true),
+			kbClient:               kibanatest.MockKibana(http.StatusOK, m{}, mockVersion, true),
 			method:                 http.MethodPut,
 			respStatus:             http.StatusMethodNotAllowed,
 			respCacheControlHeader: "max-age=300, must-revalidate",
@@ -164,7 +164,7 @@ var (
 		},
 
 		"Unauthorized": {
-			kbClient:               tests.MockKibana(http.StatusUnauthorized, m{"error": "Unauthorized"}, mockVersion, true),
+			kbClient:               kibanatest.MockKibana(http.StatusUnauthorized, m{"error": "Unauthorized"}, mockVersion, true),
 			method:                 http.MethodGet,
 			queryParams:            map[string]string{"service.name": "opbeans-node"},
 			respStatus:             http.StatusServiceUnavailable,
@@ -224,7 +224,7 @@ func TestAgentConfigHandler_NoKibanaClient(t *testing.T) {
 }
 
 func TestAgentConfigHandler_PostOk(t *testing.T) {
-	kb := tests.MockKibana(http.StatusOK, m{
+	kb := kibanatest.MockKibana(http.StatusOK, m{
 		"_id": "1",
 		"_source": m{
 			"settings": m{
@@ -244,7 +244,7 @@ func TestAgentConfigHandler_PostOk(t *testing.T) {
 
 func TestAgentConfigHandler_DefaultServiceEnvironment(t *testing.T) {
 	kb := &recordingKibanaClient{
-		Client: tests.MockKibana(http.StatusOK, m{
+		Client: kibanatest.MockKibana(http.StatusOK, m{
 			"_id": "1",
 			"_source": m{
 				"settings": m{
@@ -331,7 +331,7 @@ func TestAgentConfigRateLimit(t *testing.T) {
 }
 
 func getHandler(agent string) request.Handler {
-	kb := tests.MockKibana(http.StatusOK, m{
+	kb := kibanatest.MockKibana(http.StatusOK, m{
 		"_id": "1",
 		"_source": m{
 			"settings": m{

--- a/beater/jaeger/grpc_test.go
+++ b/beater/jaeger/grpc_test.go
@@ -38,7 +38,7 @@ import (
 
 	"github.com/elastic/apm-server/agentcfg"
 	"github.com/elastic/apm-server/beater/beatertest"
-	"github.com/elastic/apm-server/tests"
+	"github.com/elastic/apm-server/kibana/kibanatest"
 )
 
 func TestGRPCCollector_PostSpans(t *testing.T) {
@@ -208,7 +208,7 @@ func (tc *testGRPCSampler) setup() {
 	if tc.kibanaVersion == nil {
 		tc.kibanaVersion = common.MustNewVersion("7.7.0")
 	}
-	client := tests.MockKibana(tc.kibanaCode, tc.kibanaBody, *tc.kibanaVersion, true)
+	client := kibanatest.MockKibana(tc.kibanaCode, tc.kibanaBody, *tc.kibanaVersion, true)
 	fetcher := agentcfg.NewKibanaFetcher(client, time.Second)
 	tc.sampler = &grpcSampler{logp.L(), fetcher}
 	beatertest.ClearRegistry(gRPCSamplingMonitoringMap)

--- a/kibana/kibanatest/kibana.go
+++ b/kibana/kibanatest/kibana.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package tests
+package kibanatest
 
 import (
 	"context"


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Move tests.MockKibanaClient to its own package (#5273)