### PR TITLE
docs: document central config troubleshooting

### DIFF
--- a/docs/legacy/common-problems.asciidoc
+++ b/docs/legacy/common-problems.asciidoc
@@ -298,7 +298,7 @@ Central configuration can also be disabled at the APM agent level.
 
 For cause #2, investigate why {es} is not responding in a timely manner.
 {kib}'s queries to {es} are simple, so it may just be that {es} is unhealthy.
-If that's not the problem, you may need to use {ref}index-modules-slowlog.html[Search Slow Log] to investigate your {es} logs.
+If that's not the problem, you may need to use {ref}/index-modules-slowlog.html[Search Slow Log] to investigate your {es} logs.
 
 To avoid this problem entirely,
 we recommend <<upgrade-to-apm-integration,upgrading to the Elastic APM integration>>.

--- a/docs/legacy/common-problems.asciidoc
+++ b/docs/legacy/common-problems.asciidoc
@@ -16,6 +16,7 @@ This section describes common problems you might encounter with APM Server.
 * <<field-limit-exceeded>>
 * <<io-timeout>>
 * <<server-es-down>>
+* <<central-config-troubleshooting>>
 
 [[no-data-indexed]]
 [float]
@@ -37,8 +38,6 @@ containing `[request]` in the APM Server logs.
 If no requests are logged, it might be that SSL is <<ssl-client-fails, misconfigured>> or that the host is wrong.
 Particularly, if you are using Docker, ensure to bind to the right interface (for example, set
 `apm-server.host = 0.0.0.0:8200` to match any IP) and set the `SERVER_URL` setting in the agent accordingly.
-
-
 
 If you see requests coming through the APM Server but they are not accepted (response code other than `202`), consider
 the response code to narrow down the possible causes (see sections below).
@@ -133,7 +132,6 @@ telnet <hostname or IP> 5044
 ----------------------------------------------------------------------
 
 * Verify that the certificate is valid and that the hostname and IP match.
-+
 
 * Use OpenSSL to test connectivity to the target server and diagnose problems.
 See the https://www.openssl.org/docs/manmaster/apps/s_client.html[OpenSSL documentation] for more info.
@@ -273,3 +271,34 @@ with configurable size and time between flushes.
 {apm-ruby-ref}/configuration.html#config-api-buffer-size[`api_buffer_size`].
 * **RUM agent** - No internal queue. Data is lost.
 * **.NET agent** - No internal queue. Data is lost.
+
+[[central-config-troubleshooting]]
+[float]
+=== `/api/apm/settings/agent-configuration/search` errors
+
+If you're instrumenting and starting a lot of services at the same time
+or using a very large number of service or environment names,
+you may see the following APM Server logs related to APM agent central configuration:
+
+* `.../api/apm/settings/agent-configuration/search: context canceled`
+* `.../api/apm/settings/agent-configuration/search: net/http: TLS handshake timeout`
+
+There are two possible causes:
+
+1. {kib} is overwhelmed by the number of requests coming from APM Server.
+2. {es} can't reply quickly enough to {kib}.
+
+For cause #1, try one or more of the following:
+
+* Increase the <<elasticsearch-output,`apm-server.kibana.timeout`>> setting.
+* Increase the <<setup-kibana-endpoint,`agent.config.cache.expiration`>>.
+* Increase Kibana's resources so that it is able to manage more requests.
+* If you're not using APM central configuration, disable it with <<setup-kibana-endpoint,`apm-server.kibana.enabled`>>.
+Central configuration can also be disabled at the APM agent level.
+
+For cause #2, investigate why {es} is not responding in a timely manner.
+{kib}'s queries to {es} are simple, so it may just be that {es} is unhealthy.
+If that's not the problem, you may need to use {ref}index-modules-slowlog.html[Search Slow Log] to investigate your {es} logs.
+
+To avoid this problem entirely,
+we recommend <<upgrade-to-apm-integration,upgrading to the Elastic APM integration>>.


### PR DESCRIPTION
### Summary

This PR adds documentation explaining the following APM logs:

```
.../api/apm/settings/agent-configuration/search": context canceled
.../api/apm/settings/agent-configuration/search": net/http: TLS handshake timeout
```


Closes https://github.com/elastic/observability-docs/issues/1573.