### PR TITLE
ci: Daily Releasable Artifacts stages

### DIFF
--- a/.ci/scripts/package-docker-snapshot.sh
+++ b/.ci/scripts/package-docker-snapshot.sh
@@ -11,7 +11,8 @@ set -euo pipefail
 NEW_TAG=${1:?Docker tag is not set}
 NEW_IMAGE=${2:?Docker image is not set}
 
-export PLATFORMS='linux/amd64'
+# linux/amd64 is in the default list already
+export PLATFORMS="${PLATFORMS:-+linux/amd64}"
 export TYPE='docker'
 export SNAPSHOT='true'
 export IMAGE="docker.elastic.co/apm/apm-server"

--- a/.ci/scripts/release-manager.sh
+++ b/.ci/scripts/release-manager.sh
@@ -3,6 +3,9 @@
 # This script is executed by the release snapshot stage.
 # It requires the below environment variables:
 # - BRANCH_NAME
+# - VAULT_ADDR
+# - VAULT_ROLE_ID
+# - VAULT_SECRET_ID
 #
 set -uexo pipefail
 
@@ -14,7 +17,6 @@ chmod -R a+w build/distributions
 IMAGE=docker.elastic.co/infra/release-manager:latest
 docker pull $IMAGE
 
-set +x
 # Generate checksum files and upload to GCS
 docker run --rm \
   --name release-manager \

--- a/.ci/scripts/release-manager.sh
+++ b/.ci/scripts/release-manager.sh
@@ -15,7 +15,7 @@ chmod -R a+w build/distributions
 
 # ensure the latest image has been pulled
 IMAGE=docker.elastic.co/infra/release-manager:latest
-docker pull $IMAGE
+docker pull --quiet $IMAGE
 
 # Generate checksum files and upload to GCS
 docker run --rm \
@@ -23,7 +23,7 @@ docker run --rm \
   -e VAULT_ADDR \
   -e VAULT_ROLE_ID \
   -e VAULT_SECRET_ID \
-  --mount type=bind,readonly=false,src="$PWD/build/distributions",target=/artifacts \
+  --mount type=bind,readonly=false,src="$PWD",target=/artifacts \
   "$IMAGE" \
     cli collect \
       --project apm-server \

--- a/.ci/scripts/release-manager.sh
+++ b/.ci/scripts/release-manager.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# This script is executed by the release snapshot stage.
+# It requires the below environment variables:
+# - BRANCH_NAME
+#
+set -uexo pipefail
+
+# set required permissions on artifacts and directory
+chmod -R a+r build/distributions/*
+chmod -R a+w build/distributions
+
+# ensure the latest image has been pulled
+IMAGE=docker.elastic.co/infra/release-manager:latest
+docker pull $IMAGE
+
+set +x
+# Generate checksum files and upload to GCS
+docker run --rm \
+  --name release-manager \
+  -e VAULT_ADDR \
+  -e VAULT_ROLE_ID \
+  -e VAULT_SECRET_ID \
+  --mount type=bind,readonly=false,src="$PWD/build/distributions",target=/artifacts \
+  "$IMAGE" \
+    cli collect \
+      --project apm-server \
+      --branch "$BRANCH_NAME" \
+      --commit "$(git rev-parse HEAD)" \
+      --workflow "snapshot" \
+      --artifact-set main

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -547,7 +547,8 @@ pipeline {
           stage('Package') {
             environment {
               PLATFORMS = "${isArm() ? 'linux/arm64' : 'linux/amd64'}"
-              NEW_TAG =  "${isArm() ? env.GIT_BASE_COMMIT + '-arm' : env.GIT_BASE_COMMIT}"
+              NEW_TAG = "${isArm() ? env.GIT_BASE_COMMIT + '-arm' : env.GIT_BASE_COMMIT}"
+              PACKAGES = "${isArm() ? 'docker' : ''}"
             }
             steps {
               withGithubNotify(context: "Package-${PLATFORM}") {
@@ -555,7 +556,7 @@ pipeline {
                 unstash 'source'
                 dir("${BASE_DIR}"){
                   withMageEnv(){
-                    sh(label: 'Build packages', script: './.ci/scripts/package.sh')
+                    sh(label: 'Build packages', script: 'make release-manager-snapshot')
                     dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
                     sh(label: 'Package & Push', script: "./.ci/scripts/package-docker-snapshot.sh ${NEW_TAG} ${env.DOCKER_IMAGE}")
                   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -611,7 +611,7 @@ pipeline {
         }
       }
       steps {
-        googleStorageDownload(bucketUri: "gs://${JOB_GCS_BUCKET}/commits/${env.GIT_BASE_COMMIT}",
+        googleStorageDownload(bucketUri: "gs://${JOB_GCS_BUCKET}/commits/${env.GIT_BASE_COMMIT}/*.*",
                               credentialsId: "${JOB_GCS_CREDENTIALS}",
                               localDirectory: "${BASE_DIR}/build/distributions")
         dir("${BASE_DIR}") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -594,7 +594,9 @@ pipeline {
               }
             }
             steps {
-              echo 'TBD'
+              dir("${BASE_DIR}") {
+                sh(label: 'release-manager.sh', script: ".ci/scripts/release-manager.sh")
+              }
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -584,31 +584,46 @@ pipeline {
                 pattern: "${BASE_DIR}/build/distributions/**/*",
                 sharedPublicly: true,
                 showInline: true)
