### PR TITLE
ingest/pipeline: fix compat with old Elasticsearch

### DIFF
--- a/apmpackage/apm/data_stream/app_metrics/elasticsearch/ingest_pipeline/apm_convert_destination_address.json
+++ b/apmpackage/apm/data_stream/app_metrics/elasticsearch/ingest_pipeline/apm_convert_destination_address.json
@@ -2,11 +2,10 @@
   "description": "Convert destination.address to an IP, storing in destination.ip",
   "processors": [
     {
-      "convert": {
-        "field": "destination.address",
-        "target_field": "destination.ip",
-        "type": "ip",
-        "ignore_missing": true,
+      "set": {
+        "if": "ctx.destination?.address != null",
+        "field": "destination.ip",
+        "value": "{{destination.address}}",
         "ignore_failure": true
       }
     }

--- a/apmpackage/apm/data_stream/app_metrics/elasticsearch/ingest_pipeline/apm_error_grouping_name.json
+++ b/apmpackage/apm/data_stream/app_metrics/elasticsearch/ingest_pipeline/apm_error_grouping_name.json
@@ -10,7 +10,7 @@
     {
       "set": {
         "field": "error.grouping_name",
-        "copy_from": "error.log.message",
+        "value": "{{error.log.message}}",
         "if": "ctx.error?.log?.message != null"
       }
     }

--- a/apmpackage/apm/data_stream/error_logs/elasticsearch/ingest_pipeline/apm_convert_destination_address.json
+++ b/apmpackage/apm/data_stream/error_logs/elasticsearch/ingest_pipeline/apm_convert_destination_address.json
@@ -2,11 +2,10 @@
   "description": "Convert destination.address to an IP, storing in destination.ip",
   "processors": [
     {
-      "convert": {
-        "field": "destination.address",
-        "target_field": "destination.ip",
-        "type": "ip",
-        "ignore_missing": true,
+      "set": {
+        "if": "ctx.destination?.address != null",
+        "field": "destination.ip",
+        "value": "{{destination.address}}",
         "ignore_failure": true
       }
     }

--- a/apmpackage/apm/data_stream/error_logs/elasticsearch/ingest_pipeline/apm_error_grouping_name.json
+++ b/apmpackage/apm/data_stream/error_logs/elasticsearch/ingest_pipeline/apm_error_grouping_name.json
@@ -10,7 +10,7 @@
     {
       "set": {
         "field": "error.grouping_name",
-        "copy_from": "error.log.message",
+        "value": "{{error.log.message}}",
         "if": "ctx.error?.log?.message != null"
       }
     }

--- a/apmpackage/apm/data_stream/internal_metrics/elasticsearch/ingest_pipeline/apm_convert_destination_address.json
+++ b/apmpackage/apm/data_stream/internal_metrics/elasticsearch/ingest_pipeline/apm_convert_destination_address.json
@@ -2,11 +2,10 @@
   "description": "Convert destination.address to an IP, storing in destination.ip",
   "processors": [
     {
-      "convert": {
-        "field": "destination.address",
-        "target_field": "destination.ip",
-        "type": "ip",
-        "ignore_missing": true,
+      "set": {
+        "if": "ctx.destination?.address != null",
+        "field": "destination.ip",
+        "value": "{{destination.address}}",
         "ignore_failure": true
       }
     }

--- a/apmpackage/apm/data_stream/internal_metrics/elasticsearch/ingest_pipeline/apm_error_grouping_name.json
+++ b/apmpackage/apm/data_stream/internal_metrics/elasticsearch/ingest_pipeline/apm_error_grouping_name.json
@@ -10,7 +10,7 @@
     {
       "set": {
         "field": "error.grouping_name",
-        "copy_from": "error.log.message",
+        "value": "{{error.log.message}}",
         "if": "ctx.error?.log?.message != null"
       }
     }

--- a/apmpackage/apm/data_stream/profile_metrics/elasticsearch/ingest_pipeline/apm_convert_destination_address.json
+++ b/apmpackage/apm/data_stream/profile_metrics/elasticsearch/ingest_pipeline/apm_convert_destination_address.json
@@ -2,11 +2,10 @@
   "description": "Convert destination.address to an IP, storing in destination.ip",
   "processors": [
     {
-      "convert": {
-        "field": "destination.address",
-        "target_field": "destination.ip",
-        "type": "ip",
-        "ignore_missing": true,
+      "set": {
+        "if": "ctx.destination?.address != null",
+        "field": "destination.ip",
+        "value": "{{destination.address}}",
         "ignore_failure": true
       }
     }

--- a/apmpackage/apm/data_stream/profile_metrics/elasticsearch/ingest_pipeline/apm_error_grouping_name.json
+++ b/apmpackage/apm/data_stream/profile_metrics/elasticsearch/ingest_pipeline/apm_error_grouping_name.json
@@ -10,7 +10,7 @@
     {
       "set": {
         "field": "error.grouping_name",
-        "copy_from": "error.log.message",
+        "value": "{{error.log.message}}",
         "if": "ctx.error?.log?.message != null"
       }
     }

--- a/apmpackage/apm/data_stream/traces/elasticsearch/ingest_pipeline/apm_convert_destination_address.json
+++ b/apmpackage/apm/data_stream/traces/elasticsearch/ingest_pipeline/apm_convert_destination_address.json
@@ -2,11 +2,10 @@
   "description": "Convert destination.address to an IP, storing in destination.ip",
   "processors": [
     {
-      "convert": {
-        "field": "destination.address",
-        "target_field": "destination.ip",
-        "type": "ip",
-        "ignore_missing": true,
+      "set": {
+        "if": "ctx.destination?.address != null",
+        "field": "destination.ip",
+        "value": "{{destination.address}}",
         "ignore_failure": true
       }
     }

--- a/apmpackage/apm/data_stream/traces/elasticsearch/ingest_pipeline/apm_error_grouping_name.json
+++ b/apmpackage/apm/data_stream/traces/elasticsearch/ingest_pipeline/apm_error_grouping_name.json
@@ -10,7 +10,7 @@
     {
       "set": {
         "field": "error.grouping_name",
-        "copy_from": "error.log.message",
+        "value": "{{error.log.message}}",
         "if": "ctx.error?.log?.message != null"
       }
     }

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -8,6 +8,7 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 
 [float]
 ==== Bug fixes
+- Fix apm_error_grouping_name and apm_convert_destination_address {pull}5876[5876]
 
 [float]
 ==== Intake API Changes

--- a/ingest/pipeline/definition.json
+++ b/ingest/pipeline/definition.json
@@ -139,11 +139,10 @@
       "description": "Convert destination.address to an IP, storing in destination.ip",
       "processors": [
         {
-          "convert": {
-            "field": "destination.address",
-            "target_field": "destination.ip",
-            "type": "ip",
-            "ignore_missing": true,
+          "set": {
+            "if": "ctx.destination?.address != null",
+            "field": "destination.ip",
+            "value": "{{destination.address}}",
             "ignore_failure": true
           }
         }
@@ -192,7 +191,7 @@
         {
           "set": {
             "field": "error.grouping_name",
-            "copy_from": "error.log.message",
+            "value": "{{error.log.message}}",
             "if": "ctx.error?.log?.message != null"
           }
         }

--- a/ingest/pipeline/definition.yml
+++ b/ingest/pipeline/definition.yml
@@ -87,11 +87,10 @@ apm_ingest_timestamp:
 apm_convert_destination_address:
   description: Convert destination.address to an IP, storing in destination.ip
   processors:
-  - convert:
-      field: destination.address
-      target_field: destination.ip
-      type: ip
-      ignore_missing: true
+  - set:
+      if: ctx.destination?.address != null
+      field: destination.ip
+      value: "{{destination.address}}"
       ignore_failure: true
 
 apm_remove_span_metadata:
@@ -122,7 +121,7 @@ apm_error_grouping_name:
       if: ctx.error?.exception?.length != null && ctx.error?.exception?.length > 0
   - set:
       field: error.grouping_name
-      copy_from: error.log.message
+      value: "{{error.log.message}}"
       if: ctx.error?.log?.message != null
 
 # TODO(axw) handle unit in metric descriptions.


### PR DESCRIPTION
## Motivation/summary

Fix compatibility with older Elasticsearch versions:

 - don't use set.copy_from, it's not supported before 7.11
 - don't use convert, converting IPs was only added in 7.13

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

Run apm-server with 7.0.0

## Related issues

Closes https://github.com/elastic/apm-server/issues/5786
Closes https://github.com/elastic/apm-server/issues/5807