### PR TITLE
update-beats: git add fields updates

### DIFF
--- a/.ci/scripts/update-beats.sh
+++ b/.ci/scripts/update-beats.sh
@@ -9,7 +9,9 @@ make update-beats
 COMMIT_MESSAGE="Update to elastic/beats@$(go list -m -f {{.Version}} github.com/elastic/beats/... | cut -d- -f3)"
 
 git checkout -b "update-beats-$(date "+%Y%m%d%H%M%S")"
-git add go.mod go.sum NOTICE.txt .go-version docs/version.asciidoc
+git add go.mod go.sum NOTICE.txt \
+	.go-version docs/version.asciidoc \
+	docs/fields.asciidoc include/fields.go x-pack/apm-server/include/fields.go
 find . -maxdepth 2 -name Dockerfile -exec git add {} \;
 
 git diff --staged --quiet || git commit -m "$COMMIT_MESSAGE"


### PR DESCRIPTION
## Motivation/summary

When running `make update-beats`, it is possible for fields to change. When this happens, we'll need to `git add` the following additional files:
 - include/fields.go
 - x-pack/apm-server/fields.go
 - docs/fields.asciidoc

See https://github.com/elastic/apm-server/pull/5834

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

None