### PR TITLE
Java attacher remove vmarg conversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ release-manager-snapshot: release
 .PHONY: release-manager-release
 release-manager-release: release
 
-JAVA_ATTACHER_VERSION:=1.27.0
+JAVA_ATTACHER_VERSION:=1.28.3
 JAVA_ATTACHER_JAR:=apm-agent-attach-cli-$(JAVA_ATTACHER_VERSION)-slim.jar
 JAVA_ATTACHER_SIG:=$(JAVA_ATTACHER_JAR).asc
 JAVA_ATTACHER_BASE_URL:=https://repo1.maven.org/maven2/co/elastic/apm/apm-agent-attach-cli

--- a/beater/java_attacher/java_attacher.go
+++ b/beater/java_attacher/java_attacher.go
@@ -133,17 +133,6 @@ func (j JavaAttacher) formatArgs() []string {
 
 	for _, flag := range j.cfg.DiscoveryRules {
 		for name, value := range flag {
-			if strings.HasSuffix(name, "vmarg") {
-				// TODO(stn): the bundled version of
-				// java-attacher, 1.27.0, only supports
-				// `-vmargs`. This will be changed to `-vmarg`
-				// in the future. For consistency in naming and
-				// with other projects, expose `-vmarg` to the
-				// user, but internally convert it. This should
-				// be removed once the bundled java-attacher
-				// version supports `-vmarg`.
-				name += "s"
-			}
 			args = append(args, "--"+name, value)
 		}
 	}

--- a/beater/java_attacher/java_attacher_test.go
+++ b/beater/java_attacher/java_attacher_test.go
@@ -84,7 +84,7 @@ func TestBuild(t *testing.T) {
 
 	want := filepath.FromSlash("/usr/bin/java -jar ./java-attacher.jar") +
 		" --continuous --log-level debug --download-agent-version 1.25.0 --exclude-user root --include-main MyApplication " +
-		"--include-main my-application.jar --include-vmargs elastic.apm.agent.attach=true " +
+		"--include-main my-application.jar --include-vmarg elastic.apm.agent.attach=true " +
 		"--config server_url=http://localhost:8200"
 
 	cmdArgs := strings.Join(cmd.Args, " ")


### PR DESCRIPTION
## Motivation/summary

Remove internal conversion to `vmargs` when constructing java-attacher command

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/master/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

## How to test these changes

1. download the java-attacher and place it alongside the apm-server binary
    ```
    make build/apm-agent-attach-cli-1.28.3-slim.jar
    cp build/java-attacher.jar .
    ```
2. add the following to `apm-server.yml` nested under `apm-server`
    ```
    java_attacher:
      enabled: true
      download-agent-version: 1.28.3
      discovery-rules:
      - include-vmarg: "elastic.apm.attach=true"
      - include-main: opbeans
      - exclude-main: ".*"
      config:
        server_url: "http://localhost:8200"
    ```
3. start apm-server: `./apm-server -e -E logging.level=debug`
4. check for the debug output with the constructed java-attacher commandline invocation:
    ```
    starting java attacher with command: /bin/java -jar ./java-attacher.jar --continuous --log-level debug --download-agent-version 1.28.3 --include-vmarg elastic.apm.attach=true --include-main opbeans --exclude-main .* --config server_url=http://localhost:8200
    ```
5. verify there is no error output from the running java-attacher

## Related issues

https://github.com/elastic/apm-server/issues/6898