### PR TITLE
Handle wrapped ctx canceled errors for apmsoak

### DIFF
--- a/systemtest/cmd/apmsoak/main.go
+++ b/systemtest/cmd/apmsoak/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"log"
 	"os"
@@ -34,7 +35,7 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 	if err := soaktest.RunBlocking(ctx); err != nil {
-		if err != context.Canceled {
+		if !errors.Is(err, context.Canceled) {
 			log.Fatal(err)
 		}
 	}


### PR DESCRIPTION
Context cancel is a normal exit for apmsoak.