### PR TITLE
[automation] update elastic stack version for testing 7.14.0-25663e85

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       kibana: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0-28665d9b-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0-25663e85-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -61,7 +61,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.14.0-28665d9b-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.14.0-25663e85-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -85,7 +85,7 @@ services:
       package-registry: { condition: service_healthy }
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:7.14.0-28665d9b-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:7.14.0-25663e85-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:

--- a/systemtest/approvals/TestFleetIntegration.approved.json
+++ b/systemtest/approvals/TestFleetIntegration.approved.json
@@ -13,7 +13,7 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "untrusted_user",
+                "agent_id_status": "missing",
                 "ingested": "dynamic",
                 "outcome": "unknown"
             },


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Thu, 24 Jun 2021 05:14:20 GMT, release_branch:7.x, prefix:, end_time:Thu, 24 Jun 2021 09:53:40 GMT, manifest_version:2.0.0, version:7.14.0-SNAPSHOT, branch:7.x, build_id:7.14.0-25663e85, build_duration_seconds:16760]