### PR TITLE
[automation] update elastic stack version for testing 8.3.0-657f2d50

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       fleet-server: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.3.0-4cd86339-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.3.0-657f2d50-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -39,7 +39,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.3.0-4cd86339-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.3.0-657f2d50-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -60,7 +60,7 @@ services:
       - "./testing/docker/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml"
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:8.3.0-4cd86339-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:8.3.0-657f2d50-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:
@@ -100,7 +100,7 @@ services:
       - "./build/integrations/apm:/packages/local/apm"
 
   metricbeat:
-    image: docker.elastic.co/beats/metricbeat:8.3.0-4cd86339-SNAPSHOT
+    image: docker.elastic.co/beats/metricbeat:8.3.0-657f2d50-SNAPSHOT
     environment:
       ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'
       ELASTICSEARCH_USERNAME: "${KIBANA_ES_USER:-admin}"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Mon, 4 Apr 2022 15:09:13 GMT, release_branch:master, prefix:, end_time:Mon, 4 Apr 2022 21:39:53 GMT, manifest_version:2.0.0, version:8.3.0-SNAPSHOT, branch:master, build_id:8.3.0-657f2d50, build_duration_seconds:23440]