### PR TITLE
systemtest: unskip TestTailSampling

### DIFF
--- a/systemtest/sampling_test.go
+++ b/systemtest/sampling_test.go
@@ -90,8 +90,6 @@ func TestDropUnsampled(t *testing.T) {
 }
 
 func TestTailSampling(t *testing.T) {
-	// We should remove the skip once the issue is resolved.
-	t.Skip("Skipped due: https://github.com/elastic/fleet-server/issues/1048")
 	systemtest.CleanupElasticsearch(t)
 
 	apmIntegration1 := newAPMIntegration(t, map[string]interface{}{


### PR DESCRIPTION
Unskip systemtest.TestTailSampling, as the privileges issue (https://github.com/elastic/fleet-server/issues/1048) has been fixed.