### PR TITLE
Add 8.4.0 changelog

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,4 +1,5 @@
 include::./changelogs/head.asciidoc[]
+include::./changelogs/8.4.asciidoc[]
 include::./changelogs/8.3.asciidoc[]
 include::./changelogs/8.2.asciidoc[]
 include::./changelogs/8.1.asciidoc[]

--- a/changelogs/8.4.asciidoc
+++ b/changelogs/8.4.asciidoc
@@ -1,0 +1,27 @@
+[[release-notes-8.4.0]]
+== APM version 8.4.0
+
+https://github.com/elastic/apm-server/compare/8.3\...8.4[View commits]
+
+[float]
+==== Breaking Changes
+- APM Server no longer crashes on an invalid tail-based sampling config; it
+  continues running TBS disabled {pull}8375[8375]
+
+[float]
+==== Deprecations
+
+[float]
+==== Bug fixes
+- Fix race for deducing destination service fields for OTel bridge {pull}8363[8363]
+- Fix processors receiving events even after the server has stopped {pull}8388[8388]
+
+[float]
+==== Intake API Changes
+
+[float]
+==== Added
+- Added support for `service.target.{type,name}` to be inferred from OpenTelemetry events {pull}8334[8334]
+- Added support for OpenTelemetry summary metrics {pull}7772[7772]
+- Upgraded bundled APM Java agent attacher CLI to version 1.32.0, which supports the `latest` version tag {pull}8374[8374]
+- Added `span.name` to `service_destination` metrics {pull}8391[8391]

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -1,26 +1,19 @@
 [[release-notes-head]]
 == APM version HEAD
 
-https://github.com/elastic/apm-server/compare/8.4\...main[View commits]
+https://github.com/elastic/apm-server/compare/8.5\...main[View commits]
 
 [float]
 ==== Breaking Changes
-- APM Server no longer crashes on an invalid tail-based sampling config; it
-  continues running TBS disabled {pull}8375[8375]
 
 [float]
 ==== Deprecations
 
 [float]
 ==== Bug fixes
-- Fix race for deducing destination service fields for OTel bridge {pull}8363[8363]
 
 [float]
 ==== Intake API Changes
 
 [float]
 ==== Added
-- Added support for `service.target.{type,name}` to be inferred from OpenTelemetry events {pull}8334[8334]
-- Added support for OpenTelemetry summary metrics {pull}7772[7772]
-- Upgraded bundled APM Java agent attacher CLI to version 1.32.0, which supports the `latest` version tag {pull}8374[8374]
-- Added `span.name` to `service_destination` metrics {pull}8391[8391]


### PR DESCRIPTION
Changelogs for 8.4.0, to be backported to 8.4 branch.

~The `changelogs/head.asciidoc` will be added by separate PR since it doesn't require backporting~ The elasticsearch-ci/docs step fails with missing head.asciidoc file