### PR TITLE
Drop deprecated `span.{start,http}` fields

### DIFF
--- a/apmpackage/apm/data_stream/rum_traces/fields/fields.yml
+++ b/apmpackage/apm/data_stream/rum_traces/fields/fields.yml
@@ -319,13 +319,6 @@
       type: keyword
       description: |
         Generic designation of a span in the scope of a transaction.
-    - name: start
-      type: group
-      fields:
-        - name: us
-          type: long
-          description: |
-            Offset relative to the transaction's timestamp identifying the start of the span, in microseconds.
     - name: subtype
       type: keyword
       description: |

--- a/apmpackage/apm/data_stream/traces/fields/fields.yml
+++ b/apmpackage/apm/data_stream/traces/fields/fields.yml
@@ -319,13 +319,6 @@
       type: keyword
       description: |
         Generic designation of a span in the scope of a transaction.
-    - name: start
-      type: group
-      fields:
-        - name: us
-          type: long
-          description: |
-            Offset relative to the transaction's timestamp identifying the start of the span, in microseconds.
     - name: subtype
       type: keyword
       description: |

--- a/apmpackage/apm/docs/README.md
+++ b/apmpackage/apm/docs/README.md
@@ -167,7 +167,6 @@ Traces are written to `traces-apm-*` data streams, except for RUM traces, which 
 | span.message.age.ms | Age of a message in milliseconds. | long |
 | span.message.queue.name | Name of the message queue or topic where the message is published or received. | keyword |
 | span.name | Generic designation of a span in the scope of a transaction. | keyword |
-| span.start.us | Offset relative to the transaction's timestamp identifying the start of the span, in microseconds. | long |
 | span.subtype | A further sub-division of the type (e.g. postgresql, elasticsearch) | keyword |
 | span.sync | Indicates whether the span was executed synchronously or asynchronously. | boolean |
 | span.type | Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', 'cache', etc). | keyword |

--- a/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
@@ -397,21 +397,6 @@
                 "duration": {
                     "us": 3781
                 },
-                "http": {
-                    "method": "GET",
-                    "response": {
-                        "decoded_body_size": 401,
-                        "encoded_body_size": 356,
-                        "headers": {
-                            "Content-Type": [
-                                "application/json"
-                            ]
-                        },
-                        "status_code": 302,
-                        "transfer_size": 300.12
-                    }
-                },
-                "http.url.original": "http://localhost:8000",
                 "id": "1234567890aaaade",
                 "name": "GET users-authenticated",
                 "stacktrace": [

--- a/beater/test_approved_es_documents/TestPublishIntegrationMinimalEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationMinimalEvents.approved.json
@@ -155,9 +155,6 @@
                 },
                 "id": "0123456a89012345",
                 "name": "GET /api/types",
-                "start": {
-                    "us": 1845
-                },
                 "type": "request"
             },
             "timestamp": {

--- a/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json
@@ -243,9 +243,6 @@
                 },
                 "id": "1234abcdef567895",
                 "name": "GET /api/types",
-                "start": {
-                    "us": 22000
-                },
                 "type": "request"
             },
             "timestamp": {
@@ -376,9 +373,6 @@
                 },
                 "id": "0123456a89012345",
                 "name": "GET /api/types",
-                "start": {
-                    "us": 1845
-                },
                 "subtype": "http",
                 "type": "request"
             },
@@ -508,9 +502,6 @@
                 },
                 "id": "abcde56a89012345",
                 "name": "get /api/types",
-                "start": {
-                    "us": 0
-                },
                 "subtype": "http",
                 "sync": false,
                 "type": "request"
@@ -670,16 +661,6 @@
                 "duration": {
                     "us": 3781
                 },
-                "http": {
-                    "method": "GET",
-                    "response": {
-                        "decoded_body_size": 401,
-                        "encoded_body_size": 356,
-                        "status_code": 200,
-                        "transfer_size": 300.12
-                    }
-                },
-                "http.url.original": "http://localhost:8000",
                 "id": "1234567890aaaade",
                 "name": "SELECT FROM product_types",
                 "stacktrace": [
@@ -731,9 +712,6 @@
                         }
                     }
                 ],
