### PR TITLE
Introduce `apm-server.auth.anonymous` config

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -19,6 +19,34 @@ apm-server:
     # Define a shared secret token for authorizing agents using the "Bearer" authorization method.
     #secret_token:
 
+    # Allow anonymous access only for specified agents and/or services. This is primarily intended to allow
+    # limited access for untrusted agents, such as Real User Monitoring.
+    #anonymous:
+      # By default anonymous auth is automatically enabled when either auth.api_key or
+      # auth.secret_token is enabled, and RUM is enabled. Otherwise, anonymous auth is
+      # disabled by default.
+      #
+      # When anonymous auth is enabled, only agents matching allow_agent and services
+      # matching allow_service are allowed. See below for details on default values for
+      # allow_agent.
+      #enabled:
+
+      # Allow anonymous access only for specified agents.
+      #allow_agent: [rum-js, js-base]
+
+      # Allow anonymous access only for specified service names. By default, all service names are allowed.
+      #allow_service: []
+
+      # Rate-limit anonymous access by IP and number of events.
+      #rate_limit:
+        # Rate limiting is defined per unique client IP address, for a limited number of IP addresses.
+        # Sites with many concurrent clients should consider increasing this limit. Defaults to 1000.
+        #ip_limit: 1000
+
+        # Defines the maximum amount of events allowed per IP per second. Defaults to 300. The overall
+        # maximum event throughput for anonymous access is (event_limit * ip_limit).
+        #event_limit: 300
+
   # Maximum permitted size in bytes of a request's header accepted by the server to be processed.
   #max_header_size: 1048576
 
@@ -214,6 +242,10 @@ apm-server:
   #rum:
     #enabled: false
 
+    # Rate-limit RUM agents.
+    #
+    # WARNING: This configuration is deprecated and replaced with `apm-server.auth.anonymous.rate_limit`,
+    # and will be removed in the 8.0 release. If that config is defined, this one will be ignored.
     #event_rate:
 
       # Defines the maximum amount of events allowed to be sent to the APM Server RUM
@@ -230,6 +262,9 @@ apm-server:
     # A list of service names to allow, to limit service-specific indices and data streams
     # created for unauthenticated RUM events.
     # If the list is empty, any service name is allowed.
+    #
+    # WARNING: This configuration is deprecated and replaced with `apm-server.auth.anonymous.allow_service`,
+    # and will be removed in the 8.0 release. If that config is defined, this one will be ignored.
     #allow_service_names: []
 
     # A list of permitted origins for real user monitoring.

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -19,6 +19,34 @@ apm-server:
     # Define a shared secret token for authorizing agents using the "Bearer" authorization method.
     #secret_token:
 
+    # Allow anonymous access only for specified agents and/or services. This is primarily intended to allow
+    # limited access for untrusted agents, such as Real User Monitoring.
+    #anonymous:
+      # By default anonymous auth is automatically enabled when either auth.api_key or
+      # auth.secret_token is enabled, and RUM is enabled. Otherwise, anonymous auth is
+      # disabled by default.
+      #
+      # When anonymous auth is enabled, only agents matching allow_agent and services
+      # matching allow_service are allowed. See below for details on default values for
+      # allow_agent.
+      #enabled:
+
+      # Allow anonymous access only for specified agents.
+      #allow_agent: [rum-js, js-base]
+
+      # Allow anonymous access only for specified service names. By default, all service names are allowed.
+      #allow_service: []
+
+      # Rate-limit anonymous access by IP and number of events.
+      #rate_limit:
+        # Rate limiting is defined per unique client IP address, for a limited number of IP addresses.
+        # Sites with many concurrent clients should consider increasing this limit. Defaults to 1000.
+        #ip_limit: 1000
+
+        # Defines the maximum amount of events allowed per IP per second. Defaults to 300. The overall
+        # maximum event throughput for anonymous access is (event_limit * ip_limit).
+        #event_limit: 300
+
   # Maximum permitted size in bytes of a request's header accepted by the server to be processed.
   #max_header_size: 1048576
 
@@ -214,6 +242,10 @@ apm-server:
   #rum:
     #enabled: false
 
+    # Rate-limit RUM agents.
+    #
+    # WARNING: This configuration is deprecated and replaced with `apm-server.auth.anonymous.rate_limit`,
+    # and will be removed in the 8.0 release. If that config is defined, this one will be ignored.
     #event_rate:
 
       # Defines the maximum amount of events allowed to be sent to the APM Server RUM
@@ -230,6 +262,9 @@ apm-server:
     # A list of service names to allow, to limit service-specific indices and data streams
     # created for unauthenticated RUM events.
     # If the list is empty, any service name is allowed.
+    #
+    # WARNING: This configuration is deprecated and replaced with `apm-server.auth.anonymous.allow_service`,
+    # and will be removed in the 8.0 release. If that config is defined, this one will be ignored.
     #allow_service_names: []
 
     # A list of permitted origins for real user monitoring.

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -19,6 +19,34 @@ apm-server:
     # Define a shared secret token for authorizing agents using the "Bearer" authorization method.
     #secret_token:
 
