### PR TITLE
[7.x] Document data streams migration limitations (#5771)

### DIFF
--- a/docs/apm-package/apm-integration.asciidoc
+++ b/docs/apm-package/apm-integration.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>APM integration ({agent})</titleabbrev>
 ++++
 
-experimental::[]
+beta::[]
 
 {agent} is a single, unified way to add monitoring for logs, metrics, and other types of data to each host.
 The APM integration for {agent} assigns the APM input to a specified policy,
@@ -33,7 +33,16 @@ download and enroll an {agent} on the same machines that your instrumented servi
 [[apm-integration-limitations]]
 === Limitations
 
-The APM integration has the following limitations:
+IMPORTANT: This integration is still in beta and does not have feature parity with standalone APM.
+Do not migrate production deployments.
+
+Data steams migration::
+Existing APM users will need to migrate to data streams to use the APM integration.
+This change cannot be reverted, and impacts how APM Server and its indices are configured -- see <<apm-integration-naming-scheme>> and <<apm-integration-configure>>.
+Additionally, users on {ece} require additional steps prior to migrating, like configuring TLS certificates for the connection between APM Server and {es}.
+
+Stack monitoring::
+<<monitoring,Stack monitoring>> is not yet available.
 
 Index lifecycle management (ILM)::
 A default ILM policy, named `traces-apm.traces-default_policy` is created for all event types.

--- a/docs/apm-package/configure.asciidoc
+++ b/docs/apm-package/configure.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Configure</titleabbrev>
 ++++
 
-experimental::[]
+beta::[]
 
 Templates, pipelines, index lifecycle management, etc.,
 cannot be configured with APM Server or Fleet, and must instead be configured in {kib} or with

--- a/docs/apm-package/data-streams.asciidoc
+++ b/docs/apm-package/data-streams.asciidoc
@@ -1,7 +1,24 @@
 [[apm-integration-data-streams]]
 == Data streams
 
-experimental::[]
+****
+beta::[]
+
+Existing APM users need to migrate to data streams to use the APM integration.
+The integration does not have feature parity with standalone APM.
+Production deployments should not be migrated at this time.
+
+Migration limitations include:
+
+* This change cannot be reverted
+* This change impacts how APM Server and its indices are configured -- see <<apm-integration-naming-scheme>> and <<apm-integration-configure>>
+* Users on {ece} require additional steps prior to migrating, like configuring TLS certificates for the connection between APM Server and {es}
+* Additional <<apm-integration-limitations,APM integration limitations>>
+****
+
+[discrete]
+[[apm-integration-naming-scheme]]
+=== Data stream naming scheme
 
 {agent} uses data streams to store append-only time series data across multiple indices
 while giving users a single named resource for requests.

--- a/docs/apm-package/input-apm.asciidoc
+++ b/docs/apm-package/input-apm.asciidoc
@@ -7,7 +7,7 @@
 <titleabbrev>Input settings</titleabbrev>
 ++++
 
-experimental::[]
+beta::[]
 
 To edit the APM integration input settings, open {kib} and select:
 **Fleet** / **Integrations** / **Elastic APM** / **Add Elastic APM**.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Document data streams migration limitations (#5771)