### PR TITLE
changed .mergify.yml to use queue instead of merge actions

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -81,6 +81,7 @@ pull_request_rules:
     conditions:
       - label=automation
       - files=docker-compose.yml
+      - check-success=apm-ci/pr-merge
     actions:
       queue:
         method: squash
@@ -101,6 +102,7 @@ pull_request_rules:
       - label=automation
       - base~=^update-beats
       - files~=^(go.mod|go.sum|NOTICE.txt)
+      - check-success=apm-ci/pr-merge
     actions:
       queue:
         method: squash

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -79,9 +79,9 @@ pull_request_rules:
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
   - name: Automatic squash and merge with success checks and the file docker-compose.yml is modified.
     conditions:
+      - check-success=apm-ci/pr-merge
       - label=automation
       - files=docker-compose.yml
-      - check-success=apm-ci/pr-merge
     actions:
       queue:
         method: squash
@@ -99,10 +99,10 @@ pull_request_rules:
       delete_head_branch:
   - name: automatic merge when CI passes for the make update-beats
     conditions:
+      - check-success=apm-ci/pr-merge
       - label=automation
       - base~=^update-beats
       - files~=^(go.mod|go.sum|NOTICE.txt)
-      - check-success=apm-ci/pr-merge
     actions:
       queue:
         method: squash

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,7 @@
+queue_rules:
+  - name: default
+    conditions:
+      - check-success=apm-ci/pr-merge
 pull_request_rules:
   - name: ask to resolve conflict
     conditions:
@@ -75,13 +79,12 @@ pull_request_rules:
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
   - name: Automatic squash and merge with success checks and the file docker-compose.yml is modified.
     conditions:
-      - check-success=apm-ci/pr-merge
       - label=automation
       - files=docker-compose.yml
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart+fasttrack
+        name: default
   - name: delete upstream branch with changes on docker-compose.yml after merging/closing it
     conditions:
       - or:
@@ -95,14 +98,13 @@ pull_request_rules:
       delete_head_branch:
   - name: automatic merge when CI passes for the make update-beats
     conditions:
-      - check-success=apm-ci/pr-merge
       - label=automation
       - base~=^update-beats
       - files~=^(go.mod|go.sum|NOTICE.txt)
     actions:
-      merge:
+      queue:
         method: squash
-        strict: smart+fasttrack
+        name: default
   - name: delete upstream branch after merging changes for the make update-beats
     conditions:
       - or:


### PR DESCRIPTION
## Motivation/summary

It changes merge action to queue in .mergify.yml

The configuration uses the deprecated strict mode of the merge action.
A brownout is planned for the whole December 6th, 2021 day.
This option will be removed on January 10th, 2022.
For more information: https://blog.mergify.io/strict-mode-deprecation/
