### PR TITLE
Fix broken link to Docker getting started

### DIFF
--- a/docs/legacy/guide/quick-start-overview.asciidoc
+++ b/docs/legacy/guide/quick-start-overview.asciidoc
@@ -53,7 +53,7 @@ If you're interested in learning more about all of the APM features available,
 or running the Elastic stack on Docker in a production environment, see the following documentation:
 
 * {apm-server-ref-v}/running-on-docker.html[Running APM Server on Docker]
-* {stack-gs}/get-started-docker.html[Running the {stack} on Docker]
+* {stack-gs}/get-started-stack-docker.html[Running the {stack} on Docker]
 
 endif::[]
 // end::dev-environment[]


### PR DESCRIPTION
Fixes a broken link found in the "Bump version to 8.4" PR: https://github.com/elastic/docs/pull/2484

```
18:39:21 INFO:build_docs:Bad cross-document links:
18:39:21 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/guide/8.4/quick-start-overview.html contains broken links to:
18:39:21 INFO:build_docs:   - en/elastic-stack-get-started/8.4/get-started-docker.html
18:39:21 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/guide/current/quick-start-overview.html contains broken links to:
18:39:21 INFO:build_docs:   - en/elastic-stack-get-started/8.4/get-started-docker.html
```

I'm not sure if I've got the labels right so I'd appreciate any help. 🙏 