### PR TITLE
ci: use the microbenchmarks-pool

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -416,11 +416,7 @@ pipeline {
         Finally archive the results.
         */
         stage('Benchmarking') {
-          // As long as the existing baremetal are not based on the same specs
-          // we use https://apm-ci.elastic.co/computer/worker-1225339/
-          // further context in https://github.com/elastic/apm-server/pull/8471
-          // agent { label 'linux && metal' }
-          agent { label 'worker-1225339' }
+          agent { label 'microbenchmarks-pool' }
           options { skipDefaultCheckout() }
           when {
             beforeAgent true


### PR DESCRIPTION
### What

From now on we will use the same CI workers for the micro-benchmarking

