### PR TITLE
add faas.{name,verson} to tx + txmetrics

### DIFF
--- a/apmpackage/apm/data_stream/traces/fields/fields.yml
+++ b/apmpackage/apm/data_stream/traces/fields/fields.yml
@@ -55,6 +55,14 @@
       type: keyword
       description: |
         The trigger type.
+    - name: name
+      type: keyword
+      description: |
+        The lambda function name.
+    - name: version
+      type: keyword
+      description: |
+        The lambda function version.
 - name: http
   type: group
   fields:

--- a/docs/spec/v2/transaction.json
+++ b/docs/spec/v2/transaction.json
@@ -833,6 +833,13 @@
             "string"
           ]
         },
+        "name": {
+          "description": "The lambda function name.",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "trigger": {
           "description": "Trigger attributes.",
           "type": [
@@ -855,6 +862,13 @@
               ]
             }
           }
+        },
+        "version": {
+          "description": "The lambda function version.",
+          "type": [
+            "null",
+            "string"
+          ]
         }
       }
     },

--- a/model/apmevent_test.go
+++ b/model/apmevent_test.go
@@ -109,6 +109,8 @@ func TestAPMEventFields(t *testing.T) {
 				Execution:        "execution",
 				TriggerType:      "http",
 				TriggerRequestID: "abc123",
+				Name:             "faasName",
+				Version:          "1.0.0",
 			},
 			Cloud: Cloud{
 				Origin: &CloudOrigin{
@@ -184,6 +186,8 @@ func TestAPMEventFields(t *testing.T) {
 				"execution":          "execution",
 				"trigger.type":       "http",
 				"trigger.request_id": "abc123",
+				"name":               "faasName",
+				"version":            "1.0.0",
 			},
 			"cloud": common.MapStr{
 				"origin": common.MapStr{

--- a/model/faas.go
+++ b/model/faas.go
@@ -26,6 +26,8 @@ type FAAS struct {
 	Execution        string
 	TriggerType      string
 	TriggerRequestID string
+	Name             string
+	Version          string
 }
 
 func (f *FAAS) fields() common.MapStr {
@@ -35,5 +37,7 @@ func (f *FAAS) fields() common.MapStr {
 	fields.maybeSetString("execution", f.Execution)
 	fields.maybeSetString("trigger.type", f.TriggerType)
 	fields.maybeSetString("trigger.request_id", f.TriggerRequestID)
+	fields.maybeSetString("name", f.Name)
+	fields.maybeSetString("version", f.Version)
 	return common.MapStr(fields)
 }

--- a/model/modeldecoder/rumv3/metadata_test.go
+++ b/model/modeldecoder/rumv3/metadata_test.go
@@ -65,6 +65,8 @@ func metadataExceptions(keys ...string) func(key string) bool {
 		"FAAS.Execution",
 		"FAAS.TriggerType",
 		"FAAS.TriggerRequestID",
+		"FAAS.Name",
+		"FAAS.Version",
 		"Experimental",
 		"HTTP",
 		"Kubernetes",

--- a/model/modeldecoder/v2/decoder.go
+++ b/model/modeldecoder/v2/decoder.go
@@ -243,6 +243,12 @@ func mapToFAASModel(from faas, faas *model.FAAS) {
 		if from.Trigger.RequestID.IsSet() {
 			faas.TriggerRequestID = from.Trigger.RequestID.Val
 		}
+		if from.Name.IsSet() {
+			faas.Name = from.Name.Val
+		}
+		if from.Version.IsSet() {
+			faas.Version = from.Version.Val
+		}
 	}
 }
 

--- a/model/modeldecoder/v2/metadata_test.go
+++ b/model/modeldecoder/v2/metadata_test.go
@@ -75,6 +75,8 @@ func isUnmappedMetadataField(key string) bool {
 		"FAAS.Execution",
 		"FAAS.TriggerType",
 		"FAAS.TriggerRequestID",
+		"FAAS.Name",
+		"FAAS.Version",
 		"HTTP",
 		"HTTP.Request",
 		"HTTP.Response",

--- a/model/modeldecoder/v2/model.go
+++ b/model/modeldecoder/v2/model.go
@@ -105,6 +105,10 @@ type faas struct {
 	Execution nullable.String `json:"execution"`
 	// Trigger attributes.
 	Trigger trigger `json:"trigger"`
+	// The lambda function name.
+	Name nullable.String `json:"name"`
+	// The lambda function version.
+	Version nullable.String `json:"version"`
 }
 
 type trigger struct {

--- a/model/modeldecoder/v2/model_generated.go
+++ b/model/modeldecoder/v2/model_generated.go
@@ -2187,7 +2187,7 @@ func (val *transactionDroppedSpansDurationSum) validate() error {
 }
 
 func (val *faas) IsSet() bool {
-	return val.ID.IsSet() || val.Coldstart.IsSet() || val.Execution.IsSet() || val.Trigger.IsSet()
+	return val.ID.IsSet() || val.Coldstart.IsSet() || val.Execution.IsSet() || val.Trigger.IsSet() || val.Name.IsSet() || val.Version.IsSet()
 }
 
 func (val *faas) Reset() {
@@ -2195,6 +2195,8 @@ func (val *faas) Reset() {
 	val.Coldstart.Reset()
 	val.Execution.Reset()
 	val.Trigger.Reset()
+	val.Name.Reset()
+	val.Version.Reset()
 }
 
 func (val *faas) validate() error {

--- a/model/modeldecoder/v2/transaction_test.go
+++ b/model/modeldecoder/v2/transaction_test.go
@@ -149,12 +149,16 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 		input.FAAS.Execution.Set("execution")
 		input.FAAS.Trigger.Type.Set("http")
 		input.FAAS.Trigger.RequestID.Set("abc123")
+		input.FAAS.Name.Set("faasName")
+		input.FAAS.Version.Set("1.0.0")
 		mapToTransactionModel(&input, &out)
 		assert.Equal(t, "faasID", out.FAAS.ID)
 		assert.True(t, *out.FAAS.Coldstart)
 		assert.Equal(t, "execution", out.FAAS.Execution)
 		assert.Equal(t, "http", out.FAAS.TriggerType)
 		assert.Equal(t, "abc123", out.FAAS.TriggerRequestID)
+		assert.Equal(t, "faasName", out.FAAS.Name)
+		assert.Equal(t, "1.0.0", out.FAAS.Version)
 	})
 
 	t.Run("dropped_span_stats", func(t *testing.T) {

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -376,6 +376,8 @@ func (a *Aggregator) makeTransactionAggregationKey(event model.APMEvent, interva
 		faasColdstart:   event.FAAS.Coldstart,
 		faasID:          event.FAAS.ID,
 		faasTriggerType: event.FAAS.TriggerType,
+		faasName:        event.FAAS.Name,
+		faasVersion:     event.FAAS.Version,
 	}
 }
 
@@ -434,6 +436,8 @@ func makeMetricset(
 			Coldstart:   key.faasColdstart,
 			ID:          key.faasID,
 			TriggerType: key.faasTriggerType,
+			Name:        key.faasName,
+			Version:     key.faasVersion,
 		},
 		Processor: model.MetricsetProcessor,
 		Metricset: &model.Metricset{
@@ -478,6 +482,8 @@ type transactionAggregationKey struct {
 	timestamp              time.Time
 	faasColdstart          *bool
 	faasID                 string
+	faasName               string
+	faasVersion            string
 	agentName              string
 	hostOSPlatform         string
 	kubernetesPodName      string
@@ -547,6 +553,8 @@ func (k *transactionAggregationKey) hash() uint64 {
 	h.WriteString(k.eventOutcome)
 	h.WriteString(k.faasID)
 	h.WriteString(k.faasTriggerType)
+	h.WriteString(k.faasName)
+	h.WriteString(k.faasVersion)
 	return h.Sum64()
 }
 

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
@@ -475,6 +475,8 @@ func TestAggregationFields(t *testing.T) {
 		&input.Host.OS.Platform,
 		&input.FAAS.ID,
 		&input.FAAS.TriggerType,
+		&input.FAAS.Name,
+		&input.FAAS.Version,
 	}
 	boolInputFields := []*bool{
 		input.FAAS.Coldstart,


### PR DESCRIPTION
## Motivation/summary

We want to capture `faas.name` and `faas.version` for lambda functions

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

## How to test these changes

1. Send FaaS transactions to apm-server
2. Check that `faas.name` and `faas.version` show up in the transaction documents and transaction metrics

## Related issues

closes https://github.com/elastic/apm-server/issues/7410
