### PR TITLE
modelindexer: fix @timestamp format

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -40,6 +40,7 @@ https://github.com/elastic/apm-server/compare/7.15\...master[View commits]
 - Populate the timestamp field for `agent_config` metricsets {pull}6382[6382]
 - Query elasticsearch output `cluster_uuid` on startup {pull}6591[6591]
 - Skip unhandled fields in bulk responses in the experimental Elasticsearch output {pull}6631[6631]
+- Fix the format of `@timestamp` to include fractional seconds when using experimental Elasticsearch output {pull}6646[6646]
 
 [float]
 ==== Intake API Changes

--- a/model/modelindexer/indexer.go
+++ b/model/modelindexer/indexer.go
@@ -42,6 +42,11 @@ import (
 
 const (
 	logRateLimit = time.Minute
+
+	// timestampFormat formats timestamps according to Elasticsearch's
+	// strict_date_optional_time date format, which includes a fractional
+	// seconds component.
+	timestampFormat = "2006-01-02T15:04:05.000Z07:00"
 )
 
 // ErrClosed is returned from methods of closed Indexers.
@@ -244,7 +249,7 @@ func (i *Indexer) processEvent(ctx context.Context, event *model.APMEvent) error
 func encodeBeatEvent(in beat.Event, out *fastjson.Writer) error {
 	out.RawByte('{')
 	out.RawString(`"@timestamp":"`)
-	out.Time(in.Timestamp, time.RFC3339)
+	out.Time(in.Timestamp, timestampFormat)
 	out.RawByte('"')
 	for k, v := range in.Fields {
 		out.RawByte(',')

--- a/model/modelindexer/indexer_test.go
+++ b/model/modelindexer/indexer_test.go
@@ -98,6 +98,59 @@ func TestModelIndexer(t *testing.T) {
 	}, indexer.Stats())
 }
 
+func TestModelIndexerEncoding(t *testing.T) {
+	var indexed []map[string]interface{}
+	client := newMockElasticsearchClient(t, func(w http.ResponseWriter, r *http.Request) {
+		scanner := bufio.NewScanner(r.Body)
+		var result elasticsearch.BulkIndexerResponse
+		for scanner.Scan() {
+			action := make(map[string]interface{})
+			if err := json.NewDecoder(strings.NewReader(scanner.Text())).Decode(&action); err != nil {
+				panic(err)
+			}
+			var actionType string
+			for actionType = range action {
+			}
+			if !scanner.Scan() {
+				panic("expected source")
+			}
+
+			var doc map[string]interface{}
+			if err := json.Unmarshal([]byte(scanner.Text()), &doc); err != nil {
+				panic(err)
+			}
+			indexed = append(indexed, doc)
+			result.Items = append(result.Items, map[string]esutil.BulkIndexerResponseItem{actionType: {}})
+		}
+		json.NewEncoder(w).Encode(result)
+	})
+	indexer, err := modelindexer.New(client, modelindexer.Config{FlushInterval: time.Minute})
+	require.NoError(t, err)
+	defer indexer.Close(context.Background())
+
+	batch := model.Batch{{
+		Timestamp: time.Unix(123, 456789111).UTC(),
+		DataStream: model.DataStream{
+			Type:      "logs",
+			Dataset:   "apm_server",
+			Namespace: "testing",
+		},
+	}}
+	err = indexer.ProcessBatch(context.Background(), &batch)
+	require.NoError(t, err)
+
+	// Closing the indexer flushes enqueued events.
+	err = indexer.Close(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, []map[string]interface{}{{
+		"@timestamp":            "1970-01-01T00:02:03.456Z",
+		"data_stream.type":      "logs",
+		"data_stream.dataset":   "apm_server",
+		"data_stream.namespace": "testing",
+	}}, indexed)
+}
+
 func TestModelIndexerFlushInterval(t *testing.T) {
 	requests := make(chan struct{}, 1)
 	client := newMockElasticsearchClient(t, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Motivation/summary

Update the timestamp format used for encoding `@timestamp` so it includes fractional seconds, with millisecond precision.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

1. Run apm-server `-E output.elasticsearch.experimental=true`
2. Check that indexed docs' `@timestamp` fields have a fractional seconds component

## Related issues

https://github.com/elastic/apm-server/issues/6360