### PR TITLE
dra: add who to contact with if a DRA or package failure

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -109,7 +109,8 @@ pipeline {
           }
           post {
             failure {
-              notifyStatus(subject: "[${env.REPO}@${env.BRANCH_NAME}] package failed")
+              notifyStatus(subject: "[${env.REPO}@${env.BRANCH_NAME}] package failed.",
+                           body: 'Contact the Productivity team if you need further assistance')
             }
           }
         }
@@ -134,7 +135,8 @@ pipeline {
             failure {
               notifyStatus(analyse: true,
                            file: "${BASE_DIR}/${env.DRA_OUTPUT}",
-                           subject: "[${env.REPO}@${env.BRANCH_NAME}] DRA failed")
+                           subject: "[${env.REPO}@${env.BRANCH_NAME}] DRA failed.",
+                           body: 'Contact the Release Platform team')
             }
           }
         }
@@ -209,6 +211,7 @@ def notifyStatus(def args = [:]) {
   def releaseManagerFile = args.get('file', '')
   def analyse = args.get('analyse', false)
   def subject = args.get('subject', '')
+  def body = args.get('body', '')
   releaseManagerNotification(file: releaseManagerFile,
                              analyse: analyse,
                              slackChannel: "${env.SLACK_CHANNEL}",
@@ -216,7 +219,7 @@ def notifyStatus(def args = [:]) {
                              slackCredentialsId: 'jenkins-slack-integration-token',
                              to: "${env.NOTIFY_TO}",
                              subject: subject,
-                             body: "Build: (<${env.RUN_DISPLAY_URL}|here>)")
+                             body: "Build: (<${env.RUN_DISPLAY_URL}|here>).\n ${body}")
 }
 
 def runIfNoMainAndNoStaging(Closure body) {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -110,7 +110,7 @@ pipeline {
           post {
             failure {
               notifyStatus(subject: "[${env.REPO}@${env.BRANCH_NAME}] package failed.",
-                           body: 'Contact the Productivity team if you need further assistance')
+                           body: 'Contact the Productivity team [#observablt-robots] if you need further assistance.')
             }
           }
         }
@@ -136,7 +136,7 @@ pipeline {
               notifyStatus(analyse: true,
                            file: "${BASE_DIR}/${env.DRA_OUTPUT}",
                            subject: "[${env.REPO}@${env.BRANCH_NAME}] DRA failed.",
-                           body: 'Contact the Release Platform team')
+                           body: 'Contact the Release Platform team [#platform-release].')
             }
           }
         }


### PR DESCRIPTION
### What

DRA failures are different than package failures, therefore, let's add who to contact with if further analysis is required.

### Why

DRA is a black box so only the system owners know about it, therefore the product teams need to care only for the package generation in case something fails, otherwise, redirect the failures to the system owners.


### Question

Do we want to notify to the system owners by email/slack?