### PR TITLE
txmetrics: add `faas.id` to aggregation key

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -20,6 +20,9 @@
     - description: added `error.id` field to `error_logs` data stream
       type: bugfix
       link: https://github.com/elastic/apm-server/pull/7123
+    - description: Added field mapping for `faas.id` to internal_metrics data stream
+      type: enhancement
+      link: https://github.com/elastic/apm-server/pull/7361
 - version: "8.0.0"
   changes:
     - description: support setting `download-agent-version`

--- a/apmpackage/apm/data_stream/internal_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/internal_metrics/fields/fields.yml
@@ -7,6 +7,10 @@
       type: boolean
       description: |
         Boolean indicating whether the function invocation was a coldstart or not.
+    - name: id
+      type: keyword
+      description: |
+        A unique identifier of the invoked serverless function.
     - name: trigger.type
       type: keyword
       description: |

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -374,6 +374,7 @@ func (a *Aggregator) makeTransactionAggregationKey(event model.APMEvent, interva
 		cloudMachineType:      event.Cloud.MachineType,
 
 		faasColdstart:   event.FAAS.Coldstart,
+		faasID:          event.FAAS.ID,
 		faasTriggerType: event.FAAS.TriggerType,
 	}
 }
@@ -431,6 +432,7 @@ func makeMetricset(
 		},
 		FAAS: model.FAAS{
 			Coldstart:   key.faasColdstart,
+			ID:          key.faasID,
 			TriggerType: key.faasTriggerType,
 		},
 		Processor: model.MetricsetProcessor,
@@ -475,6 +477,7 @@ type metricsMapEntry struct {
 type transactionAggregationKey struct {
 	timestamp              time.Time
 	faasColdstart          *bool
+	faasID                 string
 	agentName              string
 	hostOSPlatform         string
 	kubernetesPodName      string
@@ -542,6 +545,7 @@ func (k *transactionAggregationKey) hash() uint64 {
 	h.WriteString(k.transactionResult)
 	h.WriteString(k.transactionType)
 	h.WriteString(k.eventOutcome)
+	h.WriteString(k.faasID)
 	h.WriteString(k.faasTriggerType)
 	return h.Sum64()
 }

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
@@ -473,6 +473,7 @@ func TestAggregationFields(t *testing.T) {
 		&input.Service.Runtime.Name,
 		&input.Service.Runtime.Version,
 		&input.Host.OS.Platform,
+		&input.FAAS.ID,
 		&input.FAAS.TriggerType,
 	}
 	boolInputFields := []*bool{


### PR DESCRIPTION
## Motivation/summary

Add `faas.id` to the transaction metrics aggregation key. This is used by the UI to display the function name.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
~- [ ] Documentation has been updated~

## How to test these changes

1. Send some FaaS transactions to APM Server
2. Check the `faas.id` field shows up in the transaction metrics

## Related issues

Fixes #7344