### PR TITLE
sampling: Handle `ErrNOSPC` and `os.PathError`

### DIFF
--- a/dev_docs/tbs.md
+++ b/dev_docs/tbs.md
@@ -61,3 +61,13 @@ As mentioned above, APM Servers will buffer events locally until a sampling deci
 For this purpose, we use [BadgerDB](https://github.com/dgraph-io/badger). BadgerDB is designed for
 fast writes, which is important for our use case: we write all events here, and read out only the
 sampled ones. All non-sampled events will be removed from the store through TTL expiry.
+
+BadgerDB doesn't provide a setting to limit disk usage, which is not ideal, since APM Server will
+most likely be running with a limit on storage and allowing BadgerDB to consume all disk space
+will eventually cause the APM Server to malfunction. For this reason, we default to sampling all
+incoming events should writes fail when the disk is full. Eventually, this behavior should be
+configurable and allow users to either discard or sample incoming events when the disk is full.
+
+Furthermore, we should limit how much the BadgerDB size is allowed to grow to, to avoid consuming
+all disk space thus reducing the chances of causing the APM Server to malfunction due no disk space
+available.

--- a/docs/sampling.asciidoc
+++ b/docs/sampling.asciidoc
@@ -150,6 +150,10 @@ Requiring this default policy ensures that traces are only dropped intentionally
 If you enable tail-based sampling and send a transaction that does not match any of the policies,
 APM Server will reject the transaction with the error `no matching policy`.
 
+Please note that by default APM Server doesn't have a hard limit on how much disk space the
+local trace buffer is allowed to consume. For this reason, high throughput deployments may use all
+available disk space.
+
 ===== Example configuration
 
 This example defines three tail-based sampling polices:

--- a/x-pack/apm-server/sampling/eventstorage/badger.go
+++ b/x-pack/apm-server/sampling/eventstorage/badger.go
@@ -27,6 +27,6 @@ func OpenBadger(storageDir string, valueLogFileSize int64) (*badger.DB, error) {
 	if valueLogFileSize > 0 {
 		badgerOpts.ValueLogFileSize = valueLogFileSize
 	}
-	badgerOpts.Logger = LogpAdaptor{Logger: logger}
+	badgerOpts.Logger = &LogpAdaptor{Logger: logger}
 	return badger.Open(badgerOpts)
 }

--- a/x-pack/apm-server/sampling/eventstorage/logger.go
+++ b/x-pack/apm-server/sampling/eventstorage/logger.go
@@ -4,14 +4,50 @@
 
 package eventstorage
 
-import "github.com/elastic/elastic-agent-libs/logp"
+import (
+	"fmt"
+	"sync"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+)
 
 // LogpAdaptor adapts logp.Logger to the badger.Logger interface.
 type LogpAdaptor struct {
 	*logp.Logger
+
+	mu   sync.RWMutex
+	last string
+}
+
+// Errorf prints the log message when the current message isn't the same as the
+// previously logged message.
+func (a *LogpAdaptor) Errorf(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	if a.skipLog(msg) {
+		return
+	}
+	if a.setLast(msg) {
+		a.Logger.Errorf(format, args...)
+	}
+}
+
+func (a *LogpAdaptor) skipLog(msg string) bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return msg == a.last
+}
+
+func (a *LogpAdaptor) setLast(msg string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	shouldSet := msg != a.last
+	if shouldSet {
+		a.last = msg
+	}
+	return shouldSet
 }
 
 // Warningf adapts badger.Logger.Warningf to logp.Logger.Warngf.
-func (a LogpAdaptor) Warningf(format string, args ...interface{}) {
+func (a *LogpAdaptor) Warningf(format string, args ...interface{}) {
 	a.Warnf(format, args...)
 }


### PR DESCRIPTION
## Motivation/summary

This patch handles how the tail sampling processor behaves when writes
to the BadgerDB fail with `ErrNOSPC` or `os.PathError`. By default, any
traces will be sampled when after BadgerDB has consumed all disk space.

Additionally, we're ignoring the two errors above when failing to write
the subscriber position to disk, since that would cause the server to
shut down.

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
- [x] Documentation has been updated

## How to test these changes

It is not the most straightforward change to test in macOS, since using Docker for desktop doesn't allow you to change the VM filesystem, for this reason it can only be tested in Linux.

I used an AWS VM (Amazon Linux 2) to test these changes, but had to do a few changes to how the root filesystem is mounted to allow the XFS `pquota,prjquota` to take effect.

<img width="1662" alt="Screen Shot 2022-06-17 at 09 04 28" src="https://user-images.githubusercontent.com/7286993/174244876-c9eb6636-307e-442d-891c-3208306d969c.png">

## Related issues

Closes #8314