### PR TITLE
[8.1] Add X-Elastic-Product-Origin header to es requests (#7442)

### DIFF
--- a/model/modelindexer/bulk_indexer.go
+++ b/model/modelindexer/bulk_indexer.go
@@ -35,7 +35,8 @@ import (
 )
 
 var (
-	gzipHeader = http.Header{"Content-Encoding": []string{"gzip"}}
+	esHeader   = http.Header{"X-Elastic-Product-Origin": []string{"observability"}}
+	gzipHeader = http.Header{"Content-Encoding": []string{"gzip"}, "X-Elastic-Product-Origin": []string{"observability"}}
 	newline    = []byte("\n")
 )
 
@@ -146,6 +147,7 @@ func (b *bulkIndexer) Flush(ctx context.Context) (elasticsearch.BulkIndexerRespo
 	}
 
 	req := esapi.BulkRequest{Body: &b.buf}
+	req.Header = esHeader
 	if b.gzipw != nil {
 		req.Header = gzipHeader
 	}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [Add X-Elastic-Product-Origin header to es requests (#7442)](https://github.com/elastic/apm-server/pull/7442)

<!--- Backport version: 8.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)