### PR TITLE
Deprecate `apm-server.capture_personal_data`

### DIFF
--- a/beater/api/mux.go
+++ b/beater/api/mux.go
@@ -153,7 +153,7 @@ type routeBuilder struct {
 
 func (r *routeBuilder) profileHandler() (request.Handler, error) {
 	requestMetadataFunc := emptyRequestMetadata
-	if r.cfg.AugmentEnabled {
+	if r.cfg.RumConfig.AugmentEnabled {
 		requestMetadataFunc = backendRequestMetadata
 	}
 	h := profile.Handler(requestMetadataFunc, r.batchProcessor)
@@ -167,7 +167,7 @@ func (r *routeBuilder) firehoseHandler() (request.Handler, error) {
 
 func (r *routeBuilder) backendIntakeHandler() (request.Handler, error) {
 	requestMetadataFunc := emptyRequestMetadata
-	if r.cfg.AugmentEnabled {
+	if r.cfg.RumConfig.AugmentEnabled {
 		requestMetadataFunc = backendRequestMetadata
 	}
 	h := intake.Handler(stream.BackendProcessor(r.cfg), requestMetadataFunc, r.batchProcessor)
@@ -176,7 +176,7 @@ func (r *routeBuilder) backendIntakeHandler() (request.Handler, error) {
 
 func (r *routeBuilder) rumIntakeHandler(newProcessor func(*config.Config) *stream.Processor) func() (request.Handler, error) {
 	requestMetadataFunc := emptyRequestMetadata
-	if r.cfg.AugmentEnabled {
+	if r.cfg.RumConfig.AugmentEnabled {
 		requestMetadataFunc = rumRequestMetadata
 	}
 	return func() (request.Handler, error) {

--- a/beater/config/rum.go
+++ b/beater/config/rum.go
@@ -41,12 +41,24 @@ const (
 // RumConfig holds config information related to the RUM endpoint
 type RumConfig struct {
 	Enabled             bool                `config:"enabled"`
+	AugmentEnabled      bool                `config:"capture_personal_data"`
 	AllowOrigins        []string            `config:"allow_origins"`
 	AllowHeaders        []string            `config:"allow_headers"`
 	ResponseHeaders     map[string][]string `config:"response_headers"`
 	LibraryPattern      string              `config:"library_pattern"`
 	ExcludeFromGrouping string              `config:"exclude_from_grouping"`
 	SourceMapping       SourceMapping       `config:"source_mapping"`
+
+	augmentEnabledSet bool
+}
+
+func (s *RumConfig) Unpack(inp *common.Config) error {
+	type underlyingRumConfig RumConfig
+	if err := inp.Unpack((*underlyingRumConfig)(s)); err != nil {
+		return errors.Wrap(err, "error unpacking rum config")
+	}
+	s.augmentEnabledSet = inp.HasField("capture_personal_data")
+	return nil
 }
 
 // SourceMapping holds sourcemap config information
@@ -115,6 +127,7 @@ func defaultSourcemapping() SourceMapping {
 
 func defaultRum() RumConfig {
 	return RumConfig{
+		AugmentEnabled:      true,
 		AllowOrigins:        []string{allowAllOrigins},
 		AllowHeaders:        []string{},
 		SourceMapping:       defaultSourcemapping(),

--- a/beater/server.go
+++ b/beater/server.go
@@ -224,7 +224,7 @@ func newGRPCServer(
 		),
 	)
 
-	if cfg.AugmentEnabled {
+	if cfg.RumConfig.AugmentEnabled {
 		// Add a model processor that sets `client.ip` for events from end-user devices.
 		batchProcessor = modelprocessor.Chained{
 			model.ProcessBatchFunc(otlp.SetClientMetadata),

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -44,5 +44,9 @@ https://github.com/elastic/apm-server/compare/7.15\...master[View commits]
 - APM Server now has beta support to receive OpenTelemetry Logs on the OTLP/GRPC receiver {pull}6768[6768]
 
 [float]
+==== Deprecated
+- `apm-server.capture_personal_data` is deprecated and `apm-server.rum.capture_personal_data` should be used instead {pull}6835[6835]
+
+[float]
 ==== Licensing Changes
 - Updated the `x-pack` source files license to the Elastic License 2.0 {pull}6524[6524]


### PR DESCRIPTION
## Motivation/summary

Deprecates `apm-server.capture_personal_data`, and adds a new setting
under the RUM config `apm-server.rum.capture_personal_data`. Deprecation
log messages will be used if the depreacted setting is used.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/master/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

1. `make`
2. `./apm-server -E output.elasticsearch.username=admin -E output.elasticsearch.password=changeme -E apm-server.capture_personal_data=true -e` and verify that a deprecation message is logged
```
apm-server.capture_personal_data is deprecated and will be removed in a future version, please use apm-server.rum.capture_personal_data instead
```
3. `./apm-server -E output.elasticsearch.username=admin -E output.elasticsearch.password=changeme -E apm-server.capture_personal_data=false -E apm-server.rum.capture_personal_data=true -e` and verify that two deprecation messages are logged. (Previous and this one).
```
apm-server.capture_personal_data and apm-server.rum.capture_personal_data  are both set, apm-server.capture_personal_data will be ignored
```
4. `./apm-server -E output.elasticsearch.username=admin -E output.elasticsearch.password=changeme -E apm-server.rum.capture_personal_data=false -e` and verify that no deprecation messages for this setting are logged.


## Related issues

Closes #3273