### PR TITLE
[7.14] docs: update data streams naming (#5859)

### DIFF
--- a/docs/apm-package/data-streams.asciidoc
+++ b/docs/apm-package/data-streams.asciidoc
@@ -31,33 +31,30 @@ Traces::
 Traces are comprised of {apm-overview-ref-v}/apm-data-model.html[spans and transactions].
 Traces are stored in the following data stream:
 
-- Application traces: `traces-apm.<service.name>-<namespace>`
+- Application traces: `traces-apm-<namespace>`
 
 Metrics::
 
 Metrics include application-based metrics and basic system metrics.
 Metrics are stored in the following data streams:
 
-- Application defined metrics: `metrics-apm.<service.name>-<namespace>`
-- APM internal metrics: `metrics-apm.internal.<service.name>-<namespace>`
-- APM profiling metrics: `metrics-apm.profiling.<service.name>-<namespace>`
+- Application defined metrics: `metrics-apm.app.<service.name>-<namespace>`
+- APM internal metrics: `metrics-apm.internal-<namespace>`
+- APM profiling metrics: `metrics-apm.profiling-<namespace>`
 
 Logs::
 
 Logs include application error events and application logs.
 Logs are stored in the following data streams:
 
-- Application logs: `logs-<service.name>-<namespace>`
-- APM error/exception logging: `logs-apm.error.<service.name>-<namespace>`
+- APM error/exception logging: `logs-apm.error-<namespace>`
 
 [discrete]
 [[apm-integration-service-name]]
 === Service names
 
 The APM integration maps an instrumented service's name–defined in each APM agent's
-configuration–to the index that its data is stored in {es}.
-This process provides more granular security and retentions policies,
-and simplifies the overall APM experience.
+configuration–to the index that its application defined metrics are stored in {es}.
 Service names therefore must follow index naming rules:
 
 * Service names are case-insensitive and must be unique.


### PR DESCRIPTION
Backports the following commits to 7.14:
 - docs: update data streams naming (#5859)