### PR TITLE
smoketest: Add APM Integration assertions

### DIFF
--- a/testing/infra/terraform/modules/ec_deployment/README.md
+++ b/testing/infra/terraform/modules/ec_deployment/README.md
@@ -9,13 +9,14 @@ used to configure the module, please refer to the [EC Provider docs](https://reg
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_ec"></a> [ec](#requirement\_ec) | >=0.4.0 |
+| <a name="requirement_ec"></a> [ec](#requirement\_ec) | >=0.4.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_ec"></a> [ec](#provider\_ec) | 0.4.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | n/a |
 | <a name="provider_local"></a> [local](#provider\_local) | n/a |
 | <a name="provider_null"></a> [null](#provider\_null) | n/a |
 
@@ -30,13 +31,14 @@ used to configure the module, please refer to the [EC Provider docs](https://reg
 | [null_resource.enable_expvar](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.secret_token](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [ec_stack.deployment_version](https://registry.terraform.io/providers/elastic/ec/latest/docs/data-sources/stack) | data source |
+| [external_external.secret_token](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_apm_server_expvar"></a> [apm\_server\_expvar](#input\_apm\_server\_expvar) | Wether or not to enable APM Server's expvar endpoint. Defaults to true | `bool` | `true` | no |
-| <a name="input_apm_server_pprof"></a> [apm\_server\_pprof](#input\_apm\_server\_pprof) | Wether or not to enable APM Server's pprof endpoint. Defaults to true | `bool` | `true` | no |
+| <a name="input_apm_server_expvar"></a> [apm\_server\_expvar](#input\_apm\_server\_expvar) | Whether or not to enable APM Server's expvar endpoint. Defaults to true | `bool` | `true` | no |
+| <a name="input_apm_server_pprof"></a> [apm\_server\_pprof](#input\_apm\_server\_pprof) | Whether or not to enable APM Server's pprof endpoint. Defaults to true | `bool` | `true` | no |
 | <a name="input_apm_server_size"></a> [apm\_server\_size](#input\_apm\_server\_size) | Optional apm server instance size | `string` | `"1g"` | no |
 | <a name="input_apm_server_zone_count"></a> [apm\_server\_zone\_count](#input\_apm\_server\_zone\_count) | Optional apm server zone count | `number` | `1` | no |
 | <a name="input_deployment_name_prefix"></a> [deployment\_name\_prefix](#input\_deployment\_name\_prefix) | Optional ESS or ECE region. Defaults to GCP US West 2 (Los Angeles) | `string` | `"apmserver"` | no |
@@ -61,4 +63,5 @@ used to configure the module, please refer to the [EC Provider docs](https://reg
 | <a name="output_elasticsearch_url"></a> [elasticsearch\_url](#output\_elasticsearch\_url) | The secure Elasticsearch URL |
 | <a name="output_elasticsearch_username"></a> [elasticsearch\_username](#output\_elasticsearch\_username) | The Elasticsearch username |
 | <a name="output_kibana_url"></a> [kibana\_url](#output\_kibana\_url) | The secure Kibana URL |
+| <a name="output_stack_version"></a> [stack\_version](#output\_stack\_version) | The matching stack pack version from the provided stack\_version |
 <!-- END_TF_DOCS -->

--- a/testing/infra/terraform/modules/ec_deployment/outputs.tf
+++ b/testing/infra/terraform/modules/ec_deployment/outputs.tf
@@ -30,3 +30,8 @@ output "elasticsearch_password" {
   sensitive   = true
   description = "The Elasticsearch password"
 }
+
+output "stack_version" {
+  value       = data.ec_stack.deployment_version.version
+  description = "The matching stack pack version from the provided stack_version"
+}

--- a/testing/smoke/basic_upgrade/basic-upgrade.sh
+++ b/testing/smoke/basic_upgrade/basic-upgrade.sh
@@ -5,7 +5,7 @@ set -eo pipefail
 # Load common lib
 . $(git rev-parse --show-toplevel)/testing/smoke/lib.sh
 
-# Load all versions except SNAPSHOTS
+# Load the latest versions except SNAPSHOTS
 VERSIONS=$(curl -s --fail https://artifacts-api.elastic.co/v1/versions | jq -r -c '[.versions[] | select(. | endswith("-SNAPSHOT") | not)] | sort')
 
 VERSION=${1}
@@ -21,9 +21,11 @@ if [[ ${MAJOR_VERSION} -eq 7 ]]; then
     LATEST_VERSION=$(curl -s --fail https://artifacts-api.elastic.co/v1/versions/${MAJOR_VERSION}.${MINOR_VERSION} | jq -r '.version.builds[0].version')
     PREV_LATEST_VERSION=$(echo ${MAJOR_VERSION}.${MINOR_VERSION}.$(( $(echo ${LATEST_VERSION} | cut -d '.' -f3) -1 )))
 elif [[ ${MAJOR_VERSION} -eq 8 ]]; then
-    ASSERT_EVENTS_FUNC=data_stream_assert_events
+    ASSERT_EVENTS_FUNC=data_stream_assertions
     LATEST_VERSION=$(echo ${VERSIONS} | jq -r "[.[] | select(. | contains(\"${VERSION}\"))] | last")
-    PREV_LATEST_VERSION=$(echo ${VERSIONS} | jq -r "[.[] | select(. | contains(\"$(echo ${MAJOR_VERSION}.$(( ${MINOR_VERSION} -1 )))\"))] | last")
+    # https://artifacts-api.elastic.co/v1/versions only provides the last two
+    # major versions and minor versions. For that reason, we use a regex.
+    PREV_LATEST_VERSION=$(echo "${MAJOR_VERSION}.$(( ${MINOR_VERSION} -1 )).[0-9]?([0-9])\$")
     INTEGRATIONS_SERVER=true
 else
     echo "version ${VERSION} not supported"
@@ -43,10 +45,10 @@ trap "terraform_destroy" EXIT
 terraform_apply ${PREV_LATEST_VERSION} ${INTEGRATIONS_SERVER}
 healthcheck 1
 send_events
-${ASSERT_EVENTS_FUNC} ${PREV_LATEST_VERSION}
+${ASSERT_EVENTS_FUNC} ${STACK_VERSION}
 
-echo "-> Upgrading APM Server to ${LATEST_VERSION}"
+echo "-> Upgrading APM Server from ${STACK_VERSION} to ${LATEST_VERSION}"
 terraform_apply ${LATEST_VERSION} ${INTEGRATIONS_SERVER}
 healthcheck 1
 send_events
-${ASSERT_EVENTS_FUNC} ${LATEST_VERSION}
+${ASSERT_EVENTS_FUNC} ${STACK_VERSION}

--- a/testing/smoke/basic_upgrade/legacy-managed.sh
+++ b/testing/smoke/basic_upgrade/legacy-managed.sh
@@ -20,4 +20,4 @@ echo "-> Upgrading APM Server to managed mode"
 upgrade_managed ${LATEST_VERSION}
 healthcheck 1
 send_events
-data_stream_assert_events ${LATEST_VERSION}
+data_stream_assertions ${LATEST_VERSION}

--- a/testing/smoke/basic_upgrade/main.tf
+++ b/testing/smoke/basic_upgrade/main.tf
@@ -71,3 +71,8 @@ output "elasticsearch_password" {
   sensitive   = true
   description = "The Elasticsearch password"
 }
+
+output "stack_version" {
+  value       = module.ec_deployment.stack_version
+  description = "The matching stack pack version from the provided stack_version"
+}

--- a/testing/smoke/basic_upgrade/standalone-major-managed.sh
+++ b/testing/smoke/basic_upgrade/standalone-major-managed.sh
@@ -23,10 +23,10 @@ legacy_assertions ${LATEST_VERSION}
 terraform_apply ${NEXT_MAJOR_LATEST}
 healthcheck 1
 send_events
-data_stream_assert_events ${NEXT_MAJOR_LATEST}
+data_stream_assertions ${NEXT_MAJOR_LATEST}
 
 upgrade_managed ${NEXT_MAJOR_LATEST}
 healthcheck 1
 send_events
 # Assert there are 2 instances of the same event, since we ingested data twice.
-data_stream_assert_events ${NEXT_MAJOR_LATEST} 2
+data_stream_assertions ${NEXT_MAJOR_LATEST} 2

--- a/testing/smoke/lib.sh
+++ b/testing/smoke/lib.sh
@@ -246,17 +246,11 @@ data_stream_assert_pipelines() {
     # NOTE(marclop) we could assert that the pipelines have some sort of version suffix
     # in their name, however, the APM package version may not equal the deployment version.
     echo "-> Asserting ingest pipelines..."
-    local SUCCESS=true
     local RESPONSE=$(elasticsearch_curl '/_ingest/pipeline/*apm*')
     local HAS_APM_PIPELINES=$(echo ${RESPONSE} | jq -r '.|length>0')
     if [[ ${HAS_APM_PIPELINES} != true ]]; then
-        SUCCESS=false
         echo "-> Did not find any APM ingest pipelines"
         echo ${RESPONSE}
-    fi
-
-    if [[ ${SUCCESS} == false ]]; then
-        echo "-> Failed asserting ingest pipelines"
         return 31
     fi
 }


### PR DESCRIPTION
## Motivation/summary

Adds the remaining assertions for the assets which are created by fleet
from the APM Integration (or APM package). It includes:

- Component templates and ILM Policies (these two are performed together
  since they are very closely tied).
- Ingest pipelines.

It also fixes the smoke tests which were previously broken since the
elastic artifacts API only returns the last few previous versions and
doesn't provide a comprehensive directory for all the released versions.
We now use a regex expression to match the previous minor latest patch
version (if 8.3.2 is the latest, then `8.2.latest` will be used).

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

1. Export credentials for ESS.
2. `make smoketest/all SMOKETEST_VERSIONS=7.17,latest`
3. Ensure the status code is 0.

## Related issues

Closes #8303 
