### PR TITLE
systemtest: build apm-server with cgo disabled

### DIFF
--- a/systemtest/apmservertest/command.go
+++ b/systemtest/apmservertest/command.go
@@ -180,7 +180,7 @@ func BuildServerBinary(goos, goarch string) (string, error) {
 
 	log.Println("Building apm-server...")
 	cmd := exec.Command("go", "build", "-o", abspath, "./x-pack/apm-server")
-	cmd.Env = append(os.Environ(), "GOOS="+goos)
+	cmd.Env = append(os.Environ(), "GOOS="+goos, "CGO_ENABLED=0")
 	if goarch != "" {
 		cmd.Env = append(cmd.Env, "GOARCH="+goarch)
 	}


### PR DESCRIPTION
This fixes system tests on Ubuntu 22.04, where the glibc version is too new for the elastic-agent container image. Without this change, the `apm-server` program cannot be executed; it fails with errors like:

> ```/usr/share/elastic-agent/data/elastic-agent-bd86cc/install/apm-server-8.3.0-SNAPSHOT-linux-x86_64/apm-server: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /usr/share/elastic-agent/data/elastic-agent-bd86cc/install/apm-server-8.3.0-SNAPSHOT-linux-x86_64/apm-server)```