### PR TITLE
Add package settings for service metrics

### DIFF
--- a/apmpackage/apm/agent/input/template.yml.hbs
+++ b/apmpackage/apm/agent/input/template.yml.hbs
@@ -28,6 +28,9 @@ apm-server:
     max_header_size: {{max_header_bytes}}
     read_timeout: {{read_timeout}}
     response_headers: {{response_headers}}
+    aggregation:
+        service:
+            enabled: {{service_metrics_enabled}}
     java_attacher:
       enabled: {{java_attacher_enabled}}
       discovery-rules: {{java_attacher_discovery_rules}}

--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -3,6 +3,9 @@
 # change type can be one of: enhancement, bugfix, breaking-change
 - version: "generated"
   changes:
+    - description: Add package settings to enable the experimental collection of service metrics
+      type: enhancement
+      link: https://github.com/elastic/apm-server/pull/9145
     - description: Added faas fields for app logs datastream
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/9068

--- a/apmpackage/apm/manifest.yml
+++ b/apmpackage/apm/manifest.yml
@@ -163,6 +163,9 @@ policy_templates:
           - name: tail_sampling_storage_limit
             type: text
             default: "3GB"
+          - name: service_metrics_enabled
+            type: bool
+            default: false
         template_path: template.yml.hbs
 owner:
   github: elastic/apm-server


### PR DESCRIPTION
This will allow managed users to actually try the new experimental feature. 

Relates to: #8607 