### PR TITLE
Set the runtime for mobile agents using the OS information

### DIFF
--- a/internal/processor/otel/metadata.go
+++ b/internal/processor/otel/metadata.go
@@ -169,6 +169,11 @@ func translateResourceMetadata(resource pcommon.Resource, out *model.APMEvent) {
 		out.Host.OS.Type = "ios"
 	}
 
+	if out.Service.Runtime.Name == nil && (out.Host.OS.Name == "Android" || out.Host.OS.Name == "iOS") {
+		out.Service.Runtime.Name = out.Host.OS.Name
+		out.Service.Runtime.Version = out.Host.OS.Version
+	}
+
 	if strings.HasPrefix(exporterVersion, "Jaeger") {
 		// version is of format `Jaeger-<agentlanguage>-<version>`, e.g. `Jaeger-Go-2.20.0`
 		const nVersionParts = 3

--- a/internal/processor/otel/metadata_test.go
+++ b/internal/processor/otel/metadata_test.go
@@ -211,7 +211,14 @@ func TestResourceConventions(t *testing.T) {
 			},
 			expected: model.APMEvent{
 				Agent:   defaultAgent,
-				Service: defaultService,
+				Service: model.Service{
+					Name:     "unknown",
+					Language: model.Language{Name: "unknown"},
+					Runtime: model.Runtime{
+						Name:    "iOS",
+						Version: "15.6",
+					},
+				},
 				Host: model.Host{
 					OS: model.OS{
 						Name:     "iOS",
@@ -232,7 +239,14 @@ func TestResourceConventions(t *testing.T) {
 			},
 			expected: model.APMEvent{
 				Agent:   defaultAgent,
-				Service: defaultService,
+				Service: model.Service{
+					Name:     "unknown",
+					Language: model.Language{Name: "unknown"},
+					Runtime: model.Runtime{
+						Name:    "Android",
+						Version: "13",
+					},
+				},
 				Host: model.Host{
 					OS: model.OS{
 						Name:     "Android",


### PR DESCRIPTION
For mobile agents the `runtime.*` fields can be directly derived from the `os.*` fields (unless it's explicitly overwritten by the agents). This is common for both, iOS and Android. 



## Motivation/summary
With this PR, the APM server sets the `service.runtime.name` and `service.runtime.version` to the same values as `host.os.name` and `host.os.version` in case that the `process.runtime.name` field is not explicitly provided (which is the default for the iOS and Android agents).

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

