### PR TITLE
[8.1] 8.1.0 release notes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,2 +1,3 @@
 include::./changelogs/head.asciidoc[]
 include::./changelogs/8.0.asciidoc[]
+include::./changelogs/8.1.asciidoc[]

--- a/changelogs/8.0.asciidoc
+++ b/changelogs/8.0.asciidoc
@@ -22,6 +22,7 @@ https://github.com/elastic/apm-server/compare/v8.0.0\...v8.0.1[View commits]
 
 - Fix mixing of labels across OpenTelemetry log records {pull}7358[7358]
 - Fix panic when processing OpenTelemetry histogram metrics without bounds {pull}7316[7316]
+- Fix waiting for events to be flushed when shutting down APM Server {pull}7352[7352]
 
 [float]
 [[release-notes-8.0.0]]

--- a/changelogs/8.1.asciidoc
+++ b/changelogs/8.1.asciidoc
@@ -1,0 +1,18 @@
+[[release-notes-8.1]]
+== APM version 8.1
+
+https://github.com/elastic/apm-server/compare/8.0\...8.1[View commits]
+
+* <<release-notes-8.1.0>>
+
+[float]
+[[release-notes-8.1.0]]
+=== APM version 8.1.0
+
+[float]
+==== Bug fixes
+- Fix infinite loop in tail-based sampling subscriber causing high CPU and repeated Elasticsearch searches {pull}7211[7211]
+
+[float]
+==== Added
+- Added several dimensions to the aggregated transaction metrics {pull}7033[7033]

--- a/changelogs/8.1.asciidoc
+++ b/changelogs/8.1.asciidoc
@@ -10,9 +10,10 @@ https://github.com/elastic/apm-server/compare/8.0\...8.1[View commits]
 === APM version 8.1.0
 
 [float]
-==== Bug fixes
-- Fix infinite loop in tail-based sampling subscriber causing high CPU and repeated Elasticsearch searches {pull}7211[7211]
+==== Added
+- Tail-based sampling is now generally available
+- Added several dimensions to the aggregated transaction metrics {pull}7033[7033]
 
 [float]
-==== Added
-- Added several dimensions to the aggregated transaction metrics {pull}7033[7033]
+==== Bug fixes
+- Fix infinite loop in tail-based sampling subscriber causing high CPU and repeated Elasticsearch searches {pull}7211[7211]

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -1,21 +1,13 @@
 [[release-notes-head]]
 == APM version HEAD
 
-https://github.com/elastic/apm-server/compare/8.0\...main[View commits]
-
-Starting in version 8.0.0, {fleet} uses the APM integration to set up and manage APM index templates,
-ILM policies, and ingest pipelines. APM Server will only send data to {es} _after_ the APM integration has been installed.
-See <<apm-server-configuration>> for more information.
+https://github.com/elastic/apm-server/compare/8.1\...main[View commits]
 
 [float]
 ==== Breaking Changes
 
 [float]
 ==== Bug fixes
-- Fix infinite loop in tail-based sampling subscriber causing high CPU and repeated Elasticsearch searches {pull}7211[7211]
-- Fix panic when processing OpenTelemetry histogram metrics without bounds {pull}7316[7316]
-- Fix mixing of labels across OpenTelemetry log records {pull}7358[7358]
-- Fix waiting for events to be flushed when shutting down APM Server {pull}7352[7352]
 - Fix missing stack monitoring metrics {pull}7428[7428]
 
 [float]
@@ -23,6 +15,8 @@ See <<apm-server-configuration>> for more information.
 
 [float]
 ==== Added
+
+
+// still waiting on these?
 - `apm-server` artifacts now have the apm java-attacher.jar packaged alongside them {pull}6593[6593]
 - Run the java attacher jar when configured and not in a cloud environment {pull}6617[6617]
-- Added several dimensions to the aggregated transaction metrics {pull}7033[7033]

--- a/docs/apm-breaking.asciidoc
+++ b/docs/apm-breaking.asciidoc
@@ -5,13 +5,21 @@
 === Breaking Changes
 
 // These tagged regions are required for the stack-docs repo includes
-// tag::81-bc[]
-// end::81-bc[]
+// tag::82-bc[]
+// end::82-bc[]
 // tag::notable-v8-breaking-changes[]
 // end::notable-v8-breaking-changes[]
 
 This section describes the breaking changes and deprecations introduced in this release
 and previous minor versions.
+
+[float]
+[[breaking-changes-8.1]]
+=== 8.1
+
+// tag::81-bc[]
+There are no breaking changes in APM.
+// end::81-bc[]
 
 [float]
 [[breaking-changes-8.0]]

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -8,6 +8,7 @@
 This section summarizes the changes in each release.
 
 * <<release-notes-8.0>>
+* <<release-notes-8.1>>
 
 Looking for a previous version? See the {apm-guide-7x}/release-notes.html[7.x release notes].
 


### PR DESCRIPTION
Adds release notes and breaking changes for 8.1.0.

* A link to TBS docs will be added in the TBS PR.
* Needs to be cherrypicked to `main`. 