### PR TITLE
smoke: Add legacy ingest, ILM, template assertions

### DIFF
--- a/testing/smoke/basic_upgrade/basic-upgrade.sh
+++ b/testing/smoke/basic_upgrade/basic-upgrade.sh
@@ -12,7 +12,7 @@ MAJOR_VERSION=$(echo ${VERSION} | cut -d '.' -f1 )
 MINOR_VERSION=$(echo ${VERSION} | cut -d '.' -f2 )
 
 if [[ ${MAJOR_VERSION} -eq 7 ]]; then
-    ASSERT_EVENTS_FUNC=legacy_assert_events
+    ASSERT_EVENTS_FUNC=legacy_assertions
     LATEST_VERSION=$(curl -s --fail https://artifacts-api.elastic.co/v1/versions/${MAJOR_VERSION}.${MINOR_VERSION} | jq -r '.version.builds[0].version')
     PREV_LATEST_VERSION=$(echo ${MAJOR_VERSION}.${MINOR_VERSION}.$(( $(echo ${LATEST_VERSION} | cut -d '.' -f3) -1 )))
 elif [[ ${MAJOR_VERSION} -eq 8 ]]; then

--- a/testing/smoke/basic_upgrade/legacy-managed.sh
+++ b/testing/smoke/basic_upgrade/legacy-managed.sh
@@ -14,7 +14,7 @@ trap "terraform_destroy" EXIT
 terraform_apply ${LATEST_VERSION}
 healthcheck 1
 send_events
-legacy_assert_events ${LATEST_VERSION}
+legacy_assertions ${LATEST_VERSION}
 
 echo "-> Upgrading APM Server to managed mode"
 upgrade_managed ${LATEST_VERSION}

--- a/testing/smoke/basic_upgrade/standalone-major-managed.sh
+++ b/testing/smoke/basic_upgrade/standalone-major-managed.sh
@@ -16,7 +16,7 @@ trap "terraform_destroy" EXIT
 terraform_apply ${LATEST_VERSION}
 healthcheck 1
 send_events
-legacy_assert_events ${LATEST_VERSION}
+legacy_assertions ${LATEST_VERSION}
 
 terraform_apply ${NEXT_MAJOR_LATEST}
 healthcheck 1
@@ -26,5 +26,5 @@ data_stream_assert_events ${NEXT_MAJOR_LATEST}
 upgrade_managed ${NEXT_MAJOR_LATEST}
 healthcheck 1
 send_events
-Assert there are 2 instances of the same event, since we ingested data twice.
+# Assert there are 2 instances of the same event, since we ingested data twice.
 data_stream_assert_events ${NEXT_MAJOR_LATEST} 2


### PR DESCRIPTION
## Motivation/summary

Adds assertions for the legacy ingest pipelines, ILM policies and index
templates in the smoke tests.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

Run smoke tests.

## Related issues

Part of #8303
