### PR TITLE
[otlp] log message for successful request

### DIFF
--- a/beater/interceptors/logging.go
+++ b/beater/interceptors/logging.go
@@ -58,12 +58,11 @@ func Logging(logger *logp.Logger) grpc.UnaryServerInterceptor {
 			"event.duration", time.Since(start),
 			"grpc.response.status_code", res.Code(),
 		)
-
 		if err != nil {
 			logger.With("error.message", res.Message()).Error(logp.Error(err))
-		} else {
-			logger.Info(res.Message())
+			return nil, err
 		}
-		return resp, err
+		logger.Info("request accepted")
+		return resp, nil
 	}
 }


### PR DESCRIPTION
`res.Message()` contains the message from
`err.Error()` used to create it. When
`err == nil`, `log.Info(res.Message())` is an
empty string. Simply log "request accepted" as is
done for the http intake handler.

closes #7784

## How to test these changes

see reproduction steps in https://github.com/elastic/apm-server/issues/7784.

update the connection string to connect with your apm-server
```go
client := otlpmetricgrpc.NewClient(otlpmetricgrpc.WithInsecure(), otlpmetricgrpc.WithEndpoint("localhost:54174"))
```