### PR TITLE
[automation] update elastic stack version for testing 8.1.0-5e490954

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       kibana: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.1.0-dbc834fd-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.1.0-5e490954-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -38,7 +38,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.1.0-dbc834fd-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.1.0-5e490954-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -62,7 +62,7 @@ services:
       package-registry: { condition: service_healthy }
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:8.1.0-dbc834fd-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:8.1.0-5e490954-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Thu, 6 Jan 2022 12:13:22 GMT, release_branch:master, prefix:, end_time:Thu, 6 Jan 2022 18:02:53 GMT, manifest_version:2.0.0, version:8.1.0-SNAPSHOT, branch:master, build_id:8.1.0-5e490954, build_duration_seconds:20971]