### PR TITLE
[automation] update elastic stack version for testing 8.2.1-d6d75d75

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       fleet-server: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.0-56396fd0-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.1-d6d75d75-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -39,7 +39,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.2.0-56396fd0-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.2.1-d6d75d75-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -60,7 +60,7 @@ services:
       - "./testing/docker/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml"
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:8.2.0-56396fd0-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:8.2.1-d6d75d75-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Tue, 10 May 2022 00:14:30 GMT, release_branch:8.2, prefix:, end_time:Tue, 10 May 2022 03:56:53 GMT, manifest_version:2.1.0, version:8.2.1-SNAPSHOT, branch:8.2, build_id:8.2.1-d6d75d75, build_duration_seconds:13343]