### PR TITLE
cancel server process context after timeout

### DIFF
--- a/systemtest/apikeycmd_test.go
+++ b/systemtest/apikeycmd_test.go
@@ -58,7 +58,7 @@ func apiKeyCommandConfig(cfg apmservertest.Config, subcommand string, args ...st
 	userargs := args
 	args = append([]string{subcommand}, esargs...)
 	args = append(args, userargs...)
-	return apmservertest.ServerCommand("apikey", args...)
+	return apmservertest.ServerCommand(context.Background(), "apikey", args...)
 }
 
 func TestAPIKeyCreate(t *testing.T) {

--- a/systemtest/apmservertest/command.go
+++ b/systemtest/apmservertest/command.go
@@ -18,6 +18,7 @@
 package apmservertest
 
 import (
+	"context"
 	"io/ioutil"
 	"log"
 	"os"
@@ -32,14 +33,14 @@ import (
 
 // ServerCommand returns a ServerCmd (wrapping os/exec) for running
 // apm-server with args.
-func ServerCommand(subcommand string, args ...string) *ServerCmd {
+func ServerCommand(ctx context.Context, subcommand string, args ...string) *ServerCmd {
 	binary, buildErr := BuildServerBinary(runtime.GOOS)
 	if buildErr != nil {
 		// Dummy command; Start etc. will return the build error.
 		binary = "/usr/bin/false"
 	}
 	args = append([]string{subcommand}, args...)
-	cmd := exec.Command(binary, args...)
+	cmd := exec.CommandContext(ctx, binary, args...)
 	cmd.SysProcAttr = serverCommandSysProcAttr
 	return &ServerCmd{
 		Cmd:        cmd,

--- a/systemtest/apmservertest/server.go
+++ b/systemtest/apmservertest/server.go
@@ -163,7 +163,6 @@ func (s *Server) start(tls bool) error {
 	args = append(args, "--path.home", ".") // working directory, s.Dir
 
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	s.cmd = ServerCommand(ctx, "run", args...)
 	s.cmd.Dir = s.Dir
 
@@ -187,12 +186,12 @@ func (s *Server) start(tls bool) error {
 	s.Dir = s.cmd.Dir
 	s.tb.Cleanup(func() {
 		errc := make(chan error)
+		defer cancel()
 		go func() { errc <- s.Close() }()
 		select {
 		case <-errc:
 			close(errc)
 		case <-time.After(10 * time.Second):
-			cancel()
 			// Channel receive on errc never happened. Start up a
 			// goroutine to receive on errc and then clean up the
 			// associated resources.

--- a/systemtest/export_test.go
+++ b/systemtest/export_test.go
@@ -18,6 +18,7 @@
 package systemtest_test
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -39,7 +40,7 @@ func exportConfigCommand(t *testing.T, args ...string) (_ *apmservertest.ServerC
 
 	allArgs := []string{"config", "--path.home", tempdir}
 	allArgs = append(allArgs, args...)
-	return apmservertest.ServerCommand("export", allArgs...), tempdir
+	return apmservertest.ServerCommand(context.Background(), "export", allArgs...), tempdir
 }
 
 func TestExportConfigDefaults(t *testing.T) {


### PR DESCRIPTION
Attempting to short-circuit cleaning up the apm-server when the system gets stuck waiting

from https://github.com/elastic/apm-server/issues/7564:
```
[2022-03-17T06:33:38.633Z] goroutine 1885 [syscall, 17 minutes]:
[2022-03-17T06:33:38.633Z] syscall.Syscall6(0xf7, 0x1, 0x90ce, 0xc000247bd0, 0x1000004, 0x0, 0x0)
[2022-03-17T06:33:38.633Z] 	/var/lib/jenkins/workspace/pm-server_apm-server-mbp_PR-7561/.gvm/versions/go1.17.6.linux.amd64/src/syscall/asm_linux_amd64.s:43 +0x5
[2022-03-17T06:33:38.633Z] os.(*Process).blockUntilWaitable(0xc0024cdc80)
[2022-03-17T06:33:38.633Z] 	/var/lib/jenkins/workspace/pm-server_apm-server-mbp_PR-7561/.gvm/versions/go1.17.6.linux.amd64/src/os/wait_waitid.go:33 +0x9c
[2022-03-17T06:33:38.633Z] os.(*Process).wait(0xc0024cdc80)
[2022-03-17T06:33:38.633Z] 	/var/lib/jenkins/workspace/pm-server_apm-server-mbp_PR-7561/.gvm/versions/go1.17.6.linux.amd64/src/os/exec_unix.go:23 +0x28
[2022-03-17T06:33:38.633Z] os.(*Process).Wait(...)
[2022-03-17T06:33:38.633Z] 	/var/lib/jenkins/workspace/pm-server_apm-server-mbp_PR-7561/.gvm/versions/go1.17.6.linux.amd64/src/os/exec.go:132
[2022-03-17T06:33:38.633Z] os/exec.(*Cmd).Wait(0xc001d3d340)
[2022-03-17T06:33:38.633Z] 	/var/lib/jenkins/workspace/pm-server_apm-server-mbp_PR-7561/.gvm/versions/go1.17.6.linux.amd64/src/os/exec/exec.go:507 +0x54
[2022-03-17T06:33:38.633Z] github.com/elastic/apm-server/systemtest/apmservertest.(*ServerCmd).Wait(0xc000247e00)
[2022-03-17T06:33:38.633Z] 	/var/lib/jenkins/workspace/pm-server_apm-server-mbp_PR-7561/src/github.com/elastic/apm-server/systemtest/apmservertest/command.go:101 +0x5d
[2022-03-17T06:33:38.633Z] github.com/elastic/apm-server/systemtest/apmservertest.(*Server).Wait(0xc0000c4d80)
[2022-03-17T06:33:38.633Z] 	/var/lib/jenkins/workspace/pm-server_apm-server-mbp_PR-7561/src/github.com/elastic/apm-server/systemtest/apmservertest/server.go:436 +0x1b7
[2022-03-17T06:33:38.633Z] github.com/elastic/apm-server/systemtest/apmservertest.(*Server).Close(0xc0000c4d80)
[2022-03-17T06:33:38.633Z] 	/var/lib/jenkins/workspace/pm-server_apm-server-mbp_PR-7561/src/github.com/elastic/apm-server/systemtest/apmservertest/server.go:406 +0x85
```

Based on this panic output and [reading the code](https://github.com/elastic/apm-server/blob/main/systemtest/apmservertest/server.go#L400-L407), my assumption is that the call to `*Server.Close()` does not return an error when sending SIGINT to the underlying process, enters the `*Server.Wait()` code, but *something* happens that causes the syscall to block, from which we never return.

Canceling the process context will call SIGKILL, which should hopefully free up the process so the tests can move along.

closes https://github.com/elastic/apm-server/issues/7564