### PR TITLE
apmpackage: copy full field hierarchy

### DIFF
--- a/apmpackage/apm/data_stream/app_metrics/fields/base-fields.yml
+++ b/apmpackage/apm/data_stream/app_metrics/fields/base-fields.yml
@@ -10,3 +10,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: ecs.version
+  type: keyword
+  description: ECS version the event conforms to.

--- a/apmpackage/apm/data_stream/app_metrics/fields/ecs.yml
+++ b/apmpackage/apm/data_stream/app_metrics/fields/ecs.yml
@@ -1,122 +1,173 @@
-- name: agent.ephemeral_id
-  type: keyword
+- name: agent
+  type: group
+  fields:
+    - name: ephemeral_id
+      type: keyword
+      description: |
+        The Ephemeral ID identifies a running process.
+    - name: name
+      type: keyword
+      description: |
+        Name of the agent used.
+    - name: version
+      type: keyword
+      description: |
+        Version of the agent used.
+- name: client
+  type: group
+  fields:
+    - name: domain
+      type: keyword
+      description: |
+        Client domain.
+      ignore_above: 1024
+    - name: ip
+      type: ip
+      description: |
+        IP address of the client of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
+    - name: port
+      type: long
+      description: |
+        Port of the client.
+- name: cloud
+  title: Cloud
+  type: group
   description: |
-    The Ephemeral ID identifies a running process.
-- name: agent.name
-  type: keyword
+    Cloud metadata reported by agents
+  fields:
+    - name: account
+      type: group
+      fields:
+        - name: id
+          level: extended
+          type: keyword
+          description: Cloud account ID
+          ignore_above: 1024
+        - name: name
+          level: extended
+          type: keyword
+          description: Cloud account name
+          ignore_above: 1024
+    - name: availability_zone
+      level: extended
+      type: keyword
+      description: Cloud availability zone name
+      ignore_above: 1024
+    - name: instance
+      type: group
+      fields:
+        - name: id
+          level: extended
+          type: keyword
+          description: Cloud instance/machine ID
+          ignore_above: 1024
+        - name: name
+          level: extended
+          type: keyword
+          description: Cloud instance/machine name
+          ignore_above: 1024
+    - name: machine
+      type: group
+      fields:
+        - name: type
+          level: extended
+          type: keyword
+          description: Cloud instance/machine type
+          ignore_above: 1024
+    - name: project
+      type: group
+      fields:
+        - name: id
+          level: extended
+          type: keyword
+          description: Cloud project ID
+          ignore_above: 1024
+        - name: name
+          level: extended
+          type: keyword
+          description: Cloud project name
+          ignore_above: 1024
+    - name: provider
+      level: extended
+      type: keyword
+      description: Cloud provider name
+      ignore_above: 1024
+    - name: region
+      level: extended
+      type: keyword
+      description: Cloud region name
+      ignore_above: 1024
+    - name: service
+      type: group
+      fields:
+        - name: name
+          level: extended
+          type: keyword
+          description: |
+            Cloud service name, intended to distinguish services running on different platforms within a provider.
+          ignore_above: 1024
+- name: container
+  title: Container
+  type: group
   description: |
-    Name of the agent used.
-- name: agent.version
-  type: keyword
+    Container fields are used for meta information about the specific container that is the source of information. These fields help correlate data based containers from any runtime.
+  fields:
+    - name: id
+      type: keyword
+      description: |
+        Unique container id.
+- name: destination
+  title: Destination
+  type: group
+  description: |-
+    Destination fields describe details about the destination of a packet/event.
+    Destination fields are usually populated in conjunction with source fields.
+  fields:
+    - name: address
+      level: extended
+      type: keyword
+      description: Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is.
+      ignore_above: 1024
+    - name: ip
+      level: core
+      type: ip
+      description: IP addess of the destination. Can be one of multiple IPv4 or IPv6 addresses.
+    - name: port
+      level: core
+      type: long
+      format: string
+      description: Port of the destination.
+- name: host
+  type: group
   description: |
-    Version of the agent used.
-- name: client.domain
-  type: keyword
-  description: |
-    Client domain.
-  ignore_above: 1024
-- name: client.ip
-  type: ip
-  description: |
-    IP address of the client of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
-- name: client.port
-  type: long
-  description: |
-    Port of the client.
-- name: cloud.account.id
-  level: extended
-  type: keyword
-  description: Cloud account ID
-  ignore_above: 1024
-- name: cloud.account.name
-  level: extended
-  type: keyword
-  description: Cloud account name
-  ignore_above: 1024
-- name: cloud.availability_zone
-  level: extended
-  type: keyword
-  description: Cloud availability zone name
-  ignore_above: 1024
-- name: cloud.instance.id
-  level: extended
-  type: keyword
-  description: Cloud instance/machine ID
-  ignore_above: 1024
-- name: cloud.instance.name
-  level: extended
-  type: keyword
-  description: Cloud instance/machine name
-  ignore_above: 1024
-- name: cloud.machine.type
-  level: extended
-  type: keyword
-  description: Cloud instance/machine type
-  ignore_above: 1024
-- name: cloud.project.id
-  level: extended
-  type: keyword
-  description: Cloud project ID
-  ignore_above: 1024
-- name: cloud.project.name
-  level: extended
-  type: keyword
-  description: Cloud project name
-  ignore_above: 1024
-- name: cloud.provider
-  level: extended
-  type: keyword
-  description: Cloud provider name
-  ignore_above: 1024
-- name: cloud.region
-  level: extended
-  type: keyword
-  description: Cloud region name
-  ignore_above: 1024
-- name: cloud.service.name
-  level: extended
-  type: keyword
-  description: |
-    Cloud service name, intended to distinguish services running on different platforms within a provider.
-  ignore_above: 1024
-- name: container.id
-  type: keyword
-  description: |
-    Unique container id.
-- name: destination.address
-  level: extended
-  type: keyword
-  description: Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is.
-  ignore_above: 1024
-- name: destination.ip
-  level: core
-  type: ip
-  description: IP addess of the destination. Can be one of multiple IPv4 or IPv6 addresses.
-- name: destination.port
-  level: core
-  type: long
-  format: string
-  description: Port of the destination.
-- name: host.architecture
-  type: keyword
-  description: |
-    The architecture of the host the event was recorded on.
-- name: host.hostname
-  type: keyword
-  description: |
-    The hostname of the host the event was recorded on.
-- name: host.ip
-  type: ip
-  description: |
-    IP of the host that records the event.
-- name: host.name
-  type: keyword
-  description: |
-    Name of the host the event was recorded on. It can contain same information as host.hostname or a name specified by the user.
-- name: host.os.platform
-  type: keyword
-  description: |
-    The platform of the host the event was recorded on.
+    Optional host fields.
+  fields:
+    - name: architecture
+      type: keyword
+      description: |
+        The architecture of the host the event was recorded on.
+    - name: hostname
+      type: keyword
+      description: |
+        The hostname of the host the event was recorded on.
+    - name: ip
+      type: ip
+      description: |
+        IP of the host that records the event.
+    - name: name
+      type: keyword
+      description: |
+        Name of the host the event was recorded on. It can contain same information as host.hostname or a name specified by the user.
+    - name: os
+      title: Operating System
+      type: group
+      description: |
+        The OS fields contain information about the operating system.
+      fields:
+        - name: platform
+          type: keyword
+          description: |
+            The platform of the host the event was recorded on.
 - name: labels
   type: object
   description: |
@@ -127,112 +178,152 @@
     - object_type: boolean
     - object_type: scaled_float
       scaling_factor: 1000000
-- name: observer.hostname
-  type: keyword
+- name: observer
+  type: group
+  fields:
+    - name: hostname
+      type: keyword
+      description: |
+        Hostname of the APM Server.
+    - name: type
+      type: keyword
+      description: |
+        The type will be set to `apm-server`.
+    - name: version
+      type: keyword
+      description: |
+        APM Server version.
+- name: process
+  type: group
   description: |
-    Hostname of the APM Server.
-- name: observer.type
-  type: keyword
+    Information pertaining to the running process where the data was collected
+  fields:
+    - name: args
+      level: extended
+      type: keyword
+      description: |
+        Process arguments. May be filtered to protect sensitive information.
+    - name: pid
+      type: long
+      description: |
+        Numeric process ID of the service process.
+    - name: ppid
+      type: long
+      description: |
+        Numeric ID of the service's parent process.
+    - name: title
+      type: keyword
+      description: |
+        Service process title.
+- name: service
+  type: group
   description: |
-    The type will be set to `apm-server`.
-- name: observer.version
-  type: keyword
+    Service fields.
+  fields:
+    - name: name
+      type: keyword
+      description: |
+        Immutable name of the service emitting this event.
+    - name: node
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Unique meaningful name of the service node.
+    - name: version
+      type: keyword
+      description: |
+        Version of the service emitting this event.
+- name: source
+  type: group
+  fields:
+    - name: domain
+      type: keyword
+      description: |
+        Source domain.
+      ignore_above: 1024
+    - name: ip
+      type: ip
+      description: |
+        IP address of the source of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
+    - name: port
+      type: long
+      description: |
+        Port of the source.
+- name: user
+  type: group
+  fields:
+    - name: email
+      type: keyword
+      description: |
+        Email of the logged in user.
+    - name: id
+      type: keyword
+      description: |
+        Identifier of the logged in user.
+    - name: name
+      type: keyword
+      description: |
+        The username of the logged in user.
+- name: user_agent
+  title: User agent
+  type: group
   description: |
-    APM Server version.
-- name: process.args
-  level: extended
-  type: keyword
-  description: |
-    Process arguments. May be filtered to protect sensitive information.
-- name: process.pid
-  type: long
-  description: |
-    Numeric process ID of the service process.
-- name: process.ppid
-  type: long
-  description: |
-    Numeric ID of the service's parent process.
-- name: process.title
-  type: keyword
-  description: |
-    Service process title.
-- name: service.name
-  type: keyword
-  description: |
-    Immutable name of the service emitting this event.
-- name: service.node.name
-  type: keyword
-  description: |
-    Unique meaningful name of the service node.
-- name: service.version
-  type: keyword
-  description: |
-    Version of the service emitting this event.
-- name: source.domain
-  type: keyword
-  description: |
-    Source domain.
-  ignore_above: 1024
-- name: source.ip
-  type: ip
-  description: |
-    IP address of the source of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
-- name: source.port
-  type: long
-  description: |
-    Port of the source.
-- name: user.email
-  type: keyword
-  description: |
-    Email of the logged in user.
-- name: user.id
-  type: keyword
-  description: |
-    Identifier of the logged in user.
-- name: user.name
-  type: keyword
-  description: |
-    The username of the logged in user.
-- name: user_agent.device.name
-  type: keyword
-  description: |
-    Name of the device.
-- name: user_agent.name
-  type: keyword
-  description: |
-    Name of the user agent.
-- name: user_agent.original
-  type: keyword
-  description: |
-    Unparsed version of the user_agent.
-  multi_fields:
-    - name: text
-      type: text
-- name: user_agent.os.family
-  type: keyword
-  description: |
-    OS family (such as redhat, debian, freebsd, windows).
-- name: user_agent.os.full
-  type: keyword
-  description: |
-    Operating system name, including the version or code name.
-- name: user_agent.os.kernel
-  type: keyword
-  description: |
-    Operating system kernel version as a raw string.
-- name: user_agent.os.name
-  type: keyword
-  description: |
-    Operating system name, without the version.
-- name: user_agent.os.platform
-  type: keyword
-  description: |
-    Operating system platform (such centos, ubuntu, windows).
-- name: user_agent.os.version
-  type: keyword
-  description: |
-    Operating system version as a raw string.
-- name: user_agent.version
-  type: keyword
-  description: |
-    Version of the user agent.
+    The user_agent fields normally come from a browser request. They often show up in web service logs coming from the parsed user agent string.
+  fields:
+    - name: device
+      title: Device
+      type: group
+      description: |
+        Information concerning the device.
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the device.
+    - name: name
+      type: keyword
+      description: |
+        Name of the user agent.
+    - name: original
+      type: keyword
+      description: |
+        Unparsed version of the user_agent.
+      multi_fields:
+        - name: text
+          type: text
+    - name: os
+      title: Operating System
+      type: group
+      description: |
+        The OS fields contain information about the operating system.
+      fields:
+        - name: family
+          type: keyword
+          description: |
+            OS family (such as redhat, debian, freebsd, windows).
+        - name: full
+          type: keyword
+          description: |
+            Operating system name, including the version or code name.
+        - name: kernel
+          type: keyword
+          description: |
+            Operating system kernel version as a raw string.
+        - name: name
+          type: keyword
+          description: |
+            Operating system name, without the version.
+        - name: platform
+          type: keyword
+          description: |
+            Operating system platform (such centos, ubuntu, windows).
+        - name: version
+          type: keyword
+          description: |
+            Operating system version as a raw string.
+    - name: version
+      type: keyword
+      description: |
+        Version of the user agent.

--- a/apmpackage/apm/data_stream/app_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/app_metrics/fields/fields.yml
@@ -4,185 +4,289 @@
   dynamic: true
 - name: histogram
   type: histogram
-- name: kubernetes.namespace
-  type: keyword
+- name: kubernetes
+  title: Kubernetes
+  type: group
   description: |
-    Kubernetes namespace
-- name: kubernetes.node.name
-  type: keyword
-  description: |
-    Kubernetes node name
-- name: kubernetes.pod.name
-  type: keyword
-  description: |
-    Kubernetes pod name
-- name: kubernetes.pod.uid
-  type: keyword
-  description: |
-    Kubernetes Pod UID
-- name: metricset.name
-  type: keyword
-  description: |
-    Name of the set of metrics.
+    Kubernetes metadata reported by agents
+  fields:
+    - name: namespace
+      type: keyword
+      description: |
+        Kubernetes namespace
+    - name: node
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Kubernetes node name
+    - name: pod
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Kubernetes pod name
+        - name: uid
+          type: keyword
+          description: |
+            Kubernetes Pod UID
+- name: metricset
+  type: group
+  fields:
+    - name: name
+      type: keyword
+      description: |
+        Name of the set of metrics.
 - name: metricset.period
   type: long
   description: Current data collection period for this event in milliseconds.
   unit: ms
-- name: network.carrier.icc
-  type: keyword
+- name: network
+  type: group
   description: |
-    ISO country code, eg. US
-- name: network.carrier.mcc
-  type: keyword
-  description: |
-    Mobile country code
-- name: network.carrier.mnc
-  type: keyword
-  description: |
-    Mobile network code
-- name: network.carrier.name
-  type: keyword
-  description: |
-    Carrier name, eg. Vodafone, T-Mobile, etc.
-- name: network.connection.subtype
-  type: keyword
-  description: |
-    Detailed network connection sub-type, e.g. "LTE", "CDMA"
-- name: network.connection.type
-  type: keyword
-  description: |
-    Network connection type, eg. "wifi", "cell"
-- name: observer.listening
-  type: keyword
-  description: |
-    Address the server is listening on.
-- name: observer.version_major
-  type: byte
-  description: |
-    Major version number of the observer
+    Optional network fields
+  fields:
+    - name: carrier
+      type: group
+      description: |
+        Network operator
+      fields:
+        - name: icc
+          type: keyword
+          description: |
+            ISO country code, eg. US
+        - name: mcc
+          type: keyword
+          description: |
+            Mobile country code
+        - name: mnc
+          type: keyword
+          description: |
+            Mobile network code
+        - name: name
+          type: keyword
+          description: |
+            Carrier name, eg. Vodafone, T-Mobile, etc.
+    - name: connection
+      type: group
+      description: |
+        Network connection details
+      fields:
+        - name: subtype
+          type: keyword
+          description: |
+            Detailed network connection sub-type, e.g. "LTE", "CDMA"
+        - name: type
+          type: keyword
+          description: |
+            Network connection type, eg. "wifi", "cell"
+- name: observer
+  type: group
+  fields:
+    - name: listening
+      type: keyword
+      description: |
+        Address the server is listening on.
+    - name: version_major
+      type: byte
+      description: |
+        Major version number of the observer
 - name: processor.event
   type: keyword
   description: Processor event.
 - name: processor.name
   type: keyword
   description: Processor name.
-- name: service.environment
-  type: keyword
+- name: service
+  type: group
   description: |
-    Service environment.
-- name: service.framework.name
-  type: keyword
+    Service fields.
+  fields:
+    - name: environment
+      type: keyword
+      description: |
+        Service environment.
+    - name: framework
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the framework used.
+        - name: version
+          type: keyword
+          description: |
+            Version of the framework used.
+    - name: language
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the programming language used.
+        - name: version
+          type: keyword
+          description: |
+            Version of the programming language used.
+    - name: runtime
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the runtime used.
+        - name: version
+          type: keyword
+          description: |
+            Version of the runtime used.
+- name: system
+  type: group
   description: |
