### PR TITLE
testing/ec_deployment: Fix apm_secret_token

### DIFF
--- a/testing/benchmark/main.tf
+++ b/testing/benchmark/main.tf
@@ -14,12 +14,12 @@ terraform {
 
 locals {
   ci_tags = {
-      environment  = var.ENVIRONMENT
-      repo         = var.REPO
-      branch       = var.BRANCH
-      build        = var.BUILD_ID
-      created_date = var.CREATED_DATE
-    }
+    environment  = var.ENVIRONMENT
+    repo         = var.REPO
+    branch       = var.BRANCH
+    build        = var.BUILD_ID
+    created_date = var.CREATED_DATE
+  }
 }
 
 provider "ec" {}
@@ -68,6 +68,6 @@ module "benchmark_worker" {
   apmbench_bin_path = var.apmbench_bin_path
   instance_type     = var.worker_instance_type
 
-  public_key        = var.public_key
-  private_key       = var.private_key
+  public_key  = var.public_key
+  private_key = var.private_key
 }

--- a/testing/infra/terraform/modules/ec_deployment/.gitignore
+++ b/testing/infra/terraform/modules/ec_deployment/.gitignore
@@ -1,3 +1,2 @@
 scripts/enable_expvar.sh
 scripts/secret_token.sh
-secret_token.json

--- a/testing/infra/terraform/modules/ec_deployment/deployment.tf
+++ b/testing/infra/terraform/modules/ec_deployment/deployment.tf
@@ -143,7 +143,12 @@ resource "null_resource" "secret_token" {
   }
 }
 
-data "local_file" "secret_token" {
-  depends_on = [null_resource.secret_token]
-  filename = "${path.module}/secret_token.json"
+# Since the secret token value is set in the APM Integration policy, we need
+# an "external" resource to run a shell script that returns the secret token
+# as {"value":"SECRET_TOKEN"}.
+data "external" "secret_token" {
+  count       = var.integrations_server ? 1 : 0
+  depends_on  = [local_file.secret_token]
+  program     = ["/bin/bash", "-c", "scripts/secret_token.sh"]
+  working_dir = path.module
 }

--- a/testing/infra/terraform/modules/ec_deployment/outputs.tf
+++ b/testing/infra/terraform/modules/ec_deployment/outputs.tf
@@ -14,7 +14,7 @@ output "apm_url" {
 }
 
 output "apm_secret_token" {
-  value       = var.integrations_server ? jsondecode(data.local_file.secret_token.content).secret_token : ec_deployment.deployment.apm_secret_token
+  value       = var.integrations_server ? data.external.secret_token.0.result.value : ec_deployment.deployment.apm_secret_token
   sensitive   = true
   description = "The APM Secret token"
 }

--- a/testing/infra/terraform/modules/ec_deployment/scripts/secret_token.tftpl
+++ b/testing/infra/terraform/modules/ec_deployment/scripts/secret_token.tftpl
@@ -6,4 +6,4 @@ KIBANA_AUTH=elastic:${elastic_password}
 SECRET_TOKEN=$(curl -s -u $${KIBANA_AUTH} $${KIBANA_ENDPOINT} $${KIBANA_ENDPOINT} |\
     jq -r '.item | select(.inputs[].policy_template == "apmserver") .inputs[].vars.secret_token.value' | uniq)
 
-echo "{\"secret_token\":\"$${SECRET_TOKEN}\"}" > secret_token.json
+echo "{\"value\":\"$${SECRET_TOKEN}\"}"

--- a/testing/infra/terraform/modules/ec_deployment/terraform.tf
+++ b/testing/infra/terraform/modules/ec_deployment/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = ">=0.4.0"
+      version = ">=0.4.1"
     }
   }
 }


### PR DESCRIPTION
## Motivation/summary

After #8376 got merged, the `ec_deployment` was broken if `integrations_
server=true` wasn't set on the module. Reading a local file that is
created during a terraform run for an output value didn't work. Instead,
use the "external" resource to run a program that returns a JSON output
and parse the secret_token from the APM Integration policy that way.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

1. `cd testing/benchmark`
2. `make`
3. `terraform output -raw apm_secret_token` returns a valid secret token

## Related issues

The benchmarks couldn't be run nightly.
