### PR TITLE
Move grouping key calculation to model processor

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -445,8 +445,8 @@ func (s *serverRunner) wrapRunServerWithPreprocessors(runServer RunServerFunc) R
 	processors := []model.BatchProcessor{
 		modelprocessor.SetSystemHostname{},
 		modelprocessor.SetServiceNodeName{},
-		// Set metricset.name for well-known agent metrics.
 		modelprocessor.SetMetricsetName{},
+		modelprocessor.SetGroupingKey{},
 	}
 	if s.config.DefaultServiceEnvironment != "" {
 		processors = append(processors, &modelprocessor.SetDefaultServiceEnvironment{
@@ -671,7 +671,7 @@ func WrapRunServerWithProcessors(runServer RunServerFunc, processors ...model.Ba
 		return runServer
 	}
 	return func(ctx context.Context, args ServerParams) error {
-		processors = append(processors, args.BatchProcessor)
+		processors := append(processors, args.BatchProcessor)
 		args.BatchProcessor = modelprocessor.Chained(processors)
 		return runServer(ctx, args)
 	}

--- a/model/modeldecoder/rumv3/error_test.go
+++ b/model/modeldecoder/rumv3/error_test.go
@@ -123,6 +123,8 @@ func TestDecodeMapToErrorModel(t *testing.T) {
 				"URL", "Page.URL",
 				// exception.parent is only set after calling `flattenExceptionTree` (not part of decoding)
 				"Exception.Parent",
+				// GroupingKey is set by a model processor
+				"GroupingKey",
 				// stacktrace original and sourcemap values are set when sourcemapping is applied
 				"Exception.Stacktrace.Original",
 				"Exception.Stacktrace.Sourcemap",

--- a/model/modeldecoder/v2/error_test.go
+++ b/model/modeldecoder/v2/error_test.go
@@ -145,6 +145,8 @@ func TestDecodeMapToErrorModel(t *testing.T) {
 				"Page.URL",
 				// exception.parent is only set after calling `flattenExceptionTree` (not part of decoding)
 				"Exception.Parent",
+				// GroupingKey is set by a model processor
+				"GroupingKey",
 				// stacktrace original and sourcemap values are set when sourcemapping is applied
 				"Exception.Stacktrace.Original",
 				"Exception.Stacktrace.Sourcemap",

--- a/model/modelprocessor/groupingkey.go
+++ b/model/modelprocessor/groupingkey.go
@@ -1,0 +1,130 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package modelprocessor
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"hash"
+	"io"
+
+	"github.com/elastic/apm-server/model"
+)
+
+// SetGroupingKey is a model.BatchProcessor that sets the grouping key for errors
+// by hashing their stack frames.
+type SetGroupingKey struct{}
+
+// ProcessBatch sets the grouping key for errors.
+func (s SetGroupingKey) ProcessBatch(ctx context.Context, b *model.Batch) error {
+	for _, event := range *b {
+		if event.Error != nil {
+			s.processError(ctx, event.Error)
+		}
+	}
+	return nil
+}
+
+func (s SetGroupingKey) processError(ctx context.Context, event *model.Error) {
+	hash := md5.New()
+	var updated bool
+	if event.Exception != nil {
+		if s.hashExceptionTree(event.Exception, hash, s.hashExceptionType) {
+			updated = true
+		}
+	}
+	if event.Log != nil {
+		if s.maybeWriteString(event.Log.ParamMessage, hash) {
+			updated = true
+		}
+	}
+	var haveExceptionStacktrace bool
+	if event.Exception != nil {
+		haveExceptionStacktrace = s.hashExceptionTree(event.Exception, hash, s.hashExceptionStacktrace)
+		updated = updated || haveExceptionStacktrace
+	}
+	if !haveExceptionStacktrace && event.Log != nil {
+		if s.hashStacktrace(event.Log.Stacktrace, hash) {
+			updated = true
+		}
+	}
+	if !updated {
+		if event.Exception != nil {
+			updated = s.hashExceptionTree(event.Exception, hash, s.hashExceptionMessage)
+		}
+		if !updated && event.Log != nil {
+			s.maybeWriteString(event.Log.Message, hash)
+		}
+	}
+	event.GroupingKey = hex.EncodeToString(hash.Sum(nil))
+}
+
+func (s SetGroupingKey) hashExceptionTree(e *model.Exception, out hash.Hash, f func(*model.Exception, hash.Hash) bool) bool {
+	updated := f(e, out)
+	for _, cause := range e.Cause {
+		if s.hashExceptionTree(&cause, out, f) {
+			updated = true
+		}
+	}
+	return updated
+}
+
+func (s SetGroupingKey) hashExceptionType(e *model.Exception, out hash.Hash) bool {
+	return s.maybeWriteString(e.Type, out)
+}
+
+func (s SetGroupingKey) hashExceptionMessage(e *model.Exception, out hash.Hash) bool {
+	return s.maybeWriteString(e.Message, out)
+}
+
+func (s SetGroupingKey) hashExceptionStacktrace(e *model.Exception, out hash.Hash) bool {
+	return s.hashStacktrace(e.Stacktrace, out)
+}
+
+func (s SetGroupingKey) hashStacktrace(stacktrace model.Stacktrace, out hash.Hash) bool {
+	var updated bool
+	for _, frame := range stacktrace {
+		if frame.ExcludeFromGrouping {
+			continue
+		}
+		switch {
+		case frame.Module != "":
+			io.WriteString(out, frame.Module)
+			updated = true
+		case frame.Filename != "":
+			io.WriteString(out, frame.Filename)
+			updated = true
+		case frame.Classname != "":
+			io.WriteString(out, frame.Classname)
+			updated = true
+		}
+		if s.maybeWriteString(frame.Function, out) {
+			updated = true
+		}
+	}
+	return updated
+}
+
+func (SetGroupingKey) maybeWriteString(s string, out hash.Hash) bool {
+	if s == "" {
+		return false
+	}
+	io.WriteString(out, s)
+	return true
+}

--- a/model/modelprocessor/groupingkey_test.go
+++ b/model/modelprocessor/groupingkey_test.go
@@ -1,0 +1,132 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package modelprocessor_test
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-server/model"
+	"github.com/elastic/apm-server/model/modelprocessor"
+)
+
+func TestSetGroupingKey(t *testing.T) {
+	tests := map[string]struct {
+		input       model.Error
+		groupingKey string
+	}{
+		"empty": {
+			input:       model.Error{},
+			groupingKey: hashStrings( /*empty*/ ),
+		},
+		"exception_type_log_parammessage": {
+			input: model.Error{
+				Exception: &model.Exception{
+					Type: "exception_type",
+				},
+				Log: &model.Log{
+					ParamMessage: "log_parammessage",
+				},
+			},
+			groupingKey: hashStrings("exception_type", "log_parammessage"),
+		},
+		"exception_stacktrace": {
+			input: model.Error{
+				Exception: &model.Exception{
+					Stacktrace: model.Stacktrace{
+						{Module: "module", Filename: "filename", Classname: "classname", Function: "func_1"},
+						{Filename: "filename", Classname: "classname", Function: "func_2"},
+						{ExcludeFromGrouping: true, Function: "func_3"},
+					},
+					Cause: []model.Exception{{
+						Stacktrace: model.Stacktrace{
+							{Classname: "classname", Function: "func_4"},
+						},
+						Cause: []model.Exception{{
+							Stacktrace: model.Stacktrace{
+								{Function: "func_5"},
+							},
+						}},
+					}, {
+						Stacktrace: model.Stacktrace{
+							{Function: "func_6"},
+						},
+					}},
+				},
+				Log: &model.Log{Stacktrace: model.Stacktrace{{Filename: "abc"}}}, // ignored
+			},
+			groupingKey: hashStrings(
+				"module", "func_1", "filename", "func_2", "classname", "func_4", "func_5", "func_6",
+			),
+		},
+		"log_stacktrace": {
+			input: model.Error{
+				Log: &model.Log{
+					Stacktrace: model.Stacktrace{{Function: "function"}},
+				},
+			},
+			groupingKey: hashStrings("function"),
+		},
+		"exception_message": {
+			input: model.Error{
+				Exception: &model.Exception{
+					Message: "message_1",
+					Cause: []model.Exception{{
+						Message: "message_2",
+						Cause: []model.Exception{
+							{Message: "message_3"},
+						},
+					}, {
+						Message: "message_4",
+					}},
+				},
+				Log: &model.Log{Message: "log_message"}, // ignored
+			},
+			groupingKey: hashStrings("message_1", "message_2", "message_3", "message_4"),
+		},
+		"log_message": {
+			input: model.Error{
+				Log: &model.Log{Message: "log_message"}, // ignored
+			},
+			groupingKey: hashStrings("log_message"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			batch := model.Batch{{Error: &test.input}}
+			processor := modelprocessor.SetGroupingKey{}
+			err := processor.ProcessBatch(context.Background(), &batch)
+			assert.NoError(t, err)
+			assert.Equal(t, test.groupingKey, batch[0].Error.GroupingKey)
+		})
+	}
+
+}
+
+func hashStrings(s ...string) string {
+	md5 := md5.New()
+	for _, s := range s {
+		md5.Write([]byte(s))
+	}
+	return hex.EncodeToString(md5.Sum(nil))
+}

--- a/processor/otel/test_approved/span_jaeger_http.approved.json
+++ b/processor/otel/test_approved/span_jaeger_http.approved.json
@@ -87,7 +87,6 @@
                         "message": "no connection established"
                     }
                 ],
-                "grouping_key": "c9221918248f05433f6b81c46a666aee",
                 "log": {
                     "message": "retrying connection"
                 }
@@ -122,7 +121,6 @@
                 "version": "unknown"
             },
             "error": {
-                "grouping_key": "23b7ac1bdf1ca957f9f581cfadee467c",
                 "log": {
                     "message": "nullPointer exception"
                 }
@@ -161,8 +159,7 @@
                     {
                         "message": "no connection established"
                     }
-                ],
-                "grouping_key": "c9221918248f05433f6b81c46a666aee"
+                ]
             },
             "host": {
                 "hostname": "host-abc"
@@ -198,8 +195,7 @@
                     {
                         "message": "no connection established"
                     }
-                ],
-                "grouping_key": "c9221918248f05433f6b81c46a666aee"
+                ]
             },
             "host": {
                 "hostname": "host-abc"
@@ -235,8 +231,7 @@
                     {
                         "type": "DBClosedException"
                     }
-                ],
-                "grouping_key": "b0cf243ae3f66aa9e6bbed022417d274"
+                ]
             },
             "host": {
                 "hostname": "host-abc"
@@ -268,7 +263,6 @@
                 "version": "unknown"
             },
             "error": {
-                "grouping_key": "c9221918248f05433f6b81c46a666aee",
                 "log": {
                     "message": "no connection established"
                 }

--- a/processor/otel/test_approved/transaction_jaeger_full.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_full.approved.json
@@ -75,7 +75,6 @@
                         "message": "no connection established"
                     }
                 ],
