### PR TITLE
[mergify] backport policy for the master branch only

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -104,7 +104,7 @@ pull_request_rules:
   - name: notify the backport policy
     conditions:
       - -label~=^backport
-      - -base=master
+      - base=master
     actions:
       comment:
         message: |


### PR DESCRIPTION
### What

The backport policy should only apply for PRs targeting the master branch.