### PR TITLE
[java-attacher] convert -vmarg to -vmargs

### DIFF
--- a/beater/config/java_attacher.go
+++ b/beater/config/java_attacher.go
@@ -47,13 +47,13 @@ func (j JavaAttacherConfig) setup() error {
 }
 
 var allowlist = map[string]struct{}{
-	"include-all":    {},
-	"include-main":   {},
-	"include-vmargs": {},
-	"include-user":   {},
-	"exclude-main":   {},
-	"exclude-vmargs": {},
-	"exclude-user":   {},
+	"include-all":   {},
+	"include-main":  {},
+	"include-vmarg": {},
+	"include-user":  {},
+	"exclude-main":  {},
+	"exclude-vmarg": {},
+	"exclude-user":  {},
 }
 
 func defaultJavaAttacherConfig() JavaAttacherConfig {

--- a/beater/config/java_attacher_test.go
+++ b/beater/config/java_attacher_test.go
@@ -26,7 +26,7 @@ import (
 func TestJavaAttacherConfig(t *testing.T) {
 	discoveryRules := []map[string]string{
 		map[string]string{"include-main": "main.jar"},
-		map[string]string{"include-vmargs": "elastic.apm.agent.attach=true"},
+		map[string]string{"include-vmarg": "elastic.apm.agent.attach=true"},
 		map[string]string{"exclude-user": "root"},
 	}
 	config := JavaAttacherConfig{

--- a/beater/java_attacher/java_attacher.go
+++ b/beater/java_attacher/java_attacher.go
@@ -133,6 +133,17 @@ func (j JavaAttacher) formatArgs() []string {
 
 	for _, flag := range j.cfg.DiscoveryRules {
 		for name, value := range flag {
+			if strings.HasSuffix(name, "vmarg") {
+				// TODO(stn): the bundled version of
+				// java-attacher, 1.27.0, only supports
+				// `-vmargs`. This will be changed to `-vmarg`
+				// in the future. For consistency in naming and
+				// with other projects, expose `-vmarg` to the
+				// user, but internally convert it. This should
+				// be removed once the bundled java-attacher
+				// version supports `-vmarg`.
+				name += "s"
+			}
 			args = append(args, "--"+name, value)
 		}
 	}

--- a/beater/java_attacher/java_attacher_test.go
+++ b/beater/java_attacher/java_attacher_test.go
@@ -84,7 +84,7 @@ func TestBuild(t *testing.T) {
 
 	want := filepath.FromSlash("/usr/bin/java -jar ./java-attacher.jar") +
 		" --continuous --log-level debug --download-agent-version 1.25.0 --exclude-user root --include-main MyApplication " +
-		"--include-main my-application.jar --include-vmarg elastic.apm.agent.attach=true " +
+		"--include-main my-application.jar --include-vmargs elastic.apm.agent.attach=true " +
 		"--config server_url=http://localhost:8200"
 
 	cmdArgs := strings.Join(cmd.Args, " ")


### PR DESCRIPTION
## Motivation/summary

The bundled version of the java-attacher currently
uses -vmargs, but in the future will support
-vmarg. Externally accept -vmarg to remain
consisten, and convert it to -vmargs. When the
java-attacher version is upgraded, this conversion
can be removed.

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/master/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

## How to test these changes

Start apm-server using a java attacher config that includes `--include-vmarg`, and `log.level: debug`. Verify that the java-attacher starts, and that the debug output showing the command line executed has `--include-vmargs`.

Verify that the server complains when started with `--include-vmargs`.