### PR TITLE
Fix update-beats CI job for 7.17

### DIFF
--- a/.ci/scripts/update-beats.sh
+++ b/.ci/scripts/update-beats.sh
@@ -11,7 +11,7 @@ COMMIT_MESSAGE="Update to elastic/beats@$(go list -m -f {{.Version}} github.com/
 git checkout -b "update-beats-$(date "+%Y%m%d%H%M%S")"
 git add --ignore-errors go.mod go.sum NOTICE.txt \
 	.go-version docs/version.asciidoc \
-	docs/fields.asciidoc include/fields.go x-pack/apm-server/include/fields.go
+	include/fields.go x-pack/apm-server/include/fields.go
 
 find . -maxdepth 2 -name Dockerfile -exec git add {} \;
 


### PR DESCRIPTION
Slight variation on https://github.com/elastic/apm-server/pull/7178 (keeps include/fields.go)