### PR TITLE
Support service.target.{type, name} for OTLP events

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -20,6 +20,7 @@ https://github.com/elastic/apm-server/compare/8.4\...main[View commits]
 
 [float]
 ==== Added
+- Added support for `service.target.{type,name}` to be inferred from OpenTelemetry events {pull}8334[8334]
 - Added support for OpenTelemetry summary metrics {pull}7772[7772]
 - Upgraded bundled APM Java agent attacher CLI to version 1.32.0, which supports the `latest` version tag {pull}8374[8374]
 - Added `span.name` to `service_destination` metrics {pull}8391[8391]

--- a/model/modeldecoder/v2/span_test.go
+++ b/model/modeldecoder/v2/span_test.go
@@ -281,6 +281,10 @@ func TestDecodeMapToSpanModel(t *testing.T) {
 			mapToSpanModel(&input, &event)
 			assert.Equal(t, expected, event.URL)
 			assert.Equal(t, "CLIENT", event.Span.Kind)
+			assert.Equal(t, &model.ServiceTarget{
+				Type: "http",
+				Name: "testing.invalid:80",
+			}, event.Service.Target)
 		})
 
 		t.Run("http-destination", func(t *testing.T) {
@@ -308,6 +312,10 @@ func TestDecodeMapToSpanModel(t *testing.T) {
 			assert.Equal(t, expectedDestination, event.Destination)
 			assert.Equal(t, expectedDestinationService, event.Span.DestinationService)
 			assert.Equal(t, "CLIENT", event.Span.Kind)
+			assert.Equal(t, &model.ServiceTarget{
+				Type: "http",
+				Name: "testing.invalid:443",
+			}, event.Service.Target)
 		})
 
 		t.Run("db", func(t *testing.T) {
@@ -337,13 +345,16 @@ func TestDecodeMapToSpanModel(t *testing.T) {
 			assert.Equal(t, "mysql", event.Span.Subtype)
 			assert.Equal(t, "", event.Span.Action)
 			assert.Equal(t, "CLIENT", event.Span.Kind)
-
 			assert.Equal(t, &model.DB{
 				Instance:  "ShopDb",
 				Statement: "SELECT * FROM orders WHERE order_id = 'o4711'",
 				Type:      "mysql",
 				UserName:  "billing_user",
 			}, event.Span.DB)
+			assert.Equal(t, &model.ServiceTarget{
+				Type: "mysql",
+				Name: "ShopDb",
+			}, event.Service.Target)
 		})
 
 		t.Run("rpc", func(t *testing.T) {
@@ -377,6 +388,10 @@ func TestDecodeMapToSpanModel(t *testing.T) {
 				Name:     "10.20.30.40:123",
 				Resource: "10.20.30.40:123",
 			}, event.Span.DestinationService)
+			assert.Equal(t, &model.ServiceTarget{
+				Type: "grpc",
+				Name: "myservice.EchoService",
+			}, event.Service.Target)
 		})
 
 		t.Run("messaging", func(t *testing.T) {
@@ -408,7 +423,10 @@ func TestDecodeMapToSpanModel(t *testing.T) {
 				Name:     "kafka",
 				Resource: "kafka/myTopic",
 			}, event.Span.DestinationService)
-
+			assert.Equal(t, &model.ServiceTarget{
+				Type: "kafka",
+				Name: "myTopic",
+			}, event.Service.Target)
 		})
 
 		t.Run("network", func(t *testing.T) {

--- a/processor/otel/test_approved/span_jaeger_db.approved.json
+++ b/processor/otel/test_approved/span_jaeger_db.approved.json
@@ -33,7 +33,7 @@
                 },
                 "name": "unknown",
                 "target": {
-                    "name": "sql",
+                    "name": "db01",
                     "type": "mysql"
                 }
             },

--- a/processor/otel/test_approved/span_jaeger_db.approved.json
+++ b/processor/otel/test_approved/span_jaeger_db.approved.json
@@ -31,7 +31,11 @@
                 "language": {
                     "name": "unknown"
                 },
