### PR TITLE
docs: update transaction metrics

### DIFF
--- a/docs/transaction-metrics.asciidoc
+++ b/docs/transaction-metrics.asciidoc
@@ -33,7 +33,7 @@ apm-server:
 ==== `enabled`
 
 Enables the collection and publishing of transaction metrics.
-Enabling this setting the removes the need to store unsampled transactions, reducing storage costs.
+Enabling this setting removes the need to store unsampled transactions, reducing storage costs.
 Storing unsampled transactions is controlled independently with <<sampling-keep_unsampled>>.
 
 Default: `true`.

--- a/docs/transaction-metrics.asciidoc
+++ b/docs/transaction-metrics.asciidoc
@@ -9,7 +9,7 @@ experimental[]
 ++++
 
 When enabled, {beatname_uc} produces transaction histogram metrics that are used to power the APM app.
-Shifting this responsibility from APM app to APM Server results in improved query performance and removes the need to store unsampled transactions.
+Shifting this responsibility from APM app to APM Server removes the need to store unsampled transactions, reducing storage costs.
 
 Example config file:
 
@@ -33,9 +33,10 @@ apm-server:
 ==== `enabled`
 
 Enables the collection and publishing of transaction metrics.
-This setting improves query performance in the APM app.
+Enabling this setting the removes the need to store unsampled transactions, reducing storage costs.
+Storing unsampled transactions is controlled independently with <<sampling-keep_unsampled>>.
 
-Default: `false`.
+Default: `true`.
 
 IMPORTANT: To prevent inaccuracies in the APM app, transaction metrics must also be enabled in
 Kibana with `xpack.apm.searchAggregatedTransactions`.
@@ -57,7 +58,7 @@ Maximum number of transaction groups to keep track of.
 Once exceeded, APM Server devolves into recording a metrics document for each transaction that is not in one
 of the transaction groups being tracked.
 
-Default: `1000`.
+Default: `10000`.
 
 [[transactions-hdrhistogram_significant_figures]]
 [float]
@@ -69,17 +70,6 @@ Supported values are `1` through `5`.
 See {ref}/search-aggregations-metrics-percentile-aggregation.html#_hdr_histogram_2[HDR histogram] for more information.
 
 Default: `2`.
-
-[[transactions-lru_size]]
-[float]
-==== `rum.user_agent.lru_size`
-
-This option controls the cache size of RUM user-agent strings.
-
-RUM "page-load" transactions are aggregated on the user-agent name, which requires user-agent parsing.
-To avoid parsing every user-agent, a cache of user-agent strings is maintained.
-
-Default: `5000`.
 
 [float]
 [[configuration-sampling]]


### PR DESCRIPTION
## Motivation/summary

Update apm-server.aggregation.transactions.* docs:

- `enabled` defaults to true since 7.13
- `max_groups` defaults to 10000 since 7.10
- `rum.user_agent.lru_size` was dropped (I forget when)

Also change some of the wording around the purpose of these metrics:
they are primarily about reducing storage costs, not improving query
performance. The latter is expected to eventually be the case, but
has not yet been proven and is not hte primary goal.