### PR TITLE
modelindexer: Reduce locking on flushActive

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -13,6 +13,7 @@ https://github.com/elastic/apm-server/compare/8.1\...main[View commits]
 [float]
 ==== Bug fixes
 - Do not overwrite `service version` if no transaction/error/... specific `service.name` is given {pull}7281[7281]
+- modelindexer: Fix indexing performance regression due to locking bug {pull}7649[7649]
 
 [float]
 ==== Intake API Changes

--- a/model/modelindexer/indexer.go
+++ b/model/modelindexer/indexer.go
@@ -334,9 +334,9 @@ func (i *Indexer) flushActive(ctx context.Context) error {
 	}()
 
 	i.activeMu.Lock()
-	defer i.activeMu.Unlock()
 	bulkIndexer := i.active
 	i.active = nil
+	i.activeMu.Unlock()
 	err := i.flush(ctx, bulkIndexer)
 	bulkIndexer.Reset()
 	i.available <- bulkIndexer


### PR DESCRIPTION
## Motivation/summary

This patch unlocks the `i.activeMu` mutex in flushActive as soon as the
`i.active` reference has been set to `nil`. This severely minimizes the
lock contention and achives similar or higher indexing throughput when
comparing the benchmarks before #7352 was introduced.

The microbenchmark results seem to indicate that we're back to the
previous indexing performance with this change:

```console
$ go test -bench ... # Current main
goos: darwin
goarch: arm64
pkg: github.com/elastic/apm-server/model/modelindexer
BenchmarkModelIndexer/NoCompression-8        4653790    2527 ns/op
BenchmarkModelIndexer/BestSpeed-8            2909288	4051 ns/op
BenchmarkModelIndexer/DefaultCompression-8   1691677	6674 ns/op
BenchmarkModelIndexer/BestCompression-8      1234953    8334 ns/op
PASS
ok  	github.com/elastic/apm-server/model/modelindexer	70.585s
```

```console
$ go test -bench ... # This patch
goos: darwin
goarch: arm64
pkg: github.com/elastic/apm-server/model/modelindexer
BenchmarkModelIndexer/NoCompression-8         	 8702388	  1344 ns/op
BenchmarkModelIndexer/BestSpeed-8             	 5097385	  2238 ns/op
BenchmarkModelIndexer/DefaultCompression-8    	 2639126	  4821 ns/op
BenchmarkModelIndexer/BestCompression-8       	 1586126	  7350 ns/op
PASS
ok  	github.com/elastic/apm-server/model/modelindexer	64.933s
```

The contention is much worse when the APM Server is actually running and
indexing against an Elasticsearch cluster since the lock is held for the
entire `bulkIndexer.Flush` operation, which includes network latency.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

I've been testing change impact the with `apmbench`:

1. `cd systemtest/cmd/apmbench && go build .`
2. `./apmbench -run BenchmarkAgent -benchtime=60s -agents=4`
3. The throughput of the benchmark should be higher for the patch than for `8.0.1+`.

## apmbench macro benchmark results

Tested locally with docker compose.

### 8.0.0

```console
$ ./apmbench -run BenchmarkAgent -benchtime=60s -agents=4
BenchmarkAgentGo-4    	      86	 764408034 ns/op	         0 error_responses/sec	       137.4 errors/sec	      6850 events/sec	       317.1 metrics/sec	      4517 spans/sec	      1879 txs/sec	 2379673 B/op	   14144 allocs/op
BenchmarkAgentNodeJS-4	     180	 513062855 ns/op	         0 error_responses/sec	        95.50 errors/sec	      3926 events/sec	       236.0 metrics/sec	      2068 spans/sec	      1526 txs/sec	 2412227 B/op	    8235 allocs/op
BenchmarkAgentPython-4	      44	1843640168 ns/op	         0 error_responses/sec	        39.05 errors/sec	      3813 events/sec	      1154 metrics/sec	      2212 spans/sec	       407.9 txs/sec	 5875730 B/op	   14428 allocs/op
BenchmarkAgentRuby-4  	      85	1552024937 ns/op	         0 error_responses/sec	        86.34 errors/sec	      2422 events/sec	       180.6 metrics/sec	      1423 spans/sec	       731.9 txs/sec	 3270417 B/op	   20423 allocs/op
```

### 8.0.1

```console
$ ./apmbench -run BenchmarkAgent -benchtime=60s -agents=4
BenchmarkAgentGo-4    	      32	2002199674 ns/op	         0 error_responses/sec	        52.44 errors/sec	      2617 events/sec	       122.5 metrics/sec	      1725 spans/sec	       717.2 txs/sec	 1593068 B/op	    7305 allocs/op
BenchmarkAgentNodeJS-4	      85	 851107791 ns/op	         0 error_responses/sec	        57.57 errors/sec	      2367 events/sec	       142.4 metrics/sec	      1247 spans/sec	       920.0 txs/sec	 2224859 B/op	    5257 allocs/op
BenchmarkAgentPython-4	      28	2702281876 ns/op	         0 error_responses/sec	        26.64 errors/sec	      2600 events/sec	       785.1 metrics/sec	      1509 spans/sec	       278.3 txs/sec	 7428360 B/op	   27696 allocs/op
BenchmarkAgentRuby-4  	      56	1632397635 ns/op	         0 error_responses/sec	        82.09 errors/sec	      2304 events/sec	       173.6 metrics/sec	      1353 spans/sec	       695.9 txs/sec	 1794028 B/op	    5029 allocs/op
```

### This patch

```console
$ ./apmbench -run BenchmarkAgent -benchtime=60s -agents=4
BenchmarkAgentGo-4    	      91	 739067571 ns/op	         0 error_responses/sec	       142.1 errors/sec	      7084 events/sec	       327.2 metrics/sec	      4672 spans/sec	      1943 txs/sec	 2736078 B/op	   16770 allocs/op
BenchmarkAgentNodeJS-4	     163	 473777176 ns/op	         0 error_responses/sec	       103.4 errors/sec	      4249 events/sec	       253.6 metrics/sec	      2239 spans/sec	      1653 txs/sec	 2359816 B/op	    7656 allocs/op
BenchmarkAgentPython-4	      34	1856595239 ns/op	         0 error_responses/sec	        38.78 errors/sec	      3783 events/sec	      1142 metrics/sec	      2197 spans/sec	       405.0 txs/sec	 7494392 B/op	   30396 allocs/op
BenchmarkAgentRuby-4  	      81	1044728229 ns/op	         0 error_responses/sec	       128.3 errors/sec	      3596 events/sec	       266.9 metrics/sec	      2113 spans/sec	      1087 txs/sec	 2060678 B/op	    8060 allocs/op
```

## Related issues

Discovered while working on #7216 