### PR TITLE
Fix modelindexer benchmarks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/elastic/gmux v0.2.0
 	github.com/elastic/go-elasticsearch/v8 v8.0.0-alpha.0.20220127111727-5269e7e57568
 	github.com/elastic/go-hdrhistogram v0.1.0
+	github.com/elastic/go-lookslike v0.3.0
 	github.com/elastic/go-ucfg v0.8.4
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible
 	github.com/gofrs/uuid v4.2.0+incompatible

--- a/model/modelindexer/indexer_test.go
+++ b/model/modelindexer/indexer_test.go
@@ -635,11 +635,10 @@ func newMockElasticsearchClientConfig(
 	t testing.TB, bulkHandler http.HandlerFunc,
 ) *elasticsearch.Config {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/_bulk", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Elastic-Product", "Elasticsearch")
-		fmt.Fprintln(w, `{"version":{"number":"1.2.3"}}`)
+		bulkHandler.ServeHTTP(w, r)
 	})
-	mux.Handle("/_bulk", bulkHandler)
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 


### PR DESCRIPTION
Fix the modelindexer benchmarks, which were failing due to the mock Elasticsearch server not returning the appropriate X-Elastic-Product header.