### PR TITLE
[java-attacher] update to v1.28.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ release-manager-snapshot: release
 .PHONY: release-manager-release
 release-manager-release: release
 
-JAVA_ATTACHER_VERSION:=1.28.3
+JAVA_ATTACHER_VERSION:=1.28.4
 JAVA_ATTACHER_JAR:=apm-agent-attach-cli-$(JAVA_ATTACHER_VERSION)-slim.jar
 JAVA_ATTACHER_SIG:=$(JAVA_ATTACHER_JAR).asc
 JAVA_ATTACHER_BASE_URL:=https://repo1.maven.org/maven2/co/elastic/apm/apm-agent-attach-cli


### PR DESCRIPTION
## Motivation/summary

Update the patch-level version of the java
attacher for security updates.

## Related issues

closes https://github.com/elastic/apm-server/issues/6887
