### PR TITLE
.ci: fix apmpackage trigger condition

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -126,7 +126,7 @@ pipeline {
           when {
             allOf {
               // The apmpackage stage gets triggered as described in https://github.com/elastic/apm-server/issues/6970
-              changeset pattern: '(cmd/version.go|apmpackage/.*)', comparator: 'REGEXP'
+              changeset pattern: '(internal/version/.*|apmpackage/.*)', comparator: 'REGEXP'
               not { changeRequest() }
             }
           }


### PR DESCRIPTION
## Motivation/summary

The version file was recently moved from `cmd/version.go` to `internal/version/version.go`. We need to update the Jenkins pipeline to trigger packaging on changes to this file.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

N/A