### PR TITLE
make: Add BENCH_BENCHTIME and BENCH_COUNT to bench

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,11 @@ check-approvals: $(APPROVALS)
 check: $(MAGE) check-fmt check-headers
 	@$(MAGE) check
 
+BENCH_BENCHTIME?=100ms
+BENCH_COUNT?=1
 .PHONY: bench
 bench:
-	@$(GO) test -benchmem -run=XXX -benchtime=100ms -bench='.*' ./...
+	@$(GO) test -count=$(BENCH_COUNT) -benchmem -run=XXX -benchtime=$(BENCH_BENCHTIME) -bench='.*' ./...
 
 ##############################################################################
 # Rules for updating config files, etc.


### PR DESCRIPTION
## Motivation/summary

Adds two new variables `BENCH_BENCHTIME` and `BENCH_COUNT` to the bench
make target. This allows us to run the micro-benchmarks with different
parameters.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A
