### PR TITLE
Remove `apm-server.aggregation.transactions.enabled`

### DIFF
--- a/beater/config/aggregation.go
+++ b/beater/config/aggregation.go
@@ -38,7 +38,6 @@ type AggregationConfig struct {
 
 // TransactionAggregationConfig holds configuration related to transaction metrics aggregation.
 type TransactionAggregationConfig struct {
-	Enabled                        bool          `config:"enabled"`
 	Interval                       time.Duration `config:"interval" validate:"min=1"`
 	MaxTransactionGroups           int           `config:"max_groups" validate:"min=1"`
 	HDRHistogramSignificantFigures int           `config:"hdrhistogram_significant_figures" validate:"min=1, max=5"`
@@ -54,7 +53,6 @@ type ServiceDestinationAggregationConfig struct {
 func defaultAggregationConfig() AggregationConfig {
 	return AggregationConfig{
 		Transactions: TransactionAggregationConfig{
-			Enabled:                        true,
 			Interval:                       defaultTransactionAggregationInterval,
 			MaxTransactionGroups:           defaultTransactionAggregationMaxGroups,
 			HDRHistogramSignificantFigures: defaultTransactionAggregationHDRHistogramSignificantFigures,

--- a/beater/config/config.go
+++ b/beater/config/config.go
@@ -132,18 +132,6 @@ func NewConfig(ucfg *common.Config, outputESCfg *common.Config) (*Config, error)
 			"in a subsequent version.",
 		)
 	}
-	if !c.Sampling.KeepUnsampled && !c.Aggregation.Transactions.Enabled {
-		// Unsampled transactions should only be dropped
-		// when transaction aggregation is enabled in the
-		// server. This means the aggregations performed
-		// by the APM UI will not have access to a complete
-		// representation of the latency distribution.
-		logger.Warn("" +
-			"apm-server.sampling.keep_unsampled and " +
-			"apm-server.aggregation.transactions.enabled are both false, " +
-			"which will lead to incorrect metrics being reported in the APM UI",
-		)
-	}
 
 	if c.DataStreams.Enabled || (outputESCfg != nil && (outputESCfg.HasField("pipeline") || outputESCfg.HasField("pipelines"))) {
 		c.Pipeline = ""

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -265,7 +265,6 @@ func TestUnpackConfig(t *testing.T) {
 				},
 				Aggregation: AggregationConfig{
 					Transactions: TransactionAggregationConfig{
-						Enabled:                        false,
 						Interval:                       time.Second,
 						MaxTransactionGroups:           123,
 						HDRHistogramSignificantFigures: 1,
@@ -453,7 +452,6 @@ func TestUnpackConfig(t *testing.T) {
 				},
 				Aggregation: AggregationConfig{
 					Transactions: TransactionAggregationConfig{
-						Enabled:                        false,
 						Interval:                       time.Minute,
 						MaxTransactionGroups:           10000,
 						HDRHistogramSignificantFigures: 2,

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -21,6 +21,7 @@ https://github.com/elastic/apm-server/compare/7.15\...master[View commits]
 - Removed legacy Jaeger gRPC/HTTP endpoints {pull}6417[6417]
 - Removed source map upload endpoint {pull}6447[6447]
 - Removed unsupported libbeat `processors` configuration {pull}6474[6474]
+- Removed `apm-server.aggregation.transactions.enabled` configuration option {pull}6495[6495]
 
 [float]
 ==== Bug fixes

--- a/docs/legacy/transaction-metrics.asciidoc
+++ b/docs/legacy/transaction-metrics.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Transaction metrics</titleabbrev>
 ++++
 
-By default, {beatname_uc} produces transaction histogram metrics that are used to power the APM app.
+{beatname_uc} produces transaction histogram metrics that are used to power the APM app.
 Shifting this responsibility from APM app to APM Server removes the need to store unsampled transactions, reducing storage costs.
 
 Example config file:

--- a/docs/legacy/transaction-metrics.asciidoc
+++ b/docs/legacy/transaction-metrics.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Transaction metrics</titleabbrev>
 ++++
 
-When enabled, {beatname_uc} produces transaction histogram metrics that are used to power the APM app.
+By default, {beatname_uc} produces transaction histogram metrics that are used to power the APM app.
 Shifting this responsibility from APM app to APM Server removes the need to store unsampled transactions, reducing storage costs.
 
 Example config file:
@@ -16,7 +16,6 @@ Example config file:
 apm-server:
   aggregation:
     transactions:
-      enabled: true
       interval: 1m
   sampling:
     keep_unsampled: false
@@ -25,20 +24,6 @@ apm-server:
 [float]
 [[configuration-aggregation]]
 === Configuration options: `apm-server.aggregation.transactions.*`
-
-[[transactions-enabled]]
-[float]
-==== `enabled`
-
-Enables the collection and publishing of transaction metrics.
-Enabling this setting removes the need to store unsampled transactions, reducing storage costs.
-Storing unsampled transactions is controlled independently with <<sampling-keep_unsampled>>.
-
-Default: `true`.
-
-IMPORTANT: To prevent inaccuracies in the APM app, transaction metrics must also be enabled in
-Kibana with `xpack.apm.searchAggregatedTransactions`.
-See {kibana-ref}/apm-settings-in-kibana.html[APM app settings] for more information.
 
 [[transactions-interval]]
 [float]
@@ -83,6 +68,3 @@ Controls the recording of unsampled transaction documents.
 Dropping unsampled documents (`keep_unsampled: false`) reduces APM's storage consumption.
 
 Default: `true`.
-
-IMPORTANT: Unsampled transactions should only be dropped when `apm-server.aggregation.transactions.enabled` is `true`,
-otherwise, the APM app will report inaccurate metrics.

--- a/systemtest/aggregation_test.go
+++ b/systemtest/aggregation_test.go
@@ -46,7 +46,6 @@ func TestTransactionAggregation(t *testing.T) {
 	}
 	srv.Config.Aggregation = &apmservertest.AggregationConfig{
 		Transactions: &apmservertest.TransactionAggregationConfig{
-			Enabled:  true,
 			Interval: time.Second,
 		},
 	}
@@ -120,7 +119,6 @@ func TestTransactionAggregationShutdown(t *testing.T) {
 	srv := apmservertest.NewUnstartedServer(t)
 	srv.Config.Aggregation = &apmservertest.AggregationConfig{
 		Transactions: &apmservertest.TransactionAggregationConfig{
-			Enabled: true,
 			// Set aggregation_interval to something that would cause
 			// a timeout if we were to wait that long. The server
 			// should flush metrics on shutdown without waiting for

--- a/systemtest/apmservertest/config.go
+++ b/systemtest/apmservertest/config.go
@@ -380,7 +380,6 @@ type AggregationConfig struct {
 
 // TransactionAggregationConfig holds APM Server transaction metrics aggregation configuration.
 type TransactionAggregationConfig struct {
-	Enabled  bool
 	Interval time.Duration
 }
 
@@ -388,11 +387,9 @@ func (m *TransactionAggregationConfig) MarshalJSON() ([]byte, error) {
 	// time.Duration is encoded as int64.
 	// Convert time.Durations to durations, to encode as duration strings.
 	type config struct {
-		Enabled  bool   `json:"enabled"`
 		Interval string `json:"interval,omitempty"`
 	}
 	return json.Marshal(config{
-		Enabled:  m.Enabled,
 		Interval: durationString(m.Interval),
 	})
 }
@@ -407,11 +404,9 @@ func (s *ServiceDestinationAggregationConfig) MarshalJSON() ([]byte, error) {
 	// time.Duration is encoded as int64.
 	// Convert time.Durations to durations, to encode as duration strings.
 	type config struct {
-		Enabled  bool   `json:"enabled"`
 		Interval string `json:"interval,omitempty"`
 	}
 	return json.Marshal(config{
-		Enabled:  s.Enabled,
 		Interval: durationString(s.Interval),
 	})
 }

--- a/systemtest/sampling_test.go
+++ b/systemtest/sampling_test.go
@@ -70,26 +70,6 @@ func TestKeepUnsampled(t *testing.T) {
 	}
 }
 
-func TestKeepUnsampledWarning(t *testing.T) {
-	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewUnstartedServer(t)
-	srv.Config.Sampling = &apmservertest.SamplingConfig{KeepUnsampled: false}
-	srv.Config.Aggregation = &apmservertest.AggregationConfig{
-		Transactions: &apmservertest.TransactionAggregationConfig{Enabled: false},
-	}
-	require.NoError(t, srv.Start())
-	require.NoError(t, srv.Close())
-
-	var messages []string
-	for _, log := range srv.Logs.All() {
-		messages = append(messages, log.Message)
-	}
-	assert.Contains(t, messages, ""+
-		"apm-server.sampling.keep_unsampled and apm-server.aggregation.transactions.enabled are both false, "+
-		"which will lead to incorrect metrics being reported in the APM UI",
-	)
-}
-
 func TestTailSampling(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
 	err := systemtest.Fleet.InstallPackage(systemtest.IntegrationPackage.Name, systemtest.IntegrationPackage.Version)

--- a/x-pack/apm-server/main.go
+++ b/x-pack/apm-server/main.go
@@ -43,8 +43,8 @@ var (
 )
 
 type namedProcessor struct {
-	name string
 	processor
+	name string
 }
 
 type processor interface {
@@ -56,23 +56,21 @@ type processor interface {
 // newProcessors returns a list of processors which will process
 // events in sequential order, prior to the events being published.
 func newProcessors(args beater.ServerParams) ([]namedProcessor, error) {
-	var processors []namedProcessor
-	if args.Config.Aggregation.Transactions.Enabled {
-		const name = "transaction metrics aggregation"
-		args.Logger.Infof("creating %s with config: %+v", name, args.Config.Aggregation.Transactions)
-		agg, err := txmetrics.NewAggregator(txmetrics.AggregatorConfig{
-			BatchProcessor:                 args.BatchProcessor,
-			MaxTransactionGroups:           args.Config.Aggregation.Transactions.MaxTransactionGroups,
-			MetricsInterval:                args.Config.Aggregation.Transactions.Interval,
-			HDRHistogramSignificantFigures: args.Config.Aggregation.Transactions.HDRHistogramSignificantFigures,
-		})
-		if err != nil {
-			return nil, errors.Wrapf(err, "error creating %s", name)
-		}
-		processors = append(processors, namedProcessor{name: name, processor: agg})
-		aggregationMonitoringRegistry.Remove("txmetrics")
-		monitoring.NewFunc(aggregationMonitoringRegistry, "txmetrics", agg.CollectMonitoring, monitoring.Report)
+	processors := make([]namedProcessor, 0, 3)
+	const name = "transaction metrics aggregation"
+	args.Logger.Infof("creating %s with config: %+v", name, args.Config.Aggregation.Transactions)
+	agg, err := txmetrics.NewAggregator(txmetrics.AggregatorConfig{
+		BatchProcessor:                 args.BatchProcessor,
+		MaxTransactionGroups:           args.Config.Aggregation.Transactions.MaxTransactionGroups,
+		MetricsInterval:                args.Config.Aggregation.Transactions.Interval,
+		HDRHistogramSignificantFigures: args.Config.Aggregation.Transactions.HDRHistogramSignificantFigures,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating %s", name)
 	}
+	processors = append(processors, namedProcessor{name: name, processor: agg})
+	aggregationMonitoringRegistry.Remove("txmetrics")
+	monitoring.NewFunc(aggregationMonitoringRegistry, "txmetrics", agg.CollectMonitoring, monitoring.Report)
 	if args.Config.Aggregation.ServiceDestinations.Enabled {
 		const name = "service destinations aggregation"
 		args.Logger.Infof("creating %s with config: %+v", name, args.Config.Aggregation.ServiceDestinations)
@@ -111,7 +109,7 @@ func newTailSamplingProcessor(args beater.ServerParams) (*sampling.Processor, er
 	}
 
 	storageDir := paths.Resolve(paths.Data, tailSamplingStorageDir)
-	badgerDB, err := getBadgerDB(storageDir)
+	badgerDB, err = getBadgerDB(storageDir)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get Badger database")
 	}

--- a/x-pack/apm-server/main_test.go
+++ b/x-pack/apm-server/main_test.go
@@ -66,7 +66,6 @@ func TestMonitoring(t *testing.T) {
 
 	cfg := config.DefaultConfig()
 	cfg.DataStreams.Enabled = true
-	cfg.Aggregation.Transactions.Enabled = true
 	cfg.Sampling.Tail.Enabled = true
 	cfg.Sampling.Tail.Policies = []config.TailSamplingPolicy{{SampleRate: 0.1}}
 


### PR DESCRIPTION
## Motivation/summary

Completely removes the `apm-server.aggregation.transactions.enabled`
configuration settings and changes the `apm-server` to always aggregate
transaction metrics.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
- [x] Documentation has been updated

## How to test these changes

1. `docker-compose up -d`
2. `make`
3. `./apm-server -E apm-server.aggregation.transactions.enabled=false -E output.elasticsearch.username=admin -E output.elasticsearch.password=changeme -e`
4. `curl -H "Content-type: application/x-ndjson" --data-binary @testdata/intake-v2/transactions.ndjson http://localhost:8200/intake/v2/events`
5. Go to Kibana Dev Tools and validate that transaciton metrics were ingested:

```javascript
GET *metric*/_search
{
  "_source": [false], 
  "fields": [
    "transaction.duration.*"
  ], 
  "query": {
    "exists": {
      "field": "transaction.duration.histogram"
    }
  }
}
```

There should be 4 results and all of them must have `transaction.duration.histogram`.

## Related issues

Closes #6348