### PR TITLE
beater/auth: update error message when apikey is not base64 encoded

### DIFF
--- a/beater/auth/apikey_test.go
+++ b/beater/auth/apikey_test.go
@@ -53,13 +53,6 @@ func TestAPIKeyAuthorizer(t *testing.T) {
 	authenticator, err := NewAuthenticator(config.AgentAuth{APIKey: apikeyAuthConfig})
 	require.NoError(t, err)
 
-	_, _, err = authenticator.Authenticate(context.Background(), headers.APIKey, "notbase64")
-	require.Error(t, err)
-
-	_, _, err = authenticator.Authenticate(context.Background(), headers.APIKey,
-		base64.StdEncoding.EncodeToString([]byte("notidcolonvalue")))
-	require.Error(t, err)
-
 	credentials := base64.StdEncoding.EncodeToString([]byte("valid_id:key_value"))
 	_, authz, err := authenticator.Authenticate(context.Background(), headers.APIKey, credentials)
 	require.NoError(t, err)

--- a/beater/auth/authenticator_test.go
+++ b/beater/auth/authenticator_test.go
@@ -154,7 +154,7 @@ func TestAuthenticatorAPIKeyErrors(t *testing.T) {
 	assert.Nil(t, authz)
 
 	details, authz, err = authenticator.Authenticate(context.Background(), headers.APIKey, "invalid_base64")
-	assert.EqualError(t, err, "authentication failed: illegal base64 data at input byte 7")
+	assert.EqualError(t, err, "authentication failed: improperly encoded ApiKey credentials: expected base64(ID:APIKey): illegal base64 data at input byte 7")
 	assert.True(t, errors.Is(err, ErrAuthFailed))
 	assert.Zero(t, details)
 	assert.Nil(t, authz)


### PR DESCRIPTION
## Motivation/summary

Currently logged when users are typically just getting started: `authentication failed: illegal base64 data at input byte 16`.

This provides a bit more context on where the issue is.