### PR TITLE
[tbs] log config err and continue

### DIFF
--- a/beater/config/sampling_test.go
+++ b/beater/config/sampling_test.go
@@ -35,18 +35,20 @@ func TestSamplingPoliciesValidation(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("NoPolicies", func(t *testing.T) {
-		_, err := NewConfig(config.MustNewConfigFrom(map[string]interface{}{
+		c, err := NewConfig(config.MustNewConfigFrom(map[string]interface{}{
 			"sampling.tail.enabled": true,
 		}), nil)
-		assert.EqualError(t, err, "Error processing configuration: invalid tail sampling config: no policies specified accessing 'sampling.tail'")
+		assert.NoError(t, err)
+		assert.False(t, c.Sampling.Tail.Enabled)
 	})
 	t.Run("NoDefaultPolicies", func(t *testing.T) {
-		_, err := NewConfig(config.MustNewConfigFrom(map[string]interface{}{
+		c, err := NewConfig(config.MustNewConfigFrom(map[string]interface{}{
 			"sampling.tail.policies": []map[string]interface{}{{
 				"service.name": "foo",
 				"sample_rate":  0.5,
 			}},
 		}), nil)
-		assert.EqualError(t, err, "Error processing configuration: invalid tail sampling config: no default (empty criteria) policy specified accessing 'sampling.tail'")
+		assert.NoError(t, err)
+		assert.False(t, c.Sampling.Tail.Enabled)
 	})
 }


### PR DESCRIPTION
## Motivation/summary

If the provided tail-based sampling config is
invalid, log that there was an error and continue
running with tbs disabled.

closes #8220

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

## How to test these changes

- run apm-server with an invalid tbs config, like
    ```yml
    apm-server:
      sampling:
        tail:
          enabled: true
    ```
- observe the logs for both error and info logs saying there was an issue with tbs, and the server is running with it disabled
- observe apm-server is running