### PR TITLE
dra: retry docker pull

### DIFF
--- a/.ci/scripts/release-manager.sh
+++ b/.ci/scripts/release-manager.sh
@@ -35,7 +35,7 @@ done
 
 # ensure the latest image has been pulled
 IMAGE=docker.elastic.co/infra/release-manager:latest
-(retry 3 docker pull "${IMAGE}") || echo "Error pulling ${IMAGE} Docker image, we continue"
+(retry 3 docker pull --quiet "${IMAGE}") || echo "Error pulling ${IMAGE} Docker image, we continue"
 
 # Generate checksum files and upload to GCS
 docker run --rm \

--- a/.ci/scripts/release-manager.sh
+++ b/.ci/scripts/release-manager.sh
@@ -9,6 +9,8 @@
 #
 set -uexo pipefail
 
+source /usr/local/bin/bash_standard_lib.sh
+
 # set required permissions on artifacts and directory
 chmod -R a+r build/distributions/*
 chmod -R a+w build/distributions
@@ -33,7 +35,7 @@ done
 
 # ensure the latest image has been pulled
 IMAGE=docker.elastic.co/infra/release-manager:latest
-docker pull --quiet $IMAGE
+(retry 3 docker pull "${IMAGE}") || echo "Error pulling ${IMAGE} Docker image, we continue"
 
 # Generate checksum files and upload to GCS
 docker run --rm \

--- a/.ci/scripts/release-manager.sh
+++ b/.ci/scripts/release-manager.sh
@@ -36,6 +36,7 @@ done
 # ensure the latest image has been pulled
 IMAGE=docker.elastic.co/infra/release-manager:latest
 (retry 3 docker pull --quiet "${IMAGE}") || echo "Error pulling ${IMAGE} Docker image, we continue"
+docker images --filter=reference=$IMAGE
 
 # Generate checksum files and upload to GCS
 docker run --rm \


### PR DESCRIPTION
### What

`docker.elastic.co` might not be available, so let's rely on the cached docker images by default, but let's try to pull the recent docker image too.

### Why

Reduce the environmental issues