### PR TITLE
magefile: stop setting Platforms

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -47,16 +47,6 @@ func init() {
 		DocBranch:   filepath.Join(repo.RootDir, "docs/version.asciidoc"),
 	})
 
-	// Filter platforms to those that are supported by apm-server.
-	mage.Platforms = mage.Platforms.Filter(strings.Join([]string{
-		"linux/amd64",
-		"linux/386",
-		"linux/arm64",
-		"windows/386",
-		"windows/amd64",
-		"darwin/amd64",
-	}, " "))
-
 	mage.BeatDescription = "Elastic APM Server"
 	mage.BeatURL = "https://www.elastic.co/apm"
 	mage.BeatIndexPrefix = "apm"


### PR DESCRIPTION
## Motivation/summary

Platforms is only used by CrossBuild, and is not relevant when using Go's native cross-compilation support like we do in apm-server.

See https://github.com/elastic/apm-server/pull/8434#issuecomment-1162879704

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

`make release`

## Related issues

None