### PR TITLE
[automation] update elastic stack version for testing 7.17.1-d1501547

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       fleet-server: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.1-48ecd1f2-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.1-d1501547-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -62,7 +62,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.17.1-48ecd1f2-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.17.1-d1501547-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -86,7 +86,7 @@ services:
       package-registry: { condition: service_healthy }
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:7.17.1-48ecd1f2-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:7.17.1-d1501547-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Mon, 14 Feb 2022 05:14:22 GMT, release_branch:7.17, prefix:, end_time:Mon, 14 Feb 2022 09:40:28 GMT, manifest_version:2.0.0, version:7.17.1-SNAPSHOT, branch:7.17, build_id:7.17.1-d1501547, build_duration_seconds:15966]