### PR TITLE
docs: add and link to java agent cert docs

### DIFF
--- a/docs/legacy/ssl-input-settings.asciidoc
+++ b/docs/legacy/ssl-input-settings.asciidoc
@@ -70,7 +70,8 @@ This configures what types of client authentication are supported. The valid opt
 are `none`, `optional`, and `required`. The default is `none`.
 If `certificate_authorities` has been specified, this setting will automatically change to `required`.
 This option only needs to be configured when the agent is expected to provide a client certificate.
-Sending client certificates is currently only supported by the RUM agent through the browser
+Sending client certificates is currently only supported by the RUM agent through the browser,
+the Java agent (see {apm-java-ref-v}/ssl-configuration.html[Agent certificate authentication]),
 and by the Jaeger agent.
 
 * `none` - Disables client authentication.

--- a/docs/legacy/ssl-input-settings.asciidoc
+++ b/docs/legacy/ssl-input-settings.asciidoc
@@ -59,7 +59,8 @@ The list of curve types for ECDHE (Elliptic Curve Diffie-Hellman ephemeral key e
 The list of root certificates for verifying client certificates.
 If `certificate_authorities` is empty or not set, the trusted certificate authorities of the host system are used.
 If `certificate_authorities` is set, `client_authentication` will be automatically set to `required`.
-Sending client certificates is currently only supported by the RUM agent through the browser
+Sending client certificates is currently only supported by the RUM agent through the browser,
+the Java agent (see {apm-java-ref-v}/ssl-configuration.html[Agent certificate authentication]),
 and by the Jaeger agent.
 
 [float]

--- a/docs/legacy/ssl-input-settings.asciidoc
+++ b/docs/legacy/ssl-input-settings.asciidoc
@@ -61,7 +61,7 @@ If `certificate_authorities` is empty or not set, the trusted certificate author
 If `certificate_authorities` is set, `client_authentication` will be automatically set to `required`.
 Sending client certificates is currently only supported by the RUM agent through the browser,
 the Java agent (see {apm-java-ref-v}/ssl-configuration.html[Agent certificate authentication]),
-and by the Jaeger agent.
+and the Jaeger agent.
 
 [float]
 ==== `client_authentication`
@@ -72,7 +72,7 @@ If `certificate_authorities` has been specified, this setting will automatically
 This option only needs to be configured when the agent is expected to provide a client certificate.
 Sending client certificates is currently only supported by the RUM agent through the browser,
 the Java agent (see {apm-java-ref-v}/ssl-configuration.html[Agent certificate authentication]),
-and by the Jaeger agent.
+and the Jaeger agent.
 
 * `none` - Disables client authentication.
 * `optional` - When a client certificate is given, the server will verify it.


### PR DESCRIPTION
### Summary

This is a small PR that adds the Java agent to the list of agents that support sending client certificates.

* Closes https://github.com/elastic/apm-server/issues/8057.