### PR TITLE
Add pprof_enabled config option

### DIFF
--- a/apmpackage/apm/agent/input/template.yml.hbs
+++ b/apmpackage/apm/agent/input/template.yml.hbs
@@ -21,6 +21,7 @@ apm-server:
     idle_timeout: {{idle_timeout}}
     default_service_environment: {{default_service_environment}}
     expvar.enabled: {{expvar_enabled}}
+    pprof.enabled: {{pprof_enabled}}
     host: {{host}}
     max_connections: {{max_connections}}
     max_event_size: {{max_event_bytes}}

--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -9,6 +9,9 @@
     - description: Remove the release tag
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/7792
+    - description: Added config option for `pprof_enabled`
+      type: enhancement
+      link: https://github.com/elastic/apm-server/pull/8002
 - version: "8.2.0"
   changes:
     - description: Field mapping for `source.nat.ip` and `source.nat.port` added to data streams

--- a/apmpackage/apm/manifest.yml
+++ b/apmpackage/apm/manifest.yml
@@ -122,6 +122,9 @@ policy_templates:
           - name: expvar_enabled
             type: bool
             default: false
+          - name: pprof_enabled
+            type: bool
+            default: false
           - name: java_attacher_discovery_rules
             type: yaml
           - name: java_attacher_agent_version


### PR DESCRIPTION
## Motivation/summary

Allow easier debugging by having an option to dynamically set pprof_enabled config for the APM server.

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

## How to test these changes

To be tested in combination with the required UI work done for displaying and toggling the `pprof_enabled` toggle from UI.

## Related issues

#7733 
