### PR TITLE
ci: packaging pipeline should not notify build status in github comments

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -139,7 +139,7 @@ pipeline {
   }
   post {
     cleanup {
-      notifyBuildResult()
+      notifyBuildResult(prComment: false)
     }
     failure {
       notifyStatus(slackStatus: 'danger', subject: "[${env.REPO}] DRA failed", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)")


### PR DESCRIPTION
### What

GitHub PR comments are created to help with debugging, since the `packaging` pipeline is not running for PRs, then it should not notify anything.