### PR TITLE
Add support for summary metrics

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -3,9 +3,9 @@
 # change type can be one of: enhancement, bugfix, breaking-change
 - version: "8.4.0"
   changes:
-    - description: Placeholder for 8.4.0 changelog
+    - description: Added support for dynamically mapping summary metrics
       type: enhancement
-      link: https://github.com/elastic/apm-server/pull/xxx
+      link: https://github.com/elastic/apm-server/pull/7772
 - version: "8.3.0"
   changes:
     - description: Field mapping for `target.name` and `target.type` added to traces data stream

--- a/apmpackage/apm/data_stream/app_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/apmpackage/apm/data_stream/app_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -19,6 +19,8 @@ processors:
           String metric_type = description.type;
           if (metric_type == "histogram") {
             dynamic_templates[name] = "histogram";
+          } else if (metric_type == "summary") {
+            dynamic_templates[name] = "summary";
           }
         }
         ctx._dynamic_templates = dynamic_templates;

--- a/apmpackage/apm/data_stream/app_metrics/manifest.yml
+++ b/apmpackage/apm/data_stream/app_metrics/manifest.yml
@@ -16,6 +16,13 @@ elasticsearch:
         - histogram:
             mapping:
               type: histogram
+        - summary:
+            mapping:
+              type: aggregate_metric_double
+              metrics:
+                - sum
+                - value_count
+              default_metric: value_count
         - numeric_labels:
             path_match: numeric_labels.*
             mapping:

--- a/beater/otlp/grpc_test.go
+++ b/beater/otlp/grpc_test.go
@@ -123,10 +123,7 @@ func TestConsumeMetricsGRPC(t *testing.T) {
 		actual[key] = value
 	})
 	assert.Equal(t, map[string]interface{}{
-		// In both of the requests we send above,
-		// the metrics do not have a type and so
-		// we treat them as unsupported metrics.
-		"consumer.unsupported_dropped": int64(2),
+		"consumer.unsupported_dropped": int64(0),
 
 		"request.count":                int64(2),
 		"response.count":               int64(2),

--- a/beater/otlp/http_test.go
+++ b/beater/otlp/http_test.go
@@ -120,10 +120,7 @@ func TestConsumeMetricsHTTP(t *testing.T) {
 		actual[key] = value
 	})
 	assert.Equal(t, map[string]interface{}{
-		// In the request we send above,
-		// the metrics do not have a type and so
-		// we treat them as unsupported metrics.
-		"consumer.unsupported_dropped": int64(1),
+		"consumer.unsupported_dropped": int64(0),
 
 		"request.count":                int64(1),
 		"response.count":               int64(1),

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -17,3 +17,4 @@ https://github.com/elastic/apm-server/compare/8.4\...main[View commits]
 
 [float]
 ==== Added
+- Added support for OpenTelemetry summary metrics {pull}7772[7772]

--- a/model/metricset_test.go
+++ b/model/metricset_test.go
@@ -80,6 +80,13 @@ func TestMetricset(t *testing.T) {
 							Values: []float64{1.1, 2.2, 3.3},
 						},
 					},
+					"request_summary": {
+						Type: "summary",
+						SummaryMetric: SummaryMetric{
+							Count: 10,
+							Sum:   123.456,
+						},
+					},
 					"just_type": {
 						Type:  "counter",
 						Value: 123,
@@ -95,12 +102,19 @@ func TestMetricset(t *testing.T) {
 					"counts": []int64{1, 2, 3},
 					"values": []float64{1.1, 2.2, 3.3},
 				},
+				"request_summary": mapstr.M{
+					"sum":         123.456,
+					"value_count": int64(10),
+				},
 				"just_type": 123.0,
 				"just_unit": 0.99,
 				"_metric_descriptions": mapstr.M{
 					"latency_histogram": mapstr.M{
 						"type": "histogram",
 						"unit": "s",
+					},
+					"request_summary": mapstr.M{
+						"type": "summary",
 					},
 					"just_type": mapstr.M{
 						"type": "counter",

--- a/processor/otel/metrics.go
+++ b/processor/otel/metrics.go
@@ -344,11 +344,8 @@ func (c *Consumer) addMetric(metric pdata.Metric, ms metricsets) bool {
 		dps := metric.Summary().DataPoints()
 		for i := 0; i < dps.Len(); i++ {
 			dp := dps.At(i)
-			if sample, ok := summarySample(dp); ok {
-				ms.upsert(dp.Timestamp().AsTime(), metric.Name(), dp.Attributes(), sample)
-			} else {
-				anyDropped = true
-			}
+			sample := summarySample(dp)
+			ms.upsert(dp.Timestamp().AsTime(), metric.Name(), dp.Attributes(), sample)
 		}
 	default:
 		// Unsupported metric: report that it has been dropped.
@@ -376,14 +373,14 @@ func numberSample(dp pdata.NumberDataPoint, metricType model.MetricType) (model.
 	}, true
 }
 
-func summarySample(dp pdata.SummaryDataPoint) (model.MetricsetSample, bool) {
+func summarySample(dp pdata.SummaryDataPoint) model.MetricsetSample {
 	return model.MetricsetSample{
 		Type: model.MetricTypeSummary,
 		SummaryMetric: model.SummaryMetric{
 			Count: int64(dp.Count()),
 			Sum:   dp.Sum(),
 		},
-	}, true
+	}
 }
 
 func histogramSample(bucketCounts []uint64, explicitBounds []float64) (model.MetricsetSample, bool) {

--- a/systemtest/approvals/TestOTLPGRPCMetrics.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCMetrics.approved.json
@@ -3,6 +3,45 @@
         {
             "@timestamp": "dynamic",
             "agent": {
+                "name": "otlp",
+                "version": "unknown"
+            },
+            "data_stream.dataset": "apm.app.unknown",
+            "data_stream.namespace": "default",
+            "data_stream.type": "metrics",
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "agent_id_status": "missing",
+                "ingested": "dynamic"
+            },
+            "metricset.name": "app",
+            "observer": {
+                "ephemeral_id": "dynamic",
+                "hostname": "dynamic",
+                "id": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "language": {
+                    "name": "unknown"
+                },
+                "name": "unknown"
+            },
+            "summary": {
+                "sum": 123.456,
+                "value_count": 10
+            }
+        },
+        {
+            "@timestamp": "dynamic",
+            "agent": {
                 "name": "opentelemetry/go",
                 "version": "1.5.0"
             },


### PR DESCRIPTION
## Motivation/summary

Add support for summary metrics: a combined count and sum of aggregated measurements, a la Prometheus summaries. We also add partial support for OpenTelemetry summary kind metrics; we store the count and sum, but drop quantiles.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
~- [ ] Documentation has been updated~

## How to test these changes

1. Instrument an application with a Prometheus summary metric
1. Using opentelemetry-collector-contrib, scrape Prometheus endpoint with the [prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver), and export to APM Server as OTLP
1. Check that summary metric is indexed into `metrics-apm.app.*-default` as an `aggregate_metric_double` field type

## Related issues

Closes https://github.com/elastic/apm-server/issues/5359