### PR TITLE
docs: add 7.13.3 release notes

### DIFF
--- a/changelogs/7.13.asciidoc
+++ b/changelogs/7.13.asciidoc
@@ -3,9 +3,18 @@
 
 https://github.com/elastic/apm-server/compare/7.12\...7.13[View commits]
 
+* <<release-notes-7.13.3>>
 * <<release-notes-7.13.2>>
 * <<release-notes-7.13.1>>
 * <<release-notes-7.13.0>>
+
+[float]
+[[release-notes-7.13.3]]
+=== APM Server version 7.13.3
+
+https://github.com/elastic/apm-server/compare/v7.13.2\...v7.13.3[View commits]
+
+No significant changes.
 
 [float]
 [[release-notes-7.13.2]]


### PR DESCRIPTION
Adds 7.13.3 release notes.

**Reviewers**: Should https://github.com/elastic/apm-server/pull/5506 be noted?