### PR TITLE
ci: honour BENCH_COUNT with 5 for the benchmark

### DIFF
--- a/.ci/scripts/bench.sh
+++ b/.ci/scripts/bench.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-make bench | tee bench.out
+BENCH_COUNT=5 make bench | tee bench.out


### PR DESCRIPTION
## Motivation/summary

As discussed in https://github.com/elastic/apm-pipeline-library/pull/1748

let's honour the BENCH_COUNT variable as it was added in https://github.com/elastic/apm-server/pull/8472/files

### Test

It ran as expected in the CI 
<img width="572" alt="image" src="https://user-images.githubusercontent.com/2871786/175916465-bfbc8222-97ab-4d34-90a5-436c49add53c.png">
