### PR TITLE
Add support for span links

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -6,6 +6,9 @@
     - description: updated traces and rum_traces ingest pipelines to translate `event.duration` to `<event>.duration.us`
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/7261
+    - description: added `span.links` fields to traces and rum_traces data streams
+      type: enhancement
+      link: https://github.com/elastic/apm-server/issues/7171
 - version: "8.1.0"
   changes:
     - description: Added field mapping for `faas.coldstart` and `faas.trigger.type`

--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -8,7 +8,7 @@
       link: https://github.com/elastic/apm-server/pull/7261
     - description: added `span.links` fields to traces and rum_traces data streams
       type: enhancement
-      link: https://github.com/elastic/apm-server/issues/7171
+      link: https://github.com/elastic/apm-server/pull/7291
 - version: "8.1.0"
   changes:
     - description: Added field mapping for `faas.coldstart` and `faas.trigger.type`

--- a/apmpackage/apm/data_stream/traces/fields/fields.yml
+++ b/apmpackage/apm/data_stream/traces/fields/fields.yml
@@ -247,6 +247,17 @@
       type: keyword
       description: |
         "The kind of span: CLIENT, SERVER, PRODUCER, CONSUMER, or INTERNAL."
+    - name: links
+      type: group
+      fields:
+        - name: trace.id
+          type: keyword
+          description: |
+            Unique identifier of the linked trace.
+        - name: span.id
+          type: keyword
+          description: |
+            Unique identifier of the linked span.
     - name: composite
       type: group
       fields:

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -24,3 +24,4 @@ See <<apm-server-configuration>> for more information.
 - Run the java attacher jar when configured and not in a cloud environment {pull}6617[6617]
 - Added several dimensions to the aggregated transaction metrics {pull}7033[7033]
 - Implemented translation of OpenTelemetry host system metrics (CPU utilization / Memory usage) {pull}7090[7090]
+- Added support for storing OpenTelemetry span links as `span.links` {pull}7291[7291]

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/elastic/gmux v0.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.0.0-alpha.0.20220127111727-5269e7e57568
 	github.com/elastic/go-hdrhistogram v0.1.0
+	github.com/elastic/go-lookslike v0.3.0
 	github.com/elastic/go-ucfg v0.8.4
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible
 	github.com/gofrs/uuid v4.2.0+incompatible

--- a/model/modeldecoder/rumv3/transaction_test.go
+++ b/model/modeldecoder/rumv3/transaction_test.go
@@ -247,6 +247,7 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 				// ExcludeFromGrouping is set when processing the event
 				"Stacktrace.ExcludeFromGrouping",
 				// Not set for span events:
+				"Links",
 				"DestinationService.ResponseTime",
 				"DestinationService.ResponseTime.Count",
 				"DestinationService.ResponseTime.Sum",

