### PR TITLE
config: Enable `auth.anonymous` when `rum.enabled`

### DIFF
--- a/beater/config/auth.go
+++ b/beater/config/auth.go
@@ -34,8 +34,7 @@ type AgentAuth struct {
 }
 
 func (a *AgentAuth) setAnonymousDefaults(logger *logp.Logger, rumEnabled bool) error {
-	if a.Anonymous.configured {
-		// Anonymous access explicitly configured.
+	if a.Anonymous.enabledSet {
 		return nil
 	}
 	if !a.APIKey.Enabled && a.SecretToken == "" {
@@ -90,7 +89,7 @@ type AnonymousAgentAuth struct {
 	AllowService []string  `config:"allow_service"`
 	RateLimit    RateLimit `config:"rate_limit"`
 
-	configured bool // anon explicitly defined
+	enabledSet bool // enabled explicitly set.
 }
 
 func (a *AnonymousAgentAuth) Unpack(in *common.Config) error {
@@ -98,7 +97,7 @@ func (a *AnonymousAgentAuth) Unpack(in *common.Config) error {
 	if err := in.Unpack((*underlyingAnonymousAgentAuth)(a)); err != nil {
 		return errors.Wrap(err, "error unpacking anon config")
 	}
-	a.configured = true
+	a.enabledSet = in.HasField("enabled")
 	return nil
 }
 

--- a/beater/config/auth_test.go
+++ b/beater/config/auth_test.go
@@ -118,7 +118,35 @@ func TestAnonymousAgentAuth(t *testing.T) {
 					EventLimit: 300,
 					IPLimit:    1000,
 				},
-				configured: true,
+				enabledSet: false,
+			},
+		},
+		"rum_enabled_anon_inferred": {
+			cfg: common.MustNewConfigFrom(`{"auth.secret_token": "abc","rum.enabled":true,"auth.anonymous.allow_service":["service-one"]}`),
+			expectedConfig: AnonymousAgentAuth{
+				Enabled:      true,
+				AllowAgent:   []string{"rum-js", "js-base"},
+				AllowService: []string{"service-one"},
+				RateLimit: RateLimit{
+					EventLimit: 300,
+					IPLimit:    1000,
+				},
+				enabledSet: false,
+			},
+		},
+		"rum_enabled_anon_disabled": {
+			cfg: common.MustNewConfigFrom(
+				`{"auth.secret_token":"abc","rum.enabled":true,"auth.anonymous.enabled":false,"auth.anonymous.allow_service":["service-one"]}`,
+			),
+			expectedConfig: AnonymousAgentAuth{
+				Enabled:      false,
+				AllowAgent:   []string{"rum-js", "js-base"},
+				AllowService: []string{"service-one"},
+				RateLimit: RateLimit{
+					EventLimit: 300,
+					IPLimit:    1000,
+				},
+				enabledSet: true,
 			},
 		},
 	} {

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -179,7 +179,7 @@ func TestUnpackConfig(t *testing.T) {
 							EventLimit: 7200,
 							IPLimit:    2000,
 						},
-						configured: true,
+						enabledSet: true,
 					},
 				},
 				TLS: &tlscommon.ServerConfig{

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -62,6 +62,7 @@ https://github.com/elastic/apm-server/compare/7.15\...master[View commits]
 - Added support for gzip compression to the experimental Elasticsearch output {pull}6449[6449]
 - Introduced a delete phase for all data streams. Traces, errors and logs are kept for 10 days, metrics are kept for 90 days {pull}6480[6480]
 - Changed RUM traces to use a dedicated data stream (`traces-apm.rum`). RUM traces are kept for 90 days {pull}6480[6480]
+- When `auth.anonymous.enabled` isn't specified and RUM is enabled (`rum.enabled:true`), `auth.anonymous.enabled` will be set to `true` {pull}6607[6607]
 
 [float]
 ==== Deprecated


### PR DESCRIPTION
## Motivation/summary

Automatically sets `auth.anonymous.enabled=true` when `rum.enabled=true`

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [] Documentation has been updated~

## How to test these changes

1. `docker-compose up -d`
2. `make`
3. `./apm-server -e -E output.elasticsearch.username=admin -E output.elasticsearch.password=changeme -E apm-server.rum.enabled=true -E apm-server.auth.secret_token=abc`
4. Verify that `anonymous access enabled for RUM` appears in the logs.

## Related issues

Closes #6570
