### PR TITLE
docs: add source map upload notes

### DIFF
--- a/docs/apm-package/apm-integration.asciidoc
+++ b/docs/apm-package/apm-integration.asciidoc
@@ -103,7 +103,7 @@ Changes are automatically propagated to your APM agents, so there’s no need to
 === Package versioning
 
 The APM package is versioned separately from the Elastic Stack.
-The current version is `0.1.0`. In the future, we may align with Elastic Stack versioning.
+In the future, we may align with Elastic Stack versioning.
 
 [discrete]
 [[apm-integration-learn-more]]

--- a/docs/sourcemap-api.asciidoc
+++ b/docs/sourcemap-api.asciidoc
@@ -10,6 +10,9 @@ IMPORTANT: You must <<configuration-rum,enable RUM support>> in the APM Server f
 The APM Server exposes an API endpoint to upload source maps for real user monitoring (RUM).
 See the <<sourcemaps,create and upload source maps>> guide to get started.
 
+If you're using the <<apm-integration,APM integration>>,
+you must use the Kibana {kibana-ref}/rum-sourcemap-api.html[source map upload API] instead.
+
 [[sourcemap-endpoint]]
 [float]
 === Upload endpoint

--- a/docs/sourcemaps.asciidoc
+++ b/docs/sourcemaps.asciidoc
@@ -5,6 +5,9 @@
 <titleabbrev>Create and upload source maps (RUM)</titleabbrev>
 ++++
 
+NOTE: This guide is only for standalone APM Server users. Users running the <<apm-integration,APM integration>>
+need to use the Kibana {kibana-ref}/rum-sourcemap-api.html[source map upload API] instead.
+
 Minifying JavaScript bundles in production is a common practice;
 it can greatly improve the load time and network latency of your applications.
 The problem with minifying code is that it can be hard to debug.


### PR DESCRIPTION
This PR makes it clear that users running the APM integration need to use the Kibana endpoint and not the APM Server endpoint to upload source maps.

It also removes an out of date reference to the current version of the APM integration.