-                "start": {
-                    "us": 2830
-                },
                 "subtype": "postgresql",
                 "sync": true,
                 "type": "db"
@@ -1013,9 +991,6 @@
                 },
                 "id": "abcdef01234567",
                 "name": "SELECT FROM p_details",
-                "start": {
-                    "us": 2830
-                },
                 "subtype": "postgresql",
                 "type": "db"
             },

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -29,6 +29,7 @@ https://github.com/elastic/apm-server/compare/7.15\...master[View commits]
 - Removed `apm-server.rum.{allowed_service,event_rate}` configuration option in favor of `apm-server.auth.anonymous.{allow_service,rate_limit}` {pull}6560[6560]
 - Removed `apm-server.{api_key,secret_token}` configuration options in favor of `apm-server.auth.{api_key,secret_token}` {pull}6560[6560]
 - Onboarding documents are no longer indexed {pull}6431[6431]
+- Removed unused `span.start.us` field, and deprecated `span.http.*` fields {pull}6602[6602]
 
 [float]
 ==== Bug fixes

--- a/model/apmevent.go
+++ b/model/apmevent.go
@@ -146,28 +146,5 @@ func (e *APMEvent) BeatEvent(ctx context.Context) beat.Event {
 	fields.maybeSetString("message", e.Message)
 	fields.maybeSetMapStr("http", e.HTTP.fields())
 	fields.maybeSetMapStr("faas", e.FAAS.fields())
-	if e.Processor == SpanProcessor {
-		// Deprecated: copy url.original and http.* to span.http.* for backwards compatibility.
-		//
-		// TODO(axw) remove this in 8.0: https://github.com/elastic/apm-server/issues/5995
-		var spanHTTPFields mapStr
-		spanHTTPFields.maybeSetString("version", e.HTTP.Version)
-		if e.HTTP.Request != nil {
-			spanHTTPFields.maybeSetString("method", e.HTTP.Request.Method)
-		}
-		if e.HTTP.Response != nil {
-			spanHTTPFields.maybeSetMapStr("response", e.HTTP.Response.fields())
-		}
-		if len(spanHTTPFields) != 0 || e.URL.Original != "" {
-			spanFieldsMap, ok := event.Fields["span"].(common.MapStr)
-			if !ok {
-				spanFieldsMap = make(common.MapStr)
-				event.Fields["span"] = spanFieldsMap
-			}
-			spanFields := mapStr(spanFieldsMap)
-			spanFields.maybeSetMapStr("http", common.MapStr(spanHTTPFields))
-			spanFields.maybeSetString("http.url.original", e.URL.Original)
-		}
-	}
 	return event
 }

--- a/model/modeldecoder/rumv3/decoder.go
+++ b/model/modeldecoder/rumv3/decoder.go
@@ -579,10 +579,6 @@ func mapToSpanModel(from *span, event *model.APMEvent) {
 		out.Stacktrace = make(model.Stacktrace, len(from.Stacktrace))
 		mapToStracktraceModel(from.Stacktrace, out.Stacktrace)
 	}