-                "grouping_key": "c9221918248f05433f6b81c46a666aee",
                 "log": {
                     "message": "retrying connection"
                 }
@@ -131,7 +130,6 @@
                 "version": "unknown"
             },
             "error": {
-                "grouping_key": "23b7ac1bdf1ca957f9f581cfadee467c",
                 "log": {
                     "message": "nullPointer exception"
                 }
@@ -191,8 +189,7 @@
                     {
                         "message": "no connection established"
                     }
-                ],
-                "grouping_key": "c9221918248f05433f6b81c46a666aee"
+                ]
             },
             "host": {
                 "hostname": "host-abc"
@@ -249,8 +246,7 @@
                     {
                         "message": "no connection established"
                     }
-                ],
-                "grouping_key": "c9221918248f05433f6b81c46a666aee"
+                ]
             },
             "host": {
                 "hostname": "host-abc"
@@ -307,8 +303,7 @@
                     {
                         "type": "DBClosedException"
                     }
-                ],
-                "grouping_key": "b0cf243ae3f66aa9e6bbed022417d274"
+                ]
             },
             "host": {
                 "hostname": "host-abc"
@@ -361,7 +356,6 @@
                 "version": "unknown"
             },
             "error": {
-                "grouping_key": "c9221918248f05433f6b81c46a666aee",
                 "log": {
                     "message": "no connection established"
                 }

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationErrors.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationErrors.approved.json
@@ -139,7 +139,6 @@
                         "type": "ConnectionError"
                     }
                 ],
