### PR TITLE
systemtest: Skip `TestTailSampling` for now

### DIFF
--- a/systemtest/sampling_test.go
+++ b/systemtest/sampling_test.go
@@ -90,6 +90,8 @@ func TestDropUnsampled(t *testing.T) {
 }
 
 func TestTailSampling(t *testing.T) {
+	// We should remove the skip once the issue is resolved.
+	t.Skip("Skipped due: https://github.com/elastic/fleet-server/issues/1048")
 	systemtest.CleanupElasticsearch(t)
 
 	apmIntegration1 := newAPMIntegration(t, map[string]interface{}{


### PR DESCRIPTION
## Motivation/summary

Skips the `TestTailSampling` systemtest until elastic/fleet-server#1048
is resolved.

## How to test these changes

N/A

## Related issues

See referenced issue.
