### PR TITLE
ci: don't install python on Windows

### DIFF
--- a/.ci/scripts/windows-build.ps1
+++ b/.ci/scripts/windows-build.ps1
@@ -34,21 +34,8 @@ $env:RACE_DETECTOR = "true"
 # Install mage.
 exec { go install github.com/magefile/mage }
 
-echo "Fetching testing dependencies"
-# TODO (elastic/beats#5050): Use a vendored copy of this.
-exec { go get github.com/docker/libcompose }
-
 if (Test-Path "build") { Remove-Item -Recurse -Force build }
 New-Item -ItemType directory -Path build\coverage | Out-Null
-
-choco install python -y -r --no-progress --version 3.8.1.20200110
-refreshenv
-$env:PATH = "C:\Python38;C:\Python38\Scripts;$env:PATH"
-$env:PYTHON_ENV = "$env:TEMP\python-env"
-python --version
-
-echo "Building fields.yml"
-exec { mage fields }
 
 echo "Building $env:beat"
 exec { mage build } "Build FAILURE"

--- a/.ci/scripts/windows-test.ps1
+++ b/.ci/scripts/windows-test.ps1
@@ -27,23 +27,12 @@ $env:PATH = "$env:GOPATH\bin;C:\tools\mingw64\bin;$env:PATH"
 # each run starts from a clean slate.
 $env:MAGEFILE_CACHE = "$env:WORKSPACE\.magefile"
 
-# Setup Python.
-choco install python -y -r --no-progress --version 3.8.1.20200110
-refreshenv
-$env:PATH = "C:\Python38;C:\Python38\Scripts;$env:PATH"
-$env:PYTHON_ENV = "$env:TEMP\python-env"
-python --version
-
 # Configure testing parameters.
 $env:TEST_COVERAGE = "true"
 $env:RACE_DETECTOR = "true"
 
 # Install mage.
 exec { go install github.com/magefile/mage }
-
-echo "Fetching testing dependencies"
-# TODO (elastic/beats#5050): Use a vendored copy of this.
-exec { go get github.com/docker/libcompose }
 
 if (Test-Path "build") { Remove-Item -Recurse -Force build }
 New-Item -ItemType directory -Path build\coverage | Out-Null


### PR DESCRIPTION
We only build the apm-server binary and run unit tests on Windows. Python is not needed, so stop installing it -- this should reduce build flakiness.