### PR TITLE
systemtest: use new auth config

### DIFF
--- a/systemtest/agentconfig.go
+++ b/systemtest/agentconfig.go
@@ -1,0 +1,76 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package systemtest
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/elastic/apm-server/systemtest/apmservertest"
+)
+
+// CreateAgentConfig creates or updates agent central config via Kibana.
+func CreateAgentConfig(t testing.TB, serviceName, serviceEnvironment, agentName string, settings map[string]string) {
+	kibanaConfig := apmservertest.DefaultConfig().Kibana
+	kibanaURL, err := url.Parse(kibanaConfig.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kibanaURL.User = url.UserPassword(kibanaConfig.Username, kibanaConfig.Password)
+	kibanaURL.Path = "/api/apm/settings/agent-configuration"
+	kibanaURL.RawQuery = "overwrite=true"
+
+	var params struct {
+		AgentName string `json:"agent_name,omitempty"`
+		Service   struct {
+			Name        string `json:"name"`
+			Environment string `json:"environment,omitempty"`
+		} `json:"service"`
+		Settings map[string]string `json:"settings"`
+	}
+	params.Service.Name = serviceName
+	params.Service.Environment = serviceEnvironment
+	params.AgentName = agentName
+	params.Settings = settings
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(params); err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest("PUT", kibanaURL.String(), &body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("kbn-xsrf", "1")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(resp.Body)
+		t.Fatalf("failed to create agent config: %s (%s)", resp.Status, strings.TrimSpace(string(body)))
+	}
+}

--- a/systemtest/apmservertest/config.go
+++ b/systemtest/apmservertest/config.go
@@ -42,15 +42,16 @@ const (
 
 // Config holds APM Server configuration.
 type Config struct {
-	SecretToken               string             `json:"apm-server.secret_token,omitempty"`
 	Jaeger                    *JaegerConfig      `json:"apm-server.jaeger,omitempty"`
 	Kibana                    *KibanaConfig      `json:"apm-server.kibana,omitempty"`
 	Aggregation               *AggregationConfig `json:"apm-server.aggregation,omitempty"`
 	Sampling                  *SamplingConfig    `json:"apm-server.sampling,omitempty"`
 	RUM                       *RUMConfig         `json:"apm-server.rum,omitempty"`
 	DataStreams               *DataStreamsConfig `json:"apm-server.data_streams,omitempty"`
-	APIKey                    *APIKeyConfig      `json:"apm-server.api_key,omitempty"`
 	DefaultServiceEnvironment string             `json:"apm-server.default_service_environment,omitempty"`
+
+	// AgentAuth holds configuration for APM agent authorization.
+	AgentAuth AgentAuthConfig `json:"apm-server.auth"`
 
 	// ResponseHeaders holds headers to add to all APM Server HTTP responses.
 	ResponseHeaders http.Header `json:"apm-server.response_headers,omitempty"`
@@ -185,8 +186,14 @@ type DataStreamsConfig struct {
 	Enabled bool `json:"enabled"`
 }
 
-// APIKeyConfig holds APM Server API Key auth configuration.
-type APIKeyConfig struct {
+// APIKeyConfig holds agent auth configuration.
+type AgentAuthConfig struct {
+	SecretToken string            `json:"secret_token,omitempty"`
+	APIKey      *APIKeyAuthConfig `json:"api_key,omitempty"`
+}
+
+// APIKeyAuthConfig holds API Key agent auth configuration.
+type APIKeyAuthConfig struct {
 	Enabled bool `json:"enabled"`
 }
 

--- a/systemtest/apmservertest/server.go
+++ b/systemtest/apmservertest/server.go
@@ -464,7 +464,7 @@ func (s *Server) Tracer() *apm.Tracer {
 		s.tb.Fatal(err)
 	}
 	httpTransport.SetServerURL(serverURL)
-	httpTransport.SetSecretToken(s.Config.SecretToken)
+	httpTransport.SetSecretToken(s.Config.AgentAuth.SecretToken)
 	httpTransport.Client.Transport.(*http.Transport).TLSClientConfig = s.TLS
 
 	var transport transport.Transport = httpTransport

--- a/systemtest/instrumentation_test.go
+++ b/systemtest/instrumentation_test.go
@@ -96,8 +96,8 @@ func TestAPMServerInstrumentationAuth(t *testing.T) {
 	test := func(t *testing.T, external, useSecretToken, useAPIKey bool) {
 		systemtest.CleanupElasticsearch(t)
 		srv := apmservertest.NewUnstartedServer(t)
-		srv.Config.SecretToken = "hunter2"
-		srv.Config.APIKey = &apmservertest.APIKeyConfig{Enabled: true}
+		srv.Config.AgentAuth.SecretToken = "hunter2"
+		srv.Config.AgentAuth.APIKey = &apmservertest.APIKeyAuthConfig{Enabled: true}
 		srv.Config.Instrumentation = &apmservertest.InstrumentationConfig{Enabled: true}
 
 		serverURLChan := make(chan string, 1)
@@ -125,7 +125,7 @@ func TestAPMServerInstrumentationAuth(t *testing.T) {
 			srv.Config.Instrumentation.Hosts = []string{proxy.URL}
 		}
 		if useSecretToken {
-			srv.Config.Instrumentation.SecretToken = srv.Config.SecretToken
+			srv.Config.Instrumentation.SecretToken = srv.Config.AgentAuth.SecretToken
 		}
 		if useAPIKey {
 			systemtest.InvalidateAPIKeys(t)

--- a/systemtest/jaeger_test.go
+++ b/systemtest/jaeger_test.go
@@ -110,7 +110,7 @@ func TestJaegerGRPCSampling(t *testing.T) {
 func TestJaegerGRPCAuth(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
 	srv := apmservertest.NewUnstartedServer(t)
-	srv.Config.SecretToken = "secret"
+	srv.Config.AgentAuth.SecretToken = "secret"
 	require.NoError(t, srv.Start())
 
 	conn, err := grpc.Dial(serverAddr(srv), grpc.WithInsecure())

--- a/systemtest/otlp_test.go
+++ b/systemtest/otlp_test.go
@@ -111,7 +111,7 @@ func TestOTLPGRPCMetrics(t *testing.T) {
 func TestOTLPGRPCAuth(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
 	srv := apmservertest.NewUnstartedServer(t)
-	srv.Config.SecretToken = "abc123"
+	srv.Config.AgentAuth.SecretToken = "abc123"
 	err := srv.Start()
 	require.NoError(t, err)
 
@@ -205,6 +205,10 @@ func sendOTLPTrace(ctx context.Context, tracerProvider *sdktrace.TracerProvider)
 	endTime := startTime.Add(time.Second)
 	_, span := tracer.Start(ctx, "operation_name", trace.WithTimestamp(startTime))
 	span.End(trace.WithTimestamp(endTime))
+	return flushTracerProvider(ctx, tracerProvider)
+}
+
+func flushTracerProvider(ctx context.Context, tracerProvider *sdktrace.TracerProvider) error {
 	if err := tracerProvider.ForceFlush(ctx); err != nil {
 		return err
 	}

--- a/systemtest/rum_test.go
+++ b/systemtest/rum_test.go
@@ -22,13 +22,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -69,33 +66,9 @@ func TestRUMXForwardedFor(t *testing.T) {
 	)
 }
 
-func TestRUMAuth(t *testing.T) {
-	// The RUM endpoint does not require auth. Start the server
-	// with a randomly generated secret token to show that RUM
-	// events can be sent without passing the secret token.
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-	secretToken := strconv.Itoa(rng.Int())
-
-	srv := apmservertest.NewUnstartedServer(t)
-	srv.Config.SecretToken = secretToken
-	srv.Config.RUM = &apmservertest.RUMConfig{Enabled: true}
-	err := srv.Start()
-	require.NoError(t, err)
-
-	systemtest.SendRUMEventsPayload(t, srv, "../testdata/intake-v2/transactions.ndjson")
-
-	req, _ := http.NewRequest("GET", srv.URL+"/config/v1/rum/agents", nil)
-	req.Header.Add("Content-Type", "application/json")
-	req.URL.RawQuery = url.Values{"service.name": []string{"service_name"}}.Encode()
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-	assert.Equal(t, http.StatusOK, resp.StatusCode)
-}
-
 func TestRUMAllowServiceNames(t *testing.T) {
 	srv := apmservertest.NewUnstartedServer(t)
-	srv.Config.SecretToken = "abc123"
+	srv.Config.AgentAuth.SecretToken = "abc123"
 	srv.Config.RUM = &apmservertest.RUMConfig{
 		Enabled:           true,
 		AllowServiceNames: []string{"allowed"},
@@ -123,7 +96,7 @@ func TestRUMAllowServiceNames(t *testing.T) {
 
 func TestRUMRateLimit(t *testing.T) {
 	srv := apmservertest.NewUnstartedServer(t)
-	srv.Config.SecretToken = "abc123" // enable auth & rate limiting
+	srv.Config.AgentAuth.SecretToken = "abc123" // enable auth & rate limiting
 	srv.Config.RUM = &apmservertest.RUMConfig{
 		Enabled: true,
 		RateLimit: &apmservertest.RUMRateLimitConfig{


### PR DESCRIPTION
## Motivation/summary

Update system tests to use `apm-server.auth.*` config, in preparation of adding anonymous access support. We also extend the TestAuth tests to cover RUM, remove the RUM-specific test, and enhance the RUM agent config test to check the results are properly restricted.

## Related issues

Extracted from https://github.com/elastic/apm-server/pull/5623
Adds a `systemtest.CreateAgentConfig` function, which can be used in https://github.com/elastic/apm-server/issues/5487