### PR TITLE
apmpackage: remove warm phase from ILM policies

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -9,6 +9,9 @@
     - description: add histogram dynamic_template to app metrics data stream
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/6043
+    - description: remove warm phase from ILM policies
+      type: enhancement
+      link: https://github.com/elastic/apm-server/pull/6229
 - version: "0.4.0"
   changes:
     - description: add anonymous auth config, replace some RUM config

--- a/apmpackage/apm/data_stream/app_metrics/elasticsearch/ilm/default_policy.json
+++ b/apmpackage/apm/data_stream/app_metrics/elasticsearch/ilm/default_policy.json
@@ -1,15 +1,6 @@
 {
     "policy": {
         "phases": {
-            "warm": {
-                "min_age": "30d",
-                "actions": {
-                    "readonly": {},
-                    "set_priority": {
-                        "priority": 50
-                    }
-                }
-            },
             "hot": {
                 "actions": {
                     "rollover": {

--- a/apmpackage/apm/data_stream/error_logs/elasticsearch/ilm/default_policy.json
+++ b/apmpackage/apm/data_stream/error_logs/elasticsearch/ilm/default_policy.json
@@ -1,15 +1,6 @@
 {
     "policy": {
         "phases": {
-            "warm": {
-                "min_age": "30d",
-                "actions": {
-                    "readonly": {},
-                    "set_priority": {
-                        "priority": 50
-                    }
-                }
-            },
             "hot": {
                 "actions": {
                     "rollover": {

--- a/apmpackage/apm/data_stream/internal_metrics/elasticsearch/ilm/default_policy.json
+++ b/apmpackage/apm/data_stream/internal_metrics/elasticsearch/ilm/default_policy.json
@@ -1,15 +1,6 @@
 {
     "policy": {
         "phases": {
-            "warm": {
-                "min_age": "30d",
-                "actions": {
-                    "readonly": {},
-                    "set_priority": {
-                        "priority": 50
-                    }
-                }
-            },
             "hot": {
                 "actions": {
                     "rollover": {

--- a/apmpackage/apm/data_stream/profile_metrics/elasticsearch/ilm/default_policy.json
+++ b/apmpackage/apm/data_stream/profile_metrics/elasticsearch/ilm/default_policy.json
@@ -1,15 +1,6 @@
 {
     "policy": {
         "phases": {
-            "warm": {
-                "min_age": "30d",
-                "actions": {
-                    "readonly": {},
-                    "set_priority": {
-                        "priority": 50
-                    }
-                }
-            },
             "hot": {
                 "actions": {
                     "rollover": {

--- a/apmpackage/apm/data_stream/traces/elasticsearch/ilm/default_policy.json
+++ b/apmpackage/apm/data_stream/traces/elasticsearch/ilm/default_policy.json
@@ -1,15 +1,6 @@
 {
     "policy": {
         "phases": {
-            "warm": {
-                "min_age": "30d",
-                "actions": {
-                    "readonly": {},
-                    "set_priority": {
-                        "priority": 50
-                    }
-                }
-            },
             "hot": {
                 "actions": {
                     "rollover": {


### PR DESCRIPTION
## Motivation/summary

Remove the warm phase from installed ILM policies. Having a warm phase by default means that even small deployments in ESS, with autoscaling enabled, will autoscale up a warm tier Elasticsearch after 30 days. That's not desirable/cost effective for small deployments.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

1. Install APM integration
2. Check that none of the installed ILM policies have a warm phase

## Related issues

Closes https://github.com/elastic/apm-server/issues/6170