### PR TITLE
fix: Dedot http.request.body.original

### DIFF
--- a/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
@@ -227,7 +227,9 @@
             },
             "http": {
                 "request": {
-                    "body.original": "Hello World",
+                    "body": {
+                        "original": "Hello World"
+                    },
                     "cookies": {
                         "c1": "v1",
                         "c2": "v2"

--- a/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
@@ -153,7 +153,9 @@
             },
             "http": {
                 "request": {
-                    "body.original": "HelloWorld",
+                    "body": {
+                        "original": "HelloWorld"
+                    },
                     "cookies": {
                         "c1": "v1",
                         "c2": "v2"
@@ -484,12 +486,14 @@
             },
             "http": {
                 "request": {
-                    "body.original": {
-                        "additional": {
-                            "bar": 123,
-                            "req": "additionalinformation"
-                        },
-                        "string": "helloworld"
+                    "body": {
+                        "original": {
+                            "additional": {
+                                "bar": 123,
+                                "req": "additionalinformation"
+                            },
+                            "string": "helloworld"
+                        }
                     },
                     "cookies": {
                         "c1": "v1",

--- a/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json
@@ -180,12 +180,14 @@
             },
             "http": {
                 "request": {
-                    "body.original": {
-                        "additional": {
-                            "bar": 123,
-                            "req": "additional information"
-                        },
-                        "str": "hello world"
+                    "body": {
+                        "original": {
+                            "additional": {
+                                "bar": 123,
+                                "req": "additional information"
+                            },
+                            "str": "hello world"
+                        }
                     },
                     "cookies": {
                         "c1": "v1",

--- a/beater/test_approved_es_documents/TestPublishIntegrationTransactionsHugeTraces.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationTransactionsHugeTraces.approved.json
@@ -52,12 +52,14 @@
             },
             "http": {
                 "request": {
-                    "body.original": {
-                        "additional": {
-                            "bar": 123,
-                            "req": "additional information"
-                        },
-                        "str": "hello world"
+                    "body": {
+                        "original": {
+                            "additional": {
+                                "bar": 123,
+                                "req": "additional information"
+                            },
+                            "str": "hello world"
+                        }
                     },
                     "cookies": {
                         "c1": "v1",

--- a/changelogs/7.15.asciidoc
+++ b/changelogs/7.15.asciidoc
@@ -6,6 +6,17 @@ https://github.com/elastic/apm-server/compare/7.14\...7.15[View commits]
 * <<release-notes-7.15.0>>
 
 [float]
+[[release-notes-7.15.1]]
+=== APM Server version 7.15.1
+
+https://github.com/elastic/apm-server/compare/v7.15.0\...v7.15.1[View commits]
+
+
+[float]
+==== Bug fixes
+- dedot http.request.body.original {pull}6256[6256]
+
+[float]
 [[release-notes-7.15.0]]
 === APM Server version 7.15.0
 

--- a/docs/data/elasticsearch/generated/errors.json
+++ b/docs/data/elasticsearch/generated/errors.json
@@ -278,7 +278,9 @@
         },
         "http": {
             "request": {
-                "body.original": "Hello World",
+                "body": {
+                    "original": "Hello World"
+                },
                 "cookies": {
                     "c1": "v1",
                     "c2": "v2"

--- a/docs/data/elasticsearch/generated/transactions.json
+++ b/docs/data/elasticsearch/generated/transactions.json
@@ -324,12 +324,14 @@
         },
         "http": {
             "request": {
-                "body.original": {
-                    "additional": {
-                        "bar": 123,
-                        "req": "additional information"
-                    },
-                    "str": "hello world"
+                "body": {
+                    "original": {
+                        "additional": {
+                            "bar": 123,
+                            "req": "additional information"
+                        },
+                        "str": "hello world"
+                    }
                 },
                 "cookies": {
                     "c1": "v1",

--- a/model/apmevent_test.go
+++ b/model/apmevent_test.go
@@ -157,8 +157,10 @@ func TestAPMEventFields(t *testing.T) {
 			},
 			"http": common.MapStr{
 				"request": common.MapStr{
-					"method":        "post",
-					"body.original": httpRequestBody,
+					"method": "post",
+					"body": mapStr{
+						"original": httpRequestBody,
+					},
 				},
 			},
 			"faas": common.MapStr{

--- a/model/http.go
+++ b/model/http.go
@@ -75,7 +75,9 @@ func (h *HTTPRequest) fields() common.MapStr {
 	fields.maybeSetMapStr("env", h.Env)
 	fields.maybeSetMapStr("cookies", h.Cookies)
 	if h.Body != nil {
-		fields.set("body.original", h.Body)
+		var body mapStr
+		body.set("original", h.Body)
+		fields.set("body", body)
 	}
 	return common.MapStr(fields)
 }

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationErrors.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationErrors.approved.json
@@ -223,7 +223,9 @@
             },
             "http": {
                 "request": {
-                    "body.original": "Hello World",
+                    "body": {
+                        "original": "Hello World"
+                    },
                     "cookies": {
                         "c1": "v1",
                         "c2": "v2"

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
@@ -149,7 +149,9 @@
             },
             "http": {
                 "request": {
-                    "body.original": "HelloWorld",
+                    "body": {
+                        "original": "HelloWorld"
+                    },
                     "cookies": {
                         "c1": "v1",
                         "c2": "v2"
@@ -459,12 +461,14 @@
             },
             "http": {
                 "request": {
-                    "body.original": {
-                        "additional": {
-                            "bar": 123,
-                            "req": "additionalinformation"
-                        },
-                        "string": "helloworld"
+                    "body": {
+                        "original": {
+                            "additional": {
+                                "bar": 123,
+                                "req": "additionalinformation"
+                            },
+                            "string": "helloworld"
+                        }
                     },
                     "cookies": {
                         "c1": "v1",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationTransactions.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationTransactions.approved.json
@@ -164,12 +164,14 @@
             },
             "http": {
                 "request": {
-                    "body.original": {
-                        "additional": {
-                            "bar": 123,
-                            "req": "additional information"
-                        },
-                        "str": "hello world"
+                    "body": {
+                        "original": {
+                            "additional": {
+                                "bar": 123,
+                                "req": "additional information"
+                            },
+                            "str": "hello world"
+                        }
                     },
                     "cookies": {
                         "c1": "v1",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationTransactionsHugeTraces.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationTransactionsHugeTraces.approved.json
@@ -48,12 +48,14 @@
             },
             "http": {
                 "request": {
-                    "body.original": {
-                        "additional": {
-                            "bar": 123,
-                            "req": "additional information"
-                        },
-                        "str": "hello world"
+                    "body": {
+                        "original": {
+                            "additional": {
+                                "bar": 123,
+                                "req": "additional information"
+                            },
+                            "str": "hello world"
+                        }
                     },
                     "cookies": {
                         "c1": "v1",

--- a/systemtest/approvals/TestTransactionDroppedSpansStatsTransaction.approved.json
+++ b/systemtest/approvals/TestTransactionDroppedSpansStatsTransaction.approved.json
@@ -62,12 +62,14 @@
             },
             "http": {
                 "request": {
-                    "body.original": {
-                        "additional": {
-                            "bar": 123,
-                            "req": "additional information"
-                        },
-                        "str": "hello world"
+                    "body": {
+                        "original": {
+                            "additional": {
+                                "bar": 123,
+                                "req": "additional information"
+                            },
+                            "str": "hello world"
+                        }
                     },
                     "cookies": {
                         "c1": "v1",

--- a/tests/system/error.approved.json
+++ b/tests/system/error.approved.json
@@ -278,7 +278,9 @@
         },
         "http": {
             "request": {
-                "body.original": "Hello World",
+                "body": {
+                    "original": "Hello World"
+                },
                 "cookies": {
                     "c1": "v1",
                     "c2": "v2"

--- a/tests/system/transaction.approved.json
+++ b/tests/system/transaction.approved.json
@@ -324,12 +324,14 @@
         },
         "http": {
             "request": {
-                "body.original": {
-                    "additional": {
-                        "bar": 123,
-                        "req": "additional information"
-                    },
-                    "str": "hello world"
+                "body": {
+                    "original": {
+                        "additional": {
+                            "bar": 123,
+                            "req": "additional information"
+                        },
+                        "str": "hello world"
+                    }
                 },
                 "cookies": {
                     "c1": "v1",


### PR DESCRIPTION
## Motivation/summary
Ensure de-dotting `http.request.body.original`, allowing to run ingest processor logic on the field. 

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

## How to test these changes
* Add apm ingest processor to apm ingest pipelien, parsing the `http.request.body.original`, for example as the one mentioned in the [discuss entry](https://discuss.elastic.co/t/apm-capture-body-is-broken-after-upgrading-from-7-14-0-to-7-15-0/285300/2)
* Index data with the request body 
* Ensure that the ingest processor is applied. 

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

fixes elastic/apm-server#6255
