### PR TITLE
[automation] update elastic stack version for testing 8.0.0-1160a953

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       kibana: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-83e38099-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-1160a953-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -38,7 +38,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.0.0-83e38099-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.0.0-1160a953-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -62,7 +62,7 @@ services:
       package-registry: { condition: service_healthy }
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:8.0.0-83e38099-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:8.0.0-1160a953-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Thu, 18 Nov 2021 00:14:03 GMT, release_branch:8.0, prefix:, end_time:Thu, 18 Nov 2021 06:32:27 GMT, manifest_version:2.0.0, version:8.0.0-SNAPSHOT, branch:8.0, build_id:8.0.0-1160a953, build_duration_seconds:22704]