### PR TITLE
[mergify] remove backport-skip if added a backport label

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -118,3 +118,10 @@ pull_request_rules:
       label:
         add:
           - backport-skip
+  - name: remove backport-skip label
+    conditions:
+      - label~=^backport-\d
+    actions:
+      label:
+        remove:
+          - backport-skip


### PR DESCRIPTION
## What is the problem this PR solves?

Keep tidy the GItHub labels in the PRs.

## How does this PR solve the problem?

Remove `backport-skip` label when the backport labels have been added.

## How to test this PR locally

NA

## Test

![image](https://user-images.githubusercontent.com/2871786/136009191-20909c29-d1e3-441c-8bf0-106a29993890.png)

https://github.com/v1v/poc-bump-automation/pull/13

## Related issues

Similar to https://github.com/elastic/beats/pull/28235