### PR TITLE
[7.x] docs: 6.8.19 release notes (#6194) (#6209)

### DIFF
--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,6 +3,7 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.19>>
 * <<release-notes-6.8.18>>
 * <<release-notes-6.8.17>>
 * <<release-notes-6.8.16>>
@@ -22,6 +23,14 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.2>>
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
+
+[float]
+[[release-notes-6.8.19]]
+=== APM Server version 6.8.19
+
+https://github.com/elastic/apm-server/compare/v6.8.18\...v6.8.19[View commits]
+
+No significant changes.
 
 [float]
 [[release-notes-6.8.18]]


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: 6.8.19 release notes (#6194) (#6209)