### PR TITLE
Disable Google cache after object upload

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -497,6 +497,12 @@ pipeline {
                   sharedPublicly: true,
                   showInline: true)
 
+                // Disable caching
+                gsutil(
+                    command: "-h 'Cache-Control:public, max-age=0' ${BUCKET_URI}",
+                    credentialsId: "${JOB_GCS_CREDENTIALS}",
+                )
+
                 // Copy those files to another location with the sha commit to test them afterward.
                 googleStorageUpload(bucket: "gs://${JOB_GCS_BUCKET}/commits/${env.GIT_BASE_COMMIT}",
                   credentialsId: "${JOB_GCS_CREDENTIALS}",
@@ -504,6 +510,12 @@ pipeline {
                   pattern: "${BASE_DIR}/build/distributions/**/*",
                   sharedPublicly: true,
                   showInline: true)
+
+                // Disable caching
+                gsutil(
+                    command: "-h 'Cache-Control:public, max-age=0' gs://${JOB_GCS_BUCKET}/commits/${env.GIT_BASE_COMMIT}",
+                    credentialsId: "${JOB_GCS_CREDENTIALS}",
+                )
               }
             }
           }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Attempt to fix failure in branch packaging test

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Refs issue in private repo.
