### PR TITLE
fix update-apm package-storage

### DIFF
--- a/.ci/scripts/Makefile
+++ b/.ci/scripts/Makefile
@@ -5,7 +5,7 @@
 BUILD=../../build
 PACKAGE_STORAGE=.package-storage
 PACKAGE_STORAGE_PATH=$(BUILD)/$(PACKAGE_STORAGE)
-PACKAGE_STORAGE_BRANCH = $(eval PACKAGE_STORAGE_BRANCH := $$(shell date "+%Y%m%d%H%M%S"))$(PACKAGE_STORAGE_BRANCH)
+PACKAGE_STORAGE_BRANCH:=update-apm-$(shell date "+%Y%m%d%H%M%S")
 APM_SERVER_VERSION=$(shell make --no-print-directory -C ../../ get-version)
 REPO_PROJECT=elastic/package-storage
 BASE_BRANCH=snapshot

--- a/.ci/scripts/Makefile
+++ b/.ci/scripts/Makefile
@@ -23,7 +23,7 @@ package-storage-snapshot:
 ## create-package-storage-pull-request : Create the pull request for the package storage
 .PHONY: create-package-storage-pull-request
 create-package-storage-pull-request:
-	@cd $(PACKAGE_STORAGE_PATH) ; \
+	cd $(PACKAGE_STORAGE_PATH) ; \
 		echo "INFO: create branch" ; \
 		git checkout -b $(PACKAGE_STORAGE_BRANCH) ; \
 		echo "INFO: add files if any" ; \

--- a/.ci/scripts/Makefile
+++ b/.ci/scripts/Makefile
@@ -5,7 +5,7 @@
 BUILD=../../build
 PACKAGE_STORAGE=.package-storage
 PACKAGE_STORAGE_PATH=$(BUILD)/$(PACKAGE_STORAGE)
-PACKAGE_STORAGE_BRANCH=update-apm-$(shell date "+%Y%m%d%H%M%S")
+PACKAGE_STORAGE_BRANCH = $(eval PACKAGE_STORAGE_BRANCH := $$(shell date "+%Y%m%d%H%M%S"))$(PACKAGE_STORAGE_BRANCH)
 APM_SERVER_VERSION=$(shell make --no-print-directory -C ../../ get-version)
 REPO_PROJECT=elastic/package-storage
 BASE_BRANCH=snapshot

--- a/.ci/scripts/Makefile
+++ b/.ci/scripts/Makefile
@@ -7,6 +7,8 @@ PACKAGE_STORAGE=.package-storage
 PACKAGE_STORAGE_PATH=$(BUILD)/$(PACKAGE_STORAGE)
 PACKAGE_STORAGE_BRANCH=update-apm-$(shell date "+%Y%m%d%H%M%S")
 APM_SERVER_VERSION=$(shell make --no-print-directory -C ../../ get-version)
+REPO_PROJECT=elastic/package-storage
+BASE_BRANCH=snapshot
 
 ##############################################################################
 # Rules for the package-storage.
@@ -15,7 +17,7 @@ APM_SERVER_VERSION=$(shell make --no-print-directory -C ../../ get-version)
 .PHONY: package-storage-snapshot
 package-storage-snapshot:
 	@rm -fr $(PACKAGE_STORAGE_PATH)
-	git clone https://github.com/elastic/package-storage.git $(PACKAGE_STORAGE_PATH) --branch snapshot --single-branch --depth=1
+	git clone https://github.com/$(REPO_PROJECT).git $(PACKAGE_STORAGE_PATH) --branch $(BASE_BRANCH) --single-branch --depth=5
 	cp -rf $(BUILD)/packages/apm/$(APM_SERVER_VERSION) $(PACKAGE_STORAGE_PATH)/packages/apm/
 
 ## create-package-storage-pull-request : Create the pull request for the package storage
@@ -40,8 +42,9 @@ create-package-storage-pull-request:
 			--title "Publish apm-$(APM_SERVER_VERSION)" \
 			--body "Automated by $${BUILD_URL}" \
 			--label automation \
-			--base snapshot \
+			--base $(BASE_BRANCH) \
 			--head $(PACKAGE_STORAGE_BRANCH) \
+			--repo $(REPO_PROJECT) \
 			--reviewer elastic/apm-server || true ; \
 
 ## get-package-storage-location : Get the package storage location


### PR DESCRIPTION
### What

Set `PACKAGE_STORAGE_BRANCH` value only once.

### Why

Solves the issue with the automation for the package-store.

```
Creating pull request for update-apm-20220825154830 into snapshot in elastic/package-storage

pull request create failed: GraphQL: Head sha can't be blank, Base sha can't be blank, No commits between snapshot and update-apm-20220825154830, Head ref must be a branch (createPullRequest)
```

https://github.com/elastic/package-storage/pull/5414 was automatically created.
