### PR TITLE
Sourcemap upload documentation: align curl example with custom app example

### DIFF
--- a/docs/legacy/sourcemaps.asciidoc
+++ b/docs/legacy/sourcemaps.asciidoc
@@ -140,7 +140,7 @@ curl -X POST "http://localhost:5601/api/apm/sourcemaps" \
 -H 'Authorization: ApiKey ${YOUR_API_KEY}' \ <2>
 -F 'service_name="foo"' \
 -F 'service_version="$SERVICEVERSION"' \
--F 'bundle_filepath="/test/e2e/general-usecase/bundle.js.map"' \
+-F 'bundle_filepath="http://localhost/app.min.js"' \
 -F 'sourcemap="@./dist/app.min.js.map"'
 ----
 <1> This example uses the version from `package.json`


### PR DESCRIPTION
## Motivation/summary

The examples concerning the `bundle_filepath` are not in line. The goal of this PR is to align them.

The documentation mentions: `bundle_filepath` - The absolute path of the final bundle as used in the web application.

So I'm not sure if should now be `http://localhost/app.min.js` or just `app.min.js`? This change aligns both examples, but I'm still not 100% sure if this is fully correct. I do however know that using `http://localhost/app.min.js` worked when we used Elastic v7.

## Checklist

- [x] Documentation has been updated
