### PR TITLE
ec_deployment: Add var to control ES masters

### DIFF
--- a/testing/benchmark/main.tf
+++ b/testing/benchmark/main.tf
@@ -51,6 +51,7 @@ module "ec_deployment" {
 
   elasticsearch_size       = var.elasticsearch_size
   elasticsearch_zone_count = var.elasticsearch_zone_count
+  elasticsearch_dedicated_masters = var.elasticsearch_dedicated_masters
 
   docker_image              = var.docker_image_override
   docker_image_tag_override = var.docker_image_tag_override

--- a/testing/benchmark/terraform.tfvars.example
+++ b/testing/benchmark/terraform.tfvars.example
@@ -27,6 +27,11 @@ user_name = "USER"
 # The number of AZs the Elasticsearch cluster should have.
 # elasticsearch_zone_count = 1
 
+# When the number of Elasticsearch instances exceeds a threshold, the cloud API
+# will return with an error requiring Elasticsearch dedicated masters to be used.
+# When that's the case, set the variable below to true.
+# elasticsearch_dedicated_masters = true
+
 # Override the docker image tag the ESS resources will use. Useful to
 # target a specific build, rather than a snapshot or released version.
 # If you'd like to only override a single tag, set the other values to

--- a/testing/benchmark/variables.tf
+++ b/testing/benchmark/variables.tf
@@ -49,6 +49,12 @@ variable "elasticsearch_zone_count" {
   description = "Optional Elasticsearch zone count"
 }
 
+variable "elasticsearch_dedicated_masters" {
+  default     = false
+  type        = bool
+  description = "Optional Elasticsearch dedicated masters"
+}
+
 variable "docker_image_tag_override" {
   default = {
     "elasticsearch" : "",

--- a/testing/infra/terraform/modules/ec_deployment/README.md
+++ b/testing/infra/terraform/modules/ec_deployment/README.md
@@ -15,7 +15,7 @@ used to configure the module, please refer to the [EC Provider docs](https://reg
 
 | Name | Version |
 |------|---------|
-| <a name="provider_ec"></a> [ec](#provider\_ec) | 0.4.0 |
+| <a name="provider_ec"></a> [ec](#provider\_ec) | >=0.4.1 |
 | <a name="provider_external"></a> [external](#provider\_external) | n/a |
 | <a name="provider_local"></a> [local](#provider\_local) | n/a |
 | <a name="provider_null"></a> [null](#provider\_null) | n/a |
@@ -28,8 +28,10 @@ used to configure the module, please refer to the [EC Provider docs](https://reg
 | [ec_deployment.deployment_monitor](https://registry.terraform.io/providers/elastic/ec/latest/docs/resources/deployment) | resource |
 | [local_file.enable_expvar](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.secret_token](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [local_file.shard_settings](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [null_resource.enable_expvar](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.secret_token](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.shard_settings](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [ec_stack.deployment_version](https://registry.terraform.io/providers/elastic/ec/latest/docs/data-sources/stack) | data source |
 | [external_external.secret_token](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
 
@@ -37,6 +39,7 @@ used to configure the module, please refer to the [EC Provider docs](https://reg
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_apm_index_shards"></a> [apm\_index\_shards](#input\_apm\_index\_shards) | The number of shards to set for APM Indices | `number` | `0` | no |
 | <a name="input_apm_server_expvar"></a> [apm\_server\_expvar](#input\_apm\_server\_expvar) | Whether or not to enable APM Server's expvar endpoint. Defaults to true | `bool` | `true` | no |
 | <a name="input_apm_server_pprof"></a> [apm\_server\_pprof](#input\_apm\_server\_pprof) | Whether or not to enable APM Server's pprof endpoint. Defaults to true | `bool` | `true` | no |
 | <a name="input_apm_server_size"></a> [apm\_server\_size](#input\_apm\_server\_size) | Optional apm server instance size | `string` | `"1g"` | no |
@@ -45,7 +48,8 @@ used to configure the module, please refer to the [EC Provider docs](https://reg
 | <a name="input_deployment_template"></a> [deployment\_template](#input\_deployment\_template) | Optional deployment template. Defaults to the CPU optimized template for GCP | `string` | `"gcp-compute-optimized-v2"` | no |
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Optional docker image overrides. The full map needs to be specified | `map(string)` | <pre>{<br>  "apm": "docker.elastic.co/cloud-release/elastic-agent-cloud",<br>  "elasticsearch": "docker.elastic.co/cloud-release/elasticsearch-cloud-ess",<br>  "kibana": "docker.elastic.co/cloud-release/kibana-cloud"<br>}</pre> | no |
 | <a name="input_docker_image_tag_override"></a> [docker\_image\_tag\_override](#input\_docker\_image\_tag\_override) | Optional docker image tag overrides, The full map needs to be specified | `map(string)` | <pre>{<br>  "apm": "",<br>  "elasticsearch": "",<br>  "kibana": ""<br>}</pre> | no |
-| <a name="input_elasticsearch_autoscale"></a> [elasticsearch\_autoscale](#input\_elasticsearch\_autoscale) | Optional autoscale the Elasticsearch deployment | `bool` | `false` | no |
+| <a name="input_elasticsearch_autoscale"></a> [elasticsearch\_autoscale](#input\_elasticsearch\_autoscale) | Optional autoscale the Elasticsearch cluster | `bool` | `false` | no |
+| <a name="input_elasticsearch_dedicated_masters"></a> [elasticsearch\_dedicated\_masters](#input\_elasticsearch\_dedicated\_masters) | Optionally use dedicated masters for the Elasticsearch cluster | `bool` | `false` | no |
 | <a name="input_elasticsearch_size"></a> [elasticsearch\_size](#input\_elasticsearch\_size) | Optional Elasticsearch instance size | `string` | `"8g"` | no |
 | <a name="input_elasticsearch_zone_count"></a> [elasticsearch\_zone\_count](#input\_elasticsearch\_zone\_count) | Optional Elasticsearch zone count | `number` | `2` | no |
 | <a name="input_integrations_server"></a> [integrations\_server](#input\_integrations\_server) | Optionally use the integrations server block instead of the apm block | `bool` | `false` | no |

--- a/testing/infra/terraform/modules/ec_deployment/deployment.tf
+++ b/testing/infra/terraform/modules/ec_deployment/deployment.tf
@@ -24,6 +24,14 @@ resource "ec_deployment" "deployment" {
       size       = var.elasticsearch_size
       zone_count = var.elasticsearch_zone_count
     }
+    dynamic "topology" {
+      for_each = var.elasticsearch_dedicated_masters ? [3] : []
+      content {
+        id         = "master"
+        size       = "1g"
+        zone_count = topology.value # Dedicated masters always need to be set in all zones
+      }
+    }
     dynamic "config" {
       for_each = var.docker_image_tag_override["elasticsearch"] != "" ? [var.docker_image["elasticsearch"]] : []
       content {

--- a/testing/infra/terraform/modules/ec_deployment/variables.tf
+++ b/testing/infra/terraform/modules/ec_deployment/variables.tf
@@ -73,7 +73,13 @@ variable "elasticsearch_zone_count" {
 variable "elasticsearch_autoscale" {
   default     = false
   type        = bool
-  description = "Optional autoscale the Elasticsearch deployment"
+  description = "Optional autoscale the Elasticsearch cluster"
+}
+
+variable "elasticsearch_dedicated_masters" {
+  default     = false
+  type        = bool
+  description = "Optionally use dedicated masters for the Elasticsearch cluster"
 }
 
 # Docker image overrides


### PR DESCRIPTION
## Motivation/summary

Adds a new variable (`elasticsearch_dedicated_masters`) to control the
use of Elasticsearch dedicated masters in an Elasticsearch cluster. In
general, once a certain number of total Elasticsearch instances has been
reached, the cloud API will respond with an error which asks the user to
set dedicated masters. The new boolean variable allows doing just that.

In general, this issue will only be experienced when the deployments are
large.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)`~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
- [x] Documentation has been updated

## How to test these changes

Create a large deployment spanning 3 zones and >= `116g` size for Elasticsearch.

## Related issues

Part of #8775
