### PR TITLE
processor/otel: handle net.host.* as span attributes

### DIFF
--- a/processor/otel/consumer.go
+++ b/processor/otel/consumer.go
@@ -65,6 +65,15 @@ const (
 	outcomeSuccess = "success"
 	outcomeFailure = "failure"
 	outcomeUnknown = "unknown"
+
+	// TODO: handle net.host.connection.subtype, which will
+	// require adding a new field to the model as well.
+
+	AttributeNetworkType        = "net.host.connection.type"
+	AttributeNetworkMCC         = "net.host.carrier.mcc"
+	AttributeNetworkMNC         = "net.host.carrier.mnc"
+	AttributeNetworkCarrierName = "net.host.carrier.name"
+	AttributeNetworkICC         = "net.host.carrier.icc"
 )
 
 // Consumer transforms open-telemetry data to be compatible with elastic APM data
@@ -335,6 +344,16 @@ func translateTransaction(
 				netPeerName = stringval
 			case conventions.AttributeNetHostName:
 				netHostName = stringval
+			case AttributeNetworkType:
+				tx.Metadata.System.Network.ConnectionType = stringval
+			case AttributeNetworkMCC:
+				tx.Metadata.System.Network.Carrier.MCC = stringval
+			case AttributeNetworkMNC:
+				tx.Metadata.System.Network.Carrier.MNC = stringval
+			case AttributeNetworkCarrierName:
+				tx.Metadata.System.Network.Carrier.Name = stringval
+			case AttributeNetworkICC:
+				tx.Metadata.System.Network.Carrier.ICC = stringval
 
 			// messaging.*
 			case "message_bus.destination", conventions.AttributeMessagingDestination:
@@ -545,6 +564,16 @@ func translateSpan(span pdata.Span, metadata model.Metadata, event *model.Span) 
 					// values containing colons, except for IPv6.
 					netPeerName = stringval
 				}
+			case AttributeNetworkType:
+				event.Metadata.System.Network.ConnectionType = stringval
+			case AttributeNetworkMCC:
+				event.Metadata.System.Network.Carrier.MCC = stringval
+			case AttributeNetworkMNC:
+				event.Metadata.System.Network.Carrier.MNC = stringval
+			case AttributeNetworkCarrierName:
+				event.Metadata.System.Network.Carrier.Name = stringval
+			case AttributeNetworkICC:
+				event.Metadata.System.Network.Carrier.ICC = stringval
 
 			// messaging.*
 			case "message_bus.destination", conventions.AttributeMessagingDestination:

--- a/processor/otel/consumer_test.go
+++ b/processor/otel/consumer_test.go
@@ -558,6 +558,30 @@ func TestMessagingSpan(t *testing.T) {
 	}, span.DestinationService)
 }
 
+func TestSpanNetworkAttributes(t *testing.T) {
+	networkAttributes := map[string]pdata.AttributeValue{
+		"net.host.connection.type": pdata.NewAttributeValueString("5G"),
+		"net.host.carrier.name":    pdata.NewAttributeValueString("Vodafone"),
+		"net.host.carrier.mnc":     pdata.NewAttributeValueString("01"),
+		"net.host.carrier.mcc":     pdata.NewAttributeValueString("101"),
+		"net.host.carrier.icc":     pdata.NewAttributeValueString("UK"),
+	}
+	tx := transformTransactionWithAttributes(t, networkAttributes)
+	span := transformSpanWithAttributes(t, networkAttributes)
+
+	expected := model.Network{
+		ConnectionType: "5G",
+		Carrier: model.Carrier{
+			Name: "Vodafone",
+			MNC:  "01",
+			MCC:  "101",
+			ICC:  "UK",
+		},
+	}
+	assert.Equal(t, expected, tx.Metadata.System.Network)
+	assert.Equal(t, expected, span.Metadata.System.Network)
+}
+
 func TestArrayLabels(t *testing.T) {
 	stringArray := pdata.NewAttributeValueArray()
 	stringArray.ArrayVal().Append(pdata.NewAttributeValueString("string1"))

--- a/processor/otel/metadata.go
+++ b/processor/otel/metadata.go
@@ -32,15 +32,6 @@ import (
 
 const (
 	AgentNameJaeger = "Jaeger"
-
-	// Network attributes are pending approval in the OTel spec, and subject to change:
-	// https://github.com/open-telemetry/opentelemetry-specification/issues/1647
-
-	AttributeNetworkType        = "net.host.connection_type"
-	AttributeNetworkMCC         = "net.host.carrier.mcc"
-	AttributeNetworkMNC         = "net.host.carrier.mnc"
-	AttributeNetworkCarrierName = "net.host.carrier.name"
-	AttributeNetworkICC         = "net.host.carrier.icc"
 )
 
 var (
@@ -104,18 +95,6 @@ func translateResourceMetadata(resource pdata.Resource, out *model.Metadata) {
 			out.System.Kubernetes.PodName = truncate(v.StringVal())
 		case conventions.AttributeK8sPodUID:
 			out.System.Kubernetes.PodUID = truncate(v.StringVal())
-
-		// network.*
-		case AttributeNetworkType:
-			out.System.Network.ConnectionType = truncate(v.StringVal())
-		case AttributeNetworkCarrierName:
-			out.System.Network.Carrier.Name = truncate(v.StringVal())
-		case AttributeNetworkMCC:
-			out.System.Network.Carrier.MCC = truncate(v.StringVal())
-		case AttributeNetworkMNC:
-			out.System.Network.Carrier.MNC = truncate(v.StringVal())
-		case AttributeNetworkICC:
-			out.System.Network.Carrier.ICC = truncate(v.StringVal())
 
 		// host.*
 		case conventions.AttributeHostName:

--- a/processor/otel/metadata_test.go
+++ b/processor/otel/metadata_test.go
@@ -194,29 +194,6 @@ func TestResourceConventions(t *testing.T) {
 				},
 			},
 		},
-		"network": {
-			attrs: map[string]pdata.AttributeValue{
-				"net.host.connection_type": pdata.NewAttributeValueString("5G"),
-				"net.host.carrier.name":    pdata.NewAttributeValueString("Vodafone"),
-				"net.host.carrier.mnc":     pdata.NewAttributeValueString("01"),
-				"net.host.carrier.mcc":     pdata.NewAttributeValueString("101"),
-				"net.host.carrier.icc":     pdata.NewAttributeValueString("UK"),
-			},
-			expected: model.Metadata{
-				Service: defaultService,
-				System: model.System{
-					Network: model.Network{
-						ConnectionType: "5G",
-						Carrier: model.Carrier{
-							Name: "Vodafone",
-							MNC:  "01",
-							MCC:  "101",
-							ICC:  "UK",
-						},
-					},
-				},
-			},
-		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			meta := transformResourceMetadata(t, test.attrs)


### PR DESCRIPTION
## Motivation/summary

We were mistakenly handling the new `net.host.*` attributes as resource attributes, whereas they should be span attributes. These fields describe a network connection which will be specific to an operation (span), and not the service (resource) performing that operation.

`net.host.connection_type` has been updated to `net.host.connection.type`, per the spec change.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

When https://github.com/elastic/apm-agent-ios/pull/46 lands, run a program instrumented with the iOS agent, and check that the information is indexed into `network.*` fields and not as labels. The only field that should show up as a label is `net.host.connection.subtype`, which is not yet mapped.

## Related issues

https://github.com/elastic/apm-server/pull/5436