### PR TITLE
apmpackage: sort internal metrics data stream

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -1,6 +1,11 @@
 # newer versions go on top
 #
 # change type can be one of: enhancement, bugfix, breaking-change
+- version: "0.5.0"
+  changes:
+    - description: define index sorting for internal metrics
+      type: enhancement
+      link: https://github.com/elastic/apm-server/pull/6116
 - version: "0.4.0"
   changes:
     - description: add anonymous auth config, replace some RUM config

--- a/apmpackage/apm/data_stream/app_metrics/elasticsearch/ingest_pipeline/default.json
+++ b/apmpackage/apm/data_stream/app_metrics/elasticsearch/ingest_pipeline/default.json
@@ -3,33 +3,33 @@
   "processors": [
     {
       "pipeline": {
-        "name": "metrics-apm.app-0.4.0-apm_ingest_timestamp"
+        "name": "metrics-apm.app-0.5.0-apm_ingest_timestamp"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.app-0.4.0-apm_user_agent"
+        "name": "metrics-apm.app-0.5.0-apm_user_agent"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.app-0.4.0-apm_user_geo"
+        "name": "metrics-apm.app-0.5.0-apm_user_geo"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.app-0.4.0-apm_remove_span_metadata"
+        "name": "metrics-apm.app-0.5.0-apm_remove_span_metadata"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.app-0.4.0-apm_error_grouping_name",
+        "name": "metrics-apm.app-0.5.0-apm_error_grouping_name",
         "if": "ctx.processor?.event == 'error'"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.app-0.4.0-apm_metrics_dynamic_template",
+        "name": "metrics-apm.app-0.5.0-apm_metrics_dynamic_template",
         "if": "ctx.processor?.event == 'metric'"
       }
     }

--- a/apmpackage/apm/data_stream/error_logs/elasticsearch/ingest_pipeline/default.json
+++ b/apmpackage/apm/data_stream/error_logs/elasticsearch/ingest_pipeline/default.json
@@ -3,33 +3,33 @@
   "processors": [
     {
       "pipeline": {
-        "name": "logs-apm.error-0.4.0-apm_ingest_timestamp"
+        "name": "logs-apm.error-0.5.0-apm_ingest_timestamp"
       }
     },
     {
       "pipeline": {
-        "name": "logs-apm.error-0.4.0-apm_user_agent"
+        "name": "logs-apm.error-0.5.0-apm_user_agent"
       }
     },
     {
       "pipeline": {
-        "name": "logs-apm.error-0.4.0-apm_user_geo"
+        "name": "logs-apm.error-0.5.0-apm_user_geo"
       }
     },
     {
       "pipeline": {
-        "name": "logs-apm.error-0.4.0-apm_remove_span_metadata"
+        "name": "logs-apm.error-0.5.0-apm_remove_span_metadata"
       }
     },
     {
       "pipeline": {
-        "name": "logs-apm.error-0.4.0-apm_error_grouping_name",
+        "name": "logs-apm.error-0.5.0-apm_error_grouping_name",
         "if": "ctx.processor?.event == 'error'"
       }
     },
     {
       "pipeline": {
-        "name": "logs-apm.error-0.4.0-apm_metrics_dynamic_template",
+        "name": "logs-apm.error-0.5.0-apm_metrics_dynamic_template",
         "if": "ctx.processor?.event == 'metric'"
       }
     }

--- a/apmpackage/apm/data_stream/internal_metrics/elasticsearch/ingest_pipeline/default.json
+++ b/apmpackage/apm/data_stream/internal_metrics/elasticsearch/ingest_pipeline/default.json
@@ -3,33 +3,33 @@
   "processors": [
     {
       "pipeline": {
-        "name": "metrics-apm.internal-0.4.0-apm_ingest_timestamp"
+        "name": "metrics-apm.internal-0.5.0-apm_ingest_timestamp"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.internal-0.4.0-apm_user_agent"
+        "name": "metrics-apm.internal-0.5.0-apm_user_agent"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.internal-0.4.0-apm_user_geo"
+        "name": "metrics-apm.internal-0.5.0-apm_user_geo"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.internal-0.4.0-apm_remove_span_metadata"
+        "name": "metrics-apm.internal-0.5.0-apm_remove_span_metadata"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.internal-0.4.0-apm_error_grouping_name",
+        "name": "metrics-apm.internal-0.5.0-apm_error_grouping_name",
         "if": "ctx.processor?.event == 'error'"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.internal-0.4.0-apm_metrics_dynamic_template",
+        "name": "metrics-apm.internal-0.5.0-apm_metrics_dynamic_template",
         "if": "ctx.processor?.event == 'metric'"
       }
     }

--- a/apmpackage/apm/data_stream/internal_metrics/manifest.yml
+++ b/apmpackage/apm/data_stream/internal_metrics/manifest.yml
@@ -8,3 +8,7 @@ elasticsearch:
       # Internal metrics should have all fields strictly mapped;
       # we are in full control of the field names.
       dynamic: strict
+    settings:
+      index:
+        sort.field: "@timestamp"
+        sort.order: desc

--- a/apmpackage/apm/data_stream/profile_metrics/elasticsearch/ingest_pipeline/default.json
+++ b/apmpackage/apm/data_stream/profile_metrics/elasticsearch/ingest_pipeline/default.json
@@ -3,33 +3,33 @@
   "processors": [
     {
       "pipeline": {
-        "name": "metrics-apm.profiling-0.4.0-apm_ingest_timestamp"
+        "name": "metrics-apm.profiling-0.5.0-apm_ingest_timestamp"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.profiling-0.4.0-apm_user_agent"
+        "name": "metrics-apm.profiling-0.5.0-apm_user_agent"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.profiling-0.4.0-apm_user_geo"
+        "name": "metrics-apm.profiling-0.5.0-apm_user_geo"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.profiling-0.4.0-apm_remove_span_metadata"
+        "name": "metrics-apm.profiling-0.5.0-apm_remove_span_metadata"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.profiling-0.4.0-apm_error_grouping_name",
+        "name": "metrics-apm.profiling-0.5.0-apm_error_grouping_name",
         "if": "ctx.processor?.event == 'error'"
       }
     },
     {
       "pipeline": {
-        "name": "metrics-apm.profiling-0.4.0-apm_metrics_dynamic_template",
+        "name": "metrics-apm.profiling-0.5.0-apm_metrics_dynamic_template",
         "if": "ctx.processor?.event == 'metric'"
       }
     }

--- a/apmpackage/apm/data_stream/traces/elasticsearch/ingest_pipeline/default.json
+++ b/apmpackage/apm/data_stream/traces/elasticsearch/ingest_pipeline/default.json
@@ -3,33 +3,33 @@
   "processors": [
     {
       "pipeline": {
-        "name": "traces-apm-0.4.0-apm_ingest_timestamp"
+        "name": "traces-apm-0.5.0-apm_ingest_timestamp"
       }
     },
     {
       "pipeline": {
-        "name": "traces-apm-0.4.0-apm_user_agent"
+        "name": "traces-apm-0.5.0-apm_user_agent"
       }
     },
     {
       "pipeline": {
-        "name": "traces-apm-0.4.0-apm_user_geo"
+        "name": "traces-apm-0.5.0-apm_user_geo"
       }
     },
     {
       "pipeline": {
-        "name": "traces-apm-0.4.0-apm_remove_span_metadata"
+        "name": "traces-apm-0.5.0-apm_remove_span_metadata"
       }
     },
     {
       "pipeline": {
-        "name": "traces-apm-0.4.0-apm_error_grouping_name",
+        "name": "traces-apm-0.5.0-apm_error_grouping_name",
         "if": "ctx.processor?.event == 'error'"
       }
     },
     {
       "pipeline": {
-        "name": "traces-apm-0.4.0-apm_metrics_dynamic_template",
+        "name": "traces-apm-0.5.0-apm_metrics_dynamic_template",
         "if": "ctx.processor?.event == 'metric'"
       }
     }

--- a/apmpackage/apm/manifest.yml
+++ b/apmpackage/apm/manifest.yml
@@ -1,7 +1,7 @@
 format_version: 1.0.0
 name: apm
 title: Elastic APM
-version: 0.4.0
+version: 0.5.0
 license: basic
 description: Ingest APM data
 type: integration

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -32,6 +32,7 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 - experimental support for writing data streams in standalone mode {pull}5928[5928]
 - Data streams now define a default `dynamic` mapping parameter, overridable in the `<data-stream>@custom` template {pull}5947[5947]
 - The `error.log.message` or `error.exception.message` field of errors will be copied to the ECS field `message` {pull}5974[5974]
+- Define index sorting for internal metrics data stream {pull}6116[6116]
 
 [float]
 ==== Deprecated


### PR DESCRIPTION
## Motivation/summary

Sort internal metrics by @timestamp, to speed up time range queries.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

1. Install the package
2. Check that `metrics-apm.internal@settings` defines `index.sort` settings

## Related issues

https://github.com/elastic/apm-server/issues/5505