### PR TITLE
docs: fix attributes

### DIFF
--- a/docs/common-problems.asciidoc
+++ b/docs/common-problems.asciidoc
@@ -22,7 +22,7 @@ If no data shows up in {es}, first make sure that your APM components are proper
 In {kib} open **Fleet** and find the host that is running the APM integration;
 confirm that its status is **Healthy**.
 If it isn't, check the {agent} logs to diagnose potential causes.
-See {fleet-guide-ref}/view-elastic-agent-status.html[view {agent} status] to learn more.
+See {fleet-guide}/view-elastic-agent-status.html[view {agent} status] to learn more.
 
 **Is APM Server happy?**
 

--- a/docs/common-problems.asciidoc
+++ b/docs/common-problems.asciidoc
@@ -24,13 +24,13 @@ confirm that its status is **Healthy**.
 If it isn't, check the {agent} logs to diagnose potential causes.
 See {fleet-guide-ref}/view-elastic-agent-status.html[view {agent} status] to learn more.
 
-**Is {apm-server} happy?**
+**Is APM Server happy?**
 
 In {kib}, open **Fleet** and select the host that is running the APM integration.
 Open the **Logs** tab and select the `elastic_agent.apm_server` dataset.
 Look for any APM Server errors that could help diagnose the problem.
 
-**Can the {apm-agent} connect to {apm-server}**
+**Can the {apm-agent} connect to APM Server**
 
 To determine if the APM agent can connect to the APM Server, send requests to the instrumented service and look for lines
 containing `[request]` in the APM Server logs.

--- a/docs/legacy/common-problems.asciidoc
+++ b/docs/legacy/common-problems.asciidoc
@@ -66,7 +66,7 @@ This will display the field data type of the `service.name` field.
 GET apm-*/_mapping/field/service.name
 ----
 
-If the `mapping.name.type` is `"text"`, your APM indices were not setup correctly.
+If the `mapping.name.type` is `"text"`, your APM indices were not set up correctly.
 
 [source,yml]
 ----
@@ -87,7 +87,7 @@ If the `mapping.name.type` is `"text"`, your APM indices were not setup correctl
    }
 }
 ----
-<1> The `service.name` `mapping.name.type` would be `"keyword"` if this field had been setup correctly.
+<1> The `service.name` `mapping.name.type` would be `"keyword"` if this field had been set up correctly.
 
 To fix this problem, you must delete and recreate your APM indices as index templates cannot be applied retroactively.
 

--- a/docs/troubleshoot-apm.asciidoc
+++ b/docs/troubleshoot-apm.asciidoc
@@ -3,7 +3,6 @@
 
 This section provides solutions to <<common-problems>>
 and <<processing-and-performance>> guidance.
-
 For additional help, see the links below.
 
 [float]
@@ -12,7 +11,7 @@ For additional help, see the links below.
 
 Elastic Agent, the APM app, and each APM agent has its own troubleshooting guide:
 
-* {fleet-guide-ref}/troubleshooting-intro.html[*Fleet and Elastic Agent* troubleshooting]
+* {fleet-guide}/troubleshooting-intro.html[*Fleet and Elastic Agent* troubleshooting]
 * {kibana-ref}/troubleshooting.html[*APM app* troubleshooting]
 * {apm-dotnet-ref-v}/troubleshooting.html[*.NET agent* troubleshooting]
 * {apm-go-ref-v}/troubleshooting.html[*Go agent* troubleshooting]


### PR DESCRIPTION
Fixes attributes in the documentation.

Follow-up to https://github.com/elastic/apm-server/pull/7901.