-    Name of the framework used.
-- name: service.framework.version
-  type: keyword
-  description: |
-    Version of the framework used.
-- name: service.language.name
-  type: keyword
-  description: |
-    Name of the programming language used.
-- name: service.language.version
-  type: keyword
-  description: |
-    Version of the programming language used.
-- name: service.runtime.name
-  type: keyword
-  description: |
-    Name of the runtime used.
-- name: service.runtime.version
-  type: keyword
-  description: |
-    Version of the runtime used.
-- name: system.cpu.total.norm.pct
-  type: scaled_float
-  format: percent
-  description: |
-    The percentage of CPU time spent by the process since the last event. This value is normalized by the number of CPU cores and it ranges from 0 to 100%.
-  metric_type: gauge
-  unit: percent
-- name: system.memory.actual.free
-  type: long
-  format: bytes
-  description: |
-    Actual free memory in bytes. It is calculated based on the OS. On Linux it consists of the free memory plus caches and buffers. On OSX it is a sum of free memory and the inactive memory. On Windows, it is equal to `system.memory.free`.
-  metric_type: gauge
-  unit: byte
-- name: system.memory.total
-  type: long
-  format: bytes
-  description: |
-    Total memory.
-  metric_type: gauge
-  unit: byte
-- name: system.process.cgroup.cpu.cfs.period.us
-  type: long
-  description: CFS period in microseconds.
-  metric_type: gauge
-  unit: micros
-- name: system.process.cgroup.cpu.cfs.quota.us
-  type: long
-  description: CFS quota in microseconds.
-  metric_type: gauge
-  unit: micros
-- name: system.process.cgroup.cpu.id
-  type: keyword
-  description: ID for the current cgroup CPU.
-- name: system.process.cgroup.cpu.stats.periods
-  type: long
-  description: Number of periods seen by the CPU.
-  metric_type: counter
-- name: system.process.cgroup.cpu.stats.throttled.ns
-  type: long
-  description: Nanoseconds spent throttled seen by the CPU.
-  metric_type: counter
-  unit: nanos
-- name: system.process.cgroup.cpu.stats.throttled.periods
-  type: long
-  description: Number of throttled periods seen by the CPU.
-  metric_type: counter
-- name: system.process.cgroup.cpuacct.id
-  type: keyword
-  description: ID for the current cgroup CPU.
-- name: system.process.cgroup.cpuacct.total.ns
-  type: long
-  description: Total CPU time for the current cgroup CPU in nanoseconds.
-  metric_type: counter
-  unit: nanos
-- name: system.process.cgroup.memory.mem.limit.bytes
-  type: long
-  format: bytes
-  description: Memory limit for the current cgroup slice.
-  metric_type: gauge
-  unit: byte
-- name: system.process.cgroup.memory.mem.usage.bytes
-  type: long
-  format: bytes
-  description: Memory usage by the current cgroup slice.
-  metric_type: gauge
-  unit: byte
-- name: system.process.cpu.total.norm.pct
-  type: scaled_float
-  format: percent
-  description: |
-    The percentage of CPU time spent by the process since the last event. This value is normalized by the number of CPU cores and it ranges from 0 to 100%.
-  metric_type: gauge
-  unit: percent
-- name: system.process.memory.rss.bytes
-  type: long
-  format: bytes
-  description: |
-    The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
-  metric_type: gauge
-  unit: byte
-- name: system.process.memory.size
-  type: long
-  format: bytes
-  description: |
-    The total virtual memory the process has.
-  metric_type: gauge
-  unit: byte
-- name: timestamp.us
-  type: long
-  description: |
-    Timestamp of the event in microseconds since Unix epoch.
+    `system` contains local system metrics.
+  fields:
+    - name: cpu
+      type: group
+      description: |
+        `cpu` contains local CPU stats.
+      fields:
+        - name: total.norm.pct
+          type: scaled_float
+          format: percent
+          description: |
+            The percentage of CPU time spent by the process since the last event. This value is normalized by the number of CPU cores and it ranges from 0 to 100%.
+          metric_type: gauge
+          unit: percent
+    - name: memory
+      type: group
+      description: |
+        `memory` contains local memory stats.
+      fields:
+        - name: actual
+          type: group
+          description: |
+            Actual memory used and free.
+          fields:
+            - name: free
+              type: long
+              format: bytes
+              description: |
+                Actual free memory in bytes. It is calculated based on the OS. On Linux it consists of the free memory plus caches and buffers. On OSX it is a sum of free memory and the inactive memory. On Windows, it is equal to `system.memory.free`.
+              metric_type: gauge
+              unit: byte
+        - name: total
+          type: long
+          format: bytes
+          description: |
+            Total memory.
+          metric_type: gauge
+          unit: byte
+    - name: process
+      type: group
+      description: |
+        `process` contains process metadata, CPU metrics, and memory metrics.
+      fields:
+        - name: cgroup
+          type: group
+          description: Metrics and limits for the cgroup, collected by APM agents on Linux.
+          fields:
+            - name: cpu
+              type: group
+              description: CPU-specific cgroup metrics and limits.
+              fields:
+                - name: cfs
+                  type: group
+                  description: Completely Fair Scheduler (CFS) cgroup metrics.
+                  fields:
+                    - name: period.us
+                      type: long
+                      description: CFS period in microseconds.
+                      metric_type: gauge
+                      unit: micros
+                    - name: quota.us
+                      type: long
+                      description: CFS quota in microseconds.
+                      metric_type: gauge
+                      unit: micros
+                - name: id
+                  type: keyword
+                  description: ID for the current cgroup CPU.
+                - name: stats.periods
+                  type: long
+                  description: Number of periods seen by the CPU.
+                  metric_type: counter
+                - name: stats.throttled.ns
+                  type: long
+                  description: Nanoseconds spent throttled seen by the CPU.
+                  metric_type: counter
+                  unit: nanos
+                - name: stats.throttled.periods
+                  type: long
+                  description: Number of throttled periods seen by the CPU.
+                  metric_type: counter
+            - name: cpuacct
+              type: group
+              description: CPU Accounting-specific cgroup metrics and limits.
+              fields:
+                - name: id
+                  type: keyword
+                  description: ID for the current cgroup CPU.
+                - name: total.ns
+                  type: long
+                  description: Total CPU time for the current cgroup CPU in nanoseconds.
+                  metric_type: counter
+                  unit: nanos
+            - name: memory
+              type: group
+              description: Memory-specific cgroup metrics and limits.
+              fields:
+                - name: mem.limit.bytes
+                  type: long
+                  format: bytes
+                  description: Memory limit for the current cgroup slice.
+                  metric_type: gauge
+                  unit: byte
+                - name: mem.usage.bytes
+                  type: long
+                  format: bytes
+                  description: Memory usage by the current cgroup slice.
+                  metric_type: gauge
+                  unit: byte
+        - name: cpu
+          type: group
+          description: |
+            `cpu` contains local CPU stats.
+          fields:
+            - name: total.norm.pct
+              type: scaled_float
+              format: percent
+              description: |
+                The percentage of CPU time spent by the process since the last event. This value is normalized by the number of CPU cores and it ranges from 0 to 100%.
+              metric_type: gauge
+              unit: percent
+        - name: memory
+          type: group
+          description: Memory-specific statistics per process.
+          fields:
+            - name: rss.bytes
+              type: long
+              format: bytes
+              description: |
+                The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
+              metric_type: gauge
+              unit: byte
+            - name: size
+              type: long
+              format: bytes
+              description: |
+                The total virtual memory the process has.
+              metric_type: gauge
+              unit: byte
+- name: timestamp
+  type: group
+  fields:
+    - name: us
+      type: long
+      description: |
+        Timestamp of the event in microseconds since Unix epoch.

--- a/apmpackage/apm/data_stream/app_metrics/manifest.yml
+++ b/apmpackage/apm/data_stream/app_metrics/manifest.yml
@@ -3,3 +3,10 @@ type: metrics
 dataset: apm.app
 dataset_is_prefix: true
 ilm_policy: metrics-apm.app_metrics-default_policy
+elasticsearch:
+  index_template:
+    mappings:
+      # Application metrics must be dynamically mapped,
+      # as their names are application-specific and not
+      # known ahead of time.
+      dynamic: true

--- a/apmpackage/apm/data_stream/error_logs/fields/base-fields.yml
+++ b/apmpackage/apm/data_stream/error_logs/fields/base-fields.yml
@@ -10,3 +10,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: ecs.version
+  type: keyword
+  description: ECS version the event conforms to.

--- a/apmpackage/apm/data_stream/error_logs/fields/ecs.yml
+++ b/apmpackage/apm/data_stream/error_logs/fields/ecs.yml
@@ -1,142 +1,207 @@
-- name: agent.ephemeral_id
-  type: keyword
+- name: agent
+  type: group
+  fields:
+    - name: ephemeral_id
+      type: keyword
+      description: |
+        The Ephemeral ID identifies a running process.
+    - name: name
+      type: keyword
+      description: |
+        Name of the agent used.
+    - name: version
+      type: keyword
+      description: |
+        Version of the agent used.
+- name: client
+  type: group
+  fields:
+    - name: domain
+      type: keyword
+      description: |
+        Client domain.
+      ignore_above: 1024
+    - name: ip
+      type: ip
+      description: |
+        IP address of the client of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
+    - name: port
+      type: long
+      description: |
+        Port of the client.
+- name: cloud
+  title: Cloud
+  type: group
   description: |
-    The Ephemeral ID identifies a running process.
-- name: agent.name
-  type: keyword
+    Cloud metadata reported by agents
+  fields:
+    - name: account
+      type: group
+      fields:
+        - name: id
+          level: extended
+          type: keyword
+          description: Cloud account ID
+          ignore_above: 1024
+        - name: name
+          level: extended
+          type: keyword
+          description: Cloud account name
+          ignore_above: 1024
+    - name: availability_zone
+      level: extended
+      type: keyword
+      description: Cloud availability zone name
+      ignore_above: 1024
+    - name: instance
+      type: group
+      fields:
+        - name: id
+          level: extended
+          type: keyword
+          description: Cloud instance/machine ID
+          ignore_above: 1024
+        - name: name
+          level: extended
+          type: keyword
+          description: Cloud instance/machine name
+          ignore_above: 1024
+    - name: machine
+      type: group
+      fields:
+        - name: type
+          level: extended
+          type: keyword
+          description: Cloud instance/machine type
+          ignore_above: 1024
+    - name: project
+      type: group
+      fields:
+        - name: id
+          level: extended
+          type: keyword
+          description: Cloud project ID
+          ignore_above: 1024
+        - name: name
+          level: extended
+          type: keyword
+          description: Cloud project name
+          ignore_above: 1024
+    - name: provider
+      level: extended
+      type: keyword
+      description: Cloud provider name
+      ignore_above: 1024
+    - name: region
+      level: extended
+      type: keyword
+      description: Cloud region name
+      ignore_above: 1024
+    - name: service
+      type: group
+      fields:
+        - name: name
+          level: extended
+          type: keyword
+          description: |
+            Cloud service name, intended to distinguish services running on different platforms within a provider.
+          ignore_above: 1024
+- name: container
+  title: Container
+  type: group
   description: |
-    Name of the agent used.
-- name: agent.version
-  type: keyword
+    Container fields are used for meta information about the specific container that is the source of information. These fields help correlate data based containers from any runtime.
+  fields:
+    - name: id
+      type: keyword
+      description: |
+        Unique container id.
+- name: destination
+  title: Destination
+  type: group
+  description: |-
+    Destination fields describe details about the destination of a packet/event.
+    Destination fields are usually populated in conjunction with source fields.
+  fields:
+    - name: address
+      level: extended
+      type: keyword
+      description: Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is.
+      ignore_above: 1024
+    - name: ip
+      level: core
+      type: ip
+      description: IP addess of the destination. Can be one of multiple IPv4 or IPv6 addresses.
+    - name: port
+      level: core
+      type: long
+      format: string
+      description: Port of the destination.
+- name: error
+  type: group
   description: |
-    Version of the agent used.
-- name: client.domain
-  type: keyword
+    Data captured by an agent representing an event occurring in a monitored service.
+  fields:
+    - name: id
+      type: keyword
+      description: |
+        The ID of the error.
+- name: host
+  type: group
   description: |
-    Client domain.
-  ignore_above: 1024
-- name: client.ip
-  type: ip
-  description: |
-    IP address of the client of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
-- name: client.port
-  type: long
-  description: |
-    Port of the client.
-- name: cloud.account.id
-  level: extended
-  type: keyword
-  description: Cloud account ID
-  ignore_above: 1024
-- name: cloud.account.name
-  level: extended
-  type: keyword
-  description: Cloud account name
-  ignore_above: 1024
-- name: cloud.availability_zone
-  level: extended
-  type: keyword
-  description: Cloud availability zone name
-  ignore_above: 1024
-- name: cloud.instance.id
-  level: extended
-  type: keyword
-  description: Cloud instance/machine ID
-  ignore_above: 1024
-- name: cloud.instance.name
-  level: extended
-  type: keyword
-  description: Cloud instance/machine name
-  ignore_above: 1024
-- name: cloud.machine.type
-  level: extended
-  type: keyword
-  description: Cloud instance/machine type
-  ignore_above: 1024
-- name: cloud.project.id
-  level: extended
-  type: keyword
-  description: Cloud project ID
-  ignore_above: 1024
-- name: cloud.project.name
-  level: extended
-  type: keyword
-  description: Cloud project name
-  ignore_above: 1024
-- name: cloud.provider
-  level: extended
-  type: keyword
-  description: Cloud provider name
-  ignore_above: 1024
-- name: cloud.region
-  level: extended
-  type: keyword
-  description: Cloud region name
-  ignore_above: 1024
-- name: cloud.service.name
-  level: extended
-  type: keyword
-  description: |
-    Cloud service name, intended to distinguish services running on different platforms within a provider.
-  ignore_above: 1024
-- name: container.id
-  type: keyword
-  description: |
-    Unique container id.
-- name: destination.address
-  level: extended
-  type: keyword
-  description: Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is.
-  ignore_above: 1024
-- name: destination.ip
-  level: core
-  type: ip
-  description: IP addess of the destination. Can be one of multiple IPv4 or IPv6 addresses.
-- name: destination.port
-  level: core
-  type: long
-  format: string
-  description: Port of the destination.
-- name: error.id
-  type: keyword
-  description: |
-    The ID of the error.
-- name: host.architecture
-  type: keyword
-  description: |
-    The architecture of the host the event was recorded on.
-- name: host.hostname
-  type: keyword
-  description: |
-    The hostname of the host the event was recorded on.
-- name: host.ip
-  type: ip
-  description: |
-    IP of the host that records the event.
-- name: host.name
-  type: keyword
-  description: |
-    Name of the host the event was recorded on. It can contain same information as host.hostname or a name specified by the user.
-- name: host.os.platform
-  type: keyword
-  description: |
-    The platform of the host the event was recorded on.
-- name: http.request.method
-  type: keyword
-  description: |
-    The http method of the request leading to this event.
-- name: http.request.referrer
-  type: keyword
-  description: Referrer for this HTTP request.
-  ignore_above: 1024
-- name: http.response.status_code
-  type: long
-  description: |
-    The status code of the HTTP response.
-- name: http.version
-  type: keyword
-  description: |
-    The http version of the request leading to this event.
+    Optional host fields.
+  fields:
+    - name: architecture
+      type: keyword
+      description: |
+        The architecture of the host the event was recorded on.
+    - name: hostname
+      type: keyword
+      description: |
+        The hostname of the host the event was recorded on.
+    - name: ip
+      type: ip
+      description: |
+        IP of the host that records the event.
+    - name: name
+      type: keyword
+      description: |
+        Name of the host the event was recorded on. It can contain same information as host.hostname or a name specified by the user.
+    - name: os
+      title: Operating System
+      type: group
+      description: |
+        The OS fields contain information about the operating system.
+      fields:
+        - name: platform
+          type: keyword
+          description: |
+            The platform of the host the event was recorded on.
+- name: http
+  type: group
+  fields:
+    - name: request
+      type: group
+      fields:
+        - name: method
+          type: keyword
+          description: |
+            The http method of the request leading to this event.
+        - name: referrer
+          type: keyword
+          description: Referrer for this HTTP request.
+          ignore_above: 1024
+    - name: response
+      type: group
+      fields:
+        - name: status_code
+          type: long
+          description: |
+            The status code of the HTTP response.
+    - name: version
+      type: keyword
+      description: |
+        The http version of the request leading to this event.
 - name: labels
   type: object
   description: |
@@ -147,152 +212,203 @@
     - object_type: boolean
     - object_type: scaled_float
       scaling_factor: 1000000
-- name: observer.hostname
-  type: keyword
+- name: observer
+  type: group
+  fields:
+    - name: hostname
+      type: keyword
+      description: |
+        Hostname of the APM Server.
+    - name: type
+      type: keyword
+      description: |
+        The type will be set to `apm-server`.
+    - name: version
+      type: keyword
+      description: |
+        APM Server version.
+- name: process
+  type: group
   description: |
-    Hostname of the APM Server.
-- name: observer.type
-  type: keyword
+    Information pertaining to the running process where the data was collected
+  fields:
+    - name: args
+      level: extended
+      type: keyword
+      description: |
+        Process arguments. May be filtered to protect sensitive information.
+    - name: pid
+      type: long
+      description: |
+        Numeric process ID of the service process.
+    - name: ppid
+      type: long
+      description: |
+        Numeric ID of the service's parent process.
+    - name: title
+      type: keyword
+      description: |
+        Service process title.
+- name: service
+  type: group
   description: |
-    The type will be set to `apm-server`.
-- name: observer.version
-  type: keyword
+    Service fields.
+  fields:
+    - name: name
+      type: keyword
+      description: |
+        Immutable name of the service emitting this event.
+    - name: node
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Unique meaningful name of the service node.
+    - name: version
+      type: keyword
+      description: |
+        Version of the service emitting this event.
+- name: source
+  type: group
+  fields:
+    - name: domain
+      type: keyword
+      description: |
+        Source domain.
+      ignore_above: 1024
+    - name: ip
+      type: ip
+      description: |
+        IP address of the source of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
+    - name: port
+      type: long
+      description: |
+        Port of the source.
+- name: trace
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      description: |
+        The ID of the trace to which the event belongs to.
+- name: transaction
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      description: |
+        The transaction ID.
+- name: url
+  type: group
   description: |
-    APM Server version.
-- name: process.args
-  level: extended
-  type: keyword
+    A complete Url, with scheme, host and path.
+  fields:
+    - name: domain
+      type: keyword
+      description: |
+        The hostname of the request, e.g. "example.com".
+    - name: fragment
+      type: keyword
+      description: |
+        A fragment specifying a location in a web page , e.g. "top".
+    - name: full
+      type: keyword
+      description: |
+        The full, possibly agent-assembled URL of the request, e.g https://example.com:443/search?q=elasticsearch#top.
+    - name: path
+      type: keyword
+      description: |
+        The path of the request, e.g. "/search".
+    - name: port
+      type: long
+      description: |
+        The port of the request, e.g. 443.
+    - name: query
+      type: keyword
+      description: |
+        The query string of the request, e.g. "q=elasticsearch".
+    - name: scheme
+      type: keyword
+      description: |
+        The protocol of the request, e.g. "https:".
+- name: user
+  type: group
+  fields:
+    - name: domain
+      type: keyword
+      description: |
+        Domain of the logged in user.
+    - name: email
+      type: keyword
+      description: |
+        Email of the logged in user.
+    - name: id
+      type: keyword
+      description: |
+        Identifier of the logged in user.
+    - name: name
+      type: keyword
+      description: |
+        The username of the logged in user.
+- name: user_agent
+  title: User agent
+  type: group
   description: |
-    Process arguments. May be filtered to protect sensitive information.
-- name: process.pid
-  type: long
-  description: |
-    Numeric process ID of the service process.
-- name: process.ppid
-  type: long
-  description: |
-    Numeric ID of the service's parent process.
-- name: process.title
-  type: keyword
-  description: |
-    Service process title.
-- name: service.name
-  type: keyword
-  description: |
-    Immutable name of the service emitting this event.
-- name: service.node.name
-  type: keyword
-  description: |
-    Unique meaningful name of the service node.
-- name: service.version
-  type: keyword
-  description: |
-    Version of the service emitting this event.
-- name: source.domain
-  type: keyword
-  description: |
-    Source domain.
-  ignore_above: 1024
-- name: source.ip
-  type: ip
-  description: |
-    IP address of the source of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
-- name: source.port
-  type: long
-  description: |
-    Port of the source.
-- name: trace.id
-  type: keyword
-  description: |
-    The ID of the trace to which the event belongs to.
-- name: transaction.id
-  type: keyword
-  description: |
-    The transaction ID.
-- name: url.domain
-  type: keyword
-  description: |
-    The hostname of the request, e.g. "example.com".
-- name: url.fragment
-  type: keyword
-  description: |
-    A fragment specifying a location in a web page , e.g. "top".
-- name: url.full
-  type: keyword
-  description: |
-    The full, possibly agent-assembled URL of the request, e.g https://example.com:443/search?q=elasticsearch#top.
-- name: url.path
-  type: keyword
-  description: |
-    The path of the request, e.g. "/search".
-- name: url.port
-  type: long
-  description: |
-    The port of the request, e.g. 443.
-- name: url.query
-  type: keyword
-  description: |
-    The query string of the request, e.g. "q=elasticsearch".
-- name: url.scheme
-  type: keyword
-  description: |
-    The protocol of the request, e.g. "https:".
-- name: user.domain
-  type: keyword
-  description: |
-    Domain of the logged in user.
-- name: user.email
-  type: keyword
-  description: |
-    Email of the logged in user.
-- name: user.id
-  type: keyword
-  description: |
-    Identifier of the logged in user.
-- name: user.name
-  type: keyword
-  description: |
-    The username of the logged in user.
-- name: user_agent.device.name
-  type: keyword
-  description: |
-    Name of the device.
-- name: user_agent.name
-  type: keyword
-  description: |
-    Name of the user agent.
-- name: user_agent.original
-  type: keyword
-  description: |
-    Unparsed version of the user_agent.
-  multi_fields:
-    - name: text
-      type: text
-- name: user_agent.os.family
-  type: keyword
-  description: |
-    OS family (such as redhat, debian, freebsd, windows).
-- name: user_agent.os.full
-  type: keyword
-  description: |
-    Operating system name, including the version or code name.
-- name: user_agent.os.kernel
-  type: keyword
-  description: |
-    Operating system kernel version as a raw string.
-- name: user_agent.os.name
-  type: keyword
-  description: |
-    Operating system name, without the version.
-- name: user_agent.os.platform
-  type: keyword
-  description: |
-    Operating system platform (such centos, ubuntu, windows).
-- name: user_agent.os.version
-  type: keyword
-  description: |
-    Operating system version as a raw string.
-- name: user_agent.version
-  type: keyword
-  description: |
-    Version of the user agent.
+    The user_agent fields normally come from a browser request. They often show up in web service logs coming from the parsed user agent string.
+  fields:
+    - name: device
+      title: Device
+      type: group
+      description: |
+        Information concerning the device.
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the device.
+    - name: name
+      type: keyword
+      description: |
+        Name of the user agent.
+    - name: original
+      type: keyword
+      description: |
+        Unparsed version of the user_agent.
+      multi_fields:
+        - name: text
+          type: text
+    - name: os
+      title: Operating System
+      type: group
+      description: |
+        The OS fields contain information about the operating system.
+      fields:
+        - name: family
+          type: keyword
+          description: |
+            OS family (such as redhat, debian, freebsd, windows).
+        - name: full
+          type: keyword
+          description: |
+            Operating system name, including the version or code name.
+        - name: kernel
+          type: keyword
+          description: |
+            Operating system kernel version as a raw string.
+        - name: name
+          type: keyword
+          description: |
+            Operating system name, without the version.
+        - name: platform
+          type: keyword
+          description: |
+            Operating system platform (such centos, ubuntu, windows).
+        - name: version
+          type: keyword
+          description: |
+            Operating system version as a raw string.
+    - name: version
+      type: keyword
+      description: |
+        Version of the user agent.

