### PR TITLE
[7.x] Fixing broken box for RUM (#5295)

### DIFF
--- a/docs/guide/agent-server-compatibility.asciidoc
+++ b/docs/guide/agent-server-compatibility.asciidoc
@@ -35,7 +35,7 @@ The chart below outlines the compatibility between different versions of the APM
 |`5.x` |≥ `6.6`
 
 // Ruby
-.3+|**Ruby agent**
+.4+|**Ruby agent**
 |`1.x` |`6.4`-`6.x`
 |`2.x` |≥ `6.5`
 |`3.x` |≥ `6.5`


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Fixing broken box for RUM (#5295)