### PR TITLE
benchmark: Use GCP Belgium (CPU optimized profile)

### DIFF
--- a/testing/benchmark/variables.tf
+++ b/testing/benchmark/variables.tf
@@ -8,13 +8,13 @@ variable "user_name" {
 ## Deployment configuration
 
 variable "ess_region" {
-  default     = "gcp-us-west2"
-  description = "Optional ESS region where the deployment will be created. Defaults to gcp-us-west2"
+  default     = "gcp-europe-west1"
+  description = "Optional ESS region where the deployment will be created. Defaults to gcp-europe-west1"
   type        = string
 }
 
 variable "deployment_template" {
-  default     = "gcp-compute-optimized-v2"
+  default     = "gcp-cpu-optimized"
   description = "Optional deployment template. Defaults to the CPU optimized template for GCP"
   type        = string
 }
@@ -83,8 +83,8 @@ variable "apm_shards" {
 ## Worker configuraiton
 
 variable "worker_region" {
-  default     = "us-west-2"
-  description = "Optional ESS region where the deployment will be created. Defaults to us-west-2 (AWS)"
+  default     = "eu-west-3"
+  description = "Optional ESS region where the deployment will be created. Defaults to eu-west-3 (AWS)"
   type        = string
 }
 


### PR DESCRIPTION
## Motivation/summary

Updates the default region and deployment template so that we make use of the Belgium CFT region which does have the CPU optimized hardware profile. This should give us a better benchmarking environment where the APM Server isn't being throttled all the time.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

Use the right hardware profile for benchmarks.
