### PR TITLE
beater: fix pprof endpoints

### DIFF
--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -909,6 +909,25 @@ func TestServerElasticsearchOutput(t *testing.T) {
 	}, snapshot)
 }
 
+func TestServerPProf(t *testing.T) {
+	ucfg, err := common.NewConfigFrom(m{"pprof.enabled": true})
+	assert.NoError(t, err)
+	server, err := setupServer(t, ucfg, nil, nil)
+	require.NoError(t, err)
+	defer server.Stop()
+
+	for _, path := range []string{
+		"/debug/pprof",
+		"/debug/pprof/goroutine",
+		"/debug/pprof/cmdline",
+	} {
+		resp, err := http.Get(server.baseURL + path)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode, path)
+	}
+}
+
 type chanClient struct {
 	done    chan struct{}
 	Channel chan beat.Event


### PR DESCRIPTION
## Motivation/summary

Fix `/debug/pprof` routes, which were broken in https://github.com/elastic/apm-server/pull/7679.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~ (fixes unreleased code)
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

1. Run apm-server with `apm-server.pprof.enabled: true`
2. Open browser, navigate to `<base-url>/debug/pprof`
3. Click the links, check they all work

## Related issues

None