### PR TITLE
fix flaky test

### DIFF
--- a/sourcemap/store_test.go
+++ b/sourcemap/store_test.go
@@ -157,14 +157,16 @@ func TestFetchTimeout(t *testing.T) {
 	var (
 		errs int64
 
-		apikey  = "supersecret"
-		name    = "webapp"
-		version = "1.0.0"
-		path    = "/my/path/to/bundle.js.map"
-		c       = http.DefaultClient
+		apikey      = "supersecret"
+		name        = "webapp"
+		version     = "1.0.0"
+		path        = "/my/path/to/bundle.js.map"
+		c           = http.DefaultClient
+		ctx, cancel = context.WithTimeout(context.Background(), time.Millisecond)
 	)
+	defer cancel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		<-r.Context().Done()
+		<-ctx.Done()
 	}))
 	defer ts.Close()
 
@@ -188,11 +190,7 @@ func TestFetchTimeout(t *testing.T) {
 	store, err := newStore(b, logger, time.Minute)
 	assert.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
-	defer cancel()
-
 	_, err = store.Fetch(ctx, name, version, path)
-	time.Sleep(10 * time.Millisecond)
 	assert.True(t, errors.Is(err, context.DeadlineExceeded))
 	atomic.AddInt64(&errs, 1)
 


### PR DESCRIPTION


<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

use same ctx.WithTimeout in server and request.
previously we were using a separate ctx.

fixes https://github.com/elastic/apm-server/issues/5571
<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## How to test these changes

Non-functional change

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->
