### PR TITLE
ci: schedule daily job

### DIFF
--- a/.ci/jobs/apm-server-schedule-daily.yml
+++ b/.ci/jobs/apm-server-schedule-daily.yml
@@ -7,7 +7,7 @@
     parameters:
       - string:
           name: branch_specifier
-          default: master
+          default: main
           description: the Git branch specifier to build
     pipeline-scm:
       script-path: .ci/schedule-daily.groovy

--- a/.ci/jobs/apm-server-schedule-daily.yml
+++ b/.ci/jobs/apm-server-schedule-daily.yml
@@ -1,0 +1,26 @@
+---
+- job:
+    name: apm-server-schedule-daily
+    display-name: Jobs scheduled daily (weekdays)
+    description: Jobs scheduled daily (weekdays)
+    project-type: pipeline
+    parameters:
+      - string:
+          name: branch_specifier
+          default: master
+          description: the Git branch specifier to build
+    pipeline-scm:
+      script-path: .ci/schedule-daily.groovy
+      scm:
+        - git:
+            url: git@github.com:elastic/apm-server.git
+            refspec: +refs/heads/*:refs/remotes/origin/*
+            wipe-workspace: 'True'
+            name: origin
+            shallow-clone: true
+            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+            reference-repo: /var/lib/jenkins/.git-references/apm-server.git
+            branches:
+              - $branch_specifier
+    triggers:
+      - timed: 'H H(2-3) * * 1-5'

--- a/.ci/jobs/apm-server-schedule-daily.yml
+++ b/.ci/jobs/apm-server-schedule-daily.yml
@@ -1,6 +1,6 @@
 ---
 - job:
-    name: apm-server-schedule-daily
+    name: apm-server/apm-server-schedule-daily
     display-name: Jobs scheduled daily (weekdays)
     description: Jobs scheduled daily (weekdays)
     project-type: pipeline

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -20,7 +20,7 @@ pipeline {
   stages {
     stage('Nighly update Beats builds') {
       steps {
-        updateBeatsBuilds(quietPeriodFactor: 2000, branches: ['master', '8.<minor>', '7.<minor>', '7.<next-minor>'])
+        updateBeatsBuilds(branches: ['master', '8.<minor>', '7.<minor>', '7.<next-minor>'])
       }
     }
   }

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -20,7 +20,7 @@ pipeline {
   stages {
     stage('Nighly update Beats builds') {
       steps {
-        updateBeatsBuilds(branches: ['master', '8.<minor>', '7.<minor>', '7.<next-minor>'])
+        updateBeatsBuilds(branches: ['main', '8.<minor>', '7.<minor>', '7.<next-minor>'])
       }
     }
   }

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -1,0 +1,63 @@
+@Library('apm@current') _
+
+pipeline {
+  agent none
+  environment {
+    NOTIFY_TO = credentials('notify-to')
+    PIPELINE_LOG_LEVEL = 'INFO'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  triggers {
+    cron('H H(2-3) * * 1-5')
+  }
+  stages {
+    stage('Nighly update Beats builds') {
+      steps {
+        updateBeatsBuilds(quietPeriodFactor: 2000, branches: ['master', '8.<minor>', '7.<minor>', '7.<next-minor>'])
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult(prComment: false)
+    }
+  }
+}
+
+def updateBeatsBuilds(Map args = [:]) {
+  def branches = []
+  // Expand macros and filter duplicated matches.
+  args.branches.each { branch ->
+    def branchName = getBranchName(branch)
+    if (!branches.contains(branchName)) {
+      branches << branchName
+    }
+  }
+  branches.each { branch ->
+    build(job: "apm-server/update-beats-mbp/${branch}", wait: false, propagate: false)
+  }
+}
+
+def getBranchName(branch) {
+  // special macro to look for the latest minor version
+  if (branch.contains('8.<minor>')) {
+   return bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor8())
+  }
+  if (branch.contains('8.<next-minor>')) {
+    return bumpUtils.getMajorMinor(bumpUtils.getNextMinorReleaseFor8())
+  }
+  if (branch.contains('7.<minor>')) {
+    return bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor7())
+  }
+  if (branch.contains('7.<next-minor>')) {
+    return bumpUtils.getMajorMinor(bumpUtils.getNextMinorReleaseFor7())
+  }
+  return branch
+}

--- a/.ci/update-beats.groovy
+++ b/.ci/update-beats.groovy
@@ -30,10 +30,6 @@ pipeline {
     JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
     PIPELINE_LOG_LEVEL = 'INFO'
   }
-  triggers {
-    // Only master branch will run on a timer basis
-    cron(env.BRANCH_NAME == 'master' ? 'H H(4-5) * * 1,5' : '')
-  }
   options {
     timeout(time: 1, unit: 'HOURS')
     buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '5'))


### PR DESCRIPTION
## Motivation/summary

Dynamically trigger jobs related to the update-beats automation. This approach uses the active branches detection, therefore we won't need to do much as older branches won't trigger any extra builds.


I'll wait for the renaming branch that happens today