### PR TITLE
docs: Update apmpackage changelog and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,6 +28,7 @@ Once the PR is ready for review there should be no unticked boxes.
 -->
 
 - [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
+- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/master/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
 - [ ] Documentation has been updated
 
 For functional changes, consider:

--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -3,6 +3,9 @@
 # change type can be one of: enhancement, bugfix, breaking-change
 - version: "8.0.0"
   changes:
+    - description: Ingested labels are now stored as event.{labels,numeric_labels}
+      type: enhancement
+      link: https://github.com/elastic/apm-server/pull/6633
     - description: added new traces-apm.rum and individual ILM policies per data stream
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/6480


### PR DESCRIPTION
## Motivation/summary

Updates the `apmpackage` changelog to include the latest changes, also
updating the PR template to include a note to update the changelog file
when changes have been made to the `apmpackage` folder.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

N/A