### PR TITLE
fix: minor fix in make clean command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ system-test:
 
 .PHONY:
 clean:
-	@rm -f build apm-server apm-server.exe
+	@rm -rf build apm-server apm-server.exe
 
 ##############################################################################
 # Checks/tests.


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

`make clean` is expected to remove a directory and files, the `-r` flag was missing from the command. 
<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## How to test these changes
run `make clean`
<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->