--- a/apmpackage/apm/data_stream/error_logs/fields/fields.yml
+++ b/apmpackage/apm/data_stream/error_logs/fields/fields.yml
@@ -1,160 +1,237 @@
-- name: error.culprit
-  type: keyword
-  description: Function call which was the primary perpetrator of this event.
-- name: error.exception.code
-  type: keyword
-  description: The error code set when the error happened, e.g. database error code.
-- name: error.exception.handled
-  type: boolean
-  description: Indicator whether the error was caught somewhere in the code or not.
-- name: error.exception.message
-  type: text
-  description: The original error message.
-- name: error.exception.module
-  type: keyword
-  description: The module namespace of the original error.
-- name: error.exception.type
-  type: keyword
-  description: The type of the original error, e.g. the Java exception class name.
-- name: error.grouping_key
-  type: keyword
+- name: error
+  type: group
   description: |
-    Hash of select properties of the logged error for grouping purposes.
-- name: error.grouping_name
-  type: keyword
-  description: |
-    Name to associate with an error group. Errors belonging to the same group (same grouping_key) may have differing values for grouping_name. Consumers may choose one arbitrarily.
-- name: error.log.level
-  type: keyword
-  description: The severity of the record.
-- name: error.log.logger_name
-  type: keyword
-  description: The name of the logger instance used.
-- name: error.log.message
-  type: text
-  description: The additionally logged error message.
-- name: error.log.param_message
-  type: keyword
-  description: |
-    A parametrized message. E.g. 'Could not connect to %s'. The property message is still required, and should be equal to the param_message, but with placeholders replaced. In some situations the param_message is used to group errors together.
+    Data captured by an agent representing an event occurring in a monitored service.
+  fields:
+    - name: culprit
+      type: keyword
+      description: Function call which was the primary perpetrator of this event.
+    - name: exception
+      type: group
+      description: |
+        Information about the originally thrown error.
+      fields:
+        - name: code
+          type: keyword
+          description: The error code set when the error happened, e.g. database error code.
+        - name: handled
+          type: boolean
+          description: Indicator whether the error was caught somewhere in the code or not.
+        - name: message
+          type: text
+          description: The original error message.
+        - name: module
+          type: keyword
+          description: The module namespace of the original error.
+        - name: type
+          type: keyword
+          description: The type of the original error, e.g. the Java exception class name.
+    - name: grouping_key
+      type: keyword
+      description: |
+        Hash of select properties of the logged error for grouping purposes.
+    - name: grouping_name
+      type: keyword
+      description: |
+        Name to associate with an error group. Errors belonging to the same group (same grouping_key) may have differing values for grouping_name. Consumers may choose one arbitrarily.
+    - name: log
+      type: group
+      description: |
+        Additional information added by logging the error.
+      fields:
+        - name: level
+          type: keyword
+          description: The severity of the record.
+        - name: logger_name
+          type: keyword
+          description: The name of the logger instance used.
+        - name: message
+          type: text
+          description: The additionally logged error message.
+        - name: param_message
+          type: keyword
+          description: |
+            A parametrized message. E.g. 'Could not connect to %s'. The property message is still required, and should be equal to the param_message, but with placeholders replaced. In some situations the param_message is used to group errors together.
 - name: experimental
   type: object
   description: Additional experimental data sent by the agents.
   dynamic: true
-- name: http.request.headers
-  type: object
+- name: http
+  type: group
+  fields:
+    - name: request
+      type: group
+      fields:
+        - name: headers
+          type: object
+          description: |
+            The canonical headers of the monitored HTTP request.
+    - name: response
+      type: group
+      fields:
+        - name: finished
+          type: boolean
+          description: |
+            Used by the Node agent to indicate when in the response life cycle an error has occurred.
+        - name: headers
+          type: object
+          description: |
+            The canonical headers of the monitored HTTP response.
+- name: kubernetes
+  title: Kubernetes
+  type: group
   description: |
-    The canonical headers of the monitored HTTP request.
-- name: http.response.finished
-  type: boolean
+    Kubernetes metadata reported by agents
+  fields:
+    - name: namespace
+      type: keyword
+      description: |
+        Kubernetes namespace
+    - name: node
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Kubernetes node name
+    - name: pod
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Kubernetes pod name
+        - name: uid
+          type: keyword
+          description: |
+            Kubernetes Pod UID
+- name: network
+  type: group
   description: |
-    Used by the Node agent to indicate when in the response life cycle an error has occurred.
-- name: http.response.headers
-  type: object
-  description: |
-    The canonical headers of the monitored HTTP response.
-- name: kubernetes.namespace
-  type: keyword
-  description: |
-    Kubernetes namespace
-- name: kubernetes.node.name
-  type: keyword
-  description: |
-    Kubernetes node name
-- name: kubernetes.pod.name
-  type: keyword
-  description: |
-    Kubernetes pod name
-- name: kubernetes.pod.uid
-  type: keyword
-  description: |
-    Kubernetes Pod UID
-- name: network.carrier.icc
-  type: keyword
-  description: |
-    ISO country code, eg. US
-- name: network.carrier.mcc
-  type: keyword
-  description: |
-    Mobile country code
-- name: network.carrier.mnc
-  type: keyword
-  description: |
-    Mobile network code
-- name: network.carrier.name
-  type: keyword
-  description: |
-    Carrier name, eg. Vodafone, T-Mobile, etc.
-- name: network.connection.subtype
-  type: keyword
-  description: |
-    Detailed network connection sub-type, e.g. "LTE", "CDMA"
-- name: network.connection.type
-  type: keyword
-  description: |
-    Network connection type, eg. "wifi", "cell"
-- name: observer.listening
-  type: keyword
-  description: |
-    Address the server is listening on.
-- name: observer.version_major
-  type: byte
-  description: |
-    Major version number of the observer
-- name: parent.id
-  type: keyword
-  description: |
-    The ID of the parent event.
+    Optional network fields
+  fields:
+    - name: carrier
+      type: group
+      description: |
+        Network operator
+      fields:
+        - name: icc
+          type: keyword
+          description: |
+            ISO country code, eg. US
+        - name: mcc
+          type: keyword
+          description: |
+            Mobile country code
+        - name: mnc
+          type: keyword
+          description: |
+            Mobile network code
+        - name: name
+          type: keyword
+          description: |
+            Carrier name, eg. Vodafone, T-Mobile, etc.
+    - name: connection
+      type: group
+      description: |
+        Network connection details
+      fields:
+        - name: subtype
+          type: keyword
+          description: |
+            Detailed network connection sub-type, e.g. "LTE", "CDMA"
+        - name: type
+          type: keyword
+          description: |
+            Network connection type, eg. "wifi", "cell"
+- name: observer
+  type: group
+  fields:
+    - name: listening
+      type: keyword
+      description: |
+        Address the server is listening on.
+    - name: version_major
+      type: byte
+      description: |
+        Major version number of the observer
+- name: parent
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      description: |
+        The ID of the parent event.
 - name: processor.event
   type: keyword
   description: Processor event.
 - name: processor.name
   type: keyword
   description: Processor name.
-- name: service.environment
-  type: keyword
+- name: service
+  type: group
   description: |
-    Service environment.
-- name: service.framework.name
-  type: keyword
-  description: |
-    Name of the framework used.
-- name: service.framework.version
-  type: keyword
-  description: |
-    Version of the framework used.
-- name: service.language.name
-  type: keyword
-  description: |
-    Name of the programming language used.
-- name: service.language.version
-  type: keyword
-  description: |
-    Version of the programming language used.
-- name: service.runtime.name
-  type: keyword
-  description: |
-    Name of the runtime used.
-- name: service.runtime.version
-  type: keyword
-  description: |
-    Version of the runtime used.
-- name: timestamp.us
-  type: long
-  description: |
-    Timestamp of the event in microseconds since Unix epoch.
-- name: transaction.name
-  type: keyword
-  description: |
-    Generic designation of a transaction in the scope of a single service (eg. 'GET /users/:id').
-  multi_fields:
-    - name: text
-      type: text
-- name: transaction.sampled
-  type: boolean
-  description: |
-    Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have spans or context.
-- name: transaction.type
-  type: keyword
-  description: |
-    Keyword of specific relevance in the service's domain (eg. 'request', 'backgroundjob', etc)
+    Service fields.
+  fields:
+    - name: environment
+      type: keyword
+      description: |
+        Service environment.
+    - name: framework
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the framework used.
+        - name: version
+          type: keyword
+          description: |
+            Version of the framework used.
+    - name: language
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the programming language used.
+        - name: version
+          type: keyword
+          description: |
+            Version of the programming language used.
+    - name: runtime
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the runtime used.
+        - name: version
+          type: keyword
+          description: |
+            Version of the runtime used.
+- name: timestamp
+  type: group
+  fields:
+    - name: us
+      type: long
+      description: |
+        Timestamp of the event in microseconds since Unix epoch.
+- name: transaction
+  type: group
+  fields:
+    - name: name
+      type: keyword
+      description: |
+        Generic designation of a transaction in the scope of a single service (eg. 'GET /users/:id').
+      multi_fields:
+        - name: text
+          type: text
+    - name: sampled
+      type: boolean
+      description: |
+        Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have spans or context.
+    - name: type
+      type: keyword
+      description: |
+        Keyword of specific relevance in the service's domain (eg. 'request', 'backgroundjob', etc)

--- a/apmpackage/apm/data_stream/error_logs/manifest.yml
+++ b/apmpackage/apm/data_stream/error_logs/manifest.yml
@@ -2,3 +2,11 @@ title: APM logs and errors
 type: logs
 dataset: apm.error
 ilm_policy: logs-apm.error_logs-default_policy
+elasticsearch:
+  index_template:
+    mappings:
+      # TODO(axw) investigate setting `dynamic: runtime`, so that fields are
+      # runtime searchable by default. That way users can, for example, perform
+      # ad-hoc searches on HTTP request headers without incurring storage cost
+      # for users who do not need this capability.
+      dynamic: false

--- a/apmpackage/apm/data_stream/internal_metrics/fields/base-fields.yml
+++ b/apmpackage/apm/data_stream/internal_metrics/fields/base-fields.yml
@@ -10,3 +10,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: ecs.version
+  type: keyword
+  description: ECS version the event conforms to.

--- a/apmpackage/apm/data_stream/internal_metrics/fields/ecs.yml
+++ b/apmpackage/apm/data_stream/internal_metrics/fields/ecs.yml
@@ -1,128 +1,182 @@
-- name: agent.ephemeral_id
-  type: keyword
+- name: agent
+  type: group
+  fields:
+    - name: ephemeral_id
+      type: keyword
+      description: |
+        The Ephemeral ID identifies a running process.
+    - name: name
+      type: keyword
+      description: |
+        Name of the agent used.
+    - name: version
+      type: keyword
+      description: |
+        Version of the agent used.
+- name: client
+  type: group
+  fields:
+    - name: domain
+      type: keyword
+      description: |
+        Client domain.
+      ignore_above: 1024
+    - name: ip
+      type: ip
+      description: |
+        IP address of the client of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
+    - name: port
+      type: long
+      description: |
+        Port of the client.
+- name: cloud
+  title: Cloud
+  type: group
   description: |
-    The Ephemeral ID identifies a running process.
-- name: agent.name
-  type: keyword
+    Cloud metadata reported by agents
+  fields:
+    - name: account
+      type: group
+      fields:
+        - name: id
+          level: extended
+          type: keyword
+          description: Cloud account ID
+          ignore_above: 1024
+        - name: name
+          level: extended
+          type: keyword
+          description: Cloud account name
+          ignore_above: 1024
+    - name: availability_zone
+      level: extended
+      type: keyword
+      description: Cloud availability zone name
+      ignore_above: 1024
+    - name: instance
+      type: group
+      fields:
+        - name: id
+          level: extended
+          type: keyword
+          description: Cloud instance/machine ID
+          ignore_above: 1024
+        - name: name
+          level: extended
+          type: keyword
+          description: Cloud instance/machine name
+          ignore_above: 1024
+    - name: machine
+      type: group
+      fields:
+        - name: type
+          level: extended
+          type: keyword
+          description: Cloud instance/machine type
+          ignore_above: 1024
+    - name: project
+      type: group
+      fields:
+        - name: id
+          level: extended
+          type: keyword
+          description: Cloud project ID
+          ignore_above: 1024
+        - name: name
+          level: extended
+          type: keyword
+          description: Cloud project name
+          ignore_above: 1024
+    - name: provider
+      level: extended
+      type: keyword
+      description: Cloud provider name
+      ignore_above: 1024
+    - name: region
+      level: extended
+      type: keyword
+      description: Cloud region name
+      ignore_above: 1024
+    - name: service
+      type: group
+      fields:
+        - name: name
+          level: extended
+          type: keyword
+          description: |
+            Cloud service name, intended to distinguish services running on different platforms within a provider.
+          ignore_above: 1024
+- name: container
+  title: Container
+  type: group
   description: |
-    Name of the agent used.
-- name: agent.version
-  type: keyword
+    Container fields are used for meta information about the specific container that is the source of information. These fields help correlate data based containers from any runtime.
+  fields:
+    - name: id
+      type: keyword
+      description: |
+        Unique container id.
+- name: destination
+  title: Destination
+  type: group
+  description: |-
+    Destination fields describe details about the destination of a packet/event.
+    Destination fields are usually populated in conjunction with source fields.
+  fields:
+    - name: address
+      level: extended
+      type: keyword
+      description: Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is.
+      ignore_above: 1024
+    - name: ip
+      level: core
+      type: ip
+      description: IP addess of the destination. Can be one of multiple IPv4 or IPv6 addresses.
+    - name: port
+      level: core
+      type: long
+      format: string
+      description: Port of the destination.
+- name: event
+  type: group
+  fields:
+    - name: outcome
+      level: core
+      type: keyword
+      description: |
+        `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event.
+      ignore_above: 1024
+- name: host
+  type: group
   description: |
-    Version of the agent used.
-- name: client.domain
-  type: keyword
-  description: |
-    Client domain.
-  ignore_above: 1024
-- name: client.ip
-  type: ip
-  description: |
-    IP address of the client of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
-- name: client.port
-  type: long
-  description: |
-    Port of the client.
-- name: cloud.account.id
-  level: extended
-  type: keyword
-  description: Cloud account ID
-  ignore_above: 1024
-- name: cloud.account.name
-  level: extended
-  type: keyword
-  description: Cloud account name
-  ignore_above: 1024
-- name: cloud.availability_zone
-  level: extended
-  type: keyword
-  description: Cloud availability zone name
-  ignore_above: 1024
-- name: cloud.instance.id
-  level: extended
-  type: keyword
-  description: Cloud instance/machine ID
-  ignore_above: 1024
-- name: cloud.instance.name
-  level: extended
-  type: keyword
-  description: Cloud instance/machine name
-  ignore_above: 1024
-- name: cloud.machine.type
-  level: extended
-  type: keyword
-  description: Cloud instance/machine type
-  ignore_above: 1024
-- name: cloud.project.id
-  level: extended
-  type: keyword
-  description: Cloud project ID
-  ignore_above: 1024
-- name: cloud.project.name
-  level: extended
-  type: keyword
-  description: Cloud project name
-  ignore_above: 1024
-- name: cloud.provider
-  level: extended
-  type: keyword
-  description: Cloud provider name
-  ignore_above: 1024
-- name: cloud.region
-  level: extended
-  type: keyword
-  description: Cloud region name
-  ignore_above: 1024
-- name: cloud.service.name
-  level: extended
-  type: keyword
-  description: |
-    Cloud service name, intended to distinguish services running on different platforms within a provider.
-  ignore_above: 1024
-- name: container.id
-  type: keyword
-  description: |
-    Unique container id.
-- name: destination.address
-  level: extended
-  type: keyword
-  description: Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is.
-  ignore_above: 1024
-- name: destination.ip
-  level: core
-  type: ip
-  description: IP addess of the destination. Can be one of multiple IPv4 or IPv6 addresses.
-- name: destination.port
-  level: core
-  type: long
-  format: string
-  description: Port of the destination.
-- name: event.outcome
-  level: core
-  type: keyword
-  description: |
-    `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event.
-  ignore_above: 1024
-- name: host.architecture
-  type: keyword
-  description: |
-    The architecture of the host the event was recorded on.
-- name: host.hostname
-  type: keyword
-  description: |
-    The hostname of the host the event was recorded on.
-- name: host.ip
-  type: ip
-  description: |
-    IP of the host that records the event.
-- name: host.name
-  type: keyword
-  description: |
-    Name of the host the event was recorded on. It can contain same information as host.hostname or a name specified by the user.
-- name: host.os.platform
-  type: keyword
-  description: |
-    The platform of the host the event was recorded on.
+    Optional host fields.
+  fields:
+    - name: architecture
+      type: keyword
+      description: |
+        The architecture of the host the event was recorded on.
+    - name: hostname
+      type: keyword
+      description: |
+        The hostname of the host the event was recorded on.
+    - name: ip
+      type: ip
+      description: |
+        IP of the host that records the event.
+    - name: name
+      type: keyword
+      description: |
+        Name of the host the event was recorded on. It can contain same information as host.hostname or a name specified by the user.
+    - name: os
+      title: Operating System
+      type: group
+      description: |
+        The OS fields contain information about the operating system.
+      fields:
+        - name: platform
+          type: keyword
+          description: |
+            The platform of the host the event was recorded on.
 - name: labels
   type: object
   description: |
