### PR TITLE
ci: use baremetal for the microbenchmarking

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -421,12 +421,6 @@ pipeline {
           when {
             beforeAgent true
             allOf {
-              anyOf {
-                branch 'main'
-                branch pattern: '\\d+\\.\\d+', comparator: 'REGEXP'
-                branch pattern: 'v\\d?', comparator: 'REGEXP'
-                expression { return params.Run_As_Main_Branch }
-              }
               expression { return params.bench_ci }
               expression { return env.ONLY_DOCS == "false" }
             }
@@ -441,6 +435,11 @@ pipeline {
                 }
                 sendBenchmarks(file: "bench.out", index: "benchmark-server")
               }
+            }
+          }
+          post {
+            cleanup {
+              deleteDir()
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -416,7 +416,7 @@ pipeline {
         Finally archive the results.
         */
         stage('Benchmarking') {
-          agent { label 'linux && immutable' }
+          agent { label 'linux && metal' }
           options { skipDefaultCheckout() }
           when {
             beforeAgent true


### PR DESCRIPTION
## Motivation/summary

- Enable micro-benchmark on a PR basis
- Run on bare metals only
- Cleanup afterwards

## Issues

Discussed in https://github.com/elastic/apm-server/pull/8471