### PR TITLE
docs: fix 7.15 breaking changes

### DIFF
--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -1,7 +1,20 @@
+:issue: https://github.com/elastic/apm-server/issues/
+:pull: https://github.com/elastic/apm-server/pull/
+
 [[breaking-changes]]
 == Breaking Changes
 APM Server is built on top of {beats-ref}/index.html[libbeat].
 As such, any breaking change in libbeat is also considered to be a breaking change in APM Server.
+
+[float]
+=== 7.15
+
+The following breaking changes were introduced in 7.15:
+
+- `network.connection_type` is now `network.connection.type` {pull}5671[5671]
+- `transaction.page` and `error.page` no longer recorded {pull}5872[5872]
+- experimental:["This breaking change applies to the experimental tail-based sampling feature."] `apm-server.sampling.tail` now requires `apm-server.data_streams.enabled` {pull}5952[5952]
+- beta:["This breaking change applies to the beta APM integration."] The `traces-sampled-*` data stream is now `traces-apm.sampled-*` {pull}5952[5952]
 
 [float]
 === 7.14

--- a/docs/guide/apm-breaking-changes.asciidoc
+++ b/docs/guide/apm-breaking-changes.asciidoc
@@ -1,3 +1,6 @@
+:issue: https://github.com/elastic/apm-server/issues/
+:pull: https://github.com/elastic/apm-server/pull/
+
 [[apm-breaking-changes]]
 == Breaking changes
 
@@ -38,6 +41,8 @@ Also see {observability-guide}/whats-new.html[What's new in Observability {minor
 // tag::715-bc[]
 [[breaking-7.15.0]]
 === 7.15.0 APM Breaking changes
+
+The following breaking changes were introduced in 7.15:
 
 - `network.connection_type` is now `network.connection.type` {pull}5671[5671]
 - `transaction.page` and `error.page` no longer recorded {pull}5872[5872]


### PR DESCRIPTION
Fixes links from the 7.15 breaking changes.