### PR TITLE
ci: support for next patch release branch 8

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -20,7 +20,7 @@ pipeline {
   stages {
     stage('Nighly update Beats builds') {
       steps {
-        updateBeatsBuilds(branches: ['main', '8.<minor>', '7.<minor>', '7.<next-minor>'])
+        updateBeatsBuilds(branches: ['main', '8.<minor>', '8.<next-patch>', '7.<minor>', '7.<next-minor>'])
       }
     }
   }
@@ -52,6 +52,10 @@ def getBranchName(branch) {
   }
   if (branch.contains('8.<next-minor>')) {
     return bumpUtils.getMajorMinor(bumpUtils.getNextMinorReleaseFor8())
+  }
+  // special macro to look for the latest minor version
+  if (branch.contains('8.<next-patch>')) {
+    return bumpUtils.getMajorMinor(bumpUtils.getNextPatchReleaseFor8())
   }
   if (branch.contains('7.<minor>')) {
     return bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor7())

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -20,7 +20,7 @@ pipeline {
   stages {
     stage('Nighly update Beats builds') {
       steps {
-        updateBeatsBuilds(branches: ['main', '8.<minor>', '8.<next-patch>', '7.<minor>', '7.<next-minor>'])
+        updateBeatsBuilds(branches: ['main', '8.<minor>', '8.<next-minor>', '8.<next-patch>', '7.<minor>'])
       }
     }
   }

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -20,7 +20,7 @@ pipeline {
   stages {
     stage('Nighly update Beats builds') {
       steps {
-        updateBeatsBuilds(branches: ['main', '8.<minor>', '8.<next-minor>', '8.<next-patch>', '7.<minor>'])
+        updateBeatsBuilds(branches: ['main', '8.<minor>', '8.<next-patch>', '7.<minor>'])
       }
     }
   }

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -32,36 +32,8 @@ pipeline {
 }
 
 def updateBeatsBuilds(Map args = [:]) {
-  def branches = []
-  // Expand macros and filter duplicated matches.
-  args.branches.each { branch ->
-    def branchName = getBranchName(branch)
-    if (!branches.contains(branchName)) {
-      branches << branchName
-    }
-  }
+  def branches = getBranchesFromAliases(aliases: args.branches)
   branches.each { branch ->
     build(job: "apm-server/update-beats-mbp/${branch}", wait: false, propagate: false)
   }
-}
-
-def getBranchName(branch) {
-  // special macro to look for the latest minor version
-  if (branch.contains('8.<minor>')) {
-   return bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor8())
-  }
-  if (branch.contains('8.<next-minor>')) {
-    return bumpUtils.getMajorMinor(bumpUtils.getNextMinorReleaseFor8())
-  }
-  // special macro to look for the latest minor version
-  if (branch.contains('8.<next-patch>')) {
-    return bumpUtils.getMajorMinor(bumpUtils.getNextPatchReleaseFor8())
-  }
-  if (branch.contains('7.<minor>')) {
-    return bumpUtils.getMajorMinor(bumpUtils.getCurrentMinorReleaseFor7())
-  }
-  if (branch.contains('7.<next-minor>')) {
-    return bumpUtils.getMajorMinor(bumpUtils.getNextMinorReleaseFor7())
-  }
-  return branch
 }


### PR DESCRIPTION
## Motivation/summary

7 major branch is only about `7.17`, while the `8` major branch supports now:
- 8.0
- 8.1

Update the daily jobs to use the right aliases since 7 major won't have any further minor releases.

## Issues

Requires https://github.com/elastic/apm-pipeline-library/pull/1548