### PR TITLE
prefer integration config's data_stream.namespace

### DIFF
--- a/beater/beater.go
+++ b/beater/beater.go
@@ -314,6 +314,7 @@ func (r *reloader) reload() error {
 		RawConfig:                r.rawConfig,
 		FleetConfig:              r.fleetConfig,
 		OutputConfig:             r.outputConfig,
+		Namespace:                r.namespace,
 	})
 	if err != nil {
 		return err
@@ -371,6 +372,7 @@ type serverRunnerParams struct {
 	RawConfig    *agentconfig.C
 	FleetConfig  *config.Fleet
 	OutputConfig agentconfig.Namespace
+	Namespace    string
 }
 
 type sharedServerRunnerParams struct {
@@ -395,6 +397,9 @@ func newServerRunner(ctx context.Context, args serverRunnerParams) (*serverRunne
 	}
 
 	runServerContext, cancel := context.WithCancel(ctx)
+	if args.Namespace == "" {
+		args.Namespace = cfg.DataStreams.Namespace
+	}
 	return &serverRunner{
 		backgroundContext:      ctx,
 		runServerContext:       runServerContext,
@@ -407,7 +412,7 @@ func newServerRunner(ctx context.Context, args serverRunnerParams) (*serverRunne
 		fleetConfig:               args.FleetConfig,
 		acker:                     args.Acker,
 		pipeline:                  args.Beat.Publisher,
-		namespace:                 cfg.DataStreams.Namespace,
+		namespace:                 args.Namespace,
 		beat:                      args.Beat,
 		logger:                    args.Logger,
 		tracer:                    args.Tracer,

--- a/beater/server_test.go
+++ b/beater/server_test.go
@@ -597,6 +597,7 @@ func TestServerOutputConfigReload(t *testing.T) {
 	}
 
 	inputConfig := agentconfig.MustNewConfigFrom(map[string]interface{}{
+		"data_stream.namespace": "custom",
 		"apm-server": map[string]interface{}{
 			"host": "localhost:0",
 			"sampling.tail": map[string]interface{}{
@@ -612,6 +613,7 @@ func TestServerOutputConfigReload(t *testing.T) {
 
 	runServerArgs := <-runServerCalls
 	assert.Equal(t, "", runServerArgs.Config.Sampling.Tail.ESConfig.Username)
+	assert.Equal(t, "custom", runServerArgs.Namespace)
 
 	// Reloaded output config should be passed into apm-server config.
 	err = apmBeat.OutputConfigReloader.Reload(&reload.ConfigWithMeta{


### PR DESCRIPTION
The incoming data_stream.namespace on the
integration config was never being used to set the
namespace for ingestion.

If set, prefer this value to that set in the
apm-server config.

closes #8087

## How to test these changes

1. start the stack and install the apm integration
2. ingest some documents; verify datastream `traces-apm-default` is there
3. update the apm integration to use a different namespace
4. ingest some documents, verify datastream `traces-apm-$NAMESPACE` is there
