### PR TITLE
Add "waitReady" preconditions for Elasticsearch clients

### DIFF
--- a/beater/api/mux_test.go
+++ b/beater/api/mux_test.go
@@ -135,5 +135,6 @@ func (m muxBuilder) build(cfg *config.Config) (http.Handler, error) {
 		ratelimitStore,
 		m.SourcemapStore,
 		m.Managed,
+		func() bool { return true },
 	)
 }

--- a/beater/api/root/handler_test.go
+++ b/beater/api/root/handler_test.go
@@ -66,4 +66,20 @@ func TestRootHandler(t *testing.T) {
 			version.Commit())
 		assert.Equal(t, body, w.Body.String())
 	})
+
+	t.Run("publish_ready", func(t *testing.T) {
+		c, w := beatertest.ContextWithResponseRecorder(http.MethodGet, "/")
+		c.Authentication.Method = auth.MethodNone
+
+		Handler(HandlerConfig{
+			PublishReady: func() bool { return false },
+			Version:      "1.2.3",
+		})(c)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, fmt.Sprintf(
+			`{"build_date":"0001-01-01T00:00:00Z","build_sha":%q,"publish_ready":false,"version":"1.2.3"}`+"\n",
+			version.Commit(),
+		), w.Body.String())
+	})
 }

--- a/beater/api/root/test_approved/integration/TestRootHandler_AuthorizationMiddleware/Authorized.approved.json
+++ b/beater/api/root/test_approved/integration/TestRootHandler_AuthorizationMiddleware/Authorized.approved.json
@@ -1,5 +1,6 @@
 {
     "build_date": "0001-01-01T00:00:00Z",
     "build_sha": "unknown",
+    "publish_ready": true,
     "version": "1.2.3"
 }

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -44,6 +44,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/common/reload"
 	"github.com/elastic/beats/v7/libbeat/esleg/eslegclient"
 	"github.com/elastic/beats/v7/libbeat/instrumentation"
+	"github.com/elastic/beats/v7/libbeat/licenser"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	esoutput "github.com/elastic/beats/v7/libbeat/outputs/elasticsearch"
 	"github.com/elastic/beats/v7/libbeat/processors"
@@ -52,6 +53,7 @@ import (
 	"github.com/elastic/apm-server/beater/config"
 	"github.com/elastic/apm-server/elasticsearch"
 	"github.com/elastic/apm-server/ingest/pipeline"
+	"github.com/elastic/apm-server/kibana"
 	kibana_client "github.com/elastic/apm-server/kibana"
 	logs "github.com/elastic/apm-server/log"
 	"github.com/elastic/apm-server/model"
@@ -123,11 +125,7 @@ func NewCreator(args CreatorParams) beat.Creator {
 				return nil, errors.New("data streams must be enabled when the server is managed")
 			}
 		}
-
-		if err := bt.registerPipelineCallback(b); err != nil {
-			return nil, err
-		}
-
+		bt.registerPipelineSetupCallback(b)
 		return bt, nil
 	}
 }
@@ -389,38 +387,56 @@ func (s *serverRunner) run(listener net.Listener) error {
 		}()
 	}
 
