### PR TITLE
ci: enable github actions for macos

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
     booleanParam(name: 'Run_As_Main_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on main branch.')
     booleanParam(name: 'arm_ci', defaultValue: true, description: 'Enable ARM build')
     booleanParam(name: 'linux_ci', defaultValue: true, description: 'Enable Linux build')
-    booleanParam(name: 'osx_ci', defaultValue: true, description: 'Enable OSX CI')
+    booleanParam(name: 'osx_ci', defaultValue: false, description: 'Enable OSX CI')
     booleanParam(name: 'windows_ci', defaultValue: false, description: 'Enable Windows CI')
     booleanParam(name: 'intake_ci', defaultValue: true, description: 'Enable test')
     booleanParam(name: 'test_ci', defaultValue: true, description: 'Enable test')

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,8 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
-      path: $BASE_DIR
+      with:
+        path: $BASE_DIR
     - name: Fetch Go version from .go-version
       run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,11 +8,15 @@ on:
       - 7.1*
       - 8.*
 
+env:
+  BASE_DIR: src/github.com/elastic/apm-server
+
 jobs:
   macos:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
+      path: $BASE_DIR
     - name: Fetch Go version from .go-version
       run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v2
@@ -21,6 +25,10 @@ jobs:
     - name: Install dependencies
       run:  go get -u github.com/magefile/mage
     - name: Run build
-      run: WORKSPACE=$GITHUB_WORKSPACE .ci/scripts/build.sh
+      run: |-
+        cd $BASE_DIR
+        WORKSPACE=$GITHUB_WORKSPACE .ci/scripts/build.sh
     - name: Run test
-      run: WORKSPACE=$GITHUB_WORKSPACE .ci/scripts/unit-test.sh
+      run: |-
+        cd $BASE_DIR
+        WORKSPACE=$GITHUB_WORKSPACE .ci/scripts/unit-test.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,26 @@
+name: macos
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - 7.1*
+      - 8.*
+
+jobs:
+  macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Fetch Go version from .go-version
+      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ env.GO_VERSION }}
+    - name: Install dependencies
+      run:  go get -u github.com/magefile/mage
+    - name: Run build
+      run: .ci/scripts/build.sh
+    - name: Run test
+      run: .ci/scripts/unit-test.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,16 +8,16 @@ on:
       - 7.1*
       - 8.*
 
-env:
-  BASE_DIR: src/github.com/elastic/apm-server
 
 jobs:
   macos:
     runs-on: macos-latest
+    env:
+      BASE_DIR: src/github.com/elastic/apm-server
     steps:
     - uses: actions/checkout@v3
       with:
-        path: $BASE_DIR
+        path: ${{ env.BASE_DIR }}
     - name: Fetch Go version from .go-version
       run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,6 +21,6 @@ jobs:
     - name: Install dependencies
       run:  go get -u github.com/magefile/mage
     - name: Run build
-      run: .ci/scripts/build.sh
+      run: WORKSPACE=$GITHUB_WORKSPACE .ci/scripts/build.sh
     - name: Run test
-      run: .ci/scripts/unit-test.sh
+      run: WORKSPACE=$GITHUB_WORKSPACE .ci/scripts/unit-test.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,12 +12,8 @@ on:
 jobs:
   macos:
     runs-on: macos-latest
-    env:
-      BASE_DIR: src/github.com/elastic/apm-server
     steps:
     - uses: actions/checkout@v3
-      with:
-        path: ${{ env.BASE_DIR }}
     - name: Fetch Go version from .go-version
       run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
@@ -26,5 +22,4 @@ jobs:
         cache: true
     - name: Run tests
       run: |-
-        cd $BASE_DIR
         go test -v ./...

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -32,4 +32,5 @@ jobs:
     - name: Run test
       run: |-
         cd $BASE_DIR
+        go get -u github.com/magefile/mage
         WORKSPACE=$GITHUB_WORKSPACE .ci/scripts/unit-test.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,14 +23,7 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}
-    - name: Install dependencies
-      run:  go get -u github.com/magefile/mage
-    - name: Run build
+    - name: Run tests
       run: |-
         cd $BASE_DIR
-        WORKSPACE=$GITHUB_WORKSPACE .ci/scripts/build.sh
-    - name: Run test
-      run: |-
-        cd $BASE_DIR
-        go get -u github.com/magefile/mage
-        WORKSPACE=$GITHUB_WORKSPACE .ci/scripts/unit-test.sh
+        go test -v ./...

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,9 +20,10 @@ jobs:
         path: ${{ env.BASE_DIR }}
     - name: Fetch Go version from .go-version
       run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
+        cache: true
     - name: Run tests
       run: |-
         cd $BASE_DIR


### PR DESCRIPTION
## Motivation/summary

Use GitHub actions for MacOS.

GitHub actions are SaaS so we don't need to worry about the MacOS workers but just use them

## Issue

A similar issue was done for beats in https://github.com/elastic/beats/pull/29032 and also disabled in the default CI controller in https://github.com/elastic/beats/pull/30591


## Follow ups

To export the telemetry data with -> https://github.com/elastic/beats/pull/32267 but to be done in the near future

