### PR TITLE
[sourcemaps] Support multiple fleet addresses when requesting a sourcemap

### DIFF
--- a/sourcemap/es_store.go
+++ b/sourcemap/es_store.go
@@ -42,7 +42,7 @@ const (
 )
 
 var (
-	errMsgESFailure         = "failure querying ES"
+	errMsgESFailure         = errMsgFailure + " ES"
 	errSourcemapWrongFormat = errors.New("Sourcemapping ES Result not in expected format")
 )
 

--- a/sourcemap/fleet_store.go
+++ b/sourcemap/fleet_store.go
@@ -124,7 +124,7 @@ func (f fleetStore) fetch(ctx context.Context, name, version, path string) (stri
 		wg.Add(1)
 		go func(fleetURL string) {
 			defer wg.Done()
-			sourcemap, err := sendRequest(f, ctx, fleetURL)
+			sourcemap, err := sendRequest(ctx, f, fleetURL)
 			select {
 			case <-ctx.Done():
 			case results <- result{sourcemap, err}:
@@ -152,7 +152,7 @@ func (f fleetStore) fetch(ctx context.Context, name, version, path string) (stri
 	return "", ctx.Err()
 }
 
-func sendRequest(f fleetStore, ctx context.Context, fleetURL string) (string, error) {
+func sendRequest(ctx context.Context, f fleetStore, fleetURL string) (string, error) {
 	req, err := http.NewRequest(http.MethodGet, fleetURL, nil)
 	if err != nil {
 		return "", err

--- a/sourcemap/fleet_store.go
+++ b/sourcemap/fleet_store.go
@@ -148,6 +148,7 @@ func (f fleetStore) fetch(ctx context.Context, name, version, path string) (stri
 	if err != nil {
 		return "", err
 	}
+	// No results were received: context was cancelled.
 	return "", ctx.Err()
 }
 

--- a/sourcemap/fleet_store_test.go
+++ b/sourcemap/fleet_store_test.go
@@ -77,4 +77,106 @@ func TestFleetFetch(t *testing.T) {
 	assert.True(t, hasAuth)
 }
 
+func TestMultipleFleetHostsFetch(t *testing.T) {
+	var (
+		hasAuth       bool
+		apikey        = "supersecret"
+		name          = "webapp"
+		version       = "1.0.0"
+		path          = "/my/path/to/bundle.js.map"
+		c             = http.DefaultClient
+		sourceMapPath = "/api/fleet/artifact"
+	)
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, sourceMapPath, r.URL.Path)
+		auth := r.Header.Get("Authorization")
+		hasAuth = auth == "ApiKey "+apikey
+		// zlib compress
+		wr := zlib.NewWriter(w)
+		defer wr.Close()
+		wr.Write([]byte(resp))
+	})
+
+	ts0 := httptest.NewServer(h)
+	defer ts0.Close()
+
+	ts1 := httptest.NewServer(h)
+	defer ts1.Close()
+
+	fleetCfg := &config.Fleet{
+		Hosts:        []string{ts0.URL[7:], ts1.URL[7:]},
+		Protocol:     "http",
+		AccessAPIKey: apikey,
+		TLS:          nil,
+	}
+
+	cfgs := []config.SourceMapMetadata{
+		{
+			ServiceName:    name,
+			ServiceVersion: version,
+			BundleFilepath: path,
+			SourceMapURL:   sourceMapPath,
+		},
+	}
+	f, err := newFleetStore(c, fleetCfg, cfgs)
+	assert.NoError(t, err)
+
+	gotRes, err := f.fetch(context.Background(), name, version, path)
+	require.NoError(t, err)
+
+	assert.Contains(t, gotRes, "webpack:///bundle.js")
+	assert.True(t, hasAuth)
+}
+
+func TestMultipleFleetHostsQueryFailureFetch(t *testing.T) {
+	var (
+		apikey        = "supersecret"
+		name          = "webapp"
+		version       = "1.0.0"
+		path          = "/my/path/to/bundle.js.map"
+		c             = http.DefaultClient
+		sourceMapPath = "/api/fleet/artifact"
+		requestCount  = 0
+	)
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "err", http.StatusInternalServerError)
+		requestCount++
+	})
+
+	ts0 := httptest.NewServer(h)
+	defer ts0.Close()
+
+	ts1 := httptest.NewServer(h)
+	defer ts1.Close()
+
+	ts2 := httptest.NewServer(h)
+	defer ts2.Close()
+
+	fleetCfg := &config.Fleet{
+		Hosts:        []string{ts0.URL[7:], ts1.URL[7:], ts2.URL[7:]},
+		Protocol:     "http",
+		AccessAPIKey: apikey,
+		TLS:          nil,
+	}
+
+	cfgs := []config.SourceMapMetadata{
+		{
+			ServiceName:    name,
+			ServiceVersion: version,
+			BundleFilepath: path,
+			SourceMapURL:   sourceMapPath,
+		},
+	}
+	f, err := newFleetStore(c, fleetCfg, cfgs)
+	assert.NoError(t, err)
+
+	resp, err := f.fetch(context.Background(), name, version, path)
+	assert.Equal(t, len(fleetCfg.Hosts), requestCount)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), errMsgFleetFailure)
+	assert.Equal(t, "", resp)
+}
+
 var resp = "{\"serviceName\":\"web-app\",\"serviceVersion\":\"1.0.0\",\"bundleFilepath\":\"/test/e2e/general-usecase/bundle.js.map\",\"sourceMap\":{\"version\":3,\"sources\":[\"webpack:///bundle.js\",\"\",\"webpack:///./scripts/index.js\",\"webpack:///./index.html\",\"webpack:///./scripts/app.js\"],\"names\":[\"modules\",\"__webpack_require__\",\"moduleId\",\"installedModules\",\"exports\",\"module\",\"id\",\"loaded\",\"call\",\"m\",\"c\",\"p\",\"foo\",\"console\",\"log\",\"foobar\"],\"mappings\":\"CAAS,SAAUA,GCInB,QAAAC,GAAAC,GAGA,GAAAC,EAAAD,GACA,MAAAC,GAAAD,GAAAE,OAGA,IAAAC,GAAAF,EAAAD,IACAE,WACAE,GAAAJ,EACAK,QAAA,EAUA,OANAP,GAAAE,GAAAM,KAAAH,EAAAD,QAAAC,IAAAD,QAAAH,GAGAI,EAAAE,QAAA,EAGAF,EAAAD,QAvBA,GAAAD,KAqCA,OATAF,GAAAQ,EAAAT,EAGAC,EAAAS,EAAAP,EAGAF,EAAAU,EAAA,GAGAV,EAAA,KDMM,SAASI,EAAQD,EAASH,GE3ChCA,EAAA,GAEAA,EAAA,GAEAW,OFmDM,SAASP,EAAQD,EAASH,GGxDhCI,EAAAD,QAAAH,EAAAU,EAAA,cH8DM,SAASN,EAAQD,GI9DvB,QAAAQ,KACAC,QAAAC,IAAAC,QAGAH\",\"file\":\"bundle.js\",\"sourcesContent\":[\"/******/ (function(modules) { // webpackBootstrap\\n/******/ \\t// The module cache\\n/******/ \\tvar installedModules = {};\\n/******/\\n/******/ \\t// The require function\\n/******/ \\tfunction __webpack_require__(moduleId) {\\n/******/\\n/******/ \\t\\t// Check if module is in cache\\n/******/ \\t\\tif(installedModules[moduleId])\\n/******/ \\t\\t\\treturn installedModules[moduleId].exports;\\n/******/\\n/******/ \\t\\t// Create a new module (and put it into the cache)\\n/******/ \\t\\tvar module = installedModules[moduleId] = {\\n/******/ \\t\\t\\texports: {},\\n/******/ \\t\\t\\tid: moduleId,\\n/******/ \\t\\t\\tloaded: false\\n/******/ \\t\\t};\\n/******/\\n/******/ \\t\\t// Execute the module function\\n/******/ \\t\\tmodules[moduleId].call(module.exports, module, module.exports, __webpack_require__);\\n/******/\\n/******/ \\t\\t// Flag the module as loaded\\n/******/ \\t\\tmodule.loaded = true;\\n/******/\\n/******/ \\t\\t// Return the exports of the module\\n/******/ \\t\\treturn module.exports;\\n/******/ \\t}\\n/******/\\n/******/\\n/******/ \\t// expose the modules object (__webpack_modules__)\\n/******/ \\t__webpack_require__.m = modules;\\n/******/\\n/******/ \\t// expose the module cache\\n/******/ \\t__webpack_require__.c = installedModules;\\n/******/\\n/******/ \\t// __webpack_public_path__\\n/******/ \\t__webpack_require__.p = \\\"\\\";\\n/******/\\n/******/ \\t// Load entry module and return exports\\n/******/ \\treturn __webpack_require__(0);\\n/******/ })\\n/************************************************************************/\\n/******/ ([\\n/* 0 */\\n/***/ function(module, exports, __webpack_require__) {\\n\\n\\t// Webpack\\n\\t__webpack_require__(1)\\n\\t\\n\\t__webpack_require__(2)\\n\\t\\n\\tfoo()\\n\\n\\n/***/ },\\n/* 1 */\\n/***/ function(module, exports, __webpack_require__) {\\n\\n\\tmodule.exports = __webpack_require__.p + \\\"index.html\\\"\\n\\n/***/ },\\n/* 2 */\\n/***/ function(module, exports) {\\n\\n\\tfunction foo() {\\n\\t    console.log(foobar)\\n\\t}\\n\\t\\n\\tfoo()\\n\\n\\n/***/ }\\n/******/ ]);\\n\\n\\n/** WEBPACK FOOTER **\\n ** bundle.js\\n **/\",\" \\t// The module cache\\n \\tvar installedModules = {};\\n\\n \\t// The require function\\n \\tfunction __webpack_require__(moduleId) {\\n\\n \\t\\t// Check if module is in cache\\n \\t\\tif(installedModules[moduleId])\\n \\t\\t\\treturn installedModules[moduleId].exports;\\n\\n \\t\\t// Create a new module (and put it into the cache)\\n \\t\\tvar module = installedModules[moduleId] = {\\n \\t\\t\\texports: {},\\n \\t\\t\\tid: moduleId,\\n \\t\\t\\tloaded: false\\n \\t\\t};\\n\\n \\t\\t// Execute the module function\\n \\t\\tmodules[moduleId].call(module.exports, module, module.exports, __webpack_require__);\\n\\n \\t\\t// Flag the module as loaded\\n \\t\\tmodule.loaded = true;\\n\\n \\t\\t// Return the exports of the module\\n \\t\\treturn module.exports;\\n \\t}\\n\\n\\n \\t// expose the modules object (__webpack_modules__)\\n \\t__webpack_require__.m = modules;\\n\\n \\t// expose the module cache\\n \\t__webpack_require__.c = installedModules;\\n\\n \\t// __webpack_public_path__\\n \\t__webpack_require__.p = \\\"\\\";\\n\\n \\t// Load entry module and return exports\\n \\treturn __webpack_require__(0);\\n\\n\\n\\n/** WEBPACK FOOTER **\\n ** webpack/bootstrap 6002740481c9666b0d38\\n **/\",\"// Webpack\\nrequire('../index.html')\\n\\nrequire('./app')\\n\\nfoo()\\n\\n\\n\\n/*****************\\n ** WEBPACK FOOTER\\n ** ./scripts/index.js\\n ** module id = 0\\n ** module chunks = 0\\n **/\",\"module.exports = __webpack_public_path__ + \\\"index.html\\\"\\n\\n\\n/*****************\\n ** WEBPACK FOOTER\\n ** ./index.html\\n ** module id = 1\\n ** module chunks = 0\\n **/\",\"function foo() {\\n    console.log(foobar)\\n}\\n\\nfoo()\\n\\n\\n\\n/*****************\\n ** WEBPACK FOOTER\\n ** ./scripts/app.js\\n ** module id = 2\\n ** module chunks = 0\\n **/\"],\"sourceRoot\":\"\"}}"