-              archiveArtifacts(artifacts: "${BASE_DIR}/build/dependencies.csv")
+              googleStorageUpload(bucket: "gs://${JOB_GCS_BUCKET}/commits/${env.GIT_BASE_COMMIT}",
+                credentialsId: "${JOB_GCS_CREDENTIALS}",
+                pathPrefix: "${BASE_DIR}/build/",
+                pattern: "${BASE_DIR}/build/dependencies.csv",
+                sharedPublicly: true,
+                showInline: true)
             }
           }
-          stage('DRA') {
-            when {
-              beforeAgent true
-              anyOf {
-                branch 'main'
-                branch pattern: '\\d+\\.\\d+', comparator: 'REGEXP'
-              }
-            }
-            steps {
-              dir("${BASE_DIR}") {
-                // Read from vault and prepare/mask the password with the vault secret/role to
-                // interact with by the release manager process.
-                // withSecretVault signature uses user_* and pass_* , those names are a bit misleading
-                // but there is no way to change the signaure since it is already used.
-                withSecretVault(secret: 'secret/apm-team/ci/release-manager-snapshot',
-                                user_key: 'VAULT_ROLE_ID', user_var_name: 'role_id',
-                                pass_key: 'VAULT_SECRET_ID', pass_var_name: 'secret_id'){
-                  withEnvMask(vars: [ [var: 'VAULT_ROLE_ID', password: env.role_id], [var: 'VAULT_SECRET_ID', password: env.secret_id]]) {
-                    sh(label: 'release-manager.sh', script: ".ci/scripts/release-manager.sh")
-                  }
-                }
-              }
+        }
+      }
+      post {
+        failure {
+          echo 'disabled'
+          // notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] DRA failed", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)")
+        }
+      }
+    }
+    stage('DRA') {
+      when {
+        beforeAgent true
+        anyOf {
+          changeRequest()
+          branch 'main'
+          branch pattern: '\\d+\\.\\d+', comparator: 'REGEXP'
+        }
+      }
+      steps {
+        googleStorageDownload(bucketUri: "gs://${JOB_GCS_BUCKET}/commits/${env.GIT_BASE_COMMIT}",
+                              credentialsId: "${JOB_GCS_CREDENTIALS}",
+                              localDirectory: "${BASE_DIR}/build/distributions")
+        dir("${BASE_DIR}") {
+          // Read from vault and prepare/mask the password with the vault secret/role to
+          // interact with by the release manager process.
+          // withSecretVault signature uses user_* and pass_* , those names are a bit misleading
+          // but there is no way to change the signaure since it is already used.
+          withSecretVault(secret: 'secret/apm-team/ci/release-manager-snapshot',
+                          user_key: 'VAULT_ROLE_ID', user_var_name: 'role_id',
+                          pass_key: 'VAULT_SECRET_ID', pass_var_name: 'secret_id'){
+            withEnvMask(vars: [ [var: 'VAULT_ROLE_ID', password: env.role_id], [var: 'VAULT_SECRET_ID', password: env.secret_id]]) {
+              sh(label: 'release-manager.sh', script: ".ci/scripts/release-manager.sh")
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -615,16 +615,8 @@ pipeline {
                               credentialsId: "${JOB_GCS_CREDENTIALS}",
                               localDirectory: "${BASE_DIR}/build/distributions")
         dir("${BASE_DIR}") {
-          // Read from vault and prepare/mask the password with the vault secret/role to
-          // interact with by the release manager process.
-          // withSecretVault signature uses user_* and pass_* , those names are a bit misleading
-          // but there is no way to change the signaure since it is already used.
-          withSecretVault(secret: 'secret/apm-team/ci/release-manager-snapshot',
-                          user_key: 'VAULT_ROLE_ID', user_var_name: 'role_id',
-                          pass_key: 'VAULT_SECRET_ID', pass_var_name: 'secret_id'){
-            withEnvMask(vars: [ [var: 'VAULT_ROLE_ID', password: env.role_id], [var: 'VAULT_SECRET_ID', password: env.secret_id]]) {
-              sh(label: 'release-manager.sh', script: ".ci/scripts/release-manager.sh")
-            }
+          getVaultSecret.readSecretWrapper {
+            sh(label: 'release-manager.sh', script: '.ci/scripts/release-manager.sh')
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -595,7 +595,17 @@ pipeline {
             }
             steps {
               dir("${BASE_DIR}") {
-                sh(label: 'release-manager.sh', script: ".ci/scripts/release-manager.sh")
+                // Read from vault and prepare/mask the password with the vault secret/role to
+                // interact with by the release manager process.
+                // withSecretVault signature uses user_* and pass_* , those names are a bit misleading
+                // but there is no way to change the signaure since it is already used.
+                withSecretVault(secret: 'secret/apm-team/ci/release-manager-snapshot',
+                                user_key: 'VAULT_ROLE_ID', user_var_name: 'role_id',
+                                pass_key: 'VAULT_SECRET_ID', pass_var_name: 'secret_id'){
+                  withEnvMask(vars: [ [var: 'VAULT_ROLE_ID', password: env.role_id], [var: 'VAULT_SECRET_ID', password: env.secret_id]]) {
+                    sh(label: 'release-manager.sh', script: ".ci/scripts/release-manager.sh")
+                  }
+                }
               }
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -611,7 +611,7 @@ pipeline {
         }
       }
       steps {
-        googleStorageDownload(bucketUri: "gs://${JOB_GCS_BUCKET}/commits/${env.GIT_BASE_COMMIT}/*.*",
+        googleStorageDownload(bucketUri: "gs://${JOB_GCS_BUCKET}/commits/${env.GIT_BASE_COMMIT}/*",
                               credentialsId: "${JOB_GCS_CREDENTIALS}",
                               localDirectory: "${BASE_DIR}/build/distributions")
         dir("${BASE_DIR}") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -615,8 +615,10 @@ pipeline {
                               credentialsId: "${JOB_GCS_CREDENTIALS}",
                               localDirectory: "${BASE_DIR}/build/distributions")
         dir("${BASE_DIR}") {
-          getVaultSecret.readSecretWrapper {
-            sh(label: 'release-manager.sh', script: '.ci/scripts/release-manager.sh')
+          script {
+            getVaultSecret.readSecretWrapper {
+              sh(label: 'release-manager.sh', script: '.ci/scripts/release-manager.sh')
+            }
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -555,8 +555,8 @@ pipeline {
                 deleteDir()
                 unstash 'source'
                 dir("${BASE_DIR}"){
-                  withMageEnv(){
-                    sh(label: 'Build packages', script: 'make release-manager-snapshot')
+                  withMageEnv() {
+                    sh(label: 'Build packages', script: './.ci/scripts/package.sh')
                     dockerLogin(secret: env.DOCKER_SECRET, registry: env.DOCKER_REGISTRY)
                     sh(label: 'Package & Push', script: "./.ci/scripts/package-docker-snapshot.sh ${NEW_TAG} ${env.DOCKER_IMAGE}")
                   }
@@ -584,6 +584,7 @@ pipeline {
                 pattern: "${BASE_DIR}/build/distributions/**/*",
                 sharedPublicly: true,
                 showInline: true)
+              archiveArtifacts(artifacts: "${BASE_DIR}/build/dependencies.csv")
             }
           }
           stage('DRA') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -610,10 +610,16 @@ pipeline {
           branch pattern: '\\d+\\.\\d+', comparator: 'REGEXP'
         }
       }
+      // JOB_GCS_BUCKET contains the bucket and some folders, let's build the folder structure
+      environment {
+        URI_SUFFIX = "commits/${env.GIT_BASE_COMMIT}"
+        PATH_PREFIX = "${JOB_GCS_BUCKET.contains('/') ? JOB_GCS_BUCKET.substring(JOB_GCS_BUCKET.indexOf('/') + 1) + '/' + env.URI_SUFFIX : env.URI_SUFFIX}"
+      }
       steps {
-        googleStorageDownload(bucketUri: "gs://${JOB_GCS_BUCKET}/commits/${env.GIT_BASE_COMMIT}/*",
+        googleStorageDownload(bucketUri: "gs://${JOB_GCS_BUCKET}/${URI_SUFFIX}/*",
                               credentialsId: "${JOB_GCS_CREDENTIALS}",
-                              localDirectory: "${BASE_DIR}/build/distributions")
+                              localDirectory: "${BASE_DIR}/build/distributions",
+                              pathPrefix: env.PATH_PREFIX)
         dir("${BASE_DIR}") {
           script {
             getVaultSecret.readSecretWrapper {


### PR DESCRIPTION
## Motivation/summary

Daily Releasable Artifacts stages for APM Server only on branches

## How to test these changes

`/package` github comment should help, though the stage for `DRA` is disabled for now.

See https://github.com/elastic/apm-server/pull/7542

## Further details

1) Notify if any failure while running the DRA process.
2) Package for arm64 and amd64.
3) Run release manager.
4) Credentials stored in vault.