### PR TITLE
systemtest: ensure unique package policy names

### DIFF
--- a/systemtest/kibana.go
+++ b/systemtest/kibana.go
@@ -128,7 +128,6 @@ func InitFleet() error {
 // This should typically be used by tests instead of directly calling the
 // fleettest.Client.CreateAgentPolicy method.
 func CreateAgentPolicy(t testing.TB, name, namespace string, vars map[string]interface{}) (*fleettest.AgentPolicy, *fleettest.EnrollmentAPIKey) {
-
 	agentPolicy, key, err := Fleet.CreateAgentPolicy(name, namespace, agentPolicyDescription)
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -178,7 +177,10 @@ func DestroyAgentPolicy(id ...string) error {
 //
 // The returned package policy is suitable for passing to Fleet.CreatePackagePolicy.
 func NewPackagePolicy(agentPolicy *fleettest.AgentPolicy, varValues map[string]interface{}) *fleettest.PackagePolicy {
-	packagePolicy := fleettest.NewPackagePolicy(IntegrationPackage, "apm", agentPolicy.Namespace, agentPolicy.ID)
+	// Package policy names must be globally unique. We generate unique agent
+	// policy names, so just append the package name to that.
+	packagePolicyName := agentPolicy.Name + "-apm"
+	packagePolicy := fleettest.NewPackagePolicy(IntegrationPackage, packagePolicyName, agentPolicy.Namespace, agentPolicy.ID)
 	packagePolicy.Package.Name = IntegrationPackage.Name
 	packagePolicy.Package.Version = IntegrationPackage.Version
 	packagePolicy.Package.Title = IntegrationPackage.Title


### PR DESCRIPTION
## Motivation/summary

`systemtest.TestTailSampling` has been failing with errors like:

```
2021/11/12 05:31:37 Container is ready id: d7064c092de5 image: elastic-agent-systemtest:8.1.0-49c447b0-SNAPSHOT
    kibana.go:141: 
        	Error Trace:	kibana.go:141
        	            				fleet_test.go:104
        	            				sampling_test.go:69
        	Error:      	Received unexpected error:
        	            	There is already a package with the same name
        	Test:       	TestTailSampling
```

Initially we thought this was flakiness in our tests, then thought maybe it was a concurrency issue in CI. Actually, it's due to a functional change in Fleet: with https://github.com/elastic/kibana/pull/115212 package policy names must not be globally unique, not just unique within their agent policy.

We now ensure package policy names we generate are globally unique by including the agent policy name.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

None