### PR TITLE
sampling: call RunValueLogGC in a loop

### DIFF
--- a/x-pack/apm-server/sampling/processor.go
+++ b/x-pack/apm-server/sampling/processor.go
@@ -387,7 +387,13 @@ func (p *Processor) Run() error {
 				return ctx.Err()
 			case <-ticker.C:
 				const discardRatio = 0.5
-				if err := p.config.DB.RunValueLogGC(discardRatio); err != nil && err != badger.ErrNoRewrite {
+				var err error
+				for err == nil {
+					// Keep garbage collecting until there are no more rewrites,
+					// or garbage collection fails.
+					err = p.config.DB.RunValueLogGC(discardRatio)
+				}
+				if err != nil && err != badger.ErrNoRewrite {
 					return err
 				}
 			}


### PR DESCRIPTION
## Motivation/summary

`RunValueLogGC` returns `ErrNoRewrite` when there are no changes to be made for GC, and should be called in a loop until it returns an error. Doing this should lead to value logs being garbage collected more quickly, as otherwise we'll wait for another tick before repeating.

See https://github.com/dgraph-io/dgraph/blob/832ebb9766f1732186eaecbf3792aff9e3766c6c/x/x.go#L1089-L1127 for how dgraph itself uses the method.

:tipping_hand_man: :tophat: @marclop 

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

None