### PR TITLE
Increase system tests timeout

### DIFF
--- a/.ci/scripts/linux-test.sh
+++ b/.ci/scripts/linux-test.sh
@@ -16,8 +16,9 @@ make update apm-server
 # Start docker-compose environment first, so it doesn't count towards the test timeout.
 docker-compose up -d
 
-SYSTEM_TESTS_XUNIT_PATH="$(pwd)/build"
-# TODO(axw) make this a Makefile target
-# TODO(mdelapenya) meanwhile there is no 'DefaultGoTestSystemArgs' at beats' GoTest implementation, this command is reproducing what Beats should provide: a gotestsum representation for system tests.
-#    In the same hand, the system tests should be tagged with "// +build systemtests"
-(cd systemtest && gotestsum --no-color -f standard-quiet --junitfile "${SYSTEM_TESTS_XUNIT_PATH}/TEST-go-system_tests.xml" --jsonfile "${SYSTEM_TESTS_XUNIT_PATH}/TEST-go-system_tests.out.json" -- -tags  systemtests ./...)
+OUTPUT_DIR="$(pwd)/build"
+OUTPUT_JSON_FILE="$OUTPUT_DIR/TEST-go-system_tests.out.json"
+OUTPUT_JUNIT_FILE="$OUTPUT_DIR/TEST-go-system_tests.xml"
+
+export GOTESTFLAGS="-v -json"
+gotestsum --no-color -f standard-quiet --jsonfile "$OUTPUT_JSON_FILE" --junitfile "$OUTPUT_JUNIT_FILE" --raw-command -- make system-test

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,14 @@
 # Variables used for various build targets.
 ##############################################################################
 
-# Enforce use of modules.
-export GO111MODULE=on
-
 # Ensure the Go version in .go_version is installed and used.
 GOROOT?=$(shell ./script/run_with_go_ver go env GOROOT)
 GO:=$(GOROOT)/bin/go
 export PATH:=$(GOROOT)/bin:$(PATH)
+
+# By default we run tests with verbose output. This may be overridden, e.g.
+# scripts may set GOTESTFLAGS=-json to format test output for processing.
+GOTESTFLAGS?=-v
 
 GOOSBUILD:=./build/$(shell $(GO) env GOOS)
 APPROVALS=$(GOOSBUILD)/approvals
@@ -45,17 +46,13 @@ apm-server:
 apm-server-oss:
 	@$(GO) build -o $@
 
-.PHONY: apm-server.test
-apm-server.test:
-	$(GO) test -c -coverpkg=github.com/elastic/apm-server/... ./x-pack/apm-server
-
-.PHONY: apm-server-oss.test
-apm-server-oss.test:
-	$(GO) test -c -coverpkg=github.com/elastic/apm-server/...
-
 .PHONY: test
 test:
-	$(GO) test -v ./...
+	$(GO) test $(GOTESTFLAGS) ./...
+
+.PHONY: system-test
+system-test:
+	@(cd systemtest; $(GO) test $(GOTESTFLAGS) -timeout=20m ./...)
 
 .PHONY:
 clean: $(MAGE)


### PR DESCRIPTION
- Increase the timeout for the system tests to 20 minutes (hardcoded)
- Introduce a `make system-test` target which runs the system tests
- Add an overrideable GOTESTFLAGS var to Makefile, used by `make test` and `make system-test`
- Update CI script to use the new target/var

Closes https://github.com/elastic/apm-server/issues/6811