### PR TITLE
docs: update APM Overview breaking changes

### DIFF
--- a/docs/guide/apm-breaking-changes.asciidoc
+++ b/docs/guide/apm-breaking-changes.asciidoc
@@ -3,6 +3,7 @@
 
 This section discusses the changes that you need to be aware of when migrating your application from one version of APM to another.
 
+* <<breaking-7.15.0>>
 * <<breaking-7.14.0>>
 * <<breaking-7.13.0>>
 * <<breaking-7.12.0>>
@@ -31,7 +32,18 @@ Also see {observability-guide}/whats-new.html[What's new in Observability {minor
 
 // tag::notable-v8-breaking-changes[]
 // end::notable-v8-breaking-changes[]
+// tag::716-bc[]
+// end::716-bc[]
+
 // tag::715-bc[]
+[[breaking-7.15.0]]
+=== 7.15.0 APM Breaking changes
+
+- `network.connection_type` is now `network.connection.type` {pull}5671[5671]
+- `transaction.page` and `error.page` no longer recorded {pull}5872[5872]
+- experimental:["This breaking change applies to the experimental tail-based sampling feature."] `apm-server.sampling.tail` now requires `apm-server.data_streams.enabled` {pull}5952[5952]
+- beta:["This breaking change applies to the beta <<apm-integration>>."] The `traces-sampled-*` data stream is now `traces-apm.sampled-*` {pull}5952[5952]
+
 // end::715-bc[]
 
 [[breaking-7.14.0]]

--- a/docs/guide/apm-breaking-changes.asciidoc
+++ b/docs/guide/apm-breaking-changes.asciidoc
@@ -42,7 +42,7 @@ Also see {observability-guide}/whats-new.html[What's new in Observability {minor
 - `network.connection_type` is now `network.connection.type` {pull}5671[5671]
 - `transaction.page` and `error.page` no longer recorded {pull}5872[5872]
 - experimental:["This breaking change applies to the experimental tail-based sampling feature."] `apm-server.sampling.tail` now requires `apm-server.data_streams.enabled` {pull}5952[5952]
-- beta:["This breaking change applies to the beta <<apm-integration>>."] The `traces-sampled-*` data stream is now `traces-apm.sampled-*` {pull}5952[5952]
+- beta:["This breaking change applies to the beta APM integration."] The `traces-sampled-*` data stream is now `traces-apm.sampled-*` {pull}5952[5952]
 
 // end::715-bc[]
 


### PR DESCRIPTION
Update APM Overview breaking changes to match the breaking changes merged in https://github.com/elastic/apm-server/pull/6178 and init 7.16 breaking changes.