### PR TITLE
apm-server: main

### DIFF
--- a/.ci/jobs/apm-server-check-changelogs-mbp.yml
+++ b/.ci/jobs/apm-server-check-changelogs-mbp.yml
@@ -12,7 +12,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: false
-        head-filter-regex: '(master|6\.8|7\.1[6789]|8\.\d+|PR-.*)'
+        head-filter-regex: '(main|6\.8|7\.1[6789]|8\.\d+|PR-.*)'
         notification-context: 'apm-ci'
         property-strategies:
           all-branches:

--- a/.ci/jobs/apm-server-check-packages-mbp.yml
+++ b/.ci/jobs/apm-server-check-packages-mbp.yml
@@ -12,13 +12,13 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: false
-        head-filter-regex: '(master|7\.1[6789]|8\.\d+)'
+        head-filter-regex: '(main|7\.1[6789]|8\.\d+)'
         notification-context: 'beats-tester'
         build-strategies:
         - skip-initial-build: true
         - named-branches:
             - exact-name:
-                name: 'master'
+                name: 'main'
                 case-sensitive: true
             - regex-name:
                 regex: '7\.1[6789]'

--- a/.ci/jobs/apm-server-mbp.yml
+++ b/.ci/jobs/apm-server-mbp.yml
@@ -13,7 +13,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
-        head-filter-regex: '(master|6\.8|7\.1[6789]|8\.\d+|PR-.*|v[0-9].*)'
+        head-filter-regex: '(main|6\.8|7\.1[6789]|8\.\d+|PR-.*|v[0-9].*)'
         notification-context: 'apm-ci'
         repo: apm-server
         repo-owner: elastic

--- a/.ci/jobs/update-beats-mbp.yml
+++ b/.ci/jobs/update-beats-mbp.yml
@@ -13,7 +13,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: false
-          head-filter-regex: '^(master|PR-.*)$'
+          head-filter-regex: '^(main|PR-.*)$'
           notification-context: 'update-beats'
           repo: apm-server
           repo-owner: elastic

--- a/.ci/jobs/update-json-schema.yml
+++ b/.ci/jobs/update-json-schema.yml
@@ -2,7 +2,7 @@
 - job:
     name: apm-server/update-json-schema-mbp
     display-name: apm-server Update json schema
-    description: Send PRs to the subscribed APM Agents if the json schema files are modified, triggered for the master branch for the elastic/apm-server project
+    description: Send PRs to the subscribed APM Agents if the json schema files are modified, triggered for the main branch for the elastic/apm-server project
     view: APM-CI
     project-type: multibranch
     script-path: .ci/update-json-schema.groovy
@@ -13,7 +13,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: false
-          head-filter-regex: '^(master|PR-.*)$'
+          head-filter-regex: '^(main|PR-.*)$'
           notification-context: 'update-json-schema'
           repo: apm-server
           repo-owner: elastic

--- a/.ci/update-beats.groovy
+++ b/.ci/update-beats.groovy
@@ -31,8 +31,8 @@ pipeline {
     PIPELINE_LOG_LEVEL = 'INFO'
   }
   triggers {
-    // Only master branch will run on a timer basis
-    cron(env.BRANCH_NAME == 'master' ? 'H H(4-5) * * 1,5' : '')
+    // Only main branch will run on a timer basis
+    cron(env.BRANCH_NAME == 'main' ? 'H H(4-5) * * 1,5' : '')
   }
   options {
     timeout(time: 1, unit: 'HOURS')

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Guidelines:
  - Once the PR is marked ready for review it is expected to pass all tests and linting,
    and you should not force-push any changes.
 
-See also https://github.com/elastic/apm-server/blob/master/CONTRIBUTING.md for more tips on contributing.
+See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
 -->
 
 ## Motivation/summary
@@ -27,8 +27,8 @@ Delete irrelevant items. The changelog should only be updated for user-facing ch
 Once the PR is ready for review there should be no unticked boxes.
 -->
 
-- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)
-- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/master/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
+- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
+- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
 - [ ] Documentation has been updated
 
 For functional changes, consider:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -20,7 +20,7 @@ pull_request_rules:
   - name: backport patches to 8.0 branch
     conditions:
       - merged
-      - base=master
+      - base=main
       - label=backport-8.0
     actions:
       backport:
@@ -32,7 +32,7 @@ pull_request_rules:
   - name: backport patches to 7.17 branch
     conditions:
       - merged
-      - base=master
+      - base=main
       - label=backport-7.17
     actions:
       backport:
@@ -44,7 +44,7 @@ pull_request_rules:
   - name: backport patches to 7.16 branch
     conditions:
       - merged
-      - base=master
+      - base=main
       - label=backport-7.16
     actions:
       backport:
@@ -56,7 +56,7 @@ pull_request_rules:
   - name: backport patches to 7.15 branch
     conditions:
       - merged
