### PR TITLE
apmpackage: Fix rum traces ILM name

### DIFF
--- a/apmpackage/apm/data_stream/rum_traces/manifest.yml
+++ b/apmpackage/apm/data_stream/rum_traces/manifest.yml
@@ -1,7 +1,7 @@
 title: APM RUM traces
 type: traces
 dataset: apm.rum
-ilm_policy: traces-apm.rum-traces-default_policy
+ilm_policy: traces-apm.rum_traces-default_policy
 elasticsearch:
   index_template:
     mappings:


### PR DESCRIPTION
## Motivation/summary

Fixes a bug where the RUM traces data stream was referencing the wrong
ILM policy, causing the RUM index to reference an invalid ILM policy.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/master/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

1. `docker-compose up -d`
2. `make`
3. `./apm-server -E output.elasticsearch.username=admin -E output.elasticsearch.password=changeme -E apm-server.rum.enabled=true -e`
4. Install the APM Integration via Kibana (8.1.0)
5. ` curl -H "Content-type: application/x-ndjson" --data-binary @testdata/intake-v2/transactions.ndjson http://localhost:8200/intake/v2/rum/events`
6. Navigate to http://localhost:5601/app/management/data/index_management/indices?includeHiddenIndices=true
7. Verify that the rum traces data stream references a valid ILM Policy

<img width="1884" alt="Screen Shot 2021-11-30 at 9 07 33 PM" src="https://user-images.githubusercontent.com/7286993/144052929-ad19fb34-e0f0-4961-91f0-6a18487e4c6e.png">

## Related issues

Closes #6755