### PR TITLE
docs: update OTel limitations

### DIFF
--- a/docs/guide/opentelemetry-elastic.asciidoc
+++ b/docs/guide/opentelemetry-elastic.asciidoc
@@ -371,7 +371,7 @@ Here is an example of AWS Lambda Node.js function managed with Terraform and the
 * https://github.com/michaelhyatt/terraform-aws-nodejs-api-worker-otel/tree/v0.23[Sample Terraform code]
 
 [[elastic-open-telemetry-known-limitations]]
-==== Limitations in 7.13
+==== Limitations
 
 
 [[elastic-open-telemetry-traces-limitations]]
@@ -385,9 +385,6 @@ Here is an example of AWS Lambda Node.js function managed with Terraform and the
 [[elastic-open-telemetry-metrics-limitations]]
 ===== OpenTelemetry metrics
 
-* OpenTelemetry histogram metrics, https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-api/latest/io/opentelemetry/api/metrics/DoubleValueRecorder.html[`DoubleValueRecorder`]
-and https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-api/latest/io/opentelemetry/api/metrics/LongValueObserver.html[`LongValueRecorder`], are not yet supported https://github.com/elastic/apm-server/issues/3195[#3195]
-* Inability to see JVM metrics in Elastic APM UI for Java applications instrumented with OpenTelemetry https://github.com/elastic/apm-server/issues/4919[#4919]
 * Inability to see host metrics in Elastic Metrics Infrastructure view when using the OpenTelemetry Collector host metrics receiver https://github.com/elastic/apm-server/issues/5310[#5310]
 
 [[elastic-open-telemetry-logs-limitations]]


### PR DESCRIPTION
Backport OTel limitation docs changes from https://github.com/elastic/apm-server/pull/6122 to 7.15, excluding those related to span events