### PR TITLE
Java attacher update integration

### DIFF
--- a/apmpackage/apm/agent/input/template.yml.hbs
+++ b/apmpackage/apm/agent/input/template.yml.hbs
@@ -29,7 +29,7 @@ apm-server:
     response_headers: {{response_headers}}
     java_attacher:
       enabled: {{java_attacher_enabled}}
-      discovery_rules: {{java_attacher_discovery_rules}}
+      discovery-rules: {{java_attacher_discovery_rules}}
     {{#if enable_rum}}
     rum:
         allow_headers:

--- a/apmpackage/apm/agent/input/template.yml.hbs
+++ b/apmpackage/apm/agent/input/template.yml.hbs
@@ -30,6 +30,7 @@ apm-server:
     java_attacher:
       enabled: {{java_attacher_enabled}}
       discovery-rules: {{java_attacher_discovery_rules}}
+      download-agent-version: {{java_attacher_agent_version}}
     {{#if enable_rum}}
     rum:
         allow_headers:

--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -8,6 +8,12 @@
       link: https://github.com/elastic/apm-server/pull/1234
 - version: "8.0.0"
   changes:
+    - description: support setting `download-agent-version`
+      type: enhancement
+      link: https://github.com/elastic/apm-server/pull/6777
+    - description: java attacher config uses `discovery-rules`, not `discovery_rules`
+      type: bugfix
+      link: https://github.com/elastic/apm-server/pull/6777
     - description: add java_attacher support
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/6741

--- a/apmpackage/apm/manifest.yml
+++ b/apmpackage/apm/manifest.yml
@@ -125,6 +125,8 @@ policy_templates:
             default: false
           - name: java_attacher_discovery_rules
             type: yaml
+          - name: java_attacher_agent_version
+            type: text
           - name: java_attacher_enabled
             type: bool
             default: false


### PR DESCRIPTION
## Motivation/summary

- support setting the java agent download version field
- fix the config value for `discover-rules`

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/master/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

