### PR TITLE
Fix gvm installation

### DIFF
--- a/_beats/dev-tools/common.bash
+++ b/_beats/dev-tools/common.bash
@@ -47,7 +47,8 @@ install_gvm() {
     chmod +x "$GVM"
   fi
 
-  debug "Gvm version $(${GVM} --version)"
+  export PATH="${GVMDIR}:${PATH}"
+  debug "Gvm version $(gvm --version)"
 }
 
 # setup_go_root "version"

--- a/_beats/dev-tools/common.bash
+++ b/_beats/dev-tools/common.bash
@@ -39,12 +39,14 @@ get_go_version() {
 # To read more about installing gvm in other platforms: https://github.com/andrewkroh/gvm#installation
 install_gvm() {
   # Install gvm
-  if [ ! -f "/usr/local/bin/gvm" ]; then
-    curl -sL -o ~/bin/gvm https://github.com/andrewkroh/gvm/releases/download/v0.3.0/gvm-linux-amd64
-    chmod +x /usr/local/bin/gvm
+  GVMDIR="$HOME/.gvm"
+  GVM="$GVMDIR/gvm"
+  if [ ! -x "$GVM" ]; then
+    mkdir -p "$GVMDIR"
+    curl -sL -o "$GVM" https://github.com/andrewkroh/gvm/releases/download/v0.3.0/gvm-linux-amd64
+    chmod +x "$GVM"
   fi
 
-  GVM="/usr/local/bin/gvm"
   debug "Gvm version $(${GVM} --version)"
 }
 


### PR DESCRIPTION
Fix a typo introduced in https://github.com/elastic/apm-server/pull/5333. I took the liberty of changing it to install to `~/.gvm/gvm` rather than `/usr/local/bin/gvm`.