### PR TITLE
Drop `transaction.breakdown.count`

### DIFF
--- a/apmpackage/apm/data_stream/internal_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/internal_metrics/fields/fields.yml
@@ -160,13 +160,6 @@
 - name: transaction
   type: group
   fields:
-    - name: breakdown
-      type: group
-      fields:
-        - name: count
-          type: long
-          description: |
-            Counter for collected breakdowns for the transaction
     - name: duration
       type: group
       fields:

--- a/apmpackage/apm/docs/README.md
+++ b/apmpackage/apm/docs/README.md
@@ -414,7 +414,6 @@ Internal metrics are written to `metrics-apm.internal-*` data streams.
 | span.subtype | A further sub-division of the type (e.g. postgresql, elasticsearch) | keyword |  |
 | span.type | Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', 'cache', etc). | keyword |  |
 | timeseries.instance | Time series instance ID | keyword |  |
-| transaction.breakdown.count | Counter for collected breakdowns for the transaction | long |  |
 | transaction.duration.histogram | Pre-aggregated histogram of transaction durations. | histogram |  |
 | transaction.name | Generic designation of a transaction in the scope of a single service (eg. 'GET /users/:id'). | keyword |  |
 | transaction.result | The result of the transaction. HTTP status code for HTTP-related transactions. | keyword |  |

--- a/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
@@ -735,7 +735,6 @@
                 "type": "db"
             },
             "transaction": {
-                "breakdown.count": 12,
                 "name": "GET/",
                 "type": "request"
             }

--- a/beater/test_approved_es_documents/TestPublishIntegrationMetricsets.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationMetricsets.approved.json
@@ -52,7 +52,6 @@
                 "type": "db"
             },
             "transaction": {
-                "breakdown.count": 12,
                 "name": "GET /",
                 "type": "request"
             },

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -17,6 +17,7 @@ https://github.com/elastic/apm-server/compare/7.15\...master[View commits]
 - Removed `ProcessPending` self-instrumentation events {pull}6243[6243]
 - experimental:["This breaking change applies to the experimental tail-based sampling feature."] Changed `apm-server.sampling.tail.events.*` metrics semantics {pull}6273[6273]
 - Removed warm phase from default ILM policy {pull}6322[6322]
+- Removed unused `transaction.breakdown.count` metric field {pull}6366[6366]
 
 [float]
 ==== Bug fixes

--- a/docs/legacy/fields.asciidoc
+++ b/docs/legacy/fields.asciidoc
@@ -5887,16 +5887,6 @@ type: long
 --
 
 
-*`transaction.breakdown.count`*::
-+
---
-Counter for collected breakdowns for the transaction
-
-
-type: long
-
---
-
 *`transaction.root`*::
 +
 --

--- a/docs/legacy/metricset-indices.asciidoc
+++ b/docs/legacy/metricset-indices.asciidoc
@@ -31,21 +31,6 @@ To power the {apm-app-ref}/transactions.html[Time spent by span type] graph,
 agents collect summarized metrics about the timings of spans and transactions,
 broken down by span type.
 
-*`transaction.breakdown.count`*::
-+
---
-The number of transactions for which breakdown metrics (`span.self_time`) have been created
-in the most recent metrics reporting interval. Some agents measure the breakdown for both
-sampled and non-sampled transactions, while others measure only for sampled transactions.
-
-These metric documents can be identified by searching for `metricset.name: transaction_breakdown`.
-
-You can filter and group by these dimensions:
-
-* `transaction.name`: The name of the transaction, for example `GET /`
-* `transaction.type`: The type of the transaction, for example `request`
---
-
 *`span.self_time.count`* and *`span.self_time.sum.us`*::
 +
 --

