### PR TITLE
Hardcode troughput settings for cloud environment

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,12 +65,13 @@ var libbeatConfigOverrides = []cfgfile.ConditionalOverride{{
 },
 	{
 		Check: func(_ *common.Config) bool {
-			cap := os.Getenv(cloudEnv)
-			_, ok := cloudMatrix[cap]
-			return ok
+			return true
 		},
 		Config: func() *common.Config {
 			cap := os.Getenv(cloudEnv)
+			if _, ok := cloudMatrix[cap]; !ok {
+				return nil
+			}
 			return common.MustNewConfigFrom(map[string]interface{}{
 				"output": map[string]interface{}{
 					"elasticsearch": map[string]interface{}{


### PR DESCRIPTION
## How to test these changes

Start apm-server with eg `CLOUD_APM_CAPACITY=512`, and check that the corresponding have the correct values.

## Related issues

Closes https://github.com/elastic/apm-server/issues/5372