### PR TITLE
model: clone labels before sanitizing

### DIFF
--- a/model/labels.go
+++ b/model/labels.go
@@ -24,14 +24,25 @@ import (
 )
 
 // Label keys are sanitized, replacing the reserved characters '.', '*' and '"'
-// with '_'. Null-valued labels are omitted.
+// with '_'. Null-valued labels are omitted. Labels must not be mutated, as it
+// may be shared by multiple events; if sanitization is required, a new map
+// will be returned.
 func sanitizeLabels(labels common.MapStr) common.MapStr {
+	cloned := false
 	for k, v := range labels {
 		if v == nil {
+			if !cloned {
+				labels = labels.Clone()
+				cloned = true
+			}
 			delete(labels, k)
 			continue
 		}
 		if k2 := sanitizeLabelKey(k); k != k2 {
+			if !cloned {
+				labels = labels.Clone()
+				cloned = true
+			}
 			delete(labels, k)
 			labels[k2] = v
 		}


### PR DESCRIPTION
## Motivation/summary

If an agent sends global labels, then events without event-specific labels will share the same map of global labels. If those global labels need sanitisation, then the server may panic due to concurrently modifying/reading the map. To prevent this, clone the labels map if sanitisation is required.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~ to be added at release time, to avoid updating live docs
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

Send a continuous stream of events with global labels that require sanitisation (e.g. a label key with a dot in it), and no event-specific labels. The server should not panic.

## Related issues

Closes https://github.com/elastic/apm-server/issues/8651