### PR TITLE
cmd: disallow libbeat processors

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -422,10 +422,7 @@ func (s *serverRunner) run(listener net.Listener) error {
 	// Send config to telemetry.
 	recordAPMServerConfig(s.config)
 
-	publisherConfig := &publish.PublisherConfig{
-		Pipeline:  s.config.Pipeline,
-		Namespace: s.namespace,
-	}
+	publisherConfig := &publish.PublisherConfig{Pipeline: s.config.Pipeline}
 	if !s.config.DataStreams.Enabled {
 		// Logs are only supported with data streams;
 		// add a beat.Processor which drops them.

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -18,6 +18,7 @@ https://github.com/elastic/apm-server/compare/7.15\...master[View commits]
 - experimental:["This breaking change applies to the experimental tail-based sampling feature."] Changed `apm-server.sampling.tail.events.*` metrics semantics {pull}6273[6273]
 - Removed warm phase from default ILM policy {pull}6322[6322]
 - Removed unused `transaction.breakdown.count` metric field {pull}6366[6366]
+- Removed unsupported libbeat `processors` configuration {pull}6474[6474]
 
 [float]
 ==== Bug fixes


### PR DESCRIPTION
## Motivation/summary

Block use of libbeat processors in apm-server. They have never been formally supported; now they are more explicitly unsupported.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

Run apm-server with `-E processors=[add_cloud_metadata:{}]`, check that it exits with an error indicating that processors are unsupported.

## Related issues

Closes #5991