### PR TITLE
docs: update data streams naming

### DIFF
--- a/docs/apm-package/data-streams.asciidoc
+++ b/docs/apm-package/data-streams.asciidoc
@@ -31,33 +31,31 @@ Traces::
 Traces are comprised of {apm-overview-ref-v}/apm-data-model.html[spans and transactions].
 Traces are stored in the following data stream:
 
-- Application traces: `traces-apm.<service.name>-<namespace>`
+- Application traces: `traces-apm-<namespace>`
 
 Metrics::
 
 Metrics include application-based metrics and basic system metrics.
 Metrics are stored in the following data streams:
 
-- Application defined metrics: `metrics-apm.<service.name>-<namespace>`
-- APM internal metrics: `metrics-apm.internal.<service.name>-<namespace>`
-- APM profiling metrics: `metrics-apm.profiling.<service.name>-<namespace>`
+- Application defined metrics: `metrics-apm.app.<service.name>-<namespace>`
+- APM internal metrics: `metrics-apm.internal-<namespace>`
+- APM profiling metrics: `metrics-apm.profiling-<namespace>`
 
 Logs::
 
 Logs include application error events and application logs.
 Logs are stored in the following data streams:
 
-- Application logs: `logs-<service.name>-<namespace>`
-- APM error/exception logging: `logs-apm.error.<service.name>-<namespace>`
+- Application logs: `logs-<namespace>`
+- APM error/exception logging: `logs-apm.error-<namespace>`
 
 [discrete]
 [[apm-integration-service-name]]
 === Service names
 
 The APM integration maps an instrumented service's name–defined in each APM agent's
-configuration–to the index that its data is stored in {es}.
-This process provides more granular security and retentions policies,
-and simplifies the overall APM experience.
+configuration–to the index that its application defined metrics are stored in {es}.
 Service names therefore must follow index naming rules:
 
 * Service names are case-insensitive and must be unique.

--- a/docs/apm-package/data-streams.asciidoc
+++ b/docs/apm-package/data-streams.asciidoc
@@ -47,7 +47,6 @@ Logs::
 Logs include application error events and application logs.
 Logs are stored in the following data streams:
 
-- Application logs: `logs-<namespace>`
 - APM error/exception logging: `logs-apm.error-<namespace>`
 
 [discrete]


### PR DESCRIPTION
## Summary

This PR updates the data stream naming scheme for the APM integration. Closes https://github.com/elastic/observability-docs/issues/842.

The readme file does not need to be updated, but additional changes in the observability-docs repo are necessary (https://github.com/elastic/observability-docs/pull/946).