### PR TITLE
ci: use github actions macos

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   macos:
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
     - uses: actions/checkout@v2
     - name: get go version

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,8 +15,6 @@ on:
 jobs:
   macos:
     runs-on: macos-latest
-    env:
-      WORKSPACE: $GITHUB_WORKSPACE
     steps:
     - uses: actions/checkout@v2
     - name: get go version
@@ -34,7 +32,10 @@ jobs:
       run:  go get -u github.com/magefile/mage
 
     - name: Run build
-      run: .ci/scripts/build.sh
+      run: make apm-server
 
-    - name: Run test
-      run: .ci/scripts/unit-test.sh
+    - name: Run update
+      run: make update
+
+    - name: Run goTestUnit
+      run: mage goTestUnit

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,6 +12,7 @@ on:
       - 8.*
       - "7.17"
 
+jobs:
   macos:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,37 @@
+name: macos
+
+on:
+  push:
+    branches:
+      - main
+      - 8.*
+      - "7.17"
+  pull_request:
+    branches:
+      - main
+      - 8.*
+      - "7.17"
+
+  macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: get go version
+      run: |
+        gv=$(cat .go-version)
+        echo "::set-output name=go::$gv"
+      id: version
+
+    - name: install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "${{steps.version.outputs.go}}"
+
+    - name: Install dependencies
+      run:  go get -u github.com/magefile/mage
+
+    - name: Run build
+      run: .ci/scripts/build.sh
+
+    - name: Run test
+      run: .ci/scripts/unit-test.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   macos:
     runs-on: macos-latest
+    env:
+      WORKSPACE: $GITHUB_WORKSPACE
     steps:
     - uses: actions/checkout@v2
     - name: get go version

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -237,6 +237,8 @@ pipeline {
           when {
             beforeAgent true
             allOf {
+              // TODO: use github actions temporarily.
+              expression { return false }
               expression { return params.osx_ci }
               expression { return env.ONLY_DOCS == "false" }
             }


### PR DESCRIPTION
We are in the transition to use ephemeral workers, but until then there is a requirement to decommission the existing MacOS workers. For such this proposal uses GitHub actions for MacOS until we can use the ephemeral workers.

There are some test failures while running on MacOS

```
=== Failed
=== FAIL: x-pack/apm-server/sampling TestStorageGC (22.06s)
    processor_test.go:621: timed out waiting for value log garbage collection

DONE 1293 tests, 4 skipped, 1 failure in 153.557s
Error: exit status 1
go test returned a non-zero value
github.com/elastic/beats/v7/dev-tools/mage.GoTest
	/Users/runner/go/pkg/mod/github.com/elastic/beats/v7@v7.0.0-alpha2.0.20220427162857-d5fe415c845b/dev-tools/mage/gotest.go:292
main.GoTestUnit
	/Users/runner/work/apm-server/apm-server/magefile.go:185
main.main.func19
	/Users/runner/work/apm-server/apm-server/mage_output_file.go:572
main.main.func12.1
	/Users/runner/work/apm-server/apm-server/mage_output_file.go:275
runtime.goexit
	/Users/runner/hostedtoolcache/go/1.17.9/x64/src/runtime/asm_amd64.s:15[81](https://github.com/elastic/apm-server/runs/6272102843?check_suite_focus=true#step:8:81)
```