### PR TITLE
[automation] update elastic stack version for testing 7.13.3-ce6a5891

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       kibana: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.13.3-9167705c-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.13.3-ce6a5891-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -61,7 +61,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.13.3-9167705c-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.13.3-ce6a5891-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -84,7 +84,7 @@ services:
       package-registry: { condition: service_healthy }
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:7.13.3-9167705c-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:7.13.3-ce6a5891-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Mon, 28 Jun 2021 00:15:48 GMT, release_branch:7.13, prefix:, end_time:Mon, 28 Jun 2021 04:54:10 GMT, manifest_version:2.0.0, version:7.13.3-SNAPSHOT, branch:7.13, build_id:7.13.3-ce6a5891, build_duration_seconds:16702]