### PR TITLE
docs: add 7.14 release notes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,5 +1,6 @@
 include::./changelogs/head.asciidoc[]
 include::./changelogs/8.0.asciidoc[]
+include::./changelogs/7.14.asciidoc[]
 include::./changelogs/7.13.asciidoc[]
 include::./changelogs/7.12.asciidoc[]
 include::./changelogs/7.11.asciidoc[]

--- a/changelogs/7.13.asciidoc
+++ b/changelogs/7.13.asciidoc
@@ -57,6 +57,7 @@ https://github.com/elastic/apm-server/compare/v7.12.1\...v7.13.0[View commits]
 ==== Bug fixes
 * Fix `setup.template` config merging {pull}4950[4950]
 * The server now responds with 503 instead of 401 when failure is unrelated to API Key validity, e.g. if Elasticsearch is inaccessible {pull}5053[5053]
+* Fix panic due to misaligned 64-bit access on 32-bit architectures {pull}5277[5277]
 
 [float]
 ==== Added

--- a/changelogs/7.14.asciidoc
+++ b/changelogs/7.14.asciidoc
@@ -1,0 +1,46 @@
+[[release-notes-7.14]]
+== APM Server version 7.14
+
+https://github.com/elastic/apm-server/compare/7.13\...7.14[View commits]
+
+* <<release-notes-7.14.0>>
+
+[float]
+[[release-notes-7.14.0]]
+=== APM Server version 7.14.0
+
+https://github.com/elastic/apm-server/compare/v7.13.4\...v7.14.0[View commits]
+
+[float]
+==== Breaking Changes
+* Removed monitoring counters `apm-server.processor.stream.errors.{queue,server,closed}` {pull}5453[5453]
+
+[float]
+==== Bug fixes
+* Fix panic on Fleet policy change when transaction metrics or tail-based sampling are enabled {pull}5670[5670]
+* Remove multipart form temporary files left behind by source map uploads {pull}5718[5718]
+* Removed service name from dataset {pull}5451[5451]
+* Fixed tail-based sampling pubsub to use _seq_no correctly {pull}5126[5126]
+
+[float]
+==== Added
+* Support fetching sourcemaps from fleet {pull}5410[5410]
+* Add support for more input variables in fleet integration {pull}5444[5444]
+* Add debug logging of OpenTelemetry payloads {pull}5474[5474]
+* Add support for OpenTelemetry labels describing mobile connectivity {pull}5436[5436]
+* Introduce `apm-server.auth.*` config {pull}5457[5457]
+* Add support for adjusting OTel event timestamps using `telemetry.sdk.elastic_export_timestamp` {pull}5433[5433]
+* Add units to metric fields {pull}5395[5395]
+* Add support for histograms to metrics intake {pull}5360[5360]
+* Display apm-server url in fleet ui's apm-server integration {pull}4895[4895]
+* Translate otel messaging.* semantic conventions to ECS {pull}5334[5334]
+* Tail-sampling processor now resumes subscription from previous position after restart {pull}5350[5350]
+* Add support for dynamic histogram metrics {pull}5239[5239]
+* Support setting agent configuration from apm-server.yml {pull}5177[5177]
+* Add metric_type and unit to field metadata of system metrics {pull}5230[5230]
+
+[float]
+==== Deprecated
+* Make `destination.service.name` and `destination.service.type` fields optional and deprecated {pull}5468[5468]
+* `apm-server.secret_token` is now `apm-server.auth.secret_token` {pull}5457[5457]
+* `apm-server.api_key` is now `apm-server.auth.api_key` {pull}5457[5457]

--- a/changelogs/7.14.asciidoc
+++ b/changelogs/7.14.asciidoc
@@ -38,6 +38,8 @@ https://github.com/elastic/apm-server/compare/v7.13.4\...v7.14.0[View commits]
 * Add support for dynamic histogram metrics {pull}5239[5239]
 * Support setting agent configuration from apm-server.yml {pull}5177[5177]
 * Add metric_type and unit to field metadata of system metrics {pull}5230[5230]
+* Under fleet, report which agent configs have been applied {pull}5481[5481]
+* Server sends its raw config to kibana when running on ECE/ESS {pull}5424[5424]
 
 [float]
 ==== Deprecated

--- a/changelogs/8.0.asciidoc
+++ b/changelogs/8.0.asciidoc
@@ -11,7 +11,6 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 
 [float]
 ==== Breaking Changes
-* Removed monitoring counters `apm-server.processor.stream.errors.{queue,server,closed}` {pull}5453[5453]
 * APM Server now responds with 403 (HTTP) and PermissionDenied (gRPC) for authenticated but unauthorized requests {pull}5545[5545]
 * `sourcemap.error` and `sourcemap.updated` are no longer set due to failing to find a matching source map {pull}5631[5631]
 * experimental:["This breaking change applies to the experimental <<apm-integration>>."] Removed `service.name` from dataset {pull}5451[5451]
@@ -19,10 +18,6 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 [float]
 ==== Bug fixes
 * Fix panic due to misaligned 64-bit access on 32-bit architectures {pull}5277[5277]
-* Fixed tail-based sampling pubsub to use _seq_no correctly {pull}5126[5126]
-* Removed service name from dataset {pull}5451[5451]
-* Fix panic on Fleet policy change when transaction metrics or tail-based sampling are enabled {pull}5670[5670]
-* Remove multipart form temporary files left behind by source map uploads {pull}5718[5718]
 
 [float]
 ==== Intake API Changes
