### PR TITLE
[automation] update elastic stack version for testing 7.17.0-32e424af

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       kibana: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0-b402b9a8-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0-32e424af-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -61,7 +61,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.17.0-b402b9a8-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.17.0-32e424af-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -85,7 +85,7 @@ services:
       package-registry: { condition: service_healthy }
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:7.17.0-b402b9a8-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:7.17.0-32e424af-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Wed, 5 Jan 2022 00:16:11 GMT, release_branch:7.17, prefix:, end_time:Wed, 5 Jan 2022 05:34:33 GMT, manifest_version:2.0.0, version:7.17.0-SNAPSHOT, branch:7.17, build_id:7.17.0-32e424af, build_duration_seconds:19102]