### PR TITLE
Update to elastic/beats@0de1d8d7ec4b, bump to 7.15.0

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -576,11 +576,11 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/beats/v7
-Version: v7.0.0-alpha2.0.20210630190704-9361be46ebf2
+Version: v7.0.0-alpha2.0.20210630220043-0de1d8d7ec4b
 Licence type (autodetected): Elastic
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/beats/v7@v7.0.0-alpha2.0.20210630190704-9361be46ebf2/LICENSE.txt:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/beats/v7@v7.0.0-alpha2.0.20210630220043-0de1d8d7ec4b/LICENSE.txt:
 
 Source code in this repository is variously licensed under the Apache License
 Version 2.0, an Apache compatible license, or the Elastic License. Outside of

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,4 +18,4 @@
 package cmd
 
 // name matches github.com/elastic/beats/v7/dev-tools/mage/settings.go parseBeatVersion
-const defaultBeatVersion = "7.14.0"
+const defaultBeatVersion = "7.15.0"

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/dop251/goja_nodejs v0.0.0-20210225215109-d91c329300e7 // indirect
 	github.com/dustin/go-humanize v1.0.0
 	github.com/elastic/apm-server/approvaltest v0.0.0-00010101000000-000000000000
-	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20210630190704-9361be46ebf2
+	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20210630220043-0de1d8d7ec4b
 	github.com/elastic/ecs v1.10.0
 	github.com/elastic/elastic-agent-client/v7 v7.0.0-20210407144825-cc1c33cfa1d0 // indirect
 	github.com/elastic/elastic-package v0.0.0-20210310173719-3b8f76516ae3

--- a/go.sum
+++ b/go.sum
@@ -347,8 +347,8 @@ github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFP
 github.com/eclipse/paho.mqtt.golang v1.2.0/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=
 github.com/eclipse/paho.mqtt.golang v1.2.1-0.20200121105743-0d940dd29fd2/go.mod h1:H9keYFcgq3Qr5OUJm/JZI/i6U7joQ8SYLhZwfeOo6Ts=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
-github.com/elastic/beats/v7 v7.0.0-alpha2.0.20210630190704-9361be46ebf2 h1:saOiIPg6L1UMYbtw9oQjMt19t2+J6ZFehb3PaE1MOmA=
-github.com/elastic/beats/v7 v7.0.0-alpha2.0.20210630190704-9361be46ebf2/go.mod h1:fUxyXKF4ucN6KfS1Ep+kkCD4e0zHbi+pfCf+qrTAlKI=
+github.com/elastic/beats/v7 v7.0.0-alpha2.0.20210630220043-0de1d8d7ec4b h1:FhD1yEtrgBoU3VGCm3puqL5d6tM5eLUidAddTZ/56Og=
+github.com/elastic/beats/v7 v7.0.0-alpha2.0.20210630220043-0de1d8d7ec4b/go.mod h1:fUxyXKF4ucN6KfS1Ep+kkCD4e0zHbi+pfCf+qrTAlKI=
 github.com/elastic/ecs v1.10.0 h1:C+0ZidF/eh5DKYAZBir3Hq9Q6aMXcwpgEuQnj4bRzKA=
 github.com/elastic/ecs v1.10.0/go.mod h1:pgiLbQsijLOJvFR8OTILLu0Ni/R/foUNg0L+T6mU9b4=
 github.com/elastic/elastic-agent-client/v7 v7.0.0-20210308165121-7dd05ee2b5a5/go.mod h1:uh/Gj9a0XEbYoM4NYz4LvaBVARz3QXLmlNjsrKY9fTc=


### PR DESCRIPTION
## Motivation/summary

Bump apm-server version on 7.x to 7.15.0, and update beats to the latest commit on the 7.x branch.
libbeat still reports 7.14.0, as https://github.com/elastic/beats/pull/26621 hasn't yet been merged.