### PR TITLE
[automation] update elastic stack version for testing 8.1.3-9689383f

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       fleet-server: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.1.3-25093d2a-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.1.3-9689383f-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -39,7 +39,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.1.3-25093d2a-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.1.3-9689383f-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -60,7 +60,7 @@ services:
       - "./testing/docker/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml"
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:8.1.3-25093d2a-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:8.1.3-9689383f-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Mon, 11 Apr 2022 17:16:15 GMT, release_branch:8.1, prefix:, end_time:Mon, 11 Apr 2022 22:18:25 GMT, manifest_version:2.0.0, version:8.1.3-SNAPSHOT, branch:8.1, build_id:8.1.3-9689383f, build_duration_seconds:18130]