### PR TITLE
package: Update version to 8.0.0

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -1,6 +1,11 @@
 # newer versions go on top
 #
 # change type can be one of: enhancement, bugfix, breaking-change
+- version: "8.0.0"
+  changes:
+    - description: added new traces-apm.rum and individual ILM policies per data stream
+      type: enhancement
+      link: https://github.com/elastic/apm-server/pull/6480
 - version: "7.16.0"
   changes:
     - description: updated package version to align with stack version

--- a/apmpackage/apm/manifest.yml
+++ b/apmpackage/apm/manifest.yml
@@ -1,14 +1,14 @@
 format_version: 1.0.0
 name: apm
 title: Elastic APM
-version: 7.16.0
+version: 8.0.0
 license: basic
 description: Ingest APM data
 type: integration
 categories: ["elastic_stack", "monitoring"]
 release: ga
 conditions:
-  kibana.version: "^7.16.0"
+  kibana.version: "^8.0.0"
 icons:
   - src: /img/logo_apm.svg
     title: APM Logo

--- a/systemtest/helpers_test.go
+++ b/systemtest/helpers_test.go
@@ -40,5 +40,7 @@ func withDataStreams(t *testing.T, f func(t *testing.T, unstartedServer *apmserv
 		srv := apmservertest.NewUnstartedServer(t)
 		srv.Config.DataStreams = &apmservertest.DataStreamsConfig{Enabled: true}
 		f(t, srv)
+		err = systemtest.Fleet.DeletePackage(systemtest.IntegrationPackage.Name, systemtest.IntegrationPackage.Version)
+		require.NoError(t, err)
 	})
 }

--- a/systemtest/helpers_test.go
+++ b/systemtest/helpers_test.go
@@ -40,7 +40,5 @@ func withDataStreams(t *testing.T, f func(t *testing.T, unstartedServer *apmserv
 		srv := apmservertest.NewUnstartedServer(t)
 		srv.Config.DataStreams = &apmservertest.DataStreamsConfig{Enabled: true}
 		f(t, srv)
-		err = systemtest.Fleet.DeletePackage(systemtest.IntegrationPackage.Name, systemtest.IntegrationPackage.Version)
-		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
## Motivation/summary

Updates the APM Package version to 8.0.0 since it was not updated when
the 7.16.0 release got pushed, and after we published the apm package
`8.0.0-dev1` to staging, the tests started installing that version of
the package instead of relying on the local package since the remote
version was higher.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

Run `go test -v -run TestRUMXForwardedFor .`, verify it doesn't fail.

## Related issues

Closes #6562
Introduced by https://github.com/elastic/package-storage/pull/2728
