### PR TITLE
Correct smoketests running in the CI

### DIFF
--- a/.ci/smoke-tests.groovy
+++ b/.ci/smoke-tests.groovy
@@ -53,11 +53,7 @@ pipeline {
                 def smokeTests = sh(returnStdout: true, script: 'make smoketest/discover').trim().split('\r?\n')
                 def smokeTestJobs = [:]
                 for (smokeTest in smokeTests) {
-                  smokeTestJobs["Run smoke tests in ${smokeTest}"] = {
-                    stage("Run smoke tests in ${smokeTest}") {
-                      sh(label: 'Run smoke tests', script: "make smoketest/run TEST_DIR=${smokeTest}")
-                    }
-                  }
+                  smokeTestJobs["Run smoke tests in ${smokeTest}"] = runSmokeTest(smokeTest)
                 }
                 parallel smokeTestJobs
               }
@@ -76,6 +72,14 @@ pipeline {
           }
         }
       }
+    }
+  }
+}
+
+def runSmokeTest(String testDir) {
+  return {
+    stage("Run smoke tests in ${testDir}") {
+      sh(label: 'Run smoke tests', script: "make smoketest/run TEST_DIR=${testDir}")
     }
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,7 @@ SMOKETEST_DIRS = $$(find $(CURRENT_DIR)/testing/smoke -mindepth 1 -maxdepth 1 -t
 
 .PHONY: smoketest/discover
 smoketest/discover:
-	@echo $(SMOKETEST_DIRS)
+	@echo "$(SMOKETEST_DIRS)"
 
 .PHONY: smoketest/run
 smoketest/run:


### PR DESCRIPTION
Signed-off-by: Adrien Mannocci <adrien.mannocci@elastic.co>

## Motivation/summary

Correct the smoke tests Jenkins job to be able to run smoke tests in // in the CI.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

* Run the associated Jenkins job.

## Related issues

#8638
