### PR TITLE
8.4 branch creation version bump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ update-beats-docs: $(PYTHON)
 # Beats synchronisation.
 ##############################################################################
 
-BEATS_VERSION?=main
+BEATS_VERSION?=8.4
 BEATS_MODULE:=$(shell $(GO) list -m -f {{.Path}} all | grep github.com/elastic/beats)
 
 .PHONY: update-beats


### PR DESCRIPTION
## Motivation/summary
Bump `BEATS_VERSION` to `8.4` after branching out. 
