### PR TITLE
apmpackage: add `url.original` field back in

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -18,6 +18,9 @@
     - description: removed `observer.version_major` field
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/7399
+    - description: added field mapping for `url.original` to traces, rum_traces, app_logs, and error_logs
+      type: bugfix
+      link: https://github.com/elastic/apm-server/pull/7698
 - version: "8.1.0"
   changes:
     - description: Added field mapping for `faas.coldstart` and `faas.trigger.type`

--- a/apmpackage/apm/data_stream/app_logs/fields/ecs.yml
+++ b/apmpackage/apm/data_stream/app_logs/fields/ecs.yml
@@ -134,6 +134,8 @@
 - external: ecs
   name: url.full
 - external: ecs
+  name: url.original
+- external: ecs
   name: url.path
 - external: ecs
   name: url.port

--- a/apmpackage/apm/data_stream/error_logs/fields/ecs.yml
+++ b/apmpackage/apm/data_stream/error_logs/fields/ecs.yml
@@ -130,6 +130,8 @@
 - external: ecs
   name: url.full
 - external: ecs
+  name: url.original
+- external: ecs
   name: url.path
 - external: ecs
   name: url.port

--- a/apmpackage/apm/data_stream/traces/fields/ecs.yml
+++ b/apmpackage/apm/data_stream/traces/fields/ecs.yml
@@ -126,6 +126,8 @@
 - external: ecs
   name: url.full
 - external: ecs
+  name: url.original
+- external: ecs
   name: url.path
 - external: ecs
   name: url.port


### PR DESCRIPTION
## Motivation/summary

Add the `url.original` field to data streams where it may be indexed. We missed this in the original translation to the integration package.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
~- [ ] Documentation has been updated~

## How to test these changes

1. Install the integration package
2. Ensure `traces-apm-*`, `traces-apm.rum-*`, `traces.apm.app-*`, and `traces-apm.error-*` index templates each have `url.original` defined.

## Related issues

Closes #7697