### PR TITLE
Chore: retry benchmarks once when failed

### DIFF
--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -36,7 +36,10 @@ pipeline {
     }
 
     stage('Benchmarks') {
-      options { skipDefaultCheckout() }
+      options {
+        skipDefaultCheckout()
+        retry(1)
+      }
       environment {
         SSH_KEY = "./id_rsa_terraform"
         TF_VAR_private_key = "./id_rsa_terraform"


### PR DESCRIPTION
## Motivation/summary

Some low % of benchmark executions suffer of cloud connectivity issues.
The entire benchmark stage will be retried in event of any error
ESS and executor(EC2) instances will be recreated. 

TL;DR Added retry option to the benchmark job. If it's failed once - it will be retried. 

## How to test these changes
run it in jenkins
