### PR TITLE
magefile: use beats/go.mod for TestPackages

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -189,6 +189,13 @@ func Version() error {
 
 // TestPackages tests the generated packages (i.e. file modes, owners, groups).
 func TestPackages() error {
+	// Run the tests using beats/go.mod.
+	defer os.Setenv("GOFLAGS", os.Getenv("GOFLAGS"))
+	beatsdir, err := mage.ElasticBeatsDir()
+	if err != nil {
+		return err
+	}
+	os.Setenv("GOFLAGS", "-modfile="+filepath.Join(beatsdir, "go.mod"))
 	return mage.TestPackages()
 }
 


### PR DESCRIPTION
## Motivation/summary

TestPackages uses dependencies that are only defined in beats go.mod/go.sum, but as we're running it from apm-server it tries
to use apm-server's go.mod/go.sum. Make sure we use the one in beats.