### PR TITLE
sampling: persist subscriber position

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -24,6 +24,7 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 * Add metric_type and unit to field metadata of system metrics {pull}5230[5230]
 * Upgrade Go to 1.15.12 {pull}[]
 * Add support for dynamic histogram metrics {pull}5239[5239]
+* Tail-sampling processor now resumes subscription from previous position after restart {pull}5350[5350]
 
 [float]
 ==== Deprecated

--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -732,7 +732,6 @@ func cloneBatch(in *model.Batch) *model.Batch {
 // and file info (including modification time).
 func waitFileModified(tb testing.TB, filename string, after time.Time) ([]byte, os.FileInfo) {
 	// Wait for subscriber_position.json to be written to the storage directory.
-	//subscriberPositionFile := filepath.Join(config.StorageDir, "subscriber_position.json")
 	timeout := time.NewTimer(10 * time.Second)
 	defer timeout.Stop()
 	ticker := time.NewTicker(50 * time.Millisecond)

--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -11,6 +11,7 @@ import (
 	"math/rand"
 	"os"
 	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/dgraph-io/badger/v2"
 	"github.com/gofrs/uuid"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -594,6 +596,30 @@ func TestStorageGC(t *testing.T) {
 	t.Fatal("timed out waiting for value log garbage collection")
 }
 
+func TestProcessRemoteTailSamplingPersistence(t *testing.T) {
+	config := newTempdirConfig(t)
+	config.Policies = []sampling.Policy{{SampleRate: 0.5}}
+	config.FlushInterval = 10 * time.Millisecond
+
+	subscriberChan := make(chan string)
+	subscriber := pubsubtest.SubscriberChan(subscriberChan)
+	config.Elasticsearch = pubsubtest.Client(nil, subscriber)
+
+	processor, err := sampling.NewProcessor(config)
+	require.NoError(t, err)
+	go processor.Run()
+	defer processor.Stop(context.Background())
+
+	// Wait for subscriber_position.json to be written to the storage directory.
+	subscriberPositionFile := filepath.Join(config.StorageDir, "subscriber_position.json")
+	data, info := waitFileModified(t, subscriberPositionFile, time.Time{})
+	assert.Equal(t, "{}", string(data))
+
+	subscriberChan <- "0102030405060708090a0b0c0d0e0f10"
+	data, _ = waitFileModified(t, subscriberPositionFile, info.ModTime())
+	assert.Equal(t, `{"index_name":1}`, string(data))
+}
+
 func withBadger(tb testing.TB, storageDir string, f func(db *badger.DB)) {
 	badgerOpts := badger.DefaultOptions(storageDir)
 	badgerOpts.Logger = nil
@@ -698,5 +724,38 @@ func cloneBatch(in *model.Batch) *model.Batch {
 	return &model.Batch{
 		Transactions: in.Transactions[:],
 		Spans:        in.Spans[:],
+	}
+}
+
+// waitFileModified waits up to 10 seconds for filename to exist and for its
+// modification time to be greater than "after", and returns the file content
+// and file info (including modification time).
+func waitFileModified(tb testing.TB, filename string, after time.Time) ([]byte, os.FileInfo) {
+	// Wait for subscriber_position.json to be written to the storage directory.
+	//subscriberPositionFile := filepath.Join(config.StorageDir, "subscriber_position.json")
+	timeout := time.NewTimer(10 * time.Second)
+	defer timeout.Stop()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+
+		select {
+		case <-ticker.C:
+			info, err := os.Stat(filename)
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			} else if err != nil {
+				tb.Fatal(err)
+			}
+			if info.ModTime().After(after) {
+				data, err := ioutil.ReadFile(filename)
+				if err != nil {
+					tb.Fatal(err)
+				}
+				return data, info
+			}
+		case <-timeout.C:
+			tb.Fatalf("timed out waiting for %q to be modified", filename)
+		}
 	}
 }

--- a/x-pack/apm-server/sampling/pubsub/position.go
+++ b/x-pack/apm-server/sampling/pubsub/position.go
@@ -1,0 +1,35 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package pubsub
+
+import "encoding/json"
+
+// SubscriberPosition holds information for the subscriber to resume after the
+// recently observed sampled trace IDs.
+//
+// The zero value is valid, and can be used to subscribe to all sampled trace IDs.
+type SubscriberPosition struct {
+	// observedSeqnos maps index names to its greatest observed _seq_no.
+	observedSeqnos map[string]int64
+}
+
+// MarshalJSON marshals the subscriber position as JSON, for persistence.
+func (p SubscriberPosition) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.observedSeqnos)
+}
+
+// UnmarshalJSON unmarshals the subscriber position from JSON.
+func (p *SubscriberPosition) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &p.observedSeqnos)
+}
+
+func copyPosition(pos SubscriberPosition) SubscriberPosition {
+	observedSeqnos := make(map[string]int64, len(pos.observedSeqnos))
+	for index, seqno := range pos.observedSeqnos {
+		observedSeqnos[index] = seqno
+	}
+	pos.observedSeqnos = observedSeqnos
+	return pos
+}

--- a/x-pack/apm-server/sampling/pubsub/pubsub_integration_test.go
+++ b/x-pack/apm-server/sampling/pubsub/pubsub_integration_test.go
@@ -135,7 +135,7 @@ func TestElasticsearchIntegration_SubscribeSampledTraceIDs(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	g.Go(func() error {
-		return es.SubscribeSampledTraceIDs(ctx, out)
+		return es.SubscribeSampledTraceIDs(ctx, pubsub.SubscriberPosition{}, out, nil)
 	})
 	assert.NoError(t, err)
 

--- a/x-pack/apm-server/sampling/pubsub/pubsubtest/client.go
+++ b/x-pack/apm-server/sampling/pubsub/pubsubtest/client.go
@@ -119,7 +119,6 @@ func (rt *channelClientRoundTripper) RoundTrip(r *http.Request) (*http.Response,
 		}
 	}
 	if handler == nil {
-		fmt.Println(r.URL.Path)
 		panic(fmt.Errorf("unhandled path %q", r.URL.Path))
 	}
 	recorder := httptest.NewRecorder()


### PR DESCRIPTION
## Motivation/summary

Currently, the tail-sampling sampled trace ID subscriber will resume searching from the beginning of each index when the server is restarted. This could be quite expensive in heavy environments. To address this issue, this PR makes the subscriber resumable across restarts.

We introduce `sampling/pubsub.Position`, which holds information about the subscriber's "position" in the sampled traces data stream. Internally this holds a map of indices to observed `_seq_no` values. `pubsub.Pubsub.SubscribeSampledTraceIDs` now accepts a channel to which it will send the subscriber's position when it changes.

The `sampling.Processor` will now persist the subsciber's position to disk in the tail-sampling local storage directory, in a file called "subscriber_position.json". When the processor starts it will read this file and initialise the subscriber with the position so it resumes searches from there.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

1. Run apm-server with tail-sampling configured
2. Send transactions
3. Check that after ~30 seconds, there's a `subscriber_position.json` file under `<data-dir>/tail_sampling`
4. Restart apm-server
5. Send some more transactions
6. Check that transactions are sampled according to tail-sampling config

For bonus points:

7. Do some long-run testing where there are a lot of tail-sampling decision documents
8. Restart apm-server and ensure it does not churn through all the old documents

## Related issues

Closes #4437