### PR TITLE
[7.x] docs: 7.14.2 release notes (#6195)

### DIFF
--- a/changelogs/7.14.asciidoc
+++ b/changelogs/7.14.asciidoc
@@ -3,8 +3,17 @@
 
 https://github.com/elastic/apm-server/compare/7.13\...7.14[View commits]
 
+* <<release-notes-7.14.2>>
 * <<release-notes-7.14.1>>
 * <<release-notes-7.14.0>>
+
+[float]
+[[release-notes-7.14.2]]
+=== APM Server version 7.14.2
+
+https://github.com/elastic/apm-server/compare/v7.14.1\...v7.14.2[View commits]
+
+No significant changes.
 
 [float]
 [[release-notes-7.14.1]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: 7.14.2 release notes (#6195)