### PR TITLE
Remove preliminary doc bubble from master and 8.0

### DIFF
--- a/docs/integrations-index.asciidoc
+++ b/docs/integrations-index.asciidoc
@@ -14,10 +14,6 @@ endif::[]
 [[apm-user-guide]]
 = APM User Guide
 
-IMPORTANT: You are looking at preliminary documentation for a future release. For current documentation, see the
-https://www.elastic.co/guide/en/apm/get-started/current/index.html[APM Overview] or
-https://www.elastic.co/guide/en/apm/server/current/index.html[APM Server Reference].
-
 include::apm-overview.asciidoc[]
 
 include::apm-components.asciidoc[]


### PR DESCRIPTION
The doc build adds this automatically. Can now be removed from 8.0 and master docs.