### PR TITLE
docs: Update anchor link to new AWS Lambda docs

### DIFF
--- a/docs/features.asciidoc
+++ b/docs/features.asciidoc
@@ -13,7 +13,7 @@
 * <<log-correlation>>
 * <<cross-cluster-search>>
 * <<span-compression>>
-* <<aws-lambda-extension>>
+* <<monitoring-aws-lambda>>
 
 include::./apm-data-security.asciidoc[]
 

--- a/docs/legacy/guide/opentracing.asciidoc
+++ b/docs/legacy/guide/opentracing.asciidoc
@@ -16,7 +16,8 @@ Not all features of the OpenTracing API are supported, and there are some Elasti
 * {apm-go-ref-v}/opentracing.html[Go agent]
 * {apm-java-ref-v}/opentracing-bridge.html[Java agent]
 * {apm-node-ref-v}/opentracing.html[Node.js agent]
-* {apm-py-ref-v}/opentelemetry-bridge.html[Python agent]
+// * {apm-py-ref-v}/opentelemetry-bridge.html[Python agent]
+* https://www.elastic.co/guide/en/apm/agent/python/6.x/opentelemetry-bridge.html[Python agent]
 * {apm-ruby-ref-v}/opentracing.html[Ruby agent]
 * {apm-rum-ref-v}/opentracing.html[JavaScript Real User Monitoring (RUM) agent]
 

--- a/docs/legacy/guide/opentracing.asciidoc
+++ b/docs/legacy/guide/opentracing.asciidoc
@@ -16,7 +16,7 @@ Not all features of the OpenTracing API are supported, and there are some Elasti
 * {apm-go-ref-v}/opentracing.html[Go agent]
 * {apm-java-ref-v}/opentracing-bridge.html[Java agent]
 * {apm-node-ref-v}/opentracing.html[Node.js agent]
-* {apm-py-ref-v}/opentracing-bridge.html[Python agent]
+* {apm-py-ref-v}/opentelemetry-bridge.html[Python agent]
 * {apm-ruby-ref-v}/opentracing.html[Ruby agent]
 * {apm-rum-ref-v}/opentracing.html[JavaScript Real User Monitoring (RUM) agent]
 


### PR DESCRIPTION
For https://github.com/elastic/apm-aws-lambda/pull/158#issuecomment-1078409137.