@@ -133,116 +187,159 @@
     - object_type: boolean
     - object_type: scaled_float
       scaling_factor: 1000000
-- name: observer.hostname
-  type: keyword
+- name: observer
+  type: group
+  fields:
+    - name: hostname
+      type: keyword
+      description: |
+        Hostname of the APM Server.
+    - name: type
+      type: keyword
+      description: |
+        The type will be set to `apm-server`.
+    - name: version
+      type: keyword
+      description: |
+        APM Server version.
+- name: process
+  type: group
   description: |
-    Hostname of the APM Server.
-- name: observer.type
-  type: keyword
+    Information pertaining to the running process where the data was collected
+  fields:
+    - name: args
+      level: extended
+      type: keyword
+      description: |
+        Process arguments. May be filtered to protect sensitive information.
+    - name: pid
+      type: long
+      description: |
+        Numeric process ID of the service process.
+    - name: ppid
+      type: long
+      description: |
+        Numeric ID of the service's parent process.
+    - name: title
+      type: keyword
+      description: |
+        Service process title.
+- name: service
+  type: group
   description: |
-    The type will be set to `apm-server`.
-- name: observer.version
-  type: keyword
+    Service fields.
+  fields:
+    - name: name
+      type: keyword
+      description: |
+        Immutable name of the service emitting this event.
+    - name: node
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Unique meaningful name of the service node.
+    - name: version
+      type: keyword
+      description: |
+        Version of the service emitting this event.
+- name: source
+  type: group
+  fields:
+    - name: domain
+      type: keyword
+      description: |
+        Source domain.
+      ignore_above: 1024
+    - name: ip
+      type: ip
+      description: |
+        IP address of the source of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
+    - name: port
+      type: long
+      description: |
+        Port of the source.
+- name: transaction
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      description: |
+        The transaction ID.
+- name: user
+  type: group
+  fields:
+    - name: email
+      type: keyword
+      description: |
+        Email of the logged in user.
+    - name: id
+      type: keyword
+      description: |
+        Identifier of the logged in user.
+    - name: name
+      type: keyword
+      description: |
+        The username of the logged in user.
+- name: user_agent
+  title: User agent
+  type: group
   description: |
-    APM Server version.
-- name: process.args
-  level: extended
-  type: keyword
-  description: |
-    Process arguments. May be filtered to protect sensitive information.
-- name: process.pid
-  type: long
-  description: |
-    Numeric process ID of the service process.
-- name: process.ppid
-  type: long
-  description: |
-    Numeric ID of the service's parent process.
-- name: process.title
-  type: keyword
-  description: |
-    Service process title.
-- name: service.name
-  type: keyword
-  description: |
-    Immutable name of the service emitting this event.
-- name: service.node.name
-  type: keyword
-  description: |
-    Unique meaningful name of the service node.
-- name: service.version
-  type: keyword
-  description: |
-    Version of the service emitting this event.
-- name: source.domain
-  type: keyword
-  description: |
-    Source domain.
-  ignore_above: 1024
-- name: source.ip
-  type: ip
-  description: |
-    IP address of the source of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
-- name: source.port
-  type: long
-  description: |
-    Port of the source.
-- name: transaction.id
-  type: keyword
-  description: |
-    The transaction ID.
-- name: user.email
-  type: keyword
-  description: |
-    Email of the logged in user.
-- name: user.id
-  type: keyword
-  description: |
-    Identifier of the logged in user.
-- name: user.name
-  type: keyword
-  description: |
-    The username of the logged in user.
-- name: user_agent.device.name
-  type: keyword
-  description: |
-    Name of the device.
-- name: user_agent.name
-  type: keyword
-  description: |
-    Name of the user agent.
-- name: user_agent.original
-  type: keyword
-  description: |
-    Unparsed version of the user_agent.
-  multi_fields:
-    - name: text
-      type: text
-- name: user_agent.os.family
-  type: keyword
-  description: |
-    OS family (such as redhat, debian, freebsd, windows).
-- name: user_agent.os.full
-  type: keyword
-  description: |
-    Operating system name, including the version or code name.
-- name: user_agent.os.kernel
-  type: keyword
-  description: |
-    Operating system kernel version as a raw string.
-- name: user_agent.os.name
-  type: keyword
-  description: |
-    Operating system name, without the version.
-- name: user_agent.os.platform
-  type: keyword
-  description: |
-    Operating system platform (such centos, ubuntu, windows).
-- name: user_agent.os.version
-  type: keyword
-  description: |
-    Operating system version as a raw string.
-- name: user_agent.version
-  type: keyword
-  description: |
-    Version of the user agent.
+    The user_agent fields normally come from a browser request. They often show up in web service logs coming from the parsed user agent string.
+  fields:
+    - name: device
+      title: Device
+      type: group
+      description: |
+        Information concerning the device.
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the device.
+    - name: name
+      type: keyword
+      description: |
+        Name of the user agent.
+    - name: original
+      type: keyword
+      description: |
+        Unparsed version of the user_agent.
+      multi_fields:
+        - name: text
+          type: text
+    - name: os
+      title: Operating System
+      type: group
+      description: |
+        The OS fields contain information about the operating system.
+      fields:
+        - name: family
+          type: keyword
+          description: |
+            OS family (such as redhat, debian, freebsd, windows).
+        - name: full
+          type: keyword
+          description: |
+            Operating system name, including the version or code name.
+        - name: kernel
+          type: keyword
+          description: |
+            Operating system kernel version as a raw string.
+        - name: name
+          type: keyword
+          description: |
+            Operating system name, without the version.
+        - name: platform
+          type: keyword
+          description: |
+            Operating system platform (such centos, ubuntu, windows).
+        - name: version
+          type: keyword
+          description: |
+            Operating system version as a raw string.
+    - name: version
+      type: keyword
+      description: |
+        Version of the user agent.

--- a/apmpackage/apm/data_stream/internal_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/internal_metrics/fields/fields.yml
@@ -4,250 +4,388 @@
   dynamic: true
 - name: histogram
   type: histogram
-- name: kubernetes.namespace
-  type: keyword
+- name: kubernetes
+  title: Kubernetes
+  type: group
   description: |
-    Kubernetes namespace
-- name: kubernetes.node.name
-  type: keyword
-  description: |
-    Kubernetes node name
-- name: kubernetes.pod.name
-  type: keyword
-  description: |
-    Kubernetes pod name
-- name: kubernetes.pod.uid
-  type: keyword
-  description: |
-    Kubernetes Pod UID
-- name: metricset.name
-  type: keyword
-  description: |
-    Name of the set of metrics.
+    Kubernetes metadata reported by agents
+  fields:
+    - name: namespace
+      type: keyword
+      description: |
+        Kubernetes namespace
+    - name: node
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Kubernetes node name
+    - name: pod
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Kubernetes pod name
+        - name: uid
+          type: keyword
+          description: |
+            Kubernetes Pod UID
+- name: metricset
+  type: group
+  fields:
+    - name: name
+      type: keyword
+      description: |
+        Name of the set of metrics.
 - name: metricset.period
   type: long
   description: Current data collection period for this event in milliseconds.
   unit: ms
-- name: network.carrier.icc
-  type: keyword
+- name: network
+  type: group
   description: |
-    ISO country code, eg. US
-- name: network.carrier.mcc
-  type: keyword
-  description: |
-    Mobile country code
-- name: network.carrier.mnc
-  type: keyword
-  description: |
-    Mobile network code
-- name: network.carrier.name
-  type: keyword
-  description: |
-    Carrier name, eg. Vodafone, T-Mobile, etc.
-- name: network.connection.subtype
-  type: keyword
-  description: |
-    Detailed network connection sub-type, e.g. "LTE", "CDMA"
-- name: network.connection.type
-  type: keyword
-  description: |
-    Network connection type, eg. "wifi", "cell"
-- name: observer.listening
-  type: keyword
-  description: |
-    Address the server is listening on.
-- name: observer.version_major
-  type: byte
-  description: |
-    Major version number of the observer
+    Optional network fields
+  fields:
+    - name: carrier
+      type: group
+      description: |
+        Network operator
+      fields:
+        - name: icc
+          type: keyword
+          description: |
+            ISO country code, eg. US
+        - name: mcc
+          type: keyword
+          description: |
+            Mobile country code
+        - name: mnc
+          type: keyword
+          description: |
+            Mobile network code
+        - name: name
+          type: keyword
+          description: |
+            Carrier name, eg. Vodafone, T-Mobile, etc.
+    - name: connection
+      type: group
+      description: |
+        Network connection details
+      fields:
+        - name: subtype
+          type: keyword
+          description: |
+            Detailed network connection sub-type, e.g. "LTE", "CDMA"
+        - name: type
+          type: keyword
+          description: |
+            Network connection type, eg. "wifi", "cell"
+- name: observer
+  type: group
+  fields:
+    - name: listening
+      type: keyword
+      description: |
+        Address the server is listening on.
+    - name: version_major
+      type: byte
+      description: |
+        Major version number of the observer
 - name: processor.event
   type: keyword
   description: Processor event.
 - name: processor.name
   type: keyword
   description: Processor name.
-- name: service.environment
-  type: keyword
+- name: service
+  type: group
   description: |
-    Service environment.
-- name: service.framework.name
-  type: keyword
+    Service fields.
+  fields:
+    - name: environment
+      type: keyword
+      description: |
+        Service environment.
+    - name: framework
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the framework used.
+        - name: version
+          type: keyword
+          description: |
+            Version of the framework used.
+    - name: language
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the programming language used.
+        - name: version
+          type: keyword
+          description: |
+            Version of the programming language used.
+    - name: runtime
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the runtime used.
+        - name: version
+          type: keyword
+          description: |
+            Version of the runtime used.
+- name: span
+  type: group
+  fields:
+    - name: destination.service
+      type: group
+      fields:
+        - name: response_time.count
+          type: long
+          description: Number of aggregated outgoing requests.
+        - name: response_time.sum.us
+          type: long
+          description: Aggregated duration of outgoing requests, in microseconds.
+          unit: micros
+    - name: self_time
+      type: group
+      description: |
+        Portion of the span's duration where no direct child was running
+      fields:
+        - name: count
+          type: long
+          description: Number of aggregated spans.
+        - name: sum
+          type: group
+          fields:
+            - name: us
+              type: long
+              description: |
+                Aggregated span duration, excluding the time periods where a direct child was running, in microseconds.
+              unit: micros
+    - name: subtype
+      type: keyword
+      description: |
+        A further sub-division of the type (e.g. postgresql, elasticsearch)
+    - name: type
+      type: keyword
+      description: |
+        Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', 'cache', etc).
+- name: system
+  type: group
   description: |
-    Name of the framework used.
-- name: service.framework.version
-  type: keyword
-  description: |
-    Version of the framework used.
-- name: service.language.name
-  type: keyword
-  description: |
-    Name of the programming language used.
-- name: service.language.version
-  type: keyword
-  description: |
-    Version of the programming language used.
-- name: service.runtime.name
-  type: keyword
-  description: |
-    Name of the runtime used.
-- name: service.runtime.version
-  type: keyword
-  description: |
-    Version of the runtime used.
-- name: span.destination.service.response_time.count
-  type: long
-  description: Number of aggregated outgoing requests.
-- name: span.destination.service.response_time.sum.us
-  type: long
-  description: Aggregated duration of outgoing requests, in microseconds.
-  unit: micros
-- name: span.self_time.count
-  type: long
-  description: Number of aggregated spans.
-- name: span.self_time.sum.us
-  type: long
-  description: |
-    Aggregated span duration, excluding the time periods where a direct child was running, in microseconds.
-  unit: micros
-- name: span.subtype
-  type: keyword
-  description: |
-    A further sub-division of the type (e.g. postgresql, elasticsearch)
-- name: span.type
-  type: keyword
-  description: |
-    Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', 'cache', etc).
-- name: system.cpu.total.norm.pct
-  type: scaled_float
-  format: percent
-  description: |
-    The percentage of CPU time spent by the process since the last event. This value is normalized by the number of CPU cores and it ranges from 0 to 100%.
-  metric_type: gauge
-  unit: percent
-- name: system.memory.actual.free
-  type: long
-  format: bytes
-  description: |
-    Actual free memory in bytes. It is calculated based on the OS. On Linux it consists of the free memory plus caches and buffers. On OSX it is a sum of free memory and the inactive memory. On Windows, it is equal to `system.memory.free`.
-  metric_type: gauge
-  unit: byte
-- name: system.memory.total
-  type: long
-  format: bytes
-  description: |
-    Total memory.
-  metric_type: gauge
-  unit: byte
-- name: system.process.cgroup.cpu.cfs.period.us
-  type: long
-  description: CFS period in microseconds.
-  metric_type: gauge
-  unit: micros
-- name: system.process.cgroup.cpu.cfs.quota.us
-  type: long
-  description: CFS quota in microseconds.
-  metric_type: gauge
-  unit: micros
-- name: system.process.cgroup.cpu.id
-  type: keyword
-  description: ID for the current cgroup CPU.
-- name: system.process.cgroup.cpu.stats.periods
-  type: long
-  description: Number of periods seen by the CPU.
-  metric_type: counter
-- name: system.process.cgroup.cpu.stats.throttled.ns
-  type: long
-  description: Nanoseconds spent throttled seen by the CPU.
-  metric_type: counter
-  unit: nanos
-- name: system.process.cgroup.cpu.stats.throttled.periods
-  type: long
-  description: Number of throttled periods seen by the CPU.
-  metric_type: counter
-- name: system.process.cgroup.cpuacct.id
-  type: keyword
-  description: ID for the current cgroup CPU.
-- name: system.process.cgroup.cpuacct.total.ns
-  type: long
-  description: Total CPU time for the current cgroup CPU in nanoseconds.
-  metric_type: counter
-  unit: nanos
-- name: system.process.cgroup.memory.mem.limit.bytes
-  type: long
-  format: bytes
-  description: Memory limit for the current cgroup slice.
-  metric_type: gauge
-  unit: byte
-- name: system.process.cgroup.memory.mem.usage.bytes
-  type: long
-  format: bytes
-  description: Memory usage by the current cgroup slice.
-  metric_type: gauge
-  unit: byte
-- name: system.process.cpu.total.norm.pct
-  type: scaled_float
-  format: percent
-  description: |
-    The percentage of CPU time spent by the process since the last event. This value is normalized by the number of CPU cores and it ranges from 0 to 100%.
-  metric_type: gauge
-  unit: percent
-- name: system.process.memory.rss.bytes
-  type: long
-  format: bytes
-  description: |
-    The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
-  metric_type: gauge
-  unit: byte
-- name: system.process.memory.size
-  type: long
-  format: bytes
-  description: |
-    The total virtual memory the process has.
-  metric_type: gauge
-  unit: byte
-- name: timestamp.us
-  type: long
-  description: |
-    Timestamp of the event in microseconds since Unix epoch.
-- name: transaction.breakdown.count
-  type: long
-  description: |
-    Counter for collected breakdowns for the transaction
-- name: transaction.duration.count
-  type: long
-  description: Number of aggregated transactions.
-- name: transaction.duration.histogram
-  type: histogram
-  description: |
-    Pre-aggregated histogram of transaction durations.
-- name: transaction.duration.sum.us
-  type: long
-  description: Aggregated transaction duration, in microseconds.
-  unit: micros
-- name: transaction.name
-  type: keyword
-  description: |
-    Generic designation of a transaction in the scope of a single service (eg. 'GET /users/:id').
-  multi_fields:
-    - name: text
-      type: text
-- name: transaction.root
-  type: boolean
-  description: |
-    Identifies metrics for root transactions. This can be used for calculating metrics for traces.
-- name: transaction.sampled
-  type: boolean
-  description: |
-    Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have spans or context.
-- name: transaction.self_time.count
-  type: long
-  description: Number of aggregated transactions.
-- name: transaction.self_time.sum.us
-  type: long
-  description: |
-    Aggregated transaction duration, excluding the time periods where a direct child was running, in microseconds.
-  unit: micros
-- name: transaction.type
-  type: keyword
-  description: |
-    Keyword of specific relevance in the service's domain (eg. 'request', 'backgroundjob', etc)
+    `system` contains local system metrics.
+  fields:
+    - name: cpu
+      type: group
+      description: |
+        `cpu` contains local CPU stats.
+      fields:
+        - name: total.norm.pct
+          type: scaled_float
+          format: percent
+          description: |
+            The percentage of CPU time spent by the process since the last event. This value is normalized by the number of CPU cores and it ranges from 0 to 100%.
+          metric_type: gauge
+          unit: percent
+    - name: memory
+      type: group
+      description: |
+        `memory` contains local memory stats.
+      fields:
+        - name: actual
+          type: group
+          description: |
+            Actual memory used and free.
+          fields:
+            - name: free
+              type: long
+              format: bytes
+              description: |
+                Actual free memory in bytes. It is calculated based on the OS. On Linux it consists of the free memory plus caches and buffers. On OSX it is a sum of free memory and the inactive memory. On Windows, it is equal to `system.memory.free`.
+              metric_type: gauge
+              unit: byte
+        - name: total
+          type: long
+          format: bytes
+          description: |
+            Total memory.
+          metric_type: gauge
+          unit: byte
+    - name: process
+      type: group
+      description: |
+        `process` contains process metadata, CPU metrics, and memory metrics.
+      fields:
+        - name: cgroup
+          type: group
+          description: Metrics and limits for the cgroup, collected by APM agents on Linux.
+          fields:
+            - name: cpu
+              type: group
+              description: CPU-specific cgroup metrics and limits.
+              fields:
+                - name: cfs
+                  type: group
+                  description: Completely Fair Scheduler (CFS) cgroup metrics.
+                  fields:
+                    - name: period.us
+                      type: long
+                      description: CFS period in microseconds.
+                      metric_type: gauge
+                      unit: micros
+                    - name: quota.us
+                      type: long
+                      description: CFS quota in microseconds.
+                      metric_type: gauge
+                      unit: micros
+                - name: id
+                  type: keyword
+                  description: ID for the current cgroup CPU.
+                - name: stats.periods
+                  type: long
+                  description: Number of periods seen by the CPU.
+                  metric_type: counter
+                - name: stats.throttled.ns
+                  type: long
+                  description: Nanoseconds spent throttled seen by the CPU.
+                  metric_type: counter
+                  unit: nanos
+                - name: stats.throttled.periods
+                  type: long
+                  description: Number of throttled periods seen by the CPU.
+                  metric_type: counter
+            - name: cpuacct
+              type: group
+              description: CPU Accounting-specific cgroup metrics and limits.
+              fields:
+                - name: id
+                  type: keyword
+                  description: ID for the current cgroup CPU.
+                - name: total.ns
+                  type: long
+                  description: Total CPU time for the current cgroup CPU in nanoseconds.
+                  metric_type: counter
+                  unit: nanos
+            - name: memory
+              type: group
+              description: Memory-specific cgroup metrics and limits.
+              fields:
+                - name: mem.limit.bytes
+                  type: long
+                  format: bytes
+                  description: Memory limit for the current cgroup slice.
+                  metric_type: gauge
+                  unit: byte
+                - name: mem.usage.bytes
+                  type: long
+                  format: bytes
+                  description: Memory usage by the current cgroup slice.
+                  metric_type: gauge
+                  unit: byte
+        - name: cpu
+          type: group
+          description: |
+            `cpu` contains local CPU stats.
+          fields:
+            - name: total.norm.pct
+              type: scaled_float
+              format: percent
+              description: |
+                The percentage of CPU time spent by the process since the last event. This value is normalized by the number of CPU cores and it ranges from 0 to 100%.
+              metric_type: gauge
+              unit: percent
+        - name: memory
+          type: group
+          description: Memory-specific statistics per process.
+          fields:
+            - name: rss.bytes
+              type: long
+              format: bytes
+              description: |
+                The Resident Set Size. The amount of memory the process occupied in main memory (RAM).
+              metric_type: gauge
+              unit: byte
+            - name: size
+              type: long
+              format: bytes
+              description: |
+                The total virtual memory the process has.
+              metric_type: gauge
+              unit: byte
+- name: timestamp
+  type: group
+  fields:
+    - name: us
+      type: long
+      description: |
+        Timestamp of the event in microseconds since Unix epoch.
+- name: transaction
+  type: group
+  fields:
+    - name: breakdown
+      type: group
+      fields:
+        - name: count
+          type: long
+          description: |
+            Counter for collected breakdowns for the transaction
+    - name: duration
+      type: group
+      fields:
+        - name: count
+          type: long
+          description: Number of aggregated transactions.
+        - name: histogram
+          type: histogram
+          description: |
+            Pre-aggregated histogram of transaction durations.
+        - name: sum
+          type: group
+          fields:
+            - name: us
+              type: long
+              description: Aggregated transaction duration, in microseconds.
+              unit: micros
+    - name: name
+      type: keyword
+      description: |
+        Generic designation of a transaction in the scope of a single service (eg. 'GET /users/:id').
+      multi_fields:
+        - name: text
+          type: text
+    - name: root
+      type: boolean
+      description: |
+        Identifies metrics for root transactions. This can be used for calculating metrics for traces.
+    - name: sampled
+      type: boolean
+      description: |
+        Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have spans or context.
+    - name: self_time
+      type: group
+      description: |
+        Portion of the transaction's duration where no direct child was running
+      fields:
+        - name: count
+          type: long
+          description: Number of aggregated transactions.
+        - name: sum
+          type: group
+          fields:
+            - name: us
+              type: long
+              description: |
+                Aggregated transaction duration, excluding the time periods where a direct child was running, in microseconds.
+              unit: micros
+    - name: type
+      type: keyword
+      description: |
+        Keyword of specific relevance in the service's domain (eg. 'request', 'backgroundjob', etc)

