### PR TITLE
update failing regexp for 1.18

### DIFF
--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -502,7 +502,7 @@ func TestServerConfigReload(t *testing.T) {
 		},
 	})}})
 	require.Error(t, err)
-	assert.Regexp(t, "listen tcp: lookup testing.invalid: .*", err.Error())
+	assert.Regexp(t, "listen tcp: lookup testing.invalid.*", err.Error())
 
 	inputConfig := agentconfig.MustNewConfigFrom(map[string]interface{}{
 		"apm-server": map[string]interface{}{


### PR DESCRIPTION
go1.18 changes the error output message slightly,
which causes the regexp to fail.

update the regexp so it passes for both the old
and new message formats.

example failure:
```
# go version
go version go1.18.1 linux/amd64

--- FAIL: TestServerConfigReload (0.06s)
    server_test.go:505: 
        	Error Trace:	server_test.go:505
        	Error:      	Expect "listen tcp: lookup testing.invalid on 127.0.0.53:53: no such host" to match "listen tcp: lookup testing.invalid: .*"
        	Test:       	TestServerConfigReload
```