### PR TITLE
jjbb: remove tags and update branches

### DIFF
--- a/.ci/jobs/apm-server-check-changelogs-mbp.yml
+++ b/.ci/jobs/apm-server-check-changelogs-mbp.yml
@@ -12,7 +12,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: false
-        head-filter-regex: '(main|6\.8|7\.1[6789]|8\.\d+|PR-.*)'
+        head-filter-regex: '(main|7\.17|8\.\d+|PR-.*)'
         notification-context: 'apm-ci'
         property-strategies:
           all-branches:

--- a/.ci/jobs/apm-server-check-packages-mbp.yml
+++ b/.ci/jobs/apm-server-check-packages-mbp.yml
@@ -12,7 +12,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: false
-        head-filter-regex: '(main|7\.1[6789]|8\.\d+)'
+        head-filter-regex: '(main|7\.17|8\.\d+)'
         notification-context: 'beats-tester'
         build-strategies:
         - skip-initial-build: true
@@ -21,7 +21,7 @@
                 name: 'main'
                 case-sensitive: true
             - regex-name:
-                regex: '7\.1[6789]'
+                regex: '7\.17'
                 case-sensitive: true
             - regex-name:
                 regex: '8\.\d+'

--- a/.ci/jobs/apm-server-mbp.yml
+++ b/.ci/jobs/apm-server-mbp.yml
@@ -12,8 +12,8 @@
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
-        discover-tags: true
-        head-filter-regex: '(main|6\.8|7\.1[6789]|8\.\d+|PR-.*|v[0-9].*)'
+        discover-tags: false
+        head-filter-regex: '(main|7\.17|8\.\d+|PR-.*)'
         notification-context: 'apm-ci'
         repo: apm-server
         repo-owner: elastic
@@ -21,9 +21,6 @@
         ssh-checkout:
           credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
         build-strategies:
-        - tags:
-            ignore-tags-older-than: -1
-            ignore-tags-newer-than: -1
         - regular-branches: true
         - change-request:
             ignore-target-only-changes: false

--- a/.ci/jobs/update-beats-mbp.yml
+++ b/.ci/jobs/update-beats-mbp.yml
@@ -13,7 +13,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: false
-          head-filter-regex: '^(main|7\.1[6789]|8\.\d+|PR-.*)$'
+          head-filter-regex: '^(main|7\.17|8\.\d+|PR-.*)$'
           notification-context: 'update-beats'
           repo: apm-server
           repo-owner: elastic

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -431,7 +431,6 @@ pipeline {
                 branch 'main'
                 branch pattern: '\\d+\\.\\d+', comparator: 'REGEXP'
                 branch pattern: 'v\\d?', comparator: 'REGEXP'
-                tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: 'REGEXP'
                 expression { return params.Run_As_Main_Branch }
               }
               expression { return params.bench_ci }
@@ -491,7 +490,6 @@ pipeline {
               anyOf {
                 branch 'main'
                 branch pattern: '\\d+\\.\\d+', comparator: 'REGEXP'
-                tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: 'REGEXP'
                 expression { return isPR() && env.BEATS_UPDATED != "false" }
                 expression { return env.GITHUB_COMMENT?.contains('package tests') || env.GITHUB_COMMENT?.contains('/package')}
                 expression { return params.Run_As_Main_Branch }


### PR DESCRIPTION
### What

Remove tags from the CI builds
Remove 6.8 and =< 7.16 branch references

### Why

Tags are coming from a particular commit from any release branch therefore they are already verified in the CI. 

If some flakiness then those errors will remain forever in the build dashboards.

Reduce the cost for building commits that have been already verified in the CI.