### PR TITLE
Update go-elasticsearch/v7

### DIFF
--- a/beater/auth/authenticator_test.go
+++ b/beater/auth/authenticator_test.go
@@ -264,8 +264,11 @@ func TestAuthenticatorAPIKeyCache(t *testing.T) {
 			assert.NoError(t, err)
 		}
 	})
-	assert.Len(t, spans, 1)
+	require.Len(t, spans, 2)
 	assert.Equal(t, "elasticsearch", spans[0].Subtype)
+	assert.Equal(t, "/", spans[0].Context.HTTP.URL.Path) // product check
+	assert.Equal(t, "elasticsearch", spans[1].Subtype)
+	assert.Equal(t, "/_security/user/_has_privileges", spans[1].Context.HTTP.URL.Path)
 
 	_, spans, _ = apmtest.WithTransaction(func(ctx context.Context) {
 		// API Key checks are cached based on the API Key ID, not the full credential.

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/elastic/ecs v1.10.0
 	github.com/elastic/elastic-agent-client/v7 v7.0.0-20210407144825-cc1c33cfa1d0 // indirect
 	github.com/elastic/gmux v0.1.0
-	github.com/elastic/go-elasticsearch/v7 v7.5.1-0.20210728153421-6462d8b84e7d
+	github.com/elastic/go-elasticsearch/v7 v7.5.1-0.20210803065541-d87f0bdcf0fe
 	github.com/elastic/go-elasticsearch/v8 v8.0.0-20210727161915-8cf93274b968
 	github.com/elastic/go-hdrhistogram v0.1.0
 	github.com/elastic/go-ucfg v0.8.4-0.20200415140258-1232bd4774a6

--- a/go.sum
+++ b/go.sum
@@ -373,6 +373,8 @@ github.com/elastic/go-concert v0.1.0 h1:gz/yvA3bseuHzoF/lNMltkL30XdPqMo+bg5o2mBx
 github.com/elastic/go-concert v0.1.0/go.mod h1:9MtFarjXroUgmm0m6HY3NSe1XiKhdktiNRRj9hWvIaM=
 github.com/elastic/go-elasticsearch/v7 v7.5.1-0.20210728153421-6462d8b84e7d h1:eW4xXKW2sVzXxlNLTxwDOfKY4ugqFENLCDHSDuK75iY=
 github.com/elastic/go-elasticsearch/v7 v7.5.1-0.20210728153421-6462d8b84e7d/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
+github.com/elastic/go-elasticsearch/v7 v7.5.1-0.20210803065541-d87f0bdcf0fe h1:hmMMoRLD/3/CVpLpg3ndrjmmxRy+EeuERjNfSujh9+Q=
+github.com/elastic/go-elasticsearch/v7 v7.5.1-0.20210803065541-d87f0bdcf0fe/go.mod h1:OJ4wdbtDNk5g503kvlHLyErCgQwwzmDtaFC4XyOxXA4=
 github.com/elastic/go-elasticsearch/v8 v8.0.0-20210727161915-8cf93274b968 h1:rDj5NfOj2IQocHyDLjbkFmn21XYljn+CaJeBwEbUL6E=
 github.com/elastic/go-elasticsearch/v8 v8.0.0-20210727161915-8cf93274b968/go.mod h1:xe9a/L2aeOgFKKgrO3ibQTnMdpAeL0GC+5/HpGScSa4=
 github.com/elastic/go-hdrhistogram v0.1.0 h1:7UVeQ9MsO5c9h8RJeH2S2lXCGi9hQB/94W6Pjjqprc4=

--- a/sourcemap/processor_test.go
+++ b/sourcemap/processor_test.go
@@ -20,7 +20,6 @@ package sourcemap
 import (
 	"context"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -260,14 +259,6 @@ func TestBatchProcessorElasticsearchUnavailable(t *testing.T) {
 
 func TestBatchProcessorTimeout(t *testing.T) {
 	var transport roundTripperFunc = func(req *http.Request) (*http.Response, error) {
-		if req.URL.Path == "/" {
-			// TODO(axw) remove product check from here when
-			// https://github.com/elastic/go-elasticsearch/pull/321 is merged,
-			// and just timeout unconditionally.
-			recorder := httptest.NewRecorder()
-			recorder.Header().Set("X-Elastic-Product", "Elasticsearch")
-			return recorder.Result(), nil
-		}
 		<-req.Context().Done()
 		return nil, req.Context().Err()
 	}


### PR DESCRIPTION
## Motivation/summary

Fixes a context propagation bug which could affect our ability to cancel requests, particularly in the source map processor.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

1. Run apm-server with source mapping enabled, with output.elasticsearch.hosts pointed to an unavailable server
2. Send some RUM events to the server that should be source mapped
3. Ensure the HTTP request to the server times out after approximately 5 seconds

## Related issues

None