### PR TITLE
systemtest: Fix apm-server log getter from test container

### DIFF
--- a/systemtest/containers.go
+++ b/systemtest/containers.go
@@ -566,7 +566,7 @@ func (c *ElasticAgentContainer) APMServerLog() (io.ReadCloser, error) {
 	return c.container.CopyFileFromContainer(
 		context.Background(), fmt.Sprintf(
 			"/usr/share/elastic-agent/state/data/logs/default/apm-server-%s-1.ndjson",
-			time.Now().Format("20060102"),
+			time.Now().UTC().Format("20060102"),
 		),
 	)
 }


### PR DESCRIPTION
I stumbled across this issue where APM-Server logs were not shown on an error of some systemtest even when the code expects them to be printed. After debugging, the root cause was that the docker container is using `UTC` timezone whereas the code which fetches the logs uses the machine's current local time.

I was also thinking maybe we can make APM-Server logs to be visible in `docker-logs` (maybe by configuring APM-Server run by elastic-agent to log to `stderr`?). Let me know what other @elastic/apm-server folks think about this. I can create an issue in the backlog if required.