### PR TITLE
Handle ctx canceled as non fatal in apmsoak

### DIFF
--- a/systemtest/cmd/apmsoak/main.go
+++ b/systemtest/cmd/apmsoak/main.go
@@ -32,8 +32,10 @@ func main() {
 	flag.Parse()
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
 	if err := soaktest.RunBlocking(ctx); err != nil {
-		log.Fatal(err)
-		cancel()
+		if err != context.Canceled {
+			log.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
## Motivation/summary

Context cancel is a normal exit for `apmsoak`.

## Checklist

~~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~~
~~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~~
~~- [ ] Documentation has been updated~~

## How to test these changes

N/A

## Related issues

N/A
