### PR TITLE
Add service name to logs

### DIFF
--- a/agentcfg/cache.go
+++ b/agentcfg/cache.go
@@ -18,6 +18,7 @@
 package agentcfg
 
 import (
+	"fmt"
 	"time"
 
 	gocache "github.com/patrickmn/go-cache"
@@ -55,7 +56,8 @@ func (c *cache) fetch(query Query, fetch func() (Result, error)) (Result, error)
 	c.gocache.SetDefault(query.id(), result)
 
 	if c.logger.IsDebug() {
-		c.logger.Debugf("Cache size %v. Added ID %v.", c.gocache.ItemCount(), query.id())
+		c.logger.Debugw(fmt.Sprintf("Cache size %v. Added ID %v.", c.gocache.ItemCount(), query.id()),
+			"service.name", query.Service.Name)
 	}
 	return result, nil
 }

--- a/beater/api/intake/handler.go
+++ b/beater/api/intake/handler.go
@@ -63,11 +63,7 @@ func Handler(processor *stream.Processor, batchProcessor model.BatchProcessor) r
 			return
 		}
 
-		metadata := model.Metadata{
-			UserAgent: model.UserAgent{Original: c.RequestMetadata.UserAgent},
-			Client:    model.Client{IP: c.RequestMetadata.ClientIP},
-			System:    model.System{IP: c.RequestMetadata.SystemIP}}
-		res := processor.HandleStream(c, c.RateLimiter, &metadata, reader, batchProcessor)
+		res := processor.HandleStream(c, reader, batchProcessor)
 		sendResponse(c, res)
 	}
 }

--- a/beater/api/intake/handler.go
+++ b/beater/api/intake/handler.go
@@ -67,7 +67,7 @@ func Handler(processor *stream.Processor, batchProcessor model.BatchProcessor) r
 			UserAgent: model.UserAgent{Original: c.RequestMetadata.UserAgent},
 			Client:    model.Client{IP: c.RequestMetadata.ClientIP},
 			System:    model.System{IP: c.RequestMetadata.SystemIP}}
-		res := processor.HandleStream(c.Request.Context(), c.RateLimiter, &metadata, reader, batchProcessor)
+		res := processor.HandleStream(c, c.RateLimiter, &metadata, reader, batchProcessor)
 		sendResponse(c, res)
 	}
 }

--- a/beater/jaeger/grpc.go
+++ b/beater/jaeger/grpc.go
@@ -110,13 +110,13 @@ func (s *grpcSampler) GetSamplingStrategy(
 		if errors.As(err, &verr) {
 			if err := checkValidationError(verr); err != nil {
 				// do not return full error details since this is part of an unprotected endpoint response
-				s.logger.With(logp.Error(err)).Error("Configured Kibana client does not support agent remote configuration")
+				s.logger.With(logp.Error(err)).With("service.name", params.ServiceName).Error("Configured Kibana client does not support agent remote configuration")
 				return nil, errors.New("agent remote configuration not supported, check server logs for more details")
 			}
 		}
 
 		// do not return full error details since this is part of an unprotected endpoint response
-		s.logger.With(logp.Error(err)).Error("No valid sampling rate fetched from Kibana.")
+		s.logger.With(logp.Error(err)).With("service.name", params.ServiceName).Error("No valid sampling rate fetched from Kibana.")
 		return nil, errors.New("no sampling rate available, check server logs for more details")
 	}
 

--- a/beater/middleware/log_middleware.go
+++ b/beater/middleware/log_middleware.go
@@ -47,7 +47,12 @@ func LogMiddleware() Middleware {
 				return
 			}
 			h(c)
+
 			c.Logger = c.Logger.With("event.duration", time.Since(start))
+			if c.ServiceName != "" {
+				c.Logger = c.Logger.With("service.name", c.ServiceName)
+			}
+
 			if c.MultipleWriteAttempts() {
 				c.Logger.Warn("multiple write attempts")
 			}

