### PR TITLE
Implement support for OTLP over HTTP (protobuf, binary)

### DIFF
--- a/beater/api/intake/otlp_handler.go
+++ b/beater/api/intake/otlp_handler.go
@@ -1,0 +1,24 @@
+package intake
+
+import (
+	"github.com/elastic/apm-server/beater/request"
+	"go.opentelemetry.io/collector/receiver/otlpreceiver"
+)
+
+func OtlpTracesHandler(receivers *otlpreceiver.HTTPReceivers) request.Handler {
+	return func(c *request.Context) {
+		otlpreceiver.HandleHTTPTraces(c.W, c.Request, receivers.TracesR)
+	}
+}
+
+func OtlpMetricsHandler(receivers *otlpreceiver.HTTPReceivers) request.Handler {
+	return func(c *request.Context) {
+		otlpreceiver.HandleHTTPMetrics(c.W, c.Request, receivers.MetricsR)
+	}
+}
+
+func OtlpLogsHandler(receivers *otlpreceiver.HTTPReceivers) request.Handler {
+	return func(c *request.Context) {
+		otlpreceiver.HandleHTTPLogs(c.W, c.Request, receivers.LogsR)
+	}
+}

--- a/beater/api/mux_test.go
+++ b/beater/api/mux_test.go
@@ -166,6 +166,7 @@ func (m muxBuilder) build(cfg *config.Config) (http.Handler, error) {
 		agentcfg.NewFetcher(cfg),
 		ratelimitStore,
 		m.SourcemapFetcher,
+		nil,
 		m.Managed,
 		func() bool { return true },
 	)

--- a/beater/otlp/common.go
+++ b/beater/otlp/common.go
@@ -1,0 +1,45 @@
+package otlp
+
+import (
+	"github.com/elastic/apm-server/beater/request"
+	"github.com/elastic/apm-server/processor/otel"
+	"github.com/elastic/beats/v7/libbeat/monitoring"
+	"sync"
+)
+
+var (
+	monitoringKeys = append(request.DefaultResultIDs,
+		request.IDResponseErrorsRateLimit,
+		request.IDResponseErrorsTimeout,
+		request.IDResponseErrorsUnauthorized,
+	)
+	currentMonitoredConsumerMu sync.RWMutex
+	currentMonitoredConsumer   *otel.Consumer
+)
+
+const (
+	metricsFullMethod = "/opentelemetry.proto.collector.metrics.v1.MetricsService/Export"
+	tracesFullMethod  = "/opentelemetry.proto.collector.trace.v1.TraceService/Export"
+	logsFullMethod    = "/opentelemetry.proto.collector.logs.v1.LogsService/Export"
+)
+
+func collectMetricsMonitoring(mode monitoring.Mode, V monitoring.Visitor) {
+	V.OnRegistryStart()
+	defer V.OnRegistryFinished()
+
+	currentMonitoredConsumerMu.RLock()
+	c := currentMonitoredConsumer
+	currentMonitoredConsumerMu.RUnlock()
+	if c == nil {
+		return
+	}
+
+	stats := c.Stats()
+	monitoring.ReportInt(V, "unsupported_dropped", stats.UnsupportedMetricsDropped)
+}
+
+func setCurrentMonitoredConsumer(c *otel.Consumer) {
+	currentMonitoredConsumerMu.Lock()
+	defer currentMonitoredConsumerMu.Unlock()
+	currentMonitoredConsumer = c
+}

--- a/beater/otlp/grpc_test.go
+++ b/beater/otlp/grpc_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/elastic/beats/v7/libbeat/monitoring"
 )
 