+    # Allow anonymous access only for specified agents and/or services. This is primarily intended to allow
+    # limited access for untrusted agents, such as Real User Monitoring.
+    #anonymous:
+      # By default anonymous auth is automatically enabled when either auth.api_key or
+      # auth.secret_token is enabled, and RUM is enabled. Otherwise, anonymous auth is
+      # disabled by default.
+      #
+      # When anonymous auth is enabled, only agents matching allow_agent and services
+      # matching allow_service are allowed. See below for details on default values for
+      # allow_agent.
+      #enabled:
+
+      # Allow anonymous access only for specified agents.
+      #allow_agent: [rum-js, js-base]
+
+      # Allow anonymous access only for specified service names. By default, all service names are allowed.
+      #allow_service: []
+
+      # Rate-limit anonymous access by IP and number of events.
+      #rate_limit:
+        # Rate limiting is defined per unique client IP address, for a limited number of IP addresses.
+        # Sites with many concurrent clients should consider increasing this limit. Defaults to 1000.
+        #ip_limit: 1000
+
+        # Defines the maximum amount of events allowed per IP per second. Defaults to 300. The overall
+        # maximum event throughput for anonymous access is (event_limit * ip_limit).
+        #event_limit: 300
+
   # Maximum permitted size in bytes of a request's header accepted by the server to be processed.
   #max_header_size: 1048576
 
@@ -214,6 +242,10 @@ apm-server:
   #rum:
     #enabled: false
 
+    # Rate-limit RUM agents.
+    #
+    # WARNING: This configuration is deprecated and replaced with `apm-server.auth.anonymous.rate_limit`,
+    # and will be removed in the 8.0 release. If that config is defined, this one will be ignored.
     #event_rate:
 
       # Defines the maximum amount of events allowed to be sent to the APM Server RUM
@@ -230,6 +262,9 @@ apm-server:
     # A list of service names to allow, to limit service-specific indices and data streams
     # created for unauthenticated RUM events.
     # If the list is empty, any service name is allowed.
+    #
+    # WARNING: This configuration is deprecated and replaced with `apm-server.auth.anonymous.allow_service`,
+    # and will be removed in the 8.0 release. If that config is defined, this one will be ignored.
     #allow_service_names: []
 
     # A list of permitted origins for real user monitoring.

--- a/apmpackage/apm/agent/input/template.yml.hbs
+++ b/apmpackage/apm/agent/input/template.yml.hbs
@@ -1,5 +1,18 @@
 apm-server:
     auth:
