### PR TITLE
docker-compose: use KIBANA_FLEET_* env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,9 +79,9 @@ services:
       FLEET_SERVER_CERT_KEY: /etc/pki/tls/private/fleet-server-key.pem
       FLEET_URL: https://fleet-server:8220
       KIBANA_FLEET_SETUP: "true"
-      KIBANA_HOST: "http://kibana:5601"
-      KIBANA_USERNAME: "${ES_SUPERUSER_USER:-admin}"
-      KIBANA_PASSWORD: "${ES_SUPERUSER_PASS:-changeme}"
+      KIBANA_FLEET_HOST: "http://kibana:5601"
+      KIBANA_FLEET_USERNAME: "${ES_SUPERUSER_USER:-admin}"
+      KIBANA_FLEET_PASSWORD: "${ES_SUPERUSER_PASS:-changeme}"
     depends_on:
       elasticsearch: { condition: service_healthy }
       kibana: { condition: service_healthy }


### PR DESCRIPTION
## Motivation/summary

Fixes an issue with elastic-agent setting up service account tokens.

`elastic-agent container` recognises `ELASTICSEARCH_{USERNAME,PASSWORD}` as fallbacks to `KIBANA_FLEET_{USERNAME,PASSWORD}`. It also suggests `KIBANA_{USERNAME,PASSWORD}` can be used (which we have been), but they are not recognised. See also https://github.com/elastic/beats/issues/29831

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/master/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

None