### PR TITLE
build: prevent unintended go.[mod|sum] mutation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ include packaging.mk
 # scripts may set GOTESTFLAGS=-json to format test output for processing.
 GOTESTFLAGS?=-v
 
+# Prevent unintended modifications of go.[mod|sum]
+GOMODFLAG?=-mod=readonly
+
 PYTHON_ENV?=.
 PYTHON_VENV_DIR:=$(PYTHON_ENV)/build/ve/$(shell $(GO) env GOOS)
 PYTHON_BIN:=$(PYTHON_VENV_DIR)/bin
@@ -48,7 +51,7 @@ LDFLAGS := \
 .PHONY: $(APM_SERVER_BINARIES)
 $(APM_SERVER_BINARIES):
 	env CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) \
-	$(GO) build -o $@ -trimpath $(GOFLAGS) -ldflags "$(LDFLAGS)" ./x-pack/apm-server
+	$(GO) build -o $@ -trimpath $(GOFLAGS) $(GOMODFLAG) -ldflags "$(LDFLAGS)" ./x-pack/apm-server
 
 build/apm-server-linux-%: GOOS=linux
 build/apm-server-darwin-%: GOOS=darwin
@@ -76,15 +79,15 @@ apm-server: build/apm-server-$(shell $(GO) env GOOS)-$(shell $(GO) env GOARCH)
 
 .PHONY: apm-server-oss
 apm-server-oss:
-	@$(GO) build -o $@ ./cmd/apm-server
+	@$(GO) build $(GOMODFLAG) -o $@ ./cmd/apm-server
 
 .PHONY: test
 test:
-	@$(GO) test $(GOTESTFLAGS) ./...
+	@$(GO) test $(GOMODFLAG) $(GOTESTFLAGS) ./...
 
 .PHONY: system-test
 system-test:
-	@(cd systemtest; $(GO) test $(GOTESTFLAGS) -timeout=20m ./...)
+	@(cd systemtest; $(GO) test $(GOMODFLAG) $(GOTESTFLAGS) -timeout=20m ./...)
 
 .PHONY:
 clean:


### PR DESCRIPTION
Signed-off-by: Florian Lehner <florian.lehner@elastic.co>

<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Make sure Go does not pull in or update dependencies when compiling or running tests. Unintended changes to go.[mod|sum] can be a security risk and therefore should be avoided.
This PR makes sure compilation or tests will fail if changes to go.[mod|sum] are needed.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] ~~Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~~
No user-facing change.
- [ ] ~~Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~~
No changes to `apmpackage`
- [ ] ~~Documentation has been updated~~
No relevant code changes.

