### PR TITLE
Makefile: dependencies.csv dependends on $PYTHON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,7 +263,7 @@ release: export PATH:=$(dir $(BIN_MAGE)):$(PATH)
 release: $(MAGE) $(PYTHON) build/$(JAVA_ATTACHER_JAR) build/dependencies.csv
 	$(MAGE) package
 
-build/dependencies.csv: go.mod
+build/dependencies.csv: $(PYTHON) go.mod
 	$(PYTHON) script/generate_notice.py ./x-pack/apm-server --csv $@
 
 .imported-java-agent-pubkey:


### PR DESCRIPTION
Make sure we build the python venv that is required to build dependencies.csv.