### PR TITLE
Filter out NaN and +/-Inf metric data points

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -43,6 +43,7 @@ https://github.com/elastic/apm-server/compare/7.15\...master[View commits]
 - Fix the format of `@timestamp` to include fractional seconds when using experimental Elasticsearch output {pull}6646[6646]
 - In accord with ECS, the server logs now set `source.address` to the immediate network peer's IP address, and `client.ip` to the originating client IP if known {pull}6690[6690]
 - `host.ip` is now stored as an array, as specified by ECS {pull}6694[6694]
+- NaN and +/-Inf values are now filtered out when translating OTLP metrics {pull}6698[6698]
 
 [float]
 ==== Intake API Changes

--- a/processor/otel/metrics.go
+++ b/processor/otel/metrics.go
@@ -37,6 +37,7 @@ package otel
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -182,6 +183,9 @@ func numberSample(dp pdata.NumberDataPoint, metricType model.MetricType) (model.
 		value = float64(dp.IntVal())
 	case pdata.MetricValueTypeDouble:
 		value = dp.DoubleVal()
+		if math.IsNaN(value) || math.IsInf(value, 0) {
+			return model.MetricsetSample{}, false
+		}
 	default:
 		return model.MetricsetSample{}, false
 	}

--- a/processor/otel/metrics_test.go
+++ b/processor/otel/metrics_test.go
@@ -36,6 +36,7 @@ package otel_test
 
 import (
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -199,6 +200,32 @@ func TestConsumeMetrics(t *testing.T) {
 			},
 		},
 	}}, events)
+}
+
+func TestConsumeMetricsNaN(t *testing.T) {
+	timestamp := time.Unix(123, 0).UTC()
+	metrics := pdata.NewMetrics()
+	resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+	instrumentationLibraryMetrics := resourceMetrics.InstrumentationLibraryMetrics().AppendEmpty()
+	metricSlice := instrumentationLibraryMetrics.Metrics()
+	appendMetric := func(name string, dataType pdata.MetricDataType) pdata.Metric {
+		metric := metricSlice.AppendEmpty()
+		metric.SetName(name)
+		metric.SetDataType(dataType)
+		return metric
+	}
+
+	for _, value := range []float64{math.NaN(), math.Inf(-1), math.Inf(1)} {
+		metric := appendMetric("gauge", pdata.MetricDataTypeGauge)
+		gauge := metric.Gauge()
+		dp := gauge.DataPoints().AppendEmpty()
+		dp.SetTimestamp(pdata.TimestampFromTime(timestamp))
+		dp.SetDoubleVal(value)
+	}
+
+	events, stats := transformMetrics(t, metrics)
+	assert.Equal(t, int64(3), stats.UnsupportedMetricsDropped)
+	assert.Empty(t, events)
 }
 
 func TestConsumeMetrics_JVM(t *testing.T) {


### PR DESCRIPTION
## Motivation/summary

Filter out metric samples with values that cannot be represented in Elasticsearch.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/master/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

See https://github.com/elastic/apm-server/issues/6641

## Related issues

Closes https://github.com/elastic/apm-server/issues/6641