### PR TITLE
[7.17] 7.17.3 release notes

### DIFF
--- a/changelogs/7.17.asciidoc
+++ b/changelogs/7.17.asciidoc
@@ -14,7 +14,9 @@ https://github.com/elastic/apm-server/compare/7.16\...7.17[View commits]
 
 https://github.com/elastic/apm-server/compare/v7.17.2\...v7.17.3[View commits]
 
-No significant changes.
+[float]
+==== Bug fixes
+- APM Server will no longer set `_doc_count` fields when used with an old (<7.11.0) version of Elasticsearch. This metadata field was added in Elasticsearch 7.12.0; setting it in earlier versions causes problems on upgrade. {pull}7704[7704]
 
 [float]
 [[release-notes-7.17.2]]

--- a/changelogs/7.17.asciidoc
+++ b/changelogs/7.17.asciidoc
@@ -3,9 +3,18 @@
 
 https://github.com/elastic/apm-server/compare/7.16\...7.17[View commits]
 
+* <<release-notes-7.17.3>>
 * <<release-notes-7.17.2>>
 * <<release-notes-7.17.1>>
 * <<release-notes-7.17.0>>
+
+[float]
+[[release-notes-7.17.3]]
+=== APM version 7.17.3
+
+https://github.com/elastic/apm-server/compare/v7.17.2\...v7.17.3[View commits]
+
+No significant changes.
 
 [float]
 [[release-notes-7.17.2]]


### PR DESCRIPTION
Adds 7.17.3 release notes based on https://github.com/elastic/apm-server/commits/7.17.
There are a few PRs that made it into this version, but none include changelog entries. 
