### PR TITLE
Add missing RUM vars to apmpackage manifest

### DIFF
--- a/apmpackage/apm/manifest.yml
+++ b/apmpackage/apm/manifest.yml
@@ -120,6 +120,20 @@ policy_templates:
             required: false
             show_user: false
             default: 10000
+          - name: rum_library_pattern
+            type: string
+            title: RUM - Library Frame Pattern
+            description: Identify library frames by matching a stacktrace frame's `file_name` and `abs_path` against this regexp.
+            required: false
+            show_user: false
+            default: '"node_modules|bower_components|~"'
+          - name: rum_exclude_from_grouping
+            type: string
+            title: RUM - Exclude from grouping
+            description: Exclude stacktrace frames from error group calculations by matching a stacktrace frame's `file_name` against this regexp.
+            required: false
+            show_user: false
+            default: '"^/webpack"'
           - name: api_key_limit
             type: integer
             title: Maximum number of API Keys for Agent authentication

--- a/apmpackage/apm/manifest.yml
+++ b/apmpackage/apm/manifest.yml
@@ -121,14 +121,14 @@ policy_templates:
             show_user: false
             default: 10000
           - name: rum_library_pattern
-            type: string
+            type: text
             title: RUM - Library Frame Pattern
             description: Identify library frames by matching a stacktrace frame's `file_name` and `abs_path` against this regexp.
             required: false
             show_user: false
             default: '"node_modules|bower_components|~"'
           - name: rum_exclude_from_grouping
-            type: string
+            type: text
             title: RUM - Exclude from grouping
             description: Exclude stacktrace frames from error group calculations by matching a stacktrace frame's `file_name` against this regexp.
             required: false


### PR DESCRIPTION
## Motivation/summary

Add missing RUM vars to apmpackage manifest. The variables are already part of the template. 

## How to test these changes

Configure regexes in APM integration and ensure that matching stacktraces are not considered when ingesting data. 
<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues
follow up on #4528
<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