--- a/apmpackage/apm/data_stream/internal_metrics/manifest.yml
+++ b/apmpackage/apm/data_stream/internal_metrics/manifest.yml
@@ -2,3 +2,9 @@ title: APM internal metrics
 type: metrics
 dataset: apm.internal
 ilm_policy: metrics-apm.internal_metrics-default_policy
+elasticsearch:
+  index_template:
+    mappings:
+      # Internal metrics should have all fields strictly mapped;
+      # we are in full control of the field names.
+      dynamic: strict

--- a/apmpackage/apm/data_stream/profile_metrics/fields/base-fields.yml
+++ b/apmpackage/apm/data_stream/profile_metrics/fields/base-fields.yml
@@ -10,3 +10,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: ecs.version
+  type: keyword
+  description: ECS version the event conforms to.

--- a/apmpackage/apm/data_stream/profile_metrics/fields/ecs.yml
+++ b/apmpackage/apm/data_stream/profile_metrics/fields/ecs.yml
@@ -1,122 +1,173 @@
-- name: agent.ephemeral_id
-  type: keyword
+- name: agent
+  type: group
+  fields:
+    - name: ephemeral_id
+      type: keyword
+      description: |
+        The Ephemeral ID identifies a running process.
+    - name: name
+      type: keyword
+      description: |
+        Name of the agent used.
+    - name: version
+      type: keyword
+      description: |
+        Version of the agent used.
+- name: client
+  type: group
+  fields:
+    - name: domain
+      type: keyword
+      description: |
+        Client domain.
+      ignore_above: 1024
+    - name: ip
+      type: ip
+      description: |
+        IP address of the client of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
+    - name: port
+      type: long
+      description: |
+        Port of the client.
+- name: cloud
+  title: Cloud
+  type: group
   description: |
-    The Ephemeral ID identifies a running process.
-- name: agent.name
-  type: keyword
+    Cloud metadata reported by agents
+  fields:
+    - name: account
+      type: group
+      fields:
+        - name: id
+          level: extended
+          type: keyword
+          description: Cloud account ID
+          ignore_above: 1024
+        - name: name
+          level: extended
+          type: keyword
+          description: Cloud account name
+          ignore_above: 1024
+    - name: availability_zone
+      level: extended
+      type: keyword
+      description: Cloud availability zone name
+      ignore_above: 1024
+    - name: instance
+      type: group
+      fields:
+        - name: id
+          level: extended
+          type: keyword
+          description: Cloud instance/machine ID
+          ignore_above: 1024
+        - name: name
+          level: extended
+          type: keyword
+          description: Cloud instance/machine name
+          ignore_above: 1024
+    - name: machine
+      type: group
+      fields:
+        - name: type
+          level: extended
+          type: keyword
+          description: Cloud instance/machine type
+          ignore_above: 1024
+    - name: project
+      type: group
+      fields:
+        - name: id
+          level: extended
+          type: keyword
+          description: Cloud project ID
+          ignore_above: 1024
+        - name: name
+          level: extended
+          type: keyword
+          description: Cloud project name
+          ignore_above: 1024
+    - name: provider
+      level: extended
+      type: keyword
+      description: Cloud provider name
+      ignore_above: 1024
+    - name: region
+      level: extended
+      type: keyword
+      description: Cloud region name
+      ignore_above: 1024
+    - name: service
+      type: group
+      fields:
+        - name: name
+          level: extended
+          type: keyword
+          description: |
+            Cloud service name, intended to distinguish services running on different platforms within a provider.
+          ignore_above: 1024
+- name: container
+  title: Container
+  type: group
   description: |
-    Name of the agent used.
-- name: agent.version
-  type: keyword
+    Container fields are used for meta information about the specific container that is the source of information. These fields help correlate data based containers from any runtime.
+  fields:
+    - name: id
+      type: keyword
+      description: |
+        Unique container id.
+- name: destination
+  title: Destination
+  type: group
+  description: |-
+    Destination fields describe details about the destination of a packet/event.
+    Destination fields are usually populated in conjunction with source fields.
+  fields:
+    - name: address
+      level: extended
+      type: keyword
+      description: Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is.
+      ignore_above: 1024
+    - name: ip
+      level: core
+      type: ip
+      description: IP addess of the destination. Can be one of multiple IPv4 or IPv6 addresses.
+    - name: port
+      level: core
+      type: long
+      format: string
+      description: Port of the destination.
+- name: host
+  type: group
   description: |
-    Version of the agent used.
-- name: client.domain
-  type: keyword
-  description: |
-    Client domain.
-  ignore_above: 1024
-- name: client.ip
-  type: ip
-  description: |
-    IP address of the client of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
-- name: client.port
-  type: long
-  description: |
-    Port of the client.
-- name: cloud.account.id
-  level: extended
-  type: keyword
-  description: Cloud account ID
-  ignore_above: 1024
-- name: cloud.account.name
-  level: extended
-  type: keyword
-  description: Cloud account name
-  ignore_above: 1024
-- name: cloud.availability_zone
-  level: extended
-  type: keyword
-  description: Cloud availability zone name
-  ignore_above: 1024
-- name: cloud.instance.id
-  level: extended
-  type: keyword
-  description: Cloud instance/machine ID
-  ignore_above: 1024
-- name: cloud.instance.name
-  level: extended
-  type: keyword
-  description: Cloud instance/machine name
-  ignore_above: 1024
-- name: cloud.machine.type
-  level: extended
-  type: keyword
-  description: Cloud instance/machine type
-  ignore_above: 1024
-- name: cloud.project.id
-  level: extended
-  type: keyword
-  description: Cloud project ID
-  ignore_above: 1024
-- name: cloud.project.name
-  level: extended
-  type: keyword
-  description: Cloud project name
-  ignore_above: 1024
-- name: cloud.provider
-  level: extended
-  type: keyword
-  description: Cloud provider name
-  ignore_above: 1024
-- name: cloud.region
-  level: extended
-  type: keyword
-  description: Cloud region name
-  ignore_above: 1024
-- name: cloud.service.name
-  level: extended
-  type: keyword
-  description: |
-    Cloud service name, intended to distinguish services running on different platforms within a provider.
-  ignore_above: 1024
-- name: container.id
-  type: keyword
-  description: |
-    Unique container id.
-- name: destination.address
-  level: extended
-  type: keyword
-  description: Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is.
-  ignore_above: 1024
-- name: destination.ip
-  level: core
-  type: ip
-  description: IP addess of the destination. Can be one of multiple IPv4 or IPv6 addresses.
-- name: destination.port
-  level: core
-  type: long
-  format: string
-  description: Port of the destination.
-- name: host.architecture
-  type: keyword
-  description: |
-    The architecture of the host the event was recorded on.
-- name: host.hostname
-  type: keyword
-  description: |
-    The hostname of the host the event was recorded on.
-- name: host.ip
-  type: ip
-  description: |
-    IP of the host that records the event.
-- name: host.name
-  type: keyword
-  description: |
-    Name of the host the event was recorded on. It can contain same information as host.hostname or a name specified by the user.
-- name: host.os.platform
-  type: keyword
-  description: |
-    The platform of the host the event was recorded on.
+    Optional host fields.
+  fields:
+    - name: architecture
+      type: keyword
+      description: |
+        The architecture of the host the event was recorded on.
+    - name: hostname
+      type: keyword
+      description: |
+        The hostname of the host the event was recorded on.
+    - name: ip
+      type: ip
+      description: |
+        IP of the host that records the event.
+    - name: name
+      type: keyword
+      description: |
+        Name of the host the event was recorded on. It can contain same information as host.hostname or a name specified by the user.
+    - name: os
+      title: Operating System
+      type: group
+      description: |
+        The OS fields contain information about the operating system.
+      fields:
+        - name: platform
+          type: keyword
+          description: |
+            The platform of the host the event was recorded on.
 - name: labels
   type: object
   description: |
@@ -127,112 +178,152 @@
     - object_type: boolean
     - object_type: scaled_float
       scaling_factor: 1000000
-- name: observer.hostname
-  type: keyword
+- name: observer
+  type: group
+  fields:
+    - name: hostname
+      type: keyword
+      description: |
+        Hostname of the APM Server.
+    - name: type
+      type: keyword
+      description: |
+        The type will be set to `apm-server`.
+    - name: version
+      type: keyword
+      description: |
+        APM Server version.
+- name: process
+  type: group
   description: |
-    Hostname of the APM Server.
-- name: observer.type
-  type: keyword
+    Information pertaining to the running process where the data was collected
+  fields:
+    - name: args
+      level: extended
+      type: keyword
+      description: |
+        Process arguments. May be filtered to protect sensitive information.
+    - name: pid
+      type: long
+      description: |
+        Numeric process ID of the service process.
+    - name: ppid
+      type: long
+      description: |
+        Numeric ID of the service's parent process.
+    - name: title
+      type: keyword
+      description: |
+        Service process title.
+- name: service
+  type: group
   description: |
-    The type will be set to `apm-server`.
-- name: observer.version
-  type: keyword
+    Service fields.
+  fields:
+    - name: name
+      type: keyword
+      description: |
+        Immutable name of the service emitting this event.
+    - name: node
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Unique meaningful name of the service node.
+    - name: version
+      type: keyword
+      description: |
+        Version of the service emitting this event.
+- name: source
+  type: group
+  fields:
+    - name: domain
+      type: keyword
+      description: |
+        Source domain.
+      ignore_above: 1024
+    - name: ip
+      type: ip
+      description: |
+        IP address of the source of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
+    - name: port
+      type: long
+      description: |
+        Port of the source.
+- name: user
+  type: group
+  fields:
+    - name: email
+      type: keyword
+      description: |
+        Email of the logged in user.
+    - name: id
+      type: keyword
+      description: |
+        Identifier of the logged in user.
+    - name: name
+      type: keyword
+      description: |
+        The username of the logged in user.
+- name: user_agent
+  title: User agent
+  type: group
   description: |
-    APM Server version.
-- name: process.args
-  level: extended
-  type: keyword
-  description: |
-    Process arguments. May be filtered to protect sensitive information.
-- name: process.pid
-  type: long
-  description: |
-    Numeric process ID of the service process.
-- name: process.ppid
-  type: long
-  description: |
-    Numeric ID of the service's parent process.
-- name: process.title
-  type: keyword
-  description: |
-    Service process title.
-- name: service.name
-  type: keyword
-  description: |
-    Immutable name of the service emitting this event.
-- name: service.node.name
-  type: keyword
-  description: |
-    Unique meaningful name of the service node.
-- name: service.version
-  type: keyword
-  description: |
-    Version of the service emitting this event.
-- name: source.domain
-  type: keyword
-  description: |
-    Source domain.
-  ignore_above: 1024
-- name: source.ip
-  type: ip
-  description: |
-    IP address of the source of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
-- name: source.port
-  type: long
-  description: |
-    Port of the source.
-- name: user.email
-  type: keyword
-  description: |
-    Email of the logged in user.
-- name: user.id
-  type: keyword
-  description: |
-    Identifier of the logged in user.
-- name: user.name
-  type: keyword
-  description: |
-    The username of the logged in user.
-- name: user_agent.device.name
-  type: keyword
-  description: |
-    Name of the device.
-- name: user_agent.name
-  type: keyword
-  description: |
-    Name of the user agent.
-- name: user_agent.original
-  type: keyword
-  description: |
-    Unparsed version of the user_agent.
-  multi_fields:
-    - name: text
-      type: text
-- name: user_agent.os.family
-  type: keyword
-  description: |
-    OS family (such as redhat, debian, freebsd, windows).
-- name: user_agent.os.full
-  type: keyword
-  description: |
-    Operating system name, including the version or code name.
-- name: user_agent.os.kernel
-  type: keyword
-  description: |
-    Operating system kernel version as a raw string.
-- name: user_agent.os.name
-  type: keyword
-  description: |
-    Operating system name, without the version.
-- name: user_agent.os.platform
-  type: keyword
-  description: |
-    Operating system platform (such centos, ubuntu, windows).
-- name: user_agent.os.version
-  type: keyword
-  description: |
-    Operating system version as a raw string.
-- name: user_agent.version
-  type: keyword
-  description: |
-    Version of the user agent.
+    The user_agent fields normally come from a browser request. They often show up in web service logs coming from the parsed user agent string.
+  fields:
+    - name: device
+      title: Device
+      type: group
+      description: |
+        Information concerning the device.
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the device.
+    - name: name
+      type: keyword
+      description: |
+        Name of the user agent.
+    - name: original
+      type: keyword
+      description: |
+        Unparsed version of the user_agent.
+      multi_fields:
+        - name: text
+          type: text
+    - name: os
+      title: Operating System
+      type: group
+      description: |
+        The OS fields contain information about the operating system.
+      fields:
+        - name: family
+          type: keyword
+          description: |
+            OS family (such as redhat, debian, freebsd, windows).
+        - name: full
+          type: keyword
+          description: |
+            Operating system name, including the version or code name.
+        - name: kernel
+          type: keyword
+          description: |
+            Operating system kernel version as a raw string.
+        - name: name
+          type: keyword
+          description: |
+            Operating system name, without the version.
+        - name: platform
+          type: keyword
+          description: |
+            Operating system platform (such centos, ubuntu, windows).
+        - name: version
+          type: keyword
+          description: |
+            Operating system version as a raw string.
+    - name: version
+      type: keyword
+      description: |
+        Version of the user agent.

--- a/apmpackage/apm/data_stream/profile_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/profile_metrics/fields/fields.yml
@@ -2,160 +2,237 @@
   type: object
   description: Additional experimental data sent by the agents.
   dynamic: true
-- name: kubernetes.namespace
-  type: keyword
+- name: kubernetes
+  title: Kubernetes
+  type: group
   description: |
-    Kubernetes namespace
-- name: kubernetes.node.name
-  type: keyword
+    Kubernetes metadata reported by agents
+  fields:
+    - name: namespace
+      type: keyword
+      description: |
+        Kubernetes namespace
+    - name: node
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Kubernetes node name
+    - name: pod
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Kubernetes pod name
+        - name: uid
+          type: keyword
+          description: |
+            Kubernetes Pod UID
+- name: network
+  type: group
   description: |
-    Kubernetes node name
-- name: kubernetes.pod.name
-  type: keyword
-  description: |
-    Kubernetes pod name
-- name: kubernetes.pod.uid
-  type: keyword
-  description: |
-    Kubernetes Pod UID
-- name: network.carrier.icc
-  type: keyword
-  description: |
-    ISO country code, eg. US
-- name: network.carrier.mcc
-  type: keyword
-  description: |
-    Mobile country code
-- name: network.carrier.mnc
-  type: keyword
-  description: |
-    Mobile network code
-- name: network.carrier.name
-  type: keyword
-  description: |
-    Carrier name, eg. Vodafone, T-Mobile, etc.
-- name: network.connection.subtype
-  type: keyword
-  description: |
-    Detailed network connection sub-type, e.g. "LTE", "CDMA"
-- name: network.connection.type
-  type: keyword
-  description: |
-    Network connection type, eg. "wifi", "cell"
-- name: observer.listening
-  type: keyword
-  description: |
-    Address the server is listening on.
-- name: observer.version_major
-  type: byte
-  description: |
-    Major version number of the observer
+    Optional network fields
+  fields:
+    - name: carrier
+      type: group
+      description: |
+        Network operator
+      fields:
+        - name: icc
+          type: keyword
+          description: |
+            ISO country code, eg. US
+        - name: mcc
+          type: keyword
+          description: |
+            Mobile country code
+        - name: mnc
+          type: keyword
+          description: |
+            Mobile network code
+        - name: name
+          type: keyword
+          description: |
+            Carrier name, eg. Vodafone, T-Mobile, etc.
+    - name: connection
+      type: group
+      description: |
+        Network connection details
+      fields:
+        - name: subtype
+          type: keyword
+          description: |
+            Detailed network connection sub-type, e.g. "LTE", "CDMA"
+        - name: type
+          type: keyword
+          description: |
+            Network connection type, eg. "wifi", "cell"
+- name: observer
+  type: group
+  fields:
+    - name: listening
+      type: keyword
+      description: |
+        Address the server is listening on.
+    - name: version_major
+      type: byte
+      description: |
+        Major version number of the observer
 - name: processor.event
   type: keyword
   description: Processor event.
 - name: processor.name
   type: keyword
   description: Processor name.
