### PR TITLE
aggregation/spanmetrics: handle composite spans

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -19,6 +19,7 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 
 [float]
 ==== Added
+- `service_destination` span metrics now take into account composite spans {pull}5896[5896]
 
 [float]
 ==== Deprecated


### PR DESCRIPTION
## Motivation/summary

Update spanmetrics to take into account composite spans, using the composite span count and duration. Like non-composite spans, these are also multiplied by the "representative count", i.e. the inverse sampling ratio.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

1. Send some composite spans to the server
2. Check that the span metrics have the expected count and duration sum

## Related issues

Closes https://github.com/elastic/apm-server/issues/5595