-	if from.Start.IsSet() {
-		val := from.Start.Val
-		out.Start = &val
-	}
 	if from.Sync.IsSet() {
 		val := from.Sync.Val
 		out.Sync = &val

--- a/model/modeldecoder/v2/decoder.go
+++ b/model/modeldecoder/v2/decoder.go
@@ -993,10 +993,6 @@ func mapToSpanModel(from *span, event *model.APMEvent) {
 		out.Stacktrace = make(model.Stacktrace, len(from.Stacktrace))
 		mapToStracktraceModel(from.Stacktrace, out.Stacktrace)
 	}
-	if from.Start.IsSet() {
-		val := from.Start.Val
-		out.Start = &val
-	}
 	if from.Sync.IsSet() {
 		val := from.Sync.Val
 		out.Sync = &val

--- a/model/modeldecoder/v2/span_test.go
+++ b/model/modeldecoder/v2/span_test.go
@@ -177,7 +177,6 @@ func TestDecodeMapToSpanModel(t *testing.T) {
 		modeldecodertest.SetStructValues(&input, defaultVal)
 		input.Start.Reset()
 		mapToSpanModel(&input, &out)
-		require.Nil(t, out.Span.Start)
 		assert.Equal(t, reqTime, out.Timestamp)
 	})
 

--- a/model/span.go
+++ b/model/span.go
@@ -46,11 +46,6 @@ type Span struct {
 	// Action holds the span action: "query", "execute", etc.
 	Action string
 
-	// Start holds the span's offset from the transaction timestamp in milliseconds.
-	//
-	// TODO(axw) drop in 8.0. See https://github.com/elastic/apm-server/issues/6000)
-	Start *float64
-
 	// SelfTime holds the aggregated span durations, for breakdown metrics.
 	SelfTime AggregatedDuration
 
@@ -147,10 +142,6 @@ func (e *Span) setFields(fields *mapStr, apmEvent *APMEvent) {
 	span.maybeSetString("subtype", e.Subtype)
 	span.maybeSetString("action", e.Action)
 	span.maybeSetBool("sync", e.Sync)
-	if e.Start != nil {
-		start := time.Duration(*e.Start * float64(time.Millisecond))
-		span.set("start", common.MapStr{"us": int(start.Microseconds())})
-	}
 	if apmEvent.Processor == SpanProcessor {
 		// TODO(axw) set `event.duration` in 8.0, and remove this field.
 		// See https://github.com/elastic/apm-server/issues/5999

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -36,7 +36,6 @@ func TestSpanTransformEmpty(t *testing.T) {
 
 func TestSpanTransform(t *testing.T) {
 	path := "test/path"
-	start := 0.65
 	hexID := "0147258369012345"
 	subtype := "amqp"
 	action := "publish"
@@ -60,7 +59,6 @@ func TestSpanTransform(t *testing.T) {
 				Kind:                "CLIENT",
 				Subtype:             subtype,
 				Action:              action,
-				Start:               &start,
 				RepresentativeCount: 5,
 				Stacktrace:          Stacktrace{{AbsPath: path}},
 				DB: &DB{
@@ -85,7 +83,6 @@ func TestSpanTransform(t *testing.T) {
 					"duration": common.MapStr{"us": int(duration.Microseconds())},
 					"name":     "myspan",
 					"kind":     "CLIENT",
-					"start":    common.MapStr{"us": 650},
 					"type":     "myspantype",
 					"subtype":  subtype,
 					"action":   action,
@@ -166,15 +163,7 @@ func TestSpanHTTPFields(t *testing.T) {
 			"original": event.URL.Original,
 		},
 		"span": common.MapStr{
-			"duration":          common.MapStr{"us": 0},
-			"http.url.original": event.URL.Original,
-			"http": common.MapStr{
-				"version": event.HTTP.Version,
-				"method":  event.HTTP.Request.Method,
-				"response": common.MapStr{
-					"status_code": event.HTTP.Response.StatusCode,
-				},
-			},
+			"duration": common.MapStr{"us": 0},
 		},
 	}, output.Fields)
 }

--- a/processor/otel/test_approved/span_jaeger_http.approved.json
+++ b/processor/otel/test_approved/span_jaeger_http.approved.json
@@ -55,13 +55,6 @@
                 "duration": {
                     "us": 79000000
                 },
-                "http": {
-                    "method": "get",
-                    "response": {
-                        "status_code": 400
-                    }
-                },
-                "http.url.original": "http://foo.bar.com?a=12",
                 "id": "0000000041414646",
                 "name": "HTTP GET",
                 "subtype": "http",

--- a/processor/otel/test_approved/span_jaeger_http_status_code.approved.json
+++ b/processor/otel/test_approved/span_jaeger_http_status_code.approved.json
@@ -48,13 +48,6 @@
                 "duration": {
                     "us": 79000000
                 },
-                "http": {
-                    "method": "get",
-                    "response": {
-                        "status_code": 202
-                    }
-                },
-                "http.url.original": "http://foo.bar.com?a=12",
                 "id": "0000000041414646",
                 "name": "HTTP GET",
                 "subtype": "http",

--- a/processor/otel/test_approved/span_jaeger_https_default_port.approved.json
+++ b/processor/otel/test_approved/span_jaeger_https_default_port.approved.json
@@ -40,7 +40,6 @@
                 "duration": {
                     "us": 79000000
                 },
-                "http.url.original": "https://foo.bar.com:443?a=12",
                 "id": "0000000041414646",
                 "name": "HTTPS GET",
                 "subtype": "http",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
@@ -375,21 +375,6 @@
                 "duration": {
                     "us": 3781
                 },
-                "http": {
-                    "method": "GET",
-                    "response": {
-                        "decoded_body_size": 401,
-                        "encoded_body_size": 356,
-                        "headers": {
-                            "Content-Type": [
-                                "application/json"
-                            ]
-                        },
-                        "status_code": 302,
-                        "transfer_size": 300.12
-                    }
-                },
-                "http.url.original": "http://localhost:8000",
                 "id": "1234567890aaaade",
                 "name": "GET users-authenticated",
                 "stacktrace": [

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationInvalidEvent.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationInvalidEvent.approved.json
@@ -34,9 +34,6 @@
                 },
                 "id": "abcdef01234567",
                 "name": "GET /api/types",
-                "start": {
-                    "us": 0
-                },
                 "type": "request"
             },
             "timestamp": {

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationInvalidJSONEvent.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationInvalidJSONEvent.approved.json
@@ -34,9 +34,6 @@
                 },
                 "id": "abcdef01234567",
                 "name": "GET /api/types",
-                "start": {
-                    "us": 0
-                },
                 "type": "request"
             },
             "timestamp": {

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationOpenTelemetryBridge.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationOpenTelemetryBridge.approved.json
@@ -247,12 +247,6 @@
                 "duration": {
                     "us": 32592
                 },
-                "http": {
-                    "method": "GET",
-                    "response": {
-                        "status_code": 200
-                    }
-                },
                 "id": "ddf109a4c4aa5f2b6e984548ca57774d",
                 "kind": "CLIENT",
                 "name": "span_name",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationOptionalTimestamps.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationOptionalTimestamps.approved.json
@@ -127,9 +127,6 @@
                 },
                 "id": "0147258369abcdef",
                 "name": "sp1",
-                "start": {
-                    "us": 10000
-                },
                 "type": "db"
             },
             "timestamp": {

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationRumTransactions.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationRumTransactions.approved.json
@@ -102,7 +102,6 @@
                 "duration": {
                     "us": 643000
                 },
-                "http.url.original": "http://localhost:8000/test/e2e/general-usecase/span",
                 "id": "aaaaaaaaaaaaaaaa",
                 "name": "transaction",
                 "stacktrace": [
@@ -127,9 +126,6 @@
                         }
                     }
                 ],
-                "start": {
-                    "us": 0
-                },
                 "type": "transaction"
             },
             "timestamp": {

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationSpans.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationSpans.approved.json
@@ -215,9 +215,6 @@
                 },
                 "id": "1234abcdef567895",
                 "name": "GET /api/types",
-                "start": {
-                    "us": 22000
-                },
                 "type": "request"
             },
             "timestamp": {
@@ -334,9 +331,6 @@
                 },
                 "id": "0123456a89012345",
                 "name": "GET /api/types",
