### PR TITLE
docs: link to APM Server central config privileges

### DIFF
--- a/docs/configure-kibana-endpoint.asciidoc
+++ b/docs/configure-kibana-endpoint.asciidoc
@@ -21,11 +21,13 @@ apm-server.kibana.host: "http://localhost:5601"
 [float]
 === Considerations
 
-* If your setup uses a <<config-secret-token>> for Agent/Server communication,
+* If your setup uses a <<config-secret-token,secret token>> for Agent/Server communication,
 the same token is used to secure this endpoint.
 * It's important to still set relevant defaults locally in each Agent's configuration.
 If APM Server is unreachable, slow to respond, returns an error, etc.,
 defaults set in the agent will apply according to their precedence.
+* APM Server needs sufficient Kibana privileges to manage central configuration.
+See <<privileges-agent-central-config>> for a list of required privileges.
 
 [float]
 === Kibana endpoint configuration options


### PR DESCRIPTION
### Summary

Closes https://github.com/elastic/apm-server/issues/3479. This issue was mostly resolved in https://github.com/elastic/apm-server/pull/3799, which added privilege docs [here](https://www.elastic.co/guide/en/apm/server/current/privileges-agent-central-config.html), but as stated in elastic/apm-server#3479, some kind of docs (a link in this case) in [Configure the Kibana endpoint](https://github.com/elastic/apm-server/pull/3799) seems helpful. This PR adds that link.