### PR TITLE
systemtest: fix sorting in approvals

### DIFF
--- a/systemtest/approvals.go
+++ b/systemtest/approvals.go
@@ -92,6 +92,9 @@ func (hits apmEventSearchHits) Less(i, j int) bool {
 		if ri.Less(rj, true) {
 			return true
 		}
+		if rj.Less(ri, true) {
+			return false
+		}
 	}
 	return false
 }

--- a/systemtest/approvals/TestCompressedSpans.approved.json
+++ b/systemtest/approvals/TestCompressedSpans.approved.json
@@ -1,68 +1,6 @@
 {
     "events": [
         {
-            "@timestamp": "1970-01-01T00:00:00.050Z",
-            "agent": {
-                "name": "go",
-                "version": "0.0.0"
-            },
-            "ecs": {
-                "version": "dynamic"
-            },
-            "event": {
-                "outcome": "success"
-            },
-            "observer": {
-                "ephemeral_id": "dynamic",
-                "hostname": "dynamic",
-                "id": "dynamic",
-                "type": "apm-server",
-                "version": "dynamic",
-                "version_major": "dynamic"
-            },
-            "parent": {
-                "id": "0000000000000001"
-            },
-            "processor": {
-                "event": "span",
-                "name": "transaction"
-            },
-            "service": {
-                "name": "systemtest"
-            },
-            "span": {
-                "composite": {
-                    "compression_strategy": "exact_match",
-                    "count": 5,
-                    "sum": {
-                        "us": 20000
-                    }
-                },
-                "destination": {
-                    "service": {
-                        "resource": "elasticsearch",
-                        "type": "db"
-                    }
-                },
-                "duration": {
-                    "us": 20000
-                },
-                "id": "0000000000000034",
-                "name": "_bulk",
-                "subtype": "elasticsearch",
-                "type": "db"
-            },
-            "timestamp": {
-                "us": 50000
-            },
-            "trace": {
-                "id": "01000000000000000000000000000000"
-            },
-            "transaction": {
-                "id": "0000000000000001"
-            }
-        },
-        {
             "@timestamp": "1970-01-01T00:00:00.000Z",
             "agent": {
                 "name": "go",
@@ -116,6 +54,68 @@
             },
             "timestamp": {
                 "us": 0
+            },
+            "trace": {
+                "id": "01000000000000000000000000000000"
+            },
+            "transaction": {
+                "id": "0000000000000001"
+            }
+        },
+        {
+            "@timestamp": "1970-01-01T00:00:00.050Z",
+            "agent": {
+                "name": "go",
+                "version": "0.0.0"
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "outcome": "success"
+            },
+            "observer": {
+                "ephemeral_id": "dynamic",
+                "hostname": "dynamic",
+                "id": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic",
+                "version_major": "dynamic"
+            },
+            "parent": {
+                "id": "0000000000000001"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "service": {
+                "name": "systemtest"
+            },
+            "span": {
+                "composite": {
+                    "compression_strategy": "exact_match",
+                    "count": 5,
+                    "sum": {
+                        "us": 20000
+                    }
+                },
+                "destination": {
+                    "service": {
+                        "resource": "elasticsearch",
+                        "type": "db"
+                    }
+                },
+                "duration": {
+                    "us": 20000
+                },
+                "id": "0000000000000034",
+                "name": "_bulk",
+                "subtype": "elasticsearch",
+                "type": "db"
+            },
+            "timestamp": {
+                "us": 50000
             },
             "trace": {
                 "id": "01000000000000000000000000000000"

--- a/systemtest/approvals/TestOTLPGRPCTraces/data_streams_enabled.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCTraces/data_streams_enabled.approved.json
@@ -1,6 +1,50 @@
 {
     "events": [
         {
+            "@timestamp": "1970-01-01T00:02:03.001Z",
+            "agent": {
+                "name": "opentelemetry/go",
+                "version": "1.0.0"
+            },
+            "data_stream.dataset": "apm.app",
+            "data_stream.namespace": "default",
+            "data_stream.type": "logs",
+            "ecs": {
+                "version": "dynamic"
+            },
+            "labels": {
+                "resource_attribute_array": [
+                    "a",
+                    "b"
+                ]
+            },
+            "message": "a_span_event",
+            "observer": {
+                "ephemeral_id": "dynamic",
+                "hostname": "dynamic",
+                "id": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic",
+                "version_major": "dynamic"
+            },
+            "processor": {
+                "event": "log",
+                "name": "log"
+            },
+            "service": {
+                "framework": {
+                    "name": "systemtest"
+                },
+                "language": {
+                    "name": "go"
+                },
+                "name": "unknown_service_systemtest_test"
+            },
+            "trace": {
+                "id": "d2acbef8b37655e48548fd9d61ad6114"
+            }
+        },
+        {
             "@timestamp": "1970-01-01T00:02:03.000Z",
             "agent": {
                 "name": "opentelemetry/go",
@@ -63,50 +107,6 @@
                 "name": "operation_name",
                 "sampled": true,
                 "type": "custom"
-            }
-        },
-        {
-            "@timestamp": "1970-01-01T00:02:03.001Z",
-            "agent": {
-                "name": "opentelemetry/go",
-                "version": "1.0.0"
-            },
-            "data_stream.dataset": "apm.app",
-            "data_stream.namespace": "default",
-            "data_stream.type": "logs",
-            "ecs": {
-                "version": "dynamic"
-            },
-            "labels": {
-                "resource_attribute_array": [
-                    "a",
-                    "b"
-                ]
-            },
-            "message": "a_span_event",
-            "observer": {
-                "ephemeral_id": "dynamic",
-                "hostname": "dynamic",
-                "id": "dynamic",
-                "type": "apm-server",
-                "version": "dynamic",
-                "version_major": "dynamic"
-            },
-            "processor": {
-                "event": "log",
-                "name": "log"
-            },
-            "service": {
-                "framework": {
-                    "name": "systemtest"
-                },
-                "language": {
-                    "name": "go"
-                },
-                "name": "unknown_service_systemtest_test"
-            },
-            "trace": {
-                "id": "d2acbef8b37655e48548fd9d61ad6114"
             }
         }
     ]

--- a/systemtest/approvals/TestRUMRoutingIntegration.approved.json
+++ b/systemtest/approvals/TestRUMRoutingIntegration.approved.json
@@ -10,6 +10,380 @@
             "data_stream.dataset": "apm.rum",
             "data_stream.namespace": "default",
             "data_stream.type": "traces",
+            "destination": {
+                "address": "localhost",
+                "port": 8003
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "agent_id_status": "missing",
+                "ingested": "dynamic",
+                "outcome": "success"
+            },
+            "http": {
+                "request": {
+                    "method": "POST"
+                },
+                "response": {
+                    "status_code": 200
+                }
+            },
+            "labels": {
+                "testTagKey": "testTagValue"
+            },
+            "network": {
+                "connection": {
+                    "type": "5G"
+                }
+            },
+            "observer": {
+                "ephemeral_id": "dynamic",
+                "hostname": "dynamic",
+                "id": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic",
+                "version_major": "dynamic"
+            },
+            "parent": {
+                "id": "ec2e280be8345240"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "service": {
+                "environment": "prod",
+                "name": "apm-a-rum-test-e2e-general-usecase"
+            },
+            "source": {
+                "ip": "dynamic",
+                "port": "dynamic"
+            },
+            "span": {
+                "destination": {
+                    "service": {
+                        "name": "http://localhost:8003",
+                        "resource": "localhost:8003",
+                        "type": "external"
+                    }
+                },
+                "duration": {
+                    "us": 11584
+                },
+                "http": {
+                    "method": "POST",
+                    "response": {
+                        "status_code": 200
+                    }
+                },
+                "http.url.original": "http://localhost:8003/data",
+                "id": "27f45fd274f976d4",
+                "name": "POST http://localhost:8003/data",
+                "start": {
+                    "us": 106520
+                },
+                "subtype": "h",
+                "sync": true,
+                "type": "external"
+            },
+            "timestamp": {
+                "us": "dynamic"
+            },
+            "trace": {
+                "id": "286ac3ad697892c406528f13c82e0ce1"
+            },
+            "transaction": {
+                "id": "ec2e280be8345240"
+            },
+            "url": {
+                "original": "http://localhost:8003/data"
+            }
+        },
+        {
+            "@timestamp": "dynamic",
+            "agent": {
+                "name": "js-base",
+                "version": "4.8.1"
+            },
+            "client": "dynamic",
+            "data_stream.dataset": "apm.rum",
+            "data_stream.namespace": "default",
+            "data_stream.type": "traces",
+            "destination": {
+                "address": "localhost",
+                "port": 8000
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "agent_id_status": "missing",
+                "ingested": "dynamic",
+                "outcome": "success"
+            },
+            "http": {
+                "request": {
+                    "method": "GET"
+                },
+                "response": {
+                    "status_code": 200
+                }
+            },
+            "labels": {
+                "testTagKey": "testTagValue"
+            },
+            "network": {
+                "connection": {
+                    "type": "5G"
+                }
+            },
+            "observer": {
+                "ephemeral_id": "dynamic",
+                "hostname": "dynamic",
+                "id": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic",
+                "version_major": "dynamic"
+            },
+            "parent": {
+                "id": "ec2e280be8345240"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "service": {
+                "environment": "prod",
+                "name": "apm-a-rum-test-e2e-general-usecase"
+            },
+            "source": {
+                "ip": "dynamic",
+                "port": "dynamic"
+            },
+            "span": {
+                "destination": {
+                    "service": {
+                        "name": "http://localhost:8000",
+                        "resource": "localhost:8000",
+                        "type": "external"
+                    }
+                },
+                "duration": {
+                    "us": 6724
+                },
+                "http": {
+                    "method": "GET",
+                    "response": {
+                        "status_code": 200
+                    }
+                },
+                "http.url.original": "http://localhost:8000/test/e2e/common/data.json?test=hamid",
+                "id": "5ecb8ee030749715",
+                "name": "GET /test/e2e/common/data.json",
+                "start": {
+                    "us": 98940
+                },
+                "subtype": "h",
+                "sync": true,
+                "type": "external"
+            },
+            "timestamp": {
+                "us": "dynamic"
+            },
+            "trace": {
+                "id": "286ac3ad697892c406528f13c82e0ce1"
+            },
+            "transaction": {
+                "id": "ec2e280be8345240"
+            },
+            "url": {
+                "original": "http://localhost:8000/test/e2e/common/data.json?test=hamid"
+            }
+        },
+        {
+            "@timestamp": "dynamic",
+            "agent": {
+                "name": "js-base",
+                "version": "4.8.1"
+            },
+            "client": "dynamic",
+            "data_stream.dataset": "apm.rum",
+            "data_stream.namespace": "default",
+            "data_stream.type": "traces",
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "agent_id_status": "missing",
+                "ingested": "dynamic",
+                "outcome": "unknown"
+            },
+            "labels": {
+                "testTagKey": "testTagValue"
+            },
+            "network": {
+                "connection": {
+                    "type": "5G"
+                }
+            },
+            "observer": {
+                "ephemeral_id": "dynamic",
+                "hostname": "dynamic",
+                "id": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic",
+                "version_major": "dynamic"
+            },
+            "parent": {
+                "id": "ec2e280be8345240"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "service": {
+                "environment": "prod",
+                "name": "apm-a-rum-test-e2e-general-usecase"
+            },
+            "source": {
+                "ip": "dynamic",
+                "port": "dynamic"
+            },
+            "span": {
+                "duration": {
+                    "us": 198070
+                },
+                "id": "9b80535c4403c9fb",
+                "name": "OpenTracing y",
+                "start": {
+                    "us": 96929
+                },
+                "type": "cu"
+            },
+            "timestamp": {
+                "us": "dynamic"
+            },
+            "trace": {
+                "id": "286ac3ad697892c406528f13c82e0ce1"
+            },
+            "transaction": {
+                "id": "ec2e280be8345240"
+            }
+        },
+        {
+            "@timestamp": "dynamic",
+            "agent": {
+                "name": "js-base",
+                "version": "4.8.1"
+            },
+            "client": "dynamic",
+            "data_stream.dataset": "apm.rum",
+            "data_stream.namespace": "default",
+            "data_stream.type": "traces",
+            "destination": {
+                "address": "localhost",
+                "port": 8003
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "agent_id_status": "missing",
+                "ingested": "dynamic",
+                "outcome": "success"
+            },
+            "http": {
+                "request": {
+                    "method": "POST"
+                },
+                "response": {
+                    "status_code": 200
+                }
+            },
+            "labels": {
+                "testTagKey": "testTagValue"
+            },
+            "network": {
+                "connection": {
+                    "type": "5G"
+                }
+            },
+            "observer": {
+                "ephemeral_id": "dynamic",
+                "hostname": "dynamic",
+                "id": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic",
+                "version_major": "dynamic"
+            },
+            "parent": {
+                "id": "bbd8bcc3be14d814"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "service": {
+                "environment": "prod",
+                "name": "apm-a-rum-test-e2e-general-usecase"
+            },
+            "source": {
+                "ip": "dynamic",
+                "port": "dynamic"
+            },
+            "span": {
+                "action": "action",
+                "destination": {
+                    "service": {
+                        "name": "http://localhost:8003",
+                        "resource": "localhost:8003",
+                        "type": "external"
+                    }
+                },
+                "duration": {
+                    "us": 15949
+                },
+                "http": {
+                    "method": "POST",
+                    "response": {
+                        "status_code": 200
+                    }
+                },
+                "http.url.original": "http://localhost:8003/fetch",
+                "id": "a3c043330bc2015e",
+                "name": "POST http://localhost:8003/fetch",
+                "start": {
+                    "us": 119935
+                },
+                "subtype": "h",
+                "sync": false,
+                "type": "external"
+            },
+            "timestamp": {
+                "us": "dynamic"
+            },
+            "trace": {
+                "id": "286ac3ad697892c406528f13c82e0ce1"
+            },
+            "transaction": {
+                "id": "ec2e280be8345240"
+            },
+            "url": {
+                "original": "http://localhost:8003/fetch"
+            }
+        },
+        {
+            "@timestamp": "dynamic",
+            "agent": {
+                "name": "js-base",
+                "version": "4.8.1"
+            },
+            "client": "dynamic",
+            "data_stream.dataset": "apm.rum",
+            "data_stream.namespace": "default",
+            "data_stream.type": "traces",
             "ecs": {
                 "version": "dynamic"
             },
@@ -69,6 +443,202 @@
             },
             "transaction": {
                 "id": "ec2e280be8345240"
+            }
+        },
+        {
+            "@timestamp": "dynamic",
+            "agent": {
+                "name": "js-base",
+                "version": "4.8.1"
+            },
+            "client": "dynamic",
+            "data_stream.dataset": "apm.rum",
+            "data_stream.namespace": "default",
+            "data_stream.type": "traces",
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "agent_id_status": "missing",
+                "ingested": "dynamic",
+                "outcome": "success"
+            },
+            "labels": {
+                "testTagKey": "testTagValue"
+            },
+            "network": {
+                "connection": {
+                    "type": "5G"
+                }
+            },
+            "observer": {
+                "ephemeral_id": "dynamic",
+                "hostname": "dynamic",
+                "id": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic",
+                "version_major": "dynamic"
+            },
+            "parent": {
+                "id": "ec2e280be8345240"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "service": {
+                "environment": "prod",
+                "name": "apm-a-rum-test-e2e-general-usecase"
+            },
+            "source": {
+                "ip": "dynamic",
+                "port": "dynamic"
+            },
+            "span": {
+                "duration": {
+                    "us": 2000
+                },
+                "id": "bc7665dc25629379",
+                "name": "Fire \"DOMContentLoaded\" event",
+                "stacktrace": [
+                    {
+                        "abs_path": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js?token=secret",
+                        "exclude_from_grouping": false,
+                        "filename": "test/e2e/general-usecase/app.e2e-bundle.min.js?token=secret",
+                        "function": "generateError",
+                        "line": {
+                            "column": 9,
+                            "number": 7662
+                        }
+                    },
+                    {
+                        "abs_path": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js?token=secret",
+                        "exclude_from_grouping": false,
+                        "filename": "test/e2e/general-usecase/app.e2e-bundle.min.js?token=secret",
+                        "function": "\u003canonymous\u003e",
+                        "line": {
+                            "column": 3,
+                            "number": 7666
+                        },
+                        "sourcemap": {
+                            "error": "unable to find sourcemap.url for service.name=apm-a-rum-test-e2e-general-usecase service.version=0.0.1 bundle.path=http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js?token=secret"
+                        }
+                    }
+                ],
+                "start": {
+                    "us": 120000
+                },
+                "subtype": "browser-timing",
+                "type": "hard-navigation"
+            },
+            "timestamp": {
+                "us": "dynamic"
+            },
+            "trace": {
+                "id": "286ac3ad697892c406528f13c82e0ce1"
+            },
+            "transaction": {
+                "id": "ec2e280be8345240"
+            }
+        },
+        {
+            "@timestamp": "dynamic",
+            "agent": {
+                "name": "js-base",
+                "version": "4.8.1"
+            },
+            "client": "dynamic",
+            "data_stream.dataset": "apm.rum",
+            "data_stream.namespace": "default",
+            "data_stream.type": "traces",
+            "destination": {
+                "address": "localhost",
+                "port": 8000
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "agent_id_status": "missing",
+                "ingested": "dynamic",
+                "outcome": "unknown"
+            },
+            "http": {
+                "response": {
+                    "decoded_body_size": 676864,
+                    "encoded_body_size": 676864,
+                    "transfer_size": 677175
+                }
+            },
+            "labels": {
+                "testTagKey": "testTagValue"
+            },
+            "network": {
+                "connection": {
+                    "type": "5G"
+                }
+            },
+            "observer": {
+                "ephemeral_id": "dynamic",
+                "hostname": "dynamic",
+                "id": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic",
+                "version_major": "dynamic"
+            },
+            "parent": {
+                "id": "ec2e280be8345240"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "service": {
+                "environment": "prod",
+                "name": "apm-a-rum-test-e2e-general-usecase"
+            },
+            "source": {
+                "ip": "dynamic",
+                "port": "dynamic"
+            },
+            "span": {
+                "destination": {
+                    "service": {
+                        "name": "http://localhost:8000",
+                        "resource": "localhost:8000",
+                        "type": "rc"
+                    }
+                },
+                "duration": {
+                    "us": 35060
+                },
+                "http": {
+                    "response": {
+                        "decoded_body_size": 676864,
+                        "encoded_body_size": 676864,
+                        "transfer_size": 677175
+                    }
+                },
+                "http.url.original": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js?token=REDACTED",
+                "id": "fb8f717930697299",
+                "name": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js",
+                "start": {
+                    "us": 22534
+                },
+                "subtype": "script",
+                "type": "rc"
+            },
+            "timestamp": {
+                "us": "dynamic"
+            },
+            "trace": {
+                "id": "286ac3ad697892c406528f13c82e0ce1"
+            },
+            "transaction": {
+                "id": "ec2e280be8345240"
+            },
+            "url": {
+                "original": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js?token=REDACTED"
             }
         },
         {
@@ -307,576 +877,6 @@
                 "name": "Go-http-client",
                 "original": "Go-http-client/1.1",
                 "version": "1.1"
-            }
-        },
-        {
-            "@timestamp": "dynamic",
-            "agent": {
-                "name": "js-base",
-                "version": "4.8.1"
-            },
-            "client": "dynamic",
-            "data_stream.dataset": "apm.rum",
-            "data_stream.namespace": "default",
-            "data_stream.type": "traces",
-            "destination": {
-                "address": "localhost",
-                "port": 8000
-            },
-            "ecs": {
-                "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
-                "outcome": "success"
-            },
-            "http": {
-                "request": {
-                    "method": "GET"
-                },
-                "response": {
-                    "status_code": 200
-                }
-            },
-            "labels": {
-                "testTagKey": "testTagValue"
-            },
-            "network": {
-                "connection": {
-                    "type": "5G"
-                }
-            },
-            "observer": {
-                "ephemeral_id": "dynamic",
-                "hostname": "dynamic",
-                "id": "dynamic",
-                "type": "apm-server",
-                "version": "dynamic",
-                "version_major": "dynamic"
-            },
-            "parent": {
-                "id": "ec2e280be8345240"
-            },
-            "processor": {
-                "event": "span",
-                "name": "transaction"
-            },
-            "service": {
-                "environment": "prod",
-                "name": "apm-a-rum-test-e2e-general-usecase"
-            },
-            "source": {
-                "ip": "dynamic",
-                "port": "dynamic"
-            },
-            "span": {
-                "destination": {
-                    "service": {
-                        "name": "http://localhost:8000",
-                        "resource": "localhost:8000",
-                        "type": "external"
-                    }
-                },
-                "duration": {
-                    "us": 6724
-                },
-                "http": {
-                    "method": "GET",
-                    "response": {
-                        "status_code": 200
-                    }
-                },
-                "http.url.original": "http://localhost:8000/test/e2e/common/data.json?test=hamid",
-                "id": "5ecb8ee030749715",
-                "name": "GET /test/e2e/common/data.json",
-                "start": {
-                    "us": 98940
-                },
-                "subtype": "h",
-                "sync": true,
-                "type": "external"
-            },
-            "timestamp": {
-                "us": "dynamic"
-            },
-            "trace": {
-                "id": "286ac3ad697892c406528f13c82e0ce1"
-            },
-            "transaction": {
-                "id": "ec2e280be8345240"
-            },
-            "url": {
-                "original": "http://localhost:8000/test/e2e/common/data.json?test=hamid"
-            }
-        },
-        {
-            "@timestamp": "dynamic",
-            "agent": {
-                "name": "js-base",
-                "version": "4.8.1"
-            },
-            "client": "dynamic",
-            "data_stream.dataset": "apm.rum",
-            "data_stream.namespace": "default",
-            "data_stream.type": "traces",
-            "ecs": {
-                "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
-                "outcome": "unknown"
-            },
-            "labels": {
-                "testTagKey": "testTagValue"
-            },
-            "network": {
-                "connection": {
-                    "type": "5G"
-                }
-            },
-            "observer": {
-                "ephemeral_id": "dynamic",
-                "hostname": "dynamic",
-                "id": "dynamic",
-                "type": "apm-server",
-                "version": "dynamic",
-                "version_major": "dynamic"
-            },
-            "parent": {
-                "id": "ec2e280be8345240"
-            },
-            "processor": {
-                "event": "span",
-                "name": "transaction"
-            },
-            "service": {
-                "environment": "prod",
-                "name": "apm-a-rum-test-e2e-general-usecase"
-            },
-            "source": {
-                "ip": "dynamic",
-                "port": "dynamic"
-            },
-            "span": {
-                "duration": {
-                    "us": 198070
-                },
-                "id": "9b80535c4403c9fb",
-                "name": "OpenTracing y",
-                "start": {
-                    "us": 96929
-                },
-                "type": "cu"
-            },
-            "timestamp": {
-                "us": "dynamic"
-            },
-            "trace": {
-                "id": "286ac3ad697892c406528f13c82e0ce1"
-            },
-            "transaction": {
-                "id": "ec2e280be8345240"
-            }
-        },
-        {
-            "@timestamp": "dynamic",
-            "agent": {
-                "name": "js-base",
-                "version": "4.8.1"
-            },
-            "client": "dynamic",
-            "data_stream.dataset": "apm.rum",
-            "data_stream.namespace": "default",
-            "data_stream.type": "traces",
-            "destination": {
-                "address": "localhost",
-                "port": 8000
-            },
-            "ecs": {
-                "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
-                "outcome": "unknown"
-            },
-            "http": {
-                "response": {
-                    "decoded_body_size": 676864,
-                    "encoded_body_size": 676864,
-                    "transfer_size": 677175
-                }
-            },
-            "labels": {
-                "testTagKey": "testTagValue"
-            },
-            "network": {
-                "connection": {
-                    "type": "5G"
-                }
-            },
-            "observer": {
-                "ephemeral_id": "dynamic",
-                "hostname": "dynamic",
-                "id": "dynamic",
-                "type": "apm-server",
-                "version": "dynamic",
-                "version_major": "dynamic"
-            },
-            "parent": {
-                "id": "ec2e280be8345240"
-            },
-            "processor": {
-                "event": "span",
-                "name": "transaction"
-            },
-            "service": {
-                "environment": "prod",
-                "name": "apm-a-rum-test-e2e-general-usecase"
-            },
-            "source": {
-                "ip": "dynamic",
-                "port": "dynamic"
-            },
-            "span": {
-                "destination": {
-                    "service": {
-                        "name": "http://localhost:8000",
-                        "resource": "localhost:8000",
-                        "type": "rc"
-                    }
-                },
-                "duration": {
-                    "us": 35060
-                },
-                "http": {
-                    "response": {
-                        "decoded_body_size": 676864,
-                        "encoded_body_size": 676864,
-                        "transfer_size": 677175
-                    }
-                },
-                "http.url.original": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js?token=REDACTED",
-                "id": "fb8f717930697299",
-                "name": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js",
-                "start": {
-                    "us": 22534
-                },
-                "subtype": "script",
-                "type": "rc"
-            },
-            "timestamp": {
-                "us": "dynamic"
-            },
-            "trace": {
-                "id": "286ac3ad697892c406528f13c82e0ce1"
-            },
-            "transaction": {
-                "id": "ec2e280be8345240"
-            },
-            "url": {
-                "original": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js?token=REDACTED"
-            }
-        },
-        {
-            "@timestamp": "dynamic",
-            "agent": {
-                "name": "js-base",
-                "version": "4.8.1"
-            },
-            "client": "dynamic",
-            "data_stream.dataset": "apm.rum",
-            "data_stream.namespace": "default",
-            "data_stream.type": "traces",
-            "ecs": {
-                "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
-                "outcome": "success"
-            },
-            "labels": {
-                "testTagKey": "testTagValue"
-            },
-            "network": {
-                "connection": {
-                    "type": "5G"
-                }
-            },
-            "observer": {
-                "ephemeral_id": "dynamic",
-                "hostname": "dynamic",
-                "id": "dynamic",
-                "type": "apm-server",
-                "version": "dynamic",
-                "version_major": "dynamic"
-            },
-            "parent": {
-                "id": "ec2e280be8345240"
-            },
-            "processor": {
-                "event": "span",
-                "name": "transaction"
-            },
-            "service": {
-                "environment": "prod",
-                "name": "apm-a-rum-test-e2e-general-usecase"
-            },
-            "source": {
-                "ip": "dynamic",
-                "port": "dynamic"
-            },
-            "span": {
-                "duration": {
-                    "us": 2000
-                },
-                "id": "bc7665dc25629379",
-                "name": "Fire \"DOMContentLoaded\" event",
-                "stacktrace": [
-                    {
-                        "abs_path": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js?token=secret",
-                        "exclude_from_grouping": false,
-                        "filename": "test/e2e/general-usecase/app.e2e-bundle.min.js?token=secret",
-                        "function": "generateError",
-                        "line": {
-                            "column": 9,
-                            "number": 7662
-                        }
-                    },
-                    {
-                        "abs_path": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js?token=secret",
-                        "exclude_from_grouping": false,
-                        "filename": "test/e2e/general-usecase/app.e2e-bundle.min.js?token=secret",
-                        "function": "\u003canonymous\u003e",
-                        "line": {
-                            "column": 3,
-                            "number": 7666
-                        },
-                        "sourcemap": {
-                            "error": "unable to find sourcemap.url for service.name=apm-a-rum-test-e2e-general-usecase service.version=0.0.1 bundle.path=http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js?token=secret"
-                        }
-                    }
-                ],
-                "start": {
-                    "us": 120000
-                },
-                "subtype": "browser-timing",
-                "type": "hard-navigation"
-            },
-            "timestamp": {
-                "us": "dynamic"
-            },
-            "trace": {
-                "id": "286ac3ad697892c406528f13c82e0ce1"
-            },
-            "transaction": {
-                "id": "ec2e280be8345240"
-            }
-        },
-        {
-            "@timestamp": "dynamic",
-            "agent": {
-                "name": "js-base",
-                "version": "4.8.1"
-            },
-            "client": "dynamic",
-            "data_stream.dataset": "apm.rum",
-            "data_stream.namespace": "default",
-            "data_stream.type": "traces",
-            "destination": {
-                "address": "localhost",
-                "port": 8003
-            },
-            "ecs": {
-                "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
-                "outcome": "success"
-            },
-            "http": {
-                "request": {
-                    "method": "POST"
-                },
-                "response": {
-                    "status_code": 200
-                }
-            },
-            "labels": {
-                "testTagKey": "testTagValue"
-            },
-            "network": {
-                "connection": {
-                    "type": "5G"
-                }
-            },
-            "observer": {
-                "ephemeral_id": "dynamic",
-                "hostname": "dynamic",
-                "id": "dynamic",
-                "type": "apm-server",
-                "version": "dynamic",
-                "version_major": "dynamic"
-            },
-            "parent": {
-                "id": "ec2e280be8345240"
-            },
-            "processor": {
-                "event": "span",
-                "name": "transaction"
-            },
-            "service": {
-                "environment": "prod",
-                "name": "apm-a-rum-test-e2e-general-usecase"
-            },
-            "source": {
-                "ip": "dynamic",
-                "port": "dynamic"
-            },
-            "span": {
-                "destination": {
-                    "service": {
-                        "name": "http://localhost:8003",
-                        "resource": "localhost:8003",
-                        "type": "external"
-                    }
-                },
-                "duration": {
-                    "us": 11584
-                },
-                "http": {
-                    "method": "POST",
-                    "response": {
-                        "status_code": 200
-                    }
-                },
-                "http.url.original": "http://localhost:8003/data",
-                "id": "27f45fd274f976d4",
-                "name": "POST http://localhost:8003/data",
-                "start": {
-                    "us": 106520
-                },
-                "subtype": "h",
-                "sync": true,
-                "type": "external"
-            },
-            "timestamp": {
-                "us": "dynamic"
-            },
-            "trace": {
-                "id": "286ac3ad697892c406528f13c82e0ce1"
-            },
-            "transaction": {
-                "id": "ec2e280be8345240"
-            },
-            "url": {
-                "original": "http://localhost:8003/data"
-            }
-        },
-        {
-            "@timestamp": "dynamic",
-            "agent": {
-                "name": "js-base",
-                "version": "4.8.1"
-            },
-            "client": "dynamic",
-            "data_stream.dataset": "apm.rum",
-            "data_stream.namespace": "default",
-            "data_stream.type": "traces",
-            "destination": {
-                "address": "localhost",
-                "port": 8003
-            },
-            "ecs": {
-                "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
-                "outcome": "success"
-            },
-            "http": {
-                "request": {
-                    "method": "POST"
-                },
-                "response": {
-                    "status_code": 200
-                }
-            },
-            "labels": {
-                "testTagKey": "testTagValue"
-            },
-            "network": {
-                "connection": {
-                    "type": "5G"
-                }
-            },
-            "observer": {
-                "ephemeral_id": "dynamic",
-                "hostname": "dynamic",
-                "id": "dynamic",
-                "type": "apm-server",
-                "version": "dynamic",
-                "version_major": "dynamic"
-            },
-            "parent": {
-                "id": "bbd8bcc3be14d814"
-            },
-            "processor": {
-                "event": "span",
-                "name": "transaction"
-            },
-            "service": {
-                "environment": "prod",
-                "name": "apm-a-rum-test-e2e-general-usecase"
-            },
-            "source": {
-                "ip": "dynamic",
-                "port": "dynamic"
-            },
-            "span": {
-                "action": "action",
-                "destination": {
-                    "service": {
-                        "name": "http://localhost:8003",
-                        "resource": "localhost:8003",
-                        "type": "external"
-                    }
-                },
-                "duration": {
-                    "us": 15949
-                },
-                "http": {
-                    "method": "POST",
-                    "response": {
-                        "status_code": 200
-                    }
-                },
-                "http.url.original": "http://localhost:8003/fetch",
-                "id": "a3c043330bc2015e",
-                "name": "POST http://localhost:8003/fetch",
-                "start": {
-                    "us": 119935
-                },
-                "subtype": "h",
-                "sync": false,
-                "type": "external"
-            },
-            "timestamp": {
-                "us": "dynamic"
-            },
-            "trace": {
-                "id": "286ac3ad697892c406528f13c82e0ce1"
-            },
-            "transaction": {
-                "id": "ec2e280be8345240"
-            },
-            "url": {
-                "original": "http://localhost:8003/fetch"
             }
         }
     ]


### PR DESCRIPTION
## Motivation/summary

Don't indicate a document is less than another just because one field is less -- all preceding sort fields must be equal.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

None