-                "name": "unknown"
+                "name": "unknown",
+                "target": {
+                    "name": "sql",
+                    "type": "mysql"
+                }
             },
             "span": {
                 "db": {

--- a/processor/otel/test_approved/span_jaeger_http.approved.json
+++ b/processor/otel/test_approved/span_jaeger_http.approved.json
@@ -45,7 +45,11 @@
                 "language": {
                     "name": "unknown"
                 },
-                "name": "unknown"
+                "name": "unknown",
+                "target": {
+                    "name": "foo.bar.com:80",
+                    "type": "http"
+                }
             },
             "span": {
                 "destination": {
@@ -108,7 +112,11 @@
                 "language": {
                     "name": "unknown"
                 },
-                "name": "unknown"
+                "name": "unknown",
+                "target": {
+                    "name": "foo.bar.com:80",
+                    "type": "http"
+                }
             },
             "timestamp": {
                 "us": 1576500418000768
@@ -153,7 +161,11 @@
                 "language": {
                     "name": "unknown"
                 },
-                "name": "unknown"
+                "name": "unknown",
+                "target": {
+                    "name": "foo.bar.com:80",
+                    "type": "http"
+                }
             },
             "timestamp": {
                 "us": 1576500418000768
@@ -200,7 +212,11 @@
                 "language": {
                     "name": "unknown"
                 },
-                "name": "unknown"
+                "name": "unknown",
+                "target": {
+                    "name": "foo.bar.com:80",
+                    "type": "http"
+                }
             },
             "timestamp": {
                 "us": 1576500418000768
@@ -247,7 +263,11 @@
                 "language": {
                     "name": "unknown"
                 },
-                "name": "unknown"
+                "name": "unknown",
+                "target": {
+                    "name": "foo.bar.com:80",
+                    "type": "http"
+                }
             },
             "timestamp": {
                 "us": 1576500418000768
@@ -294,7 +314,11 @@
                 "language": {
                     "name": "unknown"
                 },
-                "name": "unknown"
+                "name": "unknown",
+                "target": {
+                    "name": "foo.bar.com:80",
+                    "type": "http"
+                }
             },
             "timestamp": {
                 "us": 1576500418000768
@@ -339,7 +363,11 @@
                 "language": {
                     "name": "unknown"
                 },
-                "name": "unknown"
+                "name": "unknown",
+                "target": {
+                    "name": "foo.bar.com:80",
+                    "type": "http"
+                }
             },
             "timestamp": {
                 "us": 1576500418000768
@@ -384,7 +412,11 @@
                 "language": {
                     "name": "unknown"
                 },
-                "name": "unknown"
+                "name": "unknown",
+                "target": {
+                    "name": "foo.bar.com:80",
+                    "type": "http"
+                }
             },
             "trace": {
                 "id": "00000000000000000000000046467830"
@@ -426,7 +458,11 @@
                 "language": {
                     "name": "unknown"
                 },
-                "name": "unknown"
+                "name": "unknown",
+                "target": {
+                    "name": "foo.bar.com:80",
+                    "type": "http"
+                }
             },
             "trace": {
                 "id": "00000000000000000000000046467830"
@@ -467,7 +503,11 @@
                 "language": {
                     "name": "unknown"
                 },
-                "name": "unknown"
+                "name": "unknown",
+                "target": {
+                    "name": "foo.bar.com:80",
+                    "type": "http"
+                }
             },
             "trace": {
                 "id": "00000000000000000000000046467830"

--- a/processor/otel/test_approved/span_jaeger_http_status_code.approved.json
+++ b/processor/otel/test_approved/span_jaeger_http_status_code.approved.json
@@ -36,7 +36,11 @@
                 "language": {
                     "name": "unknown"
                 },
-                "name": "unknown"
+                "name": "unknown",
+                "target": {
+                    "name": "foo.bar.com:80",
+                    "type": "http"
+                }
             },
             "span": {
                 "destination": {

--- a/processor/otel/test_approved/span_jaeger_https_default_port.approved.json
+++ b/processor/otel/test_approved/span_jaeger_https_default_port.approved.json
@@ -28,7 +28,11 @@
                 "language": {
                     "name": "unknown"
                 },
-                "name": "unknown"
+                "name": "unknown",
+                "target": {
+                    "name": "foo.bar.com:443",
+                    "type": "http"
+                }
             },
             "span": {
                 "destination": {

--- a/processor/otel/test_approved/span_jaeger_messaging.approved.json
+++ b/processor/otel/test_approved/span_jaeger_messaging.approved.json
@@ -28,7 +28,11 @@
                 "language": {
                     "name": "unknown"
                 },
-                "name": "unknown"
+                "name": "unknown",
+                "target": {
+                    "name": "queue-abc",
+                    "type": "messaging"
+                }
             },
             "span": {
                 "id": "0000000041414646",

--- a/processor/otel/traces_test.go
+++ b/processor/otel/traces_test.go
@@ -1184,6 +1184,147 @@ func TestTracesLogging(t *testing.T) {
 	}
 }
 
+func TestServiceTarget(t *testing.T) {
+	test := func(t *testing.T, expected *model.ServiceTarget, input map[string]pdata.AttributeValue) {
+		t.Helper()
+		event := transformSpanWithAttributes(t, input)
+		assert.Equal(t, expected, event.Service.Target)
+	}
+	t.Run("db_spans_with_peerservice_name_system", func(t *testing.T) {
+		test(t, &model.ServiceTarget{
+			Type: "postgresql",
+			Name: "testsvc",
+		}, map[string]pdata.AttributeValue{
+			"peer.service": pdata.NewAttributeValueString("testsvc"), // takes highest priority for target.name
+			"db.name":      pdata.NewAttributeValueString("testdb"),
+			"db.system":    pdata.NewAttributeValueString("postgresql"),
+		})
+	})
+
+	t.Run("db_spans_with_name_system", func(t *testing.T) {
+		test(t, &model.ServiceTarget{
+			Type: "postgresql",
+			Name: "testdb",
+		}, map[string]pdata.AttributeValue{
+			"db.name":   pdata.NewAttributeValueString("testdb"),
+			"db.system": pdata.NewAttributeValueString("postgresql"),
+		})
+	})
+
+	t.Run("db_spans_with_name", func(t *testing.T) {
+		test(t, &model.ServiceTarget{
+			Type: "db",
+			Name: "testdb",
+		}, map[string]pdata.AttributeValue{
+			"db.name": pdata.NewAttributeValueString("testdb"),
+		})
+	})
+
+	t.Run("http_spans_with_peerservice_url", func(t *testing.T) {
+		test(t, &model.ServiceTarget{
+			Name: "testsvc",
+			Type: "http",
+		}, map[string]pdata.AttributeValue{
+			"peer.service": pdata.NewAttributeValueString("testsvc"), // takes highest priority for target.name
+			"http.url":     pdata.NewAttributeValueString("https://test-url:443/"),
+		})
+	})
+
+	t.Run("http_spans_with_url", func(t *testing.T) {
+		test(t, &model.ServiceTarget{
+			Name: "test-url:443",
+			Type: "http",
+		}, map[string]pdata.AttributeValue{
+			"http.url": pdata.NewAttributeValueString("https://test-url:443/"),
+		})
+	})
+
+	t.Run("http_spans_with_scheme_host_target", func(t *testing.T) {
+		test(t, &model.ServiceTarget{
+			Name: "test-url:443",
+			Type: "http",
+		}, map[string]pdata.AttributeValue{
+			"http.scheme": pdata.NewAttributeValueString("https"),
+			"http.host":   pdata.NewAttributeValueString("test-url:443"),
+			"http.target": pdata.NewAttributeValueString("/"),
+		})
+	})
+
+	t.Run("http_spans_with_scheme_netpeername_netpeerport_target", func(t *testing.T) {
+		test(t, &model.ServiceTarget{
+			Name: "test-url:443",
+			Type: "http",
+		}, map[string]pdata.AttributeValue{
+			"http.scheme":   pdata.NewAttributeValueString("https"),
+			"net.peer.name": pdata.NewAttributeValueString("test-url"),
+			"net.peer.ip":   pdata.NewAttributeValueString("::1"), // net.peer.name preferred
+			"net.peer.port": pdata.NewAttributeValueInt(443),
+			"http.target":   pdata.NewAttributeValueString("/"),
+		})
+	})
+
+	t.Run("http_spans_with_scheme_netpeerip_netpeerport_target", func(t *testing.T) {
+		test(t, &model.ServiceTarget{
+			Name: "[::1]:443",
+			Type: "http",
+		}, map[string]pdata.AttributeValue{
+			"http.scheme":   pdata.NewAttributeValueString("https"),
+			"net.peer.ip":   pdata.NewAttributeValueString("::1"), // net.peer.name preferred
+			"net.peer.port": pdata.NewAttributeValueInt(443),
+			"http.target":   pdata.NewAttributeValueString("/"),
+		})
+	})
+
+	t.Run("rpc_spans_with_peerservice_system_service", func(t *testing.T) {
+		test(t, &model.ServiceTarget{
+			Name: "testsvc",
+			Type: "grpc",
+		}, map[string]pdata.AttributeValue{
+			"peer.service": pdata.NewAttributeValueString("testsvc"), // takes highest priority for target.name
+			"rpc.system":   pdata.NewAttributeValueString("grpc"),
+			"rpc.service":  pdata.NewAttributeValueString("test"),
+		})
+	})
+
+	t.Run("rpc_spans_with_system_service", func(t *testing.T) {
+		test(t, &model.ServiceTarget{
+			Name: "test",
+			Type: "grpc",
+		}, map[string]pdata.AttributeValue{
+			"rpc.system":  pdata.NewAttributeValueString("grpc"),
+			"rpc.service": pdata.NewAttributeValueString("test"),
+		})
+	})
+
+	t.Run("rpc_spans_with_service", func(t *testing.T) {
+		test(t, &model.ServiceTarget{
+			Name: "test",
+			Type: "external",
+		}, map[string]pdata.AttributeValue{
+			"rpc.service": pdata.NewAttributeValueString("test"),
+		})
+	})
+
+	t.Run("messaging_spans_with_system_destination", func(t *testing.T) {
+		test(t, &model.ServiceTarget{
+			Name: "myTopic",
+			Type: "kafka",
+		}, map[string]pdata.AttributeValue{
+			"messaging.system":      pdata.NewAttributeValueString("kafka"),
+			"messaging.destination": pdata.NewAttributeValueString("myTopic"),
+		})
+	})
+
+	t.Run("messaging_spans_with_destination", func(t *testing.T) {
+		test(t, &model.ServiceTarget{
+			Name: "myTopic",
+			Type: "messaging",
+		}, map[string]pdata.AttributeValue{
+			"messaging.destination": pdata.NewAttributeValueString("myTopic"),
+		})
+	})
+}
+
 func testJaegerLogs() []jaegermodel.Log {
 	return []jaegermodel.Log{{
 		// errors that can be converted to elastic errors

--- a/processor/otel/traces_test.go
+++ b/processor/otel/traces_test.go
@@ -1190,24 +1190,24 @@ func TestServiceTarget(t *testing.T) {
 		event := transformSpanWithAttributes(t, input)
 		assert.Equal(t, expected, event.Service.Target)
 	}
-	t.Run("db_spans_with_peerservice_name_system", func(t *testing.T) {
+	t.Run("db_spans_with_peerservice_system", func(t *testing.T) {
 		test(t, &model.ServiceTarget{
 			Type: "postgresql",
 			Name: "testsvc",
 		}, map[string]pdata.AttributeValue{
-			"peer.service": pdata.NewAttributeValueString("testsvc"), // takes highest priority for target.name
-			"db.name":      pdata.NewAttributeValueString("testdb"),
+			"peer.service": pdata.NewAttributeValueString("testsvc"),
 			"db.system":    pdata.NewAttributeValueString("postgresql"),
 		})
 	})
 
-	t.Run("db_spans_with_name_system", func(t *testing.T) {
+	t.Run("db_spans_with_peerservice_name_system", func(t *testing.T) {
 		test(t, &model.ServiceTarget{
 			Type: "postgresql",
 			Name: "testdb",
 		}, map[string]pdata.AttributeValue{
-			"db.name":   pdata.NewAttributeValueString("testdb"),
-			"db.system": pdata.NewAttributeValueString("postgresql"),
+			"peer.service": pdata.NewAttributeValueString("testsvc"),
+			"db.name":      pdata.NewAttributeValueString("testdb"),
+			"db.system":    pdata.NewAttributeValueString("postgresql"),
 		})
 	})
 
@@ -1222,20 +1222,11 @@ func TestServiceTarget(t *testing.T) {
 
 	t.Run("http_spans_with_peerservice_url", func(t *testing.T) {
 		test(t, &model.ServiceTarget{
-			Name: "testsvc",
-			Type: "http",
-		}, map[string]pdata.AttributeValue{
-			"peer.service": pdata.NewAttributeValueString("testsvc"), // takes highest priority for target.name
-			"http.url":     pdata.NewAttributeValueString("https://test-url:443/"),
-		})
-	})
-
-	t.Run("http_spans_with_url", func(t *testing.T) {
-		test(t, &model.ServiceTarget{
 			Name: "test-url:443",
 			Type: "http",
 		}, map[string]pdata.AttributeValue{
-			"http.url": pdata.NewAttributeValueString("https://test-url:443/"),
+			"peer.service": pdata.NewAttributeValueString("testsvc"),
+			"http.url":     pdata.NewAttributeValueString("https://test-url:443/"),
 		})
 	})
 
@@ -1275,24 +1266,24 @@ func TestServiceTarget(t *testing.T) {
 		})
 	})
 
-	t.Run("rpc_spans_with_peerservice_system_service", func(t *testing.T) {
+	t.Run("rpc_spans_with_peerservice_system", func(t *testing.T) {
 		test(t, &model.ServiceTarget{
 			Name: "testsvc",
 			Type: "grpc",
 		}, map[string]pdata.AttributeValue{
-			"peer.service": pdata.NewAttributeValueString("testsvc"), // takes highest priority for target.name
+			"peer.service": pdata.NewAttributeValueString("testsvc"),
 			"rpc.system":   pdata.NewAttributeValueString("grpc"),
-			"rpc.service":  pdata.NewAttributeValueString("test"),
 		})
 	})
 
-	t.Run("rpc_spans_with_system_service", func(t *testing.T) {
+	t.Run("rpc_spans_with_peerservice_system_service", func(t *testing.T) {
 		test(t, &model.ServiceTarget{
 			Name: "test",
 			Type: "grpc",
 		}, map[string]pdata.AttributeValue{
-			"rpc.system":  pdata.NewAttributeValueString("grpc"),
-			"rpc.service": pdata.NewAttributeValueString("test"),
+			"peer.service": pdata.NewAttributeValueString("testsvc"),
+			"rpc.system":   pdata.NewAttributeValueString("grpc"),
+			"rpc.service":  pdata.NewAttributeValueString("test"),
 		})
 	})
 
@@ -1305,13 +1296,26 @@ func TestServiceTarget(t *testing.T) {
 		})
 	})
 
-	t.Run("messaging_spans_with_system_destination", func(t *testing.T) {
+	t.Run("messaging_spans_with_peerservice_system_destination", func(t *testing.T) {
 		test(t, &model.ServiceTarget{
 			Name: "myTopic",
 			Type: "kafka",
 		}, map[string]pdata.AttributeValue{
+			"peer.service":          pdata.NewAttributeValueString("testsvc"),
 			"messaging.system":      pdata.NewAttributeValueString("kafka"),
 			"messaging.destination": pdata.NewAttributeValueString("myTopic"),
+		})
+	})
+
+	t.Run("messaging_spans_with_peerservice_system_destination_tempdestination", func(t *testing.T) {
+		test(t, &model.ServiceTarget{
+			Name: "testsvc",
+			Type: "kafka",
+		}, map[string]pdata.AttributeValue{
+			"peer.service":               pdata.NewAttributeValueString("testsvc"),
+			"messaging.temp_destination": pdata.NewAttributeValueBool(true),
+			"messaging.system":           pdata.NewAttributeValueString("kafka"),
+			"messaging.destination":      pdata.NewAttributeValueString("myTopic"),
 		})
 	})
 

--- a/processor/stream/test_approved_es_documents/testIntakeIntegrationOpenTelemetryBridge.approved.json
+++ b/processor/stream/test_approved_es_documents/testIntakeIntegrationOpenTelemetryBridge.approved.json
@@ -239,6 +239,9 @@
                     "name": "node",
                     "version": "8.0.0"
                 },
+                "target": {
+                    "type": "http"
+                },
                 "version": "5.1.3"
             },
             "span": {


### PR DESCRIPTION
## Motivation/summary

Infer `service.target.{type, name}` from OTLP events.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~~
~~- [ ] Documentation has been updated~~

## How to test these changes

Observe that each span type the `service.target.{type, name}` in the output doc are populated as per the corresponding tables with the appropriate inputs.

1. DB spans:
    | [in]peer.service | [in]db.system | [in]db.name | [out]target.type | [out]target.name |
    |---------------|---------------|-------------|------------------|------------------|
    | testsvc | postgresql    | testdb      | postgresql       | testdb           |
    | testsvc | postgresql    | <nil>      | postgresql       | testsvc           |
    | <nil> | <nil>         | testdb      | db               | testdb           |
    | <nil> | <nil>         | <nil>       | db               | ""               |
2. HTTP spans:
    | [in]peer.service | [in]http.url | [out]target.type | [out]target.name |
    |---|---|---|---|
    | testsvc | https://test-url:443/ | http | test-url:443 |

    | [in]peer.service | [in]http.scheme | [in]http.host | [in]http.target | [out]target.type | [out]target.name |
    |---|---|---|---|---|---|
    | <nil> | https | test-url:443 | / | http | test-url:443 |

    | [in]peer.service | [in]http.scheme | [in]net.peer.name | [in]net.peer.ip | [in]net.peer.port | [in]http.target | [out]target.type | [out]target.name |
    |---|---|---|---|---|---|---|---|
    | <nil> | https | test-url | ::1 | 443 | / | http | test-url:443 |

    | [in]peer.service | [in]http.scheme | [in]net.peer.ip | [in]net.peer.port | [in]http.target | [out]target.type | [out]target.name |
    |---|---|---|---|---|---|---|
    | <nil> | https | ::1 | 443 | / | http | [::1]:443 |
3. RPC spans:
    | [in]peer.service | [in]rpc.system | [in]rpc.service | [out]target.type | [out]target.name |
    |----------------|----------------|-----------------|------------------|------------------|
    | testsvc | grpc           | test            | grpc             | testsvc             |
    | testsvc | grpc           | <nil>            | grpc             | testsvc             |
    | <nil>          | test            | external         | test             |
4. Messaging spans:
    | [in]peer.service | [in]messaging.system | [in]messaging.destination | [out]target.type | [out]target.name |
    |----------------------|----------------------|---------------------------|------------------|------------------|
    | testsvc | kafka                | test-topic                | kafka            | test-topic       |
    | testsvc | kafka                | <nil>                | kafka            | testsvc       |
    | <nil> | <nil>                | test-topic                | messaging        | test-topic       |

## Related issues

Closes #7980 
