### PR TITLE
docs: APM integration documentation

### DIFF
--- a/docs/apm-package/apm-integration.asciidoc
+++ b/docs/apm-package/apm-integration.asciidoc
@@ -1,8 +1,8 @@
 [[apm-integration]]
-= APM integration for {agent}
+== APM integration for {agent}
 
 ++++
-<titleabbrev>APM integration ({agent})</titleabbrev>
+<titleabbrev>Old integration overview (TBD)</titleabbrev>
 ++++
 
 beta::[]
@@ -115,7 +115,3 @@ In the future, we may align with Elastic Stack versioning.
 * {fleet-guide}/fleet-overview.html[Fleet overview]
 
 include::./data-streams.asciidoc[]
-
-include::./input-apm.asciidoc[]
-
-include::./configure.asciidoc[]

--- a/docs/apm-package/configure.asciidoc
+++ b/docs/apm-package/configure.asciidoc
@@ -2,7 +2,7 @@
 == Configure APM integration
 
 ++++
-<titleabbrev>Configure</titleabbrev>
+<titleabbrev>Configure (temp)</titleabbrev>
 ++++
 
 beta::[]

--- a/docs/apm-package/data-streams.asciidoc
+++ b/docs/apm-package/data-streams.asciidoc
@@ -1,5 +1,5 @@
 [[apm-integration-data-streams]]
-== Data streams
+== Data streams (temp)
 
 ****
 beta::[]

--- a/docs/apm-package/input-apm.asciidoc
+++ b/docs/apm-package/input-apm.asciidoc
@@ -4,7 +4,7 @@
 == APM input settings
 
 ++++
-<titleabbrev>Input settings</titleabbrev>
+<titleabbrev>Input settings (temp)</titleabbrev>
 ++++
 
 beta::[]

--- a/docs/configuring.asciidoc
+++ b/docs/configuring.asciidoc
@@ -1,8 +1,6 @@
 [[configuring-howto-apm-server]]
 = Configure APM Server
 
-[partintro]
---
 ++++
 <titleabbrev>Configure</titleabbrev>
 ++++
@@ -24,8 +22,6 @@ include::{libbeat-dir}/shared/configuring-intro.asciidoc[]
 * <<configuration-ssl-landing>>
 * <<transaction-metrics>>
 * <<using-environ-vars>>
-
---
 
 include::./configuration-process.asciidoc[]
 

--- a/docs/copied-from-beats/docs/monitoring/monitoring-beats.asciidoc
+++ b/docs/copied-from-beats/docs/monitoring/monitoring-beats.asciidoc
@@ -2,8 +2,6 @@
 [[monitoring]]
 = Monitor {beatname_uc}
 
-[partintro]
---
 ++++
 <titleabbrev>Monitor</titleabbrev>
 ++++
@@ -32,8 +30,6 @@ endif::[]
 //updated.
 //To learn about monitoring in general, see
 //{ref}/monitor-elasticsearch-cluster.html[Monitor a cluster].
-
---
 
 include::monitoring-internal-collection.asciidoc[]
 

--- a/docs/copied-from-beats/docs/shared-securing-beat.asciidoc
+++ b/docs/copied-from-beats/docs/shared-securing-beat.asciidoc
@@ -1,9 +1,6 @@
 [id="securing-{beatname_lc}"]
 = Secure {beatname_uc}
 
-[partintro]
-
---
 ++++
 <titleabbrev>Secure</titleabbrev>
 ++++
@@ -42,7 +39,7 @@ ifdef::beat-specific-security[]
 include::{beat-specific-security}[]
 endif::[]
 
---
+
 
 ifdef::apm-server[]
 // APM privileges

--- a/docs/exploring-es-data.asciidoc
+++ b/docs/exploring-es-data.asciidoc
@@ -1,9 +1,6 @@
 [[exploring-es-data]]
 = Explore data in {es}
 
-[partintro]
---
-
 Elastic APM stores data for each {apm-overview-ref-v}/apm-data-model.html[event type]
 in separate indices. By default, <<ilm,Index Lifecylce Management (ILM)>> is enabled and event data is stored using the following index naming patterns:
 
@@ -88,8 +85,6 @@ Then, retrieve the specific template you are interested in:
 GET  /_template/your-template-name
 ----
 // CONSOLE
-
---
 
 
 include::./transaction-indices.asciidoc[]

--- a/docs/fields.asciidoc
+++ b/docs/fields.asciidoc
@@ -6,9 +6,7 @@ This file is generated! See _meta/fields.yml and scripts/generate_fields_docs.py
 [[exported-fields]]
 = Exported fields
 
-[partintro]
 
