### PR TITLE
fleetctl: add command for setting arbitrary config

### DIFF
--- a/systemtest/cmd/fleetctl/README.md
+++ b/systemtest/cmd/fleetctl/README.md
@@ -15,3 +15,10 @@ APM integration policy editor.
 
 `fleetctl -u <kibana_url> set-policy-var <ID> tail_sampling_storage_limit=30MB`
 
+## Updating arbitrary config
+
+This command can be used to set arbitrary configuration understood by APM Server,
+where that configuration has no corresponding integration package var.
+
+`fleetctl -u <kibana_url> set-policy-config <ID> apm-server.max_concurrent_decoders=300`
+


### PR DESCRIPTION
## Motivation/summary


## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

1. Create a cloud deployment, note down the Kibana URL and `elastic` user's password
2. Run `fleetctl -u https://elastic:<password>@<kibana-host> set-policy-config elastic-cloud-apm apm-server.expvar.enabled=true`
3. Check that the server starts responding to `GET /debug/vars` requests after a little while

## Related issues

None