### PR TITLE
fix output for elastic-agent

### DIFF
--- a/beater/otlp/grpc.go
+++ b/beater/otlp/grpc.go
@@ -101,15 +101,15 @@ func setCurrentMonitoredConsumer(c *otel.Consumer) {
 }
 
 func collectMetricsMonitoring(mode monitoring.Mode, V monitoring.Visitor) {
+	V.OnRegistryStart()
+	defer V.OnRegistryFinished()
+
 	currentMonitoredConsumerMu.RLock()
 	c := currentMonitoredConsumer
 	currentMonitoredConsumerMu.RUnlock()
 	if c == nil {
 		return
 	}
-
-	V.OnRegistryStart()
-	defer V.OnRegistryFinished()
 
 	stats := c.Stats()
 	monitoring.ReportInt(V, "unsupported_dropped", stats.UnsupportedMetricsDropped)


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Fix metrics output when apm-server is being managed by elastic-agent

## How to test these changes

1. Install and start a non-fleet managed elastic-agent, having it spawn an apm-server process
2. Get stats data from the apm-server unix socket
    ```
    echo -e "GET /stats HTTP/1.0\r\n" | sudo nc -U /opt/Elastic/Agent/data/tmp/default/apm-server/apm-server.sock | awk 'NR>4{print}' | jq '.|keys'
    ```
3. Verify the output structure matches that from a standalone apm-server

## Related issues

https://github.com/elastic/beats/issues/27213
