### PR TITLE
docs: fix typo

### DIFF
--- a/docs/secure-communication-agents.asciidoc
+++ b/docs/secure-communication-agents.asciidoc
@@ -219,7 +219,7 @@ You can verify your API key has been base64-encoded correctly with the
 
 ["source","sh",subs="attributes"]
 -----
-curl -H "Authorization: ApiKey R0gzRWIzUUI3eVpiU054S3pYSy06bXQyQWl4TlZUeEcyUjd4cUZDS0NlUQ==" localhost:9200/_security/_authentication
+curl -H "Authorization: ApiKey R0gzRWIzUUI3eVpiU054S3pYSy06bXQyQWl4TlZUeEcyUjd4cUZDS0NlUQ==" localhost:9200/_security/_authenticate
 -----
 
 If the API key has been encoded correctly, you'll see a response similar to the following:


### PR DESCRIPTION
Fix typo in docs related to testing API Keys. The Elasticsearch API is `/_security/_authenticate`, not `/_security/_authentication`.