### PR TITLE
[7.14] docs: add iOS agent links (#5634)

### DIFF
--- a/docs/common-problems.asciidoc
+++ b/docs/common-problems.asciidoc
@@ -265,6 +265,7 @@ Adjusting these queues/buffers can increase the agent's overhead, so use caution
 
 * **Go agent** - Circular buffer with configurable size:
 {apm-go-ref}/configuration.html#config-api-buffer-size[`ELASTIC_APM_BUFFER_SIZE`].
+// * **iOS agent** - ??
 * **Java agent** - Internal buffer with configurable size:
 {apm-java-ref}/config-reporter.html#config-max-queue-size[`max_queue_size`].
 * **Node.js agent** - No internal queue. Data is lost.

--- a/docs/getting-started-apm-server.asciidoc
+++ b/docs/getting-started-apm-server.asciidoc
@@ -349,6 +349,7 @@ brew services start elastic/tap/apm-server-full
 If you haven't already, you can now install APM Agents in your services!
 
 * {apm-go-ref-v}/introduction.html[Go agent]
+* {apm-ios-ref-v}/intro.html[iOS agent]
 * {apm-java-ref-v}/intro.html[Java agent]
 * {apm-dotnet-ref-v}/intro.html[.NET agent]
 * {apm-node-ref-v}/intro.html[Node.js agent]

--- a/docs/guide/agent-server-compatibility.asciidoc
+++ b/docs/guide/agent-server-compatibility.asciidoc
@@ -10,6 +10,10 @@ The chart below outlines the compatibility between different versions of the APM
 .1+|**Go agent**
 |`1.x` |≥ `6.5`
 
+// iOS
+.1+|**iOS agent**
+|`0.x` |≥ `7.14`
+
 // Java
 .1+|**Java agent**
 |`1.x`|≥ `6.5`

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -50,6 +50,7 @@ When this occurs, the APM app will display the number of spans dropped.
 To configure the number of spans recorded per transaction, see the relevant Agent documentation:
 
 * Go: {apm-go-ref-v}/configuration.html#config-transaction-max-spans[`ELASTIC_APM_TRANSACTION_MAX_SPANS`]
+* iOS: _Not yet supported_
 * Java: {apm-java-ref-v}/config-core.html#config-transaction-max-spans[`transaction_max_spans`]
 * .NET: {apm-dotnet-ref-v}/config-core.html#config-transaction-max-spans[`TransactionMaxSpans`]
 * Node.js: {apm-node-ref-v}/configuration.html#transaction-max-spans[`transactionMaxSpans`]
@@ -240,6 +241,7 @@ IMPORTANT: Setting a circular object, a large object, or a non JSON serializable
 ===== Agent API reference
 
 * Go: {apm-go-ref-v}/api.html#context-set-custom[`SetCustom`]
+* iOS: _coming soon_
 * Java: {apm-java-ref-v}/public-api.html#api-transaction-add-custom-context[`addCustomContext`]
 * .NET: _coming soon_
 * Node.js: {apm-node-ref-v}/agent-api.html#apm-set-custom-context[`setCustomContext`]
@@ -265,6 +267,7 @@ Indexed means the data is searchable and aggregatable in Elasticsearch.
 
 * Go: {apm-go-ref-v}/api.html#context-set-username[`SetUsername`] | {apm-go-ref-v}/api.html#context-set-user-id[`SetUserID`] |
 {apm-go-ref-v}/api.html#context-set-user-email[`SetUserEmail`]
+* iOS: _coming soon_
 * Java: {apm-java-ref-v}/public-api.html#api-transaction-set-user[`setUser`]
 * .NET _coming soon_
 * Node.js: {apm-node-ref-v}/agent-api.html#apm-set-user-context[`setUserContext`]

--- a/docs/guide/apm-doc-directory.asciidoc
+++ b/docs/guide/apm-doc-directory.asciidoc
@@ -17,6 +17,7 @@ This data is buffered for a short period and sent on to APM Server.
 Each agent has its own documentation:
 
 * {apm-go-ref-v}/introduction.html[Go agent]
+* {apm-ios-ref-v}/intro.html[iOS agent]
 * {apm-java-ref-v}/intro.html[Java agent]
 * {apm-dotnet-ref-v}/intro.html[.NET agent]
 * {apm-node-ref-v}/intro.html[Node.js agent]

--- a/docs/guide/opentracing.asciidoc
+++ b/docs/guide/opentracing.asciidoc
@@ -9,7 +9,7 @@ This means you can reuse your existing OpenTracing instrumentation to quickly an
 [float]
 ==== Agent specific details
 
-Not all features of the OpenTracing API are supported. In addition, there are some Elastic APM specific tags you should be aware of. Please see the relevant Agent documentation for more detailed information:
+Not all features of the OpenTracing API are supported, and there are some Elastic APM-specific tags you should be aware of. Please see the relevant Agent documentation for more detailed information:
 
 * {apm-go-ref-v}/opentracing.html[Go agent]
 * {apm-java-ref-v}/opentracing-bridge.html[Java agent]
@@ -17,3 +17,5 @@ Not all features of the OpenTracing API are supported. In addition, there are so
 * {apm-py-ref-v}/opentracing-bridge.html[Python agent]
 * {apm-ruby-ref-v}/opentracing.html[Ruby agent]
 * {apm-rum-ref-v}/opentracing.html[JavaScript Real User Monitoring (RUM) agent]
+
+Additionally, the iOS agent can utilize the https://github.com/open-telemetry/opentelemetry-swift/tree/main/Sources/Importers/OpenTracingShim[`opentelemetry-swift/OpenTracingShim`].

--- a/docs/guide/troubleshooting.asciidoc
+++ b/docs/guide/troubleshooting.asciidoc
@@ -12,6 +12,7 @@ The APM Server, APM app, and each APM agent has a troubleshooting guide:
 * {kibana-ref}/troubleshooting.html[APM app troubleshooting]
 * {apm-dotnet-ref-v}/troubleshooting.html[.NET agent troubleshooting]
 * {apm-go-ref-v}/troubleshooting.html[Go agent troubleshooting]
+* {apm-ios-ref-v}/troubleshooting.html[iOS agent troubleshooting]
 * {apm-java-ref-v}/trouble-shooting.html[Java agent troubleshooting]
 * {apm-node-ref-v}/troubleshooting.html[Node.js agent troubleshooting]
 * {apm-php-ref-v}/troubleshooting.html[PHP agent troubleshooting]

--- a/docs/secure-communication-agents.asciidoc
+++ b/docs/secure-communication-agents.asciidoc
@@ -282,6 +282,7 @@ Authorized for privilege "sourcemap:write"...:    Yes
 You can now apply your newly created API keys in the configuration of each of your APM agents.
 See the relevant agent documentation for additional information:
 
+// Not relevant for RUM and iOS
 * *Go agent*: {apm-go-ref}/configuration.html#config-api-key[`ELASTIC_APM_API_KEY`]
 * *.NET agent*: {apm-dotnet-ref}/config-reporter.html#config-api-key[`ApiKey`]
 * *Java agent*: {apm-java-ref}/config-reporter.html#config-api-key[`api_key`]
@@ -483,6 +484,7 @@ as there is no way to prevent them from being publicly exposed.
 Each Agent has a configuration for setting the value of the secret token:
 
 * *Go agent*: {apm-go-ref}/configuration.html#config-secret-token[`ELASTIC_APM_SECRET_TOKEN`]
+* *iOS agent*: {apm-ios-ref-v}/configuration.html#secretToken[`secretToken`]
 * *Java agent*: {apm-java-ref}/config-reporter.html#config-secret-token[`secret_token`]
 * *.NET agent*: {apm-dotnet-ref}/config-reporter.html#config-secret-token[`ELASTIC_APM_SECRET_TOKEN`]
 * *Node.js agent*: {apm-node-ref}/configuration.html#secret-token[`Secret Token`]

--- a/docs/tab-widgets/configure-agent.asciidoc
+++ b/docs/tab-widgets/configure-agent.asciidoc
@@ -11,6 +11,7 @@ for more information and a configuration reference.
 For a full list of agent configuration options, see the relevant agent reference:
 
 * {apm-go-ref-v}/configuration.html[Go Agent configuration]
+* {apm-ios-ref-v}/configuration.html[iOS Agent configuration]
 * {apm-java-ref-v}/configuration.html[Java Agent configuration]
 * {apm-dotnet-ref-v}/configuration.html[.NET Agent configuration]
 * {apm-node-ref}/configuring-the-agent.html[Node.js Agent configuration]

--- a/docs/tab-widgets/distributed-trace-receive-widget.asciidoc
+++ b/docs/tab-widgets/distributed-trace-receive-widget.asciidoc
@@ -10,6 +10,13 @@
       Go
     </button>
     <button role="tab"
+            aria-selected="false"
+            aria-controls="ios-tab-dt-r"
+            id="ios-dt-r"
+            tabindex="-1">
+      iOS
+    </button>
+    <button role="tab"
             aria-selected="true"
             aria-controls="java-tab-dt-r"
             id="java-dt-r"
@@ -60,6 +67,17 @@
 ++++
 
 include::distributed-trace-receive.asciidoc[tag=go]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="ios-tab-dt-r"
+       aria-labelledby="ios-dt-r"
+       hidden="">
+++++
+
+include::distributed-trace-receive.asciidoc[tag=ios]
 
 ++++
   </div>

--- a/docs/tab-widgets/distributed-trace-receive.asciidoc
+++ b/docs/tab-widgets/distributed-trace-receive.asciidoc
@@ -33,6 +33,17 @@ transaction := apm.DefaultTracer.StartTransactionOptions("GET /", "request", opt
 // ***************************************************
 // ***************************************************
 
+// tag::ios[]
+
+experimental::[]
+
+_Not applicable._
+
+// end::ios[]
+
+// ***************************************************
+// ***************************************************
+
 // tag::java[]
 
 1. Create a transaction as a child of the incoming transaction with

--- a/docs/tab-widgets/distributed-trace-send-widget.asciidoc
+++ b/docs/tab-widgets/distributed-trace-send-widget.asciidoc
@@ -10,6 +10,13 @@
       Go
     </button>
     <button role="tab"
+            aria-selected="false"
+            aria-controls="ios-tab-dt"
+            id="ios-dt"
+            tabindex="-1">
+      iOS
+    </button>
+    <button role="tab"
             aria-selected="true"
             aria-controls="java-tab-dt"
             id="java-dt"
@@ -60,6 +67,17 @@
 ++++
 
 include::distributed-trace-send.asciidoc[tag=go]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="ios-tab-dt"
+       aria-labelledby="ios-dt"
+       hidden="">
+++++
+
+include::distributed-trace-send.asciidoc[tag=ios]
 
 ++++
   </div>

--- a/docs/tab-widgets/distributed-trace-send.asciidoc
+++ b/docs/tab-widgets/distributed-trace-send.asciidoc
@@ -27,6 +27,48 @@ tracestate := traceContext.State.String()
 // ***************************************************
 // ***************************************************
 
+// tag::ios[]
+
+experimental::[]
+
+The agent will automatically inject trace headers into network requests using `URLSessions`, but if you're using a non-standard network library you may need to maunually inject them. It will be done using the OpenTelemetry APIs:
+
+1. Create a `Setter`
+
+2. Create a `Span` per https://github.com/open-telemetry/opentelemetry-swift/blob/main/Examples/Simple%20Exporter/main.swift#L35[Open Telemetry standards]
+
+3. Inject trace context to header dictionary
+
+4. Follow the procedure of your network library to complete the network request. Make sure to call `span.end()` when the request succeeds or fails.  
+
+[source,swift]
+----
+import OpenTelemetryApi
+import OpenTelemetrySdk
+
+struct BasicSetter: Setter { <1>
+    func set(carrier: inout [String: String], key: String, value: String) {
+        carrier[key] = value
+    }
+}
+
+let span : Span = ... <2> 
+let setter = BasicSetter()
+let propagator = W3CTraceContextPropagator()
+var headers = [String:String]()
+
+propagator.inject(spanContext: span.context, carrier: &headers, setter:setter) <3>
+
+let request = URLRequest(...)
+request.allHTTPHeaderFields = headers
+... // make network request
+span.end()
+----
+// end::ios[]
+
+// ***************************************************
+// ***************************************************
+
 // tag::java[]
 
 1. Start a transaction with {apm-java-ref}/public-api.html#api-start-transaction[`startTransaction`],

--- a/docs/tab-widgets/install-agents-widget.asciidoc
+++ b/docs/tab-widgets/install-agents-widget.asciidoc
@@ -10,6 +10,13 @@
       Go
     </button>
     <button role="tab"
+            aria-selected="false"
+            aria-controls="ios-tab-install"
+            id="ios-install"
+            tabindex="-1">
+      iOS
+    </button>
+    <button role="tab"
             aria-selected="true"
             aria-controls="java-tab-install"
             id="java-install"
@@ -67,6 +74,17 @@
 ++++
 
 include::install-agents.asciidoc[tag=go]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="ios-tab-install"
+       aria-labelledby="ios-install"
+       hidden="">
+++++
+
+include::install-agents.asciidoc[tag=ios]
 
 ++++
   </div>

--- a/docs/tab-widgets/install-agents.asciidoc
+++ b/docs/tab-widgets/install-agents.asciidoc
@@ -57,6 +57,93 @@ func main() {
 // ***************************************************
 // ***************************************************
 
+// tag::ios[]
+
+experimental::[]
+
+*Add the agent dependency to your project*
+
+Add the Elastic APM iOS Agent as a
+https://developer.apple.com/documentation/swift_packages/adding_package_dependencies_to_your_app[package dependency]
+to your Xcode project or your `Package.swift`:
+
+[source,swift,linenums,highlight=2;10]
+----
+Package(
+    dependencies:[
+        .package(name: "iOSAgent", url: "git@github.com:elastic/apm-agent-ios.git", .branch("main")),
+    ],
+  targets:[
+    .target(
+        name: "MyApp",
+        dependencies: [
+            .product(name: "iOSAgent", package: "iOSAgent")
+        ]
+    ),
+])
+----
+
+*Initialize the agent*
+
+If you're using `SwiftUI` to build your app, add the following to `App.swift`:
+
+[source,swift,linenums,swift,highlight=2;7..12]
+----
+import SwiftUI
+import iOSAgent
+
+@main
+struct MyApp: App {
+    init() {
+        var config = AgentConfiguration()
+        config.collectorAddress = "127.0.0.1" <1>
+        config.collectorPort = 8200 <2>
+        config.collectorTLS = false <3>
+        config.secretToken = "<secret token>" <4>
+        Agent.start(with: config)
+    }
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+----
+<1> APM Server URL or IP address
+<2> APM Server port number
+<3> Enable TLS for Open telemetry exporters
+<4> Set secret token for APM server connection
+
+If you're not using `SwiftUI`, you can add the same thing to your AppDelegate file:
+
+`AppDelegate.swift`
+[source,swift,linenums,highlight=2;9..14]
+----
+import UIKit
+import iOSAgent
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        var config = AgentConfiguration()
+        config.collectorAddress = "127.0.0.1" <1>
+        config.collectorPort = 8200 <2>
+        config.collectorTLS = false <3>
+        config.secretToken = "<secret token>" <4>
+        Agent.start(with: config)
+        return true
+    }
+}
+----
+<1> APM Server url or ip address
+<2> APM Server port number
+<3> Enable TLS for Open telemetry exporters
+<4> Set secret token for APM server connection
+
+// end::ios[]
+
+// ***************************************************
+// ***************************************************
+
 // tag::java[]
 
 *Download the APM agent*

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -24,6 +24,7 @@ don't forget to check the relevant troubleshooting guides:
 * {kibana-ref}/troubleshooting.html[APM app troubleshooting]
 * {apm-dotnet-ref-v}/troubleshooting.html[.NET agent troubleshooting]
 * {apm-go-ref-v}/troubleshooting.html[Go agent troubleshooting]
+* {apm-ios-ref-v}/troubleshooting.html[iOS agent troubleshooting]
 * {apm-java-ref-v}/trouble-shooting.html[Java agent troubleshooting]
 * {apm-node-ref-v}/troubleshooting.html[Node.js agent troubleshooting]
 * {apm-php-ref-v}/troubleshooting.html[PHP agent troubleshooting]

--- a/docs/version.asciidoc
+++ b/docs/version.asciidoc
@@ -11,6 +11,7 @@ include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 // Used in conjunction with the stack attributes found here: https://github.com/elastic/docs/tree/7d62a6b66d6e9c96e4dd9a96c3dc7c75ceba0288/shared/versions/stack
 :apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
 :apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
+:apm-ios-ref-v:        https://www.elastic.co/guide/en/apm/agent/swift/{apm-ios-branch}
 :apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{apm-java-branch}
 :apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
 :apm-php-ref-v:        https://www.elastic.co/guide/en/apm/agent/php/{apm-php-branch}


### PR DESCRIPTION
Backports the following commits to 7.14:
 - docs: add iOS agent links (#5634)