### PR TITLE
compose: Wait until `fleet-server` is healthy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     depends_on:
       elasticsearch: { condition: service_healthy }
       kibana: { condition: service_healthy }
+      fleet-server: { condition: service_healthy }
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.1.0-dbc834fd-SNAPSHOT


### PR DESCRIPTION
## Motivation/summary

Updates the `proxy_dep` in `docker-compose.yml` to wait until the `fleet-server`
is healthy before exiting. This will most likely cause the
systemtest to fail less on `context.DeadlineExceeded` since the wait
won't count towards the systemtest timeout.

## Checklist

N/A

## How to test these changes

N/A

## Related issues

N/A