### PR TITLE
Only overwrite service.version if service.name is also set

### DIFF
--- a/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationErrors.approved.json
@@ -327,8 +327,7 @@
                 "runtime": {
                     "name": "node",
                     "version": "8.0.0"
-                },
-                "version": "5.1.3"
+                }
             },
             "source": {
                 "ip": "12.53.12.1"

--- a/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationEvents.approved.json
@@ -261,8 +261,7 @@
                 "runtime": {
                     "name": "Java",
                     "version": "10.0.2"
-                },
-                "version": "4.3.0"
+                }
             },
             "source": {
                 "ip": "12.53.12.1"
@@ -400,8 +399,7 @@
                 "runtime": {
                     "name": "Java",
                     "version": "10.0.2"
-                },
-                "version": "4.3.0"
+                }
             },
             "span": {
                 "action": "connect",
@@ -602,8 +600,7 @@
                 "runtime": {
                     "name": "Java",
                     "version": "10.0.2"
-                },
-                "version": "4.3.0"
+                }
             },
             "source": {
                 "ip": "12.53.12.1",

--- a/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json
+++ b/beater/test_approved_es_documents/TestPublishIntegrationSpans.approved.json
@@ -655,8 +655,7 @@
                 "runtime": {
                     "name": "node",
                     "version": "8.0.0"
-                },
-                "version": "5.1.3"
+                }
             },
             "span": {
                 "action": "query",

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -14,6 +14,7 @@ See <<apm-server-configuration>> for more information.
 [float]
 ==== Bug fixes
 - Fix infinite loop in tail-based sampling subscriber causing high CPU and repeated Elasticsearch searches {pull}7211[7211]
+- Do not overwrite `service version` if no transaction/error/... specific `service.name` is givven {pull}7281[7281]
 
 [float]
 ==== Intake API Changes

--- a/model/modeldecoder/rumv3/decoder.go
+++ b/model/modeldecoder/rumv3/decoder.go
@@ -436,15 +436,13 @@ func mapToServiceModel(from contextService, out *model.Service) {
 	}
 	if from.Name.IsSet() {
 		out.Name = from.Name.Val
+		out.Version = from.Version.Val
 	}
 	if from.Runtime.Name.IsSet() {
 		out.Runtime.Name = from.Runtime.Name.Val
 	}
 	if from.Runtime.Version.IsSet() {
 		out.Runtime.Version = from.Runtime.Version.Val
-	}
-	if from.Version.IsSet() {
-		out.Version = from.Version.Val
 	}
 }
 

--- a/model/modeldecoder/v2/decoder.go
+++ b/model/modeldecoder/v2/decoder.go
@@ -763,6 +763,7 @@ func mapToServiceModel(from contextService, out *model.Service) {
 	}
 	if from.Name.IsSet() {
 		out.Name = from.Name.Val
+		out.Version = from.Version.Val
 	}
 	if from.Node.Name.IsSet() {
 		out.Node.Name = from.Node.Name.Val
@@ -772,9 +773,6 @@ func mapToServiceModel(from contextService, out *model.Service) {
 	}
 	if from.Runtime.Version.IsSet() {
 		out.Runtime.Version = from.Runtime.Version.Val
-	}
-	if from.Version.IsSet() {
-		out.Version = from.Version.Val
 	}
 	if from.Origin.IsSet() {
 		outOrigin := &model.ServiceOrigin{}

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationErrors.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationErrors.approved.json
@@ -313,8 +313,7 @@
                 "runtime": {
                     "name": "node",
                     "version": "8.0.0"
-                },
-                "version": "5.1.3"
+                }
             },
             "source": {
                 "ip": "12.53.12.1"

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationEvents.approved.json
@@ -246,8 +246,7 @@
                 "runtime": {
                     "name": "Java",
                     "version": "10.0.2"
-                },
-                "version": "4.3.0"
+                }
             },
             "source": {
                 "ip": "12.53.12.1"
@@ -372,8 +371,7 @@
                 "runtime": {
                     "name": "Java",
                     "version": "10.0.2"
-                },
-                "version": "4.3.0"
+                }
             },
             "span": {
                 "action": "connect",
@@ -561,8 +559,7 @@
                 "runtime": {
                     "name": "Java",
                     "version": "10.0.2"
-                },
-                "version": "4.3.0"
+                }
             },
             "source": {
                 "ip": "12.53.12.1",

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationSpans.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationSpans.approved.json
@@ -575,8 +575,7 @@
                 "runtime": {
                     "name": "node",
                     "version": "8.0.0"
-                },
-                "version": "5.1.3"
+                }
             },
             "span": {
                 "action": "query",


### PR DESCRIPTION
## Motivation/summary

For metricsets the `service.version` is only overwritten if also `service.name` is given (see https://github.com/elastic/apm-server/pull/6407#issuecomment-950973237). It should be the same for transactions, errors, ...

## Checklist
- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

Ingest a transaction that only contains a `service.version`, but no `service.name`

