### PR TITLE
Revert "benchmark: Use GCP Belgium (CPU optimized profile)"

### DIFF
--- a/testing/benchmark/variables.tf
+++ b/testing/benchmark/variables.tf
@@ -8,13 +8,13 @@ variable "user_name" {
 ## Deployment configuration
 
 variable "ess_region" {
-  default     = "gcp-europe-west1"
-  description = "Optional ESS region where the deployment will be created. Defaults to gcp-europe-west1"
+  default     = "gcp-us-west2"
+  description = "Optional ESS region where the deployment will be created. Defaults to gcp-us-west2"
   type        = string
 }
 
 variable "deployment_template" {
-  default     = "gcp-cpu-optimized"
+  default     = "gcp-compute-optimized-v2"
   description = "Optional deployment template. Defaults to the CPU optimized template for GCP"
   type        = string
 }
@@ -83,8 +83,8 @@ variable "apm_shards" {
 ## Worker configuraiton
 
 variable "worker_region" {
-  default     = "eu-west-3"
-  description = "Optional ESS region where the deployment will be created. Defaults to eu-west-3 (AWS)"
+  default     = "us-west-2"
+  description = "Optional ESS region where the deployment will be created. Defaults to us-west-2 (AWS)"
   type        = string
 }
 


### PR DESCRIPTION
Reverts elastic/apm-server#9105. It turns out that GCP Belgium is not truly a CFT region and as such the `docker_image` cannot be overridden.

```
│ Error: failed creating deployment: 2 errors occurred:
│ 	* api error: clusters.cluster_plan_change_prohibited: The requested cluster configuration change is not permitted. Value of field 'elasticsearch.docker_image' cannot be changed to [docker.elastic.co/cloud-release/elasticsearch-cloud-ess:8.5.0-6b7dda2d-SNAPSHOT]. (resources.elasticsearch[0].elasticsearch.docker_image)
```