### PR TITLE
[7.16][docs] Update RUM source map absolute path logic (#6786) (forward-port)

### DIFF
--- a/docs/legacy/sourcemap-api.asciidoc
+++ b/docs/legacy/sourcemap-api.asciidoc
@@ -50,6 +50,22 @@ To do this, it tries the following:
 * Compare the event's `service.version` with the source map's `service_version`
 * Compare the stack trace frame's `abs_path` with the source map's `bundle_filepath`
 
+While comparing the stack trace frame's `abs_path` with the source map's `bundle_filepath`, the search logic will prioritize `abs_path` full matching:
+[source,console]
+---------------------------------------------------------------------------
+{
+  "sourcemap.bundle_filepath": "http://localhost/static/js/bundle.js"
+}
+---------------------------------------------------------------------------
+
+But if there is no full match, it also accepts source maps that match only the URLs path (without the host). 
+[source,console]
+---------------------------------------------------------------------------
+{
+  "sourcemap.bundle_filepath": "/static/js/bundle.js"
+}
+---------------------------------------------------------------------------
+
 If a source map is found, the `stack trace frame` attributes `filename`, `function`, `line number`, and `column number` are overwritten,
 and `abs path` is https://golang.org/pkg/path/#Clean[cleaned] to be the shortest path name equivalent to the given path name.
 If multiple source maps are found,


### PR DESCRIPTION
Cherry-pick of https://github.com/elastic/apm-server/commit/c6c6088f30b96ec4b3950c65661686a76bdb203b.