### PR TITLE
add timeout to http client

### DIFF
--- a/systemtest/agentconfig_test.go
+++ b/systemtest/agentconfig_test.go
@@ -118,7 +118,8 @@ func queryAgentConfig(t testing.TB, serverURL, serviceName, serviceEnvironment, 
 	if etag != "" {
 		req.Header.Set("If-None-Match", etag)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	c := http.Client{Timeout: 5 * time.Second}
+	resp, err := c.Do(req)
 
 	maxRetries := 10
 	var retries int
@@ -126,7 +127,7 @@ func queryAgentConfig(t testing.TB, serverURL, serviceName, serviceEnvironment, 
 		retries++
 		t.Logf("apm-server returned EOF on read, retry %d/%d...", retries, maxRetries)
 		<-time.After(500 * time.Millisecond)
-		resp, err = http.DefaultClient.Do(req)
+		resp, err = c.Do(req)
 	}
 	require.NoError(t, err)
 	defer resp.Body.Close()

--- a/systemtest/agentconfig_test.go
+++ b/systemtest/agentconfig_test.go
@@ -19,8 +19,6 @@ package systemtest_test
 
 import (
 	"encoding/json"
-	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -123,9 +121,9 @@ func queryAgentConfig(t testing.TB, serverURL, serviceName, serviceEnvironment, 
 
 	maxRetries := 10
 	var retries int
-	for errors.Is(err, io.EOF) && retries < maxRetries {
+	for err != nil && retries < maxRetries {
 		retries++
-		t.Logf("apm-server returned EOF on read, retry %d/%d...", retries, maxRetries)
+		t.Logf(`apm-server returned err="%v" on read, retry %d/%d...`, err, retries, maxRetries)
 		<-time.After(500 * time.Millisecond)
 		resp, err = c.Do(req)
 	}


### PR DESCRIPTION
the client was never timing out, causing it to
sometimes hang forever. add a timeout so the retry
logic can actually be executed.

potentially closes #7243

I've run this successfully ~200 times, with two unique non-timeout failures:

```
    fleet_test.go:183:
        	Error Trace:	fleet_test.go:183
        	            				agentconfig_test.go:49
        	Error:      	Received unexpected error:
        	            	failed to start container
        	Test:       	TestAgentConfig
    fleet_test.go:169: elastic-agent logs:
    server.go:206: log file: /home/ubuntu/workspace/apm-server/systemtest/logs/TestAgentConfig/apm-server
--- FAIL: TestAgentConfig (16.01s)
```

And then another error when making the agent config request to the container, which the retry handles now:
```
=== RUN   TestAgentConfig
2022/05/17 22:38:35 Building image elastic-agent-systemtest:8.3.0-4149272f-SNAPSHOT (amd64) from elastic-agent-systemtest:8.3.0-4149272f-SNAPSHOT...
2022/05/17 22:38:38 Built image elastic-agent-systemtest:8.3.0-4149272f-SNAPSHOT (amd64)
2022/05/17 22:38:38 Starting container id: 13daa31388e5 image: elastic-agent-systemtest:8.3.0-4149272f-SNAPSHOT
2022/05/17 22:38:39 Waiting for container id 13daa31388e5 image: elastic-agent-systemtest:8.3.0-4149272f-SNAPSHOT
2022/05/17 22:38:44 Container is ready id: 13daa31388e5 image: elastic-agent-systemtest:8.3.0-4149272f-SNAPSHOT
    agentconfig_test.go:126: apm-server returned err="Get "http://localhost:49412/config/v1/agents?service.environment=testing&service.name=systemtest_service": read tcp 127.0.0.1:58060->127.0.0.1:49412: read: connection reset by peer" on read, retry 1/10...
--- PASS: TestAgentConfig (27.02s)
```

This definitely seems like an improvement.