### PR TITLE
Move Manager.Start() and Manager.Stop() in the beat execution.

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -203,6 +203,14 @@ func (bt *beater) run(ctx context.Context, cancelContext context.CancelFunc, b *
 				ctx, reload.ReloadableFunc(reloader.reloadOutput),
 			)
 		})
+
+		// Start the manager after all the hooks are initialized
+		// and defined this ensure reloading consistency..
+		if err := b.Manager.Start(); err != nil {
+			return err
+		}
+		defer b.Manager.Stop()
+
 	} else {
 		// Management disabled, use statically defined config.
 		reloader.rawConfig = bt.rawConfig

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -19,6 +19,7 @@ See <<apm-server-configuration>> for more information.
 - Fix mixing of labels across OpenTelemetry log records {pull}7358[7358]
 - Fix waiting for events to be flushed when shutting down APM Server {pull}7352[7352]
 - Fix missing stack monitoring metrics {pull}7428[7428]
+- Ensure that the server is configured and ready before receiving configuration {pull}7488[7488]
 
 [float]
 ==== Intake API Changes


### PR DESCRIPTION
This move the Manager.Start and Stop into the Beats' run method, this
move ensure that the system is configured and ready to receive events.

Having the Manager started and stopped at the Libbeat level was causing
inconsistency when configuring the Beats by the Elastic Agent.
The problem would lead to the following behavior:

- Zombie Beats with only outputs configured
- Beats without any inputs configured
- Beats with some of the input configured.

The problem was often cause by restarting the agent and having the
machine under a significant load.

See: https://github.com/elastic/beats/pull/30694 for details

<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
