### PR TITLE
Fix: trigger signing if there is an unsigned revision

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -414,7 +414,7 @@ def signUnpublishedArtifactsWithElastic(builtPackagesPath, glob) {
     }
   }
 
-  if (!unpublished.isEmpty()) {
+  if (unpublished.isEmpty()) {
     return unpublished
   }
 


### PR DESCRIPTION
This PR fixes a bug in the `packaging.groovy`.

Unpublished package revisions should be signed before publishing.