### PR TITLE
Introduce `apm-server.auth.anonymous` config

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -19,6 +19,34 @@ apm-server:
     # Define a shared secret token for authorizing agents using the "Bearer" authorization method.
     #secret_token:
 
+    # Allow anonymous access only for specified agents and/or services. This is primarily intended to allow
+    # limited access for untrusted agents, such as Real User Monitoring.
+    #anonymous:
+      # By default anonymous auth is automatically enabled when either auth.api_key or
+      # auth.secret_token is enabled, and RUM is enabled. Otherwise, anonymous auth is
+      # disabled by default.
+      #
+      # When anonymous auth is enabled, only agents matching allow_agent and services
+      # matching allow_service are allowed. See below for details on default values for
+      # allow_agent.
+      #enabled:
+
+      # Allow anonymous access only for specified agents.
+      #allow_agent: [rum-js, js-base]
+
+      # Allow anonymous access only for specified service names. By default, all service names are allowed.
+      #allow_service: []
+
+      # Rate-limit anonymous access by IP and number of events.
+      #rate_limit:
+        # Rate limiting is defined per unique client IP address, for a limited number of IP addresses.
+        # Sites with many concurrent clients should consider increasing this limit. Defaults to 1000.
+        #ip_limit: 1000
+
+        # Defines the maximum amount of events allowed per IP per second. Defaults to 300. The overall
+        # maximum event throughput for anonymous access is (event_limit * ip_limit).
+        #event_limit: 300
+
   # Maximum permitted size in bytes of a request's header accepted by the server to be processed.
   #max_header_size: 1048576
 
@@ -214,6 +242,10 @@ apm-server:
   #rum:
     #enabled: false
 
+    # Rate-limit RUM agents.
+    #
+    # WARNING: This configuration is deprecated and replaced with `apm-server.auth.anonymous.rate_limit`,
+    # and will be removed in the 8.0 release. If that config is defined, this one will be ignored.
     #event_rate:
 
       # Defines the maximum amount of events allowed to be sent to the APM Server RUM
@@ -230,6 +262,9 @@ apm-server:
     # A list of service names to allow, to limit service-specific indices and data streams
     # created for unauthenticated RUM events.
     # If the list is empty, any service name is allowed.
+    #
+    # WARNING: This configuration is deprecated and replaced with `apm-server.auth.anonymous.allow_service`,
+    # and will be removed in the 8.0 release. If that config is defined, this one will be ignored.
     #allow_service_names: []
 
     # A list of permitted origins for real user monitoring.

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -19,6 +19,34 @@ apm-server:
     # Define a shared secret token for authorizing agents using the "Bearer" authorization method.
     #secret_token:
 
+    # Allow anonymous access only for specified agents and/or services. This is primarily intended to allow
+    # limited access for untrusted agents, such as Real User Monitoring.
+    #anonymous:
+      # By default anonymous auth is automatically enabled when either auth.api_key or
+      # auth.secret_token is enabled, and RUM is enabled. Otherwise, anonymous auth is
+      # disabled by default.
+      #
+      # When anonymous auth is enabled, only agents matching allow_agent and services
+      # matching allow_service are allowed. See below for details on default values for
+      # allow_agent.
+      #enabled:
+
+      # Allow anonymous access only for specified agents.
+      #allow_agent: [rum-js, js-base]
+
+      # Allow anonymous access only for specified service names. By default, all service names are allowed.
+      #allow_service: []
+
+      # Rate-limit anonymous access by IP and number of events.
+      #rate_limit:
+        # Rate limiting is defined per unique client IP address, for a limited number of IP addresses.
+        # Sites with many concurrent clients should consider increasing this limit. Defaults to 1000.
+        #ip_limit: 1000
+
+        # Defines the maximum amount of events allowed per IP per second. Defaults to 300. The overall
+        # maximum event throughput for anonymous access is (event_limit * ip_limit).
+        #event_limit: 300
+
   # Maximum permitted size in bytes of a request's header accepted by the server to be processed.
   #max_header_size: 1048576
 
@@ -214,6 +242,10 @@ apm-server:
   #rum:
     #enabled: false
 
+    # Rate-limit RUM agents.
+    #
+    # WARNING: This configuration is deprecated and replaced with `apm-server.auth.anonymous.rate_limit`,
+    # and will be removed in the 8.0 release. If that config is defined, this one will be ignored.
     #event_rate:
 
       # Defines the maximum amount of events allowed to be sent to the APM Server RUM
@@ -230,6 +262,9 @@ apm-server:
     # A list of service names to allow, to limit service-specific indices and data streams
     # created for unauthenticated RUM events.
     # If the list is empty, any service name is allowed.