-func TestConsumeTraces(t *testing.T) {
+func TestConsumeTracesGRPC(t *testing.T) {
 	var batches []model.Batch
 	var reportError error
 	var batchProcessor model.ProcessBatchFunc = func(ctx context.Context, batch *model.Batch) error {
@@ -46,7 +46,7 @@ func TestConsumeTraces(t *testing.T) {
 		return reportError
 	}
 
-	conn := newServer(t, batchProcessor)
+	conn := newGRPCServer(t, batchProcessor)
 	client := otlpgrpc.NewTracesClient(conn)
 
 	// Send a minimal trace to verify that everything is connected properly.
@@ -87,13 +87,13 @@ func TestConsumeTraces(t *testing.T) {
 	}, actual)
 }
 
-func TestConsumeMetrics(t *testing.T) {
+func TestConsumeMetricsGRPC(t *testing.T) {
 	var reportError error
 	var batchProcessor model.ProcessBatchFunc = func(ctx context.Context, batch *model.Batch) error {
 		return reportError
 	}
 
-	conn := newServer(t, batchProcessor)
+	conn := newGRPCServer(t, batchProcessor)
 	client := otlpgrpc.NewMetricsClient(conn)
 
 	// Send a minimal metric to verify that everything is connected properly.
@@ -126,7 +126,7 @@ func TestConsumeMetrics(t *testing.T) {
 		// In both of the requests we send above,
 		// the metrics do not have a type and so
 		// we treat them as unsupported metrics.
-		"consumer.unsupported_dropped": int64(2),
+		"gRPCConsumer.unsupported_dropped": int64(2),
 
 		"request.count":                int64(2),
 		"response.count":               int64(2),
@@ -138,7 +138,7 @@ func TestConsumeMetrics(t *testing.T) {
 	}, actual)
 }
 
-func TestConsumeLogs(t *testing.T) {
+func TestConsumeLogsGRPC(t *testing.T) {
 	var batches []model.Batch
 	var reportError error
 	var batchProcessor model.ProcessBatchFunc = func(ctx context.Context, batch *model.Batch) error {
@@ -146,7 +146,7 @@ func TestConsumeLogs(t *testing.T) {
 		return reportError
 	}
 
-	conn := newServer(t, batchProcessor)
+	conn := newGRPCServer(t, batchProcessor)
 	client := otlpgrpc.NewLogsClient(conn)
 
 	// Send a minimal log record to verify that everything is connected properly.
@@ -187,12 +187,12 @@ func TestConsumeLogs(t *testing.T) {
 	}, actual)
 }
 
-func newServer(t *testing.T, batchProcessor model.BatchProcessor) *grpc.ClientConn {
+func newGRPCServer(t *testing.T, batchProcessor model.BatchProcessor) *grpc.ClientConn {
 	lis, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 	logger := logp.NewLogger("otlp.grpc.test")
 	srv := grpc.NewServer(
-		grpc.UnaryInterceptor(interceptors.Metrics(logger, otlp.RegistryMonitoringMaps)),
+		grpc.UnaryInterceptor(interceptors.Metrics(logger, otlp.GRPCRegistryMonitoringMaps)),
 	)
 	err = otlp.RegisterGRPCServices(srv, batchProcessor)
 	require.NoError(t, err)

--- a/beater/otlp/http.go
+++ b/beater/otlp/http.go
@@ -1,0 +1,47 @@
+package otlp
+
+import (
+	"context"
+	"github.com/elastic/apm-server/beater/request"
+	"github.com/elastic/apm-server/model"
+	"github.com/elastic/apm-server/processor/otel"
+	"github.com/elastic/beats/v7/libbeat/monitoring"
+	"github.com/pkg/errors"
+	"go.opentelemetry.io/collector/receiver/otlpreceiver"
+)
+
+var (
+	httpMetricsRegistry      = monitoring.Default.NewRegistry("apm-server.otlp.http.metrics")
+	HttpMetricsMonitoringMap = request.MonitoringMapForRegistry(httpMetricsRegistry, monitoringKeys)
+	httpTracesRegistry       = monitoring.Default.NewRegistry("apm-server.otlp.http.traces")
+	HttpTracesMonitoringMap  = request.MonitoringMapForRegistry(httpTracesRegistry, monitoringKeys)
+	httpLogsRegistry         = monitoring.Default.NewRegistry("apm-server.otlp.http.logs")
+	HttpLogsMonitoringMap    = request.MonitoringMapForRegistry(httpLogsRegistry, monitoringKeys)
+)
+
+func init() {
+	monitoring.NewFunc(httpMetricsRegistry, "httpConsumer", collectMetricsMonitoring, monitoring.Report)
+}
+
+func NewHTTPReceivers(processor model.BatchProcessor) (*otlpreceiver.HTTPReceivers, error) {
+	consumer := &otel.Consumer{Processor: processor}
+	setCurrentMonitoredConsumer(consumer)
+
+	tracesR, err := otlpreceiver.NewHTTPTraceReceiver(context.Background(), consumer)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create OTLP trace receiver")
+	}
+	metricsR, err := otlpreceiver.NewHTTPMetricsReceiver(context.Background(), consumer)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create OTLP metrics receiver")
+	}
+	logsR, err := otlpreceiver.NewHTTPLogsReceiver(context.Background(), consumer)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create OTLP logs receiver")
+	}
+	return &otlpreceiver.HTTPReceivers{
+		TracesR:  tracesR,
+		MetricsR: metricsR,
+		LogsR:    logsR,
+	}, nil
+}

--- a/beater/otlp/http_test.go
+++ b/beater/otlp/http_test.go
@@ -1,0 +1,172 @@
+package otlp_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/elastic/apm-server/agentcfg"
+	"github.com/elastic/apm-server/beater/api"
+	"github.com/elastic/apm-server/beater/auth"
+	"github.com/elastic/apm-server/beater/config"
+	"github.com/elastic/apm-server/beater/otlp"
+	"github.com/elastic/apm-server/beater/ratelimit"
+	"github.com/elastic/apm-server/model"
+	"github.com/elastic/beats/v7/libbeat/beat"
+	"github.com/elastic/beats/v7/libbeat/monitoring"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/model/otlpgrpc"
+	"go.opentelemetry.io/collector/model/pdata"
+	"net"
+	"net/http"
+	"testing"
+)
+
+func TestConsumeTracesHTTP(t *testing.T) {
+	var batches []model.Batch
+	var reportError error
+	var batchProcessor model.ProcessBatchFunc = func(ctx context.Context, batch *model.Batch) error {
+		batches = append(batches, *batch)
+		return reportError
+	}
+
+	addr := newHTTPServer(t, batchProcessor)
+
+	// Send a minimal trace to verify that everything is connected properly.
+	//
+	// We intentionally do not check the published event contents; those are
+	// tested in processor/otel.
+	traces := pdata.NewTraces()
+	span := traces.ResourceSpans().AppendEmpty().InstrumentationLibrarySpans().AppendEmpty().Spans().AppendEmpty()
+	span.SetName("operation_name")
+
+	tracesRequest := otlpgrpc.NewTracesRequest()
+	tracesRequest.SetTraces(traces)
+	request, err := tracesRequest.Marshal()
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/v1/traces", addr), bytes.NewReader(request))
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	client := http.Client{}
+	_, err = client.Do(req)
+	assert.NoError(t, err)
+	require.Len(t, batches, 1)
+	assert.Len(t, batches[0], 1)
+
+	actual := map[string]interface{}{}
+	monitoring.GetRegistry("apm-server.otlp.http.traces").Do(monitoring.Full, func(key string, value interface{}) {
+		actual[key] = value
+	})
+	assert.Equal(t, map[string]interface{}{
+		"request.count":                int64(1),
+		"response.count":               int64(1),
+		"response.errors.count":        int64(0),
+		"response.valid.count":         int64(1),
+		"response.errors.ratelimit":    int64(0),
+		"response.errors.timeout":      int64(0),
+		"response.errors.unauthorized": int64(0),
+	}, actual)
+}
+
+func TestConsumeMetricsHTTP(t *testing.T) {
+	var reportError error
+	var batchProcessor model.ProcessBatchFunc = func(ctx context.Context, batch *model.Batch) error {
+		return reportError
+	}
+
+	addr := newHTTPServer(t, batchProcessor)
+
+	// Send a minimal metric to verify that everything is connected properly.
+	//
+	// We intentionally do not check the published event contents; those are
+	// tested in processor/otel.
+	metrics := pdata.NewMetrics()
+	metric := metrics.ResourceMetrics().AppendEmpty().InstrumentationLibraryMetrics().AppendEmpty().Metrics().AppendEmpty()
+	metric.SetName("metric_type")
+	metric.SetDataType(pdata.MetricDataTypeSummary)
+	metric.Summary().DataPoints().AppendEmpty()
+
+	metricsRequest := otlpgrpc.NewMetricsRequest()
+	metricsRequest.SetMetrics(metrics)
+	request, err := metricsRequest.Marshal()
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/v1/metrics", addr), bytes.NewReader(request))
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	client := http.Client{}
+	_, err = client.Do(req)
+	assert.NoError(t, err)
+
+	actual := map[string]interface{}{}
+	monitoring.GetRegistry("apm-server.otlp.http.metrics").Do(monitoring.Full, func(key string, value interface{}) {
+		actual[key] = value
+	})
+	assert.Equal(t, map[string]interface{}{
+		// In the request we send above,
+		// the metrics do not have a type and so
+		// we treat them as unsupported metrics.
+		"httpConsumer.unsupported_dropped": int64(1),
+
+		"request.count":                int64(1),
+		"response.count":               int64(1),
+		"response.errors.count":        int64(0),
+		"response.valid.count":         int64(1),
+		"response.errors.ratelimit":    int64(0),
+		"response.errors.timeout":      int64(0),
+		"response.errors.unauthorized": int64(0),
+	}, actual)
+}
+
+func TestConsumeLogsHTTP(t *testing.T) {
+	var batches []model.Batch
+	var reportError error
+	var batchProcessor model.ProcessBatchFunc = func(ctx context.Context, batch *model.Batch) error {
+		batches = append(batches, *batch)
+		return reportError
+	}
+
+	addr := newHTTPServer(t, batchProcessor)
+
+	// Send a minimal log record to verify that everything is connected properly.
+	//
+	// We intentionally do not check the published event contents; those are
+	// tested in processor/otel.
+	logs := pdata.NewLogs()
+	logRecord := logs.ResourceLogs().AppendEmpty().InstrumentationLibraryLogs().AppendEmpty().LogRecords().AppendEmpty()
+	logRecord.SetName("log_name")
+
+	logsRequest := otlpgrpc.NewLogsRequest()
+	logsRequest.SetLogs(logs)
+	request, err := logsRequest.Marshal()
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/v1/logs", addr), bytes.NewReader(request))
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	client := http.Client{}
+	_, err = client.Do(req)
+	assert.NoError(t, err)
+	require.Len(t, batches, 1)
+
+	actual := map[string]interface{}{}
+	monitoring.GetRegistry("apm-server.otlp.http.logs").Do(monitoring.Full, func(key string, value interface{}) {
+		actual[key] = value
+	})
+	assert.Equal(t, map[string]interface{}{
+		"request.count":                int64(1),
+		"response.count":               int64(1),
+		"response.errors.count":        int64(0),
+		"response.valid.count":         int64(1),
+		"response.errors.ratelimit":    int64(0),
+		"response.errors.timeout":      int64(0),
+		"response.errors.unauthorized": int64(0),
+	}, actual)
+}
+
+func newHTTPServer(t *testing.T, batchProcessor model.BatchProcessor) string {
+	lis, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	receivers, err := otlp.NewHTTPReceivers(batchProcessor)
+	require.NoError(t, err)
+	cfg := &config.Config{}
+	auth, _ := auth.NewAuthenticator(cfg.AgentAuth)
+	ratelimitStore, _ := ratelimit.NewStore(1000, 1000, 1000)
+	router, err := api.NewMux(beat.Info{Version: "1.2.3"}, cfg, batchProcessor, auth, agentcfg.NewFetcher(cfg), ratelimitStore, nil, receivers, false, func() bool { return true })
+	require.NoError(t, err)
+	srv := http.Server{Handler: router}
+	go srv.Serve(lis)
+	return lis.Addr().String()
+}

--- a/beater/request/context_test.go
+++ b/beater/request/context_test.go
@@ -73,7 +73,7 @@ func TestContext_Reset(t *testing.T) {
 
 	before := time.Now()
 	c := Context{
-		Request: r1, w: w1,
+		Request: r1, W: w1,
 		Logger: logp.NewLogger(""),
 		Result: Result{
 			StatusCode: http.StatusServiceUnavailable,
@@ -96,8 +96,8 @@ func TestContext_Reset(t *testing.T) {
 			assert.Equal(t, r2, cVal.Field(i).Interface())
 		case "Authentication":
 			assert.Equal(t, auth.AuthenticationDetails{}, cVal.Field(i).Interface())
-		case "w":
-			assert.Equal(t, w2, c.w)
+		case "W":
+			assert.Equal(t, w2, c.W)
 		case "writeAttempts":
 			assert.Equal(t, 0, c.writeAttempts)
 		case "Result":
@@ -127,7 +127,7 @@ func TestContext_Header(t *testing.T) {
 	w := httptest.NewRecorder()
 	w.Header().Set(headers.Etag, "abcd")
 	w.Header().Set(headers.Bearer, "foo")
-	c := Context{w: w}
+	c := Context{W: w}
 
 	h := http.Header{headers.Etag: []string{"abcd"}, headers.Bearer: []string{"foo"}}
 	assert.Equal(t, h, c.Header())
@@ -247,11 +247,11 @@ func TestContext_Write(t *testing.T) {
 }
 
 func testHeaderXContentTypeOptions(t *testing.T, c *Context) {
-	assert.Equal(t, "nosniff", c.w.Header().Get(headers.XContentTypeOptions))
+	assert.Equal(t, "nosniff", c.W.Header().Get(headers.XContentTypeOptions))
 }
 
 func testHeader(t *testing.T, c *Context, expected string) {
-	assert.Equal(t, expected, c.w.Header().Get(headers.ContentType))
+	assert.Equal(t, expected, c.W.Header().Get(headers.ContentType))
 	testHeaderXContentTypeOptions(t, c)
 }
 

--- a/beater/tracing.go
+++ b/beater/tracing.go
@@ -72,7 +72,8 @@ func newTracerServer(listener net.Listener, logger *logp.Logger) (*tracerServer,
 		authenticator,
 		agentcfg.NewFetcher(cfg),
 		ratelimitStore,
-		nil,                         // no sourcemap store
+		nil, // no sourcemap store
+		nil,
 		false,                       // not managed
 		func() bool { return true }, // ready for publishing
 	)

--- a/internal/.otel_collector_mixin/receiver/otlpreceiver/mixin.go
+++ b/internal/.otel_collector_mixin/receiver/otlpreceiver/mixin.go
@@ -16,6 +16,8 @@ package otlpreceiver
 
 import (
 	"context"
+	"go.opentelemetry.io/collector/component/componenterror"
+	"net/http"
 
 	"go.opentelemetry.io/otel/metric"
 	apitrace "go.opentelemetry.io/otel/trace"
@@ -48,24 +50,72 @@ var settings = component.ReceiverCreateSettings{
 	},
 }
 
-// RegisterTraceReceiver registers the trace receiver with a gRPC server.
-func RegisterTraceReceiver(ctx context.Context, consumer consumer.Traces, serverGRPC *grpc.Server) error {
+type HTTPReceivers struct {
+	TracesR  *trace.Receiver
+	MetricsR *metrics.Receiver
+	LogsR    *logs.Receiver
+}
 
+// GRPC Receivers
+
+// RegisterGRPCTraceReceiver registers the trace receiver with a gRPC server.
+func RegisterGRPCTraceReceiver(ctx context.Context, consumer consumer.Traces, serverGRPC *grpc.Server) error {
 	receiver := trace.New(config.NewComponentID("otlp"), consumer, settings)
 	otlpgrpc.RegisterTracesServer(serverGRPC, receiver)
 	return nil
 }
 
-// RegisterMetricsReceiver registers the metrics receiver with a gRPC server.
-func RegisterMetricsReceiver(ctx context.Context, consumer consumer.Metrics, serverGRPC *grpc.Server) error {
+// RegisterGRPCMetricsReceiver registers the metrics receiver with a gRPC server.
+func RegisterGRPCMetricsReceiver(ctx context.Context, consumer consumer.Metrics, serverGRPC *grpc.Server) error {
 	receiver := metrics.New(config.NewComponentID("otlp"), consumer, settings)
 	otlpgrpc.RegisterMetricsServer(serverGRPC, receiver)
 	return nil
 }
 
-// RegisterLogsReceiver registers the logs receiver with a gRPC server.
-func RegisterLogsReceiver(ctx context.Context, consumer consumer.Logs, serverGRPC *grpc.Server) error {
+// RegisterGRPCLogsReceiver registers the logs receiver with a gRPC server.
+func RegisterGRPCLogsReceiver(ctx context.Context, consumer consumer.Logs, serverGRPC *grpc.Server) error {
 	receiver := logs.New(config.NewComponentID("otlp"), consumer, settings)
 	otlpgrpc.RegisterLogsServer(serverGRPC, receiver)
 	return nil
+}
+
+// HTTP Receivers
+
+func NewHTTPTraceReceiver(ctx context.Context, consumer consumer.Traces) (*trace.Receiver, error) {
+	receiver := trace.New(config.NewComponentID("otlp"), consumer, settings)
+	if consumer == nil {
+		return nil, componenterror.ErrNilNextConsumer
+	}
+
+	return receiver, nil
+}
+
+func HandleHTTPTraces(resp http.ResponseWriter, req *http.Request, traceReceiver *trace.Receiver) {
+	handleTraces(resp, req, traceReceiver, pbEncoder)
+}
+
+func NewHTTPMetricsReceiver(ctx context.Context, consumer consumer.Metrics) (*metrics.Receiver, error) {
+	receiver := metrics.New(config.NewComponentID("otlp"), consumer, settings)
+	if consumer == nil {
+		return nil, componenterror.ErrNilNextConsumer
+	}
+
+	return receiver, nil
+}
+
+func HandleHTTPMetrics(resp http.ResponseWriter, req *http.Request, metricsReceiver *metrics.Receiver) {
+	handleMetrics(resp, req, metricsReceiver, pbEncoder)
+}
+
+func NewHTTPLogsReceiver(ctx context.Context, consumer consumer.Logs) (*logs.Receiver, error) {
+	receiver := logs.New(config.NewComponentID("otlp"), consumer, settings)
+	if consumer == nil {
+		return nil, componenterror.ErrNilNextConsumer
+	}
+
+	return receiver, nil
+}
+
+func HandleHTTPLogs(resp http.ResponseWriter, req *http.Request, logsReceiver *logs.Receiver) {
+	handleLogs(resp, req, logsReceiver, pbEncoder)
 }

--- a/internal/otel_collector/receiver/otlpreceiver/mixin.go
+++ b/internal/otel_collector/receiver/otlpreceiver/mixin.go
@@ -16,6 +16,8 @@ package otlpreceiver
 
 import (
 	"context"
+	"go.opentelemetry.io/collector/component/componenterror"
+	"net/http"
 
 	"go.opentelemetry.io/otel/metric"
 	apitrace "go.opentelemetry.io/otel/trace"
@@ -48,24 +50,72 @@ var settings = component.ReceiverCreateSettings{
 	},
 }
 
-// RegisterTraceReceiver registers the trace receiver with a gRPC server.
-func RegisterTraceReceiver(ctx context.Context, consumer consumer.Traces, serverGRPC *grpc.Server) error {
+type HTTPReceivers struct {
+	TracesR  *trace.Receiver
+	MetricsR *metrics.Receiver
+	LogsR    *logs.Receiver
+}
 
+// GRPC Receivers
+
+// RegisterGRPCTraceReceiver registers the trace receiver with a gRPC server.
+func RegisterGRPCTraceReceiver(ctx context.Context, consumer consumer.Traces, serverGRPC *grpc.Server) error {
 	receiver := trace.New(config.NewComponentID("otlp"), consumer, settings)
 	otlpgrpc.RegisterTracesServer(serverGRPC, receiver)
 	return nil
 }
 
-// RegisterMetricsReceiver registers the metrics receiver with a gRPC server.
-func RegisterMetricsReceiver(ctx context.Context, consumer consumer.Metrics, serverGRPC *grpc.Server) error {
+// RegisterGRPCMetricsReceiver registers the metrics receiver with a gRPC server.
+func RegisterGRPCMetricsReceiver(ctx context.Context, consumer consumer.Metrics, serverGRPC *grpc.Server) error {
 	receiver := metrics.New(config.NewComponentID("otlp"), consumer, settings)
 	otlpgrpc.RegisterMetricsServer(serverGRPC, receiver)
 	return nil
 }
 
-// RegisterLogsReceiver registers the logs receiver with a gRPC server.
-func RegisterLogsReceiver(ctx context.Context, consumer consumer.Logs, serverGRPC *grpc.Server) error {
+// RegisterGRPCLogsReceiver registers the logs receiver with a gRPC server.
+func RegisterGRPCLogsReceiver(ctx context.Context, consumer consumer.Logs, serverGRPC *grpc.Server) error {
 	receiver := logs.New(config.NewComponentID("otlp"), consumer, settings)
 	otlpgrpc.RegisterLogsServer(serverGRPC, receiver)
 	return nil
+}
+
+// HTTP Receivers
+
+func NewHTTPTraceReceiver(ctx context.Context, consumer consumer.Traces) (*trace.Receiver, error) {
+	receiver := trace.New(config.NewComponentID("otlp"), consumer, settings)
+	if consumer == nil {
+		return nil, componenterror.ErrNilNextConsumer
+	}
+
+	return receiver, nil
+}
+
+func HandleHTTPTraces(resp http.ResponseWriter, req *http.Request, traceReceiver *trace.Receiver) {
+	handleTraces(resp, req, traceReceiver, pbEncoder)
+}
+
+func NewHTTPMetricsReceiver(ctx context.Context, consumer consumer.Metrics) (*metrics.Receiver, error) {
+	receiver := metrics.New(config.NewComponentID("otlp"), consumer, settings)
+	if consumer == nil {
+		return nil, componenterror.ErrNilNextConsumer
+	}
+
+	return receiver, nil
+}
+
+func HandleHTTPMetrics(resp http.ResponseWriter, req *http.Request, metricsReceiver *metrics.Receiver) {
+	handleMetrics(resp, req, metricsReceiver, pbEncoder)
+}
+
+func NewHTTPLogsReceiver(ctx context.Context, consumer consumer.Logs) (*logs.Receiver, error) {
+	receiver := logs.New(config.NewComponentID("otlp"), consumer, settings)
+	if consumer == nil {
+		return nil, componenterror.ErrNilNextConsumer
+	}
+
+	return receiver, nil
+}
+
+func HandleHTTPLogs(resp http.ResponseWriter, req *http.Request, logsReceiver *logs.Receiver) {
+	handleLogs(resp, req, logsReceiver, pbEncoder)
 }


### PR DESCRIPTION
## Motivation/summary

[The APM Server currently only supports OTLP over GRPC.](https://www.elastic.co/guide/en/apm/guide/current/open-telemetry.html#open-telemetry-otlp-limitations) This PR aims to add support for OTLP over HTTP. In this first implementation, we only support binary encoding, as it is the only [currently](https://www.elastic.co/guide/en/apm/guide/current/open-telemetry.html#open-telemetry-otlp-limitations) stable format.

The implementation can be summed up as follows:
![image](https://user-images.githubusercontent.com/48380853/169282709-0db04e60-6c67-48e5-a625-2beed068633e.png)

- 6630183: Modification of the `otlpreceiver` through a mixin. The purpose of these changes is to expose the receivers and handlers bundled in the OTLP Collector.
- 74797ef: Implementation of dedicated intake handlers based on the previously exposed OTLP collector handlers.
- ef1d4fe: Create monitoring maps and a function whose purpose is to initialize the OTLP receivers on server startup.
- 3d8914a: Modify `beater/server.go` to initialize the receivers and update the Server mux to handle OTLP endpoints.

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

## How to test these changes

This PR can be tested by cloning and starting the following [testing repo](https://github.com/jlvoiseux/apm-server-otel-testing) (usage instructions included in the README).
The current target is to validate that the Java agent is able to send traces, metrics (accounting for the translation limitations [mentioned](https://github.com/elastic/apm-server/pull/7090#issuecomment-1095173022) in #7090) and logs.

**Traces**
![image](https://user-images.githubusercontent.com/48380853/169289428-101267a2-3570-49c0-a2ca-5b0acd423823.png)

**Metrics**
![image](https://user-images.githubusercontent.com/48380853/169289566-2602f77a-bc10-4730-8949-0c4605c3714e.png)

**Logs**
To be tested

## Related issues

Resolves #6128.
