### PR TITLE
Revert "[mage] filter .dmg package creation"

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -202,12 +202,6 @@ func customizePackaging() {
 
 	for idx := len(mage.Packages) - 1; idx >= 0; idx-- {
 		args := &mage.Packages[idx]
-		pkgType := args.Types[0]
-		if pkgType == mage.DMG {
-			// We do not build macOS packages.
-			mage.Packages = append(mage.Packages[:idx], mage.Packages[idx+1:]...)
-			continue
-		}
 
 		// Replace the generic Beats README.md with an APM specific one, and remove files unused by apm-server.
 		for filename, filespec := range args.Spec.Files {


### PR DESCRIPTION
This reverts commit 7a3edfdba03e5fa2e448fa92cbab401b42a08150.

`mage.DMG` is not defined (edit: removed in https://github.com/elastic/beats/pull/30097 and pulled into main since then).  I'm not sure if this was pushed by accident but it doesn't seem to have come via a pull request.  
@stuartnelson3 