+    #
+    # WARNING: This configuration is deprecated and replaced with `apm-server.auth.anonymous.allow_service`,
+    # and will be removed in the 8.0 release. If that config is defined, this one will be ignored.
     #allow_service_names: []
 
     # A list of permitted origins for real user monitoring.

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -19,6 +19,34 @@ apm-server:
     # Define a shared secret token for authorizing agents using the "Bearer" authorization method.
     #secret_token:
 
+    # Allow anonymous access only for specified agents and/or services. This is primarily intended to allow
+    # limited access for untrusted agents, such as Real User Monitoring.
+    #anonymous:
+      # By default anonymous auth is automatically enabled when either auth.api_key or
+      # auth.secret_token is enabled, and RUM is enabled. Otherwise, anonymous auth is
+      # disabled by default.
+      #
+      # When anonymous auth is enabled, only agents matching allow_agent and services
+      # matching allow_service are allowed. See below for details on default values for
+      # allow_agent.
+      #enabled:
+
+      # Allow anonymous access only for specified agents.
+      #allow_agent: [rum-js, js-base]
+
+      # Allow anonymous access only for specified service names. By default, all service names are allowed.
+      #allow_service: []
+
+      # Rate-limit anonymous access by IP and number of events.
+      #rate_limit:
+        # Rate limiting is defined per unique client IP address, for a limited number of IP addresses.
+        # Sites with many concurrent clients should consider increasing this limit. Defaults to 1000.
+        #ip_limit: 1000
+
+        # Defines the maximum amount of events allowed per IP per second. Defaults to 300. The overall
+        # maximum event throughput for anonymous access is (event_limit * ip_limit).
+        #event_limit: 300
+
   # Maximum permitted size in bytes of a request's header accepted by the server to be processed.
   #max_header_size: 1048576
 
@@ -214,6 +242,10 @@ apm-server:
   #rum:
     #enabled: false
 
+    # Rate-limit RUM agents.
+    #
+    # WARNING: This configuration is deprecated and replaced with `apm-server.auth.anonymous.rate_limit`,
+    # and will be removed in the 8.0 release. If that config is defined, this one will be ignored.
     #event_rate:
 
       # Defines the maximum amount of events allowed to be sent to the APM Server RUM
@@ -230,6 +262,9 @@ apm-server:
     # A list of service names to allow, to limit service-specific indices and data streams
     # created for unauthenticated RUM events.
     # If the list is empty, any service name is allowed.
+    #
+    # WARNING: This configuration is deprecated and replaced with `apm-server.auth.anonymous.allow_service`,
+    # and will be removed in the 8.0 release. If that config is defined, this one will be ignored.
     #allow_service_names: []
 
     # A list of permitted origins for real user monitoring.

--- a/beater/api/intake/handler.go
+++ b/beater/api/intake/handler.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/elastic/beats/v7/libbeat/monitoring"
 
+	"github.com/elastic/apm-server/beater/authorization"
 	"github.com/elastic/apm-server/beater/headers"
 	"github.com/elastic/apm-server/beater/ratelimit"
 	"github.com/elastic/apm-server/beater/request"
@@ -154,6 +155,8 @@ func writeStreamResult(c *request.Context, sr *stream.Result) {
 					errID = request.IDResponseErrorsValidate
 				case errors.Is(err, ratelimit.ErrRateLimitExceeded):
 					errID = request.IDResponseErrorsRateLimit
+				case errors.Is(err, authorization.ErrUnauthorized):
+					errID = request.IDResponseErrorsUnauthorized
 				}
 			}
 			jsonResult.Errors[i] = jsonError{Message: err.Error()}

