### PR TITLE
Bump integration to 0.4.0, use apm-server.auth config

### DIFF
--- a/apmpackage/apm/agent/input/template.yml.hbs
+++ b/apmpackage/apm/agent/input/template.yml.hbs
@@ -1,7 +1,9 @@
 apm-server:
-    api_key:
-        enabled: {{api_key_enabled}}
-        limit: {{api_key_limit}}
+    auth:
+        api_key:
+            enabled: {{api_key_enabled}}
+            limit: {{api_key_limit}}
+        secret_token: {{secret_token}}
     capture_personal_data: {{capture_personal_data}}
     idle_timeout: {{idle_timeout}}
     default_service_environment: {{default_service_environment}}
@@ -12,6 +14,7 @@ apm-server:
     max_header_size: {{max_header_bytes}}
     read_timeout: {{read_timeout}}
     response_headers: {{response_headers}}
+    {{#if enable_rum}}
     rum:
         allow_headers:
         {{#each rum_allow_headers}}
@@ -31,7 +34,7 @@ apm-server:
         exclude_from_grouping: {{rum_exclude_from_grouping}}
         library_pattern: {{rum_library_pattern}}
         response_headers: {{rum_response_headers}}
-    secret_token: {{secret_token}}
+    {{/if}}
     shutdown_timeout: {{shutdown_timeout}}
     {{#if tls_enabled}}
     ssl:

--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -5,7 +5,7 @@
   changes:
     - description: use new apm-server.auth config
       type: breaking-change
-      link: https://github.com/elastic/apm-server/pull/5623
+      link: https://github.com/elastic/apm-server/pull/5691
 - version: "0.3.0"
   changes:
     - description: added apm-server.url config

--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -1,6 +1,11 @@
 # newer versions go on top
 #
 # change type can be one of: enhancement, bugfix, breaking-change
+- version: "0.4.0"
+  changes:
+    - description: use new apm-server.auth config
+      type: breaking-change
+      link: https://github.com/elastic/apm-server/pull/5623
 - version: "0.3.0"
   changes:
     - description: added apm-server.url config

--- a/apmpackage/apm/data_stream/app_metrics/elasticsearch/ingest_pipeline/default.json
+++ b/apmpackage/apm/data_stream/app_metrics/elasticsearch/ingest_pipeline/default.json
@@ -3,33 +3,33 @@
   "processors": [
     {
       "pipeline": {
-        "name": "metrics-apm.app-0.3.0-apm_ingest_timestamp"
+        "name": "metrics-apm.app-0.4.0-apm_ingest_timestamp"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.app-0.3.0-apm_user_agent"
+        "name": "metrics-apm.app-0.4.0-apm_user_agent"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.app-0.3.0-apm_user_geo"
+        "name": "metrics-apm.app-0.4.0-apm_user_geo"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.app-0.3.0-apm_remove_span_metadata"
+        "name": "metrics-apm.app-0.4.0-apm_remove_span_metadata"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.app-0.3.0-apm_error_grouping_name",
+        "name": "metrics-apm.app-0.4.0-apm_error_grouping_name",
         "if": "ctx.processor?.event == 'error'"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.app-0.3.0-apm_metrics_dynamic_template",
+        "name": "metrics-apm.app-0.4.0-apm_metrics_dynamic_template",
         "if": "ctx.processor?.event == 'metric'"
       }
     }

--- a/apmpackage/apm/data_stream/error_logs/elasticsearch/ingest_pipeline/default.json
+++ b/apmpackage/apm/data_stream/error_logs/elasticsearch/ingest_pipeline/default.json
@@ -3,33 +3,33 @@
   "processors": [
     {
       "pipeline": {
-        "name": "logs-apm.error-0.3.0-apm_ingest_timestamp"
+        "name": "logs-apm.error-0.4.0-apm_ingest_timestamp"
       }
     },
     {
       "pipeline": {
-        "name": "logs-apm.error-0.3.0-apm_user_agent"
+        "name": "logs-apm.error-0.4.0-apm_user_agent"
       }
     },
     {
       "pipeline": {
-        "name": "logs-apm.error-0.3.0-apm_user_geo"
+        "name": "logs-apm.error-0.4.0-apm_user_geo"
       }
     },
     {
       "pipeline": {
-        "name": "logs-apm.error-0.3.0-apm_remove_span_metadata"
+        "name": "logs-apm.error-0.4.0-apm_remove_span_metadata"
       }
     },
     {
       "pipeline": {
-        "name": "logs-apm.error-0.3.0-apm_error_grouping_name",
+        "name": "logs-apm.error-0.4.0-apm_error_grouping_name",
         "if": "ctx.processor?.event == 'error'"
       }
     },
     {
       "pipeline": {
-        "name": "logs-apm.error-0.3.0-apm_metrics_dynamic_template",
+        "name": "logs-apm.error-0.4.0-apm_metrics_dynamic_template",
         "if": "ctx.processor?.event == 'metric'"
       }
     }

--- a/apmpackage/apm/data_stream/internal_metrics/elasticsearch/ingest_pipeline/default.json
+++ b/apmpackage/apm/data_stream/internal_metrics/elasticsearch/ingest_pipeline/default.json
@@ -3,33 +3,33 @@
   "processors": [
     {
       "pipeline": {
-        "name": "metrics-apm.internal-0.3.0-apm_ingest_timestamp"
+        "name": "metrics-apm.internal-0.4.0-apm_ingest_timestamp"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.internal-0.3.0-apm_user_agent"
+        "name": "metrics-apm.internal-0.4.0-apm_user_agent"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.internal-0.3.0-apm_user_geo"
+        "name": "metrics-apm.internal-0.4.0-apm_user_geo"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.internal-0.3.0-apm_remove_span_metadata"
+        "name": "metrics-apm.internal-0.4.0-apm_remove_span_metadata"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.internal-0.3.0-apm_error_grouping_name",
+        "name": "metrics-apm.internal-0.4.0-apm_error_grouping_name",
         "if": "ctx.processor?.event == 'error'"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.internal-0.3.0-apm_metrics_dynamic_template",
+        "name": "metrics-apm.internal-0.4.0-apm_metrics_dynamic_template",
         "if": "ctx.processor?.event == 'metric'"
       }
     }

--- a/apmpackage/apm/data_stream/profile_metrics/elasticsearch/ingest_pipeline/default.json
+++ b/apmpackage/apm/data_stream/profile_metrics/elasticsearch/ingest_pipeline/default.json
@@ -3,33 +3,33 @@
   "processors": [
     {
       "pipeline": {
-        "name": "metrics-apm.profiling-0.3.0-apm_ingest_timestamp"
+        "name": "metrics-apm.profiling-0.4.0-apm_ingest_timestamp"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.profiling-0.3.0-apm_user_agent"
+        "name": "metrics-apm.profiling-0.4.0-apm_user_agent"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.profiling-0.3.0-apm_user_geo"
+        "name": "metrics-apm.profiling-0.4.0-apm_user_geo"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.profiling-0.3.0-apm_remove_span_metadata"
+        "name": "metrics-apm.profiling-0.4.0-apm_remove_span_metadata"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.profiling-0.3.0-apm_error_grouping_name",
+        "name": "metrics-apm.profiling-0.4.0-apm_error_grouping_name",
         "if": "ctx.processor?.event == 'error'"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.profiling-0.3.0-apm_metrics_dynamic_template",
+        "name": "metrics-apm.profiling-0.4.0-apm_metrics_dynamic_template",
         "if": "ctx.processor?.event == 'metric'"
       }
     }

--- a/apmpackage/apm/data_stream/traces/elasticsearch/ingest_pipeline/default.json
+++ b/apmpackage/apm/data_stream/traces/elasticsearch/ingest_pipeline/default.json
@@ -3,33 +3,33 @@
   "processors": [
     {
       "pipeline": {
-        "name": "traces-apm-0.3.0-apm_ingest_timestamp"
+        "name": "traces-apm-0.4.0-apm_ingest_timestamp"
       }
     },
     {
       "pipeline": {
-        "name": "traces-apm-0.3.0-apm_user_agent"
+        "name": "traces-apm-0.4.0-apm_user_agent"
       }
     },
     {
       "pipeline": {
-        "name": "traces-apm-0.3.0-apm_user_geo"
+        "name": "traces-apm-0.4.0-apm_user_geo"
       }
     },
     {
       "pipeline": {
-        "name": "traces-apm-0.3.0-apm_remove_span_metadata"
+        "name": "traces-apm-0.4.0-apm_remove_span_metadata"
       }
     },
     {
       "pipeline": {
-        "name": "traces-apm-0.3.0-apm_error_grouping_name",
+        "name": "traces-apm-0.4.0-apm_error_grouping_name",
         "if": "ctx.processor?.event == 'error'"
       }
     },
     {
       "pipeline": {
-        "name": "traces-apm-0.3.0-apm_metrics_dynamic_template",
+        "name": "traces-apm-0.4.0-apm_metrics_dynamic_template",
         "if": "ctx.processor?.event == 'metric'"
       }
     }

--- a/apmpackage/apm/manifest.yml
+++ b/apmpackage/apm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: apm
 title: Elastic APM
-version: 0.3.0
+version: 0.4.0
 license: basic
 description: Ingest APM data
 type: integration

--- a/systemtest/fleettest/types.go
+++ b/systemtest/fleettest/types.go
@@ -99,8 +99,11 @@ type PackagePolicyTemplateInput struct {
 }
 
 type PackagePolicyTemplateInputVar struct {
-	Name string `json:"name"`
-	Type string `json:"type"`
+	Name     string      `json:"name"`
+	Type     string      `json:"type"`
+	Default  interface{} `json:"default"`
+	Required bool        `json:"required"`
+	Multi    bool        `json:"multi"`
 }
 
 type EnrollmentAPIKey struct {

--- a/systemtest/kibana.go
+++ b/systemtest/kibana.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 
 	"github.com/elastic/apm-server/systemtest/apmservertest"
+	"github.com/elastic/apm-server/systemtest/fleettest"
 )
 
 const (
@@ -29,9 +30,14 @@ const (
 	adminKibanaPass = adminElasticsearchPass
 )
 
-// KibanaURL is the base URL for Kibana, including userinfo for
-// authenticating as the admin user.
-var KibanaURL *url.URL
+var (
+	// KibanaURL is the base URL for Kibana, including userinfo for
+	// authenticating as the admin user.
+	KibanaURL *url.URL
+
+	// Fleet is a Fleet API client for use in tests.
+	Fleet *fleettest.Client
+)
 
 func init() {
 	kibanaConfig := apmservertest.DefaultConfig().Kibana
@@ -41,4 +47,5 @@ func init() {
 	}
 	u.User = url.UserPassword(adminKibanaUser, adminKibanaPass)
 	KibanaURL = u
+	Fleet = fleettest.NewClient(KibanaURL.String())
 }

--- a/systemtest/main_test.go
+++ b/systemtest/main_test.go
@@ -27,5 +27,8 @@ func TestMain(m *testing.M) {
 	if err := StartStackContainers(); err != nil {
 		log.Fatal(err)
 	}
+	if err := Fleet.Setup(); err != nil {
+		log.Fatal(err)
+	}
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
## Motivation/summary

Bump the integration package version, and update it to use `apm-server.auth.*` config. This is a prerequisite for updating the package for anonymous auth support (https://github.com/elastic/apm-server/pull/5623).

Split some of the Fleet/Elastic Agent setup out of the system test `TestFleetIntegration`, into a separate function which can be reused. There's also a fix to the package policy creation to set defaults correctly, to avoid integration editor UI errors such as https://github.com/elastic/kibana/issues/105384.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

Test that secret token and API Key auth continue to work in the Fleet integration.

## Related issues

https://github.com/elastic/apm-server/pull/5623