### PR TITLE
document how ratelimit client.ip is derived

### DIFF
--- a/docs/configuration-anonymous.asciidoc
+++ b/docs/configuration-anonymous.asciidoc
@@ -75,4 +75,14 @@ Default: `1000`
 ==== `rate_limit.event_limit`
 The maximum number of events allowed per second, per agent IP address.
 
+The APM Server first attempts to derive the IP address from proxy headers. The
+supported headers are parsed in the following order:
+
+- `Forwarded`
+- `X-Real-Ip`
+- `X-Forwarded-For`
+
+If none of these headers is present, the remote address for the incoming
+request is used.
+
 Default: `300`

--- a/docs/configuration-rum.asciidoc
+++ b/docs/configuration-rum.asciidoc
@@ -54,6 +54,16 @@ deprecated::[7.15.0, Replaced by <<config-auth-anon-event-limit,`auth.anonymous.
 
 The maximum number of events allowed per second, per agent IP address.
 
+The APM Server first attempts to derive the IP address from proxy headers. The
+supported headers are parsed in the following order:
+
+- Forwarded
+- X-Real-Ip
+- X-Forwarded-For
+
+If none of these headers is present, the remote address for the incoming
+request is used.
+
 Default: `300`
 
 [float]

--- a/docs/configuration-rum.asciidoc
+++ b/docs/configuration-rum.asciidoc
@@ -54,16 +54,6 @@ deprecated::[7.15.0, Replaced by <<config-auth-anon-event-limit,`auth.anonymous.
 
 The maximum number of events allowed per second, per agent IP address.
 
-The APM Server first attempts to derive the IP address from proxy headers. The
-supported headers are parsed in the following order:
-
-- Forwarded
-- X-Real-Ip
-- X-Forwarded-For
-
-If none of these headers is present, the remote address for the incoming
-request is used.
-
 Default: `300`
 
 [float]


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

document how `client.ip` is derived for ratelimiting anonymous events

## Checklist

~~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~~
- [x] Documentation has been updated

## How to test these changes

non-functional change

## Related issues

closes #6153
