### PR TITLE
Cherry pick release notes

### DIFF
--- a/changelogs/6.8.asciidoc
+++ b/changelogs/6.8.asciidoc
@@ -3,6 +3,7 @@
 
 https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 
+* <<release-notes-6.8.22>>
 * <<release-notes-6.8.21>>
 * <<release-notes-6.8.20>>
 * <<release-notes-6.8.19>>
@@ -25,6 +26,14 @@ https://github.com/elastic/apm-server/compare/6.7\...6.8[View commits]
 * <<release-notes-6.8.2>>
 * <<release-notes-6.8.1>>
 * <<release-notes-6.8.0>>
+
+[float]
+[[release-notes-6.8.22]]
+=== APM Server version 6.8.22
+
+https://github.com/elastic/apm-server/compare/v6.8.21\...v6.8.22[View commits]
+
+No significant changes.
 
 [float]
 [[release-notes-6.8.21]]

--- a/changelogs/7.16.asciidoc
+++ b/changelogs/7.16.asciidoc
@@ -3,8 +3,17 @@
 
 https://github.com/elastic/apm-server/compare/7.15\...7.16[View commits]
 
+* <<release-notes-7.16.2>>
 * <<release-notes-7.16.1>>
 * <<release-notes-7.16.0>>
+
+[float]
+[[release-notes-7.16.2]]
+=== APM Server version 7.16.2
+
+https://github.com/elastic/apm-server/compare/v7.16.1\...v7.16.2[View commits]
+
+No significant changes.
 
 [float]
 [[release-notes-7.16.1]]


### PR DESCRIPTION
### Summary

7.16.2 and 6.8.22 were released today. Release notes were published to the 7.16 and 6.8 branches in https://github.com/elastic/apm-server/commit/449fbe37aee7c35079b236713c4ee6c51af4cc7d and https://github.com/elastic/apm-server/commit/0de688a74ad046d717acce10742d7c5fb0dd5833, respectively. This PR cherry-picks the changes to master for backporting.

### To do

~- [ ] There's no backport label for 7.17 yet, so this needs to be manually backported to that branch~