### PR TITLE
Fix: remove unsupported rum rate limit key

### DIFF
--- a/kibana/send_config.go
+++ b/kibana/send_config.go
@@ -114,7 +114,7 @@ func flattenAndClean(conf *ucfg.Config) (map[string]interface{}, error) {
 			v = "0.0.0.0:8200"
 		}
 		if k == "apm-server.rum.rate_limit" {
-			out["apm-server.rum.event_rate.limit"] = v
+			k = "apm-server.rum.event_rate.limit"
 		}
 		if strings.HasPrefix(k, "apm-server.ssl.") {
 			// Following ssl related settings need to be synced:

--- a/kibana/send_config_test.go
+++ b/kibana/send_config_test.go
@@ -74,6 +74,7 @@ func TestFlattenAndFormat(t *testing.T) {
 	assert.Equal(t, 4, loggingFieldCount)
 	assert.Contains(t, flat, "apm-server.rum.event_rate.limit")
 	assert.Contains(t, flat, "apm-server.rum.event_rate.lru_size")
+	assert.NotContains(t, flat, "apm-server.rum.rate_limit")
 }
 
 var serverYAML = `apm-server:


### PR DESCRIPTION


<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
Fix: Remove the wrong rum rate limit setting and send the correct one instead. 

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## How to test these changes
See #5656

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues
follow up on #5656
<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