-	fleetManaged := s.beat.Manager != nil && s.beat.Manager.Enabled()
-	if !fleetManaged && s.config.DataStreams.Enabled && s.config.DataStreams.WaitForIntegration {
-		var esClient elasticsearch.Client
-		if cfg := elasticsearchOutputConfig(s.beat); cfg != nil {
-			esConfig := elasticsearch.DefaultConfig()
-			err := cfg.Unpack(&esConfig)
-			if err != nil {
-				return err
-			}
-			esClient, err = elasticsearch.NewClient(esConfig)
-			if err != nil {
-				return err
-			}
+	g, ctx := errgroup.WithContext(s.runServerContext)
+
+	// Ensure the libbeat output and go-elasticsearch clients do not index
+	// any events to Elasticsearch before the integration is ready.
+	ready := make(chan struct{})
+	g.Go(func() error {
+		defer close(ready)
+		err := s.waitReady(ctx, kibanaClient)
+		return errors.Wrap(err, "error waiting for server to be ready")
+	})
+	callbackUUID, err := esoutput.RegisterConnectCallback(func(*eslegclient.Connection) error {
+		select {
+		case <-ready:
+			return nil
+		default:
 		}
-		if kibanaClient == nil && esClient == nil {
-			return errors.New("cannot wait for integration without either Kibana or Elasticsearch config")
-		}
-		if err := waitForIntegration(
-			s.runServerContext,
-			kibanaClient,
-			esClient,
-			s.config.DataStreams.WaitForIntegrationInterval,
-			s.tracer,
-			s.logger,
-		); err != nil {
-			return errors.Wrap(err, "error waiting for integration")
-		}
+		return errors.New("integration is not ready")
+	})
+	if err != nil {
+		return err
 	}
+	defer esoutput.DeregisterConnectCallback(callbackUUID)
+	newElasticsearchClient := func(cfg *elasticsearch.Config) (elasticsearch.Client, error) {
+		httpTransport, err := elasticsearch.NewHTTPTransport(cfg)
+		if err != nil {
+			return nil, err
+		}
+		transport := &waitReadyRoundTripper{Transport: httpTransport, ready: ready}
+		return elasticsearch.NewClientParams(elasticsearch.ClientParams{
+			Config:    cfg,
+			Transport: transport,
+		})
+	}
+
+	// Register a libbeat elasticsearch output connect callback which
+	// ensures the pipeline is installed. The callback does nothing
+	// when data streams are in use.
+	pipelineCallback := newPipelineElasticsearchConnectCallback(s.config)
+	callbackUUID, err = esoutput.RegisterConnectCallback(pipelineCallback)
+	if err != nil {
+		return err
+	}
+	defer esoutput.DeregisterConnectCallback(callbackUUID)
 
 	var sourcemapStore *sourcemap.Store
 	if s.config.RumConfig.Enabled && s.config.RumConfig.SourceMapping.Enabled {
-		store, err := newSourcemapStore(s.beat.Info, s.config.RumConfig.SourceMapping, s.fleetConfig)
+		store, err := newSourcemapStore(
+			s.beat.Info, s.config.RumConfig.SourceMapping, s.fleetConfig,
+			newElasticsearchClient,
+		)
 		if err != nil {
 			return err
 		}
@@ -468,19 +484,96 @@ func (s *serverRunner) run(listener net.Listener) error {
 		}
 	}
 
-	if err := runServer(s.runServerContext, ServerParams{
-		Info:           s.beat.Info,
-		Config:         s.config,
-		Managed:        s.beat.Manager != nil && s.beat.Manager.Enabled(),
-		Namespace:      s.namespace,
-		Logger:         s.logger,
-		Tracer:         s.tracer,
-		BatchProcessor: batchProcessor,
-		SourcemapStore: sourcemapStore,
-	}); err != nil {
+	g.Go(func() error {
+		return runServer(ctx, ServerParams{
+			Info:                   s.beat.Info,
+			Config:                 s.config,
+			Managed:                s.beat.Manager != nil && s.beat.Manager.Enabled(),
+			Namespace:              s.namespace,
+			Logger:                 s.logger,
+			Tracer:                 s.tracer,
+			BatchProcessor:         batchProcessor,
+			SourcemapStore:         sourcemapStore,
+			NewElasticsearchClient: newElasticsearchClient,
+		})
+	})
+	if err := g.Wait(); err != nil {
 		return err
 	}
 	return publisher.Stop(s.backgroundContext)
+}
+
+// waitReady waits until the server is ready to index events.
+func (s *serverRunner) waitReady(ctx context.Context, kibanaClient kibana.Client) error {
+	var preconditions []func(context.Context) error
+	var esOutputClient elasticsearch.Client
+	if cfg := elasticsearchOutputConfig(s.beat); cfg != nil {
+		esConfig := elasticsearch.DefaultConfig()
+		err := cfg.Unpack(&esConfig)
+		if err != nil {
+			return err
+		}
+		esOutputClient, err = elasticsearch.NewClient(esConfig)
+		if err != nil {
+			return err
+		}
+	}
+
+	// libbeat and go-elasticsearch both ensure a minimum level of Basic.
+	//
+	// If any configured features require a higher license level, add a
+	// precondition which checks this.
+	if esOutputClient != nil {
+		requiredLicenseLevel := licenser.Basic
+		licensedFeature := ""
+		if s.config.Sampling.Tail.Enabled {
+			requiredLicenseLevel = licenser.Platinum
+			licensedFeature = "tail-based sampling"
+		}
+		if requiredLicenseLevel > licenser.Basic {
+			preconditions = append(preconditions, func(ctx context.Context) error {
+				license, err := elasticsearch.GetLicense(ctx, esOutputClient)
+				if err != nil {
+					return errors.Wrap(err, "error getting Elasticsearch licensing information")
+				}
+				if licenser.IsExpired(license) {
+					return errors.New("Elasticsearch license is expired")
+				}
+				if license.Type == licenser.Trial || license.Cover(requiredLicenseLevel) {
+					return nil
+				}
+				return fmt.Errorf(
+					"invalid license level %s: %s requires license level %s",
+					license.Type, licensedFeature, requiredLicenseLevel,
+				)
+			})
+		}
+	}
+
+	// When running standalone with data streams enabled, by default we will add
+	// a precondition that ensures the integration is installed.
+	fleetManaged := s.beat.Manager != nil && s.beat.Manager.Enabled()
+	if !fleetManaged && s.config.DataStreams.Enabled && s.config.DataStreams.WaitForIntegration {
+		if kibanaClient == nil && esOutputClient == nil {
+			return errors.New("cannot wait for integration without either Kibana or Elasticsearch config")
+		}
+		preconditions = append(preconditions, func(ctx context.Context) error {
+			return checkIntegrationInstalled(ctx, kibanaClient, esOutputClient, s.logger)
+		})
+	}
+
+	if len(preconditions) == 0 {
+		return nil
+	}
+	check := func(ctx context.Context) error {
+		for _, pre := range preconditions {
+			if err := pre(ctx); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return waitReady(ctx, s.config.WaitReadyInterval, s.tracer, s.logger, check)
 }
 
 // newFinalBatchProcessor returns the final model.BatchProcessor that publishes events.
@@ -550,14 +643,12 @@ func hasElasticsearchOutput(b *beat.Beat) bool {
 	return b.Config != nil && b.Config.Output.Name() == "elasticsearch"
 }
 
-// registerPipelineCallback registers an Elasticsearch connection callback
-// that ensures the configured pipeline is installed, if configured to do
-// so. If data streams are enabled, then pipeline registration is always
-// disabled and `setup --pipelines` will return an error.
-func (bt *beater) registerPipelineCallback(b *beat.Beat) error {
+// registerPipelineCallback registers a callback which is invoked when
+// `setup --pipelines` is called, to either register pipelines or return
+// an error depending on the configuration.
+func (bt *beater) registerPipelineSetupCallback(b *beat.Beat) {
 	if !hasElasticsearchOutput(b) {
 		bt.logger.Info("Output is not Elasticsearch: pipeline registration disabled")
-		return nil
 	}
 
 	if bt.config.DataStreams.Enabled {
@@ -565,12 +656,10 @@ func (bt *beater) registerPipelineCallback(b *beat.Beat) error {
 		b.OverwritePipelinesCallback = func(esConfig *common.Config) error {
 			return errors.New("index pipeline setup must be performed externally when using data streams, by installing the 'apm' integration package")
 		}
-		return nil
 	}
 
 	if !bt.config.Register.Ingest.Pipeline.Enabled {
 		bt.logger.Info("Pipeline registration disabled")
-		return nil
 	}
 
 	bt.logger.Info("Registering pipeline callback")
@@ -585,11 +674,21 @@ func (bt *beater) registerPipelineCallback(b *beat.Beat) error {
 		}
 		return pipeline.RegisterPipelines(conn, overwrite, path)
 	}
-	// ensure pipelines are registered when new ES connection is established.
-	_, err := esoutput.RegisterConnectCallback(func(conn *eslegclient.Connection) error {
+}
+
+// newPipelineElasticsearchConnectCallback returns an Elasticsearch connect
+// callback that ensures the configured pipeline is installed, if configured
+// to do so. If data streams are enabled, then pipeline registration is always
+// disabled.
+func newPipelineElasticsearchConnectCallback(cfg *config.Config) esoutput.ConnectCallback {
+	return func(conn *eslegclient.Connection) error {
+		if cfg.DataStreams.Enabled || !cfg.Register.Ingest.Pipeline.Enabled {
+			return nil
+		}
+		overwrite := cfg.Register.Ingest.Pipeline.Overwrite
+		path := cfg.Register.Ingest.Pipeline.Path
 		return pipeline.RegisterPipelines(conn, overwrite, path)
-	})
-	return err
+	}
 }
 
 func initTracing(b *beat.Beat, cfg *config.Config, logger *logp.Logger) (*apm.Tracer, *tracerServer, error) {
@@ -677,7 +776,12 @@ func runServerWithTracerServer(runServer RunServerFunc, tracerServer *tracerServ
 	}
 }
 
-func newSourcemapStore(beatInfo beat.Info, cfg config.SourceMapping, fleetCfg *config.Fleet) (*sourcemap.Store, error) {
+func newSourcemapStore(
+	beatInfo beat.Info,
+	cfg config.SourceMapping,
+	fleetCfg *config.Fleet,
+	newElasticsearchClient func(*elasticsearch.Config) (elasticsearch.Client, error),
+) (*sourcemap.Store, error) {
 	if fleetCfg != nil {
 		var (
 			c  = *http.DefaultClient
@@ -691,7 +795,6 @@ func newSourcemapStore(beatInfo beat.Info, cfg config.SourceMapping, fleetCfg *c
 			}
 		}
 
-		// Default for es is 90s :shrug:
 		timeout := 30 * time.Second
 		dialer := transport.NetDialer(timeout)
 		tlsDialer := transport.TLSDialer(dialer, tlsConfig, timeout)
@@ -706,7 +809,7 @@ func newSourcemapStore(beatInfo beat.Info, cfg config.SourceMapping, fleetCfg *c
 		c.Transport = apmhttp.WrapRoundTripper(rt)
 		return sourcemap.NewFleetStore(&c, fleetCfg, cfg.Metadata, cfg.Cache.Expiration)
 	}
-	c, err := elasticsearch.NewClient(cfg.ESConfig)
+	c, err := newElasticsearchClient(cfg.ESConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -54,7 +54,6 @@ import (
 	"github.com/elastic/apm-server/elasticsearch"
 	"github.com/elastic/apm-server/ingest/pipeline"
 	"github.com/elastic/apm-server/kibana"
-	kibana_client "github.com/elastic/apm-server/kibana"
 	logs "github.com/elastic/apm-server/log"
 	"github.com/elastic/apm-server/model"
 	"github.com/elastic/apm-server/model/modelprocessor"
@@ -370,9 +369,9 @@ func (s *serverRunner) run(listener net.Listener) error {
 		publisherConfig.Processor = dropLogsProcessor
 	}
 
-	var kibanaClient kibana_client.Client
+	var kibanaClient kibana.Client
 	if s.config.Kibana.Enabled {
-		kibanaClient = kibana_client.NewConnectingClient(&s.config.Kibana)
+		kibanaClient = kibana.NewConnectingClient(&s.config.Kibana)
 	}
 
 	cfg := ucfg.Config(*s.rawConfig)
@@ -381,7 +380,7 @@ func (s *serverRunner) run(listener net.Listener) error {
 	if eac := os.Getenv("ELASTIC_AGENT_CLOUD"); eac != "" && s.config.Kibana.Enabled {
 		// Don't block server startup sending the config.
 		go func() {
-			if err := kibana_client.SendConfig(s.runServerContext, kibanaClient, parentCfg); err != nil {
+			if err := kibana.SendConfig(s.runServerContext, kibanaClient, parentCfg); err != nil {
 				s.logger.Infof("failed to upload config to kibana: %v", err)
 			}
 		}()

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -649,6 +649,7 @@ func hasElasticsearchOutput(b *beat.Beat) bool {
 func (bt *beater) registerPipelineSetupCallback(b *beat.Beat) {
 	if !hasElasticsearchOutput(b) {
 		bt.logger.Info("Output is not Elasticsearch: pipeline registration disabled")
+		return
 	}
 
 	if bt.config.DataStreams.Enabled {
@@ -656,10 +657,12 @@ func (bt *beater) registerPipelineSetupCallback(b *beat.Beat) {
 		b.OverwritePipelinesCallback = func(esConfig *common.Config) error {
 			return errors.New("index pipeline setup must be performed externally when using data streams, by installing the 'apm' integration package")
 		}
+		return
 	}
 
 	if !bt.config.Register.Ingest.Pipeline.Enabled {
 		bt.logger.Info("Pipeline registration disabled")
+		return
 	}
 
 	bt.logger.Info("Registering pipeline callback")

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -43,8 +43,10 @@ import (
 	"github.com/elastic/apm-server/model"
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/idxmgmt"
 	"github.com/elastic/beats/v7/libbeat/instrumentation"
 	"github.com/elastic/beats/v7/libbeat/logp"
+	"github.com/elastic/beats/v7/libbeat/outputs"
 )
 
 type testBeater struct {
@@ -96,9 +98,16 @@ func newBeat(t *testing.T, cfg *common.Config, beatConfig *beat.BeatConfig, even
 
 	var pub beat.Pipeline
 	if events != nil {
-		// capture events
+		// capture events using the supplied channel
 		pubClient := newChanClientWith(events)
 		pub = dummyPipeline(cfg, info, pubClient)
+	} else if beatConfig != nil && beatConfig.Output.Name() == "elasticsearch" {
+		// capture events using the configured elasticsearch output
+		supporter, err := idxmgmt.DefaultSupport(logp.NewLogger("beater_test"), info, nil)
+		require.NoError(t, err)
+		outputGroup, err := outputs.Load(supporter, info, nil, "elasticsearch", beatConfig.Output.Config())
+		require.NoError(t, err)
+		pub = dummyPipeline(cfg, info, outputGroup.Clients...)
 	} else {
 		// don't capture events
 		pub = dummyPipeline(cfg, info)
@@ -254,7 +263,10 @@ func TestTransformConfigIndex(t *testing.T) {
 			cfg.RumConfig.SourceMapping.IndexPattern = indexPattern
 		}
 
-		store, err := newSourcemapStore(beat.Info{Version: "1.2.3"}, cfg.RumConfig.SourceMapping, nil)
+		store, err := newSourcemapStore(
+			beat.Info{Version: "1.2.3"}, cfg.RumConfig.SourceMapping, nil,
+			elasticsearch.NewClient,
+		)
 		require.NoError(t, err)
 		store.NotifyAdded(context.Background(), "name", "version", "path")
 		require.Len(t, requestPaths, 1)
@@ -284,7 +296,10 @@ func TestStoreUsesRUMElasticsearchConfig(t *testing.T) {
 	cfg.RumConfig.SourceMapping.ESConfig = elasticsearch.DefaultConfig()
 	cfg.RumConfig.SourceMapping.ESConfig.Hosts = []string{ts.URL}
 
-	store, err := newSourcemapStore(beat.Info{Version: "1.2.3"}, cfg.RumConfig.SourceMapping, nil)
+	store, err := newSourcemapStore(
+		beat.Info{Version: "1.2.3"}, cfg.RumConfig.SourceMapping, nil,
+		elasticsearch.NewClient,
+	)
 	require.NoError(t, err)
 	// Check that the provided rum elasticsearch config was used and
 	// Fetch() goes to the test server.
@@ -321,7 +336,7 @@ func TestFleetStoreUsed(t *testing.T) {
 		TLS:          nil,
 	}
 
-	store, err := newSourcemapStore(beat.Info{Version: "1.2.3"}, cfg.RumConfig.SourceMapping, fleetCfg)
+	store, err := newSourcemapStore(beat.Info{Version: "1.2.3"}, cfg.RumConfig.SourceMapping, fleetCfg, nil)
 	require.NoError(t, err)
 	_, err = store.Fetch(context.Background(), "app", "1.0", "/bundle/path")
 	require.NoError(t, err)

--- a/beater/config/config.go
+++ b/beater/config/config.go
@@ -77,6 +77,11 @@ type Config struct {
 	Pipeline string
 
 	AgentConfigs []AgentConfig `config:"agent_config"`
+
+	// WaitReadyInterval holds the interval for checks when waiting for
+	// the integration package to be installed, and for checking the
+	// Elasticsearch license level.
+	WaitReadyInterval time.Duration `config:"wait_ready_interval"`
 }
 
 // NewConfig creates a Config struct based on the default config and the given input params
@@ -235,5 +240,6 @@ func DefaultConfig() *Config {
 		DataStreams:         defaultDataStreamsConfig(),
 		AgentAuth:           defaultAgentAuth(),
 		JavaAttacherConfig:  defaultJavaAttacherConfig(),
+		WaitReadyInterval:   5 * time.Second,
 	}
 }

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -290,10 +290,10 @@ func TestUnpackConfig(t *testing.T) {
 				},
 				DefaultServiceEnvironment: "overridden",
 				DataStreams: DataStreamsConfig{
-					Enabled:                    false,
-					WaitForIntegration:         true,
-					WaitForIntegrationInterval: 5 * time.Second,
+					Enabled:            false,
+					WaitForIntegration: true,
 				},
+				WaitReadyInterval: 5 * time.Second,
 			},
 		},
 		"merge config with default": {
@@ -479,10 +479,10 @@ func TestUnpackConfig(t *testing.T) {
 					},
 				},
 				DataStreams: DataStreamsConfig{
-					Enabled:                    false,
-					WaitForIntegration:         false,
-					WaitForIntegrationInterval: 5 * time.Second,
+					Enabled:            false,
+					WaitForIntegration: false,
 				},
+				WaitReadyInterval: 5 * time.Second,
 			},
 		},
 		"kibana trailing slash": {

--- a/beater/server.go
+++ b/beater/server.go
@@ -41,6 +41,7 @@ import (
 	"github.com/elastic/apm-server/beater/jaeger"
 	"github.com/elastic/apm-server/beater/otlp"
 	"github.com/elastic/apm-server/beater/ratelimit"
+	"github.com/elastic/apm-server/elasticsearch"
 	"github.com/elastic/apm-server/model"
 	"github.com/elastic/apm-server/model/modelprocessor"
 	"github.com/elastic/apm-server/publish"
@@ -79,6 +80,14 @@ type ServerParams struct {
 	// BatchProcessor is the model.BatchProcessor that is used
 	// for publishing events to the output, such as Elasticsearch.
 	BatchProcessor model.BatchProcessor
+
+	// NewElasticsearchClient returns an elasticsearch.Client for cfg.
+	//
+	// This must be used whenever an elasticsearch client might be used
+	// for indexing. Under some configuration, the server will wrap the
+	// client's transport such that requests will be blocked until data
+	// streams have been initialised.
+	NewElasticsearchClient func(cfg *elasticsearch.Config) (elasticsearch.Client, error)
 }
 
 // newBaseRunServer returns the base RunServerFunc.

--- a/beater/tracing.go
+++ b/beater/tracing.go
@@ -77,8 +77,9 @@ func newTracerServer(listener net.Listener, logger *logp.Logger) (*tracerServer,
 		authenticator,
 		agentcfg.NewFetcher(cfg),
 		ratelimitStore,
-		nil,   // no sourcemap store
-		false, // not managed
+		nil,                         // no sourcemap store
+		false,                       // not managed
+		func() bool { return true }, // ready for publishing
 	)
 	if err != nil {
 		return nil, err

--- a/beater/waitready.go
+++ b/beater/waitready.go
@@ -1,0 +1,84 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beater
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"go.elastic.co/apm"
+
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+// waitReady waits for preconditions to be satisfied, by calling check
+// in a loop every interval until ctx is cancelled or check returns nil.
+func waitReady(
+	ctx context.Context,
+	interval time.Duration,
+	tracer *apm.Tracer,
+	logger *logp.Logger,
+	check func(context.Context) error,
+) error {
+	logger.Info("waiting for preconditions")
+	tx := tracer.StartTransaction("wait_for_preconditions", "init")
+	ctx = apm.ContextWithTransaction(ctx, tx)
+	var ticker *time.Ticker
+	for {
+		if ticker == nil {
+			// We start the ticker on the first iteration, rather than
+			// before the loop, so we don't have to wait for a tick
+			// (5 seconds by default) before peforming the first check.
+			ticker = time.NewTicker(interval)
+			defer ticker.Stop()
+		} else {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-ticker.C:
+			}
+		}
+		if err := check(ctx); err != nil {
+			logger.Errorf("error checking preconditions: %s", err)
+			continue
+		}
+		return nil
+	}
+}
+
+// waitReadyRoundTripper wraps a *net/http.Transport, ensuring the server's
+// indexing preconditions have been satisfied by waiting for "ready" channel
+// to be signalled, prior to allowing any requests through.
+//
+// This is used to prevent elasticsearch clients from proceeding with requests
+// until the APM integration is installed to ensure we don't index any documents
+// prior to the data stream index templates being ready.
+type waitReadyRoundTripper struct {
+	*http.Transport
+	ready <-chan struct{}
+}
+
+func (c *waitReadyRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	select {
+	case <-c.ready:
+	case <-r.Context().Done():
+		return nil, r.Context().Err()
+	}
+	return c.Transport.RoundTrip(r)
+}

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -37,6 +37,7 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 - Define index sorting for internal metrics data stream {pull}6116[6116]
 - Add histogram dynamic_template to app metrics data stream {pull}6043[6043]
 - Index OpenTelemetry span events and Jaeger logs into a log data stream {pull}6122[6122]
+- With `apm-server.data_streams.enabled` in standalone mode, the server now accepts and enqueues events while waiting for the integration to be installed {pull}6130[6130]
 
 [float]
 ==== Deprecated

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -107,7 +107,7 @@ type ClientParams struct {
 	// to Elasticsearch.
 	//
 	// If Transport is nil, then a net/http.Transport will be constructed
-	// using Config.
+	// with NewHTTPTransport(Config).
 	Transport http.RoundTripper
 }
 
@@ -125,7 +125,7 @@ func NewClientParams(args ClientParams) (Client, error) {
 
 	transport := args.Transport
 	if transport == nil {
-		httpTransport, err := httpTransport(args.Config)
+		httpTransport, err := NewHTTPTransport(args.Config)
 		if err != nil {
 			return nil, err
 		}

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -97,32 +97,71 @@ func (c clientV7) NewBulkIndexer(config BulkIndexerConfig) (BulkIndexer, error) 
 	return v7BulkIndexer{indexer}, nil
 }
 
-// NewClient parses the given config and returns  a version-aware client as an interface
+// ClientParams holds parameters for NewClientParams.
+type ClientParams struct {
+	// Config holds the user-defined configuration: Elasticsearch hosts,
+	// max retries, etc.
+	Config *Config
+
+	// Transport holds a net/http.RoundTripper to use for sending requests
+	// to Elasticsearch.
+	//
+	// If Transport is nil, then a net/http.Transport will be constructed
+	// using Config.
+	Transport http.RoundTripper
+}
+
+// NewClient returns a stack version-aware Elasticsearch client,
+// equivalent to NewClientParams(ClientParams{Config: config}).
 func NewClient(config *Config) (Client, error) {
-	if config == nil {
+	return NewClientParams(ClientParams{Config: config})
+}
+
+// NewClientParams returns a stack version-aware Elasticsearch client.
+func NewClientParams(args ClientParams) (Client, error) {
+	if args.Config == nil {
 		return nil, errConfigMissing
 	}
-	transport, addresses, headers, err := connectionConfig(config)
+
+	transport := args.Transport
+	if transport == nil {
+		httpTransport, err := httpTransport(args.Config)
+		if err != nil {
+			return nil, err
+		}
+		transport = httpTransport
+	}
+
+	addrs, err := addresses(args.Config)
 	if err != nil {
 		return nil, err
 	}
-	backoff := exponentialBackoff(config.Backoff)
-	return NewVersionedClient(config.APIKey, config.Username, config.Password, addresses, headers, transport, config.MaxRetries, backoff)
-}
 
-// NewVersionedClient returns the right elasticsearch client for the current Stack version, as an interface
-func NewVersionedClient(apikey, user, pwd string, addresses []string, headers http.Header, transport http.RoundTripper, maxRetries int, backoff backoffFunc) (Client, error) {
-	if apikey != "" {
-		apikey = base64.StdEncoding.EncodeToString([]byte(apikey))
+	var headers http.Header
+	if len(args.Config.Headers) > 0 {
+		headers = make(http.Header, len(args.Config.Headers))
+		for k, v := range args.Config.Headers {
+			headers.Set(k, v)
+		}
 	}
-	transport = apmelasticsearch.WrapRoundTripper(transport)
-	version := common.MustNewVersion(version.GetDefaultVersion())
-	if version.IsMajor(8) {
-		c, err := newV8Client(apikey, user, pwd, addresses, headers, transport, maxRetries, backoff)
-		return clientV8{c}, err
+
+	var apikey string
+	if args.Config.APIKey != "" {
+		apikey = base64.StdEncoding.EncodeToString([]byte(args.Config.APIKey))
 	}
-	c, err := newV7Client(apikey, user, pwd, addresses, headers, transport, maxRetries, backoff)
-	return clientV7{c}, err
+
+	newClient := newV7Client
+	if version := common.MustNewVersion(version.GetDefaultVersion()); version.IsMajor(8) {
+		newClient = newV8Client
+	}
+	return newClient(
+		apikey, args.Config.Username, args.Config.Password,
+		addrs,
+		headers,
+		apmelasticsearch.WrapRoundTripper(transport),
+		args.Config.MaxRetries,
+		exponentialBackoff(args.Config.Backoff),
+	)
 }
 
 func newV7Client(
@@ -132,8 +171,8 @@ func newV7Client(
 	transport http.RoundTripper,
 	maxRetries int,
 	fn backoffFunc,
-) (*esv7.Client, error) {
-	return esv7.NewClient(esv7.Config{
+) (Client, error) {
+	c, err := esv7.NewClient(esv7.Config{
 		APIKey:               apikey,
 		Username:             user,
 		Password:             pwd,
@@ -145,6 +184,10 @@ func newV7Client(
 		RetryBackoff:         fn,
 		MaxRetries:           maxRetries,
 	})
+	if err != nil {
+		return nil, err
+	}
+	return clientV7{c}, nil
 }
 
 func newV8Client(
@@ -154,8 +197,8 @@ func newV8Client(
 	transport http.RoundTripper,
 	maxRetries int,
 	fn backoffFunc,
-) (*esv8.Client, error) {
-	return esv8.NewClient(esv8.Config{
+) (Client, error) {
+	c, err := esv8.NewClient(esv8.Config{
 		APIKey:               apikey,
 		Username:             user,
 		Password:             pwd,
@@ -167,6 +210,10 @@ func newV8Client(
 		RetryBackoff:         fn,
 		MaxRetries:           maxRetries,
 	})
+	if err != nil {
+		return nil, err
+	}
+	return clientV8{c}, nil
 }
 
 func doRequest(ctx context.Context, transport esapiv7.Transport, req esapiv7.Request, out interface{}) error {

--- a/elasticsearch/client.go
+++ b/elasticsearch/client.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"io"
 	"io/ioutil"
 	"net/http"
 
@@ -50,27 +49,10 @@ type Client interface {
 
 	// Perform satisfies esapi.Transport
 	Perform(*http.Request) (*http.Response, error)
-
-	// TODO: deprecate
-	SearchQuery(ctx context.Context, index string, body io.Reader) (int, io.ReadCloser, error)
 }
 
 type clientV8 struct {
 	*esv8.Client
-}
-
-func (c clientV8) SearchQuery(ctx context.Context, index string, body io.Reader) (int, io.ReadCloser, error) {
-	response, err := c.Search(
-		c.Search.WithContext(ctx),
-		c.Search.WithIndex(index),
-		c.Search.WithBody(body),
-		c.Search.WithTrackTotalHits(true),
-		c.Search.WithPretty(),
-	)
-	if err != nil {
-		return 0, nil, err
-	}
-	return response.StatusCode, response.Body, nil
 }
 
 func (c clientV8) NewBulkIndexer(config BulkIndexerConfig) (BulkIndexer, error) {
@@ -94,20 +76,6 @@ func (c clientV8) NewBulkIndexer(config BulkIndexerConfig) (BulkIndexer, error) 
 
 type clientV7 struct {
 	*esv7.Client
-}
-
-func (c clientV7) SearchQuery(ctx context.Context, index string, body io.Reader) (int, io.ReadCloser, error) {
-	response, err := c.Search(
-		c.Search.WithContext(ctx),
-		c.Search.WithIndex(index),
-		c.Search.WithBody(body),
-		c.Search.WithTrackTotalHits(true),
-		c.Search.WithPretty(),
-	)
-	if err != nil {
-		return 0, nil, err
-	}
-	return response.StatusCode, response.Body, nil
 }
 
 func (c clientV7) NewBulkIndexer(config BulkIndexerConfig) (BulkIndexer, error) {

--- a/elasticsearch/config.go
+++ b/elasticsearch/config.go
@@ -115,7 +115,8 @@ func addresses(cfg *Config) ([]string, error) {
 	return addresses, nil
 }
 
-func httpTransport(cfg *Config) (*http.Transport, error) {
+// NewHTTPTransport returns a new net/http.Transport for cfg.
+func NewHTTPTransport(cfg *Config) (*http.Transport, error) {
 	proxy, err := httpProxyURL(cfg)
 	if err != nil {
 		return nil, err

--- a/elasticsearch/config.go
+++ b/elasticsearch/config.go
@@ -83,25 +83,6 @@ func (h Hosts) Validate() error {
 	return nil
 }
 
-func connectionConfig(config *Config) (http.RoundTripper, []string, http.Header, error) {
-	addrs, err := addresses(config)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	transp, err := httpTransport(config)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	var headers http.Header
-	if len(config.Headers) > 0 {
-		headers = make(http.Header)
-		for k, v := range config.Headers {
-			headers.Set(k, v)
-		}
-	}
-	return transp, addrs, headers, nil
-}
-
 func httpProxyURL(cfg *Config) (func(*http.Request) (*url.URL, error), error) {
 	if cfg.ProxyDisable {
 		return nil, nil

--- a/elasticsearch/license.go
+++ b/elasticsearch/license.go
@@ -15,26 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package config
+package elasticsearch
 
-// DataStreamsConfig holds data streams configuration.
-type DataStreamsConfig struct {
-	Enabled bool `config:"enabled"`
+import (
+	"context"
 
-	// WaitForIntegration controls whether APM Server waits for the Fleet
-	// integration package to be installed before indexing events.
-	//
-	// This config is ignored when running under Elastic Agent; it is intended
-	// for running APM Server standalone, relying on Fleet to install the integration
-	// for creating Elasticsearch index templates, ILM policies, and ingest pipelines.
-	//
-	// This configuration requires either a connection to Kibana or Elasticsearch.
-	WaitForIntegration bool `config:"wait_for_integration"`
-}
+	"github.com/elastic/beats/v7/libbeat/licenser"
+	"github.com/elastic/go-elasticsearch/v7/esapi"
+)
 
-func defaultDataStreamsConfig() DataStreamsConfig {
-	return DataStreamsConfig{
-		Enabled:            false,
-		WaitForIntegration: true,
+// GetLicense gets the Elasticsearch licensing information.
+func GetLicense(ctx context.Context, client Client) (licenser.License, error) {
+	var result struct {
+		License licenser.License `json:"license"`
 	}
+	req := esapi.LicenseGetRequest{}
+	if err := doRequest(ctx, client, req, &result); err != nil {
+		return licenser.License{}, err
+	}
+	return result.License, nil
 }

--- a/sourcemap/es_store_test.go
+++ b/sourcemap/es_store_test.go
@@ -155,8 +155,10 @@ func newUnavailableElasticsearchClient(t testing.TB) elasticsearch.Client {
 	var transport roundTripperFunc = func(r *http.Request) (*http.Response, error) {
 		return nil, errors.New("client error")
 	}
-	backoff := func(int) time.Duration { return 0 }
-	client, err := elasticsearch.NewVersionedClient("", "", "", []string{"testing.invalid"}, nil, transport, 1, backoff)
+	cfg := elasticsearch.DefaultConfig()
+	cfg.Hosts = []string{"testing.invalid"}
+	cfg.MaxRetries = 1
+	client, err := elasticsearch.NewClientParams(elasticsearch.ClientParams{Config: cfg, Transport: transport})
 	require.NoError(t, err)
 	return client
 }

--- a/sourcemap/processor_test.go
+++ b/sourcemap/processor_test.go
@@ -262,7 +262,13 @@ func TestBatchProcessorTimeout(t *testing.T) {
 		<-req.Context().Done()
 		return nil, req.Context().Err()
 	}
-	client, err := elasticsearch.NewVersionedClient("", "", "", []string{""}, nil, transport, 3, elasticsearch.DefaultBackoff)
+
+	cfg := elasticsearch.DefaultConfig()
+	cfg.Hosts = []string{""}
+	client, err := elasticsearch.NewClientParams(elasticsearch.ClientParams{
+		Config:    cfg,
+		Transport: transport,
+	})
 	require.NoError(t, err)
 	store, err := NewElasticsearchStore(client, "index", time.Minute)
 	require.NoError(t, err)

--- a/systemtest/apmservertest/server.go
+++ b/systemtest/apmservertest/server.go
@@ -426,6 +426,14 @@ func (s *Server) Close() error {
 	return s.Wait()
 }
 
+// Kill forcefully shuts down the server.
+func (s *Server) Kill() error {
+	if s.cmd != nil {
+		s.cmd.Process.Kill()
+	}
+	return s.Wait()
+}
+
 // Wait waits for the server to exit.
 //
 // Wait waits up to 10 seconds for the process's stderr to be closed,

--- a/x-pack/apm-server/main.go
+++ b/x-pack/apm-server/main.go
@@ -6,21 +6,16 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/elastic/beats/v7/libbeat/esleg/eslegclient"
-	"github.com/elastic/beats/v7/libbeat/licenser"
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/beats/v7/libbeat/monitoring"
-	libes "github.com/elastic/beats/v7/libbeat/outputs/elasticsearch"
 	"github.com/elastic/beats/v7/libbeat/paths"
 
 	"github.com/elastic/apm-server/beater"
-	"github.com/elastic/apm-server/elasticsearch"
 	"github.com/elastic/apm-server/model"
 	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/spanmetrics"
 	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/txmetrics"
@@ -93,44 +88,13 @@ func newProcessors(args beater.ServerParams) ([]namedProcessor, error) {
 	return processors, nil
 }
 
-// licensePlatinumCovered fails if license is neither a valid trial nor a valid platinum license.
-func licensePlatinumCovered(client *eslegclient.Connection) error {
-	log := logp.NewLogger("elasticsearch")
-	fetcher := licenser.NewElasticFetcher(client)
-	license, err := fetcher.Fetch()
-	if err != nil {
-		return fmt.Errorf("could not connect to a compatible version of Elasticsearch: %w", err)
-	}
-	if licenser.IsExpired(license) {
-		log.Errorf("%s license is expired", license.Type)
-		const errorMessage = "Elasticsearch license is not active, please check Elasticsearch's licensing information at https://www.elastic.co/subscriptions."
-		return errors.New(errorMessage)
-	}
-	licenseToCover := licenser.Platinum
-	log.Infof("Checking license for tail-based sampling covers %s", licenseToCover)
-	if license.Cover(licenseToCover) || license.Type == licenser.Trial {
-		return nil
-	}
-	return fmt.Errorf("invalid license found, tail-based sampling requires a %s or a valid trial license and received %s",
-		licenseToCover, license.Type,
-	)
-}
-
 func newTailSamplingProcessor(args beater.ServerParams) (*sampling.Processor, error) {
 	if !args.Config.DataStreams.Enabled {
 		return nil, errors.New("tail-based sampling requires data streams")
 	}
 
-	// Tail-based sampling is a Platinum-licensed feature.
-	//
-	// FIXME(axw) each time libes.RegisterGlobalCallback is called an additional global
-	// callback is registered with Elasticsearch, which fetches the license
-	// and checks it. The root command already calls libes.RegisterGlobalCallback for
-	// license basic or above. We need to make this overridable to avoid redundant checks.
-	libes.RegisterGlobalCallback(licensePlatinumCovered)
-
 	tailSamplingConfig := args.Config.Sampling.Tail
-	es, err := elasticsearch.NewClient(tailSamplingConfig.ESConfig)
+	es, err := args.NewElasticsearchClient(tailSamplingConfig.ESConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create Elasticsearch client for tail-sampling")
 	}

--- a/x-pack/apm-server/main_test.go
+++ b/x-pack/apm-server/main_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/elastic/apm-server/beater"
 	"github.com/elastic/apm-server/beater/config"
+	"github.com/elastic/apm-server/elasticsearch"
 	"github.com/elastic/apm-server/model/modelprocessor"
 )
 
@@ -71,12 +72,13 @@ func TestMonitoring(t *testing.T) {
 	// Call the wrapped runServer twice, to ensure metric registration does not panic.
 	for i := 0; i < 2; i++ {
 		err := runServer(context.Background(), beater.ServerParams{
-			Config:         cfg,
-			Logger:         logp.NewLogger(""),
-			Tracer:         apmtest.DiscardTracer,
-			BatchProcessor: modelprocessor.Nop{},
-			Managed:        true,
-			Namespace:      "default",
+			Config:                 cfg,
+			Logger:                 logp.NewLogger(""),
+			Tracer:                 apmtest.DiscardTracer,
+			BatchProcessor:         modelprocessor.Nop{},
+			Managed:                true,
+			Namespace:              "default",
+			NewElasticsearchClient: elasticsearch.NewClient,
 		})
 		assert.Equal(t, runServerError, err)
 		assert.NotEqual(t, monitoring.MakeFlatSnapshot(), aggregationMonitoringSnapshot)

--- a/x-pack/apm-server/sampling/pubsub/pubsubtest/client.go
+++ b/x-pack/apm-server/sampling/pubsub/pubsubtest/client.go
@@ -80,16 +80,10 @@ func (f SubscriberFunc) Subscribe(ctx context.Context) (string, error) {
 // requests by calling sub (if non-nil). If either function is nil, then the
 // respective operation will be a no-op.
 func Client(pub Publisher, sub Subscriber) elasticsearch.Client {
-	client, err := elasticsearch.NewVersionedClient(
-		"",                          // API Key
-		"",                          // user
-		"",                          // password,
-		[]string{"testing.invalid"}, // addresses
-		nil,                         // headers
-		&channelClientRoundTripper{pub: pub, sub: sub},
-		3,
-		elasticsearch.DefaultBackoff,
-	)
+	client, err := elasticsearch.NewClientParams(elasticsearch.ClientParams{
+		Config:    elasticsearch.DefaultConfig(),
+		Transport: &channelClientRoundTripper{pub: pub, sub: sub},
+	})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Motivation/summary

When configured for standalone+data streams, we wait for the integration to be installed. This is now checked asynchronously, blocking Elasticsearch client requests rather than the server starting up. This allows events to be received, processed, and enqueued, but not indexed until the integration is installed. The tail-based sampling license check has been moved to this new wait loop, and uses the go-elasticsearch client to fetch the license instead of libbeat.

We add a "NewElasticsearchClient" function to beater.ServerParams, which should be used to construct `elasticsearch.Clients` wherever the client may be used to perform indexing operations. The elasticsearch package API has been simplified, and some unit tests removed as a result.

Package beater tests now have the option of publishing events using the standard libbeat elasticsearch output. We use this in the wait-for-integration test to check that events are not sent to Elasticsearch until the preconditions are met. We now deregister the pipeline registration callback when the server stops to fix tests which use the elasticsearch output, as otherwise the callback added in one test bleeds into those proceeding.

The "/" HTTP route handler now reports whether the server is "publish ready", i.e. it is ready to publish events.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

1. Run apm-server with `-E apm-server.data_streams.enabled=true`
2. Send some events, verify that they are not indexed
3. Install the integration package
4. Send some more events, verify that they are indexed

## Related issues

Closes https://github.com/elastic/apm-server/issues/5949