### PR TITLE
[automation] update elastic stack version for testing 8.1.2-5d446358

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       fleet-server: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.1.2-2393b0c1-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.1.2-5d446358-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -39,7 +39,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.1.2-2393b0c1-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.1.2-5d446358-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -60,7 +60,7 @@ services:
       - "./testing/docker/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml"
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:8.1.2-2393b0c1-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:8.1.2-5d446358-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Fri, 25 Mar 2022 00:16:28 GMT, release_branch:8.1, prefix:, end_time:Fri, 25 Mar 2022 04:59:50 GMT, manifest_version:2.0.0, version:8.1.2-SNAPSHOT, branch:8.1, build_id:8.1.2-5d446358, build_duration_seconds:17002]