### PR TITLE
mergify: change backport trigger labels

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -17,7 +17,7 @@ pull_request_rules:
     conditions:
       - merged
       - base=master
-      - label=v7.15.0
+      - label=backport-7.x
     actions:
       backport:
         assignees:
@@ -29,7 +29,7 @@ pull_request_rules:
     conditions:
       - merged
       - base=master
-      - label=v7.14.0
+      - label=backport-7.14
     actions:
       backport:
         assignees:
@@ -41,25 +41,13 @@ pull_request_rules:
     conditions:
       - merged
       - base=master
-      - label=v7.13.0
+      - label=backport-7.13
     actions:
       backport:
         assignees:
           - "{{ author }}"
         branches:
           - "7.13"
-        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
-  - name: backport patches to 7.12 branch
-    conditions:
-      - merged
-      - base=master
-      - label=v7.12.0
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "7.12"
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
   - name: Automatic squash and merge with success checks and the file docker-compose.yml is modified.
     conditions:

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -54,7 +54,7 @@
 
 ## After feature freeze
 
-* Update [.mergify.yml](https://github.com/elastic/apm-server/blob/master/.mergify.yml) with a new backport rule for the next version. An example of adding v7.15 after v7.14 feature freeze is available [here](https://github.com/elastic/apm-server/pull/5601/files)
+* Update [.mergify.yml](https://github.com/elastic/apm-server/blob/master/.mergify.yml) with a new backport rule for the next version.
 
 ## On release day
 


### PR DESCRIPTION
## Motivation/summary

Change the labels used for triggering backports to explicitly specify the target branch name.

This avoids an issue where "v7.14.0" creates backports for 7.x, and then when we update mergify to have "v7.14.0" backport to 7.14 redundant backport PRs are created.

## Related issues

https://github.com/elastic/apm-server/pull/5669
https://github.com/elastic/apm-server/pull/5668
https://github.com/elastic/apm-server/pull/5667
...