### PR TITLE
Revert "ci: use the microbenchmarks-pool"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -416,7 +416,11 @@ pipeline {
         Finally archive the results.
         */
         stage('Benchmarking') {
-          agent { label 'microbenchmarks-pool' }
+          // As long as the existing baremetal are not based on the same specs
+          // we use https://apm-ci.elastic.co/computer/worker-1225339/
+          // further context in https://github.com/elastic/apm-server/pull/8471
+          // agent { label 'linux && metal' }
+          agent { label 'worker-1225339' }
           options { skipDefaultCheckout() }
           when {
             beforeAgent true


### PR DESCRIPTION
Reverts elastic/apm-server#8561 so the CI can run normally.