-- name: profile.alloc_objects.count
-  type: long
+- name: profile
+  type: group
+  fields:
+    - name: alloc_objects
+      type: group
+      fields:
+        - name: count
+          type: long
+          description: |
+            Number of objects allocated since the process started.
+    - name: alloc_space
+      type: group
+      fields:
+        - name: bytes
+          type: long
+          description: |
+            Amount of memory allocated, in bytes, since the process started.
+    - name: cpu
+      type: group
+      fields:
+        - name: ns
+          type: long
+          description: |
+            Amount of CPU time profiled, in nanoseconds.
+          unit: nanos
+    - name: duration
+      type: long
+      description: |
+        Duration of the profile, in nanoseconds. All samples within a profile will have the same duration. To aggregate durations, you should first group by the profile ID.
+      unit: nanos
+    - name: id
+      type: keyword
+      description: |
+        Unique ID for the profile. All samples within a profile will have the same profile ID.
+    - name: inuse_objects
+      type: group
+      fields:
+        - name: count
+          type: long
+          description: |
+            Number of objects allocated and currently in use.
+    - name: inuse_space
+      type: group
+      fields:
+        - name: bytes
+          type: long
+          description: |
+            Amount of memory allocated, in bytes, and currently in use.
+    - name: samples
+      type: group
+      fields:
+        - name: count
+          type: long
+          description: |
+            Number of profile samples for the profiling period.
+    - name: stack
+      type: group
+      fields:
+        - name: filename
+          type: keyword
+          description: |
+            Source code filename for a stack frame.
+        - name: function
+          type: keyword
+          description: |
+            Function name for a stack frame.
+        - name: id
+          type: keyword
+          description: |
+            Unique ID for a stack frame in the context of its callers.
+        - name: line
+          type: long
+          description: |
+            Source code line number for a stack frame.
+    - name: top
+      type: group
+      fields:
+        - name: filename
+          type: keyword
+          description: |
+            Source code filename for the top stack frame.
+        - name: function
+          type: keyword
+          description: |
+            Function name for the top stack frame.
+        - name: id
+          type: keyword
+          description: |
+            Unique ID for the top stack frame in the context of its callers.
+        - name: line
+          type: long
+          description: |
+            Source code line number for the top stack frame.
+    - name: wall
+      type: group
+      fields:
+        - name: us
+          type: long
+          description: |
+            Amount of wall time profiled, in microseconds.
+          unit: micros
+- name: service
+  type: group
   description: |
-    Number of objects allocated since the process started.
-- name: profile.alloc_space.bytes
-  type: long
-  description: |
-    Amount of memory allocated, in bytes, since the process started.
-- name: profile.cpu.ns
-  type: long
-  description: |
-    Amount of CPU time profiled, in nanoseconds.
-  unit: nanos
-- name: profile.duration
-  type: long
-  description: |
-    Duration of the profile, in nanoseconds. All samples within a profile will have the same duration. To aggregate durations, you should first group by the profile ID.
-  unit: nanos
-- name: profile.id
-  type: keyword
-  description: |
-    Unique ID for the profile. All samples within a profile will have the same profile ID.
-- name: profile.inuse_objects.count
-  type: long
-  description: |
-    Number of objects allocated and currently in use.
-- name: profile.inuse_space.bytes
-  type: long
-  description: |
-    Amount of memory allocated, in bytes, and currently in use.
-- name: profile.samples.count
-  type: long
-  description: |
-    Number of profile samples for the profiling period.
-- name: profile.stack.filename
-  type: keyword
-  description: |
-    Source code filename for a stack frame.
-- name: profile.stack.function
-  type: keyword
-  description: |
-    Function name for a stack frame.
-- name: profile.stack.id
-  type: keyword
-  description: |
-    Unique ID for a stack frame in the context of its callers.
-- name: profile.stack.line
-  type: long
-  description: |
-    Source code line number for a stack frame.
-- name: profile.top.filename
-  type: keyword
-  description: |
-    Source code filename for the top stack frame.
-- name: profile.top.function
-  type: keyword
-  description: |
-    Function name for the top stack frame.
-- name: profile.top.id
-  type: keyword
-  description: |
-    Unique ID for the top stack frame in the context of its callers.
-- name: profile.top.line
-  type: long
-  description: |
-    Source code line number for the top stack frame.
-- name: profile.wall.us
-  type: long
-  description: |
-    Amount of wall time profiled, in microseconds.
-  unit: micros
-- name: service.environment
-  type: keyword
-  description: |
-    Service environment.
-- name: service.framework.name
-  type: keyword
-  description: |
-    Name of the framework used.
-- name: service.framework.version
-  type: keyword
-  description: |
-    Version of the framework used.
-- name: service.language.name
-  type: keyword
-  description: |
-    Name of the programming language used.
-- name: service.language.version
-  type: keyword
-  description: |
-    Version of the programming language used.
-- name: service.runtime.name
-  type: keyword
-  description: |
-    Name of the runtime used.
-- name: service.runtime.version
-  type: keyword
-  description: |
-    Version of the runtime used.
-- name: timestamp.us
-  type: long
-  description: |
-    Timestamp of the event in microseconds since Unix epoch.
+    Service fields.
+  fields:
+    - name: environment
+      type: keyword
+      description: |
+        Service environment.
+    - name: framework
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the framework used.
+        - name: version
+          type: keyword
+          description: |
+            Version of the framework used.
+    - name: language
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the programming language used.
+        - name: version
+          type: keyword
+          description: |
+            Version of the programming language used.
+    - name: runtime
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the runtime used.
+        - name: version
+          type: keyword
+          description: |
+            Version of the runtime used.
+- name: timestamp
+  type: group
+  fields:
+    - name: us
+      type: long
+      description: |
+        Timestamp of the event in microseconds since Unix epoch.

--- a/apmpackage/apm/data_stream/profile_metrics/manifest.yml
+++ b/apmpackage/apm/data_stream/profile_metrics/manifest.yml
@@ -2,3 +2,9 @@ title: APM profiles
 type: metrics
 dataset: apm.profiling
 ilm_policy: metrics-apm.profile_metrics-default_policy
+elasticsearch:
+  index_template:
+    mappings:
+      # Profile metrics currently must be dynamically
+      # mapped, as pprof metric names may be customised.
+      dynamic: true

--- a/apmpackage/apm/data_stream/sampled_traces/fields/base-fields.yml
+++ b/apmpackage/apm/data_stream/sampled_traces/fields/base-fields.yml
@@ -10,3 +10,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: ecs.version
+  type: keyword
+  description: ECS version the event conforms to.

--- a/apmpackage/apm/data_stream/sampled_traces/manifest.yml
+++ b/apmpackage/apm/data_stream/sampled_traces/manifest.yml
@@ -9,3 +9,7 @@ elasticsearch:
       # global checkpoints as a way of limiting search
       # results.
       number_of_shards: 1
+    mappings:
+      # Sampled traces should have all fields strictly mapped;
+      # we are in full control of the field names.
+      dynamic: strict

--- a/apmpackage/apm/data_stream/traces/fields/base-fields.yml
+++ b/apmpackage/apm/data_stream/traces/fields/base-fields.yml
@@ -10,3 +10,6 @@
 - name: data_stream.namespace
   type: constant_keyword
   description: Data stream namespace.
+- name: ecs.version
+  type: keyword
+  description: ECS version the event conforms to.

--- a/apmpackage/apm/data_stream/traces/fields/ecs.yml
+++ b/apmpackage/apm/data_stream/traces/fields/ecs.yml
@@ -1,144 +1,207 @@
-- name: agent.ephemeral_id
-  type: keyword
+- name: agent
+  type: group
+  fields:
+    - name: ephemeral_id
+      type: keyword
+      description: |
+        The Ephemeral ID identifies a running process.
+    - name: name
+      type: keyword
+      description: |
+        Name of the agent used.
+    - name: version
+      type: keyword
+      description: |
+        Version of the agent used.
+- name: client
+  type: group
+  fields:
+    - name: domain
+      type: keyword
+      description: |
+        Client domain.
+      ignore_above: 1024
+    - name: ip
+      type: ip
+      description: |
+        IP address of the client of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
+    - name: port
+      type: long
+      description: |
+        Port of the client.
+- name: cloud
+  title: Cloud
+  type: group
   description: |
-    The Ephemeral ID identifies a running process.
-- name: agent.name
-  type: keyword
+    Cloud metadata reported by agents
+  fields:
+    - name: account
+      type: group
+      fields:
+        - name: id
+          level: extended
+          type: keyword
+          description: Cloud account ID
+          ignore_above: 1024
+        - name: name
+          level: extended
+          type: keyword
+          description: Cloud account name
+          ignore_above: 1024
+    - name: availability_zone
+      level: extended
+      type: keyword
+      description: Cloud availability zone name
+      ignore_above: 1024
+    - name: instance
+      type: group
+      fields:
+        - name: id
+          level: extended
+          type: keyword
+          description: Cloud instance/machine ID
+          ignore_above: 1024
+        - name: name
+          level: extended
+          type: keyword
+          description: Cloud instance/machine name
+          ignore_above: 1024
+    - name: machine
+      type: group
+      fields:
+        - name: type
+          level: extended
+          type: keyword
+          description: Cloud instance/machine type
+          ignore_above: 1024
+    - name: project
+      type: group
+      fields:
+        - name: id
+          level: extended
+          type: keyword
+          description: Cloud project ID
+          ignore_above: 1024
+        - name: name
+          level: extended
+          type: keyword
+          description: Cloud project name
+          ignore_above: 1024
+    - name: provider
+      level: extended
+      type: keyword
+      description: Cloud provider name
+      ignore_above: 1024
+    - name: region
+      level: extended
+      type: keyword
+      description: Cloud region name
+      ignore_above: 1024
+    - name: service
+      type: group
+      fields:
+        - name: name
+          level: extended
+          type: keyword
+          description: |
+            Cloud service name, intended to distinguish services running on different platforms within a provider.
+          ignore_above: 1024
+- name: container
+  title: Container
+  type: group
   description: |
-    Name of the agent used.
-- name: agent.version
-  type: keyword
+    Container fields are used for meta information about the specific container that is the source of information. These fields help correlate data based containers from any runtime.
+  fields:
+    - name: id
+      type: keyword
+      description: |
+        Unique container id.
+- name: destination
+  title: Destination
+  type: group
+  description: |-
+    Destination fields describe details about the destination of a packet/event.
+    Destination fields are usually populated in conjunction with source fields.
+  fields:
+    - name: address
+      level: extended
+      type: keyword
+      description: Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is.
+      ignore_above: 1024
+    - name: ip
+      level: core
+      type: ip
+      description: IP addess of the destination. Can be one of multiple IPv4 or IPv6 addresses.
+    - name: port
+      level: core
+      type: long
+      format: string
+      description: Port of the destination.
+- name: event
+  type: group
+  fields:
+    - name: outcome
+      level: core
+      type: keyword
+      description: |
+        `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event.
+      ignore_above: 1024
+- name: host
+  type: group
   description: |
-    Version of the agent used.
-- name: client.domain
-  type: keyword
-  description: |
-    Client domain.
-  ignore_above: 1024
-- name: client.ip
-  type: ip
-  description: |
-    IP address of the client of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
-- name: client.port
-  type: long
-  description: |
-    Port of the client.
-- name: cloud.account.id
-  level: extended
-  type: keyword
-  description: Cloud account ID
-  ignore_above: 1024
-- name: cloud.account.name
-  level: extended
-  type: keyword
-  description: Cloud account name
-  ignore_above: 1024
-- name: cloud.availability_zone
-  level: extended
-  type: keyword
-  description: Cloud availability zone name
-  ignore_above: 1024
-- name: cloud.instance.id
-  level: extended
-  type: keyword
-  description: Cloud instance/machine ID
-  ignore_above: 1024
-- name: cloud.instance.name
-  level: extended
-  type: keyword
-  description: Cloud instance/machine name
-  ignore_above: 1024
-- name: cloud.machine.type
-  level: extended
-  type: keyword
-  description: Cloud instance/machine type
-  ignore_above: 1024
-- name: cloud.project.id
-  level: extended
-  type: keyword
-  description: Cloud project ID
-  ignore_above: 1024
-- name: cloud.project.name
-  level: extended
-  type: keyword
-  description: Cloud project name
-  ignore_above: 1024
-- name: cloud.provider
-  level: extended
-  type: keyword
-  description: Cloud provider name
-  ignore_above: 1024
-- name: cloud.region
-  level: extended
-  type: keyword
-  description: Cloud region name
-  ignore_above: 1024
-- name: cloud.service.name
-  level: extended
-  type: keyword
-  description: |
-    Cloud service name, intended to distinguish services running on different platforms within a provider.
-  ignore_above: 1024
-- name: container.id
-  type: keyword
-  description: |
-    Unique container id.
-- name: destination.address
-  level: extended
-  type: keyword
-  description: Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the `.address` field. Then it should be duplicated to `.ip` or `.domain`, depending on which one it is.
-  ignore_above: 1024
-- name: destination.ip
-  level: core
-  type: ip
-  description: IP addess of the destination. Can be one of multiple IPv4 or IPv6 addresses.
-- name: destination.port
-  level: core
-  type: long
-  format: string
-  description: Port of the destination.
-- name: event.outcome
-  level: core
-  type: keyword
-  description: |
-    `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event.
-  ignore_above: 1024
-- name: host.architecture
-  type: keyword
-  description: |
-    The architecture of the host the event was recorded on.
-- name: host.hostname
-  type: keyword
-  description: |
-    The hostname of the host the event was recorded on.
-- name: host.ip
-  type: ip
-  description: |
-    IP of the host that records the event.
-- name: host.name
-  type: keyword
-  description: |
-    Name of the host the event was recorded on. It can contain same information as host.hostname or a name specified by the user.
-- name: host.os.platform
-  type: keyword
-  description: |
-    The platform of the host the event was recorded on.
-- name: http.request.method
-  type: keyword
-  description: |
-    The http method of the request leading to this event.
-- name: http.request.referrer
-  type: keyword
-  description: Referrer for this HTTP request.
-  ignore_above: 1024
-- name: http.response.status_code
-  type: long
-  description: |
-    The status code of the HTTP response.
-- name: http.version
-  type: keyword
-  description: |
-    The http version of the request leading to this event.
+    Optional host fields.
+  fields:
+    - name: architecture
+      type: keyword
+      description: |
+        The architecture of the host the event was recorded on.
+    - name: hostname
+      type: keyword
+      description: |
+        The hostname of the host the event was recorded on.
+    - name: ip
+      type: ip
+      description: |
+        IP of the host that records the event.
+    - name: name
+      type: keyword
+      description: |
+        Name of the host the event was recorded on. It can contain same information as host.hostname or a name specified by the user.
+    - name: os
+      title: Operating System
+      type: group
+      description: |
+        The OS fields contain information about the operating system.
+      fields:
+        - name: platform
+          type: keyword
+          description: |
+            The platform of the host the event was recorded on.
+- name: http
+  type: group
+  fields:
+    - name: request
+      type: group
+      fields:
+        - name: method
+          type: keyword
+          description: |
+            The http method of the request leading to this event.
+        - name: referrer
+          type: keyword
+          description: Referrer for this HTTP request.
+          ignore_above: 1024
+    - name: response
+      type: group
+      fields:
+        - name: status_code
+          type: long
+          description: |
+            The status code of the HTTP response.
+    - name: version
+      type: keyword
+      description: |
+        The http version of the request leading to this event.
 - name: labels
   type: object
   description: |
@@ -149,156 +212,210 @@
     - object_type: boolean
     - object_type: scaled_float
       scaling_factor: 1000000
-- name: observer.hostname
-  type: keyword
+- name: observer
+  type: group
+  fields:
+    - name: hostname
+      type: keyword
+      description: |
+        Hostname of the APM Server.
+    - name: type
+      type: keyword
+      description: |
+        The type will be set to `apm-server`.
+    - name: version
+      type: keyword
+      description: |
+        APM Server version.
+- name: process
+  type: group
   description: |
-    Hostname of the APM Server.
-- name: observer.type
-  type: keyword
+    Information pertaining to the running process where the data was collected
+  fields:
+    - name: args
+      level: extended
+      type: keyword
+      description: |
+        Process arguments. May be filtered to protect sensitive information.
+    - name: pid
+      type: long
+      description: |
+        Numeric process ID of the service process.
+    - name: ppid
+      type: long
+      description: |
+        Numeric ID of the service's parent process.
+    - name: title
+      type: keyword
+      description: |
+        Service process title.
+- name: service
+  type: group
   description: |
-    The type will be set to `apm-server`.
-- name: observer.version
-  type: keyword
+    Service fields.
+  fields:
+    - name: name
+      type: keyword
+      description: |
+        Immutable name of the service emitting this event.
+    - name: node
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Unique meaningful name of the service node.
+    - name: version
+      type: keyword
+      description: |
+        Version of the service emitting this event.
+- name: source
+  type: group
+  fields:
+    - name: domain
+      type: keyword
+      description: |
+        Source domain.
+      ignore_above: 1024
+    - name: ip
+      type: ip
+      description: |
+        IP address of the source of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
+    - name: port
+      type: long
+      description: |
+        Port of the source.
+- name: span
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      description: |
+        The ID of the span stored as hex encoded string.
+- name: trace
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      description: |
+        The ID of the trace to which the event belongs to.
+- name: transaction
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      description: |
+        The transaction ID.
+- name: url
+  type: group
   description: |
-    APM Server version.
-- name: process.args
-  level: extended
-  type: keyword
+    A complete Url, with scheme, host and path.
+  fields:
+    - name: domain
+      type: keyword
+      description: |
+        The hostname of the request, e.g. "example.com".
+    - name: fragment
+      type: keyword
+      description: |
+        A fragment specifying a location in a web page , e.g. "top".
+    - name: full
+      type: keyword
+      description: |
+        The full, possibly agent-assembled URL of the request, e.g https://example.com:443/search?q=elasticsearch#top.
+    - name: path
+      type: keyword
+      description: |
+        The path of the request, e.g. "/search".
+    - name: port
+      type: long
+      description: |
+        The port of the request, e.g. 443.
+    - name: query
+      type: keyword
+      description: |
+        The query string of the request, e.g. "q=elasticsearch".
+    - name: scheme
+      type: keyword
+      description: |
+        The protocol of the request, e.g. "https:".
+- name: user
+  type: group
+  fields:
+    - name: domain
+      type: keyword
+      description: |
+        Domain of the logged in user.
+    - name: email
+      type: keyword
+      description: |
+        Email of the logged in user.
+    - name: id
+      type: keyword
+      description: |
+        Identifier of the logged in user.
+    - name: name
+      type: keyword
+      description: |
+        The username of the logged in user.
+- name: user_agent
+  title: User agent
+  type: group
   description: |
