### PR TITLE
[automation] update elastic stack version for testing 8.1.0-f479a40a

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       kibana: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.1.0-2fdb91c4-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.1.0-f479a40a-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -61,7 +61,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.1.0-2fdb91c4-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.1.0-f479a40a-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -85,7 +85,7 @@ services:
       package-registry: { condition: service_healthy }
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:8.1.0-2fdb91c4-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:8.1.0-f479a40a-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Thu, 4 Nov 2021 12:20:09 GMT, release_branch:master, prefix:, end_time:Thu, 4 Nov 2021 19:09:39 GMT, manifest_version:2.0.0, version:8.1.0-SNAPSHOT, branch:master, build_id:8.1.0-f479a40a, build_duration_seconds:24570]