### PR TITLE
Add span links to intake v2

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -16,6 +16,7 @@ https://github.com/elastic/apm-server/compare/8.1\...main[View commits]
 [float]
 ==== Intake API Changes
 - Support for `faas.name` and `faas.version` added to intake and transaction metrics {pull}7427[7427]
+- Updated intake v2 with support for `links` in `transaction` and `span` events {pull}7553[7553]
 
 [float]
 ==== Added

--- a/docs/spec/v2/span.json
+++ b/docs/spec/v2/span.json
@@ -554,6 +554,33 @@
       "type": "string",
       "maxLength": 1024
     },
+    "links": {
+      "description": "Links holds links to other spans, potentially in other traces.",
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "span_id": {
+            "description": "SpanID holds the ID of the linked span.",
+            "type": "string",
+            "maxLength": 1024
+          },
+          "trace_id": {
+            "description": "TraceID holds the ID of the linked span's trace.",
+            "type": "string",
+            "maxLength": 1024
+          }
+        },
+        "required": [
+          "span_id",
+          "trace_id"
+        ]
+      },
+      "minItems": 0
+    },
     "name": {
       "description": "Name is the generic designation of a span in the scope of a transaction.",
       "type": "string",

--- a/docs/spec/v2/transaction.json
+++ b/docs/spec/v2/transaction.json
@@ -877,6 +877,33 @@
       "type": "string",
       "maxLength": 1024
     },
