### PR TITLE
docs: promote jaeger & transaction metrics to GA

### DIFF
--- a/docs/jaeger-reference.asciidoc
+++ b/docs/jaeger-reference.asciidoc
@@ -5,8 +5,6 @@
 <titleabbrev>Jaeger</titleabbrev>
 ++++
 
-experimental::[]
-
 // this content is reused in the how-to guides
 // tag::jaeger-intro[]
 Elastic APM integrates with https://www.jaegertracing.io/[Jaeger], an open-source, distributed tracing system.

--- a/docs/jaeger-support.asciidoc
+++ b/docs/jaeger-support.asciidoc
@@ -5,8 +5,6 @@
 <titleabbrev>Integrate with Jaeger</titleabbrev>
 ++++
 
-experimental::[]
-
 include::./jaeger-reference.asciidoc[tag=jaeger-intro]
 
 [float]

--- a/docs/transaction-metrics.asciidoc
+++ b/docs/transaction-metrics.asciidoc
@@ -2,8 +2,6 @@
 [[transaction-metrics]]
 == Configure transaction metrics
 
-experimental[]
-
 ++++
 <titleabbrev>Transaction metrics</titleabbrev>
 ++++


### PR DESCRIPTION
Remove the experimental status from Jaeger and transaction metrics features.