### PR TITLE
model: Add comments, Remove MaybeSet from labels

### DIFF
--- a/model/labels.go
+++ b/model/labels.go
@@ -18,29 +18,23 @@
 package model
 
 import (
-	"strconv"
 	"strings"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
+// Labels wraps a map[string]string or map[string][]string with utility
+// methods.
 type Labels map[string]LabelValue
 
+// LabelValue wraps a `string` or `[]slice` to be set as a value for a key.
+// Only one should be set, in cases where both are set, the `Values` field will
+// be used and `Value` will be ignored.
 type LabelValue struct {
-	Value  string
+	// Holds the label `string` value.
+	Value string
+	// Holds the label `[]string` value.
 	Values []string
-}
-
-func (l Labels) MaybeSet(k string, v interface{}) bool {
-	switch v := v.(type) {
-	case string:
-		l[k] = LabelValue{Value: v}
-	case bool:
-		l[k] = LabelValue{Value: strconv.FormatBool(v)}
-	default:
-		return false
-	}
-	return true
 }
 
 func (l Labels) Set(k string, v string) {
@@ -71,21 +65,18 @@ func (l Labels) fields() common.MapStr {
 	return sanitizeLabels(result)
 }
 
+// NumericLabels wraps a map[string]float64 or map[string][]float64 with utility
+// methods.
 type NumericLabels map[string]NumericLabelValue
 
+// NumericLabelValue wraps a `float64` or `[]float64` to be set as a value for a
+// key. Only one should be set, in cases where both are set, the `Values` field
+// will be used and `Value` will be ignored.
 type NumericLabelValue struct {
-	Value  float64
+	// Holds the label `[]float64` value.
 	Values []float64
-}
-
-func (l NumericLabels) MaybeSet(k string, v interface{}) bool {
-	switch v := v.(type) {
-	case float64:
-		l[k] = NumericLabelValue{Value: v}
-	default:
-		return false
-	}
-	return true
+	// Holds the label `float64` value.
+	Value float64
 }
 
 func (l NumericLabels) Set(k string, v float64) {

--- a/model/labels.go
+++ b/model/labels.go
@@ -45,10 +45,16 @@ func (l Labels) SetSlice(k string, v []string) {
 	l[k] = LabelValue{Values: v}
 }
 
+// Clone creates a deep copy of Labels.
 func (l Labels) Clone() Labels {
 	cp := make(Labels)
 	for k, v := range l {
-		cp[k] = v
+		to := LabelValue{Value: v.Value}
+		if len(v.Values) > 0 {
+			to.Values = make([]string, len(v.Values))
+			copy(to.Values, v.Values)
+		}
+		cp[k] = to
 	}
 	return cp
 }
@@ -87,10 +93,16 @@ func (l NumericLabels) SetSlice(k string, v []float64) {
 	l[k] = NumericLabelValue{Values: v}
 }
 
+// Clone creates a deep copy of NumericLabels.
 func (l NumericLabels) Clone() NumericLabels {
 	cp := make(NumericLabels)
 	for k, v := range l {
-		cp[k] = v
+		to := NumericLabelValue{Value: v.Value}
+		if len(v.Values) > 0 {
+			to.Values = make([]float64, len(v.Values))
+			copy(to.Values, v.Values)
+		}
+		cp[k] = to
 	}
 	return cp
 }

--- a/model/labels.go
+++ b/model/labels.go
@@ -31,9 +31,9 @@ type Labels map[string]LabelValue
 // Only one should be set, in cases where both are set, the `Values` field will
 // be used and `Value` will be ignored.
 type LabelValue struct {
-	// Holds the label `string` value.
+	// Value holds the label `string` value.
 	Value string
-	// Holds the label `[]string` value.
+	// Values holds the label `[]string` value.
 	Values []string
 }
 
@@ -79,9 +79,9 @@ type NumericLabels map[string]NumericLabelValue
 // key. Only one should be set, in cases where both are set, the `Values` field
 // will be used and `Value` will be ignored.
 type NumericLabelValue struct {
-	// Holds the label `[]float64` value.
+	// Values holds holds the label `[]float64` value.
 	Values []float64
-	// Holds the label `float64` value.
+	// Value holds the label `float64` value.
 	Value float64
 }
 

--- a/model/modeldecoder/modeldecoderutil/labels.go
+++ b/model/modeldecoder/modeldecoderutil/labels.go
@@ -44,7 +44,7 @@ func MergeLabels(eventLabels common.MapStr, to *model.APMEvent) {
 	if to.Labels == nil {
 		to.Labels = make(model.Labels)
 	}
-	for k, v := range NormalizeLabelValues(eventLabels.Clone()) {
+	for k, v := range eventLabels {
 		switch v := v.(type) {
 		case string:
 			to.Labels.Set(k, v)
@@ -52,6 +52,10 @@ func MergeLabels(eventLabels common.MapStr, to *model.APMEvent) {
 			to.Labels.Set(k, strconv.FormatBool(v))
 		case float64:
 			to.NumericLabels.Set(k, v)
+		case json.Number:
+			if floatVal, err := v.Float64(); err == nil {
+				to.NumericLabels.Set(k, floatVal)
+			}
 		}
 	}
 	if len(to.NumericLabels) == 0 {

--- a/model/modeldecoder/modeldecoderutil/labels.go
+++ b/model/modeldecoder/modeldecoderutil/labels.go
@@ -19,6 +19,7 @@ package modeldecoderutil
 
 import (
 	"encoding/json"
+	"strconv"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 
@@ -44,8 +45,13 @@ func MergeLabels(eventLabels common.MapStr, to *model.APMEvent) {
 		to.Labels = make(model.Labels)
 	}
 	for k, v := range NormalizeLabelValues(eventLabels.Clone()) {
-		if !to.NumericLabels.MaybeSet(k, v) {
-			to.Labels.MaybeSet(k, v)
+		switch v := v.(type) {
+		case string:
+			to.Labels.Set(k, v)
+		case bool:
+			to.Labels.Set(k, strconv.FormatBool(v))
+		case float64:
+			to.NumericLabels.Set(k, v)
 		}
 	}
 	if len(to.NumericLabels) == 0 {

--- a/processor/otel/traces.go
+++ b/processor/otel/traces.go
@@ -807,7 +807,7 @@ func parseSamplerAttributes(samplerType, samplerParam pdata.AttributeValue, even
 		event.Labels.Set("sampler_type", samplerType)
 		switch samplerParam.Type() {
 		case pdata.AttributeValueTypeBool:
-			event.Labels.MaybeSet("sampler_param", samplerParam.BoolVal())
+			event.Labels.Set("sampler_param", strconv.FormatBool(samplerParam.BoolVal()))
 		case pdata.AttributeValueTypeDouble:
 			event.NumericLabels.Set("sampler_param", samplerParam.DoubleVal())
 		}


### PR DESCRIPTION
## Motivation/summary

Adds some godoc comments to the `LabelValue` and `NumericLabelValue` and
removes the `MaybeSet` method.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/master/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

Non functional change.

## Related issues

Follow up from #6682
