### PR TITLE
[automation] update elastic stack version for testing 7.17.1-bf42f386

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       fleet-server: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.1-952e96f1-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.1-bf42f386-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -62,7 +62,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.17.1-952e96f1-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.17.1-bf42f386-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -86,7 +86,7 @@ services:
       package-registry: { condition: service_healthy }
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:7.17.1-952e96f1-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:7.17.1-bf42f386-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Mon, 28 Feb 2022 05:13:38 GMT, release_branch:7.17, prefix:, end_time:Mon, 28 Feb 2022 09:41:48 GMT, manifest_version:2.0.0, version:7.17.1-SNAPSHOT, branch:7.17, build_id:7.17.1-bf42f386, build_duration_seconds:16090]