### PR TITLE
docs: Update delete and update by query examples

### DIFF
--- a/docs/legacy/storage-management.asciidoc
+++ b/docs/legacy/storage-management.asciidoc
@@ -223,24 +223,18 @@ INFO      "delete_indices" action completed.
 [[delete-data-by-query]]
 ===== Delete data matching a query
 
-You can delete documents matching a specific query.
-For example, all documents with a given `service.name` use the following request:
+You can delete all APM documents matching a specific query.
+For example, to delete all documents with a given `service.name`, use the following request:
 
-["source","sh"]
+["source","console"]
 ------------------------------------------------------------
 POST /apm-*/_delete_by_query
 {
   "query": {
-    "bool": {
-      "must": [
-        {
-          "term": {
-            "service.name": {
-              "value": "old-service-name"
-            }
-          }
-        }
-      ]
+    "term": {
+      "service.name": {
+        "value": "old-service-name"
+      }
     }
   }
 }

--- a/docs/legacy/storage-management.asciidoc
+++ b/docs/legacy/storage-management.asciidoc
@@ -224,7 +224,7 @@ INFO      "delete_indices" action completed.
 ===== Delete data matching a query
 
 You can delete documents matching a specific query.
-For example, all documents with a given `context.service.name` use the following request:
+For example, all documents with a given `service.name` use the following request:
 
 ["source","sh"]
 ------------------------------------------------------------
@@ -235,7 +235,7 @@ POST /apm-*/_delete_by_query
       "must": [
         {
           "term": {
-            "context.service.name": {
+            "service.name": {
               "value": "old-service-name"
             }
           }
@@ -289,13 +289,13 @@ POST /apm-*/_update_by_query
 {
   "query": {
     "term": {
-      "context.service.name": {
+      "service.name": {
         "value": "old-service-name"
       }
     }
   },
   "script": {
-    "source": "ctx._source.context.service.name = 'new-service-name'",
+    "source": "ctx._source.service.name = 'new-service-name'",
     "lang": "painless"
   }
 }

--- a/docs/manage-storage.asciidoc
+++ b/docs/manage-storage.asciidoc
@@ -122,6 +122,27 @@ You can base actions on factors such as shard size and performance requirements.
 See <<ilm-how-to>> to learn more.
 
 [float]
+[[delete-data-query]]
+===== Delete data matching a query
+
+You can delete all APM documents matching a specific query.
+For example, to delete all documents with a given `service.name`, use the following request:
+
+["source","console"]
+----
+POST /.ds-*-apm*/_delete_by_query
+{
+  "query": {
+    "term": {
+      "service.name": {
+        "value": "old-service-name"
+      }
+    }
+  }
+}
+----
+
+[float]
 [[delete-data-in-kibana]]
 ===== Delete data via Kibana Index Management UI
 
@@ -151,7 +172,7 @@ To rename a service, send the following request:
 
 ["source","sh"]
 ------------------------------------------------------------
-POST *-apm-*/_update_by_query?expand_wildcards=all
+POST /.ds-*-apm*/_update_by_query?expand_wildcards=all
 {
   "query": {
     "term": {


### PR DESCRIPTION
### Summary

This PR updates our legacy and current `_delete_by_query` and `_update_by_query` examples. More delete by query examples are coming in https://github.com/elastic/apm-server/pull/8043. 

- [x] Removes remaining references to `context.*` fields
- [x] Adds a `_delete_by_query` data stream example
- [x] Updates the index used in our `_update_by_query` data stream example to `.ds-*-apm*` 

### Related

* Closes https://github.com/elastic/apm-server/issues/7823.
* Related to https://github.com/elastic/apm-server/pull/8145.