### PR TITLE
[automation] update elastic stack version for testing 8.4.0-b95305c2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       fleet-server: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-aff0df12-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0-b95305c2-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -40,7 +40,7 @@ services:
       - "./testing/docker/elasticsearch/ingest-geoip:/usr/share/elasticsearch/config/ingest-geoip"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.4.0-aff0df12-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.4.0-b95305c2-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -61,7 +61,7 @@ services:
       - "./testing/docker/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml"
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:8.4.0-aff0df12-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:8.4.0-b95305c2-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:
@@ -101,7 +101,7 @@ services:
       - "./build/packages/apm:/packages/local/apm"
 
   metricbeat:
-    image: docker.elastic.co/beats/metricbeat:8.4.0-aff0df12-SNAPSHOT
+    image: docker.elastic.co/beats/metricbeat:8.4.0-b95305c2-SNAPSHOT
     environment:
       ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'
       ELASTICSEARCH_USERNAME: "${KIBANA_ES_USER:-admin}"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Wed, 17 Aug 2022 00:15:47 GMT, release_branch:8.4, prefix:, end_time:Wed, 17 Aug 2022 05:18:36 GMT, manifest_version:2.1.0, version:8.4.0-SNAPSHOT, branch:8.4, build_id:8.4.0-b95305c2, build_duration_seconds:18169]