### PR TITLE
Tidy up beater/config

### DIFF
--- a/agentcfg/fetch.go
+++ b/agentcfg/fetch.go
@@ -74,11 +74,6 @@ func NewFetcher(cfg *config.Config) Fetcher {
 	if cfg.Kibana.Enabled {
 		client = kibana.NewConnectingClient(&cfg.Kibana)
 	}
-
-	if cfg.KibanaAgentConfig == nil {
-		cfg.KibanaAgentConfig = config.DefaultKibanaAgentConfig()
-	}
-
 	return NewKibanaFetcher(client, cfg.KibanaAgentConfig.Cache.Expiration)
 }
 

--- a/beater/api/config/agent/handler.go
+++ b/beater/api/config/agent/handler.go
@@ -62,7 +62,7 @@ type handler struct {
 	cacheControl, defaultServiceEnvironment string
 }
 
-func NewHandler(f agentcfg.Fetcher, config *config.KibanaAgentConfig, defaultServiceEnvironment string) request.Handler {
+func NewHandler(f agentcfg.Fetcher, config config.KibanaAgentConfig, defaultServiceEnvironment string) request.Handler {
 	if f == nil {
 		panic("fetcher must not be nil")
 	}

--- a/beater/api/config/agent/handler_test.go
+++ b/beater/api/config/agent/handler_test.go
@@ -178,13 +178,13 @@ var (
 )
 
 func TestAgentConfigHandler(t *testing.T) {
-	var cfg = config.KibanaAgentConfig{Cache: &config.Cache{Expiration: 4 * time.Second}}
+	var cfg = config.KibanaAgentConfig{Cache: config.Cache{Expiration: 4 * time.Second}}
 
 	for name, tc := range testcases {
 
 		runTest := func(t *testing.T, expectedBody map[string]string, authorized bool) {
 			f := agentcfg.NewKibanaFetcher(tc.kbClient, cfg.Cache.Expiration)
-			h := NewHandler(f, &cfg, "")
+			h := NewHandler(f, cfg, "")
 			r := httptest.NewRequest(tc.method, target(tc.queryParams), nil)
 			for k, v := range tc.requestHeader {
 				r.Header.Set(k, v)
@@ -214,9 +214,9 @@ func TestAgentConfigHandler(t *testing.T) {
 }
 
 func TestAgentConfigHandler_NoKibanaClient(t *testing.T) {
-	cfg := config.KibanaAgentConfig{Cache: &config.Cache{Expiration: time.Nanosecond}}
+	cfg := config.KibanaAgentConfig{Cache: config.Cache{Expiration: time.Nanosecond}}
 	f := agentcfg.NewKibanaFetcher(nil, cfg.Cache.Expiration)
-	h := NewHandler(f, &cfg, "")
+	h := NewHandler(f, cfg, "")
 
 	w := sendRequest(h, httptest.NewRequest(http.MethodPost, "/config", convert.ToReader(m{
 		"service": m{"name": "opbeans-node"}})))
@@ -233,9 +233,9 @@ func TestAgentConfigHandler_PostOk(t *testing.T) {
 		},
 	}, mockVersion, true)
 
-	var cfg = config.KibanaAgentConfig{Cache: &config.Cache{Expiration: time.Nanosecond}}
+	var cfg = config.KibanaAgentConfig{Cache: config.Cache{Expiration: time.Nanosecond}}
 	f := agentcfg.NewKibanaFetcher(kb, cfg.Cache.Expiration)
-	h := NewHandler(f, &cfg, "")
+	h := NewHandler(f, cfg, "")
 
 	w := sendRequest(h, httptest.NewRequest(http.MethodPost, "/config", convert.ToReader(m{
 		"service": m{"name": "opbeans-node"}})))
@@ -254,9 +254,9 @@ func TestAgentConfigHandler_DefaultServiceEnvironment(t *testing.T) {
 		}, mockVersion, true),
 	}
 
-	var cfg = config.KibanaAgentConfig{Cache: &config.Cache{Expiration: time.Nanosecond}}
+	var cfg = config.KibanaAgentConfig{Cache: config.Cache{Expiration: time.Nanosecond}}
 	f := agentcfg.NewKibanaFetcher(kb, cfg.Cache.Expiration)
-	h := NewHandler(f, &cfg, "default")
+	h := NewHandler(f, cfg, "default")
 
 	sendRequest(h, httptest.NewRequest(http.MethodPost, "/config", convert.ToReader(m{"service": m{"name": "opbeans-node", "environment": "specified"}})))
 	sendRequest(h, httptest.NewRequest(http.MethodPost, "/config", convert.ToReader(m{"service": m{"name": "opbeans-node"}})))
@@ -342,9 +342,9 @@ func getHandler(agent string) request.Handler {
 			"agent_name": agent,
 		},
 	}, mockVersion, true)
-	cfg := config.KibanaAgentConfig{Cache: &config.Cache{Expiration: time.Nanosecond}}
+	cfg := config.KibanaAgentConfig{Cache: config.Cache{Expiration: time.Nanosecond}}
 	f := agentcfg.NewKibanaFetcher(kb, cfg.Cache.Expiration)
-	return NewHandler(f, &cfg, "")
+	return NewHandler(f, cfg, "")
 }
 
 func TestIfNoneMatch(t *testing.T) {
@@ -368,7 +368,7 @@ func TestAgentConfigTraceContext(t *testing.T) {
 	kibanaCfg := config.KibanaConfig{Enabled: true, ClientConfig: libkibana.DefaultClientConfig()}
 	kibanaCfg.Host = "testKibana:12345"
 	client := kibana.NewConnectingClient(&kibanaCfg)
-	cfg := &config.KibanaAgentConfig{Cache: &config.Cache{Expiration: 5 * time.Minute}}
+	cfg := config.KibanaAgentConfig{Cache: config.Cache{Expiration: 5 * time.Minute}}
 	f := agentcfg.NewKibanaFetcher(client, cfg.Cache.Expiration)
 	handler := NewHandler(f, cfg, "default")
 	_, spans, _ := apmtest.WithTransaction(func(ctx context.Context) {

--- a/beater/api/mux.go
+++ b/beater/api/mux.go
@@ -115,12 +115,12 @@ func NewMux(
 		logger.Infof("Path %s added to request handler", route.path)
 		mux.Handle(route.path, pool.HTTPHandler(h))
 	}
-	if beaterConfig.Expvar.IsEnabled() {
+	if beaterConfig.Expvar.Enabled {
 		path := beaterConfig.Expvar.URL
 		logger.Infof("Path %s added to request handler", path)
 		mux.Handle(path, http.HandlerFunc(debugVarsHandler))
 	}
-	if beaterConfig.Pprof.IsEnabled() {
+	if beaterConfig.Pprof.Enabled {
 		const path = "/debug/pprof"
 		logger.Infof("Path %s added to request handler", path)
 		mux.Handle(path+"/", http.HandlerFunc(pprof.Index))
@@ -239,7 +239,7 @@ func rumMiddleware(cfg *config.Config, _ *authorization.Handler, m map[request.R
 		middleware.SetRumFlagMiddleware(),
 		middleware.SetIPRateLimitMiddleware(cfg.RumConfig.EventRate),
 		middleware.CORSMiddleware(cfg.RumConfig.AllowOrigins, cfg.RumConfig.AllowHeaders),
-		middleware.KillSwitchMiddleware(cfg.RumConfig.IsEnabled(), msg),
+		middleware.KillSwitchMiddleware(cfg.RumConfig.Enabled, msg),
 	)
 	if cfg.AugmentEnabled {
 		rumMiddleware = append(rumMiddleware, middleware.UserMetadataMiddleware())
@@ -254,7 +254,7 @@ func sourcemapMiddleware(cfg *config.Config, auth *authorization.Handler) []midd
 	if cfg.DataStreams.Enabled {
 		msg = "When APM Server is managed by Fleet, Sourcemaps must be uploaded directly to Elasticsearch."
 	}
-	enabled := cfg.RumConfig.IsEnabled() && cfg.RumConfig.SourceMapping.IsEnabled() && !cfg.DataStreams.Enabled
+	enabled := cfg.RumConfig.Enabled && cfg.RumConfig.SourceMapping.Enabled && !cfg.DataStreams.Enabled
 	return append(backendMiddleware(cfg, auth, sourcemap.MonitoringMap),
 		middleware.KillSwitchMiddleware(enabled, msg))
 }

--- a/beater/api/mux_intake_rum_test.go
+++ b/beater/api/mux_intake_rum_test.go
@@ -123,8 +123,7 @@ func TestRumHandler_MonitoringMiddleware(t *testing.T) {
 
 func cfgEnabledRUM() *config.Config {
 	cfg := config.DefaultConfig()
-	t := true
-	cfg.RumConfig.Enabled = &t
+	cfg.RumConfig.Enabled = true
 	return cfg
 }
 

--- a/beater/api/mux_sourcemap_handler_test.go
+++ b/beater/api/mux_sourcemap_handler_test.go
@@ -61,10 +61,8 @@ func TestSourcemapHandler_KillSwitchMiddleware(t *testing.T) {
 
 	t.Run("OffSourcemap", func(t *testing.T) {
 		cfg := config.DefaultConfig()
-		rum := true
-		cfg.RumConfig.Enabled = &rum
-		cfg.RumConfig.SourceMapping.Enabled = new(bool)
-		rec, err := requestToMuxerWithPattern(config.DefaultConfig(), AssetSourcemapPath)
+		cfg.RumConfig.SourceMapping.Enabled = true
+		rec, err := requestToMuxerWithPattern(cfg, AssetSourcemapPath)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusForbidden, rec.Code)
 		approvaltest.ApproveJSON(t, approvalPathAsset(t.Name()), rec.Body.Bytes())
@@ -80,7 +78,9 @@ func TestSourcemapHandler_KillSwitchMiddleware(t *testing.T) {
 	})
 
 	t.Run("On", func(t *testing.T) {
-		rec, err := requestToMuxerWithPattern(cfgEnabledRUM(), AssetSourcemapPath)
+		cfg := cfgEnabledRUM()
+		cfg.RumConfig.SourceMapping.Enabled = true
+		rec, err := requestToMuxerWithPattern(cfg, AssetSourcemapPath)
 		require.NoError(t, err)
 		require.NotEqual(t, http.StatusForbidden, rec.Code)
 		approvaltest.ApproveJSON(t, approvalPathAsset(t.Name()), rec.Body.Bytes())

--- a/beater/authorization/builder.go
+++ b/beater/authorization/builder.go
@@ -60,7 +60,7 @@ const (
 // based on the request Authorization header
 func NewBuilder(cfg *config.Config) (*Builder, error) {
 	b := Builder{}
-	if cfg.APIKeyConfig.IsEnabled() {
+	if cfg.APIKeyConfig.Enabled {
 		// do not use username+password for API Key requests
 		cfg.APIKeyConfig.ESConfig.Username = ""
 		cfg.APIKeyConfig.ESConfig.Password = ""

--- a/beater/authorization/builder_test.go
+++ b/beater/authorization/builder_test.go
@@ -46,8 +46,10 @@ func TestBuilder(t *testing.T) {
 				cfg.SecretToken = "xvz"
 			}
 			if tc.withApikey {
-				cfg.APIKeyConfig = &config.APIKeyConfig{
-					Enabled: true, LimitPerMin: 100, ESConfig: elasticsearch.DefaultConfig()}
+				cfg.APIKeyConfig = config.APIKeyConfig{
+					Enabled: true, LimitPerMin: 100,
+					ESConfig: elasticsearch.DefaultConfig(),
+				}
 			}
 
 			builder, err := NewBuilder(cfg)

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -103,7 +103,7 @@ func NewCreator(args CreatorParams) beat.Creator {
 			bt.logger.Errorf("Error recording telemetry data", err)
 		}
 
-		if bt.config.Pprof.IsEnabled() {
+		if bt.config.Pprof.Enabled {
 			// Profiling rates should be set once, early on in the program.
 			runtime.SetBlockProfileRate(bt.config.Pprof.BlockProfileRate)
 			runtime.SetMutexProfileFraction(bt.config.Pprof.MutexProfileRate)
@@ -488,13 +488,13 @@ func (bt *beater) registerPipelineCallback(b *beat.Beat) error {
 		return nil
 	}
 
-	if !bt.config.Register.Ingest.Pipeline.IsEnabled() {
+	if !bt.config.Register.Ingest.Pipeline.Enabled {
 		bt.logger.Info("Pipeline registration disabled")
 		return nil
 	}
 
 	bt.logger.Info("Registering pipeline callback")
-	overwrite := bt.config.Register.Ingest.Pipeline.ShouldOverwrite()
+	overwrite := bt.config.Register.Ingest.Pipeline.Overwrite
 	path := bt.config.Register.Ingest.Pipeline.Path
 
 	// ensure setup cmd is working properly
@@ -539,7 +539,7 @@ func initTracing(b *beat.Beat, cfg *config.Config, logger *logp.Logger) (*apm.Tr
 // it does not instrument the beat output
 func initLegacyTracer(info beat.Info, cfg *config.Config) (*apm.Tracer, net.Listener, error) {
 	selfInstrumentation := cfg.SelfInstrumentation
-	if selfInstrumentation == nil || !selfInstrumentation.IsEnabled() {
+	if !selfInstrumentation.Enabled {
 		return apm.DefaultTracer, nil, nil
 	}
 	conf, err := common.NewConfigFrom(cfg.SelfInstrumentation)
@@ -606,7 +606,7 @@ func newTransformConfig(beatInfo beat.Info, cfg *config.Config) (*transform.Conf
 		},
 	}
 
-	if cfg.RumConfig.IsEnabled() && cfg.RumConfig.SourceMapping.IsEnabled() && cfg.RumConfig.SourceMapping.ESConfig != nil {
+	if cfg.RumConfig.Enabled && cfg.RumConfig.SourceMapping.Enabled && cfg.RumConfig.SourceMapping.ESConfig != nil {
 		store, err := newSourcemapStore(beatInfo, cfg.RumConfig.SourceMapping)
 		if err != nil {
 			return nil, err
@@ -617,7 +617,7 @@ func newTransformConfig(beatInfo beat.Info, cfg *config.Config) (*transform.Conf
 	return transformConfig, nil
 }
 
-func newSourcemapStore(beatInfo beat.Info, cfg *config.SourceMapping) (*sourcemap.Store, error) {
+func newSourcemapStore(beatInfo beat.Info, cfg config.SourceMapping) (*sourcemap.Store, error) {
 	esClient, err := elasticsearch.NewClient(cfg.ESConfig)
 	if err != nil {
 		return nil, err

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -240,7 +240,7 @@ func TestTransformConfigIndex(t *testing.T) {
 		defer srv.Close()
 
 		cfg := config.DefaultConfig()
-		cfg.RumConfig.Enabled = newBool(true)
+		cfg.RumConfig.Enabled = true
 		cfg.RumConfig.SourceMapping.ESConfig.Hosts = []string{srv.URL}
 		if indexPattern != "" {
 			cfg.RumConfig.SourceMapping.IndexPattern = indexPattern
@@ -262,7 +262,7 @@ func TestTransformConfigIndex(t *testing.T) {
 }
 
 func TestTransformConfig(t *testing.T) {
-	test := func(rumEnabled, sourcemapEnabled *bool, expectSourcemapStore bool) {
+	test := func(rumEnabled, sourcemapEnabled bool, expectSourcemapStore bool) {
 		cfg := config.DefaultConfig()
 		cfg.RumConfig.Enabled = rumEnabled
 		cfg.RumConfig.SourceMapping.Enabled = sourcemapEnabled
@@ -275,19 +275,8 @@ func TestTransformConfig(t *testing.T) {
 		}
 	}
 
-	test(nil, nil, false)
-	test(nil, newBool(false), false)
-	test(nil, newBool(true), false)
-
-	test(newBool(false), nil, false)
-	test(newBool(false), newBool(false), false)
-	test(newBool(false), newBool(true), false)
-
-	test(newBool(true), nil, true) // sourcemap.enabled is true by default
-	test(newBool(true), newBool(false), false)
-	test(newBool(true), newBool(true), true)
-}
-
-func newBool(v bool) *bool {
-	return &v
+	test(false, false, false)
+	test(false, true, false)
+	test(true, false, false)
+	test(true, true, true)
 }

--- a/beater/config/agentconfig.go
+++ b/beater/config/agentconfig.go
@@ -1,0 +1,93 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package config
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// KibanaAgentConfig holds remote agent config information
+type KibanaAgentConfig struct {
+	Cache Cache `config:"cache"`
+}
+
+// Cache holds config information about cache expiration
+type Cache struct {
+	Expiration time.Duration `config:"expiration"`
+}
+
+// defaultKibanaAgentConfig holds the default KibanaAgentConfig
+func defaultKibanaAgentConfig() KibanaAgentConfig {
+	return KibanaAgentConfig{
+		Cache: Cache{
+			Expiration: 30 * time.Second,
+		},
+	}
+}
+
+// AgentConfig defines configuration for agents.
+type AgentConfig struct {
+	Service   Service `config:"service"`
+	AgentName string  `config:"agent.name"`
+	Etag      string  `config:"etag"`
+	Config    map[string]string
+}
+
+func (s *AgentConfig) setup() error {
+	if !s.Service.isValid() {
+		return errInvalidAgentConfigServiceName
+	}
+	if s.Config == nil {
+		return errInvalidAgentConfigMissingConfig
+	}
+
+	if s.Etag == "" {
+		m, err := json.Marshal(s)
+		if err != nil {
+			return fmt.Errorf("error generating etag for %s: %v", s.Service, err)
+		}
+		s.Etag = fmt.Sprintf("%x", md5.Sum(m))
+	}
+	return nil
+}
+
+// Service defines a unique way of identifying a running agent.
+type Service struct {
+	Name        string `config:"name"`
+	Environment string `config:"environment"`
+}
+
+// String implements the Stringer interface.
+func (s *Service) String() string {
+	var name, env string
+	if s.Name != "" {
+		name = "service.name=" + s.Name
+	}
+	if s.Environment != "" {
+		env = "service.environment=" + s.Environment
+	}
+	return strings.Join([]string{name, env}, " ")
+}
+
+func (s *Service) isValid() bool {
+	return s.Name != "" || s.Environment != ""
+}

--- a/beater/config/config.go
+++ b/beater/config/config.go
@@ -18,18 +18,13 @@
 package config
 
 import (
-	"crypto/md5"
-	"encoding/json"
-	"fmt"
 	"net"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/common/transport/tlscommon"
-	"github.com/elastic/beats/v7/libbeat/kibana"
 	"github.com/elastic/beats/v7/libbeat/logp"
 
 	logs "github.com/elastic/apm-server/log"
@@ -47,29 +42,6 @@ var (
 	errInvalidAgentConfigMissingConfig = errors.New("agent_config: no config set")
 )
 
-type KibanaConfig struct {
-	Enabled             bool   `config:"enabled"`
-	APIKey              string `config:"api_key"`
-	kibana.ClientConfig `config:",inline"`
-}
-
-func (k *KibanaConfig) Unpack(cfg *common.Config) error {
-	type kibanaConfig KibanaConfig
-	if err := cfg.Unpack((*kibanaConfig)(k)); err != nil {
-		return err
-	}
-	k.Enabled = cfg.Enabled()
-	k.Host = strings.TrimRight(k.Host, "/")
-	return nil
-}
-
-func defaultKibanaConfig() KibanaConfig {
-	return KibanaConfig{
-		Enabled:      false,
-		ClientConfig: kibana.DefaultClientConfig(),
-	}
-}
-
 // Config holds configuration information nested under the key `apm-server`
 type Config struct {
 	Host                      string                  `config:"host"`
@@ -82,17 +54,17 @@ type Config struct {
 	TLS                       *tlscommon.ServerConfig `config:"ssl"`
 	MaxConnections            int                     `config:"max_connections"`
 	ResponseHeaders           map[string][]string     `config:"response_headers"`
-	Expvar                    *ExpvarConfig           `config:"expvar"`
-	Pprof                     *PprofConfig            `config:"pprof"`
+	Expvar                    ExpvarConfig            `config:"expvar"`
+	Pprof                     PprofConfig             `config:"pprof"`
 	AugmentEnabled            bool                    `config:"capture_personal_data"`
-	SelfInstrumentation       *InstrumentationConfig  `config:"instrumentation"`
-	RumConfig                 *RumConfig              `config:"rum"`
-	Register                  *RegisterConfig         `config:"register"`
+	SelfInstrumentation       InstrumentationConfig   `config:"instrumentation"`
+	RumConfig                 RumConfig               `config:"rum"`
+	Register                  RegisterConfig          `config:"register"`
 	Mode                      Mode                    `config:"mode"`
 	Kibana                    KibanaConfig            `config:"kibana"`
-	KibanaAgentConfig         *KibanaAgentConfig      `config:"agent.config"`
+	KibanaAgentConfig         KibanaAgentConfig       `config:"agent.config"`
 	SecretToken               string                  `config:"secret_token"`
-	APIKeyConfig              *APIKeyConfig           `config:"api_key"`
+	APIKeyConfig              APIKeyConfig            `config:"api_key"`
 	JaegerConfig              JaegerConfig            `config:"jaeger"`
 	Aggregation               AggregationConfig       `config:"aggregation"`
 	Sampling                  SamplingConfig          `config:"sampling"`
@@ -102,87 +74,6 @@ type Config struct {
 	Pipeline string
 
 	AgentConfigs []AgentConfig `config:"agent_config"`
-}
-
-// AgentConfig defines configuration for agents.
-type AgentConfig struct {
-	Service   Service `config:"service"`
-	AgentName string  `config:"agent.name"`
-	Etag      string  `config:"etag"`
-	Config    map[string]string
-}
-
-func (s *AgentConfig) setup() error {
-	if !s.Service.isValid() {
-		return errInvalidAgentConfigServiceName
-	}
-	if s.Config == nil {
-		return errInvalidAgentConfigMissingConfig
-	}
-
-	if s.Etag == "" {
-		m, err := json.Marshal(s)
-		if err != nil {
-			return fmt.Errorf("error generating etag for %s: %v", s.Service, err)
-		}
-		s.Etag = fmt.Sprintf("%x", md5.Sum(m))
-	}
-	return nil
-}
-
-// Service defines a unique way of identifying a running agent.
-type Service struct {
-	Name        string `config:"name"`
-	Environment string `config:"environment"`
-}
-
-// String implements the Stringer interface.
-func (s *Service) String() string {
-	var name, env string
-	if s.Name != "" {
-		name = "service.name=" + s.Name
-	}
-	if s.Environment != "" {
-		env = "service.environment=" + s.Environment
-	}
-	return strings.Join([]string{name, env}, " ")
-}
-
-func (s *Service) isValid() bool {
-	return s.Name != "" || s.Environment != ""
-}
-
-// ExpvarConfig holds config information about exposing expvar
-type ExpvarConfig struct {
-	Enabled *bool  `config:"enabled"`
-	URL     string `config:"url"`
-}
-
-// PprofConfig holds config information about exposing pprof
-type PprofConfig struct {
-	Enabled          bool `config:"enabled"`
-	BlockProfileRate int  `config:"block_profile_rate"`
-	MemProfileRate   int  `config:"mem_profile_rate"`
-	MutexProfileRate int  `config:"mutex_profile_rate"`
-}
-
-// KibanaAgentConfig holds remote agent config information
-type KibanaAgentConfig struct {
-	Cache *Cache `config:"cache"`
-}
-
-// Cache holds config information about cache expiration
-type Cache struct {
-	Expiration time.Duration `config:"expiration"`
-}
-
-// DefaultKibanaAgentConfig holds the default KibanaAgentConfig
-func DefaultKibanaAgentConfig() *KibanaAgentConfig {
-	return &KibanaAgentConfig{
-		Cache: &Cache{
-			Expiration: 30 * time.Second,
-		},
-	}
 }
 
 // NewConfig creates a Config struct based on the default config and the given input params
@@ -211,18 +102,12 @@ func NewConfig(ucfg *common.Config, outputESCfg *common.Config) (*Config, error)
 		return nil, err
 	}
 
-	if err := c.SelfInstrumentation.setup(logger); err != nil {
-		return nil, err
-	}
-
 	if err := c.JaegerConfig.setup(c); err != nil {
 		return nil, err
 	}
 
-	if c.Sampling.Tail != nil {
-		if err := c.Sampling.Tail.setup(logger, outputESCfg); err != nil {
-			return nil, err
-		}
+	if err := c.Sampling.Tail.setup(logger, outputESCfg); err != nil {
+		return nil, err
 	}
 
 	if !c.Sampling.KeepUnsampled && !c.Aggregation.Transactions.Enabled {
@@ -244,16 +129,6 @@ func NewConfig(ucfg *common.Config, outputESCfg *common.Config) (*Config, error)
 	return c, nil
 }
 
-// IsEnabled indicates whether expvar is enabled or not
-func (c *ExpvarConfig) IsEnabled() bool {
-	return c != nil && (c.Enabled == nil || *c.Enabled)
-}
-
-// IsEnabled indicates whether pprof is enabled or not
-func (c *PprofConfig) IsEnabled() bool {
-	return c != nil && c.Enabled
-}
-
 // DefaultConfig returns a config with default settings for `apm-server` config options.
 func DefaultConfig() *Config {
 	return &Config{
@@ -266,21 +141,22 @@ func DefaultConfig() *Config {
 		MaxEventSize:    300 * 1024, // 300 kb
 		ShutdownTimeout: 5 * time.Second,
 		AugmentEnabled:  true,
-		Expvar: &ExpvarConfig{
-			Enabled: new(bool),
+		Expvar: ExpvarConfig{
+			Enabled: false,
 			URL:     "/debug/vars",
 		},
-		Pprof:             &PprofConfig{Enabled: false},
-		RumConfig:         defaultRum(),
-		Register:          defaultRegisterConfig(true),
-		Mode:              ModeProduction,
-		Kibana:            defaultKibanaConfig(),
-		KibanaAgentConfig: DefaultKibanaAgentConfig(),
-		Pipeline:          defaultAPMPipeline,
-		APIKeyConfig:      defaultAPIKeyConfig(),
-		JaegerConfig:      defaultJaeger(),
-		Aggregation:       defaultAggregationConfig(),
-		Sampling:          defaultSamplingConfig(),
-		DataStreams:       defaultDataStreamsConfig(),
+		Pprof:               PprofConfig{Enabled: false},
+		SelfInstrumentation: defaultInstrumentationConfig(),
+		RumConfig:           defaultRum(),
+		Register:            defaultRegisterConfig(),
+		Mode:                ModeProduction,
+		Kibana:              defaultKibanaConfig(),
+		KibanaAgentConfig:   defaultKibanaAgentConfig(),
+		Pipeline:            defaultAPMPipeline,
+		APIKeyConfig:        defaultAPIKeyConfig(),
+		JaegerConfig:        defaultJaeger(),
+		Aggregation:         defaultAggregationConfig(),
+		Sampling:            defaultSamplingConfig(),
+		DataStreams:         defaultDataStreamsConfig(),
 	}
 }

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -19,7 +19,6 @@ package config
 
 import (
 	"crypto/tls"
-	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -39,8 +38,6 @@ var testdataCertificateConfig = tlscommon.CertificateConfig{
 }
 
 func TestUnpackConfig(t *testing.T) {
-	falsy, truthy := false, true
-
 	kibanaNoSlashConfig := DefaultConfig()
 	kibanaNoSlashConfig.Kibana.Enabled = true
 	kibanaNoSlashConfig.Kibana.Host = "kibanahost:5601/proxy"
@@ -153,30 +150,42 @@ func TestUnpackConfig(t *testing.T) {
 				ShutdownTimeout: 9000000000,
 				SecretToken:     "1234random",
 				TLS: &tlscommon.ServerConfig{
-					Enabled:     &truthy,
+					Enabled:     newBool(true),
 					Certificate: testdataCertificateConfig,
 					ClientAuth:  4,
 					CAs:         []string{"../../testdata/tls/ca.crt.pem"},
 				},
 				AugmentEnabled: true,
-				Expvar: &ExpvarConfig{
-					Enabled: &truthy,
+				Expvar: ExpvarConfig{
+					Enabled: true,
 					URL:     "/debug/vars",
 				},
-				Pprof: &PprofConfig{
+				Pprof: PprofConfig{
 					Enabled: false,
 				},
-				RumConfig: &RumConfig{
-					Enabled: &truthy,
-					EventRate: &EventRate{
+				SelfInstrumentation: InstrumentationConfig{
+					Profiling: ProfilingConfig{
+						CPU: CPUProfiling{
+							Interval: 1 * time.Minute,
+							Duration: 10 * time.Second,
+						},
+						Heap: HeapProfiling{
+							Interval: 1 * time.Minute,
+						},
+					},
+				},
+				RumConfig: RumConfig{
+					Enabled: true,
+					EventRate: EventRate{
 						Limit:   7200,
 						LruSize: 2000,
 					},
 					AllowServiceNames: []string{"opbeans-rum"},
 					AllowOrigins:      []string{"example*"},
 					AllowHeaders:      []string{"Authorization"},
-					SourceMapping: &SourceMapping{
-						Cache:        &Cache{Expiration: 8 * time.Minute},
+					SourceMapping: SourceMapping{
+						Enabled:      true,
+						Cache:        Cache{Expiration: 8 * time.Minute},
 						IndexPattern: "apm-test*",
 						ESConfig: &elasticsearch.Config{
 							Hosts:      elasticsearch.Hosts{"localhost:9201", "localhost:9202"},
@@ -190,11 +199,11 @@ func TestUnpackConfig(t *testing.T) {
 					LibraryPattern:      "^custom",
 					ExcludeFromGrouping: "^grouping",
 				},
-				Register: &RegisterConfig{
-					Ingest: &IngestConfig{
-						Pipeline: &PipelineConfig{
-							Enabled:   &truthy,
-							Overwrite: &falsy,
+				Register: RegisterConfig{
+					Ingest: IngestConfig{
+						Pipeline: PipelineConfig{
+							Enabled:   true,
+							Overwrite: false,
 							Path:      filepath.Join("tmp", "definition.json"),
 						},
 					},
@@ -203,7 +212,7 @@ func TestUnpackConfig(t *testing.T) {
 					Enabled:      true,
 					ClientConfig: defaultKibanaConfig().ClientConfig,
 				},
-				KibanaAgentConfig: &KibanaAgentConfig{Cache: &Cache{Expiration: 2 * time.Minute}},
+				KibanaAgentConfig: KibanaAgentConfig{Cache: Cache{Expiration: 2 * time.Minute}},
 				Pipeline:          defaultAPMPipeline,
 				JaegerConfig: JaegerConfig{
 					GRPC: JaegerGRPCConfig{
@@ -211,7 +220,7 @@ func TestUnpackConfig(t *testing.T) {
 						Host:    "localhost:12345",
 						TLS: func() *tls.Config {
 							tlsServerConfig, err := tlscommon.LoadTLSServerConfig(&tlscommon.ServerConfig{
-								Enabled:     &truthy,
+								Enabled:     newBool(true),
 								Certificate: testdataCertificateConfig,
 								ClientAuth:  4,
 								CAs:         []string{"../../testdata/tls/ca.crt.pem"}})
@@ -224,7 +233,7 @@ func TestUnpackConfig(t *testing.T) {
 						Host:    "localhost:6789",
 					},
 				},
-				APIKeyConfig: &APIKeyConfig{
+				APIKeyConfig: APIKeyConfig{
 					Enabled:     true,
 					LimitPerMin: 200,
 					ESConfig: &elasticsearch.Config{
@@ -251,7 +260,7 @@ func TestUnpackConfig(t *testing.T) {
 				},
 				Sampling: SamplingConfig{
 					KeepUnsampled: true,
-					Tail: &TailSamplingConfig{
+					Tail: TailSamplingConfig{
 						Enabled:               false,
 						ESConfig:              elasticsearch.DefaultConfig(),
 						Interval:              1 * time.Minute,
@@ -318,28 +327,40 @@ func TestUnpackConfig(t *testing.T) {
 				ShutdownTimeout: 5000000000,
 				SecretToken:     "1234random",
 				TLS: &tlscommon.ServerConfig{
-					Enabled:     &truthy,
+					Enabled:     newBool(true),
 					Certificate: testdataCertificateConfig,
 					ClientAuth:  0,
 				},
 				AugmentEnabled: true,
-				Expvar: &ExpvarConfig{
-					Enabled: &truthy,
+				Expvar: ExpvarConfig{
+					Enabled: true,
 					URL:     "/debug/vars",
 				},
-				Pprof: &PprofConfig{
+				Pprof: PprofConfig{
 					Enabled: true,
 				},
-				RumConfig: &RumConfig{
-					Enabled: &truthy,
-					EventRate: &EventRate{
+				SelfInstrumentation: InstrumentationConfig{
+					Profiling: ProfilingConfig{
+						CPU: CPUProfiling{
+							Interval: 1 * time.Minute,
+							Duration: 10 * time.Second,
+						},
+						Heap: HeapProfiling{
+							Interval: 1 * time.Minute,
+						},
+					},
+				},
+				RumConfig: RumConfig{
+					Enabled: true,
+					EventRate: EventRate{
 						Limit:   300,
 						LruSize: 1000,
 					},
 					AllowOrigins: []string{"*"},
 					AllowHeaders: []string{},
-					SourceMapping: &SourceMapping{
-						Cache: &Cache{
+					SourceMapping: SourceMapping{
+						Enabled: true,
+						Cache: Cache{
 							Expiration: 7 * time.Second,
 						},
 						IndexPattern: "apm-*-sourcemap*",
@@ -348,16 +369,16 @@ func TestUnpackConfig(t *testing.T) {
 					LibraryPattern:      "rum",
 					ExcludeFromGrouping: "^/webpack",
 				},
-				Register: &RegisterConfig{
-					Ingest: &IngestConfig{
-						Pipeline: &PipelineConfig{
-							Enabled: &falsy,
+				Register: RegisterConfig{
+					Ingest: IngestConfig{
+						Pipeline: PipelineConfig{
+							Enabled: false,
 							Path:    filepath.Join("ingest", "pipeline", "definition.json"),
 						},
 					},
 				},
 				Kibana:            defaultKibanaConfig(),
-				KibanaAgentConfig: &KibanaAgentConfig{Cache: &Cache{Expiration: 30 * time.Second}},
+				KibanaAgentConfig: KibanaAgentConfig{Cache: Cache{Expiration: 30 * time.Second}},
 				Pipeline:          defaultAPMPipeline,
 				JaegerConfig: JaegerConfig{
 					GRPC: JaegerGRPCConfig{
@@ -365,9 +386,10 @@ func TestUnpackConfig(t *testing.T) {
 						Host:    "localhost:14250",
 						TLS: func() *tls.Config {
 							tlsServerConfig, err := tlscommon.LoadTLSServerConfig(&tlscommon.ServerConfig{
-								Enabled:     &truthy,
+								Enabled:     newBool(true),
 								Certificate: testdataCertificateConfig,
-								ClientAuth:  0})
+								ClientAuth:  0,
+							})
 							require.NoError(t, err)
 							return tlsServerConfig.BuildServerConfig("localhost:14250")
 						}(),
@@ -377,7 +399,7 @@ func TestUnpackConfig(t *testing.T) {
 						Host:    "localhost:14268",
 					},
 				},
-				APIKeyConfig: &APIKeyConfig{Enabled: true, LimitPerMin: 100, ESConfig: elasticsearch.DefaultConfig()},
+				APIKeyConfig: APIKeyConfig{Enabled: true, LimitPerMin: 100, ESConfig: elasticsearch.DefaultConfig()},
 				Aggregation: AggregationConfig{
 					Transactions: TransactionAggregationConfig{
 						Enabled:                        false,
@@ -393,7 +415,7 @@ func TestUnpackConfig(t *testing.T) {
 				},
 				Sampling: SamplingConfig{
 					KeepUnsampled: false,
-					Tail: &TailSamplingConfig{
+					Tail: TailSamplingConfig{
 						Enabled:               true,
 						Policies:              []TailSamplingPolicy{{SampleRate: 0.5}},
 						ESConfig:              elasticsearch.DefaultConfig(),
@@ -462,30 +484,28 @@ func TestUnpackConfig(t *testing.T) {
 	}
 }
 
+/*
 func TestPipeline(t *testing.T) {
-	truthy, falsy := true, false
 	cases := []struct {
 		c                  *PipelineConfig
 		enabled, overwrite bool
 	}{
 		{c: nil, enabled: false, overwrite: false},
 		{c: &PipelineConfig{}, enabled: true, overwrite: false}, //default values
-		{c: &PipelineConfig{Enabled: &falsy, Overwrite: &truthy},
-			enabled: false, overwrite: true},
-		{c: &PipelineConfig{Enabled: &truthy, Overwrite: &falsy},
-			enabled: true, overwrite: false},
+		{c: &PipelineConfig{Enabled: false, Overwrite: true}, enabled: false, overwrite: true},
+		{c: &PipelineConfig{Enabled: true, Overwrite: false}, enabled: true, overwrite: false},
 	}
 
 	for idx, test := range cases {
-		assert.Equal(t, test.enabled, test.c.IsEnabled(),
+		assert.Equal(t, test.enabled, test.c.Enabled,
 			fmt.Sprintf("<%v> IsEnabled() expected %v", idx, test.enabled))
 		assert.Equal(t, test.overwrite, test.c.ShouldOverwrite(),
 			fmt.Sprintf("<%v> ShouldOverwrite() expected %v", idx, test.overwrite))
 	}
 }
+*/
 
 func TestTLSSettings(t *testing.T) {
-
 	t.Run("ClientAuthentication", func(t *testing.T) {
 		for name, tc := range map[string]struct {
 			config map[string]interface{}
@@ -546,8 +566,6 @@ func TestTLSSettings(t *testing.T) {
 	})
 
 	t.Run("Enabled", func(t *testing.T) {
-		truthy := true
-		falsy := false
 		for name, tc := range map[string]struct {
 			tlsServerCfg *tlscommon.ServerConfig
 			expected     bool
@@ -556,8 +574,8 @@ func TestTLSSettings(t *testing.T) {
 			"SSL":               {tlsServerCfg: &tlscommon.ServerConfig{Enabled: nil}, expected: true},
 			"WithCert":          {tlsServerCfg: &tlscommon.ServerConfig{Certificate: tlscommon.CertificateConfig{Certificate: "Cert"}}, expected: true},
 			"WithCertAndKey":    {tlsServerCfg: &tlscommon.ServerConfig{Certificate: tlscommon.CertificateConfig{Certificate: "Cert", Key: "key"}}, expected: true},
-			"ConfiguredToFalse": {tlsServerCfg: &tlscommon.ServerConfig{Certificate: tlscommon.CertificateConfig{Certificate: "Cert", Key: "key"}, Enabled: &falsy}, expected: false},
-			"ConfiguredToTrue":  {tlsServerCfg: &tlscommon.ServerConfig{Enabled: &truthy}, expected: true},
+			"ConfiguredToFalse": {tlsServerCfg: &tlscommon.ServerConfig{Certificate: tlscommon.CertificateConfig{Certificate: "Cert", Key: "key"}, Enabled: newBool(false)}, expected: false},
+			"ConfiguredToTrue":  {tlsServerCfg: &tlscommon.ServerConfig{Enabled: newBool(true)}, expected: true},
 		} {
 			t.Run(name, func(t *testing.T) {
 				b := tc.expected
@@ -609,4 +627,8 @@ func TestNewConfig_ESConfig(t *testing.T) {
 	assert.Equal(t, []string{"192.0.0.168:9200"}, []string(cfg.APIKeyConfig.ESConfig.Hosts))
 	assert.NotNil(t, cfg.Sampling.Tail.ESConfig)
 	assert.Equal(t, []string{"192.0.0.168:9200"}, []string(cfg.Sampling.Tail.ESConfig.Hosts))
+}
+
+func newBool(v bool) *bool {
+	return &v
 }

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -484,27 +484,6 @@ func TestUnpackConfig(t *testing.T) {
 	}
 }
 
-/*
-func TestPipeline(t *testing.T) {
-	cases := []struct {
-		c                  *PipelineConfig
-		enabled, overwrite bool
-	}{
-		{c: nil, enabled: false, overwrite: false},
-		{c: &PipelineConfig{}, enabled: true, overwrite: false}, //default values
-		{c: &PipelineConfig{Enabled: false, Overwrite: true}, enabled: false, overwrite: true},
-		{c: &PipelineConfig{Enabled: true, Overwrite: false}, enabled: true, overwrite: false},
-	}
-
-	for idx, test := range cases {
-		assert.Equal(t, test.enabled, test.c.Enabled,
-			fmt.Sprintf("<%v> IsEnabled() expected %v", idx, test.enabled))
-		assert.Equal(t, test.overwrite, test.c.ShouldOverwrite(),
-			fmt.Sprintf("<%v> ShouldOverwrite() expected %v", idx, test.overwrite))
-	}
-}
-*/
-
 func TestTLSSettings(t *testing.T) {
 	t.Run("ClientAuthentication", func(t *testing.T) {
 		for name, tc := range map[string]struct {

--- a/beater/config/expvar.go
+++ b/beater/config/expvar.go
@@ -17,35 +17,8 @@
 
 package config
 
-import (
-	"fmt"
-	"net/url"
-)
-
-type urls []*url.URL
-
-func (u *urls) Unpack(c interface{}) error {
-	if c == nil {
-		return nil
-	}
-	hosts, ok := c.([]interface{})
-	if !ok {
-		return fmt.Errorf("hosts must be a list, got: %#v", c)
-	}
-
-	nu := make(urls, len(hosts))
-	for i, host := range hosts {
-		h, ok := host.(string)
-		if !ok {
-			return fmt.Errorf("host must be a string, got: %#v", h)
-		}
-		url, err := url.Parse(h)
-		if err != nil {
-			return err
-		}
-		nu[i] = url
-	}
-	*u = nu
-
-	return nil
+// ExpvarConfig holds config information about exposing expvar
+type ExpvarConfig struct {
+	Enabled bool   `config:"enabled"`
+	URL     string `config:"url"`
 }

--- a/beater/config/instrumentation.go
+++ b/beater/config/instrumentation.go
@@ -20,7 +20,6 @@ package config
 import (
 	"time"
 
-	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/go-ucfg"
 )
 
@@ -32,8 +31,8 @@ const (
 
 // InstrumentationConfig holds config information about self instrumenting the APM Server
 type InstrumentationConfig struct {
-	Enabled     *bool           `config:"enabled"`
-	Environment *string         `config:"environment"`
+	Enabled     bool            `config:"enabled"`
+	Environment string          `config:"environment"`
 	Hosts       urls            `config:"hosts"` //TODO(simi): add `validate:"nonzero"` again once https://github.com/elastic/go-ucfg/issues/147 is fixed
 	Profiling   ProfilingConfig `config:"profiling"`
 	APIKey      string          `config:"api_key"`
@@ -49,29 +48,10 @@ func (c *InstrumentationConfig) Validate() error {
 	return nil
 }
 
-// IsEnabled indicates whether self instrumentation is enabled
-func (c *InstrumentationConfig) IsEnabled() bool {
-	// self instrumentation is disabled by default.
-	return c != nil && c.Enabled != nil && *c.Enabled
-}
-
-func (c *InstrumentationConfig) setup(log *logp.Logger) error {
-	if !c.IsEnabled() {
-		return nil
-	}
-	if err := c.Profiling.CPU.setup(log); err != nil {
-		return err
-	}
-	if err := c.Profiling.Heap.setup(log); err != nil {
-		return err
-	}
-	return nil
-}
-
 // ProfilingConfig holds config information about self profiling the APM Server
 type ProfilingConfig struct {
-	CPU  *CPUProfiling  `config:"cpu"`
-	Heap *HeapProfiling `config:"heap"`
+	CPU  CPUProfiling  `config:"cpu"`
+	Heap HeapProfiling `config:"heap"`
 }
 
 // CPUProfiling holds config information about CPU profiling of the APM Server
@@ -81,41 +61,22 @@ type CPUProfiling struct {
 	Duration time.Duration `config:"duration" validate:"positive"`
 }
 
-// IsEnabled indicates whether CPU profiling is enabled or not
-func (p *CPUProfiling) IsEnabled() bool {
-	return p != nil && p.Enabled
-}
-
-func (p *CPUProfiling) setup(log *logp.Logger) error {
-	if !p.IsEnabled() {
-		return nil
-	}
-	if p.Interval <= 0 {
-		p.Interval = defaultCPUProfilingInterval
-	}
-	if p.Duration <= 0 {
-		p.Duration = defaultCPUProfilingDuration
-	}
-	return nil
-}
-
 // HeapProfiling holds config information about heap profiling of the APM Server
 type HeapProfiling struct {
 	Enabled  bool          `config:"enabled"`
 	Interval time.Duration `config:"interval" validate:"positive"`
 }
 
-// IsEnabled indicates whether heap profiling is enabled or not
-func (p *HeapProfiling) IsEnabled() bool {
-	return p != nil && p.Enabled
-}
-
-func (p *HeapProfiling) setup(log *logp.Logger) error {
-	if !p.IsEnabled() {
-		return nil
+func defaultInstrumentationConfig() InstrumentationConfig {
+	return InstrumentationConfig{
+		Profiling: ProfilingConfig{
+			CPU: CPUProfiling{
+				Interval: defaultCPUProfilingInterval,
+				Duration: defaultCPUProfilingDuration,
+			},
+			Heap: HeapProfiling{
+				Interval: defaultHeapProfilingInterval,
+			},
+		},
 	}
-	if p.Interval <= 0 {
-		p.Interval = defaultHeapProfilingInterval
-	}
-	return nil
 }

--- a/beater/config/instrumentation_test.go
+++ b/beater/config/instrumentation_test.go
@@ -40,7 +40,7 @@ func TestNonzeroHosts(t *testing.T) {
 	t.Run("Valid", func(t *testing.T) {
 		cfg, err := NewConfig(common.MustNewConfigFrom(map[string]interface{}{"instrumentation.enabled": true}), nil)
 		require.NoError(t, err)
-		assert.True(t, *cfg.SelfInstrumentation.Enabled)
+		assert.True(t, cfg.SelfInstrumentation.Enabled)
 		assert.Empty(t, cfg.SelfInstrumentation.Hosts)
 	})
 }

--- a/beater/config/pprof.go
+++ b/beater/config/pprof.go
@@ -17,35 +17,10 @@
 
 package config
 
-import (
-	"fmt"
-	"net/url"
-)
-
-type urls []*url.URL
-
-func (u *urls) Unpack(c interface{}) error {
-	if c == nil {
-		return nil
-	}
-	hosts, ok := c.([]interface{})
-	if !ok {
-		return fmt.Errorf("hosts must be a list, got: %#v", c)
-	}
-
-	nu := make(urls, len(hosts))
-	for i, host := range hosts {
-		h, ok := host.(string)
-		if !ok {
-			return fmt.Errorf("host must be a string, got: %#v", h)
-		}
-		url, err := url.Parse(h)
-		if err != nil {
-			return err
-		}
-		nu[i] = url
-	}
-	*u = nu
-
-	return nil
+// PprofConfig holds config information about exposing pprof
+type PprofConfig struct {
+	Enabled          bool `config:"enabled"`
+	BlockProfileRate int  `config:"block_profile_rate"`
+	MemProfileRate   int  `config:"mem_profile_rate"`
+	MutexProfileRate int  `config:"mutex_profile_rate"`
 }

--- a/beater/config/register.go
+++ b/beater/config/register.go
@@ -29,38 +29,30 @@ const (
 
 // RegisterConfig holds ingest config information
 type RegisterConfig struct {
-	Ingest *IngestConfig `config:"ingest"`
+	Ingest IngestConfig `config:"ingest"`
 }
 
 // IngestConfig holds config pipeline ingest information
 type IngestConfig struct {
-	Pipeline *PipelineConfig `config:"pipeline"`
+	Pipeline PipelineConfig `config:"pipeline"`
 }
 
 // PipelineConfig holds config information about registering ingest pipelines
 type PipelineConfig struct {
-	Enabled   *bool `config:"enabled"`
-	Overwrite *bool `config:"overwrite"`
+	Enabled   bool `config:"enabled"`
+	Overwrite bool `config:"overwrite"`
 	Path      string
 }
 
-// IsEnabled indicates whether pipeline registration is enabled or not
-func (c *PipelineConfig) IsEnabled() bool {
-	return c != nil && (c.Enabled == nil || *c.Enabled)
-}
-
-// ShouldOverwrite indicates whether existing pipelines should be overwritten during registration process
-func (c *PipelineConfig) ShouldOverwrite() bool {
-	return c != nil && (c.Overwrite != nil && *c.Overwrite)
-}
-
-func defaultRegisterConfig(pipelineEnabled bool) *RegisterConfig {
-	return &RegisterConfig{
-		Ingest: &IngestConfig{
-			Pipeline: &PipelineConfig{
-				Enabled: &pipelineEnabled,
-				Path: paths.Resolve(paths.Home,
-					filepath.Join("ingest", "pipeline", "definition.json")),
-			}},
+func defaultRegisterConfig() RegisterConfig {
+	return RegisterConfig{
+		Ingest: IngestConfig{
+			Pipeline: PipelineConfig{
+				Enabled: true,
+				Path: paths.Resolve(
+					paths.Home, filepath.Join("ingest", "pipeline", "definition.json"),
+				),
+			},
+		},
 	}
 }

--- a/beater/config/sampling.go
+++ b/beater/config/sampling.go
@@ -34,7 +34,7 @@ type SamplingConfig struct {
 	KeepUnsampled bool `config:"keep_unsampled"`
 
 	// Tail holds tail-sampling configuration.
-	Tail *TailSamplingConfig `config:"tail"`
+	Tail TailSamplingConfig `config:"tail"`
 }
 
 // TailSamplingConfig holds configuration related to tail-sampling.
@@ -127,7 +127,7 @@ func defaultSamplingConfig() SamplingConfig {
 		// In a future major release we will set this to
 		// false, and then later remove the option.
 		KeepUnsampled: true,
-		Tail:          &tail,
+		Tail:          tail,
 	}
 }
 

--- a/beater/http.go
+++ b/beater/http.go
@@ -96,8 +96,7 @@ func (h *httpServer) start() error {
 		h.logger.Infof("Listening on: %s:%s", addr.Network(), addr.String())
 	}
 
-	switch h.cfg.RumConfig.IsEnabled() {
-	case true:
+	if h.cfg.RumConfig.Enabled {
 		h.logger.Info("RUM endpoints enabled!")
 		for _, s := range h.cfg.RumConfig.AllowOrigins {
 			if s == "*" {
@@ -105,7 +104,7 @@ func (h *httpServer) start() error {
 				break
 			}
 		}
-	case false:
+	} else {
 		h.logger.Info("RUM endpoints disabled.")
 	}
 

--- a/beater/middleware/rate_limit_middleware.go
+++ b/beater/middleware/rate_limit_middleware.go
@@ -26,7 +26,7 @@ import (
 const burstMultiplier = 3
 
 // SetIPRateLimitMiddleware sets a rate limiter
-func SetIPRateLimitMiddleware(cfg *config.EventRate) Middleware {
+func SetIPRateLimitMiddleware(cfg config.EventRate) Middleware {
 	store, err := ratelimit.NewStore(cfg.LruSize, cfg.Limit, burstMultiplier)
 
 	return func(h request.Handler) (request.Handler, error) {

--- a/beater/telemetry.go
+++ b/beater/telemetry.go
@@ -92,20 +92,14 @@ func recordRootConfig(info beat.Info, rootCfg *common.Config) error {
 // recordAPMServerConfig records dynamic APM Server config properties for telemetry.
 // This should be called once each time runServer is called.
 func recordAPMServerConfig(cfg *config.Config) {
-	configMonitors.rumEnabled.Set(cfg.RumConfig.IsEnabled())
-	configMonitors.apiKeysEnabled.Set(cfg.APIKeyConfig.IsEnabled())
+	configMonitors.rumEnabled.Set(cfg.RumConfig.Enabled)
+	configMonitors.apiKeysEnabled.Set(cfg.APIKeyConfig.Enabled)
 	configMonitors.kibanaEnabled.Set(cfg.Kibana.Enabled)
 	configMonitors.jaegerHTTPEnabled.Set(cfg.JaegerConfig.HTTP.Enabled)
 	configMonitors.jaegerGRPCEnabled.Set(cfg.JaegerConfig.GRPC.Enabled)
 	configMonitors.sslEnabled.Set(cfg.TLS.IsEnabled())
-	configMonitors.pipelinesEnabled.Set(cfg.Register.Ingest.Pipeline.IsEnabled())
-	configMonitors.pipelinesOverwrite.Set(cfg.Register.Ingest.Pipeline.ShouldOverwrite())
-
-	tailSamplingEnabled := cfg.Sampling.Tail != nil && cfg.Sampling.Tail.Enabled
-	tailSamplingPolicies := 0
-	if tailSamplingEnabled {
-		tailSamplingPolicies = len(cfg.Sampling.Tail.Policies)
-	}
-	configMonitors.tailSamplingEnabled.Set(tailSamplingEnabled)
-	configMonitors.tailSamplingPolicies.Set(int64(tailSamplingPolicies))
+	configMonitors.pipelinesEnabled.Set(cfg.Register.Ingest.Pipeline.Enabled)
+	configMonitors.pipelinesOverwrite.Set(cfg.Register.Ingest.Pipeline.Overwrite)
+	configMonitors.tailSamplingEnabled.Set(cfg.Sampling.Tail.Enabled)
+	configMonitors.tailSamplingPolicies.Set(int64(len(cfg.Sampling.Tail.Policies)))
 }

--- a/processor/stream/processor_test.go
+++ b/processor/stream/processor_test.go
@@ -151,7 +151,7 @@ func TestIntegrationRum(t *testing.T) {
 				UserAgent: model.UserAgent{Original: "rum-2.0"},
 				Client:    model.Client{IP: net.ParseIP("192.0.0.1")}}
 
-			p := RUMV2Processor(&config.Config{MaxEventSize: 100 * 1024, RumConfig: &config.RumConfig{}})
+			p := RUMV2Processor(&config.Config{MaxEventSize: 100 * 1024})
 			actualResult := p.HandleStream(ctx, nil, &reqDecoderMeta, bytes.NewReader(payload), batchProcessor)
 			assertApproveResult(t, actualResult, test.name)
 		})
@@ -179,7 +179,7 @@ func TestRUMV3(t *testing.T) {
 				UserAgent: model.UserAgent{Original: "rum-2.0"},
 				Client:    model.Client{IP: net.ParseIP("192.0.0.1")}}
 
-			p := RUMV3Processor(&config.Config{MaxEventSize: 100 * 1024, RumConfig: &config.RumConfig{}})
+			p := RUMV3Processor(&config.Config{MaxEventSize: 100 * 1024})
 			actualResult := p.HandleStream(ctx, nil, &reqDecoderMeta, bytes.NewReader(payload), batchProcessor)
 			assertApproveResult(t, actualResult, test.name)
 		})
@@ -212,7 +212,7 @@ func TestRUMAllowedServiceNames(t *testing.T) {
 	}} {
 		p := RUMV2Processor(&config.Config{
 			MaxEventSize: 100 * 1024,
-			RumConfig:    &config.RumConfig{AllowServiceNames: test.AllowServiceNames},
+			RumConfig:    config.RumConfig{AllowServiceNames: test.AllowServiceNames},
 		})
 
 		result := p.HandleStream(context.Background(), nil, &model.Metadata{}, bytes.NewReader(payload), modelprocessor.Nop{})

--- a/x-pack/apm-server/main.go
+++ b/x-pack/apm-server/main.go
@@ -80,7 +80,7 @@ func newProcessors(args beater.ServerParams) ([]namedProcessor, error) {
 		}
 		processors = append(processors, namedProcessor{name: name, processor: spanAggregator})
 	}
-	if args.Config.Sampling.Tail != nil && args.Config.Sampling.Tail.Enabled {
+	if args.Config.Sampling.Tail.Enabled {
 		const name = "tail sampler"
 		sampler, err := newTailSamplingProcessor(args)
 		if err != nil {


### PR DESCRIPTION
## Motivation/summary

- remove some "setup" methods, set default values before unpacking
- unexport DefaultKibanaAgentConfig
- de-pointer various config fields to avoid the need for nil-pointer checks, and rely on default values; remove "IsEnabled" methods in favour of setting default values for Enabled fields and accessing those directly
- move various config types into their own files
- remove dead validator code

## How to test these changes

N/A, non-functional change.

## Related issues

Setting up for implementing https://github.com/elastic/apm-server/issues/5347