### PR TITLE
systemtest: AggShutdown wait 1s before `srv.Close`

### DIFF
--- a/systemtest/aggregation_test.go
+++ b/systemtest/aggregation_test.go
@@ -139,6 +139,11 @@ func TestTransactionAggregationShutdown(t *testing.T) {
 		estest.TermQuery{Field: "processor.event", Value: "transaction"},
 	)
 
+	// To avoid flaky tests, we wait for an additional 1s after the transaction
+	// has been indexed so the can aggregate the transaction before the server
+	// is stopped.
+	<-time.After(time.Second)
+
 	// Stop server to ensure metrics are flushed on shutdown.
 	assert.NoError(t, srv.Close())
 


### PR DESCRIPTION
## Motivation/summary

It seems that `TestTransactionAggregationShutdown` is flaky when the
`srv.Close()` is called straightaway. Adding a 1 second sleep before
calling `srv.Close()`, seems to give enough time to the APM Server to
process the transaction and aggregate it.

## How to test these changes

Comment the `time.After` line and run:

```console
$ go test -count=20 -v -run TestTransactionAggregation .
```

I've seen the test fail as much as 2 times with a count of 10.
