### PR TITLE
ci: -SNAPSHOT suffix is required

### DIFF
--- a/.ci/scripts/release-manager.sh
+++ b/.ci/scripts/release-manager.sh
@@ -16,7 +16,7 @@ chmod -R a+w build/distributions
 # rename dependencies.csv to the name expected by release-manager.
 VERSION=$(make get-version)
 mv build/distributions/dependencies.csv \
-   build/distributions/dependencies-$VERSION.csv
+   build/distributions/dependencies-$VERSION-SNAPSHOT.csv
 
 # rename docker files to support the unified release format.
 # TODO: this could be supported by the package system itself


### PR DESCRIPTION
fixes: '/artifacts/build/distributions/dependencies-8.2.0-SNAPSHOT.csv' specified for property '' does not exist.
