### PR TITLE
[CI]: use setEnvVar instead of global env variable

### DIFF
--- a/.ci/check-packages.groovy
+++ b/.ci/check-packages.groovy
@@ -40,6 +40,7 @@ pipeline {
         script {
           if(isUpstreamTrigger()) {
             try {
+              log(level: 'INFO', text: "Started by upstream pipeline. Read 'beats-tester.properties'.")
               copyArtifacts(filter: 'beats-tester.properties',
                             flatten: true,
                             projectName: "apm-server/apm-server-mbp/${env.JOB_BASE_NAME}",
@@ -48,11 +49,12 @@ pipeline {
               setEnvVar('APM_URL_BASE', props.get('APM_URL_BASE', ''))
               setEnvVar('VERSION', props.get('VERSION', '8.0.0-SNAPSHOT'))
             } catch(err) {
-              // Fallback to the head of the branch as used to be.
+              log(level: 'WARN', text: "copyArtifacts failed. Fallback to the head of the branch as used to be.")
               setEnvVar('APM_URL_BASE', params.get('APM_URL_BASE', 'https://storage.googleapis.com/apm-ci-artifacts/jobs/snapshots'))
               setEnvVar('VERSION', params.get('VERSION', '8.0.0-SNAPSHOT'))
             }
           } else {
+            log(level: 'INFO', text: "No started by upstream pipeline. Fallback to the head of the branch as used to be.")
             setEnvVar('APM_URL_BASE', params.get('APM_URL_BASE'))
             setEnvVar('VERSION', params.get('VERSION'))
           }

--- a/.ci/check-packages.groovy
+++ b/.ci/check-packages.groovy
@@ -7,11 +7,9 @@ pipeline {
   environment {
     BASE_DIR = 'src'
     PIPELINE_LOG_LEVEL = 'INFO'
-    VERSION = "${params.VERSION}"
     HOME = "${WORKSPACE}"
     // This limits ourselves to just the APM tests
     ANSIBLE_EXTRA_FLAGS = "--tags apm-server"
-    APM_URL_BASE = "${params.APM_URL_BASE}"
     LANG = "C.UTF-8"
     LC_ALL = "C.UTF-8"
     PYTHONUTF8 = "1"
@@ -54,6 +52,9 @@ pipeline {
               setEnvVar('APM_URL_BASE', params.get('APM_URL_BASE', 'https://storage.googleapis.com/apm-ci-artifacts/jobs/snapshots'))
               setEnvVar('VERSION', params.get('VERSION', '8.0.0-SNAPSHOT'))
             }
+          } else {
+            setEnvVar('APM_URL_BASE', params.get('APM_URL_BASE'))
+            setEnvVar('VERSION', params.get('VERSION'))
           }
         }
         gitCheckout(basedir: "${BASE_DIR}", repo: 'git@github.com:elastic/beats-tester.git', branch: 'master', credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba')


### PR DESCRIPTION
## Motivation/summary

It can't override the environment variable defined in the environment `{}` block, therefore let's use a different approach and add more debug traces.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

In the CI

## Related issues

Supersedes https://github.com/elastic/apm-server/pull/6009