### PR TITLE
beater/api/mux: fix Fleet agent config enablement

### DIFF
--- a/beater/tracing.go
+++ b/beater/tracing.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/elastic/apm-server/agentcfg"
 	"github.com/elastic/apm-server/beater/api"
+	"github.com/elastic/apm-server/beater/auth"
 	"github.com/elastic/apm-server/beater/config"
 	"github.com/elastic/apm-server/beater/ratelimit"
 	"github.com/elastic/apm-server/model"
@@ -64,14 +65,20 @@ func newTracerServer(listener net.Listener, logger *logp.Logger) (*tracerServer,
 	if err != nil {
 		return nil, err
 	}
+	authenticator, err := auth.NewAuthenticator(config.AgentAuth{})
+	if err != nil {
+		return nil, err
+	}
 	mux, err := api.NewMux(
 		beat.Info{},
 		cfg,
 		nopReporter,
 		processBatch,
+		authenticator,
 		agentcfg.NewFetcher(cfg),
 		ratelimitStore,
-		nil, // no sourcemap store
+		nil,   // no sourcemap store
+		false, // not managed
 	)
 	if err != nil {
 		return nil, err

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -12,6 +12,7 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 ==== Bug fixes
 - Fix apm_error_grouping_name and apm_convert_destination_address {pull}5876[5876]
 - corrected OTel attribute names for `net.host.connection.*` {pull}5671[5671]
+- Fix response to agent config when running under Fleet with no agent config defined {pull}5917[5917]
 
 [float]
 ==== Intake API Changes

--- a/systemtest/agentconfig_test.go
+++ b/systemtest/agentconfig_test.go
@@ -44,11 +44,8 @@ func TestAgentConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// Run apm-server under Fleet, exercising the Fleet agent config implementation.
-	//
-	// TODO(axw) test Fleet integration when agent config is hot-reloadable.
-	//apmIntegration := initAPMIntegration(t, map[string]interface{}{})
-	//serverURLs := []string{srv.URL, apmIntegration.URL}
-	serverURLs := []string{srv.URL}
+	apmIntegration := initAPMIntegration(t, map[string]interface{}{})
+	serverURLs := []string{srv.URL, apmIntegration.URL}
 
 	expectChange := func(serverURL string, etag string) (map[string]string, *http.Response) {
 		t.Helper()

--- a/systemtest/agentconfig_test.go
+++ b/systemtest/agentconfig_test.go
@@ -49,7 +49,7 @@ func TestAgentConfig(t *testing.T) {
 
 	expectChange := func(serverURL string, etag string) (map[string]string, *http.Response) {
 		t.Helper()
-		timer := time.NewTimer(10 * time.Second)
+		timer := time.NewTimer(time.Minute)
 		defer timer.Stop()
 		interval := 100 * time.Millisecond
 		for {


### PR DESCRIPTION
## Motivation/summary

If Fleet-managed, apm-server should not return 403 Forbidden just because there's no agent config. Add the "kill switch" middleware only if the server is _not_ Fleet-managed, and has no Kibana config. Extend the agent config system test to cover Fleet.

There is some light refactoring to inject a common `auth.Authenticator` and `model.BatchProcessor` into both the HTTP mux and gRPC services.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

1. Create a fresh cluster, add APM integration to an Elastic Agent
2. Query agent config. It should not return 403 Forbidden.

## Related issues

None.