### PR TITLE
fix apmpackage changelog

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -1,9 +1,5 @@
-- version: 8.5.0
-  changes:
-    - description: Placeholder
-      type: enhancement
-      link: https://github.com/elastic/apm-server/pull/123
-- version: "generated"
+
+- version: "8.5.0"
   changes:
     - description: Add package settings to enable the experimental collection of service metrics
       type: enhancement


### PR DESCRIPTION
Fix the apmpackage changelog

cc @elastic/observablt-robots this probably requires a change in the branch creation automation to not create a placeholder entry for release branches. 