### PR TITLE
Use deployment.environment for Metadata.Service.Environment when converting a Jaeger span.

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -32,6 +32,7 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 - experimental support for writing data streams in standalone mode {pull}5928[5928]
 - Data streams now define a default `dynamic` mapping parameter, overridable in the `<data-stream>@custom` template {pull}5947[5947]
 - The `error.log.message` or `error.exception.message` field of errors will be copied to the ECS field `message` {pull}5974[5974]
+- Use deployment.environment for Metadata.Service.Environment when converting a Jaeger span {pull}6114[6114]
 
 [float]
 ==== Deprecated

--- a/processor/otel/test_approved/transaction_jaeger_full.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_full.approved.json
@@ -33,6 +33,7 @@
                 "name": "transaction"
             },
             "service": {
+                "environment": "staging",
                 "language": {
                     "name": "unknown"
                 },
@@ -99,6 +100,7 @@
                 "name": "error"
             },
             "service": {
+                "environment": "staging",
                 "language": {
                     "name": "unknown"
                 },
@@ -155,6 +157,7 @@
                 "name": "error"
             },
             "service": {
+                "environment": "staging",
                 "language": {
                     "name": "unknown"
                 },
@@ -213,6 +216,7 @@
                 "name": "error"
             },
             "service": {
+                "environment": "staging",
                 "language": {
                     "name": "unknown"
                 },
@@ -271,6 +275,7 @@
                 "name": "error"
             },
             "service": {
+                "environment": "staging",
                 "language": {
                     "name": "unknown"
                 },
@@ -329,6 +334,7 @@
                 "name": "error"
             },
             "service": {
+                "environment": "staging",
                 "language": {
                     "name": "unknown"
                 },
@@ -385,6 +391,7 @@
                 "name": "error"
             },
             "service": {
+                "environment": "staging",
                 "language": {
                     "name": "unknown"
                 },

--- a/processor/otel/traces.go
+++ b/processor/otel/traces.go
@@ -404,6 +404,8 @@ func translateTransaction(
 			case "span.kind": // filter out
 			case "type":
 				event.Transaction.Type = stringval
+			case semconv.AttributeDeploymentEnvironment:
+				event.Service.Environment = stringval
 			case semconv.AttributeServiceVersion:
 				event.Service.Version = stringval
 			case "component":

--- a/processor/otel/traces_test.go
+++ b/processor/otel/traces_test.go
@@ -820,6 +820,7 @@ func TestConsumer_JaegerTransaction(t *testing.T) {
 					jaegerKeyValue("component", "foo"),
 					jaegerKeyValue("string.a.b", "some note"),
 					jaegerKeyValue("service.version", "1.0"),
+					jaegerKeyValue("deployment.environment", "staging"),
 				},
 				Logs: testJaegerLogs(),
 			}},


### PR DESCRIPTION
## Motivation/summary

deployment.environment is used in OpenTelemetry and already converted to Metadata.Service.Environment for OpenTelemetry spans. It would be nice if it is also supported for Jaeger spans.

## Checklist
- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
- [ ] ~Documentation has been updated~

