### PR TITLE
systemtest: fix runapm -var flag

### DIFF
--- a/systemtest/cmd/runapm/main.go
+++ b/systemtest/cmd/runapm/main.go
@@ -42,7 +42,7 @@ var (
 	force     bool
 	keep      bool
 	namespace string
-	vars      varsFlag
+	vars      = make(varsFlag)
 )
 
 func init() {


### PR DESCRIPTION
Fix runapm's `-var` flag: initialise the map, so using the flag doesn't panic.