### PR TITLE
support `output.elasticsearch.max_requests`

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -677,6 +677,7 @@ func (s *serverRunner) newFinalBatchProcessor(
 		*elasticsearch.Config `config:",inline"`
 		FlushBytes            string        `config:"flush_bytes"`
 		FlushInterval         time.Duration `config:"flush_interval"`
+		MaxRequests           int           `config:"max_requests"`
 	}
 	esConfig.FlushInterval = time.Second
 	esConfig.Config = elasticsearch.DefaultConfig()
@@ -701,6 +702,7 @@ func (s *serverRunner) newFinalBatchProcessor(
 		FlushBytes:       flushBytes,
 		FlushInterval:    esConfig.FlushInterval,
 		Tracer:           s.tracer,
+		MaxRequests:      esConfig.MaxRequests,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -20,6 +20,7 @@ https://github.com/elastic/apm-server/compare/8.2\...main[View commits]
 [float]
 ==== Added
 - System, process, and well-defined runtime metrics are now sent to the shared `metrics-apm.internal-<namespace>` data stream {pull}7882[7882]
+- Number of parallel bulk requests are now configurable via `output.elasticsearch.max_requests` {pull}8055[8055]
 
 
 // Added but still being debugged


### PR DESCRIPTION
## Motivation/summary

make the number of bulk requests in the
modelindexer configurable via
`output.elasticsearch.max_requests`

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

## How to test these changes

Configure `output.elasticsearch.max_requests` and set `http.enabled=true`. Start the apm-server, curl the stats endpoint, and confirm that the number of available bulk requests matches the amount configured:

```
# curl -s localhost:5066/stats | jq '.output.elasticsearch.bulk_requests'
{
  "available": 25,
  "completed": 0
}
```

## Related issues

closes #7719
