### PR TITLE
systemtest: use deterministic IDs and timestamps

### DIFF
--- a/systemtest/approvals/TestCompressedSpans.approved.json
+++ b/systemtest/approvals/TestCompressedSpans.approved.json
@@ -1,7 +1,7 @@
 {
     "events": [
         {
-            "@timestamp": "dynamic",
+            "@timestamp": "1970-01-01T00:00:00.050Z",
             "agent": {
                 "name": "go",
                 "version": "0.0.0"
@@ -20,7 +20,9 @@
                 "version": "dynamic",
                 "version_major": "dynamic"
             },
-            "parent": "dynamic",
+            "parent": {
+                "id": "0000000000000001"
+            },
             "processor": {
                 "event": "span",
                 "name": "transaction"
@@ -45,21 +47,23 @@
                 "duration": {
                     "us": 20000
                 },
-                "id": "dynamic",
+                "id": "0000000000000034",
                 "name": "_bulk",
                 "subtype": "elasticsearch",
                 "type": "db"
             },
-            "timestamp": "dynamic",
+            "timestamp": {
+                "us": 50000
+            },
             "trace": {
-                "id": "dynamic"
+                "id": "01000000000000000000000000000000"
             },
             "transaction": {
-                "id": "dynamic"
+                "id": "0000000000000001"
             }
         },
         {
-            "@timestamp": "dynamic",
+            "@timestamp": "1970-01-01T00:00:00.000Z",
             "agent": {
                 "name": "go",
                 "version": "0.0.0"
@@ -78,7 +82,9 @@
                 "version": "dynamic",
                 "version_major": "dynamic"
             },
-            "parent": "dynamic",
+            "parent": {
+                "id": "0000000000000001"
+            },
             "processor": {
                 "event": "span",
                 "name": "transaction"
@@ -103,17 +109,19 @@
                 "duration": {
                     "us": 50000
                 },
-                "id": "dynamic",
+                "id": "0000000000000002",
                 "name": "Calls to redis",
                 "subtype": "redis",
                 "type": "db"
             },
-            "timestamp": "dynamic",
+            "timestamp": {
+                "us": 0
+            },
             "trace": {
-                "id": "dynamic"
+                "id": "01000000000000000000000000000000"
             },
             "transaction": {
-                "id": "dynamic"
+                "id": "0000000000000001"
             }
         }
     ]

--- a/systemtest/huge_traces_test.go
+++ b/systemtest/huge_traces_test.go
@@ -18,6 +18,7 @@
 package systemtest_test
 
 import (
+	"encoding/binary"
 	"testing"
 	"time"
 
@@ -92,9 +93,24 @@ func TestCompressedSpans(t *testing.T) {
 
 	tracer := srv.Tracer()
 	tracer.SetSpanCompressionEnabled(true)
-	tx := tracer.StartTransaction("compressed-traces", "type")
 
-	startTs := time.Now()
+	var n uint64
+	nextSpanID := func() apm.SpanID {
+		var spanID apm.SpanID
+		n++
+		binary.BigEndian.PutUint64(spanID[:], n)
+		return spanID
+	}
+
+	tx := tracer.StartTransactionOptions("compressed-traces", "type", apm.TransactionOptions{
+		TraceContext: apm.TraceContext{
+			Trace:   apm.TraceID{1},
+			Options: apm.TraceOptions(0).WithRecorded(true),
+		},
+		TransactionID: nextSpanID(),
+	})
+
+	startTs := time.Unix(0, 0)
 
 	// These spans will be compressed. The redis spans will be compressed
 	// using the "same_kind" stategy, while the Elasticsearch spans will
@@ -105,7 +121,9 @@ func TestCompressedSpans(t *testing.T) {
 			cmd = "GET"
 		}
 		span := tx.StartSpanOptions(cmd, "db.redis", apm.SpanOptions{
-			ExitSpan: true, Start: startTs,
+			ExitSpan: true,
+			Start:    startTs,
+			SpanID:   nextSpanID(),
 		})
 		span.Duration = 1 * time.Millisecond
 		startTs = startTs.Add(span.Duration)
@@ -114,7 +132,9 @@ func TestCompressedSpans(t *testing.T) {
 	}
 	for i := 0; i < 5; i++ {
 		span := tx.StartSpanOptions("_bulk", "db.elasticsearch", apm.SpanOptions{
-			ExitSpan: true, Start: startTs,
+			ExitSpan: true,
+			Start:    startTs,
+			SpanID:   nextSpanID(),
 		})
 		span.Duration = 4 * time.Millisecond
 		startTs = startTs.Add(span.Duration)
@@ -127,11 +147,8 @@ func TestCompressedSpans(t *testing.T) {
 	tx.End()
 	tracer.Flush(nil)
 
-	txIgnoreFields := []string{"@timestamp", "timestamp", "trace.id", "transaction.id"}
 	spanResults := systemtest.Elasticsearch.ExpectMinDocs(t, 2, "apm*span",
 		estest.TermQuery{Field: "span.type", Value: "db"},
 	)
-	systemtest.ApproveEvents(t, t.Name(), spanResults.Hits.Hits,
-		append(txIgnoreFields, "span.id", "parent")...,
-	)
+	systemtest.ApproveEvents(t, t.Name(), spanResults.Hits.Hits)
 }


### PR DESCRIPTION
## Motivation/summary

Ensure the order of documents approved by TestCompressedSpans is deterministic, by using known timestamps and IDs. These are used when sorting the documents.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

https://apm-ci.elastic.co/job/apm-server/job/apm-server-mbp/job/PR-6499/2/testReport/github/com_elastic_apm-server_systemtest/Build_and_Test___System_and_Environment_Tests___TestCompressedSpans/