--- a/beater/request/context.go
+++ b/beater/request/context.go
@@ -47,6 +47,7 @@ type Context struct {
 	Logger          *logp.Logger
 	RateLimiter     *rate.Limiter
 	AuthResult      authorization.Result
+	ServiceName     string
 	IsRum           bool
 	Result          Result
 	RequestMetadata Metadata
@@ -75,6 +76,7 @@ func (c *Context) Reset(w http.ResponseWriter, r *http.Request) {
 	c.RateLimiter = nil
 	c.AuthResult = authorization.Result{}
 	c.IsRum = false
+	c.ServiceName = ""
 	c.Result.Reset()
 	c.RequestMetadata.Reset()
 

--- a/model/stacktrace.go
+++ b/model/stacktrace.go
@@ -68,7 +68,7 @@ func (st *Stacktrace) transform(ctx context.Context, cfg *transform.Config, rum 
 			return
 		}
 		if _, ok := sourcemapErrorSet[errMsg]; !ok {
-			logger.Debug(errMsg)
+			logger.Debugw(errMsg, "service.name", service.Name)
 			sourcemapErrorSet[errMsg] = nil
 		}
 	})

--- a/processor/otel/consumer.go
+++ b/processor/otel/consumer.go
@@ -129,7 +129,7 @@ func (c *Consumer) convertSpan(
 	metadata model.Metadata,
 	out *model.Batch,
 ) {
-	logger := logp.NewLogger(logs.Otel)
+	logger := logp.NewLogger(logs.Otel).With("service.name", metadata.Service.Name)
 
 	root := otelSpan.ParentSpanID().IsEmpty()
 

--- a/processor/stream/benchmark_test.go
+++ b/processor/stream/benchmark_test.go
@@ -19,16 +19,17 @@ package stream
 
 import (
 	"bytes"
-	"context"
 	"io/ioutil"
 	"math"
+	"net/http"
 	"path/filepath"
 	"testing"
+
+	"github.com/elastic/apm-server/beater/request"
 
 	"golang.org/x/time/rate"
 
 	"github.com/elastic/apm-server/beater/config"
-	"github.com/elastic/apm-server/model"
 )
 
 func BenchmarkBackendProcessor(b *testing.B) {
@@ -63,7 +64,7 @@ func benchmarkStreamProcessor(b *testing.B, processor *Processor, files []string
 				b.StopTimer()
 				r.Reset(data)
 				b.StartTimer()
-				processor.HandleStream(context.Background(), rl, &model.Metadata{}, r, batchProcessor)
+				processor.HandleStream(&request.Context{Request: &http.Request{}, RateLimiter: rl}, r, batchProcessor)
 			}
 		}
 	}

--- a/processor/stream/package_tests/intake_test_processor.go
+++ b/processor/stream/package_tests/intake_test_processor.go
@@ -24,7 +24,10 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"time"
+
+	"github.com/elastic/apm-server/beater/request"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 
@@ -134,7 +137,7 @@ func (p *intakeTestProcessor) Process(buf []byte) ([]beat.Event, error) {
 		return nil
 	})
 
-	result := p.HandleStream(context.TODO(), nil, &model.Metadata{}, bytes.NewBuffer(buf), batchProcessor)
+	result := p.HandleStream(&request.Context{Request: &http.Request{}}, bytes.NewBuffer(buf), batchProcessor)
 	for _, event := range events {
 		// TODO(axw) migrate all of these tests to systemtest,
 		// so we can use the proper event publishing pipeline.

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationRumErrors.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationRumErrors.approved.json
@@ -6,9 +6,6 @@
                 "name": "rum-js",
                 "version": "0.0.0"
             },
-            "client": {
-                "ip": "192.0.0.1"
-            },
             "data_stream.dataset": "apm.error.apm_agent_js",
             "data_stream.type": "logs",
             "error": {
@@ -95,6 +92,9 @@
                     "url": "http://localhost:8000/test/e2e/general-usecase/"
                 }
             },
