### PR TITLE
Make: download Go modules before "mage package"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,7 @@ release-manager-release: release
 .PHONY: release
 release: export PATH:=$(dir $(BIN_MAGE)):$(PATH)
 release: $(MAGE) build/dependencies.csv
+	$(GO) mod download all
 	$(MAGE) package
 	@$(MAGE) ironbank
 


### PR DESCRIPTION
## Motivation/summary

Trying to fix packaging, which still uses beats/dev-tools in 7.17.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

None