### PR TITLE
Set `<event>.duration.us` field in ingest pipeline

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -3,9 +3,9 @@
 # change type can be one of: enhancement, bugfix, breaking-change
 - version: "8.2.0"
   changes:
-    - description: Placeholder
+    - description: updated traces and rum_traces ingest pipelines to translate `event.duration` to `<event>.duration.us`
       type: enhancement
-      link: https://github.com/elastic/apm-server/pull/123
+      link: https://github.com/elastic/apm-server/pull/7261
 - version: "8.1.0"
   changes:
     - description: Added field mapping for `faas.coldstart` and `faas.trigger.type`

--- a/apmpackage/apm/data_stream/rum_traces/elasticsearch/ingest_pipeline/default.yml
+++ b/apmpackage/apm/data_stream/rum_traces/elasticsearch/ingest_pipeline/default.yml
@@ -7,6 +7,8 @@ processors:
       name: user_agent
   - pipeline:
       name: client_geoip
+  - pipeline:
+      name: event_duration
   - remove:
       # Remove some metadata from spans that is available in the parent transaction, to cut down on storage costs.
       if: ctx.processor?.event == 'span'

--- a/apmpackage/apm/data_stream/traces/elasticsearch/ingest_pipeline/default.yml
+++ b/apmpackage/apm/data_stream/traces/elasticsearch/ingest_pipeline/default.yml
@@ -7,6 +7,8 @@ processors:
       name: user_agent
   - pipeline:
       name: client_geoip
+  - pipeline:
+      name: event_duration
   - remove:
       # Remove some metadata from spans that is available in the parent transaction, to cut down on storage costs.
       if: ctx.processor?.event == 'span'

--- a/apmpackage/cmd/genpackage/pipelines.go
+++ b/apmpackage/cmd/genpackage/pipelines.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/elastic/beats/v7/libbeat/common"
 )
@@ -38,6 +39,7 @@ func getCommonPipeline(name string, version *common.Version) []map[string]interf
 		"observer_version": getObserverVersionPipeline(version),
 		"user_agent":       userAgentPipeline,
 		"client_geoip":     clientGeoIPPipeline,
+		"event_duration":   eventDurationPipeline,
 	}
 	return commonPipelines[name]
 }
@@ -107,5 +109,24 @@ var clientGeoIPPipeline = []map[string]interface{}{{
 				"ignore_failure": true,
 			},
 		}},
+	},
+}}
+
+// TODO(axw) remove this pipeline when we are ready to migrate the UI to
+// `event.duration`. See https://github.com/elastic/apm-server/issues/5999.
+var eventDurationPipeline = []map[string]interface{}{{
+	"script": map[string]interface{}{
+		"if": "ctx.processor?.event != null && ctx.get(ctx.processor.event) != null",
+		"source": strings.TrimSpace(`
+def durationNanos = ctx.event?.duration ?: 0;
+def eventType = ctx.processor.event;
+ctx.get(ctx.processor.event).duration = ["us": (int)(durationNanos/1000)];
+`),
+	},
+}, {
+	"remove": map[string]interface{}{
+		"field":          "event.duration",
+		"ignore_missing": true,
+		"ignore_failure": true,
 	},
 }}

--- a/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
@@ -311,6 +311,7 @@
                 "version": "1.12.0"
             },
             "event": {
+                "duration": 3781912,
                 "outcome": "success"
             },
             "host": {
@@ -413,9 +414,6 @@
                         "name": "postgres"
                     }
                 },
-                "duration": {
-                    "us": 3781
-                },
                 "id": "1234567890aaaade",
                 "name": "GET users-authenticated",
                 "stacktrace": [
@@ -480,6 +478,7 @@
                 "version": "1.12.0"
             },
             "event": {
+                "duration": 32592981,
                 "outcome": "success"
             },
             "host": {
@@ -627,9 +626,6 @@
                     },
                     "my_key": 1,
                     "some_other_value": "foobar"
-                },
-                "duration": {
-                    "us": 32592
                 },
                 "id": "4340a8e0df1906ecbfa9",
                 "name": "ResourceHttpRequestHandler",

--- a/beater/test_approved_es_documents/TestPublishIntegrationMinimalEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationMinimalEvents.approved.json
@@ -142,6 +142,7 @@
                 "version": "1.12.0"
             },
             "event": {
+                "duration": 3564298,
                 "outcome": "unknown"
             },
             "host": {
@@ -166,9 +167,6 @@
                 "name": "1234_service-12a3"
             },
             "span": {
-                "duration": {
-                    "us": 3564
-                },
                 "id": "0123456a89012345",
                 "name": "GET /api/types",
                 "type": "request"
@@ -193,6 +191,7 @@
                 "version": "1.12.0"
             },
             "event": {
+                "duration": 3564298,
                 "outcome": "unknown"
             },
             "host": {
@@ -217,9 +216,6 @@
                 "name": "1234_service-12a3"
             },
             "span": {
-                "duration": {
-                    "us": 3564
-                },
                 "id": "0123456a89012345",
                 "name": "GET /api/types",
                 "type": "request"
@@ -244,6 +240,7 @@
                 "version": "1.12.0"
             },
             "event": {
+                "duration": 32592981,
                 "outcome": "unknown"
             },
             "host": {
@@ -274,9 +271,6 @@
                 "id": "01234567890123456789abcdefabcdef"
             },
             "transaction": {
-                "duration": {
-                    "us": 32592
-                },
                 "id": "abcdef1478523690",
                 "sampled": true,
                 "span_count": {

--- a/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json
@@ -44,6 +44,7 @@
                 "version": "1.12.0"
             },
             "event": {
+                "duration": 141581000,
                 "outcome": "success"
             },
             "host": {
@@ -115,9 +116,6 @@
             },
             "span": {
                 "action": "query.custom",
-                "duration": {
-                    "us": 141581
-                },
                 "id": "abcdef01234567",
                 "name": "GET /api/types",
                 "subtype": "postgresql",
@@ -178,6 +176,7 @@
                 "version": "1.12.0"
             },
             "event": {
+                "duration": 32592981,
                 "outcome": "unknown"
             },
             "host": {
@@ -248,9 +247,6 @@
                 "version": "5.1.3"
             },
             "span": {
-                "duration": {
-                    "us": 32592
-                },
                 "id": "1234abcdef567895",
                 "name": "GET /api/types",
                 "type": "request"
@@ -310,6 +306,7 @@
                 "version": "1.12.0"
             },
             "event": {
+                "duration": 3564298,
                 "outcome": "unknown"
             },
             "host": {
@@ -384,9 +381,6 @@
                 "version": "5.1.3"
             },
             "span": {
-                "duration": {
-                    "us": 3564
-                },
                 "id": "0123456a89012345",
                 "name": "GET /api/types",
                 "subtype": "http",
@@ -447,6 +441,7 @@
                 "version": "1.12.0"
             },
             "event": {
+                "duration": 13980298,
                 "outcome": "unknown"
             },
             "host": {
@@ -518,9 +513,6 @@
             },
             "span": {
                 "action": "call",
-                "duration": {
-                    "us": 13980
-                },
                 "id": "abcde56a89012345",
                 "name": "get /api/types",
                 "subtype": "http",
@@ -585,6 +577,7 @@
                 "version": "1.12.0"
             },
             "event": {
+                "duration": 3781912,
                 "outcome": "success"
             },
             "host": {
@@ -683,9 +676,6 @@
                         "resource": "postgresql",
                         "type": "db"
                     }
-                },
-                "duration": {
-                    "us": 3781
                 },
                 "id": "1234567890aaaade",
                 "name": "SELECT FROM product_types",
