### PR TITLE
remove sourcemap es api key

### DIFF
--- a/apmpackage/apm/agent/input/template.yml.hbs
+++ b/apmpackage/apm/agent/input/template.yml.hbs
@@ -31,7 +31,6 @@ apm-server:
         exclude_from_grouping: {{rum_exclude_from_grouping}}
         library_pattern: {{rum_library_pattern}}
         response_headers: {{rum_response_headers}}
-        source_mapping.elasticsearch.api_key: {{sourcemap_api_key}}
     secret_token: {{secret_token}}
     shutdown_timeout: {{shutdown_timeout}}
     {{#if tls_enabled}}


### PR DESCRIPTION
this is no longer needed in fleet policies

<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
This was supposed to be removed already but somehow was not.

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes
Confirm the value is not rendered in fleet policies when running kibana pointing at a version of package-registry that has been [updated with these changes](https://github.com/elastic/apm-server/tree/master/apmpackage#update--fix-a-package)