-                "grouping_key": "d72b25a26fde3f3aaad1c86950acd070",
                 "id": "0123456789012345",
                 "log": {
                     "level": "warning",
@@ -382,7 +381,6 @@
                 "id": "container-id"
             },
             "error": {
-                "grouping_key": "dc8dd667f7036ec5f0bae87bf2188243",
                 "id": "xFoaabb123FFFFFF",
                 "log": {
                     "message": "no user found",
@@ -495,7 +493,6 @@
                         "message": "Cannot read property 'baz' no defined"
                     }
                 ],
-                "grouping_key": "ae0232fed4cb40e7ebc62a585a421d60",
                 "id": "cdefab0123456789"
             },
             "host": {
@@ -599,7 +596,6 @@
                         "type": "DbError"
                     }
                 ],
-                "grouping_key": "c3868d6704b923014eaffea034e70a3d",
                 "id": "cdefab0123456780"
             },
             "host": {
@@ -704,7 +700,6 @@
                 "id": "container-id"
             },
             "error": {
-                "grouping_key": "d6b3f958dfea98dc9ed2b57d5f0c48bb",
                 "id": "abcdef0123456789",
                 "log": {
                     "level": "custom log level",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
@@ -89,7 +89,6 @@
                         "type": "ConnectionError"
                     }
                 ],