---
 This document describes the fields that are exported by Apm-Server. They are
 grouped in the following categories:
 
@@ -30,7 +28,7 @@ grouped in the following categories:
 * <<exported-fields-process>>
 * <<exported-fields-system>>
 
---
+
 [[exported-fields-apm-application-metrics]]
 == APM Application Metrics fields
 
@@ -22712,4 +22710,3 @@ type: long
 format: bytes
 
 --
-

--- a/docs/guide/overview.asciidoc
+++ b/docs/guide/overview.asciidoc
@@ -1,4 +1,4 @@
-[[overview]]
+[[overview-guide]]
 == Free and open application performance monitoring
 
 ++++

--- a/docs/guide/troubleshooting.asciidoc
+++ b/docs/guide/troubleshooting.asciidoc
@@ -1,4 +1,4 @@
-[[troubleshooting]]
+[[troubleshooting-guide]]
 == Troubleshooting
 
 If you run into trouble, there are three places you can look for help.

--- a/docs/howto.asciidoc
+++ b/docs/howto.asciidoc
@@ -1,8 +1,6 @@
 [[howto-guides]]
 = How-to guides
 
-[partintro]
---
 Learn how to perform common {beatname_uc} configuration and management tasks.
 
 * <<sourcemaps>>
@@ -12,8 +10,6 @@ Learn how to perform common {beatname_uc} configuration and management tasks.
 * <<storage-management>>
 * <<configuring-ingest-node>>
 * <<tune-data-ingestion>>
-
---
 
 include::./sourcemaps.asciidoc[]
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,7 +1,6 @@
 include::./version.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-:apm-package-dir: {docdir}/apm-package
 :libbeat-dir: {docdir}/copied-from-beats/docs
 :libbeat-outputs-dir: {docdir}/copied-from-beats/outputs
 :version: {apm_server_version}
@@ -50,7 +49,14 @@ please view this documentation at https://www.elastic.co/guide/en/apm/server[ela
 endif::[]
 
 [[apm-server]]
-= APM Server Reference
+= Legacy APM Server Reference
+
+deprecated::[7.16.0]
+
+****
+🚨🚨🚨🚨
+Add some note here about what was deprecated and why.
+****
 
 include::./overview.asciidoc[]
 
@@ -58,28 +64,40 @@ include::./getting-started-apm-server.asciidoc[]
 
 include::./setting-up-and-running.asciidoc[]
 
-include::./howto.asciidoc[]
+include::./howto.asciidoc[leveloffset=+1]
 
 :beat-specific-output-config: {docdir}/configuring-output-after.asciidoc
-include::./configuring.asciidoc[]
+include::./configuring.asciidoc[leveloffset=+1]
 
 :beat-specific-security: {docdir}/security.asciidoc
-include::{libbeat-dir}/shared-securing-beat.asciidoc[]
+include::{libbeat-dir}/shared-securing-beat.asciidoc[leveloffset=+1]
 
-include::{libbeat-dir}/monitoring/monitoring-beats.asciidoc[]
+include::{libbeat-dir}/monitoring/monitoring-beats.asciidoc[leveloffset=+1]
 
-include::./intake-api.asciidoc[]
+include::./intake-api.asciidoc[leveloffset=+1]
 
-include::./exploring-es-data.asciidoc[]
+include::./exploring-es-data.asciidoc[leveloffset=+1]
 
-include::./fields.asciidoc[]
+include::./fields.asciidoc[leveloffset=+1]
 
-include::./troubleshooting.asciidoc[]
+include::./troubleshooting.asciidoc[leveloffset=+1]
 
-include::./upgrading.asciidoc[]
+include::./upgrading.asciidoc[leveloffset=+1]
 
-include::./release-notes.asciidoc[]
+include::./release-notes.asciidoc[leveloffset=+1]
 
-include::{apm-package-dir}/apm-integration.asciidoc[]
+
 
 include::./redirects.asciidoc[]
+
+
+
+Configure
+Secure
+Monitor
+API
+Explore data in Elasticsearch
+Exported fields
+Troubleshoot
+Upgrade
+Release notes

--- a/docs/intake-api.asciidoc
+++ b/docs/intake-api.asciidoc
@@ -1,15 +1,12 @@
 [[intake-api]]
 = API
 
-[partintro]
---
 The APM Server exposes endpoints for:
 
 * <<events-api,Events intake>>
 * <<sourcemap-api,Sourcemap upload>>
 * <<agent-configuration-api,Agent configuration>>
 * <<server-info,Server information>>
---
 
 include::./events-api.asciidoc[]
 include::./sourcemap-api.asciidoc[]

