### PR TITLE
processor/otel: record array resource attributes

### DIFF
--- a/processor/otel/consumer.go
+++ b/processor/otel/consumer.go
@@ -474,6 +474,8 @@ func translateSpan(span pdata.Span, metadata model.Metadata, event *model.Span) 
 
 		k := replaceDots(kDots)
 		switch v.Type() {
+		case pdata.AttributeValueTypeArray:
+			labels[k] = ifaceAnyValueArray(v.ArrayVal())
 		case pdata.AttributeValueTypeBool:
 			labels[k] = v.BoolVal()
 		case pdata.AttributeValueTypeDouble:

--- a/processor/otel/consumer.go
+++ b/processor/otel/consumer.go
@@ -261,22 +261,7 @@ func translateTransaction(
 		k := replaceDots(kDots)
 		switch v.Type() {
 		case pdata.AttributeValueTypeArray:
-			array := v.ArrayVal()
-			values := make([]interface{}, array.Len())
-			for i := range values {
-				value := array.At(i)
-				switch value.Type() {
-				case pdata.AttributeValueTypeBool:
-					values[i] = value.BoolVal()
-				case pdata.AttributeValueTypeDouble:
-					values[i] = value.DoubleVal()
-				case pdata.AttributeValueTypeInt:
-					values[i] = value.IntVal()
-				case pdata.AttributeValueTypeString:
-					values[i] = truncate(value.StringVal())
-				}
-			}
-			labels[k] = values
+			labels[k] = ifaceAnyValueArray(v.ArrayVal())
 		case pdata.AttributeValueTypeBool:
 			labels[k] = v.BoolVal()
 		case pdata.AttributeValueTypeDouble:

--- a/processor/otel/consumer_test.go
+++ b/processor/otel/consumer_test.go
@@ -575,6 +575,15 @@ func TestArrayLabels(t *testing.T) {
 		"bool_array":   []interface{}{false, true},
 		"string_array": []interface{}{"string1", "string2"},
 	}, tx.Labels)
+
+	span := transformSpanWithAttributes(t, map[string]pdata.AttributeValue{
+		"string_array": stringArray,
+		"bool_array":   boolArray,
+	})
+	assert.Equal(t, common.MapStr{
+		"bool_array":   []interface{}{false, true},
+		"string_array": []interface{}{"string1", "string2"},
+	}, span.Labels)
 }
 
 func TestConsumeTracesExportTimestamp(t *testing.T) {

--- a/processor/otel/metadata.go
+++ b/processor/otel/metadata.go
@@ -227,6 +227,16 @@ func ifaceAttributeValue(v pdata.AttributeValue) interface{} {
 		return v.DoubleVal()
 	case pdata.AttributeValueTypeBool:
 		return v.BoolVal()
+	case pdata.AttributeValueTypeArray:
+		return ifaceAnyValueArray(v.ArrayVal())
 	}
 	return nil
+}
+
+func ifaceAnyValueArray(array pdata.AnyValueArray) []interface{} {
+	values := make([]interface{}, array.Len())
+	for i := range values {
+		values[i] = ifaceAttributeValue(array.At(i))
+	}
+	return values
 }

--- a/processor/otel/metadata_test.go
+++ b/processor/otel/metadata_test.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/pdata"
 
 	"github.com/elastic/apm-server/model"
+	"github.com/elastic/beats/v7/libbeat/common"
 )
 
 func TestResourceConventions(t *testing.T) {
@@ -222,6 +223,25 @@ func TestResourceConventions(t *testing.T) {
 			assert.Equal(t, test.expected, meta)
 		})
 	}
+}
+
+func TestResourceLabels(t *testing.T) {
+	stringArray := pdata.NewAttributeValueArray()
+	stringArray.ArrayVal().Append(pdata.NewAttributeValueString("abc"))
+	stringArray.ArrayVal().Append(pdata.NewAttributeValueString("def"))
+
+	intArray := pdata.NewAttributeValueArray()
+	intArray.ArrayVal().Append(pdata.NewAttributeValueInt(123))
+	intArray.ArrayVal().Append(pdata.NewAttributeValueInt(456))
+
+	metadata := transformResourceMetadata(t, map[string]pdata.AttributeValue{
+		"string_array": stringArray,
+		"int_array":    intArray,
+	})
+	assert.Equal(t, common.MapStr{
+		"string_array": []interface{}{"abc", "def"},
+		"int_array":    []interface{}{int64(123), int64(456)},
+	}, metadata.Labels)
 }
 
 func transformResourceMetadata(t *testing.T, resourceAttrs map[string]pdata.AttributeValue) model.Metadata {

--- a/systemtest/approvals/TestOTLPGRPCTraces.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCTraces.approved.json
@@ -13,6 +13,17 @@
                 "ingested": "dynamic",
                 "outcome": "success"
             },
+            "labels": {
+                "resource_attribute_array": [
+                    "a",
+                    "b"
+                ],
+                "span_attribute_array": [
+                    "a",
+                    "b",
+                    "c"
+                ]
+            },
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",


### PR DESCRIPTION
## Motivation/summary

If an unhandled array attribute is found in resource attributes, store that as a label like we do with span attributes.

Also, handle array attributes when translating to Elastic spans and not just transactions.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

Send a trace with OTLP with array attributes at both the resource and span level, and ensure they are recorded as labels.

## Related issues

Fixes https://github.com/elastic/apm-server/issues/5663