### PR TITLE
[apmpackage] add double quotes around allow_origins {{this}}

### DIFF
--- a/apmpackage/apm/agent/input/template.yml.hbs
+++ b/apmpackage/apm/agent/input/template.yml.hbs
@@ -38,7 +38,7 @@ apm-server:
         {{/each}}
         allow_origins:
         {{#each rum_allow_origins}}
-          - {{this}}
+          - "{{this}}"
         {{/each}}
         enabled: {{enable_rum}}
         exclude_from_grouping: {{rum_exclude_from_grouping}}

--- a/apmpackage/apm/agent/input/template.yml.hbs
+++ b/apmpackage/apm/agent/input/template.yml.hbs
@@ -38,7 +38,7 @@ apm-server:
         {{/each}}
         allow_origins:
         {{#each rum_allow_origins}}
-          - "{{this}}"
+          - {{{this}}}
         {{/each}}
         enabled: {{enable_rum}}
         exclude_from_grouping: {{rum_exclude_from_grouping}}

--- a/apmpackage/apm/manifest.yml
+++ b/apmpackage/apm/manifest.yml
@@ -79,7 +79,7 @@ policy_templates:
           - name: rum_allow_origins
             type: text
             multi: true
-            default: ['*']
+            default: ['"*"']
           - name: rum_allow_headers
             type: text
             multi: true

--- a/apmpackage/apm/manifest.yml
+++ b/apmpackage/apm/manifest.yml
@@ -79,7 +79,7 @@ policy_templates:
           - name: rum_allow_origins
             type: text
             multi: true
-            default: ['"*"']
+            default: ['*']
           - name: rum_allow_headers
             type: text
             multi: true


### PR DESCRIPTION
## Motivation/summary

the wrong {{this}} was double quoted in #7598;
double quote the correct {{this}}

closes #7508

## How to test these changes

See reproduction steps [here](https://github.com/elastic/kibana/issues/121934#issuecomment-1055098129)
