### PR TITLE
release-docs: remove unnecessary steps

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -80,8 +80,6 @@ For patch releases, only the version on the existing major and minor version bra
 
 * A new [tag](https://github.com/elastic/apm-server/releases) will automatically be created on GitHub.
 
-* Bump the version in anticipation of the next release, e.g. [after 7.5.1 release](https://github.com/elastic/apm-server/pull/3045/files) bump to 7.5.2. Prepare this PR ahead of time, but only merge after release when pinged by the release manager.
-
 * Ensure that the `apmpackage` is released to production (supposed to change in `8.5`).
 
 ## When compatibility between Agents & Server changes


### PR DESCRIPTION
Opening this PR to discuss the need to create a PR post-release on the target branch in order to update hardcoded apm-server/elastic-stack versions.