### PR TITLE
packer: if no WORKSPACE then set a new path

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -6,6 +6,16 @@ source /usr/local/bin/bash_standard_lib.sh
 # shellcheck disable=SC1091
 source ./script/common.bash
 
+# This script runs within the Jenkins context, but for some reason
+# WORKSPACE is not available, this should bypass the requirement set
+# when in ./script/common.bash
+if [ -z "${WORKSPACE}" ] ; then
+	echo "WARN: WORKSPACE env variable is empty, hence creating a temporary dir"
+	WORKSPACE=$(mktemp -d)
+	export WORKSPACE
+	echo "INFO: WORKSPACE=${WORKSPACE}"
+fi
+
 jenkins_setup
 
 # Fetch Docker images used for packaging.


### PR DESCRIPTION
This script is used by the CI automation to cache some of the artifacts, to help with faster builds.

Unfortunately, the `WORKSPACE` env variable is not set properly by the automation. This should fix the problem we have found for the last month or so

### Test

```bash
.ci/packer_cache.sh
WARN: WORKSPACE env variable is empty, hence creating a temporary dir
INFO: WORKSPACE=/var/folders/hn/j6gds1qx1f5bysfn0qp0t03c0000gn/T/tmp.miMkCfme
...

```

```bash
WORKSPACE=/tmp .ci/packer_cache.sh
latest: Pulling from infra/release-manager
405f018f9d1d: Waiting 
...
```