### PR TITLE
[DOC] Document possibility of customizing apm data streams

### DIFF
--- a/docs/custom-index-template.asciidoc
+++ b/docs/custom-index-template.asciidoc
@@ -18,7 +18,8 @@ The default APM index templates can be viewed in {kib}.
 Navigate to **Stack Management** > **Index Management** > **Index Templates**, and search for `apm`.
 Select any of the APM index templates to view their relevant component templates.
 
-It is not currently possible to make changes to index templates that persist through version upgrades.
+It is possible to make changes to index templates that persist through version upgrades using the component templates
+named `@custom`, declared in the built-in `apm` index templates.
 
 // end::index-template-integration[]
 


### PR DESCRIPTION
Add a section to document the possibility to use `@custom` component templates.

Actually there's a section but it is commented out just below the line I've added.

## Checklist

- [x] Documentation has been updated
- [ ] Maintainers to add steps to validate the resulting index template is valid prior to rollover (https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-simulate-template.html)
- [ ] Maintainers to Review wording
- [ ] Backport to all versions offering `@custom`
