### PR TITLE
sampling: allow 100% tail-based sampling

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -15,6 +15,7 @@ https://github.com/elastic/apm-server/compare/8.2\...main[View commits]
 ==== Bug fixes
 - Fix a bug that caused some of the decoded events to have incorrect labels {pull}8081[8081]
 - Propagate datastream namespace changes from apm-integration into server {pull}8176[8176]
+- Allow 100% tail-based sampling {pull}8233[8233]
 
 [float]
 ==== Intake API Changes

--- a/x-pack/apm-server/sampling/config.go
+++ b/x-pack/apm-server/sampling/config.go
@@ -235,11 +235,8 @@ func (config StorageConfig) validate() error {
 }
 
 func (p Policy) validate() error {
-	// TODO(axw) allow sampling rate of 1.0 (100%), which would
-	// cause the root transaction to be indexed, and a sampling
-	// decision to be written to local storage, immediately.
-	if p.SampleRate < 0 || p.SampleRate >= 1 {
-		return errors.New("SampleRate unspecified or out of range [0,1)")
+	if p.SampleRate < 0 || p.SampleRate > 1 {
+		return errors.New("SampleRate unspecified or out of range [0,1]")
 	}
 	return nil
 }

--- a/x-pack/apm-server/sampling/config_test.go
+++ b/x-pack/apm-server/sampling/config_test.go
@@ -43,11 +43,11 @@ func TestNewProcessorConfigInvalid(t *testing.T) {
 	}}
 	assertInvalidConfigError("invalid local sampling config: Policies does not contain a default (empty criteria) policy")
 	config.Policies[0].PolicyCriteria = sampling.PolicyCriteria{}
-	for _, invalid := range []float64{-1, 1.0, 2.0} {
+	for _, invalid := range []float64{-1, 2.0} {
 		config.Policies[0].SampleRate = invalid
-		assertInvalidConfigError("invalid local sampling config: Policy 0 invalid: SampleRate unspecified or out of range [0,1)")
+		assertInvalidConfigError("invalid local sampling config: Policy 0 invalid: SampleRate unspecified or out of range [0,1]")
 	}
-	config.Policies[0].SampleRate = 0.5
+	config.Policies[0].SampleRate = 1.0
 
 	for _, invalid := range []float64{-1, 0, 2.0} {
 		config.IngestRateDecayFactor = invalid

--- a/x-pack/apm-server/sampling/processor.go
+++ b/x-pack/apm-server/sampling/processor.go
@@ -228,6 +228,10 @@ func (p *Processor) processTransaction(event *model.APMEvent) (report, stored bo
 	}
 
 	// Root transaction: apply reservoir sampling.
+	//
+	// TODO(axw) we should skip reservoir sampling when the matching
+	// policy's sampling rate is 100%, immediately index the event
+	// and record the trace sampling decision.
 	reservoirSampled, err := p.groups.sampleTrace(event)
 	if err == errTooManyTraceGroups {
 		// Too many trace groups, drop the transaction.


### PR DESCRIPTION
## Motivation/summary

Allow 100% tail-based sampling. We shouldn't disallow it, even if it's not optimal.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

1. Install Elastic Agent, add the APM integration
2. Send a steady rate of transactions
3. In the integration policy, enable tail-based sampling and set `sample_rate: 1.0`
4. Check that the transaction document throughput does not drop

## Related issues

Closes https://github.com/elastic/apm-server/issues/8222