### PR TITLE
sampling: speed up TestStorageGC

### DIFF
--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -583,12 +583,11 @@ func TestStorageGC(t *testing.T) {
 	}
 
 	vlogFilenames := func() []string {
-		dir, _ := os.Open(config.StorageDir)
-		names, _ := dir.Readdirnames(-1)
-		defer dir.Close()
+		entries, _ := os.ReadDir(config.StorageDir)
 
 		var vlogs []string
-		for _, name := range names {
+		for _, entry := range entries {
+			name := entry.Name()
 			if strings.HasSuffix(name, ".vlog") {
 				vlogs = append(vlogs, name)
 			}
@@ -597,10 +596,10 @@ func TestStorageGC(t *testing.T) {
 		return vlogs
 	}
 
-	// Process spans until more than one value log file has been created,
-	// but the first one does not exist (has been garbage collected).
-	for len(vlogFilenames()) < 2 {
-		writeBatch(50000)
+	// Process spans until value log files have been created.
+	// Garbage collection is disabled at this time.
+	for len(vlogFilenames()) < 3 {
+		writeBatch(500)
 	}
 
 	config.StorageGCInterval = 10 * time.Millisecond
@@ -609,6 +608,7 @@ func TestStorageGC(t *testing.T) {
 	go processor.Run()
 	defer processor.Stop(context.Background())
 
+	// Wait for the first value log file to be garbage collected.
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		vlogs := vlogFilenames()


### PR DESCRIPTION
## Motivation/summary

Speed up `TestStorageGC` to avoid failures in CI (and just for faster tests in general). Write events in smaller batches, and wait for more than 2 value log files to be created before we wait for garbage collection to trigger.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

Closes https://github.com/elastic/apm-server/issues/8178