### PR TITLE
Use transaction/span timestamp in metric bucketing

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -19,6 +19,7 @@ https://github.com/elastic/apm-server/compare/7.15\...master[View commits]
 [float]
 ==== Bug fixes
 - processor/otel: don't truncate `db.statement` {pull}6305[6305]
+- Use timestamp of original events for transaction/span metrics {pull}6311[6311]
 
 [float]
 ==== Intake API Changes

--- a/docs/metricset-indices.asciidoc
+++ b/docs/metricset-indices.asciidoc
@@ -94,6 +94,8 @@ You can filter and group by these dimensions (some of which are optional, for ex
 * `kubernetes.pod.name`: The name of the Kubernetes pod running the service that served the transaction
 --
 
+The `@timestamp` field of these documents holds the start of the aggregation interval.
+
 [float]
 ==== Service-destination metrics
 
@@ -117,6 +119,8 @@ You can filter and group by these dimensions:
 * `service.name`: The name of the service that made the request
 * `service.environment`: The environment of the service that made the request
 --
+
+The `@timestamp` field of these documents holds the start of the aggregation interval.
 
 [float]
 [[example-metric-document]]

--- a/systemtest/approvals/TestServiceDestinationAggregation.approved.json
+++ b/systemtest/approvals/TestServiceDestinationAggregation.approved.json
@@ -1,7 +1,7 @@
 {
     "events": [
         {
-            "@timestamp": "dynamic",
+            "@timestamp": "2006-01-02T15:04:05.000Z",
             "agent": {
                 "name": "go"
             },

--- a/systemtest/approvals/TestTransactionAggregation.approved.json
+++ b/systemtest/approvals/TestTransactionAggregation.approved.json
@@ -1,7 +1,7 @@
 {
     "events": [
         {
-            "@timestamp": "dynamic",
+            "@timestamp": "2006-01-02T15:04:05.000Z",
             "_doc_count": 5,
             "agent": {
                 "name": "go"
@@ -37,7 +37,7 @@
                 }
             },
             "timeseries": {
-                "instance": "systemtest:abc:d8f2bb8faa13bba6"
+                "instance": "systemtest:abc:b61e418e611e87bb"
             },
             "transaction": {
                 "duration.histogram": {
@@ -54,7 +54,7 @@
             }
         },
         {
-            "@timestamp": "dynamic",
+            "@timestamp": "2006-01-02T15:04:05.000Z",
             "_doc_count": 10,
             "agent": {
                 "name": "go"
@@ -90,7 +90,7 @@
                 }
             },
             "timeseries": {
-                "instance": "systemtest:def:8445550d2ba82fde"
+                "instance": "systemtest:def:faf17465cd8ab27d"
             },
             "transaction": {
                 "duration.histogram": {

--- a/systemtest/approvals/TestTransactionAggregationShutdown.approved.json
+++ b/systemtest/approvals/TestTransactionAggregationShutdown.approved.json
@@ -1,7 +1,7 @@
 {
     "events": [
         {
-            "@timestamp": "dynamic",
+            "@timestamp": "2006-01-02T15:00:00.000Z",
             "_doc_count": 1,
             "agent": {
                 "name": "go"
@@ -37,7 +37,7 @@
                 }
             },
             "timeseries": {
-                "instance": "systemtest:name:28a46e05f123d23f"
+                "instance": "systemtest:name:813c266c38717bab"
             },
             "transaction": {
                 "duration.histogram": {

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -6,6 +6,7 @@ package txmetrics
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"math"
 	"strings"
@@ -216,12 +217,11 @@ func (a *Aggregator) publish(ctx context.Context) error {
 	// TODO(axw) record either the aggregation interval in effect, or
 	// the specific time period (date_range) on the metrics documents.
 
-	now := time.Now()
 	batch := make(model.Batch, 0, a.inactive.entries)
 	for hash, entries := range a.inactive.m {
 		for _, entry := range entries {
 			totalCount, counts, values := entry.transactionMetrics.histogramBuckets()
-			batch = append(batch, makeMetricset(entry.transactionAggregationKey, hash, now, totalCount, counts, values))
+			batch = append(batch, makeMetricset(entry.transactionAggregationKey, hash, totalCount, counts, values))
 		}
 		delete(a.inactive.m, hash)
 	}
@@ -260,7 +260,7 @@ func (a *Aggregator) AggregateTransaction(event model.APMEvent) model.APMEvent {
 		return model.APMEvent{}
 	}
 
-	key := a.makeTransactionAggregationKey(event)
+	key := a.makeTransactionAggregationKey(event, a.config.MetricsInterval)
 	hash := key.hash()
 	count := transactionCount(event.Transaction)
 	if a.updateTransactionMetrics(key, hash, event.Transaction.RepresentativeCount, event.Event.Duration) {
@@ -276,7 +276,7 @@ unique transaction names.`[1:],
 	atomic.AddInt64(&a.metrics.overflowed, 1)
 	counts := []int64{int64(math.Round(count))}
 	values := []float64{float64(event.Event.Duration.Microseconds())}
-	return makeMetricset(key, hash, time.Now(), counts[0], counts, values)
+	return makeMetricset(key, hash, counts[0], counts, values)
 }
 
 func (a *Aggregator) updateTransactionMetrics(key transactionAggregationKey, hash uint64, count float64, duration time.Duration) bool {
@@ -336,8 +336,11 @@ func (a *Aggregator) updateTransactionMetrics(key transactionAggregationKey, has
 	return true
 }
 
-func (a *Aggregator) makeTransactionAggregationKey(event model.APMEvent) transactionAggregationKey {
+func (a *Aggregator) makeTransactionAggregationKey(event model.APMEvent, interval time.Duration) transactionAggregationKey {
 	return transactionAggregationKey{
+		// Group metrics by time interval.
+		timestamp: event.Timestamp.Truncate(interval),
+
 		traceRoot:         event.Parent.ID == "",
 		transactionName:   event.Transaction.Name,
 		transactionResult: event.Transaction.Result,
@@ -357,7 +360,7 @@ func (a *Aggregator) makeTransactionAggregationKey(event model.APMEvent) transac
 
 // makeMetricset makes a metricset event from key, counts, and values, with timestamp ts.
 func makeMetricset(
-	key transactionAggregationKey, hash uint64, ts time.Time, totalCount int64, counts []int64, values []float64,
+	key transactionAggregationKey, hash uint64, totalCount int64, counts []int64, values []float64,
 ) model.APMEvent {
 	// Record a timeseries instance ID, which should be uniquely identify the aggregation key.
 	var timeseriesInstanceID strings.Builder
@@ -368,7 +371,7 @@ func makeMetricset(
 	timeseriesInstanceID.WriteString(fmt.Sprintf("%x", hash))
 
 	return model.APMEvent{
-		Timestamp:  ts,
+		Timestamp:  key.timestamp,
 		Agent:      model.Agent{Name: key.agentName},
 		Container:  model.Container{ID: key.containerID},
 		Kubernetes: model.Kubernetes{PodName: key.kubernetesPodName},
@@ -421,8 +424,9 @@ type metricsMapEntry struct {
 	transactionMetrics
 }
 
-// NOTE(axw) the dimensions should be kept in sync with docs/metricset-indices.asciidoc,
+// NOTE(axw) the dimensions should be kept in sync with docs/metricset-indices.asciidoc.
 type transactionAggregationKey struct {
+	timestamp          time.Time
 	traceRoot          bool
 	agentName          string
 	containerID        string
@@ -439,6 +443,9 @@ type transactionAggregationKey struct {
 
 func (k *transactionAggregationKey) hash() uint64 {
 	var h xxhash.Digest
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(k.timestamp.UnixNano()))
+	h.Write(buf[:])
 	if k.traceRoot {
 		h.WriteString("1")
 	}

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
@@ -117,7 +117,7 @@ func TestProcessTransformablesOverflow(t *testing.T) {
 			Processor: model.MetricsetProcessor,
 			Metricset: &model.Metricset{
 				Name:                 "transaction",
-				TimeseriesInstanceID: ":baz:bc30224a3738a508",
+				TimeseriesInstanceID: ":baz:9bf2d21a00716e4a",
 				DocCount:             1,
 			},
 			Transaction: &model.Transaction{
@@ -312,7 +312,7 @@ func TestAggregateRepresentativeCount(t *testing.T) {
 			Processor: model.MetricsetProcessor,
 			Metricset: &model.Metricset{
 				Name:                 "transaction",
-				TimeseriesInstanceID: ":foo:1db641f187113b17",
+				TimeseriesInstanceID: ":foo:9f7a6aa5754581fe",
 				DocCount:             test.expectedCount,
 			},
 			Transaction: &model.Transaction{
@@ -340,6 +340,39 @@ func TestAggregateRepresentativeCount(t *testing.T) {
 	require.NotNil(t, metricsets[0].Transaction)
 	durationHistogram := metricsets[0].Transaction.DurationHistogram
 	assert.Equal(t, []int64{3 /*round(1+1.5)*/}, durationHistogram.Counts)
+}
+
+func TestAggregateTimestamp(t *testing.T) {
+	batches := make(chan model.Batch, 1)
+	agg, err := txmetrics.NewAggregator(txmetrics.AggregatorConfig{
+		BatchProcessor:                 makeChanBatchProcessor(batches),
+		MaxTransactionGroups:           2,
+		MetricsInterval:                30 * time.Second,
+		HDRHistogramSignificantFigures: 1,
+	})
+	require.NoError(t, err)
+
+	t0 := time.Unix(0, 0)
+	for _, ts := range []time.Time{t0, t0.Add(15 * time.Second), t0.Add(30 * time.Second)} {
+		agg.AggregateTransaction(model.APMEvent{
+			Timestamp:   ts,
+			Processor:   model.TransactionProcessor,
+			Transaction: &model.Transaction{Name: "name", RepresentativeCount: 1},
+		})
+	}
+
+	go agg.Run()
+	err = agg.Stop(context.Background()) // stop to flush
+	require.NoError(t, err)
+
+	batch := expectBatch(t, batches)
+	metricsets := batchMetricsets(t, batch)
+	require.Len(t, metricsets, 2)
+	sort.Slice(metricsets, func(i, j int) bool {
+		return metricsets[i].Timestamp.Before(metricsets[j].Timestamp)
+	})
+	assert.Equal(t, t0, metricsets[0].Timestamp)
+	assert.Equal(t, t0.Add(30*time.Second), metricsets[1].Timestamp)
 }
 
 func TestHDRHistogramSignificantFigures(t *testing.T) {
@@ -543,8 +576,6 @@ func batchMetricsets(t testing.TB, batch model.Batch) []model.APMEvent {
 		if event.Metricset == nil {
 			continue
 		}
-		require.NotZero(t, event.Timestamp)
-		event.Timestamp = time.Time{}
 		metricsets = append(metricsets, event)
 	}
 	return metricsets


### PR DESCRIPTION
## Motivation/summary

Update transaction and service-destination metrics to use the original event timestamp when aggregating, by adding the timestamp truncated to the aggregation interval to aggregation keys.

This ensures that events that are sent with delay or otherwise with timestamps in the past or future (e.g. synthetic test data) will be aggregated into the appropriate time windows and not in the apm-server's current aggregation time range.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
- [x] Documentation has been updated

## How to test these changes

1. Send some transactions with timestamps in the past and future
2. Check that the server produces metrics for the time ranges according to those events, and not for the real time at which the events were sent

## Related issues

Fixes #6254