-                "start": {
-                    "us": 1845
-                },
                 "subtype": "http",
                 "type": "request"
             },
@@ -452,9 +446,6 @@
                 },
                 "id": "abcde56a89012345",
                 "name": "get /api/types",
-                "start": {
-                    "us": 0
-                },
                 "subtype": "http",
                 "sync": false,
                 "type": "request"
@@ -600,16 +591,6 @@
                 "duration": {
                     "us": 3781
                 },
-                "http": {
-                    "method": "GET",
-                    "response": {
-                        "decoded_body_size": 401,
-                        "encoded_body_size": 356,
-                        "status_code": 200,
-                        "transfer_size": 300.12
-                    }
-                },
-                "http.url.original": "http://localhost:8000",
                 "id": "1234567890aaaade",
                 "name": "SELECT FROM product_types",
                 "stacktrace": [
@@ -661,9 +642,6 @@
                         }
                     }
                 ],
-                "start": {
-                    "us": 2830
-                },
                 "subtype": "postgresql",
                 "sync": true,
                 "type": "db"
@@ -915,9 +893,6 @@
                 },
                 "id": "abcdef01234567",
                 "name": "SELECT FROM p_details",
-                "start": {
-                    "us": 2830
-                },
                 "subtype": "postgresql",
                 "type": "db"
             },

