### PR TITLE
magefile: fix Package target

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -160,7 +160,7 @@ func filterPackages(types string) {
 // Use SNAPSHOT=true to build snapshots.
 // Use PLATFORMS to control the target platforms. eg linux/amd64
 // Use TYPES to control the target types. eg docker
-func Package() {
+func Package() error {
 	start := time.Now()
 	defer func() { fmt.Println("package ran for", time.Since(start)) }()
 
@@ -175,6 +175,7 @@ func Package() {
 		mg.Deps(Update, prepareIngestPackaging)
 		mg.Deps(CrossBuild, CrossBuildXPack, CrossBuildGoDaemon)
 	}
+	return mage.Package()
 }
 
 func Version() error {


### PR DESCRIPTION
Fix the Package target. I accidentally removed the dependency on `beats/dev-tools/mage.Package` in https://github.com/elastic/apm-server/pull/6101/files#diff-520109d035a196d29d0a86e9c4e6c98e98abf056141b84df68c0d48167b87b25L178