### PR TITLE
ci: remove APM Integration Tests stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,6 @@ pipeline {
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
     CODECOV_SECRET = 'secret/apm-team/ci/apm-server-codecov'
-    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/main'
     DIAGNOSTIC_INTERVAL = "${params.DIAGNOSTIC_INTERVAL}"
     ES_LOG_LEVEL = "${params.ES_LOG_LEVEL}"
     DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
@@ -42,8 +41,6 @@ pipeline {
     booleanParam(name: 'test_sys_env_ci', defaultValue: true, description: 'Enable system and environment test')
     booleanParam(name: 'bench_ci', defaultValue: true, description: 'Enable benchmarks')
     booleanParam(name: 'release_ci', defaultValue: true, description: 'Enable build the release packages')
-    booleanParam(name: 'its_ci', defaultValue: true, description: 'Enable async ITs')
-    string(name: 'DIAGNOSTIC_INTERVAL', defaultValue: "0", description: 'Elasticsearch detailed logging every X seconds')
     string(name: 'ES_LOG_LEVEL', defaultValue: "error", description: 'Elasticsearch error level')
   }
   stages {
@@ -538,36 +535,6 @@ pipeline {
                   sharedPublicly: true,
                   showInline: true)
               }
-            }
-          }
-        }
-        stage('APM Integration Tests') {
-          agent { label 'linux && immutable' }
-          options { skipDefaultCheckout() }
-          when {
-            beforeAgent true
-            allOf {
-              anyOf {
-                changeRequest()
-                expression { return !params.Run_As_Main_Branch }
-              }
-              expression { return params.its_ci }
-              expression { return env.ONLY_DOCS == "false" }
-            }
-          }
-          steps {
-            withGithubNotify(context: 'APM Integration Tests') {
-              script {
-                def buildObject = build(job: env.ITS_PIPELINE, propagate: false, wait: true,
-                      parameters: [string(name: 'INTEGRATION_TEST', value: 'All'),
-                                  string(name: 'BUILD_OPTS', value: "--apm-server-build https://github.com/elastic/${env.REPO}@${env.GIT_BASE_COMMIT}")])
-                copyArtifacts(projectName: env.ITS_PIPELINE, selector: specific(buildNumber: buildObject.number.toString()))
-              }
-            }
-          }
-          post {
-            always {
-              junit(testResults: "**/*-junit*.xml", allowEmptyResults: true, keepLongStdio: true)
             }
           }
         }


### PR DESCRIPTION
## Motivation/summary

The integration tests do not pay their weight. They take 30-40 minutes, intermittently fail due to test flakiness, and I cannot remember the last time they failed due to a change in the server. We have coverage in our system tests, so let's take back some time.

Rather than the server running tests for all agents, agents should run their own integration tests. In the rare event that the server breaks for a specific agent (i.e. not covered by system tests which just use the Go agent), agent developers can report issues to us.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

None