### PR TITLE
model: introduce APMEvent; Batch is now []model.APMEvent

### DIFF
--- a/agentcfg/reporter_test.go
+++ b/agentcfg/reporter_test.go
@@ -97,7 +97,9 @@ type batchProcessor struct {
 func (p *batchProcessor) ProcessBatch(_ context.Context, b *model.Batch) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.received = append(p.received, b.Metricsets...)
+	for _, event := range *b {
+		p.received = append(p.received, event.Metricset)
+	}
 	p.receivedc <- struct{}{}
 	return nil
 }

--- a/beater/api/profile/handler.go
+++ b/beater/api/profile/handler.go
@@ -158,15 +158,15 @@ func Handler(requestMetadataFunc RequestMetadataFunc, processor model.BatchProce
 			}
 		}
 
-		modelProfiles := make([]*model.PprofProfile, len(profiles))
+		batch := make(model.Batch, len(profiles))
 		for i, p := range profiles {
-			modelProfiles[i] = &model.PprofProfile{
+			batch[i].Profile = &model.PprofProfile{
 				Metadata: profileMetadata,
 				Profile:  p,
 			}
 		}
 
-		if err := processor.ProcessBatch(c.Request.Context(), &model.Batch{Profiles: modelProfiles}); err != nil {
+		if err := processor.ProcessBatch(c.Request.Context(), &batch); err != nil {
 			switch err {
 			case publish.ErrChannelClosed:
 				return nil, requestError{
@@ -181,7 +181,7 @@ func Handler(requestMetadataFunc RequestMetadataFunc, processor model.BatchProce
 			}
 			return nil, err
 		}
-		return &result{Accepted: len(modelProfiles)}, nil
+		return &result{Accepted: len(batch)}, nil
 	}
 	return func(c *request.Context) {
 		result, err := handle(c)

--- a/beater/api/profile/handler_test.go
+++ b/beater/api/profile/handler_test.go
@@ -140,9 +140,9 @@ func TestHandler(t *testing.T) {
 			reports: 1,
 			batchProcessor: func(t *testing.T) model.BatchProcessor {
 				return model.ProcessBatchFunc(func(ctx context.Context, batch *model.Batch) error {
-					require.Len(t, batch.Profiles, 2)
-					for _, profile := range batch.Profiles {
-						assert.Equal(t, "foo", profile.Metadata.Service.Name)
+					require.Len(t, *batch, 2)
+					for _, event := range *batch {
+						assert.Equal(t, "foo", event.Profile.Metadata.Service.Name)
 					}
 					return nil
 				})

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -154,13 +154,16 @@ func newTestBeater(
 		Logger: logger,
 		WrapRunServer: func(runServer RunServerFunc) RunServerFunc {
 			var processor model.ProcessBatchFunc = func(ctx context.Context, batch *model.Batch) error {
-				for _, tx := range batch.Transactions {
+				for _, event := range *batch {
+					if event.Transaction == nil {
+						continue
+					}
 					// Add a label to test that everything
 					// goes through the wrapped reporter.
-					if tx.Labels == nil {
-						tx.Labels = common.MapStr{}
+					if event.Transaction.Labels == nil {
+						event.Transaction.Labels = common.MapStr{}
 					}
-					tx.Labels["wrapped_reporter"] = true
+					event.Transaction.Labels["wrapped_reporter"] = true
 				}
 				return nil
 			}

--- a/beater/otlp/grpc_test.go
+++ b/beater/otlp/grpc_test.go
@@ -47,10 +47,10 @@ var (
 )
 
 func TestConsumeTraces(t *testing.T) {
-	var batches []*model.Batch
+	var batches []model.Batch
 	var reportError error
 	var batchProcessor model.ProcessBatchFunc = func(ctx context.Context, batch *model.Batch) error {
-		batches = append(batches, batch)
+		batches = append(batches, *batch)
 		return reportError
 	}
 
@@ -93,10 +93,8 @@ func TestConsumeTraces(t *testing.T) {
 	errStatus := status.Convert(err)
 	assert.Equal(t, "failed to publish events", errStatus.Message())
 	require.Len(t, batches, 2)
-
-	for _, batch := range batches {
-		assert.Equal(t, 1, batch.Len())
-	}
+	assert.Len(t, batches[0], 1)
+	assert.Len(t, batches[1], 1)
 
 	actual := map[string]interface{}{}
 	monitoring.GetRegistry("apm-server.otlp.grpc.traces").Do(monitoring.Full, func(key string, value interface{}) {

--- a/beater/processors.go
+++ b/beater/processors.go
@@ -46,7 +46,7 @@ func rateLimitBatchProcessor(ctx context.Context, batch *model.Batch) error {
 	if limiter, ok := ratelimit.FromContext(ctx); ok {
 		ctx, cancel := context.WithTimeout(ctx, rateLimitTimeout)
 		defer cancel()
-		if err := limiter.WaitN(ctx, batch.Len()); err != nil {
+		if err := limiter.WaitN(ctx, len(*batch)); err != nil {
 			return ratelimit.ErrRateLimitExceeded
 		}
 	}

--- a/beater/processors_test.go
+++ b/beater/processors_test.go
@@ -33,9 +33,9 @@ func TestRateLimitBatchProcessor(t *testing.T) {
 	limiter := rate.NewLimiter(1, 10)
 	ctx := ratelimit.ContextWithLimiter(context.Background(), limiter)
 
-	var batch model.Batch
-	for i := 0; i < 5; i++ {
-		batch.Transactions = append(batch.Transactions, &model.Transaction{})
+	batch := make(model.Batch, 5)
+	for i := range batch {
+		batch[i].Transaction = &model.Transaction{}
 	}
 	for i := 0; i < 2; i++ {
 		err := rateLimitBatchProcessor(ctx, &batch)

--- a/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
@@ -5,498 +5,6 @@
             "agent": {
                 "ephemeral_id": "e71be9ac-93b0-44b9-a997-5638f6ccfc36",
                 "name": "java",
-                "version": "1.10.0-SNAPSHOT"
-            },
-            "client": {
-                "ip": "12.53.12.1"
-            },
-            "container": {
-                "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
-            },
-            "ecs": {
-                "version": "1.8.0"
-            },
-            "event": {
-                "outcome": "success"
-            },
-            "host": {
-                "architecture": "amd64",
-                "hostname": "node-name",
-                "ip": "127.0.0.1",
-                "name": "host1",
-                "os": {
-                    "platform": "Linux"
-                }
-            },
-            "http": {
-                "request": {
-                    "body": {
-                        "original": {
-                            "additional": {
-                                "bar": 123,
-                                "req": "additionalinformation"
-                            },
-                            "string": "helloworld"
-                        }
-                    },
-                    "cookies": {
-                        "c1": "v1",
-                        "c2": "v2"
-                    },
-                    "env": {
-                        "GATEWAY_INTERFACE": "CGI/1.1",
-                        "SERVER_SOFTWARE": "nginx"
-                    },
-                    "headers": {
-                        "Content-Type": [
-                            "text/html"
-                        ],
-                        "Cookie": [
-                            "c1=v1,c2=v2"
-                        ],
-                        "Elastic-Apm-Traceparent": [
-                            "00-33a0bd4cceff0370a7c57d807032688e-69feaabc5b88d7e8-01"
-                        ],
-                        "User-Agent": [
-                            "Mozilla/5.0(Macintosh;IntelMacOSX10_10_5)AppleWebKit/537.36(KHTML,likeGecko)Chrome/51.0.2704.103Safari/537.36",
-                            "MozillaChromeEdge"
-                        ]
-                    },
-                    "method": "POST",
-                    "socket": {
-                        "encrypted": true,
-                        "remote_address": "12.53.12.1:8080"
-                    }
-                },
-                "response": {
-                    "decoded_body_size": 401.9,
-                    "encoded_body_size": 356.9,
-                    "finished": true,
-                    "headers": {
-                        "Content-Type": [
-                            "application/json"
-                        ]
-                    },
-                    "headers_sent": true,
-                    "status_code": 200,
-                    "transfer_size": 300
-                },
-                "version": "1.1"
-            },
-            "kubernetes": {
-                "namespace": "default",
-                "node": {
-                    "name": "node-name"
-                },
-                "pod": {
-                    "name": "instrumented-java-service",
-                    "uid": "b17f231da0ad128dc6c6c0b2e82f6f303d3893e3"
-                }
-            },
-            "labels": {
-                "ab_testing": true,
-                "group": "experimental",
-                "organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8",
-                "segment": 5,
-                "wrapped_reporter": true
-            },
-            "observer": {
-                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
-                "hostname": "",
-                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
-                "type": "test-apm-server",
-                "version": "1.2.3",
-                "version_major": 1
-            },
-            "parent": {
-                "id": "abcdefabcdef01234567"
-            },
-            "process": {
-                "args": [
-                    "-v"
-                ],
-                "pid": 1234,
-                "ppid": 1,
-                "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
-            },
-            "processor": {
-                "event": "transaction",
-                "name": "transaction"
-            },
-            "service": {
-                "environment": "production",
-                "framework": {
-                    "name": "spring",
-                    "version": "5.0.0"
-                },
-                "language": {
-                    "name": "Java",
-                    "version": "10.0.2"
-                },
-                "name": "experimental-java",
-                "node": {
-                    "name": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
-                },
-                "runtime": {
-                    "name": "Java",
-                    "version": "10.0.2"
-                },
-                "version": "4.3.0"
-            },
-            "source": {
-                "ip": "12.53.12.1"
-            },
-            "timestamp": {
-                "us": 1571657444929001
-            },
-            "trace": {
-                "id": "0acd456789abcdef0123456789abcdef"
-            },
-            "transaction": {
-                "custom": {
-                    "(": "notavalidregexandthatisfine",
-                    "and_objects": {
-                        "foo": [
-                            "bar",
-                            "baz"
-                        ]
-                    },
-                    "my_key": 1,
-                    "some_other_value": "foobar"
-                },
-                "duration": {
-                    "us": 32592
-                },
-                "id": "4340a8e0df1906ecbfa9",
-                "name": "ResourceHttpRequestHandler",
-                "result": "HTTP2xx",
-                "sampled": true,
-                "span_count": {
-                    "dropped": 0,
-                    "started": 17
-                },
-                "type": "http"
-            },
-            "url": {
-                "domain": "www.example.com",
-                "fragment": "#hash",
-                "full": "https://www.example.com/p/a/t/h?query=string#hash",
-                "original": "/p/a/t/h?query=string#hash",
-                "path": "/p/a/t/h",
-                "port": 8080,
-                "query": "?query=string",
-                "scheme": "https"
-            },
-            "user": {
-                "email": "foo@mail.com",
-                "id": "99",
-                "name": "foo"
-            },
-            "user_agent": {
-                "original": "Mozilla/5.0(Macintosh;IntelMacOSX10_10_5)AppleWebKit/537.36(KHTML,likeGecko)Chrome/51.0.2704.103Safari/537.36, MozillaChromeEdge"
-            }
-        },
-        {
-            "@timestamp": "2019-10-21T11:30:44.929Z",
-            "agent": {
-                "ephemeral_id": "e71be9ac-93b0-44b9-a997-5638f6ccfc36",
-                "name": "java",
-                "version": "1.10.0-SNAPSHOT"
-            },
-            "container": {
-                "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
-            },
-            "ecs": {
-                "version": "1.8.0"
-            },
-            "event": {
-                "outcome": "success"
-            },
-            "host": {
-                "architecture": "amd64",
-                "hostname": "node-name",
-                "ip": "127.0.0.1",
-                "name": "host1",
-                "os": {
-                    "platform": "Linux"
-                }
-            },
-            "http": {
-                "request.method": "GET",
-                "response": {
-                    "status_code": 200
-                }
-            },
-            "kubernetes": {
-                "namespace": "default",
-                "node": {
-                    "name": "node-name"
-                },
-                "pod": {
-                    "name": "instrumented-java-service",
-                    "uid": "b17f231da0ad128dc6c6c0b2e82f6f303d3893e3"
-                }
-            },
-            "labels": {
-                "ab_testing": true,
-                "group": "experimental",
-                "segment": 5
-            },
-            "observer": {
-                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
-                "hostname": "",
-                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
-                "type": "test-apm-server",
-                "version": "1.2.3",
-                "version_major": 1
-            },
-            "parent": {
-                "id": "abcdef0123456789"
-            },
-            "process": {
-                "args": [
-                    "-v"
-                ],
-                "pid": 1234,
-                "ppid": 1,
-                "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
-            },
-            "processor": {
-                "event": "span",
-                "name": "transaction"
-            },
-            "service": {
-                "environment": "production",
-                "framework": {
-                    "name": "spring",
-                    "version": "5.0.0"
-                },
-                "language": {
-                    "name": "Java",
-                    "version": "10.0.2"
-                },
-                "name": "opbeans-java-1",
-                "node": {
-                    "name": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
-                },
-                "runtime": {
-                    "name": "Java",
-                    "version": "10.0.2"
-                },
-                "version": "4.3.0"
-            },
-            "span": {
-                "action": "connect",
-                "db": {
-                    "instance": "customers",
-                    "link": "other.db.com",
-                    "statement": "SELECT * FROM product_types WHERE user_id = ?",
-                    "type": "sql",
-                    "user": {
-                        "name": "postgres"
-                    }
-                },
-                "duration": {
-                    "us": 3781
-                },
-                "http": {
-                    "method": "GET",
-                    "response": {
-                        "decoded_body_size": 401,
-                        "encoded_body_size": 356,
-                        "headers": {
-                            "Content-Type": [
-                                "application/json"
-                            ]
-                        },
-                        "status_code": 200,
-                        "transfer_size": 300.12
-                    },
-                    "url": {
-                        "original": "http://localhost:8000"
-                    }
-                },
-                "id": "1234567890aaaade",
-                "name": "GET users-authenticated",
-                "stacktrace": [
-                    {
-                        "exclude_from_grouping": false,
-                        "filename": "DispatcherServlet.java",
-                        "line": {
-                            "number": 547
-                        }
-                    },
-                    {
-                        "abs_path": "/tmp/AbstractView.java",
-                        "exclude_from_grouping": false,
-                        "filename": "AbstractView.java",
-                        "function": "render",
-                        "library_frame": true,
-                        "line": {
-                            "column": 4,
-                            "context": "line3",
-                            "number": 547
-                        },
-                        "module": "org.springframework.web.servlet.view",
-                        "vars": {
-                            "key": "value"
-                        }
-                    }
-                ],
-                "subtype": "http",
-                "sync": true,
-                "type": "external"
-            },
-            "timestamp": {
-                "us": 1571657444929001
-            },
-            "trace": {
-                "id": "abcdef0123456789abcdef9876543210"
-            },
-            "transaction": {
-                "id": "1234567890987654"
-            },
-            "url.original": "http://localhost:8000"
-        },
-        {
-            "@timestamp": "2019-10-21T11:30:44.929Z",
-            "agent": {
-                "ephemeral_id": "e71be9ac-93b0-44b9-a997-5638f6ccfc36",
-                "name": "java",
-                "version": "1.10.0"
-            },
-            "byte_counter": 1,
-            "container": {
-                "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
-            },
-            "dotted": {
-                "float": {
-                    "gauge": 6.12
-                }
-            },
-            "double_gauge": 3.141592653589793,
-            "ecs": {
-                "version": "1.8.0"
-            },
-            "float_gauge": 9.16,
-            "host": {
-                "architecture": "amd64",
-                "hostname": "node-name",
-                "ip": "127.0.0.1",
-                "name": "host1",
-                "os": {
-                    "platform": "Linux"
-                }
-            },
-            "integer_gauge": 42767,
-            "kubernetes": {
-                "namespace": "default",
-                "node": {
-                    "name": "node-name"
-                },
-                "pod": {
-                    "name": "instrumented-java-service",
-                    "uid": "b17f231da0ad128dc6c6c0b2e82f6f303d3893e3"
-                }
-            },
-            "labels": {
-                "ab_testing": true,
-                "code": 200,
-                "group": "experimental",
-                "segment": 5,
-                "success": true
-            },
-            "long_gauge": 3147483648,
-            "metricset.name": "span_breakdown",
-            "negative": {
-                "d": {
-                    "o": {
-                        "t": {
-                            "t": {
-                                "e": {
-                                    "d": -1022
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "observer": {
-                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
-                "hostname": "",
-                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
-                "type": "test-apm-server",
-                "version": "1.2.3",
-                "version_major": 1
-            },
-            "process": {
-                "args": [
-                    "-v"
-                ],
-                "pid": 1234,
-                "ppid": 1,
-                "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
-            },
-            "processor": {
-                "event": "metric",
-                "name": "metric"
-            },
-            "service": {
-                "environment": "production",
-                "framework": {
-                    "name": "spring",
-                    "version": "5.0.0"
-                },
-                "language": {
-                    "name": "Java",
-                    "version": "10.0.2"
-                },
-                "name": "1234_service-12a3",
-                "node": {
-                    "name": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
-                },
-                "runtime": {
-                    "name": "Java",
-                    "version": "10.0.2"
-                },
-                "version": "4.3.0"
-            },
-            "short_counter": 227,
-            "span": {
-                "self_time": {
-                    "count": 1,
-                    "sum": {
-                        "us": 633.288
-                    }
-                },
-                "subtype": "mysql",
-                "type": "db"
-            },
-            "transaction": {
-                "breakdown": {
-                    "count": 12
-                },
-                "duration": {
-                    "count": 2,
-                    "sum": {
-                        "us": 12
-                    }
-                },
-                "name": "GET/",
-                "self_time": {
-                    "count": 2,
-                    "sum": {
-                        "us": 10
-                    }
-                },
-                "type": "request"
-            }
-        },
-        {
-            "@timestamp": "2019-10-21T11:30:44.929Z",
-            "agent": {
-                "ephemeral_id": "e71be9ac-93b0-44b9-a997-5638f6ccfc36",
-                "name": "java",
                 "version": "1.10.0"
             },
             "client": {
@@ -779,6 +287,498 @@
                 "email": "user@foo.mail",
                 "id": "99",
                 "name": "foo"
+            }
+        },
+        {
+            "@timestamp": "2019-10-21T11:30:44.929Z",
+            "agent": {
+                "ephemeral_id": "e71be9ac-93b0-44b9-a997-5638f6ccfc36",
+                "name": "java",
+                "version": "1.10.0-SNAPSHOT"
+            },
+            "container": {
+                "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "event": {
+                "outcome": "success"
+            },
+            "host": {
+                "architecture": "amd64",
+                "hostname": "node-name",
+                "ip": "127.0.0.1",
+                "name": "host1",
+                "os": {
+                    "platform": "Linux"
+                }
+            },
+            "http": {
+                "request.method": "GET",
+                "response": {
+                    "status_code": 200
+                }
+            },
+            "kubernetes": {
+                "namespace": "default",
+                "node": {
+                    "name": "node-name"
+                },
+                "pod": {
+                    "name": "instrumented-java-service",
+                    "uid": "b17f231da0ad128dc6c6c0b2e82f6f303d3893e3"
+                }
+            },
+            "labels": {
+                "ab_testing": true,
+                "group": "experimental",
+                "segment": 5
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "1.2.3",
+                "version_major": 1
+            },
+            "parent": {
+                "id": "abcdef0123456789"
+            },
+            "process": {
+                "args": [
+                    "-v"
+                ],
+                "pid": 1234,
+                "ppid": 1,
+                "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "service": {
+                "environment": "production",
+                "framework": {
+                    "name": "spring",
+                    "version": "5.0.0"
+                },
+                "language": {
+                    "name": "Java",
+                    "version": "10.0.2"
+                },
+                "name": "opbeans-java-1",
+                "node": {
+                    "name": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
+                },
+                "runtime": {
+                    "name": "Java",
+                    "version": "10.0.2"
+                },
+                "version": "4.3.0"
+            },
+            "span": {
+                "action": "connect",
+                "db": {
+                    "instance": "customers",
+                    "link": "other.db.com",
+                    "statement": "SELECT * FROM product_types WHERE user_id = ?",
+                    "type": "sql",
+                    "user": {
+                        "name": "postgres"
+                    }
+                },
+                "duration": {
+                    "us": 3781
+                },
+                "http": {
+                    "method": "GET",
+                    "response": {
+                        "decoded_body_size": 401,
+                        "encoded_body_size": 356,
+                        "headers": {
+                            "Content-Type": [
+                                "application/json"
+                            ]
+                        },
+                        "status_code": 200,
+                        "transfer_size": 300.12
+                    },
+                    "url": {
+                        "original": "http://localhost:8000"
+                    }
+                },
+                "id": "1234567890aaaade",
+                "name": "GET users-authenticated",
+                "stacktrace": [
+                    {
+                        "exclude_from_grouping": false,
+                        "filename": "DispatcherServlet.java",
+                        "line": {
+                            "number": 547
+                        }
+                    },
+                    {
+                        "abs_path": "/tmp/AbstractView.java",
+                        "exclude_from_grouping": false,
+                        "filename": "AbstractView.java",
+                        "function": "render",
+                        "library_frame": true,
+                        "line": {
+                            "column": 4,
+                            "context": "line3",
+                            "number": 547
+                        },
+                        "module": "org.springframework.web.servlet.view",
+                        "vars": {
+                            "key": "value"
+                        }
+                    }
+                ],
+                "subtype": "http",
+                "sync": true,
+                "type": "external"
+            },
+            "timestamp": {
+                "us": 1571657444929001
+            },
+            "trace": {
+                "id": "abcdef0123456789abcdef9876543210"
+            },
+            "transaction": {
+                "id": "1234567890987654"
+            },
+            "url.original": "http://localhost:8000"
+        },
+        {
+            "@timestamp": "2019-10-21T11:30:44.929Z",
+            "agent": {
+                "ephemeral_id": "e71be9ac-93b0-44b9-a997-5638f6ccfc36",
+                "name": "java",
+                "version": "1.10.0-SNAPSHOT"
+            },
+            "client": {
+                "ip": "12.53.12.1"
+            },
+            "container": {
+                "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "event": {
+                "outcome": "success"
+            },
+            "host": {
+                "architecture": "amd64",
+                "hostname": "node-name",
+                "ip": "127.0.0.1",
+                "name": "host1",
+                "os": {
+                    "platform": "Linux"
+                }
+            },
+            "http": {
+                "request": {
+                    "body": {
+                        "original": {
+                            "additional": {
+                                "bar": 123,
+                                "req": "additionalinformation"
+                            },
+                            "string": "helloworld"
+                        }
+                    },
+                    "cookies": {
+                        "c1": "v1",
+                        "c2": "v2"
+                    },
+                    "env": {
+                        "GATEWAY_INTERFACE": "CGI/1.1",
+                        "SERVER_SOFTWARE": "nginx"
+                    },
+                    "headers": {
+                        "Content-Type": [
+                            "text/html"
+                        ],
+                        "Cookie": [
+                            "c1=v1,c2=v2"
+                        ],
+                        "Elastic-Apm-Traceparent": [
+                            "00-33a0bd4cceff0370a7c57d807032688e-69feaabc5b88d7e8-01"
+                        ],
+                        "User-Agent": [
+                            "Mozilla/5.0(Macintosh;IntelMacOSX10_10_5)AppleWebKit/537.36(KHTML,likeGecko)Chrome/51.0.2704.103Safari/537.36",
+                            "MozillaChromeEdge"
+                        ]
+                    },
+                    "method": "POST",
+                    "socket": {
+                        "encrypted": true,
+                        "remote_address": "12.53.12.1:8080"
+                    }
+                },
+                "response": {
+                    "decoded_body_size": 401.9,
+                    "encoded_body_size": 356.9,
+                    "finished": true,
+                    "headers": {
+                        "Content-Type": [
+                            "application/json"
+                        ]
+                    },
+                    "headers_sent": true,
+                    "status_code": 200,
+                    "transfer_size": 300
+                },
+                "version": "1.1"
+            },
+            "kubernetes": {
+                "namespace": "default",
+                "node": {
+                    "name": "node-name"
+                },
+                "pod": {
+                    "name": "instrumented-java-service",
+                    "uid": "b17f231da0ad128dc6c6c0b2e82f6f303d3893e3"
+                }
+            },
+            "labels": {
+                "ab_testing": true,
+                "group": "experimental",
+                "organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8",
+                "segment": 5,
+                "wrapped_reporter": true
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "1.2.3",
+                "version_major": 1
+            },
+            "parent": {
+                "id": "abcdefabcdef01234567"
+            },
+            "process": {
+                "args": [
+                    "-v"
+                ],
+                "pid": 1234,
+                "ppid": 1,
+                "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
+            },
+            "processor": {
+                "event": "transaction",
+                "name": "transaction"
+            },
+            "service": {
+                "environment": "production",
+                "framework": {
+                    "name": "spring",
+                    "version": "5.0.0"
+                },
+                "language": {
+                    "name": "Java",
+                    "version": "10.0.2"
+                },
+                "name": "experimental-java",
+                "node": {
+                    "name": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
+                },
+                "runtime": {
+                    "name": "Java",
+                    "version": "10.0.2"
+                },
+                "version": "4.3.0"
+            },
+            "source": {
+                "ip": "12.53.12.1"
+            },
+            "timestamp": {
+                "us": 1571657444929001
+            },
+            "trace": {
+                "id": "0acd456789abcdef0123456789abcdef"
+            },
+            "transaction": {
+                "custom": {
+                    "(": "notavalidregexandthatisfine",
+                    "and_objects": {
+                        "foo": [
+                            "bar",
+                            "baz"
+                        ]
+                    },
+                    "my_key": 1,
+                    "some_other_value": "foobar"
+                },
+                "duration": {
+                    "us": 32592
+                },
+                "id": "4340a8e0df1906ecbfa9",
+                "name": "ResourceHttpRequestHandler",
+                "result": "HTTP2xx",
+                "sampled": true,
+                "span_count": {
+                    "dropped": 0,
+                    "started": 17
+                },
+                "type": "http"
+            },
+            "url": {
+                "domain": "www.example.com",
+                "fragment": "#hash",
+                "full": "https://www.example.com/p/a/t/h?query=string#hash",
+                "original": "/p/a/t/h?query=string#hash",
+                "path": "/p/a/t/h",
+                "port": 8080,
+                "query": "?query=string",
+                "scheme": "https"
+            },
+            "user": {
+                "email": "foo@mail.com",
+                "id": "99",
+                "name": "foo"
+            },
+            "user_agent": {
+                "original": "Mozilla/5.0(Macintosh;IntelMacOSX10_10_5)AppleWebKit/537.36(KHTML,likeGecko)Chrome/51.0.2704.103Safari/537.36, MozillaChromeEdge"
+            }
+        },
+        {
+            "@timestamp": "2019-10-21T11:30:44.929Z",
+            "agent": {
+                "ephemeral_id": "e71be9ac-93b0-44b9-a997-5638f6ccfc36",
+                "name": "java",
+                "version": "1.10.0"
+            },
+            "byte_counter": 1,
+            "container": {
+                "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
+            },
+            "dotted": {
+                "float": {
+                    "gauge": 6.12
+                }
+            },
+            "double_gauge": 3.141592653589793,
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "float_gauge": 9.16,
+            "host": {
+                "architecture": "amd64",
+                "hostname": "node-name",
+                "ip": "127.0.0.1",
+                "name": "host1",
+                "os": {
+                    "platform": "Linux"
+                }
+            },
+            "integer_gauge": 42767,
+            "kubernetes": {
+                "namespace": "default",
+                "node": {
+                    "name": "node-name"
+                },
+                "pod": {
+                    "name": "instrumented-java-service",
+                    "uid": "b17f231da0ad128dc6c6c0b2e82f6f303d3893e3"
+                }
+            },
+            "labels": {
+                "ab_testing": true,
+                "code": 200,
+                "group": "experimental",
+                "segment": 5,
+                "success": true
+            },
+            "long_gauge": 3147483648,
+            "metricset.name": "span_breakdown",
+            "negative": {
+                "d": {
+                    "o": {
+                        "t": {
+                            "t": {
+                                "e": {
+                                    "d": -1022
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "1.2.3",
+                "version_major": 1
+            },
+            "process": {
+                "args": [
+                    "-v"
+                ],
+                "pid": 1234,
+                "ppid": 1,
+                "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "environment": "production",
+                "framework": {
+                    "name": "spring",
+                    "version": "5.0.0"
+                },
+                "language": {
+                    "name": "Java",
+                    "version": "10.0.2"
+                },
+                "name": "1234_service-12a3",
+                "node": {
+                    "name": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
+                },
+                "runtime": {
+                    "name": "Java",
+                    "version": "10.0.2"
+                },
+                "version": "4.3.0"
+            },
+            "short_counter": 227,
+            "span": {
+                "self_time": {
+                    "count": 1,
+                    "sum": {
+                        "us": 633.288
+                    }
+                },
+                "subtype": "mysql",
+                "type": "db"
+            },
+            "transaction": {
+                "breakdown": {
+                    "count": 12
+                },
+                "duration": {
+                    "count": 2,
+                    "sum": {
+                        "us": 12
+                    }
+                },
+                "name": "GET/",
+                "self_time": {
+                    "count": 2,
+                    "sum": {
+                        "us": 10
+                    }
+                },
+                "type": "request"
             }
         }
     ]

--- a/beater/test_approved_es_documents/TestPublishIntegrationMinimalEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationMinimalEvents.approved.json
@@ -9,186 +9,6 @@
             "ecs": {
                 "version": "1.8.0"
             },
-            "event": {
-                "outcome": "unknown"
-            },
-            "host": {
-                "ip": "127.0.0.1"
-            },
-            "labels": {
-                "wrapped_reporter": true
-            },
-            "observer": {
-                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
-                "hostname": "",
-                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
-                "type": "test-apm-server",
-                "version": "1.2.3",
-                "version_major": 1
-            },
-            "processor": {
-                "event": "transaction",
-                "name": "transaction"
-            },
-            "service": {
-                "name": "1234_service-12a3"
-            },
-            "timestamp": {
-                "us": 1547070053000000
-            },
-            "trace": {
-                "id": "01234567890123456789abcdefabcdef"
-            },
-            "transaction": {
-                "duration": {
-                    "us": 32592
-                },
-                "id": "abcdef1478523690",
-                "sampled": true,
-                "span_count": {
-                    "started": 0
-                },
-                "type": "request"
-            }
-        },
-        {
-            "@timestamp": "2019-01-09T21:40:53.000Z",
-            "agent": {
-                "name": "elastic-node",
-                "version": "3.14.0"
-            },
-            "ecs": {
-                "version": "1.8.0"
-            },
-            "event": {
-                "outcome": "unknown"
-            },
-            "host": {
-                "ip": "127.0.0.1"
-            },
-            "observer": {
-                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
-                "hostname": "",
-                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
-                "type": "test-apm-server",
-                "version": "1.2.3",
-                "version_major": 1
-            },
-            "parent": {
-                "id": "ab23456a89012345"
-            },
-            "processor": {
-                "event": "span",
-                "name": "transaction"
-            },
-            "service": {
-                "name": "1234_service-12a3"
-            },
-            "span": {
-                "duration": {
-                    "us": 3564
-                },
-                "id": "0123456a89012345",
-                "name": "GET /api/types",
-                "start": {
-                    "us": 1845
-                },
-                "type": "request"
-            },
-            "timestamp": {
-                "us": 1547070053000000
-            },
-            "trace": {
-                "id": "0123456789abcdef0123456789abcdef"
-            }
-        },
-        {
-            "@timestamp": "2018-08-30T18:53:27.154Z",
-            "agent": {
-                "name": "elastic-node",
-                "version": "3.14.0"
-            },
-            "ecs": {
-                "version": "1.8.0"
-            },
-            "event": {
-                "outcome": "unknown"
-            },
-            "host": {
-                "ip": "127.0.0.1"
-            },
-            "observer": {
-                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
-                "hostname": "",
-                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
-                "type": "test-apm-server",
-                "version": "1.2.3",
-                "version_major": 1
-            },
-            "parent": {
-                "id": "ab23456a89012345"
-            },
-            "processor": {
-                "event": "span",
-                "name": "transaction"
-            },
-            "service": {
-                "name": "1234_service-12a3"
-            },
-            "span": {
-                "duration": {
-                    "us": 3564
-                },
-                "id": "0123456a89012345",
-                "name": "GET /api/types",
-                "type": "request"
-            },
-            "timestamp": {
-                "us": 1535655207154000
-            },
-            "trace": {
-                "id": "0123456789abcdef0123456789abcdef"
-            }
-        },
-        {
-            "@timestamp": "2017-05-30T18:53:42.281Z",
-            "a": 3.2,
-            "agent": {
-                "name": "elastic-node",
-                "version": "3.14.0"
-            },
-            "ecs": {
-                "version": "1.8.0"
-            },
-            "host": {
-                "ip": "127.0.0.1"
-            },
-            "metricset.name": "app",
-            "observer": {
-                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
-                "hostname": "",
-                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
-                "type": "test-apm-server",
-                "version": "1.2.3",
-                "version_major": 1
-            },
-            "processor": {
-                "event": "metric",
-                "name": "metric"
-            },
-            "service": {
-                "name": "1234_service-12a3"
-            }
-        },
-        {
-            "@timestamp": "2019-01-09T21:40:53.000Z",
-            "agent": {
-                "name": "elastic-node",
-                "version": "3.14.0"
-            },
-            "ecs": {
-                "version": "1.8.0"
-            },
             "error": {
                 "grouping_key": "0b9cba09845a097a271c6beb4c6207f3",
                 "id": "abcdef0123456789",
@@ -296,6 +116,186 @@
             },
             "timestamp": {
                 "us": 1547070053000000
+            }
+        },
+        {
+            "@timestamp": "2019-01-09T21:40:53.000Z",
+            "agent": {
+                "name": "elastic-node",
+                "version": "3.14.0"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "event": {
+                "outcome": "unknown"
+            },
+            "host": {
+                "ip": "127.0.0.1"
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "1.2.3",
+                "version_major": 1
+            },
+            "parent": {
+                "id": "ab23456a89012345"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "service": {
+                "name": "1234_service-12a3"
+            },
+            "span": {
+                "duration": {
+                    "us": 3564
+                },
+                "id": "0123456a89012345",
+                "name": "GET /api/types",
+                "start": {
+                    "us": 1845
+                },
+                "type": "request"
+            },
+            "timestamp": {
+                "us": 1547070053000000
+            },
+            "trace": {
+                "id": "0123456789abcdef0123456789abcdef"
+            }
+        },
+        {
+            "@timestamp": "2018-08-30T18:53:27.154Z",
+            "agent": {
+                "name": "elastic-node",
+                "version": "3.14.0"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "event": {
+                "outcome": "unknown"
+            },
+            "host": {
+                "ip": "127.0.0.1"
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "1.2.3",
+                "version_major": 1
+            },
+            "parent": {
+                "id": "ab23456a89012345"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "service": {
+                "name": "1234_service-12a3"
+            },
+            "span": {
+                "duration": {
+                    "us": 3564
+                },
+                "id": "0123456a89012345",
+                "name": "GET /api/types",
+                "type": "request"
+            },
+            "timestamp": {
+                "us": 1535655207154000
+            },
+            "trace": {
+                "id": "0123456789abcdef0123456789abcdef"
+            }
+        },
+        {
+            "@timestamp": "2019-01-09T21:40:53.000Z",
+            "agent": {
+                "name": "elastic-node",
+                "version": "3.14.0"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "event": {
+                "outcome": "unknown"
+            },
+            "host": {
+                "ip": "127.0.0.1"
+            },
+            "labels": {
+                "wrapped_reporter": true
+            },
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "1.2.3",
+                "version_major": 1
+            },
+            "processor": {
+                "event": "transaction",
+                "name": "transaction"
+            },
+            "service": {
+                "name": "1234_service-12a3"
+            },
+            "timestamp": {
+                "us": 1547070053000000
+            },
+            "trace": {
+                "id": "01234567890123456789abcdefabcdef"
+            },
+            "transaction": {
+                "duration": {
+                    "us": 32592
+                },
+                "id": "abcdef1478523690",
+                "sampled": true,
+                "span_count": {
+                    "started": 0
+                },
+                "type": "request"
+            }
+        },
+        {
+            "@timestamp": "2017-05-30T18:53:42.281Z",
+            "a": 3.2,
+            "agent": {
+                "name": "elastic-node",
+                "version": "3.14.0"
+            },
+            "ecs": {
+                "version": "1.8.0"
+            },
+            "host": {
+                "ip": "127.0.0.1"
+            },
+            "metricset.name": "app",
+            "observer": {
+                "ephemeral_id": "00000000-0000-0000-0000-000000000000",
+                "hostname": "",
+                "id": "fbba762a-14dd-412c-b7e9-b79f903eb492",
+                "type": "test-apm-server",
+                "version": "1.2.3",
+                "version_major": 1
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "name": "1234_service-12a3"
             }
         }
     ]

--- a/model/apmevent.go
+++ b/model/apmevent.go
@@ -1,0 +1,40 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package model
+
+import (
+	"context"
+
+	"github.com/elastic/apm-server/transform"
+	"github.com/elastic/beats/v7/libbeat/beat"
+)
+
+// APMEvent holds the details of an APM event.
+//
+// Exactly one of the event fields should be non-nil.
+type APMEvent struct {
+	Transaction *Transaction
+	Span        *Span
+	Metricset   *Metricset
+	Error       *Error
+	Profile     *PprofProfile
+}
+
+func (e *APMEvent) Transform(ctx context.Context, cfg *transform.Config) []beat.Event {
+	return nil
+}

--- a/model/modelprocessor/environment_test.go
+++ b/model/modelprocessor/environment_test.go
@@ -45,55 +45,35 @@ func testProcessBatchMetadata(t *testing.T, processor model.BatchProcessor, in, 
 
 	// Check that the model.Batch fields have not changed since this
 	// test was last updated, to ensure we process all model types.
-	var batchFields []string
-	typ := reflect.TypeOf(model.Batch{})
+	var apmEventFields []string
+	typ := reflect.TypeOf(model.APMEvent{})
 	for i := 0; i < typ.NumField(); i++ {
-		batchFields = append(batchFields, typ.Field(i).Name)
+		apmEventFields = append(apmEventFields, typ.Field(i).Name)
 	}
 	assert.ElementsMatch(t, []string{
-		"Transactions",
-		"Spans",
-		"Metricsets",
-		"Errors",
-		"Profiles",
-	}, batchFields)
+		"Transaction",
+		"Span",
+		"Metricset",
+		"Error",
+		"Profile",
+	}, apmEventFields)
 
 	batch := &model.Batch{
-		Transactions: []*model.Transaction{
-			{Metadata: in},
-		},
-		Spans: []*model.Span{
-			{Metadata: in},
-		},
-		Metricsets: []*model.Metricset{
-			{Metadata: in},
-		},
-		Errors: []*model.Error{
-			{Metadata: in},
-		},
-		Profiles: []*model.PprofProfile{
-			{Metadata: in},
-		},
+		{Transaction: &model.Transaction{Metadata: in}},
+		{Span: &model.Span{Metadata: in}},
+		{Metricset: &model.Metricset{Metadata: in}},
+		{Error: &model.Error{Metadata: in}},
+		{Profile: &model.PprofProfile{Metadata: in}},
 	}
 	err := processor.ProcessBatch(context.Background(), batch)
 	require.NoError(t, err)
 
 	expected := &model.Batch{
-		Transactions: []*model.Transaction{
-			{Metadata: out},
-		},
-		Spans: []*model.Span{
-			{Metadata: out},
-		},
-		Metricsets: []*model.Metricset{
-			{Metadata: out},
-		},
-		Errors: []*model.Error{
-			{Metadata: out},
-		},
-		Profiles: []*model.PprofProfile{
-			{Metadata: out},
-		},
+		{Transaction: &model.Transaction{Metadata: out}},
+		{Span: &model.Span{Metadata: out}},
+		{Metricset: &model.Metricset{Metadata: out}},
+		{Error: &model.Error{Metadata: out}},
+		{Profile: &model.PprofProfile{Metadata: out}},
 	}
 	assert.Equal(t, expected, batch)
 }

--- a/model/modelprocessor/metadata.go
+++ b/model/modelprocessor/metadata.go
@@ -29,29 +29,28 @@ type MetadataProcessorFunc func(ctx context.Context, meta *model.Metadata) error
 
 // ProcessBatch calls f with the metadata of each event in b.
 func (f MetadataProcessorFunc) ProcessBatch(ctx context.Context, b *model.Batch) error {
-	for _, event := range b.Transactions {
-		if err := f(ctx, &event.Metadata); err != nil {
-			return err
-		}
-	}
-	for _, event := range b.Spans {
-		if err := f(ctx, &event.Metadata); err != nil {
-			return err
-		}
-	}
-	for _, event := range b.Metricsets {
-		if err := f(ctx, &event.Metadata); err != nil {
-			return err
-		}
-	}
-	for _, event := range b.Errors {
-		if err := f(ctx, &event.Metadata); err != nil {
-			return err
-		}
-	}
-	for _, event := range b.Profiles {
-		if err := f(ctx, &event.Metadata); err != nil {
-			return err
+	for _, event := range *b {
+		switch {
+		case event.Transaction != nil:
+			if err := f(ctx, &event.Transaction.Metadata); err != nil {
+				return err
+			}
+		case event.Span != nil:
+			if err := f(ctx, &event.Span.Metadata); err != nil {
+				return err
+			}
+		case event.Metricset != nil:
+			if err := f(ctx, &event.Metricset.Metadata); err != nil {
+				return err
+			}
+		case event.Error != nil:
+			if err := f(ctx, &event.Error.Metadata); err != nil {
+				return err
+			}
+		case event.Profile != nil:
+			if err := f(ctx, &event.Profile.Metadata); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/model/modelprocessor/metricsetname.go
+++ b/model/modelprocessor/metricsetname.go
@@ -39,8 +39,9 @@ type SetMetricsetName struct{}
 // will be given a specific name, while all other metrics will be given the name
 // "app".
 func (SetMetricsetName) ProcessBatch(ctx context.Context, b *model.Batch) error {
-	for _, ms := range b.Metricsets {
-		if ms.Name != "" || len(ms.Samples) == 0 {
+	for _, event := range *b {
+		ms := event.Metricset
+		if ms == nil || ms.Name != "" || len(ms.Samples) == 0 {
 			continue
 		}
 		ms.Name = appMetricsetName

--- a/model/modelprocessor/metricsetname_test.go
+++ b/model/modelprocessor/metricsetname_test.go
@@ -69,11 +69,11 @@ func TestSetMetricsetName(t *testing.T) {
 	}}
 
 	for _, test := range tests {
-		batch := &model.Batch{Metricsets: []*model.Metricset{&test.metricset}}
+		batch := model.Batch{{Metricset: &test.metricset}}
 		processor := modelprocessor.SetMetricsetName{}
-		err := processor.ProcessBatch(context.Background(), batch)
+		err := processor.ProcessBatch(context.Background(), &batch)
 		assert.NoError(t, err)
-		assert.Equal(t, test.name, batch.Metricsets[0].Name)
+		assert.Equal(t, test.name, batch[0].Metricset.Name)
 	}
 
 }

--- a/model/profile_test.go
+++ b/model/profile_test.go
@@ -87,7 +87,7 @@ func TestPprofProfileTransform(t *testing.T) {
 		},
 	}
 
-	batch := &model.Batch{Profiles: []*model.PprofProfile{&pp}}
+	batch := &model.Batch{{Profile: &pp}}
 	output := batch.Transform(context.Background(), &transform.Config{DataStreams: true})
 	require.Len(t, output, 2)
 	assert.Equal(t, output[0], output[1])

--- a/processor/otel/consumer.go
+++ b/processor/otel/consumer.go
@@ -202,7 +202,7 @@ func (c *Consumer) convertSpan(
 			Outcome:   spanStatusOutcome(otelSpan.Status()),
 		}
 		translateTransaction(otelSpan, otelLibrary, metadata, &transactionBuilder{Transaction: transaction})
-		out.Transactions = append(out.Transactions, transaction)
+		*out = append(*out, model.APMEvent{Transaction: transaction})
 	} else {
 		span = &model.Span{
 			Metadata:  metadata,
@@ -215,7 +215,7 @@ func (c *Consumer) convertSpan(
 			Outcome:   spanStatusOutcome(otelSpan.Status()),
 		}
 		translateSpan(otelSpan, metadata, span)
-		out.Spans = append(out.Spans, span)
+		*out = append(*out, model.APMEvent{Span: span})
 	}
 
 	events := otelSpan.Events()
@@ -816,7 +816,7 @@ func convertSpanEvent(
 		if span != nil {
 			addSpanCtxToErr(span, e)
 		}
-		out.Errors = append(out.Errors, e)
+		*out = append(*out, model.APMEvent{Error: e})
 	}
 }
 

--- a/processor/otel/consumer_test.go
+++ b/processor/otel/consumer_test.go
@@ -90,12 +90,11 @@ func TestOutcome(t *testing.T) {
 		spans.Spans().Append(otelSpan1)
 		spans.Spans().Append(otelSpan2)
 		batch := transformTraces(t, traces)
-		require.Len(t, batch.Transactions, 1)
-		require.Len(t, batch.Spans, 1)
+		require.Len(t, batch, 2)
 
-		assert.Equal(t, expectedOutcome, batch.Transactions[0].Outcome)
-		assert.Equal(t, expectedResult, batch.Transactions[0].Result)
-		assert.Equal(t, expectedOutcome, batch.Spans[0].Outcome)
+		assert.Equal(t, expectedOutcome, batch[0].Transaction.Outcome)
+		assert.Equal(t, expectedResult, batch[0].Transaction.Result)
+		assert.Equal(t, expectedOutcome, batch[1].Span.Outcome)
 	}
 
 	test(t, "unknown", "", pdata.StatusCodeUnset)
@@ -116,11 +115,10 @@ func TestRepresentativeCount(t *testing.T) {
 	spans.Spans().Append(otelSpan1)
 	spans.Spans().Append(otelSpan2)
 	batch := transformTraces(t, traces)
-	require.Len(t, batch.Transactions, 1)
-	require.Len(t, batch.Spans, 1)
+	require.Len(t, batch, 2)
 
-	assert.Equal(t, 1.0, batch.Transactions[0].RepresentativeCount)
-	assert.Equal(t, 1.0, batch.Spans[0].RepresentativeCount)
+	assert.Equal(t, 1.0, batch[0].Transaction.RepresentativeCount)
+	assert.Equal(t, 1.0, batch[1].Span.RepresentativeCount)
 }
 
 func TestHTTPTransactionURL(t *testing.T) {
@@ -470,7 +468,7 @@ func TestInstrumentationLibrary(t *testing.T) {
 	otelSpan.SetSpanID(pdata.NewSpanID([8]byte{2}))
 	spans.Spans().Append(otelSpan)
 	events := transformTraces(t, traces)
-	tx := events.Transactions[0]
+	tx := events[0].Transaction
 
 	assert.Equal(t, "library-name", tx.Metadata.Service.Framework.Name)
 	assert.Equal(t, "1.2.3", tx.Metadata.Service.Framework.Version)
@@ -633,18 +631,16 @@ func TestConsumeTracesExportTimestamp(t *testing.T) {
 	otelSpan2.Events().Append(otelSpanEvent)
 
 	batch := transformTraces(t, traces)
-	require.Len(t, batch.Transactions, 1)
-	require.Len(t, batch.Spans, 1)
-	require.Len(t, batch.Errors, 1)
+	require.Len(t, batch, 3)
 
 	// Give some leeway for one event, and check other events' timestamps relative to that one.
-	assert.InDelta(t, now.Add(transactionOffset).Unix(), batch.Transactions[0].Timestamp.Unix(), allowedError)
-	assert.Equal(t, spanOffset-transactionOffset, batch.Spans[0].Timestamp.Sub(batch.Transactions[0].Timestamp))
-	assert.Equal(t, exceptionOffset-transactionOffset, batch.Errors[0].Timestamp.Sub(batch.Transactions[0].Timestamp))
+	assert.InDelta(t, now.Add(transactionOffset).Unix(), batch[0].Transaction.Timestamp.Unix(), allowedError)
+	assert.Equal(t, spanOffset-transactionOffset, batch[1].Span.Timestamp.Sub(batch[0].Transaction.Timestamp))
+	assert.Equal(t, exceptionOffset-transactionOffset, batch[2].Error.Timestamp.Sub(batch[0].Transaction.Timestamp))
 
 	// Durations should be unaffected.
-	assert.Equal(t, float64(transactionDuration.Milliseconds()), batch.Transactions[0].Duration)
-	assert.Equal(t, float64(spanDuration.Milliseconds()), batch.Spans[0].Duration)
+	assert.Equal(t, float64(transactionDuration.Milliseconds()), batch[0].Transaction.Duration)
+	assert.Equal(t, float64(spanDuration.Milliseconds()), batch[1].Span.Duration)
 }
 
 func TestConsumer_JaegerMetadata(t *testing.T) {
@@ -737,14 +733,14 @@ func TestConsumer_JaegerSampleRate(t *testing.T) {
 	recorder := batchRecorderBatchProcessor(&batches)
 	require.NoError(t, (&otel.Consumer{Processor: recorder}).ConsumeTraces(context.Background(), traces))
 	require.Len(t, batches, 1)
-	batch := batches[0]
+	batch := *batches[0]
 
 	events := transformBatch(context.Background(), batches...)
 	approveEvents(t, "jaeger_sampling_rate", events)
 
-	tx1 := batch.Transactions[0]
-	tx2 := batch.Transactions[1]
-	span := batch.Spans[0]
+	tx1 := batch[0].Transaction
+	span := batch[1].Span
+	tx2 := batch[2].Transaction
 	assert.Equal(t, 1.25 /* 1/0.8 */, tx1.RepresentativeCount)
 	assert.Equal(t, 2.5 /* 1/0.4 */, span.RepresentativeCount)
 	assert.Zero(t, tx2.RepresentativeCount) // not set for non-probabilistic
@@ -767,8 +763,9 @@ func TestConsumer_JaegerTraceID(t *testing.T) {
 	traces := jaegertranslator.ProtoBatchToInternalTraces(jaegerBatch)
 	require.NoError(t, (&otel.Consumer{Processor: recorder}).ConsumeTraces(context.Background(), traces))
 
-	assert.Equal(t, "00000000000000000000000046467830", batches[0].Transactions[0].TraceID)
-	assert.Equal(t, "00000000464678300000000046467830", batches[0].Transactions[1].TraceID)
+	batch := *batches[0]
+	assert.Equal(t, "00000000000000000000000046467830", batch[0].Transaction.TraceID)
+	assert.Equal(t, "00000000464678300000000046467830", batch[1].Transaction.TraceID)
 }
 
 func TestConsumer_JaegerTransaction(t *testing.T) {
@@ -1031,8 +1028,9 @@ func TestJaegerServiceVersion(t *testing.T) {
 	recorder := batchRecorderBatchProcessor(&batches)
 	require.NoError(t, (&otel.Consumer{Processor: recorder}).ConsumeTraces(context.Background(), traces))
 
-	assert.Equal(t, "process_tag_value", batches[0].Transactions[0].Metadata.Service.Version)
-	assert.Equal(t, "span_tag_value", batches[0].Transactions[1].Metadata.Service.Version)
+	batch := *batches[0]
+	assert.Equal(t, "process_tag_value", batch[0].Transaction.Metadata.Service.Version)
+	assert.Equal(t, "span_tag_value", batch[1].Transaction.Metadata.Service.Version)
 }
 
 func TestTracesLogging(t *testing.T) {
@@ -1191,7 +1189,7 @@ func transformTransactionWithAttributes(t *testing.T, attrs map[string]pdata.Att
 	otelSpan.Attributes().InitFromMap(attrs)
 	spans.Spans().Append(otelSpan)
 	events := transformTraces(t, traces)
-	return events.Transactions[0]
+	return events[0].Transaction
 }
 
 func transformSpanWithAttributes(t *testing.T, attrs map[string]pdata.AttributeValue, configFns ...func(pdata.Span)) *model.Span {
@@ -1206,7 +1204,7 @@ func transformSpanWithAttributes(t *testing.T, attrs map[string]pdata.AttributeV
 	otelSpan.Attributes().InitFromMap(attrs)
 	spans.Spans().Append(otelSpan)
 	events := transformTraces(t, traces)
-	return events.Spans[0]
+	return events[0].Span
 }
 
 func transformTransactionSpanEvents(t *testing.T, language string, spanEvents ...pdata.SpanEvent) (*model.Transaction, []*model.Error) {
@@ -1223,16 +1221,21 @@ func transformTransactionSpanEvents(t *testing.T, language string, spanEvents ..
 	spans.Spans().Append(otelSpan)
 	events := transformTraces(t, traces)
 	require.NotEmpty(t, events)
-	return events.Transactions[0], events.Errors
+
+	errors := make([]*model.Error, len(events)-1)
+	for i, event := range events[1:] {
+		errors[i] = event.Error
+	}
+	return events[0].Transaction, errors
 }
 
-func transformTraces(t *testing.T, traces pdata.Traces) *model.Batch {
-	var processed *model.Batch
+func transformTraces(t *testing.T, traces pdata.Traces) model.Batch {
+	var processed model.Batch
 	processor := model.ProcessBatchFunc(func(ctx context.Context, batch *model.Batch) error {
 		if processed != nil {
 			panic("already processes batch")
 		}
-		processed = batch
+		processed = *batch
 		return nil
 	})
 	require.NoError(t, (&otel.Consumer{Processor: processor}).ConsumeTraces(context.Background(), traces))

--- a/processor/otel/metadata_test.go
+++ b/processor/otel/metadata_test.go
@@ -232,5 +232,5 @@ func transformResourceMetadata(t *testing.T, resourceAttrs map[string]pdata.Attr
 	otelSpan.SetSpanID(pdata.NewSpanID([8]byte{2}))
 	spans.Spans().Append(otelSpan)
 	events := transformTraces(t, traces)
-	return events.Transactions[0].Metadata
+	return events[0].Transaction.Metadata
 }

--- a/processor/otel/metrics.go
+++ b/processor/otel/metrics.go
@@ -103,7 +103,7 @@ func (c *Consumer) convertInstrumentationLibraryMetrics(
 	for _, m := range ms {
 		m.Metadata = metadata
 		m.Timestamp = m.Timestamp.Add(timeDelta)
-		out.Metricsets = append(out.Metricsets, m.Metricset)
+		*out = append(*out, model.APMEvent{Metricset: m.Metricset})
 	}
 	if unsupported > 0 {
 		atomic.AddInt64(&c.stats.unsupportedMetricsDropped, unsupported)

--- a/processor/otel/metrics_test.go
+++ b/processor/otel/metrics_test.go
@@ -381,5 +381,11 @@ func transformMetrics(t *testing.T, metrics pdata.Metrics) ([]*model.Metricset, 
 	err := consumer.ConsumeMetrics(context.Background(), metrics)
 	require.NoError(t, err)
 	require.Len(t, batches, 1)
-	return batches[0].Metricsets, consumer.Stats()
+
+	batch := *batches[0]
+	metricsets := make([]*model.Metricset, len(batch))
+	for i, event := range batch {
+		metricsets[i] = event.Metricset
+	}
+	return metricsets, consumer.Stats()
 }

--- a/processor/otel/test_approved/jaeger_sampling_rate.approved.json
+++ b/processor/otel/test_approved/jaeger_sampling_rate.approved.json
@@ -50,46 +50,6 @@
             "host": {
                 "hostname": "host-abc"
             },
-            "labels": {
-                "sampler_param": 2,
-                "sampler_type": "ratelimiting"
-            },
-            "processor": {
-                "event": "transaction",
-                "name": "transaction"
-            },
-            "service": {
-                "language": {
-                    "name": "unknown"
-                },
-                "name": "unknown"
-            },
-            "timestamp": {
-                "us": 1576500418000768
-            },
-            "transaction": {
-                "duration": {
-                    "us": 79000000
-                },
-                "id": "",
-                "sampled": true,
-                "type": "custom"
-            }
-        },
-        {
-            "@timestamp": "2019-12-16T12:46:58.000Z",
-            "agent": {
-                "name": "Jaeger",
-                "version": "unknown"
-            },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
-            "event": {
-                "outcome": "unknown"
-            },
-            "host": {
-                "hostname": "host-abc"
-            },
             "parent": {
                 "id": "0000000000000001"
             },
@@ -115,6 +75,46 @@
             },
             "trace": {
                 "id": "00000000000000010000000000000001"
+            }
+        },
+        {
+            "@timestamp": "2019-12-16T12:46:58.000Z",
+            "agent": {
+                "name": "Jaeger",
+                "version": "unknown"
+            },
+            "data_stream.dataset": "apm",
+            "data_stream.type": "traces",
+            "event": {
+                "outcome": "unknown"
+            },
+            "host": {
+                "hostname": "host-abc"
+            },
+            "labels": {
+                "sampler_param": 2,
+                "sampler_type": "ratelimiting"
+            },
+            "processor": {
+                "event": "transaction",
+                "name": "transaction"
+            },
+            "service": {
+                "language": {
+                    "name": "unknown"
+                },
+                "name": "unknown"
+            },
+            "timestamp": {
+                "us": 1576500418000768
+            },
+            "transaction": {
+                "duration": {
+                    "us": 79000000
+                },
+                "id": "",
+                "sampled": true,
+                "type": "custom"
             }
         }
     ]

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
@@ -5,469 +5,6 @@
             "agent": {
                 "ephemeral_id": "e71be9ac-93b0-44b9-a997-5638f6ccfc36",
                 "name": "java",
-                "version": "1.10.0-SNAPSHOT"
-            },
-            "client": {
-                "ip": "12.53.12.1"
-            },
-            "container": {
-                "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
-            },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
-            "event": {
-                "outcome": "success"
-            },
-            "host": {
-                "architecture": "amd64",
-                "hostname": "8ec7ceb99074",
-                "ip": "192.0.0.1",
-                "name": "host1",
-                "os": {
-                    "platform": "Linux"
-                }
-            },
-            "http": {
-                "request": {
-                    "body": {
-                        "original": {
-                            "additional": {
-                                "bar": 123,
-                                "req": "additionalinformation"
-                            },
-                            "string": "helloworld"
-                        }
-                    },
-                    "cookies": {
-                        "c1": "v1",
-                        "c2": "v2"
-                    },
-                    "env": {
-                        "GATEWAY_INTERFACE": "CGI/1.1",
-                        "SERVER_SOFTWARE": "nginx"
-                    },
-                    "headers": {
-                        "Content-Type": [
-                            "text/html"
-                        ],
-                        "Cookie": [
-                            "c1=v1,c2=v2"
-                        ],
-                        "Elastic-Apm-Traceparent": [
-                            "00-33a0bd4cceff0370a7c57d807032688e-69feaabc5b88d7e8-01"
-                        ],
-                        "User-Agent": [
-                            "Mozilla/5.0(Macintosh;IntelMacOSX10_10_5)AppleWebKit/537.36(KHTML,likeGecko)Chrome/51.0.2704.103Safari/537.36",
-                            "MozillaChromeEdge"
-                        ]
-                    },
-                    "method": "POST",
-                    "socket": {
-                        "encrypted": true,
-                        "remote_address": "12.53.12.1:8080"
-                    }
-                },
-                "response": {
-                    "decoded_body_size": 401.9,
-                    "encoded_body_size": 356.9,
-                    "finished": true,
-                    "headers": {
-                        "Content-Type": [
-                            "application/json"
-                        ]
-                    },
-                    "headers_sent": true,
-                    "status_code": 200,
-                    "transfer_size": 300
-                },
-                "version": "1.1"
-            },
-            "kubernetes": {
-                "namespace": "default",
-                "node": {
-                    "name": "node-name"
-                },
-                "pod": {
-                    "name": "instrumented-java-service",
-                    "uid": "b17f231da0ad128dc6c6c0b2e82f6f303d3893e3"
-                }
-            },
-            "labels": {
-                "ab_testing": true,
-                "group": "experimental",
-                "organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8",
-                "segment": 5
-            },
-            "parent": {
-                "id": "abcdefabcdef01234567"
-            },
-            "process": {
-                "args": [
-                    "-v"
-                ],
-                "pid": 1234,
-                "ppid": 1,
-                "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
-            },
-            "processor": {
-                "event": "transaction",
-                "name": "transaction"
-            },
-            "service": {
-                "environment": "production",
-                "framework": {
-                    "name": "spring",
-                    "version": "5.0.0"
-                },
-                "language": {
-                    "name": "Java",
-                    "version": "10.0.2"
-                },
-                "name": "experimental-java",
-                "node": {
-                    "name": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
-                },
-                "runtime": {
-                    "name": "Java",
-                    "version": "10.0.2"
-                },
-                "version": "4.3.0"
-            },
-            "source": {
-                "ip": "12.53.12.1"
-            },
-            "timestamp": {
-                "us": 1571657444929001
-            },
-            "trace": {
-                "id": "0acd456789abcdef0123456789abcdef"
-            },
-            "transaction": {
-                "custom": {
-                    "(": "notavalidregexandthatisfine",
-                    "and_objects": {
-                        "foo": [
-                            "bar",
-                            "baz"
-                        ]
-                    },
-                    "my_key": 1,
-                    "some_other_value": "foobar"
-                },
-                "duration": {
-                    "us": 32592
-                },
-                "id": "4340a8e0df1906ecbfa9",
-                "name": "ResourceHttpRequestHandler",
-                "result": "HTTP2xx",
-                "sampled": true,
-                "span_count": {
-                    "dropped": 0,
-                    "started": 17
-                },
-                "type": "http"
-            },
-            "url": {
-                "domain": "www.example.com",
-                "fragment": "#hash",
-                "full": "https://www.example.com/p/a/t/h?query=string#hash",
-                "original": "/p/a/t/h?query=string#hash",
-                "path": "/p/a/t/h",
-                "port": 8080,
-                "query": "?query=string",
-                "scheme": "https"
-            },
-            "user": {
-                "email": "foo@mail.com",
-                "id": "99",
-                "name": "foo"
-            },
-            "user_agent": {
-                "original": "Mozilla/5.0(Macintosh;IntelMacOSX10_10_5)AppleWebKit/537.36(KHTML,likeGecko)Chrome/51.0.2704.103Safari/537.36, MozillaChromeEdge"
-            }
-        },
-        {
-            "@timestamp": "2019-10-21T11:30:44.929Z",
-            "agent": {
-                "ephemeral_id": "e71be9ac-93b0-44b9-a997-5638f6ccfc36",
-                "name": "java",
-                "version": "1.10.0-SNAPSHOT"
-            },
-            "container": {
-                "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
-            },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
-            "event": {
-                "outcome": "success"
-            },
-            "host": {
-                "architecture": "amd64",
-                "hostname": "8ec7ceb99074",
-                "ip": "192.0.0.1",
-                "name": "host1",
-                "os": {
-                    "platform": "Linux"
-                }
-            },
-            "http": {
-                "request.method": "GET",
-                "response": {
-                    "status_code": 200
-                }
-            },
-            "kubernetes": {
-                "namespace": "default",
-                "node": {
-                    "name": "node-name"
-                },
-                "pod": {
-                    "name": "instrumented-java-service",
-                    "uid": "b17f231da0ad128dc6c6c0b2e82f6f303d3893e3"
-                }
-            },
-            "labels": {
-                "ab_testing": true,
-                "group": "experimental",
-                "segment": 5
-            },
-            "parent": {
-                "id": "abcdef0123456789"
-            },
-            "process": {
-                "args": [
-                    "-v"
-                ],
-                "pid": 1234,
-                "ppid": 1,
-                "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
-            },
-            "processor": {
-                "event": "span",
-                "name": "transaction"
-            },
-            "service": {
-                "environment": "production",
-                "framework": {
-                    "name": "spring",
-                    "version": "5.0.0"
-                },
-                "language": {
-                    "name": "Java",
-                    "version": "10.0.2"
-                },
-                "name": "opbeans-java-1",
-                "node": {
-                    "name": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
-                },
-                "runtime": {
-                    "name": "Java",
-                    "version": "10.0.2"
-                },
-                "version": "4.3.0"
-            },
-            "span": {
-                "action": "connect",
-                "db": {
-                    "instance": "customers",
-                    "link": "other.db.com",
-                    "statement": "SELECT * FROM product_types WHERE user_id = ?",
-                    "type": "sql",
-                    "user": {
-                        "name": "postgres"
-                    }
-                },
-                "duration": {
-                    "us": 3781
-                },
-                "http": {
-                    "method": "GET",
-                    "response": {
-                        "decoded_body_size": 401,
-                        "encoded_body_size": 356,
-                        "headers": {
-                            "Content-Type": [
-                                "application/json"
-                            ]
-                        },
-                        "status_code": 200,
-                        "transfer_size": 300.12
-                    },
-                    "url": {
-                        "original": "http://localhost:8000"
-                    }
-                },
-                "id": "1234567890aaaade",
-                "name": "GET users-authenticated",
-                "stacktrace": [
-                    {
-                        "exclude_from_grouping": false,
-                        "filename": "DispatcherServlet.java",
-                        "line": {
-                            "number": 547
-                        }
-                    },
-                    {
-                        "abs_path": "/tmp/AbstractView.java",
-                        "exclude_from_grouping": false,
-                        "filename": "AbstractView.java",
-                        "function": "render",
-                        "library_frame": true,
-                        "line": {
-                            "column": 4,
-                            "context": "line3",
-                            "number": 547
-                        },
-                        "module": "org.springframework.web.servlet.view",
-                        "vars": {
-                            "key": "value"
-                        }
-                    }
-                ],
-                "subtype": "http",
-                "sync": true,
-                "type": "external"
-            },
-            "timestamp": {
-                "us": 1571657444929001
-            },
-            "trace": {
-                "id": "abcdef0123456789abcdef9876543210"
-            },
-            "transaction": {
-                "id": "1234567890987654"
-            },
-            "url.original": "http://localhost:8000"
-        },
-        {
-            "@timestamp": "2019-10-21T11:30:44.929Z",
-            "agent": {
-                "ephemeral_id": "e71be9ac-93b0-44b9-a997-5638f6ccfc36",
-                "name": "java",
-                "version": "1.10.0"
-            },
-            "byte_counter": 1,
-            "container": {
-                "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
-            },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.type": "metrics",
-            "dotted": {
-                "float": {
-                    "gauge": 6.12
-                }
-            },
-            "double_gauge": 3.141592653589793,
-            "float_gauge": 9.16,
-            "host": {
-                "architecture": "amd64",
-                "hostname": "8ec7ceb99074",
-                "ip": "192.0.0.1",
-                "name": "host1",
-                "os": {
-                    "platform": "Linux"
-                }
-            },
-            "integer_gauge": 42767,
-            "kubernetes": {
-                "namespace": "default",
-                "node": {
-                    "name": "node-name"
-                },
-                "pod": {
-                    "name": "instrumented-java-service",
-                    "uid": "b17f231da0ad128dc6c6c0b2e82f6f303d3893e3"
-                }
-            },
-            "labels": {
-                "ab_testing": true,
-                "code": 200,
-                "group": "experimental",
-                "segment": 5,
-                "success": true
-            },
-            "long_gauge": 3147483648,
-            "negative": {
-                "d": {
-                    "o": {
-                        "t": {
-                            "t": {
-                                "e": {
-                                    "d": -1022
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "process": {
-                "args": [
-                    "-v"
-                ],
-                "pid": 1234,
-                "ppid": 1,
-                "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
-            },
-            "processor": {
-                "event": "metric",
-                "name": "metric"
-            },
-            "service": {
-                "environment": "production",
-                "framework": {
-                    "name": "spring",
-                    "version": "5.0.0"
-                },
-                "language": {
-                    "name": "Java",
-                    "version": "10.0.2"
-                },
-                "name": "1234_service-12a3",
-                "node": {
-                    "name": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
-                },
-                "runtime": {
-                    "name": "Java",
-                    "version": "10.0.2"
-                },
-                "version": "4.3.0"
-            },
-            "short_counter": 227,
-            "span": {
-                "self_time": {
-                    "count": 1,
-                    "sum": {
-                        "us": 633.288
-                    }
-                },
-                "subtype": "mysql",
-                "type": "db"
-            },
-            "transaction": {
-                "breakdown": {
-                    "count": 12
-                },
-                "duration": {
-                    "count": 2,
-                    "sum": {
-                        "us": 12
-                    }
-                },
-                "name": "GET/",
-                "self_time": {
-                    "count": 2,
-                    "sum": {
-                        "us": 10
-                    }
-                },
-                "type": "request"
-            }
-        },
-        {
-            "@timestamp": "2019-10-21T11:30:44.929Z",
-            "agent": {
-                "ephemeral_id": "e71be9ac-93b0-44b9-a997-5638f6ccfc36",
-                "name": "java",
                 "version": "1.10.0"
             },
             "client": {
@@ -741,6 +278,469 @@
                 "email": "user@foo.mail",
                 "id": "99",
                 "name": "foo"
+            }
+        },
+        {
+            "@timestamp": "2019-10-21T11:30:44.929Z",
+            "agent": {
+                "ephemeral_id": "e71be9ac-93b0-44b9-a997-5638f6ccfc36",
+                "name": "java",
+                "version": "1.10.0-SNAPSHOT"
+            },
+            "container": {
+                "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
+            },
+            "data_stream.dataset": "apm",
+            "data_stream.type": "traces",
+            "event": {
+                "outcome": "success"
+            },
+            "host": {
+                "architecture": "amd64",
+                "hostname": "8ec7ceb99074",
+                "ip": "192.0.0.1",
+                "name": "host1",
+                "os": {
+                    "platform": "Linux"
+                }
+            },
+            "http": {
+                "request.method": "GET",
+                "response": {
+                    "status_code": 200
+                }
+            },
+            "kubernetes": {
+                "namespace": "default",
+                "node": {
+                    "name": "node-name"
+                },
+                "pod": {
+                    "name": "instrumented-java-service",
+                    "uid": "b17f231da0ad128dc6c6c0b2e82f6f303d3893e3"
+                }
+            },
+            "labels": {
+                "ab_testing": true,
+                "group": "experimental",
+                "segment": 5
+            },
+            "parent": {
+                "id": "abcdef0123456789"
+            },
+            "process": {
+                "args": [
+                    "-v"
+                ],
+                "pid": 1234,
+                "ppid": 1,
+                "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "service": {
+                "environment": "production",
+                "framework": {
+                    "name": "spring",
+                    "version": "5.0.0"
+                },
+                "language": {
+                    "name": "Java",
+                    "version": "10.0.2"
+                },
+                "name": "opbeans-java-1",
+                "node": {
+                    "name": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
+                },
+                "runtime": {
+                    "name": "Java",
+                    "version": "10.0.2"
+                },
+                "version": "4.3.0"
+            },
+            "span": {
+                "action": "connect",
+                "db": {
+                    "instance": "customers",
+                    "link": "other.db.com",
+                    "statement": "SELECT * FROM product_types WHERE user_id = ?",
+                    "type": "sql",
+                    "user": {
+                        "name": "postgres"
+                    }
+                },
+                "duration": {
+                    "us": 3781
+                },
+                "http": {
+                    "method": "GET",
+                    "response": {
+                        "decoded_body_size": 401,
+                        "encoded_body_size": 356,
+                        "headers": {
+                            "Content-Type": [
+                                "application/json"
+                            ]
+                        },
+                        "status_code": 200,
+                        "transfer_size": 300.12
+                    },
+                    "url": {
+                        "original": "http://localhost:8000"
+                    }
+                },
+                "id": "1234567890aaaade",
+                "name": "GET users-authenticated",
+                "stacktrace": [
+                    {
+                        "exclude_from_grouping": false,
+                        "filename": "DispatcherServlet.java",
+                        "line": {
+                            "number": 547
+                        }
+                    },
+                    {
+                        "abs_path": "/tmp/AbstractView.java",
+                        "exclude_from_grouping": false,
+                        "filename": "AbstractView.java",
+                        "function": "render",
+                        "library_frame": true,
+                        "line": {
+                            "column": 4,
+                            "context": "line3",
+                            "number": 547
+                        },
+                        "module": "org.springframework.web.servlet.view",
+                        "vars": {
+                            "key": "value"
+                        }
+                    }
+                ],
+                "subtype": "http",
+                "sync": true,
+                "type": "external"
+            },
+            "timestamp": {
+                "us": 1571657444929001
+            },
+            "trace": {
+                "id": "abcdef0123456789abcdef9876543210"
+            },
+            "transaction": {
+                "id": "1234567890987654"
+            },
+            "url.original": "http://localhost:8000"
+        },
+        {
+            "@timestamp": "2019-10-21T11:30:44.929Z",
+            "agent": {
+                "ephemeral_id": "e71be9ac-93b0-44b9-a997-5638f6ccfc36",
+                "name": "java",
+                "version": "1.10.0-SNAPSHOT"
+            },
+            "client": {
+                "ip": "12.53.12.1"
+            },
+            "container": {
+                "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
+            },
+            "data_stream.dataset": "apm",
+            "data_stream.type": "traces",
+            "event": {
+                "outcome": "success"
+            },
+            "host": {
+                "architecture": "amd64",
+                "hostname": "8ec7ceb99074",
+                "ip": "192.0.0.1",
+                "name": "host1",
+                "os": {
+                    "platform": "Linux"
+                }
+            },
+            "http": {
+                "request": {
+                    "body": {
+                        "original": {
+                            "additional": {
+                                "bar": 123,
+                                "req": "additionalinformation"
+                            },
+                            "string": "helloworld"
+                        }
+                    },
+                    "cookies": {
+                        "c1": "v1",
+                        "c2": "v2"
+                    },
+                    "env": {
+                        "GATEWAY_INTERFACE": "CGI/1.1",
+                        "SERVER_SOFTWARE": "nginx"
+                    },
+                    "headers": {
+                        "Content-Type": [
+                            "text/html"
+                        ],
+                        "Cookie": [
+                            "c1=v1,c2=v2"
+                        ],
+                        "Elastic-Apm-Traceparent": [
+                            "00-33a0bd4cceff0370a7c57d807032688e-69feaabc5b88d7e8-01"
+                        ],
+                        "User-Agent": [
+                            "Mozilla/5.0(Macintosh;IntelMacOSX10_10_5)AppleWebKit/537.36(KHTML,likeGecko)Chrome/51.0.2704.103Safari/537.36",
+                            "MozillaChromeEdge"
+                        ]
+                    },
+                    "method": "POST",
+                    "socket": {
+                        "encrypted": true,
+                        "remote_address": "12.53.12.1:8080"
+                    }
+                },
+                "response": {
+                    "decoded_body_size": 401.9,
+                    "encoded_body_size": 356.9,
+                    "finished": true,
+                    "headers": {
+                        "Content-Type": [
+                            "application/json"
+                        ]
+                    },
+                    "headers_sent": true,
+                    "status_code": 200,
+                    "transfer_size": 300
+                },
+                "version": "1.1"
+            },
+            "kubernetes": {
+                "namespace": "default",
+                "node": {
+                    "name": "node-name"
+                },
+                "pod": {
+                    "name": "instrumented-java-service",
+                    "uid": "b17f231da0ad128dc6c6c0b2e82f6f303d3893e3"
+                }
+            },
+            "labels": {
+                "ab_testing": true,
+                "group": "experimental",
+                "organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8",
+                "segment": 5
+            },
+            "parent": {
+                "id": "abcdefabcdef01234567"
+            },
+            "process": {
+                "args": [
+                    "-v"
+                ],
+                "pid": 1234,
+                "ppid": 1,
+                "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
+            },
+            "processor": {
+                "event": "transaction",
+                "name": "transaction"
+            },
+            "service": {
+                "environment": "production",
+                "framework": {
+                    "name": "spring",
+                    "version": "5.0.0"
+                },
+                "language": {
+                    "name": "Java",
+                    "version": "10.0.2"
+                },
+                "name": "experimental-java",
+                "node": {
+                    "name": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
+                },
+                "runtime": {
+                    "name": "Java",
+                    "version": "10.0.2"
+                },
+                "version": "4.3.0"
+            },
+            "source": {
+                "ip": "12.53.12.1"
+            },
+            "timestamp": {
+                "us": 1571657444929001
+            },
+            "trace": {
+                "id": "0acd456789abcdef0123456789abcdef"
+            },
+            "transaction": {
+                "custom": {
+                    "(": "notavalidregexandthatisfine",
+                    "and_objects": {
+                        "foo": [
+                            "bar",
+                            "baz"
+                        ]
+                    },
+                    "my_key": 1,
+                    "some_other_value": "foobar"
+                },
+                "duration": {
+                    "us": 32592
+                },
+                "id": "4340a8e0df1906ecbfa9",
+                "name": "ResourceHttpRequestHandler",
+                "result": "HTTP2xx",
+                "sampled": true,
+                "span_count": {
+                    "dropped": 0,
+                    "started": 17
+                },
+                "type": "http"
+            },
+            "url": {
+                "domain": "www.example.com",
+                "fragment": "#hash",
+                "full": "https://www.example.com/p/a/t/h?query=string#hash",
+                "original": "/p/a/t/h?query=string#hash",
+                "path": "/p/a/t/h",
+                "port": 8080,
+                "query": "?query=string",
+                "scheme": "https"
+            },
+            "user": {
+                "email": "foo@mail.com",
+                "id": "99",
+                "name": "foo"
+            },
+            "user_agent": {
+                "original": "Mozilla/5.0(Macintosh;IntelMacOSX10_10_5)AppleWebKit/537.36(KHTML,likeGecko)Chrome/51.0.2704.103Safari/537.36, MozillaChromeEdge"
+            }
+        },
+        {
+            "@timestamp": "2019-10-21T11:30:44.929Z",
+            "agent": {
+                "ephemeral_id": "e71be9ac-93b0-44b9-a997-5638f6ccfc36",
+                "name": "java",
+                "version": "1.10.0"
+            },
+            "byte_counter": 1,
+            "container": {
+                "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
+            },
+            "data_stream.dataset": "apm.internal",
+            "data_stream.type": "metrics",
+            "dotted": {
+                "float": {
+                    "gauge": 6.12
+                }
+            },
+            "double_gauge": 3.141592653589793,
+            "float_gauge": 9.16,
+            "host": {
+                "architecture": "amd64",
+                "hostname": "8ec7ceb99074",
+                "ip": "192.0.0.1",
+                "name": "host1",
+                "os": {
+                    "platform": "Linux"
+                }
+            },
+            "integer_gauge": 42767,
+            "kubernetes": {
+                "namespace": "default",
+                "node": {
+                    "name": "node-name"
+                },
+                "pod": {
+                    "name": "instrumented-java-service",
+                    "uid": "b17f231da0ad128dc6c6c0b2e82f6f303d3893e3"
+                }
+            },
+            "labels": {
+                "ab_testing": true,
+                "code": 200,
+                "group": "experimental",
+                "segment": 5,
+                "success": true
+            },
+            "long_gauge": 3147483648,
+            "negative": {
+                "d": {
+                    "o": {
+                        "t": {
+                            "t": {
+                                "e": {
+                                    "d": -1022
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "process": {
+                "args": [
+                    "-v"
+                ],
+                "pid": 1234,
+                "ppid": 1,
+                "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "environment": "production",
+                "framework": {
+                    "name": "spring",
+                    "version": "5.0.0"
+                },
+                "language": {
+                    "name": "Java",
+                    "version": "10.0.2"
+                },
+                "name": "1234_service-12a3",
+                "node": {
+                    "name": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
+                },
+                "runtime": {
+                    "name": "Java",
+                    "version": "10.0.2"
+                },
+                "version": "4.3.0"
+            },
+            "short_counter": 227,
+            "span": {
+                "self_time": {
+                    "count": 1,
+                    "sum": {
+                        "us": 633.288
+                    }
+                },
+                "subtype": "mysql",
+                "type": "db"
+            },
+            "transaction": {
+                "breakdown": {
+                    "count": 12
+                },
+                "duration": {
+                    "count": 2,
+                    "sum": {
+                        "us": 12
+                    }
+                },
+                "name": "GET/",
+                "self_time": {
+                    "count": 2,
+                    "sum": {
+                        "us": 10
+                    }
+                },
+                "type": "request"
             }
         }
     ]

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationMinimalService.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationMinimalService.approved.json
@@ -1,37 +1,6 @@
 {
     "events": [
         {
-            "@timestamp": "2017-05-30T18:53:42.281Z",
-            "agent": {
-                "name": "elastic-node",
-                "version": "3.14.0"
-            },
-            "data_stream.dataset": "apm.app.1234_service_12a3",
-            "data_stream.type": "metrics",
-            "go": {
-                "memstats": {
-                    "heap": {
-                        "sys": {
-                            "bytes": 61235
-                        }
-                    }
-                }
-            },
-            "host": {
-                "ip": "192.0.0.1"
-            },
-            "processor": {
-                "event": "metric",
-                "name": "metric"
-            },
-            "service": {
-                "language": {
-                    "name": "ecmascript"
-                },
-                "name": "1234_service-12a3"
-            }
-        },
-        {
             "@timestamp": "2018-08-09T15:04:05.999Z",
             "agent": {
                 "name": "elastic-node",
@@ -62,6 +31,37 @@
             },
             "timestamp": {
                 "us": 1533827045999000
+            }
+        },
+        {
+            "@timestamp": "2017-05-30T18:53:42.281Z",
+            "agent": {
+                "name": "elastic-node",
+                "version": "3.14.0"
+            },
+            "data_stream.dataset": "apm.app.1234_service_12a3",
+            "data_stream.type": "metrics",
+            "go": {
+                "memstats": {
+                    "heap": {
+                        "sys": {
+                            "bytes": 61235
+                        }
+                    }
+                }
+            },
+            "host": {
+                "ip": "192.0.0.1"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "language": {
+                    "name": "ecmascript"
+                },
+                "name": "1234_service-12a3"
             }
         }
     ]

--- a/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
@@ -149,6 +149,177 @@
             }
         },
         {
+            "@timestamp": "2018-08-01T10:00:00.000Z",
+            "agent": {
+                "name": "js-base",
+                "version": "4.8.1"
+            },
+            "client": {
+                "ip": "192.0.0.1"
+            },
+            "data_stream.dataset": "apm.internal",
+            "data_stream.type": "metrics",
+            "labels": {
+                "testTagKey": "testTagValue"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "environment": "prod",
+                "framework": {
+                    "name": "angular",
+                    "version": "2"
+                },
+                "language": {
+                    "name": "javascript",
+                    "version": "6"
+                },
+                "name": "apm-a-rum-test-e2e-general-usecase",
+                "runtime": {
+                    "name": "v8",
+                    "version": "8.0"
+                },
+                "version": "0.0.1"
+            },
+            "transaction": {
+                "breakdown": {
+                    "count": 1
+                },
+                "duration": {
+                    "count": 1,
+                    "sum": {
+                        "us": 295
+                    }
+                },
+                "name": "general-usecase-initial-p-load",
+                "type": "p-load"
+            },
+            "user": {
+                "email": "user@email.com",
+                "id": "123",
+                "name": "John Doe"
+            },
+            "user_agent": {
+                "original": "rum-2.0"
+            }
+        },
+        {
+            "@timestamp": "2018-08-01T10:00:00.000Z",
+            "agent": {
+                "name": "js-base",
+                "version": "4.8.1"
+            },
+            "client": {
+                "ip": "192.0.0.1"
+            },
+            "data_stream.dataset": "apm.internal",
+            "data_stream.type": "metrics",
+            "labels": {
+                "testTagKey": "testTagValue"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "environment": "prod",
+                "framework": {
+                    "name": "angular",
+                    "version": "2"
+                },
+                "language": {
+                    "name": "javascript",
+                    "version": "6"
+                },
+                "name": "apm-a-rum-test-e2e-general-usecase",
+                "runtime": {
+                    "name": "v8",
+                    "version": "8.0"
+                },
+                "version": "0.0.1"
+            },
+            "span": {
+                "self_time": {
+                    "count": 1,
+                    "sum": {
+                        "us": 1
+                    }
+                },
+                "type": "Request"
+            },
+            "transaction": {
+                "name": "general-usecase-initial-p-load",
+                "type": "p-load"
+            },
+            "user": {
+                "email": "user@email.com",
+                "id": "123",
+                "name": "John Doe"
+            },
+            "user_agent": {
+                "original": "rum-2.0"
+            }
+        },
+        {
+            "@timestamp": "2018-08-01T10:00:00.000Z",
+            "agent": {
+                "name": "js-base",
+                "version": "4.8.1"
+            },
+            "client": {
+                "ip": "192.0.0.1"
+            },
+            "data_stream.dataset": "apm.internal",
+            "data_stream.type": "metrics",
+            "labels": {
+                "testTagKey": "testTagValue"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "environment": "prod",
+                "framework": {
+                    "name": "angular",
+                    "version": "2"
+                },
+                "language": {
+                    "name": "javascript",
+                    "version": "6"
+                },
+                "name": "apm-a-rum-test-e2e-general-usecase",
+                "runtime": {
+                    "name": "v8",
+                    "version": "8.0"
+                },
+                "version": "0.0.1"
+            },
+            "span": {
+                "self_time": {
+                    "count": 1,
+                    "sum": {
+                        "us": 1
+                    }
+                },
+                "type": "Response"
+            },
+            "transaction": {
+                "name": "general-usecase-initial-p-load",
+                "type": "p-load"
+            },
+            "user": {
+                "email": "user@email.com",
+                "id": "123",
+                "name": "John Doe"
+            },
+            "user_agent": {
+                "original": "rum-2.0"
+            }
+        },
+        {
             "@timestamp": "2018-08-01T10:00:00.004Z",
             "agent": {
                 "name": "js-base",
@@ -834,177 +1005,6 @@
             },
             "transaction": {
                 "id": "ec2e280be8345240"
-            },
-            "user": {
-                "email": "user@email.com",
-                "id": "123",
-                "name": "John Doe"
-            },
-            "user_agent": {
-                "original": "rum-2.0"
-            }
-        },
-        {
-            "@timestamp": "2018-08-01T10:00:00.000Z",
-            "agent": {
-                "name": "js-base",
-                "version": "4.8.1"
-            },
-            "client": {
-                "ip": "192.0.0.1"
-            },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.type": "metrics",
-            "labels": {
-                "testTagKey": "testTagValue"
-            },
-            "processor": {
-                "event": "metric",
-                "name": "metric"
-            },
-            "service": {
-                "environment": "prod",
-                "framework": {
-                    "name": "angular",
-                    "version": "2"
-                },
-                "language": {
-                    "name": "javascript",
-                    "version": "6"
-                },
-                "name": "apm-a-rum-test-e2e-general-usecase",
-                "runtime": {
-                    "name": "v8",
-                    "version": "8.0"
-                },
-                "version": "0.0.1"
-            },
-            "transaction": {
-                "breakdown": {
-                    "count": 1
-                },
-                "duration": {
-                    "count": 1,
-                    "sum": {
-                        "us": 295
-                    }
-                },
-                "name": "general-usecase-initial-p-load",
-                "type": "p-load"
-            },
-            "user": {
-                "email": "user@email.com",
-                "id": "123",
-                "name": "John Doe"
-            },
-            "user_agent": {
-                "original": "rum-2.0"
-            }
-        },
-        {
-            "@timestamp": "2018-08-01T10:00:00.000Z",
-            "agent": {
-                "name": "js-base",
-                "version": "4.8.1"
-            },
-            "client": {
-                "ip": "192.0.0.1"
-            },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.type": "metrics",
-            "labels": {
-                "testTagKey": "testTagValue"
-            },
-            "processor": {
-                "event": "metric",
-                "name": "metric"
-            },
-            "service": {
-                "environment": "prod",
-                "framework": {
-                    "name": "angular",
-                    "version": "2"
-                },
-                "language": {
-                    "name": "javascript",
-                    "version": "6"
-                },
-                "name": "apm-a-rum-test-e2e-general-usecase",
-                "runtime": {
-                    "name": "v8",
-                    "version": "8.0"
-                },
-                "version": "0.0.1"
-            },
-            "span": {
-                "self_time": {
-                    "count": 1,
-                    "sum": {
-                        "us": 1
-                    }
-                },
-                "type": "Request"
-            },
-            "transaction": {
-                "name": "general-usecase-initial-p-load",
-                "type": "p-load"
-            },
-            "user": {
-                "email": "user@email.com",
-                "id": "123",
-                "name": "John Doe"
-            },
-            "user_agent": {
-                "original": "rum-2.0"
-            }
-        },
-        {
-            "@timestamp": "2018-08-01T10:00:00.000Z",
-            "agent": {
-                "name": "js-base",
-                "version": "4.8.1"
-            },
-            "client": {
-                "ip": "192.0.0.1"
-            },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.type": "metrics",
-            "labels": {
-                "testTagKey": "testTagValue"
-            },
-            "processor": {
-                "event": "metric",
-                "name": "metric"
-            },
-            "service": {
-                "environment": "prod",
-                "framework": {
-                    "name": "angular",
-                    "version": "2"
-                },
-                "language": {
-                    "name": "javascript",
-                    "version": "6"
-                },
-                "name": "apm-a-rum-test-e2e-general-usecase",
-                "runtime": {
-                    "name": "v8",
-                    "version": "8.0"
-                },
-                "version": "0.0.1"
-            },
-            "span": {
-                "self_time": {
-                    "count": 1,
-                    "sum": {
-                        "us": 1
-                    }
-                },
-                "type": "Response"
-            },
-            "transaction": {
-                "name": "general-usecase-initial-p-load",
-                "type": "p-load"
             },
             "user": {
                 "email": "user@email.com",

--- a/sampling/sampling_test.go
+++ b/sampling/sampling_test.go
@@ -39,17 +39,24 @@ func TestNewDiscardUnsampledBatchProcessor(t *testing.T) {
 	t5 := &model.Transaction{Sampled: newBool(true)}
 
 	batch := model.Batch{
-		Transactions: []*model.Transaction{t1, t2, t3, t4, t5},
-		Spans:        []*model.Span{span},
+		{Transaction: t1},
+		{Transaction: t2},
+		{Span: span},
+		{Transaction: t3},
+		{Transaction: t4},
+		{Transaction: t5},
 	}
+
 	err := batchProcessor.ProcessBatch(context.Background(), &batch)
 	assert.NoError(t, err)
 
 	// Note that t3 gets sent to the back of the slice;
 	// this reporter is not order-preserving.
 	assert.Equal(t, model.Batch{
-		Transactions: []*model.Transaction{t1, t5, t3},
-		Spans:        []*model.Span{span},
+		{Transaction: t1},
+		{Transaction: t5},
+		{Span: span},
+		{Transaction: t3},
 	}, batch)
 
 	expectedMonitoring := monitoring.MakeFlatSnapshot()

--- a/testdata/jaeger/batch_1.approved.json
+++ b/testdata/jaeger/batch_1.approved.json
@@ -91,6 +91,48 @@
             }
         },
         {
+            "@timestamp": "2019-12-20T07:41:45.006Z",
+            "agent": {
+                "ephemeral_id": "2e3f8db3eb77fae0",
+                "name": "Jaeger/Go",
+                "version": "2.20.1"
+            },
+            "error": {
+                "exception": [
+                    {
+                        "message": "redis timeout"
+                    }
+                ],
+                "grouping_key": "dd09a7d0d9dde0adfcd694967c5a88de",
+                "log": {
+                    "message": "redis timeout"
+                }
+            },
+            "host": {
+                "hostname": "host01",
+                "ip": "10.0.0.13"
+            },
+            "parent": {
+                "id": "333295bfb438ea03"
+            },
+            "processor": {
+                "event": "error",
+                "name": "error"
+            },
+            "service": {
+                "language": {
+                    "name": "Go"
+                },
+                "name": "redis"
+            },
+            "timestamp": {
+                "us": 1576827705006847
+            },
+            "trace": {
+                "id": "00000000000000007be2fd98d0973be3"
+            }
+        },
+        {
             "@timestamp": "2019-12-20T07:41:45.007Z",
             "agent": {
                 "ephemeral_id": "2e3f8db3eb77fae0",
@@ -310,6 +352,48 @@
             },
             "timestamp": {
                 "us": 1576827705054046
+            },
+            "trace": {
+                "id": "00000000000000007be2fd98d0973be3"
+            }
+        },
+        {
+            "@timestamp": "2019-12-20T07:41:45.089Z",
+            "agent": {
+                "ephemeral_id": "2e3f8db3eb77fae0",
+                "name": "Jaeger/Go",
+                "version": "2.20.1"
+            },
+            "error": {
+                "exception": [
+                    {
+                        "message": "redis timeout"
+                    }
+                ],
+                "grouping_key": "dd09a7d0d9dde0adfcd694967c5a88de",
+                "log": {
+                    "message": "redis timeout"
+                }
+            },
+            "host": {
+                "hostname": "host01",
+                "ip": "10.0.0.13"
+            },
+            "parent": {
+                "id": "614811d6c498bfb0"
+            },
+            "processor": {
+                "event": "error",
+                "name": "error"
+            },
+            "service": {
+                "language": {
+                    "name": "Go"
+                },
+                "name": "redis"
+            },
+            "timestamp": {
+                "us": 1576827705089372
             },
             "trace": {
                 "id": "00000000000000007be2fd98d0973be3"
@@ -547,6 +631,48 @@
                 "name": "Jaeger/Go",
                 "version": "2.20.1"
             },
+            "error": {
+                "exception": [
+                    {
+                        "message": "redis timeout"
+                    }
+                ],
+                "grouping_key": "dd09a7d0d9dde0adfcd694967c5a88de",
+                "log": {
+                    "message": "redis timeout"
+                }
+            },
+            "host": {
+                "hostname": "host01",
+                "ip": "10.0.0.13"
+            },
+            "parent": {
+                "id": "0242ee3774d9eab1"
+            },
+            "processor": {
+                "event": "error",
+                "name": "error"
+            },
+            "service": {
+                "language": {
+                    "name": "Go"
+                },
+                "name": "redis"
+            },
+            "timestamp": {
+                "us": 1576827705172347
+            },
+            "trace": {
+                "id": "00000000000000007be2fd98d0973be3"
+            }
+        },
+        {
+            "@timestamp": "2019-12-20T07:41:45.172Z",
+            "agent": {
+                "ephemeral_id": "2e3f8db3eb77fae0",
+                "name": "Jaeger/Go",
+                "version": "2.20.1"
+            },
             "event": {
                 "outcome": "unknown"
             },
@@ -625,132 +751,6 @@
             },
             "timestamp": {
                 "us": 1576827705186670
-            },
-            "trace": {
-                "id": "00000000000000007be2fd98d0973be3"
-            }
-        },
-        {
-            "@timestamp": "2019-12-20T07:41:45.006Z",
-            "agent": {
-                "ephemeral_id": "2e3f8db3eb77fae0",
-                "name": "Jaeger/Go",
-                "version": "2.20.1"
-            },
-            "error": {
-                "exception": [
-                    {
-                        "message": "redis timeout"
-                    }
-                ],
-                "grouping_key": "dd09a7d0d9dde0adfcd694967c5a88de",
-                "log": {
-                    "message": "redis timeout"
-                }
-            },
-            "host": {
-                "hostname": "host01",
-                "ip": "10.0.0.13"
-            },
-            "parent": {
-                "id": "333295bfb438ea03"
-            },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
-            "service": {
-                "language": {
-                    "name": "Go"
-                },
-                "name": "redis"
-            },
-            "timestamp": {
-                "us": 1576827705006847
-            },
-            "trace": {
-                "id": "00000000000000007be2fd98d0973be3"
-            }
-        },
-        {
-            "@timestamp": "2019-12-20T07:41:45.089Z",
-            "agent": {
-                "ephemeral_id": "2e3f8db3eb77fae0",
-                "name": "Jaeger/Go",
-                "version": "2.20.1"
-            },
-            "error": {
-                "exception": [
-                    {
-                        "message": "redis timeout"
-                    }
-                ],
-                "grouping_key": "dd09a7d0d9dde0adfcd694967c5a88de",
-                "log": {
-                    "message": "redis timeout"
-                }
-            },
-            "host": {
-                "hostname": "host01",
-                "ip": "10.0.0.13"
-            },
-            "parent": {
-                "id": "614811d6c498bfb0"
-            },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
-            "service": {
-                "language": {
-                    "name": "Go"
-                },
-                "name": "redis"
-            },
-            "timestamp": {
-                "us": 1576827705089372
-            },
-            "trace": {
-                "id": "00000000000000007be2fd98d0973be3"
-            }
-        },
-        {
-            "@timestamp": "2019-12-20T07:41:45.172Z",
-            "agent": {
-                "ephemeral_id": "2e3f8db3eb77fae0",
-                "name": "Jaeger/Go",
-                "version": "2.20.1"
-            },
-            "error": {
-                "exception": [
-                    {
-                        "message": "redis timeout"
-                    }
-                ],
-                "grouping_key": "dd09a7d0d9dde0adfcd694967c5a88de",
-                "log": {
-                    "message": "redis timeout"
-                }
-            },
-            "host": {
-                "hostname": "host01",
-                "ip": "10.0.0.13"
-            },
-            "parent": {
-                "id": "0242ee3774d9eab1"
-            },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
-            "service": {
-                "language": {
-                    "name": "Go"
-                },
-                "name": "redis"
-            },
-            "timestamp": {
-                "us": 1576827705172347
             },
             "trace": {
                 "id": "00000000000000007be2fd98d0973be3"

--- a/x-pack/apm-server/sampling/eventstorage/storage.go
+++ b/x-pack/apm-server/sampling/eventstorage/storage.go
@@ -222,7 +222,7 @@ func (rw *ReadWriter) ReadEvents(traceID string, out *model.Batch) error {
 			}); err != nil {
 				return err
 			}
-			out.Transactions = append(out.Transactions, &event)
+			*out = append(*out, model.APMEvent{Transaction: &event})
 		case entryMetaSpan:
 			var event model.Span
 			if err := item.Value(func(data []byte) error {
@@ -230,7 +230,7 @@ func (rw *ReadWriter) ReadEvents(traceID string, out *model.Batch) error {
 			}); err != nil {
 				return err
 			}
-			out.Spans = append(out.Spans, &event)
+			*out = append(*out, model.APMEvent{Span: &event})
 		default:
 			// Unknown entry meta: ignore.
 			continue

--- a/x-pack/apm-server/sampling/eventstorage/storage_bench_test.go
+++ b/x-pack/apm-server/sampling/eventstorage/storage_bench_test.go
@@ -84,14 +84,14 @@ func BenchmarkReadEvents(b *testing.B) {
 				b.ResetTimer()
 				var batch model.Batch
 				for i := 0; i < b.N; i++ {
-					batch.Reset()
+					batch = batch[:0]
 					if err := readWriter.ReadEvents(traceUUID.String(), &batch); err != nil {
 						b.Fatal(err)
 					}
-					if batch.Len() != count {
+					if len(batch) != count {
 						panic(fmt.Errorf(
 							"event count mismatch: expected %d, got %d",
-							count, batch.Len(),
+							count, len(batch),
 						))
 					}
 				}

--- a/x-pack/apm-server/sampling/processor_bench_test.go
+++ b/x-pack/apm-server/sampling/processor_bench_test.go
@@ -47,10 +47,13 @@ func BenchmarkProcess(b *testing.B) {
 				ID:       hex.EncodeToString(spanID),
 				ParentID: spanParentID,
 			}
-			if err := processor.ProcessBatch(context.Background(), &model.Batch{
-				Transactions: []*model.Transaction{transaction},
-				Spans:        []*model.Span{span, span, span},
-			}); err != nil {
+			batch := model.Batch{
+				{Transaction: transaction},
+				{Span: span},
+				{Span: span},
+				{Span: span},
+			}
+			if err := processor.ProcessBatch(context.Background(), &batch); err != nil {
 				b.Fatal(err)
 			}
 		}

--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -36,15 +36,15 @@ func TestProcessUnsampled(t *testing.T) {
 	go processor.Run()
 	defer processor.Stop(context.Background())
 
-	in := &model.Batch{
-		Transactions: []*model.Transaction{{
+	in := model.Batch{{
+		Transaction: &model.Transaction{
 			TraceID: "0102030405060708090a0b0c0d0e0f10",
 			ID:      "0102030405060708",
 			Sampled: newBool(false),
-		}},
-	}
-	out := cloneBatch(in)
-	err = processor.ProcessBatch(context.Background(), out)
+		},
+	}}
+	out := in[:]
+	err = processor.ProcessBatch(context.Background(), &out)
 	require.NoError(t, err)
 
 	// Unsampled transaction should be reported immediately.
@@ -94,19 +94,21 @@ func TestProcessAlreadyTailSampled(t *testing.T) {
 		ID:      "0102030405060711",
 	}
 
-	batch := &model.Batch{
-		Transactions: []*model.Transaction{transaction1, transaction2},
-		Spans:        []*model.Span{span1, span2},
+	batch := model.Batch{
+		{Transaction: transaction1},
+		{Transaction: transaction2},
+		{Span: span1},
+		{Span: span2},
 	}
-	err = processor.ProcessBatch(context.Background(), batch)
+	err = processor.ProcessBatch(context.Background(), &batch)
 	require.NoError(t, err)
 
 	// Tail sampling decision already made. The first transaction and span should be
 	// reported immediately, whereas the second ones should be written storage since
 	// they were received after the trace sampling entry expired.
-	assert.Equal(t, &model.Batch{
-		Transactions: []*model.Transaction{transaction1},
-		Spans:        []*model.Span{span1},
+	assert.Equal(t, model.Batch{
+		{Transaction: transaction1},
+		{Span: span1},
 	}, batch)
 
 	expectedMonitoring := monitoring.MakeFlatSnapshot()
@@ -130,8 +132,8 @@ func TestProcessAlreadyTailSampled(t *testing.T) {
 		err = reader.ReadEvents(traceID2, &batch)
 		assert.NoError(t, err)
 		assert.Equal(t, model.Batch{
-			Spans:        []*model.Span{span2},
-			Transactions: []*model.Transaction{transaction2},
+			{Transaction: transaction2},
+			{Span: span2},
 		}, batch)
 	})
 }
@@ -149,37 +151,34 @@ func TestProcessLocalTailSampling(t *testing.T) {
 	traceID1 := "0102030405060708090a0b0c0d0e0f10"
 	traceID2 := "0102030405060708090a0b0c0d0e0f11"
 	trace1Events := model.Batch{
-		Transactions: []*model.Transaction{{
+		{Transaction: &model.Transaction{
 			TraceID:  traceID1,
 			ID:       "0102030405060708",
 			Duration: 123,
 		}},
-		Spans: []*model.Span{{
+		{Span: &model.Span{
 			TraceID:  traceID1,
 			ID:       "0102030405060709",
 			Duration: 123,
 		}},
 	}
 	trace2Events := model.Batch{
-		Transactions: []*model.Transaction{{
+		{Transaction: &model.Transaction{
 			TraceID:  traceID2,
 			ID:       "0102030405060710",
 			Duration: 456,
 		}},
-		Spans: []*model.Span{{
+		{Span: &model.Span{
 			TraceID:  traceID2,
 			ID:       "0102030405060711",
 			Duration: 456,
 		}},
 	}
 
-	in := &model.Batch{
-		Transactions: append(trace1Events.Transactions[:], trace2Events.Transactions...),
-		Spans:        append(trace1Events.Spans[:], trace2Events.Spans...),
-	}
-	err = processor.ProcessBatch(context.Background(), in)
+	in := append(trace1Events[:], trace2Events...)
+	err = processor.ProcessBatch(context.Background(), &in)
 	require.NoError(t, err)
-	assert.Equal(t, 0, in.Len())
+	assert.Empty(t, in)
 
 	// Start periodic tail-sampling. We start the processor after processing
 	// events to ensure all events are processed before any local sampling
@@ -242,7 +241,7 @@ func TestProcessLocalTailSampling(t *testing.T) {
 		// Even though the trace is unsampled, the events will be
 		// available in storage until the TTL expires, as they're
 		// written there first.
-		batch.Reset()
+		batch = batch[:0]
 		err = reader.ReadEvents(unsampledTraceID, &batch)
 		assert.NoError(t, err)
 		assert.Equal(t, unsampledTraceEvents, batch)
@@ -262,16 +261,16 @@ func TestProcessLocalTailSamplingUnsampled(t *testing.T) {
 	for i := range traceIDs {
 		traceID := uuid.Must(uuid.NewV4()).String()
 		traceIDs[i] = traceID
-		batch := model.Batch{
-			Transactions: []*model.Transaction{{
+		batch := model.Batch{{
+			Transaction: &model.Transaction{
 				TraceID:  traceID,
 				ID:       traceID,
 				Duration: 1,
-			}},
-		}
+			},
+		}}
 		err := processor.ProcessBatch(context.Background(), &batch)
 		require.NoError(t, err)
-		assert.Equal(t, 0, batch.Len())
+		assert.Empty(t, batch)
 	}
 
 	// Stop the processor so we can access the database.
@@ -320,12 +319,12 @@ func TestProcessLocalTailSamplingPolicyOrder(t *testing.T) {
 	rng := rand.New(rand.NewSource(0))
 	metadata := model.Metadata{Service: model.Service{Name: "service_name"}}
 	numTransactions := 100
-	events := &model.Batch{Transactions: make([]*model.Transaction, numTransactions)}
-	for i := 0; i < 100; i++ {
+	events := make(model.Batch, numTransactions)
+	for i := range events {
 		var traceIDBytes [16]byte
 		_, err := rng.Read(traceIDBytes[:])
 		require.NoError(t, err)
-		events.Transactions[i] = &model.Transaction{
+		events[i].Transaction = &model.Transaction{
 			Metadata: metadata,
 			Name:     "trace_name",
 			TraceID:  fmt.Sprintf("%x", traceIDBytes[:]),
@@ -334,9 +333,9 @@ func TestProcessLocalTailSamplingPolicyOrder(t *testing.T) {
 		}
 	}
 
-	err = processor.ProcessBatch(context.Background(), events)
+	err = processor.ProcessBatch(context.Background(), &events)
 	require.NoError(t, err)
-	assert.Equal(t, 0, events.Len())
+	assert.Empty(t, events)
 
 	// Start periodic tail-sampling. We start the processor after processing
 	// events to ensure all events are processed before any local sampling
@@ -374,12 +373,12 @@ func TestProcessRemoteTailSampling(t *testing.T) {
 	subscriber := pubsubtest.SubscriberChan(subscriberChan)
 	config.Elasticsearch = pubsubtest.Client(publisher, subscriber)
 
-	reported := make(chan *model.Batch)
+	reported := make(chan model.Batch)
 	config.BatchProcessor = model.ProcessBatchFunc(func(ctx context.Context, batch *model.Batch) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case reported <- batch:
+		case reported <- *batch:
 			return nil
 		}
 	})
@@ -391,18 +390,18 @@ func TestProcessRemoteTailSampling(t *testing.T) {
 
 	traceID1 := "0102030405060708090a0b0c0d0e0f10"
 	traceID2 := "0102030405060708090a0b0c0d0e0f11"
-	trace1Events := &model.Batch{
-		Spans: []*model.Span{{
+	trace1Events := model.Batch{{
+		Span: &model.Span{
 			TraceID:  traceID1,
 			ID:       "0102030405060709",
 			Duration: 123,
-		}},
-	}
+		},
+	}}
 
-	in := cloneBatch(trace1Events)
-	err = processor.ProcessBatch(context.Background(), in)
+	in := trace1Events[:]
+	err = processor.ProcessBatch(context.Background(), &in)
 	require.NoError(t, err)
-	assert.Equal(t, 0, in.Len())
+	assert.Empty(t, in)
 
 	// Simulate receiving remote sampling decisions multiple times,
 	// to show that we don't report duplicate events.
@@ -411,7 +410,7 @@ func TestProcessRemoteTailSampling(t *testing.T) {
 	subscriberChan <- traceID2
 	subscriberChan <- traceID1
 
-	var events *model.Batch
+	var events model.Batch
 	select {
 	case events = <-reported:
 	case <-time.After(10 * time.Second):
@@ -456,7 +455,7 @@ func TestProcessRemoteTailSampling(t *testing.T) {
 		batch = model.Batch{}
 		err = reader.ReadEvents(traceID2, &batch)
 		assert.NoError(t, err)
-		assert.Zero(t, batch)
+		assert.Empty(t, batch)
 	})
 }
 
@@ -472,16 +471,16 @@ func TestGroupsMonitoring(t *testing.T) {
 	defer processor.Stop(context.Background())
 
 	for i := 0; i < config.MaxDynamicServices+1; i++ {
-		err := processor.ProcessBatch(context.Background(), &model.Batch{
-			Transactions: []*model.Transaction{{
+		err := processor.ProcessBatch(context.Background(), &model.Batch{{
+			Transaction: &model.Transaction{
 				Metadata: model.Metadata{
 					Service: model.Service{Name: fmt.Sprintf("service_%d", i)},
 				},
 				TraceID:  uuid.Must(uuid.NewV4()).String(),
 				ID:       "0102030405060709",
 				Duration: 123,
-			}},
-		})
+			},
+		}})
 		require.NoError(t, err)
 	}
 
@@ -502,16 +501,16 @@ func TestStorageMonitoring(t *testing.T) {
 	defer processor.Stop(context.Background())
 	for i := 0; i < 100; i++ {
 		traceID := uuid.Must(uuid.NewV4()).String()
-		batch := model.Batch{
-			Transactions: []*model.Transaction{{
+		batch := model.Batch{{
+			Transaction: &model.Transaction{
 				TraceID:  traceID,
 				ID:       traceID,
 				Duration: 123,
-			}},
-		}
+			},
+		}}
 		err := processor.ProcessBatch(context.Background(), &batch)
 		require.NoError(t, err)
-		assert.Equal(t, 0, batch.Len())
+		assert.Empty(t, batch)
 	}
 
 	// Stop the processor and create a new one, which will reopen storage
@@ -544,16 +543,16 @@ func TestStorageGC(t *testing.T) {
 		defer processor.Stop(context.Background())
 		for i := 0; i < n; i++ {
 			traceID := uuid.Must(uuid.NewV4()).String()
-			batch := model.Batch{
-				Spans: []*model.Span{{
+			batch := model.Batch{{
+				Span: &model.Span{
 					TraceID:  traceID,
 					ID:       traceID,
 					Duration: 123,
-				}},
-			}
+				},
+			}}
 			err := processor.ProcessBatch(context.Background(), &batch)
 			require.NoError(t, err)
-			assert.Equal(t, 0, batch.Len())
+			assert.Empty(t, batch)
 		}
 	}
 
@@ -718,13 +717,6 @@ func collectProcessorMetrics(p *sampling.Processor) monitoring.FlatSnapshot {
 
 func newBool(v bool) *bool {
 	return &v
-}
-
-func cloneBatch(in *model.Batch) *model.Batch {
-	return &model.Batch{
-		Transactions: in.Transactions[:],
-		Spans:        in.Spans[:],
-	}
 }
 
 // waitFileModified waits up to 10 seconds for filename to exist and for its


### PR DESCRIPTION
## Motivation/summary

Introduce model.APMEvent, a sort of discriminated union of all possible APM event types. In the future I intend to define model types in protobuf and generate the Go code. The APMEvent type will evolve to map directly to the Elasticsearch docs we produce, along these lines:

```
message APMEvent {
  google.protobuf.Timestamp timestamp = 1;
  Event event = 2;
  Trace trace = 3;
  Transaction transaction = 4;
  Span span = 5;
  Metricset metricset = 6;
  Parent parent = 7;
  Agent agent = 8;
  Client client = 9;
  Cloud cloud = 10;
  Container container = 11;
  Host host = 12;
  Kubernetes kubernetes = 13;
  map<string, LabelValue> labels = 14;
  Process process = 15;
  Service service = 16;
  Session session = 17;
  User user = 18;
  UserAgent user_agent = 19;
  HTTP http = 20;
  URL url = 21;
  Child child = 22;
  Error error = 23;
}
```

When we do that, we'll be moving common fields (e.g. service details, labels) to APMEvent, and out of the specific event objects. By moving common fields to this top-level type, we'll be able to generate code for encoding to Beats events.

## How to test these changes

N/A, non-functional change.

## Related issues

https://github.com/elastic/apm-server/issues/4120
https://github.com/elastic/apm-server/issues/4410
https://github.com/elastic/apm-server/issues/3565