### PR TITLE
dra: enforce version

### DIFF
--- a/.ci/scripts/release-manager.sh
+++ b/.ci/scripts/release-manager.sh
@@ -51,4 +51,5 @@ docker run --rm \
       --branch "$BRANCH_NAME" \
       --commit "$(git rev-parse HEAD)" \
       --workflow "snapshot" \
-      --artifact-set main
+      --artifact-set main \
+      --version "${VERSION}"


### PR DESCRIPTION
### What

Enforce the version to be the one in this project rather than the one in the Unified Release.

### Why

Product teams might update the version earlier than the version in the unified release, so therefore this will reduce the changes of non-up-to-date versions.

> version (optional) is the version of the artifacts to expect, for example 8.0.1. This is useful so that asynchronous builds can bump their versions before the version number inside of the release manager container is bumped.

Fixes

```
/artifacts/build/distributions/apm-server-8.1.1-SNAPSHOT-i386.deb'
```

while artifacts are pointing to 8.1.2:

```
build/distributions/apm-server-8.1.2-SNAPSHOT-i386.deb
```

See https://apm-ci.elastic.co/blue/organizations/jenkins/apm-server%2Fapm-server-package-mbp/detail/8.1/26/pipeline
