### PR TITLE
publisher: Allow processor use within apm-server

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -422,7 +422,7 @@ func (s *serverRunner) run(listener net.Listener) error {
 	// Send config to telemetry.
 	recordAPMServerConfig(s.config)
 
-	publisherConfig := &publish.PublisherConfig{Pipeline: s.config.Pipeline}
+	publisherConfig := publish.PublisherConfig{Pipeline: s.config.Pipeline}
 	if !s.config.DataStreams.Enabled {
 		// Logs are only supported with data streams;
 		// add a beat.Processor which drops them.

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -343,3 +343,21 @@ func TestFleetStoreUsed(t *testing.T) {
 
 	assert.True(t, called)
 }
+
+func Test_newDropLogsBeatProcessor(t *testing.T) {
+	dropLogsProcessor, err := newDropLogsBeatProcessor()
+	require.NoError(t, err)
+
+	event := beat.Event{
+		Timestamp: time.Now(),
+		Fields: common.MapStr{
+			"processor": common.MapStr{
+				"event": "log",
+				"name":  "log",
+			},
+		},
+	}
+	result, err := dropLogsProcessor.Run(&event)
+	require.NoError(t, err)
+	require.Nil(t, result)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,21 +90,21 @@ func DefaultSettings() instance.Settings {
 	}
 }
 
-func processingSupport(info beat.Info, log *logp.Logger, beatCfg *common.Config) (processing.Supporter, error) {
+func processingSupport(_ beat.Info, _ *logp.Logger, beatCfg *common.Config) (processing.Supporter, error) {
 	if beatCfg.HasField("processors") {
 		return nil, errors.New("libbeat processors are not supported")
 	}
-	return nopProcessingSupporter{}, nil
+	return processingSupporter{}, nil
 }
 
-type nopProcessingSupporter struct{}
+type processingSupporter struct{}
 
-func (nopProcessingSupporter) Close() error {
+func (processingSupporter) Close() error {
 	return nil
 }
 
-func (nopProcessingSupporter) Create(beat.ProcessingConfig, bool) (beat.Processor, error) {
-	return nil, nil
+func (processingSupporter) Create(cfg beat.ProcessingConfig, _ bool) (beat.Processor, error) {
+	return cfg.Processor, nil
 }
 
 // NewRootCommand returns the "apm-server" root command.

--- a/publish/pub.go
+++ b/publish/pub.go
@@ -79,11 +79,11 @@ var (
 	ErrChannelClosed = errors.New("can't send batch, publisher is being stopped")
 )
 
-// newPublisher creates a new publisher instance.
+// NewPublisher creates a new publisher instance.
 //
 // GOMAXPROCS goroutines are started for forwarding events to libbeat.
 // Stop must be called to close the beat.Client and free resources.
-func NewPublisher(pipeline beat.Pipeline, tracer *apm.Tracer, cfg *PublisherConfig) (*Publisher, error) {
+func NewPublisher(pipeline beat.Pipeline, tracer *apm.Tracer, cfg PublisherConfig) (*Publisher, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, errors.Wrap(err, "invalid config")
 	}

--- a/publish/pub_test.go
+++ b/publish/pub_test.go
@@ -53,7 +53,7 @@ func TestPublisherStop(t *testing.T) {
 	// so we can simulate a pipeline that blocks indefinitely.
 	pipeline := newBlockingPipeline(t)
 	publisher, err := publish.NewPublisher(
-		pipeline, apmtest.DiscardTracer, &publish.PublisherConfig{},
+		pipeline, apmtest.DiscardTracer, publish.PublisherConfig{},
 	)
 	require.NoError(t, err)
 	defer func() {
@@ -96,7 +96,7 @@ func TestPublisherStopShutdownInactive(t *testing.T) {
 	publisher, err := publish.NewPublisher(
 		newBlockingPipeline(t),
 		apmtest.DiscardTracer,
-		&publish.PublisherConfig{},
+		publish.PublisherConfig{},
 	)
 	require.NoError(t, err)
 
@@ -156,7 +156,7 @@ func BenchmarkPublisher(b *testing.B) {
 	publisher, err := publish.NewPublisher(
 		pipetool.WithACKer(pipeline, acker),
 		apmtest.DiscardTracer,
-		&publish.PublisherConfig{},
+		publish.PublisherConfig{},
 	)
 	require.NoError(b, err)
 

--- a/systemtest/otlp_test.go
+++ b/systemtest/otlp_test.go
@@ -104,6 +104,12 @@ func testOTLPGRPCTraces(t *testing.T, srv *apmservertest.Server) {
 		MinimumShouldMatch: 1,
 	})
 	systemtest.ApproveEvents(t, t.Name(), result.Hits.Hits)
+
+	// Ensure that the log event was filtered by libbeat.
+	if srv.Config.DataStreams == nil || !srv.Config.DataStreams.Enabled {
+		filtered := srv.GetExpvar().Vars["libbeat.pipeline.events.filtered"].(float64)
+		assert.Equal(t, float64(1), filtered, "libbeat pipeline processor should have filtered the span log event")
+	}
 }
 
 func TestOTLPGRPCMetrics(t *testing.T) {


### PR DESCRIPTION
## Motivation/summary

Fixes a bug which prevented the libbeat pipeline client from using the
`drop_event` processor we use to drop events with `processor.event: log`
set, when data streams are disabled.

## How to test these changes

1. Start APM Server in standalone mode with data_streams disabled.
2. Send an OTLP span with an event.
3. Verify that no log events are indexed (`processor.event: log`)

OR

1. `cd systemtest && go test -v -count=1 -run TestOTLPGRPCTraces/data_streams_disabled .`
2. Navigate to [Kibana dev tools](http://localhost:5601/app/dev_tools#/console)
3. Ensure that the following query returns:
```javascript
GET apm-*,traces-apm*,logs-apm*/_search
{
  "_source": [false],
  "fields": [
    "processor.event"
  ], 
  "query": {
    "match": {
      "trace.id": "d2acbef8b37655e48548fd9d61ad6114"
    }
  }
}
```

```javascript
{
  "took" : 5,
  "timed_out" : false,
  "_shards" : {
    "total" : 6,
    "successful" : 6,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 1,
      "relation" : "eq"
    },
    "max_score" : 0.2876821,
    "hits" : [
      {
        "_index" : "apm-8.1.0-transaction-000001",
        "_id" : "8afV43wBmY5U_dKZiKf9",
        "_score" : 0.2876821,
        "_source" : { },
        "fields" : {
          "processor.event" : [
            "transaction"
          ]
        }
      }
    ]
  }
}
```

## Related issues

Introduced in #6474