### PR TITLE
Makefile: add `go mod download` to `make update`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ docker-compose.override.yml:
 
 update: fields go-generate add-headers copy-docs build-package notice $(MAGE)
 	@$(MAGE) update
+	@go mod download all # make sure go.sum is complete
 
 fields_sources=\
   $(shell find model -name fields.yml) \


### PR DESCRIPTION
## Motivation/summary

This is run by `make check-full`. If go.sum is not up to date, it will be updated, and CI will fail in the Intake (make check-full) step due to files not being up to date.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

None