### PR TITLE
sammpling: refactor to read/write model.APMEvents

### DIFF
--- a/x-pack/apm-server/sampling/eventstorage/codec.go
+++ b/x-pack/apm-server/sampling/eventstorage/codec.go
@@ -1,5 +1,0 @@
-// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
-
-package eventstorage

--- a/x-pack/apm-server/sampling/eventstorage/jsoncodec.go
+++ b/x-pack/apm-server/sampling/eventstorage/jsoncodec.go
@@ -17,22 +17,12 @@ import (
 // JSONCodec is an implementation of Codec, using JSON encoding.
 type JSONCodec struct{}
 
-// DecodeSpan decodes data as JSON into span.
-func (JSONCodec) DecodeSpan(data []byte, span *model.Span) error {
-	return jsoniter.ConfigFastest.Unmarshal(data, span)
+// DecodeEvent decodes data as JSON into event.
+func (JSONCodec) DecodeEvent(data []byte, event *model.APMEvent) error {
+	return jsoniter.ConfigFastest.Unmarshal(data, event)
 }
 
-// DecodeTransaction decodes data as JSON into tx.
-func (JSONCodec) DecodeTransaction(data []byte, tx *model.Transaction) error {
-	return jsoniter.ConfigFastest.Unmarshal(data, tx)
-}
-
-// EncodeSpan encodes span as JSON.
-func (JSONCodec) EncodeSpan(span *model.Span) ([]byte, error) {
-	return json.Marshal(span)
-}
-
-// EncodeTransaction encodes tx as JSON.
-func (JSONCodec) EncodeTransaction(tx *model.Transaction) ([]byte, error) {
-	return json.Marshal(tx)
+// EncodeEvent encodes event as JSON.
+func (JSONCodec) EncodeEvent(event *model.APMEvent) ([]byte, error) {
+	return json.Marshal(event)
 }

--- a/x-pack/apm-server/sampling/eventstorage/sharded.go
+++ b/x-pack/apm-server/sampling/eventstorage/sharded.go
@@ -51,19 +51,14 @@ func (s *ShardedReadWriter) Flush() error {
 	return result
 }
 
-// ReadEvents calls Writer.ReadEvents, using a sharded, locked, Writer.
-func (s *ShardedReadWriter) ReadEvents(traceID string, out *model.Batch) error {
-	return s.getWriter(traceID).ReadEvents(traceID, out)
+// ReadTraceEvents calls Writer.ReadTraceEvents, using a sharded, locked, Writer.
+func (s *ShardedReadWriter) ReadTraceEvents(traceID string, out *model.Batch) error {
+	return s.getWriter(traceID).ReadTraceEvents(traceID, out)
 }
 
-// WriteTransaction calls Writer.WriteTransaction, using a sharded, locked, Writer.
-func (s *ShardedReadWriter) WriteTransaction(tx *model.Transaction) error {
-	return s.getWriter(tx.TraceID).WriteTransaction(tx)
-}
-
-// WriteSpan calls Writer.WriteSpan, using a sharded, locked, Writer.
-func (s *ShardedReadWriter) WriteSpan(span *model.Span) error {
-	return s.getWriter(span.TraceID).WriteSpan(span)
+// WriteTraceEvent calls Writer.WriteTraceEvent, using a sharded, locked, Writer.
+func (s *ShardedReadWriter) WriteTraceEvent(traceID, id string, event *model.APMEvent) error {
+	return s.getWriter(traceID).WriteTraceEvent(traceID, id, event)
 }
 
 // WriteTraceSampled calls Writer.WriteTraceSampled, using a sharded, locked, Writer.
@@ -76,14 +71,9 @@ func (s *ShardedReadWriter) IsTraceSampled(traceID string) (bool, error) {
 	return s.getWriter(traceID).IsTraceSampled(traceID)
 }
 
-// DeleteTransaction calls Writer.DeleteTransaction, using a sharded, locked, Writer.
-func (s *ShardedReadWriter) DeleteTransaction(tx *model.Transaction) error {
-	return s.getWriter(tx.TraceID).DeleteTransaction(tx)
-}
-
-// DeleteSpan calls Writer.DeleteSpan, using a sharded, locked, Writer.
-func (s *ShardedReadWriter) DeleteSpan(span *model.Span) error {
-	return s.getWriter(span.TraceID).DeleteSpan(span)
+// DeleteTraceEvent calls Writer.DeleteTraceEvent, using a sharded, locked, Writer.
+func (s *ShardedReadWriter) DeleteTraceEvent(traceID, id string) error {
+	return s.getWriter(traceID).DeleteTraceEvent(traceID, id)
 }
 
 // getWriter returns an event storage writer for the given trace ID.
@@ -114,22 +104,16 @@ func (rw *lockedReadWriter) Flush() error {
 	return rw.rw.Flush()
 }
 
-func (rw *lockedReadWriter) ReadEvents(traceID string, out *model.Batch) error {
+func (rw *lockedReadWriter) ReadTraceEvents(traceID string, out *model.Batch) error {
 	rw.mu.Lock()
 	defer rw.mu.Unlock()
-	return rw.rw.ReadEvents(traceID, out)
+	return rw.rw.ReadTraceEvents(traceID, out)
 }
 
-func (rw *lockedReadWriter) WriteTransaction(tx *model.Transaction) error {
+func (rw *lockedReadWriter) WriteTraceEvent(traceID, id string, event *model.APMEvent) error {
 	rw.mu.Lock()
 	defer rw.mu.Unlock()
-	return rw.rw.WriteTransaction(tx)
-}
-
-func (rw *lockedReadWriter) WriteSpan(s *model.Span) error {
-	rw.mu.Lock()
-	defer rw.mu.Unlock()
-	return rw.rw.WriteSpan(s)
+	return rw.rw.WriteTraceEvent(traceID, id, event)
 }
 
 func (rw *lockedReadWriter) WriteTraceSampled(traceID string, sampled bool) error {
@@ -144,14 +128,8 @@ func (rw *lockedReadWriter) IsTraceSampled(traceID string) (bool, error) {
 	return rw.rw.IsTraceSampled(traceID)
 }
 
-func (rw *lockedReadWriter) DeleteTransaction(tx *model.Transaction) error {
+func (rw *lockedReadWriter) DeleteTraceEvent(traceID, id string) error {
 	rw.mu.Lock()
 	defer rw.mu.Unlock()
-	return rw.rw.DeleteTransaction(tx)
-}
-
-func (rw *lockedReadWriter) DeleteSpan(span *model.Span) error {
-	rw.mu.Lock()
-	defer rw.mu.Unlock()
-	return rw.rw.DeleteSpan(span)
+	return rw.rw.DeleteTraceEvent(traceID, id)
 }

--- a/x-pack/apm-server/sampling/processor.go
+++ b/x-pack/apm-server/sampling/processor.go
@@ -154,19 +154,19 @@ func (p *Processor) ProcessBatch(ctx context.Context, batch *model.Batch) error 
 	}
 	events := *batch
 	for i := 0; i < len(events); i++ {
-		event := events[i]
+		event := &events[i]
 		var report, stored bool
 		if event.Transaction != nil {
 			var err error
 			atomic.AddInt64(&p.eventMetrics.processed, 1)
-			report, stored, err = p.processTransaction(event.Transaction)
+			report, stored, err = p.processTransaction(event)
 			if err != nil {
 				return err
 			}
 		} else if event.Span != nil {
 			var err error
 			atomic.AddInt64(&p.eventMetrics.processed, 1)
-			report, stored, err = p.processSpan(event.Span)
+			report, stored, err = p.processSpan(event)
 			if err != nil {
 				return err
 			}
@@ -201,14 +201,14 @@ func (p *Processor) updateProcessorMetrics(report, stored bool) {
 	}
 }
 
-func (p *Processor) processTransaction(tx *model.Transaction) (report, stored bool, _ error) {
-	if !tx.Sampled {
+func (p *Processor) processTransaction(event *model.APMEvent) (report, stored bool, _ error) {
+	if !event.Transaction.Sampled {
 		// (Head-based) unsampled transactions are passed through
 		// by the tail sampler.
 		return true, false, nil
 	}
 
-	traceSampled, err := p.storage.IsTraceSampled(tx.TraceID)
+	traceSampled, err := p.storage.IsTraceSampled(event.Transaction.TraceID)
 	switch err {
 	case nil:
 		// Tail-sampling decision has been made: report the transaction
@@ -222,14 +222,16 @@ func (p *Processor) processTransaction(tx *model.Transaction) (report, stored bo
 		return false, false, err
 	}
 
-	if tx.ParentID != "" {
+	if event.Transaction.ParentID != "" {
 		// Non-root transaction: write to local storage while we wait
 		// for a sampling decision.
-		return false, true, p.storage.WriteTransaction(tx)
+		return false, true, p.storage.WriteTraceEvent(
+			event.Transaction.TraceID, event.Transaction.ID, event,
+		)
 	}
 
 	// Root transaction: apply reservoir sampling.
-	reservoirSampled, err := p.groups.sampleTrace(tx)
+	reservoirSampled, err := p.groups.sampleTrace(event.Transaction)
 	if err == errTooManyTraceGroups {
 		// Too many trace groups, drop the transaction.
 		p.tooManyGroupsLogger.Warn(`
@@ -249,21 +251,25 @@ sampling policies without service name specified.
 		// This is a local optimisation only. To avoid creating network
 		// traffic and load on Elasticsearch for uninteresting root
 		// transactions, we do not propagate this to other APM Servers.
-		return false, false, p.storage.WriteTraceSampled(tx.TraceID, false)
+		return false, false, p.storage.WriteTraceSampled(event.Transaction.TraceID, false)
 	}
 
 	// The root transaction was admitted to the sampling reservoir, so we
 	// can proceed to write the transaction to storage; we may index it later,
 	// after finalising the sampling decision.
-	return false, true, p.storage.WriteTransaction(tx)
+	return false, true, p.storage.WriteTraceEvent(
+		event.Transaction.TraceID, event.Transaction.ID, event,
+	)
 }
 
-func (p *Processor) processSpan(span *model.Span) (report, stored bool, _ error) {
-	traceSampled, err := p.storage.IsTraceSampled(span.TraceID)
+func (p *Processor) processSpan(event *model.APMEvent) (report, stored bool, _ error) {
+	traceSampled, err := p.storage.IsTraceSampled(event.Span.TraceID)
 	if err != nil {
 		if err == eventstorage.ErrNotFound {
-			// Tail-sampling decision has not yet been made, write span to local storage.
-			return false, true, p.storage.WriteSpan(span)
+			// Tail-sampling decision has not yet been made, write event to local storage.
+			return false, true, p.storage.WriteTraceEvent(
+				event.Span.TraceID, event.Span.ID, event,
+			)
 		}
 		return false, false, err
 	}
@@ -445,7 +451,7 @@ func (p *Processor) Run() error {
 				return err
 			}
 			var events model.Batch
-			if err := p.storage.ReadEvents(traceID, &events); err != nil {
+			if err := p.storage.ReadTraceEvents(traceID, &events); err != nil {
 				return err
 			}
 			if n := len(events); n > 0 {
@@ -459,11 +465,11 @@ func (p *Processor) Run() error {
 					// at-most-once, not guaranteed.
 					for _, event := range events {
 						if event.Transaction != nil {
-							if err := p.storage.DeleteTransaction(event.Transaction); err != nil {
+							if err := p.storage.DeleteTraceEvent(event.Transaction.TraceID, event.Transaction.ID); err != nil {
 								return errors.Wrap(err, "failed to delete transaction from local storage")
 							}
 						} else if event.Span != nil {
-							if err := p.storage.DeleteSpan(event.Span); err != nil {
+							if err := p.storage.DeleteTraceEvent(event.Span.TraceID, event.Span.ID); err != nil {
 								return errors.Wrap(err, "failed to delete span from local storage")
 							}
 						}

--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -127,11 +127,11 @@ func TestProcessAlreadyTailSampled(t *testing.T) {
 		defer reader.Close()
 
 		var batch model.Batch
-		err := reader.ReadEvents(traceID1, &batch)
+		err := reader.ReadTraceEvents(traceID1, &batch)
 		assert.NoError(t, err)
 		assert.Zero(t, batch)
 
-		err = reader.ReadEvents(traceID2, &batch)
+		err = reader.ReadTraceEvents(traceID2, &batch)
 		assert.NoError(t, err)
 		assert.Equal(t, model.Batch{
 			{Transaction: transaction2},
@@ -238,7 +238,7 @@ func TestProcessLocalTailSampling(t *testing.T) {
 		assert.False(t, sampled)
 
 		var batch model.Batch
-		err = reader.ReadEvents(sampledTraceID, &batch)
+		err = reader.ReadTraceEvents(sampledTraceID, &batch)
 		assert.NoError(t, err)
 		assert.Equal(t, sampledTraceEvents, batch)
 
@@ -246,7 +246,7 @@ func TestProcessLocalTailSampling(t *testing.T) {
 		// available in storage until the TTL expires, as they're
 		// written there first.
 		batch = batch[:0]
-		err = reader.ReadEvents(unsampledTraceID, &batch)
+		err = reader.ReadTraceEvents(unsampledTraceID, &batch)
 		assert.NoError(t, err)
 		assert.Equal(t, unsampledTraceEvents, batch)
 	})
@@ -454,12 +454,12 @@ func TestProcessRemoteTailSampling(t *testing.T) {
 		assert.True(t, sampled)
 
 		var batch model.Batch
-		err = reader.ReadEvents(traceID1, &batch)
+		err = reader.ReadTraceEvents(traceID1, &batch)
 		assert.NoError(t, err)
 		assert.Zero(t, batch) // events are deleted from local storage
 
 		batch = model.Batch{}
-		err = reader.ReadEvents(traceID2, &batch)
+		err = reader.ReadTraceEvents(traceID2, &batch)
 		assert.NoError(t, err)
 		assert.Empty(t, batch)
 	})


### PR DESCRIPTION
## Motivation/summary

Update the tail-based sampling package to read and write model.APMEvents, rather than model.Transactions and model.Spans.
This is in preparation for moving "metadata" up to APMEvent.

There is a breaking change to the tail-based sampling event storage: the "meta" byte used for identifying trace events is 'e', where we previously used 'T' for transactions and 'S' for spans. This feature is not yet GA, is not yet documented, and there will be further breaking changes; hence it is not highlighted in the changelog.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

#4120