--- a/beater/authorization/anonymous_test.go
+++ b/beater/authorization/anonymous_test.go
@@ -1,0 +1,94 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package authorization_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-server/beater/authorization"
+	"github.com/elastic/apm-server/beater/config"
+)
+
+func TestAnonymousAuth(t *testing.T) {
+	for name, test := range map[string]struct {
+		allowAgent   []string
+		allowService []string
+		resource     authorization.Resource
+		expectResult authorization.Result
+	}{
+		"allow_any": {
+			allowAgent:   nil,
+			allowService: nil,
+			resource:     authorization.Resource{AgentName: "iOS/swift", ServiceName: "opbeans-ios"},
+			expectResult: authorization.Result{Authorized: true, Anonymous: true},
+		},
+		"allow_agent": {
+			allowAgent:   []string{"iOS/swift"},
+			allowService: nil,
+			resource:     authorization.Resource{AgentName: "iOS/swift", ServiceName: "opbeans-ios"},
+			expectResult: authorization.Result{Authorized: true, Anonymous: true},
+		},
+		"deny_agent": {
+			allowAgent:   []string{"rum-js"},
+			allowService: nil,
+			resource:     authorization.Resource{AgentName: "iOS/swift", ServiceName: "opbeans-ios"},
+			expectResult: authorization.Result{Authorized: false, Anonymous: true, Reason: `agent "iOS/swift" not allowed`},
+		},
+		"allow_service": {
+			allowService: []string{"opbeans-ios"},
+			resource:     authorization.Resource{AgentName: "iOS/swift", ServiceName: "opbeans-ios"},
+			expectResult: authorization.Result{Authorized: true, Anonymous: true},
+		},
+		"deny_service": {
+			allowService: []string{"opbeans-rum"},
+			resource:     authorization.Resource{AgentName: "iOS/swift", ServiceName: "opbeans-ios"},
+			expectResult: authorization.Result{Authorized: false, Anonymous: true, Reason: `service "opbeans-ios" not allowed`},
+		},
+		"allow_agent_unspecified": {
+			allowAgent:   []string{"iOS/swift"},
+			resource:     authorization.Resource{ServiceName: "opbeans-ios"}, // AgentName not specified
+			expectResult: authorization.Result{Authorized: true, Anonymous: true},
+		},
+		"allow_service_unspecified": {
+			allowService: []string{"opbeans-ios"},
+			resource:     authorization.Resource{AgentName: "iOS/swift"}, // ServiceName not specified
+			expectResult: authorization.Result{Authorized: true, Anonymous: true},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			auth := getAnonymousAuth(t, config.AnonymousAgentAuth{
+				Enabled:      true,
+				AllowAgent:   test.allowAgent,
+				AllowService: test.allowService,
+			})
+			result, err := auth.AuthorizedFor(context.Background(), test.resource)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectResult, result)
+		})
+	}
+}
+
+func getAnonymousAuth(t testing.TB, cfg config.AnonymousAgentAuth) authorization.Authorization {
+	builder, err := authorization.NewBuilder(config.AgentAuth{Anonymous: cfg})
+	require.NoError(t, err)
+	return builder.ForAnyOfPrivileges().AuthorizationFor("", "")
+}

