### PR TITLE
ci: speed up packaging and DRA

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -30,6 +30,7 @@ pipeline {
   stages {
     stage('Filter build') {
       agent { label 'ubuntu-18 && immutable' }
+      options { skipDefaultCheckout() }
       when {
         beforeAgent true
         anyOf {
@@ -85,6 +86,7 @@ pipeline {
             }
             stages {
               stage('Package') {
+                options { skipDefaultCheckout() }
                 environment {
                   PLATFORMS = "${isArm() ? 'linux/arm64' : ''}"
                   PACKAGES = "${isArm() ? 'docker' : ''}"
@@ -96,6 +98,7 @@ pipeline {
                 }
               }
               stage('Publish') {
+                options { skipDefaultCheckout() }
                 steps {
                   runIfNoMainAndNoStaging() {
                     publishArtifacts(type: env.TYPE)
@@ -106,6 +109,7 @@ pipeline {
           }
         }
         stage('DRA') {
+          options { skipDefaultCheckout() }
           // The Unified Release process keeps moving branches as soon as a new
           // minor version is created, therefore old release branches won't be able
           // to use the release manager as their definition is removed.

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -26,3 +26,6 @@ if [ -x "$(command -v docker)" ]; then
   (retry 2 docker pull "${image}") || echo "Error pulling ${image} Docker image, we continue"
   done
 fi
+
+# To fetch all the required toolchain (docker images) that might change overtime
+make release-manager-snapshot || true


### PR DESCRIPTION
Faster builds with:

1) less duplicated checkout

<img width="1212" alt="image" src="https://user-images.githubusercontent.com/2871786/160613201-4360b1fa-5b39-4a03-a37d-957638b16ca6.png">

The first step is not required since we use stash/unstash to copy the workspace between stages and workers.

2) cached docker images

