### PR TITLE
Add deprecation note for 32-bit system

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -163,6 +163,11 @@ func (bt *beater) run(ctx context.Context, cancelContext context.CancelFunc, b *
 		defer tracer.Close()
 	}
 
+	// add deprecation warning if running on a 32-bit system
+	if runtime.GOARCH == "386" {
+		bt.logger.Warn("deprecated target architecture: 32-bit systems support will be removed")
+	}
+
 	reloader := reloader{
 		runServerContext: ctx,
 		args: sharedServerRunnerParams{


### PR DESCRIPTION

## Motivation/summary

Add deprecation note for APM Server on 32 bit systems. 

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~


## How to test these changes
Build binaries and run on a 32 bit system. The log message should be issued as warning. 
<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues
partially fixes #7677

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
