### PR TITLE
apmpackage: fix changelog

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -1,5 +1,4 @@
-
-- version: "8.5.0"
+- version: generated
   changes:
     - description: Add package settings to enable the experimental collection of service metrics
       type: enhancement


### PR DESCRIPTION
## Motivation/summary

Fix 8.5 snapshot package build.

The top-most version must be "generated", which is replaced at package generation/build time. For `make build-package-snapshot`, the version includes a timestamp.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
~- [ ] Documentation has been updated~

## How to test these changes

Make sure 8.5 DRA succeeds.

## Related issues

None