### PR TITLE
kibana expects the apm-config as a json string

### DIFF
--- a/kibana/send_config.go
+++ b/kibana/send_config.go
@@ -44,7 +44,11 @@ func SendConfig(ctx context.Context, client Client, conf *ucfg.Config) error {
 		return err
 	}
 
-	b, err := json.Marshal(format(flat))
+	formatted, err := format(flat)
+	if err != nil {
+		return err
+	}
+	b, err := json.Marshal(formatted)
 	if err != nil {
 		return err
 	}
@@ -74,8 +78,12 @@ func SendConfig(ctx context.Context, client Client, conf *ucfg.Config) error {
 	}
 }
 
-func format(m map[string]interface{}) map[string]interface{} {
-	return map[string]interface{}{"schemaJson": m}
+func format(m map[string]interface{}) (map[string]string, error) {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{"schemaJson": string(b)}, nil
 }
 
 func flattenAndClean(conf *ucfg.Config) (map[string]interface{}, error) {

--- a/kibana/send_config_test.go
+++ b/kibana/send_config_test.go
@@ -18,6 +18,7 @@
 package kibana
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -38,11 +39,14 @@ func TestFlattenAndFormat(t *testing.T) {
 	flat, err := flattenAndClean(&c)
 	assert.NoError(t, err)
 
-	flat = format(flat)
-	assert.Contains(t, flat, "schemaJson")
+	formatted, err := format(flat)
+	assert.Contains(t, formatted, "schemaJson")
 
-	flat = flat["schemaJson"].(map[string]interface{})
-	for k := range flat {
+	cfg := formatted["schemaJson"]
+	parsed := make(map[string]interface{})
+	require.NoError(t, json.Unmarshal([]byte(cfg), &parsed))
+
+	for k := range parsed {
 		assert.NotContains(t, k, "elasticsearch")
 		assert.NotContains(t, k, "kibana")
 		assert.NotContains(t, k, "instrumentation")

--- a/kibana/send_config_test.go
+++ b/kibana/send_config_test.go
@@ -37,9 +37,10 @@ func TestFlattenAndFormat(t *testing.T) {
 	require.NoError(t, err)
 
 	flat, err := flattenAndClean(&c)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	formatted, err := format(flat)
+	require.NoError(t, err)
 	assert.Contains(t, formatted, "schemaJson")
 
 	cfg := formatted["schemaJson"]


### PR DESCRIPTION

<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

The expected format in kibana was clarified to me by @ogupte 

This might change in the future, in which case
this commit can be reverted to the previous
version that sent a serialized json blob


