### PR TITLE
[7.14] docs: add 6.8.18 release notes (#5861)

### DIFF
--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,6 +3,7 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.18>>
 * <<release-notes-6.8.17>>
 * <<release-notes-6.8.16>>
 * <<release-notes-6.8.15>>
@@ -21,6 +22,14 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.2>>
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
+
+[float]
+[[release-notes-6.8.18]]
+=== APM Server version 6.8.18
+
+https://github.com/elastic/apm-server/compare/v6.8.17\...v6.8.18[View commits]
+
+No significant changes.
 
 [float]
 [[release-notes-6.8.17]]

--- a/changelogs/7.0.asciidoc
+++ b/changelogs/7.0.asciidoc
@@ -25,7 +25,7 @@ https://github.com/elastic/apm-server/compare/v7.0.0\...v7.0.1[View commits]
 [[release-notes-7.0.0]]
 === APM Server version 7.0.0
 
-https://github.com/elastic/apm-server/compare/v6.8.5\...v7.0.0[View commits]
+https://github.com/elastic/apm-server/compare/v6.8.18\...v7.0.0[View commits]
 
 These release notes include all changes made in the alpha, beta, and RC releases of 7.0.0.
 


### PR DESCRIPTION
Backports the following commits to 7.14:
 - docs: add 6.8.18 release notes (#5861)