### PR TITLE
docs: Update `logging.files.permissions` to consider umask

### DIFF
--- a/docs/legacy/copied-from-beats/docs/loggingconfig.asciidoc
+++ b/docs/legacy/copied-from-beats/docs/loggingconfig.asciidoc
@@ -34,7 +34,7 @@ logging.files:
   path: /var/log/{beatname_lc}
   name: {beatname_lc}
   keepfiles: 7
-  permissions: 0644
+  permissions: 0640
 ----
 endif::win_only[]
 
@@ -47,7 +47,7 @@ logging.files:
   path: C:{backslash}ProgramData{backslash}{beatname_lc}{backslash}Logs
   name: {beatname_lc}
   keepfiles: 7
-  permissions: 0644
+  permissions: 0640
 ----
 endif::win_only[]
 
@@ -226,12 +226,13 @@ The permissions mask to apply when rotating log files. The default value is
 expressed in octal notation. In Go, numbers in octal notation must start with
 '0'.
 
+The most permissive mask allowed is 0640. If a higher permissions mask is
+specified via this setting, it will be subject to an umask of 0027.
+
 Examples:
 
-* 0644: give read and write access to the file owner, and read access to all others.
+* 0640: give read and write access to the file owner, and read access to members of the group associated with the file.
 * 0600: give read and write access to the file owner, and no access to all others.
-* 0664: give read and write access to the file owner and members of the group
-associated with the file, as well as read access to all other users.
 
 [float]
 ==== `logging.files.interval`


### PR DESCRIPTION
### Summary

Updates the `logging.files.permissions` examples to `0640` and `0600` and explains that the most permissive mask allowed is `0640` per https://github.com/elastic/beats/pull/28347.

### Related

* Closes https://github.com/elastic/apm-server/issues/5899.