### PR TITLE
docs: fix three more links

### DIFF
--- a/docs/legacy/guide/apm-breaking-changes.asciidoc
+++ b/docs/legacy/guide/apm-breaking-changes.asciidoc
@@ -205,8 +205,7 @@ APM has aligned with the field names defined in the
 https://github.com/elastic/ecs[Elastic Common Schema (ECS)].
 Utilizing this common schema will allow for easier data correlation within Elasticsearch.
 +
-See the {apm-overview-ref-v}/breaking-7.0.0.html#breaking-ecs[ECS field changes]
-table for full details on which fields have changed.
+See the ECS field changes table for full details on which fields have changed.
 
 APM UI::
 +

--- a/docs/legacy/tab-widgets/configure-server.asciidoc
+++ b/docs/legacy/tab-widgets/configure-server.asciidoc
@@ -10,10 +10,10 @@ Full details are available in the {cloud}/ec-manage-apm-settings.html[APM user s
 // tag::self-managed[]
 
 If you've installed APM Server yourself, you can edit the `apm-server.yml` configuration file to make changes.
-More information is available in {apm-server-ref-v}/configuring-howto-apm-server.html[configuring APM Server].
+More information is available in {apm-guide-ref}/configuring-howto-apm-server.html[configuring APM Server].
 
 Don't forget to also read about
-{apm-server-ref-v}/securing-apm-server.html[securing APM Server], and
-{apm-server-ref-v}/monitoring.html[monitoring APM Server].
+{apm-guide-ref}/securing-apm-server.html[securing APM Server], and
+{apm-guide-ref}/monitoring.html[monitoring APM Server].
 
 // end::self-managed[]

--- a/docs/legacy/upgrading-to-70.asciidoc
+++ b/docs/legacy/upgrading-to-70.asciidoc
@@ -6,7 +6,7 @@
 ++++
 
 Before upgrading to APM Server v7.0,
-there are some {apm-overview-ref-v}/breaking-7.0.0.html[breaking changes]
+there are some {apm-guide-ref}/breaking-7.0.0.html[breaking changes]
 in the APM Server and the APM UI that you should be aware of.
 
 [float]

--- a/docs/legacy/upgrading.asciidoc
+++ b/docs/legacy/upgrading.asciidoc
@@ -14,7 +14,7 @@ Any exceptions will be explained in <<breaking-changes,breaking changes>>.
 
 * Review the APM Server {apm-guide-ref}/release-notes.html[release notes] and <<breaking-changes,breaking changes>>
 for changes between your current APM Server version and the one you are upgrading to.
-* Review the APM stack {apm-overview-ref-v}/apm-breaking-changes.html[breaking changes] and Observability
+* Review the APM stack {apm-guide-ref}/apm-breaking.html[breaking changes] and Observability
 {observability-guide}/whats-new.html[What's new in {minor-version}] for important changes to other APM components.
 
 [discrete]


### PR DESCRIPTION
Just a few more links to fix:

```
18:36:10 INFO:build_docs:Bad cross-document links:
18:37:04 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/guide/7.16/release-notes-7.0.html contains broken links to:
18:37:04 INFO:build_docs:   - en/apm/get-started/7.16/breaking-7.0.0.html
18:37:04 INFO:build_docs:   - en/apm/server/7.16/breaking-changes.html
18:37:04 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/guide/8.0/release-notes-7.0.html contains broken links to:
18:37:04 INFO:build_docs:   - en/apm/get-started/8.0/breaking-7.0.0.html
18:37:04 INFO:build_docs:   - en/apm/server/8.0/breaking-changes.html
18:37:04 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/guide/current/release-notes-7.0.html contains broken links to:
18:37:04 INFO:build_docs:   - en/apm/get-started/master/breaking-7.0.0.html
18:37:04 INFO:build_docs:   - en/apm/server/master/breaking-changes.html
18:37:04 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/guide/master/release-notes-7.0.html contains broken links to:
18:37:04 INFO:build_docs:   - en/apm/get-started/master/breaking-7.0.0.html
18:37:04 INFO:build_docs:   - en/apm/server/master/breaking-changes.html
```