### PR TITLE
processor/otel: add debug logging of payloads

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -30,6 +30,7 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 * Add support for adjusting OTel event timestamps using `telemetry.sdk.elastic_export_timestamp` {pull}5433[5433]
 * Add support for OpenTelemetry labels describing mobile connectivity {pull}5436[5436]
 * Introduce `apm-server.auth.*` config {pull}5457[5457]
+* Add debug logging of OpenTelemetry payloads {pull}5474[5474]
 
 [float]
 ==== Deprecated

--- a/internal/.otel_collector_mixin/otlptext/mixin.go
+++ b/internal/.otel_collector_mixin/otlptext/mixin.go
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlptext
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/otlptext"
+)
+
+func Traces(td pdata.Traces) string {
+	return otlptext.Traces(td)
+}
+
+func Metrics(md pdata.Metrics) string {
+	return otlptext.Metrics(md)
+}

--- a/internal/otel_collector/otlptext/mixin.go
+++ b/internal/otel_collector/otlptext/mixin.go
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package otlptext
+
+import (
+	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/internal/otlptext"
+)
+
+func Traces(td pdata.Traces) string {
+	return otlptext.Traces(td)
+}
+
+func Metrics(md pdata.Metrics) string {
+	return otlptext.Metrics(md)
+}

--- a/processor/otel/consumer_test.go
+++ b/processor/otel/consumer_test.go
@@ -52,6 +52,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 
 	"github.com/elastic/apm-server/approvaltest"
 	"github.com/elastic/apm-server/beater/beatertest"
@@ -1032,6 +1033,21 @@ func TestJaegerServiceVersion(t *testing.T) {
 
 	assert.Equal(t, "process_tag_value", batches[0].Transactions[0].Metadata.Service.Version)
 	assert.Equal(t, "span_tag_value", batches[0].Transactions[1].Metadata.Service.Version)
+}
+
+func TestTracesLogging(t *testing.T) {
+	for _, level := range []logp.Level{logp.InfoLevel, logp.DebugLevel} {
+		t.Run(level.String(), func(t *testing.T) {
+			logp.DevelopmentSetup(logp.ToObserverOutput(), logp.WithLevel(level))
+			transformTraces(t, pdata.NewTraces())
+			logs := logp.ObserverLogs().TakeAll()
+			if level == logp.InfoLevel {
+				assert.Empty(t, logs)
+			} else {
+				assert.NotEmpty(t, logs)
+			}
+		})
+	}
 }
 
 func testJaegerLogs() []jaegermodel.Log {

--- a/processor/otel/metrics.go
+++ b/processor/otel/metrics.go
@@ -43,15 +43,22 @@ import (
 	"time"
 
 	"go.opentelemetry.io/collector/consumer/pdata"
+	"go.opentelemetry.io/collector/otlptext"
 
+	logs "github.com/elastic/apm-server/log"
 	"github.com/elastic/apm-server/model"
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/logp"
 )
 
 // ConsumeMetrics consumes OpenTelemetry metrics data, converting into
 // the Elastic APM metrics model and sending to the reporter.
 func (c *Consumer) ConsumeMetrics(ctx context.Context, metrics pdata.Metrics) error {
 	receiveTimestamp := time.Now()
+	logger := logp.NewLogger(logs.Otel)
+	if logger.IsDebug() {
+		logger.Debug(otlptext.Metrics(metrics))
+	}
 	batch := c.convertMetrics(metrics, receiveTimestamp)
 	return c.Processor.ProcessBatch(ctx, batch)
 }


### PR DESCRIPTION
## Motivation/summary

Add debug logging of OpenTelemetry traces and metrics payloads. We transform the spans, so it may be useful to log the original payload when transformation goes awry.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

1. Run `apm-server -e -d otel`
2. Send OpenTelemetry traces and metrics
3. Check that the payloads are logged
4. Run again without debug selectors, check that payloads are not logged

## Related issues

Closes https://github.com/elastic/apm-server/issues/5431