-    Process arguments. May be filtered to protect sensitive information.
-- name: process.pid
-  type: long
-  description: |
-    Numeric process ID of the service process.
-- name: process.ppid
-  type: long
-  description: |
-    Numeric ID of the service's parent process.
-- name: process.title
-  type: keyword
-  description: |
-    Service process title.
-- name: service.name
-  type: keyword
-  description: |
-    Immutable name of the service emitting this event.
-- name: service.node.name
-  type: keyword
-  description: |
-    Unique meaningful name of the service node.
-- name: service.version
-  type: keyword
-  description: |
-    Version of the service emitting this event.
-- name: source.domain
-  type: keyword
-  description: |
-    Source domain.
-  ignore_above: 1024
-- name: source.ip
-  type: ip
-  description: |
-    IP address of the source of a recorded event. This is typically obtained from a request's X-Forwarded-For or the X-Real-IP header or falls back to a given configuration for remote address.
-- name: source.port
-  type: long
-  description: |
-    Port of the source.
-- name: span.id
-  type: keyword
-  description: |
-    The ID of the span stored as hex encoded string.
-- name: trace.id
-  type: keyword
-  description: |
-    The ID of the trace to which the event belongs to.
-- name: transaction.id
-  type: keyword
-  description: |
-    The transaction ID.
-- name: url.domain
-  type: keyword
-  description: |
-    The hostname of the request, e.g. "example.com".
-- name: url.fragment
-  type: keyword
-  description: |
-    A fragment specifying a location in a web page , e.g. "top".
-- name: url.full
-  type: keyword
-  description: |
-    The full, possibly agent-assembled URL of the request, e.g https://example.com:443/search?q=elasticsearch#top.
-- name: url.path
-  type: keyword
-  description: |
-    The path of the request, e.g. "/search".
-- name: url.port
-  type: long
-  description: |
-    The port of the request, e.g. 443.
-- name: url.query
-  type: keyword
-  description: |
-    The query string of the request, e.g. "q=elasticsearch".
-- name: url.scheme
-  type: keyword
-  description: |
-    The protocol of the request, e.g. "https:".
-- name: user.domain
-  type: keyword
-  description: |
-    Domain of the logged in user.
-- name: user.email
-  type: keyword
-  description: |
-    Email of the logged in user.
-- name: user.id
-  type: keyword
-  description: |
-    Identifier of the logged in user.
-- name: user.name
-  type: keyword
-  description: |
-    The username of the logged in user.
-- name: user_agent.device.name
-  type: keyword
-  description: |
-    Name of the device.
-- name: user_agent.name
-  type: keyword
-  description: |
-    Name of the user agent.
-- name: user_agent.original
-  type: keyword
-  description: |
-    Unparsed version of the user_agent.
-  multi_fields:
-    - name: text
-      type: text
-- name: user_agent.os.family
-  type: keyword
-  description: |
-    OS family (such as redhat, debian, freebsd, windows).
-- name: user_agent.os.full
-  type: keyword
-  description: |
-    Operating system name, including the version or code name.
-- name: user_agent.os.kernel
-  type: keyword
-  description: |
-    Operating system kernel version as a raw string.
-- name: user_agent.os.name
-  type: keyword
-  description: |
-    Operating system name, without the version.
-- name: user_agent.os.platform
-  type: keyword
-  description: |
-    Operating system platform (such centos, ubuntu, windows).
-- name: user_agent.os.version
-  type: keyword
-  description: |
-    Operating system version as a raw string.
-- name: user_agent.version
-  type: keyword
-  description: |
-    Version of the user agent.
+    The user_agent fields normally come from a browser request. They often show up in web service logs coming from the parsed user agent string.
+  fields:
+    - name: device
+      title: Device
+      type: group
+      description: |
+        Information concerning the device.
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the device.
+    - name: name
+      type: keyword
+      description: |
+        Name of the user agent.
+    - name: original
+      type: keyword
+      description: |
+        Unparsed version of the user_agent.
+      multi_fields:
+        - name: text
+          type: text
+    - name: os
+      title: Operating System
+      type: group
+      description: |
+        The OS fields contain information about the operating system.
+      fields:
+        - name: family
+          type: keyword
+          description: |
+            OS family (such as redhat, debian, freebsd, windows).
+        - name: full
+          type: keyword
+          description: |
+            Operating system name, including the version or code name.
+        - name: kernel
+          type: keyword
+          description: |
+            Operating system kernel version as a raw string.
+        - name: name
+          type: keyword
+          description: |
+            Operating system name, without the version.
+        - name: platform
+          type: keyword
+          description: |
+            Operating system platform (such centos, ubuntu, windows).
+        - name: version
+          type: keyword
+          description: |
+            Operating system version as a raw string.
+    - name: version
+      type: keyword
+      description: |
+        Version of the user agent.

--- a/apmpackage/apm/data_stream/traces/fields/fields.yml
+++ b/apmpackage/apm/data_stream/traces/fields/fields.yml
@@ -1,249 +1,373 @@
-- name: child.id
-  type: keyword
-  description: |
-    The ID(s) of the child event(s).
+- name: child
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      description: |
+        The ID(s) of the child event(s).
 - name: experimental
   type: object
   description: Additional experimental data sent by the agents.
   dynamic: true
-- name: http.request.headers
-  type: object
+- name: http
+  type: group
+  fields:
+    - name: request
+      type: group
+      fields:
+        - name: headers
+          type: object
+          description: |
+            The canonical headers of the monitored HTTP request.
+    - name: response
+      type: group
+      fields:
+        - name: finished
+          type: boolean
+          description: |
+            Used by the Node agent to indicate when in the response life cycle an error has occurred.
+        - name: headers
+          type: object
+          description: |
+            The canonical headers of the monitored HTTP response.
+- name: kubernetes
+  title: Kubernetes
+  type: group
   description: |
-    The canonical headers of the monitored HTTP request.
-- name: http.response.finished
-  type: boolean
+    Kubernetes metadata reported by agents
+  fields:
+    - name: namespace
+      type: keyword
+      description: |
+        Kubernetes namespace
+    - name: node
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Kubernetes node name
+    - name: pod
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Kubernetes pod name
+        - name: uid
+          type: keyword
+          description: |
+            Kubernetes Pod UID
+- name: network
+  type: group
   description: |
-    Used by the Node agent to indicate when in the response life cycle an error has occurred.
-- name: http.response.headers
-  type: object
-  description: |
-    The canonical headers of the monitored HTTP response.
-- name: kubernetes.namespace
-  type: keyword
-  description: |
-    Kubernetes namespace
-- name: kubernetes.node.name
-  type: keyword
-  description: |
-    Kubernetes node name
-- name: kubernetes.pod.name
-  type: keyword
-  description: |
-    Kubernetes pod name
-- name: kubernetes.pod.uid
-  type: keyword
-  description: |
-    Kubernetes Pod UID
-- name: network.carrier.icc
-  type: keyword
-  description: |
-    ISO country code, eg. US
-- name: network.carrier.mcc
-  type: keyword
-  description: |
-    Mobile country code
-- name: network.carrier.mnc
-  type: keyword
-  description: |
-    Mobile network code
-- name: network.carrier.name
-  type: keyword
-  description: |
-    Carrier name, eg. Vodafone, T-Mobile, etc.
-- name: network.connection.subtype
-  type: keyword
-  description: |
-    Detailed network connection sub-type, e.g. "LTE", "CDMA"
-- name: network.connection.type
-  type: keyword
-  description: |
-    Network connection type, eg. "wifi", "cell"
-- name: observer.listening
-  type: keyword
-  description: |
-    Address the server is listening on.
-- name: observer.version_major
-  type: byte
-  description: |
-    Major version number of the observer
-- name: parent.id
-  type: keyword
-  description: |
-    The ID of the parent event.
+    Optional network fields
+  fields:
+    - name: carrier
+      type: group
+      description: |
+        Network operator
+      fields:
+        - name: icc
+          type: keyword
+          description: |
+            ISO country code, eg. US
+        - name: mcc
+          type: keyword
+          description: |
+            Mobile country code
+        - name: mnc
+          type: keyword
+          description: |
+            Mobile network code
+        - name: name
+          type: keyword
+          description: |
+            Carrier name, eg. Vodafone, T-Mobile, etc.
+    - name: connection
+      type: group
+      description: |
+        Network connection details
+      fields:
+        - name: subtype
+          type: keyword
+          description: |
+            Detailed network connection sub-type, e.g. "LTE", "CDMA"
+        - name: type
+          type: keyword
+          description: |
+            Network connection type, eg. "wifi", "cell"
+- name: observer
+  type: group
+  fields:
+    - name: listening
+      type: keyword
+      description: |
+        Address the server is listening on.
+    - name: version_major
+      type: byte
+      description: |
+        Major version number of the observer
+- name: parent
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      description: |
+        The ID of the parent event.
 - name: processor.event
   type: keyword
   description: Processor event.
 - name: processor.name
   type: keyword
   description: Processor name.
-- name: service.environment
-  type: keyword
+- name: service
+  type: group
   description: |
-    Service environment.
-- name: service.framework.name
-  type: keyword
-  description: |
-    Name of the framework used.
-- name: service.framework.version
-  type: keyword
-  description: |
-    Version of the framework used.
-- name: service.language.name
-  type: keyword
-  description: |
-    Name of the programming language used.
-- name: service.language.version
-  type: keyword
-  description: |
-    Version of the programming language used.
-- name: service.runtime.name
-  type: keyword
-  description: |
-    Name of the runtime used.
-- name: service.runtime.version
-  type: keyword
-  description: |
-    Version of the runtime used.
-- name: session.id
-  type: keyword
-  description: |
-    The ID of the session to which the event belongs.
-  ignore_above: 1024
-- name: session.sequence
-  type: long
-  description: |
-    The sequence number of the event within the session to which the event belongs.
-- name: span.action
-  type: keyword
-  description: |
-    The specific kind of event within the sub-type represented by the span (e.g. query, connect)
-- name: span.composite.compression_strategy
-  type: keyword
-  description: |
-    The compression strategy that was used.
-- name: span.composite.count
-  type: long
-  description: |
-    Number of compressed spans the composite span represents.
-- name: span.composite.sum.us
-  type: long
-  description: |
-    Sum of the durations of the compressed spans, in microseconds.
-- name: span.db.link
-  type: keyword
-  description: |
-    Database link.
-- name: span.db.rows_affected
-  type: long
-  description: |
-    Number of rows affected by the database statement.
-- name: span.destination.service.name
-  type: keyword
-  description: |
-    Identifier for the destination service (e.g. 'http://elastic.co', 'elasticsearch', 'rabbitmq') DEPRECATED: this field will be removed in a future release
-- name: span.destination.service.resource
-  type: keyword
-  description: |
-    Identifier for the destination service resource being operated on (e.g. 'http://elastic.co:80', 'elasticsearch', 'rabbitmq/queue_name')
-- name: span.destination.service.type
-  type: keyword
-  description: |
-    Type of the destination service (e.g. 'db', 'elasticsearch'). Should typically be the same as span.type. DEPRECATED: this field will be removed in a future release
-- name: span.duration.us
-  type: long
-  description: |
-    Duration of the span, in microseconds.
-- name: span.message.age.ms
-  type: long
-  description: |
-    Age of a message in milliseconds.
-- name: span.message.queue.name
-  type: keyword
-  description: |
-    Name of the message queue or topic where the message is published or received.
-- name: span.name
-  type: keyword
-  description: |
-    Generic designation of a span in the scope of a transaction.
-- name: span.start.us
-  type: long
-  description: |
-    Offset relative to the transaction's timestamp identifying the start of the span, in microseconds.
-- name: span.subtype
-  type: keyword
-  description: |
-    A further sub-division of the type (e.g. postgresql, elasticsearch)
-- name: span.sync
-  type: boolean
-  description: |
-    Indicates whether the span was executed synchronously or asynchronously.
-- name: span.type
-  type: keyword
-  description: |
-    Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', 'cache', etc).
-- name: timestamp.us
-  type: long
-  description: |
-    Timestamp of the event in microseconds since Unix epoch.
-- name: transaction.duration.us
-  type: long
-  description: |
-    Total duration of this transaction, in microseconds.
-- name: transaction.experience.cls
-  type: scaled_float
-  description: The Cumulative Layout Shift metric
-- name: transaction.experience.fid
-  type: scaled_float
-  description: The First Input Delay metric
-- name: transaction.experience.longtask.count
-  type: long
-  description: The total number of of longtasks
-- name: transaction.experience.longtask.max
-  type: scaled_float
-  description: The max longtask duration
-- name: transaction.experience.longtask.sum
-  type: scaled_float
-  description: The sum of longtask durations
-- name: transaction.experience.tbt
-  type: scaled_float
-  description: The Total Blocking Time metric
-- name: transaction.marks
-  type: object
-  description: |
-    A user-defined mapping of groups of marks in milliseconds.
-  dynamic: true
-- name: transaction.marks.*.*
-  type: object
-  description: |
-    A user-defined mapping of groups of marks in milliseconds.
-  dynamic: true
-- name: transaction.message.age.ms
-  type: long
-  description: |
-    Age of a message in milliseconds.
-- name: transaction.message.queue.name
-  type: keyword
-  description: |
-    Name of the message queue or topic where the message is published or received.
-- name: transaction.name
-  type: keyword
-  description: |
-    Generic designation of a transaction in the scope of a single service (eg. 'GET /users/:id').
-  multi_fields:
-    - name: text
-      type: text
-- name: transaction.result
-  type: keyword
-  description: |
-    The result of the transaction. HTTP status code for HTTP-related transactions.
-- name: transaction.sampled
-  type: boolean
-  description: |
-    Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have spans or context.
-- name: transaction.span_count.dropped
-  type: long
-  description: The total amount of dropped spans for this transaction.
-- name: transaction.type
-  type: keyword
-  description: |
-    Keyword of specific relevance in the service's domain (eg. 'request', 'backgroundjob', etc)
+    Service fields.
+  fields:
+    - name: environment
+      type: keyword
+      description: |
+        Service environment.
+    - name: framework
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the framework used.
+        - name: version
+          type: keyword
+          description: |
+            Version of the framework used.
+    - name: language
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the programming language used.
+        - name: version
+          type: keyword
+          description: |
+            Version of the programming language used.
+    - name: runtime
+      type: group
+      fields:
+        - name: name
+          type: keyword
+          description: |
+            Name of the runtime used.
+        - name: version
+          type: keyword
+          description: |
+            Version of the runtime used.
+- name: session
+  type: group
+  fields:
+    - name: id
+      type: keyword
+      description: |
+        The ID of the session to which the event belongs.
+      ignore_above: 1024
+    - name: sequence
+      type: long
+      description: |
+        The sequence number of the event within the session to which the event belongs.
+- name: span
+  type: group
+  fields:
+    - name: action
+      type: keyword
+      description: |
+        The specific kind of event within the sub-type represented by the span (e.g. query, connect)
+    - name: composite
+      type: group
+      fields:
+        - name: compression_strategy
+          type: keyword
+          description: |
+            The compression strategy that was used.
+        - name: count
+          type: long
+          description: |
+            Number of compressed spans the composite span represents.
+        - name: sum
+          type: group
+          fields:
+            - name: us
+              type: long
+              description: |
+                Sum of the durations of the compressed spans, in microseconds.
+    - name: db
+      type: group
+      fields:
+        - name: link
+          type: keyword
+          description: |
+            Database link.
+        - name: rows_affected
+          type: long
+          description: |
+            Number of rows affected by the database statement.
+    - name: destination
+      type: group
+      fields:
+        - name: service
+          type: group
+          description: Destination service context
+          fields:
+            - name: name
+              type: keyword
+              description: |
+                Identifier for the destination service (e.g. 'http://elastic.co', 'elasticsearch', 'rabbitmq') DEPRECATED: this field will be removed in a future release
+            - name: resource
+              type: keyword
+              description: |
+                Identifier for the destination service resource being operated on (e.g. 'http://elastic.co:80', 'elasticsearch', 'rabbitmq/queue_name')
+            - name: type
+              type: keyword
+              description: |
+                Type of the destination service (e.g. 'db', 'elasticsearch'). Should typically be the same as span.type. DEPRECATED: this field will be removed in a future release
+    - name: duration
+      type: group
+      fields:
+        - name: us
+          type: long
+          description: |
+            Duration of the span, in microseconds.
+    - name: message
+      type: group
+      fields:
+        - name: age
+          type: group
+          fields:
+            - name: ms
+              type: long
+              description: |
+                Age of a message in milliseconds.
+        - name: queue
+          type: group
+          fields:
+            - name: name
+              type: keyword
+              description: |
+                Name of the message queue or topic where the message is published or received.
+    - name: name
+      type: keyword
+      description: |
+        Generic designation of a span in the scope of a transaction.
+    - name: start
+      type: group
+      fields:
+        - name: us
+          type: long
+          description: |
+            Offset relative to the transaction's timestamp identifying the start of the span, in microseconds.
+    - name: subtype
+      type: keyword
+      description: |
+        A further sub-division of the type (e.g. postgresql, elasticsearch)
+    - name: sync
+      type: boolean
+      description: |
+        Indicates whether the span was executed synchronously or asynchronously.
+    - name: type
+      type: keyword
+      description: |
+        Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', 'cache', etc).
+- name: timestamp
+  type: group
+  fields:
+    - name: us
+      type: long
+      description: |
+        Timestamp of the event in microseconds since Unix epoch.
+- name: transaction
+  type: group
+  fields:
+    - name: duration
+      type: group
+      fields:
+        - name: us
+          type: long
+          description: |
+            Total duration of this transaction, in microseconds.
+    - name: experience
+      type: group
+      fields:
+        - name: cls
+          type: scaled_float
+          description: The Cumulative Layout Shift metric
+        - name: fid
+          type: scaled_float
+          description: The First Input Delay metric
+        - name: longtask
+          type: group
+          description: Longtask duration/count metrics
+          fields:
+            - name: count
+              type: long
+              description: The total number of of longtasks
+            - name: max
+              type: scaled_float
+              description: The max longtask duration
+            - name: sum
+              type: scaled_float
+              description: The sum of longtask durations
+        - name: tbt
+          type: scaled_float
+          description: The Total Blocking Time metric
+    - name: marks
+      type: object
+      description: |
+        A user-defined mapping of groups of marks in milliseconds.
+      dynamic: true
+    - name: marks.*.*
+      type: object
+      description: |
+        A user-defined mapping of groups of marks in milliseconds.
+      dynamic: true
+    - name: message
+      type: group
+      fields:
+        - name: age
+          type: group
+          fields:
+            - name: ms
+              type: long
+              description: |
+                Age of a message in milliseconds.
+        - name: queue
+          type: group
+          fields:
+            - name: name
+              type: keyword
+              description: |
+                Name of the message queue or topic where the message is published or received.
+    - name: name
+      type: keyword
+      description: |
+        Generic designation of a transaction in the scope of a single service (eg. 'GET /users/:id').
+      multi_fields:
+        - name: text
+          type: text
+    - name: result
+      type: keyword
+      description: |
+        The result of the transaction. HTTP status code for HTTP-related transactions.
+    - name: sampled
+      type: boolean
+      description: |
+        Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have spans or context.
+    - name: span_count
+      type: group
+      fields:
+        - name: dropped
+          type: long
+          description: The total amount of dropped spans for this transaction.
+    - name: type
+      type: keyword
+      description: |
+        Keyword of specific relevance in the service's domain (eg. 'request', 'backgroundjob', etc)

--- a/apmpackage/apm/data_stream/traces/manifest.yml
+++ b/apmpackage/apm/data_stream/traces/manifest.yml
@@ -2,3 +2,11 @@ title: APM traces
 type: traces
 dataset: apm
 ilm_policy: traces-apm.traces-default_policy
+elasticsearch:
+  index_template:
+    mappings:
+      # TODO(axw) investigate setting `dynamic: runtime`, so that fields are
+      # runtime searchable by default. That way users can, for example, perform
+      # ad-hoc searches on HTTP request headers without incurring storage cost
+      # for users who do not need this capability.
+      dynamic: false

--- a/apmpackage/apm/docs/README.md
+++ b/apmpackage/apm/docs/README.md
@@ -54,9 +54,6 @@ Traces are written to `traces-apm.*` indices.
 | Field | Description | Type | ECS |
 |---|---|---|:---:|
 |@timestamp|Event timestamp.|date|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
-|data\_stream.type|Data stream type.|constant\_keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
-|data\_stream.dataset|Data stream dataset.|constant\_keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
-|data\_stream.namespace|Data stream namespace.|constant\_keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |agent.ephemeral\_id|The Ephemeral ID identifies a running process.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |agent.name|Name of the agent used.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |agent.version|Version of the agent used.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
@@ -76,9 +73,13 @@ Traces are written to `traces-apm.*` indices.
 |cloud.region|Cloud region name|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |cloud.service.name|Cloud service name, intended to distinguish services running on different platforms within a provider.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |container.id|Unique container id.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
