### PR TITLE
docs: fix info API response

### DIFF
--- a/docs/api-info.asciidoc
+++ b/docs/api-info.asciidoc
@@ -19,23 +19,21 @@ This endpoint always returns an HTTP 200.
 
 If <<api-key>> or a <<secret-token>> is configured, requests to this endpoint must be authenticated.
 
-Set the `Accept` header set to `text/plain` to move the server information to the root level of the response, removing `ok`.
-
 [float]
 [[api-info-examples]]
 ==== Example
 
-Example server information request:
+Example APM Server information request:
 
 ["source","sh",subs="attributes"]
 ---------------------------------------------------------------------------
-curl http://127.0.0.1:8200/
+curl -X POST http://127.0.0.1:8200/ \
+  -H "Authorization: Bearer secret_token"
 
 {
-  "ok": {
-    "build_date": "2021-10-27T18:49:58Z",
-    "build_sha": "bc4d9a286a65b4283c2462404add86a26be61dca",
-    "version": "7.16.0"
-  }
+  "build_date": "2021-12-18T19:59:06Z",
+  "build_sha": "24fe620eeff5a19e2133c940c7e5ce1ceddb1445",
+  "publish_ready": true,
+  "version": "{version}"
 }
 ---------------------------------------------------------------------------

--- a/docs/legacy/server-info.asciidoc
+++ b/docs/legacy/server-info.asciidoc
@@ -25,23 +25,21 @@ This endpoint always returns an HTTP 200.
 
 If an <<api-key-legacy>> or <<secret-token-legacy>> is set, only requests including <<secure-communication-agents,authentication>> will receive server details.
 
-Set the `Accept` header set to `text/plain` to move the server information to the root level of the response, removing `ok`.
-
 [[server-info-examples]]
 [float]
 ==== Example
 
-Example server information request:
+Example APM Server information request:
 
 ["source","sh",subs="attributes"]
 ---------------------------------------------------------------------------
-curl http://127.0.0.1:8200/
+curl -X POST http://127.0.0.1:8200/ \
+  -H "Authorization: Bearer secret_token"
 
 {
-  "ok": {
-    "build_date": "2018-07-27T18:49:58Z",
-    "build_sha": "bc4d9a286a65b4283c2462404add86a26be61dca",
-    "version": "7.0.0-alpha1"
-  }
+  "build_date": "2021-12-18T19:59:06Z",
+  "build_sha": "24fe620eeff5a19e2133c940c7e5ce1ceddb1445",
+  "publish_ready": true,
+  "version": "{version}"
 }
 ---------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

Fixes the APM Server info API response by removing the enclosing `"ok": {...}` object. I've also update the example to use a secret token.

Thanks to @trentm for spotting this. It has apparently been wrong since https://github.com/elastic/apm-server/pull/1748.