### PR TITLE
systemtest: `queryAgentConfig` retry on `io.EOF`

### DIFF
--- a/systemtest/agentconfig_test.go
+++ b/systemtest/agentconfig_test.go
@@ -19,6 +19,8 @@ package systemtest_test
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -117,6 +119,15 @@ func queryAgentConfig(t testing.TB, serverURL, serviceName, serviceEnvironment, 
 		req.Header.Set("If-None-Match", etag)
 	}
 	resp, err := http.DefaultClient.Do(req)
+
+	maxRetries := 10
+	var retries int
+	for errors.Is(err, io.EOF) && retries < maxRetries {
+		retries++
+		t.Logf("fleet returned EOF on read, retry %d/%d...", retries, maxRetries)
+		<-time.After(500 * time.Millisecond)
+		resp, err = http.DefaultClient.Do(req)
+	}
 	require.NoError(t, err)
 	defer resp.Body.Close()
 

--- a/systemtest/agentconfig_test.go
+++ b/systemtest/agentconfig_test.go
@@ -124,7 +124,7 @@ func queryAgentConfig(t testing.TB, serverURL, serviceName, serviceEnvironment, 
 	var retries int
 	for errors.Is(err, io.EOF) && retries < maxRetries {
 		retries++
-		t.Logf("fleet returned EOF on read, retry %d/%d...", retries, maxRetries)
+		t.Logf("apm-server returned EOF on read, retry %d/%d...", retries, maxRetries)
 		<-time.After(500 * time.Millisecond)
 		resp, err = http.DefaultClient.Do(req)
 	}


### PR DESCRIPTION
## Motivation/summary

Adds retrying logic when the response from fleet-server returns `io.EOF`
up to 10 times, with a retry timer of 500 Milliseconds.

## How to test these changes

1. `go test -v -count=10 -run TestAgentConfig .`
2. Check that `agentconfig_test.go:127: fleet returned EOF on read, retry 1/10...` appears on the output and the test ultimately pass.
