### PR TITLE
[automation] update elastic stack version for testing 7.14.1-8dd23e93

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       kibana: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.1-22366df8-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.1-8dd23e93-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -61,7 +61,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.14.1-22366df8-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.14.1-8dd23e93-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -85,7 +85,7 @@ services:
       package-registry: { condition: service_healthy }
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:7.14.1-22366df8-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:7.14.1-8dd23e93-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Sun, 8 Aug 2021 12:14:46 GMT, release_branch:7.14, prefix:, end_time:Sun, 8 Aug 2021 17:43:13 GMT, manifest_version:2.0.0, version:7.14.1-SNAPSHOT, branch:7.14, build_id:7.14.1-8dd23e93, build_duration_seconds:19707]