### PR TITLE
[automation] update elastic stack version for testing 8.2.4-e7c42e26

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       fleet-server: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.4-b7bb3a0c-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.4-e7c42e26-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -40,7 +40,7 @@ services:
       - "./testing/docker/elasticsearch/ingest-geoip:/usr/share/elasticsearch/config/ingest-geoip"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.2.4-b7bb3a0c-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.2.4-e7c42e26-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -61,7 +61,7 @@ services:
       - "./testing/docker/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml"
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:8.2.4-b7bb3a0c-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:8.2.4-e7c42e26-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Wed, 29 Jun 2022 05:14:48 GMT, release_branch:8.2, prefix:, end_time:Wed, 29 Jun 2022 09:39:00 GMT, manifest_version:2.1.0, version:8.2.4-SNAPSHOT, branch:8.2, build_id:8.2.4-e7c42e26, build_duration_seconds:15852]