### PR TITLE
allow data stream namespace configuration for standalone

### DIFF
--- a/_meta/beat.yml
+++ b/_meta/beat.yml
@@ -81,6 +81,9 @@ apm-server:
   # request from the agent.
   #default_service_environment:
 
+  # All events will be recorded in this data stream namespace when not managed by fleet.
+  # data_streams.namespace: default
+
   # Enable APM Server Golang expvar support (https://golang.org/pkg/expvar/).
   #expvar:
     #enabled: false

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -81,6 +81,9 @@ apm-server:
   # request from the agent.
   #default_service_environment:
 
+  # All events will be recorded in this data stream namespace when not managed by fleet.
+  # data_streams.namespace: default
+
   # Enable APM Server Golang expvar support (https://golang.org/pkg/expvar/).
   #expvar:
     #enabled: false

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -81,6 +81,9 @@ apm-server:
   # request from the agent.
   #default_service_environment:
 
+  # All events will be recorded in this data stream namespace when not managed by fleet.
+  # data_streams.namespace: default
+
   # Enable APM Server Golang expvar support (https://golang.org/pkg/expvar/).
   #expvar:
     #enabled: false

--- a/beater/beater.go
+++ b/beater/beater.go
@@ -205,7 +205,6 @@ func (bt *beater) run(ctx context.Context, cancelContext context.CancelFunc, b *
 		})
 	} else {
 		// Management disabled, use statically defined config.
-		reloader.namespace = "default"
 		reloader.rawConfig = bt.rawConfig
 		if b.Config != nil {
 			reloader.outputConfig = b.Config.Output
@@ -299,7 +298,6 @@ func (r *reloader) reload() error {
 
 	runner, err := newServerRunner(r.runServerContext, serverRunnerParams{
 		sharedServerRunnerParams: r.args,
-		Namespace:                r.namespace,
 		RawConfig:                r.rawConfig,
 		FleetConfig:              r.fleetConfig,
 		OutputConfig:             r.outputConfig,
@@ -357,7 +355,6 @@ type serverRunner struct {
 type serverRunnerParams struct {
 	sharedServerRunnerParams
 
-	Namespace    string
 	RawConfig    *common.Config
 	FleetConfig  *config.Fleet
 	OutputConfig common.ConfigNamespace
@@ -397,7 +394,7 @@ func newServerRunner(ctx context.Context, args serverRunnerParams) (*serverRunne
 		fleetConfig:               args.FleetConfig,
 		acker:                     args.Acker,
 		pipeline:                  args.Beat.Publisher,
-		namespace:                 args.Namespace,
+		namespace:                 cfg.DataStreams.Namespace,
 		beat:                      args.Beat,
 		logger:                    args.Logger,
 		tracer:                    args.Tracer,

--- a/beater/config/config_test.go
+++ b/beater/config/config_test.go
@@ -261,6 +261,7 @@ func TestUnpackConfig(t *testing.T) {
 				},
 				DefaultServiceEnvironment: "overridden",
 				DataStreams: DataStreamsConfig{
+					Namespace:          "default",
 					WaitForIntegration: true,
 				},
 				WaitReadyInterval: 5 * time.Second,
@@ -315,7 +316,10 @@ func TestUnpackConfig(t *testing.T) {
 					"interval":          "2m",
 					"ingest_rate_decay": 1.0,
 				},
-				"data_streams.wait_for_integration": false,
+				"data_streams": map[string]interface{}{
+					"namespace":            "foo",
+					"wait_for_integration": false,
+				},
 			},
 			outCfg: &Config{
 				Host:            "localhost:3000",
@@ -404,6 +408,7 @@ func TestUnpackConfig(t *testing.T) {
 					},
 				},
 				DataStreams: DataStreamsConfig{
+					Namespace:          "foo",
 					WaitForIntegration: false,
 				},
 				WaitReadyInterval: 5 * time.Second,

--- a/beater/config/data_streams.go
+++ b/beater/config/data_streams.go
@@ -19,6 +19,8 @@ package config
 
 // DataStreamsConfig holds data streams configuration.
 type DataStreamsConfig struct {
+	Namespace string `config:"namespace"`
+
 	// WaitForIntegration controls whether APM Server waits for the Fleet
 	// integration package to be installed before indexing events.
 	//
@@ -32,6 +34,7 @@ type DataStreamsConfig struct {
 
 func defaultDataStreamsConfig() DataStreamsConfig {
 	return DataStreamsConfig{
+		Namespace:          "default",
 		WaitForIntegration: true,
 	}
 }

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -26,3 +26,4 @@ See <<apm-server-configuration>> for more information.
 - Added several dimensions to the aggregated transaction metrics {pull}7033[7033]
 - Implemented translation of OpenTelemetry host system metrics (CPU utilization / Memory usage) {pull}7090[7090]
 - Added support for storing OpenTelemetry span links as `span.links` {pull}7291[7291]
+- Added data stream namespace configuration for standalone with `apm-server.data_streams.namespace` {pull}XXX[XXX]

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -26,4 +26,4 @@ See <<apm-server-configuration>> for more information.
 - Added several dimensions to the aggregated transaction metrics {pull}7033[7033]
 - Implemented translation of OpenTelemetry host system metrics (CPU utilization / Memory usage) {pull}7090[7090]
 - Added support for storing OpenTelemetry span links as `span.links` {pull}7291[7291]
-- Added data stream namespace configuration for standalone with `apm-server.data_streams.namespace` {pull}XXX[XXX]
+- Added data stream namespace configuration for standalone with `apm-server.data_streams.namespace` {pull}7314[7314]


### PR DESCRIPTION
using `apm-server.data_streams.namespace`

## Motivation/summary

closes #7313 

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

## How to test these changes

Start an unmanaged apm-server with `apm-server.data_streams.namespace` set and inspect the trace data streams created.