### PR TITLE
model: make APMEvents 1:1 with beat.Events

### DIFF
--- a/beater/api/profile/convert.go
+++ b/beater/api/profile/convert.go
@@ -1,0 +1,128 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package profile
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/gofrs/uuid"
+	"github.com/google/pprof/profile"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+
+	"github.com/elastic/apm-server/model"
+)
+
+// appendProfileSampleBatch converts a pprof profile into a batch of model.ProfileSamples,
+// and appends it to out.
+func appendProfileSampleBatch(pp *profile.Profile, metadata model.Metadata, out model.Batch) model.Batch {
+
+	// Precompute value field names for use in each event.
+	// TODO(axw) limit to well-known value names?
+	profileTimestamp := time.Unix(0, pp.TimeNanos)
+	valueFieldNames := make([]string, len(pp.SampleType))
+	for i, sampleType := range pp.SampleType {
+		sampleUnit := normalizeUnit(sampleType.Unit)
+		// Go profiles report samples.count, Node.js profiles report sample.count.
+		// We use samples.count for both so we can aggregate on one field.
+		if sampleType.Type == "sample" || sampleType.Type == "samples" {
+			valueFieldNames[i] = "samples.count"
+		} else {
+			valueFieldNames[i] = sampleType.Type + "." + sampleUnit
+		}
+
+	}
+
+	// Generate a unique profile ID shared by all samples in the profile.
+	// If we can't generate a UUID for whatever reason, omit the profile ID.
+	var profileID string
+	if uuid, err := uuid.NewV4(); err == nil {
+		profileID = fmt.Sprintf("%x", uuid)
+	}
+
+	for _, sample := range pp.Sample {
+		var stack []model.ProfileSampleStackframe
+		if n := len(sample.Location); n > 0 {
+			hash := xxhash.New()
+			stack = make([]model.ProfileSampleStackframe, n)
+			for i := len(sample.Location) - 1; i >= 0; i-- {
+				loc := sample.Location[i]
+				line := loc.Line[0] // aggregated at function level
+
+				// NOTE(axw) Currently we hash the function names so that
+				// we can aggregate stacks across multiple builds, or where
+				// binaries are not reproducible.
+				//
+				// If we decide to identify stack traces and frames using
+				// function addresses, then need to subtract the mapping's
+				// start address to eliminate the effects of ASLR, i.e.
+				//
+				//     var buf [8]byte
+				//     binary.BigEndian.PutUint64(buf[:], loc.Address-loc.Mapping.Start)
+				//     hash.Write(buf[:])
+
+				hash.WriteString(line.Function.Name)
+				stack[i] = model.ProfileSampleStackframe{
+					ID:       fmt.Sprintf("%x", hash.Sum(nil)),
+					Function: line.Function.Name,
+					Filename: line.Function.Filename,
+					Line:     line.Line,
+				}
+			}
+		}
+
+		var labels common.MapStr
+		if n := len(sample.Label); n > 0 {
+			labels = make(common.MapStr, n)
+			for k, v := range sample.Label {
+				labels[k] = v
+			}
+		}
+
+		values := make(map[string]int64, len(sample.Value))
+		for i, value := range sample.Value {
+			values[valueFieldNames[i]] = value
+		}
+
+		out = append(out, model.APMEvent{
+			ProfileSample: &model.ProfileSample{
+				Metadata:  metadata,
+				Timestamp: profileTimestamp,
+				Duration:  time.Duration(pp.DurationNanos),
+				ProfileID: profileID,
+				Stack:     stack,
+				Labels:    labels,
+				Values:    values,
+			},
+		})
+	}
+	return out
+}
+
+func normalizeUnit(unit string) string {
+	switch unit {
+	case "nanoseconds":
+		unit = "ns"
+
+	case "microseconds":
+		unit = "us"
+	}
+	return unit
+}

--- a/beater/api/profile/handler.go
+++ b/beater/api/profile/handler.go
@@ -158,14 +158,10 @@ func Handler(requestMetadataFunc RequestMetadataFunc, processor model.BatchProce
 			}
 		}
 