--- a/docs/spec/rumv3/transaction.json
+++ b/docs/spec/rumv3/transaction.json
@@ -446,22 +446,6 @@
             "description": "Samples hold application metrics collected from the agent.",
             "type": "object",
             "properties": {
-              "xbc": {
-                "description": "TransactionBreakdownCount The number of transactions for which breakdown metrics (span.self_time) have been created.",
-                "type": [
-                  "null",
-                  "object"
-                ],
-                "properties": {
-                  "v": {
-                    "description": "Value holds the value of a single metric sample.",
-                    "type": "number"
-                  }
-                },
-                "required": [
-                  "v"
-                ]
-              },
               "ysc": {
                 "description": "SpanSelfTimeCount holds the count of the related spans' self_time.",
                 "type": [

--- a/model/metricset_test.go
+++ b/model/metricset_test.go
@@ -126,10 +126,9 @@ func TestTransformMetricsetTransaction(t *testing.T) {
 	event := APMEvent{
 		Processor: MetricsetProcessor,
 		Transaction: &Transaction{
-			Name:           "transaction_name",
-			Type:           "transaction_type",
-			Result:         "transaction_result",
-			BreakdownCount: 123,
+			Name:   "transaction_name",
+			Type:   "transaction_type",
+			Result: "transaction_result",
 			DurationHistogram: Histogram{
 				Counts: []int64{1, 2, 3},
 				Values: []float64{4.5, 6.0, 9.0},
@@ -142,10 +141,9 @@ func TestTransformMetricsetTransaction(t *testing.T) {
 		"processor":      common.MapStr{"name": "metric", "event": "metric"},
 		"metricset.name": "transaction",
 		"transaction": common.MapStr{
-			"name":            "transaction_name",
-			"type":            "transaction_type",
-			"result":          "transaction_result",
-			"breakdown.count": 123,
+			"name":   "transaction_name",
+			"type":   "transaction_type",
+			"result": "transaction_result",
 			"duration.histogram": common.MapStr{
 				"counts": []int64{1, 2, 3},
 				"values": []float64{4.5, 6.0, 9.0},

--- a/model/modeldecoder/rumv3/model.go
+++ b/model/modeldecoder/rumv3/model.go
@@ -317,8 +317,6 @@ type transactionMetricset struct {
 }
 
 type transactionMetricsetSamples struct {
-	// TransactionBreakdownCount The number of transactions for which breakdown metrics (span.self_time) have been created.
-	TransactionBreakdownCount metricsetSampleValue `json:"xbc"`
 	// SpanSelfTimeCount holds the count of the related spans' self_time.
 	SpanSelfTimeCount metricsetSampleValue `json:"ysc"`
 	// SpanSelfTimeSum holds the sum of the related spans' self_time.

--- a/model/modeldecoder/rumv3/model_generated.go
+++ b/model/modeldecoder/rumv3/model_generated.go
@@ -1009,11 +1009,10 @@ func (val *transactionMetricset) validate() error {
 }
 
 func (val *transactionMetricsetSamples) IsSet() bool {
-	return val.TransactionBreakdownCount.IsSet() || val.SpanSelfTimeCount.IsSet() || val.SpanSelfTimeSum.IsSet()
+	return val.SpanSelfTimeCount.IsSet() || val.SpanSelfTimeSum.IsSet()
 }
 
 func (val *transactionMetricsetSamples) Reset() {
-	val.TransactionBreakdownCount.Reset()
 	val.SpanSelfTimeCount.Reset()
 	val.SpanSelfTimeSum.Reset()
 }
@@ -1021,9 +1020,6 @@ func (val *transactionMetricsetSamples) Reset() {
 func (val *transactionMetricsetSamples) validate() error {
 	if !val.IsSet() {
 		return nil
-	}
-	if err := val.TransactionBreakdownCount.validate(); err != nil {
-		return errors.Wrapf(err, "xbc")
 	}
 	if err := val.SpanSelfTimeCount.validate(); err != nil {
 		return errors.Wrapf(err, "ysc")

--- a/model/modeldecoder/rumv3/model_test.go
+++ b/model/modeldecoder/rumv3/model_test.go
@@ -312,25 +312,6 @@ func TestMetadataRequiredValidationRules(t *testing.T) {
 	modeldecodertest.SetZeroStructValue(&event, cb)
 }
 
-func TestTransactionMetricsetRequiredValidationRules(t *testing.T) {
-	// setup: create full struct with sample values set
-	var tx transaction
-	s := `{"me":[{"sa":{"ysc":{"v":2048},"xbc":{"v":1}},"y":{"t":"db","su":"mysql"}}]}`
-	modeldecodertest.DecodeData(t, strings.NewReader(s), "me", &tx)
-	// test vanilla struct is valid
-	require.Len(t, tx.Metricsets, 1)
-	require.NoError(t, tx.Metricsets[0].validate())
-
-	// iterate through struct, remove every key one by one
-	// and test that validation behaves as expected
-	requiredKeys := map[string]interface{}{
-		"sa":   nil, //samples
-		"sa.v": nil, //samples.*.value
-	}
-	cb := assertRequiredFn(t, requiredKeys, tx.Metricsets[0].validate)
-	modeldecodertest.SetZeroStructValue(&tx.Metricsets[0], cb)
-}
-
 func TestTransactionRequiredValidationRules(t *testing.T) {
 	// setup: create full metadata struct with arbitrary values set
 	var event transaction

--- a/model/modeldecoder/v2/metricset_test.go
+++ b/model/modeldecoder/v2/metricset_test.go
@@ -170,11 +170,12 @@ func TestDecodeMapToMetricsetModel(t *testing.T) {
 func TestDecodeMetricsetInternal(t *testing.T) {
 	var batch model.Batch
 
+	// There are no known metrics in the samples. Because "transaction" is set,
+	// the metricset will be omitted.
 	err := DecodeNestedMetricset(decoder.NewJSONDecoder(strings.NewReader(`{
 		"metricset": {
 			"timestamp": 0,
 			"samples": {
-				"transaction.breakdown.count": {"value": 123},
 				"transaction.duration.count": {"value": 456},
 				"transaction.duration.sum.us": {"value": 789}
 			},
@@ -185,6 +186,7 @@ func TestDecodeMetricsetInternal(t *testing.T) {
 		}
 	}`)), &modeldecoder.Input{}, &batch)
 	require.NoError(t, err)
+	require.Empty(t, batch)
 
 	err = DecodeNestedMetricset(decoder.NewJSONDecoder(strings.NewReader(`{
 		"metricset": {
@@ -206,15 +208,6 @@ func TestDecodeMetricsetInternal(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, model.Batch{{
-		Timestamp: time.Unix(0, 0).UTC(),
-		Processor: model.MetricsetProcessor,
-		Metricset: &model.Metricset{},
-		Transaction: &model.Transaction{
-			Name:           "transaction_name",
-			Type:           "transaction_type",
-			BreakdownCount: 123,
-		},
-	}, {
 		Timestamp: time.Unix(0, 0).UTC(),
 		Processor: model.MetricsetProcessor,
 		Metricset: &model.Metricset{},

--- a/model/modeldecoder/v2/transaction_test.go
+++ b/model/modeldecoder/v2/transaction_test.go
@@ -251,7 +251,6 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 				"AggregatedDuration",
 				"AggregatedDuration.Count",
 				"AggregatedDuration.Sum",
-				"BreakdownCount",
 				"DurationHistogram",
 				"DurationHistogram.Counts",
 				"DurationHistogram.Values",

--- a/model/modelprocessor/metricsetname.go
+++ b/model/modelprocessor/metricsetname.go
@@ -24,9 +24,8 @@ import (
 )
 
 const (
-	spanBreakdownMetricsetName        = "span_breakdown"
-	transactionBreakdownMetricsetName = "transaction_breakdown"
-	appMetricsetName                  = "app"
+	spanBreakdownMetricsetName = "span_breakdown"
+	appMetricsetName           = "app"
 )
 
 // SetMetricsetName is a transform.Processor that sets a name for
@@ -44,12 +43,7 @@ func (SetMetricsetName) ProcessBatch(ctx context.Context, b *model.Batch) error 
 			continue
 		}
 		ms.Name = appMetricsetName
-		if event.Transaction == nil {
-			// Not a breakdown metricset.
-			continue
-		}
-		ms.Name = transactionBreakdownMetricsetName
-		if event.Span != nil && event.Span.SelfTime.Count > 0 {
+		if event.Transaction != nil && event.Span != nil && event.Span.SelfTime.Count > 0 {
 			ms.Name = spanBreakdownMetricsetName
 		}
 	}

--- a/model/modelprocessor/metricsetname_test.go
+++ b/model/modelprocessor/metricsetname_test.go
@@ -41,17 +41,6 @@ func TestSetMetricsetName(t *testing.T) {
 		name: "already_set",
 	}, {
 		event: model.APMEvent{
-			Metricset: &model.Metricset{
-				Samples: map[string]model.MetricsetSample{},
-			},
-			Transaction: &model.Transaction{
-				Type:           "request",
-				BreakdownCount: 1,
-			},
-		},
-		name: "transaction_breakdown",
-	}, {
-		event: model.APMEvent{
 			Metricset:   &model.Metricset{},
 			Transaction: &model.Transaction{Type: "request"},
 			Span: &model.Span{

--- a/model/transaction.go
+++ b/model/transaction.go
@@ -55,10 +55,6 @@ type Transaction struct {
 	// duration metrics.
 	DurationHistogram Histogram
 
-	// BreakdownCount holds transaction breakdown count, for
-	// breakdown metrics.
-	BreakdownCount int
-
 	Marks          TransactionMarks
 	Message        *Message
 	SpanCount      SpanCount
@@ -117,9 +113,6 @@ func (e *Transaction) setFields(fields *mapStr, apmEvent *APMEvent) {
 	}
 	if e.Root {
 		transaction.set("root", e.Root)
-	}
-	if e.BreakdownCount > 0 {
-		transaction.set("breakdown.count", e.BreakdownCount)
 	}
 	var dss []common.MapStr
 	for _, v := range e.DroppedSpansStats {

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
@@ -691,7 +691,6 @@
                 "type": "db"
             },
             "transaction": {
-                "breakdown.count": 12,
                 "name": "GET/",
                 "type": "request"
             }

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationMetricsets.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationMetricsets.approved.json
@@ -41,7 +41,6 @@
                 "type": "db"
             },
             "transaction": {
-                "breakdown.count": 12,
                 "name": "GET /",
                 "type": "request"
             },

--- a/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
@@ -188,61 +188,6 @@
             "source": {
                 "ip": "192.0.0.1"
             },
-            "transaction": {
-                "breakdown.count": 1,
-                "name": "general-usecase-initial-p-load",
-                "type": "p-load"
-            },
-            "user": {
-                "email": "user@email.com",
-                "id": "123",
-                "name": "John Doe"
-            },
-            "user_agent": {
-                "original": "rum-2.0"
-            }
-        },
-        {
-            "@timestamp": "2018-08-01T10:00:00.000Z",
-            "agent": {
-                "name": "js-base",
-                "version": "4.8.1"
-            },
-            "client": {
-                "ip": "192.0.0.2"
-            },
-            "labels": {
-                "testTagKey": "testTagValue"
-            },
-            "network": {
-                "connection": {
-                    "type": "5G"
-                }
-            },
-            "processor": {
-                "event": "metric",
-                "name": "metric"
-            },
-            "service": {
-                "environment": "prod",
-                "framework": {
-                    "name": "angular",
-                    "version": "2"
-                },
-                "language": {
-                    "name": "javascript",
-                    "version": "6"
-                },
-                "name": "apm-a-rum-test-e2e-general-usecase",
-                "runtime": {
-                    "name": "v8",
-                    "version": "8.0"
-                },
-                "version": "0.0.1"
-            },
-            "source": {
-                "ip": "192.0.0.1"
-            },
             "span": {
                 "self_time": {
                     "count": 1,

--- a/systemtest/approvals/TestApprovedMetrics/data_streams_disabled.approved.json
+++ b/systemtest/approvals/TestApprovedMetrics/data_streams_disabled.approved.json
@@ -279,7 +279,6 @@
                 "type": "db"
             },
             "transaction": {
-                "breakdown.count": 12,
                 "name": "GET /",
                 "type": "request"
             },

--- a/systemtest/approvals/TestApprovedMetrics/data_streams_enabled.approved.json
+++ b/systemtest/approvals/TestApprovedMetrics/data_streams_enabled.approved.json
@@ -299,7 +299,6 @@
                 "type": "db"
             },
             "transaction": {
-                "breakdown.count": 12,
                 "name": "GET /",
                 "type": "request"
             },

--- a/systemtest/approvals/TestRUMXForwardedFor/data_streams_disabled.approved.json
+++ b/systemtest/approvals/TestRUMXForwardedFor/data_streams_disabled.approved.json
@@ -53,7 +53,6 @@
                 "type": "external"
             },
             "transaction": {
-                "breakdown.count": 12,
                 "name": "GET /",
                 "type": "request"
             },

--- a/systemtest/approvals/TestRUMXForwardedFor/data_streams_enabled.approved.json
+++ b/systemtest/approvals/TestRUMXForwardedFor/data_streams_enabled.approved.json
@@ -57,7 +57,6 @@
                 "type": "external"
             },
             "transaction": {
-                "breakdown.count": 12,
                 "name": "GET /",
                 "type": "request"
             },

--- a/systemtest/ingest_test.go
+++ b/systemtest/ingest_test.go
@@ -102,7 +102,7 @@ func TestDataStreamMigrationIngestPipeline(t *testing.T) {
 		estest.TermQuery{Field: "processor.event", Value: "transaction"},
 		estest.TermQuery{Field: "processor.event", Value: "span"},
 		estest.TermQuery{Field: "processor.event", Value: "error"},
-		estest.TermQuery{Field: "metricset.name", Value: "transaction_breakdown"},
+		estest.TermQuery{Field: "metricset.name", Value: "span_breakdown"},
 		estest.TermQuery{Field: "metricset.name", Value: "app"},
 	} {
 		systemtest.Elasticsearch.ExpectDocs(t, "apm-*", query)

--- a/systemtest/metrics_test.go
+++ b/systemtest/metrics_test.go
@@ -97,7 +97,7 @@ func TestBreakdownMetrics(t *testing.T) {
 	tracer.SendMetrics(nil)
 	tracer.Flush(nil)
 
-	result := systemtest.Elasticsearch.ExpectMinDocs(t, 3, "apm-*", estest.BoolQuery{
+	result := systemtest.Elasticsearch.ExpectMinDocs(t, 2, "apm-*", estest.BoolQuery{
 		Filter: []interface{}{
 			estest.TermQuery{
 				Field: "processor.event",
@@ -112,9 +112,6 @@ func TestBreakdownMetrics(t *testing.T) {
 
 	docs := unmarshalMetricsetDocs(t, result.Hits.Hits)
 	assert.ElementsMatch(t, []metricsetDoc{{
-		Trasaction:    metricsetTransaction{Type: "tx_type"},
-		MetricsetName: "transaction_breakdown",
-	}, {
 		Trasaction:    metricsetTransaction{Type: "tx_type"},
 		Span:          metricsetSpan{Type: "span_type"},
 		MetricsetName: "span_breakdown",


### PR DESCRIPTION
## Motivation/summary

Stop recording `transaction.breakdown.count`, which is not used anywhere. This was the last remaining "transaction breakdown" metric, so transaction_breakdown metricsets are no longer indexed.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
- [x] Documentation has been updated

## How to test these changes

1. Run server with `-E instrumentation.enabled=true`
2. Send some load to the server, wait for a minute or so
3. Check that "Time spent by span type" graphs show up and look plausibly correct
4. Check that there are no documents with a `transaction.breakdown.count` field, or with `metricset.name: transaction_breakdown`

## Related issues

Closes #6358