### PR TITLE
[automation] update elastic stack version for testing 8.2.0-63f66f47

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       fleet-server: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0-14a8abdc-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0-63f66f47-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -39,7 +39,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.2.0-14a8abdc-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.2.0-63f66f47-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -60,7 +60,7 @@ services:
       - "./testing/docker/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml"
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:8.2.0-14a8abdc-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:8.2.0-63f66f47-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Tue, 26 Apr 2022 00:14:18 GMT, release_branch:8.2, prefix:, end_time:Tue, 26 Apr 2022 04:06:52 GMT, manifest_version:2.0.0, version:8.2.0-SNAPSHOT, branch:8.2, build_id:8.2.0-63f66f47, build_duration_seconds:13954]