### PR TITLE
Added support for transaction.name in an error object to the intake API

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -36,6 +36,7 @@ https://github.com/elastic/apm-server/compare/7.15\...master[View commits]
 - `context.message.routing_key` was added to the intake API {pull}6177[6177]
 - `transaction.dropped_spans_stats` was added to the intake API {pull}6200[6200]
 - map incoming OTel spans from agent bridges to apm spans/transactions {pull}6308[6308]
+- `transaction.name` was added to errors object the intake API {pull}6539[6539]
 
 [float]
 ==== Added

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -36,7 +36,7 @@ https://github.com/elastic/apm-server/compare/7.15\...master[View commits]
 - `context.message.routing_key` was added to the intake API {pull}6177[6177]
 - `transaction.dropped_spans_stats` was added to the intake API {pull}6200[6200]
 - map incoming OTel spans from agent bridges to apm spans/transactions {pull}6308[6308]
-- `transaction.name` was added to errors object the intake API {pull}6539[6539]
+- `transaction.name` was added to the error objects in the intake API {pull}6539[6539]
 
 [float]
 ==== Added

--- a/docs/spec/rumv3/error.json
+++ b/docs/spec/rumv3/error.json
@@ -695,6 +695,14 @@
         "object"
       ],
       "properties": {
+        "n": {
+          "description": "Name is the generic designation of a transaction in the scope of a single service, eg: 'GET /users/:id'.",
+          "type": [
+            "null",
+            "string"
+          ],
+          "maxLength": 1024
+        },
         "sm": {
           "description": "Sampled indicates whether or not the full information for a transaction is captured. If a transaction is unsampled no spans and less context information will be reported.",
           "type": [

--- a/docs/spec/v2/error.json
+++ b/docs/spec/v2/error.json
@@ -1096,6 +1096,14 @@
         "object"
       ],
       "properties": {
+        "name": {
+          "description": "Name is the generic designation of a transaction in the scope of a single service, eg: 'GET /users/:id'.",
+          "type": [
+            "null",
+            "string"
+          ],
+          "maxLength": 1024
+        },
         "sampled": {
           "description": "Sampled indicates whether or not the full information for a transaction is captured. If a transaction is unsampled no spans and less context information will be reported.",
           "type": [

--- a/model/modeldecoder/rumv3/decoder.go
+++ b/model/modeldecoder/rumv3/decoder.go
@@ -249,6 +249,9 @@ func mapToErrorModel(from *errorEvent, event *model.APMEvent) {
 		if from.Transaction.Sampled.IsSet() {
 			event.Transaction.Sampled = from.Transaction.Sampled.Val
 		}
+		if from.Transaction.Name.IsSet() {
+			event.Transaction.Name = from.Transaction.Name.Val
+		}
 		if from.Transaction.Type.IsSet() {
 			event.Transaction.Type = from.Transaction.Type.Val
 		}

--- a/model/modeldecoder/rumv3/error_test.go
+++ b/model/modeldecoder/rumv3/error_test.go
@@ -201,4 +201,12 @@ func TestDecodeMapToErrorModel(t *testing.T) {
 		mapToErrorModel(&input, &out)
 		assert.Equal(t, "123", out.Error.Exception.Code)
 	})
+
+	t.Run("transaction-name", func(t *testing.T) {
+		var input errorEvent
+		var out model.APMEvent
+		input.Transaction.Name.Set("My Transaction")
+		mapToErrorModel(&input, &out)
+		assert.Equal(t, "My Transaction", out.Transaction.Name)
+	})
 }

--- a/model/modeldecoder/rumv3/model.go
+++ b/model/modeldecoder/rumv3/model.go
@@ -233,6 +233,9 @@ type errorTransactionRef struct {
 	// is captured. If a transaction is unsampled no spans and less context
 	// information will be reported.
 	Sampled nullable.Bool `json:"sm"`
+	// Name is the generic designation of a transaction in the scope of a
+	// single service, eg: 'GET /users/:id'.
+	Name nullable.String `json:"n" validate:"maxLength=1024"`
 	// Type expresses the correlated transaction's type as keyword that has
 	// specific relevance within the service's domain,
 	// eg: 'request', 'backgroundjob'.

--- a/model/modeldecoder/rumv3/model_generated.go
+++ b/model/modeldecoder/rumv3/model_generated.go
@@ -803,17 +803,21 @@ func (val *errorLog) validate() error {
 }
 
 func (val *errorTransactionRef) IsSet() bool {
-	return val.Sampled.IsSet() || val.Type.IsSet()
+	return val.Sampled.IsSet() || val.Name.IsSet() || val.Type.IsSet()
 }
 
 func (val *errorTransactionRef) Reset() {
 	val.Sampled.Reset()
+	val.Name.Reset()
 	val.Type.Reset()
 }
 
 func (val *errorTransactionRef) validate() error {
 	if !val.IsSet() {
 		return nil
+	}
+	if val.Name.IsSet() && utf8.RuneCountInString(val.Name.Val) > 1024 {
+		return fmt.Errorf("'n': validation rule 'maxLength(1024)' violated")
 	}
 	if val.Type.IsSet() && utf8.RuneCountInString(val.Type.Val) > 1024 {
 		return fmt.Errorf("'t': validation rule 'maxLength(1024)' violated")

--- a/model/modeldecoder/v2/decoder.go
+++ b/model/modeldecoder/v2/decoder.go
@@ -396,6 +396,9 @@ func mapToErrorModel(from *errorEvent, event *model.APMEvent) {
 		if from.Transaction.Sampled.IsSet() {
 			event.Transaction.Sampled = from.Transaction.Sampled.Val
 		}
+		if from.Transaction.Name.IsSet() {
+			event.Transaction.Name = from.Transaction.Name.Val
+		}
 		if from.Transaction.Type.IsSet() {
 			event.Transaction.Type = from.Transaction.Type.Val
 		}

--- a/model/modeldecoder/v2/error_test.go
+++ b/model/modeldecoder/v2/error_test.go
@@ -197,4 +197,12 @@ func TestDecodeMapToErrorModel(t *testing.T) {
 		mapToErrorModel(&input, &out)
 		assert.Equal(t, "123", out.Error.Exception.Code)
 	})
+
+	t.Run("transaction-name", func(t *testing.T) {
+		var input errorEvent
+		var out model.APMEvent
+		input.Transaction.Name.Set("My Transaction")
+		mapToErrorModel(&input, &out)
+		assert.Equal(t, "My Transaction", out.Transaction.Name)
+	})
 }

--- a/model/modeldecoder/v2/model.go
+++ b/model/modeldecoder/v2/model.go
@@ -398,6 +398,9 @@ type errorTransactionRef struct {
 	// is captured. If a transaction is unsampled no spans and less context
 	// information will be reported.
 	Sampled nullable.Bool `json:"sampled"`
+	// Name is the generic designation of a transaction in the scope of a
+	// single service, eg: 'GET /users/:id'.
+	Name nullable.String `json:"name" validate:"maxLength=1024"`
 	// Type expresses the correlated transaction's type as keyword that has
 	// specific relevance within the service's domain,
 	// eg: 'request', 'backgroundjob'.

--- a/model/modeldecoder/v2/model_generated.go
+++ b/model/modeldecoder/v2/model_generated.go
@@ -1432,17 +1432,21 @@ func (val *errorLog) validate() error {
 }
 
 func (val *errorTransactionRef) IsSet() bool {
-	return val.Sampled.IsSet() || val.Type.IsSet()
+	return val.Sampled.IsSet() || val.Name.IsSet() || val.Type.IsSet()
 }
 
 func (val *errorTransactionRef) Reset() {
 	val.Sampled.Reset()
+	val.Name.Reset()
 	val.Type.Reset()
 }
 
 func (val *errorTransactionRef) validate() error {
 	if !val.IsSet() {
 		return nil
+	}
+	if val.Name.IsSet() && utf8.RuneCountInString(val.Name.Val) > 1024 {
+		return fmt.Errorf("'name': validation rule 'maxLength(1024)' violated")
 	}
 	if val.Type.IsSet() && utf8.RuneCountInString(val.Type.Val) > 1024 {
 		return fmt.Errorf("'type': validation rule 'maxLength(1024)' violated")


### PR DESCRIPTION
## Motivation/summary
Fixes #6529

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)

## How to test these changes
I added unit tests
