### PR TITLE
Add deprecation warnings about ES setup

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -42,3 +42,4 @@ https://github.com/elastic/apm-server/compare/7.13\...master[View commits]
 [float]
 ==== Deprecated
 - Setting `service.version` as a span tag (Jaeger) or attribute (OTel) is deprecated; use tracer tags (Jaeger) and resource attributes (OTel) {pull}6131[6131]
+- Setting up Elasticsearch templates, ILM policies, and pipelines directly with apm-server is now deprecated. Users should use the integration package {pull}6145[6145]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -112,12 +112,14 @@ func modifyBuiltinCommands(rootCmd *cmd.BeatsRootCmd, settings instance.Settings
 
 	// only add defined flags to setup command
 	setup := rootCmd.SetupCmd
-	setup.Short = "Setup Elasticsearch index management components and pipelines"
+	setup.Short = "Setup Elasticsearch index management components and pipelines (deprecated)"
 	setup.Long = `This command does initial setup of the environment:
 
  * Index management including loading Elasticsearch templates, ILM policies and write aliases.
  * Ingest pipelines
-`
+
+` + idxmgmt.SetupDeprecatedWarning + "\n"
+
 	setup.ResetFlags()
 
 	//lint:ignore SA1019 Setting up template must still be supported until next major version upgrade.

--- a/docs/configuration-process.asciidoc
+++ b/docs/configuration-process.asciidoc
@@ -188,8 +188,6 @@ The default is the number of logical CPUs available in the system.
 [float]
 === Configuration options: `data_streams`
 
-experimental::[]
-
 [[data_streams.enabled]]
 [float]
 ==== `enabled`

--- a/docs/configuring-ingest.asciidoc
+++ b/docs/configuring-ingest.asciidoc
@@ -4,6 +4,8 @@
 [[configuring-ingest-node]]
 == Parse data using ingest node pipelines
 
+deprecated::[7.16.0,Users should now use the <<apm-integration>>, which includes ingest node pipeline management. See <<apm-integration-pipelines>>]
+
 You can configure APM Server to use an {ref}/ingest.html[ingest node]
 to pre-process documents before indexing them in {es}.
 A pipeline definition specifies the series of pipelines or processors that will transform each document in a specific way.

--- a/docs/getting-started-apm-server.asciidoc
+++ b/docs/getting-started-apm-server.asciidoc
@@ -237,8 +237,7 @@ Full details are available in the {cloud}/ec-manage-apm-settings.html[APM user s
 [float]
 ===== APM integration for Elastic Agent
 
-If you're running APM Server as an Elastic Agent integration, you can configure settings via
-{fleet-guide}/agent-policy.html[Elastic Agent policies].
+If you're running the <<apm-integration>>, you can configure settings via {fleet-guide}/agent-policy.html[Elastic Agent policies].
 
 [float]
 ===== Standalone

--- a/docs/getting-started-apm-server.asciidoc
+++ b/docs/getting-started-apm-server.asciidoc
@@ -238,7 +238,7 @@ Full details are available in the {cloud}/ec-manage-apm-settings.html[APM user s
 ===== APM integration for Elastic Agent
 
 If you're running APM Server as an Elastic Agent integration, you can configure settings via
-{fleet}/agent-policy.html[Elastic Agent policies].
+{fleet-guide}/agent-policy.html[Elastic Agent policies].
 
 [float]
 ===== Standalone

--- a/docs/getting-started-apm-server.asciidoc
+++ b/docs/getting-started-apm-server.asciidoc
@@ -241,11 +241,7 @@ If you're running APM Server as an Elastic Agent integration, you can configure 
 {fleet}/agent-policy.html[Elastic Agent policies].
 
 [float]
-===== Standalone (data streams)
-
-[float]
-[[index-template-config]]
-===== Standalone (classic indices)
+===== Standalone
 
 You can edit the `apm-server.yml` configuration file to customize it to your needs.
 The location of this file varies by platform, but the <<directory-layout>> will help you locate it.
@@ -253,14 +249,15 @@ All available configuration options are outlined in
 {apm-server-ref-v}/configuring-howto-apm-server.html[configuring APM Server].
 
 [float]
-====== Standalone (data streams)
+====== Standalone setup (data streams)
 
 If you're running APM Server as a standalone process, we recommend that you configure <<data_streams.enabled>>
 to write events to data streams in the same way as the <<apm-integration>>. You will need to install the APM
 integration package to set up Elasticsearch before APM Server becomes operative.
 
 [float]
-====== Standalone (classic indices)
+[[index-template-config]]
+====== Standalone setup (classic indices)
 
 deprecated::[7.16.0,Users should now use the <<apm-integration>> or configure <<data_streams.enabled>>.]
 

--- a/docs/getting-started-apm-server.asciidoc
+++ b/docs/getting-started-apm-server.asciidoc
@@ -260,7 +260,8 @@ integration package to set up Elasticsearch before APM Server becomes operative.
 
 deprecated::[7.16.0,Users should now use the <<apm-integration>> or configure <<data_streams.enabled,`data_streams.enabled`>>.]
 
-It is recommended that you run the `setup` command before starting {beatname_uc}.
+When running APM Server standalone with classic indices,
+we recommend that you run the `setup` command before starting {beatname_uc}.
 
 The `setup` command sets up the initial environment, including the Elasticsearch index template,
 and ILM write alias. In Elasticsearch, {ref}/index-templates.html[index templates]

--- a/docs/getting-started-apm-server.asciidoc
+++ b/docs/getting-started-apm-server.asciidoc
@@ -259,7 +259,7 @@ integration package to set up Elasticsearch before APM Server becomes operative.
 [[index-template-config]]
 ====== Standalone setup (classic indices)
 
-deprecated::[7.16.0,Users should now use the <<apm-integration>> or configure <<data_streams.enabled>>.]
+deprecated::[7.16.0,Users should now use the <<apm-integration>> or configure <<data_streams.enabled,`data_streams.enabled`>>.]
 
 It is recommended that you run the `setup` command before starting {beatname_uc}.
 

--- a/docs/getting-started-apm-server.asciidoc
+++ b/docs/getting-started-apm-server.asciidoc
@@ -251,7 +251,7 @@ All available configuration options are outlined in
 [float]
 ====== Standalone setup (data streams)
 
-If you're running APM Server as a standalone process, we recommend that you configure <<data_streams.enabled>>
+If you're running APM Server as a standalone process, we recommend that you configure <<data_streams.enabled,`data_streams.enabled`>>
 to write events to data streams in the same way as the <<apm-integration>>. You will need to install the APM
 integration package to set up Elasticsearch before APM Server becomes operative.
 

--- a/docs/getting-started-apm-server.asciidoc
+++ b/docs/getting-started-apm-server.asciidoc
@@ -232,10 +232,39 @@ Any changes are automatically appended to the `apm-server.yml` configuration fil
 Full details are available in the {cloud}/ec-manage-apm-settings.html[APM user settings] documentation.
 
 [float]
-[[index-template-config]]
 ==== Self installation
 
-It is recommend that you run the `setup` command before starting {beatname_uc}.
+[float]
+===== APM integration for Elastic Agent
+
+If you're running APM Server as an Elastic Agent integration, you can configure settings via
+{fleet}/agent-policy.html[Elastic Agent policies].
+
+[float]
+===== Standalone (data streams)
+
+[float]
+[[index-template-config]]
+===== Standalone (classic indices)
+
+You can edit the `apm-server.yml` configuration file to customize it to your needs.
+The location of this file varies by platform, but the <<directory-layout>> will help you locate it.
+All available configuration options are outlined in
+{apm-server-ref-v}/configuring-howto-apm-server.html[configuring APM Server].
+
+[float]
+====== Standalone (data streams)
+
+If you're running APM Server as a standalone process, we recommend that you configure <<data_streams.enabled>>
+to write events to data streams in the same way as the <<apm-integration>>. You will need to install the APM
+integration package to set up Elasticsearch before APM Server becomes operative.
+
+[float]
+====== Standalone (classic indices)
+
+deprecated::[7.16.0,Users should now use the <<apm-integration>> or configure <<data_streams.enabled>>.]
+
+It is recommended that you run the `setup` command before starting {beatname_uc}.
 
 The `setup` command sets up the initial environment, including the Elasticsearch index template,
 and ILM write alias. In Elasticsearch, {ref}/index-templates.html[index templates]

--- a/docs/ilm-reference.asciidoc
+++ b/docs/ilm-reference.asciidoc
@@ -2,6 +2,8 @@
 [role="xpack"]
 == Configure Index lifecycle management (ILM)
 
+deprecated::[7.16.0,Users should now use the <<apm-integration>>. See <<apm-integration-ilm>>]
+
 ++++
 <titleabbrev>Index lifecycle management</titleabbrev>
 ++++

--- a/docs/ilm.asciidoc
+++ b/docs/ilm.asciidoc
@@ -2,6 +2,8 @@
 [role="xpack"]
 == Custom index lifecycle management with APM Server
 
+deprecated::[7.16.0,Users should now use the <<apm-integration>>. See <<apm-integration-ilm>>]
+
 ++++
 <titleabbrev>Customize index lifecycle management</titleabbrev>
 ++++

--- a/idxmgmt/manager_test.go
+++ b/idxmgmt/manager_test.go
@@ -43,7 +43,6 @@ func TestManager_VerifySetup(t *testing.T) {
 		version               string
 		esCfg                 common.MapStr
 
-		ok   bool
 		warn string
 	}{
 		"SetupTemplateDisabled": {
@@ -101,7 +100,6 @@ func TestManager_VerifySetup(t *testing.T) {
 		"EverythingEnabled": {
 			templateEnabled: true, loadTemplate: libidxmgmt.LoadModeEnabled,
 			ilmSetupEnabled: true, ilmSetupOverwrite: true, loadILM: libidxmgmt.LoadModeEnabled,
-			ok: true,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -123,7 +121,8 @@ func TestManager_VerifySetup(t *testing.T) {
 			}
 			manager := support.Manager(newMockClientHandler(version), nil)
 			ok, warn := manager.VerifySetup(tc.loadTemplate, tc.loadILM)
-			require.Equal(t, tc.ok, ok, warn)
+			require.False(t, ok, warn)
+			assert.Contains(t, warn, SetupDeprecatedWarning)
 			assert.Contains(t, warn, tc.warn)
 		})
 	}

--- a/idxmgmt/supporter_factory.go
+++ b/idxmgmt/supporter_factory.go
@@ -147,10 +147,10 @@ func checkTemplateESSettings(tmplCfg template.TemplateConfig, indexCfg *unmanage
 }
 
 func (cfg *IndexManagementConfig) logWarnings(log *logp.Logger) {
-	if !cfg.DataStreams {
-		return
+	format := "deprecated config `%s` specified. This config will be removed in 8.0."
+	if cfg.DataStreams {
+		format = "`%s` specified, but will be ignored as data streams are enabled"
 	}
-	const format = "`%s` specified, but will be ignored as data streams are enabled"
 	if cfg.setupTemplateSpecified {
 		log.Warnf(format, "setup.template")
 	}


### PR DESCRIPTION
## Motivation/summary

Log warnings when index management config is explicitly configured in standalone mode, and print a warning message when users run `apm-server setup`.

Also, remove old check for `setup.dashboards` config in beater.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
- [x] Documentation has been updated

## How to test these changes

1. Run `apm-server setup`, should print out a warning message.
2. Run `apm-server`, should not print any warnings (no custom config)
3. Run `apm-server -E apm-server.ilm.enabled=true`, should log a warning about the config being deprecated
4. Run `apm-server -E apm-server.data_streams.enabled=true`, should not log any warnings

## Related issues

Closes https://github.com/elastic/apm-server/issues/5914