### PR TITLE
model/modelindexer: skip unknown response fields

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -38,6 +38,7 @@ https://github.com/elastic/apm-server/compare/7.15\...master[View commits]
 - Use timestamp of original events for transaction/span metrics {pull}6311[6311]
 - Populate the timestamp field for `agent_config` metricsets {pull}6382[6382]
 - Query elasticsearch output `cluster_uuid` on startup {pull}6591[6591]
+- Skip unhandled fields in bulk responses in the experimental Elasticsearch output {pull}6631[6631]
 
 [float]
 ==== Intake API Changes

--- a/model/modelindexer/bulk_indexer.go
+++ b/model/modelindexer/bulk_indexer.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
 	"go.elastic.co/fastjson"
 
 	"github.com/elastic/go-elasticsearch/v8/esapi"
@@ -174,7 +175,9 @@ func (b *bulkIndexer) Flush(ctx context.Context) (elasticsearch.BulkIndexerRespo
 			b.resp.HasErrors = iter.ReadBool()
 		case "items":
 			iter.ReadVal(&b.resp.Items)
+		default:
+			iter.Skip()
 		}
 	}
-	return b.resp, iter.Error
+	return b.resp, errors.Wrap(iter.Error, "error decoding bulk response")
 }

--- a/model/modelindexer/indexer_test.go
+++ b/model/modelindexer/indexer_test.go
@@ -298,6 +298,26 @@ func TestModelIndexerCloseFlushContext(t *testing.T) {
 	}
 }
 
+func TestModelIndexerUnknownResponseFields(t *testing.T) {
+	client := newMockElasticsearchClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"ingest_took":123}`))
+	})
+	indexer, err := modelindexer.New(client, modelindexer.Config{})
+	require.NoError(t, err)
+	defer indexer.Close(context.Background())
+
+	batch := model.Batch{model.APMEvent{Timestamp: time.Now(), DataStream: model.DataStream{
+		Type:      "logs",
+		Dataset:   "apm_server",
+		Namespace: "testing",
+	}}}
+	err = indexer.ProcessBatch(context.Background(), &batch)
+	require.NoError(t, err)
+
+	err = indexer.Close(context.Background())
+	assert.NoError(t, err)
+}
+
 func BenchmarkModelIndexer(b *testing.B) {
 	b.Run("NoCompression", func(b *testing.B) {
 		benchmarkModelIndexer(b, gzip.NoCompression)


### PR DESCRIPTION
## Motivation/summary

Fix a bug in modelindexer's bulk response decoder. We need to skip over unknown/unhandled fields, e.g. ingest_took. This field is not specified in the go-elasticsearch bulk response type, so we don't handle it.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

1. Run apm-server with `-E output.elasticsearch.experimental=true`
2. Send events
3. Check logs for modelindexer errors

## Related issues

None