### PR TITLE
Fix link to Docker getting started

### DIFF
--- a/docs/legacy/guide/quick-start-overview.asciidoc
+++ b/docs/legacy/guide/quick-start-overview.asciidoc
@@ -53,7 +53,7 @@ If you're interested in learning more about all of the APM features available,
 or running the Elastic stack on Docker in a production environment, see the following documentation:
 
 * {apm-server-ref-v}/running-on-docker.html[Running APM Server on Docker]
-* {stack-gs}/get-started-stack-docker.html[Running the {stack} on Docker]
+* {ref}/docker.html#docker-compose-file[Running {es} and {kib} on Docker]
 
 endif::[]
 // end::dev-environment[]


### PR DESCRIPTION
This is a redo of #8791 because I botched it up the first time around (sorry!). :-)

Rel: https://github.com/elastic/apm-server/pull/8502 
