### PR TITLE
docs: add oTel to getting started

### DIFF
--- a/docs/legacy/tab-widgets/install-agents-widget.asciidoc
+++ b/docs/legacy/tab-widgets/install-agents-widget.asciidoc
@@ -65,6 +65,13 @@
         tabindex="-1">
       RUM
     </button>
+    <button role="tab"
+        aria-selected="false"
+        aria-controls="otel-tab-install"
+        id="otel-install"
+        tabindex="-1">
+      OpenTelemetry
+    </button>
   </div>
   <div tabindex="0"
        role="tabpanel"
@@ -161,6 +168,20 @@ include::install-agents.asciidoc[tag=ruby]
 ++++
 
 include::install-agents.asciidoc[tag=rum]
+
+++++
+  </div>
+  <div tabindex="0"
+      role="tabpanel"
+      id="otel-tab-install"
+      aria-labelledby="otel-install"
+      hidden="">
+++++
+
+include::../../open-telemetry.asciidoc[tag=otel-get-started]
+
+Additional boostrap code may be required.
+See the {apm-guide-ref}/open-telemetry.html[Elastic OpenTelemetry guide] for more information, configuration options, and limitations of this feature.
 
 ++++
   </div>

--- a/docs/open-telemetry.asciidoc
+++ b/docs/open-telemetry.asciidoc
@@ -36,14 +36,16 @@ image::./legacy/guide/images/open-telemetry-protocol-arch.png[OpenTelemetry Elas
 
 [float]
 [[instrument-apps-otel]]
-====== Instrument applications
+===== Instrument applications
 
-To export traces and metrics to APM Server, ensure that you have instrumented your services and applications
-with the OpenTelemetry API, SDK, or both. For example, if you are a Java developer, you need to instrument your Java app using the
+// tag::otel-get-started[]
+To export traces and metrics to APM Server, instrument your services and applications
+with the OpenTelemetry API, SDK, or both. For example, if you are a Java developer, you need to instrument your Java app with the
 https://github.com/open-telemetry/opentelemetry-java-instrumentation[OpenTelemetry agent for Java].
+See the https://opentelemetry.io/docs/instrumentation/[OpenTelemetry Instrumentation guides] to download the
+OpenTelemetry Agent or SDK for your language.
 
-By defining the following environment variables, you can configure the OTLP endpoint so that the OpenTelemetry agent communicates with
-APM Server.
+Define the following environment variables to configure the OpenTelemetry agent and enable communication with Elastic APM.
 
 [source,bash]
 ----
@@ -59,19 +61,22 @@ java -javaagent:/path/to/opentelemetry-javaagent-all.jar \
 
 |===
 
-| `OTEL_RESOURCE_ATTRIBUTES` | Fields that describe the service and the environment that the service runs in. See <<open-telemetry-resource-attributes>> for more information.
+| `OTEL_RESOURCE_ATTRIBUTES` | Fields that describe the service and the environment that the service runs in. See
+{apm-guide-ref}/open-telemetry.html#open-telemetry-resource-attributes[Resource attributes] for more information.
 
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | APM Server URL. The host and port that APM Server listens for events on.
 
 | `OTEL_EXPORTER_OTLP_HEADERS` | Authorization header that includes the Elastic APM Secret token or API key: `"Authorization=Bearer an_apm_secret_token"` or `"Authorization=ApiKey an_api_key"`.
 
-For information on how to format an API key, see our <<api-key,API key>> docs.
+For information on how to format an API key, see
+{apm-guide-ref}/api-key.html[API keys].
 
 Please note the required space between `Bearer` and `an_apm_secret_token`, and `APIKey` and `an_api_key`.
 
 | `OTEL_EXPORTER_OTLP_CERTIFICATE` | The trusted certificate used to verify the TLS credentials of the client. (optional)
 
 |===
+// end::otel-get-started[]
 
 You are now ready to collect traces and <<open-telemetry-collect-metrics,metrics>> before <<open-telemetry-verify-metrics,verifying metrics>>
 and <<open-telemetry-visualize,visualizing metrics>> in {kib}.


### PR DESCRIPTION
### Summary

This PR adds an OpenTelemetry tab to [Step 4: Install APM agents](http://localhost:8000/guide/deploy-agent-to-send-data.html#add-apm-integration-agents) of our getting started guide:

<img width="717" alt="Screen Shot 2022-08-29 at 9 07 01 PM" src="https://user-images.githubusercontent.com/5618806/187347161-68197953-5a0a-4afd-9d09-918bc51a82dc.png">

The content of the new OpenTelemetry tab is single-sourced directly from our [OpenTelemetry instrumentation docs](https://www.elastic.co/guide/en/apm/guide/current/open-telemetry.html#instrument-apps-otel). I reworked the docs a bit to be useful in both locations and better match the in-product tutorial added in https://github.com/elastic/kibana/issues/133383.

* Closes https://github.com/elastic/observability-docs/issues/2061.