+|data\_stream.dataset|Data stream dataset.|constant\_keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
+|data\_stream.namespace|Data stream namespace.|constant\_keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
+|data\_stream.type|Data stream type.|constant\_keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |destination.address|Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the \`.address\` field. Then it should be duplicated to \`.ip\` or \`.domain\`, depending on which one it is.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |destination.ip|IP addess of the destination. Can be one of multiple IPv4 or IPv6 addresses.|ip|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |destination.port|Port of the destination.|long|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
+|ecs.version|ECS version the event conforms to.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |event.outcome|\`event.outcome\` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |experimental|Additional experimental data sent by the agents.|object|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-no.png)  |
 |host.architecture|The architecture of the host the event was recorded on.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
@@ -426,9 +427,6 @@ Metrics are written to `metrics-apm.app.*`, `metrics-apm.internal.*`, and `metri
 | Field | Description | Type | ECS |
 |---|---|---|:---:|
 |@timestamp|Event timestamp.|date|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
-|data\_stream.type|Data stream type.|constant\_keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
-|data\_stream.dataset|Data stream dataset.|constant\_keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
-|data\_stream.namespace|Data stream namespace.|constant\_keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |agent.ephemeral\_id|The Ephemeral ID identifies a running process.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |agent.name|Name of the agent used.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |agent.version|Version of the agent used.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
@@ -447,9 +445,13 @@ Metrics are written to `metrics-apm.app.*`, `metrics-apm.internal.*`, and `metri
 |cloud.region|Cloud region name|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |cloud.service.name|Cloud service name, intended to distinguish services running on different platforms within a provider.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |container.id|Unique container id.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
+|data\_stream.dataset|Data stream dataset.|constant\_keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
+|data\_stream.namespace|Data stream namespace.|constant\_keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
+|data\_stream.type|Data stream type.|constant\_keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |destination.address|Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the \`.address\` field. Then it should be duplicated to \`.ip\` or \`.domain\`, depending on which one it is.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |destination.ip|IP addess of the destination. Can be one of multiple IPv4 or IPv6 addresses.|ip|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |destination.port|Port of the destination.|long|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
+|ecs.version|ECS version the event conforms to.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |experimental|Additional experimental data sent by the agents.|object|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-no.png)  |
 |histogram||histogram|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-no.png)  |
 |host.architecture|The architecture of the host the event was recorded on.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
@@ -592,9 +594,6 @@ Logs are written to `logs-apm.error.*` indices.
 | Field | Description | Type | ECS |
 |---|---|---|:---:|
 |@timestamp|Event timestamp.|date|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
-|data\_stream.type|Data stream type.|constant\_keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
-|data\_stream.dataset|Data stream dataset.|constant\_keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
-|data\_stream.namespace|Data stream namespace.|constant\_keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |agent.ephemeral\_id|The Ephemeral ID identifies a running process.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |agent.name|Name of the agent used.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |agent.version|Version of the agent used.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
@@ -613,9 +612,13 @@ Logs are written to `logs-apm.error.*` indices.
 |cloud.region|Cloud region name|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |cloud.service.name|Cloud service name, intended to distinguish services running on different platforms within a provider.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |container.id|Unique container id.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
+|data\_stream.dataset|Data stream dataset.|constant\_keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
+|data\_stream.namespace|Data stream namespace.|constant\_keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
+|data\_stream.type|Data stream type.|constant\_keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |destination.address|Some event destination addresses are defined ambiguously. The event will sometimes list an IP, a domain or a unix socket.  You should always store the raw address in the \`.address\` field. Then it should be duplicated to \`.ip\` or \`.domain\`, depending on which one it is.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |destination.ip|IP addess of the destination. Can be one of multiple IPv4 or IPv6 addresses.|ip|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |destination.port|Port of the destination.|long|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
+|ecs.version|ECS version the event conforms to.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-yes.png)  |
 |error.culprit|Function call which was the primary perpetrator of this event.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-no.png)  |
 |error.exception.code|The error code set when the error happened, e.g. database error code.|keyword|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-no.png)  |
 |error.exception.handled|Indicator whether the error was caught somewhere in the code or not.|boolean|  ![](https://doc-icons.s3.us-east-2.amazonaws.com/icon-no.png)  |

--- a/apmpackage/cmd/gen-package/field.go
+++ b/apmpackage/cmd/gen-package/field.go
@@ -18,16 +18,22 @@
 package main
 
 type field struct {
-	Name             string                 `yaml:"name,omitempty"`
-	Key              string                 `yaml:"key,omitempty"`
-	Title            string                 `yaml:"title,omitempty"`
-	Group            *int                   `yaml:"group,omitempty"`
-	Level            string                 `yaml:"level,omitempty"`
-	Required         *bool                  `yaml:"required,omitempty"`
-	Type             string                 `yaml:"type,omitempty"`
-	Format           string                 `yaml:"format,omitempty"`
-	Description      string                 `yaml:"description,omitempty"`
-	Dynamic          bool                   `yaml:"dynamic,omitempty"`
+	Name        string `yaml:"name,omitempty"`
+	Key         string `yaml:"key,omitempty"`
+	Title       string `yaml:"title,omitempty"`
+	Level       string `yaml:"level,omitempty"`
+	Required    *bool  `yaml:"required,omitempty"`
+	Type        string `yaml:"type,omitempty"`
+	Format      string `yaml:"format,omitempty"`
+	Description string `yaml:"description,omitempty"`
+
+	// Dynamic controls whether a field is dynamically mapped.
+	//
+	// Note: we intentionally omit "dynamic: false", as we set
+	// a default dynamic mapping value for each data stream and
+	// opt *in* to dynamically mapping where needed.
+	Dynamic bool `yaml:"dynamic,omitempty"`
+
 	ObjectTypeParams interface{}            `yaml:"object_type_params,omitempty"`
 	Release          string                 `yaml:"release,omitempty"`
 	Alias            string                 `yaml:"alias,omitempty"`
@@ -38,13 +44,8 @@ type field struct {
 	Fields           []field                `yaml:"fields,omitempty"`
 	MetricType       string                 `yaml:"metric_type,omitempty"`
 	Unit             string                 `yaml:"unit,omitempty"`
-	IsECS            bool                   `yaml:"-"`
-	HasECS           bool                   `yaml:"-"`
-	HasNonECS        bool                   `yaml:"-"`
-}
 
-func (f field) isNonECSLeaf() bool {
-	return f.Type != "group" && !f.IsECS
+	IsECS bool `yaml:"-"`
 }
 
 type multiFieldDefinition struct {
@@ -52,9 +53,4 @@ type multiFieldDefinition struct {
 	Type         string `yaml:"type,omitempty"`
 	Norms        *bool  `yaml:"norms,omitempty"`
 	DefaultField *bool  `yaml:"default_field,omitempty"`
-}
-
-func copyFieldRoot(f field) field {
-	f.Fields = nil
-	return f
 }

--- a/apmpackage/cmd/gen-package/genfields.go
+++ b/apmpackage/cmd/gen-package/genfields.go
@@ -23,113 +23,113 @@ import (
 	"net/http"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/ecs/code/go/ecs"
 )
 
-func generateFields() map[string][]field {
+func generateFields() map[string]fieldMap {
 
 	ecsFlatFields := loadECSFields()
 
-	inputFieldsFiles := map[string][]field{
-		"error_logs":       format("model/error/_meta/fields.yml"),
-		"internal_metrics": format("model/metricset/_meta/fields.yml", "x-pack/apm-server/fields/_meta/fields.yml"),
-		"profile_metrics":  format("model/profile/_meta/fields.yml"),
-		"traces":           format("model/transaction/_meta/fields.yml", "model/span/_meta/fields.yml"),
+	inputFieldsFiles := map[string]fieldMap{
+		"error_logs":       readFields("model/error/_meta/fields.yml"),
+		"internal_metrics": readFields("model/metricset/_meta/fields.yml", "x-pack/apm-server/fields/_meta/fields.yml"),
+		"profile_metrics":  readFields("model/profile/_meta/fields.yml"),
+		"traces":           readFields("model/transaction/_meta/fields.yml", "model/span/_meta/fields.yml"),
 	}
-	inputFieldsFiles["app_metrics"] = filterInternalMetrics(inputFieldsFiles["internal_metrics"])
 
-	for streamType, inputFields := range inputFieldsFiles {
+	appMetrics := readFields("model/metricset/_meta/fields.yml", "x-pack/apm-server/fields/_meta/fields.yml")
+	delete(appMetrics, "transaction")
+	delete(appMetrics, "span")
+	delete(appMetrics, "event")
+	inputFieldsFiles["app_metrics"] = appMetrics
+
+	for streamType, fields := range inputFieldsFiles {
 		log.Printf("%s", streamType)
-		var ecsFields []field
-		var nonECSFields []field
-		for _, fields := range populateECSInfo(ecsFlatFields, inputFields) {
-			ecs, nonECS := splitECSFields(fields)
-			if len(ecs.Fields) > 0 || ecs.IsECS {
-				ecsFields = append(ecsFields, ecs)
-			}
-			if len(nonECS.Fields) > 0 || ecs.isNonECSLeaf() {
-				nonECSFields = append(nonECSFields, nonECS)
-			}
+		populateECSInfo(ecsFlatFields, fields)
+		for _, field := range fields {
+			log.Printf(" - %s (%s)", field.Name, field.Type)
 		}
-		var writeOutFields = func(fName string, data []field) {
-			bytes, err := yaml.Marshal(&data)
-			if err != nil {
-				panic(err)
-			}
-			err = ioutil.WriteFile(filepath.Join(fieldsPath(streamType), fName), bytes, 0644)
-			if err != nil {
-				panic(err)
-			}
+		ecsFields, nonECSFields := splitFields(fields)
+
+		var topLevelECSFields, topLevelNonECSFields []field
+		for _, field := range ecsFields {
+			topLevelECSFields = append(topLevelECSFields, field.field)
 		}
-		if len(ecsFields) > 0 {
-			writeOutFields("ecs.yml", ecsFields)
+		for _, field := range nonECSFields {
+			topLevelNonECSFields = append(topLevelNonECSFields, field.field)
 		}
-		if len(nonECSFields) > 0 {
-			writeOutFields("fields.yml", nonECSFields)
-		}
+		sortFields(topLevelECSFields)
+		sortFields(topLevelNonECSFields)
+		writeFields(streamType, "ecs.yml", topLevelECSFields)
+		writeFields(streamType, "fields.yml", topLevelNonECSFields)
 	}
 	return inputFieldsFiles
 }
 
-func filterInternalMetrics(fields []field) []field {
-	var ret []field
-	var isInternal = func(s string) bool {
-		return strings.HasPrefix(s, "transaction") ||
-			strings.HasPrefix(s, "span") ||
-			strings.HasPrefix(s, "event")
+func writeFields(streamType, filename string, data []field) {
+	if len(data) == 0 {
+		return
 	}
-	for _, f := range fields {
-		if !isInternal(f.Name) {
-			ret = append(ret, f)
-		}
+	bytes, err := yaml.Marshal(data)
+	if err != nil {
+		panic(err)
 	}
-	return ret
+	err = ioutil.WriteFile(filepath.Join(fieldsPath(streamType), filename), bytes, 0644)
+	if err != nil {
+		panic(err)
+	}
 }
 
-func populateECSInfo(ecsFlatFields map[string]interface{}, inputFields []field) []field {
-	var traverse func(string, []field) ([]field, bool, bool)
-	traverse = func(fName string, fs []field) ([]field, bool, bool) {
-		var ecsCount int
-		for idx, field := range fs {
+// populateECSInfo sets the IsECS property of each field. Group fields
+// will have IsECS set only if all sub-fields have IsECS set.
+func populateECSInfo(ecsFlatFields map[string]interface{}, inputFields fieldMap) {
+	var traverse func(path string, fields fieldMap) (ecsOnly bool)
+	traverse = func(path string, fields fieldMap) bool {
+		ecsOnly := true
+		for name, field := range fields {
 			fieldName := field.Name
-			if fName != "" {
-				fieldName = fName + "." + fieldName
+			if path != "" {
+				fieldName = path + "." + fieldName
 			}
 			if field.Type != "group" {
-				_, ok := ecsFlatFields[fieldName]
-				fs[idx].IsECS = ok
-				if ok {
-					ecsCount = ecsCount + 1
-				}
+				_, field.IsECS = ecsFlatFields[fieldName]
 			} else {
-				fs[idx].Fields, fs[idx].HasECS, fs[idx].HasNonECS = traverse(fieldName, field.Fields)
+				field.IsECS = traverse(fieldName, field.fields)
 			}
+			fields[name] = field
+			ecsOnly = ecsOnly && field.IsECS
 		}
-		// first boolean returned indicates whether there is at least an ECS field in the group
-		// second boolean returned indicates whether there is at least a non-ECS field in the group
-		return fs, ecsCount > 0, ecsCount < len(fs)
+		return ecsOnly
 	}
-	ret, _, _ := traverse("", inputFields)
-	return ret
+	traverse("", inputFields)
 }
 
-func splitECSFields(parent field) (field, field) {
-	ecsCopy := copyFieldRoot(parent)
-	nonECSCopy := copyFieldRoot(parent)
-	for _, field := range parent.Fields {
-		ecsChild, nonECSChild := splitECSFields(field)
-		if ecsChild.HasECS || ecsChild.IsECS {
-			ecsCopy.Fields = append(ecsCopy.Fields, ecsChild)
+// splitFields splits fields into ECS and non-ECS fieldMaps.
+func splitFields(fields fieldMap) (ecsFields, nonECSFields fieldMap) {
+	ecsFields = make(fieldMap)
+	nonECSFields = make(fieldMap)
+	for name, field := range fields {
+		if field.IsECS {
+			ecsFields[name] = field
+			continue
+		} else if field.Type != "group" {
+			nonECSFields[name] = field
+			continue
 		}
-		if nonECSChild.HasNonECS || nonECSChild.isNonECSLeaf() {
-			nonECSCopy.Fields = append(nonECSCopy.Fields, nonECSChild)
+		subECSFields, subNonECSFields := splitFields(field.fields)
+		fieldCopy := field.field
+		fieldCopy.Fields = nil // recreated by update calls
+		if len(subECSFields) > 0 {
+			ecsFields[name] = fieldMapItem{field: fieldCopy, fields: subECSFields}
+			ecsFields.update(fieldCopy)
 		}
+		nonECSFields[name] = fieldMapItem{field: fieldCopy, fields: subNonECSFields}
+		nonECSFields.update(fieldCopy)
 	}
-	return ecsCopy, nonECSCopy
+	return ecsFields, nonECSFields
 }
 
 func loadECSFields() map[string]interface{} {
@@ -148,19 +148,66 @@ func loadECSFields() map[string]interface{} {
 	return ret
 }
 
-func format(fileNames ...string) []field {
-	return order(dedup(flatten("", concatFields(fileNames...))))
-}
-
-func concatFields(fileNames ...string) []field {
-	var ret []field
+// readFields reads fields from all of the specified files,
+// merging them into a fieldMap.
+func readFields(fileNames ...string) fieldMap {
+	fields := make(fieldMap)
 	for _, fname := range fileNames {
-		fs := loadFieldsFile(fname)
-		for _, key := range fs {
-			ret = append(ret, key.Fields...)
+		for _, key := range loadFieldsFile(fname) {
+			for _, field := range key.Fields {
+				fields.update(field)
+			}
 		}
 	}
-	return ret
+	return fields
+}
+
+func flattenFields(fields fieldMap) []field {
+	var flattened []field
+	var traverse func(path string, fields fieldMap)
+	traverse = func(path string, fields fieldMap) {
+		for name, field := range fields {
+			full := path
+			if full != "" {
+				full += "."
+			}
+			full += name
+			field.Name = full
+			if field.Type == "group" {
+				traverse(full, field.fields)
+			} else {
+				flattened = append(flattened, field.field)
+			}
+		}
+	}
+	traverse("", fields)
+	sortFields(flattened)
+	return flattened
+}
+
+type fieldMap map[string]fieldMapItem
+
+type fieldMapItem struct {
+	field
+	fields fieldMap
+}
+
+func (m fieldMap) update(f field) {
+	item := m[f.Name]
+	item.field = f
+	if item.fields == nil {
+		item.fields = make(fieldMap)
+	}
+	for _, f := range f.Fields {
+		item.fields.update(f)
+	}
+	// Update the Fields slice, in case of merges.
+	item.Fields = item.Fields[:0]
+	for _, f := range item.fields {
+		item.Fields = append(item.Fields, f.field)
+	}
+	sortFields(item.Fields)
+	m[f.Name] = item
 }
 
 func loadFieldsFile(path string) []field {
@@ -168,57 +215,15 @@ func loadFieldsFile(path string) []field {
 	if err != nil {
 		panic(err)
 	}
-
 	var fs []field
-	err = yaml.Unmarshal(fields, &fs)
-	if err != nil {
+	if err := yaml.Unmarshal(fields, &fs); err != nil {
 		panic(err)
 	}
-	return overrideFieldValues(fs)
-}
-
-func overrideFieldValues(fs []field) []field {
-	var ret []field
-	for _, f := range fs {
-		if f.Type == "" {
-			f.Type = "keyword"
-		}
-		f.Fields = overrideFieldValues(f.Fields)
-		ret = append(ret, f)
-	}
-	return ret
-}
-
-func dedup(fs []field) []field {
-	var m = make(map[string]field)
-	for _, f := range fs {
-		m[f.Name] = f
-	}
-	var ret []field
-	for _, v := range m {
-		ret = append(ret, v)
-	}
-	return ret
-}
-
-func order(fs []field) []field {
-	sort.Slice(fs, func(i, j int) bool {
-		return fs[i].Name < fs[j].Name
-	})
 	return fs
 }
 
-func flatten(name string, fs []field) []field {
-	var ret []field
-	for _, f := range fs {
-		if name != "" {
-			f.Name = name + "." + f.Name
-		}
-		if f.Type == "group" {
-			ret = append(ret, flatten(f.Name, f.Fields)...)
-		} else {
-			ret = append(ret, f)
-		}
-	}
-	return ret
+func sortFields(fields []field) {
+	sort.Slice(fields, func(i, j int) bool {
+		return fields[i].Name < fields[j].Name
+	})
 }

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -23,6 +23,7 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 - `service_destination` span metrics now take into account composite spans {pull}5896[5896]
 - add zero-downtime config reloads via `SO_REUSEPORT` {pull}5911[5911]
 - experimental support for writing data streams in standalone mode {pull}5928[5928]
+- Data streams now define a default `dynamic` mapping parameter, overridable in the `<data-stream>@custom` template {pull}5947[5947]
 
 [float]
 ==== Deprecated


### PR DESCRIPTION
## Motivation/summary

Fix integration package index template mappings by copying the full field hierarchy to the integration package, instead of just flattened leaf fields. Copying only leaf fields means we miss inherited group properties such as `dynamic`.

- set a default `dynamic` property for each data stream mapping
- add `ecs.version` to base fields

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

1. Install the integration
2. Run apm-server with data streams (e.g. `-E apm-server.data_streams.enabled=true`)
3. Send some HTTP transactions with request headers, check that APM Server indexes them successfully
4. Check that the request headers are not indexed

## Related issues

https://github.com/elastic/apm-server/issues/5707