### PR TITLE
Restructure model.Metricset

### DIFF
--- a/agentcfg/reporter.go
+++ b/agentcfg/reporter.go
@@ -86,9 +86,11 @@ func (r Reporter) Run(ctx context.Context) error {
 		batch := make(model.Batch, 0, len(applied))
 		for etag := range applied {
 			batch = append(batch, model.APMEvent{Metricset: &model.Metricset{
-				Name:    "agent_config",
-				Labels:  common.MapStr{"etag": etag},
-				Samples: []model.Sample{{Name: "agent_config_applied", Value: 1}},
+				Name:   "agent_config",
+				Labels: common.MapStr{"etag": etag},
+				Samples: map[string]model.MetricsetSample{
+					"agent_config_applied": {Value: 1},
+				},
 			}})
 		}
 		// Reset applied map, so that we report only configs applied

--- a/apmpackage/apm/docs/README.md
+++ b/apmpackage/apm/docs/README.md
@@ -534,15 +534,7 @@ Metrics are written to `metrics-apm.app.*`, `metrics-apm.internal.*`, and `metri
   "event": {
     "ingested": "2020-04-22T14:55:05.425020Z"
   },
-  "go": {
-    "memstats": {
-      "heap": {
-        "sys": {
-          "bytes": 6520832
-        }
-      }
-    }
-  },
+  "go.memstats.heap.sys.bytes": 6520832,
   "host": {
     "ip": "127.0.0.1"
   },

--- a/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
@@ -658,11 +658,7 @@
             "container": {
                 "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
             },
-            "dotted": {
-                "float": {
-                    "gauge": 6.12
-                }
-            },
+            "dotted.float.gauge": 6.12,
             "double_gauge": 3.141592653589793,
             "ecs": {
                 "version": "1.10.0"
@@ -697,19 +693,7 @@
             },
             "long_gauge": 3147483648,
             "metricset.name": "span_breakdown",
-            "negative": {
-                "d": {
-                    "o": {
-                        "t": {
-                            "t": {
-                                "e": {
-                                    "d": -1022
-                                }
-                            }
-                        }
-                    }
-                }
-            },
+            "negative.d.o.t.t.e.d": -1022,
             "observer": {
                 "ephemeral_id": "00000000-0000-0000-0000-000000000000",
                 "hostname": "",
@@ -752,34 +736,20 @@
             },
             "short_counter": 227,
             "span": {
-                "self_time": {
-                    "count": 1,
-                    "sum": {
-                        "us": 633.288
-                    }
-                },
                 "subtype": "mysql",
                 "type": "db"
             },
+            "span.self_time.count": 1,
+            "span.self_time.sum.us": 633.288,
             "transaction": {
-                "breakdown": {
-                    "count": 12
-                },
-                "duration": {
-                    "count": 2,
-                    "sum": {
-                        "us": 12
-                    }
-                },
                 "name": "GET/",
-                "self_time": {
-                    "count": 2,
-                    "sum": {
-                        "us": 10
-                    }
-                },
                 "type": "request"
-            }
+            },
+            "transaction.breakdown.count": 12,
+            "transaction.duration.count": 2,
+            "transaction.duration.sum.us": 12,
+            "transaction.self_time.count": 2,
+            "transaction.self_time.sum.us": 10
         }
     ]
 }

--- a/beater/test_approved_es_documents/TestPublishIntegrationMetricsets.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationMetricsets.approved.json
@@ -7,11 +7,7 @@
                 "version": "3.14.0"
             },
             "byte_counter": 1,
-            "dotted": {
-                "float": {
-                    "gauge": 6.12
-                }
-            },
+            "dotted.float.gauge": 6.12,
             "double_gauge": 3.141592653589793,
             "ecs": {
                 "version": "1.10.0"
@@ -30,19 +26,7 @@
             },
             "long_gauge": 3147483648,
             "metricset.name": "span_breakdown",
-            "negative": {
-                "d": {
-                    "o": {
-                        "t": {
-                            "t": {
-                                "e": {
-                                    "d": -1022
-                                }
-                            }
-                        }
-                    }
-                }
-            },
+            "negative.d.o.t.t.e.d": -1022,
             "observer": {
                 "ephemeral_id": "00000000-0000-0000-0000-000000000000",
                 "hostname": "",
@@ -69,34 +53,20 @@
             },
             "short_counter": 227,
             "span": {
-                "self_time": {
-                    "count": 1,
-                    "sum": {
-                        "us": 633.288
-                    }
-                },
                 "subtype": "mysql",
                 "type": "db"
             },
+            "span.self_time.count": 1,
+            "span.self_time.sum.us": 633.288,
             "transaction": {
-                "breakdown": {
-                    "count": 12
-                },
-                "duration": {
-                    "count": 2,
-                    "sum": {
-                        "us": 12
-                    }
-                },
                 "name": "GET /",
-                "self_time": {
-                    "count": 2,
-                    "sum": {
-                        "us": 10
-                    }
-                },
                 "type": "request"
             },
+            "transaction.breakdown.count": 12,
+            "transaction.duration.count": 2,
+            "transaction.duration.sum.us": 12,
+            "transaction.self_time.count": 2,
+            "transaction.self_time.sum.us": 10,
             "user": {
                 "email": "user@mail.com",
                 "id": "axb123hg",
@@ -112,15 +82,7 @@
             "ecs": {
                 "version": "1.10.0"
             },
-            "go": {
-                "memstats": {
-                    "heap": {
-                        "sys": {
-                            "bytes": 6520832
-                        }
-                    }
-                }
-            },
+            "go.memstats.heap.sys.bytes": 6520832,
             "host": {
                 "ip": "127.0.0.1"
             },
@@ -200,22 +162,8 @@
                     "name": "node-1"
                 }
             },
-            "system": {
-                "process": {
-                    "cgroup": {
-                        "memory": {
-                            "mem": {
-                                "limit": {
-                                    "bytes": 2048
-                                },
-                                "usage": {
-                                    "bytes": 1024
-                                }
-                            }
-                        }
-                    }
-                }
-            },
+            "system.process.cgroup.memory.mem.limit.bytes": 2048,
+            "system.process.cgroup.memory.mem.usage.bytes": 1024,
             "user": {
                 "email": "user@mail.com",
                 "id": "axb123hg",
@@ -263,36 +211,14 @@
                     "name": "node-1"
                 }
             },
-            "system": {
-                "process": {
-                    "cgroup": {
-                        "cpu": {
-                            "cfs": {
-                                "period": {
-                                    "us": 1024
-                                },
-                                "quota": {
-                                    "us": 2048
-                                }
-                            },
-                            "id": 2048,
-                            "stats": {
-                                "periods": 2048,
-                                "throttled": {
-                                    "ns": 2048,
-                                    "periods": 2048
-                                }
-                            }
-                        },
-                        "cpuacct": {
-                            "id": 2048,
-                            "total": {
-                                "ns": 2048
-                            }
-                        }
-                    }
-                }
-            },
+            "system.process.cgroup.cpu.cfs.period.us": 1024,
+            "system.process.cgroup.cpu.cfs.quota.us": 2048,
+            "system.process.cgroup.cpu.id": 2048,
+            "system.process.cgroup.cpu.stats.periods": 2048,
+            "system.process.cgroup.cpu.stats.throttled.ns": 2048,
+            "system.process.cgroup.cpu.stats.throttled.periods": 2048,
+            "system.process.cgroup.cpuacct.id": 2048,
+            "system.process.cgroup.cpuacct.total.ns": 2048,
             "user": {
                 "email": "user@mail.com",
                 "id": "axb123hg",
@@ -301,7 +227,6 @@
         },
         {
             "@timestamp": "2017-05-30T18:53:41.366Z",
-            "_doc_count": 6,
             "_metric_descriptions": {
                 "latency_distribution": {
                     "type": "histogram",

--- a/docs/data/elasticsearch/generated/metricsets.json
+++ b/docs/data/elasticsearch/generated/metricsets.json
@@ -11,15 +11,7 @@
         "event": {
             "ingested": "2020-04-22T14:55:05.425020Z"
         },
-        "go": {
-            "memstats": {
-                "heap": {
-                    "sys": {
-                        "bytes": 6520832.0
-                    }
-                }
-            }
-        },
+        "go.memstats.heap.sys.bytes": 6520832.0,
         "host": {
             "ip": "127.0.0.1"
         },
@@ -102,22 +94,8 @@
                 "name": "node-1"
             }
         },
-        "system": {
-            "process": {
-                "cgroup": {
-                    "memory": {
-                        "mem": {
-                            "limit": {
-                                "bytes": 2048
-                            },
-                            "usage": {
-                                "bytes": 1024
-                            }
-                        }
-                    }
-                }
-            }
-        },
+        "system.process.cgroup.memory.mem.limit.bytes": 2048,
+        "system.process.cgroup.memory.mem.usage.bytes": 1024,
         "user": {
             "email": "user@mail.com",
             "id": "axb123hg",
@@ -168,36 +146,14 @@
                 "name": "node-1"
             }
         },
-        "system": {
-            "process": {
-                "cgroup": {
-                    "cpu": {
-                        "cfs": {
-                            "period": {
-                                "us": 1024
-                            },
-                            "quota": {
-                                "us": 2048
-                            }
-                        },
-                        "id": 2048,
-                        "stats": {
-                            "periods": 2048,
-                            "throttled": {
-                                "ns": 2048,
-                                "periods": 2048
-                            }
-                        }
-                    },
-                    "cpuacct": {
-                        "id": 2048,
-                        "total": {
-                            "ns": 2048
-                        }
-                    }
-                }
-            }
-        },
+        "system.process.cgroup.cpu.cfs.period.us": 1024,
+        "system.process.cgroup.cpu.cfs.quota.us": 2048,
+        "system.process.cgroup.cpu.id": 2048,
+        "system.process.cgroup.cpu.stats.periods": 2048,
+        "system.process.cgroup.cpu.stats.throttled.ns": 2048,
+        "system.process.cgroup.cpu.stats.throttled.periods": 2048,
+        "system.process.cgroup.cpuacct.id": 2048,
+        "system.process.cgroup.cpuacct.total.ns": 2048,
         "user": {
             "email": "user@mail.com",
             "id": "axb123hg",
@@ -274,11 +230,7 @@
             "version": "3.14.0"
         },
         "byte_counter": 1,
-        "dotted": {
-            "float": {
-                "gauge": 6.12
-            }
-        },
+        "dotted.float.gauge": 6.12,
         "double_gauge": 3.141592653589793,
         "ecs": {
             "version": "1.10.0"
@@ -300,19 +252,7 @@
         },
         "long_gauge": 3147483648.0,
         "metricset.name": "span_breakdown",
-        "negative": {
-            "d": {
-                "o": {
-                    "t": {
-                        "t": {
-                            "e": {
-                                "d": -1022
-                            }
-                        }
-                    }
-                }
-            }
-        },
+        "negative.d.o.t.t.e.d": -1022,
         "observer": {
             "ephemeral_id": "8785cbe1-7f89-4279-84c2-6c33979531fb",
             "hostname": "ix.lan",
@@ -339,34 +279,20 @@
         },
         "short_counter": 227,
         "span": {
-            "self_time": {
-                "count": 1,
-                "sum": {
-                    "us": 633.288
-                }
-            },
             "subtype": "mysql",
             "type": "db"
         },
+        "span.self_time.count": 1,
+        "span.self_time.sum.us": 633.288,
         "transaction": {
-            "breakdown": {
-                "count": 12
-            },
-            "duration": {
-                "count": 2,
-                "sum": {
-                    "us": 12
-                }
-            },
             "name": "GET /",
-            "self_time": {
-                "count": 2,
-                "sum": {
-                    "us": 10
-                }
-            },
             "type": "request"
         },
+        "transaction.breakdown.count": 12,
+        "transaction.duration.count": 2,
+        "transaction.duration.sum.us": 12,
+        "transaction.self_time.count": 2,
+        "transaction.self_time.sum.us": 10,
         "user": {
             "email": "user@mail.com",
             "id": "axb123hg",

--- a/model/modeldecoder/rumv3/decoder.go
+++ b/model/modeldecoder/rumv3/decoder.go
@@ -404,25 +404,31 @@ func mapToMetricsetModel(from *metricset, metadata *model.Metadata, reqTime time
 
 	// map samples information
 	if from.Samples.IsSet() {
+		out.Samples = make(map[string]model.MetricsetSample)
 		if from.Samples.TransactionDurationCount.Value.IsSet() {
-			s := model.Sample{Name: metricsetSamplesTransactionDurationCountName, Value: from.Samples.TransactionDurationCount.Value.Val}
-			out.Samples = append(out.Samples, s)
+			out.Samples[metricsetSamplesTransactionDurationCountName] = model.MetricsetSample{
+				Value: from.Samples.TransactionDurationCount.Value.Val,
+			}
 		}
 		if from.Samples.TransactionDurationSum.Value.IsSet() {
-			s := model.Sample{Name: metricsetSamplesTransactionDurationSumName, Value: from.Samples.TransactionDurationSum.Value.Val}
-			out.Samples = append(out.Samples, s)
+			out.Samples[metricsetSamplesTransactionDurationSumName] = model.MetricsetSample{
+				Value: from.Samples.TransactionDurationSum.Value.Val,
+			}
 		}
 		if from.Samples.TransactionBreakdownCount.Value.IsSet() {
-			s := model.Sample{Name: metricsetSamplesTransactionBreakdownCountName, Value: from.Samples.TransactionBreakdownCount.Value.Val}
-			out.Samples = append(out.Samples, s)
+			out.Samples[metricsetSamplesTransactionBreakdownCountName] = model.MetricsetSample{
+				Value: from.Samples.TransactionBreakdownCount.Value.Val,
+			}
 		}
 		if from.Samples.SpanSelfTimeCount.Value.IsSet() {
-			s := model.Sample{Name: metricsetSamplesSpanSelfTimeCountName, Value: from.Samples.SpanSelfTimeCount.Value.Val}
-			out.Samples = append(out.Samples, s)
+			out.Samples[metricsetSamplesSpanSelfTimeCountName] = model.MetricsetSample{
+				Value: from.Samples.SpanSelfTimeCount.Value.Val,
+			}
 		}
 		if from.Samples.SpanSelfTimeSum.Value.IsSet() {
-			s := model.Sample{Name: metricsetSamplesSpanSelfTimeSumName, Value: from.Samples.SpanSelfTimeSum.Value.Val}
-			out.Samples = append(out.Samples, s)
+			out.Samples[metricsetSamplesSpanSelfTimeSumName] = model.MetricsetSample{
+				Value: from.Samples.SpanSelfTimeSum.Value.Val,
+			}
 		}
 	}
 

--- a/model/modeldecoder/rumv3/transaction_test.go
+++ b/model/modeldecoder/rumv3/transaction_test.go
@@ -56,9 +56,9 @@ func TestDecodeNestedTransaction(t *testing.T) {
 		assert.Equal(t, now, out.Transaction.Timestamp)
 		// ensure nested metricsets are decoded
 		require.Equal(t, 2, len(out.Metricsets))
-		assert.Equal(t, []model.Sample{{Name: "transaction.duration.sum.us", Value: 2048}}, out.Metricsets[0].Samples)
+		assert.Equal(t, map[string]model.MetricsetSample{"transaction.duration.sum.us": {Value: 2048}}, out.Metricsets[0].Samples)
 		m := out.Metricsets[1]
-		assert.Equal(t, []model.Sample{{Name: "span.self_time.count", Value: 5}}, m.Samples)
+		assert.Equal(t, map[string]model.MetricsetSample{"span.self_time.count": {Value: 5}}, m.Samples)
 		assert.Equal(t, "tr-a", m.Transaction.Name)
 		assert.Equal(t, "request", m.Transaction.Type)
 		assert.Equal(t, now, m.Timestamp)

--- a/model/modeldecoder/v2/decoder.go
+++ b/model/modeldecoder/v2/decoder.go
@@ -559,8 +559,7 @@ func mapToMetricsetModel(from *metricset, metadata *model.Metadata, reqTime time
 
 	// map samples information
 	if len(from.Samples) > 0 {
-		out.Samples = make([]model.Sample, len(from.Samples))
-		i := 0
+		out.Samples = make(map[string]model.MetricsetSample, len(from.Samples))
 		for name, sample := range from.Samples {
 			var counts []int64
 			var values []float64
@@ -572,15 +571,13 @@ func mapToMetricsetModel(from *metricset, metadata *model.Metadata, reqTime time
 				counts = make([]int64, n)
 				copy(counts, sample.Counts)
 			}
-			out.Samples[i] = model.Sample{
-				Name:   name,
+			out.Samples[name] = model.MetricsetSample{
 				Type:   model.MetricType(sample.Type.Val),
 				Unit:   sample.Unit.Val,
 				Value:  sample.Value.Val,
 				Values: values,
 				Counts: counts,
 			}
-			i++
 		}
 	}
 

--- a/model/modelprocessor/metricsetname.go
+++ b/model/modelprocessor/metricsetname.go
@@ -19,7 +19,6 @@ package modelprocessor
 
 import (
 	"context"
-	"strings"
 
 	"github.com/elastic/apm-server/model"
 )
@@ -49,20 +48,10 @@ func (SetMetricsetName) ProcessBatch(ctx context.Context, b *model.Batch) error 
 			// Not a breakdown metricset.
 			continue
 		}
-		if ms.Span.Type != "" {
-			for _, sample := range ms.Samples {
-				if strings.HasPrefix(sample.Name, "span.self_time.") {
-					ms.Name = spanBreakdownMetricsetName
-					break
-				}
-			}
-		} else {
-			for _, sample := range ms.Samples {
-				if strings.HasPrefix(sample.Name, "transaction.breakdown.") {
-					ms.Name = transactionBreakdownMetricsetName
-					break
-				}
-			}
+		if _, ok := ms.Samples["span.self_time.count"]; ok {
+			ms.Name = spanBreakdownMetricsetName
+		} else if _, ok := ms.Samples["transaction.breakdown.count"]; ok {
+			ms.Name = transactionBreakdownMetricsetName
 		}
 	}
 	return nil

--- a/model/modelprocessor/metricsetname_test.go
+++ b/model/modelprocessor/metricsetname_test.go
@@ -42,28 +42,26 @@ func TestSetMetricsetName(t *testing.T) {
 		name:      "",
 	}, {
 		metricset: model.Metricset{
-			Samples: []model.Sample{{
-				Name: "transaction.breakdown.count",
-			}},
+			Samples: map[string]model.MetricsetSample{
+				"transaction.breakdown.count": {},
+			},
 		},
 		name: "app",
 	}, {
 		metricset: model.Metricset{
 			Transaction: model.MetricsetTransaction{Type: "request"},
-			Samples: []model.Sample{{
-				Name: "transaction.duration.count",
-			}, {
-				Name: "transaction.breakdown.count",
-			}},
+			Samples: map[string]model.MetricsetSample{
+				"transaction.duration.count":  {},
+				"transaction.breakdown.count": {},
+			},
 		},
 		name: "transaction_breakdown",
 	}, {
 		metricset: model.Metricset{
 			Transaction: model.MetricsetTransaction{Type: "request"},
-			Span:        model.MetricsetSpan{Type: "app"},
-			Samples: []model.Sample{{
-				Name: "span.self_time.count",
-			}},
+			Samples: map[string]model.MetricsetSample{
+				"span.self_time.count": {},
+			},
 		},
 		name: "span_breakdown",
 	}}

--- a/processor/otel/metrics_test.go
+++ b/processor/otel/metrics_test.go
@@ -168,19 +168,18 @@ func TestConsumeMetrics(t *testing.T) {
 	assert.Equal(t, []*model.Metricset{{
 		Metadata:  metadata,
 		Timestamp: timestamp0,
-		Samples: []model.Sample{
-			{Name: "int_gauge_metric", Value: 1, Type: "gauge"},
-			{Name: "double_gauge_metric", Value: 5, Type: "gauge"},
-			{Name: "int_sum_metric", Value: 9, Type: "counter"},
-			{Name: "double_sum_metric", Value: 12, Type: "counter"},
-
-			{
-				Name: "histogram_metric", Type: "histogram",
+		Samples: map[string]model.MetricsetSample{
+			"int_gauge_metric":    {Value: 1, Type: "gauge"},
+			"double_gauge_metric": {Value: 5, Type: "gauge"},
+			"int_sum_metric":      {Value: 9, Type: "counter"},
+			"double_sum_metric":   {Value: 12, Type: "counter"},
+			"histogram_metric": {
+				Type:   "histogram",
 				Counts: []int64{1, 1, 2, 3},
 				Values: []float64{-1, 0.5, 2.75, 3.5},
 			},
-			{
-				Name: "int_histogram_metric", Type: "histogram",
+			"int_histogram_metric": {
+				Type:   "histogram",
 				Counts: []int64{1, 2, 3},
 				Values: []float64{1.5, 2.5, 3},
 			},
@@ -188,35 +187,35 @@ func TestConsumeMetrics(t *testing.T) {
 	}, {
 		Metadata:  metadata,
 		Timestamp: timestamp1,
-		Samples: []model.Sample{
-			{Name: "int_gauge_metric", Value: 3, Type: "gauge"},
-			{Name: "double_gauge_metric", Value: 7, Type: "gauge"},
+		Samples: map[string]model.MetricsetSample{
+			"int_gauge_metric":    {Value: 3, Type: "gauge"},
+			"double_gauge_metric": {Value: 7, Type: "gauge"},
 		},
 	}, {
 		Metadata:  metadata,
 		Timestamp: timestamp1,
 		Labels:    common.MapStr{"k": "v"},
-		Samples: []model.Sample{
-			{Name: "int_gauge_metric", Value: 2, Type: "gauge"},
-			{Name: "double_gauge_metric", Value: 6, Type: "gauge"},
-			{Name: "int_sum_metric", Value: 10, Type: "counter"},
-			{Name: "double_sum_metric", Value: 13, Type: "counter"},
+		Samples: map[string]model.MetricsetSample{
+			"int_gauge_metric":    {Value: 2, Type: "gauge"},
+			"double_gauge_metric": {Value: 6, Type: "gauge"},
+			"int_sum_metric":      {Value: 10, Type: "counter"},
+			"double_sum_metric":   {Value: 13, Type: "counter"},
 		},
 	}, {
 		Metadata:  metadata,
 		Timestamp: timestamp1,
 		Labels:    common.MapStr{"k": "v2"},
-		Samples: []model.Sample{
-			{Name: "int_gauge_metric", Value: 4, Type: "gauge"},
-			{Name: "double_gauge_metric", Value: 8, Type: "gauge"},
+		Samples: map[string]model.MetricsetSample{
+			"int_gauge_metric":    {Value: 4, Type: "gauge"},
+			"double_gauge_metric": {Value: 8, Type: "gauge"},
 		},
 	}, {
 		Metadata:  metadata,
 		Timestamp: timestamp1,
 		Labels:    common.MapStr{"k2": "v"},
-		Samples: []model.Sample{
-			{Name: "int_sum_metric", Value: 11, Type: "counter"},
-			{Name: "double_sum_metric", Value: 14, Type: "counter"},
+		Samples: map[string]model.MetricsetSample{
+			"int_sum_metric":    {Value: 11, Type: "counter"},
+			"double_sum_metric": {Value: 14, Type: "counter"},
 		},
 	}}, metricsets)
 }
@@ -275,46 +274,50 @@ func TestConsumeMetrics_JVM(t *testing.T) {
 	assert.Equal(t, []*model.Metricset{{
 		Metadata:  metadata,
 		Timestamp: timestamp,
-		Samples: []model.Sample{{
-			Type:  "gauge",
-			Name:  "jvm.memory.heap.used",
-			Value: 42,
-		}},
+		Samples: map[string]model.MetricsetSample{
+			"jvm.memory.heap.used": {
+				Type:  "gauge",
+				Value: 42,
+			},
+		},
 	}, {
 		Metadata:  metadata,
 		Timestamp: timestamp,
 		Labels:    common.MapStr{"gc": "G1 Young Generation"},
-		Samples: []model.Sample{{
-			Type:  "counter",
-			Name:  "runtime.jvm.gc.time",
-			Value: 9,
-		}, {
-			Type:  "counter",
-			Name:  "runtime.jvm.gc.count",
-			Value: 2,
-		}},
+		Samples: map[string]model.MetricsetSample{
+			"runtime.jvm.gc.time": {
+				Type:  "counter",
+				Value: 9,
+			},
+			"runtime.jvm.gc.count": {
+				Type:  "counter",
+				Value: 2,
+			},
+		},
 	}, {
 		Metadata:  metadata,
 		Timestamp: timestamp,
 		Labels:    common.MapStr{"name": "G1 Young Generation"},
-		Samples: []model.Sample{{
-			Type:  "counter",
-			Name:  "jvm.gc.time",
-			Value: 9,
-		}, {
-			Type:  "counter",
-			Name:  "jvm.gc.count",
-			Value: 2,
-		}},
+		Samples: map[string]model.MetricsetSample{
+			"jvm.gc.time": {
+				Type:  "counter",
+				Value: 9,
+			},
+			"jvm.gc.count": {
+				Type:  "counter",
+				Value: 2,
+			},
+		},
 	}, {
 		Metadata:  metadata,
 		Timestamp: timestamp,
 		Labels:    common.MapStr{"area": "heap", "type": "used"},
-		Samples: []model.Sample{{
-			Type:  "gauge",
-			Name:  "runtime.jvm.memory.area",
-			Value: 42,
-		}},
+		Samples: map[string]model.MetricsetSample{
+			"runtime.jvm.memory.area": {
+				Type:  "gauge",
+				Value: 42,
+			},
+		},
 	}}, metricsets)
 }
 

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
@@ -624,11 +624,7 @@
             "container": {
                 "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
             },
-            "dotted": {
-                "float": {
-                    "gauge": 6.12
-                }
-            },
+            "dotted.float.gauge": 6.12,
             "double_gauge": 3.141592653589793,
             "float_gauge": 9.16,
             "host": {
@@ -659,19 +655,7 @@
                 "success": true
             },
             "long_gauge": 3147483648,
-            "negative": {
-                "d": {
-                    "o": {
-                        "t": {
-                            "t": {
-                                "e": {
-                                    "d": -1022
-                                }
-                            }
-                        }
-                    }
-                }
-            },
+            "negative.d.o.t.t.e.d": -1022,
             "process": {
                 "args": [
                     "-v"
@@ -706,34 +690,20 @@
             },
             "short_counter": 227,
             "span": {
-                "self_time": {
-                    "count": 1,
-                    "sum": {
-                        "us": 633.288
-                    }
-                },
                 "subtype": "mysql",
                 "type": "db"
             },
+            "span.self_time.count": 1,
+            "span.self_time.sum.us": 633.288,
             "transaction": {
-                "breakdown": {
-                    "count": 12
-                },
-                "duration": {
-                    "count": 2,
-                    "sum": {
-                        "us": 12
-                    }
-                },
                 "name": "GET/",
-                "self_time": {
-                    "count": 2,
-                    "sum": {
-                        "us": 10
-                    }
-                },
                 "type": "request"
-            }
+            },
+            "transaction.breakdown.count": 12,
+            "transaction.duration.count": 2,
+            "transaction.duration.sum.us": 12,
+            "transaction.self_time.count": 2,
+            "transaction.self_time.sum.us": 10
         }
     ]
 }

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationMetricsets.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationMetricsets.approved.json
@@ -7,11 +7,7 @@
                 "version": "3.14.0"
             },
             "byte_counter": 1,
-            "dotted": {
-                "float": {
-                    "gauge": 6.12
-                }
-            },
+            "dotted.float.gauge": 6.12,
             "double_gauge": 3.141592653589793,
             "float_gauge": 9.16,
             "host": {
@@ -26,19 +22,7 @@
                 "tag2": 2
             },
             "long_gauge": 3147483648,
-            "negative": {
-                "d": {
-                    "o": {
-                        "t": {
-                            "t": {
-                                "e": {
-                                    "d": -1022
-                                }
-                            }
-                        }
-                    }
-                }
-            },
+            "negative.d.o.t.t.e.d": -1022,
             "process": {
                 "pid": 1234
             },
@@ -57,34 +41,20 @@
             },
             "short_counter": 227,
             "span": {
-                "self_time": {
-                    "count": 1,
-                    "sum": {
-                        "us": 633.288
-                    }
-                },
                 "subtype": "mysql",
                 "type": "db"
             },
+            "span.self_time.count": 1,
+            "span.self_time.sum.us": 633.288,
             "transaction": {
-                "breakdown": {
-                    "count": 12
-                },
-                "duration": {
-                    "count": 2,
-                    "sum": {
-                        "us": 12
-                    }
-                },
                 "name": "GET /",
-                "self_time": {
-                    "count": 2,
-                    "sum": {
-                        "us": 10
-                    }
-                },
                 "type": "request"
             },
+            "transaction.breakdown.count": 12,
+            "transaction.duration.count": 2,
+            "transaction.duration.sum.us": 12,
+            "transaction.self_time.count": 2,
+            "transaction.self_time.sum.us": 10,
             "user": {
                 "email": "user@mail.com",
                 "id": "axb123hg",
@@ -97,15 +67,7 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "go": {
-                "memstats": {
-                    "heap": {
-                        "sys": {
-                            "bytes": 6520832
-                        }
-                    }
-                }
-            },
+            "go.memstats.heap.sys.bytes": 6520832,
             "host": {
                 "ip": "192.0.0.1"
             },
@@ -164,22 +126,8 @@
                     "name": "node-1"
                 }
             },
-            "system": {
-                "process": {
-                    "cgroup": {
-                        "memory": {
-                            "mem": {
-                                "limit": {
-                                    "bytes": 2048
-                                },
-                                "usage": {
-                                    "bytes": 1024
-                                }
-                            }
-                        }
-                    }
-                }
-            },
+            "system.process.cgroup.memory.mem.limit.bytes": 2048,
+            "system.process.cgroup.memory.mem.usage.bytes": 1024,
             "user": {
                 "email": "user@mail.com",
                 "id": "axb123hg",
@@ -215,36 +163,14 @@
                     "name": "node-1"
                 }
             },
-            "system": {
-                "process": {
-                    "cgroup": {
-                        "cpu": {
-                            "cfs": {
-                                "period": {
-                                    "us": 1024
-                                },
-                                "quota": {
-                                    "us": 2048
-                                }
-                            },
-                            "id": 2048,
-                            "stats": {
-                                "periods": 2048,
-                                "throttled": {
-                                    "ns": 2048,
-                                    "periods": 2048
-                                }
-                            }
-                        },
-                        "cpuacct": {
-                            "id": 2048,
-                            "total": {
-                                "ns": 2048
-                            }
-                        }
-                    }
-                }
-            },
+            "system.process.cgroup.cpu.cfs.period.us": 1024,
+            "system.process.cgroup.cpu.cfs.quota.us": 2048,
+            "system.process.cgroup.cpu.id": 2048,
+            "system.process.cgroup.cpu.stats.periods": 2048,
+            "system.process.cgroup.cpu.stats.throttled.ns": 2048,
+            "system.process.cgroup.cpu.stats.throttled.periods": 2048,
+            "system.process.cgroup.cpuacct.id": 2048,
+            "system.process.cgroup.cpuacct.total.ns": 2048,
             "user": {
                 "email": "user@mail.com",
                 "id": "axb123hg",
@@ -253,7 +179,6 @@
         },
         {
             "@timestamp": "2017-05-30T18:53:41.366Z",
-            "_doc_count": 6,
             "_metric_descriptions": {
                 "latency_distribution": {
                     "type": "histogram",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationMinimalService.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationMinimalService.approved.json
@@ -37,15 +37,7 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "go": {
-                "memstats": {
-                    "heap": {
-                        "sys": {
-                            "bytes": 61235
-                        }
-                    }
-                }
-            },
+            "go.memstats.heap.sys.bytes": 61235,
             "host": {
                 "ip": "192.0.0.1"
             },

--- a/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
@@ -180,18 +180,12 @@
                 "version": "0.0.1"
             },
             "transaction": {
-                "breakdown": {
-                    "count": 1
-                },
-                "duration": {
-                    "count": 1,
-                    "sum": {
-                        "us": 295
-                    }
-                },
                 "name": "general-usecase-initial-p-load",
                 "type": "p-load"
             },
+            "transaction.breakdown.count": 1,
+            "transaction.duration.count": 1,
+            "transaction.duration.sum.us": 295,
             "user": {
                 "email": "user@email.com",
                 "id": "123",
@@ -235,14 +229,10 @@
                 "version": "0.0.1"
             },
             "span": {
-                "self_time": {
-                    "count": 1,
-                    "sum": {
-                        "us": 1
-                    }
-                },
                 "type": "Request"
             },
+            "span.self_time.count": 1,
+            "span.self_time.sum.us": 1,
             "transaction": {
                 "name": "general-usecase-initial-p-load",
                 "type": "p-load"
@@ -290,14 +280,10 @@
                 "version": "0.0.1"
             },
             "span": {
-                "self_time": {
-                    "count": 1,
-                    "sum": {
-                        "us": 1
-                    }
-                },
                 "type": "Response"
             },
+            "span.self_time.count": 1,
+            "span.self_time.sum.us": 1,
             "transaction": {
                 "name": "general-usecase-initial-p-load",
                 "type": "p-load"
@@ -1026,15 +1012,11 @@
                 "version": "0.0.1"
             },
             "span": {
-                "self_time": {
-                    "count": 1,
-                    "sum": {
-                        "us": 124
-                    }
-                },
                 "subtype": "subtype",
                 "type": "Processing"
             },
+            "span.self_time.count": 1,
+            "span.self_time.sum.us": 124,
             "user": {
                 "email": "user@email.com",
                 "id": "123",

--- a/systemtest/approvals/TestApprovedMetrics.approved.json
+++ b/systemtest/approvals/TestApprovedMetrics.approved.json
@@ -12,15 +12,7 @@
             "event": {
                 "ingested": "dynamic"
             },
-            "go": {
-                "memstats": {
-                    "heap": {
-                        "sys": {
-                            "bytes": 6520832
-                        }
-                    }
-                }
-            },
+            "go.memstats.heap.sys.bytes": 6520832,
             "host": {
                 "ip": "127.0.0.1"
             },
@@ -103,22 +95,8 @@
                     "name": "node-1"
                 }
             },
-            "system": {
-                "process": {
-                    "cgroup": {
-                        "memory": {
-                            "mem": {
-                                "limit": {
-                                    "bytes": 2048
-                                },
-                                "usage": {
-                                    "bytes": 1024
-                                }
-                            }
-                        }
-                    }
-                }
-            },
+            "system.process.cgroup.memory.mem.limit.bytes": 2048,
+            "system.process.cgroup.memory.mem.usage.bytes": 1024,
             "user": {
                 "email": "user@mail.com",
                 "id": "axb123hg",
@@ -169,36 +147,14 @@
                     "name": "node-1"
                 }
             },
-            "system": {
-                "process": {
-                    "cgroup": {
-                        "cpu": {
-                            "cfs": {
-                                "period": {
-                                    "us": 1024
-                                },
-                                "quota": {
-                                    "us": 2048
-                                }
-                            },
-                            "id": 2048,
-                            "stats": {
-                                "periods": 2048,
-                                "throttled": {
-                                    "ns": 2048,
-                                    "periods": 2048
-                                }
-                            }
-                        },
-                        "cpuacct": {
-                            "id": 2048,
-                            "total": {
-                                "ns": 2048
-                            }
-                        }
-                    }
-                }
-            },
+            "system.process.cgroup.cpu.cfs.period.us": 1024,
+            "system.process.cgroup.cpu.cfs.quota.us": 2048,
+            "system.process.cgroup.cpu.id": 2048,
+            "system.process.cgroup.cpu.stats.periods": 2048,
+            "system.process.cgroup.cpu.stats.throttled.ns": 2048,
+            "system.process.cgroup.cpu.stats.throttled.periods": 2048,
+            "system.process.cgroup.cpuacct.id": 2048,
+            "system.process.cgroup.cpuacct.total.ns": 2048,
             "user": {
                 "email": "user@mail.com",
                 "id": "axb123hg",
@@ -207,7 +163,6 @@
         },
         {
             "@timestamp": "2017-05-30T18:53:41.366Z",
-            "_doc_count": 6,
             "agent": {
                 "name": "elastic-node",
                 "version": "3.14.0"
@@ -275,11 +230,7 @@
                 "version": "3.14.0"
             },
             "byte_counter": 1,
-            "dotted": {
-                "float": {
-                    "gauge": 6.12
-                }
-            },
+            "dotted.float.gauge": 6.12,
             "double_gauge": 3.141592653589793,
             "ecs": {
                 "version": "dynamic"
@@ -301,19 +252,7 @@
             },
             "long_gauge": 3147483648,
             "metricset.name": "span_breakdown",
-            "negative": {
-                "d": {
-                    "o": {
-                        "t": {
-                            "t": {
-                                "e": {
-                                    "d": -1022
-                                }
-                            }
-                        }
-                    }
-                }
-            },
+            "negative.d.o.t.t.e.d": -1022,
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",
@@ -340,34 +279,20 @@
             },
             "short_counter": 227,
             "span": {
-                "self_time": {
-                    "count": 1,
-                    "sum": {
-                        "us": 633.288
-                    }
-                },
                 "subtype": "mysql",
                 "type": "db"
             },
+            "span.self_time.count": 1,
+            "span.self_time.sum.us": 633.288,
             "transaction": {
-                "breakdown": {
-                    "count": 12
-                },
-                "duration": {
-                    "count": 2,
-                    "sum": {
-                        "us": 12
-                    }
-                },
                 "name": "GET /",
-                "self_time": {
-                    "count": 2,
-                    "sum": {
-                        "us": 10
-                    }
-                },
                 "type": "request"
             },
+            "transaction.breakdown.count": 12,
+            "transaction.duration.count": 2,
+            "transaction.duration.sum.us": 12,
+            "transaction.self_time.count": 2,
+            "transaction.self_time.sum.us": 10,
             "user": {
                 "email": "user@mail.com",
                 "id": "axb123hg",

--- a/systemtest/approvals/TestServiceDestinationAggregation.approved.json
+++ b/systemtest/approvals/TestServiceDestinationAggregation.approved.json
@@ -12,10 +12,8 @@
                 "ingested": "dynamic",
                 "outcome": "unknown"
             },
-            "metricset": {
-                "period": 1000
-            },
             "metricset.name": "service_destination",
+            "metricset.period": 1000,
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",
@@ -34,16 +32,12 @@
             "span": {
                 "destination": {
                     "service": {
-                        "resource": "resource",
-                        "response_time": {
-                            "count": 5,
-                            "sum": {
-                                "us": 5000000
-                            }
-                        }
+                        "resource": "resource"
                     }
                 }
-            }
+            },
+            "span.destination.service.response_time.count": 5,
+            "span.destination.service.response_time.sum.us": 5000000
         }
     ]
 }

--- a/systemtest/approvals/TestTransactionAggregation.approved.json
+++ b/systemtest/approvals/TestTransactionAggregation.approved.json
@@ -40,19 +40,17 @@
                 "instance": "systemtest:abc:29d4be3fbd7f200f"
             },
             "transaction": {
-                "duration": {
-                    "histogram": {
-                        "counts": [
-                            5
-                        ],
-                        "values": [
-                            1003519
-                        ]
-                    }
-                },
                 "name": "abc",
                 "root": true,
                 "type": "backend"
+            },
+            "transaction.duration.histogram": {
+                "counts": [
+                    5
+                ],
+                "values": [
+                    1003519
+                ]
             }
         },
         {
@@ -95,19 +93,17 @@
                 "instance": "systemtest:def:41b636ee77bc8c1c"
             },
             "transaction": {
-                "duration": {
-                    "histogram": {
-                        "counts": [
-                            10
-                        ],
-                        "values": [
-                            1003519
-                        ]
-                    }
-                },
                 "name": "def",
                 "root": true,
                 "type": "backend"
+            },
+            "transaction.duration.histogram": {
+                "counts": [
+                    10
+                ],
+                "values": [
+                    1003519
+                ]
             }
         }
     ]

--- a/systemtest/approvals/TestTransactionAggregationShutdown.approved.json
+++ b/systemtest/approvals/TestTransactionAggregationShutdown.approved.json
@@ -40,19 +40,17 @@
                 "instance": "systemtest:name:56ef3b5d147616b4"
             },
             "transaction": {
-                "duration": {
-                    "histogram": {
-                        "counts": [
-                            1
-                        ],
-                        "values": [
-                            1003519
-                        ]
-                    }
-                },
                 "name": "name",
                 "root": true,
                 "type": "type"
+            },
+            "transaction.duration.histogram": {
+                "counts": [
+                    1
+                ],
+                "values": [
+                    1003519
+                ]
             }
         }
     ]

--- a/systemtest/metrics_test.go
+++ b/systemtest/metrics_test.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -148,7 +149,10 @@ func TestApplicationMetrics(t *testing.T) {
 	for _, fieldName := range expectedFields {
 		var found bool
 		for _, hit := range result.Hits.Hits {
-			if gjson.GetBytes(hit.RawSource, fieldName).Exists() {
+			// Metrics are written with dotted field names rather than
+			// as hierarchical objects, so escape dots in the gjson path.
+			path := strings.Replace(fieldName, ".", "\\.", -1)
+			if gjson.GetBytes(hit.RawSource, path).Exists() {
 				found = true
 				break
 			}

--- a/tests/system/metricset.approved.json
+++ b/tests/system/metricset.approved.json
@@ -11,15 +11,7 @@
         "event": {
             "ingested": "2020-04-22T14:55:05.425020Z"
         },
-        "go": {
-            "memstats": {
-                "heap": {
-                    "sys": {
-                        "bytes": 6520832.0
-                    }
-                }
-            }
-        },
+        "go.memstats.heap.sys.bytes": 6520832.0,
         "host": {
             "ip": "127.0.0.1"
         },
@@ -102,22 +94,8 @@
                 "name": "node-1"
             }
         },
-        "system": {
-            "process": {
-                "cgroup": {
-                    "memory": {
-                        "mem": {
-                            "limit": {
-                                "bytes": 2048
-                            },
-                            "usage": {
-                                "bytes": 1024
-                            }
-                        }
-                    }
-                }
-            }
-        },
+        "system.process.cgroup.memory.mem.limit.bytes": 2048,
+        "system.process.cgroup.memory.mem.usage.bytes": 1024,
         "user": {
             "email": "user@mail.com",
             "id": "axb123hg",
@@ -168,36 +146,14 @@
                 "name": "node-1"
             }
         },
-        "system": {
-            "process": {
-                "cgroup": {
-                    "cpu": {
-                        "cfs": {
-                            "period": {
-                                "us": 1024
-                            },
-                            "quota": {
-                                "us": 2048
-                            }
-                        },
-                        "id": 2048,
-                        "stats": {
-                            "periods": 2048,
-                            "throttled": {
-                                "ns": 2048,
-                                "periods": 2048
-                            }
-                        }
-                    },
-                    "cpuacct": {
-                        "id": 2048,
-                        "total": {
-                            "ns": 2048
-                        }
-                    }
-                }
-            }
-        },
+        "system.process.cgroup.cpu.cfs.period.us": 1024,
+        "system.process.cgroup.cpu.cfs.quota.us": 2048,
+        "system.process.cgroup.cpu.id": 2048,
+        "system.process.cgroup.cpu.stats.periods": 2048,
+        "system.process.cgroup.cpu.stats.throttled.ns": 2048,
+        "system.process.cgroup.cpu.stats.throttled.periods": 2048,
+        "system.process.cgroup.cpuacct.id": 2048,
+        "system.process.cgroup.cpuacct.total.ns": 2048,
         "user": {
             "email": "user@mail.com",
             "id": "axb123hg",
@@ -274,11 +230,7 @@
             "version": "3.14.0"
         },
         "byte_counter": 1,
-        "dotted": {
-            "float": {
-                "gauge": 6.12
-            }
-        },
+        "dotted.float.gauge": 6.12,
         "double_gauge": 3.141592653589793,
         "ecs": {
             "version": "1.10.0"
@@ -300,19 +252,7 @@
         },
         "long_gauge": 3147483648.0,
         "metricset.name": "span_breakdown",
-        "negative": {
-            "d": {
-                "o": {
-                    "t": {
-                        "t": {
-                            "e": {
-                                "d": -1022
-                            }
-                        }
-                    }
-                }
-            }
-        },
+        "negative.d.o.t.t.e.d": -1022,
         "observer": {
             "ephemeral_id": "8785cbe1-7f89-4279-84c2-6c33979531fb",
             "hostname": "ix.lan",
@@ -339,34 +279,20 @@
         },
         "short_counter": 227,
         "span": {
-            "self_time": {
-                "count": 1,
-                "sum": {
-                    "us": 633.288
-                }
-            },
             "subtype": "mysql",
             "type": "db"
         },
+        "span.self_time.count": 1,
+        "span.self_time.sum.us": 633.288,
         "transaction": {
-            "breakdown": {
-                "count": 12
-            },
-            "duration": {
-                "count": 2,
-                "sum": {
-                    "us": 12
-                }
-            },
             "name": "GET /",
-            "self_time": {
-                "count": 2,
-                "sum": {
-                    "us": 10
-                }
-            },
             "type": "request"
         },
+        "transaction.breakdown.count": 12,
+        "transaction.duration.count": 2,
+        "transaction.duration.sum.us": 12,
+        "transaction.self_time.count": 2,
+        "transaction.self_time.sum.us": 10,
         "user": {
             "email": "user@mail.com",
             "id": "axb123hg",

--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
@@ -274,13 +274,11 @@ func makeMetricset(timestamp time.Time, key aggregationKey, metrics spanMetrics,
 		Span: model.MetricsetSpan{
 			DestinationService: model.DestinationService{Resource: key.resource},
 		},
-		Samples: []model.Sample{
-			{
-				Name:  "span.destination.service.response_time.count",
+		Samples: map[string]model.MetricsetSample{
+			"span.destination.service.response_time.count": {
 				Value: math.Round(metrics.count),
 			},
-			{
-				Name:  "span.destination.service.response_time.sum.us",
+			"span.destination.service.response_time.sum.us": {
 				Value: math.Round(metrics.sum),
 			},
 		},
@@ -291,10 +289,9 @@ func makeMetricset(timestamp time.Time, key aggregationKey, metrics spanMetrics,
 		// An interval of zero means the metricset is computed
 		// from an instantaneous value, meaning there is no
 		// aggregation period.
-		out.Samples = append(out.Samples, model.Sample{
-			Name:  "metricset.period",
+		out.Samples["metricset.period"] = model.MetricsetSample{
 			Value: float64(interval),
-		})
+		}
 	}
 	return out
 }

--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator_test.go
@@ -128,10 +128,10 @@ func TestAggregatorRun(t *testing.T) {
 		Span: model.MetricsetSpan{
 			DestinationService: model.DestinationService{Resource: destinationX},
 		},
-		Samples: []model.Sample{
-			{Name: "span.destination.service.response_time.count", Value: 100.0},
-			{Name: "span.destination.service.response_time.sum.us", Value: 10000000.0},
-			{Name: "metricset.period", Value: 10},
+		Samples: map[string]model.MetricsetSample{
+			"span.destination.service.response_time.count":  {Value: 100.0},
+			"span.destination.service.response_time.sum.us": {Value: 10000000.0},
+			"metricset.period": {Value: 10},
 		},
 	}, {
 		Name: "service_destination",
@@ -144,10 +144,10 @@ func TestAggregatorRun(t *testing.T) {
 		Span: model.MetricsetSpan{
 			DestinationService: model.DestinationService{Resource: destinationZ},
 		},
-		Samples: []model.Sample{
-			{Name: "span.destination.service.response_time.count", Value: 100.0},
-			{Name: "span.destination.service.response_time.sum.us", Value: 10000000.0},
-			{Name: "metricset.period", Value: 10},
+		Samples: map[string]model.MetricsetSample{
+			"span.destination.service.response_time.count":  {Value: 100.0},
+			"span.destination.service.response_time.sum.us": {Value: 10000000.0},
+			"metricset.period": {Value: 10},
 		},
 	}, {
 		Name: "service_destination",
@@ -160,10 +160,10 @@ func TestAggregatorRun(t *testing.T) {
 		Span: model.MetricsetSpan{
 			DestinationService: model.DestinationService{Resource: destinationZ},
 		},
-		Samples: []model.Sample{
-			{Name: "span.destination.service.response_time.count", Value: 300.0},
-			{Name: "span.destination.service.response_time.sum.us", Value: 30000000.0},
-			{Name: "metricset.period", Value: 10},
+		Samples: map[string]model.MetricsetSample{
+			"span.destination.service.response_time.count":  {Value: 300.0},
+			"span.destination.service.response_time.sum.us": {Value: 30000000.0},
+			"metricset.period": {Value: 10},
 		},
 	}, {
 		Name: "service_destination",
@@ -176,10 +176,10 @@ func TestAggregatorRun(t *testing.T) {
 		Span: model.MetricsetSpan{
 			DestinationService: model.DestinationService{Resource: destinationZ},
 		},
-		Samples: []model.Sample{
-			{Name: "span.destination.service.response_time.count", Value: 100.0},
-			{Name: "span.destination.service.response_time.sum.us", Value: 10000000.0},
-			{Name: "metricset.period", Value: 10},
+		Samples: map[string]model.MetricsetSample{
+			"span.destination.service.response_time.count":  {Value: 100.0},
+			"span.destination.service.response_time.sum.us": {Value: 10000000.0},
+			"metricset.period": {Value: 10},
 		},
 	}}, metricsets)
 
@@ -234,9 +234,9 @@ func TestAggregatorOverflow(t *testing.T) {
 			Span: model.MetricsetSpan{
 				DestinationService: model.DestinationService{Resource: "destination3"},
 			},
-			Samples: []model.Sample{
-				{Name: "span.destination.service.response_time.count", Value: 1.0},
-				{Name: "span.destination.service.response_time.sum.us", Value: 100000.0},
+			Samples: map[string]model.MetricsetSample{
+				"span.destination.service.response_time.count":  {Value: 1.0},
+				"span.destination.service.response_time.sum.us": {Value: 100000.0},
 				// No metricset.period is recorded as these metrics are instantanous, not aggregated.
 			},
 		}, m)

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -220,8 +220,8 @@ func (a *Aggregator) publish(ctx context.Context) error {
 	batch := make(model.Batch, 0, a.inactive.entries)
 	for hash, entries := range a.inactive.m {
 		for _, entry := range entries {
-			counts, values := entry.transactionMetrics.histogramBuckets()
-			metricset := makeMetricset(entry.transactionAggregationKey, hash, now, counts, values)
+			totalCount, counts, values := entry.transactionMetrics.histogramBuckets()
+			metricset := makeMetricset(entry.transactionAggregationKey, hash, now, totalCount, counts, values)
 			batch = append(batch, model.APMEvent{Metricset: &metricset})
 		}
 		delete(a.inactive.m, hash)
@@ -278,7 +278,7 @@ unique transaction names.`[1:],
 	atomic.AddInt64(&a.metrics.overflowed, 1)
 	counts := []int64{int64(math.Round(count))}
 	values := []float64{float64(durationMicros(duration))}
-	metricset := makeMetricset(key, hash, time.Now(), counts, values)
+	metricset := makeMetricset(key, hash, time.Now(), counts[0], counts, values)
 	return &metricset
 }
 
