### PR TITLE
make: fix get-version with space

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ REVIEWDOG=$(GOOSBUILD)/reviewdog
 STATICCHECK=$(GOOSBUILD)/staticcheck
 ELASTICPACKAGE=$(GOOSBUILD)/elastic-package
 
+APM_SERVER_VERSION=$(shell grep defaultBeatVersion cmd/version.go | cut -d'=' -f2 | tr -d '" ')
+
 PYTHON_ENV?=.
 PYTHON_BIN:=$(PYTHON_ENV)/build/ve/$(shell $(GO) env GOOS)/bin
 PYTHON=$(PYTHON_BIN)/python
@@ -146,7 +148,7 @@ endif
 ## get-version : Get the apm server version
 .PHONY: get-version
 get-version:
-	@grep defaultBeatVersion cmd/version.go | cut -d'=' -f2 | tr -d '" '
+	@echo $(APM_SERVER_VERSION)
 
 ##############################################################################
 # Documentation.

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ endif
 ## get-version : Get the apm server version
 .PHONY: get-version
 get-version:
-	@grep defaultBeatVersion cmd/version.go | cut -d'=' -f2 | tr -d '"'
+	@grep defaultBeatVersion cmd/version.go | cut -d'=' -f2 | tr -d '" '
 
 ##############################################################################
 # Documentation.


### PR DESCRIPTION
### What

Left trim spaces in the version


### Why

Otherwise

```
mv build/distributions/dependencies.csv build/distributions/dependencies- 7.17.2-SNAPSHOT.csv
```

### Issue


Use partial changes from https://github.com/elastic/apm-server/pull/6802/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R28