### PR TITLE
smoketest: Add apm-ci link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://apm-ci.elastic.co/buildStatus/icon?job=apm-server/apm-server-mbp/main)](https://apm-ci.elastic.co/job/apm-server/job/apm-server-mbp/view/change-requests/job/main/)
+[![Smoke Tests](https://apm-ci.elastic.co/buildStatus/icon?job=apm-server/smoke-tests-mbp/main&subject=smoke%20tests)](https://apm-ci.elastic.co/job/apm-server/job/smoke-tests-mbp/job/main/)
 
 # APM Server
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -147,7 +147,8 @@ be configured to use an ECE installation) with some light bash scripting which i
 and upgrades, but ensures there aren't any major problems with APM Server accepting and indexing events where
 it should.
 
-The smoke tests can be found under [`testing/smoke`](./testing/smoke)
+The smoke tests can be found under [`testing/smoke`](./testing/smoke) and the latest CI runs can be found in
+the [APM CI dashboard](https://ela.st/apm-server-smoke-tests).
 
 ## Manual testing
 


### PR DESCRIPTION
## Motivation/summary

Adds the apm-ci link in the `TESTING.md` and `README.md` build badge.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~
