### PR TITLE
ci: Run `go mod download` before systemtest

### DIFF
--- a/.ci/scripts/linux-test.sh
+++ b/.ci/scripts/linux-test.sh
@@ -22,8 +22,7 @@ OUTPUT_JUNIT_FILE="$OUTPUT_DIR/TEST-go-system_tests.xml"
 
 # Download systemtest dependencies soo the download time doesn't count towards
 # the test timeout.
-APM_ROOT=$(pwd)
-cd systemtest && go mod download && cd ${APM_ROOT}
+cd systemtest && go mod download && cd -
 
 export GOTESTFLAGS="-v -json"
 gotestsum --no-color -f standard-quiet --jsonfile "$OUTPUT_JSON_FILE" --junitfile "$OUTPUT_JUNIT_FILE" --raw-command -- make system-test

--- a/.ci/scripts/linux-test.sh
+++ b/.ci/scripts/linux-test.sh
@@ -20,5 +20,10 @@ OUTPUT_DIR="$(pwd)/build"
 OUTPUT_JSON_FILE="$OUTPUT_DIR/TEST-go-system_tests.out.json"
 OUTPUT_JUNIT_FILE="$OUTPUT_DIR/TEST-go-system_tests.xml"
 
+# Download systemtest dependencies soo the download time doesn't count towards
+# the test timeout.
+APM_ROOT=$(pwd)
+cd systemtest && go mod download && cd ${APM_ROOT}
+
 export GOTESTFLAGS="-v -json"
 gotestsum --no-color -f standard-quiet --jsonfile "$OUTPUT_JSON_FILE" --junitfile "$OUTPUT_JUNIT_FILE" --raw-command -- make system-test


### PR DESCRIPTION
## Motivation/summary

Downloads all the systemtest modules before running the tests so the
download time doesn't count towards the systemtest test timeout.

## How to test these changes

N/A

## Related issues

N/A