### PR TITLE
packer_cache: restore permissions and ownership

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -40,8 +40,8 @@ if docker version >/dev/null ; then
   set -e
   echo "Change ownership of all files inside the specific folder from root/root to current user/group"
   set -x
-  docker run -v "$(pwd)":/beat ${DOCKER_IMAGE} sh -c "find /beat -user 0 -exec chown -h $(id -u):$(id -g) {} \;"
+  docker run -v "$(pwd)":/beat ${DOCKER_IMAGE} sh -c "find /beat -user 0 -exec chown -h $(id -u):$(id -g) {} \;" || true
 fi
 
 echo "Change permissions with write access of all files"
-chmod -R +w .
+chmod -R +w . || true

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -27,7 +27,7 @@ if [ -x "$(command -v docker)" ]; then
   done
 fi
 
-echo "Fetch all the required toolchain (docker images) that might change overtime"
+echo "Fetch all the required toolchain (docker images) that might change over time"
 make release-manager-snapshot || true
 
 if docker version >/dev/null ; then

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -27,5 +27,21 @@ if [ -x "$(command -v docker)" ]; then
   done
 fi
 
-# To fetch all the required toolchain (docker images) that might change overtime
+echo "Fetch all the required toolchain (docker images) that might change overtime"
 make release-manager-snapshot || true
+
+if docker version >/dev/null ; then
+  ## Detect architecture to support ARM specific docker images.
+  ARCH=$(uname -m| tr '[:upper:]' '[:lower:]')
+  DOCKER_IMAGE=alpine:3.4
+  if [ "${ARCH}" == "aarch64" ] ; then
+    DOCKER_IMAGE=arm64v8/alpine:3
+  fi
+  set -e
+  echo "Change ownership of all files inside the specific folder from root/root to current user/group"
+  set -x
+  docker run -v "$(pwd)":/beat ${DOCKER_IMAGE} sh -c "find /beat -user 0 -exec chown -h $(id -u):$(id -g) {} \;"
+fi
+
+echo "Change permissions with write access of all files"
+chmod -R +w .


### PR DESCRIPTION
### What

Fix permissions to help with tearing down the workspace

### Why

The `packer-cache` process fails when deleting the workspace to move forward to the next caching repository.


```
INFO:     googlecompute: TASK [packer_cache : run the packer_cache.sh script from apm-server.git repo] ***
INFO:     googlecompute: changed: [default]
INFO:     googlecompute:
INFO:     googlecompute: TASK [packer_cache : remove the apm-server.git reference repository shallow clone] ***
INFO:     googlecompute: fatal: [default]: FAILED! => {"changed": false, "msg": "rmtree failed: [Errno 13] Permission denied: '/tmp/apm-server.git/x-pack/apm-server.git/build/golang-crossbuild'"}
INFO:     googlecompute:
INFO:     googlecompute: PLAY RECAP *********************************************************************
INFO:     googlecompute: default                    : ok=37   changed=2    unreachable=0    failed=1    skipped=1
```