### PR TITLE
docs: Remove extra space in link

### DIFF
--- a/changelogs/8.2.asciidoc
+++ b/changelogs/8.2.asciidoc
@@ -16,7 +16,7 @@ https://github.com/elastic/apm-server/compare/8.2.2\...8.2.3[View commits]
 
 [float]
 ==== Bug fixes
-- Added `tags` field mapping to `internal_metrics` data stream {pull} 8292[8292]
+- Added `tags` field mapping to `internal_metrics` data stream {pull}8292[8292]
 
 [float]
 [[release-notes-8.2.2]]


### PR DESCRIPTION
Removes extra space in external doc link.

I've already made this change in the 8.2 and 8.3 backports, so it does not need to be backported.