### PR TITLE
[automation] update elastic stack version for testing 8.0.0-09bea260

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       fleet-server: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-f8220c88-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.0.0-09bea260-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -39,7 +39,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.0.0-f8220c88-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.0.0-09bea260-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -63,7 +63,7 @@ services:
       package-registry: { condition: service_healthy }
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:8.0.0-f8220c88-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:8.0.0-09bea260-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Tue, 1 Feb 2022 00:14:42 GMT, release_branch:8.0, prefix:, end_time:Tue, 1 Feb 2022 04:58:46 GMT, manifest_version:2.0.0, version:8.0.0-SNAPSHOT, branch:8.0, build_id:8.0.0-09bea260, build_duration_seconds:17044]