### PR TITLE
docs: clarify secret token create/update

### DIFF
--- a/docs/input-apm.asciidoc
+++ b/docs/input-apm.asciidoc
@@ -9,9 +9,11 @@
 
 Configure and customize APM integration settings directly in {kib}:
 
+// tag::edit-integration-settings[]
 . Open {kib} and navigate to **{fleet}**.
 . Under the **Agent policies** tab, select the policy you would like to configure.
 . Find the Elastic APM integration and select **Actions** > **Edit integration**.
+// end::edit-integration-settings[]
 
 [float]
 [[apm-input-general-settings]]

--- a/docs/secure-agent-communication.asciidoc
+++ b/docs/secure-agent-communication.asciidoc
@@ -219,10 +219,12 @@ as there is no way to prevent them from being publicly exposed.
 [[create-secret-token]]
 === Create a secret token
 
-// lint ignore fleet
-Define a secret token in the <<input-apm,APM integration settings>>.
-Alternatively, {ess} and {ece} deployments provision a secret token when the deployment is created.
-The secret token can be found and reset in the {ecloud} console under **Deployments** -- **APM & Fleet**.
+Create or update a secret token in {fleet}.
+
+include::./input-apm.asciidoc[tag=edit-integration-settings]
++
+. Navigate to **Agent authorization** > **Secret token** and set the value of your token.
+. Click **Save integration**. The APM Server will restart before the change takes effect.
 
 [[configure-secret-token]]
 [float]


### PR DESCRIPTION
## Summary

There are two methods for setting/resetting the APM secret token:

### Legacy/Standalone

A "reset token" button exists in the Elasticsearch Service UI on the APM & Fleet page:

<img width="304" alt="Screen Shot 2022-07-05 at 4 25 14 PM" src="https://user-images.githubusercontent.com/5618806/177433013-df70ddc3-b39a-422d-ab7f-9bdb6c389886.png">

This is documented [here](https://www.elastic.co/guide/en/apm/guide/8.3/secret-token-legacy.html#set-secret-token) and AFAICT doesn't need to be updated.

### APM integration

The APM secret token cannot be reset from the Elasticsearch Service UI—it must be reset in the integration settings. This PR updates the [APM integration docs](https://www.elastic.co/guide/en/apm/guide/8.3/secret-token.html#create-secret-token) to the following.

<img width="764" alt="Screen Shot 2022-07-05 at 4 20 56 PM" src="https://user-images.githubusercontent.com/5618806/177432933-11b56776-7165-4e99-b021-00c9b777e120.png">

## Related issues

* Closes https://github.com/elastic/apm/issues/656.