+            "host": {
+                "ip": "192.0.0.1"
+            },
             "http": {
                 "request": {
                     "referrer": "http://localhost:8000/test/e2e/"
@@ -107,9 +107,6 @@
             "service": {
                 "name": "apm-agent-js",
                 "version": "1.0.1"
-            },
-            "source": {
-                "ip": "192.0.0.1"
             },
             "timestamp": {
                 "us": 1512735530291000

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationRumTransactions.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationRumTransactions.approved.json
@@ -6,13 +6,13 @@
                 "name": "rum-js",
                 "version": "0.0.0"
             },
-            "client": {
-                "ip": "192.0.0.1"
-            },
             "data_stream.dataset": "apm.apm_agent_js",
             "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
+            },
+            "host": {
+                "ip": "192.0.0.1"
             },
             "http": {
                 "request": {
@@ -26,9 +26,6 @@
             "service": {
                 "name": "apm-agent-js",
                 "version": "1.0.0"
-            },
-            "source": {
-                "ip": "192.0.0.1"
             },
             "timestamp": {
                 "us": 1533117600000000
@@ -74,13 +71,13 @@
                 "name": "rum-js",
                 "version": "0.0.0"
             },
-            "client": {
-                "ip": "192.0.0.1"
-            },
             "data_stream.dataset": "apm.apm_agent_js",
             "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
+            },
+            "host": {
+                "ip": "192.0.0.1"
             },
             "parent": {
                 "id": "611f4fa950f04631"

--- a/processor/stream/test_approved_es_documents/testIntakeRUMV3Errors.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeRUMV3Errors.approved.json
@@ -6,9 +6,6 @@
                 "name": "js-base",
                 "version": "4.8.1"
             },
-            "client": {
-                "ip": "192.0.0.1"
-            },
             "data_stream.dataset": "apm.error.apm_a_rum_test_e2e_general_usecase",
             "data_stream.type": "logs",
             "error": {
@@ -51,6 +48,9 @@
                     "url": "http://localhost:8000/test/e2e/general-usecase/"
                 }
             },
+            "host": {
+                "ip": "192.0.0.1"
+            },
             "http": {
                 "request": {
                     "referrer": "http://localhost:8000/test/e2e/"
@@ -69,9 +69,6 @@
                 },
                 "name": "apm-a-rum-test-e2e-general-usecase",
                 "version": "0.0.1"
-            },
-            "source": {
-                "ip": "192.0.0.1"
             },
             "timestamp": {
                 "us": 1533117600000000

--- a/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
@@ -6,13 +6,13 @@
                 "name": "js-base",
                 "version": "4.8.1"
             },
-            "client": {
-                "ip": "192.0.0.1"
-            },
             "data_stream.dataset": "apm.apm_a_rum_test_e2e_general_usecase",
             "data_stream.type": "traces",
             "event": {
                 "outcome": "success"
+            },
+            "host": {
+                "ip": "192.0.0.1"
             },
             "http": {
                 "request": {
@@ -63,9 +63,6 @@
                     "version": "8.0"
                 },
                 "version": "0.0.1"
-            },
-            "source": {
-                "ip": "192.0.0.1"
             },
             "timestamp": {
                 "us": 1533117600000000
@@ -154,13 +151,13 @@
                 "name": "js-base",
                 "version": "4.8.1"
             },
-            "client": {
-                "ip": "192.0.0.1"
-            },
             "data_stream.dataset": "apm.apm_a_rum_test_e2e_general_usecase",
             "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
+            },
+            "host": {
+                "ip": "192.0.0.1"
             },
             "labels": {
                 "testTagKey": "testTagValue"
@@ -225,13 +222,13 @@
                 "name": "js-base",
                 "version": "4.8.1"
             },
