### PR TITLE
package: Verify APM server/package versions match

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,12 @@ endif
 ## get-version : Get the apm server version
 .PHONY: get-version
 get-version:
-	@grep defaultBeatVersion cmd/version.go | cut -d'=' -f2 | tr -d '"'
+	@grep defaultBeatVersion cmd/version.go | cut -d'=' -f2 | tr -d '" '
+
+## get-version : Get the apm package version
+.PHONY: get-package-version
+get-package-version:
+	@grep ^version: apmpackage/apm/manifest.yml | cut -d':' -f2 | tr -d " "
 
 ##############################################################################
 # Documentation.
@@ -178,6 +183,9 @@ check-package: $(ELASTICPACKAGE)
 	@(cd apmpackage/apm; $(CURDIR)/$(ELASTICPACKAGE) check)
 	@diff -ru apmpackage/apm/data_stream/traces/fields apmpackage/apm/data_stream/rum_traces/fields || \
 		echo "-> 'traces-apm' and 'traces-apm.rum' data stream fields should be equal"
+	$(eval SERVER_V=$(shell make get-version))
+	$(eval PKG_V=$(shell make get-package-version))
+	@if [ $(SERVER_V) != $(PKG_V) ]; then echo "-> APM Server ($(SERVER_V)) and APM Package ($(PKG_V)) versions should be equal."; fi
 format-package: $(ELASTICPACKAGE)
 	@(cd apmpackage/apm; $(CURDIR)/$(ELASTICPACKAGE) format)
 build-package: $(ELASTICPACKAGE)

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ endif
 get-version:
 	@grep defaultBeatVersion cmd/version.go | cut -d'=' -f2 | tr -d '" '
 
-## get-version : Get the apm package version
+## get-package-version : Get the apm package version
 .PHONY: get-package-version
 get-package-version:
 	@grep ^version: apmpackage/apm/manifest.yml | cut -d':' -f2 | tr -d " "

--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -1,6 +1,11 @@
 # newer versions go on top
 #
 # change type can be one of: enhancement, bugfix, breaking-change
+- version: "8.1.0"
+  changes:
+    - description: REPLACE ME WITH ACTUAL CHANGE LOG
+      type: enhancement
+      link: https://github.com/elastic/apm-server/pull/1234
 - version: "8.0.0"
   changes:
     - description: Ingested labels are now stored as event.{labels,numeric_labels}

--- a/apmpackage/apm/manifest.yml
+++ b/apmpackage/apm/manifest.yml
@@ -1,14 +1,14 @@
 format_version: 1.0.0
 name: apm
 title: Elastic APM
-version: 8.0.0
+version: 8.1.0
 license: basic
 description: Ingest APM data
 type: integration
 categories: ["elastic_stack", "monitoring"]
 release: ga
 conditions:
-  kibana.version: "^8.0.0"
+  kibana.version: "^8.1.0"
 icons:
   - src: /img/logo_apm.svg
     title: APM Logo


### PR DESCRIPTION
## Motivation/summary

Adds a check to `check-package` which ensures the apm-server and package
versions are equal, otherwise returns with an error.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/master/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

Closes #6571
