### PR TITLE
docs: it’s a switch, not an upgrade

### DIFF
--- a/docs/upgrading-to-integration.asciidoc
+++ b/docs/upgrading-to-integration.asciidoc
@@ -1,5 +1,5 @@
 [[upgrade-to-apm-integration]]
-=== Upgrade to the Elastic APM integration
+=== Switch to the Elastic APM integration
 
 The APM integration offers a number of benefits over the standalone method of running APM Server:
 
@@ -56,7 +56,7 @@ There are some limitations to be aware of:
 * An {agent} with the APM integration enabled must be managed by {fleet}.
 
 [discrete]
-=== Upgrade
+=== Make the switch
 
 Select a guide below to get started.
 
@@ -66,10 +66,10 @@ Select a guide below to get started.
 // ********************************************************
 
 [[apm-integration-upgrade-steps]]
-==== Upgrade a self-installation to the APM integration
+==== Switch a self-installation to the APM integration
 
 ++++
-<titleabbrev>Upgrade a self-installation</titleabbrev>
+<titleabbrev>Switch a self-installation</titleabbrev>
 ++++
 
 . <<apm-integration-upgrade-1>>
@@ -140,15 +140,15 @@ no reconfiguration is required in your APM agents.
 Once data from upgraded APM agents is visible in the {apm-app},
 it's safe to stop the legacy APM Server process.
 
-Congratulations -- you've now upgraded to the latest and greatest in Elastic APM!
+Congratulations -- you've now switched to the latest and greatest in Elastic APM!
 
 // ********************************************************
 
 [[apm-integration-upgrade-steps-ess]]
-==== Upgrade an {ecloud} cluster to the APM integration
+==== Switch an {ecloud} cluster to the APM integration
 
 ++++
-<titleabbrev>Upgrade an {ecloud} cluster</titleabbrev>
+<titleabbrev>Switch an {ecloud} cluster</titleabbrev>
 ++++
 
 . <<apm-integration-upgrade-ess-1>>
@@ -211,4 +211,4 @@ Here you can edit the number and size of each availability zone.
 
 image::./images/scale-apm.png[scale APM]
 
-Congratulations -- you’ve now upgraded to the latest and greatest in Elastic APM!
+Congratulations -- you’ve now switched to the latest and greatest in Elastic APM!

--- a/docs/upgrading-to-integration.asciidoc
+++ b/docs/upgrading-to-integration.asciidoc
@@ -140,7 +140,7 @@ no reconfiguration is required in your APM agents.
 Once data from upgraded APM agents is visible in the {apm-app},
 it's safe to stop the legacy APM Server process.
 
-Congratulations -- you've now switched to the latest and greatest in Elastic APM!
+Congratulations -- you now have the latest and greatest in Elastic APM!
 
 // ********************************************************
 
@@ -211,4 +211,4 @@ Here you can edit the number and size of each availability zone.
 
 image::./images/scale-apm.png[scale APM]
 
-Congratulations -- you’ve now switched to the latest and greatest in Elastic APM!
+Congratulations -- you now have the latest and greatest in Elastic APM!


### PR DESCRIPTION
### Summary

This PR changes our dialog from "upgrade to the APM integration" to "switch to the APM integration". This change is based on feedback linked in https://github.com/elastic/apm-server/issues/8252.

Closes https://github.com/elastic/apm-server/issues/8252.

We don't usually backport doc changes to EOL branches, but I'll take this one back to 7.16.