### PR TITLE
ci: archive bench output from the base_dir folder

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -439,9 +439,8 @@ pipeline {
                 withMageEnv(){
                   sh(label: 'Run benchmarks', script: './.ci/scripts/bench.sh')
                 }
-                archiveArtifacts artifacts: 'bench.out'
+                sendBenchmarks(file: "bench.out", index: "benchmark-server")
               }
-              sendBenchmarks(file: "${BASE_DIR}/bench.out", index: "benchmark-server")
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -439,6 +439,7 @@ pipeline {
                 withMageEnv(){
                   sh(label: 'Run benchmarks', script: './.ci/scripts/bench.sh')
                 }
+                archiveArtifacts artifacts: 'bench.out'
               }
               sendBenchmarks(file: "${BASE_DIR}/bench.out", index: "benchmark-server")
             }


### PR DESCRIPTION
## Motivation/summary

This will help us to generate a report with [bench](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) so we can enable the APM Server micro-benchmarks on PRs  and report back the diff.

The archive already happens within the `sendBenchmark` but it uses the [BASE_DIR](https://github.com/elastic/apm-pipeline-library/blob/fcbe07578ae42d3a5c63b2dacecf5a982cc7268b/vars/sendBenchmarks.groovy#L37-L39) relative path.
<img width="626" alt="image" src="https://user-images.githubusercontent.com/2871786/175493177-44d01390-f1b3-4de4-bf18-68ed9f56ae5c.png">

To help with, let's archive the file in the root directory instead


