### PR TITLE
beater: watch output config changes

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -86,11 +86,12 @@ func NewCreator(args CreatorParams) beat.Creator {
 			logger = logp.NewLogger(logs.Beater)
 		}
 		bt := &beater{
-			rawConfig:     ucfg,
-			stopped:       false,
-			logger:        logger,
-			wrapRunServer: args.WrapRunServer,
-			waitPublished: publish.NewWaitPublishedAcker(),
+			rawConfig:            ucfg,
+			stopped:              false,
+			logger:               logger,
+			wrapRunServer:        args.WrapRunServer,
+			waitPublished:        publish.NewWaitPublishedAcker(),
+			outputConfigReloader: newChanReloader(),
 		}
 
 		var err error
@@ -116,17 +117,25 @@ func NewCreator(args CreatorParams) beat.Creator {
 				return nil, errors.New("data streams must be enabled when the server is managed")
 			}
 		}
+
+		if b.Manager != nil && b.Manager.Enabled() {
+			// Subscribe to output changes for reconfiguring apm-server's Elasticsearch
+			// clients, which use the Elasticsearch output config by default.
+			b.OutputConfigReloader = bt.outputConfigReloader
+		}
+
 		bt.registerPipelineSetupCallback(b)
 		return bt, nil
 	}
 }
 
 type beater struct {
-	rawConfig     *common.Config
-	config        *config.Config
-	logger        *logp.Logger
-	wrapRunServer func(RunServerFunc) RunServerFunc
-	waitPublished *publish.WaitPublishedAcker
+	rawConfig            *common.Config
+	config               *config.Config
+	logger               *logp.Logger
+	wrapRunServer        func(RunServerFunc) RunServerFunc
+	waitPublished        *publish.WaitPublishedAcker
+	outputConfigReloader *chanReloader
 
 	mutex      sync.Mutex // guards stopServer and stopped
 	stopServer func()
@@ -138,77 +147,101 @@ type beater struct {
 func (bt *beater) Run(b *beat.Beat) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	done, err := bt.start(ctx, cancel, b)
-	if err != nil {
+	if err := bt.run(ctx, cancel, b); err != nil {
 		return err
 	}
-	<-done
 	bt.waitPublished.Wait(ctx)
 	return nil
 }
 
-func (bt *beater) start(ctx context.Context, cancelContext context.CancelFunc, b *beat.Beat) (<-chan struct{}, error) {
-	done := make(chan struct{})
-	bt.mutex.Lock()
-	defer bt.mutex.Unlock()
-	if bt.stopped {
-		close(done)
-		return done, nil
-	}
-
+func (bt *beater) run(ctx context.Context, cancelContext context.CancelFunc, b *beat.Beat) error {
 	tracer, tracerServer, err := initTracing(b, bt.config, bt.logger)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	closeTracer := func() error { return nil }
+	if tracerServer != nil {
+		defer tracerServer.Close()
+	}
 	if tracer != nil {
-		closeTracer = func() error {
-			tracer.Close()
-			if tracerServer != nil {
-				return tracerServer.Close()
-			}
-			return nil
-		}
-	}
-
-	sharedArgs := sharedServerRunnerParams{
-		Beat:          b,
-		WrapRunServer: bt.wrapRunServer,
-		Logger:        bt.logger,
-		Tracer:        tracer,
-		TracerServer:  tracerServer,
-		Acker:         bt.waitPublished,
+		defer tracer.Close()
 	}
 
 	reloader := reloader{
 		runServerContext: ctx,
-		args:             sharedArgs,
+		args: sharedServerRunnerParams{
+			Beat:          b,
+			WrapRunServer: bt.wrapRunServer,
+			Logger:        bt.logger,
+			Tracer:        tracer,
+			TracerServer:  tracerServer,
+			Acker:         bt.waitPublished,
+		},
 	}
-	bt.stopServer = func() {
-		defer close(done)
-		defer closeTracer()
+
+	stopped := make(chan struct{})
+	stopServer := func() {
+		defer close(stopped)
 		if bt.config.ShutdownTimeout > 0 {
 			time.AfterFunc(bt.config.ShutdownTimeout, cancelContext)
 		}
 		reloader.stop()
 	}
+	if !bt.setStopServerFunc(stopServer) {
+		// Server has already been stopped.
+		stopServer()
+		return nil
+	}
+
+	g, ctx := errgroup.WithContext(context.Background())
+	g.Go(func() error {
+		<-stopped
+		return nil
+	})
 	if b.Manager != nil && b.Manager.Enabled() {
+		// Managed by Agent: register input and output reloaders to reconfigure the server.
 		reload.Register.MustRegisterList("inputs", &reloader)
+		g.Go(func() error {
+			return bt.outputConfigReloader.serve(
+				ctx, reload.ReloadableFunc(reloader.reloadOutput),
+			)
+		})
 	} else {
 		// Management disabled, use statically defined config.
-		if err := reloader.reload(bt.rawConfig, "default", nil); err != nil {
-			return nil, err
+		reloader.namespace = "default"
+		reloader.rawConfig = bt.rawConfig
+		if b.Config != nil {
+			reloader.outputConfig = b.Config.Output
+		}
+		if err := reloader.reload(); err != nil {
+			return err
 		}
 	}
-	return done, nil
+	return g.Wait()
+}
+
+// setStopServerFunc sets a function to call when the server is stopped.
+//
+// setStopServerFunc returns false if the server has already been stopped.
+func (bt *beater) setStopServerFunc(stopServer func()) bool {
+	bt.mutex.Lock()
+	defer bt.mutex.Unlock()
+	if bt.stopped {
+		return false
+	}
+	bt.stopServer = stopServer
+	return true
 }
 
 type reloader struct {
 	runServerContext context.Context
 	args             sharedServerRunnerParams
 
-	mu     sync.Mutex
-	runner *serverRunner
+	mu           sync.Mutex
+	namespace    string
+	rawConfig    *common.Config
+	outputConfig common.ConfigNamespace
+	fleetConfig  *config.Fleet
+	runner       *serverRunner
 }
 
 func (r *reloader) stop() {
@@ -227,6 +260,7 @@ func (r *reloader) Reload(configs []*reload.ConfigWithMeta) error {
 		return fmt.Errorf("only 1 input supported, got %d", n)
 	}
 	cfg := configs[0]
+
 	integrationConfig, err := config.NewIntegrationConfig(cfg.Config)
 	if err != nil {
 		return err
@@ -237,17 +271,42 @@ func (r *reloader) Reload(configs []*reload.ConfigWithMeta) error {
 	}
 	apmServerCommonConfig := integrationConfig.APMServer
 	apmServerCommonConfig.Merge(common.MustNewConfigFrom(`{"data_streams.enabled": true}`))
-	return r.reload(apmServerCommonConfig, namespace, &integrationConfig.Fleet)
+
+	r.mu.Lock()
+	r.namespace = namespace
+	r.rawConfig = apmServerCommonConfig
+	r.fleetConfig = &integrationConfig.Fleet
+	r.mu.Unlock()
+	return r.reload()
 }
 
-func (r *reloader) reload(rawConfig *common.Config, namespace string, fleetConfig *config.Fleet) error {
+func (r *reloader) reloadOutput(config *reload.ConfigWithMeta) error {
+	var outputConfig common.ConfigNamespace
+	if config != nil {
+		if err := config.Config.Unpack(&outputConfig); err != nil {
+			return err
+		}
+	}
+	r.mu.Lock()
+	r.outputConfig = outputConfig
+	r.mu.Unlock()
+	return r.reload()
+}
+
+func (r *reloader) reload() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if r.rawConfig == nil {
+		// APM Server config not loaded yet.
+		return nil
+	}
+
 	runner, err := newServerRunner(r.runServerContext, serverRunnerParams{
 		sharedServerRunnerParams: r.args,
-		Namespace:                namespace,
-		RawConfig:                rawConfig,
-		FleetConfig:              fleetConfig,
+		Namespace:                r.namespace,
+		RawConfig:                r.rawConfig,
+		FleetConfig:              r.fleetConfig,
+		OutputConfig:             r.outputConfig,
 	})
 	if err != nil {
 		return err
@@ -284,25 +343,27 @@ type serverRunner struct {
 	cancelRunServerContext context.CancelFunc
 	done                   chan struct{}
 
-	pipeline      beat.PipelineConnector
-	acker         *publish.WaitPublishedAcker
-	namespace     string
-	config        *config.Config
-	rawConfig     *common.Config
-	fleetConfig   *config.Fleet
-	beat          *beat.Beat
-	logger        *logp.Logger
-	tracer        *apm.Tracer
-	tracerServer  *tracerServer
-	wrapRunServer func(RunServerFunc) RunServerFunc
+	pipeline                  beat.PipelineConnector
+	acker                     *publish.WaitPublishedAcker
+	namespace                 string
+	config                    *config.Config
+	rawConfig                 *common.Config
+	elasticsearchOutputConfig *common.Config
+	fleetConfig               *config.Fleet
+	beat                      *beat.Beat
+	logger                    *logp.Logger
+	tracer                    *apm.Tracer
+	tracerServer              *tracerServer
+	wrapRunServer             func(RunServerFunc) RunServerFunc
 }
 
 type serverRunnerParams struct {
 	sharedServerRunnerParams
 
-	Namespace   string
-	RawConfig   *common.Config
-	FleetConfig *config.Fleet
+	Namespace    string
+	RawConfig    *common.Config
+	FleetConfig  *config.Fleet
+	OutputConfig common.ConfigNamespace
 }
 
 type sharedServerRunnerParams struct {
@@ -315,7 +376,12 @@ type sharedServerRunnerParams struct {
 }
 
 func newServerRunner(ctx context.Context, args serverRunnerParams) (*serverRunner, error) {
-	cfg, err := config.NewConfig(args.RawConfig, elasticsearchOutputConfig(args.Beat))
+	var esOutputConfig *common.Config
+	if args.OutputConfig.Name() == "elasticsearch" {
+		esOutputConfig = args.OutputConfig.Config()
+	}
+
+	cfg, err := config.NewConfig(args.RawConfig, esOutputConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -327,17 +393,18 @@ func newServerRunner(ctx context.Context, args serverRunnerParams) (*serverRunne
 		cancelRunServerContext: cancel,
 		done:                   make(chan struct{}),
 
-		config:        cfg,
-		rawConfig:     args.RawConfig,
-		fleetConfig:   args.FleetConfig,
-		acker:         args.Acker,
-		pipeline:      args.Beat.Publisher,
-		namespace:     args.Namespace,
-		beat:          args.Beat,
-		logger:        args.Logger,
-		tracer:        args.Tracer,
-		tracerServer:  args.TracerServer,
-		wrapRunServer: args.WrapRunServer,
+		config:                    cfg,
+		rawConfig:                 args.RawConfig,
+		elasticsearchOutputConfig: esOutputConfig,
+		fleetConfig:               args.FleetConfig,
+		acker:                     args.Acker,
+		pipeline:                  args.Beat.Publisher,
+		namespace:                 args.Namespace,
+		beat:                      args.Beat,
+		logger:                    args.Logger,
+		tracer:                    args.Tracer,
+		tracerServer:              args.TracerServer,
+		wrapRunServer:             args.WrapRunServer,
 	}, nil
 }
 
@@ -503,9 +570,9 @@ func (s *serverRunner) run(listener net.Listener) error {
 func (s *serverRunner) waitReady(ctx context.Context, kibanaClient kibana.Client) error {
 	var preconditions []func(context.Context) error
 	var esOutputClient elasticsearch.Client
-	if cfg := elasticsearchOutputConfig(s.beat); cfg != nil {
+	if s.elasticsearchOutputConfig != nil {
 		esConfig := elasticsearch.DefaultConfig()
-		err := cfg.Unpack(&esConfig)
+		err := s.elasticsearchOutputConfig.Unpack(&esConfig)
 		if err != nil {
 			return err
 		}
@@ -730,6 +797,7 @@ func (bt *beater) Stop() {
 		"stopping apm-server... waiting maximum of %v seconds for queues to drain",
 		bt.config.ShutdownTimeout.Seconds(),
 	)
+	bt.outputConfigReloader.cancel()
 	bt.stopServer()
 	bt.stopped = true
 }
@@ -844,4 +912,56 @@ func newDropLogsBeatProcessor() (beat.ProcessorList, error) {
 			},
 		}),
 	})
+}
+
+type chanReloader struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	ch     chan reloadRequest
+}
+
+func newChanReloader() *chanReloader {
+	ctx, cancel := context.WithCancel(context.Background())
+	ch := make(chan reloadRequest)
+	return &chanReloader{ctx, cancel, ch}
+}
+
+type reloadRequest struct {
+	cfg    *reload.ConfigWithMeta
+	result chan<- error
+}
+
+func (r *chanReloader) Reload(cfg *reload.ConfigWithMeta) error {
+	result := make(chan error, 1)
+	select {
+	case <-r.ctx.Done():
+		return r.ctx.Err()
+	case r.ch <- reloadRequest{cfg: cfg, result: result}:
+	}
+	select {
+	case <-r.ctx.Done():
+		return r.ctx.Err()
+	case err := <-result:
+		return err
+	}
+}
+
+func (r *chanReloader) serve(ctx context.Context, reloader reload.Reloadable) error {
+	for {
+		select {
+		case <-r.ctx.Done():
+			return r.ctx.Err()
+		case <-ctx.Done():
+			return ctx.Err()
+		case req := <-r.ch:
+			err := reloader.Reload(req.cfg)
+			select {
+			case <-r.ctx.Done():
+				return r.ctx.Err()
+			case <-ctx.Done():
+				return ctx.Err()
+			case req.result <- err:
+			}
+		}
+	}
 }

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -569,12 +569,15 @@ func TestServerOutputConfigReload(t *testing.T) {
 	apmBeat, cfg := newBeat(t, cfg, nil, nil)
 	apmBeat.Manager = &mockManager{enabled: true}
 
+	var mu sync.Mutex
 	var runServerCalls []ServerParams
 	createBeater := NewCreator(CreatorParams{
 		Logger: logp.NewLogger(""),
 		WrapRunServer: func(runServer RunServerFunc) RunServerFunc {
 			return func(ctx context.Context, args ServerParams) error {
+				mu.Lock()
 				runServerCalls = append(runServerCalls, args)
+				mu.Unlock()
 				return runServer(ctx, args)
 			}
 		},

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -472,6 +472,7 @@ func TestServerConfigReload(t *testing.T) {
 	apmBeat.Manager = &mockManager{enabled: true}
 	beater, err := newTestBeater(t, apmBeat, cfg, nil)
 	require.NoError(t, err)
+	require.NotNil(t, apmBeat.OutputConfigReloader)
 	beater.start()
 
 	// Now that the beater is running, send config changes. The reloader
@@ -532,11 +533,98 @@ func TestServerConfigReload(t *testing.T) {
 
 	addr2, err := beater.waitListenAddr(1 * time.Second)
 	require.NoError(t, err)
-	assert.Empty(t, healthcheck(addr2)) // empty as auth is required but not specified
+	assert.Empty(t, healthcheck(addr2))
 
 	// First HTTP server should have been stopped.
 	_, err = http.Get("http://" + addr1)
 	assert.Error(t, err)
+
+	// Reload output config, should also cause HTTP server to be restarted.
+	err = apmBeat.OutputConfigReloader.Reload(&reload.ConfigWithMeta{Config: common.NewConfig()})
+	assert.NoError(t, err)
+
+	addr3, err := beater.waitListenAddr(1 * time.Second)
+	require.NoError(t, err)
+	assert.Empty(t, healthcheck(addr3)) // empty as auth is required but not specified
+
+	// Second HTTP server should have been stopped.
+	_, err = http.Get("http://" + addr2)
+	assert.Error(t, err)
+}
+
+func TestServerOutputConfigReload(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping server test")
+	}
+
+	// The beater has no way of unregistering itself from reload.Register,
+	// so we create a fresh registry and replace it after the test.
+	oldRegister := reload.Register
+	defer func() {
+		reload.Register = oldRegister
+	}()
+	reload.Register = reload.NewRegistry()
+
+	cfg := common.MustNewConfigFrom(map[string]interface{}{"data_streams.enabled": true})
+	apmBeat, cfg := newBeat(t, cfg, nil, nil)
+	apmBeat.Manager = &mockManager{enabled: true}
+
+	var runServerCalls []ServerParams
+	createBeater := NewCreator(CreatorParams{
+		Logger: logp.NewLogger(""),
+		WrapRunServer: func(runServer RunServerFunc) RunServerFunc {
+			return func(ctx context.Context, args ServerParams) error {
+				runServerCalls = append(runServerCalls, args)
+				return runServer(ctx, args)
+			}
+		},
+	})
+	beater, err := createBeater(apmBeat, cfg)
+	require.NoError(t, err)
+	t.Cleanup(beater.Stop)
+	go beater.Run(apmBeat)
+
+	// Now that the beater is running, send config changes. The reloader
+	// is not registered until after the beater starts running, so we
+	// must loop until it is set.
+	var reloadable reload.ReloadableList
+	for {
+		// The Reloader is not registered until after the beat has started running.
+		reloadable = reload.Register.GetReloadableList("inputs")
+		if reloadable != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	inputConfig := common.MustNewConfigFrom(map[string]interface{}{
+		"apm-server": map[string]interface{}{
+			"host": "localhost:0",
+			"sampling.tail": map[string]interface{}{
+				"enabled": true,
+				"policies": []map[string]interface{}{{
+					"sample_rate": 0.5,
+				}},
+			},
+		},
+	})
+	err = reloadable.Reload([]*reload.ConfigWithMeta{{Config: inputConfig}})
+	require.NoError(t, err)
+
+	// Reloaded output config should be passed into apm-server config.
+	err = apmBeat.OutputConfigReloader.Reload(&reload.ConfigWithMeta{
+		Config: common.MustNewConfigFrom(map[string]interface{}{
+			"elasticsearch.username": "updated",
+		}),
+	})
+	assert.NoError(t, err)
+	beater.Stop()
+
+	// Server should have been started twice: once with initial output config,
+	// and once with the updated output config.
+	require.Len(t, runServerCalls, 2)
+	assert.Equal(t, "", runServerCalls[0].Config.Sampling.Tail.ESConfig.Username)
+	assert.Equal(t, "updated", runServerCalls[1].Config.Sampling.Tail.ESConfig.Username)
 }
 
 func TestServerWaitForIntegrationKibana(t *testing.T) {


### PR DESCRIPTION
## Motivation/summary

Watch libbeat output config changes, and restart the beater with updated config. This enables us to propagate the Elasticsearch output config to tail-based sampling when running under Fleet.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~ (non user facing change)
~- [ ] Documentation has been updated~

## How to test these changes

Can't be manually tested yet, needs UI for configuring tail-sampling policies.

## Related issues

#5490