### PR TITLE
.ci: don't notify of packaging failure on PRs

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -118,7 +118,7 @@ pipeline {
           }
           post {
             failure {
-              if (!isPR()) {
+              whenTrue(isBranch()) {
                 notifyStatus(subject: "[${env.REPO}@${env.BRANCH_NAME}] package failed.",
                              body: 'Contact the Productivity team [#observablt-robots] if you need further assistance.')
               }

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -118,8 +118,10 @@ pipeline {
           }
           post {
             failure {
-              notifyStatus(subject: "[${env.REPO}@${env.BRANCH_NAME}] package failed.",
-                           body: 'Contact the Productivity team [#observablt-robots] if you need further assistance.')
+              if (!isPR()) {
+                notifyStatus(subject: "[${env.REPO}@${env.BRANCH_NAME}] package failed.",
+                             body: 'Contact the Productivity team [#observablt-robots] if you need further assistance.')
+              }
             }
           }
         }


### PR DESCRIPTION
## Motivation/summary

Don't send notifications if packaging fails in a PR. Notifications are only relevant for branch builds; developers should check PR status directly.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

N/A