### PR TITLE
ci: use downstream pattern

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -14,6 +14,7 @@ pipeline {
     DOCKER_REGISTRY = 'docker.elastic.co'
     DRA_OUTPUT = 'release-manager.out'
     COMMIT = "${params?.COMMIT}"
+    JOB_GIT_CREDENTIALS = "f6c7695a-671e-4f4f-a331-acdce44ff9ba"
   }
   options {
     timeout(time: 2, unit: 'HOURS')
@@ -312,7 +313,10 @@ def withGitContext(Closure body) {
 def smartGitCheckout() {
   // Checkout the given commit
   if (env.COMMIT?.trim()) {
-    gitCheckout(basedir: "${BASE_DIR}", branch: env.COMMIT)
+    gitCheckout(basedir: "${BASE_DIR}",
+                branch: "${env.COMMIT}",
+                credentialsId: "${JOB_GIT_CREDENTIALS}",
+                repo: "https://github.com/elastic/${REPO}.git")
   } else {
     gitCheckout(basedir: "${BASE_DIR}",
                 githubNotifyFirstTimeContributor: false,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -537,6 +537,15 @@ pipeline {
           }
         }
         stage('Downstream') {
+          options { skipDefaultCheckout() }
+          when {
+            beforeAgent true
+            anyOf {
+              branch 'main'
+              branch pattern: '\\d+\\.\\d+', comparator: 'REGEXP'
+              expression { return params.Run_As_Main_Branch }
+            }
+          }
           steps {
             build(job: "apm-server/apm-server-package-mbp/${env.JOB_BASE_NAME}",
                   propagate: false,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -536,6 +536,14 @@ pipeline {
             }
           }
         }
+        stage('Downstream') {
+          steps {
+            build(job: "apm-server/apm-server-package-mbp/${env.JOB_BASE_NAME}",
+                  propagate: false,
+                  wait: false,
+                  parameters: [string(name: 'COMMIT', value: "${env.GIT_BASE_COMMIT}")])
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Motivation/summary

Use the downstream pattern to run the packaging pipeline and then pass over the Git commit to be used.

The parentstream pattern does not support the Git commit approach by default and therefore it requires further changes to accomplish the same.

## How to test these changes

In the CI.

## Further context

When the `packaging` pipeline runs there is a chance that a new commit has been pushed to the `main` branch before the `packaging` has even get triggered, therefore the `packaging` pipeline will run but it will not use the original commit.

While using the downtream pattern, then we can orchestrate what builds to run from the `main pipeline` and the pass the sha commit to those jobs. 

## Test

I can set the commit to be used:

<img width="2459" alt="image" src="https://user-images.githubusercontent.com/2871786/165714302-89254c4f-aa55-4423-91b4-e8ace1d2d625.png">


## Follow up

JJBB to be configured with 

```yaml
        property-strategies:
          all-branches:
          - suppress-scm-triggering: true
```

In a follow up, since it will not require to lister for git events anymore.