### PR TITLE
[bump][automation] skip backports for the automation

### DIFF
--- a/.ci/update-beats.groovy
+++ b/.ci/update-beats.groovy
@@ -82,7 +82,7 @@ pipeline {
 def createPullRequest(Map args = [:]) {
   def title = '[automation] update libbeat and beats packaging'
   def message = createPRDescription()
-  def labels = "automation"
+  def labels = "automation,backport-skip"
   if (params.DRY_RUN_MODE) {
     log(level: 'INFO', text: "DRY-RUN: createPullRequest(labels: ${labels}, message: '${message}')")
     return


### PR DESCRIPTION
## What does this PR do?

Add `backport-skip` label for certain projects that use the automated bump process

## Why is it important?

Avoid missing backport labels in the notifications

## Related issues

Caused by https://github.com/elastic/apm-server/pull/6186
