### PR TITLE
perf: refactor host:port extraction method to make it zero-allocation

### DIFF
--- a/internal/beater/request/context.go
+++ b/internal/beater/request/context.go
@@ -113,7 +113,7 @@ func (c *Context) Reset(w http.ResponseWriter, r *http.Request) {
 	c.Result.Reset()
 
 	if r != nil {
-		ip, port := netutil.ParseIPPort(netutil.MaybeSplitHostPort(r.RemoteAddr))
+		ip, port := netutil.SplitAddrPort(r.RemoteAddr)
 		c.SourceIP, c.ClientIP = ip, ip
 		c.SourcePort, c.ClientPort = int(port), int(port)
 		if ip, port := netutil.ClientAddrFromHeaders(r.Header); ip.IsValid() {

--- a/internal/model/modeldecoder/v2/decoder.go
+++ b/internal/model/modeldecoder/v2/decoder.go
@@ -312,9 +312,7 @@ func mapToCloudModel(from contextCloud, cloud *model.Cloud) {
 func mapToClientModel(from contextRequest, source *model.Source, client *model.Client) {
 	// http.Request.Headers and http.Request.Socket are only set for backend events.
 	if !source.IP.IsValid() {
-		ip, port := netutil.ParseIPPort(
-			netutil.MaybeSplitHostPort(from.Socket.RemoteAddress.Val),
-		)
+		ip, port := netutil.SplitAddrPort(from.Socket.RemoteAddress.Val)
 		source.IP, source.Port = ip, int(port)
 	}
 	if !client.IP.IsValid() {

--- a/internal/netutil/netutil.go
+++ b/internal/netutil/netutil.go
@@ -18,7 +18,6 @@
 package netutil
 
 import (
-	"net"
 	"net/http"
 	"net/netip"
 	"strconv"
@@ -54,11 +53,11 @@ func parseForwardedHeader(header http.Header) (netip.Addr, uint16) {
 		return netip.Addr{}, 0
 	}
 
-	return ParseIPPort(MaybeSplitHostPort(forwarded.For))
+	return SplitAddrPort(forwarded.For)
 }
 
 func parseXRealIP(header http.Header) (netip.Addr, uint16) {
-	return ParseIPPort(MaybeSplitHostPort(getHeader(header, "X-Real-Ip", "x-real-ip")))
+	return SplitAddrPort(getHeader(header, "X-Real-Ip", "x-real-ip"))
 }
 
 func parseXForwardedFor(header http.Header) (netip.Addr, uint16) {
@@ -66,7 +65,7 @@ func parseXForwardedFor(header http.Header) (netip.Addr, uint16) {
 		if sep := strings.IndexRune(xff, ','); sep > 0 {
 			xff = xff[:sep]
 		}
-		return ParseIPPort(MaybeSplitHostPort(strings.TrimSpace(xff)))
+		return SplitAddrPort(strings.TrimSpace(xff))
 	}
 	return netip.Addr{}, 0
 }
@@ -124,50 +123,64 @@ func parseForwarded(f string) forwardedHeader {
 				continue
 			}
 		}
-		switch strings.ToLower(key) {
-		case "for":
+		switch {
+		case strings.EqualFold(key, "for"):
 			result.For = value
-		case "host":
+		case strings.EqualFold(key, "host"):
 			result.Host = value
-		case "proto":
+		case strings.EqualFold(key, "proto"):
 			result.Proto = value
 		}
 	}
 	return result
 }
 
-// ParseIPPort parses h as an IP and, if successful and p is non-empty, p as a port.
-// If h cannot be parsed as an IP or p is non-empty and cannot be parsed as a port,
-// ParseIPPort will return (nil, 0). If p is empty, 0 will be returned for the port.
-func ParseIPPort(h, p string) (netip.Addr, uint16) {
-	ip, err := netip.ParseAddr(h)
-	if err != nil {
+// SplitAddrPort splits a network address of the form "host",
+// "host:port", "[host]:port" or "[host]:port" into a netip.Addr
+// and port.
+//
+// If input has no port, 0 will be returned for the port.
+// If input cannot be parsed or it is empty, (invalidip, 0) will
+// be returned.
+func SplitAddrPort(in string) (netip.Addr, uint16) {
+	if in == "" {
 		return netip.Addr{}, 0
 	}
-	if p == "" {
-		return ip, 0
-	}
-	port, err := strconv.ParseUint(p, 10, 16)
-	if err != nil {
-		return netip.Addr{}, 0
-	}
-	return ip, uint16(port)
-}
 
-// MaybeSplitHostPort returns the result of net.SplitHostPort if it
-// would return without an error, otherwise it returns (in, ""). This
-// can be used when splitting a string which may be either a host, or
-// host:port pair.
-func MaybeSplitHostPort(in string) (host, port string) {
-	if strings.LastIndexByte(in, ':') == -1 {
-		// In the common (relative to other "errors") case that
-		// there is no colon, we can avoid allocations by not
-		// calling SplitHostPort.
-		return in, ""
+	// IPv6
+	if strings.Count(in, ":") > 1 {
+		// If [ is missing, there is no port
+		if strings.Index(in, "[") == -1 {
+			if addr, err := netip.ParseAddr(in); err == nil {
+				return addr, 0
+			}
+
+			return netip.Addr{}, 0
+		}
+
+		// [host]:port
+		if addr, err := netip.ParseAddrPort(in); err == nil {
+			return addr.Addr(), addr.Port()
+		}
+
+		return netip.Addr{}, 0
 	}
-	host, port, err := net.SplitHostPort(in)
-	if err != nil {
-		return in, ""
+
+	// IPv4
+
+	// If : is missing, there is no port
+	if strings.Index(in, ":") == -1 {
+		if addr, err := netip.ParseAddr(in); err == nil {
+			return addr, 0
+		}
+
+		return netip.Addr{}, 0
 	}
-	return host, port
+
+	// host:port
+	if addr, err := netip.ParseAddrPort(in); err == nil {
+		return addr.Addr(), addr.Port()
+	}
+
+	return netip.Addr{}, 0
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Replace ParseIP+MaybeSplitHostPort with SplitAddrPort and make use of
the new netip package.
Avoid using net.SplitHostPort as it creates a string allocation.
Use EqualFold when parsing the Forwarded header to avoid lowercasing
the string and creating additional allocations.

Benchmarks:

```
name                                  old time/op    new time/op    delta
ContextReset/Forwarded_ipv4-16          2.47µs ± 2%    2.52µs ± 3%    +1.98%  (p=0.022 n=10+10)
ContextReset/Forwarded_ipv6-16          2.58µs ± 3%    2.54µs ± 1%    -1.22%  (p=0.020 n=10+10)
ContextReset/X-Real-IP_ipv4-16          2.47µs ± 2%    2.43µs ± 2%    -1.42%  (p=0.035 n=10+10)
ContextReset/X-Real-IP_ipv6-16          2.77µs ± 3%    2.49µs ± 2%    -9.93%  (p=0.000 n=10+10)
ContextReset/Remote_Addr_ipv4-16        2.63µs ± 4%    2.45µs ± 1%    -6.90%  (p=0.000 n=10+10)
ContextReset/Remote_Addr_ipv6-16        2.89µs ± 7%    2.46µs ± 1%   -14.78%  (p=0.000 n=10+10)
ContextReset/X-Forwarded-For_ipv4-16    2.73µs ± 4%    2.48µs ± 3%    -9.18%  (p=0.000 n=10+10)
ContextReset/X-Forwarded-For_ipv6-16    2.95µs ± 3%    2.52µs ± 2%   -14.47%  (p=0.000 n=10+9)

name                                  old alloc/op   new alloc/op   delta
ContextReset/Forwarded_ipv4-16           0.00B          0.00B           ~     (all equal)
ContextReset/Forwarded_ipv6-16           3.00B ± 0%     0.00B       -100.00%  (p=0.000 n=10+10)
ContextReset/X-Real-IP_ipv4-16           0.00B          0.00B           ~     (all equal)
ContextReset/X-Real-IP_ipv6-16           32.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
ContextReset/Remote_Addr_ipv4-16         48.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
ContextReset/Remote_Addr_ipv6-16         80.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
ContextReset/X-Forwarded-For_ipv4-16     48.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
ContextReset/X-Forwarded-For_ipv6-16     80.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)

name                                  old allocs/op  new allocs/op  delta
ContextReset/Forwarded_ipv4-16            0.00           0.00           ~     (all equal)
ContextReset/Forwarded_ipv6-16            1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
ContextReset/X-Real-IP_ipv4-16            0.00           0.00           ~     (all equal)
ContextReset/X-Real-IP_ipv6-16            1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
ContextReset/Remote_Addr_ipv4-16          1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
ContextReset/Remote_Addr_ipv6-16          2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
ContextReset/X-Forwarded-For_ipv4-16      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
ContextReset/X-Forwarded-For_ipv6-16      2.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
