### PR TITLE
packaging: exclude the pipeline

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -128,7 +128,7 @@ pipeline {
           when {
             allOf {
               // The apmpackage stage gets triggered as described in https://github.com/elastic/apm-server/issues/6970
-              changeset pattern: '(cmd/version.go|apmpackage/.*|.ci/packaging.groovy)', comparator: 'REGEXP'
+              changeset pattern: '(cmd/version.go|apmpackage/.*)', comparator: 'REGEXP'
               not { changeRequest() }
             }
           }

--- a/.ci/scripts/Makefile
+++ b/.ci/scripts/Makefile
@@ -26,20 +26,23 @@ create-package-storage-pull-request:
 		git checkout -b $(PACKAGE_STORAGE_BRANCH) ; \
 		echo "INFO: add files if any" ; \
 		git add . ; \
+		echo "INFO: any changes" ; \
+		rm .changes 2>/dev/null || true ; \
+		git diff --staged --quiet || touch .changes ; \
 		echo "INFO: commit changes if any" ; \
-		git diff --staged --quiet || git commit -m "[automation] Publish apm-$(APM_SERVER_VERSION)" ; \
+		test -f .changes && git commit -m "[automation] Publish apm-$(APM_SERVER_VERSION)" || true ; \
 		echo "INFO: show remote details" ; \
 		git remote -v ; \
-		echo "INFO: push branch" ; \
-		git push --set-upstream origin $(PACKAGE_STORAGE_BRANCH) ; \
-		echo "INFO: create pull request" ; \
-		gh pr create \
+		echo "INFO: push branch if changes" ; \
+		test -f .changes && git push --set-upstream origin $(PACKAGE_STORAGE_BRANCH) || true ; \
+		echo "INFO: create pull request if changes" ; \
+		test -f .changes && gh pr create \
 			--title "Publish apm-$(APM_SERVER_VERSION)" \
 			--body "Automated by $${BUILD_URL}" \
 			--label automation \
 			--base snapshot \
 			--head $(PACKAGE_STORAGE_BRANCH) \
-			--reviewer elastic/apm-server
+			--reviewer elastic/apm-server || true ; \
 
 ## get-package-storage-location : Get the package storage location
 .PHONY: get-package-storage-location


### PR DESCRIPTION
## Motivation/summary

Changes in the packaging.groovy should not trigger the apmpackage stage. Additionally if no changes to be applied then do nothing, otherwise `gh` will fail if creating a PR without changes.

## Test

Given the changes in this particular PR and the below patch:

```diff
diff --git a/.ci/scripts/Makefile b/.ci/scripts/Makefile
index e6853614f..c3c17ebbb 100644
--- a/.ci/scripts/Makefile
+++ b/.ci/scripts/Makefile
@@ -42,6 +42,7 @@ create-package-storage-pull-request:
 			--label automation \
 			--base snapshot \
 			--head $(PACKAGE_STORAGE_BRANCH) \
+			--repo v1v/package-storage \
 			--reviewer elastic/apm-server || true ; \
 
```

A branch was created:

<img width="1204" alt="image" src="https://user-images.githubusercontent.com/2871786/166886873-4b1edf55-ad72-43e1-90cb-afc3102ace56.png">

```
 make -C .ci/scripts create-package-storage-pull-request
INFO: create branch
Switched to a new branch 'update-apm-20220505092108'
INFO: add files if any
INFO: any changes
INFO: commit changes if any
[update-apm-20220505092108 064131e] [automation] Publish apm-8.3.0
 1 file changed, 2 insertions(+)
INFO: show remote details
origin	https://github.com/elastic/package-storage.git (fetch)
origin	https://github.com/elastic/package-storage.git (push)
INFO: push branch if changes
Enumerating objects: 5, done.
Counting objects: 100% (5/5), done.
Delta compression using up to 16 threads
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 973 bytes | 973.00 KiB/s, done.
Total 3 (delta 2), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
remote: 
remote: Create a pull request for 'update-apm-20220505092108' on GitHub by visiting:
remote:      https://github.com/elastic/package-storage/pull/new/update-apm-20220505092108
remote: 
To https://github.com/elastic/package-storage.git
 * [new branch]      update-apm-20220505092108 -> update-apm-20220505092108
Branch 'update-apm-20220505092108' set up to track remote branch 'update-apm-20220505092108' from 'origin'.
INFO: create pull request if changes
Warning: 1 uncommitted change

```