### PR TITLE
[7.16] modelindexer: add support for gzip compression (#6449)

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -699,8 +699,9 @@ func (s *serverRunner) newFinalBatchProcessor(p *publish.Publisher) (model.Batch
 		return nil, nil, err
 	}
 	indexer, err := modelindexer.New(client, modelindexer.Config{
-		FlushBytes:    flushBytes,
-		FlushInterval: esConfig.FlushInterval,
+		CompressionLevel: esConfig.CompressionLevel,
+		FlushBytes:       flushBytes,
+		FlushInterval:    esConfig.FlushInterval,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/elasticsearch/config.go
+++ b/elasticsearch/config.go
@@ -58,6 +58,10 @@ type Config struct {
 	Headers      map[string]string `config:"headers"`
 	MaxRetries   int               `config:"max_retries"`
 
+	// CompressionLevel holds the gzip compression level used when bulk indexing
+	// with modelindexer; it is otherwise ignored.
+	CompressionLevel int `config:"compression_level" validate:"min=0, max=9"`
+
 	elasticsearch.Backoff `config:"backoff"`
 }
 

--- a/elasticsearch/config_test.go
+++ b/elasticsearch/config_test.go
@@ -164,14 +164,11 @@ func TestBeatsConfigSynced(t *testing.T) {
 	}
 
 	knownUnhandled := []string{
-		"backoff",
 		"bulk_max_size",
-		"compression_level",
 		"escape_html",
 		// TODO Kerberos auth (https://github.com/elastic/apm-server/issues/3794)
 		"kerberos",
 		"loadbalance",
-		"max_retries",
 		"parameters",
 		"transport",
 		"non_indexable_policy",

--- a/model/modelindexer/bulk_indexer.go
+++ b/model/modelindexer/bulk_indexer.go
@@ -19,8 +19,11 @@ package modelindexer
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 
 	jsoniter "github.com/json-iterator/go"
 	"go.elastic.co/fastjson"
@@ -28,6 +31,11 @@ import (
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 
 	"github.com/elastic/apm-server/elasticsearch"
+)
+
+var (
+	gzipHeader = http.Header{"Content-Encoding": []string{"gzip"}}
+	newline    = []byte("\n")
 )
 
 // NOTE(axw) please avoid introducing apm-server specific details to this code;
@@ -51,19 +59,33 @@ type bulkIndexer struct {
 	client     elasticsearch.Client
 	itemsAdded int
 	jsonw      fastjson.Writer
+	gzipw      *gzip.Writer
+	copybuf    [32 * 1024]byte
+	writer     io.Writer
 	buf        bytes.Buffer
 	respBuf    bytes.Buffer
 	resp       elasticsearch.BulkIndexerResponse
 }
 
-func newBulkIndexer(client elasticsearch.Client) *bulkIndexer {
-	return &bulkIndexer{client: client}
+func newBulkIndexer(client elasticsearch.Client, compressionLevel int) *bulkIndexer {
+	b := &bulkIndexer{client: client}
+	if compressionLevel != gzip.NoCompression {
+		b.gzipw, _ = gzip.NewWriterLevel(&b.buf, compressionLevel)
+		b.writer = b.gzipw
+	} else {
+		b.writer = &b.buf
+	}
+	b.Reset()
+	return b
 }
 
 // BulkIndexer resets b, ready for a new request.
 func (b *bulkIndexer) Reset() {
 	b.itemsAdded = 0
 	b.buf.Reset()
+	if b.gzipw != nil {
+		b.gzipw.Reset(&b.buf)
+	}
 	b.respBuf.Reset()
 	b.resp = elasticsearch.BulkIndexerResponse{Items: b.resp.Items[:0]}
 }
@@ -81,10 +103,10 @@ func (b *bulkIndexer) Len() int {
 // Add encodes an item in the buffer.
 func (b *bulkIndexer) Add(item elasticsearch.BulkIndexerItem) error {
 	b.writeMeta(item)
-	if _, err := b.buf.ReadFrom(item.Body); err != nil {
+	if _, err := io.CopyBuffer(b.writer, item.Body, b.copybuf[:]); err != nil {
 		return err
 	}
-	b.buf.WriteRune('\n')
+	b.writer.Write(newline)
 	b.itemsAdded++
 	return nil
 }
@@ -105,7 +127,7 @@ func (b *bulkIndexer) writeMeta(item elasticsearch.BulkIndexerItem) {
 		b.jsonw.String(item.Index)
 	}
 	b.jsonw.RawString("}}\n")
-	b.buf.Write(b.jsonw.Bytes())
+	b.writer.Write(b.jsonw.Bytes())
 	b.jsonw.Reset()
 }
 
@@ -114,8 +136,16 @@ func (b *bulkIndexer) Flush(ctx context.Context) (elasticsearch.BulkIndexerRespo
 	if b.itemsAdded == 0 {
 		return elasticsearch.BulkIndexerResponse{}, nil
 	}
+	if b.gzipw != nil {
+		if err := b.gzipw.Flush(); err != nil {
+			return elasticsearch.BulkIndexerResponse{}, err
+		}
+	}
 
 	req := esapi.BulkRequest{Body: &b.buf}
+	if b.gzipw != nil {
+		req.Header = gzipHeader
+	}
 	res, err := req.Do(ctx, b.client)
 	if err != nil {
 		return elasticsearch.BulkIndexerResponse{}, err

--- a/model/modelindexer/indexer.go
+++ b/model/modelindexer/indexer.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -77,6 +78,12 @@ type Indexer struct {
 
 // Config holds configuration for Indexer.
 type Config struct {
+	// CompressionLevel holds the gzip compression level, from 0 (gzip.NoCompression)
+	// to 9 (gzip.BestCompression). Higher values provide greater compression, at a
+	// greater cost of CPU. The special value -1 (gzip.DefaultCompression) selects the
+	// default compression level.
+	CompressionLevel int
+
 	// MaxRequests holds the maximum number of bulk index requests to execute concurrently.
 	// The maximum memory usage of Indexer is thus approximately MaxRequests*FlushBytes.
 	//
@@ -97,6 +104,12 @@ type Config struct {
 // New returns a new Indexer that indexes events directly into data streams.
 func New(client elasticsearch.Client, cfg Config) (*Indexer, error) {
 	logger := logp.NewLogger("modelindexer", logs.WithRateLimit(logRateLimit))
+	if cfg.CompressionLevel < -1 || cfg.CompressionLevel > 9 {
+		return nil, fmt.Errorf(
+			"expected CompressionLevel in range [-1,9], got %d",
+			cfg.CompressionLevel,
+		)
+	}
 	if cfg.MaxRequests <= 0 {
 		cfg.MaxRequests = 10
 	}
@@ -108,7 +121,7 @@ func New(client elasticsearch.Client, cfg Config) (*Indexer, error) {
 	}
 	available := make(chan *bulkIndexer, cfg.MaxRequests)
 	for i := 0; i < cfg.MaxRequests; i++ {
-		available <- newBulkIndexer(client)
+		available <- newBulkIndexer(client, cfg.CompressionLevel)
 	}
 	return &Indexer{
 		config:    cfg,

--- a/model/modelindexer/indexer_test.go
+++ b/model/modelindexer/indexer_test.go
@@ -19,6 +19,7 @@ package modelindexer_test
 
 import (
 	"bufio"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -29,8 +30,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.elastic.co/fastjson"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/go-elasticsearch/v7/esutil"
@@ -296,31 +299,75 @@ func TestModelIndexerCloseFlushContext(t *testing.T) {
 }
 
 func BenchmarkModelIndexer(b *testing.B) {
+	b.Run("NoCompression", func(b *testing.B) {
+		benchmarkModelIndexer(b, gzip.NoCompression)
+	})
+	b.Run("BestSpeed", func(b *testing.B) {
+		benchmarkModelIndexer(b, gzip.BestSpeed)
+	})
+	b.Run("DefaultCompression", func(b *testing.B) {
+		benchmarkModelIndexer(b, gzip.DefaultCompression)
+	})
+	b.Run("BestCompression", func(b *testing.B) {
+		benchmarkModelIndexer(b, gzip.BestCompression)
+	})
+}
+
+func benchmarkModelIndexer(b *testing.B, compressionLevel int) {
 	var indexed int64
 	client := newMockElasticsearchClient(b, func(w http.ResponseWriter, r *http.Request) {
-		scanner := bufio.NewScanner(r.Body)
-		var n int64
-		for scanner.Scan() {
-			if scanner.Scan() {
-				n++
+		body := r.Body
+		switch r.Header.Get("Content-Encoding") {
+		case "gzip":
+			r, err := gzip.NewReader(body)
+			if err != nil {
+				panic(err)
 			}
+			defer r.Close()
+			body = r
 		}
+
+		var n int64
+		var jsonw fastjson.Writer
+		jsonw.RawString(`{"items":[`)
+		first := true
+		scanner := bufio.NewScanner(body)
+		for scanner.Scan() {
+			// Action is always "create", skip decoding to avoid
+			// inflating allocations in benchmark.
+			if !scanner.Scan() {
+				panic("expected source")
+			}
+			if first {
+				first = false
+			} else {
+				jsonw.RawByte(',')
+			}
+			jsonw.RawString(`{"create":{"status":201}}`)
+			n++
+		}
+		jsonw.RawString(`]}`)
+		w.Write(jsonw.Bytes())
 		atomic.AddInt64(&indexed, n)
-		fmt.Fprintln(w, "{}")
 	})
 
-	indexer, err := modelindexer.New(client, modelindexer.Config{FlushInterval: time.Second})
+	indexer, err := modelindexer.New(client, modelindexer.Config{
+		CompressionLevel: compressionLevel,
+		FlushInterval:    time.Second,
+	})
 	require.NoError(b, err)
 	defer indexer.Close(context.Background())
 
-	batch := model.Batch{
-		model.APMEvent{
-			Processor: model.TransactionProcessor,
-			Timestamp: time.Now(),
-		},
-	}
 	b.RunParallel(func(pb *testing.PB) {
+		batch := model.Batch{
+			model.APMEvent{
+				Processor:   model.TransactionProcessor,
+				Transaction: &model.Transaction{},
+			},
+		}
 		for pb.Next() {
+			batch[0].Timestamp = time.Now()
+			batch[0].Transaction.ID = uuid.Must(uuid.NewV4()).String()
 			if err := indexer.ProcessBatch(context.Background(), &batch); err != nil {
 				b.Fatal(err)
 			}

--- a/x-pack/apm-server/main.go
+++ b/x-pack/apm-server/main.go
@@ -138,7 +138,8 @@ func newTailSamplingProcessor(args beater.ServerParams) (*sampling.Processor, er
 			IngestRateDecayFactor: tailSamplingConfig.IngestRateDecayFactor,
 		},
 		RemoteSamplingConfig: sampling.RemoteSamplingConfig{
-			Elasticsearch: es,
+			CompressionLevel: tailSamplingConfig.ESConfig.CompressionLevel,
+			Elasticsearch:    es,
 			SampledTracesDataStream: sampling.DataStreamConfig{
 				Type:      "traces",
 				Dataset:   "apm.sampled",

--- a/x-pack/apm-server/sampling/config.go
+++ b/x-pack/apm-server/sampling/config.go
@@ -62,6 +62,10 @@ type LocalSamplingConfig struct {
 // RemoteSamplingConfig holds Processor configuration related to publishing and
 // subscribing to remote sampling decisions.
 type RemoteSamplingConfig struct {
+	// CompressionLevel holds the gzip compression level to use when bulk
+	// indexing sampled trace IDs.
+	CompressionLevel int
+
 	// Elasticsearch holds the Elasticsearch client to use for publishing
 	// and subscribing to remote sampling decisions.
 	Elasticsearch elasticsearch.Client
@@ -198,6 +202,9 @@ func (config LocalSamplingConfig) validate() error {
 }
 
 func (config RemoteSamplingConfig) validate() error {
+	if config.CompressionLevel < -1 || config.CompressionLevel > 9 {
+		return errors.New("CompressionLevel out of range [-1,9]")
+	}
 	if config.Elasticsearch == nil {
 		return errors.New("Elasticsearch unspecified")
 	}

--- a/x-pack/apm-server/sampling/config_test.go
+++ b/x-pack/apm-server/sampling/config_test.go
@@ -55,6 +55,10 @@ func TestNewProcessorConfigInvalid(t *testing.T) {
 	}
 	config.IngestRateDecayFactor = 0.5
 
+	config.CompressionLevel = 11
+	assertInvalidConfigError("invalid remote sampling config: CompressionLevel out of range [-1,9]")
+	config.CompressionLevel = 0
+
 	assertInvalidConfigError("invalid remote sampling config: Elasticsearch unspecified")
 	var elasticsearchClient struct {
 		elasticsearch.Client

--- a/x-pack/apm-server/sampling/pubsub/config.go
+++ b/x-pack/apm-server/sampling/pubsub/config.go
@@ -21,6 +21,10 @@ type Config struct {
 	// trace ID observations.
 	Client elasticsearch.Client
 
+	// CompressionLevel holds the gzip compression level to use when bulk indexing.
+	// See model/modelindexer.Config.CompressionLevel for details.
+	CompressionLevel int
+
 	// DataStream holds the data stream.
 	DataStream DataStreamConfig
 

--- a/x-pack/apm-server/sampling/pubsub/pubsub.go
+++ b/x-pack/apm-server/sampling/pubsub/pubsub.go
@@ -5,7 +5,6 @@
 package pubsub
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -16,15 +15,15 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"go.elastic.co/fastjson"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/elastic/beats/v7/libbeat/logp"
 	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/elastic/go-elasticsearch/v7/esutil"
 
-	"github.com/elastic/apm-server/elasticsearch"
 	logs "github.com/elastic/apm-server/log"
+	"github.com/elastic/apm-server/model"
+	"github.com/elastic/apm-server/model/modelindexer"
 )
 
 // ErrClosed may be returned by Pubsub methods after the Close method is called.
@@ -61,12 +60,9 @@ func New(config Config) (*Pubsub, error) {
 // indexing them into Elasticsearch. PublishSampledTraceIDs returns when
 // ctx is canceled.
 func (p *Pubsub) PublishSampledTraceIDs(ctx context.Context, traceIDs <-chan string) error {
-	indexer, err := p.config.Client.NewBulkIndexer(elasticsearch.BulkIndexerConfig{
-		Index:         p.config.DataStream.String(),
-		FlushInterval: p.config.FlushInterval,
-		OnError: func(ctx context.Context, err error) {
-			p.config.Logger.With(logp.Error(err)).Debug("publishing sampled trace IDs failed")
-		},
+	indexer, err := modelindexer.New(p.config.Client, modelindexer.Config{
+		CompressionLevel: p.config.CompressionLevel,
+		FlushInterval:    p.config.FlushInterval,
 	})
 	if err != nil {
 		return err
@@ -92,21 +88,17 @@ func (p *Pubsub) PublishSampledTraceIDs(ctx context.Context, traceIDs <-chan str
 			}
 			return closeIndexer()
 		case id := <-traceIDs:
-			var json fastjson.Writer
-			p.marshalTraceIDDocument(&json, id, time.Now(), p.config.DataStream)
-			if err := indexer.Add(ctx, elasticsearch.BulkIndexerItem{
-				Action:    "create",
-				Body:      bytes.NewReader(json.Bytes()),
-				OnFailure: p.onBulkIndexerItemFailure,
-			}); err != nil {
+			doc := model.APMEvent{
+				Timestamp:  time.Now(),
+				DataStream: model.DataStream(p.config.DataStream),
+				Observer:   model.Observer{ID: p.config.BeatID},
+				Trace:      model.Trace{ID: id},
+			}
+			if err := indexer.ProcessBatch(ctx, &model.Batch{doc}); err != nil {
 				return err
 			}
 		}
 	}
-}
-
-func (p *Pubsub) onBulkIndexerItemFailure(ctx context.Context, item elasticsearch.BulkIndexerItem, resp elasticsearch.BulkIndexerResponseItem, err error) {
-	p.config.Logger.With(logp.Error(err)).Debug("publishing sampled trace ID failed", resp.Error)
 }
 
 // SubscribeSampledTraceIDs subscribes to sampled trace IDs after the given position,
@@ -327,23 +319,6 @@ func (p *Pubsub) doSearchRequest(ctx context.Context, index string, body io.Read
 		return fmt.Errorf("search request failed: %s", message)
 	}
 	return json.NewDecoder(resp.Body).Decode(out)
-}
-
-func (p *Pubsub) marshalTraceIDDocument(w *fastjson.Writer, traceID string, timestamp time.Time, dataStream DataStreamConfig) {
-	w.RawString(`{"@timestamp":"`)
-	w.Time(timestamp.UTC(), time.RFC3339Nano)
-	w.RawString(`","data_stream.type":`)
-	w.String(dataStream.Type)
-	w.RawString(`,"data_stream.dataset":`)
-	w.String(dataStream.Dataset)
-	w.RawString(`,"data_stream.namespace":`)
-	w.String(dataStream.Namespace)
-	w.RawString(`,"observer":{"id":`)
-	w.String(p.config.BeatID)
-	w.RawString(`},`)
-	w.RawString(`"trace":{"id":`)
-	w.String(traceID)
-	w.RawString(`}}`)
 }
 
 type traceIDDocument struct {

--- a/x-pack/apm-server/sampling/pubsub/pubsub_test.go
+++ b/x-pack/apm-server/sampling/pubsub/pubsub_test.go
@@ -91,7 +91,9 @@ func TestPublishSampledTraceIDs(t *testing.T) {
 					break
 				}
 				assert.NoError(t, err)
-				assert.Equal(t, map[string]interface{}{"create": map[string]interface{}{}}, action)
+				assert.Equal(t, map[string]interface{}{"create": map[string]interface{}{
+					"_index": dataStream.String(),
+				}}, action)
 
 				doc := make(map[string]interface{})
 				assert.NoError(t, d.Decode(&doc))
@@ -338,7 +340,7 @@ func newMockElasticsearchServer(t testing.TB) *mockElasticsearchServer {
 		}
 		panic(fmt.Errorf("unexpected URL path: %s", r.URL.Path))
 	})
-	mux.HandleFunc("/"+dataStream.String()+"/_bulk", m.handleBulk)
+	mux.HandleFunc("/_bulk", m.handleBulk)
 	mux.HandleFunc("/"+dataStream.String()+"/_stats/get", m.handleStats)
 	mux.HandleFunc("/index_name/_refresh", m.handleRefresh)
 	mux.HandleFunc("/index_name/_search", m.handleSearch)


### PR DESCRIPTION
Backports the following commits to 7.16:
 - modelindexer: add support for gzip compression (#6449)