### PR TITLE
docs: Update 7.15 changelog for `7.15.1`

### DIFF
--- a/changelogs/7.15.asciidoc
+++ b/changelogs/7.15.asciidoc
@@ -14,7 +14,8 @@ https://github.com/elastic/apm-server/compare/v7.15.0\...v7.15.1[View commits]
 
 [float]
 ==== Bug fixes
-- dedot http.request.body.original {pull}6256[6256]
+- dedot `http.request.body.original` {pull}6256[6256]
+- processor/otel: don't truncate `db.statement` {pull}6305[6305]
 
 [float]
 [[release-notes-7.15.0]]

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -20,7 +20,6 @@ https://github.com/elastic/apm-server/compare/7.15\...master[View commits]
 
 [float]
 ==== Bug fixes
-- processor/otel: don't truncate `db.statement` {pull}6305[6305]
 - Use timestamp of original events for transaction/span metrics {pull}6311[6311]
 
 [float]


### PR DESCRIPTION
## Motivation/summary

Updates the `7.15.asciidoc` changelog with the db truncate fix, removes
the entry from `head.asciidoc`.
## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
