### PR TITLE
Override healthcheck for the package-registry docker container for running the system tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,6 +115,10 @@ services:
     ports:
       - 8080
     entrypoint: /entrypoint.sh
+    healthcheck:
+      test: ["CMD-SHELL", "curl --fail localhost:8080/health"]
+      retries: 100
+      interval: 5s
     volumes:
       - "./testing/docker/package-registry/entrypoint.sh:/entrypoint.sh"
       - "./testing/docker/package-registry/config.yml:/package-registry/config.yml"


### PR DESCRIPTION
## Motivation/summary

Existing default health check in the package-registry timeout after 30 seconds. See https://github.com/elastic/package-registry/blob/master/Dockerfile#L37

But the docker container takes a bit longer than 30 seconds therefore the health check reports unhealthy and the system tests cannot be executed.

For instance, the build number 996 in the master branch failed and the docker logs for the package-registry container can be seen [here](https://apm-ci.elastic.co/job/apm-server/job/apm-server-mbp/job/master/996/artifact/docker-info/c3660573cbe9.log/*view*/), in a nutshell the package manifest took 36 to be loaded:

```
2021/06/14 15:48:08 system              	    0.13.3	/packages/snapshot/system/0.13.3
2021/06/14 15:48:08 traefik             	     0.2.0	/packages/snapshot/traefik/0.2.0
2021/06/14 15:48:08 windows             	     0.8.2	/packages/snapshot/windows/0.8.2
2021/06/14 15:48:08 zeek                	     0.7.3	/packages/snapshot/zeek/0.7.3
2021/06/14 15:48:08 zeek                	     0.7.4	/packages/snapshot/zeek/0.7.4
2021/06/14 15:48:08 zookeeper           	     0.2.6	/packages/snapshot/zookeeper/0.2.6
2021/06/14 15:48:08 Packages in /packages/local:
2021/06/14 15:48:08 apm                 	     0.3.0	/packages/local/apm/0.3.0
2021/06/14 15:48:44 402 package manifests loaded.
```

## How to test these changes

```bash
$ cd systemtest && go test -run Fleet
```

## Related issues

https://github.com/elastic/apm-server/pull/4650

## Follow ups

The package-registry tests take an average of 4 seconds to load those 420 packages, so there might be something in the docker host that produces this particular slowness? I'll debug a bit further to know what OS/version for the CI worker is used when running the system tests

Kudos to @mtojek who helped me to debug this issue 🙏 
