### PR TITLE
Map `error.id` in error_logs data stream

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -6,7 +6,7 @@
     - description: Added field mapping for `faas.coldstart` and `faas.trigger.type`
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/7033
-    - desscription: added `error.id` field to `error_logs` data stream
+    - description: added `error.id` field to `error_logs` data stream
       type: bugfix
       link: https://github.com/elastic/apm-server/pull/7123
 - version: "8.0.0"

--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -6,6 +6,9 @@
     - description: Added field mapping for `faas.coldstart` and `faas.trigger.type`
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/7033
+    - desscription: added `error.id` field to `error_logs` data stream
+      type: bugfix
+      link: https://github.com/elastic/apm-server/pull/7123
 - version: "8.0.0"
   changes:
     - description: support setting `download-agent-version`

--- a/apmpackage/apm/data_stream/error_logs/fields/ecs.yml
+++ b/apmpackage/apm/data_stream/error_logs/fields/ecs.yml
@@ -57,6 +57,8 @@
 - external: ecs
   name: ecs.version
 - external: ecs
+  name: error.id
+- external: ecs
   name: event.outcome
 - external: ecs
   name: host.architecture


### PR DESCRIPTION
## Motivation/summary

Add the `error.id` field to `logs-apm.error-*` data streams mapping. This field was accidentally omitted when migrating from beats fields.yml to the integration package.

## Checklist


~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/master/CHANGELOG.asciidoc)~
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/master/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
~- [ ] Documentation has been updated~

## How to test these changes

1. Install APM integration
2. Send error events, e.g. using the Go agent's API
3. Navigate to the errors page in the APM UI, click on an error instance, and click the "metadata" tab

Error metadata tab should open without any issues.

## Related issues

Closes https://github.com/elastic/apm-server/issues/7122