### PR TITLE
[7.x] Update secure-communication-agents.asciidoc (#5379)

### DIFF
--- a/docs/secure-communication-agents.asciidoc
+++ b/docs/secure-communication-agents.asciidoc
@@ -463,6 +463,9 @@ as there is no way to prevent them from being publicly exposed.
 
 **APM Server configuration**
 
+NOTE: {ess} and {ece} deployments provision a secret token when the deployment is created.
+The secret token can be found and reset in the {ecloud} console under **Deployments** -- **APM & Fleet**.
+
 Here's how you set the secret token in APM Server:
 
 [source,yaml]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Update secure-communication-agents.asciidoc (#5379)