+        anonymous:
+            allow_agent:
+                {{#each anonymous_allow_agent}}
+                - {{this}}
+                {{/each}}
+            allow_service:
+                {{#each anonymous_allow_service}}
+                - {{this}}
+                {{/each}}
+            enabled: {{anonymous_enabled}}
+            rate_limit:
+                event_limit: {{anonymous_rate_limit_event_limit}}
+                ip_limit: {{anonymous_rate_limit_ip_limit}}
         api_key:
             enabled: {{api_key_enabled}}
             limit: {{api_key_limit}}
@@ -24,13 +37,7 @@ apm-server:
         {{#each rum_allow_origins}}
           - {{this}}
         {{/each}}
-        allow_service_names:
-        {{#each rum_allow_service_names}}
-          - {{this}}
-        {{/each}}
         enabled: {{enable_rum}}
-        event_rate.limit: {{rum_event_rate_limit}}
-        event_rate.lru_size: {{rum_event_rate_lru_size}}
         exclude_from_grouping: {{rum_exclude_from_grouping}}
         library_pattern: {{rum_library_pattern}}
         response_headers: {{rum_response_headers}}

--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -3,6 +3,9 @@
 # change type can be one of: enhancement, bugfix, breaking-change
 - version: "0.4.0"
   changes:
+    - description: add anonymous auth config, replace some RUM config
+      type: breaking-change
+      link: https://github.com/elastic/apm-server/pull/5623
     - description: use new apm-server.auth config
       type: breaking-change
       link: https://github.com/elastic/apm-server/pull/5691

--- a/apmpackage/apm/manifest.yml
+++ b/apmpackage/apm/manifest.yml
@@ -72,17 +72,46 @@ policy_templates:
             required: true
             show_user: true
             default: true
+          - name: anonymous_enabled
+            type: bool
+            title: Anonymous Agent access
+            description: Enable anonymous access to APM Server for select APM Agents.
+            required: false
+            show_user: true
+            default: true
+          - name: anonymous_allow_agent
+            type: text
+            title: Anonymous Agent access - allowed agents
+            description: Allowed agent names for anonymous access.
+            multi: true
+            required: false
+            show_user: false
+            default: ['rum-js', 'js-base', 'iOS/swift']
+          - name: anonymous_allow_service
+            type: text
+            title: Anonymous Agent access - allowed services
+            description: Allowed service names for anonymous access.
+            multi: true
+            required: false
+            show_user: false
+          - name: anonymous_rate_limit_event_limit
+            type: integer
+            title: Anonymous Agent access - event rate limit (event limit)
+            description: Maximum number of events per client IP per second.
+            required: false
+            show_user: false
+            default: 10
+          - name: anonymous_rate_limit_ip_limit
+            type: integer
+            title: Anonymous Agent access - rate limit (IP limit)
+            description: Number of unique client IPs for which a distinct rate limit will be maintained.
+            required: false
+            show_user: false
+            default: 10000
           - name: default_service_environment
             type: text
             title: Default Service Environment
             description: Default service environment to record in events which have no service environment defined.
-            required: false
-            show_user: false
-          - name: rum_allow_service_names
-            type: text
-            title: RUM - Allowed Service Names
-            description: Allowed service names for events sent by RUM agents.
-            multi: true
             required: false
             show_user: false
           - name: rum_allow_origins
@@ -106,20 +135,6 @@ policy_templates:
             description: Added to RUM responses, e.g. for security policy compliance.
             required: false
             show_user: false
-          - name: rum_event_rate_limit
-            type: integer
-            title: RUM - Rate limit events per IP
-            description: Maximum number of events allowed per IP per second.
-            required: false
-            show_user: false
-            default: 10
-          - name: rum_event_rate_lru_size
-            type: integer
-            title: RUM - Rate limit cache size
-            description: Number of unique IPs to be cached for the rate limiter.
-            required: false
-            show_user: false
-            default: 10000
           - name: rum_library_pattern
             type: text
             title: RUM - Library Frame Pattern

--- a/beater/api/asset/sourcemap/test_approved/integration/TestSourcemapHandler_AuthorizationMiddleware/Forbidden.approved.json
+++ b/beater/api/asset/sourcemap/test_approved/integration/TestSourcemapHandler_AuthorizationMiddleware/Forbidden.approved.json
@@ -1,0 +1,3 @@
+{
+    "error": "unauthorized: anonymous access not permitted for sourcemap uploads"
+}

--- a/beater/api/config/agent/handler.go
+++ b/beater/api/config/agent/handler.go
@@ -113,7 +113,7 @@ func (h *handler) Handle(c *request.Context) {
 		c.Write()
 		return
 	}
-	if c.Authentication.Method == "" {
+	if c.Authentication.Method == auth.MethodAnonymous {
 		// Unauthenticated client, restrict results.
 		query.InsecureAgents = h.allowAnonymousAgents
 	}
@@ -234,7 +234,7 @@ func extractQueryError(c *request.Context, err error) {
 }
 
 func authErrMsg(c *request.Context, fullMsg, shortMsg string) string {
-	if c.Authentication.Method != "" {
+	if c.Authentication.Method != auth.MethodAnonymous {
 		return fullMsg
 	}
 	return shortMsg

--- a/beater/api/root/handler.go
+++ b/beater/api/root/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/monitoring"
 	"github.com/elastic/beats/v7/libbeat/version"
 
+	"github.com/elastic/apm-server/beater/auth"
 	"github.com/elastic/apm-server/beater/request"
 )
 
@@ -40,7 +41,7 @@ type HandlerConfig struct {
 }
 
 // Handler returns error if route does not exist,
-// otherwise returns information about the server. The detail level differs for authorized and non-authorized requests.
+// otherwise returns information about the server. The detail level differs for authenticated and anonymous requests.
 //TODO: only allow GET, HEAD requests (breaking change)
 func Handler(cfg HandlerConfig) request.Handler {
 	serverInfo := common.MapStr{
@@ -56,7 +57,7 @@ func Handler(cfg HandlerConfig) request.Handler {
 			return
 		}
 		c.Result.SetDefault(request.IDResponseValidOK)
-		if c.Authentication.Method != "" {
+		if c.Authentication.Method != auth.MethodAnonymous {
 			c.Result.Body = serverInfo
 		}
 		c.Write()

--- a/beater/api/root/handler_test.go
+++ b/beater/api/root/handler_test.go
@@ -49,7 +49,7 @@ func TestRootHandler(t *testing.T) {
 
 	t.Run("unauthenticated", func(t *testing.T) {
 		c, w := beatertest.ContextWithResponseRecorder(http.MethodGet, "/")
-		c.Authentication.Method = ""
+		c.Authentication.Method = auth.MethodAnonymous
 		Handler(HandlerConfig{Version: "1.2.3"})(c)
 
 		assert.Equal(t, http.StatusOK, w.Code)

--- a/beater/auth/anonymous.go
+++ b/beater/auth/anonymous.go
@@ -19,12 +19,62 @@ package auth
 
 import (
 	"context"
+	"fmt"
 )
 
-// AnonymousAuth implements the Authorizer interface.
-type AnonymousAuth struct{}
+func newAnonymousAuth(allowAgent, allowService []string) *anonymousAuth {
+	a := &anonymousAuth{
+		allowedAgents:   make(map[string]bool),
+		allowedServices: make(map[string]bool),
+	}
+	for _, name := range allowAgent {
+		a.allowedAgents[name] = true
+	}
+	for _, name := range allowService {
+		a.allowedServices[name] = true
+	}
+	return a
+}
 
-// Authorize always returns nil, indicating the request is authorized.
-func (AnonymousAuth) Authorize(context.Context, Action, Resource) error {
-	return nil
+// anonymousAuth implements the Authorization interface, allowing anonymous access with
+// optional restriction on agent and service name.
+type anonymousAuth struct {
+	allowedAgents   map[string]bool
+	allowedServices map[string]bool
+}
+
+// Authorize checks if anonymous access is authorized for the given action and resource.
+func (a *anonymousAuth) Authorize(ctx context.Context, action Action, resource Resource) error {
+	switch action {
+	case ActionAgentConfig:
+		// Anonymous access to agent config should be restricted by service.
+		// Agent config queries do not provide an agent name, so that is not
+		// checked here. Instead, the agent config handlers will filter results
+		// down to those in the allowed agent list.
+		if len(a.allowedServices) != 0 && !a.allowedServices[resource.ServiceName] {
+			return fmt.Errorf(
+				"%w: anonymous access not permitted for service %q",
+				ErrUnauthorized, resource.ServiceName,
+			)
+		}
+		return nil
+	case ActionEventIngest:
+		if len(a.allowedServices) != 0 && !a.allowedServices[resource.ServiceName] {
+			return fmt.Errorf(
+				"%w: anonymous access not permitted for service %q",
+				ErrUnauthorized, resource.ServiceName,
+			)
+		}
+		if len(a.allowedAgents) != 0 && !a.allowedAgents[resource.AgentName] {
+			return fmt.Errorf(
+				"%w: anonymous access not permitted for agent %q",
+				ErrUnauthorized, resource.AgentName,
+			)
+		}
+		return nil
+	case ActionSourcemapUpload:
+		return fmt.Errorf("%w: anonymous access not permitted for sourcemap uploads", ErrUnauthorized)
+	default:
+		return fmt.Errorf("unknown action %q", action)
+	}
 }

--- a/beater/auth/anonymous_test.go
+++ b/beater/auth/anonymous_test.go
@@ -1,0 +1,140 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-server/beater/auth"
+	"github.com/elastic/apm-server/beater/config"
+)
+
+func TestAnonymousAuthorizer(t *testing.T) {
+	for name, test := range map[string]struct {
+		allowAgent   []string
+		allowService []string
+		action       auth.Action
+		resource     auth.Resource
+		expectErr    error
+	}{
+		"deny_sourcemap_upload": {
+			allowAgent:   nil,
+			allowService: nil,
+			action:       auth.ActionSourcemapUpload,
+			resource:     auth.Resource{AgentName: "iOS/swift", ServiceName: "opbeans-ios"},
+			expectErr:    fmt.Errorf(`%w: anonymous access not permitted for sourcemap uploads`, auth.ErrUnauthorized),
+		},
+		"deny_unknown_action": {
+			allowAgent:   nil,
+			allowService: nil,
+			action:       "discombobulate",
+			resource:     auth.Resource{AgentName: "iOS/swift", ServiceName: "opbeans-ios"},
+			expectErr:    errors.New(`unknown action "discombobulate"`),
+		},
+		"allow_any_agent_config": {
+			allowAgent:   nil,
+			allowService: nil,
+			action:       auth.ActionAgentConfig,
+			resource:     auth.Resource{AgentName: "iOS/swift", ServiceName: "opbeans-ios"},
+		},
+		"allow_any_ingest": {
+			allowAgent:   nil,
+			allowService: nil,
+			action:       auth.ActionEventIngest,
+			resource:     auth.Resource{AgentName: "iOS/swift", ServiceName: "opbeans-ios"},
+		},
+		"allow_agent": {
+			allowAgent:   []string{"iOS/swift"},
+			allowService: nil,
+			action:       auth.ActionAgentConfig,
+			resource:     auth.Resource{AgentName: "iOS/swift", ServiceName: "opbeans-ios"},
+		},
+		"deny_agent": {
+			allowAgent:   []string{"rum-js"},
+			allowService: nil,
+			action:       auth.ActionEventIngest,
+			resource:     auth.Resource{AgentName: "iOS/swift", ServiceName: "opbeans-ios"},
+			expectErr:    fmt.Errorf(`%w: anonymous access not permitted for agent "iOS/swift"`, auth.ErrUnauthorized),
+		},
+		"allow_service": {
+			allowService: []string{"opbeans-ios"},
+			action:       auth.ActionAgentConfig,
+			resource:     auth.Resource{AgentName: "iOS/swift", ServiceName: "opbeans-ios"},
+		},
+		"deny_service": {
+			allowService: []string{"opbeans-rum"},
+			action:       auth.ActionAgentConfig,
+			resource:     auth.Resource{AgentName: "iOS/swift", ServiceName: "opbeans-ios"},
+			expectErr:    fmt.Errorf(`%w: anonymous access not permitted for service "opbeans-ios"`, auth.ErrUnauthorized),
+		},
+		"allow_agent_config_agent_unspecified": {
+			allowAgent: []string{"iOS/swift"},
+			action:     auth.ActionAgentConfig,
+			resource:   auth.Resource{ServiceName: "opbeans-ios"}, // AgentName not checked for agent config
+		},
+		"deny_agent_config_service_unspecified": {
+			allowService: []string{"opbeans-ios"},
+			action:       auth.ActionAgentConfig,
+			resource:     auth.Resource{AgentName: "iOS/swift"},
+			expectErr:    fmt.Errorf(`%w: anonymous access not permitted for service ""`, auth.ErrUnauthorized),
+		},
+		"deny_event_ingest_agent_unspecified": {
+			allowAgent: []string{"iOS/swift"},
+			action:     auth.ActionEventIngest,
+			resource:   auth.Resource{ServiceName: "opbeans-ios"},
+			expectErr:  fmt.Errorf(`%w: anonymous access not permitted for agent ""`, auth.ErrUnauthorized),
+		},
+		"deny_event_ingest_service_unspecified": {
+			allowService: []string{"opbeans-ios"},
+			action:       auth.ActionAgentConfig,
+			resource:     auth.Resource{AgentName: "iOS/swift"},
+			expectErr:    fmt.Errorf(`%w: anonymous access not permitted for service ""`, auth.ErrUnauthorized),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			authorizer := getAnonymousAuthorizer(t, config.AnonymousAgentAuth{
+				Enabled:      true,
+				AllowAgent:   test.allowAgent,
+				AllowService: test.allowService,
+			})
+			err := authorizer.Authorize(context.Background(), test.action, test.resource)
+			if test.expectErr != nil {
+				assert.Equal(t, test.expectErr, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func getAnonymousAuthorizer(t testing.TB, cfg config.AnonymousAgentAuth) auth.Authorizer {
+	authenticator, err := auth.NewAuthenticator(config.AgentAuth{
+		SecretToken: "whatever", // required to enable anonymous auth
+		Anonymous:   cfg,
+	})
+	require.NoError(t, err)
+	_, authorizer, err := authenticator.Authenticate(context.Background(), "", "")
+	require.NoError(t, err)
+	return authorizer
+}

--- a/beater/config/auth.go
+++ b/beater/config/auth.go
@@ -28,8 +28,25 @@ import (
 
 // AgentAuth holds config related to agent auth.
 type AgentAuth struct {
-	APIKey      APIKeyAgentAuth `config:"api_key"`
-	SecretToken string          `config:"secret_token"`
+	Anonymous   AnonymousAgentAuth `config:"anonymous"`
+	APIKey      APIKeyAgentAuth    `config:"api_key"`
+	SecretToken string             `config:"secret_token"`
+}
+
+func (a *AgentAuth) setAnonymousDefaults(logger *logp.Logger, rumEnabled bool) error {
+	if a.Anonymous.configured {
+		// Anonymous access explicitly configured.
+		return nil
+	}
+	if !a.APIKey.Enabled && a.SecretToken == "" {
+		// No auth is required.
+		return nil
+	}
+	if rumEnabled {
+		logger.Info("anonymous access enabled for RUM")
+		a.Anonymous.Enabled = true
+	}
+	return nil
 }
 
 // APIKeyAgentAuth holds config related to API Key auth for agents.
@@ -63,9 +80,43 @@ func (a *APIKeyAgentAuth) setup(log *logp.Logger, outputESCfg *common.Config) er
 	return nil
 }
 
+// AnonymousAgentAuth holds config related to anonymous access for agents.
+//
+// If RUM is enabled, and either secret_token or api_key auth is defined,
+// then anonymous auth will be enabled for RUM by default.
+type AnonymousAgentAuth struct {
+	Enabled      bool      `config:"enabled"`
+	AllowAgent   []string  `config:"allow_agent"`
+	AllowService []string  `config:"allow_service"`
+	RateLimit    RateLimit `config:"rate_limit"`
+
+	configured bool // anon explicitly defined
+}
+
+func (a *AnonymousAgentAuth) Unpack(in *common.Config) error {
+	type underlyingAnonymousAgentAuth AnonymousAgentAuth
+	if err := in.Unpack((*underlyingAnonymousAgentAuth)(a)); err != nil {
+		return errors.Wrap(err, "error unpacking anon config")
+	}
+	a.configured = true
+	return nil
+}
+
 func defaultAgentAuth() AgentAuth {
 	return AgentAuth{
-		APIKey: defaultAPIKeyAgentAuth(),
+		Anonymous: defaultAnonymousAgentAuth(),
+		APIKey:    defaultAPIKeyAgentAuth(),
+	}
+}
+
+func defaultAnonymousAgentAuth() AnonymousAgentAuth {
+	return AnonymousAgentAuth{
+		Enabled:    false,
+		AllowAgent: []string{"rum-js", "js-base"},
+		RateLimit: RateLimit{
+			EventLimit: 300,
+			IPLimit:    1000,
+		},
 	}
 }
 

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -164,6 +164,15 @@ func TestUnpackConfig(t *testing.T) {
 						configured:   true,
 						esConfigured: true,
 					},
+					Anonymous: AnonymousAgentAuth{
+						Enabled:      true,
+						AllowService: []string{"opbeans-rum"},
+						AllowAgent:   []string{"rum-js", "js-base"},
+						RateLimit: RateLimit{
+							EventLimit: 7200,
+							IPLimit:    2000,
+						},
+					},
 				},
 				TLS: &tlscommon.ServerConfig{
 					Enabled:     newBool(true),
@@ -191,14 +200,9 @@ func TestUnpackConfig(t *testing.T) {
 					},
 				},
 				RumConfig: RumConfig{
-					Enabled: true,
-					EventRate: EventRate{
-						Limit:   7200,
-						LruSize: 2000,
-					},
-					AllowServiceNames: []string{"opbeans-rum"},
-					AllowOrigins:      []string{"example*"},
-					AllowHeaders:      []string{"Authorization"},
+					Enabled:      true,
+					AllowOrigins: []string{"example*"},
+					AllowHeaders: []string{"Authorization"},
 					SourceMapping: SourceMapping{
 						Enabled:      true,
 						Cache:        Cache{Expiration: 8 * time.Minute},
@@ -347,6 +351,14 @@ func TestUnpackConfig(t *testing.T) {
 						ESConfig:    elasticsearch.DefaultConfig(),
 						configured:  true,
 					},
+					Anonymous: AnonymousAgentAuth{
+						Enabled:    true,
+						AllowAgent: []string{"rum-js", "js-base"},
+						RateLimit: RateLimit{
+							EventLimit: 300,
+							IPLimit:    1000,
+						},
+					},
 				},
 				TLS: &tlscommon.ServerConfig{
 					Enabled:     newBool(true),
@@ -373,11 +385,7 @@ func TestUnpackConfig(t *testing.T) {
 					},
 				},
 				RumConfig: RumConfig{
-					Enabled: true,
-					EventRate: EventRate{
-						Limit:   300,
-						LruSize: 1000,
-					},
+					Enabled:      true,
 					AllowOrigins: []string{"*"},
 					AllowHeaders: []string{},
 					SourceMapping: SourceMapping{

--- a/beater/config/ratelimit.go
+++ b/beater/config/ratelimit.go
@@ -1,0 +1,31 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package config
+
+// RateLimit holds configuration related to IP and event rate limiting.
+type RateLimit struct {
+	// EventLimit holds the event rate limit per IP, measured in
+	// events per second.
+	EventLimit int `config:"event_limit"`
+
+	// IPLimit holds the maximum number of client IPs for which we
+	// will maintain a distinct event rate limit. Once this has been
+	// reached, clients will begin sharing rate limiters. This is
+	// done to avoid DDoS attacks.
+	IPLimit int `config:"ip_limit"`
+}

--- a/beater/config/rum.go
+++ b/beater/config/rum.go
@@ -31,8 +31,6 @@ import (
 
 const (
 	allowAllOrigins                 = "*"
-	defaultEventRateLimit           = 300
-	defaultEventRateLRUSize         = 1000
 	defaultExcludeFromGrouping      = "^/webpack"
 	defaultLibraryPattern           = "node_modules|bower_components|~"
 	defaultSourcemapCacheExpiration = 5 * time.Minute
@@ -43,20 +41,12 @@ const (
 // RumConfig holds config information related to the RUM endpoint
 type RumConfig struct {
 	Enabled             bool                `config:"enabled"`
-	EventRate           EventRate           `config:"event_rate"`
-	AllowServiceNames   []string            `config:"allow_service_names"`
 	AllowOrigins        []string            `config:"allow_origins"`
 	AllowHeaders        []string            `config:"allow_headers"`
 	ResponseHeaders     map[string][]string `config:"response_headers"`
 	LibraryPattern      string              `config:"library_pattern"`
 	ExcludeFromGrouping string              `config:"exclude_from_grouping"`
 	SourceMapping       SourceMapping       `config:"source_mapping"`
-}
-
-// EventRate holds config information about event rate limiting
-type EventRate struct {
-	Limit   int `config:"limit"`
-	LruSize int `config:"lru_size"`
 }
 
 // SourceMapping holds sourcemap config information
@@ -125,10 +115,6 @@ func defaultSourcemapping() SourceMapping {
 
 func defaultRum() RumConfig {
 	return RumConfig{
-		EventRate: EventRate{
-			Limit:   defaultEventRateLimit,
-			LruSize: defaultEventRateLRUSize,
-		},
 		AllowOrigins:        []string{allowAllOrigins},
 		AllowHeaders:        []string{},
 		SourceMapping:       defaultSourcemapping(),

--- a/beater/interceptors/auth_test.go
+++ b/beater/interceptors/auth_test.go
@@ -43,7 +43,8 @@ func TestAuth(t *testing.T) {
 
 	authenticated := authenticatorFunc(func(ctx context.Context, kind, token string) (auth.AuthenticationDetails, auth.Authorizer, error) {
 		assert.Equal(t, 123, ctx.Value(contextKey{}))
-		return auth.AuthenticationDetails{Method: auth.MethodSecretToken}, auth.AnonymousAuth{}, nil
+		var authz authorizerFunc = func(context.Context, auth.Action, auth.Resource) error { return nil }
+		return auth.AuthenticationDetails{Method: auth.MethodSecretToken}, authz, nil
 	})
 	authFailed := authenticatorFunc(func(ctx context.Context, kind, token string) (auth.AuthenticationDetails, auth.Authorizer, error) {
 		return auth.AuthenticationDetails{}, nil, auth.ErrAuthFailed

--- a/beater/jaeger/grpc_test.go
+++ b/beater/jaeger/grpc_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/elastic/apm-server/agentcfg"
 	"github.com/elastic/apm-server/beater/auth"
 	"github.com/elastic/apm-server/beater/beatertest"
+	"github.com/elastic/apm-server/beater/config"
 	"github.com/elastic/apm-server/kibana/kibanatest"
 )
 
@@ -153,8 +154,14 @@ func TestGRPCSampler_GetSamplingStrategy(t *testing.T) {
 			tc.setup()
 			params := &api_v2.SamplingStrategyParameters{ServiceName: "serviceA"}
 
+			authenticator, err := auth.NewAuthenticator(config.AgentAuth{
+				Anonymous: config.AnonymousAgentAuth{Enabled: true},
+			})
+			require.NoError(t, err)
 			ctx := context.Background()
-			ctx = auth.ContextWithAuthorizer(ctx, auth.AnonymousAuth{})
+			_, authz, err := authenticator.Authenticate(ctx, "", "")
+			require.NoError(t, err)
+			ctx = auth.ContextWithAuthorizer(ctx, authz)
 			resp, err := tc.sampler.GetSamplingStrategy(ctx, params)
 
 			// assert sampling response

--- a/beater/middleware/auth_middleware_test.go
+++ b/beater/middleware/auth_middleware_test.go
@@ -75,7 +75,7 @@ func TestAuthMiddleware(t *testing.T) {
 			var authenticator authenticatorFunc = func(ctx context.Context, kind, token string) (auth.AuthenticationDetails, auth.Authorizer, error) {
 				assert.Equal(t, tc.expectKind, kind)
 				assert.Equal(t, tc.expectToken, token)
-				return auth.AuthenticationDetails{Method: auth.MethodSecretToken}, auth.AnonymousAuth{}, tc.authError
+				return auth.AuthenticationDetails{Method: auth.MethodSecretToken}, denyAll{}, tc.authError
 			}
 			m := AuthMiddleware(authenticator, tc.authRequired)
 			Apply(m, beatertest.Handler202)(c)

--- a/beater/middleware/rate_limit_middleware.go
+++ b/beater/middleware/rate_limit_middleware.go
@@ -18,6 +18,7 @@
 package middleware
 
 import (
+	"github.com/elastic/apm-server/beater/auth"
 	"github.com/elastic/apm-server/beater/ratelimit"
 	"github.com/elastic/apm-server/beater/request"
 )
@@ -31,7 +32,7 @@ import (
 func AnonymousRateLimitMiddleware(store *ratelimit.Store) Middleware {
 	return func(h request.Handler) (request.Handler, error) {
 		return func(c *request.Context) {
-			if c.Authentication.Method == "" {
+			if c.Authentication.Method == auth.MethodAnonymous {
 				limiter := store.ForIP(c.SourceIP)
 				if !limiter.Allow() {
 					c.Result.SetWithError(

--- a/beater/server.go
+++ b/beater/server.go
@@ -136,8 +136,8 @@ func newServer(
 ) (server, error) {
 	agentcfgFetchReporter := agentcfg.NewReporter(agentcfg.NewFetcher(cfg), batchProcessor, 30*time.Second)
 	ratelimitStore, err := ratelimit.NewStore(
-		cfg.RumConfig.EventRate.LruSize,
-		cfg.RumConfig.EventRate.Limit,
+		cfg.AgentAuth.Anonymous.RateLimit.IPLimit,
+		cfg.AgentAuth.Anonymous.RateLimit.EventLimit,
 		3, // burst multiplier
 	)
 	if err != nil {

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -39,7 +39,7 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 * Under fleet, report which agent configs have been applied {pull}5481[5481]
 * Server sends its raw config to kibana when running on ECE/ESS {pull}5424[5424]
 * Add HTTP span fields as top level ECS fields {pull}5396[5396]
-
+* Introduce `apm-server.auth.anonymous.*` config {pull}5623[5623]
 
 [float]
 ==== Deprecated

--- a/systemtest/apmservertest/config.go
+++ b/systemtest/apmservertest/config.go
@@ -164,16 +164,7 @@ type RUMConfig struct {
 	// ResponseHeaders holds headers to add to all APM Server RUM HTTP responses.
 	ResponseHeaders http.Header `json:"response_headers,omitempty"`
 
-	// RateLimit holds event rate limit configuration.
-	RateLimit *RUMRateLimitConfig `json:"event_rate,omitempty"`
-
 	Sourcemap *RUMSourcemapConfig `json:"source_mapping,omitempty"`
-}
-
-// RUMRateLimitConfig holds APM Server RUM event rate limit configuration.
-type RUMRateLimitConfig struct {
-	IPLimit    int `json:"lru_size,omitempty"`
-	EventLimit int `json:"limit,omitempty"`
 }
 
 // RUMSourcemapConfig holds APM Server RUM sourcemap configuration.
@@ -194,13 +185,28 @@ type DataStreamsConfig struct {
 
 // APIKeyConfig holds agent auth configuration.
 type AgentAuthConfig struct {
-	SecretToken string            `json:"secret_token,omitempty"`
-	APIKey      *APIKeyAuthConfig `json:"api_key,omitempty"`
+	SecretToken string               `json:"secret_token,omitempty"`
+	APIKey      *APIKeyAuthConfig    `json:"api_key,omitempty"`
+	Anonymous   *AnonymousAuthConfig `json:"anonymous,omitempty"`
 }
 
 // APIKeyAuthConfig holds API Key agent auth configuration.
 type APIKeyAuthConfig struct {
 	Enabled bool `json:"enabled"`
+}
+
+// AnonymousAuthConfig holds anonymous agent auth configuration.
+type AnonymousAuthConfig struct {
+	Enabled      bool             `json:"enabled"`
+	AllowAgent   []string         `json:"allow_agent,omitempty"`
+	AllowService []string         `json:"allow_service,omitempty"`
+	RateLimit    *RateLimitConfig `json:"rate_limit,omitempty"`
+}
+
+// RateLimitConfig holds event rate limit configuration.
+type RateLimitConfig struct {
+	IPLimit    int `json:"ip_limit,omitempty"`
+	EventLimit int `json:"event_limit,omitempty"`
 }
 
 // InstrumentationConfig holds APM Server instrumentation configuration.

--- a/systemtest/otlp_test.go
+++ b/systemtest/otlp_test.go
@@ -38,6 +38,7 @@ import (
 	sdkresource "go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -167,6 +168,124 @@ func TestOTLPClientIP(t *testing.T) {
 		Field: "service.name", Value: "service2",
 	})
 	assert.True(t, gjson.GetBytes(result.Hits.Hits[0].RawSource, "client.ip").Exists())
+}
+
+func TestOTLPAnonymous(t *testing.T) {
+	srv := apmservertest.NewUnstartedServer(t)
+	srv.Config.AgentAuth.SecretToken = "abc123" // enable auth & rate limiting
+	srv.Config.AgentAuth.Anonymous = &apmservertest.AnonymousAuthConfig{
+		Enabled:      true,
+		AllowAgent:   []string{"iOS/swift"},
+		AllowService: []string{"allowed_service"},
+	}
+	err := srv.Start()
+	require.NoError(t, err)
+
+	sendEvent := func(telemetrySDKName, telemetrySDKLanguage, serviceName string) error {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		var attributes []attribute.KeyValue
+		if serviceName != "" {
+			attributes = append(attributes, attribute.String("service.name", serviceName))
+		}
+		if telemetrySDKName != "" {
+			attributes = append(attributes, attribute.String("telemetry.sdk.name", telemetrySDKName))
+		}
+		if telemetrySDKLanguage != "" {
+			attributes = append(attributes, attribute.String("telemetry.sdk.language", telemetrySDKLanguage))
+		}
+		exporter := newOTLPExporter(t, srv)
+		resource := sdkresource.NewWithAttributes(attributes...)
+		return sendOTLPTrace(ctx, newOTLPTracerProvider(exporter, sdktrace.WithResource(resource)))
+	}
+
+	err = sendEvent("iOS", "swift", "allowed_service")
+	assert.NoError(t, err)
+
+	err = sendEvent("open-telemetry", "go", "allowed_service")
+	assert.Error(t, err)
+	errStatus, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.PermissionDenied, errStatus.Code())
+	assert.Equal(t, `unauthorized: anonymous access not permitted for agent "open-telemetry/go"`, errStatus.Message())
+
+	err = sendEvent("iOS", "swift", "unallowed_service")
+	assert.Error(t, err)
+	errStatus, ok = status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.PermissionDenied, errStatus.Code())
+	assert.Equal(t, `unauthorized: anonymous access not permitted for service "unallowed_service"`, errStatus.Message())
+
+	// If the client does not send telemetry.sdk.*, we default agent name "otlp".
+	// This means it is not possible to bypass the allowed agents list.
+	err = sendEvent("", "", "allowed_service")
+	assert.Error(t, err)
+	errStatus, ok = status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.PermissionDenied, errStatus.Code())
+	assert.Equal(t, `unauthorized: anonymous access not permitted for agent "otlp"`, errStatus.Message())
+
+	// If the client does not send a service name, we default to "unknown".
+	// This means it is not possible to bypass the allowed services list.
+	err = sendEvent("iOS", "swift", "")
+	assert.Error(t, err)
+	errStatus, ok = status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.PermissionDenied, errStatus.Code())
+	assert.Equal(t, `unauthorized: anonymous access not permitted for service "unknown"`, errStatus.Message())
+}
+
+func TestOTLPRateLimit(t *testing.T) {
+	// The configured rate limit.
+	const eventRateLimit = 10
+
+	// The actual rate limit: a 3x "burst multiplier" is applied,
+	// and each gRPC method call is counted towards the event rate
+	// limit as well.
+	const sendEventLimit = (3 * eventRateLimit) / 2
+
+	srv := apmservertest.NewUnstartedServer(t)
+	srv.Config.AgentAuth.SecretToken = "abc123" // enable auth & rate limiting
+	srv.Config.AgentAuth.Anonymous = &apmservertest.AnonymousAuthConfig{
+		Enabled:    true,
+		AllowAgent: []string{"iOS/swift"},
+		RateLimit: &apmservertest.RateLimitConfig{
+			IPLimit:    2,
+			EventLimit: eventRateLimit,
+		},
+	}
+	err := srv.Start()
+	require.NoError(t, err)
+
+	sendEvent := func(ip string) error {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		exporter := newOTLPExporter(t, srv, otlpgrpc.WithHeaders(map[string]string{"x-real-ip": ip}))
+		resource := sdkresource.NewWithAttributes(
+			attribute.String("service.name", "service2"),
+			attribute.String("telemetry.sdk.name", "iOS"),
+			attribute.String("telemetry.sdk.language", "swift"),
+		)
+		return sendOTLPTrace(ctx, newOTLPTracerProvider(exporter, sdktrace.WithResource(resource)))
+	}
+
+	// Check that for the configured IP limit (2), we can handle 3*event_limit without being rate limited.
+	var g errgroup.Group
+	for i := 0; i < sendEventLimit; i++ {
+		g.Go(func() error { return sendEvent("10.11.12.13") })
+		g.Go(func() error { return sendEvent("10.11.12.14") })
+	}
+	err = g.Wait()
+	assert.NoError(t, err)
+
+	// The rate limiter cache only has space for 2 IPs, so the 3rd one reuses an existing
+	// limiter, which will have already been exhausted.
+	err = sendEvent("10.11.12.15")
+	require.Error(t, err)
+	errStatus, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.ResourceExhausted, errStatus.Code())
+	assert.Equal(t, "rate limit exceeded", errStatus.Message())
 }
 
 func newOTLPExporter(t testing.TB, srv *apmservertest.Server, options ...otlpgrpc.Option) *otlp.Exporter {


### PR DESCRIPTION
## Motivation/summary

Generalise the ability for agents to send events unauthenticated (anonymous) but rate-limited. Until now this has been a RUM-only feature, but we now find ourselves needing it also for the iOS agent.

Anonymous auth is disabled by default, but is automatically enabled when RUM is enabled as long as `apm-server.auth.anonymous` hasn't been explicitly configured. The existing RUM config for allowed services and rate limiting are deprecated and replaced with equivalent config under `apm-server.auth.anonymous.*`.

Instead of restricting anonymous auth to requests going by endpoint (i.e. RUM intake and agent config), we now restrict based on the provided agent and service names. There was previously nothing stopping clients from spoofing RUM agents, e.g. sending events to the RUM intake with a non-RUM agent name, so this is not any less secure.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~ https://github.com/elastic/apm-server/issues/5698

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

1. Ensure existing config works as before: RUM should be allowed to send data without any auth token when secret_token or api_key auth is enabled; ensure no other agents can send data without an auth token.
2. Define `apm-server.auth.anonymous.allow_agent: [iOS/swift]`, check that the iOS/swift agent can send data without an auth token.
3. Define `apm-server.auth.anonymous.allow_service: [opbeans-rum]`, check that opbeans-rum can send data. Change it to something else and check that opbeans-rum cannot send data.

## Related issues

Closes #5347