### PR TITLE
Fix race condition while reading attributes in translate span

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -11,6 +11,7 @@ https://github.com/elastic/apm-server/compare/8.4\...main[View commits]
 
 [float]
 ==== Bug fixes
+- Fix race for deducing destination service fields for OTel bridge {pull}8363[8363]
 
 [float]
 ==== Intake API Changes


### PR DESCRIPTION
## Motivation/summary

In some cases, when certain OTel attributes are passed together the results can be indeterministic due to processing inter-dependent fields while ranging over the OTel attribute map.

The following cases have been fixed:

- messaging.system and peer.service for messaging spans
- (net.peer.name OR peer.hostname) and peer.addresss

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~~
~~- [ ] Documentation has been updated~~

## How to test these changes

1. Run the unit test `TestMessagingSpan_DestinationResource` multiple times
```go test processor/otel/traces_test.go -run TestMessagingSpan_DestinationResource -count 15 -v```
2. Observe that they are not flaky


## Related issues

Closes #8351 
