### PR TITLE
apmpackage: mark package as GA

### DIFF
--- a/apmpackage/apm/manifest.yml
+++ b/apmpackage/apm/manifest.yml
@@ -6,9 +6,9 @@ license: basic
 description: Ingest APM data
 type: integration
 categories: ["elastic_stack", "monitoring"]
-release: experimental # experimental / beta / ga
+release: ga
 conditions:
-  kibana.version: "^7.13.0"
+  kibana.version: "^7.16.0"
 icons:
   - src: /img/logo_apm.svg
     title: APM Logo


### PR DESCRIPTION
## Motivation/summary

Update the integration package's release status to GA. Update the required Kibana version while we're at it.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

1. Navigate to the integrations UI in Kibana, install the APM integration
2. Check that it does not have an experimental badge like in the following screenshot

![image](https://user-images.githubusercontent.com/843579/132477327-56b45766-28e2-4c8f-87ad-96f04e760544.png)

## Related issues

https://github.com/elastic/apm-server/issues/4636