--- a/sourcemap/fleet_store_test.go
+++ b/sourcemap/fleet_store_test.go
@@ -89,7 +89,6 @@ func TestFleetFetch(t *testing.T) {
 
 func TestFailedAndSuccessfulFleetHostsFetch(t *testing.T) {
 	var (
-		called        int32
 		apikey        = "supersecret"
 		name          = "webapp"
 		version       = "1.0.0"
@@ -99,13 +98,11 @@ func TestFailedAndSuccessfulFleetHostsFetch(t *testing.T) {
 	)
 
 	hError := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&called, 1)
 		http.Error(w, "err", http.StatusInternalServerError)
 	})
 	ts0 := httptest.NewServer(hError)
 
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&called, 1)
 		wr := zlib.NewWriter(w)
 		defer wr.Close()
 		wr.Write([]byte(resp))

--- a/sourcemap/store.go
+++ b/sourcemap/store.go
@@ -36,7 +36,8 @@ const (
 )
 
 var (
-	errInit = errors.New("Cache cannot be initialized. Expiration and CleanupInterval need to be >= 0")
+	errMsgFailure = "failure querying"
+	errInit       = errors.New("Cache cannot be initialized. Expiration and CleanupInterval need to be >= 0")
 )
 
 // Store holds information necessary to fetch a sourcemap, either from an
