### PR TITLE
disable seccomp by default

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -27,3 +27,4 @@ See <<apm-server-configuration>> for more information.
 - Added several dimensions to the aggregated transaction metrics {pull}7033[7033]
 - Implemented translation of OpenTelemetry host system metrics (CPU utilization / Memory usage) {pull}7090[7090]
 - Added support for storing OpenTelemetry span links as `span.links` {pull}7291[7291]
+- seccomp is disabled by default {pull}7308[7308]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,7 +64,19 @@ var libbeatConfigOverrides = func() []cfgfile.ConditionalOverride {
 					"output.elasticsearch.compression_level": 5,
 				})
 			}(),
-		}}
+		},
+		{
+			Check: func(_ *common.Config) bool {
+				return true
+			},
+			Config: func() *common.Config {
+				// default to turning off seccomp
+				return common.MustNewConfigFrom(map[string]interface{}{
+					"seccomp.enabled": false,
+				})
+			}(),
+		},
+	}
 }
 
 // DefaultSettings return the default settings for APM Server to pass into

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -35,7 +35,7 @@ func TestCloudEnv(t *testing.T) {
 
 	// no cloud environment variable set
 	settings := DefaultSettings()
-	assert.Len(t, settings.ConfigOverrides, 2)
+	assert.Len(t, settings.ConfigOverrides, 3)
 	assert.False(t, settings.ConfigOverrides[1].Check(nil))
 
 	// cloud environment picked up

--- a/systemtest/export_test.go
+++ b/systemtest/export_test.go
@@ -56,6 +56,8 @@ path:
   data: /home/apm-server/data
   home: /home/apm-server
   logs: /home/apm-server/logs
+seccomp:
+  enabled: false
 `[1:], "/home/apm-server", tempdir)
 	assert.Equal(t, expectedConfig, string(out))
 }
@@ -63,6 +65,7 @@ path:
 func TestExportConfigOverrideDefaults(t *testing.T) {
 	cmd, tempdir := exportConfigCommand(t,
 		"-E", "logging.metrics.enabled=true",
+		"-E", "seccomp.enabled=true",
 	)
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err)
@@ -76,6 +79,8 @@ path:
   data: /home/apm-server/data
   home: /home/apm-server
   logs: /home/apm-server/logs
+seccomp:
+  enabled: true
 `[1:], "/home/apm-server", tempdir)
 	assert.Equal(t, expectedConfig, string(out))
 }


### PR DESCRIPTION
## Motivation/summary

disable seccomp (linux-only) to allow fork/exec'ing the java attacher

## How to test these changes

0. ensure `java-attacher.jar` is in the same directory as the `apm-server` binary
1. add the following to `apm-server.yml`
    ```yml
    logging.level: debug
    apm-server:
      java_attacher:
        enabled: true
        download-agent-version: 1.28.4
        discovery-rules:
        - include-main: opbeans
        - exclude-main: ".*"
        config:
          server_url: "http://localhost:8200"
    ```
2. start the apm-server, check that there's no seccomp error message:
    ```
    # ./apm-server -c apm-server.yml -e 2>&1 | grep fork
    {"log.level":"error","@timestamp":"2022-02-16T12:34:54.385+0100","log.logger":"beater","log.origin":{"file.name":"beater/beater.go","file.line":447},"message":"failed to run java attacher: fork/exec /bin/java: operation not permitted","service.name":"apm-server","ecs.version":"1.6.0"}
    ```

## Related issues

closes https://github.com/elastic/apm-server/issues/7305