-                "grouping_key": "9a4054e958afe722b5877e8fac578ff3",
                 "id": "9876543210abcdeffedcba0123456789",
                 "log": {
                     "level": "error",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationMetadataNullValues.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationMetadataNullValues.approved.json
@@ -7,7 +7,6 @@
                 "version": "3.14.0"
             },
             "error": {
-                "grouping_key": "d6b3f958dfea98dc9ed2b57d5f0c48bb",
                 "id": "abcdef0123456789",
                 "log": {
                     "level": "custom log level",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationMinimalService.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationMinimalService.approved.json
@@ -7,7 +7,6 @@
                 "version": "3.14.0"
             },
             "error": {
-                "grouping_key": "d6b3f958dfea98dc9ed2b57d5f0c48bb",
                 "id": "abcdef0123456789",
                 "log": {
                     "level": "custom log level",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationRumErrors.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationRumErrors.approved.json
@@ -70,7 +70,6 @@
                         "type": "Error"
                     }
                 ],
-                "grouping_key": "52fbc9c2d1a61bf905b4a11c708006fd",
                 "id": "aba2688e033848ce9c4e4005f1caa534",
                 "log": {
                     "message": "Uncaught Error: log timeout test error",

--- a/processor/stream/test_approved_es_documents/testIntakeRUMV3Errors.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeRUMV3Errors.approved.json
@@ -42,7 +42,6 @@
                         "type": "Error"
                     }
                 ],
-                "grouping_key": "e5fa86c0df837d142aa0520eb2661d8d",
                 "id": "3661352868c17c78b773d2f1beae6d41",
                 "page": {
                     "referer": "http://localhost:8000/test/e2e/",

--- a/testdata/jaeger/batch_0.approved.json
+++ b/testdata/jaeger/batch_0.approved.json
@@ -61,7 +61,6 @@
                         "message": "redis timeout"
                     }
                 ],
-                "grouping_key": "dd09a7d0d9dde0adfcd694967c5a88de",
                 "log": {
                     "message": "Retrying GetDriver after error"
                 }
@@ -107,7 +106,6 @@
                         "message": "redis timeout"
                     }
                 ],
-                "grouping_key": "dd09a7d0d9dde0adfcd694967c5a88de",
                 "log": {
                     "message": "Retrying GetDriver after error"
                 }
@@ -153,7 +151,6 @@
                         "message": "redis timeout"
                     }
                 ],
-                "grouping_key": "dd09a7d0d9dde0adfcd694967c5a88de",
                 "log": {
                     "message": "Retrying GetDriver after error"
                 }

--- a/testdata/jaeger/batch_1.approved.json
+++ b/testdata/jaeger/batch_1.approved.json
@@ -103,7 +103,6 @@
                         "message": "redis timeout"
                     }
                 ],
-                "grouping_key": "dd09a7d0d9dde0adfcd694967c5a88de",
                 "log": {
                     "message": "redis timeout"
                 }
@@ -370,7 +369,6 @@
                         "message": "redis timeout"
                     }
                 ],
-                "grouping_key": "dd09a7d0d9dde0adfcd694967c5a88de",
                 "log": {
                     "message": "redis timeout"
                 }
@@ -637,7 +635,6 @@
                         "message": "redis timeout"
                     }
                 ],
-                "grouping_key": "dd09a7d0d9dde0adfcd694967c5a88de",
                 "log": {
                     "message": "redis timeout"
                 }


### PR DESCRIPTION
## Motivation/summary

Move error grouping key calculation out of model transformation into a model processor, so we can generate transformation code. "grouping_key" has disappeared from many of the test approval files, as they run without the model processors. Note that the system tests approvals have not changed.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

Non-functional change.

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
