### PR TITLE
Don't panic re-registering monitoring functions

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -13,6 +13,7 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 * Fix panic due to misaligned 64-bit access on 32-bit architectures {pull}5277[5277]
 * Fixed tail-based sampling pubsub to use _seq_no correctly {pull}5126[5126]
 * Removed service name from dataset {pull}5451[5451]
+* Fix panic on Fleet policy change when transaction metrics or tail-based sampling are enabled {pull}5670[5670]
 
 [float]
 ==== Intake API Changes

--- a/x-pack/apm-server/main_test.go
+++ b/x-pack/apm-server/main_test.go
@@ -7,8 +7,23 @@ package main
 // This file is mandatory as otherwise the apm-server.test binary is not generated correctly.
 
 import (
+	"context"
 	"flag"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pkg/errors"
+	"go.elastic.co/apm/apmtest"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/monitoring"
+	"github.com/elastic/beats/v7/libbeat/paths"
+
+	"github.com/elastic/apm-server/beater"
+	"github.com/elastic/apm-server/beater/config"
+	"github.com/elastic/apm-server/model/modelprocessor"
 )
 
 var systemTest *bool
@@ -26,5 +41,44 @@ func init() {
 func TestSystem(t *testing.T) {
 	if *systemTest {
 		main()
+	}
+}
+
+func TestMonitoring(t *testing.T) {
+	// samplingMonitoringRegistry will be nil, as under normal circumstances
+	// we rely on apm-server/sampling to create the registry.
+	samplingMonitoringRegistry = monitoring.NewRegistry()
+
+	var aggregationMonitoringSnapshot, tailSamplingMonitoringSnapshot monitoring.FlatSnapshot
+	runServerError := errors.New("runServer")
+	runServer := func(ctx context.Context, args beater.ServerParams) error {
+		aggregationMonitoringSnapshot = monitoring.CollectFlatSnapshot(aggregationMonitoringRegistry, monitoring.Full, false)
+		tailSamplingMonitoringSnapshot = monitoring.CollectFlatSnapshot(samplingMonitoringRegistry, monitoring.Full, false)
+		return runServerError
+	}
+	runServer = wrapRunServer(runServer)
+
+	home := t.TempDir()
+	err := paths.InitPaths(&paths.Path{Home: home})
+	require.NoError(t, err)
+
+	cfg := config.DefaultConfig()
+	cfg.Aggregation.Transactions.Enabled = true
+	cfg.Sampling.Tail.Enabled = true
+	cfg.Sampling.Tail.Policies = []config.TailSamplingPolicy{{SampleRate: 0.1}}
+
+	// Call the wrapped runServer twice, to ensure metric registration does not panic.
+	for i := 0; i < 2; i++ {
+		err := runServer(context.Background(), beater.ServerParams{
+			Config:         cfg,
+			Logger:         logp.NewLogger(""),
+			Tracer:         apmtest.DiscardTracer,
+			BatchProcessor: modelprocessor.Nop{},
+			Managed:        true,
+			Namespace:      "default",
+		})
+		assert.Equal(t, runServerError, err)
+		assert.NotEqual(t, monitoring.MakeFlatSnapshot(), aggregationMonitoringSnapshot)
+		assert.NotEqual(t, monitoring.MakeFlatSnapshot(), tailSamplingMonitoringSnapshot)
 	}
 }


### PR DESCRIPTION
## Motivation/summary

When the server's policy changes, the server will internally stop and restart various workers, and re-register monitoring related to those workers. We must remove the existing monitoring vars first, to avoid panicking on re-registration.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

1. Run apm-server with Fleet
2. Modify the policy (e.g. toggle RUM on/off)
3. Check that apm-server continues to run, picking up the new config

## Related issues

Fixes https://github.com/elastic/apm-server/issues/5665