### PR TITLE
beater: implement reload.ReloadableList directly

### DIFF
--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -484,7 +484,7 @@ func TestServerConfigReload(t *testing.T) {
 
 	// The config must contain an "apm-server" section, and will be rejected otherwise.
 	err = reloadable.Reload([]*reload.ConfigWithMeta{{Config: common.NewConfig()}})
-	assert.EqualError(t, err, "1 error: Error creating runner from config: 'apm-server' not found in integration config")
+	assert.EqualError(t, err, "'apm-server' not found in integration config")
 
 	inputConfig := common.MustNewConfigFrom(map[string]interface{}{
 		"apm-server": map[string]interface{}{


### PR DESCRIPTION
## Motivation/summary

Use reload.ReloadableList, rather than cfgfile.NewRunnerList.
cfgfile.NewRunnerList forces a restart every time the config
changes, which we want to move away from.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

Non-functional change.

## Related issues

https://github.com/elastic/apm-server/issues/5039