### PR TITLE
[docs] Fix images and link to input settings

### DIFF
--- a/docs/apm-components.asciidoc
+++ b/docs/apm-components.asciidoc
@@ -58,7 +58,7 @@ and improves compatibility across the Elastic Stack.
 The Elastic integration runs on {fleet-guide}[{agent}]. {agent} is a single, unified way to add monitoring for logs,
 metrics, traces, and other types of data to each host.
 A single agent makes it easier and faster to deploy monitoring across your infrastructure.
-The agent’s single, unified policy makes it easier to add integrations for new data sources.
+The agent's single, unified policy makes it easier to add integrations for new data sources.
 
 [float]
 === Elasticsearch

--- a/docs/input-apm.asciidoc
+++ b/docs/input-apm.asciidoc
@@ -7,10 +7,11 @@
 <titleabbrev>Input settings</titleabbrev>
 ++++
 
-To edit the APM integration input settings:
+Configure and customize APM integration settings directly in {kib}:
 
-. Open {kib}, click **Add data**, and search for and select "Elastic APM".
-. Under the polices tab, select **Actions** > **Edit integration**.
+. Open {kib} and navigate to **Fleet**.
+. Under the **Agent policies** tab, select the policy you would like to configure.
+. Find the Elastic APM integration and select **Actions** > **Edit integration**.
 
 [float]
 [[apm-input-general-settings]]

--- a/docs/legacy/guide/apm-doc-directory.asciidoc
+++ b/docs/legacy/guide/apm-doc-directory.asciidoc
@@ -6,7 +6,7 @@ If you've already upgraded, see <<apm-components>>.
 
 Elastic APM consists of four components: *APM agents*, *APM Server*, *Elasticsearch*, and *Kibana*.
 
-image::./../legacy/guide/images/apm-architecture-cloud.png[Architecture of Elastic APM]
+image::./images/apm-architecture-cloud.png[Architecture of Elastic APM]
 
 [float]
 === APM Agents

--- a/docs/legacy/guide/distributed-tracing.asciidoc
+++ b/docs/legacy/guide/distributed-tracing.asciidoc
@@ -42,17 +42,17 @@ and continues to propagate the trace.
 In this example, Elastic's Ruby agent communicates with Elastic's Java agent.
 Both support the `traceparent` header, and trace data is successfully propagated.
 
-image::./legacy/guide/images/dt-trace-ex1.png[How traceparent propagation works]
+image::./images/dt-trace-ex1.png[How traceparent propagation works]
 
 In this example, Elastic's Ruby agent communicates with OpenTelemetry's Java agent.
 Both support the `traceparent` header, and trace data is successfully propagated.
 
-image::./legacy/guide/images/dt-trace-ex2.png[How traceparent propagation works]
+image::./images/dt-trace-ex2.png[How traceparent propagation works]
 
 In this example, the trace meets a piece of middleware that doesn't propagate the `traceparent` header.
 The distributed trace ends and any further communication will result in a new trace.
 
-image::./legacy/guide/images/dt-trace-ex3.png[How traceparent propagation works]
+image::./images/dt-trace-ex3.png[How traceparent propagation works]
 
 
 [float]
@@ -83,7 +83,7 @@ For backward-compatibility purposes, new versions of Elastic agents still suppor
 The APM app's timeline visualization provides a visual deep-dive into each of your application's traces:
 
 [role="screenshot"]
-image::./legacy/guide/images/apm-distributed-tracing.png[Distributed tracing in the APM UI]
+image::./images/apm-distributed-tracing.png[Distributed tracing in the APM UI]
 
 [float]
 === Manual distributed tracing

--- a/docs/legacy/guide/trace-sampling.asciidoc
+++ b/docs/legacy/guide/trace-sampling.asciidoc
@@ -64,7 +64,7 @@ In the first example, `Service A` samples at `.5` (`50%`). In the second, `Servi
 Each subsequent service respects the initial sampling decision, regardless of their configured sample rate.
 The result is a sampling percentage that matches the initiating service:
 
-image::./../legacy/guide/images/dt-sampling-example.png[How sampling impacts distributed tracing]
+image::./images/dt-sampling-example.png[How sampling impacts distributed tracing]
 
 [float]
 ==== APM app implications

--- a/docs/secure-agent-communication.asciidoc
+++ b/docs/secure-agent-communication.asciidoc
@@ -22,7 +22,7 @@ TLS is disabled by default.
 When TLS is enabled for APM Server inbound communication, agents will verify the identity
 of the APM Server by authenticating its certificate.
 
-Enable TLS in the APM integration configuration panel; a certificate and corresponding private key are required.
+Enable TLS in the <<input-apm,APM integration settings>>; a certificate and corresponding private key are required.
 The certificate and private key can either be issued by a trusted certificate authority (CA)
 or be <<agent-self-sign,self-signed>>.
 
@@ -87,7 +87,7 @@ and there is no dedicated support for SSL/TLS client certificate authentication 
 IMPORTANT: API keys are sent as plain-text,
 so they only provide security when used in combination with <<agent-tls,TLS>>.
 
-Enable API key authorization in the APM integration configuration panel.
+Enable API key authorization in the <<input-apm,APM integration settings>>.
 When enabled, API keys are used to authorize requests to the APM Server.
 
 You can assign one or more unique privileges to each API key:
@@ -107,7 +107,7 @@ make sure <<agent-tls,TLS>> is enabled, then complete these steps:
 [float]
 === Enable API keys
 
-Enable API key authorization in the APM integration configuration panel.
+Enable API key authorization in the <<input-apm,APM integration settings>>.
 You should also set a limit on the number of unique API keys that APM Server allows per minute;
 this value should be the number of unique API keys configured in your monitored services.
 
@@ -173,7 +173,7 @@ See the relevant agent documentation for additional information:
 IMPORTANT: Secret tokens are sent as plain-text,
 so they only provide security when used in combination with <<agent-tls,TLS>>.
 
-Define a secret token in the APM integration configuration panel.
+Define a secret token in the <<input-apm,APM integration settings>>.
 When defined, secret tokens are used to authorize requests to the APM Server.
 Both the APM agent and APM integration must be configured with the same secret token for the request to be accepted.
 
@@ -190,7 +190,7 @@ as there is no way to prevent them from being publicly exposed.
 [[create-secret-token]]
 === Create a secret token
 
-Define a secret token in the APM integration configuration panel.
+Define a secret token in the <<input-apm,APM integration settings>>.
 Alternatively, {ess} and {ece} deployments provision a secret token when the deployment is created.
 The secret token can be found and reset in the {ecloud} console under **Deployments** -- **APM & Fleet**.
 


### PR DESCRIPTION
### Summary

- [x] Fixes two images in the legacy documentation
- [x] Adds links to the APM input settings


### Related

Closes https://github.com/elastic/apm-server/issues/7443.
Closes https://github.com/elastic/observability-docs/issues/1288.