### PR TITLE
beater/request: clear multpart.Form on reset

### DIFF
--- a/beater/request/context.go
+++ b/beater/request/context.go
@@ -58,17 +58,27 @@ func NewContext() *Context {
 	return &Context{}
 }
 
-// Reset allows to reuse a context by removing all request specific information
+// Reset allows to reuse a context by removing all request specific information.
+//
+// It is valid to call Reset(nil, nil), which will just clear all information.
+// If w and r are non-nil, the context will be associated with them for handling
+// the request, and information such as the user agent and source IP will be
+// extracted for handlers.
 func (c *Context) Reset(w http.ResponseWriter, r *http.Request) {
-	c.Request = r
+	if c.Request != nil && c.Request.MultipartForm != nil {
+		c.Request.MultipartForm.RemoveAll()
+	}
 	c.Logger = nil
 	c.Authentication = auth.AuthenticationDetails{}
 	c.Result.Reset()
-	c.SourceIP = utility.ExtractIP(r)
-	c.UserAgent = utility.UserAgentHeader(r.Header)
+	c.writeAttempts = 0
 
 	c.w = w
-	c.writeAttempts = 0
+	c.Request = r
+	if r != nil {
+		c.SourceIP = utility.ExtractIP(r)
+		c.UserAgent = utility.UserAgentHeader(r.Header)
+	}
 }
 
 // Header returns the http.Header of the context's writer

--- a/beater/request/context_pool.go
+++ b/beater/request/context_pool.go
@@ -42,6 +42,7 @@ func (pool *ContextPool) HTTPHandler(h Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c := pool.p.Get().(*Context)
 		defer pool.p.Put(c)
+		defer c.Reset(nil, nil)
 		c.Reset(w, r)
 		h(c)
 	})

--- a/beater/request/context_test.go
+++ b/beater/request/context_test.go
@@ -18,14 +18,18 @@
 package request
 
 import (
+	"bytes"
+	"mime/multipart"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"testing"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 
@@ -44,6 +48,27 @@ func TestContext_Reset(t *testing.T) {
 	r2.RemoteAddr = "10.1.2.3:1234"
 	r2.Header.Set("User-Agent", "ua2")
 
+	var multipartBuf bytes.Buffer
+	multipartWriter := multipart.NewWriter(&multipartBuf)
+	fw, err := multipartWriter.CreateFormFile("a_file", "filename.txt")
+	require.NoError(t, err)
+	fw.Write([]byte("abc"))
+	err = multipartWriter.Close()
+	require.NoError(t, err)
+
+	multipartReader := multipart.NewReader(&multipartBuf, multipartWriter.Boundary())
+	form, err := multipartReader.ReadForm(0) // always write to /tmp
+	require.NoError(t, err)
+	r1.MultipartForm = form
+
+	// Check that a temp file was written.
+	require.Len(t, form.File["a_file"], 1)
+	formFile, err := form.File["a_file"][0].Open()
+	require.NoError(t, err)
+	formTempFile := formFile.(*os.File)
+	formTempFilename := formTempFile.Name()
+	formFile.Close()
+
 	c := Context{
 		Request: r1, w: w1,
 		Logger: logp.NewLogger(""),
@@ -54,6 +79,10 @@ func TestContext_Reset(t *testing.T) {
 		},
 	}
 	c.Reset(w2, r2)
+
+	// Resetting the context should have removed r1's temporary form file.
+	_, err = os.Stat(formTempFilename)
+	require.True(t, os.IsNotExist(err))
 
 	// use reflection to ensure all fields of `context` are tested
 	cType := reflect.TypeOf(c)

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -16,6 +16,7 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 * Fixed tail-based sampling pubsub to use _seq_no correctly {pull}5126[5126]
 * Removed service name from dataset {pull}5451[5451]
 * Fix panic on Fleet policy change when transaction metrics or tail-based sampling are enabled {pull}5670[5670]
+* Remove multipart form temporary files left behind by source map uploads {pull}5718[5718]
 
 [float]
 ==== Intake API Changes


### PR DESCRIPTION
## Motivation/summary

After completing a request, immediately reset the context so we don't hold onto memory while the context in the memory pool.

When resetting request context, call mime/multipart.Form.RemoveAll to remove temporary files created for storing uploaded source maps. Although net/http does this at the end of a request, it does so on the original net/http.Request. This does not work when the request is copied (e.g. using Request.WithContext), which we do in various middleware.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

1. Upload a source map that is greater than 32MB in size
2. Check that no "multipart-*" files are left behind in /tmp

## Related issues

Fixes https://github.com/elastic/apm-server/issues/5689