### PR TITLE
docs: correct default TLS support

### DIFF
--- a/docs/apm-input-settings.asciidoc
+++ b/docs/apm-input-settings.asciidoc
@@ -302,7 +302,7 @@ Supported protocol versions
 
 | (array) A list of allowed TLS protocol versions.
 
-*Default:* `["TLSv1.0", "TLSv1.1", "TLSv1.2"]`
+*Default:* `["TLSv1.1", "TLSv1.2", "TLSv1.3"]`
 // end::tls_supported_protocols-setting[]
 
 // =============================================================================


### PR DESCRIPTION
related to https://github.com/elastic/apm-server/issues/3453, seems to be have been lost along the way. @bmorelli25  - can you investigate how that might have happened?  Also, do you have a handy way to backport this all the way to 7.6.0?