### PR TITLE
apmbench: Add `BenchmarkAgentAll` benchmark

### DIFF
--- a/systemtest/cmd/apmbench/main.go
+++ b/systemtest/cmd/apmbench/main.go
@@ -66,6 +66,16 @@ func BenchmarkOTLPTraces(b *testing.B, l *rate.Limiter) {
 	})
 }
 
+// BenchmarkAgentAll matches all the agent event files, allowing the benchmark
+// to contain a wider mix of events compared to the other BenchmarkAgent<Name>
+// benchmarks. The objective is to measure how the APM Server performs when it
+// receives events from multiple agents.
+// Even though files are loaded alphabetically and the events sent sequentially
+// there is inherent randomness in the order the events are sent to APM Sever.
+func BenchmarkAgentAll(b *testing.B, l *rate.Limiter) {
+	benchmarkAgent(b, l, `*.ndjson`)
+}
+
 func BenchmarkAgentGo(b *testing.B, l *rate.Limiter) {
 	benchmarkAgent(b, l, `go*.ndjson`)
 }
@@ -95,6 +105,7 @@ func main() {
 	if err := benchtest.Run(
 		Benchmark1000Transactions,
 		BenchmarkOTLPTraces,
+		BenchmarkAgentAll,
 		BenchmarkAgentGo,
 		BenchmarkAgentNodeJS,
 		BenchmarkAgentPython,


### PR DESCRIPTION
## Motivation/summary

Adds a new benchmark `BenchmarkAgentAll`, which matches all `*.ndjson`
files. The objective of this benchmark is to have different goroutines
send data from different agents at the same time.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

1. `cd systemtest/cmd/apmbench && go build .`
2. `./apmbench -run BenchmarkAgent`

## Related issues

Part of #7540
