### PR TITLE
[7.15] docs: prepare 7.15 release notes (#6178)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,5 +1,3 @@
-include::./changelogs/head.asciidoc[]
-include::./changelogs/8.0.asciidoc[]
 include::./changelogs/7.15.asciidoc[]
 include::./changelogs/7.14.asciidoc[]
 include::./changelogs/7.13.asciidoc[]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,3 +1,6 @@
+include::./changelogs/head.asciidoc[]
+include::./changelogs/8.0.asciidoc[]
+include::./changelogs/7.15.asciidoc[]
 include::./changelogs/7.14.asciidoc[]
 include::./changelogs/7.13.asciidoc[]
 include::./changelogs/7.12.asciidoc[]

--- a/changelogs/7.14.asciidoc
+++ b/changelogs/7.14.asciidoc
@@ -39,6 +39,8 @@ https://github.com/elastic/apm-server/compare/v7.13.4\...v7.14.0[View commits]
 * Remove multipart form temporary files left behind by source map uploads {pull}5718[5718]
 * Removed service name from dataset {pull}5451[5451]
 * Fixed tail-based sampling pubsub to use _seq_no correctly {pull}5126[5126]
+* Fix apm_error_grouping_name and apm_convert_destination_address {pull}5876[5876]
+
 
 [float]
 ==== Added

--- a/changelogs/7.15.asciidoc
+++ b/changelogs/7.15.asciidoc
@@ -1,0 +1,36 @@
+[[release-notes-7.15]]
+== APM Server version 7.15
+
+https://github.com/elastic/apm-server/compare/7.14\...7.15[View commits]
+
+* <<release-notes-7.15.0>>
+
+[float]
+[[release-notes-7.15.0]]
+=== APM Server version 7.15.0
+
+https://github.com/elastic/apm-server/compare/v7.14.2\...v7.15.0[View commits]
+
+[float]
+==== Breaking Changes
+- `network.connection_type` is now `network.connection.type` {pull}5671[5671]
+- `transaction.page` and `error.page` no longer recorded {pull}5872[5872]
+- experimental:["This breaking change applies to the experimental tail-based sampling feature."] `apm-server.sampling.tail` now requires `apm-server.data_streams.enabled` {pull}5952[5952]
+- beta:["This breaking change applies to the beta <<apm-integration>>."] The `traces-sampled-*` data stream is now `traces-apm.sampled-*` {pull}5952[5952]
+
+[float]
+==== Bug fixes
+- corrected OTel attribute names for `net.host.connection.*` {pull}5671[5671]
+- Fix response to agent config when running under Fleet with no agent config defined {pull}5917[5917]
+- Fix handling of OTLP sum/gauge metrics with integer values {pull}6106[6106]
+
+[float]
+==== Intake API changes
+- `network.connection.type` was added to stream metadata {pull}5671[5671]
+
+[float]
+==== Added
+- `service_destination` span metrics now take into account composite spans {pull}5896[5896]
+- add zero-downtime config reloads via `SO_REUSEPORT` {pull}5911[5911]
+- experimental support for writing data streams in standalone mode {pull}5928[5928]
+- Data streams now define a default `dynamic` mapping parameter, overridable in the `<data-stream>@custom` template {pull}5947[5947]

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -10,6 +10,7 @@
 --
 This following sections summarizes the changes in each release.
 
+* <<release-notes-7.15>>
 * <<release-notes-7.14>>
 * <<release-notes-7.13>>
 * <<release-notes-7.12>>


### PR DESCRIPTION
Backports the following commits to 7.15:
 - docs: prepare release notes (#6178)