### PR TITLE
processor/otel: drop histograms without bounds

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -15,6 +15,7 @@ See <<apm-server-configuration>> for more information.
 ==== Bug fixes
 - Fix infinite loop in tail-based sampling subscriber causing high CPU and repeated Elasticsearch searches {pull}7211[7211]
 - Do not overwrite `service version` if no transaction/error/... specific `service.name` is givven {pull}7281[7281]
+- Fix panic when processing OpenTelemetry histogram metrics without bounds {pull}7316[7316]
 
 [float]
 ==== Intake API Changes

--- a/processor/otel/metrics.go
+++ b/processor/otel/metrics.go
@@ -383,7 +383,7 @@ func histogramSample(bucketCounts []uint64, explicitBounds []float64) (model.Met
 	//
 	// The values in the explicit_bounds array must be strictly increasing.
 	//
-	if len(bucketCounts) != len(explicitBounds)+1 {
+	if len(bucketCounts) != len(explicitBounds)+1 || len(explicitBounds) == 0 {
 		return model.MetricsetSample{}, false
 	}
 

--- a/processor/otel/metrics_test.go
+++ b/processor/otel/metrics_test.go
@@ -116,6 +116,14 @@ func TestConsumeMetrics(t *testing.T) {
 	invalidHistogramDP.SetExplicitBounds([]float64{1, 2, 3})
 	expectDropped++
 
+	metric = appendMetric("invalid_histogram_metric2", pdata.MetricDataTypeHistogram)
+	invalidHistogram = metric.Histogram()
+	invalidHistogramDP = invalidHistogram.DataPoints().AppendEmpty()
+	invalidHistogramDP.SetTimestamp(pdata.NewTimestampFromTime(timestamp0))
+	invalidHistogramDP.SetBucketCounts([]uint64{1})
+	invalidHistogramDP.SetExplicitBounds([]float64{}) // should be non-empty
+	expectDropped++
+
 	// Summary metrics are not yet supported, and will be dropped.
 	metric = appendMetric("summary_metric", pdata.MetricDataTypeSummary)
 	metric.Summary().DataPoints().AppendEmpty()


### PR DESCRIPTION
## Motivation/summary

Drop OpenTelemetry histograms that have no explicit bounds defined.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

See https://github.com/elastic/apm-server/issues/7282

## Related issues

Closes https://github.com/elastic/apm-server/issues/7282