### PR TITLE
ci: use changeset

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -69,8 +69,6 @@ pipeline {
             setEnvVar('IS_BRANCH_AVAILABLE', isBranchUnifiedReleaseAvailable(env.BRANCH_NAME))
             dir("${BASE_DIR}"){
               setEnvVar('VERSION', sh(label: 'Get version', script: 'make get-version', returnStdout: true)?.trim())
-              // The apmpackage stage gets triggered as described in https://github.com/elastic/apm-server/issues/6970
-              setEnvVar('IS_APM_PACKAGE', isGitRegionMatch(patterns: [ '(cmd/version.go|apmpackage/.*|.ci/packaging.groovy)' ], comparator: 'regexp'))
             }
           }
         }
@@ -123,7 +121,8 @@ pipeline {
         stage('apmpackage') {
           options { skipDefaultCheckout() }
           when {
-            expression { return env.IS_APM_PACKAGE == "true" }
+            // The apmpackage stage gets triggered as described in https://github.com/elastic/apm-server/issues/6970
+            changeset pattern: '(cmd/version.go|apmpackage/.*|.ci/packaging.groovy)', comparator: 'REGEXP'
           }
           steps {
             runWithMage() {


### PR DESCRIPTION
## Motivation/summary

Parentstream pattern didn't work well with https://github.com/elastic/apm-pipeline-library/blob/main/vars/isGitRegionMatch.groovy#L39 

Since a previous build for the same commit was triggered (git push event) but the following build if the main pipeline was built successfully used the same commit therefore it didn't work as expected.

Let's use the native support in jenkins instead in addition to remove the jjbb: scm integration in https://github.com/elastic/apm-server/pull/7996