### PR TITLE
chore: Nightly schedule for benchmarks

### DIFF
--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -38,7 +38,9 @@ pipeline {
     stage('Benchmarks') {
       options { skipDefaultCheckout() }
       environment {
-        SSH_KEY = "~/.ssh/id_rsa_terraform"
+        SSH_KEY = "./id_rsa_terraform"
+        TF_VAR_private_key = "./id_rsa_terraform"
+        TF_VAR_public_key = "./id_rsa_terraform.pub"
         // cloud tags
         TF_VAR_BUILD_ID = "${env.BUILD_ID}"
         TF_VAR_ENVIRONMENT= 'ci'

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -22,6 +22,7 @@ pipeline {
       steps {
         updateBeatsBuilds(branches: ['main', '8.<minor>', '8.<next-patch>', '7.<minor>'])
         runWindowsBuilds(branches: ['main', '8.<minor>', '8.<next-patch>', '7.<minor>'])
+        runBenchmarks(branches: ['main'])
       }
     }
   }
@@ -47,5 +48,12 @@ def runWindowsBuilds(Map args = [:]) {
             booleanParam(name: 'windows_ci', value: true)
           ],
           wait: false, propagate: false)
+  }
+}
+
+def runBenchmarks(Map args = [:]) {
+  def branches = getBranchesFromAliases(aliases: args.branches)
+  branches.each { branch ->
+    build(job: "apm-server/benchmarks/${branch}", wait: false, propagate: false)
   }
 }


### PR DESCRIPTION

Creates scheduled benchmark execution every night on the `main` branch
Fixes `SSH_KEY` variable

## Related issues
https://github.com/elastic/apm-server/issues/7846
