### PR TITLE
Fix usage of date cmd for unix systems in packaging

### DIFF
--- a/packaging.mk
+++ b/packaging.mk
@@ -22,7 +22,7 @@ build/LICENSE.txt: licenses/ELASTIC-LICENSE-2.0.txt
 export DOCKER_BUILDKIT=1
 
 DOCKER_BUILD_ARGS := \
-	--build-arg BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%Sz") \
+	--build-arg BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%S%z") \
 	--build-arg VCS_REF=$(GITCOMMIT)
 
 DOCKER_IMAGES := \

--- a/packaging.mk
+++ b/packaging.mk
@@ -22,7 +22,7 @@ build/LICENSE.txt: licenses/ELASTIC-LICENSE-2.0.txt
 export DOCKER_BUILDKIT=1
 
 DOCKER_BUILD_ARGS := \
-	--build-arg BUILD_DATE=$(shell date -u --iso-8601=seconds) \
+	--build-arg BUILD_DATE=$(shell date -u +"%Y-%m-%dT%H:%M:%Sz") \
 	--build-arg VCS_REF=$(GITCOMMIT)
 
 DOCKER_IMAGES := \


### PR DESCRIPTION
## Motivation/summary

`date` on MacOS doesn't support `--iso-8601` flag. Behaviour of changes in this PR:

```
# As per previous cmd
$ gdate -u --iso-8601=seconds                                             
2022-08-04T12:00:47+00:00

# As per new cmd
$ date -u +"%Y-%m-%dT%H:%M:%S%z"                                          
2022-08-04T12:01:24+0000
```

## Checklist

~~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~~
~~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~~
~~- [ ] Documentation has been updated~~

## How to test these changes
N/A

## Related issues

N/A