### PR TITLE
[java-attacher] update amd64 seccomp filter

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -52,6 +52,8 @@ import (
 	"github.com/elastic/apm-server/beater/config"
 	javaattacher "github.com/elastic/apm-server/beater/java_attacher"
 	"github.com/elastic/apm-server/elasticsearch"
+
+	// Imported to update seccomp filter on linux.
 	_ "github.com/elastic/apm-server/include"
 	"github.com/elastic/apm-server/kibana"
 	logs "github.com/elastic/apm-server/log"

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -52,6 +52,7 @@ import (
 	"github.com/elastic/apm-server/beater/config"
 	javaattacher "github.com/elastic/apm-server/beater/java_attacher"
 	"github.com/elastic/apm-server/elasticsearch"
+	_ "github.com/elastic/apm-server/include"
 	"github.com/elastic/apm-server/kibana"
 	logs "github.com/elastic/apm-server/log"
 	"github.com/elastic/apm-server/model"

--- a/include/seccomp.go
+++ b/include/seccomp.go
@@ -1,0 +1,18 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package include

--- a/include/seccomp_linux_amd64.go
+++ b/include/seccomp_linux_amd64.go
@@ -1,0 +1,35 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build linux && amd64
+// +build linux,amd64
+
+package include
+
+import (
+	"github.com/elastic/beats/v7/libbeat/common/seccomp"
+	"github.com/elastic/beats/v7/libbeat/logp"
+
+	logs "github.com/elastic/apm-server/log"
+)
+
+func init() {
+	if err := seccomp.ModifyDefaultPolicy(seccomp.AddSyscall, "fork", "execve", "prlimit64", "socketpair", "vfork", "getegid"); err != nil {
+		logger := logp.NewLogger(logs.Config)
+		logger.Warnf("seccomp: failed to add syscalls required to run java-attacher: %v", err)
+	}
+}


### PR DESCRIPTION
## Motivation/summary

add the required syscalls to the seccomp filter for the apm-server to fork the java-attacher, and for the java-attacher to run.

**Note:**

I attempted to modify the filter from within the `beat.Creator` returned by `beater.NewCreator`, but it appears that function is executed after the default seccomp filter has already been loaded by libbeat. We are only allowed to set the seccomp filter a single time. Because this didn't work, the seccomp filter is **always being updated**, even if the apm-server isn't configured to fork the java-attacher process.

I can see where always adding `fork`, `vfork`, and `execve` to the seccomp filter could be viewed as problematic from a security perspective. An alternative to this PR would be to have the elastic-agent write out [the seccomp filter](https://gist.github.com/stuartnelson3/0fecf0f25198b3b791aa3faa59f96cae) to an initial apm-server.yml used to start the apm-server. As mentioned elsewhere, the yml seccomp filter would need to be different based on the current cpu architecture.

## How to test these changes

Verify that starting the server both in standalone and managed mode start the java-attacher

## Related issues

closes #7017