### PR TITLE
Upgrading Java agent attacher CLI to 1.32.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ release-manager-release: release
 
 .PHONY: release
 
-JAVA_ATTACHER_VERSION:=1.28.4
+JAVA_ATTACHER_VERSION:=1.32.0
 JAVA_ATTACHER_JAR:=apm-agent-attach-cli-$(JAVA_ATTACHER_VERSION)-slim.jar
 JAVA_ATTACHER_SIG:=$(JAVA_ATTACHER_JAR).asc
 JAVA_ATTACHER_BASE_URL:=https://repo1.maven.org/maven2/co/elastic/apm/apm-agent-attach-cli

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -19,3 +19,4 @@ https://github.com/elastic/apm-server/compare/8.4\...main[View commits]
 [float]
 ==== Added
 - Added support for OpenTelemetry summary metrics {pull}7772[7772]
+- Upgraded bundled APM Java agent attacher CLI to version 1.32.0, which supports the `latest` version tag {pull}8374[8374]


### PR DESCRIPTION
Is there anything else required in order to package the Java agent CLI?