### PR TITLE
Remove warm phase from default ILM policy

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -468,12 +468,6 @@ apm-server:
                     #max_age: "30d"
                   #set_priority:
                     #priority: 100
-              #warm:
-                #min_age: "30d"
-                #actions:
-                  #set_priority:
-                    #priority: 50
-                  #readonly: {}
 
 
 

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -468,12 +468,6 @@ apm-server:
                     #max_age: "30d"
                   #set_priority:
                     #priority: 100
-              #warm:
-                #min_age: "30d"
-                #actions:
-                  #set_priority:
-                    #priority: 50
-                  #readonly: {}
 
 
 

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -468,12 +468,6 @@ apm-server:
                     #max_age: "30d"
                   #set_priority:
                     #priority: 100
-              #warm:
-                #min_age: "30d"
-                #actions:
-                  #set_priority:
-                    #priority: 50
-                  #readonly: {}
 
 
 

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -15,6 +15,7 @@ https://github.com/elastic/apm-server/compare/7.15\...master[View commits]
 - Removed unused `transaction.duration.{count,sum.us}` metric fields {pull}6174[6174]
 - Removed `apm-server.sampling.tail.storage_dir` config {pull}6236[6236]
 - Removed `ProcessPending` self-instrumentation events {pull}6243[6243]
+- Removed warm phase from default ILM policy {pull}6322[6322]
 
 [float]
 ==== Bug fixes

--- a/docs/apm-package/apm-integration.asciidoc
+++ b/docs/apm-package/apm-integration.asciidoc
@@ -46,8 +46,7 @@ Stack monitoring::
 
 Index lifecycle management (ILM)::
 A default ILM policy, named `traces-apm.traces-default_policy` is created for all event types.
-This policy moves indices to a warm data tier after 30 days.
-No default cold or delete data tier is defined.
+No default warm, cold, or delete data tiers are defined.
 It is not possible to configure this policy in APM Server or {agent}–
 it must be configured with {es} or {kib}.
 See {ref}/example-using-index-lifecycle-policy.html[Customize built-in ILM policies] for more information.

--- a/docs/ilm-reference.asciidoc
+++ b/docs/ilm-reference.asciidoc
@@ -28,14 +28,13 @@ will be applied to all APM indices as long as all of the following conditions ar
 * `output.elasticsearch` is enabled.
 * Custom `index` or `indices` settings are not configured.
 
-The default ILM policy applies *hot* and *warm* phases to all APM events:
+The default ILM policy applies only a *hot* phase to all APM events:
 `span`, `transaction`, `error`, and `metric`.
-*Cold* and *delete* phases are not defined.
+
+*Warm*, *cold*, and *delete* phases are not defined.
 
 * *Hot* -- Rollover data when the index reaches a maximum size of 50gb or a maximum age of 30 days:
 `max_size: 50gb`, `max_age: 30d`
-
-* *Warm* -- Move to warm phase after 30 days: `min_age: 30d`
 
 [float]
 [[ilm-default-config]]
@@ -74,12 +73,6 @@ apm-server:
                     max_age: "30d"
                   set_priority:
                     priority: 100
-              warm:
-                min_age: "30d"
-                actions:
-                  set_priority:
-                    priority: 50
-                  readonly: {}
 ----
 
 [float]

--- a/idxmgmt/ilm/config.go
+++ b/idxmgmt/ilm/config.go
@@ -246,15 +246,6 @@ func defaultPolicies() map[string]Policy {
 								},
 							},
 						},
-						"warm": map[string]interface{}{
-							"min_age": "30d",
-							"actions": map[string]interface{}{
-								"set_priority": map[string]interface{}{
-									"priority": 50,
-								},
-								"readonly": map[string]interface{}{},
-							},
-						},
 					},
 				},
 			},

--- a/tests/system/test_export.py
+++ b/tests/system/test_export.py
@@ -79,7 +79,7 @@ class TestExportILMPolicy(ExportCommandTest):
                 with open(os.path.join(dir, file)) as f:
                     policy = json.load(f)
                 assert "hot" in policy["policy"]["phases"]
-                assert "warm" in policy["policy"]["phases"]
+                assert "warm" not in policy["policy"]["phases"]
                 assert "delete" not in policy["policy"]["phases"]
 
 


### PR DESCRIPTION
## Motivation/summary

Remove warm phase from default ILM policy for standalone. Having a warm phase by default causes warm data nodes to spin up after 30 days when autoscaling is enabled; this is surprising to users, and was unintended.

This does not affect existing deployments unless they explicitly opt into overwriting the ILM policy during server initialisation/setup. Users who wish to have a warm phase and have enabled overwriting will need to customise their ILM policy in `apm-server.yml`.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
- [x] Documentation has been updated

## How to test these changes

1. Run apm-server in a clean cluster
2. Check that the the ILM policy created does not include a warm phase

## Related issues

Closes https://github.com/elastic/apm-server/issues/6170