### PR TITLE
ci: fix comment issue regex

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger("(${obltGitHubComments()}|^run\\W+(?:the\\W+)?(hey-apm|package|arm)\\W+tests|^\/test|^\/hey-apm|^\/package)")
+    issueCommentTrigger("(${obltGitHubComments()}|^run\\W+(?:the\\W+)?(hey-apm|package|arm)\\W+tests|^/test|^/hey-apm|^/package)")
   }
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger("(${obltGitHubComments()}|^run\\W+(?:the\\W+)?(hey-apm|package|arm)\\W+)?tests|^/test|^/hey-apm|^/package)")
+    issueCommentTrigger("(${obltGitHubComments()}|^run\\W+(?:the\\W+)?(hey-apm|package|arm)\\W+tests|^\/test|^\/hey-apm|^\/package)")
   }
   parameters {
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')


### PR DESCRIPTION
## Motivation/summary

Fixes the GitHub issue comment regex, that had an extra `)`

## Test


Let's ensure the comments work as expected


`/test` worked fine

![image](https://user-images.githubusercontent.com/2871786/135833745-9a8a1903-035c-4951-898c-e5604532e0d5.png)


`/package` worked fine

![image](https://user-images.githubusercontent.com/2871786/135835013-f0ddd8d9-dacc-48cb-9723-43323d0064e5.png)