--- a/beater/authorization/builder_test.go
+++ b/beater/authorization/builder_test.go
@@ -18,6 +18,7 @@
 package authorization
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -30,13 +31,21 @@ import (
 
 func TestBuilder(t *testing.T) {
 	for name, tc := range map[string]struct {
-		withBearer, withApikey bool
-		bearer                 *bearerBuilder
+		withBearer    bool
+		withApikey    bool
+		withAnonymous bool
+		bearer        *bearerBuilder
 	}{
-		"no auth": {},
-		"bearer":  {withBearer: true, bearer: &bearerBuilder{"xvz"}},
-		"apikey":  {withApikey: true},
-		"all":     {withApikey: true, withBearer: true, bearer: &bearerBuilder{"xvz"}},
+		"no auth":   {},
+		"bearer":    {withBearer: true, bearer: &bearerBuilder{"xvz"}},
+		"apikey":    {withApikey: true},
+		"anonymous": {withAnonymous: true},
+		"all": {
+			withApikey:    true,
+			withBearer:    true,
+			withAnonymous: true,
+			bearer:        &bearerBuilder{"xvz"},
+		},
 	} {
 
 		setup := func() *Builder {
@@ -50,7 +59,9 @@ func TestBuilder(t *testing.T) {
 					ESConfig: elasticsearch.DefaultConfig(),
 				}
 			}
-
+			if tc.withAnonymous {
+				cfg.Anonymous.Enabled = true
+			}
 			builder, err := NewBuilder(cfg)
 			require.NoError(t, err)
 			return builder
@@ -64,7 +75,6 @@ func TestBuilder(t *testing.T) {
 				assert.NotNil(t, builder.apikey.esClient)
 			}
 		})
-
 		t.Run("ForPrivilege"+name, func(t *testing.T) {
 			builder := setup()
 			h := builder.ForPrivilege(PrivilegeSourcemapWrite.Action)
@@ -76,14 +86,13 @@ func TestBuilder(t *testing.T) {
 				assert.Equal(t, builder.apikey.cache, h.apikey.cache)
 			}
 		})
-
 		t.Run("AuthorizationFor"+name, func(t *testing.T) {
 			builder := setup()
 			h := builder.ForPrivilege(PrivilegeSourcemapWrite.Action)
 			auth := h.AuthorizationFor("ApiKey", "")
 			if tc.withApikey {
 				assert.IsType(t, &apikeyAuth{}, auth)
-			} else if tc.withBearer {
+			} else if tc.withBearer || tc.withAnonymous {
 				assert.Equal(t, denyAuth{}, auth)
 			} else {
 				assert.Equal(t, allowAuth{}, auth)
@@ -92,26 +101,51 @@ func TestBuilder(t *testing.T) {
 			auth = h.AuthorizationFor("Bearer", "")
 			if tc.withBearer {
 				assert.IsType(t, &bearerAuth{}, auth)
-			} else if tc.withApikey {
+			} else if tc.withApikey || tc.withAnonymous {
 				assert.Equal(t, denyAuth{}, auth)
 			} else {
 				assert.Equal(t, allowAuth{}, auth)
 			}
 
 			auth = h.AuthorizationFor("Anything", "")
-			if tc.withBearer || tc.withApikey {
+			if tc.withBearer || tc.withApikey || tc.withAnonymous {
 				assert.Equal(t, denyAuth{reason: `unknown Authorization kind Anything: expected 'Authorization: Bearer secret_token' or 'Authorization: ApiKey base64(API key ID:API key)'`}, auth)
 			} else {
 				assert.Equal(t, allowAuth{}, auth)
 			}
 
 			auth = h.AuthorizationFor("", "Value")
-			if tc.withBearer || tc.withApikey {
+			if tc.withAnonymous {
+				assert.Equal(t, &anonymousAuth{
+					allowedAgents:   make(map[string]bool),
+					allowedServices: make(map[string]bool),
+				}, auth)
+			} else if tc.withBearer || tc.withApikey {
 				assert.Equal(t, denyAuth{reason: `missing or improperly formatted Authorization header: expected 'Authorization: Bearer secret_token' or 'Authorization: ApiKey base64(API key ID:API key)'`}, auth)
 			} else {
 				assert.Equal(t, allowAuth{}, auth)
 			}
 		})
 	}
+
+}
+
+func TestHandlerWithAnonymousDisabled(t *testing.T) {
+	builder, _ := NewBuilder(config.AgentAuth{
+		SecretToken: "abc123",
+		Anonymous: config.AnonymousAgentAuth{
+			Enabled: true,
+		},
+	})
+	anonymousEnabled := builder.ForAnyOfPrivileges()
+	anonymousDisabled := anonymousEnabled.WithAnonymousDisabled()
+
+	result, err := anonymousDisabled.AuthorizationFor("", "").AuthorizedFor(context.Background(), Resource{})
+	require.NoError(t, err)
+	assert.Equal(t, Result{Authorized: false, Reason: "missing or improperly formatted Authorization header: expected 'Authorization: Bearer secret_token' or 'Authorization: ApiKey base64(API key ID:API key)'"}, result)
+
+	result, err = anonymousEnabled.AuthorizationFor("", "").AuthorizedFor(context.Background(), Resource{})
+	require.NoError(t, err)
+	assert.Equal(t, Result{Authorized: true, Anonymous: true}, result)
 
 }

--- a/beater/config/auth_test.go
+++ b/beater/config/auth_test.go
@@ -102,6 +102,59 @@ func TestAPIKeyAgentAuth_ESConfig(t *testing.T) {
 	}
 }
 
+func TestAnonymousAgentAuth(t *testing.T) {
+	for name, tc := range map[string]struct {
+		cfg            *common.Config
+		expectedConfig AnonymousAgentAuth
+	}{
+		"default": {
+			cfg:            common.NewConfig(),
+			expectedConfig: defaultAnonymousAgentAuth(),
+		},
+		"allow_service": {
+			cfg: common.MustNewConfigFrom(`{"auth.anonymous.allow_service":["service-one"]}`),
+			expectedConfig: AnonymousAgentAuth{
+				AllowAgent:   []string{"rum-js"},
+				AllowService: []string{"service-one"},
+				RateLimit: RateLimit{
+					EventLimit: 300,
+					IPLimit:    1000,
+				},
+				configured: true,
+			},
+		},
+		"deprecated_rum_allow_service_names": {
+			cfg: common.MustNewConfigFrom(`{"rum.allow_service_names":["service-two"]}`),
+			expectedConfig: AnonymousAgentAuth{
+				AllowAgent:   []string{"rum-js"},
+				AllowService: []string{"service-two"},
+				RateLimit: RateLimit{
+					EventLimit: 300,
+					IPLimit:    1000,
+				},
+			},
+		},
+		"deprecated_rum_allow_service_names_conflict": {
+			cfg: common.MustNewConfigFrom(`{"auth.anonymous.allow_service":["service-one"], "rum.allow_service_names":["service-two"]}`),
+			expectedConfig: AnonymousAgentAuth{
+				AllowAgent:   []string{"rum-js"},
+				AllowService: []string{"service-one"},
+				RateLimit: RateLimit{
+					EventLimit: 300,
+					IPLimit:    1000,
+				},
+				configured: true,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := NewConfig(tc.cfg, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedConfig, cfg.AgentAuth.Anonymous)
+		})
+	}
+}
+
 func TestSecretTokenAuth(t *testing.T) {
 	for name, tc := range map[string]struct {
 		cfg      *common.Config

--- a/beater/config/config.go
+++ b/beater/config/config.go
@@ -105,6 +105,10 @@ func NewConfig(ucfg *common.Config, outputESCfg *common.Config) (*Config, error)
 		return nil, err
 	}
 
+	if err := c.AgentAuth.setAnonymousDefaults(logger, c.RumConfig.Enabled); err != nil {
+		return nil, err
+	}
+
 	if err := c.AgentAuth.APIKey.setup(logger, outputESCfg); err != nil {
 		return nil, err
 	}
@@ -139,9 +143,18 @@ func NewConfig(ucfg *common.Config, outputESCfg *common.Config) (*Config, error)
 // setDeprecatedConfig translates deprecated top-level config attributes to the
 // current config structure.
 func setDeprecatedConfig(out *Config, in *common.Config, logger *logp.Logger) error {
+	type deprecatedRUMEventRateConfig struct {
+		Limit   int `config:"limit"`
+		LruSize int `config:"lru_size"`
+	}
+	type deprecatedRUMConfig struct {
+		EventRate         *deprecatedRUMEventRateConfig `config:"event_rate"`
+		AllowServiceNames []string                      `config:"allow_service_names"`
+	}
 	var deprecatedConfig struct {
-		APIKey      APIKeyAgentAuth `config:"api_key"`
-		SecretToken string          `config:"secret_token"`
+		APIKey      APIKeyAgentAuth      `config:"api_key"`
+		RUM         *deprecatedRUMConfig `config:"rum"`
+		SecretToken string               `config:"secret_token"`
 	}
 	deprecatedConfig.APIKey = defaultAPIKeyAgentAuth()
 	if err := in.Unpack(&deprecatedConfig); err != nil {
@@ -157,6 +170,27 @@ func setDeprecatedConfig(out *Config, in *common.Config, logger *logp.Logger) er
 			warnIgnored("apm-server.api_key", "apm-server.auth.api_key")
 		} else {
 			out.AgentAuth.APIKey = deprecatedConfig.APIKey
+		}
+	}
+	if deprecatedConfig.RUM != nil {
+		// "apm-server.rum.event_rate" -> "apm-server.auth.anonymous.rate_limit"
+		if deprecatedConfig.RUM.EventRate != nil {
+			if out.AgentAuth.Anonymous.configured {
+				warnIgnored("apm-server.rum.event_rate", "apm-server.auth.anonymous")
+			} else {
+				out.AgentAuth.Anonymous.RateLimit = RateLimit{
+					EventLimit: deprecatedConfig.RUM.EventRate.Limit,
+					IPLimit:    deprecatedConfig.RUM.EventRate.LruSize,
+				}
+			}
+		}
+		// "apm-server.rum.allow_service_names" -> "apm-server.auth.anonymous.allow_service"
+		if len(deprecatedConfig.RUM.AllowServiceNames) > 0 {
+			if out.AgentAuth.Anonymous.configured {
+				warnIgnored("apm-server.rum.allow_service_names", "apm-server.auth.anonymous")
+			} else {
+				out.AgentAuth.Anonymous.AllowService = deprecatedConfig.RUM.AllowServiceNames
+			}
 		}
 	}
 	if deprecatedConfig.SecretToken != "" {

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -163,6 +163,15 @@ func TestUnpackConfig(t *testing.T) {
 						configured:   true,
 						esConfigured: true,
 					},
+					Anonymous: AnonymousAgentAuth{
+						Enabled:      true,
+						AllowService: []string{"opbeans-rum"},
+						AllowAgent:   []string{"rum-js"},
+						RateLimit: RateLimit{
+							EventLimit: 7200,
+							IPLimit:    2000,
+						},
+					},
 				},
 				TLS: &tlscommon.ServerConfig{
 					Enabled:     newBool(true),
@@ -190,14 +199,9 @@ func TestUnpackConfig(t *testing.T) {
 					},
 				},
 				RumConfig: RumConfig{
-					Enabled: true,
-					EventRate: EventRate{
-						Limit:   7200,
-						LruSize: 2000,
-					},
-					AllowServiceNames: []string{"opbeans-rum"},
-					AllowOrigins:      []string{"example*"},
-					AllowHeaders:      []string{"Authorization"},
+					Enabled:      true,
+					AllowOrigins: []string{"example*"},
+					AllowHeaders: []string{"Authorization"},
 					SourceMapping: SourceMapping{
 						Enabled:      true,
 						Cache:        Cache{Expiration: 8 * time.Minute},
@@ -345,6 +349,14 @@ func TestUnpackConfig(t *testing.T) {
 						ESConfig:    elasticsearch.DefaultConfig(),
 						configured:  true,
 					},
+					Anonymous: AnonymousAgentAuth{
+						Enabled:    true,
+						AllowAgent: []string{"rum-js"},
+						RateLimit: RateLimit{
+							EventLimit: 300,
+							IPLimit:    1000,
+						},
+					},
 				},
 				TLS: &tlscommon.ServerConfig{
 					Enabled:     newBool(true),
@@ -371,11 +383,7 @@ func TestUnpackConfig(t *testing.T) {
 					},
 				},
 				RumConfig: RumConfig{
-					Enabled: true,
-					EventRate: EventRate{
-						Limit:   300,
-						LruSize: 1000,
-					},
+					Enabled:      true,
 					AllowOrigins: []string{"*"},
 					AllowHeaders: []string{},
 					SourceMapping: SourceMapping{

--- a/beater/config/ratelimit.go
+++ b/beater/config/ratelimit.go
@@ -1,0 +1,31 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package config
+
+// RateLimit holds configuration related to IP and event rate limiting.
+type RateLimit struct {
+	// EventLimit holds the event rate limit per IP, measured in
+	// events per second.
+	EventLimit int `config:"event_limit"`
+
+	// IPLimit holds the maximum number of client IPs for which we
+	// will maintain a distinct event rate limit. Once this has been
+	// reached, clients will begin sharing rate limiters. This is
+	// done to avoid DDoS attacks.
+	IPLimit int `config:"ip_limit"`
+}

--- a/beater/config/rum.go
+++ b/beater/config/rum.go
@@ -31,8 +31,6 @@ import (
 
 const (
 	allowAllOrigins                 = "*"
-	defaultEventRateLimit           = 300
-	defaultEventRateLRUSize         = 1000
 	defaultExcludeFromGrouping      = "^/webpack"
 	defaultLibraryPattern           = "node_modules|bower_components|~"
 	defaultSourcemapCacheExpiration = 5 * time.Minute
@@ -42,20 +40,12 @@ const (
 // RumConfig holds config information related to the RUM endpoint
 type RumConfig struct {
 	Enabled             bool                `config:"enabled"`
-	EventRate           EventRate           `config:"event_rate"`
-	AllowServiceNames   []string            `config:"allow_service_names"`
 	AllowOrigins        []string            `config:"allow_origins"`
 	AllowHeaders        []string            `config:"allow_headers"`
 	ResponseHeaders     map[string][]string `config:"response_headers"`
 	LibraryPattern      string              `config:"library_pattern"`
 	ExcludeFromGrouping string              `config:"exclude_from_grouping"`
 	SourceMapping       SourceMapping       `config:"source_mapping"`
-}
-
-// EventRate holds config information about event rate limiting
-type EventRate struct {
-	Limit   int `config:"limit"`
-	LruSize int `config:"lru_size"`
 }
 
 // SourceMapping holds sourcemap config information
@@ -122,10 +112,6 @@ func defaultSourcemapping() SourceMapping {
 
 func defaultRum() RumConfig {
 	return RumConfig{
-		EventRate: EventRate{
-			Limit:   defaultEventRateLimit,
-			LruSize: defaultEventRateLRUSize,
-		},
 		AllowOrigins:        []string{allowAllOrigins},
 		AllowHeaders:        []string{},
 		SourceMapping:       defaultSourcemapping(),

--- a/beater/server.go
+++ b/beater/server.go
@@ -119,8 +119,8 @@ func newServer(
 ) (server, error) {
 	agentcfgFetcher := agentcfg.NewFetcher(cfg)
 	ratelimitStore, err := ratelimit.NewStore(
-		cfg.RumConfig.EventRate.LruSize,
-		cfg.RumConfig.EventRate.Limit,
+		cfg.AgentAuth.Anonymous.RateLimit.IPLimit,
+		cfg.AgentAuth.Anonymous.RateLimit.EventLimit,
 		3, // burst multiplier
 	)
 	if err != nil {

--- a/systemtest/agentconfig.go
+++ b/systemtest/agentconfig.go
@@ -1,0 +1,76 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package systemtest
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/elastic/apm-server/systemtest/apmservertest"
+)
+
+// CreateAgentConfig creates or updates agent central config via Kibana.
+func CreateAgentConfig(t testing.TB, serviceName, serviceEnvironment, agentName string, settings map[string]string) {
+	kibanaConfig := apmservertest.DefaultConfig().Kibana
+	kibanaURL, err := url.Parse(kibanaConfig.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kibanaURL.User = url.UserPassword(kibanaConfig.Username, kibanaConfig.Password)
+	kibanaURL.Path = "/api/apm/settings/agent-configuration"
+	kibanaURL.RawQuery = "overwrite=true"
+
+	var params struct {
+		AgentName string `json:"agent_name,omitempty"`
+		Service   struct {
+			Name        string `json:"name"`
+			Environment string `json:"environment,omitempty"`
+		} `json:"service"`
+		Settings map[string]string `json:"settings"`
+	}
+	params.Service.Name = serviceName
+	params.Service.Environment = serviceEnvironment
+	params.AgentName = agentName
+	params.Settings = settings
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(params); err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest("PUT", kibanaURL.String(), &body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("kbn-xsrf", "1")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("failed to create agent config: %s (%s)", resp.Status, strings.TrimSpace(string(body)))
+	}
+}

--- a/systemtest/apmservertest/config.go
+++ b/systemtest/apmservertest/config.go
@@ -42,15 +42,16 @@ const (
 
 // Config holds APM Server configuration.
 type Config struct {
-	SecretToken               string             `json:"apm-server.secret_token,omitempty"`
 	Jaeger                    *JaegerConfig      `json:"apm-server.jaeger,omitempty"`
 	Kibana                    *KibanaConfig      `json:"apm-server.kibana,omitempty"`
 	Aggregation               *AggregationConfig `json:"apm-server.aggregation,omitempty"`
 	Sampling                  *SamplingConfig    `json:"apm-server.sampling,omitempty"`
 	RUM                       *RUMConfig         `json:"apm-server.rum,omitempty"`
 	DataStreams               *DataStreamsConfig `json:"apm-server.data_streams,omitempty"`
-	APIKey                    *APIKeyConfig      `json:"apm-server.api_key,omitempty"`
 	DefaultServiceEnvironment string             `json:"apm-server.default_service_environment,omitempty"`
+
+	// AgentAuth holds configuration for APM agent authorization.
+	AgentAuth AgentAuthConfig `json:"apm-server.auth"`
 
 	// ResponseHeaders holds headers to add to all APM Server HTTP responses.
 	ResponseHeaders http.Header `json:"apm-server.response_headers,omitempty"`
@@ -156,15 +157,6 @@ type RUMConfig struct {
 
 	// ResponseHeaders holds headers to add to all APM Server RUM HTTP responses.
 	ResponseHeaders http.Header `json:"response_headers,omitempty"`
-
-	// RateLimit holds event rate limit configuration.
-	RateLimit *RUMRateLimitConfig `json:"event_rate,omitempty"`
-}
-
-// RUMRateLimitConfig holds APM Server RUM event rate limit configuration.
-type RUMRateLimitConfig struct {
-	IPLimit    int `json:"lru_size,omitempty"`
-	EventLimit int `json:"limit,omitempty"`
 }
 
 // DataStreamsConfig holds APM Server data streams configuration.
@@ -172,9 +164,30 @@ type DataStreamsConfig struct {
 	Enabled bool `json:"enabled"`
 }
 
-// APIKeyConfig holds APM Server API Key auth configuration.
-type APIKeyConfig struct {
+// APIKeyConfig holds agent auth configuration.
+type AgentAuthConfig struct {
+	SecretToken string               `json:"secret_token,omitempty"`
+	APIKey      *APIKeyAuthConfig    `json:"api_key,omitempty"`
+	Anonymous   *AnonymousAuthConfig `json:"anonymous,omitempty"`
+}
+
+// APIKeyAuthConfig holds API Key agent auth configuration.
+type APIKeyAuthConfig struct {
 	Enabled bool `json:"enabled"`
+}
+
+// AnonymousAuthConfig holds anonymous agent auth configuration.
+type AnonymousAuthConfig struct {
+	Enabled      bool             `json:"enabled"`
+	AllowAgent   []string         `json:"allow_agent,omitempty"`
+	AllowService []string         `json:"allow_service,omitempty"`
+	RateLimit    *RateLimitConfig `json:"rate_limit,omitempty"`
+}
+
+// RateLimitConfig holds event rate limit configuration.
+type RateLimitConfig struct {
+	IPLimit    int `json:"ip_limit,omitempty"`
+	EventLimit int `json:"event_limit,omitempty"`
 }
 
 // InstrumentationConfig holds APM Server instrumentation configuration.

--- a/systemtest/apmservertest/server.go
+++ b/systemtest/apmservertest/server.go
@@ -464,7 +464,7 @@ func (s *Server) Tracer() *apm.Tracer {
 		s.tb.Fatal(err)
 	}
 	httpTransport.SetServerURL(serverURL)
-	httpTransport.SetSecretToken(s.Config.SecretToken)
+	httpTransport.SetSecretToken(s.Config.AgentAuth.SecretToken)
 	httpTransport.Client.Transport.(*http.Transport).TLSClientConfig = s.TLS
 
 	var transport transport.Transport = httpTransport

--- a/systemtest/auth_test.go
+++ b/systemtest/auth_test.go
@@ -42,8 +42,8 @@ func TestAuth(t *testing.T) {
 	secretToken := strconv.Itoa(rng.Int())
 
 	srv := apmservertest.NewUnstartedServer(t)
-	srv.Config.SecretToken = secretToken
-	srv.Config.APIKey = &apmservertest.APIKeyConfig{Enabled: true}
+	srv.Config.AgentAuth.SecretToken = secretToken
+	srv.Config.AgentAuth.APIKey = &apmservertest.APIKeyAuthConfig{Enabled: true}
 	srv.Config.RUM = &apmservertest.RUMConfig{Enabled: true}
 	err := srv.Start()
 	require.NoError(t, err)

--- a/systemtest/instrumentation_test.go
+++ b/systemtest/instrumentation_test.go
@@ -96,8 +96,8 @@ func TestAPMServerInstrumentationAuth(t *testing.T) {
 	test := func(t *testing.T, external, useSecretToken, useAPIKey bool) {
 		systemtest.CleanupElasticsearch(t)
 		srv := apmservertest.NewUnstartedServer(t)
-		srv.Config.SecretToken = "hunter2"
-		srv.Config.APIKey = &apmservertest.APIKeyConfig{Enabled: true}
+		srv.Config.AgentAuth.SecretToken = "hunter2"
+		srv.Config.AgentAuth.APIKey = &apmservertest.APIKeyAuthConfig{Enabled: true}
 		srv.Config.Instrumentation = &apmservertest.InstrumentationConfig{Enabled: true}
 
 		serverURLChan := make(chan string, 1)
@@ -125,7 +125,7 @@ func TestAPMServerInstrumentationAuth(t *testing.T) {
 			srv.Config.Instrumentation.Hosts = []string{proxy.URL}
 		}
 		if useSecretToken {
-			srv.Config.Instrumentation.SecretToken = srv.Config.SecretToken
+			srv.Config.Instrumentation.SecretToken = srv.Config.AgentAuth.SecretToken
 		}
 		if useAPIKey {
 			systemtest.InvalidateAPIKeys(t)

--- a/systemtest/jaeger_test.go
+++ b/systemtest/jaeger_test.go
@@ -110,7 +110,7 @@ func TestJaegerGRPCSampling(t *testing.T) {
 func TestJaegerGRPCAuth(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
 	srv := apmservertest.NewUnstartedServer(t)
-	srv.Config.SecretToken = "secret"
+	srv.Config.AgentAuth.SecretToken = "secret"
 	require.NoError(t, srv.Start())
 
 	conn, err := grpc.Dial(serverAddr(srv), grpc.WithInsecure())


### PR DESCRIPTION
## Motivation/summary

Generalise the ability for agents to send events unauthenticated (anonymous) but rate-limited. Until now this has been a RUM-only feature, but we now find ourselves needing it also for the iOS agent.

Anonymous auth is disabled by default, but is automatically enabled when RUM is enabled as long as `apm-server.auth.anonymous` hasn't been explicitly configured. The existing RUM config for allowed services and rate limiting are deprecated and replaced with equivalent config under `apm-server.auth.anonymous.*`.

Instead of restricting anonymous auth to requests going by endpoint (i.e. RUM intake and agent config), we now restrict based on the provided agent and service names. There was previously nothing stopping clients from spoofing RUM agents, e.g. sending events to the RUM intake with a non-RUM agent name, so this is not any less secure.

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

## How to test these changes

1. Ensure existing config works as before: RUM should be allowed to send data without any auth token when secret_token or api_key auth is enabled; ensure no other agents can send data without an auth token.
2. Define `apm-server.auth.anonymous.allow_agent: [iOS/swift]`, check that the iOS/swift agent can send data without an auth token.
3. Define `apm-server.auth.anonymous.allow_service: [opbeans-rum]`, check that opbeans-rum can send data. Change it to something else and check that opbeans-rum cannot send data.

## Related issues

Closes https://github.com/elastic/apm-server/issues/5347