### PR TITLE
docs: How to monitor Agent-managed APM Server

### DIFF
--- a/docs/how-to.asciidoc
+++ b/docs/how-to.asciidoc
@@ -5,12 +5,15 @@ Learn how to perform common APM configuration and management tasks.
 
 * <<source-map-how-to>>
 * <<jaeger-integration>>
+* <<monitor-apm>>
 * <<ingest-pipelines>>
 * <<custom-index-template>>
 
 include::./source-map-how-to.asciidoc[]
 
 include::./jaeger-integration.asciidoc[]
+
+include::./monitor.asciidoc[]
 
 include::./ingest-pipelines.asciidoc[]
 

--- a/docs/monitor.asciidoc
+++ b/docs/monitor.asciidoc
@@ -1,0 +1,207 @@
+[[monitor-apm]]
+=== Monitor APM Server
+
+Use the {stack} {monitor-features} to gain insight into the real-time health and performance of APM Server.
+Stack monitoring exposes key metrics, like intake response count, intake error rate, output event rate,
+output failed event rate, and more.
+
+[float]
+[[monitor-apm-cloud]]
+=== Monitor APM running on {ecloud}
+
+{ecloud} manages the installation and configuration of a monitoring agent for you -- so
+all you have to do is flip a switch and watch the data pour in.
+
+* **{ess}** user? See {ece-ref}/ece-enable-logging-and-monitoring.html[ESS: Enable logging and monitoring].
+* **{ece}** user? See {cloud}/ec-enable-logging-and-monitoring.html[ECE: Enable logging and monitoring].
+
+[float]
+[[monitor-apm-self-install]]
+=== Monitor a self-installation of APM
+
+NOTE: This guide assumes you are already ingesting APM data into the {stack}.
+
+In 8.0 and later, you can use {metricbeat} to collect data about APM Server and ship it to a monitoring cluster.
+To collect and ship monitoring data:
+
+. <<configure-ea-monitoring-data>>
+. <<install-config-metricbeat>>
+
+[float]
+[[configure-ea-monitoring-data]]
+==== Configure {agent} to send monitoring data
+
+. Enable monitoring of {agent} by adding the following settings to your `elastic-agent.yml` configuration file:
++
+--
+[source,yaml]
+----
+agent.monitoring:
+  http:
+    enabled: true <1>
+    host: localhost <2>
+    port: 6791 <3>
+----
+<1> Enable monitoring
+<2> The host to expose logs/metrics on
+<3> The port to expose logs/metrics on
+--
+
+. Stop {agent}
++
+If {agent} is already running, you must stop it.
+Use the command that work with your system:
++
+--
+include::{obs-repo-dir}/ingest-management/tab-widgets/stop-widget.asciidoc[]
+--
+
+. Start {agent}
++
+Use the command that work with your system:
++
+--
+include::{obs-repo-dir}/ingest-management/tab-widgets/start-widget.asciidoc[]
+--
+
+[float]
+[[install-config-metricbeat]]
+==== Install and configure {metricbeat} to collect monitoring data
+
+. Install {metricbeat} on the same server as {agent}. To learn how, see
+{metricbeat-ref}/metricbeat-installation-configuration.html[Get started with {metricbeat}].
+If you already have {metricbeat} installed, skip this step.
+
+. Enable the `beat-xpack` module in {metricbeat}.
++
+--
+For example, to enable the default configuration in the `modules.d` directory,
+run the following command, using the correct command syntax for your OS:
+
+["source","sh",subs="attributes,callouts"]
+----
+metricbeat modules enable beat-xpack
+----
+
+For more information, see
+{metricbeat-ref}/configuration-metricbeat.html[Configure modules] and
+{metricbeat-ref}/metricbeat-module-beat.html[beat module].
+--
+
+. Configure the `beat-xpack` module in {metricbeat}.
++
+--
+When complete, your `modules.d/beat-xpack.yml` file should look similar to this:
+
+[source,yaml]
+----
+- module: beat
+  xpack.enabled: true
+  period: 10s
+  hosts: ["http://localhost:6791"]
+  basepath: "/processes/apm-server-default"
+  username: remote_monitoring_user
+  password: your_password
+----
+
+.. Do not change the  `module` name or `xpack.enabled` boolean;
+these are required for stack monitoring. We recommend accepting the default `period` for now.
+
+.. Set the `hosts` to match the host:port configured in your `elastic-agent.yml` file.
+In this example, that's `http://localhost:6791`.
++
+To monitor multiple APM Server instances running in multiple {agent}s, specify a list of hosts, for example:
++
+[source,yaml]
+----
+hosts: ["http://localhost:5066","http://localhost:5067","http://localhost:5068"]
+----
++
+If you configured {agent} to use encrypted communications, you must access
+it via HTTPS. For example, use a `hosts` setting like `https://localhost:5066`.
+
+.. APM Server metrics are exposed at `/processes/apm-server-default`. Add this location as the `basepath`.
+
+.. Set the `username` and `password` settings as required by your
+environment. If Elastic {security-features} are enabled, you must provide a username
+and password so that {metricbeat} can collect metrics successfully:
+
+... Create a user on the {es} cluster that has the
+`remote_monitoring_collector` {ref}/built-in-roles.html[built-in role].
+Alternatively, if it's available in your environment, use the
+`remote_monitoring_user` {ref}/built-in-users.html[built-in user].
+
+... Add the `username` and `password` settings to the beat module configuration
+file.
+--
+
+. Optional: Disable the system module in the {metricbeat}.
++
+--
+By default, the {metricbeat-ref}/metricbeat-module-system.html[system module] is
+enabled. The information it collects, however, is not shown on the
+*Stack Monitoring* page in {kib}. Unless you want to use that information for
+other purposes, run the following command:
+
+["source","sh",subs="attributes,callouts"]
+----
+metricbeat modules disable system
+----
+--
+
+. Identify where to send the monitoring data. +
++
+--
+TIP: In production environments, you should send your deployment logs and metrics to a dedicated
+monitoring deployment (referred to as the _monitoring cluster_).
+Monitoring indexes logs and metrics into {es} and these indexes consume storage, memory,
+and CPU cycles like any other index.
+By using a separate monitoring deployment, you avoid affecting your other production deployments and can
+view the logs and metrics even when a production deployment is unavailable.
+
+For example, specify the {es} output information in the {metricbeat}
+configuration file (`metricbeat.yml`):
+
+[source,yaml]
+----
+output.elasticsearch:
+  # Array of hosts to connect to.
+  hosts: ["http://es-mon-1:9200", "http://es-mon2:9200"] <1>
+
+  # Optional protocol and basic auth credentials.
+  #protocol: "https"
+  #api_key:  "id:api_key" <2>
+  #username: "elastic"
+  #password: "changeme"
+----
+<1> In this example, the data is stored on a monitoring cluster with nodes
+`es-mon-1` and `es-mon-2`.
+<2> Specify one of `api_key` or `username`/`password`.
+
+If you configured the monitoring cluster to use encrypted communications, you
+must access it via HTTPS. For example, use a `hosts` setting like
+`https://es-mon-1:9200`.
+
+IMPORTANT: The {es} {monitor-features} use ingest pipelines, therefore the
+cluster that stores the monitoring data must have at least one ingest node.
+
+If the {es} {security-features} are enabled on the monitoring cluster, you
+must provide a valid user ID and password so that {metricbeat} can send metrics
+successfully:
+
+.. Create a user on the monitoring cluster that has the
+`remote_monitoring_agent` {ref}/built-in-roles.html[built-in role].
+Alternatively, if it's available in your environment, use the
+`remote_monitoring_user` {ref}/built-in-users.html[built-in user].
+
+.. Add the `username` and `password` settings to the {es} output information in
+the {metricbeat} configuration file.
+
+For more information about these configuration options, see
+{metricbeat-ref}/elasticsearch-output.html[Configure the {es} output].
+--
+
+. {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}] to begin
+collecting monitoring data.
+
+. {kibana-ref}/monitoring-data.html[View the monitoring data in {kib}].


### PR DESCRIPTION
Documents how to enable Stack Monitoring with agent-managed apm-server.

Closes https://github.com/elastic/apm-server/issues/5987.