### PR TITLE
dra: run release-manager if branch is available

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -65,6 +65,7 @@ pipeline {
             setEnvVar('URI_SUFFIX', "commits/${env.GIT_BASE_COMMIT}")
             // JOB_GCS_BUCKET contains the bucket and some folders, let's build the folder structure
             setEnvVar('PATH_PREFIX', "${JOB_GCS_BUCKET.contains('/') ? JOB_GCS_BUCKET.substring(JOB_GCS_BUCKET.indexOf('/') + 1) + '/' + env.URI_SUFFIX : env.URI_SUFFIX}")
+            setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable(env.BRANCH_NAME))
           }
         }
         stage('Package') {
@@ -119,6 +120,12 @@ pipeline {
           }
         }
         stage('DRA') {
+          // The Unified Release process keeps moving branches as soon as a new
+          // minor version is created, therefore old release branches won't be able
+          // to use the release manager as their definition is removed.
+          when {
+            expression { return env.IS_BRANCH_AVAILABLE == "true" }
+          }
           steps {
             googleStorageDownload(bucketUri: "gs://${JOB_GCS_BUCKET}/${URI_SUFFIX}/*",
                                   credentialsId: "${JOB_GCS_CREDENTIALS}",


### PR DESCRIPTION
## Motivation/summary

Stop publishing staging/snapshot images for an old release branch but keep building them.


For instance, `8.0` is not available anymore therefore the `DRA` stage in the `packaging` pipeline failed with:

```
The specified build file '/vagrant/release/8.0.gradle' does not exist.
```

This approach will allow us to only run for the available branch if any

Requires https://github.com/elastic/apm-pipeline-library/pull/1618