### PR TITLE
[java-attacher] invalid config fails open

### DIFF
--- a/beater/config/config.go
+++ b/beater/config/config.go
@@ -114,7 +114,7 @@ func NewConfig(ucfg *common.Config, outputESCfg *common.Config) (*Config, error)
 	}
 
 	if err := c.JavaAttacherConfig.setup(); err != nil {
-		logger.Errorf("failed to setup java-attacher: %v", err)
+		logger.Warnf("failed to setup java-attacher: %v", err)
 		c.JavaAttacherConfig = defaultJavaAttacherConfig()
 	}
 

--- a/beater/config/config.go
+++ b/beater/config/config.go
@@ -114,7 +114,8 @@ func NewConfig(ucfg *common.Config, outputESCfg *common.Config) (*Config, error)
 	}
 
 	if err := c.JavaAttacherConfig.setup(); err != nil {
-		return nil, err
+		logger.Errorf("failed to setup java-attacher: %v", err)
+		c.JavaAttacherConfig = defaultJavaAttacherConfig()
 	}
 
 	return c, nil

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -70,6 +70,19 @@ func TestUnpackConfig(t *testing.T) {
 			inpCfg: map[string]interface{}{},
 			outCfg: DefaultConfig(),
 		},
+		"invalid java-attacher config": {
+			inpCfg: map[string]interface{}{
+				"java_attacher": map[string]interface{}{
+					"enabled": true,
+					"discovery-rules": []map[string]interface{}{
+						map[string]interface{}{
+							"disallowed-key": "opbeans",
+						},
+					},
+				},
+			},
+			outCfg: DefaultConfig(),
+		},
 		"overwrite default": {
 			inpCfg: map[string]interface{}{
 				"host":                  "localhost:3000",


### PR DESCRIPTION
## Motivation/summary

Currently, an invalid java-attacher config prevents the server from starting up. Server operation should not depend on the java-attacher having a valid config. Log the error if it exists, and move along.

QUESTION:

Currently, this is being logged as an error. Do we want to use a different log level for this?

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/master/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

1. start `apm-server` with the following added to the config:
    ```yaml
    apm-server:
      java_attacher:
        enabled: true
        discovery-rules:
        - disallowed-flag: opbeans
    ```
2. Check the error logs for a message about the invalid flag
3. The apm-server should not exit

## Related issues

closes https://github.com/elastic/apm-server/issues/6814