-      - base=master
+      - base=main
       - label=backport-7.15
     actions:
       backport:
@@ -68,7 +68,7 @@ pull_request_rules:
   - name: backport patches to 7.14 branch
     conditions:
       - merged
-      - base=master
+      - base=main
       - label=backport-7.14
     actions:
       backport:
@@ -80,7 +80,7 @@ pull_request_rules:
   - name: backport patches to 7.13 branch
     conditions:
       - merged
-      - base=master
+      - base=main
       - label=backport-7.13
     actions:
       backport:
@@ -132,7 +132,7 @@ pull_request_rules:
   - name: notify the backport policy
     conditions:
       - -label~=^backport
-      - base=master
+      - base=main
     actions:
       comment:
         message: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Please read our [pull request template](.github/pull_request_template.md), which
 
 ### Workflow
 
-All feature development and most bug fixes hit the master branch first.
+All feature development and most bug fixes hit the main branch first.
 Pull requests should be reviewed by someone with commit access.
 Once approved,
 the author of the pull request,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
     issueCommentTrigger("(${obltGitHubComments()}|^run\\W+(?:the\\W+)?(hey-apm|package|arm)\\W+tests|^/test|^/hey-apm|^/package)")
   }
   parameters {
-    booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
+    booleanParam(name: 'Run_As_Main_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on main branch.')
     booleanParam(name: 'arm_ci', defaultValue: true, description: 'Enable ARM build')
     booleanParam(name: 'linux_ci', defaultValue: true, description: 'Enable Linux build')
     booleanParam(name: 'osx_ci', defaultValue: true, description: 'Enable OSX CI')
@@ -389,11 +389,11 @@ pipeline {
             beforeAgent true
             allOf {
               anyOf {
-                branch 'master'
+                branch 'main'
                 branch pattern: '\\d+\\.\\d+', comparator: 'REGEXP'
                 branch pattern: 'v\\d?', comparator: 'REGEXP'
                 tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: 'REGEXP'
-                expression { return params.Run_As_Master_Branch }
+                expression { return params.Run_As_Main_Branch }
               }
               expression { return params.bench_ci }
               expression { return env.ONLY_DOCS == "false" }
@@ -450,12 +450,12 @@ pipeline {
               expression { return params.release_ci }
               expression { return env.ONLY_DOCS == "false" }
               anyOf {
-                branch 'master'
+                branch 'main'
                 branch pattern: '\\d+\\.\\d+', comparator: 'REGEXP'
                 tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: 'REGEXP'
                 expression { return isPR() && env.BEATS_UPDATED != "false" }
                 expression { return env.GITHUB_COMMENT?.contains('package tests') || env.GITHUB_COMMENT?.contains('/package')}
-                expression { return params.Run_As_Master_Branch }
+                expression { return params.Run_As_Main_Branch }
               }
             }
           }
@@ -507,7 +507,7 @@ pipeline {
             allOf {
               anyOf {
                 changeRequest()
-                expression { return !params.Run_As_Master_Branch }
+                expression { return !params.Run_As_Main_Branch }
               }
               expression { return params.its_ci }
               expression { return env.ONLY_DOCS == "false" }

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ update-beats-docs: $(PYTHON)
 # Beats synchronisation.
 ##############################################################################
 
-BEATS_VERSION?=master
+BEATS_VERSION?=main
 BEATS_MODULE:=$(shell $(GO) list -m -f {{.Path}} all | grep github.com/elastic/beats)
 
 .PHONY: update-beats
@@ -145,7 +145,7 @@ update-beats-module:
 ##############################################################################
 
 GOLINT_TARGETS?=$(shell $(GO) list ./...)
-GOLINT_UPSTREAM?=origin/master
+GOLINT_UPSTREAM?=origin/main
 REVIEWDOG_FLAGS?=-conf=reviewdog.yml -f=golint -diff="git diff $(GOLINT_UPSTREAM)"
 GOLINT_COMMAND=$(GOLINT) ${GOLINT_TARGETS} | grep -v "should have comment" | $(REVIEWDOG) $(REVIEWDOG_FLAGS)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://apm-ci.elastic.co/buildStatus/icon?job=apm-server/apm-server-mbp/master)](https://apm-ci.elastic.co/job/apm-server/job/apm-server-mbp/view/change-requests/job/master/)
-[![codecov.io](https://codecov.io/github/elastic/apm-server/coverage.svg?branch=master)](https://codecov.io/github/elastic/apm-server?branch=master)
+[![Build Status](https://apm-ci.elastic.co/buildStatus/icon?job=apm-server/apm-server-mbp/main)](https://apm-ci.elastic.co/job/apm-server/job/apm-server-mbp/view/change-requests/job/main/)
+[![codecov.io](https://codecov.io/github/elastic/apm-server/coverage.svg?branch=main)](https://codecov.io/github/elastic/apm-server?branch=main)
 
 # APM Server
 
@@ -96,7 +96,7 @@ below.
 ### Updating libbeat
 
 By running `make update-beats` the `github.com/elastic/beats/vN` module will be updated to the most recent
-commit from the master branch, and a minimal set of files will be copied into the apm-server tree.
+commit from the main branch, and a minimal set of files will be copied into the apm-server tree.
 
 You can specify an alternative branch or commit by specifying the `BEATS_VERSION` variable, such as:
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,7 +5,7 @@
 * Backport all relevant commits
 
   e.g. start with following command to see which files differ that are not necessarily expected:
-  `git diff elastic/master --name-only | grep -v '^vendor/' | grep -v '^docs/' | grep -v '^_beats'`
+  `git diff elastic/main --name-only | grep -v '^vendor/' | grep -v '^docs/' | grep -v '^_beats'`
 
 * Update beats
 
@@ -13,13 +13,13 @@
 
 * Update Changelog
 
-  * Review existing [changelogs/head](https://github.com/elastic/apm-server/tree/master/changelogs/head.asciidoc) to ensure all relevant notes have been added
+  * Review existing [changelogs/head](https://github.com/elastic/apm-server/tree/main/changelogs/head.asciidoc) to ensure all relevant notes have been added
   * Move changelogs from _head_ to _release_version_:
-    * Minor version: Create new changelog file from [changelogs/head.asciidoc](https://github.com/elastic/apm-server/blob/master/changelogs/head.asciidoc)
+    * Minor version: Create new changelog file from [changelogs/head.asciidoc](https://github.com/elastic/apm-server/blob/main/changelogs/head.asciidoc)
       If changes should not be backported, keep them in the _changelogs/head.asciidoc_ file.
     * Patch version: Add new section to existing release notes. ([Sample PR](https://github.com/elastic/apm-server/pull/2064/files))
 
-    Create PR in `master` and backport.
+    Create PR in `main` and backport.
 
   * Run the [`check_changelogs.py`](script/check_changelogs.py) script to ensure changelogs are synced across branches. This will soon be a PR check.
   * Don't forget to update the "SUPPORTED_VERSIONS" to include a new branch if necessary.
@@ -37,16 +37,16 @@
   `go get github.com/elastic/go-elasticsearch/v$major@$major.$minor`
 
 * The following may also need to be updated manually:
-    * APM Overview's [release highlights](https://github.com/elastic/apm-server/blob/master/docs/guide/apm-release-notes.asciidoc) - Anything exciting across the APM stack!
-    * APM Overview's [breaking changes](https://github.com/elastic/apm-server/blob/master/docs/guide/apm-breaking-changes.asciidoc) - Any breaking changes across the APM stack.
-    * APM Server's [breaking changes](https://github.com/elastic/apm-server/blob/master/docs/breaking-changes.asciidoc) - Any APM Server breaking changes.
-    * APM Server's [upgrade guide](https://github.com/elastic/apm-server/blob/master/docs/upgrading.asciidoc).
+    * APM Overview's [release highlights](https://github.com/elastic/apm-server/blob/main/docs/guide/apm-release-notes.asciidoc) - Anything exciting across the APM stack!
+    * APM Overview's [breaking changes](https://github.com/elastic/apm-server/blob/main/docs/guide/apm-breaking-changes.asciidoc) - Any breaking changes across the APM stack.
+    * APM Server's [breaking changes](https://github.com/elastic/apm-server/blob/main/docs/breaking-changes.asciidoc) - Any APM Server breaking changes.
+    * APM Server's [upgrade guide](https://github.com/elastic/apm-server/blob/main/docs/upgrading.asciidoc).
 
-* For major releases, update and smoke test the dev quick start [`docker-compose.yml`](https://github.com/elastic/apm-server/blob/master/docs/guide/docker-compose.yml).
+* For major releases, update and smoke test the dev quick start [`docker-compose.yml`](https://github.com/elastic/apm-server/blob/main/docs/guide/docker-compose.yml).
 
 ## After feature freeze
 
-* Update [.mergify.yml](https://github.com/elastic/apm-server/blob/master/.mergify.yml) with a new backport rule for the next version.
+* Update [.mergify.yml](https://github.com/elastic/apm-server/blob/main/.mergify.yml) with a new backport rule for the next version.
 
 ## On release day
 
@@ -62,7 +62,7 @@
 
 ## When compatibility between Agents & Server changes
 
-* Update the [agent/server compatibility matrix](https://github.com/elastic/apm-server/blob/master/docs/guide/agent-server-compatibility.asciidoc).
+* Update the [agent/server compatibility matrix](https://github.com/elastic/apm-server/blob/main/docs/guide/agent-server-compatibility.asciidoc).
 
 ## Templates
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,7 +1,7 @@
 # APM Server-Testing
 
 ## Automated Testing
-The tests are built on top of the [Beats Test Framework](https://github.com/elastic/beats/blob/master/docs/devguide/testing.asciidoc), where you can find a detailed description on how to run the test suite.
+The tests are built on top of the [Beats Test Framework](https://github.com/elastic/beats/blob/main/docs/devguide/testing.asciidoc), where you can find a detailed description on how to run the test suite.
 
 ### Quick Overview
 
@@ -31,7 +31,7 @@ With your changes in the current working tree, do:
 ```
 $ go get -u golang.org/x/tools/cmd/benchcmp
 $ make bench > new.txt
-$ git checkout master
+$ git checkout main
 $ make bench > old.txt
 $ benchcmp old.txt new.txt
 ```

--- a/apmpackage/README.md
+++ b/apmpackage/README.md
@@ -22,11 +22,11 @@
    installed assets (ie. templates and pipelines), and the generated `apm` input in the policy.
     - If you need to change the package, you *must* remove the installed integration first. You can use the UI
     or the API, eg: `curl -X DELETE -u admin:changeme -H kbn-xsrf:true http://localhost:5601/api/fleet/epm/packages/apm-0.1.0`
-    See [API docs](https://github.com/elastic/kibana/tree/master/x-pack/plugins/fleet/dev_docs/api) for details.
+    See [API docs](https://github.com/elastic/kibana/tree/main/x-pack/plugins/fleet/dev_docs/api) for details.
     You normally don't need to restart the registry (an exception to this is eg. if you change a `hbs` template file).
 
 5. Upload to the snapshot registry
-    - When everything works and `apmpackage/apm/` changes have been merged to `master`, copy the new package to
+    - When everything works and `apmpackage/apm/` changes have been merged to `main`, copy the new package to
     `package-storage/packages/apm/<version>` in the `package-storage` repo, `snapshot` branch.
     Do *NOT* override any existing packages. Instead, bump the qualifier version (eg: `0.1.0-dev.1` to `0.1.0-dev.2`)
     both in the folder name and the content (`manifest.yml` and `default.json` pipelines)

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -1,4 +1,4 @@
 // This file exists to keep the current build working.
-// Delete this file when the APM Overview is no longer built in master and 7.16
+// Delete this file when the APM Overview is no longer built in main and 7.16
 
 include::../legacy/guide/index.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,4 @@
 // This file exists to keep the current build working.
-// Delete this file when the APM Server Reference is no longer built in master and 7.16
+// Delete this file when the APM Server Reference is no longer built in main and 7.16
 
 include::legacy/index.asciidoc[]

--- a/docs/integrations-index.asciidoc
+++ b/docs/integrations-index.asciidoc
@@ -9,7 +9,7 @@ include::./notices.asciidoc[]
 
 :github_repo_link: https://github.com/elastic/apm-server/blob/v{version}
 ifeval::["{version}" == "8.0.0"]
-:github_repo_link: https://github.com/elastic/apm-server/blob/master
+:github_repo_link: https://github.com/elastic/apm-server/blob/main
 endif::[]
 
 [[apm-user-guide]]

--- a/docs/legacy/index.asciidoc
+++ b/docs/legacy/index.asciidoc
@@ -41,7 +41,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 :github_repo_link: https://github.com/elastic/apm-server/blob/v{version}
 ifeval::["{version}" == "8.0.0"]
-:github_repo_link: https://github.com/elastic/apm-server/blob/master
+:github_repo_link: https://github.com/elastic/apm-server/blob/main
 endif::[]
 
 :downloads: https://artifacts.elastic.co/downloads/apm-server

--- a/docs/legacy/redirects.asciidoc
+++ b/docs/legacy/redirects.asciidoc
@@ -244,7 +244,7 @@ Loading dashboards from APM Server is no longer supported. Please see the {kiban
 Loading Kibana dashboards from APM Server is no longer supported.
 Please use the {kibana-ref}/xpack-apm.html[Kibana APM UI] instead.
 As an alternative, a small number of dashboards and visualizations are available in the
-https://github.com/elastic/apm-contrib/tree/master/kibana[apm-contrib] repository.
+https://github.com/elastic/apm-contrib/tree/main/kibana[apm-contrib] repository.
 
 // [role="exclude",id="rum"]
 // === Rum


### PR DESCRIPTION
## What does this PR do?

Rename `master` for `main` in:
- Jenkins pipelines
- JJBB files
- https://github.com/elastic/apm-server URLs with the `blob/master` reference
- https://github.com/elastic/beats URLs with the `blob/master` reference
- mergify

## Why is it important?

Neutral naming initiative

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## Related

Requires https://github.com/elastic/beats/pull/29710