### PR TITLE
docs: remove Homebrew

### DIFF
--- a/docs/legacy/copied-from-beats/docs/shared-directory-layout.asciidoc
+++ b/docs/legacy/copied-from-beats/docs/shared-directory-layout.asciidoc
@@ -102,20 +102,6 @@ ifndef::win_only[]
 
 endif::win_only[]
 
-ifdef::mac_os[]
-[float]
-===== brew
-[cols="<h,<,<m",options="header",]
-|=======================================================================
-| Type   | Description | Location
-| home   | Home of the {beatname_uc} installation. | /usr/local/var/homebrew/linked/{beatname_lc}-full
-| bin    | The location for the binary files. | /usr/local/var/homebrew/linked/{beatname_lc}-full/bin
-| config | The location for configuration files. | /usr/local/etc/{beatname_lc}
-| data   | The location for persistent data files. | /usr/local/var/lib/{beatname_lc}
-| logs   | The location for the logs created by {beatname_uc}. | /usr/local/var/log/{beatname_lc}
-|=======================================================================
-endif::mac_os[]
-
 ifdef::win_only[]
 
 ["source","sh",subs="attributes"]

--- a/docs/legacy/getting-started-apm-server.asciidoc
+++ b/docs/legacy/getting-started-apm-server.asciidoc
@@ -182,34 +182,6 @@ For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-servi
 
 endif::[]
 
-[[brew]]
-*Homebrew:*
-
-ifeval::["{release-state}"=="unreleased"]
-
-Version {version} of APM Server has not yet been released.
-
-endif::[]
-
-ifeval::["{release-state}"!="unreleased"]
-
-You can install the Elastic Stack, including APM Server, on macOS with the
-https://brew.sh/[Homebrew] package manager. First, tap the Elastic Homebrew repository:
-
-[source,sh]
--------------------------
-brew tap elastic/tap
--------------------------
-
-Next, use `brew install` to install APM Server:
-
-[source,sh]
--------------------------
-brew install elastic/tap/apm-server-full
--------------------------
-
-endif::[]
-
 [[docker]]
 *Docker:*
 
@@ -331,24 +303,6 @@ sudo -u apm-server apm-server [<argument...>]
 
 By default, APM Server loads its configuration file from `/etc/apm-server/apm-server.yml`.
 See the <<_deb_and_rpm,deb & rpm default paths>> for a full directory layout.
-
-[float]
-[[running-brew]]
-==== Brew
-
-To start APM Server, run:
-
-["source","sh"]
------
-apm-server -e
------
-
-To have launchd start APM Server and restart it at login, run:
-
-["source","sh"]
------
-brew services start elastic/tap/apm-server-full
------
 
 // *******************************************************
 // STEP 4


### PR DESCRIPTION
### Summary

Removes Homebrew documentation. A breaking change has been added to https://github.com/elastic/apm-server/pull/7202.