### PR TITLE
Update mergify with 7.15 backport rule

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -17,13 +17,25 @@ pull_request_rules:
     conditions:
       - merged
       - base=master
-      - label=v7.14.0
+      - label=v7.15.0
     actions:
       backport:
         assignees:
           - "{{ author }}"
         branches:
           - "7.x"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+  - name: backport patches to 7.14 branch
+    conditions:
+      - merged
+      - base=master
+      - label=v7.14.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "7.14"
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
   - name: backport patches to 7.13 branch
     conditions:


### PR DESCRIPTION
Update mergify config to add the v7.15.0 backport rule and update the v7.14.0 rule.