### PR TITLE
[automation] update elastic stack version for testing 7.15.2-5325c15b

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       kibana: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.2-fecae5f4-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.2-5325c15b-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -61,7 +61,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.15.2-fecae5f4-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.15.2-5325c15b-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -85,7 +85,7 @@ services:
       package-registry: { condition: service_healthy }
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:7.15.2-fecae5f4-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:7.15.2-5325c15b-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Mon, 1 Nov 2021 00:15:49 GMT, release_branch:7.15, prefix:, end_time:Mon, 1 Nov 2021 06:32:25 GMT, manifest_version:2.0.0, version:7.15.2-SNAPSHOT, branch:7.15, build_id:7.15.2-5325c15b, build_duration_seconds:22596]