### PR TITLE
[automation] update elastic stack version for testing 8.1.3-28740185

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       fleet-server: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.1.3-5c80e943-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.1.3-28740185-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -39,7 +39,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.1.3-5c80e943-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.1.3-28740185-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -60,7 +60,7 @@ services:
       - "./testing/docker/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml"
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:8.1.3-5c80e943-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:8.1.3-28740185-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Sun, 17 Apr 2022 05:15:42 GMT, release_branch:8.1, prefix:, end_time:Sun, 17 Apr 2022 09:59:44 GMT, manifest_version:2.0.0, version:8.1.3-SNAPSHOT, branch:8.1, build_id:8.1.3-28740185, build_duration_seconds:17042]