### PR TITLE
docs: add tech preview mutating webhook docs

### DIFF
--- a/docs/apm-mutating-webhook.asciidoc
+++ b/docs/apm-mutating-webhook.asciidoc
@@ -1,0 +1,4 @@
+// Pulls the APM mutating webhook docs from here:
+// https://github.com/elastic/apm-mutating-webhook/blob/main/docs/apm-mutating-webhook.asciidoc
+
+include::{apm-webhook-repo-dir}/apm-mutating-webhook.asciidoc[]

--- a/docs/features.asciidoc
+++ b/docs/features.asciidoc
@@ -14,6 +14,7 @@
 * <<cross-cluster-search>>
 * <<span-compression>>
 * <<monitoring-aws-lambda>>
+* <<apm-mutating-admission-webhook>>
 
 include::./apm-data-security.asciidoc[]
 
@@ -32,3 +33,5 @@ include::./cross-cluster-search.asciidoc[]
 include::./span-compression.asciidoc[]
 
 include::./aws-lambda-extension.asciidoc[leveloffset=+2]
+
+include::./apm-mutating-webhook.asciidoc[leveloffset=+2]

--- a/docs/integrations-index.asciidoc
+++ b/docs/integrations-index.asciidoc
@@ -3,9 +3,10 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 include::./notices.asciidoc[]
 
 :apm-integration-docs:
-:apm-package-dir:    {docdir}/apm-package
-:obs-repo-dir:       {observability-docs-root}/docs/en
+:apm-package-dir:        {docdir}/apm-package
+:obs-repo-dir:           {observability-docs-root}/docs/en
 :apm-aws-repo-dir:       {apm-aws-lambda-root}/docs
+:apm-webhook-repo-dir:   {apm-mutating-webhook-root}/docs
 
 :github_repo_link: https://github.com/elastic/apm-server/blob/v{version}
 ifeval::["{version}" == "8.0.0"]


### PR DESCRIPTION
### Summary

Adds APM mutating webhook documentation to the APM Guide. If you have content suggestions, please add them to https://github.com/elastic/apm-mutating-webhook/issues/37.

**[Preview this PR here](https://apm-server_8889.docs-preview.app.elstc.co/guide/en/apm/guide/master/apm-mutating-admission-webhook.html)**

### Related

* For https://github.com/elastic/apm-mutating-webhook/issues/37.