### PR TITLE
magefile: build x-pack/apm-server

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -68,6 +68,7 @@ func init() {
 // Build builds the Beat binary.
 func Build() error {
 	args := mage.DefaultBuildArgs()
+	args.InputFiles = []string{"./x-pack/apm-server"}
 	args.Name += "-" + mage.Platform.GOOS + "-" + mage.Platform.Arch
 	args.OutputDir = "build"
 	args.CGO = false


### PR DESCRIPTION
## Motivation/summary

Fix `Build` mage target to build `x-pack/apm-server`. Also, use `make apm-server` to build the binary in system tests, to ensure there are no discrepancies between what we test and what we package.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

Create an ESS deployment with Integrations Server, ensure APM Server becomes healthy.

## Related issues

Closes https://github.com/elastic/apm-server/issues/8426
Closes https://github.com/elastic/fleet-server/issues/1574