### PR TITLE
jjbb: enable 7.17 branch

### DIFF
--- a/.ci/jobs/apm-server-check-changelogs-mbp.yml
+++ b/.ci/jobs/apm-server-check-changelogs-mbp.yml
@@ -12,7 +12,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: false
-        head-filter-regex: '(master|7\.1[6789]|8\.\d+|PR-.*)'
+        head-filter-regex: '(master|6\.8|7\.1[6789]|8\.\d+|PR-.*)'
         notification-context: 'apm-ci'
         property-strategies:
           all-branches:

--- a/.ci/jobs/apm-server-check-changelogs-mbp.yml
+++ b/.ci/jobs/apm-server-check-changelogs-mbp.yml
@@ -12,7 +12,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: false
-        head-filter-regex: '(master|6\.8|7\.16|8\.\d+|PR-.*)'
+        head-filter-regex: '(master|7\.1[6789]|8\.\d+|PR-.*)'
         notification-context: 'apm-ci'
         property-strategies:
           all-branches:

--- a/.ci/jobs/apm-server-check-packages-mbp.yml
+++ b/.ci/jobs/apm-server-check-packages-mbp.yml
@@ -12,7 +12,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: false
-        head-filter-regex: '(master|7\.16|8\.\d+)'
+        head-filter-regex: '(master|7\.1[6789]|8\.\d+)'
         notification-context: 'beats-tester'
         build-strategies:
         - skip-initial-build: true
@@ -21,7 +21,7 @@
                 name: 'master'
                 case-sensitive: true
             - regex-name:
-                regex: '7\.1\d'
+                regex: '7\.1[6789]'
                 case-sensitive: true
             - regex-name:
                 regex: '8\.\d+'

--- a/.ci/jobs/apm-server-mbp.yml
+++ b/.ci/jobs/apm-server-mbp.yml
@@ -13,7 +13,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
-        head-filter-regex: '(master|6\.8|7\.16|8\.\d+|PR-.*|v[0-9].*)'
+        head-filter-regex: '(master|6\.8|7\.1[6789]|8\.\d+|PR-.*|v[0-9].*)'
         notification-context: 'apm-ci'
         repo: apm-server
         repo-owner: elastic


### PR DESCRIPTION
## Motivation/summary

`7.16` was in theory the last branch so we put in place some changes to simplify the regex. But `7.17` is now the next minor for the 7 line. Let's support `7.18` and so on just in case

Otherwise, the CI won't run builds for the 7.17 branch!