### PR TITLE
tests/system: update metricset test

### DIFF
--- a/docs/data/elasticsearch/generated/metricsets.json
+++ b/docs/data/elasticsearch/generated/metricsets.json
@@ -205,6 +205,69 @@
         }
     },
     {
+        "@timestamp": "2017-05-30T18:53:41.366Z",
+        "_doc_count": 6,
+        "agent": {
+            "name": "elastic-node",
+            "version": "3.14.0"
+        },
+        "ecs": {
+            "version": "1.8.0"
+        },
+        "event": {
+            "ingested": "2020-09-08T15:57:10.396695Z"
+        },
+        "host": {
+            "ip": "127.0.0.1"
+        },
+        "labels": {
+            "tag1": "one",
+            "tag2": 2
+        },
+        "latency_distribution": {
+            "counts": [
+                1,
+                2,
+                3
+            ],
+            "values": [
+                1.1,
+                2.2,
+                3.3
+            ]
+        },
+        "metricset.name": "app",
+        "observer": {
+            "ephemeral_id": "2f30050f-81e6-491a-a54f-e7d94eec17b5",
+            "hostname": "simmac.net",
+            "id": "02f6cb38-c1ce-4382-9478-4c8b4cdbda9c",
+            "type": "apm-server",
+            "version": "8.0.0",
+            "version_major": 8
+        },
+        "process": {
+            "pid": 1234
+        },
+        "processor": {
+            "event": "metric",
+            "name": "metric"
+        },
+        "service": {
+            "language": {
+                "name": "ecmascript"
+            },
+            "name": "1234_service-12a3",
+            "node": {
+                "name": "node-1"
+            }
+        },
+        "user": {
+            "email": "user@mail.com",
+            "id": "axb123hg",
+            "name": "logged-in-user"
+        }
+    },
+    {
         "@timestamp": "2017-05-30T18:53:42.281Z",
         "agent": {
             "name": "elastic-node",

--- a/tests/system/metricset.approved.json
+++ b/tests/system/metricset.approved.json
@@ -205,6 +205,69 @@
         }
     },
     {
+        "@timestamp": "2017-05-30T18:53:41.366Z",
+        "_doc_count": 6,
+        "agent": {
+            "name": "elastic-node",
+            "version": "3.14.0"
+        },
+        "ecs": {
+            "version": "1.8.0"
+        },
+        "event": {
+            "ingested": "2020-09-08T15:57:10.396695Z"
+        },
+        "host": {
+            "ip": "127.0.0.1"
+        },
+        "labels": {
+            "tag1": "one",
+            "tag2": 2
+        },
+        "latency_distribution": {
+            "counts": [
+                1,
+                2,
+                3
+            ],
+            "values": [
+                1.1,
+                2.2,
+                3.3
+            ]
+        },
+        "metricset.name": "app",
+        "observer": {
+            "ephemeral_id": "2f30050f-81e6-491a-a54f-e7d94eec17b5",
+            "hostname": "simmac.net",
+            "id": "02f6cb38-c1ce-4382-9478-4c8b4cdbda9c",
+            "type": "apm-server",
+            "version": "8.0.0",
+            "version_major": 8
+        },
+        "process": {
+            "pid": 1234
+        },
+        "processor": {
+            "event": "metric",
+            "name": "metric"
+        },
+        "service": {
+            "language": {
+                "name": "ecmascript"
+            },
+            "name": "1234_service-12a3",
+            "node": {
+                "name": "node-1"
+            }
+        },
+        "user": {
+            "email": "user@mail.com",
+            "id": "axb123hg",
+            "name": "logged-in-user"
+        }
+    },
+    {
         "@timestamp": "2017-05-30T18:53:42.281Z",
         "agent": {
             "name": "elastic-node",

--- a/tests/system/test_integration.py
+++ b/tests/system/test_integration.py
@@ -79,11 +79,13 @@ class Test(ElasticTest):
         self.check_backend_error_sourcemap(index_error, count=4)
 
     def test_load_docs_with_template_and_add_metricset(self):
-        self.load_docs_with_template(self.get_metricset_payload_path(), self.intake_url, 'metric', 4)
+        # NOTE(axw) this test is redundant with systemtest.TestApprovedMetrics,
+        # but we use the output of this test for generating documentation.
+        self.load_docs_with_template(self.get_metricset_payload_path(), self.intake_url, 'metric', 5)
         self.assert_no_logged_warnings()
 
         # compare existing ES documents for metricsets with new ones
-        metricset_docs = self.wait_for_events('metric', 4, index=index_metric)
+        metricset_docs = self.wait_for_events('metric', 5, index=index_metric)
         self.approve_docs('metricset', metricset_docs)
 
 


### PR DESCRIPTION
## Motivation/summary

Update old Python-based system test due to the new metric added to testdata. The test is redundant with systemtest.TestApprovedMetrics, except we use the output of this one (which is a bit different) for generating user documentation. We should find another solution to that later.

## How to test these changes

N/A, non-functional change.

## Related issues

None.