### PR TITLE
[7.13] docs: free and open terminology (#5641)

### DIFF
--- a/docs/guide/apm-doc-directory.asciidoc
+++ b/docs/guide/apm-doc-directory.asciidoc
@@ -28,7 +28,7 @@ Each agent has its own documentation:
 [float]
 ==== APM Server
 
-APM Server is an open source application that receives performance data from your APM agents.
+APM Server is a free and open application that receives performance data from your APM agents.
 It's a {apm-server-ref-v}/overview.html#why-separate-component[separate component by design],
 which helps keep the agents light, prevents certain security risks, and improves compatibility across the Elastic Stack.
 
@@ -46,14 +46,14 @@ Here you can learn more about {apm-server-ref-v}/getting-started-apm-server.html
 [float]
 ==== Elasticsearch
 
-{ref}/index.html[Elasticsearch] is a highly scalable open source full-text search and analytics engine.
+{ref}/index.html[Elasticsearch] is a highly scalable free and open full-text search and analytics engine.
 It allows you to store, search, and analyze large volumes of data quickly and in near real time.
 Elasticsearch is used to store APM performance metrics and make use of its aggregations.
 
 [float]
 ==== Kibana APM app
 
-{kibana-ref}/index.html[Kibana] is an open source analytics and visualization platform designed to work with Elasticsearch.
+{kibana-ref}/index.html[Kibana] is a free and open analytics and visualization platform designed to work with Elasticsearch.
 You use Kibana to search, view, and interact with data stored in Elasticsearch.
 
 Since application performance monitoring is all about visualizing data and detecting bottlenecks,

--- a/docs/guide/overview.asciidoc
+++ b/docs/guide/overview.asciidoc
@@ -1,5 +1,5 @@
 [[overview]]
-== Open source application performance monitoring
+== Free and open application performance monitoring
 
 ++++
 <titleabbrev>What is APM?</titleabbrev>

--- a/docs/guide/troubleshooting.asciidoc
+++ b/docs/guide/troubleshooting.asciidoc
@@ -23,7 +23,7 @@ The APM Server, APM app, and each APM agent has a troubleshooting guide:
 === Elastic Support
 
 We offer a support experience unlike any other.
-Our team of professionals 'speak human and code', and love open source and making your day.
+Our team of professionals 'speak human and code' and love making your day.
 https://www.elastic.co/subscriptions[Learn more about subscriptions].
 
 [float]


### PR DESCRIPTION
Backports the following commits to 7.13:
 - docs: free and open terminology (#5641)