### PR TITLE
Fix Windows build

### DIFF
--- a/go.mk
+++ b/go.mk
@@ -16,11 +16,6 @@ TERRAFORMDOCS=$(GOOSBUILD)/terraform-docs
 GOBENCH=$(GOOSBUILD)/gobench
 APM_SERVER_VERSION=$(shell grep "const Version" $(GITROOT)/internal/version/version.go | cut -d'=' -f2 | tr -d '" ')
 
-# NOTE(axw) BEAT_VERSION is used by beats/dev-tools/mage in preference to
-# trying to read the version from cmd/version.go. This should not be used
-# for any other purpose; use APM_SERVER_VERSION instead.
-export BEAT_VERSION=$(APM_SERVER_VERSION)
-
 ##############################################################################
 # Rules for creating and installing build tools.
 ##############################################################################


### PR DESCRIPTION
## Motivation/summary

Revert back to reading apm-server version from a file, to fix the Windows build.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

None