### PR TITLE
model/modeldecoder: decode events into model.Batch

### DIFF
--- a/beater/api/intake/handler.go
+++ b/beater/api/intake/handler.go
@@ -56,7 +56,7 @@ var (
 type StreamHandler interface {
 	HandleStream(
 		ctx context.Context,
-		meta *model.Metadata,
+		meta model.Metadata,
 		stream io.Reader,
 		batchSize int,
 		processor model.BatchProcessor,
@@ -87,7 +87,7 @@ func Handler(handler StreamHandler, requestMetadataFunc RequestMetadataFunc, bat
 		var result stream.Result
 		if err := handler.HandleStream(
 			c.Request.Context(),
-			&metadata,
+			metadata,
 			reader,
 			batchSize,
 			batchProcessor,

--- a/model/modeldecoder/rumv3/decoder.go
+++ b/model/modeldecoder/rumv3/decoder.go
@@ -92,9 +92,7 @@ func releaseTransactionRoot(m *transactionRoot) {
 	transactionRootPool.Put(m)
 }
 
-// DecodeNestedMetadata uses the given decoder to create the input models,
-// then runs the defined validations on the input models
-// and finally maps the values fom the input model to the given *model.Metadata instance
+// DecodeNestedMetadata decodes metadata from d, updating out.
 func DecodeNestedMetadata(d decoder.Decoder, out *model.Metadata) error {
 	root := fetchMetadataRoot()
 	defer releaseMetadataRoot(root)
@@ -108,12 +106,10 @@ func DecodeNestedMetadata(d decoder.Decoder, out *model.Metadata) error {
 	return nil
 }
 
-// DecodeNestedError uses the given decoder to create the input model,
-// then runs the defined validations on the input model
-// and finally maps the values fom the input model to the given *model.Error instance
+// DecodeNestedError decodes an error from d, appending it to batch.
 //
 // DecodeNestedError should be used when the stream in the decoder contains the `error` key
-func DecodeNestedError(d decoder.Decoder, input *modeldecoder.Input, out *model.Error) error {
+func DecodeNestedError(d decoder.Decoder, input *modeldecoder.Input, batch *model.Batch) error {
 	root := fetchErrorRoot()
 	defer releaseErrorRoot(root)
 	if err := d.Decode(root); err != nil && err != io.EOF {
@@ -122,16 +118,16 @@ func DecodeNestedError(d decoder.Decoder, input *modeldecoder.Input, out *model.
 	if err := root.validate(); err != nil {
 		return modeldecoder.NewValidationErr(err)
 	}
-	mapToErrorModel(&root.Error, &input.Metadata, input.RequestTime, out)
+	var event model.APMEvent
+	mapToErrorModel(&root.Error, input.Metadata, input.RequestTime, &event)
+	*batch = append(*batch, event)
 	return nil
 }
 
-// DecodeNestedMetricset uses the given decoder to create the input model,
-// then runs the defined validations on the input model
-// and finally maps the values fom the input model to the given *model.Metricset instance
+// DecodeNestedMetricset decodes a metricset from d, appending it to batch.
 //
 // DecodeNestedMetricset should be used when the stream in the decoder contains the `metricset` key
-func DecodeNestedMetricset(d decoder.Decoder, input *modeldecoder.Input, out *model.Metricset) error {
+func DecodeNestedMetricset(d decoder.Decoder, input *modeldecoder.Input, batch *model.Batch) error {
 	root := fetchMetricsetRoot()
 	defer releaseMetricsetRoot(root)
 	if err := d.Decode(root); err != nil && err != io.EOF {
@@ -140,24 +136,17 @@ func DecodeNestedMetricset(d decoder.Decoder, input *modeldecoder.Input, out *mo
 	if err := root.validate(); err != nil {
 		return modeldecoder.NewValidationErr(err)
 	}
-	mapToMetricsetModel(&root.Metricset, &input.Metadata, input.RequestTime, out)
+	var event model.APMEvent
+	mapToMetricsetModel(&root.Metricset, input.Metadata, input.RequestTime, &event)
+	*batch = append(*batch, event)
 	return nil
 }
 
-// Transaction is a wrapper around input models that can be nested inside a
-// RUM v3 transaction
-type Transaction struct {
-	Transaction model.Transaction
-	Metricsets  []*model.Metricset
-	Spans       []*model.Span
-}
-
-// DecodeNestedTransaction uses the given decoder to create the input model,
-// then runs the defined validations on the input model
-// and finally maps the values fom the input model to the given *model.Transaction instance
+// DecodeNestedTransaction a transaction and zero or more nested spans and
+// metricsets, appending them to batch.
 //
 // DecodeNestedTransaction should be used when the decoder contains the `transaction` key
-func DecodeNestedTransaction(d decoder.Decoder, input *modeldecoder.Input, out *Transaction) error {
+func DecodeNestedTransaction(d decoder.Decoder, input *modeldecoder.Input, batch *model.Batch) error {
 	root := fetchTransactionRoot()
 	defer releaseTransactionRoot(root)
 	if err := d.Decode(root); err != nil && err != io.EOF {
@@ -166,43 +155,47 @@ func DecodeNestedTransaction(d decoder.Decoder, input *modeldecoder.Input, out *
 	if err := root.validate(); err != nil {
 		return modeldecoder.NewValidationErr(err)
 	}
-	mapToTransactionModel(&root.Transaction, &input.Metadata, input.RequestTime, &out.Transaction)
+
+	var transaction model.APMEvent
+	mapToTransactionModel(&root.Transaction, input.Metadata, input.RequestTime, &transaction)
+	*batch = append(*batch, transaction)
+
 	for _, m := range root.Transaction.Metricsets {
-		var outM model.Metricset
-		mapToMetricsetModel(&m, &input.Metadata, input.RequestTime, &outM)
-		outM.Transaction.Name = out.Transaction.Name
-		outM.Transaction.Type = out.Transaction.Type
-		out.Metricsets = append(out.Metricsets, &outM)
+		var metricset model.APMEvent
+		mapToMetricsetModel(&m, input.Metadata, input.RequestTime, &metricset)
+		metricset.Metricset.Transaction.Name = transaction.Transaction.Name
+		metricset.Metricset.Transaction.Type = transaction.Transaction.Type
+		*batch = append(*batch, metricset)
 	}
-	out.Spans = make([]*model.Span, len(root.Transaction.Spans))
-	for idx, s := range root.Transaction.Spans {
-		var outS model.Span
-		mapToSpanModel(&s, &input.Metadata, input.RequestTime, &outS)
-		outS.TransactionID = out.Transaction.ID
-		outS.TraceID = out.Transaction.TraceID
-		if s.ParentIndex.IsSet() && s.ParentIndex.Val >= 0 && s.ParentIndex.Val < idx {
-			outS.ParentID = out.Spans[s.ParentIndex.Val].ID
+
+	offset := len(*batch)
+	for _, s := range root.Transaction.Spans {
+		var span model.APMEvent
+		mapToSpanModel(&s, input.Metadata, input.RequestTime, &span)
+		span.Span.TransactionID = transaction.Transaction.ID
+		span.Span.TraceID = transaction.Transaction.TraceID
+		*batch = append(*batch, span)
+	}
+	spans := (*batch)[offset:]
+	for i, s := range root.Transaction.Spans {
+		if s.ParentIndex.IsSet() && s.ParentIndex.Val >= 0 && s.ParentIndex.Val < len(spans) {
+			spans[i].Span.ParentID = spans[s.ParentIndex.Val].Span.ID
 		} else {
-			outS.ParentID = out.Transaction.ID
+			spans[i].Span.ParentID = spans[i].Span.TransactionID
 		}
-		out.Spans[idx] = &outS
 	}
 	return nil
 }
 
-func mapToErrorModel(from *errorEvent, metadata *model.Metadata, reqTime time.Time, out *model.Error) {
-	// set metadata information
-	if metadata != nil {
-		out.Metadata = *metadata
-	}
-	if from == nil {
-		return
-	}
+func mapToErrorModel(from *errorEvent, metadata model.Metadata, reqTime time.Time, event *model.APMEvent) {
+	out := &model.Error{Metadata: metadata}
+	event.Error = out
+
 	// overwrite metadata with event specific information
 	mapToServiceModel(from.Context.Service, &out.Metadata.Service)
 	mapToAgentModel(from.Context.Service.Agent, &out.Metadata.Agent)
 	overwriteUserInMetadataModel(from.Context.User, &out.Metadata)
-	mapToUserAgentModel(from.Context.Request.Headers, &out.Metadata)
+	mapToUserAgentModel(from.Context.Request.Headers, &out.Metadata.UserAgent)
 
 	// map errorEvent specific data
 	if from.Context.IsSet() {
@@ -390,14 +383,10 @@ func mapToMetadataModel(m *metadata, out *model.Metadata) {
 	}
 }
 
-func mapToMetricsetModel(from *metricset, metadata *model.Metadata, reqTime time.Time, out *model.Metricset) {
-	// set metadata as they are - no values are overwritten by the event
-	if metadata != nil {
-		out.Metadata = *metadata
-	}
-	if from == nil {
-		return
-	}
+func mapToMetricsetModel(from *metricset, metadata model.Metadata, reqTime time.Time, event *model.APMEvent) {
+	out := &model.Metricset{Metadata: metadata}
+	event.Metricset = out
+
 	// set timestamp from requst time
 	out.Timestamp = reqTime
 
@@ -524,14 +513,10 @@ func mapToAgentModel(from contextServiceAgent, out *model.Agent) {
 	}
 }
 
-func mapToSpanModel(from *span, metadata *model.Metadata, reqTime time.Time, out *model.Span) {
-	// set metadata information for span
-	if metadata != nil {
-		out.Metadata = *metadata
-	}
-	if from == nil {
-		return
-	}
+func mapToSpanModel(from *span, metadata model.Metadata, reqTime time.Time, event *model.APMEvent) {
+	out := &model.Span{Metadata: metadata}
+	event.Span = out
+
 	// map span specific data
 	if !from.Action.IsSet() && !from.Subtype.IsSet() {
 		sep := "."
@@ -702,19 +687,15 @@ func mapToStracktraceModel(from []stacktraceFrame, out model.Stacktrace) {
 	}
 }
 
-func mapToTransactionModel(from *transaction, metadata *model.Metadata, reqTime time.Time, out *model.Transaction) {
-	// set metadata information
-	if metadata != nil {
-		out.Metadata = *metadata
-	}
-	if from == nil {
-		return
-	}
+func mapToTransactionModel(from *transaction, metadata model.Metadata, reqTime time.Time, event *model.APMEvent) {
+	out := &model.Transaction{Metadata: metadata}
+	event.Transaction = out
+
 	// overwrite metadata with event specific information
 	mapToServiceModel(from.Context.Service, &out.Metadata.Service)
 	mapToAgentModel(from.Context.Service.Agent, &out.Metadata.Agent)
 	overwriteUserInMetadataModel(from.Context.User, &out.Metadata)
-	mapToUserAgentModel(from.Context.Request.Headers, &out.Metadata)
+	mapToUserAgentModel(from.Context.Request.Headers, &out.Metadata.UserAgent)
 
 	// map transaction specific data
 
@@ -850,11 +831,11 @@ func mapToTransactionModel(from *transaction, metadata *model.Metadata, reqTime 
 	}
 }
 
-func mapToUserAgentModel(from nullable.HTTPHeader, out *model.Metadata) {
+func mapToUserAgentModel(from nullable.HTTPHeader, out *model.UserAgent) {
 	// overwrite userAgent information if available
 	if from.IsSet() {
 		if h := from.Val.Values(textproto.CanonicalMIMEHeaderKey("User-Agent")); len(h) > 0 {
-			out.UserAgent.Original = strings.Join(h, ", ")
+			out.Original = strings.Join(h, ", ")
 		}
 	}
 }

--- a/model/modeldecoder/rumv3/error_test.go
+++ b/model/modeldecoder/rumv3/error_test.go
@@ -48,27 +48,29 @@ func TestDecodeNestedError(t *testing.T) {
 		input := modeldecoder.Input{Metadata: model.Metadata{}, RequestTime: now}
 		str := `{"e":{"id":"a-b-c","timestamp":1599996822281000,"log":{"mg":"abc"}}}`
 		dec := decoder.NewJSONDecoder(strings.NewReader(str))
-		var out model.Error
-		require.NoError(t, DecodeNestedError(dec, &input, &out))
-		assert.Equal(t, "2020-09-13 11:33:42.281 +0000 UTC", out.Timestamp.String())
+		var batch model.Batch
+		require.NoError(t, DecodeNestedError(dec, &input, &batch))
+		require.Len(t, batch, 1)
+		require.NotNil(t, batch[0].Error)
+		assert.Equal(t, "2020-09-13 11:33:42.281 +0000 UTC", batch[0].Error.Timestamp.String())
 
 		// if no timestamp is provided, fall back to request time
 		input = modeldecoder.Input{Metadata: model.Metadata{}, RequestTime: now}
 		str = `{"e":{"id":"a-b-c","log":{"mg":"abc"}}}`
 		dec = decoder.NewJSONDecoder(strings.NewReader(str))
-		out = model.Error{}
-		require.NoError(t, DecodeNestedError(dec, &input, &out))
-		assert.Equal(t, now, out.Timestamp)
+		batch = model.Batch{}
+		require.NoError(t, DecodeNestedError(dec, &input, &batch))
+		assert.Equal(t, now, batch[0].Error.Timestamp)
 
 		// test decode
-		err := DecodeNestedError(decoder.NewJSONDecoder(strings.NewReader(`malformed`)), &input, &out)
+		err := DecodeNestedError(decoder.NewJSONDecoder(strings.NewReader(`malformed`)), &input, &batch)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "decode")
 	})
 
 	t.Run("validate", func(t *testing.T) {
-		var out model.Error
-		err := DecodeNestedError(decoder.NewJSONDecoder(strings.NewReader(`{}`)), &modeldecoder.Input{}, &out)
+		var batch model.Batch
+		err := DecodeNestedError(decoder.NewJSONDecoder(strings.NewReader(`{}`)), &modeldecoder.Input{}, &batch)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "validation")
 	})
@@ -78,17 +80,17 @@ func TestDecodeMapToErrorModel(t *testing.T) {
 	t.Run("metadata-set", func(t *testing.T) {
 		// do not overwrite metadata with zero event values
 		var input errorEvent
-		var out model.Error
+		var out model.APMEvent
 		mapToErrorModel(&input, initializedMetadata(), time.Now(), &out)
 		// iterate through metadata model and assert values are set
 		defaultVal := modeldecodertest.DefaultValues()
-		modeldecodertest.AssertStructValues(t, &out.Metadata, metadataExceptions(), defaultVal)
+		modeldecodertest.AssertStructValues(t, &out.Error.Metadata, metadataExceptions(), defaultVal)
 	})
 
 	t.Run("metadata-overwrite", func(t *testing.T) {
 		// overwrite defined metadata with event metadata values
 		var input errorEvent
-		var out model.Error
+		var out model.APMEvent
 		otherVal := modeldecodertest.NonDefaultValues()
 		modeldecodertest.SetStructValues(&input, otherVal)
 		mapToErrorModel(&input, initializedMetadata(), time.Now(), &out)
@@ -97,18 +99,18 @@ func TestDecodeMapToErrorModel(t *testing.T) {
 		// ensure event Metadata are updated where expected
 		otherVal = modeldecodertest.NonDefaultValues()
 		userAgent := strings.Join(otherVal.HTTPHeader.Values("User-Agent"), ", ")
-		assert.Equal(t, userAgent, out.Metadata.UserAgent.Original)
+		assert.Equal(t, userAgent, out.Error.Metadata.UserAgent.Original)
 		// do not overwrite client.ip if already set in metadata
 		ip := modeldecodertest.DefaultValues().IP
-		assert.Equal(t, ip, out.Metadata.Client.IP, out.Metadata.Client.IP.String())
+		assert.Equal(t, ip, out.Error.Metadata.Client.IP, out.Error.Metadata.Client.IP.String())
 		// metadata labels and event labels should not be merged
 		mLabels := common.MapStr{"init0": "init", "init1": "init", "init2": "init"}
 		tLabels := common.MapStr{"overwritten0": "overwritten", "overwritten1": "overwritten"}
-		assert.Equal(t, mLabels, out.Metadata.Labels)
-		assert.Equal(t, tLabels, out.Labels)
+		assert.Equal(t, mLabels, out.Error.Metadata.Labels)
+		assert.Equal(t, tLabels, out.Error.Labels)
 		// service and user values should be set
-		modeldecodertest.AssertStructValues(t, &out.Metadata.Service, metadataExceptions("Node", "Agent.EphemeralID"), otherVal)
-		modeldecodertest.AssertStructValues(t, &out.Metadata.User, metadataExceptions(), otherVal)
+		modeldecodertest.AssertStructValues(t, &out.Error.Metadata.Service, metadataExceptions("Node", "Agent.EphemeralID"), otherVal)
+		modeldecodertest.AssertStructValues(t, &out.Error.Metadata.User, metadataExceptions(), otherVal)
 	})
 
 	t.Run("error-values", func(t *testing.T) {
@@ -149,13 +151,13 @@ func TestDecodeMapToErrorModel(t *testing.T) {
 			return false
 		}
 		var input errorEvent
-		var out1, out2 model.Error
+		var out1, out2 model.APMEvent
 		reqTime := time.Now().Add(time.Second)
 		defaultVal := modeldecodertest.DefaultValues()
 		modeldecodertest.SetStructValues(&input, defaultVal)
 		mapToErrorModel(&input, initializedMetadata(), reqTime, &out1)
 		input.Reset()
-		modeldecodertest.AssertStructValues(t, &out1, exceptions, defaultVal)
+		modeldecodertest.AssertStructValues(t, out1.Error, exceptions, defaultVal)
 
 		// set Timestamp to requestTime if eventTime is zero
 		defaultVal.Update(time.Time{})
@@ -163,61 +165,61 @@ func TestDecodeMapToErrorModel(t *testing.T) {
 		mapToErrorModel(&input, initializedMetadata(), reqTime, &out1)
 		defaultVal.Update(reqTime)
 		input.Reset()
-		modeldecodertest.AssertStructValues(t, &out1, exceptions, defaultVal)
+		modeldecodertest.AssertStructValues(t, out1.Error, exceptions, defaultVal)
 
 		// reuse input model for different event
 		// ensure memory is not shared by reusing input model
 		otherVal := modeldecodertest.NonDefaultValues()
 		modeldecodertest.SetStructValues(&input, otherVal)
 		mapToErrorModel(&input, initializedMetadata(), reqTime, &out2)
-		modeldecodertest.AssertStructValues(t, &out2, exceptions, otherVal)
-		modeldecodertest.AssertStructValues(t, &out1, exceptions, defaultVal)
+		modeldecodertest.AssertStructValues(t, out2.Error, exceptions, otherVal)
+		modeldecodertest.AssertStructValues(t, out1.Error, exceptions, defaultVal)
 	})
 
 	t.Run("page.URL", func(t *testing.T) {
 		var input errorEvent
 		input.Context.Page.URL.Set("https://my.site.test:9201")
-		var out model.Error
+		var out model.APMEvent
 		mapToErrorModel(&input, initializedMetadata(), time.Now(), &out)
-		assert.Equal(t, "https://my.site.test:9201", out.Page.URL.Full)
-		assert.Equal(t, "https://my.site.test:9201", out.URL.Full)
-		assert.Equal(t, 9201, out.Page.URL.Port)
-		assert.Equal(t, "https", out.Page.URL.Scheme)
+		assert.Equal(t, "https://my.site.test:9201", out.Error.Page.URL.Full)
+		assert.Equal(t, "https://my.site.test:9201", out.Error.URL.Full)
+		assert.Equal(t, 9201, out.Error.Page.URL.Port)
+		assert.Equal(t, "https", out.Error.Page.URL.Scheme)
 	})
 
 	t.Run("page.referer", func(t *testing.T) {
 		var input errorEvent
 		input.Context.Page.Referer.Set("https://my.site.test:9201")
-		var out model.Error
+		var out model.APMEvent
 		mapToErrorModel(&input, initializedMetadata(), time.Now(), &out)
-		assert.Equal(t, "https://my.site.test:9201", out.Page.Referer)
-		assert.Equal(t, "https://my.site.test:9201", out.HTTP.Request.Referrer)
+		assert.Equal(t, "https://my.site.test:9201", out.Error.Page.Referer)
+		assert.Equal(t, "https://my.site.test:9201", out.Error.HTTP.Request.Referrer)
 	})
 
 	t.Run("loggerName", func(t *testing.T) {
 		var input errorEvent
 		input.Log.Message.Set("log message")
-		var out model.Error
+		var out model.APMEvent
 		mapToErrorModel(&input, initializedMetadata(), time.Now(), &out)
-		require.NotNil(t, out.Log.LoggerName)
-		assert.Equal(t, "default", out.Log.LoggerName)
+		require.NotNil(t, out.Error.Log.LoggerName)
+		assert.Equal(t, "default", out.Error.Log.LoggerName)
 	})
 
 	t.Run("http-headers", func(t *testing.T) {
 		var input errorEvent
 		input.Context.Request.Headers.Set(http.Header{"a": []string{"b"}, "c": []string{"d", "e"}})
 		input.Context.Response.Headers.Set(http.Header{"f": []string{"g"}})
-		var out model.Error
+		var out model.APMEvent
 		mapToErrorModel(&input, initializedMetadata(), time.Now(), &out)
-		assert.Equal(t, common.MapStr{"a": []string{"b"}, "c": []string{"d", "e"}}, out.HTTP.Request.Headers)
-		assert.Equal(t, common.MapStr{"f": []string{"g"}}, out.HTTP.Response.Headers)
+		assert.Equal(t, common.MapStr{"a": []string{"b"}, "c": []string{"d", "e"}}, out.Error.HTTP.Request.Headers)
+		assert.Equal(t, common.MapStr{"f": []string{"g"}}, out.Error.HTTP.Response.Headers)
 	})
 
 	t.Run("exception-code", func(t *testing.T) {
 		var input errorEvent
-		var out model.Error
+		var out model.APMEvent
 		input.Exception.Code.Set(123.456)
-		mapToErrorModel(&input, &model.Metadata{}, time.Now(), &out)
-		assert.Equal(t, "123", out.Exception.Code)
+		mapToErrorModel(&input, model.Metadata{}, time.Now(), &out)
+		assert.Equal(t, "123", out.Error.Exception.Code)
 	})
 }

--- a/model/modeldecoder/rumv3/metadata_test.go
+++ b/model/modeldecoder/rumv3/metadata_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 // initializedMetadata returns a metadata model populated with default values
-func initializedMetadata() *model.Metadata {
+func initializedMetadata() model.Metadata {
 	var input metadata
 	var out model.Metadata
 	modeldecodertest.SetStructValues(&input, modeldecodertest.DefaultValues())
@@ -43,7 +43,7 @@ func initializedMetadata() *model.Metadata {
 	out.Client.Domain = "init"
 	out.Client.IP = net.ParseIP("127.0.0.1")
 	out.Client.Port = 1
-	return &out
+	return out
 }
 
 func metadataExceptions(keys ...string) func(key string) bool {
@@ -137,22 +137,22 @@ func TestDecodeMetadataMappingToModel(t *testing.T) {
 		out := initializedMetadata()
 		// iterate through model and assert values are set
 		defaultVal := modeldecodertest.DefaultValues()
-		assert.Equal(t, expected(defaultVal.Str, defaultVal.IP, defaultVal.N), out)
+		assert.Equal(t, expected(defaultVal.Str, defaultVal.IP, defaultVal.N), &out)
 
 		// overwrite model metadata with specified Values
 		// then iterate through model and assert values are overwritten
 		var input metadata
 		otherVal := modeldecodertest.NonDefaultValues()
 		modeldecodertest.SetStructValues(&input, otherVal)
-		mapToMetadataModel(&input, out)
-		assert.Equal(t, expected(otherVal.Str, otherVal.IP, otherVal.N), out)
+		mapToMetadataModel(&input, &out)
+		assert.Equal(t, expected(otherVal.Str, otherVal.IP, otherVal.N), &out)
 
 		// map an empty modeldecoder metadata to the model
 		// and assert values are unchanged
 		input.Reset()
 		modeldecodertest.SetZeroStructValues(&input)
-		mapToMetadataModel(&input, out)
-		assert.Equal(t, expected(otherVal.Str, otherVal.IP, otherVal.N), out)
+		mapToMetadataModel(&input, &out)
+		assert.Equal(t, expected(otherVal.Str, otherVal.IP, otherVal.N), &out)
 	})
 
 	t.Run("reused-memory", func(t *testing.T) {

--- a/model/modeldecoder/rumv3/transaction_test.go
+++ b/model/modeldecoder/rumv3/transaction_test.go
@@ -49,29 +49,35 @@ func TestDecodeNestedTransaction(t *testing.T) {
 		input := modeldecoder.Input{Metadata: model.Metadata{}, RequestTime: now}
 		str := `{"x":{"n":"tr-a","d":100,"id":"100","tid":"1","t":"request","yc":{"sd":2},"y":[{"n":"a","d":10,"t":"http","id":"123","s":20}],"me":[{"sa":{"xds":{"v":2048}}},{"sa":{"ysc":{"v":5}}}]}}`
 		dec := decoder.NewJSONDecoder(strings.NewReader(str))
-		var out Transaction
-		require.NoError(t, DecodeNestedTransaction(dec, &input, &out))
-		assert.Equal(t, "request", out.Transaction.Type)
+		var batch model.Batch
+		require.NoError(t, DecodeNestedTransaction(dec, &input, &batch))
+		require.Len(t, batch, 4) // 1 transaction, 2 metricsets, 1 span
+		require.NotNil(t, batch[0].Transaction)
+		require.NotNil(t, batch[1].Metricset)
+		require.NotNil(t, batch[2].Metricset)
+		require.NotNil(t, batch[3].Span)
+
+		assert.Equal(t, "request", batch[0].Transaction.Type)
 		// fall back to request time
-		assert.Equal(t, now, out.Transaction.Timestamp)
+		assert.Equal(t, now, batch[0].Transaction.Timestamp)
+
 		// ensure nested metricsets are decoded
-		require.Equal(t, 2, len(out.Metricsets))
-		assert.Equal(t, map[string]model.MetricsetSample{"transaction.duration.sum.us": {Value: 2048}}, out.Metricsets[0].Samples)
-		m := out.Metricsets[1]
+		assert.Equal(t, map[string]model.MetricsetSample{"transaction.duration.sum.us": {Value: 2048}}, batch[1].Metricset.Samples)
+		m := batch[2].Metricset
 		assert.Equal(t, map[string]model.MetricsetSample{"span.self_time.count": {Value: 5}}, m.Samples)
 		assert.Equal(t, "tr-a", m.Transaction.Name)
 		assert.Equal(t, "request", m.Transaction.Type)
 		assert.Equal(t, now, m.Timestamp)
+
 		// ensure nested spans are decoded
-		require.Equal(t, 1, len(out.Spans))
-		sp := out.Spans[0]
+		sp := batch[3].Span
 		start := time.Duration(20 * 1000 * 1000)
 		assert.Equal(t, now.Add(start), sp.Timestamp) //add start to timestamp
 		assert.Equal(t, "100", sp.TransactionID)
 		assert.Equal(t, "1", sp.TraceID)
 		assert.Equal(t, "100", sp.ParentID)
 
-		err := DecodeNestedTransaction(decoder.NewJSONDecoder(strings.NewReader(`malformed`)), &input, &out)
+		err := DecodeNestedTransaction(decoder.NewJSONDecoder(strings.NewReader(`malformed`)), &input, &batch)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "decode")
 	})
@@ -81,8 +87,8 @@ func TestDecodeNestedTransaction(t *testing.T) {
 		input := modeldecoder.Input{Metadata: model.Metadata{}, RequestTime: now}
 		str := `{"x":{"d":100,"id":"100","tid":"1","t":"request","yc":{"sd":2},"k":{"a":{"dc":0.1,"di":0.2,"ds":0.3,"de":0.4,"fb":0.5,"fp":0.6,"lp":0.7,"long":0.8},"nt":{"fs":0.1,"ls":0.2,"le":0.3,"cs":0.4,"ce":0.5,"qs":0.6,"rs":0.7,"re":0.8,"dl":0.9,"di":0.11,"ds":0.21,"de":0.31,"dc":0.41,"es":0.51,"ee":6,"long":0.99},"long":{"long":0.1}}}}`
 		dec := decoder.NewJSONDecoder(strings.NewReader(str))
-		var out Transaction
-		require.NoError(t, DecodeNestedTransaction(dec, &input, &out))
+		var batch model.Batch
+		require.NoError(t, DecodeNestedTransaction(dec, &input, &batch))
 		marks := model.TransactionMarks{
 			"agent": map[string]float64{
 				"domComplete":                0.1,
@@ -116,12 +122,12 @@ func TestDecodeNestedTransaction(t *testing.T) {
 				"long": 0.1,
 			},
 		}
-		assert.Equal(t, marks, out.Transaction.Marks)
+		assert.Equal(t, marks, batch[0].Transaction.Marks)
 	})
 
 	t.Run("validate", func(t *testing.T) {
-		var out Transaction
-		err := DecodeNestedTransaction(decoder.NewJSONDecoder(strings.NewReader(`{}`)), &modeldecoder.Input{}, &out)
+		var batch model.Batch
+		err := DecodeNestedTransaction(decoder.NewJSONDecoder(strings.NewReader(`{}`)), &modeldecoder.Input{}, &batch)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "validation")
 	})
@@ -133,44 +139,44 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 	t.Run("metadata-set", func(t *testing.T) {
 		// do not overwrite metadata with zero transaction values
 		var input transaction
-		var out model.Transaction
+		var out model.APMEvent
 		mapToTransactionModel(&input, initializedMetadata(), time.Now(), &out)
 		// iterate through metadata model and assert values are set
-		modeldecodertest.AssertStructValues(t, &out.Metadata, metadataExceptions(), modeldecodertest.DefaultValues())
+		modeldecodertest.AssertStructValues(t, &out.Transaction.Metadata, metadataExceptions(), modeldecodertest.DefaultValues())
 	})
 
 	t.Run("metadata-overwrite", func(t *testing.T) {
 		// overwrite defined metadata with transaction metadata values
 		var input transaction
-		var out model.Transaction
+		var out model.APMEvent
 		otherVal := modeldecodertest.NonDefaultValues()
 		modeldecodertest.SetStructValues(&input, otherVal)
 		mapToTransactionModel(&input, initializedMetadata(), time.Now(), &out)
 
 		// user-agent should be set to context request header values
-		assert.Equal(t, "d, e", out.Metadata.UserAgent.Original)
+		assert.Equal(t, "d, e", out.Transaction.Metadata.UserAgent.Original)
 		// do not overwrite client.ip if already set in metadata
-		assert.Equal(t, localhostIP, out.Metadata.Client.IP, out.Metadata.Client.IP.String())
+		assert.Equal(t, localhostIP, out.Transaction.Metadata.Client.IP, out.Transaction.Metadata.Client.IP.String())
 		// metadata labels and transaction labels should not be merged
 		mLabels := common.MapStr{"init0": "init", "init1": "init", "init2": "init"}
-		assert.Equal(t, mLabels, out.Metadata.Labels)
+		assert.Equal(t, mLabels, out.Transaction.Metadata.Labels)
 		tLabels := common.MapStr{"overwritten0": "overwritten", "overwritten1": "overwritten"}
-		assert.Equal(t, tLabels, out.Labels)
+		assert.Equal(t, tLabels, out.Transaction.Labels)
 		// service values should be set
-		modeldecodertest.AssertStructValues(t, &out.Metadata.Service, metadataExceptions("Node", "Agent.EphemeralID"), otherVal)
+		modeldecodertest.AssertStructValues(t, &out.Transaction.Metadata.Service, metadataExceptions("Node", "Agent.EphemeralID"), otherVal)
 		// user values should be set
-		modeldecodertest.AssertStructValues(t, &out.Metadata.User, metadataExceptions(), otherVal)
+		modeldecodertest.AssertStructValues(t, &out.Transaction.Metadata.User, metadataExceptions(), otherVal)
 	})
 
 	t.Run("overwrite-user", func(t *testing.T) {
 		// user should be populated by metadata or event specific, but not merged
-		var inputTr transaction
-		var tr model.Transaction
-		inputTr.Context.User.Email.Set("test@user.com")
-		mapToTransactionModel(&inputTr, initializedMetadata(), time.Now(), &tr)
-		assert.Equal(t, "test@user.com", tr.Metadata.User.Email)
-		assert.Zero(t, tr.Metadata.User.ID)
-		assert.Zero(t, tr.Metadata.User.Name)
+		var input transaction
+		var out model.APMEvent
+		input.Context.User.Email.Set("test@user.com")
+		mapToTransactionModel(&input, initializedMetadata(), time.Now(), &out)
+		assert.Equal(t, "test@user.com", out.Transaction.Metadata.User.Email)
+		assert.Zero(t, out.Transaction.Metadata.User.ID)
+		assert.Zero(t, out.Transaction.Metadata.User.Name)
 	})
 
 	t.Run("transaction-values", func(t *testing.T) {
@@ -198,22 +204,22 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 		}
 
 		var input transaction
-		var out1, out2 model.Transaction
+		var out1, out2 model.APMEvent
 		reqTime := time.Now().Add(time.Second)
 		defaultVal := modeldecodertest.DefaultValues()
 		modeldecodertest.SetStructValues(&input, defaultVal)
 		mapToTransactionModel(&input, initializedMetadata(), reqTime, &out1)
 		input.Reset()
 		defaultVal.Update(reqTime) //for rumv3 the timestamp is always set from the request time
-		modeldecodertest.AssertStructValues(t, &out1, exceptions, defaultVal)
+		modeldecodertest.AssertStructValues(t, out1.Transaction, exceptions, defaultVal)
 
 		// ensure memory is not shared by reusing input model
 		otherVal := modeldecodertest.NonDefaultValues()
 		otherVal.Update(reqTime) //for rumv3 the timestamp is always set from the request time
 		modeldecodertest.SetStructValues(&input, otherVal)
 		mapToTransactionModel(&input, initializedMetadata(), reqTime, &out2)
-		modeldecodertest.AssertStructValues(t, &out2, exceptions, otherVal)
-		modeldecodertest.AssertStructValues(t, &out1, exceptions, defaultVal)
+		modeldecodertest.AssertStructValues(t, out2.Transaction, exceptions, otherVal)
+		modeldecodertest.AssertStructValues(t, out1.Transaction, exceptions, defaultVal)
 	})
 
 	t.Run("span-values", func(t *testing.T) {
@@ -262,7 +268,7 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 		}
 
 		var input span
-		var out1, out2 model.Span
+		var out1, out2 model.APMEvent
 		reqTime := time.Now().Add(time.Second)
 		defaultVal := modeldecodertest.DefaultValues()
 		modeldecodertest.SetStructValues(&input, defaultVal)
@@ -270,7 +276,7 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 		input.Reset()
 		defaultStart := time.Duration(defaultVal.Float * 1000 * 1000)
 		defaultVal.Update(reqTime.Add(defaultStart)) //for rumv3 the timestamp is always set from the request time
-		modeldecodertest.AssertStructValues(t, &out1, exceptions, defaultVal)
+		modeldecodertest.AssertStructValues(t, out1.Span, exceptions, defaultVal)
 
 		// ensure memory is not shared by reusing input model
 		otherVal := modeldecodertest.NonDefaultValues()
@@ -278,106 +284,106 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 		mapToSpanModel(&input, initializedMetadata(), reqTime, &out2)
 		otherStart := time.Duration(otherVal.Float * 1000 * 1000)
 		otherVal.Update(reqTime.Add(otherStart)) //for rumv3 the timestamp is always set from the request time
-		modeldecodertest.AssertStructValues(t, &out2, exceptions, otherVal)
-		modeldecodertest.AssertStructValues(t, &out1, exceptions, defaultVal)
+		modeldecodertest.AssertStructValues(t, out2.Span, exceptions, otherVal)
+		modeldecodertest.AssertStructValues(t, out1.Span, exceptions, defaultVal)
 	})
 
 	t.Run("span-outcome", func(t *testing.T) {
 		var input span
-		var out model.Span
+		var out model.APMEvent
 		modeldecodertest.SetStructValues(&input, modeldecodertest.DefaultValues())
 		// set from input, ignore status code
 		input.Outcome.Set("failure")
 		input.Context.HTTP.StatusCode.Set(http.StatusPermanentRedirect)
-		mapToSpanModel(&input, &model.Metadata{}, time.Now(), &out)
-		assert.Equal(t, "failure", out.Outcome)
+		mapToSpanModel(&input, model.Metadata{}, time.Now(), &out)
+		assert.Equal(t, "failure", out.Span.Outcome)
 		// derive from span fields - success
 		input.Outcome.Reset()
 		input.Context.HTTP.StatusCode.Set(http.StatusPermanentRedirect)
-		mapToSpanModel(&input, &model.Metadata{}, time.Now(), &out)
-		assert.Equal(t, "success", out.Outcome)
+		mapToSpanModel(&input, model.Metadata{}, time.Now(), &out)
+		assert.Equal(t, "success", out.Span.Outcome)
 		// derive from span fields - failure
 		input.Outcome.Reset()
 		input.Context.HTTP.StatusCode.Set(http.StatusBadRequest)
-		mapToSpanModel(&input, &model.Metadata{}, time.Now(), &out)
-		assert.Equal(t, "failure", out.Outcome)
+		mapToSpanModel(&input, model.Metadata{}, time.Now(), &out)
+		assert.Equal(t, "failure", out.Span.Outcome)
 		// derive from span fields - unknown
 		input.Outcome.Reset()
 		input.Context.HTTP.StatusCode.Reset()
-		mapToSpanModel(&input, &model.Metadata{}, time.Now(), &out)
-		assert.Equal(t, "unknown", out.Outcome)
+		mapToSpanModel(&input, model.Metadata{}, time.Now(), &out)
+		assert.Equal(t, "unknown", out.Span.Outcome)
 	})
 
 	t.Run("transaction-outcome", func(t *testing.T) {
 		var input transaction
-		var out model.Transaction
+		var out model.APMEvent
 		modeldecodertest.SetStructValues(&input, modeldecodertest.DefaultValues())
 		// set from input, ignore status code
 		input.Outcome.Set("failure")
 		input.Context.Response.StatusCode.Set(http.StatusBadRequest)
-		mapToTransactionModel(&input, &model.Metadata{}, time.Now(), &out)
-		assert.Equal(t, "failure", out.Outcome)
+		mapToTransactionModel(&input, model.Metadata{}, time.Now(), &out)
+		assert.Equal(t, "failure", out.Transaction.Outcome)
 		// derive from span fields - success
 		input.Outcome.Reset()
 		input.Context.Response.StatusCode.Set(http.StatusBadRequest)
-		mapToTransactionModel(&input, &model.Metadata{}, time.Now(), &out)
-		assert.Equal(t, "success", out.Outcome)
+		mapToTransactionModel(&input, model.Metadata{}, time.Now(), &out)
+		assert.Equal(t, "success", out.Transaction.Outcome)
 		// derive from span fields - failure
 		input.Outcome.Reset()
 		input.Context.Response.StatusCode.Set(http.StatusInternalServerError)
-		mapToTransactionModel(&input, &model.Metadata{}, time.Now(), &out)
-		assert.Equal(t, "failure", out.Outcome)
+		mapToTransactionModel(&input, model.Metadata{}, time.Now(), &out)
+		assert.Equal(t, "failure", out.Transaction.Outcome)
 		// derive from span fields - unknown
 		input.Outcome.Reset()
 		input.Context.Response.StatusCode.Reset()
-		mapToTransactionModel(&input, &model.Metadata{}, time.Now(), &out)
-		assert.Equal(t, "unknown", out.Outcome)
+		mapToTransactionModel(&input, model.Metadata{}, time.Now(), &out)
+		assert.Equal(t, "unknown", out.Transaction.Outcome)
 	})
 
 	t.Run("page.URL", func(t *testing.T) {
-		var inputTr transaction
-		inputTr.Context.Page.URL.Set("https://my.site.test:9201")
-		var tr model.Transaction
-		mapToTransactionModel(&inputTr, initializedMetadata(), time.Now(), &tr)
-		assert.Equal(t, "https://my.site.test:9201", tr.Page.URL.Full)
-		assert.Equal(t, "https://my.site.test:9201", tr.URL.Full)
-		assert.Equal(t, 9201, tr.Page.URL.Port)
-		assert.Equal(t, "https", tr.Page.URL.Scheme)
+		var input transaction
+		input.Context.Page.URL.Set("https://my.site.test:9201")
+		var out model.APMEvent
+		mapToTransactionModel(&input, initializedMetadata(), time.Now(), &out)
+		assert.Equal(t, "https://my.site.test:9201", out.Transaction.Page.URL.Full)
+		assert.Equal(t, "https://my.site.test:9201", out.Transaction.URL.Full)
+		assert.Equal(t, 9201, out.Transaction.Page.URL.Port)
+		assert.Equal(t, "https", out.Transaction.Page.URL.Scheme)
 	})
 
 	t.Run("page.referer", func(t *testing.T) {
-		var inputTr transaction
-		inputTr.Context.Page.Referer.Set("https://my.site.test:9201")
-		var tr model.Transaction
-		mapToTransactionModel(&inputTr, initializedMetadata(), time.Now(), &tr)
-		assert.Equal(t, "https://my.site.test:9201", tr.Page.Referer)
-		assert.Equal(t, "https://my.site.test:9201", tr.HTTP.Request.Referrer)
+		var input transaction
+		input.Context.Page.Referer.Set("https://my.site.test:9201")
+		var out model.APMEvent
+		mapToTransactionModel(&input, initializedMetadata(), time.Now(), &out)
+		assert.Equal(t, "https://my.site.test:9201", out.Transaction.Page.Referer)
+		assert.Equal(t, "https://my.site.test:9201", out.Transaction.HTTP.Request.Referrer)
 	})
 
 	t.Run("http-headers", func(t *testing.T) {
 		var input transaction
 		input.Context.Request.Headers.Set(http.Header{"a": []string{"b"}, "c": []string{"d", "e"}})
 		input.Context.Response.Headers.Set(http.Header{"f": []string{"g"}})
-		var out model.Transaction
+		var out model.APMEvent
 		mapToTransactionModel(&input, initializedMetadata(), time.Now(), &out)
-		assert.Equal(t, common.MapStr{"a": []string{"b"}, "c": []string{"d", "e"}}, out.HTTP.Request.Headers)
-		assert.Equal(t, common.MapStr{"f": []string{"g"}}, out.HTTP.Response.Headers)
+		assert.Equal(t, common.MapStr{"a": []string{"b"}, "c": []string{"d", "e"}}, out.Transaction.HTTP.Request.Headers)
+		assert.Equal(t, common.MapStr{"f": []string{"g"}}, out.Transaction.HTTP.Response.Headers)
 	})
 
 	t.Run("session", func(t *testing.T) {
 		var input transaction
-		var out model.Transaction
+		var out model.APMEvent
 		modeldecodertest.SetStructValues(&input, modeldecodertest.DefaultValues())
 		input.Session.ID.Reset()
-		mapToTransactionModel(&input, &model.Metadata{}, time.Now(), &out)
-		assert.Equal(t, model.TransactionSession{}, out.Session)
+		mapToTransactionModel(&input, model.Metadata{}, time.Now(), &out)
+		assert.Equal(t, model.TransactionSession{}, out.Transaction.Session)
 
 		input.Session.ID.Set("session_id")
 		input.Session.Sequence.Set(123)
-		mapToTransactionModel(&input, &model.Metadata{}, time.Now(), &out)
+		mapToTransactionModel(&input, model.Metadata{}, time.Now(), &out)
 		assert.Equal(t, model.TransactionSession{
 			ID:       "session_id",
 			Sequence: 123,
-		}, out.Session)
+		}, out.Transaction.Session)
 	})
 }

--- a/model/modeldecoder/v2/error_test.go
+++ b/model/modeldecoder/v2/error_test.go
@@ -49,28 +49,30 @@ func TestDecodeNestedError(t *testing.T) {
 		input := modeldecoder.Input{Metadata: model.Metadata{}, RequestTime: now, Config: modeldecoder.Config{Experimental: true}}
 		str := `{"error":{"id":"a-b-c","timestamp":1599996822281000,"log":{"message":"abc"},"context":{"experimental":"exp"}}}`
 		dec := decoder.NewJSONDecoder(strings.NewReader(str))
-		var out model.Error
-		require.NoError(t, DecodeNestedError(dec, &input, &out))
-		assert.Equal(t, "exp", out.Experimental)
-		assert.Equal(t, "2020-09-13 11:33:42.281 +0000 UTC", out.Timestamp.String())
+		var batch model.Batch
+		require.NoError(t, DecodeNestedError(dec, &input, &batch))
+		require.Len(t, batch, 1)
+		require.NotNil(t, batch[0].Error)
+		assert.Equal(t, "exp", batch[0].Error.Experimental)
+		assert.Equal(t, "2020-09-13 11:33:42.281 +0000 UTC", batch[0].Error.Timestamp.String())
 
 		input = modeldecoder.Input{Metadata: model.Metadata{}, RequestTime: now, Config: modeldecoder.Config{Experimental: false}}
 		str = `{"error":{"id":"a-b-c","log":{"message":"abc"},"context":{"experimental":"exp"}}}`
 		dec = decoder.NewJSONDecoder(strings.NewReader(str))
-		out = model.Error{}
-		require.NoError(t, DecodeNestedError(dec, &input, &out))
+		batch = model.Batch{}
+		require.NoError(t, DecodeNestedError(dec, &input, &batch))
 		// experimental should only be set if allowed by configuration
-		assert.Nil(t, out.Experimental)
+		assert.Nil(t, batch[0].Error.Experimental)
 		// if no timestamp is provided, fall back to request time
-		assert.Equal(t, now, out.Timestamp)
+		assert.Equal(t, now, batch[0].Error.Timestamp)
 
-		err := DecodeNestedError(decoder.NewJSONDecoder(strings.NewReader(`malformed`)), &input, &out)
+		err := DecodeNestedError(decoder.NewJSONDecoder(strings.NewReader(`malformed`)), &input, &batch)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "decode")
 	})
 
 	t.Run("validate", func(t *testing.T) {
-		var out model.Error
+		var out model.Batch
 		err := DecodeNestedError(decoder.NewJSONDecoder(strings.NewReader(`{}`)), &modeldecoder.Input{}, &out)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "validation")
@@ -85,17 +87,17 @@ func TestDecodeMapToErrorModel(t *testing.T) {
 	t.Run("metadata-set", func(t *testing.T) {
 		// do not overwrite metadata with zero event values
 		var input errorEvent
-		var out model.Error
+		var out model.APMEvent
 		mapToErrorModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{}, &out)
 		// iterate through metadata model and assert values are set
 		defaultVal := modeldecodertest.DefaultValues()
-		modeldecodertest.AssertStructValues(t, &out.Metadata, exceptions, defaultVal)
+		modeldecodertest.AssertStructValues(t, &out.Error.Metadata, exceptions, defaultVal)
 	})
 
 	t.Run("metadata-overwrite", func(t *testing.T) {
 		// overwrite defined metadata with event metadata values
 		var input errorEvent
-		var out model.Error
+		var out model.APMEvent
 		otherVal := modeldecodertest.NonDefaultValues()
 		modeldecodertest.SetStructValues(&input, otherVal)
 		mapToErrorModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{Experimental: true}, &out)
@@ -104,36 +106,36 @@ func TestDecodeMapToErrorModel(t *testing.T) {
 		// ensure event Metadata are updated where expected
 		otherVal = modeldecodertest.NonDefaultValues()
 		userAgent := strings.Join(otherVal.HTTPHeader.Values("User-Agent"), ", ")
-		assert.Equal(t, userAgent, out.Metadata.UserAgent.Original)
+		assert.Equal(t, userAgent, out.Error.Metadata.UserAgent.Original)
 		// do not overwrite client.ip if already set in metadata
 		ip := modeldecodertest.DefaultValues().IP
-		assert.Equal(t, ip, out.Metadata.Client.IP, out.Metadata.Client.IP.String())
+		assert.Equal(t, ip, out.Error.Metadata.Client.IP, out.Error.Metadata.Client.IP.String())
 		// metadata labels and event labels should not be merged
 		mLabels := common.MapStr{"init0": "init", "init1": "init", "init2": "init"}
 		tLabels := common.MapStr{"overwritten0": "overwritten", "overwritten1": "overwritten"}
-		assert.Equal(t, mLabels, out.Metadata.Labels)
-		assert.Equal(t, tLabels, out.Labels)
+		assert.Equal(t, mLabels, out.Error.Metadata.Labels)
+		assert.Equal(t, tLabels, out.Error.Labels)
 		// service and user values should be set
-		modeldecodertest.AssertStructValues(t, &out.Metadata.Service, exceptions, otherVal)
-		modeldecodertest.AssertStructValues(t, &out.Metadata.User, exceptions, otherVal)
+		modeldecodertest.AssertStructValues(t, &out.Error.Metadata.Service, exceptions, otherVal)
+		modeldecodertest.AssertStructValues(t, &out.Error.Metadata.User, exceptions, otherVal)
 	})
 
 	t.Run("client-ip-header", func(t *testing.T) {
 		var input errorEvent
-		var out model.Error
+		var out model.APMEvent
 		input.Context.Request.Headers.Set(http.Header{})
 		input.Context.Request.Headers.Val.Add("x-real-ip", gatewayIP.String())
 		input.Context.Request.Socket.RemoteAddress.Set(randomIP.String())
-		mapToErrorModel(&input, &model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, gatewayIP, out.Metadata.Client.IP, out.Metadata.Client.IP.String())
+		mapToErrorModel(&input, model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
+		assert.Equal(t, gatewayIP, out.Error.Metadata.Client.IP, out.Error.Metadata.Client.IP.String())
 	})
 
 	t.Run("client-ip-socket", func(t *testing.T) {
 		var input errorEvent
-		var out model.Error
+		var out model.APMEvent
 		input.Context.Request.Socket.RemoteAddress.Set(randomIP.String())
-		mapToErrorModel(&input, &model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, randomIP, out.Metadata.Client.IP, out.Metadata.Client.IP.String())
+		mapToErrorModel(&input, model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
+		assert.Equal(t, randomIP, out.Error.Metadata.Client.IP, out.Error.Metadata.Client.IP.String())
 	})
 
 	t.Run("error-values", func(t *testing.T) {
@@ -165,13 +167,13 @@ func TestDecodeMapToErrorModel(t *testing.T) {
 			return false
 		}
 		var input errorEvent
-		var out1, out2 model.Error
+		var out1, out2 model.APMEvent
 		reqTime := time.Now().Add(time.Second)
 		defaultVal := modeldecodertest.DefaultValues()
 		modeldecodertest.SetStructValues(&input, defaultVal)
 		mapToErrorModel(&input, initializedMetadata(), reqTime, modeldecoder.Config{Experimental: true}, &out1)
 		input.Reset()
-		modeldecodertest.AssertStructValues(t, &out1, exceptions, defaultVal)
+		modeldecodertest.AssertStructValues(t, out1.Error, exceptions, defaultVal)
 
 		// set Timestamp to requestTime if eventTime is zero
 		defaultVal.Update(time.Time{})
@@ -179,52 +181,52 @@ func TestDecodeMapToErrorModel(t *testing.T) {
 		mapToErrorModel(&input, initializedMetadata(), reqTime, modeldecoder.Config{Experimental: true}, &out1)
 		defaultVal.Update(reqTime)
 		input.Reset()
-		modeldecodertest.AssertStructValues(t, &out1, exceptions, defaultVal)
+		modeldecodertest.AssertStructValues(t, out1.Error, exceptions, defaultVal)
 
 		// reuse input model for different event
 		// ensure memory is not shared by reusing input model
 		otherVal := modeldecodertest.NonDefaultValues()
 		modeldecodertest.SetStructValues(&input, otherVal)
 		mapToErrorModel(&input, initializedMetadata(), reqTime, modeldecoder.Config{Experimental: true}, &out2)
-		modeldecodertest.AssertStructValues(t, &out2, exceptions, otherVal)
-		modeldecodertest.AssertStructValues(t, &out1, exceptions, defaultVal)
+		modeldecodertest.AssertStructValues(t, out2.Error, exceptions, otherVal)
+		modeldecodertest.AssertStructValues(t, out1.Error, exceptions, defaultVal)
 	})
 
 	t.Run("http-headers", func(t *testing.T) {
 		var input errorEvent
 		input.Context.Request.Headers.Set(http.Header{"a": []string{"b"}, "c": []string{"d", "e"}})
 		input.Context.Response.Headers.Set(http.Header{"f": []string{"g"}})
-		var out model.Error
+		var out model.APMEvent
 		mapToErrorModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{Experimental: false}, &out)
-		assert.Equal(t, common.MapStr{"a": []string{"b"}, "c": []string{"d", "e"}}, out.HTTP.Request.Headers)
-		assert.Equal(t, common.MapStr{"f": []string{"g"}}, out.HTTP.Response.Headers)
+		assert.Equal(t, common.MapStr{"a": []string{"b"}, "c": []string{"d", "e"}}, out.Error.HTTP.Request.Headers)
+		assert.Equal(t, common.MapStr{"f": []string{"g"}}, out.Error.HTTP.Response.Headers)
 	})
 
 	t.Run("page.URL", func(t *testing.T) {
 		var input errorEvent
 		input.Context.Page.URL.Set("https://my.site.test:9201")
-		var out model.Error
+		var out model.APMEvent
 		mapToErrorModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, "https://my.site.test:9201", out.Page.URL.Full)
-		assert.Equal(t, "https://my.site.test:9201", out.URL.Full)
-		assert.Equal(t, 9201, out.Page.URL.Port)
-		assert.Equal(t, "https", out.Page.URL.Scheme)
+		assert.Equal(t, "https://my.site.test:9201", out.Error.Page.URL.Full)
+		assert.Equal(t, "https://my.site.test:9201", out.Error.URL.Full)
+		assert.Equal(t, 9201, out.Error.Page.URL.Port)
+		assert.Equal(t, "https", out.Error.Page.URL.Scheme)
 	})
 
 	t.Run("page.referer", func(t *testing.T) {
 		var input errorEvent
 		input.Context.Page.Referer.Set("https://my.site.test:9201")
-		var out model.Error
+		var out model.APMEvent
 		mapToErrorModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, "https://my.site.test:9201", out.Page.Referer)
-		assert.Equal(t, "https://my.site.test:9201", out.HTTP.Request.Referrer)
+		assert.Equal(t, "https://my.site.test:9201", out.Error.Page.Referer)
+		assert.Equal(t, "https://my.site.test:9201", out.Error.HTTP.Request.Referrer)
 	})
 
 	t.Run("exception-code", func(t *testing.T) {
 		var input errorEvent
-		var out model.Error
+		var out model.APMEvent
 		input.Exception.Code.Set(123.456)
-		mapToErrorModel(&input, &model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, "123", out.Exception.Code)
+		mapToErrorModel(&input, model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
+		assert.Equal(t, "123", out.Error.Exception.Code)
 	})
 }

--- a/model/modeldecoder/v2/metadata_test.go
+++ b/model/modeldecoder/v2/metadata_test.go
@@ -64,9 +64,9 @@ func isUnmappedMetadataField(key string) bool {
 	return false
 }
 
-func initializedMetadata() *model.Metadata {
+func initializedMetadata() model.Metadata {
 	_, metadata := initializedInputMetadata(modeldecodertest.DefaultValues())
-	return &metadata
+	return metadata
 }
 
 func initializedInputMetadata(values *modeldecodertest.Values) (metadata, model.Metadata) {

--- a/model/modeldecoder/v2/span_test.go
+++ b/model/modeldecoder/v2/span_test.go
@@ -48,17 +48,19 @@ func TestDecodeNestedSpan(t *testing.T) {
 		input := modeldecoder.Input{Metadata: model.Metadata{}, RequestTime: time.Now(), Config: modeldecoder.Config{}}
 		str := `{"span":{"duration":100,"id":"a-b-c","name":"s","parent_id":"parent-123","trace_id":"trace-ab","type":"db","start":143}}`
 		dec := decoder.NewJSONDecoder(strings.NewReader(str))
-		var out model.Span
-		require.NoError(t, DecodeNestedSpan(dec, &input, &out))
+		var batch model.Batch
+		require.NoError(t, DecodeNestedSpan(dec, &input, &batch))
+		require.Len(t, batch, 1)
+		require.NotNil(t, batch[0].Span)
 
-		err := DecodeNestedSpan(decoder.NewJSONDecoder(strings.NewReader(`malformed`)), &input, &out)
+		err := DecodeNestedSpan(decoder.NewJSONDecoder(strings.NewReader(`malformed`)), &input, &batch)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "decode")
 	})
 
 	t.Run("validate", func(t *testing.T) {
-		var out model.Span
-		err := DecodeNestedSpan(decoder.NewJSONDecoder(strings.NewReader(`{}`)), &modeldecoder.Input{}, &out)
+		var batch model.Batch
+		err := DecodeNestedSpan(decoder.NewJSONDecoder(strings.NewReader(`{}`)), &modeldecoder.Input{}, &batch)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "validation")
 	})
@@ -68,11 +70,11 @@ func TestDecodeMapToSpanModel(t *testing.T) {
 	t.Run("set-metadata", func(t *testing.T) {
 		exceptions := func(key string) bool { return strings.HasPrefix(key, "System.Network") }
 		var input span
-		var out model.Span
+		var out model.APMEvent
 		mapToSpanModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{}, &out)
 		// iterate through metadata model and assert values are set
 		defaultVal := modeldecodertest.DefaultValues()
-		modeldecodertest.AssertStructValues(t, &out.Metadata, exceptions, defaultVal)
+		modeldecodertest.AssertStructValues(t, &out.Span.Metadata, exceptions, defaultVal)
 	})
 
 	t.Run("experimental", func(t *testing.T) {
@@ -80,18 +82,18 @@ func TestDecodeMapToSpanModel(t *testing.T) {
 		input := modeldecoder.Input{Metadata: model.Metadata{}, RequestTime: time.Now(), Config: modeldecoder.Config{Experimental: true}}
 		str := `{"span":{"context":{"experimental":"exp"},"duration":100,"id":"a-b-c","name":"s","parent_id":"parent-123","trace_id":"trace-ab","type":"db","start":143}}`
 		dec := decoder.NewJSONDecoder(strings.NewReader(str))
-		var out model.Span
-		require.NoError(t, DecodeNestedSpan(dec, &input, &out))
-		assert.Equal(t, "exp", out.Experimental)
+		var batch model.Batch
+		require.NoError(t, DecodeNestedSpan(dec, &input, &batch))
+		assert.Equal(t, "exp", batch[0].Span.Experimental)
 
 		// experimental disabled
 		input = modeldecoder.Input{Metadata: model.Metadata{}, RequestTime: time.Now(), Config: modeldecoder.Config{Experimental: false}}
 		str = `{"span":{"context":{"experimental":"exp"},"duration":100,"id":"a-b-c","name":"s","parent_id":"parent-123","trace_id":"trace-ab","type":"db","start":143}}`
 		dec = decoder.NewJSONDecoder(strings.NewReader(str))
-		out = model.Span{}
-		require.NoError(t, DecodeNestedSpan(dec, &input, &out))
+		batch = model.Batch{}
+		require.NoError(t, DecodeNestedSpan(dec, &input, &batch))
 		// experimental should only be set if allowed by configuration
-		assert.Nil(t, out.Experimental)
+		assert.Nil(t, batch[0].Span.Experimental)
 	})
 
 	t.Run("span-values", func(t *testing.T) {
@@ -132,13 +134,13 @@ func TestDecodeMapToSpanModel(t *testing.T) {
 		}
 
 		var input span
-		var out1, out2 model.Span
+		var out1, out2 model.APMEvent
 		reqTime := time.Now().Add(time.Second)
 		defaultVal := modeldecodertest.DefaultValues()
 		modeldecodertest.SetStructValues(&input, defaultVal)
 		mapToSpanModel(&input, initializedMetadata(), reqTime, modeldecoder.Config{Experimental: true}, &out1)
 		input.Reset()
-		modeldecodertest.AssertStructValues(t, &out1, exceptions, defaultVal)
+		modeldecodertest.AssertStructValues(t, out1.Span, exceptions, defaultVal)
 
 		// reuse input model for different event
 		// ensure memory is not shared by reusing input model
@@ -146,39 +148,39 @@ func TestDecodeMapToSpanModel(t *testing.T) {
 		modeldecodertest.SetStructValues(&input, otherVal)
 		mapToSpanModel(&input, initializedMetadata(), reqTime, modeldecoder.Config{Experimental: true}, &out2)
 		input.Reset()
-		modeldecodertest.AssertStructValues(t, &out2, exceptions, otherVal)
-		modeldecodertest.AssertStructValues(t, &out1, exceptions, defaultVal)
+		modeldecodertest.AssertStructValues(t, out2.Span, exceptions, otherVal)
+		modeldecodertest.AssertStructValues(t, out1.Span, exceptions, defaultVal)
 	})
 
 	t.Run("outcome", func(t *testing.T) {
 		var input span
-		var out model.Span
+		var out model.APMEvent
 		modeldecodertest.SetStructValues(&input, modeldecodertest.DefaultValues())
 		// set from input, ignore status code
 		input.Outcome.Set("failure")
 		input.Context.HTTP.StatusCode.Set(http.StatusPermanentRedirect)
-		mapToSpanModel(&input, &model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, "failure", out.Outcome)
+		mapToSpanModel(&input, model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
+		assert.Equal(t, "failure", out.Span.Outcome)
 		// derive from other fields - success
 		input.Outcome.Reset()
 		input.Context.HTTP.StatusCode.Set(http.StatusPermanentRedirect)
-		mapToSpanModel(&input, &model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, "success", out.Outcome)
+		mapToSpanModel(&input, model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
+		assert.Equal(t, "success", out.Span.Outcome)
 		// derive from other fields - failure
 		input.Outcome.Reset()
 		input.Context.HTTP.StatusCode.Set(http.StatusBadRequest)
-		mapToSpanModel(&input, &model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, "failure", out.Outcome)
+		mapToSpanModel(&input, model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
+		assert.Equal(t, "failure", out.Span.Outcome)
 		// derive from other fields - unknown
 		input.Outcome.Reset()
 		input.Context.HTTP.StatusCode.Reset()
-		mapToSpanModel(&input, &model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, "unknown", out.Outcome)
+		mapToSpanModel(&input, model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
+		assert.Equal(t, "unknown", out.Span.Outcome)
 	})
 
 	t.Run("timestamp", func(t *testing.T) {
 		var input span
-		var out model.Span
+		var out model.APMEvent
 		reqTime := time.Now().Add(time.Hour)
 		// add start to requestTime if eventTime is zero and start is given
 		defaultVal := modeldecodertest.DefaultValues()
@@ -186,33 +188,33 @@ func TestDecodeMapToSpanModel(t *testing.T) {
 		modeldecodertest.SetStructValues(&input, defaultVal)
 		mapToSpanModel(&input, initializedMetadata(), reqTime, modeldecoder.Config{}, &out)
 		timestamp := reqTime.Add(time.Duration((20.5) * float64(time.Millisecond)))
-		assert.Equal(t, timestamp, out.Timestamp)
+		assert.Equal(t, timestamp, out.Span.Timestamp)
 		// set requestTime if eventTime is zero and start is not set
-		out = model.Span{}
+		out = model.APMEvent{}
 		modeldecodertest.SetStructValues(&input, defaultVal)
 		input.Start.Reset()
 		mapToSpanModel(&input, initializedMetadata(), reqTime, modeldecoder.Config{}, &out)
-		require.Nil(t, out.Start)
-		assert.Equal(t, reqTime, out.Timestamp)
+		require.Nil(t, out.Span.Start)
+		assert.Equal(t, reqTime, out.Span.Timestamp)
 	})
 
 	t.Run("sample-rate", func(t *testing.T) {
 		var input span
-		var out model.Span
+		var out model.APMEvent
 		modeldecodertest.SetStructValues(&input, modeldecodertest.DefaultValues())
 		// sample rate is set to > 0
 		input.SampleRate.Set(0.25)
 		mapToSpanModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, 4.0, out.RepresentativeCount)
+		assert.Equal(t, 4.0, out.Span.RepresentativeCount)
 		// sample rate is not set
-		out.RepresentativeCount = 0.0
+		out.Span.RepresentativeCount = 0.0
 		input.SampleRate.Reset()
 		mapToSpanModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, 0.0, out.RepresentativeCount)
+		assert.Equal(t, 0.0, out.Span.RepresentativeCount)
 		// sample rate is set to 0
 		input.SampleRate.Set(0)
 		mapToSpanModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, 0.0, out.RepresentativeCount)
+		assert.Equal(t, 0.0, out.Span.RepresentativeCount)
 	})
 
 	t.Run("type-subtype-action", func(t *testing.T) {
@@ -249,11 +251,11 @@ func TestDecodeMapToSpanModel(t *testing.T) {
 				} else {
 					input.Action.Reset()
 				}
-				var out model.Span
+				var out model.APMEvent
 				mapToSpanModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{}, &out)
-				assert.Equal(t, tc.typ, out.Type)
-				assert.Equal(t, tc.subtype, out.Subtype)
-				assert.Equal(t, tc.action, out.Action)
+				assert.Equal(t, tc.typ, out.Span.Type)
+				assert.Equal(t, tc.subtype, out.Span.Subtype)
+				assert.Equal(t, tc.action, out.Span.Action)
 			})
 		}
 	})
@@ -261,8 +263,8 @@ func TestDecodeMapToSpanModel(t *testing.T) {
 	t.Run("http-headers", func(t *testing.T) {
 		var input span
 		input.Context.HTTP.Response.Headers.Set(http.Header{"a": []string{"b", "c"}})
-		var out model.Span
+		var out model.APMEvent
 		mapToSpanModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, common.MapStr{"a": []string{"b", "c"}}, out.HTTP.Response.Headers)
+		assert.Equal(t, common.MapStr{"a": []string{"b", "c"}}, out.Span.HTTP.Response.Headers)
 	})
 }

--- a/model/modeldecoder/v2/transaction_test.go
+++ b/model/modeldecoder/v2/transaction_test.go
@@ -50,30 +50,33 @@ func TestDecodeNestedTransaction(t *testing.T) {
 		input := modeldecoder.Input{Metadata: model.Metadata{}, RequestTime: now, Config: modeldecoder.Config{Experimental: true}}
 		str := `{"transaction":{"duration":100,"timestamp":1599996822281000,"id":"100","trace_id":"1","type":"request","span_count":{"started":2},"context":{"experimental":"exp"}}}`
 		dec := decoder.NewJSONDecoder(strings.NewReader(str))
-		var out model.Transaction
-		require.NoError(t, DecodeNestedTransaction(dec, &input, &out))
-		assert.Equal(t, "request", out.Type)
-		assert.Equal(t, "exp", out.Experimental)
-		assert.Equal(t, "2020-09-13 11:33:42.281 +0000 UTC", out.Timestamp.String())
+
+		var batch model.Batch
+		require.NoError(t, DecodeNestedTransaction(dec, &input, &batch))
+		require.Len(t, batch, 1)
+		require.NotNil(t, batch[0].Transaction)
+		assert.Equal(t, "request", batch[0].Transaction.Type)
+		assert.Equal(t, "exp", batch[0].Transaction.Experimental)
+		assert.Equal(t, "2020-09-13 11:33:42.281 +0000 UTC", batch[0].Transaction.Timestamp.String())
 
 		input = modeldecoder.Input{Metadata: model.Metadata{}, RequestTime: now, Config: modeldecoder.Config{Experimental: false}}
 		str = `{"transaction":{"duration":100,"id":"100","trace_id":"1","type":"request","span_count":{"started":2},"context":{"experimental":"exp"}}}`
 		dec = decoder.NewJSONDecoder(strings.NewReader(str))
-		out = model.Transaction{}
-		require.NoError(t, DecodeNestedTransaction(dec, &input, &out))
+		batch = model.Batch{}
+		require.NoError(t, DecodeNestedTransaction(dec, &input, &batch))
 		// experimental should only be set if allowed by configuration
-		assert.Nil(t, out.Experimental)
+		assert.Nil(t, batch[0].Transaction.Experimental)
 		// if no timestamp is provided, fall back to request time
-		assert.Equal(t, now, out.Timestamp)
+		assert.Equal(t, now, batch[0].Transaction.Timestamp)
 
-		err := DecodeNestedTransaction(decoder.NewJSONDecoder(strings.NewReader(`malformed`)), &input, &out)
+		err := DecodeNestedTransaction(decoder.NewJSONDecoder(strings.NewReader(`malformed`)), &input, &batch)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "decode")
 	})
 
 	t.Run("validate", func(t *testing.T) {
-		var out model.Transaction
-		err := DecodeNestedTransaction(decoder.NewJSONDecoder(strings.NewReader(`{}`)), &modeldecoder.Input{}, &out)
+		var batch model.Batch
+		err := DecodeNestedTransaction(decoder.NewJSONDecoder(strings.NewReader(`{}`)), &modeldecoder.Input{}, &batch)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "validation")
 	})
@@ -89,16 +92,16 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 	t.Run("metadata-set", func(t *testing.T) {
 		// do not overwrite metadata with zero event values
 		var input transaction
-		var out model.Transaction
+		var out model.APMEvent
 		mapToTransactionModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{Experimental: true}, &out)
 		// iterate through metadata model and assert values are set
-		modeldecodertest.AssertStructValues(t, &out.Metadata, exceptions, modeldecodertest.DefaultValues())
+		modeldecodertest.AssertStructValues(t, &out.Transaction.Metadata, exceptions, modeldecodertest.DefaultValues())
 	})
 
 	t.Run("metadata-overwrite", func(t *testing.T) {
 		// overwrite defined metadata with event metadata values
 		var input transaction
-		var out model.Transaction
+		var out model.APMEvent
 		otherVal := modeldecodertest.NonDefaultValues()
 		modeldecodertest.SetStructValues(&input, otherVal)
 		mapToTransactionModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{Experimental: true}, &out)
@@ -107,57 +110,57 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 		// ensure event Metadata are updated where expected
 		otherVal = modeldecodertest.NonDefaultValues()
 		userAgent := strings.Join(otherVal.HTTPHeader.Values("User-Agent"), ", ")
-		assert.Equal(t, userAgent, out.Metadata.UserAgent.Original)
+		assert.Equal(t, userAgent, out.Transaction.Metadata.UserAgent.Original)
 		// do not overwrite client.ip if already set in metadata
 		ip := modeldecodertest.DefaultValues().IP
-		assert.Equal(t, ip, out.Metadata.Client.IP, out.Metadata.Client.IP.String())
+		assert.Equal(t, ip, out.Transaction.Metadata.Client.IP, out.Transaction.Metadata.Client.IP.String())
 		// metadata labels and event labels should not be merged
 		mLabels := common.MapStr{"init0": "init", "init1": "init", "init2": "init"}
 		tLabels := common.MapStr{"overwritten0": "overwritten", "overwritten1": "overwritten"}
-		assert.Equal(t, mLabels, out.Metadata.Labels)
-		assert.Equal(t, tLabels, out.Labels)
+		assert.Equal(t, mLabels, out.Transaction.Metadata.Labels)
+		assert.Equal(t, tLabels, out.Transaction.Labels)
 		// service and user values should be set
-		modeldecodertest.AssertStructValues(t, &out.Metadata.Service, exceptions, otherVal)
-		modeldecodertest.AssertStructValues(t, &out.Metadata.User, exceptions, otherVal)
+		modeldecodertest.AssertStructValues(t, &out.Transaction.Metadata.Service, exceptions, otherVal)
+		modeldecodertest.AssertStructValues(t, &out.Transaction.Metadata.User, exceptions, otherVal)
 	})
 
 	t.Run("client-ip-header", func(t *testing.T) {
 		var input transaction
-		var out model.Transaction
+		var out model.APMEvent
 		input.Context.Request.Headers.Set(http.Header{})
 		input.Context.Request.Socket.RemoteAddress.Set(randomIP.String())
 		// from headers (case insensitive)
 		input.Context.Request.Headers.Val.Add("x-Real-ip", gatewayIP.String())
-		mapToTransactionModel(&input, &model.Metadata{}, time.Now(), modeldecoder.Config{Experimental: false}, &out)
-		assert.Equal(t, gatewayIP.String(), out.Metadata.Client.IP.String())
+		mapToTransactionModel(&input, model.Metadata{}, time.Now(), modeldecoder.Config{Experimental: false}, &out)
+		assert.Equal(t, gatewayIP.String(), out.Transaction.Metadata.Client.IP.String())
 		// ignore if set in metadata
-		out = model.Transaction{}
+		out = model.APMEvent{}
 		metadata := model.Metadata{Client: model.Client{IP: net.ParseIP("192.17.1.1")}}
-		mapToTransactionModel(&input, &metadata, time.Now(), modeldecoder.Config{Experimental: false}, &out)
-		assert.Equal(t, "192.17.1.1", out.Metadata.Client.IP.String())
+		mapToTransactionModel(&input, metadata, time.Now(), modeldecoder.Config{Experimental: false}, &out)
+		assert.Equal(t, "192.17.1.1", out.Transaction.Metadata.Client.IP.String())
 	})
 
 	t.Run("client-ip-socket", func(t *testing.T) {
 		var input transaction
-		var out model.Transaction
+		var out model.APMEvent
 		// set invalid headers
 		input.Context.Request.Headers.Set(http.Header{})
 		input.Context.Request.Headers.Val.Add("x-Real-ip", "192.13.14:8097")
 		input.Context.Request.Socket.RemoteAddress.Set(randomIP.String())
-		mapToTransactionModel(&input, &model.Metadata{}, time.Now(), modeldecoder.Config{Experimental: false}, &out)
+		mapToTransactionModel(&input, model.Metadata{}, time.Now(), modeldecoder.Config{Experimental: false}, &out)
 		// ensure client ip is populated from socket
-		assert.Equal(t, randomIP.String(), out.Metadata.Client.IP.String())
+		assert.Equal(t, randomIP.String(), out.Transaction.Metadata.Client.IP.String())
 	})
 
 	t.Run("overwrite-user", func(t *testing.T) {
 		// user should be populated by metadata or event specific, but not merged
 		var input transaction
-		var out model.Transaction
+		var out model.APMEvent
 		input.Context.User.Email.Set("test@user.com")
 		mapToTransactionModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{Experimental: false}, &out)
-		assert.Equal(t, "test@user.com", out.Metadata.User.Email)
-		assert.Zero(t, out.Metadata.User.ID)
-		assert.Zero(t, out.Metadata.User.Name)
+		assert.Equal(t, "test@user.com", out.Transaction.Metadata.User.Email)
+		assert.Zero(t, out.Transaction.Metadata.User.ID)
+		assert.Zero(t, out.Transaction.Metadata.User.Name)
 	})
 
 	t.Run("transaction-values", func(t *testing.T) {
@@ -174,7 +177,7 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 		}
 
 		var input transaction
-		var out1, out2 model.Transaction
+		var out1, out2 model.APMEvent
 		reqTime := time.Now().Add(time.Second)
 		defaultVal := modeldecodertest.DefaultValues()
 		modeldecodertest.SetStructValues(&input, defaultVal)
@@ -202,10 +205,10 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 		var input transaction
 		input.Context.Request.Headers.Set(http.Header{"a": []string{"b"}, "c": []string{"d", "e"}})
 		input.Context.Response.Headers.Set(http.Header{"f": []string{"g"}})
-		var out model.Transaction
+		var out model.APMEvent
 		mapToTransactionModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{Experimental: false}, &out)
-		assert.Equal(t, common.MapStr{"a": []string{"b"}, "c": []string{"d", "e"}}, out.HTTP.Request.Headers)
-		assert.Equal(t, common.MapStr{"f": []string{"g"}}, out.HTTP.Response.Headers)
+		assert.Equal(t, common.MapStr{"a": []string{"b"}, "c": []string{"d", "e"}}, out.Transaction.HTTP.Request.Headers)
+		assert.Equal(t, common.MapStr{"f": []string{"g"}}, out.Transaction.HTTP.Response.Headers)
 	})
 
 	t.Run("http-request-body", func(t *testing.T) {
@@ -215,91 +218,91 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 			"b": nil,
 			"c": "d",
 		})
-		var out model.Transaction
+		var out model.APMEvent
 		mapToTransactionModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{Experimental: false}, &out)
-		assert.Equal(t, map[string]interface{}{"a": common.Float(123.456), "c": "d"}, out.HTTP.Request.Body)
+		assert.Equal(t, map[string]interface{}{"a": common.Float(123.456), "c": "d"}, out.Transaction.HTTP.Request.Body)
 	})
 
 	t.Run("page.URL", func(t *testing.T) {
 		var input transaction
 		input.Context.Page.URL.Set("https://my.site.test:9201")
-		var out model.Transaction
+		var out model.APMEvent
 		mapToTransactionModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{Experimental: false}, &out)
-		assert.Equal(t, "https://my.site.test:9201", out.Page.URL.Full)
-		assert.Equal(t, "https://my.site.test:9201", out.URL.Full)
-		assert.Equal(t, 9201, out.Page.URL.Port)
-		assert.Equal(t, "https", out.Page.URL.Scheme)
+		assert.Equal(t, "https://my.site.test:9201", out.Transaction.Page.URL.Full)
+		assert.Equal(t, "https://my.site.test:9201", out.Transaction.URL.Full)
+		assert.Equal(t, 9201, out.Transaction.Page.URL.Port)
+		assert.Equal(t, "https", out.Transaction.Page.URL.Scheme)
 	})
 
 	t.Run("page.referer", func(t *testing.T) {
 		var input transaction
 		input.Context.Page.Referer.Set("https://my.site.test:9201")
-		var out model.Transaction
+		var out model.APMEvent
 		mapToTransactionModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{Experimental: false}, &out)
-		assert.Equal(t, "https://my.site.test:9201", out.Page.Referer)
-		assert.Equal(t, "https://my.site.test:9201", out.HTTP.Request.Referrer)
+		assert.Equal(t, "https://my.site.test:9201", out.Transaction.Page.Referer)
+		assert.Equal(t, "https://my.site.test:9201", out.Transaction.HTTP.Request.Referrer)
 	})
 
 	t.Run("sample-rate", func(t *testing.T) {
 		var input transaction
-		var out model.Transaction
+		var out model.APMEvent
 		modeldecodertest.SetStructValues(&input, modeldecodertest.DefaultValues())
 		// sample rate is set to > 0
 		input.SampleRate.Set(0.25)
 		mapToTransactionModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, 4.0, out.RepresentativeCount)
+		assert.Equal(t, 4.0, out.Transaction.RepresentativeCount)
 		// sample rate is not set -> Representative Count should be 1 by default
-		out.RepresentativeCount = 0.0 //reset to zero value
+		out.Transaction.RepresentativeCount = 0.0 //reset to zero value
 		input.SampleRate.Reset()
 		mapToTransactionModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, 1.0, out.RepresentativeCount)
+		assert.Equal(t, 1.0, out.Transaction.RepresentativeCount)
 		// sample rate is set to 0
-		out.RepresentativeCount = 0.0 //reset to zero value
+		out.Transaction.RepresentativeCount = 0.0 //reset to zero value
 		input.SampleRate.Set(0)
 		mapToTransactionModel(&input, initializedMetadata(), time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, 0.0, out.RepresentativeCount)
+		assert.Equal(t, 0.0, out.Transaction.RepresentativeCount)
 	})
 
 	t.Run("outcome", func(t *testing.T) {
 		var input transaction
-		var out model.Transaction
+		var out model.APMEvent
 		modeldecodertest.SetStructValues(&input, modeldecodertest.DefaultValues())
 		// set from input, ignore status code
 		input.Outcome.Set("failure")
 		input.Context.Response.StatusCode.Set(http.StatusBadRequest)
-		mapToTransactionModel(&input, &model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, "failure", out.Outcome)
+		mapToTransactionModel(&input, model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
+		assert.Equal(t, "failure", out.Transaction.Outcome)
 		// derive from other fields - success
 		input.Outcome.Reset()
 		input.Context.Response.StatusCode.Set(http.StatusBadRequest)
-		mapToTransactionModel(&input, &model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, "success", out.Outcome)
+		mapToTransactionModel(&input, model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
+		assert.Equal(t, "success", out.Transaction.Outcome)
 		// derive from other fields - failure
 		input.Outcome.Reset()
 		input.Context.Response.StatusCode.Set(http.StatusInternalServerError)
-		mapToTransactionModel(&input, &model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, "failure", out.Outcome)
+		mapToTransactionModel(&input, model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
+		assert.Equal(t, "failure", out.Transaction.Outcome)
 		// derive from other fields - unknown
 		input.Outcome.Reset()
 		input.Context.Response.StatusCode.Reset()
-		mapToTransactionModel(&input, &model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, "unknown", out.Outcome)
+		mapToTransactionModel(&input, model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
+		assert.Equal(t, "unknown", out.Transaction.Outcome)
 	})
 
 	t.Run("session", func(t *testing.T) {
 		var input transaction
-		var out model.Transaction
+		var out model.APMEvent
 		modeldecodertest.SetStructValues(&input, modeldecodertest.DefaultValues())
 		input.Session.ID.Reset()
-		mapToTransactionModel(&input, &model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
-		assert.Equal(t, model.TransactionSession{}, out.Session)
+		mapToTransactionModel(&input, model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
+		assert.Equal(t, model.TransactionSession{}, out.Transaction.Session)
 
 		input.Session.ID.Set("session_id")
 		input.Session.Sequence.Set(123)
-		mapToTransactionModel(&input, &model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
+		mapToTransactionModel(&input, model.Metadata{}, time.Now(), modeldecoder.Config{}, &out)
 		assert.Equal(t, model.TransactionSession{
 			ID:       "session_id",
 			Sequence: 123,
-		}, out.Session)
+		}, out.Transaction.Session)
 	})
 }

--- a/processor/stream/benchmark_test.go
+++ b/processor/stream/benchmark_test.go
@@ -58,7 +58,7 @@ func benchmarkStreamProcessor(b *testing.B, processor *Processor, files []string
 			b.StartTimer()
 
 			var result Result
-			processor.HandleStream(context.Background(), &model.Metadata{}, r, batchSize, batchProcessor, &result)
+			processor.HandleStream(context.Background(), model.Metadata{}, r, batchSize, batchProcessor, &result)
 		}
 	}
 

--- a/processor/stream/processor_test.go
+++ b/processor/stream/processor_test.go
@@ -54,7 +54,7 @@ func TestHandlerReadStreamError(t *testing.T) {
 	sp := BackendProcessor(&config.Config{MaxEventSize: 100 * 1024})
 
 	var actualResult Result
-	err = sp.HandleStream(context.Background(), &model.Metadata{}, timeoutReader, 10, processor, &actualResult)
+	err = sp.HandleStream(context.Background(), model.Metadata{}, timeoutReader, 10, processor, &actualResult)
 	assert.EqualError(t, err, "timeout")
 	assert.Equal(t, Result{Accepted: accepted}, actualResult)
 }
@@ -80,7 +80,7 @@ func TestHandlerReportingStreamError(t *testing.T) {
 
 		var actualResult Result
 		err := sp.HandleStream(
-			context.Background(), &model.Metadata{},
+			context.Background(), model.Metadata{},
 			bytes.NewReader(payload), 10, processor, &actualResult,
 		)
 		assert.Equal(t, test.err, err)
@@ -177,11 +177,13 @@ func TestIntegrationESOutput(t *testing.T) {
 			ctx := utility.ContextWithRequestTime(context.Background(), reqTimestamp)
 			batchProcessor := makeApproveEventsBatchProcessor(t, name, &accepted)
 
-			reqDecoderMeta := &model.Metadata{Host: model.Host{IP: net.ParseIP("192.0.0.1")}}
+			metadata := model.Metadata{
+				Host: model.Host{IP: net.ParseIP("192.0.0.1")},
+			}
 
 			p := BackendProcessor(&config.Config{MaxEventSize: 100 * 1024})
 			var actualResult Result
-			err = p.HandleStream(ctx, reqDecoderMeta, bytes.NewReader(payload), 10, batchProcessor, &actualResult)
+			err = p.HandleStream(ctx, metadata, bytes.NewReader(payload), 10, batchProcessor, &actualResult)
 			if test.err != nil {
 				assert.Equal(t, test.err, err)
 			} else {
@@ -210,13 +212,14 @@ func TestIntegrationRum(t *testing.T) {
 			ctx := utility.ContextWithRequestTime(context.Background(), reqTimestamp)
 			batchProcessor := makeApproveEventsBatchProcessor(t, name, &accepted)
 
-			reqDecoderMeta := model.Metadata{
+			metadata := model.Metadata{
 				UserAgent: model.UserAgent{Original: "rum-2.0"},
-				Client:    model.Client{IP: net.ParseIP("192.0.0.1")}}
+				Client:    model.Client{IP: net.ParseIP("192.0.0.1")},
+			}
 
 			p := RUMV2Processor(&config.Config{MaxEventSize: 100 * 1024})
 			var actualResult Result
-			err = p.HandleStream(ctx, &reqDecoderMeta, bytes.NewReader(payload), 10, batchProcessor, &actualResult)
+			err = p.HandleStream(ctx, metadata, bytes.NewReader(payload), 10, batchProcessor, &actualResult)
 			require.NoError(t, err)
 			assert.Equal(t, Result{Accepted: accepted}, actualResult)
 		})
@@ -241,13 +244,14 @@ func TestRUMV3(t *testing.T) {
 			ctx := utility.ContextWithRequestTime(context.Background(), reqTimestamp)
 			batchProcessor := makeApproveEventsBatchProcessor(t, name, &accepted)
 
-			reqDecoderMeta := model.Metadata{
+			metadata := model.Metadata{
 				UserAgent: model.UserAgent{Original: "rum-2.0"},
-				Client:    model.Client{IP: net.ParseIP("192.0.0.1")}}
+				Client:    model.Client{IP: net.ParseIP("192.0.0.1")},
+			}
 
 			p := RUMV3Processor(&config.Config{MaxEventSize: 100 * 1024})
 			var actualResult Result
-			err = p.HandleStream(ctx, &reqDecoderMeta, bytes.NewReader(payload), 10, batchProcessor, &actualResult)
+			err = p.HandleStream(ctx, metadata, bytes.NewReader(payload), 10, batchProcessor, &actualResult)
 			require.NoError(t, err)
 			assert.Equal(t, Result{Accepted: accepted}, actualResult)
 		})


### PR DESCRIPTION
## Motivation/summary

Modify the model/modeldecoder API such Decode function decode events into a model.Batch. This is another precursor to moving metadata up to APMEvent, where we will need to decode into an APMEvent rather than the nested event types (model.Transaction, etc.)

This change also enables us to remove the rumv3.Transaction exception, and have rumv3 add multiple events directly to the batch in the case of transactions with nested spans and metricsets. This in turn simplifies processor/stream.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

Non-functional change.

## Related issues

#4120
#3565