-		batch := make(model.Batch, len(profiles))
-		for i, p := range profiles {
-			batch[i].Profile = &model.PprofProfile{
-				Metadata: profileMetadata,
-				Profile:  p,
-			}
+		var batch model.Batch
+		for _, profile := range profiles {
+			batch = appendProfileSampleBatch(profile, profileMetadata, batch)
 		}
-
 		if err := processor.ProcessBatch(c.Request.Context(), &batch); err != nil {
 			switch err {
 			case publish.ErrChannelClosed:

--- a/model/apmevent.go
+++ b/model/apmevent.go
@@ -28,13 +28,25 @@ import (
 //
 // Exactly one of the event fields should be non-nil.
 type APMEvent struct {
-	Transaction *Transaction
-	Span        *Span
-	Metricset   *Metricset
-	Error       *Error
-	Profile     *PprofProfile
+	Transaction   *Transaction
+	Span          *Span
+	Metricset     *Metricset
+	Error         *Error
+	ProfileSample *ProfileSample
 }
 
-func (e *APMEvent) Transform(ctx context.Context, cfg *transform.Config) []beat.Event {
-	return nil
+func (e *APMEvent) appendBeatEvent(ctx context.Context, cfg *transform.Config, out []beat.Event) []beat.Event {
+	switch {
+	case e.Transaction != nil:
+		out = append(out, e.Transaction.toBeatEvent(cfg))
+	case e.Span != nil:
+		out = append(out, e.Span.toBeatEvent(ctx, cfg))
+	case e.Metricset != nil:
+		out = append(out, e.Metricset.toBeatEvent(cfg))
+	case e.Error != nil:
+		out = append(out, e.Error.toBeatEvent(ctx, cfg))
+	case e.ProfileSample != nil:
+		out = append(out, e.ProfileSample.toBeatEvent(cfg))
+	}
+	return out
 }

--- a/model/batch.go
+++ b/model/batch.go
@@ -49,18 +49,7 @@ type Batch []APMEvent
 func (b *Batch) Transform(ctx context.Context, cfg *transform.Config) []beat.Event {
 	out := make([]beat.Event, 0, len(*b))
 	for _, event := range *b {
-		switch {
-		case event.Transaction != nil:
-			out = event.Transaction.appendBeatEvents(cfg, out)
-		case event.Span != nil:
-			out = event.Span.appendBeatEvents(ctx, cfg, out)
-		case event.Metricset != nil:
-			out = event.Metricset.appendBeatEvents(cfg, out)
-		case event.Error != nil:
-			out = event.Error.appendBeatEvents(ctx, cfg, out)
-		case event.Profile != nil:
-			out = event.Profile.appendBeatEvents(cfg, out)
-		}
+		out = event.appendBeatEvent(ctx, cfg, out)
 	}
 	return out
 }

--- a/model/error.go
+++ b/model/error.go
@@ -100,7 +100,7 @@ type Log struct {
 	Stacktrace   Stacktrace
 }
 
-func (e *Error) appendBeatEvents(ctx context.Context, cfg *transform.Config, events []beat.Event) []beat.Event {
+func (e *Error) toBeatEvent(ctx context.Context, cfg *transform.Config) beat.Event {
 	errorTransformations.Inc()
 
 	if e.Exception != nil {
@@ -151,10 +151,10 @@ func (e *Error) appendBeatEvents(ctx context.Context, cfg *transform.Config, eve
 	fields.maybeSetMapStr("trace", common.MapStr(trace))
 	fields.maybeSetMapStr("timestamp", utility.TimeAsMicros(e.Timestamp))
 
-	return append(events, beat.Event{
+	return beat.Event{
 		Fields:    common.MapStr(fields),
 		Timestamp: e.Timestamp,
-	})
+	}
 }
 
 func (e *Error) fields(ctx context.Context, cfg *transform.Config) common.MapStr {

--- a/model/error_test.go
+++ b/model/error_test.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/apm-server/transform"
 
@@ -252,9 +251,8 @@ func TestEventFields(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			output := tc.Error.appendBeatEvents(context.Background(), &transform.Config{}, nil)
-			require.Len(t, output, 1)
-			fields := output[0].Fields["error"]
+			output := tc.Error.toBeatEvent(context.Background(), &transform.Config{})
+			fields := output.Fields["error"]
 			assert.Equal(t, tc.Output, fields)
 		})
 	}
@@ -398,11 +396,7 @@ func TestEvents(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			outputEvents := tc.Error.appendBeatEvents(context.Background(), &transform.Config{
-				DataStreams: true,
-			}, nil)
-			require.Len(t, outputEvents, 1)
-			outputEvent := outputEvents[0]
+			outputEvent := tc.Error.toBeatEvent(context.Background(), &transform.Config{DataStreams: true})
 			assert.Equal(t, tc.Output, outputEvent.Fields)
 			assert.Equal(t, timestamp, outputEvent.Timestamp)
 
@@ -554,8 +548,8 @@ func TestErrorTransformPage(t *testing.T) {
 	}
 
 	for idx, test := range tests {
-		output := test.Error.appendBeatEvents(context.Background(), &transform.Config{}, nil)
-		assert.Equal(t, test.Output, output[0].Fields["url"], fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
+		output := test.Error.toBeatEvent(context.Background(), &transform.Config{})
+		assert.Equal(t, test.Output, output.Fields["url"], fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 	}
 }
 

--- a/model/metricset.go
+++ b/model/metricset.go
@@ -179,12 +179,8 @@ type MetricsetSpan struct {
 	DestinationService DestinationService
 }
 
-func (me *Metricset) appendBeatEvents(cfg *transform.Config, events []beat.Event) []beat.Event {
+func (me *Metricset) toBeatEvent(cfg *transform.Config) beat.Event {
 	metricsetTransformations.Inc()
-	if me == nil {
-		return nil
-	}
-
 	fields := mapStr{}
 	for _, sample := range me.Samples {
 		if err := sample.set(common.MapStr(fields)); err != nil {
@@ -250,10 +246,10 @@ func (me *Metricset) appendBeatEvents(cfg *transform.Config, events []beat.Event
 		fields[datastreams.TypeField] = datastreams.MetricsType
 	}
 
-	return append(events, beat.Event{
+	return beat.Event{
 		Fields:    common.MapStr(fields),
 		Timestamp: me.Timestamp,
-	})
+	}
 }
 
 func (e *MetricsetEventCategorization) fields() common.MapStr {

--- a/model/metricset_test.go
+++ b/model/metricset_test.go
@@ -49,39 +49,30 @@ func TestTransform(t *testing.T) {
 
 	tests := []struct {
 		Metricset *Metricset
-		Output    []common.MapStr
+		Output    common.MapStr
 		Msg       string
 	}{
 		{
-			Metricset: nil,
-			Output:    nil,
-			Msg:       "Nil metric",
-		},
-		{
 			Metricset: &Metricset{Timestamp: timestamp, Metadata: metadata},
-			Output: []common.MapStr{
-				{
-					"data_stream.type":    "metrics",
-					"data_stream.dataset": "apm.app.myservice",
-					"processor":           common.MapStr{"event": "metric", "name": "metric"},
-					"service": common.MapStr{
-						"name": "myservice",
-					},
+			Output: common.MapStr{
+				"data_stream.type":    "metrics",
+				"data_stream.dataset": "apm.app.myservice",
+				"processor":           common.MapStr{"event": "metric", "name": "metric"},
+				"service": common.MapStr{
+					"name": "myservice",
 				},
 			},
 			Msg: "Payload with empty metric.",
 		},
 		{
 			Metricset: &Metricset{Timestamp: timestamp, Metadata: metadata, Name: "raj"},
-			Output: []common.MapStr{
-				{
-					"data_stream.type":    "metrics",
-					"data_stream.dataset": "apm.app.myservice",
-					"processor":           common.MapStr{"event": "metric", "name": "metric"},
-					"metricset.name":      "raj",
-					"service": common.MapStr{
-						"name": "myservice",
-					},
+			Output: common.MapStr{
+				"data_stream.type":    "metrics",
+				"data_stream.dataset": "apm.app.myservice",
+				"processor":           common.MapStr{"event": "metric", "name": "metric"},
+				"metricset.name":      "raj",
+				"service": common.MapStr{
+					"name": "myservice",
 				},
 			},
 			Msg: "Payload with metricset name.",
@@ -102,17 +93,15 @@ func TestTransform(t *testing.T) {
 					},
 				},
 			},
-			Output: []common.MapStr{
-				{
-					"data_stream.type":    "metrics",
-					"data_stream.dataset": "apm.app.myservice",
-					"processor":           common.MapStr{"event": "metric", "name": "metric"},
-					"service":             common.MapStr{"name": "myservice"},
-					"labels":              common.MapStr{"a_b": "a.b.value"},
+			Output: common.MapStr{
+				"data_stream.type":    "metrics",
+				"data_stream.dataset": "apm.app.myservice",
+				"processor":           common.MapStr{"event": "metric", "name": "metric"},
+				"service":             common.MapStr{"name": "myservice"},
+				"labels":              common.MapStr{"a_b": "a.b.value"},
 
-					"a":    common.MapStr{"counter": float64(612)},
-					"some": common.MapStr{"gauge": float64(9.16)},
-				},
+				"a":    common.MapStr{"counter": float64(612)},
+				"some": common.MapStr{"gauge": float64(9.16)},
 			},
 			Msg: "Payload with valid metric.",
 		},
@@ -127,18 +116,16 @@ func TestTransform(t *testing.T) {
 					Value: 123,
 				}},
 			},
-			Output: []common.MapStr{
-				{
-					"data_stream.type":    "metrics",
-					"data_stream.dataset": "apm.internal",
-					"processor":           common.MapStr{"event": "metric", "name": "metric"},
-					"service":             common.MapStr{"name": "myservice"},
-					"transaction":         common.MapStr{"type": trType, "name": trName},
-					"span": common.MapStr{
-						"type": spType, "subtype": spSubtype,
-						"self_time": common.MapStr{
-							"count": 123.0,
-						},
+			Output: common.MapStr{
+				"data_stream.type":    "metrics",
+				"data_stream.dataset": "apm.internal",
+				"processor":           common.MapStr{"event": "metric", "name": "metric"},
+				"service":             common.MapStr{"name": "myservice"},
+				"transaction":         common.MapStr{"type": trType, "name": trName},
+				"span": common.MapStr{
+					"type": spType, "subtype": spSubtype,
+					"self_time": common.MapStr{
+						"count": 123.0,
 					},
 				},
 			},
@@ -165,28 +152,26 @@ func TestTransform(t *testing.T) {
 					},
 				},
 			},
-			Output: []common.MapStr{
-				{
-					"data_stream.type":    "metrics",
-					"data_stream.dataset": "apm.internal",
-					"processor":           common.MapStr{"event": "metric", "name": "metric"},
-					"service":             common.MapStr{"name": "myservice"},
-					"event":               common.MapStr{"outcome": eventOutcome},
-					"timeseries":          common.MapStr{"instance": "foo"},
-					"transaction": common.MapStr{
-						"type":   trType,
-						"name":   trName,
-						"result": trResult,
-						"root":   true,
-						"duration": common.MapStr{
-							"histogram": common.MapStr{
-								"counts": []int64{1, 2, 3},
-								"values": []float64{4.5, 6.0, 9.0},
-							},
+			Output: common.MapStr{
+				"data_stream.type":    "metrics",
+				"data_stream.dataset": "apm.internal",
+				"processor":           common.MapStr{"event": "metric", "name": "metric"},
+				"service":             common.MapStr{"name": "myservice"},
+				"event":               common.MapStr{"outcome": eventOutcome},
+				"timeseries":          common.MapStr{"instance": "foo"},
+				"transaction": common.MapStr{
+					"type":   trType,
+					"name":   trName,
+					"result": trResult,
+					"root":   true,
+					"duration": common.MapStr{
+						"histogram": common.MapStr{
+							"counts": []int64{1, 2, 3},
+							"values": []float64{4.5, 6.0, 9.0},
 						},
 					},
-					"_doc_count": int64(6), // 1+2+3
 				},
+				"_doc_count": int64(6), // 1+2+3
 			},
 			Msg: "Payload with transaction duration.",
 		},
@@ -208,20 +193,18 @@ func TestTransform(t *testing.T) {
 					},
 				},
 			},
-			Output: []common.MapStr{
-				{
-					"data_stream.type":    "metrics",
-					"data_stream.dataset": "apm.internal",
-					"processor":           common.MapStr{"event": "metric", "name": "metric"},
-					"service":             common.MapStr{"name": "myservice"},
-					"span": common.MapStr{"type": spType, "subtype": spSubtype,
-						"destination": common.MapStr{"service": common.MapStr{"resource": resource}}},
-					"destination": common.MapStr{"service": common.MapStr{"response_time": common.MapStr{
-						"count": 40.0,
-						"sum":   common.MapStr{"us": 500000.0},
-					},
-					},
-					},
+			Output: common.MapStr{
+				"data_stream.type":    "metrics",
+				"data_stream.dataset": "apm.internal",
+				"processor":           common.MapStr{"event": "metric", "name": "metric"},
+				"service":             common.MapStr{"name": "myservice"},
+				"span": common.MapStr{"type": spType, "subtype": spSubtype,
+					"destination": common.MapStr{"service": common.MapStr{"resource": resource}}},
+				"destination": common.MapStr{"service": common.MapStr{"response_time": common.MapStr{
+					"count": 40.0,
+					"sum":   common.MapStr{"us": 500000.0},
+				},
+				},
 				},
 			},
 			Msg: "Payload with destination service.",
@@ -246,29 +229,27 @@ func TestTransform(t *testing.T) {
 					Value: 0.99,
 				}},
 			},
-			Output: []common.MapStr{
-				{
-					"data_stream.type":    "metrics",
-					"data_stream.dataset": "apm.app.myservice",
-					"processor":           common.MapStr{"event": "metric", "name": "metric"},
-					"service":             common.MapStr{"name": "myservice"},
+			Output: common.MapStr{
+				"data_stream.type":    "metrics",
+				"data_stream.dataset": "apm.app.myservice",
+				"processor":           common.MapStr{"event": "metric", "name": "metric"},
+				"service":             common.MapStr{"name": "myservice"},
+				"latency_histogram": common.MapStr{
+					"counts": []int64{1, 2, 3},
+					"values": []float64{1.1, 2.2, 3.3},
+				},
+				"just_type": 123.0,
+				"just_unit": 0.99,
+				"_metric_descriptions": common.MapStr{
 					"latency_histogram": common.MapStr{
-						"counts": []int64{1, 2, 3},
-						"values": []float64{1.1, 2.2, 3.3},
+						"type": "histogram",
+						"unit": "s",
 					},
-					"just_type": 123.0,
-					"just_unit": 0.99,
-					"_metric_descriptions": common.MapStr{
-						"latency_histogram": common.MapStr{
-							"type": "histogram",
-							"unit": "s",
-						},
-						"just_type": common.MapStr{
-							"type": "counter",
-						},
-						"just_unit": common.MapStr{
-							"unit": "percent",
-						},
+					"just_type": common.MapStr{
+						"type": "counter",
+					},
+					"just_unit": common.MapStr{
+						"unit": "percent",
 					},
 				},
 			},
@@ -277,11 +258,8 @@ func TestTransform(t *testing.T) {
 	}
 
 	for idx, test := range tests {
-		outputEvents := test.Metricset.appendBeatEvents(&transform.Config{DataStreams: true}, nil)
-
-		for j, outputEvent := range outputEvents {
-			assert.Equal(t, test.Output[j], outputEvent.Fields, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
-			assert.Equal(t, timestamp, outputEvent.Timestamp, fmt.Sprintf("Bad timestamp at idx %v; %s", idx, test.Msg))
-		}
+		outputEvent := test.Metricset.toBeatEvent(&transform.Config{DataStreams: true})
+		assert.Equal(t, test.Output, outputEvent.Fields, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
+		assert.Equal(t, timestamp, outputEvent.Timestamp, fmt.Sprintf("Bad timestamp at idx %v; %s", idx, test.Msg))
 	}
 }

--- a/model/modelprocessor/environment_test.go
+++ b/model/modelprocessor/environment_test.go
@@ -55,7 +55,7 @@ func testProcessBatchMetadata(t *testing.T, processor model.BatchProcessor, in, 
 		"Span",
 		"Metricset",
 		"Error",
-		"Profile",
+		"ProfileSample",
 	}, apmEventFields)
 
 	batch := &model.Batch{
@@ -63,7 +63,7 @@ func testProcessBatchMetadata(t *testing.T, processor model.BatchProcessor, in, 
 		{Span: &model.Span{Metadata: in}},
 		{Metricset: &model.Metricset{Metadata: in}},
 		{Error: &model.Error{Metadata: in}},
-		{Profile: &model.PprofProfile{Metadata: in}},
+		{ProfileSample: &model.ProfileSample{Metadata: in}},
 	}
 	err := processor.ProcessBatch(context.Background(), batch)
 	require.NoError(t, err)
@@ -73,7 +73,7 @@ func testProcessBatchMetadata(t *testing.T, processor model.BatchProcessor, in, 
 		{Span: &model.Span{Metadata: out}},
 		{Metricset: &model.Metricset{Metadata: out}},
 		{Error: &model.Error{Metadata: out}},
-		{Profile: &model.PprofProfile{Metadata: out}},
+		{ProfileSample: &model.ProfileSample{Metadata: out}},
 	}
 	assert.Equal(t, expected, batch)
 }

--- a/model/modelprocessor/metadata.go
+++ b/model/modelprocessor/metadata.go
@@ -47,8 +47,8 @@ func (f MetadataProcessorFunc) ProcessBatch(ctx context.Context, b *model.Batch)
 			if err := f(ctx, &event.Error.Metadata); err != nil {
 				return err
 			}
-		case event.Profile != nil:
-			if err := f(ctx, &event.Profile.Metadata); err != nil {
+		case event.ProfileSample != nil:
+			if err := f(ctx, &event.ProfileSample.Metadata); err != nil {
 				return err
 			}
 		}

--- a/model/profile.go
+++ b/model/profile.go
@@ -18,17 +18,13 @@
 package model
 
 import (
-	"fmt"
 	"time"
 
-	"github.com/cespare/xxhash/v2"
-	"github.com/gofrs/uuid"
-	"github.com/google/pprof/profile"
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/common"
 
 	"github.com/elastic/apm-server/datastreams"
 	"github.com/elastic/apm-server/transform"
-	"github.com/elastic/beats/v7/libbeat/beat"
-	"github.com/elastic/beats/v7/libbeat/common"
 )
 
 const (
@@ -42,117 +38,65 @@ var profileProcessorEntry = common.MapStr{
 	"event": profileDocType,
 }
 
-// PprofProfile represents a resource profile.
-type PprofProfile struct {
-	Metadata Metadata
-	Profile  *profile.Profile
+// ProfileSample holds a profiling sample.
+type ProfileSample struct {
+	Metadata  Metadata
+	Timestamp time.Time
+	Duration  time.Duration
+	ProfileID string
+	Stack     []ProfileSampleStackframe
+	Labels    common.MapStr
+	Values    map[string]int64
 }
 
-// appendBeatEvents transforms a Profile into a sequence of beat.Events (one per profile sample),
-// and appends them to events.
-func (pp PprofProfile) appendBeatEvents(cfg *transform.Config, events []beat.Event) []beat.Event {
-	// Precompute value field names for use in each event.
-	// TODO(axw) limit to well-known value names?
-	profileTimestamp := time.Unix(0, pp.Profile.TimeNanos)
-	valueFieldNames := make([]string, len(pp.Profile.SampleType))
-	for i, sampleType := range pp.Profile.SampleType {
-		sampleUnit := normalizeUnit(sampleType.Unit)
-		// Go profiles report samples.count, Node.js profiles report sample.count.
-		// We use samples.count for both so we can aggregate on one field.
-		if sampleType.Type == "sample" || sampleType.Type == "samples" {
-			valueFieldNames[i] = "samples.count"
-		} else {
-			valueFieldNames[i] = sampleType.Type + "." + sampleUnit
-		}
-
-	}
-
-	// Generate a unique profile ID shared by all samples in the profile.
-	// If we can't generate a UUID for whatever reason, omit the profile ID.
-	var profileID string
-	if uuid, err := uuid.NewV4(); err == nil {
-		profileID = fmt.Sprintf("%x", uuid)
-	}
-
-	// Profiles are stored in their own "metrics" data stream, with a data
-	// set per service. This enables managing retention of profiling data
-	// per-service, and indepedently of lower volume metrics.
-	for _, sample := range pp.Profile.Sample {
-		profileFields := common.MapStr{}
-		if profileID != "" {
-			profileFields["id"] = profileID
-		}
-		if pp.Profile.DurationNanos > 0 {
-			profileFields["duration"] = pp.Profile.DurationNanos
-		}
-		if len(sample.Location) > 0 {
-			hash := xxhash.New()
-			stack := make([]common.MapStr, len(sample.Location))
-			for i := len(sample.Location) - 1; i >= 0; i-- {
-				loc := sample.Location[i]
-				line := loc.Line[0] // aggregated at function level
-
-				// NOTE(axw) Currently we hash the function names so that
-				// we can aggregate stacks across multiple builds, or where
-				// binaries are not reproducible.
-				//
-				// If we decide to identify stack traces and frames using
-				// function addresses, then need to subtract the mapping's
-				// start address to eliminate the effects of ASLR, i.e.
-				//
-				//     var buf [8]byte
-				//     binary.BigEndian.PutUint64(buf[:], loc.Address-loc.Mapping.Start)
-				//     hash.Write(buf[:])
-
-				hash.WriteString(line.Function.Name)
-				fields := mapStr{
-					"id":       fmt.Sprintf("%x", hash.Sum(nil)),
-					"function": line.Function.Name,
-				}
-				if fields.maybeSetString("filename", line.Function.Filename) {
-					if line.Line > 0 {
-						fields.set("line", line.Line)
-					}
-				}
-				stack[i] = common.MapStr(fields)
-			}
-			profileFields["stack"] = stack
-			profileFields["top"] = stack[0]
-		}
-		for i, v := range sample.Value {
-			profileFields[valueFieldNames[i]] = v
-		}
-		fields := mapStr{
-			"processor":    profileProcessorEntry,
-			profileDocType: profileFields,
-		}
-		if cfg.DataStreams {
-			fields[datastreams.TypeField] = datastreams.MetricsType
-			fields[datastreams.DatasetField] = ProfilesDataset
-		}
-		var profileLabels common.MapStr
-		if len(sample.Label) > 0 {
-			profileLabels = make(common.MapStr)
-			for k, v := range sample.Label {
-				profileLabels[k] = v
-			}
-		}
-		pp.Metadata.set(&fields, profileLabels)
-		events = append(events, beat.Event{
-			Timestamp: profileTimestamp,
-			Fields:    common.MapStr(fields),
-		})
-	}
-	return events
+// ProfileSampleStackframe holds details of a stack frame for a profile sample.
+type ProfileSampleStackframe struct {
+	ID       string
+	Function string
+	Filename string
+	Line     int64
 }
 
-func normalizeUnit(unit string) string {
-	switch unit {
-	case "nanoseconds":
-		unit = "ns"
-
-	case "microseconds":
-		unit = "us"
+func (p *ProfileSample) toBeatEvent(cfg *transform.Config) beat.Event {
+	var profileFields mapStr
+	profileFields.maybeSetString("id", p.ProfileID)
+	if p.Duration > 0 {
+		profileFields.set("duration", int64(p.Duration))
 	}
-	return unit
+
+	if len(p.Stack) > 0 {
+		stackFields := make([]common.MapStr, len(p.Stack))
+		for i, frame := range p.Stack {
+			frameFields := mapStr{
+				"id":       frame.ID,
+				"function": frame.Function,
+			}
+			if frameFields.maybeSetString("filename", frame.Filename) {
+				if frame.Line > 0 {
+					frameFields.set("line", frame.Line)
+				}
+			}
+			stackFields[i] = common.MapStr(frameFields)
+		}
+		profileFields.set("stack", stackFields)
+		profileFields.set("top", stackFields[0])
+	}
+	for k, v := range p.Values {
+		profileFields.set(k, v)
+	}
+
+	fields := mapStr{
+		"processor":    profileProcessorEntry,
+		profileDocType: common.MapStr(profileFields),
+	}
+	p.Metadata.set(&fields, p.Labels)
+	if cfg.DataStreams {
+		fields[datastreams.TypeField] = datastreams.MetricsType
+		fields[datastreams.DatasetField] = ProfilesDataset
+	}
+
+	return beat.Event{
+		Timestamp: p.Timestamp,
+		Fields:    common.MapStr(fields),
+	}
 }

--- a/model/profile_test.go
+++ b/model/profile_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	pprof_profile "github.com/google/pprof/profile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -32,7 +31,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
-func TestPprofProfileTransform(t *testing.T) {
+func TestProfileSampleTransform(t *testing.T) {
 	serviceName, env := "myService", "staging"
 	service := model.Service{
 		Name:        serviceName,
@@ -40,62 +39,37 @@ func TestPprofProfileTransform(t *testing.T) {
 	}
 
 	timestamp := time.Unix(123, 456)
-	pp := model.PprofProfile{
-		Metadata: model.Metadata{Service: service},
-		Profile: &pprof_profile.Profile{
-			TimeNanos:     timestamp.UnixNano(),
-			DurationNanos: int64(10 * time.Second),
-			SampleType: []*pprof_profile.ValueType{
-				{Type: "sample", Unit: "count"},
-				{Type: "cpu", Unit: "nanoseconds"},
-				{Type: "wall", Unit: "microseconds"},
-				{Type: "inuse_space", Unit: "bytes"},
-			},
-			Sample: []*pprof_profile.Sample{{
-				Value: []int64{1, 123, 789, 456},
-				Label: map[string][]string{
-					"key1": []string{"abc", "def"},
-					"key2": []string{"ghi"},
-				},
-				Location: []*pprof_profile.Location{{
-					Line: []pprof_profile.Line{{
-						Function: &pprof_profile.Function{Name: "foo", Filename: "foo.go"},
-						Line:     1,
-					}},
-				}, {
-					Line: []pprof_profile.Line{{
-						Function: &pprof_profile.Function{Name: "bar", Filename: "bar.go"},
-					}},
-				}},
-			}, {
-				Value: []int64{1, 123, 789, 456},
-				Label: map[string][]string{
-					"key1": []string{"abc", "def"},
-					"key2": []string{"ghi"},
-				},
-				Location: []*pprof_profile.Location{{
-					Line: []pprof_profile.Line{{
-						Function: &pprof_profile.Function{Name: "foo", Filename: "foo.go"},
-						Line:     1,
-					}},
-				}, {
-					Line: []pprof_profile.Line{{
-						Function: &pprof_profile.Function{Name: "bar", Filename: "bar.go"},
-					}},
-				}},
-			}},
+	sample := model.ProfileSample{
+		Metadata:  model.Metadata{Service: service},
+		Timestamp: timestamp,
+		Duration:  10 * time.Second,
+		ProfileID: "profile_id",
+		Stack: []model.ProfileSampleStackframe{{
+			ID:       "foo_id",
+			Function: "foo",
+			Filename: "foo.go",
+			Line:     1,
+		}, {
+			ID:       "bar_id",
+			Function: "bar",
+			Filename: "bar.go",
+		}},
+		Labels: common.MapStr{
+			"key1": []string{"abc", "def"},
+			"key2": []string{"ghi"},
+		},
+		Values: map[string]int64{
+			"samples.count":     1,
+			"cpu.ns":            123,
+			"wall.us":           789,
+			"inuse_space.bytes": 456,
 		},
 	}
 
-	batch := &model.Batch{{Profile: &pp}}
+	batch := &model.Batch{{ProfileSample: &sample}, {ProfileSample: &sample}}
 	output := batch.Transform(context.Background(), &transform.Config{DataStreams: true})
 	require.Len(t, output, 2)
 	assert.Equal(t, output[0], output[1])
-
-	if profileMap, ok := output[0].Fields["profile"].(common.MapStr); ok {
-		assert.NotZero(t, profileMap["id"])
-		profileMap["id"] = "random"
-	}
 
 	assert.Equal(t, beat.Event{
 		Timestamp: timestamp,
@@ -112,7 +86,7 @@ func TestPprofProfileTransform(t *testing.T) {
 				"key2": []string{"ghi"},
 			},
 			"profile": common.MapStr{
-				"id":                "random",
+				"id":                "profile_id",
 				"duration":          int64(10 * time.Second),
 				"cpu.ns":            int64(123),
 				"wall.us":           int64(789),
@@ -122,17 +96,17 @@ func TestPprofProfileTransform(t *testing.T) {
 					"function": "foo",
 					"filename": "foo.go",
 					"line":     int64(1),
-					"id":       "98430081820ed765",
+					"id":       "foo_id",
 				},
 				"stack": []common.MapStr{{
 					"function": "foo",
 					"filename": "foo.go",
 					"line":     int64(1),
-					"id":       "98430081820ed765",
+					"id":       "foo_id",
 				}, {
 					"function": "bar",
 					"filename": "bar.go",
-					"id":       "48a37c90ad27a659",
+					"id":       "bar_id",
 				}},
 			},
 		},

--- a/model/span.go
+++ b/model/span.go
@@ -189,7 +189,7 @@ func (d *DestinationService) fields() common.MapStr {
 	return common.MapStr(fields)
 }
 
-func (e *Span) appendBeatEvents(ctx context.Context, cfg *transform.Config, events []beat.Event) []beat.Event {
+func (e *Span) toBeatEvent(ctx context.Context, cfg *transform.Config) beat.Event {
 	spanTransformations.Inc()
 	if frames := len(e.Stacktrace); frames > 0 {
 		spanStacktraceCounter.Inc()
@@ -238,10 +238,10 @@ func (e *Span) appendBeatEvents(ctx context.Context, cfg *transform.Config, even
 
 	common.MapStr(fields).Put("event.outcome", e.Outcome)
 
-	return append(events, beat.Event{
+	return beat.Event{
 		Fields:    common.MapStr(fields),
 		Timestamp: e.Timestamp,
-	})
+	}
 }
 
 func (e *Span) fields(ctx context.Context, cfg *transform.Config) common.MapStr {

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -176,10 +176,7 @@ func TestSpanTransform(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		output := test.Span.appendBeatEvents(context.Background(), &transform.Config{
-			DataStreams: true,
-		}, nil)
-		fields := output[0].Fields
-		assert.Equal(t, test.Output, fields, test.Msg)
+		output := test.Span.toBeatEvent(context.Background(), &transform.Config{DataStreams: true})
+		assert.Equal(t, test.Output, output.Fields, test.Msg)
 	}
 }

--- a/model/transaction.go
+++ b/model/transaction.go
@@ -120,7 +120,7 @@ func (e *Transaction) fields() common.MapStr {
 	return common.MapStr(fields)
 }
 
-func (e *Transaction) appendBeatEvents(cfg *transform.Config, events []beat.Event) []beat.Event {
+func (e *Transaction) toBeatEvent(cfg *transform.Config) beat.Event {
 	transactionTransformations.Inc()
 
 	fields := mapStr{
@@ -155,10 +155,10 @@ func (e *Transaction) appendBeatEvents(cfg *transform.Config, events []beat.Even
 	}
 	common.MapStr(fields).Put("event.outcome", e.Outcome)
 
-	return append(events, beat.Event{
+	return beat.Event{
 		Timestamp: e.Timestamp,
 		Fields:    common.MapStr(fields),
-	})
+	}
 }
 
 type TransactionMarks map[string]TransactionMark


### PR DESCRIPTION
## Motivation/summary

Change `model.APMEvent` to map to a single `beat.Event`, so we can later move common event properties such as "Metadata" up to the `APMEvent` type, and map `APMEvent` programatically.

The only one that did not already was `model.PprofPofile`. We redefine this as `model.ProfileSample`, which describes
a single profile sample, and move the conversion of pprof profiles to a batch of profile samples to the HTTP handler.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

Non-functional change.

## Related issues

https://github.com/elastic/apm-server/issues/4410
https://github.com/elastic/apm-server/issues/4120
https://github.com/elastic/apm-server/issues/3565