### PR TITLE
Update command-reference.asciidoc

### DIFF
--- a/docs/legacy/copied-from-beats/docs/command-reference.asciidoc
+++ b/docs/legacy/copied-from-beats/docs/command-reference.asciidoc
@@ -178,7 +178,7 @@ When used with `verify`, asks for the `config_agent:read` privilege.
 
 *`--credentials CREDS`*::
 Required for the `verify` subcommand. Specifies the credentials for which to to check privileges.
-Credentials are the base64 encoded representation of the API key's `id:name`.
+Credentials are the base64 encoded representation of the API key's `id:api_key`.
 
 *`--expiration TIME`*::
 When used with `create`, specifies the expiration for the key, e.g., "1d" (default never).


### PR DESCRIPTION
`--credentials` explanation seems to have wrong desription as base64 encoded of `id:name`. but I think it would be base64 encoded of `id:api_key`.  Plesae double check.