### PR TITLE
apmpackage: fix Kibana URL in README

### DIFF
--- a/apmpackage/README.md
+++ b/apmpackage/README.md
@@ -21,7 +21,7 @@
     - Go to the Fleet UI, install the integration and test what you need. You generally will want to have a look at the
    installed assets (ie. templates and pipelines), and the generated `apm` input in the policy.
     - If you need to change the package, you *must* remove the installed integration first. You can use the UI
-    or the API, eg: `curl -X DELETE -k -u admin:changeme -H kbn-xsrf:true https://localhost:5601/api/fleet/epm/packages/apm-0.1.0`
+    or the API, eg: `curl -X DELETE -u admin:changeme -H kbn-xsrf:true http://localhost:5601/api/fleet/epm/packages/apm-0.1.0`
     See [API docs](https://github.com/elastic/kibana/tree/master/x-pack/plugins/fleet/dev_docs/api) for details.
     You normally don't need to restart the registry (an exception to this is eg. if you change a `hbs` template file).
 


### PR DESCRIPTION
Follow up to https://github.com/elastic/apm-server/pull/7042: update localhost Kibana URL to use `http`, not `https`, and drop `-k` flag.