### PR TITLE
apmpackage: fix cluster privilege

### DIFF
--- a/apmpackage/apm/manifest.yml
+++ b/apmpackage/apm/manifest.yml
@@ -33,7 +33,7 @@ screenshots:
     type: image/png
 elasticsearch:
   privileges:
-    cluster: ['monitor/main']
+    cluster: ['cluster:monitor/main']
 policy_templates:
   - name: apmserver
     title: Elastic APM Integration


### PR DESCRIPTION
## Motivation/summary

The Fleet system tests are failing with this error message in the apm-server logs:

> ```{"log.level":"error","@timestamp":"2021-10-20T10:09:10.395Z","log.logger":"publisher_pipeline_output","log.origin":{"file.name":"pipeline/output.go","file.line":154},"message":"Failed to connect to backoff(elasticsearch(http://elasticsearch:9200)): 400 Bad Request: {\"error\":{\"root_cause\":[{\"type\":\"illegal_argument_exception\",\"reason\":\"unknown cluster privilege [monitor/main]. a privilege must be either one of the predefined cluster privilege names [manage_own_api_key,none,cancel_task,delegate_pki,grant_api_key,manage_autoscaling,manage_enrich,manage_index_templates,manage_logstash_pipelines,manage_oidc,manage_saml,manage_service_account,manage_token,monitor_ml,monitor_rollup,monitor_snapshot,monitor_text_structure,monitor_watcher,read_ccr,read_ilm,read_pipeline,read_slm,transport_client,create_snapshot,manage_ccr,manage_ilm,manage_ml,manage_rollup,manage_slm,manage_watcher,monitor_data_frame_transforms,monitor_transform,manage_api_key,manage_ingest_pipelines,manage_pipeline,manage_data_frame_transforms,manage_transform,manage_security,monitor,manage,all] or a pattern over one of the available cluster actions\"}],\"type\":\"illegal_argument_exception\",\"reason\":\"unknown cluster privilege [monitor/main]. a privilege must be either one of the predefined cluster privilege names [manage_own_api_key,none,cancel_task,delegate_pki,grant_api_key,manage_autoscaling,manage_enrich,manage_index_templates,manage_logstash_pipelines,manage_oidc,manage_saml,manage_service_account,manage_token,monitor_ml,monitor_rollup,monitor_snapshot,monitor_text_structure,monitor_watcher,read_ccr,read_ilm,read_pipeline,read_slm,transport_client,create_snapshot,manage_ccr,manage_ilm,manage_ml,manage_rollup,manage_slm,manage_watcher,monitor_data_frame_transforms,monitor_transform,manage_api_key,manage_ingest_pipelines,manage_pipeline,manage_data_frame_transforms,manage_transform,manage_security,monitor,manage,all] or a pattern over one of the available cluster actions\"},\"status\":400}","service.name":"apm-server","ecs.version":"1.6.0"}```

Per elastic/elastic-agent#145, the privilege we need is `cluster:monitor/main`, not `monitor/main`.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

Cherry-pick https://github.com/elastic/apm-server/pull/6395, check that the Fleet system tests pass.

## Related issues

None