@@ -114,10 +115,10 @@ func (s *Store) Fetch(ctx context.Context, name, version, path string) (*sourcem
 		s.mu.Unlock()
 	}()
 
-	// fetch from Elasticsearch and ensure caching for all non-temporary results
+	// fetch from the store and ensure caching for all non-temporary results
 	sourcemapStr, err := s.backend.fetch(ctx, name, version, path)
 	if err != nil {
-		if !strings.Contains(err.Error(), "failure querying") {
+		if !strings.Contains(err.Error(), errMsgFailure) {
 			s.add(key, nil)
 		}
 		return nil, err


### PR DESCRIPTION
These changes support fetching sourcemaps from one of many fleet servers. It sends the request to all the fleet servers in parallel and returns the first successful response.

I've made some adjustments to the `fleetStore` struct to keep a map of the `(service.name, service.version, bundle.filepath)` combinations to the `sourcemap.url`. I've also added a separate slice to store the list of base fleet server addresses, which represent the configured protocol with the host and port of a given fleet server.

The full url is constructed when the sourcemap is fetched using a base fleet server url and the sourcemap url (path).

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

Closes #5514 

## How to test these changes

Taking the test plan from https://github.com/elastic/apm-server/pull/5410:

Run elasticsearch and multiple elastic-agents in fleet mode. 2 or 3 should be sufficient for this test.

Start kibana and apm-server with the fleet-server sourcemap code.

- Upload a sourcemap via kibana
- Confirm an updated config with the new source_maps block has been pushed to apm-server
- Confirm ingesting rum traces for the uploaded sourcemap get mapped appropriately
