### PR TITLE
docs: re-add sourcemap:write

### DIFF
--- a/docs/legacy/secure-communication-agents.asciidoc
+++ b/docs/legacy/secure-communication-agents.asciidoc
@@ -106,7 +106,7 @@ POST /_security/role/apm_agent_key_role
   "cluster": ["manage_own_api_key"],
   "applications": [{
     "application": "apm",
-    "privileges": ["event:write", "config_agent:read"],
+    "privileges": ["event:write", "config_agent:read", "sourcemap:write"],
     "resources": ["*"]
   }]
 }

--- a/docs/secure-agent-communication.asciidoc
+++ b/docs/secure-agent-communication.asciidoc
@@ -138,7 +138,8 @@ POST /_security/role/apm_agent_key_role
          "application":"apm",
          "privileges":[
             "event:write",
-            "config_agent:read"
+            "config_agent:read",
+            "sourcemap:write"
          ],
          "resources":[ "*" ]
       },


### PR DESCRIPTION
### Summary

This PR re-adds the `sourcemap:write` privilege to our documentation until the bug described in https://github.com/elastic/kibana/issues/132353 is fixed.

It's possible—dare I say, likely—that I've missed something here, but I _think_ these two lines fix the problem described in https://github.com/elastic/kibana/issues/132689.

