### PR TITLE
[automation] update elastic stack version for testing 8.0.0-467e0885

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       kibana: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-78724554-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-467e0885-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -61,7 +61,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.0.0-78724554-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.0.0-467e0885-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -85,7 +85,7 @@ services:
       package-registry: { condition: service_healthy }
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:8.0.0-78724554-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:8.0.0-467e0885-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Mon, 6 Sep 2021 12:24:23 GMT, release_branch:master, prefix:, end_time:Mon, 6 Sep 2021 19:33:54 GMT, manifest_version:2.0.0, version:8.0.0-SNAPSHOT, branch:master, build_id:8.0.0-467e0885, build_duration_seconds:25771]