--- a/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
@@ -322,9 +322,6 @@
                 },
                 "id": "bbd8bcc3be14d814",
                 "name": "Requesting and receiving the document",
-                "start": {
-                    "us": 4000
-                },
                 "subtype": "browser-timing",
                 "type": "hard-navigation"
             },
@@ -399,9 +396,6 @@
                 },
                 "id": "fc546e87a90a774f",
                 "name": "Parsing the document, executing sy. scripts",
-                "start": {
-                    "us": 14000
-                },
                 "subtype": "browser-timing",
                 "type": "hard-navigation"
             },
@@ -492,19 +486,8 @@
                 "duration": {
                     "us": 35060
                 },
-                "http": {
-                    "response": {
-                        "decoded_body_size": 676864,
-                        "encoded_body_size": 676864,
-                        "transfer_size": 677175
-                    }
-                },
-                "http.url.original": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js?token=REDACTED",
                 "id": "fb8f717930697299",
                 "name": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js",
-                "start": {
-                    "us": 22534
-                },
                 "subtype": "script",
                 "type": "rc"
             },
@@ -582,9 +565,6 @@
                 },
                 "id": "9b80535c4403c9fb",
                 "name": "OpenTracing y",
-                "start": {
-                    "us": 96929
-                },
                 "type": "cu"
             },
             "timestamp": {
@@ -675,18 +655,8 @@
                 "duration": {
                     "us": 6724
                 },
-                "http": {
-                    "method": "GET",
-                    "response": {
-                        "status_code": 200
-                    }
-                },
-                "http.url.original": "http://localhost:8000/test/e2e/common/data.json?test=hamid",
                 "id": "5ecb8ee030749715",
                 "name": "GET /test/e2e/common/data.json",
-                "start": {
-                    "us": 98940
-                },
                 "subtype": "h",
                 "sync": true,
                 "type": "external"
@@ -782,18 +752,8 @@
                 "duration": {
                     "us": 11584
                 },
-                "http": {
-                    "method": "POST",
-                    "response": {
-                        "status_code": 200
-                    }
-                },
-                "http.url.original": "http://localhost:8003/data",
                 "id": "27f45fd274f976d4",
                 "name": "POST http://localhost:8003/data",
-                "start": {
-                    "us": 106520
-                },
                 "subtype": "h",
                 "sync": true,
                 "type": "external"
@@ -890,18 +850,8 @@
                 "duration": {
                     "us": 15949
                 },
-                "http": {
-                    "method": "POST",
-                    "response": {
-                        "status_code": 200
-                    }
-                },
-                "http.url.original": "http://localhost:8003/fetch",
                 "id": "a3c043330bc2015e",
                 "name": "POST http://localhost:8003/fetch",
-                "start": {
-                    "us": 119935
-                },
                 "subtype": "h",
                 "sync": false,
                 "type": "external"
@@ -1002,9 +952,6 @@
                         }
                     }
                 ],
-                "start": {
-                    "us": 120000
-                },
                 "subtype": "browser-timing",
                 "type": "hard-navigation"
             },

--- a/systemtest/approvals/TestNoMatchingSourcemap.approved.json
+++ b/systemtest/approvals/TestNoMatchingSourcemap.approved.json
@@ -46,7 +46,6 @@
                 "duration": {
                     "us": 643000
                 },
-                "http.url.original": "http://localhost:8000/test/e2e/general-usecase/span",
                 "id": "aaaaaaaaaaaaaaaa",
                 "name": "transaction",
                 "stacktrace": [
@@ -72,9 +71,6 @@
                         }
                     }
                 ],