--- a/model/modeldecoder/v2/span_test.go
+++ b/model/modeldecoder/v2/span_test.go
@@ -94,6 +94,7 @@ func TestDecodeMapToSpanModel(t *testing.T) {
 				"Kind",
 
 				// Not set for spans:
+				"Links",
 				"DestinationService.ResponseTime",
 				"DestinationService.ResponseTime.Count",
 				"DestinationService.ResponseTime.Sum",

--- a/model/span.go
+++ b/model/span.go
@@ -52,6 +52,7 @@ type Span struct {
 	Message    *Message
 	Stacktrace Stacktrace
 	Sync       *bool
+	Links      []SpanLink
 
 	DB                 *DB
 	DestinationService *DestinationService
@@ -157,5 +158,12 @@ func (e *Span) fields() common.MapStr {
 		span.set("stacktrace", st)
 	}
 	span.maybeSetMapStr("self_time", e.SelfTime.fields())
+	if n := len(e.Links); n > 0 {
+		links := make([]common.MapStr, n)
+		for i, link := range e.Links {
+			links[i] = link.fields()
+		}
+		span.set("links", links)
+	}
 	return common.MapStr(span)
 }

--- a/model/span_test.go
+++ b/model/span_test.go
@@ -44,6 +44,7 @@ func TestSpanTransform(t *testing.T) {
 	timestampUs := timestamp.UnixNano() / 1000
 	instance, statement, dbType, user, rowsAffected := "db01", "select *", "sql", "jane", 5
 	destServiceType, destServiceName, destServiceResource := "db", "elasticsearch", "elasticsearch"
+	links := []SpanLink{{Span: Span{ID: "linked_span"}, Trace: Trace{ID: "linked_trace"}}}
 
 	tests := []struct {
 		Span   Span
@@ -75,6 +76,7 @@ func TestSpanTransform(t *testing.T) {
 				},
 				Message:   &Message{QueueName: "users"},
 				Composite: &Composite{Count: 10, Sum: 1.1, CompressionStrategy: "exact_match"},
+				Links:     links,
 			},
 			Output: common.MapStr{
 				"processor": common.MapStr{"name": "transaction", "event": "span"},
@@ -110,6 +112,10 @@ func TestSpanTransform(t *testing.T) {
 						"sum":                  common.MapStr{"us": 1100},
 						"compression_strategy": "exact_match",
 					},
+					"links": []common.MapStr{{
+						"span":  common.MapStr{"id": "linked_span"},
+						"trace": common.MapStr{"id": "linked_trace"},
+					}},
 				},
 				"timestamp": common.MapStr{"us": int(timestampUs)},
 			},

--- a/model/spanlink.go
+++ b/model/spanlink.go
@@ -1,0 +1,37 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package model
+
+import "github.com/elastic/beats/v7/libbeat/common"
+
+// SpanLink represents a link between two span events,
+// possibly (but not necessarily) in different traces.
+type SpanLink struct {
+	// Span holds information about the linked span event.
+	Span Span
+
+	// Trace holds information about the trace of the linked span event.
+	Trace Trace
+}
+
+func (l *SpanLink) fields() common.MapStr {
+	var fields mapStr
+	fields.maybeSetMapStr("span", l.Span.fields())
+	fields.maybeSetMapStr("trace", l.Trace.fields())
+	return common.MapStr(fields)
+}

--- a/model/spanlink_test.go
+++ b/model/spanlink_test.go
@@ -1,0 +1,63 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+func TestSpanLinkFields(t *testing.T) {
+	tests := []struct {
+		Input    SpanLink
+		Expected common.MapStr
+	}{{
+		Input:    SpanLink{},
+		Expected: nil,
+	}, {
+		Input: SpanLink{
+			Span: Span{ID: "span_id"},
+		},
+		Expected: common.MapStr{
+			"span": common.MapStr{"id": "span_id"},
+		},
+	}, {
+		Input: SpanLink{
+			Trace: Trace{ID: "trace_id"},
+		},
+		Expected: common.MapStr{
+			"trace": common.MapStr{"id": "trace_id"},
+		},
+	}, {
+		Input: SpanLink{
+			Span:  Span{ID: "span_id"},
+			Trace: Trace{ID: "trace_id"},
+		},
+		Expected: common.MapStr{
+			"span":  common.MapStr{"id": "span_id"},
+			"trace": common.MapStr{"id": "trace_id"},
+		},
+	}}
+	for _, test := range tests {
+		output := test.Input.fields()
+		assert.Equal(t, test.Expected, output)
+	}
+}


### PR DESCRIPTION
## Motivation/summary

This PR adds support for span links to our data model, enabling a span/transaction to be associated with zero or more other spans/transactions. We use `span.links` and `span.links.span.id` regardless of whether the linked entities are spans or transactions.

The PR also adds support for capturing OpenTelemetry span links.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
~- [ ] Documentation has been updated~

## How to test these changes

1. Using an OpenTelemetry SDK, send a span with links to APM Server.
2. Check that the trace ID and span ID of the link are stored. Any attributes or trace-state associated with the link should not be stored.
3. Ensure the trace can be find when searching `traces-apm*` and querying by `span.links.trace.id`

## Related issues

Closes https://github.com/elastic/apm-server/issues/7171