### PR TITLE
docs: update OTel messaging spans limitation

### DIFF
--- a/docs/legacy/guide/opentelemetry-elastic.asciidoc
+++ b/docs/legacy/guide/opentelemetry-elastic.asciidoc
@@ -390,7 +390,7 @@ Here is an example of AWS Lambda Node.js function managed with Terraform and the
 [[elastic-open-telemetry-traces-limitations]]
 ===== OpenTelemetry traces
 
-* Traces of applications using `messaging` semantics might be wrongly displayed or not shown in the APM UI. You may only see `spans` coming from such services, but no `transaction` https://github.com/elastic/apm-server/issues/5094[#5094]
+* Traces of applications using `messaging` semantics might be wrongly displayed as `transactions` in the APM UI, while they should be considered `spans`. https://github.com/elastic/apm-server/issues/7001[#7001]
 * Inability to see Stack traces in spans
 * Inability in APM views to view the "Time Spent by Span Type" https://github.com/elastic/apm-server/issues/5747[#5747]
 * Metrics derived from traces (throughput, latency, and errors) are not accurate when traces are sampled before being ingested by Elastic Observability (ie by an OpenTelemetry Collector or OpenTelemetry APM agent or SDK) https://github.com/elastic/apm/issues/472[#472]

--- a/docs/open-telemetry.asciidoc
+++ b/docs/open-telemetry.asciidoc
@@ -386,7 +386,7 @@ Here is an example of AWS Lambda Node.js function managed with Terraform and the
 [[open-telemetry-traces-limitations]]
 ===== OpenTelemetry traces
 
-* Traces of applications using `messaging` semantics might be wrongly displayed or not shown in the APM UI. You may only see `spans` coming from such services, but no `transaction` https://github.com/elastic/apm-server/issues/5094[#5094]
+* Traces of applications using `messaging` semantics might be wrongly displayed as `transactions` in the APM UI, while they should be considered `spans`. https://github.com/elastic/apm-server/issues/7001[#7001]
 * Inability to see Stack traces in spans
 * Inability in APM views to view the "Time Spent by Span Type" https://github.com/elastic/apm-server/issues/5747[#5747]
 * Metrics derived from traces (throughput, latency, and errors) are not accurate when traces are sampled before being ingested by Elastic Observability (ie by an OpenTelemetry Collector or OpenTelemetry APM agent or SDK) https://github.com/elastic/apm/issues/472[#472]


### PR DESCRIPTION
## Motivation/summary

Update OpenTelemetry limitations with a link to https://github.com/elastic/apm-server/issues/7001, remove outdated link.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/master/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
- [x] Documentation has been updated

## How to test these changes

N/A

## Related issues

https://github.com/elastic/apm-server/issues/7001