-                "start": {
-                    "us": 0
-                },
                 "type": "transaction"
             },
             "timestamp": {

--- a/systemtest/approvals/TestRUMRoutingIntegration.approved.json
+++ b/systemtest/approvals/TestRUMRoutingIntegration.approved.json
@@ -72,18 +72,8 @@
                 "duration": {
                     "us": 11584
                 },
-                "http": {
-                    "method": "POST",
-                    "response": {
-                        "status_code": 200
-                    }
-                },
-                "http.url.original": "http://localhost:8003/data",
                 "id": "27f45fd274f976d4",
                 "name": "POST http://localhost:8003/data",
-                "start": {
-                    "us": 106520
-                },
                 "subtype": "h",
                 "sync": true,
                 "type": "external"
@@ -173,18 +163,8 @@
                 "duration": {
                     "us": 6724
                 },
-                "http": {
-                    "method": "GET",
-                    "response": {
-                        "status_code": 200
-                    }
-                },
-                "http.url.original": "http://localhost:8000/test/e2e/common/data.json?test=hamid",
                 "id": "5ecb8ee030749715",
                 "name": "GET /test/e2e/common/data.json",
-                "start": {
-                    "us": 98940
-                },
                 "subtype": "h",
                 "sync": true,
                 "type": "external"
@@ -257,9 +237,6 @@
                 },
                 "id": "9b80535c4403c9fb",
                 "name": "OpenTracing y",
-                "start": {
-                    "us": 96929
-                },
                 "type": "cu"
             },
             "timestamp": {
@@ -345,18 +322,8 @@
                 "duration": {
                     "us": 15949
                 },
-                "http": {
-                    "method": "POST",
-                    "response": {
-                        "status_code": 200
-                    }
-                },
-                "http.url.original": "http://localhost:8003/fetch",
                 "id": "a3c043330bc2015e",
                 "name": "POST http://localhost:8003/fetch",
-                "start": {
-                    "us": 119935
-                },
                 "subtype": "h",
                 "sync": false,
                 "type": "external"
@@ -429,9 +396,6 @@
                 },
                 "id": "bbd8bcc3be14d814",
                 "name": "Requesting and receiving the document",
-                "start": {
-                    "us": 4000
-                },
                 "subtype": "browser-timing",
                 "type": "hard-navigation"
             },
@@ -525,9 +489,6 @@
                         }
                     }
                 ],
-                "start": {
-                    "us": 120000
-                },
                 "subtype": "browser-timing",
                 "type": "hard-navigation"
             },
@@ -612,19 +573,8 @@
                 "duration": {
                     "us": 35060
                 },
-                "http": {
-                    "response": {
-                        "decoded_body_size": 676864,
-                        "encoded_body_size": 676864,
-                        "transfer_size": 677175
-                    }
-                },
-                "http.url.original": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js?token=REDACTED",
                 "id": "fb8f717930697299",
                 "name": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js",
-                "start": {
-                    "us": 22534
-                },
                 "subtype": "script",
                 "type": "rc"
             },
@@ -696,9 +646,6 @@
                 },
                 "id": "fc546e87a90a774f",
                 "name": "Parsing the document, executing sy. scripts",
-                "start": {
-                    "us": 14000
-                },
                 "subtype": "browser-timing",
                 "type": "hard-navigation"
             },

--- a/systemtest/approvals/TestRUMSpanSourcemapping.approved.json
+++ b/systemtest/approvals/TestRUMSpanSourcemapping.approved.json
@@ -46,7 +46,6 @@
                 "duration": {
                     "us": 643000
                 },
-                "http.url.original": "http://localhost:8000/test/e2e/general-usecase/span",
                 "id": "aaaaaaaaaaaaaaaa",
                 "name": "transaction",
                 "stacktrace": [
@@ -123,9 +122,6 @@
                         }
                     }
                 ],
-                "start": {
-                    "us": 0
-                },
                 "type": "transaction"
             },
             "timestamp": {


### PR DESCRIPTION
## Motivation/summary

Drop deprecated `span.{start,http}` fields:
- `span.start.us` is not used by the UI
- `span.http.*` fields have been copied to ECS field sets, `http.*` and `url.*`, since 7.14

A minor change to the UI is required to pick up the ECS fields: https://github.com/elastic/kibana/pull/118485

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

1. Send some RUM transactions and spans, check the spans have no `span.start.us` field
2. Send some HTTP client spans, check they have no `span.http.*` fields

## Related issues

Closes https://github.com/elastic/apm-server/issues/5995
Closes https://github.com/elastic/apm-server/issues/6000