### PR TITLE
Add tags field to internal_metrics data stream

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -20,6 +20,9 @@
     - description: Added field mappings for system, process, and runtime metrics to internal metrics data stream
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/7882
+    - description: Added tags field mapping to internal_metrics data stream
+      type: bugfix
+      link: https://github.com/elastic/apm-server/pull/8292
 - version: "8.2.0"
   changes:
     - description: Field mapping for `source.nat.ip` and `source.nat.port` added to data streams

--- a/apmpackage/apm/data_stream/internal_metrics/fields/ecs.yml
+++ b/apmpackage/apm/data_stream/internal_metrics/fields/ecs.yml
@@ -106,6 +106,8 @@
 - external: ecs
   name: source.nat.port
 - external: ecs
+  name: tags
+- external: ecs
   name: user.domain
 - external: ecs
   name: user.email


### PR DESCRIPTION
## Motivation/summary

Documents added to `metrics-apm.internal-<namespace>` may have `client.ip`, and may require geoIP enrichment. If the geoip ingest processor cannot download the database, it will add a tag to the document. As we do not have the `tags` field defined, and we use strict mapping for this data stream, this leads to an indexing error.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
~- [ ] Documentation has been updated~

## How to test these changes

1. Modify docker-compose.yml's Elasticsearch service, adding `ingest.geoip.downloader.enabled=false` to its environment and removing the ingest-geoip volume.
2. Send some metrics to the RUM events endpoint with a public IP set. e.g. `curl -H "X-Real-Ip: 8.8.8.8" -X POST -H Content-Type:application/x-ndjson http://localhost:8200/intake/v2/rum/events --data-binary @testdata/intake-v2/metricsets.ndjson`

With the fix, metric documents should be indexed with a `tags` field.

## Related issues

Closes https://github.com/elastic/apm-server/issues/7465