### PR TITLE
[mergify] add backport policy and default label

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -114,7 +114,6 @@ pull_request_rules:
           * `backport-7./d` is the label to automatically backport to the `7./d` branch. /d is the digit
 
           NOTE: `backport-skip` has been added to this pull request.
-          ```
       label:
         add:
           - backport-skip

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -104,6 +104,7 @@ pull_request_rules:
   - name: notify the backport policy
     conditions:
       - -label~=^backport
+      - -base=master
     actions:
       comment:
         message: |
@@ -111,9 +112,9 @@ pull_request_rules:
           To fixup this pull request, you need to add the backport labels for the needed
           branches, such as:
           * `backport-7.x` is the label to automatically backport to the `7.x` branch.
-          * `backport-7./d` is the label to automatically backport to the `7./d` branch. /d is the digit
+          * `backport-7./d` is the label to automatically backport to the `7./d` branch. `/d` is the digit
 
-          NOTE: `backport-skip` has been added to this pull request.
+          **NOTE**: `backport-skip` has been added to this pull request.
       label:
         add:
           - backport-skip

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -103,7 +103,7 @@ pull_request_rules:
       delete_head_branch:
   - name: notify the backport policy
     conditions:
-      - label~=^backport
+      - -label~=^backport
     actions:
       comment:
         message: |

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -103,7 +103,7 @@ pull_request_rules:
       delete_head_branch:
   - name: notify the backport policy
     conditions:
-      -label~=^backport
+      - label~=^backport
     actions:
       comment:
         message: |

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -101,3 +101,20 @@ pull_request_rules:
         - head~=^update-beats
     actions:
       delete_head_branch:
+  - name: notify the backport policy
+    conditions:
+      -label~=^backport
+    actions:
+      comment:
+        message: |
+          This pull request does not have a backport label. Could you fix it @{{author}}? 🙏
+          To fixup this pull request, you need to add the backport labels for the needed
+          branches, such as:
+          * `backport-7.x` is the label to automatically backport to the `7.x` branch.
+          * `backport-7./d` is the label to automatically backport to the `7./d` branch. /d is the digit
+
+          NOTE: `backport-skip` has been added to this pull request.
+          ```
+      label:
+        add:
+          - backport-skip


### PR DESCRIPTION
## Motivation/summary

Notify PR contributors about the backport policy.

This policy will notify what are the different backport options and tag the PR with the `backport-skip`.

We can think about enforcing this rule to do not allow merges but for the time being, what do you think?


## Test

See https://github.com/elastic/apm-pipeline-library/pull/1281#issuecomment-922766344 and https://github.com/elastic/apm-pipeline-library/pull/1281#event-5327050151