### PR TITLE
[automation] update elastic stack version for testing 7.14.0-f385fee6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       kibana: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0-9eca24b7-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0-f385fee6-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -61,7 +61,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.14.0-9eca24b7-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.14.0-f385fee6-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -85,7 +85,7 @@ services:
       package-registry: { condition: service_healthy }
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:7.14.0-9eca24b7-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:7.14.0-f385fee6-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Wed, 26 May 2021 05:26:20 GMT, release_branch:7.x, prefix:, end_time:Wed, 26 May 2021 10:07:36 GMT, manifest_version:2.0.0, version:7.14.0-SNAPSHOT, branch:7.x, build_id:7.14.0-f385fee6, build_duration_seconds:16876]