### PR TITLE
[jjbb] add regex for the active branches

### DIFF
--- a/.ci/jobs/apm-server-check-changelogs-mbp.yml
+++ b/.ci/jobs/apm-server-check-changelogs-mbp.yml
@@ -12,7 +12,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: false
-        head-filter-regex: '(master|6\.*|7\.*|8\.*|PR-.*)'
+        head-filter-regex: '(master|6\.8|7\.16|8\.\d+|PR-.*)'
         notification-context: 'apm-ci'
         property-strategies:
           all-branches:

--- a/.ci/jobs/apm-server-check-packages-mbp.yml
+++ b/.ci/jobs/apm-server-check-packages-mbp.yml
@@ -12,7 +12,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: false
-        head-filter-regex: '(master|7\.1\d|8\.\d+)'
+        head-filter-regex: '(master|7\.16|8\.\d+)'
         notification-context: 'beats-tester'
         build-strategies:
         - skip-initial-build: true

--- a/.ci/jobs/apm-server-mbp.yml
+++ b/.ci/jobs/apm-server-mbp.yml
@@ -13,7 +13,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
-        head-filter-regex: '(master|6\.*|7\.*|8\.*|PR-.*|v[0-9].*)'
+        head-filter-regex: '(master|6\.8|7\.16|8\.\d+|PR-.*|v[0-9].*)'
         notification-context: 'apm-ci'
         repo: apm-server
         repo-owner: elastic


### PR DESCRIPTION
## Motivation/summary

Tidy up the Jenkisn Multibranch pipelines with only the active branches and release branches. In other words, all the automation with `mergify`, `dependabot` or the `bump automation` should not be added as branches.

Similar to https://github.com/elastic/apm-server/pull/6561 but with a different regex, otherwise the branches are not reported :/