### PR TITLE
beater: improve tests

### DIFF
--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -372,6 +372,7 @@ func TestQueryClusterUUIDRegistriesExist(t *testing.T) {
 
 func TestQueryClusterUUIDRegistriesDoNotExist(t *testing.T) {
 	stateRegistry := monitoring.GetNamespace("state").GetRegistry()
+	stateRegistry.Clear()
 	defer stateRegistry.Clear()
 
 	ctx := context.Background()

--- a/beater/beater_test.go
+++ b/beater/beater_test.go
@@ -354,6 +354,9 @@ func TestFleetStoreUsed(t *testing.T) {
 
 func TestQueryClusterUUIDRegistriesExist(t *testing.T) {
 	stateRegistry := monitoring.GetNamespace("state").GetRegistry()
+	stateRegistry.Clear()
+	defer stateRegistry.Clear()
+
 	elasticsearchRegistry := stateRegistry.NewRegistry("outputs.elasticsearch")
 	monitoring.NewString(elasticsearchRegistry, "cluster_uuid")
 
@@ -368,13 +371,15 @@ func TestQueryClusterUUIDRegistriesExist(t *testing.T) {
 }
 
 func TestQueryClusterUUIDRegistriesDoNotExist(t *testing.T) {
+	stateRegistry := monitoring.GetNamespace("state").GetRegistry()
+	defer stateRegistry.Clear()
+
 	ctx := context.Background()
 	clusterUUID := "abc123"
 	client := &mockClusterUUIDClient{ClusterUUID: clusterUUID}
 	err := queryClusterUUID(ctx, client)
 	require.NoError(t, err)
 
-	stateRegistry := monitoring.GetNamespace("state").GetRegistry()
 	elasticsearchRegistry := stateRegistry.GetRegistry("outputs.elasticsearch")
 	require.NotNil(t, elasticsearchRegistry)
 

--- a/beater/integration_test.go
+++ b/beater/integration_test.go
@@ -114,7 +114,7 @@ func testPublish(t *testing.T, client *http.Client, req *http.Request, events <-
 			adjustMissingTimestamp(&event)
 			docs = append(docs, beatertest.EncodeEventDoc(event))
 		case <-timeout.C:
-			break
+			t.Fatal("timed out waiting for events")
 		}
 	}
 	return docs


### PR DESCRIPTION
- Speed up TestPublishIntegration tests, which were each waiting for
  one second to gather events. Instead, we now decode the HTTP response
  body to identify the number of events received; and then we wait for
  that many events to be published.

- Tidy up the monitoring registry in TestQueryClusterUUID* tests, so
  they can be run multiple times (i.e. with `go test -count=N`)