### PR TITLE
Add “Team:Docs” issues to obs-docs project

### DIFF
--- a/.github/workflows/add-to-docs-project.yml
+++ b/.github/workflows/add-to-docs-project.yml
@@ -1,0 +1,27 @@
+name: Add to obs-docs project
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  add_to_project:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'Team:Docs'}}
+    steps:
+      - uses: octokit/graphql-action@v2.x
+        id: add_to_project
+        with:
+          headers: '{"GraphQL-Features": "projects_next_graphql"}'
+          query: |
+            mutation add_to_project($projectid:ID!,$contentid:ID!) {
+              addProjectNextItem(input:{projectId:$projectid contentId:$contentid}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }
+          projectid: ${{ env.PROJECT_ID }}
+          contentid: ${{ github.event.issue.node_id }}
+        env:
+          PROJECT_ID: "PN_kwDOAGc3Zs0iZw"
+          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}


### PR DESCRIPTION
### Summary

Per conversation with Silvia, this PR adds issues labeled, `Team:Docs` to the Observability Docs project board.

One thing we might want to discuss is whether you still want documentation issues to be added to the APM Server team board. If no changes are made to the other workflow, `Team:Docs` issues will be added to both.