-            "client": {
-                "ip": "192.0.0.1"
-            },
             "data_stream.dataset": "apm.apm_a_rum_test_e2e_general_usecase",
             "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
+            },
+            "host": {
+                "ip": "192.0.0.1"
             },
             "labels": {
                 "testTagKey": "testTagValue"
@@ -296,9 +293,6 @@
                 "name": "js-base",
                 "version": "4.8.1"
             },
-            "client": {
-                "ip": "192.0.0.1"
-            },
             "data_stream.dataset": "apm.apm_a_rum_test_e2e_general_usecase",
             "data_stream.type": "traces",
             "destination": {
@@ -307,6 +301,9 @@
             },
             "event": {
                 "outcome": "unknown"
+            },
+            "host": {
+                "ip": "192.0.0.1"
             },
             "labels": {
                 "testTagKey": "testTagValue"
@@ -388,13 +385,13 @@
                 "name": "js-base",
                 "version": "4.8.1"
             },
-            "client": {
-                "ip": "192.0.0.1"
-            },
             "data_stream.dataset": "apm.apm_a_rum_test_e2e_general_usecase",
             "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
+            },
+            "host": {
+                "ip": "192.0.0.1"
             },
             "labels": {
                 "testTagKey": "testTagValue"
@@ -458,9 +455,6 @@
                 "name": "js-base",
                 "version": "4.8.1"
             },
-            "client": {
-                "ip": "192.0.0.1"
-            },
             "data_stream.dataset": "apm.apm_a_rum_test_e2e_general_usecase",
             "data_stream.type": "traces",
             "destination": {
@@ -469,6 +463,9 @@
             },
             "event": {
                 "outcome": "success"
+            },
+            "host": {
+                "ip": "192.0.0.1"
             },
             "labels": {
                 "testTagKey": "testTagValue"
@@ -550,9 +547,6 @@
                 "name": "js-base",
                 "version": "4.8.1"
             },
-            "client": {
-                "ip": "192.0.0.1"
-            },
             "data_stream.dataset": "apm.apm_a_rum_test_e2e_general_usecase",
             "data_stream.type": "traces",
             "destination": {
@@ -561,6 +555,9 @@
             },
             "event": {
                 "outcome": "success"
+            },
+            "host": {
+                "ip": "192.0.0.1"
             },
             "labels": {
                 "testTagKey": "testTagValue"
@@ -642,9 +639,6 @@
                 "name": "js-base",
                 "version": "4.8.1"
             },
-            "client": {
-                "ip": "192.0.0.1"
-            },
             "data_stream.dataset": "apm.apm_a_rum_test_e2e_general_usecase",
             "data_stream.type": "traces",
             "destination": {
@@ -653,6 +647,9 @@
             },
             "event": {
                 "outcome": "success"
+            },
+            "host": {
+                "ip": "192.0.0.1"
             },
             "labels": {
                 "testTagKey": "testTagValue"
@@ -735,13 +732,13 @@
                 "name": "js-base",
                 "version": "4.8.1"
             },
-            "client": {
-                "ip": "192.0.0.1"
-            },
             "data_stream.dataset": "apm.apm_a_rum_test_e2e_general_usecase",
             "data_stream.type": "traces",
             "event": {
                 "outcome": "success"
+            },
+            "host": {
+                "ip": "192.0.0.1"
             },
             "labels": {
                 "testTagKey": "testTagValue"
@@ -828,11 +825,11 @@
                 "name": "js-base",
                 "version": "4.8.1"
             },
-            "client": {
-                "ip": "192.0.0.1"
-            },
             "data_stream.dataset": "apm.internal.apm_a_rum_test_e2e_general_usecase",
             "data_stream.type": "metrics",
+            "host": {
+                "ip": "192.0.0.1"
+            },
             "labels": {
                 "testTagKey": "testTagValue"
             },
@@ -885,11 +882,11 @@
                 "name": "js-base",
                 "version": "4.8.1"
             },
