### PR TITLE
[automation] update elastic stack version for testing 8.1.4-37d447ec

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       fleet-server: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.1.4-86899ed7-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.1.4-37d447ec-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -39,7 +39,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.1.4-86899ed7-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.1.4-37d447ec-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -60,7 +60,7 @@ services:
       - "./testing/docker/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml"
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:8.1.4-86899ed7-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:8.1.4-37d447ec-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Wed, 4 May 2022 17:14:07 GMT, release_branch:8.1, prefix:, end_time:Wed, 4 May 2022 21:55:27 GMT, manifest_version:2.0.0, version:8.1.4-SNAPSHOT, branch:8.1, build_id:8.1.4-37d447ec, build_duration_seconds:16880]