### PR TITLE
Add initial support of smoketests in CI

### DIFF
--- a/.ci/jobs/apm-server-smoketests-mbp.yml
+++ b/.ci/jobs/apm-server-smoketests-mbp.yml
@@ -1,6 +1,6 @@
 ---
 - job:
-    name: apm-server/smoke-tests
+    name: apm-server/smoke-tests-mbp
     display-name: APM Server Smoke Tests
     description: APM Server Smoke Tests
     project-type: multibranch

--- a/.ci/jobs/apm-server-smoketests-mbp.yml
+++ b/.ci/jobs/apm-server-smoketests-mbp.yml
@@ -1,0 +1,45 @@
+---
+- job:
+    name: apm-server/smoke-tests
+    display-name: APM Server Smoke Tests
+    description: APM Server Smoke Tests
+    project-type: multibranch
+    concurrent: true
+    script-path: .ci/smoke-tests.groovy
+    scm:
+    - github:
+        branch-discovery: no-pr
+        discover-pr-forks-strategy: merge-current
+        discover-pr-forks-trust: permission
+        discover-pr-origin: merge-current
+        discover-tags: false
+        head-filter-regex: '(main|7\.17|8\.\d+|PR-.*)'
+        notification-context: 'apm-server-smoketests'
+        repo: apm-server
+        repo-owner: elastic
+        credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken
+        ssh-checkout:
+          credentials: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+        build-strategies:
+        - regular-branches: true
+        - change-request:
+            ignore-target-only-changes: true
+        clean:
+          after: true
+          before: true
+        prune: true
+        shallow-clone: true
+        depth: 3
+        do-not-fetch-tags: true
+        submodule:
+          disable: false
+          recursive: true
+          parent-credentials: true
+          timeout: 100
+          reference-repo: /var/lib/jenkins/.git-references/apm-server.git
+        timeout: '15'
+        use-author: true
+        wipe-workspace: true
+        property-strategies:
+          all-branches:
+          - suppress-scm-triggering: true

--- a/.ci/smoke-tests.groovy
+++ b/.ci/smoke-tests.groovy
@@ -1,0 +1,70 @@
+#!/usr/bin/env groovy
+@Library('apm@current') _
+
+pipeline {
+  agent { label 'linux && immutable' }
+  environment {
+    REPO = 'apm-server'
+    BASE_DIR = "src/github.com/elastic/${env.REPO}"
+    AWS_ACCOUNT_SECRET = 'secret/observability-team/ci/elastic-observability-aws-account-auth'
+    EC_KEY_SECRET = 'secret/observability-team/ci/elastic-cloud/observability-pro'
+    TERRAFORM_VERSION = '1.2.3'
+
+    CREATED_DATE = "${new Date().getTime()}"
+  }
+
+  options {
+    timeout(time: 3, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '100', artifactNumToKeepStr: '30', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
+  }
+  parameters {
+    string(name: 'SMOKETEST_VERSIONS', defaultValue: 'latest', description: 'Run smoke tests using following APM versions')
+  }
+  stages {
+    stage('Checkout') {
+      options { skipDefaultCheckout() }
+      steps {
+        deleteDir()
+        gitCheckout(basedir: "${BASE_DIR}", shallow: false)
+      }
+    }
+
+    stage('Smoke Tests') {
+      options { skipDefaultCheckout() }
+      environment {
+        SSH_KEY = "./id_rsa_terraform"
+        TF_VAR_private_key = "./id_rsa_terraform"
+        TF_VAR_public_key = "./id_rsa_terraform.pub"
+        // cloud tags
+        TF_VAR_BUILD_ID = "${env.BUILD_ID}"
+        TF_VAR_ENVIRONMENT= 'ci'
+        TF_VAR_BRANCH = "${env.BRANCH_NAME.toLowerCase().replaceAll('[^a-z0-9-]', '-')}"
+        TF_VAR_REPO = "${REPO}"
+      }
+      steps {
+        dir ("${BASE_DIR}") {
+          withGoEnv() {
+            withTestClusterEnv {
+              sh(label: 'Run smoke tests', script: 'make smoketest')
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+def withTestClusterEnv(Closure body) {  
+  withAWSEnv(secret: "${AWS_ACCOUNT_SECRET}", version: "2.7.6") {
+    withTerraformEnv(version: "${TERRAFORM_VERSION}") {
+      withSecretVault(secret: "${EC_KEY_SECRET}", data: ['apiKey': 'EC_API_KEY'] ) {
+        body()
+      }
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: Adrien Mannocci <adrien.mannocci@elastic.co>

<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

* Implementation of smoke tests within the CI.

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## Related issues

Ref #8303
<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
