### PR TITLE
ci: Introduce schedule-everyday job for benchmarks

### DIFF
--- a/.ci/jobs/apm-server-schedule-everyday.yml
+++ b/.ci/jobs/apm-server-schedule-everyday.yml
@@ -1,0 +1,26 @@
+---
+- job:
+    name: apm-server/apm-server-schedule-everyday
+    display-name: Jobs scheduled everyday
+    description: Jobs scheduled everyday
+    project-type: pipeline
+    parameters:
+      - string:
+          name: branch_specifier
+          default: main
+          description: the Git branch specifier to build
+    pipeline-scm:
+      script-path: .ci/schedule-everyday.groovy
+      scm:
+        - git:
+            url: git@github.com:elastic/apm-server.git
+            refspec: +refs/heads/*:refs/remotes/origin/*
+            wipe-workspace: 'True'
+            name: origin
+            shallow-clone: true
+            credentials-id: f6c7695a-671e-4f4f-a331-acdce44ff9ba
+            reference-repo: /var/lib/jenkins/.git-references/apm-server.git
+            branches:
+              - $branch_specifier
+    triggers:
+      - timed: 'H H(3-4) * * *'

--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -23,7 +23,6 @@ pipeline {
         updateBeatsBuilds(branches: ['main', '8.<minor>', '8.<next-patch>', '7.<minor>'])
         runWindowsBuilds(branches: ['main', '8.<minor>', '8.<next-patch>', '7.<minor>'])
         runSmokeTests(branches: ['main'])
-        runBenchmarks(branches: ['main'])
       }
     }
   }
@@ -49,13 +48,6 @@ def runWindowsBuilds(Map args = [:]) {
             booleanParam(name: 'windows_ci', value: true)
           ],
           wait: false, propagate: false)
-  }
-}
-
-def runBenchmarks(Map args = [:]) {
-  def branches = getBranchesFromAliases(aliases: args.branches)
-  branches.each { branch ->
-    build(job: "apm-server/benchmarks/${branch}", wait: false, propagate: false)
   }
 }
 

--- a/.ci/schedule-everyday.groovy
+++ b/.ci/schedule-everyday.groovy
@@ -1,0 +1,39 @@
+@Library('apm@current') _
+
+pipeline {
+  agent none
+  environment {
+    NOTIFY_TO = credentials('notify-to')
+    PIPELINE_LOG_LEVEL = 'INFO'
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  triggers {
+    cron('H H(3-4) * * *')
+  }
+  stages {
+    stage('Nighly benchmarks') {
+      steps {
+        runBenchmarks(branches: ['main'])
+      }
+    }
+  }
+  post {
+    cleanup {
+      notifyBuildResult(prComment: false)
+    }
+  }
+}
+
+def runBenchmarks(Map args = [:]) {
+  def branches = getBranchesFromAliases(aliases: args.branches)
+  branches.each { branch ->
+    build(job: "apm-server/benchmarks/${branch}", wait: false, propagate: false)
+  }
+}


### PR DESCRIPTION
## Motivation/summary

Adds a new `schedule-everyday` job that is run every day (weekends too)
which is now responsible for scheduling the benchmarks. This is to allow
more data points for performance tracking purposes.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

??