+    "links": {
+      "description": "Links holds links to other spans, potentially in other traces.",
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "span_id": {
+            "description": "SpanID holds the ID of the linked span.",
+            "type": "string",
+            "maxLength": 1024
+          },
+          "trace_id": {
+            "description": "TraceID holds the ID of the linked span's trace.",
+            "type": "string",
+            "maxLength": 1024
+          }
+        },
+        "required": [
+          "span_id",
+          "trace_id"
+        ]
+      },
+      "minItems": 0
+    },
     "marks": {
       "description": "Marks capture the timing of a significant event during the lifetime of a transaction. Marks are organized into groups and can be set by the user or the agent. Marks are only reported by RUM agents.",
       "type": [

--- a/model/modeldecoder/v2/decoder.go
+++ b/model/modeldecoder/v2/decoder.go
@@ -1016,6 +1016,9 @@ func mapToSpanModel(from *span, event *model.APMEvent) {
 	if from.OTel.IsSet() {
 		mapOTelAttributesSpan(from.OTel, event)
 	}
+	if len(from.Links) > 0 {
+		mapSpanLinks(from.Links, &out.Links)
+	}
 }
 
 func mapToStracktraceModel(from []stacktraceFrame, out model.Stacktrace) {
@@ -1240,6 +1243,13 @@ func mapToTransactionModel(from *transaction, event *model.APMEvent) {
 		}
 		mapOTelAttributesTransaction(from.OTel, event)
 	}
+
+	if len(from.Links) > 0 {
+		if event.Span == nil {
+			event.Span = &model.Span{}
+		}
+		mapSpanLinks(from.Links, &event.Span.Links)
+	}
 }
 
 func mapOTelAttributesTransaction(from otel, out *model.APMEvent) {
@@ -1401,4 +1411,14 @@ func isOTelDoubleAttribute(k string) bool {
 		return true
 	}
 	return false
+}
+
+func mapSpanLinks(from []spanLink, out *[]model.SpanLink) {
+	*out = make([]model.SpanLink, len(from))
+	for i, link := range from {
+		(*out)[i] = model.SpanLink{
+			Span:  model.Span{ID: link.SpanID.Val},
+			Trace: model.Trace{ID: link.TraceID.Val},
+		}
+	}
 }

--- a/model/modeldecoder/v2/model.go
+++ b/model/modeldecoder/v2/model.go
@@ -741,7 +741,10 @@ type span struct {
 	// Type holds the span's type, and can have specific keywords
 	// within the service's domain (eg: 'request', 'backgroundjob', etc)
 	Type nullable.String `json:"type" validate:"required,maxLength=1024"`
-	_    struct{}        `validate:"requiredAnyOf=start;timestamp"`
+	// Links holds links to other spans, potentially in other traces.
+	Links []spanLink `json:"links"`
+
+	_ struct{} `validate:"requiredAnyOf=start;timestamp"`
 }
 
 type spanContext struct {
@@ -930,6 +933,8 @@ type transaction struct {
 	// UserExperience holds metrics for measuring real user experience.
 	// This information is only sent by RUM agents.
 	UserExperience transactionUserExperience `json:"experience"`
+	// Links holds links to other spans, potentially in other traces.
+	Links []spanLink `json:"links"`
 }
 
 type otel struct {
@@ -1030,4 +1035,12 @@ type transactionDroppedSpansDuration struct {
 type transactionDroppedSpansDurationSum struct {
 	// Us represents the summation of the span duration.
 	Us nullable.Int `json:"us" validate:"min=0"`
+}
+
+type spanLink struct {
+	// SpanID holds the ID of the linked span.
+	SpanID nullable.String `json:"span_id" validate:"required,maxLength=1024"`
+
+	// TraceID holds the ID of the linked span's trace.
+	TraceID nullable.String `json:"trace_id" validate:"required,maxLength=1024"`
 }

--- a/model/modeldecoder/v2/model_generated.go
+++ b/model/modeldecoder/v2/model_generated.go
@@ -1651,7 +1651,7 @@ func (val *spanRoot) validate() error {
 }
 
 func (val *span) IsSet() bool {
-	return val.Action.IsSet() || (len(val.ChildIDs) > 0) || val.Composite.IsSet() || val.Context.IsSet() || val.Duration.IsSet() || val.ID.IsSet() || val.Name.IsSet() || val.Outcome.IsSet() || val.OTel.IsSet() || val.ParentID.IsSet() || val.SampleRate.IsSet() || (len(val.Stacktrace) > 0) || val.Start.IsSet() || val.Subtype.IsSet() || val.Sync.IsSet() || val.Timestamp.IsSet() || val.TraceID.IsSet() || val.TransactionID.IsSet() || val.Type.IsSet()
+	return val.Action.IsSet() || (len(val.ChildIDs) > 0) || val.Composite.IsSet() || val.Context.IsSet() || val.Duration.IsSet() || val.ID.IsSet() || val.Name.IsSet() || val.Outcome.IsSet() || val.OTel.IsSet() || val.ParentID.IsSet() || val.SampleRate.IsSet() || (len(val.Stacktrace) > 0) || val.Start.IsSet() || val.Subtype.IsSet() || val.Sync.IsSet() || val.Timestamp.IsSet() || val.TraceID.IsSet() || val.TransactionID.IsSet() || val.Type.IsSet() || (len(val.Links) > 0)
 }
 
 func (val *span) Reset() {
@@ -1677,6 +1677,10 @@ func (val *span) Reset() {
 	val.TraceID.Reset()
 	val.TransactionID.Reset()
 	val.Type.Reset()
+	for i := range val.Links {
+		val.Links[i].Reset()
+	}
+	val.Links = val.Links[:0]
 }
 
 func (val *span) validate() error {
@@ -1758,6 +1762,11 @@ func (val *span) validate() error {
 	}
 	if !val.Type.IsSet() {
 		return fmt.Errorf("'type' required")
+	}
+	for _, elem := range val.Links {
+		if err := elem.validate(); err != nil {
+			return errors.Wrapf(err, "links")
+		}
 	}
 	if !val.Start.IsSet() && !val.Timestamp.IsSet() {
 		return fmt.Errorf("requires at least one of the fields 'start;timestamp'")
@@ -1983,6 +1992,34 @@ func (val *otel) validate() error {
 	return nil
 }
 
+func (val *spanLink) IsSet() bool {
+	return val.SpanID.IsSet() || val.TraceID.IsSet()
+}
+
+func (val *spanLink) Reset() {
+	val.SpanID.Reset()
+	val.TraceID.Reset()
+}
+
+func (val *spanLink) validate() error {
+	if !val.IsSet() {
+		return nil
+	}
+	if val.SpanID.IsSet() && utf8.RuneCountInString(val.SpanID.Val) > 1024 {
+		return fmt.Errorf("'span_id': validation rule 'maxLength(1024)' violated")
+	}
+	if !val.SpanID.IsSet() {
+		return fmt.Errorf("'span_id' required")
+	}
+	if val.TraceID.IsSet() && utf8.RuneCountInString(val.TraceID.Val) > 1024 {
+		return fmt.Errorf("'trace_id': validation rule 'maxLength(1024)' violated")
+	}
+	if !val.TraceID.IsSet() {
+		return fmt.Errorf("'trace_id' required")
+	}
+	return nil
+}
+
 func (val *transactionRoot) IsSet() bool {
 	return val.Transaction.IsSet()
 }
@@ -2002,7 +2039,7 @@ func (val *transactionRoot) validate() error {
 }
 
 func (val *transaction) IsSet() bool {
-	return val.Context.IsSet() || (len(val.DroppedSpanStats) > 0) || val.Duration.IsSet() || val.FAAS.IsSet() || val.ID.IsSet() || val.Marks.IsSet() || val.Name.IsSet() || val.OTel.IsSet() || val.Outcome.IsSet() || val.ParentID.IsSet() || val.Result.IsSet() || val.Sampled.IsSet() || val.SampleRate.IsSet() || val.Session.IsSet() || val.SpanCount.IsSet() || val.Timestamp.IsSet() || val.TraceID.IsSet() || val.Type.IsSet() || val.UserExperience.IsSet()
+	return val.Context.IsSet() || (len(val.DroppedSpanStats) > 0) || val.Duration.IsSet() || val.FAAS.IsSet() || val.ID.IsSet() || val.Marks.IsSet() || val.Name.IsSet() || val.OTel.IsSet() || val.Outcome.IsSet() || val.ParentID.IsSet() || val.Result.IsSet() || val.Sampled.IsSet() || val.SampleRate.IsSet() || val.Session.IsSet() || val.SpanCount.IsSet() || val.Timestamp.IsSet() || val.TraceID.IsSet() || val.Type.IsSet() || val.UserExperience.IsSet() || (len(val.Links) > 0)
 }
 
 func (val *transaction) Reset() {
@@ -2028,6 +2065,10 @@ func (val *transaction) Reset() {
 	val.TraceID.Reset()
 	val.Type.Reset()
 	val.UserExperience.Reset()
+	for i := range val.Links {
+		val.Links[i].Reset()
+	}
+	val.Links = val.Links[:0]
 }
 
 func (val *transaction) validate() error {
@@ -2107,6 +2148,11 @@ func (val *transaction) validate() error {
 	}
 	if err := val.UserExperience.validate(); err != nil {
 		return errors.Wrapf(err, "experience")
+	}
+	for _, elem := range val.Links {
+		if err := elem.validate(); err != nil {
+			return errors.Wrapf(err, "links")
+		}
 	}
 	return nil
 }

--- a/model/modeldecoder/v2/model_test.go
+++ b/model/modeldecoder/v2/model_test.go
@@ -526,6 +526,8 @@ func TestSpanRequiredValidationRules(t *testing.T) {
 		"composite.count":                      nil,
 		"composite.sum":                        nil,
 		"composite.compression_strategy":       nil,
+		"links.span_id":                        nil,
+		"links.trace_id":                       nil,
 	}
 	cb := assertRequiredFn(t, requiredKeys, event.validate)
 	modeldecodertest.SetZeroStructValue(&event, cb)
@@ -557,6 +559,8 @@ func TestTransactionRequiredValidationRules(t *testing.T) {
 		"experience.longtask.sum":   nil,
 		"experience.longtask.max":   nil,
 		"session.id":                nil,
+		"links.span_id":             nil,
+		"links.trace_id":            nil,
 	}
 	cb := assertRequiredFn(t, requiredKeys, event.validate)
 	modeldecodertest.SetZeroStructValue(&event, cb)

--- a/model/modeldecoder/v2/transaction_test.go
+++ b/model/modeldecoder/v2/transaction_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/elastic/apm-server/model"
 	"github.com/elastic/apm-server/model/modeldecoder"
 	"github.com/elastic/apm-server/model/modeldecoder/modeldecodertest"
+	"github.com/elastic/apm-server/model/modeldecoder/nullable"
 	"github.com/elastic/beats/v7/libbeat/common"
 )
 
@@ -568,7 +569,7 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 		})
 	})
 	t.Run("labels", func(t *testing.T) {
-		var input span
+		var input transaction
 		input.Context.Tags = common.MapStr{
 			"a": "b",
 			"c": float64(12315124131),
@@ -576,7 +577,7 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 			"e": true,
 		}
 		var out model.APMEvent
-		mapToSpanModel(&input, &out)
+		mapToTransactionModel(&input, &out)
 		assert.Equal(t, model.Labels{
 			"a": {Value: "b"},
 			"e": {Value: "true"},
@@ -585,5 +586,25 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 			"c": {Value: float64(12315124131)},
 			"d": {Value: float64(12315124131.12315124131)},
 		}, out.NumericLabels)
+	})
+	t.Run("links", func(t *testing.T) {
+		var input transaction
+		input.Links = []spanLink{{
+			SpanID:  nullable.String{Val: "span1"},
+			TraceID: nullable.String{Val: "trace1"},
+		}, {
+			SpanID:  nullable.String{Val: "span2"},
+			TraceID: nullable.String{Val: "trace2"},
+		}}
+		var out model.APMEvent
+		mapToTransactionModel(&input, &out)
+
+		assert.Equal(t, []model.SpanLink{{
+			Span:  model.Span{ID: "span1"},
+			Trace: model.Trace{ID: "trace1"},
+		}, {
+			Span:  model.Span{ID: "span2"},
+			Trace: model.Trace{ID: "trace2"},
+		}}, out.Span.Links)
 	})
 }

--- a/processor/stream/processor_test.go
+++ b/processor/stream/processor_test.go
@@ -124,6 +124,9 @@ func TestIntegrationESOutput(t *testing.T) {
 		name: "OpenTelemetryBridge",
 		path: "otel-bridge.ndjson",
 	}, {
+		name: "SpanLinks",
+		path: "span-links.ndjson",
+	}, {
 		name: "InvalidEvent",
 		path: "invalid-event.ndjson",
 		errors: []error{

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationSpanLinks.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationSpanLinks.approved.json
@@ -1,0 +1,108 @@
+{
+    "events": [
+        {
+            "@timestamp": "2018-08-01T10:00:00.001Z",
+            "agent": {
+                "name": "elastic-node",
+                "version": "3.14.0"
+            },
+            "event": {
+                "duration": 3564298,
+                "outcome": "unknown"
+            },
+            "host": {
+                "ip": [
+                    "192.0.0.1"
+                ]
+            },
+            "parent": {
+                "id": "ab23456a89012345"
+            },
+            "processor": {
+                "event": "span",
+                "name": "transaction"
+            },
+            "service": {
+                "name": "1234_service-12a3"
+            },
+            "span": {
+                "id": "0123456a89012345",
+                "links": [
+                    {
+                        "span": {
+                            "id": "linked_span_1"
+                        },
+                        "trace": {
+                            "id": "linked_trace_1"
+                        }
+                    }
+                ],
+                "name": "GET /api/types",
+                "type": "request"
+            },
+            "timestamp": {
+                "us": 1533117600001845
+            },
+            "trace": {
+                "id": "0123456789abcdef0123456789abcdef"
+            }
+        },
+        {
+            "@timestamp": "2018-08-01T10:00:00.000Z",
+            "agent": {
+                "name": "elastic-node",
+                "version": "3.14.0"
+            },
+            "event": {
+                "duration": 32592981,
+                "outcome": "unknown"
+            },
+            "host": {
+                "ip": [
+                    "192.0.0.1"
+                ]
+            },
+            "processor": {
+                "event": "transaction",
+                "name": "transaction"
+            },
+            "service": {
+                "name": "1234_service-12a3"
+            },
+            "span": {
+                "links": [
+                    {
+                        "span": {
+                            "id": "linked_span_2"
+                        },
+                        "trace": {
+                            "id": "linked_trace_2"
+                        }
+                    },
+                    {
+                        "span": {
+                            "id": "linked_span_3"
+                        },
+                        "trace": {
+                            "id": "linked_trace_3"
+                        }
+                    }
+                ]
+            },
+            "timestamp": {
+                "us": 1533117600000000
+            },
+            "trace": {
+                "id": "01234567890123456789abcdefabcdef"
+            },
+            "transaction": {
+                "id": "abcdef1478523690",
+                "sampled": true,
+                "span_count": {
+                    "started": 0
+                },
+                "type": "request"
+            }
+        }
+    ]
+}

--- a/testdata/intake-v2/span-links.ndjson
+++ b/testdata/intake-v2/span-links.ndjson
@@ -1,0 +1,3 @@
+{"metadata": { "service": {"name": "1234_service-12a3", "agent": {"version": "3.14.0", "name": "elastic-node"}}}}
+{"span": {"id": "0123456a89012345", "trace_id": "0123456789abcdef0123456789abcdef", "parent_id": "ab23456a89012345", "name": "GET /api/types", "type": "request", "start": 1.845, "duration": 3.5642981, "links": [{"span_id": "linked_span_1", "trace_id": "linked_trace_1"}]}}
+{"transaction": {"trace_id": "01234567890123456789abcdefabcdef", "id": "abcdef1478523690", "type": "request", "duration": 32.592981, "span_count": {"started": 0}, "links": [{"span_id": "linked_span_2", "trace_id": "linked_trace_2"}, {"span_id": "linked_span_3", "trace_id": "linked_trace_3"}]}}


### PR DESCRIPTION
## Motivation/summary

Add support for span links to intake v2, for spans and transactions. I have intentionally not added support to the RUM v3 intake, as there is no need for span links there at present.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

1. Send `testdata/intake-v2/span-links.ndjson` to apm-server
2. Check the spans and transactions indexed in Elasticsearch have `span.links` fields populated accordingly

## Related issues

Closes https://github.com/elastic/apm-server/issues/7304