### PR TITLE
7.16-docs: Fixed image links in opentelemetry doc

### DIFF
--- a/docs/open-telemetry.asciidoc
+++ b/docs/open-telemetry.asciidoc
@@ -33,7 +33,7 @@ Elastic APM Server natively supports the OpenTelemetry protocol.
 This means trace data and metrics collected from your applications and infrastructure can
 be sent directly to Elastic APM Server using the OpenTelemetry protocol.
 
-image::./../legacy/guide/images/open-telemetry-protocol-arch.png[OpenTelemetry Elastic architecture diagram]
+image::./../docs/legacy/guide/images/open-telemetry-protocol-arch.png[OpenTelemetry Elastic architecture diagram]
 
 [float]
 [[instrument-apps-otel]]
@@ -183,7 +183,7 @@ In this example eCommerce OpenTelemetry dashboard, there are four visualizations
 KPI metrics, along with performance-related metrics.
 
 [role="screenshot"]
-image::./../legacy/guide/images/ecommerce-dashboard.png[OpenTelemetry visualizations]
+image::./../docs/legacy/guide/images/ecommerce-dashboard.png[OpenTelemetry visualizations]
 
 Let's look at how this dashboard was created, specifically the Sales USD and System load visualizations.
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

Links were pointing to wrong location, so https://www.elastic.co/guide/en/apm/guide/7.16/open-telemetry.html was not showing  images.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->
- [X] Documentation has been updated

