### PR TITLE
apmbench: Fix broken `-benchtime`

### DIFF
--- a/systemtest/benchtest/main.go
+++ b/systemtest/benchtest/main.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"flag"
 	"fmt"
 	"log"
 	"math"
@@ -143,6 +144,11 @@ func benchmarkFuncName(f BenchmarkFunc) (string, error) {
 // are all prefixed with "Benchmark", like those that are designed
 // to work with "go test".
 func Run(allBenchmarks ...BenchmarkFunc) error {
+	// Set flags in package testing.
+	testing.Init()
+	if err := flag.Set("test.benchtime", benchConfig.Benchtime.String()); err != nil {
+		return err
+	}
 	// Sets the http.DefaultClient.Transport.TLSClientConfig.InsecureSkipVerify
 	// to match the "-secure" flag value.
 	verifyTLS := loadgen.Config.Secure


### PR DESCRIPTION
## Motivation/summary

Fixes the `-benchtime` flag which has no effect currently (benchmarks
are currently only running for 1s, regardless of what is set in the
benchtime flag).

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

Run apmbench with a -benchtime of 1m and verify it runs for at least 1m. (set -warmup-events to 0 so there's no warmup).

## Related issues

Fixes the regression introduced by #8440.
