### PR TITLE
dropped_spans_stats: Remove `type`, `subtype` fields

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -465,15 +465,19 @@ func (s *serverRunner) run(listener net.Listener) error {
 	}
 	runServer = s.wrapRunServerWithPreprocessors(runServer)
 
-	batchProcessor := s.newFinalBatchProcessor(reporter)
+	batchProcessor := make(modelprocessor.Chained, 0, 3)
 	if !s.config.Sampling.KeepUnsampled {
 		// The server has been configured to discard unsampled
 		// transactions. Make sure this is done just before calling
 		// the publisher to avoid affecting aggregations.
-		batchProcessor = modelprocessor.Chained{
-			sampling.NewDiscardUnsampledBatchProcessor(), batchProcessor,
-		}
+		batchProcessor = append(batchProcessor,
+			sampling.NewDiscardUnsampledBatchProcessor(),
+		)
 	}
+	batchProcessor = append(batchProcessor,
+		modelprocessor.DropedSpansStatsDiscarder{},
+		s.newFinalBatchProcessor(reporter),
+	)
 
 	g.Go(func() error {
 		return runServer(ctx, ServerParams{

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -475,7 +475,7 @@ func (s *serverRunner) run(listener net.Listener) error {
 		)
 	}
 	batchProcessor = append(batchProcessor,
-		modelprocessor.DropedSpansStatsDiscarder{},
+		modelprocessor.DroppedSpansStatsDiscarder{},
 		s.newFinalBatchProcessor(reporter),
 	)
 

--- a/beater/test_approved_es_documents/TestPublishIntegrationTransactionsHugeTraces.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationTransactionsHugeTraces.approved.json
@@ -186,28 +186,6 @@
                     "my_key": 1,
                     "some_other_value": "foo bar"
                 },
-                "dropped_spans_stats": [
-                    {
-                        "destination_service_resource": "example.com:443",
-                        "duration": {
-                            "count": 2,
-                            "sum.us": 123456
-                        },
-                        "outcome": "failure",
-                        "subtype": "http",
-                        "type": "request"
-                    },
-                    {
-                        "destination_service_resource": "mysql",
-                        "duration": {
-                            "count": 1,
-                            "sum.us": 9876543
-                        },
-                        "outcome": "success",
-                        "subtype": "mysql",
-                        "type": "db"
-                    }
-                ],
                 "duration": {
                     "us": 32592
                 },

--- a/docs/spec/v2/transaction.json
+++ b/docs/spec/v2/transaction.json
@@ -733,22 +733,6 @@
               "unknown",
               null
             ]
-          },
-          "subtype": {
-            "description": "Subtype is a further sub-division of the type (e.g. postgresql, elasticsearch)",
-            "type": [
-              "null",
-              "string"
-            ],
-            "maxLength": 1024
-          },
-          "type": {
-            "description": "Type holds the dropped span's type, and can have specific keywords within the service's domain (eg: 'request', 'backgroundjob', etc)",
-            "type": [
-              "null",
-              "string"
-            ],
-            "maxLength": 1024
           }
         }
       },