-            "client": {
-                "ip": "192.0.0.1"
-            },
             "data_stream.dataset": "apm.internal.apm_a_rum_test_e2e_general_usecase",
             "data_stream.type": "metrics",
+            "host": {
+                "ip": "192.0.0.1"
+            },
             "labels": {
                 "testTagKey": "testTagValue"
             },
@@ -942,11 +939,11 @@
                 "name": "js-base",
                 "version": "4.8.1"
             },
-            "client": {
-                "ip": "192.0.0.1"
-            },
             "data_stream.dataset": "apm.internal.apm_a_rum_test_e2e_general_usecase",
             "data_stream.type": "metrics",
+            "host": {
+                "ip": "192.0.0.1"
+            },
             "labels": {
                 "testTagKey": "testTagValue"
             },
@@ -999,11 +996,11 @@
                 "name": "js-base",
                 "version": "4.8.1"
             },
-            "client": {
-                "ip": "192.0.0.1"
-            },
             "data_stream.dataset": "apm.internal.apm_a_rum_test_e2e_general_usecase",
             "data_stream.type": "metrics",
+            "host": {
+                "ip": "192.0.0.1"
+            },
             "labels": {
                 "tag1": "value1",
                 "testTagKey": "testTagValue"

--- a/sourcemap/es_store.go
+++ b/sourcemap/es_store.go
@@ -109,8 +109,8 @@ func parse(body io.ReadCloser, name, version, path string, logger *logp.Logger) 
 
 	var esSourcemap string
 	if hits > 1 {
-		logger.Warnf("%d sourcemaps found for service %s version %s and file %s, using the most recent one",
-			hits, name, version, path)
+		logger.Warnw(fmt.Sprintf("%d sourcemaps found", hits),
+			"service.name", name, "service.version", version, "file.path", path)
 	}
 	esSourcemap = esSourcemapResponse.Hits.Hits[0].Source.Sourcemap.Sourcemap
 	// until https://github.com/golang/go/issues/19858 is resolved

--- a/sourcemap/store.go
+++ b/sourcemap/store.go
@@ -99,8 +99,7 @@ func (s *Store) Fetch(ctx context.Context, name string, version string, path str
 // Added ensures the internal cache is cleared for the given parameters. This should be called when a sourcemap is uploaded.
 func (s *Store) Added(ctx context.Context, name string, version string, path string) {
 	if sourcemap, err := s.Fetch(ctx, name, version, path); err == nil && sourcemap != nil {
-		s.logger.Warnf("Overriding sourcemap for service %s version %s and file %s",
-			name, version, path)
+		s.logger.Warnw("Overriding sourcemap", "service.name", name, "service.version", version, "file.path", path)
 	}
 	key := key([]string{name, version, path})
 	s.cache.Delete(key)

--- a/tests/system/test_integration_sourcemap.py
+++ b/tests/system/test_integration_sourcemap.py
@@ -57,10 +57,10 @@ class SourcemappingIntegrationTest(BaseSourcemapTest):
         assert self.log_contains(
             "Overriding sourcemap"), "A log should be written when a sourcemap is overwritten"
         self.upload_sourcemap(expected_ct=3)
-        assert self.log_contains("2 sourcemaps found for service"), \
+        assert self.log_contains("2 sourcemaps found"), \
             "the 3rd fetch should query ES and find that there are 2 sourcemaps with the same caching key"
         self.assert_no_logged_warnings(
-            ["WARN.*Overriding sourcemap", "WARN.*2 sourcemaps found for service"])
+            ["WARN.*Overriding sourcemap", "WARN.*2 sourcemaps found"])
 
     def test_backend_span(self):
         # ensure source mapping is not applied to backend events


### PR DESCRIPTION
Implements part of https://github.com/elastic/apm-server/issues/5034

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

## How to test these changes

Send some events to apm-server, check that `service.name` is in the request logs