### PR TITLE
feat: set a default User-Agent field value when making HTTP requests

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -17,3 +17,4 @@ https://github.com/elastic/apm-server/compare/8.5\...main[View commits]
 
 [float]
 ==== Added
+- Set a default User-Agent field value when making HTTP requests {pull}8758[8758]

--- a/internal/beater/server_test.go
+++ b/internal/beater/server_test.go
@@ -941,7 +941,8 @@ func TestServerElasticsearchOutput(t *testing.T) {
 	select {
 	case r := <-bulkCh:
 		userAgent := r.UserAgent()
-		assert.True(t, strings.HasPrefix(userAgent, "go-elasticsearch"), userAgent)
+		assert.True(t, strings.Contains(userAgent, "Elastic-APM-Server"), userAgent)
+		assert.True(t, strings.Contains(userAgent, "go-elasticsearch"), userAgent)
 	case <-time.After(10 * time.Second):
 		t.Fatal("timed out waiting for bulk request")
 	}

--- a/internal/elasticsearch/client.go
+++ b/internal/elasticsearch/client.go
@@ -125,7 +125,9 @@ func NewClientParams(args ClientParams) (Client, error) {
 		}
 	}
 
-	headers.Set("User-Agent", userAgent)
+	if headers.Get("User-Agent") == "" {
+		headers.Set("User-Agent", userAgent)
+	}
 
 	var apikey string
 	if args.Config.APIKey != "" {

--- a/internal/elasticsearch/client.go
+++ b/internal/elasticsearch/client.go
@@ -21,11 +21,13 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
 	"go.elastic.co/apm/module/apmelasticsearch/v2"
 
+	"github.com/elastic/apm-server/internal/version"
 	esv8 "github.com/elastic/go-elasticsearch/v8"
 	esapiv8 "github.com/elastic/go-elasticsearch/v8/esapi"
 	esutilv8 "github.com/elastic/go-elasticsearch/v8/esutil"
@@ -37,6 +39,8 @@ var retryableStatuses = []int{
 	http.StatusServiceUnavailable,
 	http.StatusGatewayTimeout,
 }
+
+var userAgent = fmt.Sprintf("Elastic-APM-Server/%s go-elasticsearch/%s", version.Version, esv8.Version)
 
 // Client is an interface designed to abstract away version differences between elasticsearch clients
 type Client interface {
@@ -114,13 +118,14 @@ func NewClientParams(args ClientParams) (Client, error) {
 		return nil, err
 	}
 
-	var headers http.Header
+	headers := make(http.Header, len(args.Config.Headers)+1)
 	if len(args.Config.Headers) > 0 {
-		headers = make(http.Header, len(args.Config.Headers))
 		for k, v := range args.Config.Headers {
 			headers.Set(k, v)
 		}
 	}
+
+	headers.Set("User-Agent", userAgent)
 
 	var apikey string
 	if args.Config.APIKey != "" {


### PR DESCRIPTION


<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Add the apm server version in the user agent and
a small test to verify the user agent is being used.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Closes https://github.com/elastic/apm-server/issues/8711