--- a/docs/integrations-index.asciidoc
+++ b/docs/integrations-index.asciidoc
@@ -1,0 +1,69 @@
+include::./version.asciidoc[]
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
+[[apm-integration-guide]]
+= APM Integration Guide
+
+
+// THIS IS APM OVERVIEW CONTENT
+include::./guide/overview.asciidoc[]
+
+include::./guide/apm-doc-directory.asciidoc[]
+
+include::./guide/install-and-run.asciidoc[]
+
+include::./guide/quick-start-overview.asciidoc[]
+
+include::./guide/apm-data-model.asciidoc[]
+
+include::./guide/features.asciidoc[]
+
+include::./guide/agent-server-compatibility.asciidoc[]
+
+// include::./guide/troubleshooting.asciidoc[]
+
+// include::./guide/apm-breaking-changes.asciidoc[]
+
+// include::./guide/redirects.asciidoc[]
+
+
+
+:apm-package-dir: {docdir}/apm-package
+include::{apm-package-dir}/apm-integration.asciidoc[]
+
+
+== Set up (temp)
+
+text
+
+== Upgrade from legacy APM Server (temp)
+
+text
+
+== Administer (temp)
+
+text
+
+== How to (temp)
+
+text
+
+// configure stuff
+include::{apm-package-dir}/configure.asciidoc[]
+// input settings
+include::{apm-package-dir}/input-apm.asciidoc[]
+
+== API (temp)
+
+text
+
+== Explore your data (temp)
+
+text
+
+== Troubleshoot (temp)
+
+text
+
+// This includes the APM Server Reference
+include::./index.asciidoc[]

--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -10,20 +10,20 @@ The following pages have moved or been deleted.
 
 This page has moved. Please see {apm-overview-ref-v}/apm-data-model.html[APM data model].
 
-[role="exclude",id="errors"]
-=== Errors
+// [role="exclude",id="errors"]
+// === Errors
 
-This page has moved. Please see {apm-overview-ref-v}/errors.html[Errors].
+// This page has moved. Please see {apm-overview-ref-v}/errors.html[Errors].
 
-[role="exclude",id="transactions"]
-=== Transactions
+// [role="exclude",id="transactions"]
+// === Transactions
 
-This page has moved. Please see {apm-overview-ref-v}/transactions.html[Transactions].
+// This page has moved. Please see {apm-overview-ref-v}/transactions.html[Transactions].
 
-[role="exclude",id="transactions-spans"]
-=== Spans
+// [role="exclude",id="transactions-spans"]
+// === Spans
 
-This page has moved. Please see {apm-overview-ref-v}/transaction-spans.html[Spans].
+// This page has moved. Please see {apm-overview-ref-v}/transaction-spans.html[Spans].
 
 // Error API
 
@@ -246,7 +246,7 @@ Please use the {kibana-ref}/xpack-apm.html[Kibana APM UI] instead.
 As an alternative, a small number of dashboards and visualizations are available in the
 https://github.com/elastic/apm-contrib/tree/master/kibana[apm-contrib] repository.
 
-[role="exclude",id="rum"]
-=== Rum
+// [role="exclude",id="rum"]
+// === Rum
 
-This section has moved. Please see <<configuration-rum>>.
+// This section has moved. Please see <<configuration-rum>>.

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -5,9 +5,6 @@
 :issue: https://github.com/elastic/apm-server/issues/
 :pull: https://github.com/elastic/apm-server/pull/
 
-[partintro]
-
---
 This following sections summarizes the changes in each release.
 
 * <<release-notes-8.0>>
@@ -35,6 +32,5 @@ This following sections summarizes the changes in each release.
 * <<release-notes-6.3>>
 * <<release-notes-6.2>>
 * <<release-notes-6.1>>
---
 
 include::{root-dir}/CHANGELOG.asciidoc[]

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -1,8 +1,6 @@
 [[troubleshooting]]
 = Troubleshoot
 
-[partintro]
---
 If you have issues installing or running APM Server,
 read the following tips:
 
@@ -31,8 +29,6 @@ don't forget to check the relevant troubleshooting guides:
 * {apm-py-ref-v}/troubleshooting.html[Python agent troubleshooting]
 * {apm-ruby-ref-v}/debugging.html[Ruby agent troubleshooting]
 * {apm-rum-ref-v}/troubleshooting.html[RUM troubleshooting]
-
---
 
 include::common-problems.asciidoc[]
 


### PR DESCRIPTION
### Summary

// coming soon


### Build it

```
$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-server/docs/integrations-index.asciidoc --chunk 2 --open
```

### To do

- [ ] Fix broken old redirects
- [ ] Fix `fields.asciidoc` script which was manually overwritten in ab092ac