@@ -30,21 +25,7 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 
 [float]
 ==== Added
-* Support setting agent configuration from apm-server.yml {pull}5177[5177]
-* Add metric_type and unit to field metadata of system metrics {pull}5230[5230]
-* Display apm-server url in fleet ui's apm-server integration {pull}4895[4895]
-* Translate otel messaging.* semantic conventions to ECS {pull}5334[5334]
-* Add support for dynamic histogram metrics {pull}5239[5239]
-* Tail-sampling processor now resumes subscription from previous position after restart {pull}5350[5350]
-* Add support for histograms to metrics intake {pull}5360[5360]
 * Upgrade Go to 1.16.5 {pull}5454[5454]
-* Add units to metric fields {pull}5395[5395]
-* Support fetching sourcemaps from fleet {pull}5410[5410]
-* Add support for adjusting OTel event timestamps using `telemetry.sdk.elastic_export_timestamp` {pull}5433[5433]
-* Add support for OpenTelemetry labels describing mobile connectivity {pull}5436[5436]
-* Introduce `apm-server.auth.*` config {pull}5457[5457]
-* Add debug logging of OpenTelemetry payloads {pull}5474[5474]
-* Add support for more input variables in fleet integration {pull}5444[5444]
 * Under fleet, report which agent configs have been applied {pull}5481[5481]
 * Server sends its raw config to kibana when running on ECE/ESS {pull}5424[5424]
 * Add HTTP span fields as top level ECS fields {pull}5396[5396]
@@ -52,8 +33,5 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 * Upgrade Go to 1.16.6 {pull}5754[5754]
 * Introduce ingest pipeline `apm_data_stream_migration` for migrating pre-data stream indices {5768}[5768]
 
-[float]
-==== Deprecated
-* Make `destination.service.name` and `destination.service.type` fields optional and deprecated {pull}5468[5468]
-* `apm-server.secret_token` is now `apm-server.auth.secret_token` {pull}5457[5457]
-* `apm-server.api_key` is now `apm-server.auth.api_key` {pull}5457[5457]
+// [float]
+// ==== Deprecated

--- a/changelogs/8.0.asciidoc
+++ b/changelogs/8.0.asciidoc
@@ -15,9 +15,8 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 * `sourcemap.error` and `sourcemap.updated` are no longer set due to failing to find a matching source map {pull}5631[5631]
 * experimental:["This breaking change applies to the experimental <<apm-integration>>."] Removed `service.name` from dataset {pull}5451[5451]
 
-[float]
-==== Bug fixes
-* Fix panic due to misaligned 64-bit access on 32-bit architectures {pull}5277[5277]
+// [float]
+// ==== Bug fixes
 
 [float]
 ==== Intake API Changes

--- a/changelogs/8.0.asciidoc
+++ b/changelogs/8.0.asciidoc
@@ -25,8 +25,6 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 [float]
 ==== Added
 * Upgrade Go to 1.16.5 {pull}5454[5454]
-* Under fleet, report which agent configs have been applied {pull}5481[5481]
-* Server sends its raw config to kibana when running on ECE/ESS {pull}5424[5424]
 * Add HTTP span fields as top level ECS fields {pull}5396[5396]
 * Introduce `apm-server.auth.anonymous.*` config {pull}5623[5623]
 * Upgrade Go to 1.16.6 {pull}5754[5754]

--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -4,6 +4,10 @@ APM Server is built on top of {beats-ref}/index.html[libbeat].
 As such, any breaking change in libbeat is also considered to be a breaking change in APM Server.
 
 [float]
+=== 7.14
+There are no breaking changes in APM Server.
+
+[float]
 === 7.13
 There are no breaking changes in APM Server.
 

--- a/docs/guide/apm-breaking-changes.asciidoc
+++ b/docs/guide/apm-breaking-changes.asciidoc
@@ -3,6 +3,7 @@
 
 This section discusses the changes that you need to be aware of when migrating your application from one version of APM to another.
 
+* <<breaking-7.14.0>>
 * <<breaking-7.13.0>>
 * <<breaking-7.12.0>>
 * <<breaking-7.11.0>>
@@ -30,7 +31,14 @@ Also see {observability-guide}/whats-new.html[What's new in Observability {minor
 
 // tag::notable-v8-breaking-changes[]
 // end::notable-v8-breaking-changes[]
+// tag::715-bc[]
+// end::715-bc[]
+
+[[breaking-7.14.0]]
+=== 7.14.0 APM Breaking changes
+
 // tag::714-bc[]
+No breaking changes.
 // end::714-bc[]
 
 [[breaking-7.13.0]]

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -11,6 +11,7 @@
 This following sections summarizes the changes in each release.
 
 * <<release-notes-8.0>>
+* <<release-notes-7.14>>
 * <<release-notes-7.13>>
 * <<release-notes-7.12>>
 * <<release-notes-7.11>>


### PR DESCRIPTION
### Summary

This PR moves certain release notes from `8.0.0-alpha1` to `7.14.0`.

### Oops

@axw I think I messed up in https://github.com/elastic/apm-server/pull/5802. 

### Other

This PR _should_ update [stack-docs](https://github.com/elastic/stack-docs/tree/master/docs/en/install-upgrade) when backported to 7.14.