### PR TITLE
systemtest: add dimensions to approval sorting

### DIFF
--- a/systemtest/approvals.go
+++ b/systemtest/approvals.go
@@ -71,6 +71,8 @@ var apmEventSortFields = []string{
 	"error.id",
 	"timeseries.instance",
 	"span.destination.service.resource",
+	"transaction.type",
+	"service.name",
 	"@timestamp", // last resort, order is generally guaranteed
 }
 


### PR DESCRIPTION
## Motivation/summary

Fix TestServiceMetricsAggregation by adding service.name and transaction.type fields to the approvals document sorting. Without this, service metrics may be inconsistently ordered, which leads to the test failing randomly.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

Run the `TestServiceMetricsAggregation` test a bunch of times.

## Related issues

None