### PR TITLE
processor/otel: deprecate `service.version` span tag

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -40,3 +40,4 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 
 [float]
 ==== Deprecated
+- Setting `service.version` as a span tag (Jaeger) or attribute (OTel) is deprecated; use tracer tags (Jaeger) and resource attributes (OTel) {pull}6131[6131]

--- a/processor/otel/traces.go
+++ b/processor/otel/traces.go
@@ -406,6 +406,10 @@ func translateTransaction(
 			case "type":
 				event.Transaction.Type = stringval
 			case semconv.AttributeServiceVersion:
+				// NOTE support for sending service.version as a span tag
+				// is deprecated, and will be removed in 8.0. Instrumentation
+				// should set this as a resource attribute (OTel) or tracer
+				// tag (Jaeger).
 				event.Service.Version = stringval
 			case "component":
 				component = stringval


### PR DESCRIPTION
## Motivation/summary

Deprecate interpreting `service.version` as a span tag. We'll remove this in 8.0, and from then on instrumentation will have to use tracer tags (Jaeger) or resource attributes (OTel).

https://github.com/elastic/apm-server/pull/4061 added support for setting `service.version` via Jaeger span tags. In retrospect, we should not have done this; service version should be coming through as a tracer tag, as it applies to the service as a whole and not individual spans.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

https://github.com/elastic/apm-server/pull/6114#issuecomment-913274016