### PR TITLE
CI: archive chocolatey.log

### DIFF
--- a/.ci/scripts/windows-build.ps1
+++ b/.ci/scripts/windows-build.ps1
@@ -42,6 +42,7 @@ if (Test-Path "build") { Remove-Item -Recurse -Force build }
 New-Item -ItemType directory -Path build\coverage | Out-Null
 
 choco install python -y -r --no-progress --version 3.8.1.20200110
+cp C:\ProgramData\chocolatey\logs\chocolatey.log windows_build_chocolatey.log
 refreshenv
 $env:PATH = "C:\Python38;C:\Python38\Scripts;$env:PATH"
 $env:PYTHON_ENV = "$env:TEMP\python-env"

--- a/.ci/scripts/windows-test.ps1
+++ b/.ci/scripts/windows-test.ps1
@@ -29,6 +29,7 @@ $env:MAGEFILE_CACHE = "$env:WORKSPACE\.magefile"
 
 # Setup Python.
 choco install python -y -r --no-progress --version 3.8.1.20200110
+cp C:\ProgramData\chocolatey\logs\chocolatey.log windows_test_chocolatey.log
 refreshenv
 $env:PATH = "C:\Python38;C:\Python38\Scripts;$env:PATH"
 $env:PYTHON_ENV = "$env:TEMP\python-env"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -180,6 +180,7 @@ pipeline {
           }
           post {
             always {
+              archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/*chocolatey.log")
               junit(allowEmptyResults: true,
                 keepLongStdio: true,
                 testResults: "${BASE_DIR}/build/TEST-*.xml")


### PR DESCRIPTION
## Motivation/summary

Recently in apm-server we've been seeing build failures on Windows related to installing Python via Chocolatey, let's store the `chocolatey.log` file to help with the debugging.