### PR TITLE
 Update APM Add to Project Parameter Types

### DIFF
--- a/.github/workflows/add-to-apm-project.yml
+++ b/.github/workflows/add-to-apm-project.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           headers: '{"GraphQL-Features": "projects_next_graphql"}'
           query: |
-            mutation add_to_project($projectid:String!,$contentid:String!) {
+            mutation add_to_project($projectid:ID!,$contentid:ID!) {
               addProjectNextItem(input:{projectId:$projectid contentId:$contentid}) {
                 projectNextItem {
                   id
@@ -29,7 +29,7 @@ jobs:
         with:
           headers: '{"GraphQL-Features": "projects_next_graphql"}'
           query: |
-            mutation label_team($projectid:String!,$itemid:String!,$fieldid:String!,$value:String!) {
+            mutation label_team($projectid:ID!,$itemid:ID!,$fieldid:ID!,$value:String!) {
               updateProjectNextItemField(input: { projectId:$projectid itemId:$itemid fieldId:$fieldid value:$value }) {
                 projectNextItem {
                   id


### PR DESCRIPTION
https://github.com/elastic/apm-server/actions/runs/1909820154 is suddenly failing with:
```
Type mismatch on variable $projectid and argument projectId (String! / ID!)
```