### PR TITLE
beater/api/intake: fix rate limiting

### DIFF
--- a/beater/api/intake/handler.go
+++ b/beater/api/intake/handler.go
@@ -81,6 +81,8 @@ func Handler(handler StreamHandler, requestMetadataFunc RequestMetadataFunc, bat
 			return
 		}
 
+		// copy batchProcessor to avoid updating closure below
+		batchProcessor := batchProcessor
 		if limiter, ok := ratelimit.FromContext(c.Request.Context()); ok {
 			// Apply rate limiting after reading but before processing any events.
 			batchProcessor = modelprocessor.Chained{

--- a/systemtest/rum_test.go
+++ b/systemtest/rum_test.go
@@ -184,13 +184,11 @@ func TestRUMRateLimit(t *testing.T) {
 	// Just check that rate limiting is wired up. More specific rate limiting scenarios are unit tested.
 
 	var g errgroup.Group
-	g.Go(func() error { return sendEvents("10.11.12.13", srv.Config.RUM.RateLimit.EventLimit) })
-	g.Go(func() error { return sendEvents("10.11.12.14", srv.Config.RUM.RateLimit.EventLimit) })
+	g.Go(func() error { return sendEvents("10.11.12.13", srv.Config.RUM.RateLimit.EventLimit*3) })
+	g.Go(func() error { return sendEvents("10.11.12.14", srv.Config.RUM.RateLimit.EventLimit*3) })
 	assert.NoError(t, g.Wait())
 
 	g = errgroup.Group{}
-	g.Go(func() error { return sendEvents("10.11.12.13", srv.Config.RUM.RateLimit.EventLimit) })
-	g.Go(func() error { return sendEvents("10.11.12.14", srv.Config.RUM.RateLimit.EventLimit) })
 	g.Go(func() error { return sendEvents("10.11.12.15", srv.Config.RUM.RateLimit.EventLimit) })
 	err = g.Wait()
 	require.Error(t, err)


### PR DESCRIPTION
## Motivation/summary

Copy the batch processor in the closure before copying, to avoid wrapping it multiple times.

## How to test these changes

Enable RUM, send 200 RUM events over 10 requests - make sure this completes without triggering the rate limiter.

## Related issues

None, fixes bug introduced in https://github.com/elastic/apm-server/pull/5492