### PR TITLE
packaging: actually gzip docker tarballs

### DIFF
--- a/packaging.mk
+++ b/packaging.mk
@@ -51,7 +51,7 @@ $(DOCKER_IMAGE_RELEASE_TARBALLS):
 $(DOCKER_IMAGE_SNAPSHOT_TARBALLS):
 $(DISTDIR)/%-$(DOCKER_IMAGE_SUFFIX): build/docker/%.txt
 	@mkdir -p $(@D)
-	docker save -o $@ $(shell cat $<)
+	docker save $(shell cat $<) | gzip -c > $@
 
 ##############################################################################
 # Java agent attacher. Fetched from Maven and verified with the committed key.


### PR DESCRIPTION
## Motivation/summary

Fix docker-image.tar.gz targets to gzip the tarballs, not just name them gzipped tarballs.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

1. `make package-docker`
2. `cat build/distributions/apm-server-ubi8-8.5.0-docker-image.tar.gz | gunzip | docker load`

## Related issues

Closes https://github.com/elastic/apm-server/issues/8823