### PR TITLE
docs: link to air-gap instructions

### DIFF
--- a/docs/legacy/getting-started-apm-server.asciidoc
+++ b/docs/legacy/getting-started-apm-server.asciidoc
@@ -216,6 +216,10 @@ ILM policies, and ingest pipelines. APM Server will only send data to {es} _afte
 
 // This content is reused in the upgrading guide
 // tag::install-apm-integration[]
+NOTE: An internet connection is required to install the APM integration.
+If your environment has network traffic restrictions, there are ways to work around this requirement.
+See {fleet-guide}/air-gapped.html[Air-gapped environments] for more information.
+
 . Open {kib} and select **Add integrations** > **Elastic APM**.
 . Click **APM integration**.
 . Click **Add Elastic APM**.


### PR DESCRIPTION
One part of https://github.com/elastic/apm-server/issues/7219. Updates https://www.elastic.co/guide/en/apm/guide/master/apm-server-configuration.html. 