--- a/model/modeldecoder/v2/decoder.go
+++ b/model/modeldecoder/v2/decoder.go
@@ -242,12 +242,6 @@ func mapToDroppedSpansModel(from []transactionDroppedSpanStats, tx *model.Transa
 	for _, f := range from {
 		if f.IsSet() {
 			var to model.DroppedSpanStats
-			if f.Type.IsSet() {
-				to.Type = f.Type.Val
-			}
-			if f.Subtype.IsSet() {
-				to.Subtype = f.Subtype.Val
-			}
 			if f.DestinationServiceResource.IsSet() {
 				to.DestinationServiceResource = f.DestinationServiceResource.Val
 			}

--- a/model/modeldecoder/v2/model.go
+++ b/model/modeldecoder/v2/model.go
@@ -980,11 +980,6 @@ type user struct {
 }
 
 type transactionDroppedSpanStats struct {
-	// Type holds the dropped span's type, and can have specific keywords
-	// within the service's domain (eg: 'request', 'backgroundjob', etc)
-	Type nullable.String `json:"type" validate:"maxLength=1024"`
-	// Subtype is a further sub-division of the type (e.g. postgresql, elasticsearch)
-	Subtype nullable.String `json:"subtype" validate:"maxLength=1024"`
 	// DestinationServiceResource identifies the destination service resource
 	// being operated on. e.g. 'http://elastic.co:80', 'elasticsearch', 'rabbitmq/queue_name'.
 	DestinationServiceResource nullable.String `json:"destination_service_resource" validate:"maxLength=1024"`

--- a/model/modeldecoder/v2/model_generated.go
+++ b/model/modeldecoder/v2/model_generated.go
@@ -2056,12 +2056,10 @@ func (val *transaction) validate() error {
 }
 
 func (val *transactionDroppedSpanStats) IsSet() bool {
-	return val.Type.IsSet() || val.Subtype.IsSet() || val.DestinationServiceResource.IsSet() || val.Outcome.IsSet() || val.Duration.IsSet()
+	return val.DestinationServiceResource.IsSet() || val.Outcome.IsSet() || val.Duration.IsSet()
 }
 
 func (val *transactionDroppedSpanStats) Reset() {
-	val.Type.Reset()
-	val.Subtype.Reset()
 	val.DestinationServiceResource.Reset()
 	val.Outcome.Reset()
 	val.Duration.Reset()
@@ -2070,12 +2068,6 @@ func (val *transactionDroppedSpanStats) Reset() {
 func (val *transactionDroppedSpanStats) validate() error {
 	if !val.IsSet() {
 		return nil
-	}
-	if val.Type.IsSet() && utf8.RuneCountInString(val.Type.Val) > 1024 {
-		return fmt.Errorf("'type': validation rule 'maxLength(1024)' violated")
-	}
-	if val.Subtype.IsSet() && utf8.RuneCountInString(val.Subtype.Val) > 1024 {
-		return fmt.Errorf("'subtype': validation rule 'maxLength(1024)' violated")
 	}
 	if val.DestinationServiceResource.IsSet() && utf8.RuneCountInString(val.DestinationServiceResource.Val) > 1024 {
 		return fmt.Errorf("'destination_service_resource': validation rule 'maxLength(1024)' violated")

--- a/model/modeldecoder/v2/transaction_test.go
+++ b/model/modeldecoder/v2/transaction_test.go
@@ -159,14 +159,10 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 		var esDss, mysqlDss transactionDroppedSpanStats
 
 		durationSumUs := 10_290_000
-		esDss.Type.Set("request")
-		esDss.Subtype.Set("elasticsearch")
 		esDss.DestinationServiceResource.Set("https://elasticsearch:9200")
 		esDss.Outcome.Set("success")
 		esDss.Duration.Count.Set(2)
 		esDss.Duration.Sum.Us.Set(durationSumUs)
-		mysqlDss.Type.Set("query")
-		mysqlDss.Subtype.Set("mysql")
 		mysqlDss.DestinationServiceResource.Set("mysql://mysql:3306")
 		mysqlDss.Outcome.Set("unknown")
 		mysqlDss.Duration.Count.Set(10)
@@ -177,8 +173,6 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 		expected := model.APMEvent{Transaction: &model.Transaction{
 			DroppedSpansStats: []model.DroppedSpanStats{
 				{
-					Type:                       "request",
-					Subtype:                    "elasticsearch",
 					DestinationServiceResource: "https://elasticsearch:9200",
 					Outcome:                    "success",
 					Duration: model.AggregatedDuration{
@@ -187,8 +181,6 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 					},
 				},
 				{
-					Type:                       "query",
-					Subtype:                    "mysql",
 					DestinationServiceResource: "mysql://mysql:3306",
 					Outcome:                    "unknown",
 					Duration: model.AggregatedDuration{

--- a/model/modelprocessor/dropped_spans_stats.go
+++ b/model/modelprocessor/dropped_spans_stats.go
@@ -1,0 +1,41 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package modelprocessor
+
+import (
+	"context"
+
+	"github.com/elastic/apm-server/model"
+)
+
+type DropedSpansStatsDiscarder struct{}
+
+// ProcessBatch removes model.APMEvent.Transaction.DroppedSpanStats since we
+// only use that field to process and publish metricsets. The MetricSets are
+// aggregated and published only for the Elastic licensed `apm-server` but we
+// make sure the source isn't ever stored, ASL2 or Elastic licensed.
+func (DropedSpansStatsDiscarder) ProcessBatch(_ context.Context, batch *model.Batch) error {
+	for i := range *batch {
+		event := &(*batch)[i]
+		tx := event.Transaction
+		if event.Processor == model.TransactionProcessor && tx != nil {
+			event.Transaction.DroppedSpansStats = nil
+		}
+	}
+	return nil
+}

--- a/model/modelprocessor/dropped_spans_stats.go
+++ b/model/modelprocessor/dropped_spans_stats.go
@@ -23,13 +23,15 @@ import (
 	"github.com/elastic/apm-server/model"
 )
 
-type DropedSpansStatsDiscarder struct{}
-
-// ProcessBatch removes model.APMEvent.Transaction.DroppedSpanStats since we
+// DroppedSpansStatsDiscarder removes the Transaction.DroppedSpanStats since we
 // only use that field to process and publish metricsets. The MetricSets are
 // aggregated and published only for the Elastic licensed `apm-server` but we
 // make sure the source isn't ever stored, ASL2 or Elastic licensed.
-func (DropedSpansStatsDiscarder) ProcessBatch(_ context.Context, batch *model.Batch) error {
+type DroppedSpansStatsDiscarder struct{}
+
+// ProcessBatch modifies the batches with a transaction processor, unsetting
+// the DroppedSpansStats field
+func (DroppedSpansStatsDiscarder) ProcessBatch(_ context.Context, batch *model.Batch) error {
 	for i := range *batch {
 		event := &(*batch)[i]
 		tx := event.Transaction

--- a/model/transaction.go
+++ b/model/transaction.go
@@ -158,8 +158,6 @@ func (m TransactionMark) fields() common.MapStr {
 }
 
 type DroppedSpanStats struct {
-	Type                       string
-	Subtype                    string
 	DestinationServiceResource string
 	Outcome                    string
 	Duration                   AggregatedDuration
@@ -167,8 +165,6 @@ type DroppedSpanStats struct {
 
 func (stat DroppedSpanStats) fields() common.MapStr {
 	var out mapStr
-	out.maybeSetString("type", stat.Type)
-	out.maybeSetString("subtype", stat.Subtype)
 	out.maybeSetString("destination_service_resource",
 		stat.DestinationServiceResource,
 	)

--- a/model/transaction_test.go
+++ b/model/transaction_test.go
@@ -125,8 +125,6 @@ func TestTransactionTransform(t *testing.T) {
 				SpanCount: SpanCount{Started: &startedSpans, Dropped: &dropped},
 				DroppedSpansStats: []DroppedSpanStats{
 					{
-						Type:                       "query",
-						Subtype:                    "mysql",
 						DestinationServiceResource: "mysql://server:3306",
 						Outcome:                    "success",
 						Duration: AggregatedDuration{
@@ -135,8 +133,6 @@ func TestTransactionTransform(t *testing.T) {
 						},
 					},
 					{
-						Type:                       "request",
-						Subtype:                    "elasticsearch",
 						DestinationServiceResource: "http://elasticsearch:9200",
 						Outcome:                    "unknown",
 						Duration: AggregatedDuration{
@@ -159,15 +155,11 @@ func TestTransactionTransform(t *testing.T) {
 						"destination_service_resource": "mysql://server:3306",
 						"duration":                     common.MapStr{"count": 5, "sum.us": int64(65980)},
 						"outcome":                      "success",
-						"subtype":                      "mysql",
-						"type":                         "query",
 					},
 					{
 						"destination_service_resource": "http://elasticsearch:9200",
 						"duration":                     common.MapStr{"count": 15, "sum.us": int64(65980)},
 						"outcome":                      "unknown",
-						"subtype":                      "elasticsearch",
-						"type":                         "request",
 					},
 				},
 				"sampled": true,

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationTransactionsHugeTraces.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationTransactionsHugeTraces.approved.json
@@ -181,9 +181,7 @@
                             "count": 2,
                             "sum.us": 123456
                         },
-                        "outcome": "failure",
-                        "subtype": "http",
-                        "type": "request"
+                        "outcome": "failure"
                     },
                     {
                         "destination_service_resource": "mysql",
@@ -191,9 +189,7 @@
                             "count": 1,
                             "sum.us": 9876543
                         },
-                        "outcome": "success",
-                        "subtype": "mysql",
-                        "type": "db"
+                        "outcome": "success"
                     }
                 ],
                 "duration": {

--- a/systemtest/approvals/TestTransactionDroppedSpansStatsTransaction.approved.json
+++ b/systemtest/approvals/TestTransactionDroppedSpansStatsTransaction.approved.json
@@ -196,28 +196,6 @@
                     "my_key": 1,
                     "some_other_value": "foo bar"
                 },
-                "dropped_spans_stats": [
-                    {
-                        "destination_service_resource": "example.com:443",
-                        "duration": {
-                            "count": 2,
-                            "sum.us": 123456
-                        },
-                        "outcome": "failure",
-                        "subtype": "http",
-                        "type": "request"
-                    },
-                    {
-                        "destination_service_resource": "mysql",
-                        "duration": {
-                            "count": 1,
-                            "sum.us": 9876543
-                        },
-                        "outcome": "success",
-                        "subtype": "mysql",
-                        "type": "db"
-                    }
-                ],
                 "duration": {
                     "us": 32592
                 },

--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
@@ -199,6 +199,9 @@ func (a *Aggregator) ProcessBatch(ctx context.Context, b *model.Batch) error {
 					*b = append(*b, msEvent)
 				}
 			}
+			// NOTE(marclop) The event.Transaction.DroppedSpansStats is unset
+			// via the `modelprocessor.DropedSpansStatsDiscarder` appended just
+			// before the Elasticsearch publisher.
 			continue
 		}
 	}

--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
@@ -200,7 +200,7 @@ func (a *Aggregator) ProcessBatch(ctx context.Context, b *model.Batch) error {
 				}
 			}
 			// NOTE(marclop) The event.Transaction.DroppedSpansStats is unset
-			// via the `modelprocessor.DropedSpansStatsDiscarder` appended just
+			// via the `modelprocessor.DroppedSpansStatsDiscarder` appended just
 			// before the Elasticsearch publisher.
 			continue
 		}

--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator_test.go
@@ -243,8 +243,6 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 			RepresentativeCount: 2,
 			DroppedSpansStats: []model.DroppedSpanStats{
 				{
-					Type:                       "request",
-					Subtype:                    "elasticsearch",
 					DestinationServiceResource: "https://elasticsearch:9200",
 					Outcome:                    "success",
 					Duration: model.AggregatedDuration{
@@ -253,8 +251,6 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 					},
 				},
 				{
-					Type:                       "query",
-					Subtype:                    "mysql",
 					DestinationServiceResource: "mysql://mysql:3306",
 					Outcome:                    "unknown",
 					Duration: model.AggregatedDuration{


### PR DESCRIPTION
## Motivation/summary

Removes the `dropped_spans_stats.{type,subtype}` fields from the intake
API and sets the `model.APMEvent.Transaction.DroppedSpansStats` to `nil`
after the metricsets have been created for the `dropped_spans_stats`.

Introduces a new `modelprocessor.DroppedSpansStatsDiscarder` since we do
not want to send the `model.APMEvent.Transaction.DroppedSpansStats` to
the published and store it in Elasticsearch, since the only use for the
field is the process the relevant metricsets for spans that are dropped.
To allow any processors before the new processor is run, it is appended
just before the publisher.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- ~[ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
- [x] Documentation has been updated

## How to test these changes

The system tests cover the base usage, but to test this change:

1. `make && docker compose up -d`
3. Run APM server: `./apm-server -E output.elasticsearch.username=admin -E output.elasticsearch.password=changeme -e`
4. Ingest `testdata/intake-v2/transactions-huge_traces.ndjson `:
    - `curl -H "Content-type: application/x-ndjson" --data-binary @testdata/intake-v2/transactions-huge_traces.ndjson http://localhost:8200/intake/v2/events`

### Run the following query in `Dev Tools > Console`
```
GET /apm*-span,apm*-transaction/_search
{
  "query": {
    "term": {
      "transaction.id": "ddf109a4c4aa5f2b6e984548ca57774c"
    }
  }
}
```

Assert that the document has no `dropped_spans_stats` field under `_source`.

### Verify that `chatty-service` has the two dependencies listed in the `.ndjson` file
<img width="1655" alt="Screen Shot 2021-09-30 at 4 22 37 PM" src="https://user-images.githubusercontent.com/7286993/135473632-b9ff40d0-c38e-4d3a-a89a-b23f336cc04f.png">


## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->

Follow up from #6200 
Part of amended spec elastic/apm#515