### PR TITLE
Allow soak test load gen to configure agent count

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -110,7 +110,9 @@ sustained and continuous load for the purpose of soak testing:
 ```console
 $ cd systemtest/cmd/apmsoak
 $ go run main.go -h
-Usage of /var/folders/k9/z1yw8fsn0sjbl5yy7z2rsdpr0000gn/T/go-build2038486186/b001/exe/main:
+Usage of /var/folders/k9/z1yw8fsn0sjbl5yy7z2rsdpr0000gn/T/go-build4164012609/b001/exe/main:
+  -agents-replicas int
+    	Number of agents replicas to use, each replica launches 4 agents, one for each type (default 1)
   -max-rate value
     	Max event rate as epm or eps with burst size=max(1000, 2*eps), <= 0 values evaluate to Inf (default 0epm)
   -secret-token string

--- a/systemtest/soaktest/config.go
+++ b/systemtest/soaktest/config.go
@@ -1,0 +1,35 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package soaktest
+
+import (
+	"flag"
+)
+
+var soakConfig struct {
+	AgentsReplicas int
+}
+
+func init() {
+	flag.IntVar(
+		&soakConfig.AgentsReplicas,
+		"agents-replicas",
+		1,
+		"Number of agents replicas to use, each replica launches 4 agents, one for each type",
+	)
+}

--- a/systemtest/soaktest/soaktest.go
+++ b/systemtest/soaktest/soaktest.go
@@ -30,11 +30,13 @@ func RunBlocking(ctx context.Context) error {
 	limiter := loadgen.GetNewLimiter(loadgen.Config.MaxEPM)
 	g, gCtx := errgroup.WithContext(ctx)
 
-	for _, expr := range []string{`go*.ndjson`, `nodejs*.ndjson`, `python*.ndjson`, `ruby*.ndjson`} {
-		expr := expr
-		g.Go(func() error {
-			return runAgent(gCtx, expr, limiter)
-		})
+	for i := 0; i < soakConfig.AgentsReplicas; i++ {
+		for _, expr := range []string{`go*.ndjson`, `nodejs*.ndjson`, `python*.ndjson`, `ruby*.ndjson`} {
+			expr := expr
+			g.Go(func() error {
+				return runAgent(gCtx, expr, limiter)
+			})
+		}
 	}
 
 	return g.Wait()


### PR DESCRIPTION
## Motivation/summary

Based on benchmarking against a 1GB, Upto 2.7vCPU APM Server, the max event rate that the tool can produce with a set of 4 agents sending events to emulate go, node, python and ruby agents is ~2000/sec. This PR will allow setting replicas for the set of agents to go beyond the above limit.

## Checklist

~~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~~
~~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~~
- [x] Documentation has been updated

## How to test these changes

1. Run ```go run cmd/apmsoak/main.go -server <apm-server-url> -secret-token <secret-token> -max-rate 5000eps -agents-replicas 3``` (make sure you are using a big ES instance backing the APM Server, 16GB instance will work)
2. Observe in stack monitoring the request rate to be greater than 2000 eps)
