### PR TITLE
systemtest: Add `span.type` as sortable field

### DIFF
--- a/systemtest/approvals.go
+++ b/systemtest/approvals.go
@@ -72,6 +72,7 @@ var apmEventSortFields = []string{
 	"timeseries.instance",
 	"span.destination.service.resource",
 	"transaction.type",
+	"span.type",
 	"service.name",
 	"@timestamp", // last resort before _id; order is generally guaranteed
 }


### PR DESCRIPTION
## Motivation/summary

Fix `TestIngestPipelineDataStreamMigration` flakiness.

## How to test these changes

`cd systemtest && go test -v -run TestIngestPipelineDataStreamMigration -count=100 .`

## Related issues

Flaky systemtest.
