### PR TITLE
[cloud] Remove cloud defaults from user settings sent to Kibana

### DIFF
--- a/kibana/send_config.go
+++ b/kibana/send_config.go
@@ -97,6 +97,22 @@ func flattenAndClean(conf *ucfg.Config) (map[string]interface{}, error) {
 		if strings.HasPrefix(k, "instrumentation") {
 			continue
 		}
+		if strings.HasPrefix(k, "logging.") {
+			switch k[8:] {
+			case "level", "selectors", "metrics.enabled", "metrics.period":
+			default:
+				continue
+			}
+		}
+		if strings.HasPrefix(k, "path") {
+			continue
+		}
+		if k == "gc_percent" || k == "name" || k == "xpack.monitoring.enabled" {
+			continue
+		}
+		if k == "apm-server.host" {
+			v = "0.0.0.0:8200"
+		}
 		if strings.HasPrefix(k, "apm-server.ssl.") {
 			// Following ssl related settings need to be synced:
 			// apm-server.ssl.enabled


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
Remove the config options that are set by cloud allocator (not by user) and that are not supported in the integration. 
See [supported user settings](https://www.elastic.co/guide/en/cloud/current/ec-manage-apm-settings.html#ec-apm-settings).

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

## How to test these changes
Create deployment in shared ECE environment and ensure that none of these options shows up as unsupported when triggering the migration.
<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related Issue
follow up on https://github.com/elastic/apm-server/issues/5377
