### PR TITLE
benchmark: Add `BENCHMARK_MAX_RATE` tune warmup

### DIFF
--- a/systemtest/benchtest/main.go
+++ b/systemtest/benchtest/main.go
@@ -264,7 +264,7 @@ func warmup(agents int, events uint, url, token string) error {
 	close(errs)
 	var merr multierror.Errors
 	for err := range errs {
-		if err != nil {
+		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 			merr = append(merr, err)
 		}
 	}
@@ -289,6 +289,6 @@ func warmupTimeout(ingestRate float64, events uint, epm, agents, cpus int) time.
 	// the apmbench runner can do.
 	factor := math.Max(1, float64(agents)/float64(cpus))
 	timeoutSeconds := math.Max(float64(events)/ingestRate, 1) *
-		float64(agents) * factor
+		float64(agents*2) * factor
 	return time.Duration(math.Max(timeoutSeconds, 15)) * time.Second
 }

--- a/systemtest/benchtest/main_test.go
+++ b/systemtest/benchtest/main_test.go
@@ -123,7 +123,7 @@ func Test_warmupTimeout(t *testing.T) {
 				agents:     16,
 				cpus:       2,
 			},
-			expected: 128 * time.Second,
+			expected: 256 * time.Second,
 		},
 		{
 			name: "5000 events 500 agents",
@@ -133,7 +133,7 @@ func Test_warmupTimeout(t *testing.T) {
 				agents:     500,
 				cpus:       16,
 			},
-			expected: 78125 * time.Second,
+			expected: 156250 * time.Second,
 		},
 		{
 			name: "5000 events 500 agents with 8 cpus",
@@ -143,7 +143,7 @@ func Test_warmupTimeout(t *testing.T) {
 				agents:     500,
 				cpus:       8,
 			},
-			expected: 156250 * time.Second,
+			expected: 312500 * time.Second,
 		},
 		{
 			name: "50k events",
@@ -153,7 +153,7 @@ func Test_warmupTimeout(t *testing.T) {
 				agents:     1,
 				cpus:       16,
 			},
-			expected: 50 * time.Second,
+			expected: 100 * time.Second,
 		},
 		{
 			name: "default events 16 agents",
@@ -163,7 +163,7 @@ func Test_warmupTimeout(t *testing.T) {
 				agents:     16,
 				cpus:       16,
 			},
-			expected: 80 * time.Second,
+			expected: 160 * time.Second,
 		},
 		{
 			name: "default events 32 agents",
@@ -173,7 +173,7 @@ func Test_warmupTimeout(t *testing.T) {
 				agents:     32,
 				cpus:       16,
 			},
-			expected: 320 * time.Second,
+			expected: 640 * time.Second,
 		},
 		{
 			name: "default events 12000 epm (200/s) yields a bigger timeout",
@@ -184,7 +184,7 @@ func Test_warmupTimeout(t *testing.T) {
 				agents:     32,
 				cpus:       16,
 			},
-			expected: 1600 * time.Second,
+			expected: 3200 * time.Second,
 		},
 	}
 	for _, tt := range tests {

--- a/testing/benchmark/Makefile
+++ b/testing/benchmark/Makefile
@@ -4,13 +4,14 @@ APMBENCH_GOARCH ?= amd64
 
 TFVARS_SOURCE ?= terraform.tfvars.example
 
-BENCHMARK_WARMUP ?= 10000
+BENCHMARK_WARMUP ?= 40000
 BENCHMARK_AGENTS ?= 64
 BENCHMARK_COUNT ?= 3
 BENCHMARK_TIME ?= 2m
 BENCHMARK_RUN ?= Benchmark
 BENCHMARK_RESULT ?= benchmark-result.txt
 BENCHMARK_DETAILED ?= true
+BENCHMARK_MAX_RATE ?= 0epm
 
 GOBENCH_INDEX ?= apmbench-v2
 GOBENCH_USERNAME ?= admin
@@ -67,8 +68,8 @@ destroy:
 	@terraform destroy -auto-approve
 
 .PHONY: log-benckmark-profile
-log-benckmark-profile: 
-	@echo "Starting benchmarks..."	
+log-benckmark-profile:
+	@echo "Starting benchmarks..."
 	@echo "Benchmark warmup events: $(BENCHMARK_WARMUP)"
 	@echo "Benchmarks count: $(BENCHMARK_COUNT)"
 	@echo "Benchmark duration: $(BENCHMARK_TIME)"
@@ -78,7 +79,7 @@ log-benckmark-profile:
 run-benchmark: log-benckmark-profile
 	@ssh $(SSH_OPTS) -i $(SSH_KEY) $(SSH_USER)@$(WORKER_IP) ". .envrc && bin/apmbench -run='$(BENCHMARK_RUN)' \
 	-benchtime=$(BENCHMARK_TIME) -count=$(BENCHMARK_COUNT) -warmup-events=$(BENCHMARK_WARMUP) \
-	-agents=$(BENCHMARK_AGENTS) -detailed=$(BENCHMARK_DETAILED)" 2>&1 | tee $(BENCHMARK_RESULT)
+	-agents=$(BENCHMARK_AGENTS) -detailed=$(BENCHMARK_DETAILED) -max-rate=$(BENCHMARK_MAX_RATE)" 2>&1 | tee $(BENCHMARK_RESULT)
 
 .PHONY: index-benchmark-results
 index-benchmark-results: $(GOBENCH) _default-gobench-vars


### PR DESCRIPTION
## Motivation/summary

Adds a new `BENCHMARK_MAX_RATE` variable which defaults to `0eps` or
disabled max rate, tunes the `BENCHMARK_WARMUP` to `40,000` events to be
sent as the warmup to the APM Server (`10,000` was enough, but `40,000`
ensures that the CPU credts have been exhausted for a 1g deployment).

Also, modifies the warmup functon to not return an error on warmup
should the error be `context.DeadlineExceeded`, and adds more weight to
the number of agents specified.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

0. (export ess credentials)
1. `cd testing/benchmark`
2. `make all run-benchmark BENCHMARK_WARMUP=50000 BENCHMARK_MAX_RATE=5000eps BENCHMARK_TIME=30s BENCHMARK_COUNT=1`

## Related issues

Improvements while working on #7868