@@ -359,7 +359,9 @@ func (a *Aggregator) makeTransactionAggregationKey(tx *model.Transaction) transa
 }
 
 // makeMetricset makes a Metricset from key, counts, and values, with timestamp ts.
-func makeMetricset(key transactionAggregationKey, hash uint64, ts time.Time, counts []int64, values []float64) model.Metricset {
+func makeMetricset(
+	key transactionAggregationKey, hash uint64, ts time.Time, totalCount int64, counts []int64, values []float64,
+) model.Metricset {
 	out := model.Metricset{
 		Timestamp: ts,
 		Name:      metricsetName,
@@ -385,11 +387,14 @@ func makeMetricset(key transactionAggregationKey, hash uint64, ts time.Time, cou
 			Result: key.transactionResult,
 			Root:   key.traceRoot,
 		},
-		Samples: []model.Sample{{
-			Name:   "transaction.duration.histogram",
-			Counts: counts,
-			Values: values,
-		}},
+		Samples: map[string]model.MetricsetSample{
+			"transaction.duration.histogram": {
+				Type:   model.MetricTypeHistogram,
+				Counts: counts,
+				Values: values,
+			},
+		},
+		DocCount: totalCount,
 	}
 
 	// Record an timeseries instance ID, which should be uniquely identify the aggregation key.
@@ -466,7 +471,7 @@ func (m *transactionMetrics) recordDuration(d time.Duration, n float64) {
 	m.histogram.RecordValuesAtomic(durationMicros(d), count)
 }
 
-func (m *transactionMetrics) histogramBuckets() (counts []int64, values []float64) {
+func (m *transactionMetrics) histogramBuckets() (totalCount int64, counts []int64, values []float64) {
 	// From https://www.elastic.co/guide/en/elasticsearch/reference/current/histogram.html:
 	//
 	// "For the High Dynamic Range (HDR) histogram mode, the values array represents
@@ -479,11 +484,12 @@ func (m *transactionMetrics) histogramBuckets() (counts []int64, values []float6
 		if b.Count <= 0 {
 			continue
 		}
-		count := math.Round(float64(b.Count) / histogramCountScale)
-		counts = append(counts, int64(count))
+		count := int64(math.Round(float64(b.Count) / histogramCountScale))
+		counts = append(counts, count)
 		values = append(values, float64(b.To))
+		totalCount += count
 	}
-	return counts, values
+	return totalCount, counts, values
 }
 
 func transactionCount(tx *model.Transaction) float64 {


### PR DESCRIPTION
## Motivation/summary

A few smallish changes to the `model.Metricset` type, for future-proofing. The goal is to make the type suitable for generating transformation to `beat.Events` logic later, while making the type better suited to protobuf definition in the short term.

`model.Metricset.Samples` is now a map, instead of a slice of named metrics, and the metrics fields are added as flat dotted field namess rather than hierarchical objects.

In the future we will send the samples map as-is (with values, type, and unit) to Elasticsearch and perform transformation to top-level metrics fields and dynamic templates completely in the ingest pipeline.

`model.Sample` is now called `model.MetricsetSample`, to clarify its relationship with `model.Metricset`.

We no longer set "_doc_count" in transformation; this is now part of the type and is set in transaction metrics aggregation
for "transaction.duration.histogram", the only metric where it is expected to be set.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

Non-functional change.

## Related issues

#4120
#3565