### PR TITLE
Move setting of data_stream fields to processor

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -457,6 +457,11 @@ func (s *serverRunner) wrapRunServerWithPreprocessors(runServer RunServerFunc) R
 			DefaultServiceEnvironment: s.config.DefaultServiceEnvironment,
 		})
 	}
+	if s.config.DataStreams.Enabled {
+		processors = append(processors, &modelprocessor.SetDataStream{
+			Namespace: s.namespace,
+		})
+	}
 	return WrapRunServerWithProcessors(runServer, processors...)
 }
 
@@ -627,7 +632,6 @@ func runServerWithTracerServer(runServer RunServerFunc, tracerServer *tracerServ
 
 func newTransformConfig(beatInfo beat.Info, cfg *config.Config) *transform.Config {
 	return &transform.Config{
-		DataStreams: cfg.DataStreams.Enabled,
 		RUM: transform.RUMConfig{
 			LibraryPattern:      regexp.MustCompile(cfg.RumConfig.LibraryPattern),
 			ExcludeFromGrouping: regexp.MustCompile(cfg.RumConfig.ExcludeFromGrouping),

--- a/model/datastream.go
+++ b/model/datastream.go
@@ -15,28 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package transform
+package model
 
-import (
-	"context"
-	"regexp"
+import "github.com/elastic/apm-server/datastreams"
 
-	"github.com/elastic/beats/v7/libbeat/beat"
-)
+// DataStream identifies the data stream to which an event will be written.
+type DataStream struct {
+	// Type holds the data_stream.type identifier.
+	Type string
 
-// Transformable is an interface implemented by all top-level model objects for
-// translating to beat.Events.
-type Transformable interface {
-	Transform(context.Context, *Config) []beat.Event
+	// Dataset holds the data_stream.dataset identifier.
+	Dataset string
+
+	// Namespace holds the data_stream.namespace identifier.
+	Namespace string
 }
 
-// Config holds general transformation configuration.
-type Config struct {
-	RUM RUMConfig
-}
-
-// RUMConfig holds RUM-related transformation configuration.
-type RUMConfig struct {
-	LibraryPattern      *regexp.Regexp
-	ExcludeFromGrouping *regexp.Regexp
+func (d *DataStream) setFields(fields *mapStr) {
+	fields.maybeSetString(datastreams.TypeField, d.Type)
+	fields.maybeSetString(datastreams.DatasetField, d.Dataset)
+	fields.maybeSetString(datastreams.NamespaceField, d.Namespace)
 }

--- a/model/error.go
+++ b/model/error.go
@@ -32,7 +32,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/monitoring"
 
-	"github.com/elastic/apm-server/datastreams"
 	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/apm-server/utility"
 )
@@ -113,14 +112,6 @@ func (e *Error) toBeatEvent(ctx context.Context, cfg *transform.Config) beat.Eve
 	fields := mapStr{
 		"error":     e.fields(ctx, cfg),
 		"processor": errorProcessorEntry,
-	}
-
-	if cfg.DataStreams {
-		// Errors are stored in an APM errors-specific "logs" data stream, per service.
-		// By storing errors in a "logs" data stream, they can be viewed in the Logs app
-		// in Kibana.
-		fields[datastreams.TypeField] = datastreams.LogsType
-		fields[datastreams.DatasetField] = ErrorsDataset
 	}
 
 	// first set the generic metadata (order is relevant)

--- a/model/error_test.go
+++ b/model/error_test.go
@@ -295,10 +295,8 @@ func TestEvents(t *testing.T) {
 		"valid": {
 			Error: &Error{Timestamp: timestamp, Metadata: md},
 			Output: common.MapStr{
-				"data_stream.type":    "logs",
-				"data_stream.dataset": "apm.error",
-				"agent":               common.MapStr{"name": "go", "version": "1.0"},
-				"service":             common.MapStr{"name": "myservice", "version": "1.0"},
+				"agent":   common.MapStr{"name": "go", "version": "1.0"},
+				"service": common.MapStr{"name": "myservice", "version": "1.0"},
 				"error": common.MapStr{
 					"grouping_key": "d41d8cd98f00b204e9800998ecf8427e",
 				},
@@ -310,11 +308,9 @@ func TestEvents(t *testing.T) {
 		"notSampled": {
 			Error: &Error{Timestamp: timestamp, Metadata: md, TransactionSampled: &sampledFalse},
 			Output: common.MapStr{
-				"data_stream.type":    "logs",
-				"data_stream.dataset": "apm.error",
-				"transaction":         common.MapStr{"sampled": false},
-				"agent":               common.MapStr{"name": "go", "version": "1.0"},
-				"service":             common.MapStr{"name": "myservice", "version": "1.0"},
+				"transaction": common.MapStr{"sampled": false},
+				"agent":       common.MapStr{"name": "go", "version": "1.0"},
+				"service":     common.MapStr{"name": "myservice", "version": "1.0"},
 				"error": common.MapStr{
 					"grouping_key": "d41d8cd98f00b204e9800998ecf8427e",
 				},
@@ -326,9 +322,7 @@ func TestEvents(t *testing.T) {
 		"withMeta": {
 			Error: &Error{Timestamp: timestamp, Metadata: md, TransactionType: transactionType},
 			Output: common.MapStr{
-				"data_stream.type":    "logs",
-				"data_stream.dataset": "apm.error",
-				"transaction":         common.MapStr{"type": "request"},
+				"transaction": common.MapStr{"type": "request"},
 				"error": common.MapStr{
 					"grouping_key": "d41d8cd98f00b204e9800998ecf8427e",
 				},
@@ -359,15 +353,13 @@ func TestEvents(t *testing.T) {
 			},
 
 			Output: common.MapStr{
-				"data_stream.type":    "logs",
-				"data_stream.dataset": "apm.error",
-				"labels":              common.MapStr{"key": true, "label": 101},
-				"service":             common.MapStr{"name": "myservice", "version": "1.0"},
-				"agent":               common.MapStr{"name": "go", "version": "1.0"},
-				"user":                common.MapStr{"id": uid, "email": email},
-				"client":              common.MapStr{"ip": userIP},
-				"source":              common.MapStr{"ip": userIP},
-				"user_agent":          common.MapStr{"original": userAgent},
+				"labels":     common.MapStr{"key": true, "label": 101},
+				"service":    common.MapStr{"name": "myservice", "version": "1.0"},
+				"agent":      common.MapStr{"name": "go", "version": "1.0"},
+				"user":       common.MapStr{"id": uid, "email": email},
+				"client":     common.MapStr{"ip": userIP},
+				"source":     common.MapStr{"ip": userIP},
+				"user_agent": common.MapStr{"original": userAgent},
 				"error": common.MapStr{
 					"custom": common.MapStr{
 						"foo_bar": "baz",
@@ -396,7 +388,7 @@ func TestEvents(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			outputEvent := tc.Error.toBeatEvent(context.Background(), &transform.Config{DataStreams: true})
+			outputEvent := tc.Error.toBeatEvent(context.Background(), &transform.Config{})
 			assert.Equal(t, tc.Output, outputEvent.Fields)
 			assert.Equal(t, timestamp, outputEvent.Timestamp)
 

--- a/model/metricset_test.go
+++ b/model/metricset_test.go
@@ -55,9 +55,7 @@ func TestTransform(t *testing.T) {
 		{
 			Metricset: &Metricset{Timestamp: timestamp, Metadata: metadata},
 			Output: common.MapStr{
-				"data_stream.type":    "metrics",
-				"data_stream.dataset": "apm.app.myservice",
-				"processor":           common.MapStr{"event": "metric", "name": "metric"},
+				"processor": common.MapStr{"event": "metric", "name": "metric"},
 				"service": common.MapStr{
 					"name": "myservice",
 				},
@@ -67,10 +65,8 @@ func TestTransform(t *testing.T) {
 		{
 			Metricset: &Metricset{Timestamp: timestamp, Metadata: metadata, Name: "raj"},
 			Output: common.MapStr{
-				"data_stream.type":    "metrics",
-				"data_stream.dataset": "apm.app.myservice",
-				"processor":           common.MapStr{"event": "metric", "name": "metric"},
-				"metricset.name":      "raj",
+				"processor":      common.MapStr{"event": "metric", "name": "metric"},
+				"metricset.name": "raj",
 				"service": common.MapStr{
 					"name": "myservice",
 				},
@@ -94,11 +90,9 @@ func TestTransform(t *testing.T) {
 				},
 			},
 			Output: common.MapStr{
-				"data_stream.type":    "metrics",
-				"data_stream.dataset": "apm.app.myservice",
-				"processor":           common.MapStr{"event": "metric", "name": "metric"},
-				"service":             common.MapStr{"name": "myservice"},
-				"labels":              common.MapStr{"a_b": "a.b.value"},
+				"processor": common.MapStr{"event": "metric", "name": "metric"},
+				"service":   common.MapStr{"name": "myservice"},
+				"labels":    common.MapStr{"a_b": "a.b.value"},
 
 				"a":    common.MapStr{"counter": float64(612)},
 				"some": common.MapStr{"gauge": float64(9.16)},
@@ -117,11 +111,9 @@ func TestTransform(t *testing.T) {
 				}},
 			},
 			Output: common.MapStr{
-				"data_stream.type":    "metrics",
-				"data_stream.dataset": "apm.internal",
-				"processor":           common.MapStr{"event": "metric", "name": "metric"},
-				"service":             common.MapStr{"name": "myservice"},
-				"transaction":         common.MapStr{"type": trType, "name": trName},
+				"processor":   common.MapStr{"event": "metric", "name": "metric"},
+				"service":     common.MapStr{"name": "myservice"},
+				"transaction": common.MapStr{"type": trType, "name": trName},
 				"span": common.MapStr{
 					"type": spType, "subtype": spSubtype,
 					"self_time": common.MapStr{
@@ -153,12 +145,10 @@ func TestTransform(t *testing.T) {
 				},
 			},
 			Output: common.MapStr{
-				"data_stream.type":    "metrics",
-				"data_stream.dataset": "apm.internal",
-				"processor":           common.MapStr{"event": "metric", "name": "metric"},
-				"service":             common.MapStr{"name": "myservice"},
-				"event":               common.MapStr{"outcome": eventOutcome},
-				"timeseries":          common.MapStr{"instance": "foo"},
+				"processor":  common.MapStr{"event": "metric", "name": "metric"},
+				"service":    common.MapStr{"name": "myservice"},
+				"event":      common.MapStr{"outcome": eventOutcome},
+				"timeseries": common.MapStr{"instance": "foo"},
 				"transaction": common.MapStr{
 					"type":   trType,
 					"name":   trName,
@@ -194,10 +184,8 @@ func TestTransform(t *testing.T) {
 				},
 			},
 			Output: common.MapStr{
-				"data_stream.type":    "metrics",
-				"data_stream.dataset": "apm.internal",
-				"processor":           common.MapStr{"event": "metric", "name": "metric"},
-				"service":             common.MapStr{"name": "myservice"},
+				"processor": common.MapStr{"event": "metric", "name": "metric"},
+				"service":   common.MapStr{"name": "myservice"},
 				"span": common.MapStr{"type": spType, "subtype": spSubtype,
 					"destination": common.MapStr{"service": common.MapStr{"resource": resource}}},
 				"destination": common.MapStr{"service": common.MapStr{"response_time": common.MapStr{
@@ -230,10 +218,8 @@ func TestTransform(t *testing.T) {
 				}},
 			},
 			Output: common.MapStr{
-				"data_stream.type":    "metrics",
-				"data_stream.dataset": "apm.app.myservice",
-				"processor":           common.MapStr{"event": "metric", "name": "metric"},
-				"service":             common.MapStr{"name": "myservice"},
+				"processor": common.MapStr{"event": "metric", "name": "metric"},
+				"service":   common.MapStr{"name": "myservice"},
 				"latency_histogram": common.MapStr{
 					"counts": []int64{1, 2, 3},
 					"values": []float64{1.1, 2.2, 3.3},
@@ -258,7 +244,7 @@ func TestTransform(t *testing.T) {
 	}
 
 	for idx, test := range tests {
-		outputEvent := test.Metricset.toBeatEvent(&transform.Config{DataStreams: true})
+		outputEvent := test.Metricset.toBeatEvent(&transform.Config{})
 		assert.Equal(t, test.Output, outputEvent.Fields, fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
 		assert.Equal(t, timestamp, outputEvent.Timestamp, fmt.Sprintf("Bad timestamp at idx %v; %s", idx, test.Msg))
 	}

--- a/model/modelprocessor/datastream.go
+++ b/model/modelprocessor/datastream.go
@@ -1,0 +1,72 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package modelprocessor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/elastic/apm-server/datastreams"
+	"github.com/elastic/apm-server/model"
+)
+
+// SetDataStream is a model.BatchProcessor that sets the data stream for events.
+type SetDataStream struct {
+	Namespace string
+}
+
+// ProcessBatch sets data stream fields for each event in b.
+func (s *SetDataStream) ProcessBatch(ctx context.Context, b *model.Batch) error {
+	for i := range *b {
+		s.setDataStream(&(*b)[i])
+	}
+	return nil
+}
+
+func (s *SetDataStream) setDataStream(event *model.APMEvent) {
+	switch {
+	case event.Transaction != nil || event.Span != nil:
+		event.DataStream.Type = datastreams.TracesType
+		event.DataStream.Dataset = model.TracesDataset
+	case event.Error != nil:
+		event.DataStream.Type = datastreams.LogsType
+		event.DataStream.Dataset = model.ErrorsDataset
+	case event.Metricset != nil:
+		event.DataStream.Type = datastreams.MetricsType
+		// Metrics that include well-defined transaction/span fields
+		// (i.e. breakdown metrics, transaction and span metrics) will
+		// be stored separately from application and runtime metrics.
+		event.DataStream.Dataset = model.InternalMetricsDataset
+		if isApplicationMetricset(event.Metricset) {
+			event.DataStream.Dataset = fmt.Sprintf(
+				"%s.%s", model.AppMetricsDataset,
+				datastreams.NormalizeServiceName(event.Metricset.Metadata.Service.Name),
+			)
+		}
+	case event.ProfileSample != nil:
+		event.DataStream.Type = datastreams.MetricsType
+		event.DataStream.Dataset = model.ProfilesDataset
+	}
+	event.DataStream.Namespace = s.Namespace
+}
+
+func isApplicationMetricset(ms *model.Metricset) bool {
+	return ms.Event == (model.MetricsetEventCategorization{}) &&
+		ms.Transaction == (model.MetricsetTransaction{}) &&
+		ms.Span == (model.MetricsetSpan{})
+}

--- a/model/modelprocessor/datastream_test.go
+++ b/model/modelprocessor/datastream_test.go
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package modelprocessor_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-server/model"
+	"github.com/elastic/apm-server/model/modelprocessor"
+)
+
+func TestSetDataStream(t *testing.T) {
+	tests := []struct {
+		input  model.APMEvent
+		output model.DataStream
+	}{{
+		input:  model.APMEvent{},
+		output: model.DataStream{Namespace: "custom"},
+	}, {
+		input:  model.APMEvent{Transaction: &model.Transaction{}},
+		output: model.DataStream{Type: "traces", Dataset: "apm", Namespace: "custom"},
+	}, {
+		input:  model.APMEvent{Span: &model.Span{}},
+		output: model.DataStream{Type: "traces", Dataset: "apm", Namespace: "custom"},
+	}, {
+		input:  model.APMEvent{Error: &model.Error{}},
+		output: model.DataStream{Type: "logs", Dataset: "apm.error", Namespace: "custom"},
+	}, {
+		input: model.APMEvent{Metricset: &model.Metricset{
+			Metadata:    model.Metadata{Service: model.Service{Name: "service-name"}},
+			Transaction: model.MetricsetTransaction{Name: "foo"},
+		}},
+		output: model.DataStream{Type: "metrics", Dataset: "apm.internal", Namespace: "custom"},
+	}, {
+		input: model.APMEvent{Metricset: &model.Metricset{
+			Metadata: model.Metadata{Service: model.Service{Name: "service-name"}},
+		}},
+		output: model.DataStream{Type: "metrics", Dataset: "apm.app.service_name", Namespace: "custom"},
+	}, {
+		input:  model.APMEvent{ProfileSample: &model.ProfileSample{}},
+		output: model.DataStream{Type: "metrics", Dataset: "apm.profiling", Namespace: "custom"},
+	}}
+
+	for _, test := range tests {
+		batch := model.Batch{test.input}
+		processor := modelprocessor.SetDataStream{Namespace: "custom"}
+		err := processor.ProcessBatch(context.Background(), &batch)
+		assert.NoError(t, err)
+		assert.Equal(t, test.output, batch[0].DataStream)
+	}
+
+}

--- a/model/modelprocessor/environment_test.go
+++ b/model/modelprocessor/environment_test.go
@@ -51,6 +51,7 @@ func testProcessBatchMetadata(t *testing.T, processor model.BatchProcessor, in, 
 		apmEventFields = append(apmEventFields, typ.Field(i).Name)
 	}
 	assert.ElementsMatch(t, []string{
+		"DataStream",
 		"Transaction",
 		"Span",
 		"Metricset",

--- a/model/profile.go
+++ b/model/profile.go
@@ -23,7 +23,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
 
-	"github.com/elastic/apm-server/datastreams"
 	"github.com/elastic/apm-server/transform"
 )
 
@@ -57,7 +56,7 @@ type ProfileSampleStackframe struct {
 	Line     int64
 }
 
-func (p *ProfileSample) toBeatEvent(cfg *transform.Config) beat.Event {
+func (p *ProfileSample) toBeatEvent(*transform.Config) beat.Event {
 	var profileFields mapStr
 	profileFields.maybeSetString("id", p.ProfileID)
 	if p.Duration > 0 {
@@ -90,10 +89,6 @@ func (p *ProfileSample) toBeatEvent(cfg *transform.Config) beat.Event {
 		profileDocType: common.MapStr(profileFields),
 	}
 	p.Metadata.set(&fields, p.Labels)
-	if cfg.DataStreams {
-		fields[datastreams.TypeField] = datastreams.MetricsType
-		fields[datastreams.DatasetField] = ProfilesDataset
-	}
 
 	return beat.Event{
 		Timestamp: p.Timestamp,

--- a/model/profile_test.go
+++ b/model/profile_test.go
@@ -67,16 +67,14 @@ func TestProfileSampleTransform(t *testing.T) {
 	}
 
 	batch := &model.Batch{{ProfileSample: &sample}, {ProfileSample: &sample}}
-	output := batch.Transform(context.Background(), &transform.Config{DataStreams: true})
+	output := batch.Transform(context.Background(), &transform.Config{})
 	require.Len(t, output, 2)
 	assert.Equal(t, output[0], output[1])
 
 	assert.Equal(t, beat.Event{
 		Timestamp: timestamp,
 		Fields: common.MapStr{
-			"data_stream.type":    "metrics",
-			"data_stream.dataset": "apm.profiling",
-			"processor":           common.MapStr{"event": "profile", "name": "profile"},
+			"processor": common.MapStr{"event": "profile", "name": "profile"},
 			"service": common.MapStr{
 				"name":        "myService",
 				"environment": "staging",

--- a/model/span.go
+++ b/model/span.go
@@ -25,7 +25,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/monitoring"
 
-	"github.com/elastic/apm-server/datastreams"
 	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/apm-server/utility"
 )
@@ -195,12 +194,6 @@ func (e *Span) toBeatEvent(ctx context.Context, cfg *transform.Config) beat.Even
 	fields := mapStr{
 		"processor": spanProcessorEntry,
 		spanDocType: e.fields(ctx, cfg),
-	}
-
-	if cfg.DataStreams {
-		// Spans are stored in a "traces" data stream along with transactions.
-		fields[datastreams.TypeField] = datastreams.TracesType
-		fields[datastreams.DatasetField] = TracesDataset
 	}
 
 	// first set the generic metadata

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -56,10 +56,8 @@ func TestSpanTransform(t *testing.T) {
 			Msg:  "Span without a Stacktrace",
 			Span: Span{Timestamp: timestamp, Metadata: metadata},
 			Output: common.MapStr{
-				"data_stream.type":    "traces",
-				"data_stream.dataset": "apm",
-				"processor":           common.MapStr{"event": "span", "name": "transaction"},
-				"service":             common.MapStr{"name": serviceName, "environment": env, "version": serviceVersion},
+				"processor": common.MapStr{"event": "span", "name": "transaction"},
+				"service":   common.MapStr{"name": serviceName, "environment": env, "version": serviceVersion},
 				"span": common.MapStr{
 					"duration": common.MapStr{"us": 0},
 					"name":     "",
@@ -74,10 +72,8 @@ func TestSpanTransform(t *testing.T) {
 			Msg:  "Span with outcome",
 			Span: Span{Timestamp: timestamp, Metadata: metadata, Outcome: "success"},
 			Output: common.MapStr{
-				"data_stream.type":    "traces",
-				"data_stream.dataset": "apm",
-				"processor":           common.MapStr{"event": "span", "name": "transaction"},
-				"service":             common.MapStr{"name": serviceName, "environment": env, "version": serviceVersion},
+				"processor": common.MapStr{"event": "span", "name": "transaction"},
+				"service":   common.MapStr{"name": serviceName, "environment": env, "version": serviceVersion},
 				"span": common.MapStr{
 					"duration": common.MapStr{"us": 0},
 					"name":     "",
@@ -123,8 +119,6 @@ func TestSpanTransform(t *testing.T) {
 				Message: &Message{QueueName: "users"},
 			},
 			Output: common.MapStr{
-				"data_stream.type":    "traces",
-				"data_stream.dataset": "apm",
 				"span": common.MapStr{
 					"id":       hexID,
 					"duration": common.MapStr{"us": 1200},
@@ -176,7 +170,7 @@ func TestSpanTransform(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		output := test.Span.toBeatEvent(context.Background(), &transform.Config{DataStreams: true})
+		output := test.Span.toBeatEvent(context.Background(), &transform.Config{})
 		assert.Equal(t, test.Output, output.Fields, test.Msg)
 	}
 }

--- a/model/transaction.go
+++ b/model/transaction.go
@@ -24,7 +24,6 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common"
 	"github.com/elastic/beats/v7/libbeat/monitoring"
 
-	"github.com/elastic/apm-server/datastreams"
 	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/apm-server/utility"
 )
@@ -120,18 +119,12 @@ func (e *Transaction) fields() common.MapStr {
 	return common.MapStr(fields)
 }
 
-func (e *Transaction) toBeatEvent(cfg *transform.Config) beat.Event {
+func (e *Transaction) toBeatEvent(*transform.Config) beat.Event {
 	transactionTransformations.Inc()
 
 	fields := mapStr{
 		"processor":        transactionProcessorEntry,
 		transactionDocType: e.fields(),
-	}
-
-	if cfg.DataStreams {
-		// Transactions are stored in a "traces" data stream along with spans.
-		fields[datastreams.TypeField] = datastreams.TracesType
-		fields[datastreams.DatasetField] = TracesDataset
 	}
 
 	// first set generic metadata (order is relevant)

--- a/model/transaction_test.go
+++ b/model/transaction_test.go
@@ -175,14 +175,12 @@ func TestEventsTransformWithMetadata(t *testing.T) {
 		Custom:    common.MapStr{"foo.bar": "baz"},
 		Message:   &Message{QueueName: "routeUser"},
 	}
-	event := txWithContext.toBeatEvent(&transform.Config{DataStreams: true})
+	event := txWithContext.toBeatEvent(&transform.Config{})
 	assert.Equal(t, event.Fields, common.MapStr{
-		"data_stream.type":    "traces",
-		"data_stream.dataset": "apm",
-		"user":                common.MapStr{"id": "123", "name": "jane"},
-		"client":              common.MapStr{"ip": ip},
-		"source":              common.MapStr{"ip": ip},
-		"user_agent":          common.MapStr{"original": userAgent},
+		"user":       common.MapStr{"id": "123", "name": "jane"},
+		"client":     common.MapStr{"ip": ip},
+		"source":     common.MapStr{"ip": ip},
+		"user_agent": common.MapStr{"original": userAgent},
 		"host": common.MapStr{
 			"architecture": "darwin",
 			"hostname":     "a.b.c",

--- a/processor/otel/consumer_test.go
+++ b/processor/otel/consumer_test.go
@@ -1133,7 +1133,7 @@ func eventRecorderBatchProcessor(out *[]beat.Event) model.BatchProcessor {
 func transformBatch(ctx context.Context, batches ...*model.Batch) []beat.Event {
 	var out []beat.Event
 	for _, batch := range batches {
-		out = append(out, batch.Transform(ctx, &transform.Config{DataStreams: true})...)
+		out = append(out, batch.Transform(ctx, &transform.Config{})...)
 	}
 	return out
 }

--- a/processor/otel/test_approved/jaeger_sampling_rate.approved.json
+++ b/processor/otel/test_approved/jaeger_sampling_rate.approved.json
@@ -6,8 +6,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },
@@ -42,8 +40,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },
@@ -83,8 +79,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },

--- a/processor/otel/test_approved/metadata_jaeger-no-language.approved.json
+++ b/processor/otel/test_approved/metadata_jaeger-no-language.approved.json
@@ -6,8 +6,6 @@
                 "name": "Jaeger",
                 "version": "3.4.12"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },

--- a/processor/otel/test_approved/metadata_jaeger-version.approved.json
+++ b/processor/otel/test_approved/metadata_jaeger-version.approved.json
@@ -6,8 +6,6 @@
                 "name": "Jaeger/PHP",
                 "version": "3.4.12"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },

--- a/processor/otel/test_approved/metadata_jaeger.approved.json
+++ b/processor/otel/test_approved/metadata_jaeger.approved.json
@@ -7,8 +7,6 @@
                 "name": "Jaeger/C++",
                 "version": "3.2.1"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },

--- a/processor/otel/test_approved/span_jaeger_custom.approved.json
+++ b/processor/otel/test_approved/span_jaeger_custom.approved.json
@@ -6,8 +6,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },

--- a/processor/otel/test_approved/span_jaeger_db.approved.json
+++ b/processor/otel/test_approved/span_jaeger_db.approved.json
@@ -6,8 +6,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "destination": {
                 "address": "db",
                 "port": 3306

--- a/processor/otel/test_approved/span_jaeger_http.approved.json
+++ b/processor/otel/test_approved/span_jaeger_http.approved.json
@@ -6,8 +6,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "destination": {
                 "address": "foo.bar.com",
                 "port": 80
@@ -83,8 +81,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "exception": [
                     {
@@ -125,8 +121,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "grouping_key": "23b7ac1bdf1ca957f9f581cfadee467c",
                 "log": {
@@ -162,8 +156,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "exception": [
                     {
@@ -201,8 +193,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "exception": [
                     {
@@ -240,8 +230,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "exception": [
                     {
@@ -279,8 +267,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "grouping_key": "c9221918248f05433f6b81c46a666aee",
                 "log": {

--- a/processor/otel/test_approved/span_jaeger_http_status_code.approved.json
+++ b/processor/otel/test_approved/span_jaeger_http_status_code.approved.json
@@ -6,8 +6,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "destination": {
                 "address": "foo.bar.com",
                 "port": 80

--- a/processor/otel/test_approved/span_jaeger_https_default_port.approved.json
+++ b/processor/otel/test_approved/span_jaeger_https_default_port.approved.json
@@ -6,8 +6,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "destination": {
                 "address": "foo.bar.com",
                 "port": 443

--- a/processor/otel/test_approved/span_jaeger_messaging.approved.json
+++ b/processor/otel/test_approved/span_jaeger_messaging.approved.json
@@ -6,8 +6,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "destination": {
                 "address": "mq",
                 "port": 1234

--- a/processor/otel/test_approved/span_jaeger_subtype_component.approved.json
+++ b/processor/otel/test_approved/span_jaeger_subtype_component.approved.json
@@ -6,8 +6,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },

--- a/processor/otel/test_approved/transaction_jaeger_custom.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_custom.approved.json
@@ -6,8 +6,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },

--- a/processor/otel/test_approved/transaction_jaeger_full.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_full.approved.json
@@ -6,8 +6,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "failure"
             },
@@ -71,8 +69,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "exception": [
                     {
@@ -134,8 +130,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "grouping_key": "23b7ac1bdf1ca957f9f581cfadee467c",
                 "log": {
@@ -192,8 +186,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "exception": [
                     {
@@ -252,8 +244,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "exception": [
                     {
@@ -312,8 +302,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "exception": [
                     {
@@ -372,8 +360,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "grouping_key": "c9221918248f05433f6b81c46a666aee",
                 "log": {

--- a/processor/otel/test_approved/transaction_jaeger_no_attrs.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_no_attrs.approved.json
@@ -6,8 +6,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "failure"
             },

--- a/processor/otel/test_approved/transaction_jaeger_type_component.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_type_component.approved.json
@@ -6,8 +6,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },

--- a/processor/otel/test_approved/transaction_jaeger_type_messaging.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_type_messaging.approved.json
@@ -6,8 +6,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },

--- a/processor/otel/test_approved/transaction_jaeger_type_request.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_type_request.approved.json
@@ -6,8 +6,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "failure"
             },

--- a/processor/otel/test_approved/transaction_jaeger_type_request_result.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_type_request_result.approved.json
@@ -6,8 +6,6 @@
                 "name": "Jaeger",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "success"
             },

--- a/processor/stream/processor_test.go
+++ b/processor/stream/processor_test.go
@@ -257,7 +257,7 @@ func TestRUMV3(t *testing.T) {
 
 func makeApproveEventsBatchProcessor(t *testing.T, name string, count *int) model.BatchProcessor {
 	return model.ProcessBatchFunc(func(ctx context.Context, b *model.Batch) error {
-		events := b.Transform(ctx, &transform.Config{DataStreams: true})
+		events := b.Transform(ctx, &transform.Config{})
 		*count += len(events)
 		docs := beatertest.EncodeEventDocs(events...)
 		approvaltest.ApproveEventDocs(t, name, docs)

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationErrors.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationErrors.approved.json
@@ -36,8 +36,6 @@
             "container": {
                 "id": "container-id"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "culprit": "my.module.function_name",
                 "custom": {
@@ -384,8 +382,6 @@
             "container": {
                 "id": "container-id"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "grouping_key": "dc8dd667f7036ec5f0bae87bf2188243",
                 "id": "xFoaabb123FFFFFF",
@@ -494,8 +490,6 @@
             "container": {
                 "id": "container-id"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "exception": [
                     {
@@ -600,8 +594,6 @@
             "container": {
                 "id": "container-id"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "exception": [
                     {
@@ -712,8 +704,6 @@
             "container": {
                 "id": "container-id"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "grouping_key": "d6b3f958dfea98dc9ed2b57d5f0c48bb",
                 "id": "abcdef0123456789",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
@@ -13,8 +13,6 @@
             "container": {
                 "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "culprit": "opbeans.controllers.DTInterceptor.preHandle(DTInterceptor.java:73)",
                 "custom": {
@@ -290,8 +288,6 @@
             "container": {
                 "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "success"
             },
@@ -446,8 +442,6 @@
             "container": {
                 "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "success"
             },
@@ -630,8 +624,6 @@
             "container": {
                 "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
             },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.type": "metrics",
             "dotted": {
                 "float": {
                     "gauge": 6.12

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationInvalidEvent.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationInvalidEvent.approved.json
@@ -6,8 +6,6 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationInvalidJSONEvent.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationInvalidJSONEvent.approved.json
@@ -6,8 +6,6 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationMetadataNullValues.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationMetadataNullValues.approved.json
@@ -6,8 +6,6 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "grouping_key": "d6b3f958dfea98dc9ed2b57d5f0c48bb",
                 "id": "abcdef0123456789",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationMetricsets.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationMetricsets.approved.json
@@ -7,8 +7,6 @@
                 "version": "3.14.0"
             },
             "byte_counter": 1,
-            "data_stream.dataset": "apm.internal",
-            "data_stream.type": "metrics",
             "dotted": {
                 "float": {
                     "gauge": 6.12
@@ -99,8 +97,6 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm.app.1234_service_12a3",
-            "data_stream.type": "metrics",
             "go": {
                 "memstats": {
                     "heap": {
@@ -145,8 +141,6 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm.app.1234_service_12a3",
-            "data_stream.type": "metrics",
             "host": {
                 "ip": "192.0.0.1"
             },
@@ -198,8 +192,6 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm.app.1234_service_12a3",
-            "data_stream.type": "metrics",
             "host": {
                 "ip": "192.0.0.1"
             },
@@ -272,8 +264,6 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm.app.1234_service_12a3",
-            "data_stream.type": "metrics",
             "host": {
                 "ip": "192.0.0.1"
             },

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationMinimalService.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationMinimalService.approved.json
@@ -6,8 +6,6 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "grouping_key": "d6b3f958dfea98dc9ed2b57d5f0c48bb",
                 "id": "abcdef0123456789",
@@ -39,8 +37,6 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm.app.1234_service_12a3",
-            "data_stream.type": "metrics",
             "go": {
                 "memstats": {
                     "heap": {

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationOptionalTimestamps.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationOptionalTimestamps.approved.json
@@ -6,8 +6,6 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },
@@ -79,8 +77,6 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },
@@ -157,8 +153,6 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm.app.backendspans",
-            "data_stream.type": "metrics",
             "host": {
                 "architecture": "x64",
                 "hostname": "prod1.example.com",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationRumErrors.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationRumErrors.approved.json
@@ -9,8 +9,6 @@
             "client": {
                 "ip": "192.0.0.1"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "culprit": "test/e2e/general-usecase/bundle.js.map",
                 "exception": [

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationRumTransactions.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationRumTransactions.approved.json
@@ -9,8 +9,6 @@
             "client": {
                 "ip": "192.0.0.1"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },
@@ -77,8 +75,6 @@
             "client": {
                 "ip": "192.0.0.1"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationSpans.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationSpans.approved.json
@@ -37,8 +37,6 @@
             "container": {
                 "id": "container-id"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "success"
             },
@@ -154,8 +152,6 @@
             "container": {
                 "id": "container-id"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },
@@ -272,8 +268,6 @@
             "container": {
                 "id": "container-id"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },
@@ -394,8 +388,6 @@
             "container": {
                 "id": "container-id"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },
@@ -513,8 +505,6 @@
             "container": {
                 "id": "container-id"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "destination": {
                 "address": "0:0::0:1",
                 "port": 5432
@@ -720,8 +710,6 @@
             "container": {
                 "id": "container-id"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "destination": {
                 "address": "0:0::0:1"
             },

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationTransactions.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationTransactions.approved.json
@@ -32,8 +32,6 @@
             "container": {
                 "id": "container-id"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },
@@ -153,8 +151,6 @@
             "container": {
                 "id": "container-id"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "success"
             },
@@ -366,8 +362,6 @@
             "container": {
                 "id": "container-id"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },
@@ -510,8 +504,6 @@
             "container": {
                 "id": "container-id"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },

--- a/processor/stream/test_approved_es_documents/testIntakeRUMV3Errors.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeRUMV3Errors.approved.json
@@ -9,8 +9,6 @@
             "client": {
                 "ip": "192.0.0.1"
             },
-            "data_stream.dataset": "apm.error",
-            "data_stream.type": "logs",
             "error": {
                 "culprit": "test/e2e/general-usecase/app.e2e-bundle.min.js?token=secret",
                 "custom": {

--- a/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
@@ -9,8 +9,6 @@
             "client": {
                 "ip": "192.0.0.1"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "success"
             },
@@ -157,8 +155,6 @@
             "client": {
                 "ip": "192.0.0.1"
             },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.type": "metrics",
             "labels": {
                 "testTagKey": "testTagValue"
             },
@@ -214,8 +210,6 @@
             "client": {
                 "ip": "192.0.0.1"
             },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.type": "metrics",
             "labels": {
                 "testTagKey": "testTagValue"
             },
@@ -271,8 +265,6 @@
             "client": {
                 "ip": "192.0.0.1"
             },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.type": "metrics",
             "labels": {
                 "testTagKey": "testTagValue"
             },
@@ -328,8 +320,6 @@
             "client": {
                 "ip": "192.0.0.1"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },
@@ -399,8 +389,6 @@
             "client": {
                 "ip": "192.0.0.1"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },
@@ -470,8 +458,6 @@
             "client": {
                 "ip": "192.0.0.1"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "destination": {
                 "address": "localhost",
                 "port": 8000
@@ -563,8 +549,6 @@
             "client": {
                 "ip": "192.0.0.1"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "unknown"
             },
@@ -633,8 +617,6 @@
             "client": {
                 "ip": "192.0.0.1"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "destination": {
                 "address": "localhost",
                 "port": 8000
@@ -732,8 +714,6 @@
             "client": {
                 "ip": "192.0.0.1"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "destination": {
                 "address": "localhost",
                 "port": 8003
@@ -831,8 +811,6 @@
             "client": {
                 "ip": "192.0.0.1"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "destination": {
                 "address": "localhost",
                 "port": 8003
@@ -931,8 +909,6 @@
             "client": {
                 "ip": "192.0.0.1"
             },
-            "data_stream.dataset": "apm",
-            "data_stream.type": "traces",
             "event": {
                 "outcome": "success"
             },
@@ -1024,8 +1000,6 @@
             "client": {
                 "ip": "192.0.0.1"
             },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.type": "metrics",
             "labels": {
                 "tag1": "value1",
                 "testTagKey": "testTagValue"

--- a/publish/pub.go
+++ b/publish/pub.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pkg/errors"
 	"go.elastic.co/apm"
 
-	"github.com/elastic/apm-server/datastreams"
 	"github.com/elastic/apm-server/transform"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
@@ -103,9 +102,6 @@ func NewPublisher(pipeline beat.Pipeline, tracer *apm.Tracer, cfg *PublisherConf
 	processingCfg := beat.ProcessingConfig{
 		Fields:    common.MapStr{"observer": observerFields},
 		Processor: cfg.Processor,
-	}
-	if cfg.TransformConfig.DataStreams {
-		processingCfg.Fields[datastreams.NamespaceField] = cfg.Namespace
 	}
 	if cfg.Pipeline != "" {
 		processingCfg.Meta = map[string]interface{}{"pipeline": cfg.Pipeline}


### PR DESCRIPTION
## Motivation/summary

Move the logic associated with setting data_stream fields out of model, into a model processor. Most of our tests will not run the model processor, hence why the data_stream fields disappear from approvals. Importantly, the TestFleetIntegration system test's approval file (which doesn't and shouldn't show up in the diff) retains the fields.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

Non-functional change.

## Related issues

#4410
#4120
#3565