### PR TITLE
docs: add 8.1.1 release notes

### DIFF
--- a/changelogs/8.1.asciidoc
+++ b/changelogs/8.1.asciidoc
@@ -3,12 +3,36 @@
 
 https://github.com/elastic/apm-server/compare/8.0\...8.1[View commits]
 
+// * <<release-notes-8.1.2>>
+* <<release-notes-8.1.1>>
 * <<release-notes-8.1.0>>
-* <<release-notes-8.1.2>>
+
+// [float]
+// [[release-notes-8.1.2]]
+// === APM version 8.1.2
+
+// https://github.com/elastic/apm-server/compare/8.1.1\...8.1.2[View commits]
+
+// [float]
+// ==== Bug fixes
+// - Fix setting a timestamp on RUM data when capturing personal data is disabled {pull}7567[7567]
+
+[float]
+[[release-notes-8.1.1]]
+=== APM version 8.1.1
+
+https://github.com/elastic/apm-server/compare/8.1.0\...8.1.1[View commits]
+
+[float]
+==== Bug fixes
+- Fix missing stack monitoring metrics {pull}7428[7428]
+
 
 [float]
 [[release-notes-8.1.0]]
 === APM version 8.1.0
+
+https://github.com/elastic/apm-server/compare/8.0.1\...8.1.0[View commits]
 
 [float]
 ==== Added
@@ -18,14 +42,3 @@ https://github.com/elastic/apm-server/compare/8.0\...8.1[View commits]
 [float]
 ==== Bug fixes
 - Fix infinite loop in tail-based sampling subscriber causing high CPU and repeated Elasticsearch searches {pull}7211[7211]
-
-https://github.com/elastic/apm-server/compare/8.1.0\...8.1.2[View commits]
-
-[float]
-[[release-notes-8.1.2]]
-=== APM version 8.1.2
-
-[float]
-==== Bug fixes
-- Fix missing stack monitoring metrics {pull}7428[7428]
-- Fix setting a timestamp on RUM data when capturing personal data is disabled {pull}7567[7567]


### PR DESCRIPTION
### Summary

- [x] Adds the 8.1.1 release notes.

Note: 8.1.2 release notes were added in https://github.com/elastic/apm-server/commit/f1be74a473090bee3208722f3578616850a8c7c5. Based on the [BC2 commit hash](https://github.com/elastic/apm-server/commits/c28d7e2d938e46066ea80b31b8161d28be0ecd63), I've moved #7428 to 8.1.1 and commented out 8.1.2 to avoid user confusion.