### PR TITLE
runapm: make policy name and reinstall flags

### DIFF
--- a/systemtest/cmd/runapm/main.go
+++ b/systemtest/cmd/runapm/main.go
@@ -34,20 +34,23 @@ import (
 )
 
 const (
-	policyName        = "runapm"
 	policyDescription = "policy created by apm-server/systemtest/cmd/runapm"
 )
 
 var (
-	force     bool
-	keep      bool
-	namespace string
-	vars      = make(varsFlag)
+	force            bool
+	reinstallPackage bool
+	keep             bool
+	policyName       string
+	namespace        string
+	vars             = make(varsFlag)
 )
 
 func init() {
+	flag.StringVar(&policyName, "policy", "runapm", "Agent policy name")
 	flag.StringVar(&namespace, "namespace", "default", "Agent policy namespace")
 	flag.BoolVar(&force, "f", false, "Force agent policy creation, deleting existing policy if found")
+	flag.BoolVar(&reinstallPackage, "reinstall", true, "Reinstall APM integration package")
 	flag.BoolVar(&keep, "keep", false, "If true, agent policy and agent will not be destroyed on exit")
 	flag.Var(vars, "var", "Define a package var (k=v), with values being YAML-encoded; can be specified more than once")
 }
@@ -99,7 +102,7 @@ func Main() error {
 			}
 		}
 	}
-	if err := systemtest.InitFleet(); err != nil {
+	if err := systemtest.InitFleetPackage(reinstallPackage); err != nil {
 		return err
 	}
 

--- a/systemtest/kibana.go
+++ b/systemtest/kibana.go
@@ -88,7 +88,13 @@ func InitFleet() error {
 	if err := DestroyAgentPolicy(ids...); err != nil {
 		return fmt.Errorf("failed to destroy agent policy: %w", err)
 	}
+	return InitFleetPackage(true)
+}
 
+// InitFleetPackage installs or reinstalls the APM integration package, and
+// sets IntegrationPackage to the install package. InitFleetPackage assumes
+// that Fleet has been set up already.
+func InitFleetPackage(reinstall bool) error {
 	packages, err := Fleet.ListPackages()
 	if err != nil {
 		return err
@@ -104,6 +110,9 @@ func InitFleet() error {
 			return err
 		}
 		if IntegrationPackage.Status == "installed" {
+			if !reinstall {
+				return nil
+			}
 			if err := Fleet.DeletePackage(pkg.Name, pkg.Version); err != nil {
 				return fmt.Errorf(
 					"failed to delete package %s-%s: %w",
@@ -116,7 +125,11 @@ func InitFleet() error {
 	if IntegrationPackage == nil {
 		return errors.New("could not find package 'apm'")
 	}
-	return Fleet.InstallPackage(IntegrationPackage.Name, IntegrationPackage.Version)
+	if err := Fleet.InstallPackage(IntegrationPackage.Name, IntegrationPackage.Version); err != nil {
+		return err
+	}
+	IntegrationPackage, err = Fleet.Package(IntegrationPackage.Name, IntegrationPackage.Version)
+	return err
 }
 
 // CreateAgentPolicy creates an Agent policy with the given name and namespace,


### PR DESCRIPTION
Make the policy name configurable, and make reinstallation of the APM integration package optional, through additional CLI flags.

This makes it possible to run multiple agents, each with their own integration policy. This can be useful when multiple APM Servers are required, e.g. for tail-based sampling.