### PR TITLE
docs: Add canonical URLs to legacy APM documentation

### DIFF
--- a/docs/agent-configuration.asciidoc
+++ b/docs/agent-configuration.asciidoc
@@ -1,4 +1,4 @@
-[[agent-configuration-api]]
+[id="agent-configuration-api",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/api-config.html"]
 == Agent configuration API
 
 ++++

--- a/docs/api-keys.asciidoc
+++ b/docs/api-keys.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[beats-api-keys]]
+[id="beats-api-keys",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/api-key.html"]
 == Grant access using API keys
 
 Instead of using usernames and passwords, you can use API keys to grant

--- a/docs/apm-package/apm-integration.asciidoc
+++ b/docs/apm-package/apm-integration.asciidoc
@@ -1,4 +1,4 @@
-[[apm-integration]]
+[id="apm-integration",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/upgrade-to-apm-integration.html"]
 = APM integration for {agent}
 
 ++++

--- a/docs/apm-package/configure.asciidoc
+++ b/docs/apm-package/configure.asciidoc
@@ -11,7 +11,7 @@ Templates, pipelines, index lifecycle management, etc.,
 cannot be configured with APM Server or Fleet, and must instead be configured in {kib} or with
 {es} APIs.
 
-[[apm-integration-templates]]
+[id="apm-integration-templates",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/custom-index-template.html"]
 === Index templates
 
 The APM integration loads default index templates into {es}.
@@ -22,7 +22,7 @@ Search for `apm`.
 
 See {ref}/index-templates.html[index templates] for more information.
 
-[[apm-integration-pipelines]]
+[id="apm-integration-pipelines",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/ingest-pipelines.html"]
 === Pipelines
 
 The APM integration loads default ingest node pipelines into {es}.
@@ -33,7 +33,7 @@ Search for `apm`.
 
 See {ref}/ingest.html[ingest node pipelines] for more information.
 
-[[apm-integration-ilm]]
+[id="apm-integration-ilm",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/ilm-how-to.html"]
 === Index lifecycle management (ILM)
 
 The index lifecycle management (ILM) feature in {es} allows you to automate the

--- a/docs/apm-package/data-streams.asciidoc
+++ b/docs/apm-package/data-streams.asciidoc
@@ -1,4 +1,4 @@
-[[apm-integration-data-streams]]
+[id="apm-integration-data-streams",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/apm-data-streams.html"]
 == Data streams
 
 ****

--- a/docs/apm-package/input-apm.asciidoc
+++ b/docs/apm-package/input-apm.asciidoc
@@ -1,6 +1,6 @@
 :input-type: apm
 
-[[input-apm]]
+[id="input-apm",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/input-apm.html"]
 == APM input settings
 
 ++++

--- a/docs/breaking-changes.asciidoc
+++ b/docs/breaking-changes.asciidoc
@@ -1,7 +1,7 @@
 :issue: https://github.com/elastic/apm-server/issues/
 :pull: https://github.com/elastic/apm-server/pull/
 
-[[breaking-changes]]
+[id="breaking-changes",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/apm-breaking.html"]
 == Breaking Changes
 APM Server is built on top of {beats-ref}/index.html[libbeat].
 As such, any breaking change in libbeat is also considered to be a breaking change in APM Server.

--- a/docs/configuration-anonymous.asciidoc
+++ b/docs/configuration-anonymous.asciidoc
@@ -1,4 +1,4 @@
-[[configuration-anonymous]]
+[id="configuration-anonymous",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/anonymous-auth.html"]
 == Anonymous auth configuration options
 
 ++++

--- a/docs/configuring.asciidoc
+++ b/docs/configuring.asciidoc
@@ -1,4 +1,4 @@
-[[configuring-howto-apm-server]]
+[id="configuring-howto-apm-server",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/configuring-howto-apm-server.html"]
 = Configure APM Server
 
 [partintro]

--- a/docs/error-api.asciidoc
+++ b/docs/error-api.asciidoc
@@ -1,4 +1,4 @@
-[[error-api]]
+[id="error-api",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/api-error.html"]
 === Errors
 
 An error or a logged error message captured by an agent occurring in a monitored service.

--- a/docs/events-api.asciidoc
+++ b/docs/events-api.asciidoc
@@ -1,4 +1,4 @@
-[[events-api]]
+[id="events-api",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/api-events.html"]
 == Events Intake API
 
 ++++

--- a/docs/getting-started-apm-server.asciidoc
+++ b/docs/getting-started-apm-server.asciidoc
@@ -1,4 +1,4 @@
-[[getting-started-apm-server]]
+[id="getting-started-apm-server",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/apm-quick-start.html"]
 == Getting started with APM Server
 
 ++++

--- a/docs/guide/agent-server-compatibility.asciidoc
+++ b/docs/guide/agent-server-compatibility.asciidoc
@@ -1,4 +1,4 @@
-[[agent-server-compatibility]]
+[id="agent-server-compatibility",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/agent-server-compatibility.html"]
 == Agent and Server compatibility
 
 The chart below outlines the compatibility between different versions of the APM agents and the APM Server.

--- a/docs/guide/apm-breaking-changes.asciidoc
+++ b/docs/guide/apm-breaking-changes.asciidoc
@@ -1,7 +1,7 @@
 :issue: https://github.com/elastic/apm-server/issues/
 :pull: https://github.com/elastic/apm-server/pull/
 
-[[apm-breaking-changes]]
+[id="apm-breaking-changes",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/apm-breaking.html"]
 == Breaking changes
 
 This section discusses the changes that you need to be aware of when migrating your application from one version of APM to another.

--- a/docs/guide/apm-data-model.asciidoc
+++ b/docs/guide/apm-data-model.asciidoc
@@ -1,4 +1,4 @@
-[[apm-data-model]]
+[id="apm-data-model",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/data-model.html"]
 == Data Model
 
 Elastic APM agents capture different types of information from within their instrumented applications.
@@ -11,7 +11,7 @@ These are known as events, and can be `spans`, `transactions`, `errors`, or `met
 
 Events can contain additional <<metadata,metadata>> which further enriches your data.
 
-[[transaction-spans]]
+[id="transaction-spans",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/data-model-spans.html"]
 === Spans
 
 *Spans* contain information about the execution of a specific code path.
@@ -68,7 +68,7 @@ Agents know how many spans a transaction should have;
 if the number of expected spans does not equal the number of spans received by the APM Server,
 the APM app will calculate the difference and display a message.
 
-[[transactions]]
+[id="transactions",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/data-model-transactions.html"]
 === Transactions
 
 *Transactions* are a special kind of <<transaction-spans,span>> that have additional attributes associated with them.
@@ -118,7 +118,7 @@ non-keyword fields (e.g. `span.db.statement`) to 10,000 characters.
 
 Transactions are stored in {apm-server-ref-v}/transaction-indices.html[transaction indices].
 
-[[errors]]
+[id="errors",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/data-model-errors.html"]
 === Errors
 
 An error event contains at least
@@ -148,7 +148,7 @@ non-keyword fields (e.g. `error.exception.message`) to 10,000 characters.
 
 Errors are stored in {apm-server-ref-v}/error-indices.html[error indices].
 
-[[metrics]]
+[id="metrics",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/data-model-metrics.html"]
 === Metrics
 
 APM agents automatically pick up basic host-level metrics,
@@ -176,7 +176,7 @@ For a full list of tracked metrics, see the relevant agent documentation:
 * {apm-ruby-ref-v}/metrics.html[Ruby]
 
 // This heading is linked to from the APM UI section in Kibana
-[[metadata]]
+[id="metadata",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/data-model-metadata.html"]
 === Metadata
 
 Metadata can enrich your events and make application performance monitoring even more useful.

--- a/docs/guide/apm-doc-directory.asciidoc
+++ b/docs/guide/apm-doc-directory.asciidoc
@@ -1,4 +1,4 @@
-[[components]]
+[id="components",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/apm-components.html"]
 === Components and documentation
 
 Elastic APM consists of four components: *APM agents*, *APM Server*, *Elasticsearch*, and *Kibana*.

--- a/docs/guide/cross-cluster-search.asciidoc
+++ b/docs/guide/cross-cluster-search.asciidoc
@@ -1,4 +1,4 @@
-[[apm-cross-cluster-search]]
+[id="apm-cross-cluster-search",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/cross-cluster-search.html"]
 === Cross-cluster search
 
 Elastic APM utilizes Elasticsearch's cross-cluster search functionality.

--- a/docs/guide/data-security.asciidoc
+++ b/docs/guide/data-security.asciidoc
@@ -1,4 +1,4 @@
-[[data-security]]
+[id="data-security",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/apm-data-security.html"]
 === Data security
 
 When setting up Elastic APM, it's essential to review all captured data carefully to ensure

--- a/docs/guide/distributed-tracing.asciidoc
+++ b/docs/guide/distributed-tracing.asciidoc
@@ -1,4 +1,4 @@
-[[distributed-tracing]]
+[id="distributed-tracing",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/apm-distributed-tracing.html"]
 === Distributed tracing
 
 A `trace` is a group of <<transactions,transactions>> and <<transaction-spans,spans>> with a common root.

--- a/docs/guide/features.asciidoc
+++ b/docs/guide/features.asciidoc
@@ -1,4 +1,4 @@
-[[apm-features]]
+[id="apm-features",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/features.html"]
 == Elastic APM features
 
 ++++

--- a/docs/guide/index.asciidoc
+++ b/docs/guide/index.asciidoc
@@ -8,7 +8,7 @@ NOTE: For the best reading experience,
 please view this documentation at https://www.elastic.co/guide/en/apm/get-started[elastic.co]
 endif::[]
 
-[[gettting-started]]
+[id="gettting-started",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/index.html"]
 = APM Overview
 
 include::./overview.asciidoc[]

--- a/docs/guide/install-and-run.asciidoc
+++ b/docs/guide/install-and-run.asciidoc
@@ -1,4 +1,4 @@
-[[install-and-run]]
+[id="install-and-run",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/apm-quick-start.html"]
 == Quick start guide
 
 This guide describes how to get started quickly with Elastic APM. You’ll learn how to:

--- a/docs/guide/obs-integrations.asciidoc
+++ b/docs/guide/obs-integrations.asciidoc
@@ -1,4 +1,4 @@
-[[observability-integrations]]
+[id="observability-integrations",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/log-correlation.html"]
 === Observability integrations
 
 Elastic APM supports integrations with other observability solutions.

--- a/docs/guide/opentelemetry-elastic.asciidoc
+++ b/docs/guide/opentelemetry-elastic.asciidoc
@@ -1,4 +1,4 @@
-[[open-telemetry-elastic]]
+[id="open-telemetry-elastic",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/open-telemetry.html"]
 === OpenTelemetry integration
 
 :ot-spec:       https://github.com/open-telemetry/opentelemetry-specification/blob/master/README.md

--- a/docs/guide/overview.asciidoc
+++ b/docs/guide/overview.asciidoc
@@ -1,4 +1,4 @@
-[[overview]]
+[id="overview",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/apm-overview.html"]
 == Free and open application performance monitoring
 
 ++++

--- a/docs/guide/rum.asciidoc
+++ b/docs/guide/rum.asciidoc
@@ -1,4 +1,4 @@
-[[rum]]
+[id="rum",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/apm-rum.html"]
 === Real User Monitoring (RUM)
 Real User Monitoring captures user interaction with clients such as web browsers.
 The {apm-rum-ref-v}[JavaScript Agent] is Elastic’s RUM Agent.

--- a/docs/guide/trace-sampling.asciidoc
+++ b/docs/guide/trace-sampling.asciidoc
@@ -1,4 +1,4 @@
-[[trace-sampling]]
+[id="trace-sampling",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/sampling.html"]
 === Transaction sampling
 
 Elastic APM supports head-based, probability sampling.

--- a/docs/howto.asciidoc
+++ b/docs/howto.asciidoc
@@ -1,4 +1,4 @@
-[[howto-guides]]
+[id="howto-guides",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/how-to-guides.html"]
 = How-to guides
 
 [partintro]

--- a/docs/ilm-reference.asciidoc
+++ b/docs/ilm-reference.asciidoc
@@ -1,4 +1,4 @@
-[[ilm-reference]]
+[id="ilm-reference",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/ilm-how-to.html"]
 [role="xpack"]
 == Configure Index lifecycle management (ILM)
 

--- a/docs/ilm.asciidoc
+++ b/docs/ilm.asciidoc
@@ -1,4 +1,4 @@
-[[ilm]]
+[id="ilm",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/ilm-how-to.html"]
 [role="xpack"]
 == Custom index lifecycle management with APM Server
 

--- a/docs/intake-api.asciidoc
+++ b/docs/intake-api.asciidoc
@@ -1,4 +1,4 @@
-[[intake-api]]
+[id="intake-api",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/api-events.html"]
 = API
 
 [partintro]

--- a/docs/jaeger-reference.asciidoc
+++ b/docs/jaeger-reference.asciidoc
@@ -1,4 +1,4 @@
-[[jaeger-reference]]
+[id="jaeger-reference",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/jaeger-integration.html"]
 == Configure Jaeger
 
 ++++

--- a/docs/jaeger-support.asciidoc
+++ b/docs/jaeger-support.asciidoc
@@ -1,4 +1,4 @@
-[[jaeger]]
+[id="jaeger",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/jaeger-integration.html"]
 == Jaeger integration
 
 ++++

--- a/docs/metadata-api.asciidoc
+++ b/docs/metadata-api.asciidoc
@@ -1,4 +1,4 @@
-[[metadata-api]]
+[id="metadata-api",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/api-metadata.html"]
 === Metadata
 
 Every new connection to the APM Server starts with a `metadata` stanza.

--- a/docs/metricset-api.asciidoc
+++ b/docs/metricset-api.asciidoc
@@ -1,4 +1,4 @@
-[[metricset-api]]
+[id="metricset-api",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/api-metricset.html"]
 === Metrics
 
 Metrics contain application metric data captured by an APM agent.

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -1,6 +1,6 @@
 :root-dir: ../
 
-[[release-notes]]
+[id="release-notes",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/release-notes.html"]
 = Release notes
 :issue: https://github.com/elastic/apm-server/issues/
 :pull: https://github.com/elastic/apm-server/pull/

--- a/docs/secure-communication-agents.asciidoc
+++ b/docs/secure-communication-agents.asciidoc
@@ -1,4 +1,4 @@
-[[secure-communication-agents]]
+[id="secure-communication-agents",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/secure-agent-communication.html"]
 == Secure communication with APM agents
 
 Communication between APM agents and APM Server can be both encrypted and authenticated.
@@ -22,7 +22,7 @@ There is a less straightforward and more restrictive way to authenticate clients
 <<ssl-client-authentication,SSL/TLS client authentication>>, which is currently a mainstream option only
 for the RUM agent (through the browser) and the Jaeger agent.
 
-[[ssl-setup]]
+[id="ssl-setup",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/agent-tls.html"]
 === SSL/TLS communication
 
 // Use the shared ssl short description

--- a/docs/server-info.asciidoc
+++ b/docs/server-info.asciidoc
@@ -1,4 +1,4 @@
-[[server-info]]
+[id="server-info",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/api-info.html"]
 == Server Information API
 
 ++++

--- a/docs/sourcemap-api.asciidoc
+++ b/docs/sourcemap-api.asciidoc
@@ -55,7 +55,7 @@ While comparing the stack trace frame's `abs_path` with the source map's `bundle
 }
 ---------------------------------------------------------------------------
 
-But if there is no full match, it also accepts source maps that match only the URLs path (without the host). 
+But if there is no full match, it also accepts source maps that match only the URLs path (without the host).
 [source,console]
 ---------------------------------------------------------------------------
 {

--- a/docs/sourcemaps.asciidoc
+++ b/docs/sourcemaps.asciidoc
@@ -1,4 +1,4 @@
-[[sourcemaps]]
+[id="sourcemaps",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/source-map-how-to.html"]
 == How to apply source maps to error stack traces when using minified bundles
 
 ++++

--- a/docs/span-api.asciidoc
+++ b/docs/span-api.asciidoc
@@ -1,4 +1,4 @@
-[[span-api]]
+[id="span-api",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/api-span.html"]
 === Spans
 
 Spans are events captured by an agent occurring in a monitored service.

--- a/docs/transaction-api.asciidoc
+++ b/docs/transaction-api.asciidoc
@@ -1,4 +1,4 @@
-[[transaction-api]]
+[id="transaction-api",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/api-transaction.html"]
 === Transactions
 
 Transactions are events corresponding to an incoming request or similar task occurring in a monitored service.

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -1,4 +1,4 @@
-[[upgrading]]
+[id="upgrading",canonical-url="https://www.elastic.co/guide/en/apm/guide/current/upgrade.html"]
 = Upgrade APM Server
 
 ++++


### PR DESCRIPTION
### Summary

In Elastic Stack version 7.16, the **APM Guide** was introduced. This guide is a combination of two previous documentation books, the **APM Server Reference** and the **APM Overview**. Forevermore, the 7.15 versions of the **APM Server Reference** and **APM Overview** will be marked as `current` <sup>1</sup> . This poses a problem: the **Server Reference** and **Overview** have strong SEO rankings, leading many google searches to these out-of-date docs, instead of to the _real_ `current` **APM Guide** documentation.

This PR adds a [canonical URL](https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls) to pages in the 7.15 **APM Server Reference** and **APM Overview** that have similar or duplicate content in the current **APM Guide**. The hope is that these canonical references point searches to the new documentation, instead of the old docs.

<sup>1</sup> This is a limitation of current build


### Notes for myself if I have to do this again:

* Find: `\[\[(.+)\]\]`
* Replace: `[id="$1",canonical-url=""]`

### Related

* Adding canonical URLs to documentation pages is a new feature added in https://github.com/elastic/docs/pull/2373. Thanks, @gtback.