@@ -801,6 +791,7 @@
                 "version": "1.12.0"
             },
             "event": {
+                "duration": 141581000,
                 "outcome": "unknown"
             },
             "host": {
@@ -872,9 +863,6 @@
             },
             "span": {
                 "action": "receive",
-                "duration": {
-                    "us": 141581
-                },
                 "id": "00xxx12312312312",
                 "message": {
                     "age": {
@@ -944,6 +932,7 @@
                 "version": "1.12.0"
             },
             "event": {
+                "duration": 378191200,
                 "outcome": "success"
             },
             "host": {
@@ -1021,9 +1010,6 @@
                     "sum": {
                         "us": 359298
                     }
-                },
-                "duration": {
-                    "us": 378191
                 },
                 "id": "abcdef01234567",
                 "name": "SELECT FROM p_details",

--- a/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationTransactions.approved.json
@@ -39,6 +39,7 @@
                 "version": "1.12.0"
             },
             "event": {
+                "duration": 32592981,
                 "outcome": "unknown"
             },
             "host": {
@@ -121,9 +122,6 @@
                 "id": "0123456789abcdef0123456789abcdef"
             },
             "transaction": {
-                "duration": {
-                    "us": 32592
-                },
                 "id": "945254c567a5417e",
                 "sampled": true,
                 "span_count": {
@@ -179,6 +177,7 @@
                 "version": "1.12.0"
             },
             "event": {
+                "duration": 32592981,
                 "outcome": "success"
             },
             "host": {
@@ -329,9 +328,6 @@
                     "my_key": 1,
                     "some_other_value": "foo bar"
                 },
-                "duration": {
-                    "us": 32592
-                },
                 "id": "4340a8e0df1906ecbfa9",
                 "name": "GET /api/types",
                 "result": "success",
@@ -400,6 +396,7 @@
                 "version": "1.12.0"
             },
             "event": {
+                "duration": 13980558,
                 "outcome": "unknown"
             },
             "host": {
@@ -484,9 +481,6 @@
                 "id": "0acd456789abcdef0123456789abcdef"
             },
             "transaction": {
-                "duration": {
-                    "us": 13980
-                },
                 "experience": {
                     "cls": 1,
                     "fid": 2,
@@ -560,6 +554,7 @@
                 "version": "1.12.0"
             },
             "event": {
+                "duration": 3000000,
                 "outcome": "unknown"
             },
             "host": {
@@ -646,9 +641,6 @@
                 "id": "0123456789abcdef0123456789abcdef"
             },
             "transaction": {
-                "duration": {
-                    "us": 3000
-                },
                 "id": "00xxxxFFaaaa1234",
                 "message": {
                     "age": {
@@ -727,6 +719,7 @@
                 "version": "1.12.0"
             },
             "event": {
+                "duration": 38853000,
                 "outcome": "unknown"
             },
             "faas": {
@@ -817,9 +810,6 @@
                 "id": "eb56529a1f461c5e7e2f66ecb075e983"
             },
             "transaction": {
-                "duration": {
-                    "us": 38853
-                },
                 "id": "142e61450efb8574",
                 "name": "july-2021-delete-after-july-31",
                 "result": "success",

--- a/beater/test_approved_es_documents/TestPublishIntegrationTransactionsHugeTraces.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationTransactionsHugeTraces.approved.json
@@ -42,6 +42,7 @@
                 "version": "1.12.0"
             },
             "event": {
+                "duration": 32592981,
                 "outcome": "success"
             },
             "host": {
@@ -191,9 +192,6 @@
                     },
                     "my_key": 1,
                     "some_other_value": "foo bar"
-                },
-                "duration": {
-                    "us": 32592
                 },
                 "id": "ddf109a4c4aa5f2b6e984548ca57774c",
                 "name": "GET /api/types",

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -9,6 +9,7 @@ See <<apm-server-configuration>> for more information.
 
 [float]
 ==== Breaking Changes
+- APM Server now emits events with `event.duration`, and renames the field to `<event>.duration.us` in an ingest pipeline {pull}7261[7261]
 
 [float]
 ==== Bug fixes

--- a/model/apmevent.go
+++ b/model/apmevent.go
@@ -91,20 +91,22 @@ func (e *APMEvent) BeatEvent(ctx context.Context) beat.Event {
 		Timestamp: e.Timestamp,
 		Fields:    make(common.MapStr),
 	}
+	fields := (*mapStr)(&event.Fields)
+
 	if e.Transaction != nil {
-		e.Transaction.setFields((*mapStr)(&event.Fields), e)
+		fields.maybeSetMapStr("transaction", e.Transaction.fields())
 	}
 	if e.Span != nil {
-		e.Span.setFields((*mapStr)(&event.Fields), e)
+		fields.maybeSetMapStr("span", e.Span.fields())
 	}
 	if e.Metricset != nil {
 		e.Metricset.setFields((*mapStr)(&event.Fields))
 	}
 	if e.Error != nil {
-		e.Error.setFields((*mapStr)(&event.Fields))
+		fields.maybeSetMapStr("error", e.Error.fields())
 	}
 	if e.ProfileSample != nil {
-		e.ProfileSample.setFields((*mapStr)(&event.Fields))
+		fields.maybeSetMapStr("profile", e.ProfileSample.fields())
 	}
 
 	// Set high resolution timestamp.
@@ -118,7 +120,6 @@ func (e *APMEvent) BeatEvent(ctx context.Context) beat.Event {
 	}
 
 	// Set top-level field sets.
-	fields := (*mapStr)(&event.Fields)
 	event.Timestamp = e.Timestamp
 	e.DataStream.setFields(fields)
 	if e.ECSVersion != "" {

--- a/model/apmevent_test.go
+++ b/model/apmevent_test.go
@@ -46,6 +46,7 @@ func TestAPMEventFields(t *testing.T) {
 	httpRequestMethod := "post"
 	httpRequestBody := "<html><marquee>hello world</marquee></html>"
 	coldstart := true
+	eventDuration := time.Microsecond
 
 	for _, test := range []struct {
 		input  APMEvent
@@ -77,7 +78,7 @@ func TestAPMEventFields(t *testing.T) {
 			Destination: Destination{Address: destinationAddress, Port: destinationPort},
 			Process:     Process{Pid: pid},
 			User:        User{ID: uid, Email: mail},
-			Event:       Event{Outcome: outcome},
+			Event:       Event{Outcome: outcome, Duration: eventDuration},
 			Session:     Session{ID: "session_id"},
 			URL:         URL{Original: "url"},
 			Labels: map[string]LabelValue{
@@ -143,7 +144,7 @@ func TestAPMEventFields(t *testing.T) {
 				"ip":      destinationAddress,
 				"port":    destinationPort,
 			},
-			"event":   common.MapStr{"outcome": outcome},
+			"event":   common.MapStr{"outcome": outcome, "duration": eventDuration.Nanoseconds()},
 			"session": common.MapStr{"id": "session_id"},
 			"url":     common.MapStr{"original": "url"},
 			"labels": common.MapStr{

--- a/model/error.go
+++ b/model/error.go
@@ -60,7 +60,7 @@ type ErrorLog struct {
 	Stacktrace   Stacktrace
 }
 
-func (e *Error) setFields(fields *mapStr) {
+func (e *Error) fields() common.MapStr {
 	var errorFields mapStr
 	errorFields.maybeSetString("id", e.ID)
 	if e.Exception != nil {
@@ -71,7 +71,7 @@ func (e *Error) setFields(fields *mapStr) {
 	errorFields.maybeSetString("culprit", e.Culprit)
 	errorFields.maybeSetMapStr("custom", customFields(e.Custom))
 	errorFields.maybeSetString("grouping_key", e.GroupingKey)
-	fields.set("error", common.MapStr(errorFields))
+	return common.MapStr(errorFields)
 }
 
 func (e *Error) logFields() common.MapStr {

--- a/model/error_test.go
+++ b/model/error_test.go
@@ -109,7 +109,13 @@ func TestHandleExceptionTree(t *testing.T) {
 	}}, exceptionField)
 }
 
-func TestEventFields(t *testing.T) {
+func TestErrorFieldsEmpty(t *testing.T) {
+	event := APMEvent{Error: &Error{}}
+	beatEvent := event.BeatEvent(context.Background())
+	assert.Empty(t, beatEvent.Fields)
+}
+
+func TestErrorFields(t *testing.T) {
 	id := "45678"
 	culprit := "some trigger"
 
@@ -143,10 +149,6 @@ func TestEventFields(t *testing.T) {
 		Error  Error
 		Output common.MapStr
 	}{
-		"minimal": {
-			Error:  Error{},
-			Output: common.MapStr(nil),
-		},
 		"withGroupingKey": {
 			Error:  Error{GroupingKey: "foo"},
 			Output: common.MapStr{"grouping_key": "foo"},

--- a/model/event.go
+++ b/model/event.go
@@ -29,9 +29,7 @@ import (
 type Event struct {
 	// Duration holds the event duration.
 	//
-	// TODO(axw) emit an `event.duration` field with the duration in
-	// nanoseconds, in 8.0. For now we emit event-specific duration fields.
-	// See https://github.com/elastic/apm-server/issues/5999
+	// Duration is only added as a field (`duration`) if greater than zero.
 	Duration time.Duration
 
 	// Outcome holds the event outcome: "success", "failure", or "unknown".
@@ -50,6 +48,9 @@ func (e *Event) fields() common.MapStr {
 	fields.maybeSetString("action", e.Action)
 	if e.Severity > 0 {
 		fields.set("severity", e.Severity)
+	}
+	if e.Duration > 0 {
+		fields.set("duration", e.Duration.Nanoseconds())
 	}
 	return common.MapStr(fields)
 }

--- a/model/profile.go
+++ b/model/profile.go
@@ -46,7 +46,7 @@ type ProfileSampleStackframe struct {
 	Line     int64
 }
 
-func (p *ProfileSample) setFields(fields *mapStr) {
+func (p *ProfileSample) fields() common.MapStr {
 	var profileFields mapStr
 	profileFields.maybeSetString("id", p.ProfileID)
 	if p.Duration > 0 {
@@ -73,5 +73,5 @@ func (p *ProfileSample) setFields(fields *mapStr) {
 	for k, v := range p.Values {
 		profileFields.set(k, v)
 	}
-	fields.set("profile", common.MapStr(profileFields))
+	return common.MapStr(profileFields)
 }

--- a/model/span.go
+++ b/model/span.go
@@ -133,7 +133,7 @@ func (c *Composite) fields() common.MapStr {
 	return common.MapStr(fields)
 }
 
-func (e *Span) setFields(fields *mapStr, apmEvent *APMEvent) {
+func (e *Span) fields() common.MapStr {
 	var span mapStr
 	span.maybeSetString("name", e.Name)
 	span.maybeSetString("type", e.Type)
@@ -142,11 +142,6 @@ func (e *Span) setFields(fields *mapStr, apmEvent *APMEvent) {
 	span.maybeSetString("subtype", e.Subtype)
 	span.maybeSetString("action", e.Action)
 	span.maybeSetBool("sync", e.Sync)
-	if apmEvent.Processor == SpanProcessor {
-		// TODO(axw) set `event.duration` in 8.0, and remove this field.
-		// See https://github.com/elastic/apm-server/issues/5999
-		span.set("duration", common.MapStr{"us": int(apmEvent.Event.Duration.Microseconds())})
-	}
 	span.maybeSetMapStr("db", e.DB.fields())
 	span.maybeSetMapStr("message", e.Message.Fields())
 	span.maybeSetMapStr("composite", e.Composite.fields())
@@ -162,5 +157,5 @@ func (e *Span) setFields(fields *mapStr, apmEvent *APMEvent) {
 		span.set("stacktrace", st)
 	}
 	span.maybeSetMapStr("self_time", e.SelfTime.fields())
-	fields.maybeSetMapStr("span", common.MapStr(span))
+	return common.MapStr(span)
 }

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -78,14 +78,14 @@ func TestSpanTransform(t *testing.T) {
 			},
 			Output: common.MapStr{
 				"processor": common.MapStr{"name": "transaction", "event": "span"},
+				"event":     common.MapStr{"duration": duration.Nanoseconds()},
 				"span": common.MapStr{
-					"id":       hexID,
-					"duration": common.MapStr{"us": int(duration.Microseconds())},
-					"name":     "myspan",
-					"kind":     "CLIENT",
-					"type":     "myspantype",
-					"subtype":  subtype,
-					"action":   action,
+					"id":      hexID,
+					"name":    "myspan",
+					"kind":    "CLIENT",
+					"type":    "myspantype",
+					"subtype": subtype,
+					"action":  action,
 					"stacktrace": []common.MapStr{{
 						"exclude_from_grouping": false,
 						"abs_path":              path,
@@ -161,9 +161,6 @@ func TestSpanHTTPFields(t *testing.T) {
 		},
 		"url": common.MapStr{
 			"original": event.URL.Original,
-		},
-		"span": common.MapStr{
-			"duration": common.MapStr{"us": 0},
 		},
 	}, output.Fields)
 }

--- a/model/transaction.go
+++ b/model/transaction.go
@@ -83,13 +83,8 @@ type SpanCount struct {
 	Started *int
 }
 
-func (e *Transaction) setFields(fields *mapStr, apmEvent *APMEvent) {
+func (e *Transaction) fields() common.MapStr {
 	var transaction mapStr
-	if apmEvent.Processor == TransactionProcessor {
-		// TODO(axw) set `event.duration` in 8.0, and remove this field.
-		// See https://github.com/elastic/apm-server/issues/5999
-		transaction.set("duration", common.MapStr{"us": int(apmEvent.Event.Duration.Microseconds())})
-	}
 	transaction.maybeSetString("id", e.ID)
 	transaction.maybeSetString("type", e.Type)
 	transaction.maybeSetMapStr("duration.histogram", e.DurationHistogram.fields())
@@ -122,7 +117,7 @@ func (e *Transaction) setFields(fields *mapStr, apmEvent *APMEvent) {
 	if len(dss) > 0 {
 		transaction.set("dropped_spans_stats", dss)
 	}
-	fields.maybeSetMapStr("transaction", common.MapStr(transaction))
+	return common.MapStr(transaction)
 }
 
 type TransactionMarks map[string]TransactionMark

--- a/model/transaction_test.go
+++ b/model/transaction_test.go
@@ -47,21 +47,13 @@ func TestTransactionTransform(t *testing.T) {
 		Msg         string
 	}{
 		{
-			Transaction: Transaction{},
-			Output: common.MapStr{
-				"duration": common.MapStr{"us": 65980},
-			},
-			Msg: "Empty Transaction",
-		},
-		{
 			Transaction: Transaction{
 				ID:   id,
 				Type: "tx",
 			},
 			Output: common.MapStr{
-				"id":       id,
-				"type":     "tx",
-				"duration": common.MapStr{"us": 65980},
+				"id":   id,
+				"type": "tx",
 			},
 			Msg: "SpanCount empty",
 		},
@@ -74,7 +66,6 @@ func TestTransactionTransform(t *testing.T) {
 			Output: common.MapStr{
 				"id":         id,
 				"type":       "tx",
-				"duration":   common.MapStr{"us": 65980},
 				"span_count": common.MapStr{"started": 14},
 			},
 			Msg: "SpanCount only contains `started`",
@@ -88,7 +79,6 @@ func TestTransactionTransform(t *testing.T) {
 			Output: common.MapStr{
 				"id":         id,
 				"type":       "tx",
-				"duration":   common.MapStr{"us": 65980},
 				"span_count": common.MapStr{"dropped": 5},
 			},
 			Msg: "SpanCount only contains `dropped`",
@@ -108,7 +98,6 @@ func TestTransactionTransform(t *testing.T) {
 				"name":       "mytransaction",
 				"type":       "tx",
 				"result":     "tx result",
-				"duration":   common.MapStr{"us": 65980},
 				"span_count": common.MapStr{"started": 14, "dropped": 5},
 				"sampled":    true,
 				"root":       true,
@@ -148,7 +137,6 @@ func TestTransactionTransform(t *testing.T) {
 				"name":       "mytransaction",
 				"type":       "tx",
 				"result":     "tx result",
-				"duration":   common.MapStr{"us": 65980},
 				"span_count": common.MapStr{"started": 14, "dropped": 5},
 				"dropped_spans_stats": []common.MapStr{
 					{
@@ -173,7 +161,6 @@ func TestTransactionTransform(t *testing.T) {
 		event := APMEvent{
 			Processor:   TransactionProcessor,
 			Transaction: &test.Transaction,
-			Event:       Event{Duration: duration},
 		}
 		beatEvent := event.BeatEvent(context.Background())
 		assert.Equal(t, test.Output, beatEvent.Fields["transaction"], fmt.Sprintf("Failed at idx %v; %s", idx, test.Msg))
@@ -230,8 +217,7 @@ func TestEventsTransformWithMetadata(t *testing.T) {
 			"node":    common.MapStr{"name": serviceNodeName},
 		},
 		"transaction": common.MapStr{
-			"duration": common.MapStr{"us": 0},
-			"sampled":  true,
+			"sampled": true,
 			"custom": common.MapStr{
 				"foo_bar": "baz",
 			},

--- a/processor/otel/test_approved/jaeger_sampling_rate.approved.json
+++ b/processor/otel/test_approved/jaeger_sampling_rate.approved.json
@@ -7,6 +7,7 @@
                 "version": "unknown"
             },
             "event": {
+                "duration": 79000000000,
                 "outcome": "unknown"
             },
             "host": {
@@ -26,9 +27,6 @@
                 "us": 1576500418000768
             },
             "transaction": {
-                "duration": {
-                    "us": 79000000
-                },
                 "sampled": true,
                 "type": "unknown"
             }
@@ -40,6 +38,7 @@
                 "version": "unknown"
             },
             "event": {
+                "duration": 79000000000,
                 "outcome": "unknown"
             },
             "host": {
@@ -59,9 +58,6 @@
                 "name": "unknown"
             },
             "span": {
-                "duration": {
-                    "us": 79000000
-                },
                 "type": "unknown"
             },
             "timestamp": {
@@ -78,6 +74,7 @@
                 "version": "unknown"
             },
             "event": {
+                "duration": 79000000000,
                 "outcome": "unknown"
             },
             "host": {
@@ -103,9 +100,6 @@
                 "us": 1576500418000768
             },
             "transaction": {
-                "duration": {
-                    "us": 79000000
-                },
                 "sampled": true,
                 "type": "unknown"
             }

--- a/processor/otel/test_approved/metadata_jaeger-no-language.approved.json
+++ b/processor/otel/test_approved/metadata_jaeger-no-language.approved.json
@@ -26,9 +26,6 @@
                 "id": "00000000000000000000000046467830"
             },
             "transaction": {
-                "duration": {
-                    "us": 0
-                },
                 "id": "0000000041414646",
                 "sampled": true,
                 "type": "unknown"

--- a/processor/otel/test_approved/metadata_jaeger-version.approved.json
+++ b/processor/otel/test_approved/metadata_jaeger-version.approved.json
@@ -26,9 +26,6 @@
                 "id": "00000000000000000000000046467830"
             },
             "transaction": {
-                "duration": {
-                    "us": 0
-                },
                 "id": "0000000041414646",
                 "sampled": true,
                 "type": "unknown"

--- a/processor/otel/test_approved/metadata_jaeger.approved.json
+++ b/processor/otel/test_approved/metadata_jaeger.approved.json
@@ -37,9 +37,6 @@
                 "id": "00000000000000000000000046467830"
             },
             "transaction": {
-                "duration": {
-                    "us": 0
-                },
                 "id": "0000000041414646",
                 "sampled": true,
                 "type": "unknown"

--- a/processor/otel/test_approved/span_jaeger_custom.approved.json
+++ b/processor/otel/test_approved/span_jaeger_custom.approved.json
@@ -7,6 +7,7 @@
                 "version": "unknown"
             },
             "event": {
+                "duration": 79000000000,
                 "outcome": "unknown"
             },
             "host": {
@@ -26,9 +27,6 @@
                 "name": "unknown"
             },
             "span": {
-                "duration": {
-                    "us": 79000000
-                },
                 "id": "0000000041414646",
                 "type": "unknown"
             },

--- a/processor/otel/test_approved/span_jaeger_db.approved.json
+++ b/processor/otel/test_approved/span_jaeger_db.approved.json
@@ -11,6 +11,7 @@
                 "port": 3306
             },
             "event": {
+                "duration": 79000000000,
                 "outcome": "unknown"
             },
             "host": {
@@ -47,9 +48,6 @@
                         "resource": "mysql://db:3306",
                         "type": "db"
                     }
-                },
-                "duration": {
-                    "us": 79000000
                 },
                 "id": "0000000041414646",
                 "subtype": "mysql",

--- a/processor/otel/test_approved/span_jaeger_http.approved.json
+++ b/processor/otel/test_approved/span_jaeger_http.approved.json
@@ -11,6 +11,7 @@
                 "port": 80
             },
             "event": {
+                "duration": 79000000000,
                 "outcome": "failure"
             },
             "host": {
@@ -53,9 +54,6 @@
                         "resource": "foo.bar.com:80",
                         "type": "external"
                     }
-                },
-                "duration": {
-                    "us": 79000000
                 },
                 "id": "0000000041414646",
                 "name": "HTTP GET",

--- a/processor/otel/test_approved/span_jaeger_http_status_code.approved.json
+++ b/processor/otel/test_approved/span_jaeger_http_status_code.approved.json
@@ -11,6 +11,7 @@
                 "port": 80
             },
             "event": {
+                "duration": 79000000000,
                 "outcome": "success"
             },
             "host": {
@@ -44,9 +45,6 @@
                         "resource": "foo.bar.com:80",
                         "type": "external"
                     }
-                },
-                "duration": {
-                    "us": 79000000
                 },
                 "id": "0000000041414646",
                 "name": "HTTP GET",

--- a/processor/otel/test_approved/span_jaeger_https_default_port.approved.json
+++ b/processor/otel/test_approved/span_jaeger_https_default_port.approved.json
@@ -11,6 +11,7 @@
                 "port": 443
             },
             "event": {
+                "duration": 79000000000,
                 "outcome": "unknown"
             },
             "host": {
@@ -36,9 +37,6 @@
                         "resource": "foo.bar.com:443",
                         "type": "external"
                     }
-                },
-                "duration": {
-                    "us": 79000000
                 },
                 "id": "0000000041414646",
                 "name": "HTTPS GET",

--- a/processor/otel/test_approved/span_jaeger_messaging.approved.json
+++ b/processor/otel/test_approved/span_jaeger_messaging.approved.json
@@ -11,6 +11,7 @@
                 "port": 1234
             },
             "event": {
+                "duration": 79000000000,
                 "outcome": "unknown"
             },
             "host": {
@@ -30,9 +31,6 @@
                 "name": "unknown"
             },
             "span": {
-                "duration": {
-                    "us": 79000000
-                },
                 "id": "0000000041414646",
                 "message": {
                     "queue": {

--- a/processor/otel/test_approved/span_jaeger_subtype_component.approved.json
+++ b/processor/otel/test_approved/span_jaeger_subtype_component.approved.json
@@ -7,6 +7,7 @@
                 "version": "unknown"
             },
             "event": {
+                "duration": 79000000000,
                 "outcome": "unknown"
             },
             "host": {
@@ -29,9 +30,6 @@
                 "name": "unknown"
             },
             "span": {
-                "duration": {
-                    "us": 79000000
-                },
                 "id": "0000000041414646",
                 "type": "unknown"
             },

--- a/processor/otel/test_approved/transaction_jaeger_custom.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_custom.approved.json
@@ -29,9 +29,6 @@
                 "us": 1576500418000768
             },
             "transaction": {
-                "duration": {
-                    "us": 0
-                },
                 "sampled": true,
                 "type": "unknown"
             }

--- a/processor/otel/test_approved/transaction_jaeger_full.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_full.approved.json
@@ -7,6 +7,7 @@
                 "version": "unknown"
             },
             "event": {
+                "duration": 79000000000,
                 "outcome": "failure"
             },
             "host": {
@@ -48,9 +49,6 @@
                 "id": "00000000000000000000000046467830"
             },
             "transaction": {
-                "duration": {
-                    "us": 79000000
-                },
                 "id": "0000000041414646",
                 "name": "HTTP GET",
                 "result": "HTTP 4xx",

--- a/processor/otel/test_approved/transaction_jaeger_no_attrs.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_no_attrs.approved.json
@@ -7,6 +7,7 @@
                 "version": "unknown"
             },
             "event": {
+                "duration": 79000000000,
                 "outcome": "failure"
             },
             "host": {
@@ -26,9 +27,6 @@
                 "us": 1576500418000768
             },
             "transaction": {
-                "duration": {
-                    "us": 79000000
-                },
                 "result": "Error",
                 "sampled": true,
                 "type": "unknown"

--- a/processor/otel/test_approved/transaction_jaeger_type_component.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_type_component.approved.json
@@ -29,9 +29,6 @@
                 "us": 1576500418000768
             },
             "transaction": {
-                "duration": {
-                    "us": 0
-                },
                 "sampled": true,
                 "type": "unknown"
             }

--- a/processor/otel/test_approved/transaction_jaeger_type_messaging.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_type_messaging.approved.json
@@ -29,9 +29,6 @@
                 "us": 1576500418000768
             },
             "transaction": {
-                "duration": {
-                    "us": 0
-                },
                 "message": {
                     "queue": {
                         "name": "queue-abc"

--- a/processor/otel/test_approved/transaction_jaeger_type_request.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_type_request.approved.json
@@ -37,9 +37,6 @@
                 "us": 1576500418000768
             },
             "transaction": {
-                "duration": {
-                    "us": 0
-                },
                 "result": "HTTP 5xx",
                 "sampled": true,
                 "type": "request"

--- a/processor/otel/test_approved/transaction_jaeger_type_request_result.approved.json
+++ b/processor/otel/test_approved/transaction_jaeger_type_request_result.approved.json
@@ -34,9 +34,6 @@
                 "us": 1576500418000768
             },
             "transaction": {
-                "duration": {
-                    "us": 0
-                },
                 "result": "HTTP 2xx",
                 "sampled": true,
                 "type": "request"

--- a/processor/otel/traces.go
+++ b/processor/otel/traces.go
@@ -235,7 +235,7 @@ func (c *Consumer) convertSpan(
 	events := otelSpan.Events()
 	event.Labels = baseEvent.Labels               // only copy common labels to span events
 	event.NumericLabels = baseEvent.NumericLabels // only copy common labels to span events
-	event.Event.Outcome = ""                      // don't set event.outcome for span events
+	event.Event = model.Event{}                   // don't copy event.* to span events
 	event.Destination = model.Destination{}       // don't set destination for span events
 	for i := 0; i < events.Len(); i++ {
 		*out = append(*out, convertSpanEvent(logger, events.At(i), event, timeDelta))

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
@@ -290,6 +290,7 @@
                 "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
             },
             "event": {
+                "duration": 3781912,
                 "outcome": "success"
             },
             "host": {
@@ -385,9 +386,6 @@
                         "name": "postgres"
                     }
                 },
-                "duration": {
-                    "us": 3781
-                },
                 "id": "1234567890aaaade",
                 "name": "GET users-authenticated",
                 "stacktrace": [
@@ -446,6 +444,7 @@
                 "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
             },
             "event": {
+                "duration": 32592981,
                 "outcome": "success"
             },
             "host": {
@@ -586,9 +585,6 @@
                     },
                     "my_key": 1,
                     "some_other_value": "foobar"
-                },
-                "duration": {
-                    "us": 32592
                 },
                 "id": "4340a8e0df1906ecbfa9",
                 "name": "ResourceHttpRequestHandler",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationInvalidEvent.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationInvalidEvent.approved.json
@@ -7,6 +7,7 @@
                 "version": "3.14.0"
             },
             "event": {
+                "duration": 141581000,
                 "outcome": "unknown"
             },
             "host": {
@@ -31,9 +32,6 @@
                 "name": "1234_service-12a3"
             },
             "span": {
-                "duration": {
-                    "us": 141581
-                },
                 "id": "abcdef01234567",
                 "name": "GET /api/types",
                 "type": "request"

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationInvalidJSONEvent.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationInvalidJSONEvent.approved.json
@@ -7,6 +7,7 @@
                 "version": "3.14.0"
             },
             "event": {
+                "duration": 141581000,
                 "outcome": "unknown"
             },
             "host": {
@@ -31,9 +32,6 @@
                 "name": "1234_service-12a3"
             },
             "span": {
-                "duration": {
-                    "us": 141581
-                },
                 "id": "abcdef01234567",
                 "name": "GET /api/types",
                 "type": "request"

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationOpenTelemetryBridge.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationOpenTelemetryBridge.approved.json
@@ -33,6 +33,7 @@
                 "id": "container-id"
             },
             "event": {
+                "duration": 32592981,
                 "outcome": "success"
             },
             "host": {
@@ -113,9 +114,6 @@
                 "id": "646df3b8b5279e982cc12a2f1ac004f3"
             },
             "transaction": {
-                "duration": {
-                    "us": 32592
-                },
                 "id": "ddf109a4c4aa5f2b6e984548ca57774c",
                 "message": {
                     "queue": {
@@ -170,6 +168,7 @@
                 "id": "container-id"
             },
             "event": {
+                "duration": 32592981,
                 "outcome": "success"
             },
             "host": {
@@ -252,9 +251,6 @@
                 "version": "5.1.3"
             },
             "span": {
-                "duration": {
-                    "us": 32592
-                },
                 "id": "ddf109a4c4aa5f2b6e984548ca57774d",
                 "kind": "CLIENT",
                 "name": "span_name",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationOptionalTimestamps.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationOptionalTimestamps.approved.json
@@ -7,6 +7,7 @@
                 "version": "3.14.0"
             },
             "event": {
+                "duration": 12000000,
                 "outcome": "unknown"
             },
             "host": {
@@ -56,9 +57,6 @@
                 "id": "abcdefabcdef01234567890123456789"
             },
             "transaction": {
-                "duration": {
-                    "us": 12000
-                },
                 "id": "1111222233334444",
                 "name": "tx1",
                 "sampled": true,
@@ -80,6 +78,7 @@
                 "version": "3.14.0"
             },
             "event": {
+                "duration": 20000000,
                 "outcome": "unknown"
             },
             "host": {
@@ -126,9 +125,6 @@
                 "version": "5.1.3"
             },
             "span": {
-                "duration": {
-                    "us": 20000
-                },
                 "id": "0147258369abcdef",
                 "name": "sp1",
                 "type": "db"

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationRumTransactions.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationRumTransactions.approved.json
@@ -10,6 +10,7 @@
                 "ip": "192.0.0.2"
             },
             "event": {
+                "duration": 643000000,
                 "outcome": "unknown"
             },
             "http": {
@@ -40,9 +41,6 @@
                 "id": "611f4fa950f04631aaaaaaaaaaaaaaaa"
             },
             "transaction": {
-                "duration": {
-                    "us": 643000
-                },
                 "experience": {
                     "cls": 1,
                     "fid": 2,
@@ -77,6 +75,7 @@
                 "ip": "192.0.0.2"
             },
             "event": {
+                "duration": 643000000,
                 "outcome": "unknown"
             },
             "network": {
@@ -99,9 +98,6 @@
                 "ip": "192.0.0.1"
             },
             "span": {
-                "duration": {
-                    "us": 643000
-                },
                 "id": "aaaaaaaaaaaaaaaa",
                 "name": "transaction",
                 "stacktrace": [

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationSpans.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationSpans.approved.json
@@ -38,6 +38,7 @@
                 "id": "container-id"
             },
             "event": {
+                "duration": 141581000,
                 "outcome": "success"
             },
             "host": {
@@ -99,9 +100,6 @@
             },
             "span": {
                 "action": "query.custom",
-                "duration": {
-                    "us": 141581
-                },
                 "id": "abcdef01234567",
                 "name": "GET /api/types",
                 "subtype": "postgresql",
@@ -156,6 +154,7 @@
                 "id": "container-id"
             },
             "event": {
+                "duration": 32592981,
                 "outcome": "unknown"
             },
             "host": {
@@ -216,9 +215,6 @@
                 "version": "5.1.3"
             },
             "span": {
-                "duration": {
-                    "us": 32592
-                },
                 "id": "1234abcdef567895",
                 "name": "GET /api/types",
                 "type": "request"
@@ -272,6 +268,7 @@
                 "id": "container-id"
             },
             "event": {
+                "duration": 3564298,
                 "outcome": "unknown"
             },
             "host": {
@@ -336,9 +333,6 @@
                 "version": "5.1.3"
             },
             "span": {
-                "duration": {
-                    "us": 3564
-                },
                 "id": "0123456a89012345",
                 "name": "GET /api/types",
                 "subtype": "http",
@@ -393,6 +387,7 @@
                 "id": "container-id"
             },
             "event": {
+                "duration": 13980298,
                 "outcome": "unknown"
             },
             "host": {
@@ -454,9 +449,6 @@
             },
             "span": {
                 "action": "call",
-                "duration": {
-                    "us": 13980
-                },
                 "id": "abcde56a89012345",
                 "name": "get /api/types",
                 "subtype": "http",
@@ -515,6 +507,7 @@
                 "port": 5432
             },
             "event": {
+                "duration": 3781912,
                 "outcome": "success"
             },
             "host": {
@@ -603,9 +596,6 @@
                         "resource": "postgresql",
                         "type": "db"
                     }
-                },
-                "duration": {
-                    "us": 3781
                 },
                 "id": "1234567890aaaade",
                 "name": "SELECT FROM product_types",
@@ -715,6 +705,7 @@
                 "ip": "0:0::0:1"
             },
             "event": {
+                "duration": 141581000,
                 "outcome": "unknown"
             },
             "host": {
@@ -776,9 +767,6 @@
             },
             "span": {
                 "action": "receive",
-                "duration": {
-                    "us": 141581
-                },
                 "id": "00xxx12312312312",
                 "message": {
                     "age": {
@@ -842,6 +830,7 @@
                 "id": "container-id"
             },
             "event": {
+                "duration": 378191200,
                 "outcome": "success"
             },
             "host": {
@@ -909,9 +898,6 @@
                     "sum": {
                         "us": 359298
                     }
-                },
-                "duration": {
-                    "us": 378191
                 },
                 "id": "abcdef01234567",
                 "name": "SELECT FROM p_details",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationTransactions.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationTransactions.approved.json
@@ -33,6 +33,7 @@
                 "id": "container-id"
             },
             "event": {
+                "duration": 32592981,
                 "outcome": "unknown"
             },
             "host": {
@@ -107,9 +108,6 @@
                 "id": "0123456789abcdef0123456789abcdef"
             },
             "transaction": {
-                "duration": {
-                    "us": 32592
-                },
                 "id": "945254c567a5417e",
                 "sampled": true,
                 "span_count": {
@@ -159,6 +157,7 @@
                 "id": "container-id"
             },
             "event": {
+                "duration": 32592981,
                 "outcome": "success"
             },
             "host": {
@@ -301,9 +300,6 @@
                     "my_key": 1,
                     "some_other_value": "foo bar"
                 },
-                "duration": {
-                    "us": 32592
-                },
                 "id": "4340a8e0df1906ecbfa9",
                 "name": "GET /api/types",
                 "result": "success",
@@ -366,6 +362,7 @@
                 "id": "container-id"
             },
             "event": {
+                "duration": 13980558,
                 "outcome": "unknown"
             },
             "host": {
@@ -442,9 +439,6 @@
                 "id": "0acd456789abcdef0123456789abcdef"
             },
             "transaction": {
-                "duration": {
-                    "us": 13980
-                },
                 "experience": {
                     "cls": 1,
                     "fid": 2,
@@ -512,6 +506,7 @@
                 "id": "container-id"
             },
             "event": {
+                "duration": 3000000,
                 "outcome": "unknown"
             },
             "host": {
@@ -590,9 +585,6 @@
                 "id": "0123456789abcdef0123456789abcdef"
             },
             "transaction": {
-                "duration": {
-                    "us": 3000
-                },
                 "id": "00xxxxFFaaaa1234",
                 "message": {
                     "age": {
@@ -665,6 +657,7 @@
                 "id": "container-id"
             },
             "event": {
+                "duration": 38853000,
                 "outcome": "unknown"
             },
             "faas": {
@@ -747,9 +740,6 @@
                 "id": "eb56529a1f461c5e7e2f66ecb075e983"
             },
             "transaction": {
-                "duration": {
-                    "us": 38853
-                },
                 "id": "142e61450efb8574",
                 "name": "july-2021-delete-after-july-31",
                 "result": "success",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationTransactionsHugeTraces.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationTransactionsHugeTraces.approved.json
@@ -36,6 +36,7 @@
                 "id": "container-id"
             },
             "event": {
+                "duration": 32592981,
                 "outcome": "success"
             },
             "host": {
@@ -196,9 +197,6 @@
                         "outcome": "success"
                     }
                 ],
-                "duration": {
-                    "us": 32592
-                },
                 "id": "ddf109a4c4aa5f2b6e984548ca57774c",
                 "name": "GET /api/types",
                 "result": "success",

--- a/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeRUMV3Events.approved.json
@@ -10,6 +10,7 @@
                 "ip": "192.0.0.2"
             },
             "event": {
+                "duration": 295000000,
                 "outcome": "success"
             },
             "http": {
@@ -79,9 +80,6 @@
             "transaction": {
                 "custom": {
                     "testContext": "testContext"
-                },
-                "duration": {
-                    "us": 295000
                 },
                 "experience": {
                     "cls": 1,
@@ -279,6 +277,7 @@
                 "ip": "192.0.0.2"
             },
             "event": {
+                "duration": 2000000,
                 "outcome": "unknown"
             },
             "labels": {
@@ -317,9 +316,6 @@
                 "ip": "192.0.0.1"
             },
             "span": {
-                "duration": {
-                    "us": 2000
-                },
                 "id": "bbd8bcc3be14d814",
                 "name": "Requesting and receiving the document",
                 "subtype": "browser-timing",
@@ -353,6 +349,7 @@
                 "ip": "192.0.0.2"
             },
             "event": {
+                "duration": 106000000,
                 "outcome": "unknown"
             },
             "labels": {
@@ -391,9 +388,6 @@
                 "ip": "192.0.0.1"
             },
             "span": {
-                "duration": {
-                    "us": 106000
-                },
                 "id": "fc546e87a90a774f",
                 "name": "Parsing the document, executing sy. scripts",
                 "subtype": "browser-timing",
@@ -431,6 +425,7 @@
                 "port": 8000
             },
             "event": {
+                "duration": 35060000,
                 "outcome": "unknown"
             },
             "http": {
@@ -483,9 +478,6 @@
                         "type": "rc"
                     }
                 },
-                "duration": {
-                    "us": 35060
-                },
                 "id": "fb8f717930697299",
                 "name": "http://localhost:8000/test/e2e/general-usecase/app.e2e-bundle.min.js",
                 "subtype": "script",
@@ -522,6 +514,7 @@
                 "ip": "192.0.0.2"
             },
             "event": {
+                "duration": 198070000,
                 "outcome": "unknown"
             },
             "labels": {
@@ -560,9 +553,6 @@
                 "ip": "192.0.0.1"
             },
             "span": {
-                "duration": {
-                    "us": 198070
-                },
                 "id": "9b80535c4403c9fb",
                 "name": "OpenTracing y",
                 "type": "cu"
@@ -599,6 +589,7 @@
                 "port": 8000
             },
             "event": {
+                "duration": 6724999,
                 "outcome": "success"
             },
             "http": {
@@ -652,9 +643,6 @@
                         "type": "external"
                     }
                 },
-                "duration": {
-                    "us": 6724
-                },
                 "id": "5ecb8ee030749715",
                 "name": "GET /test/e2e/common/data.json",
                 "subtype": "h",
@@ -696,6 +684,7 @@
                 "port": 8003
             },
             "event": {
+                "duration": 11584999,
                 "outcome": "success"
             },
             "http": {
@@ -749,9 +738,6 @@
                         "type": "external"
                     }
                 },
-                "duration": {
-                    "us": 11584
-                },
                 "id": "27f45fd274f976d4",
                 "name": "POST http://localhost:8003/data",
                 "subtype": "h",
@@ -793,6 +779,7 @@
                 "port": 8003
             },
             "event": {
+                "duration": 15949999,
                 "outcome": "success"
             },
             "http": {
@@ -847,9 +834,6 @@
                         "type": "external"
                     }
                 },
-                "duration": {
-                    "us": 15949
-                },
                 "id": "a3c043330bc2015e",
                 "name": "POST http://localhost:8003/fetch",
                 "subtype": "h",
@@ -887,6 +871,7 @@
                 "ip": "192.0.0.2"
             },
             "event": {
+                "duration": 2000000,
                 "outcome": "success"
             },
             "labels": {
@@ -925,9 +910,6 @@
                 "ip": "192.0.0.1"
             },
             "span": {
-                "duration": {
-                    "us": 2000
-                },
                 "id": "bc7665dc25629379",
                 "name": "Fire \"DOMContentLoaded\" event",
                 "stacktrace": [

--- a/testdata/jaeger/batch_0.approved.json
+++ b/testdata/jaeger/batch_0.approved.json
@@ -8,6 +8,7 @@
                 "version": "2.20.1"
             },
             "event": {
+                "duration": 243417000,
                 "outcome": "unknown"
             },
             "host": {
@@ -43,9 +44,6 @@
                 "id": "00000000000000007be2fd98d0973be3"
             },
             "transaction": {
-                "duration": {
-                    "us": 243417
-                },
                 "id": "7be2fd98d0973be3",
                 "name": "Driver::findNearest",
                 "sampled": true,

--- a/testdata/jaeger/batch_1.approved.json
+++ b/testdata/jaeger/batch_1.approved.json
@@ -8,6 +8,7 @@
                 "version": "2.20.1"
             },
             "event": {
+                "duration": 19711000,
                 "outcome": "unknown"
             },
             "host": {
@@ -33,9 +34,6 @@
                 "name": "redis"
             },
             "span": {
-                "duration": {
-                    "us": 19711
-                },
                 "id": "6e09e8bcefd6b828",
                 "name": "FindDriverIDs",
                 "type": "unknown"
@@ -90,6 +88,7 @@
                 "version": "2.20.1"
             },
             "event": {
+                "duration": 33732000,
                 "outcome": "failure"
             },
             "host": {
@@ -115,9 +114,6 @@
                 "name": "redis"
             },
             "span": {
-                "duration": {
-                    "us": 33732
-                },
                 "id": "333295bfb438ea03",
                 "name": "GetDriver",
                 "type": "unknown"
@@ -183,6 +179,7 @@
                 "version": "2.20.1"
             },
             "event": {
+                "duration": 9240000,
                 "outcome": "unknown"
             },
             "host": {
@@ -208,9 +205,6 @@
                 "name": "redis"
             },
             "span": {
-                "duration": {
-                    "us": 9240
-                },
                 "id": "627c37a97e475c2f",
                 "name": "GetDriver",
                 "type": "unknown"
@@ -230,6 +224,7 @@
                 "version": "2.20.1"
             },
             "event": {
+                "duration": 12561000,
                 "outcome": "unknown"
             },
             "host": {
@@ -255,9 +250,6 @@
                 "name": "redis"
             },
             "span": {
-                "duration": {
-                    "us": 12561
-                },
                 "id": "7bd7663d39c5a847",
                 "name": "GetDriver",
                 "type": "unknown"
@@ -277,6 +269,7 @@
                 "version": "2.20.1"
             },
             "event": {
+                "duration": 10630000,
                 "outcome": "unknown"
             },
             "host": {
@@ -302,9 +295,6 @@
                 "name": "redis"
             },
             "span": {
-                "duration": {
-                    "us": 10630
-                },
                 "id": "6b4051dd2a5e2366",
                 "name": "GetDriver",
                 "type": "unknown"
@@ -324,6 +314,7 @@
                 "version": "2.20.1"
             },
             "event": {
+                "duration": 13946000,
                 "outcome": "unknown"
             },
             "host": {
@@ -349,9 +340,6 @@
                 "name": "redis"
             },
             "span": {
-                "duration": {
-                    "us": 13946
-                },
                 "id": "6df97a86b9b3451b",
                 "name": "GetDriver",
                 "type": "unknown"
@@ -371,6 +359,7 @@
                 "version": "2.20.1"
             },
             "event": {
+                "duration": 35375000,
                 "outcome": "failure"
             },
             "host": {
@@ -396,9 +385,6 @@
                 "name": "redis"
             },
             "span": {
-                "duration": {
-                    "us": 35375
-                },
                 "id": "614811d6c498bfb0",
                 "name": "GetDriver",
                 "type": "unknown"
@@ -464,6 +450,7 @@
                 "version": "2.20.1"
             },
             "event": {
+                "duration": 11802000,
                 "outcome": "unknown"
             },
             "host": {
@@ -489,9 +476,6 @@
                 "name": "redis"
             },
             "span": {
-                "duration": {
-                    "us": 11802
-                },
                 "id": "231604559da84d61",
                 "name": "GetDriver",
                 "type": "unknown"
@@ -511,6 +495,7 @@
                 "version": "2.20.1"
             },
             "event": {
+                "duration": 12236000,
                 "outcome": "unknown"
             },
             "host": {
@@ -536,9 +521,6 @@
                 "name": "redis"
             },
             "span": {
-                "duration": {
-                    "us": 12236
-                },
                 "id": "61f7ecf24d13c36a",
                 "name": "GetDriver",
                 "type": "unknown"
@@ -558,6 +540,7 @@
                 "version": "2.20.1"
             },
             "event": {
+                "duration": 11986000,
                 "outcome": "unknown"
             },
             "host": {
@@ -583,9 +566,6 @@
                 "name": "redis"
             },
             "span": {
-                "duration": {
-                    "us": 11986
-                },
                 "id": "2ef335bad24accc2",
                 "name": "GetDriver",
                 "type": "unknown"
@@ -605,6 +585,7 @@
                 "version": "2.20.1"
             },
             "event": {
+                "duration": 7311000,
                 "outcome": "unknown"
             },
             "host": {
@@ -630,9 +611,6 @@
                 "name": "redis"
             },
             "span": {
-                "duration": {
-                    "us": 7311
-                },
                 "id": "38ec645e7201224d",
                 "name": "GetDriver",
                 "type": "unknown"
@@ -652,6 +630,7 @@
                 "version": "2.20.1"
             },
             "event": {
+                "duration": 39602000,
                 "outcome": "failure"
             },
             "host": {
@@ -677,9 +656,6 @@
                 "name": "redis"
             },
             "span": {
-                "duration": {
-                    "us": 39602
-                },
                 "id": "0242ee3774d9eab1",
                 "name": "GetDriver",
                 "type": "unknown"
@@ -745,6 +721,7 @@
                 "version": "2.20.1"
             },
             "event": {
+                "duration": 14029000,
                 "outcome": "unknown"
             },
             "host": {
@@ -770,9 +747,6 @@
                 "name": "redis"
             },
             "span": {
-                "duration": {
-                    "us": 14029
-                },
                 "id": "6a63d1e81cfc7d95",
                 "name": "GetDriver",
                 "type": "unknown"
@@ -792,6 +766,7 @@
                 "version": "2.20.1"
             },
             "event": {
+                "duration": 10431000,
                 "outcome": "unknown"
             },
             "host": {
@@ -817,9 +792,6 @@
                 "name": "redis"
             },
             "span": {
-                "duration": {
-                    "us": 10431
-                },
                 "id": "2b4c28f02b272f17",
                 "name": "GetDriver",
                 "type": "unknown"


### PR DESCRIPTION
## Motivation/summary

Update package `model` to no longer set `transaction.duration.us` or `span.duration.us`, and instead set `event.duration`. Update our ingest pipelines to use `event.duration` to set the legacy fields, and then remove `event.duration`. This pipeline can be removed once when we are ready and able to update the APM UI to use `event.duration` directly.

I have listed this as a breaking change in the top-level changelog, as it will have visible effects for anyone not using the Elasticsearch output or the packaged ingest pipeline. I have not done this in the integration package changelog, as I assume the ingest pipeline is always in use there.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
~- [ ] Documentation has been updated~

## How to test these changes

Send transactions and spans with zero and non-zero durations, and ensure they each have `transaction.duration.us` or `span.duration.us` set, and do not have `event.duration` set.

## Related issues

Prerequisite of https://github.com/elastic/apm-server/issues/5999
Part of https://github.com/elastic/apm-server/issues/3565 and https://github.com/elastic/apm-server/issues/4120