### PR TITLE
apmpackage: flatten fields.yml files

### DIFF
--- a/apmpackage/apm/data_stream/app_logs/fields/fields.yml
+++ b/apmpackage/apm/data_stream/app_logs/fields/fields.yml
@@ -1,140 +1,97 @@
-- name: http
-  type: group
-  fields:
-    - name: request
-      type: group
-      fields:
-        - name: headers
-          type: object
-          description: |
-            The canonical headers of the monitored HTTP request.
-    - name: response
-      type: group
-      fields:
-        - name: finished
-          type: boolean
-          description: |
-            Used by the Node agent to indicate when in the response life cycle an error has occurred.
-        - name: headers
-          type: object
-          description: |
-            The canonical headers of the monitored HTTP response.
-- name: kubernetes
-  title: Kubernetes
-  type: group
+- name: http.request.headers
+  type: object
   description: |
-    Kubernetes metadata reported by agents
-  fields:
-    - name: namespace
-      type: keyword
-      description: |
-        Kubernetes namespace
-    - name: node
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Kubernetes node name
-    - name: pod
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Kubernetes pod name
-        - name: uid
-          type: keyword
-          description: |
-            Kubernetes Pod UID
-- name: observer
-  type: group
-  fields:
-    - name: ephemeral_id
-      type: keyword
-      description: |
-        Ephemeral identifier of the APM Server.
-    - name: id
-      type: keyword
-      description: |
-        Unique identifier of the APM Server.
+    The canonical headers of the monitored HTTP request.
+- name: http.response.finished
+  type: boolean
+  description: |
+    Used by the Node agent to indicate when in the response life cycle an error has occurred.
+- name: http.response.headers
+  type: object
+  description: |
+    The canonical headers of the monitored HTTP response.
+- name: kubernetes.namespace
+  type: keyword
+  description: |
+    Kubernetes namespace
+- name: kubernetes.node.name
+  type: keyword
+  description: |
+    Kubernetes node name
+- name: kubernetes.pod.name
+  type: keyword
+  description: |
+    Kubernetes pod name
+- name: kubernetes.pod.uid
+  type: keyword
+  description: |
+    Kubernetes Pod UID
+- name: observer.ephemeral_id
+  type: keyword
+  description: |
+    Ephemeral identifier of the APM Server.
+- name: observer.id
+  type: keyword
+  description: |
+    Unique identifier of the APM Server.
 - name: processor.event
   type: constant_keyword
   description: Processor event.
 - name: processor.name
   type: constant_keyword
   description: Processor name.
-- name: service
-  type: group
+- name: service.framework.name
+  type: keyword
   description: |
-    Service fields.
-  fields:
-    - name: framework
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Name of the framework used.
-        - name: version
-          type: keyword
-          description: |
-            Version of the framework used.
-    - name: language
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Name of the programming language used.
-        - name: version
-          type: keyword
-          description: |
-            Version of the programming language used.
-    - name: runtime
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Name of the runtime used.
-        - name: version
-          type: keyword
-          description: |
-            Version of the runtime used.
-- name: faas
-  type: group
+    Name of the framework used.
+- name: service.framework.version
+  type: keyword
   description: |
-    Function as a service fields.
-  fields:
-    - name: id
-      type: keyword
-      description: |
-        A unique identifier of the invoked serverless function.
-    - name: coldstart
-      type: boolean
-      description: |
-        Boolean indicating whether the function invocation was a coldstart or not.
-    - name: execution
-      type: keyword
-      description: |
-        Request ID of the function invocation.
-    - name: trigger.request_id
-      type: keyword
-      description: |
-        The ID of the origin trigger request.
-    - name: trigger.type
-      type: keyword
-      description: |
-        The trigger type.
-    - name: name
-      type: keyword
-      description: |
-        The lambda function name.
-    - name: version
-      type: keyword
-      description: |
-        The lambda function version.
+    Version of the framework used.
+- name: service.language.name
+  type: keyword
+  description: |
+    Name of the programming language used.
+- name: service.language.version
+  type: keyword
+  description: |
+    Version of the programming language used.
+- name: service.runtime.name
+  type: keyword
+  description: |
+    Name of the runtime used.
+- name: service.runtime.version
+  type: keyword
+  description: |
+    Version of the runtime used.
+- name: faas.id
+  type: keyword
+  description: |
+    A unique identifier of the invoked serverless function.
+- name: faas.coldstart
+  type: boolean
+  description: |
+    Boolean indicating whether the function invocation was a coldstart or not.
+- name: faas.execution
+  type: keyword
+  description: |
+    Request ID of the function invocation.
+- name: faas.trigger.request_id
+  type: keyword
+  description: |
+    The ID of the origin trigger request.
+- name: faas.trigger.type
+  type: keyword
+  description: |
+    The trigger type.
+- name: faas.name
+  type: keyword
+  description: |
+    The lambda function name.
+- name: faas.version
+  type: keyword
+  description: |
+    The lambda function version.
 - name: numeric_labels
   type: object
   dynamic: true

--- a/apmpackage/apm/data_stream/app_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/app_metrics/fields/fields.yml
@@ -1,107 +1,65 @@
-- name: kubernetes
-  title: Kubernetes
-  type: group
+- name: kubernetes.namespace
+  type: keyword
   description: |
-    Kubernetes metadata reported by agents
-  fields:
-    - name: namespace
-      type: keyword
-      description: |
-        Kubernetes namespace
-    - name: node
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Kubernetes node name
-    - name: pod
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Kubernetes pod name
-        - name: uid
-          type: keyword
-          description: |
-            Kubernetes Pod UID
-- name: metricset
-  type: group
-  fields:
-    - name: name
-      type: keyword
-      description: |
-        Name of the set of metrics.
-- name: network
-  type: group
+    Kubernetes namespace
+- name: kubernetes.node.name
+  type: keyword
   description: |
-    Optional network fields
-  fields:
-    - name: connection
-      type: group
-      description: |
-        Network connection details
-      fields:
-        - name: type
-          type: keyword
-          description: |
-            Network connection type, eg. "wifi", "cell"
-- name: observer
-  type: group
-  fields:
-    - name: ephemeral_id
-      type: keyword
-      description: |
-        Ephemeral identifier of the APM Server.
-    - name: id
-      type: keyword
-      description: |
-        Unique identifier of the APM Server.
+    Kubernetes node name
+- name: kubernetes.pod.name
+  type: keyword
+  description: |
+    Kubernetes pod name
+- name: kubernetes.pod.uid
+  type: keyword
+  description: |
+    Kubernetes Pod UID
+- name: metricset.name
+  type: keyword
+  description: |
+    Name of the set of metrics.
+- name: network.connection.type
+  type: keyword
+  description: |
+    Network connection type, eg. "wifi", "cell"
+- name: observer.ephemeral_id
+  type: keyword
+  description: |
+    Ephemeral identifier of the APM Server.
+- name: observer.id
+  type: keyword
+  description: |
+    Unique identifier of the APM Server.
 - name: processor.event
   type: constant_keyword
   description: Processor event.
 - name: processor.name
   type: constant_keyword
   description: Processor name.
-- name: service
-  type: group
+- name: service.framework.name
+  type: keyword
   description: |
-    Service fields.
-  fields:
-    - name: framework
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Name of the framework used.
-        - name: version
-          type: keyword
-          description: |
-            Version of the framework used.
-    - name: language
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Name of the programming language used.
-        - name: version
-          type: keyword
-          description: |
-            Version of the programming language used.
-    - name: runtime
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Name of the runtime used.
-        - name: version
-          type: keyword
-          description: |
-            Version of the runtime used.
+    Name of the framework used.
+- name: service.framework.version
+  type: keyword
+  description: |
+    Version of the framework used.
+- name: service.language.name
+  type: keyword
+  description: |
+    Name of the programming language used.
+- name: service.language.version
+  type: keyword
+  description: |
+    Version of the programming language used.
+- name: service.runtime.name
+  type: keyword
+  description: |
+    Name of the runtime used.
+- name: service.runtime.version
+  type: keyword
+  description: |
+    Version of the runtime used.
 - name: numeric_labels
   type: object
   dynamic: true

--- a/apmpackage/apm/data_stream/error_logs/fields/fields.yml
+++ b/apmpackage/apm/data_stream/error_logs/fields/fields.yml
@@ -1,229 +1,152 @@
-- name: error
-  type: group
+- name: error.culprit
+  type: keyword
+  description: Function call which was the primary perpetrator of this event.
+- name: error.exception.code
+  type: keyword
+  description: The error code set when the error happened, e.g. database error code.
+- name: error.exception.handled
+  type: boolean
+  description: Indicator whether the error was caught somewhere in the code or not.
+- name: error.exception.message
+  type: text
+  description: The original error message.
+- name: error.exception.module
+  type: keyword
+  description: The module namespace of the original error.
+- name: error.exception.type
+  type: keyword
+  description: The type of the original error, e.g. the Java exception class name.
+- name: error.grouping_key
+  type: keyword
   description: |
-    Data captured by an agent representing an event occurring in a monitored service.
-  fields:
-    - name: culprit
-      type: keyword
-      description: Function call which was the primary perpetrator of this event.
-    - name: exception
-      type: group
-      description: |
-        Information about the originally thrown error.
-      fields:
-        - name: code
-          type: keyword
-          description: The error code set when the error happened, e.g. database error code.
-        - name: handled
-          type: boolean
-          description: Indicator whether the error was caught somewhere in the code or not.
-        - name: message
-          type: text
-          description: The original error message.
-        - name: module
-          type: keyword
-          description: The module namespace of the original error.
-        - name: type
-          type: keyword
-          description: The type of the original error, e.g. the Java exception class name.
-    - name: grouping_key
-      type: keyword
-      description: |
-        Hash of select properties of the logged error for grouping purposes.
-    - name: grouping_name
-      type: keyword
-      description: |
-        Name to associate with an error group. Errors belonging to the same group (same grouping_key) may have differing values for grouping_name. Consumers may choose one arbitrarily.
-    - name: log
-      type: group
-      description: |
-        Additional information added by logging the error.
-      fields:
-        - name: level
-          type: keyword
-          description: The severity of the record.
-        - name: logger_name
-          type: keyword
-          description: The name of the logger instance used.
-        - name: message
-          type: text
-          description: The additionally logged error message.
-        - name: param_message
-          type: keyword
-          description: |
-            A parametrized message. E.g. 'Could not connect to %s'. The property message is still required, and should be equal to the param_message, but with placeholders replaced. In some situations the param_message is used to group errors together.
-- name: http
-  type: group
-  fields:
-    - name: request
-      type: group
-      fields:
-        - name: headers
-          type: object
-          description: |
-            The canonical headers of the monitored HTTP request.
-    - name: response
-      type: group
-      fields:
-        - name: finished
-          type: boolean
-          description: |
-            Used by the Node agent to indicate when in the response life cycle an error has occurred.
-        - name: headers
-          type: object
-          description: |
-            The canonical headers of the monitored HTTP response.
-- name: kubernetes
-  title: Kubernetes
-  type: group
+    Hash of select properties of the logged error for grouping purposes.
+- name: error.grouping_name
+  type: keyword
   description: |
-    Kubernetes metadata reported by agents
-  fields:
-    - name: namespace
-      type: keyword
-      description: |
-        Kubernetes namespace
-    - name: node
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Kubernetes node name
-    - name: pod
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Kubernetes pod name
-        - name: uid
-          type: keyword
-          description: |
-            Kubernetes Pod UID
-- name: network
-  type: group
+    Name to associate with an error group. Errors belonging to the same group (same grouping_key) may have differing values for grouping_name. Consumers may choose one arbitrarily.
+- name: error.log.level
+  type: keyword
+  description: The severity of the record.
+- name: error.log.logger_name
+  type: keyword
+  description: The name of the logger instance used.
+- name: error.log.message
+  type: text
+  description: The additionally logged error message.
+- name: error.log.param_message
+  type: keyword
   description: |
-    Optional network fields
-  fields:
-    - name: carrier
-      type: group
-      description: |
-        Network operator
-      fields:
-        - name: icc
-          type: keyword
-          description: |
-            ISO country code, eg. US
-        - name: mcc
-          type: keyword
-          description: |
-            Mobile country code
-        - name: mnc
-          type: keyword
-          description: |
-            Mobile network code
-        - name: name
-          type: keyword
-          description: |
-            Carrier name, eg. Vodafone, T-Mobile, etc.
-    - name: connection
-      type: group
-      description: |
-        Network connection details
-      fields:
-        - name: subtype
-          type: keyword
-          description: |
-            Detailed network connection sub-type, e.g. "LTE", "CDMA"
-        - name: type
-          type: keyword
-          description: |
-            Network connection type, eg. "wifi", "cell"
-- name: observer
-  type: group
-  fields:
-    - name: ephemeral_id
-      type: keyword
-      description: |
-        Ephemeral identifier of the APM Server.
-    - name: id
-      type: keyword
-      description: |
-        Unique identifier of the APM Server.
-- name: parent
-  type: group
-  fields:
-    - name: id
-      type: keyword
-      description: |
-        The ID of the parent event.
+    A parametrized message. E.g. 'Could not connect to %s'. The property message is still required, and should be equal to the param_message, but with placeholders replaced. In some situations the param_message is used to group errors together.
+- name: http.request.headers
+  type: object
+  description: |
+    The canonical headers of the monitored HTTP request.
+- name: http.response.finished
+  type: boolean
+  description: |
+    Used by the Node agent to indicate when in the response life cycle an error has occurred.
+- name: http.response.headers
+  type: object
+  description: |
+    The canonical headers of the monitored HTTP response.
+- name: kubernetes.namespace
+  type: keyword
+  description: |
+    Kubernetes namespace
+- name: kubernetes.node.name
+  type: keyword
+  description: |
+    Kubernetes node name
+- name: kubernetes.pod.name
+  type: keyword
+  description: |
+    Kubernetes pod name
+- name: kubernetes.pod.uid
+  type: keyword
+  description: |
+    Kubernetes Pod UID
+- name: network.carrier.icc
+  type: keyword
+  description: |
+    ISO country code, eg. US
+- name: network.carrier.mcc
+  type: keyword
+  description: |
+    Mobile country code
+- name: network.carrier.mnc
+  type: keyword
+  description: |
+    Mobile network code
+- name: network.carrier.name
+  type: keyword
+  description: |
+    Carrier name, eg. Vodafone, T-Mobile, etc.
+- name: network.connection.subtype
+  type: keyword
+  description: |
+    Detailed network connection sub-type, e.g. "LTE", "CDMA"
+- name: network.connection.type
+  type: keyword
+  description: |
+    Network connection type, eg. "wifi", "cell"
+- name: observer.ephemeral_id
+  type: keyword
+  description: |
+    Ephemeral identifier of the APM Server.
+- name: observer.id
+  type: keyword
+  description: |
+    Unique identifier of the APM Server.
+- name: parent.id
+  type: keyword
+  description: |
+    The ID of the parent event.
 - name: processor.event
   type: constant_keyword
   description: Processor event.
 - name: processor.name
   type: constant_keyword
   description: Processor name.
-- name: service
-  type: group
+- name: service.framework.name
+  type: keyword
   description: |
-    Service fields.
-  fields:
-    - name: framework
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Name of the framework used.
-        - name: version
-          type: keyword
-          description: |
-            Version of the framework used.
-    - name: language
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Name of the programming language used.
-        - name: version
-          type: keyword
-          description: |
-            Version of the programming language used.
-    - name: runtime
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Name of the runtime used.
-        - name: version
-          type: keyword
-          description: |
-            Version of the runtime used.
-- name: timestamp
-  type: group
-  fields:
-    - name: us
-      type: long
-      description: |
-        Timestamp of the event in microseconds since Unix epoch.
-- name: transaction
-  type: group
-  fields:
-    - name: sampled
-      type: boolean
-      description: |
-        Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have spans or context.
-    - name: name
-      type: keyword
-      description: |
-        Keyword of designation of a transaction in the scope of a single service, eg: 'GET /users/:id'.
-    - name: type
-      type: keyword
-      description: |
-        Keyword of specific relevance in the service's domain (eg. 'request', 'backgroundjob', etc)
+    Name of the framework used.
+- name: service.framework.version
+  type: keyword
+  description: |
+    Version of the framework used.
+- name: service.language.name
+  type: keyword
+  description: |
+    Name of the programming language used.
+- name: service.language.version
+  type: keyword
+  description: |
+    Version of the programming language used.
+- name: service.runtime.name
+  type: keyword
+  description: |
+    Name of the runtime used.
+- name: service.runtime.version
+  type: keyword
+  description: |
+    Version of the runtime used.
+- name: timestamp.us
+  type: long
+  description: |
+    Timestamp of the event in microseconds since Unix epoch.
+- name: transaction.sampled
+  type: boolean
+  description: |
+    Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have spans or context.
+- name: transaction.name
+  type: keyword
+  description: |
+    Keyword of designation of a transaction in the scope of a single service, eg: 'GET /users/:id'.
+- name: transaction.type
+  type: keyword
+  description: |
+    Keyword of specific relevance in the service's domain (eg. 'request', 'backgroundjob', etc)
 - name: numeric_labels
   type: object
   dynamic: true

--- a/apmpackage/apm/data_stream/internal_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/internal_metrics/fields/fields.yml
@@ -1,206 +1,135 @@
-- name: faas
-  type: group
+- name: faas.coldstart
+  type: boolean
   description: |
-    Function as a service fields.
-  fields:
-    - name: coldstart
-      type: boolean
-      description: |
-        Boolean indicating whether the function invocation was a coldstart or not.
-    - name: id
-      type: keyword
-      description: |
-        A unique identifier of the invoked serverless function.
-    - name: execution
-      type: keyword
-      description: |
-        Request ID of the function invocation.
-    - name: trigger.request_id
-      type: keyword
-      description: |
-        The ID of the origin trigger request.
-    - name: trigger.type
-      type: keyword
-      description: |
-        The trigger type.
-    - name: name
-      type: keyword
-      description: |
-        The lambda function name.
-    - name: version
-      type: keyword
-      description: |
-        The lambda function version.
-- name: kubernetes
-  title: Kubernetes
-  type: group
+    Boolean indicating whether the function invocation was a coldstart or not.
+- name: faas.id
+  type: keyword
   description: |
-    Kubernetes metadata reported by agents
-  fields:
-    - name: namespace
-      type: keyword
-      description: |
-        Kubernetes namespace
-    - name: node
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Kubernetes node name
-    - name: pod
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Kubernetes pod name
-        - name: uid
-          type: keyword
-          description: |
-            Kubernetes Pod UID
-- name: metricset
-  type: group
-  fields:
-    - name: name
-      type: keyword
-      description: |
-        Name of the set of metrics.
+    A unique identifier of the invoked serverless function.
+- name: faas.execution
+  type: keyword
+  description: |
+    Request ID of the function invocation.
+- name: faas.trigger.request_id
+  type: keyword
+  description: |
+    The ID of the origin trigger request.
+- name: faas.trigger.type
+  type: keyword
+  description: |
+    The trigger type.
+- name: faas.name
+  type: keyword
+  description: |
+    The lambda function name.
+- name: faas.version
+  type: keyword
+  description: |
+    The lambda function version.
+- name: kubernetes.namespace
+  type: keyword
+  description: |
+    Kubernetes namespace
+- name: kubernetes.node.name
+  type: keyword
+  description: |
+    Kubernetes node name
+- name: kubernetes.pod.name
+  type: keyword
+  description: |
+    Kubernetes pod name
+- name: kubernetes.pod.uid
+  type: keyword
+  description: |
+    Kubernetes Pod UID
+- name: metricset.name
+  type: keyword
+  description: |
+    Name of the set of metrics.
 - name: agent_config_applied
   type: long
   description: Value for agent_config_applied
-- name: network
-  type: group
+- name: network.connection.type
+  type: keyword
   description: |
-    Optional network fields
-  fields:
-    - name: connection
-      type: group
-      description: |
-        Network connection details
-      fields:
-        - name: type
-          type: keyword
-          description: |
-            Network connection type, eg. "wifi", "cell"
-- name: observer
-  type: group
-  fields:
-    - name: ephemeral_id
-      type: keyword
-      description: |
-        Ephemeral identifier of the APM Server.
-    - name: id
-      type: keyword
-      description: |
-        Unique identifier of the APM Server.
+    Network connection type, eg. "wifi", "cell"
+- name: observer.ephemeral_id
+  type: keyword
+  description: |
+    Ephemeral identifier of the APM Server.
+- name: observer.id
+  type: keyword
+  description: |
+    Unique identifier of the APM Server.
 - name: processor.event
   type: constant_keyword
   description: Processor event.
 - name: processor.name
   type: constant_keyword
   description: Processor name.
-- name: service
-  type: group
+- name: service.framework.name
+  type: keyword
   description: |
-    Service fields.
-  fields:
-    - name: framework
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Name of the framework used.
-        - name: version
-          type: keyword
-          description: |
-            Version of the framework used.
-    - name: language
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Name of the programming language used.
-        - name: version
-          type: keyword
-          description: |
-            Version of the programming language used.
-    - name: runtime
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Name of the runtime used.
-        - name: version
-          type: keyword
-          description: |
-            Version of the runtime used.
-    - name: target
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Target service for which data is collected.
-        - name: type
-          type: keyword
-          description: |
-            Type of the target service for which data is collected
-- name: span
-  type: group
-  fields:
-    - name: destination
-      type: group
-      fields:
-        - name: service
-          type: group
-          description: Destination service context
-          fields:
-            - name: resource
-              type: keyword
-              description: |
-                Identifier for the destination service resource being operated on (e.g. 'http://elastic.co:80', 'elasticsearch', 'rabbitmq/queue_name')
-    - name: destination.service
-      type: group
-      fields:
-        - name: response_time.count
-          type: long
-          description: Number of aggregated outgoing requests.
-        - name: response_time.sum.us
-          type: long
-          description: Aggregated duration of outgoing requests, in microseconds.
-          unit: micros
-    - name: self_time
-      type: group
-      description: |
-        Portion of the span's duration where no direct child was running
-      fields:
-        - name: count
-          type: long
-          description: Number of aggregated spans.
-        - name: sum
-          type: group
-          fields:
-            - name: us
-              type: long
-              description: |
-                Aggregated span duration, excluding the time periods where a direct child was running, in microseconds.
-              unit: micros
-    - name: name
-      type: keyword
-      description: |
-        Generic designation of a span in the scope of a transaction.
-    - name: subtype
-      type: keyword
-      description: |
-        A further sub-division of the type (e.g. postgresql, elasticsearch)
-    - name: type
-      type: keyword
-      description: |
-        Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', 'cache', etc).
+    Name of the framework used.
+- name: service.framework.version
+  type: keyword
+  description: |
+    Version of the framework used.
+- name: service.language.name
+  type: keyword
+  description: |
+    Name of the programming language used.
+- name: service.language.version
+  type: keyword
+  description: |
+    Version of the programming language used.
+- name: service.runtime.name
+  type: keyword
+  description: |
+    Name of the runtime used.
+- name: service.runtime.version
+  type: keyword
+  description: |
+    Version of the runtime used.
+- name: service.target.name
+  type: keyword
+  description: |
+    Target service for which data is collected.
+- name: service.target.type
+  type: keyword
+  description: |
+    Type of the target service for which data is collected
+- name: span.destination.service.resource
+  type: keyword
+  description: |
+    Identifier for the destination service resource being operated on (e.g. 'http://elastic.co:80', 'elasticsearch', 'rabbitmq/queue_name')
+- name: span.destination.service.response_time.count
+  type: long
+  description: Number of aggregated outgoing requests.
+- name: span.destination.service.response_time.sum.us
+  type: long
+  description: Aggregated duration of outgoing requests, in microseconds.
+  unit: micros
+- name: span.self_time.count
+  type: long
+  description: Number of aggregated spans.
+- name: span.self_time.sum.us
+  type: long
+  description: |
+    Aggregated span duration, excluding the time periods where a direct child was running, in microseconds.
+  unit: micros
+- name: span.name
+  type: keyword
+  description: |
+    Generic designation of a span in the scope of a transaction.
+- name: span.subtype
+  type: keyword
+  description: |
+    A further sub-division of the type (e.g. postgresql, elasticsearch)
+- name: span.type
+  type: keyword
+  description: |
+    Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', 'cache', etc).
 - name: timeseries.instance
   type: keyword
   description: Time series instance ID
@@ -210,52 +139,38 @@
 - name: transaction.success_count
   type: long
   description: "Count of transactions with 'event.outcome: success'"
-- name: transaction
-  type: group
-  fields:
-    - name: duration
-      type: group
-      fields:
-        - name: histogram
-          type: histogram
-          description: |
-            Pre-aggregated histogram of transaction durations.
-    - name: name
-      type: keyword
-      description: |
-        Generic designation of a transaction in the scope of a single service (eg. 'GET /users/:id').
-    - name: result
-      type: keyword
-      description: |
-        The result of the transaction. HTTP status code for HTTP-related transactions.
-    - name: root
-      type: boolean
-      description: |
-        Identifies metrics for root transactions. This can be used for calculating metrics for traces.
-    - name: sampled
-      type: boolean
-      description: |
-        Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have spans or context.
-    - name: self_time
-      type: group
-      description: |
-        Portion of the transaction's duration where no direct child was running
-      fields:
-        - name: count
-          type: long
-          description: Number of aggregated transactions.
-        - name: sum
-          type: group
-          fields:
-            - name: us
-              type: long
-              description: |
-                Aggregated transaction duration, excluding the time periods where a direct child was running, in microseconds.
-              unit: micros
-    - name: type
-      type: keyword
-      description: |
-        Keyword of specific relevance in the service's domain (eg. 'request', 'backgroundjob', etc)
+- name: transaction.duration.histogram
+  type: histogram
+  description: |
+    Pre-aggregated histogram of transaction durations.
+- name: transaction.name
+  type: keyword
+  description: |
+    Generic designation of a transaction in the scope of a single service (eg. 'GET /users/:id').
+- name: transaction.result
+  type: keyword
+  description: |
+    The result of the transaction. HTTP status code for HTTP-related transactions.
+- name: transaction.root
+  type: boolean
+  description: |
+    Identifies metrics for root transactions. This can be used for calculating metrics for traces.
+- name: transaction.sampled
+  type: boolean
+  description: |
+    Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have spans or context.
+- name: transaction.self_time.count
+  type: long
+  description: Number of aggregated transactions.
+- name: transaction.self_time.sum.us
+  type: long
+  description: |
+    Aggregated transaction duration, excluding the time periods where a direct child was running, in microseconds.
+  unit: micros
+- name: transaction.type
+  type: keyword
+  description: |
+    Keyword of specific relevance in the service's domain (eg. 'request', 'backgroundjob', etc)
 - name: numeric_labels
   type: object
   dynamic: true

--- a/apmpackage/apm/data_stream/traces/fields/fields.yml
+++ b/apmpackage/apm/data_stream/traces/fields/fields.yml
@@ -1,455 +1,311 @@
-- name: child
-  type: group
-  fields:
-    - name: id
-      type: keyword
-      description: |
-        The ID(s) of the child event(s).
-- name: cloud
-  title: Cloud
-  type: group
+- name: child.id
+  type: keyword
   description: |
-    Cloud metadata reported by agents
-  fields:
-    - name: origin
-      type: group
-      fields:
-        - name: account.id
-          type: keyword
-          description: |
-            The cloud account or organization id used to identify different entities in a multi-tenant environment.
-        - name: provider
-          type: keyword
-          description: |
-            Name of the cloud provider.
-        - name: region
-          type: keyword
-          description: |
-            Region in which this host, resource, or service is located.
-        - name: service.name
-          type: keyword
-          description: |
-            The cloud service name is intended to distinguish services running on different platforms within a provider.
-- name: faas
-  type: group
+    The ID(s) of the child event(s).
+- name: cloud.origin.account.id
+  type: keyword
   description: |
-    Function as a service fields.
-  fields:
-    - name: id
-      type: keyword
-      description: |
-        A unique identifier of the invoked serverless function.
-    - name: coldstart
-      type: boolean
-      description: |
-        Boolean indicating whether the function invocation was a coldstart or not.
-    - name: execution
-      type: keyword
-      description: |
-        Request ID of the function invocation.
-    - name: trigger.request_id
-      type: keyword
-      description: |
-        The ID of the origin trigger request.
-    - name: trigger.type
-      type: keyword
-      description: |
-        The trigger type.
-    - name: name
-      type: keyword
-      description: |
-        The lambda function name.
-    - name: version
-      type: keyword
-      description: |
-        The lambda function version.
-- name: http
-  type: group
-  fields:
-    - name: request
-      type: group
-      fields:
-        - name: headers
-          type: object
-          description: |
-            The canonical headers of the monitored HTTP request.
-    - name: response
-      type: group
-      fields:
-        - name: finished
-          type: boolean
-          description: |
-            Used by the Node agent to indicate when in the response life cycle an error has occurred.
-        - name: headers
-          type: object
-          description: |
-            The canonical headers of the monitored HTTP response.
-- name: kubernetes
-  title: Kubernetes
-  type: group
+    The cloud account or organization id used to identify different entities in a multi-tenant environment.
+- name: cloud.origin.provider
+  type: keyword
   description: |
-    Kubernetes metadata reported by agents
-  fields:
-    - name: namespace
-      type: keyword
-      description: |
-        Kubernetes namespace
-    - name: node
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Kubernetes node name
-    - name: pod
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Kubernetes pod name
-        - name: uid
-          type: keyword
-          description: |
-            Kubernetes Pod UID
-- name: network
-  type: group
+    Name of the cloud provider.
+- name: cloud.origin.region
+  type: keyword
   description: |
-    Optional network fields
-  fields:
-    - name: carrier
-      type: group
-      description: |
-        Network operator
-      fields:
-        - name: icc
-          type: keyword
-          description: |
-            ISO country code, eg. US
-        - name: mcc
-          type: keyword
-          description: |
-            Mobile country code
-        - name: mnc
-          type: keyword
-          description: |
-            Mobile network code
-        - name: name
-          type: keyword
-          description: |
-            Carrier name, eg. Vodafone, T-Mobile, etc.
-    - name: connection
-      type: group
-      description: |
-        Network connection details
-      fields:
-        - name: subtype
-          type: keyword
-          description: |
-            Detailed network connection sub-type, e.g. "LTE", "CDMA"
-        - name: type
-          type: keyword
-          description: |
-            Network connection type, eg. "wifi", "cell"
-- name: observer
-  type: group
-  fields:
-    - name: ephemeral_id
-      type: keyword
-      description: |
-        Ephemeral identifier of the APM Server.
-    - name: id
-      type: keyword
-      description: |
-        Unique identifier of the APM Server.
-- name: parent
-  type: group
-  fields:
-    - name: id
-      type: keyword
-      description: |
-        The ID of the parent event.
+    Region in which this host, resource, or service is located.
+- name: cloud.origin.service.name
+  type: keyword
+  description: |
+    The cloud service name is intended to distinguish services running on different platforms within a provider.
+- name: faas.id
+  type: keyword
+  description: |
+    A unique identifier of the invoked serverless function.
+- name: faas.coldstart
+  type: boolean
+  description: |
+    Boolean indicating whether the function invocation was a coldstart or not.
+- name: faas.execution
+  type: keyword
+  description: |
+    Request ID of the function invocation.
+- name: faas.trigger.request_id
+  type: keyword
+  description: |
+    The ID of the origin trigger request.
+- name: faas.trigger.type
+  type: keyword
+  description: |
+    The trigger type.
+- name: faas.name
+  type: keyword
+  description: |
+    The lambda function name.
+- name: faas.version
+  type: keyword
+  description: |
+    The lambda function version.
+- name: http.request.headers
+  type: object
+  description: |
+    The canonical headers of the monitored HTTP request.
+- name: http.response.finished
+  type: boolean
+  description: |
+    Used by the Node agent to indicate when in the response life cycle an error has occurred.
+- name: http.response.headers
+  type: object
+  description: |
+    The canonical headers of the monitored HTTP response.
+- name: kubernetes.namespace
+  type: keyword
+  description: |
+    Kubernetes namespace
+- name: kubernetes.node.name
+  type: keyword
+  description: |
+    Kubernetes node name
+- name: kubernetes.pod.name
+  type: keyword
+  description: |
+    Kubernetes pod name
+- name: kubernetes.pod.uid
+  type: keyword
+  description: |
+    Kubernetes Pod UID
+- name: network.carrier.icc
+  type: keyword
+  description: |
+    ISO country code, eg. US
+- name: network.carrier.mcc
+  type: keyword
+  description: |
+    Mobile country code
+- name: network.carrier.mnc
+  type: keyword
+  description: |
+    Mobile network code
+- name: network.carrier.name
+  type: keyword
+  description: |
+    Carrier name, eg. Vodafone, T-Mobile, etc.
+- name: network.connection.subtype
+  type: keyword
+  description: |
+    Detailed network connection sub-type, e.g. "LTE", "CDMA"
+- name: network.connection.type
+  type: keyword
+  description: |
+    Network connection type, eg. "wifi", "cell"
+- name: observer.ephemeral_id
+  type: keyword
+  description: |
+    Ephemeral identifier of the APM Server.
+- name: observer.id
+  type: keyword
+  description: |
+    Unique identifier of the APM Server.
+- name: parent.id
+  type: keyword
+  description: |
+    The ID of the parent event.
 - name: processor.event
   type: keyword
   description: Processor event.
 - name: processor.name
   type: constant_keyword
   description: Processor name.
-- name: service
-  type: group
+- name: service.framework.name
+  type: keyword
   description: |
-    Service fields.
-  fields:
-    - name: framework
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Name of the framework used.
-        - name: version
-          type: keyword
-          description: |
-            Version of the framework used.
-    - name: language
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Name of the programming language used.
-        - name: version
-          type: keyword
-          description: |
-            Version of the programming language used.
-    - name: origin
-      type: group
-      fields:
-        - name: id
-          type: keyword
-          description: |
-            Immutable id of the service emitting this event.
-        - name: name
-          type: keyword
-          description: |
-            Immutable name of the service emitting this event.
-        - name: version
-          type: keyword
-          description: |
-            The version of the service the data was collected from.
-    - name: target
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Target service for which data is collected.
-        - name: type
-          type: keyword
-          description: |
-            Type of the target service for which data is collected
-    - name: runtime
-      type: group
-      fields:
-        - name: name
-          type: keyword
-          description: |
-            Name of the runtime used.
-        - name: version
-          type: keyword
-          description: |
-            Version of the runtime used.
-- name: session
-  type: group
-  fields:
-    - name: id
-      type: keyword
-      description: |
-        The ID of the session to which the event belongs.
-      ignore_above: 1024
-    - name: sequence
-      type: long
-      description: |
-        The sequence number of the event within the session to which the event belongs.
-- name: span
-  type: group
-  fields:
-    - name: action
-      type: keyword
-      description: |
-        The specific kind of event within the sub-type represented by the span (e.g. query, connect)
-    - name: kind
-      type: keyword
-      description: |
-        "The kind of span: CLIENT, SERVER, PRODUCER, CONSUMER, or INTERNAL."
-    - name: links
-      type: group
-      fields:
-        - name: trace.id
-          type: keyword
-          description: |
-            Unique identifier of the linked trace.
-        - name: span.id
-          type: keyword
-          description: |
-            Unique identifier of the linked span.
-    - name: composite
-      type: group
-      fields:
-        - name: compression_strategy
-          type: keyword
-          description: |
-            The compression strategy that was used.
-        - name: count
-          type: long
-          description: |
-            Number of compressed spans the composite span represents.
-        - name: sum
-          type: group
-          fields:
-            - name: us
-              type: long
-              description: |
-                Sum of the durations of the compressed spans, in microseconds.
-    - name: db
-      type: group
-      fields:
-        - name: link
-          type: keyword
-          description: |
-            Database link.
-        - name: rows_affected
-          type: long
-          description: |
-            Number of rows affected by the database statement.
-    - name: destination
-      type: group
-      fields:
-        - name: service
-          type: group
-          description: Destination service context
-          fields:
-            - name: name
-              type: keyword
-              description: |
-                Identifier for the destination service (e.g. 'http://elastic.co', 'elasticsearch', 'rabbitmq') DEPRECATED: this field will be removed in a future release
-            - name: resource
-              type: keyword
-              description: |
-                Identifier for the destination service resource being operated on (e.g. 'http://elastic.co:80', 'elasticsearch', 'rabbitmq/queue_name')
-            - name: type
-              type: keyword
-              description: |
-                Type of the destination service (e.g. 'db', 'elasticsearch'). Should typically be the same as span.type. DEPRECATED: this field will be removed in a future release
-    - name: duration
-      type: group
-      fields:
-        - name: us
-          type: long
-          description: |
-            Duration of the span, in microseconds.
-    - name: message
-      type: group
-      fields:
-        - name: age
-          type: group
-          fields:
-            - name: ms
-              type: long
-              description: |
-                Age of a message in milliseconds.
-        - name: queue
-          type: group
-          fields:
-            - name: name
-              type: keyword
-              description: |
-                Name of the message queue or topic where the message is published or received.
-    - name: name
-      type: keyword
-      description: |
-        Generic designation of a span in the scope of a transaction.
-    - name: subtype
-      type: keyword
-      description: |
-        A further sub-division of the type (e.g. postgresql, elasticsearch)
-    - name: sync
-      type: boolean
-      description: |
-        Indicates whether the span was executed synchronously or asynchronously.
-    - name: type
-      type: keyword
-      description: |
-        Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', 'cache', etc).
-- name: timestamp
-  type: group
-  fields:
-    - name: us
-      type: long
-      description: |
-        Timestamp of the event in microseconds since Unix epoch.
-- name: transaction
-  type: group
-  fields:
-    - name: duration
-      type: group
-      fields:
-        - name: us
-          type: long
-          description: |
-            Total duration of this transaction, in microseconds.
-    - name: experience
-      type: group
-      fields:
-        - name: cls
-          type: scaled_float
-          description: The Cumulative Layout Shift metric
-        - name: fid
-          type: scaled_float
-          description: The First Input Delay metric
-        - name: longtask
-          type: group
-          description: Longtask duration/count metrics
-          fields:
-            - name: count
-              type: long
-              description: The total number of of longtasks
-            - name: max
-              type: scaled_float
-              description: The max longtask duration
-            - name: sum
-              type: scaled_float
-              description: The sum of longtask durations
-        - name: tbt
-          type: scaled_float
-          description: The Total Blocking Time metric
-    - name: marks
-      type: object
-      description: |
-        A user-defined mapping of groups of marks in milliseconds.
-      dynamic: true
-    - name: message
-      type: group
-      fields:
-        - name: age
-          type: group
-          fields:
-            - name: ms
-              type: long
-              description: |
-                Age of a message in milliseconds.
-        - name: queue
-          type: group
-          fields:
-            - name: name
-              type: keyword
-              description: |
-                Name of the message queue or topic where the message is published or received.
-    - name: name
-      type: keyword
-      description: |
-        Generic designation of a transaction in the scope of a single service (eg. 'GET /users/:id').
-      multi_fields:
-        - name: text
-          type: text
-    - name: result
-      type: keyword
-      description: |
-        The result of the transaction. HTTP status code for HTTP-related transactions.
-    - name: sampled
-      type: boolean
-      description: |
-        Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have spans or context.
-    - name: span_count
-      type: group
-      fields:
-        - name: dropped
-          type: long
-          description: The total amount of dropped spans for this transaction.
-    - name: type
-      type: keyword
-      description: |
-        Keyword of specific relevance in the service's domain (eg. 'request', 'backgroundjob', etc)
+    Name of the framework used.
+- name: service.framework.version
+  type: keyword
+  description: |
+    Version of the framework used.
+- name: service.language.name
+  type: keyword
+  description: |
+    Name of the programming language used.
+- name: service.language.version
+  type: keyword
+  description: |
+    Version of the programming language used.
+- name: service.origin.id
+  type: keyword
+  description: |
+    Immutable id of the service emitting this event.
+- name: service.origin.name
+  type: keyword
+  description: |
+    Immutable name of the service emitting this event.
+- name: service.origin.version
+  type: keyword
+  description: |
+    The version of the service the data was collected from.
+- name: service.target.name
+  type: keyword
+  description: |
+    Target service for which data is collected.
+- name: service.target.type
+  type: keyword
+  description: |
+    Type of the target service for which data is collected
+- name: service.runtime.name
+  type: keyword
+  description: |
+    Name of the runtime used.
+- name: service.runtime.version
+  type: keyword
+  description: |
+    Version of the runtime used.
+- name: session.id
+  type: keyword
+  description: |
+    The ID of the session to which the event belongs.
+  ignore_above: 1024
+- name: session.sequence
+  type: long
+  description: |
+    The sequence number of the event within the session to which the event belongs.
+- name: span.action
+  type: keyword
+  description: |
+    The specific kind of event within the sub-type represented by the span (e.g. query, connect)
+- name: span.kind
+  type: keyword
+  description: |
+    "The kind of span: CLIENT, SERVER, PRODUCER, CONSUMER, or INTERNAL."
+- name: span.links.trace.id
+  type: keyword
+  description: |
+    Unique identifier of the linked trace.
+- name: span.links.span.id
+  type: keyword
+  description: |
+    Unique identifier of the linked span.
+- name: span.composite.compression_strategy
+  type: keyword
+  description: |
+    The compression strategy that was used.
+- name: span.composite.count
+  type: long
+  description: |
+    Number of compressed spans the composite span represents.
+- name: span.composite.sum.us
+  type: long
+  description: |
+    Sum of the durations of the compressed spans, in microseconds.
+- name: span.db.link
+  type: keyword
+  description: |
+    Database link.
+- name: span.db.rows_affected
+  type: long
+  description: |
+    Number of rows affected by the database statement.
+- name: span.destination.service.name
+  type: keyword
+  description: |
+    Identifier for the destination service (e.g. 'http://elastic.co', 'elasticsearch', 'rabbitmq') DEPRECATED: this field will be removed in a future release
+- name: span.destination.service.resource
+  type: keyword
+  description: |
+    Identifier for the destination service resource being operated on (e.g. 'http://elastic.co:80', 'elasticsearch', 'rabbitmq/queue_name')
+- name: span.destination.service.type
+  type: keyword
+  description: |
+    Type of the destination service (e.g. 'db', 'elasticsearch'). Should typically be the same as span.type. DEPRECATED: this field will be removed in a future release
+- name: span.duration.us
+  type: long
+  description: |
+    Duration of the span, in microseconds.
+- name: span.message.age.ms
+  type: long
+  description: |
+    Age of a message in milliseconds.
+- name: span.message.queue.name
+  type: keyword
+  description: |
+    Name of the message queue or topic where the message is published or received.
+- name: span.name
+  type: keyword
+  description: |
+    Generic designation of a span in the scope of a transaction.
+- name: span.subtype
+  type: keyword
+  description: |
+    A further sub-division of the type (e.g. postgresql, elasticsearch)
+- name: span.sync
+  type: boolean
+  description: |
+    Indicates whether the span was executed synchronously or asynchronously.
+- name: span.type
+  type: keyword
+  description: |
+    Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', 'cache', etc).
+- name: timestamp.us
+  type: long
+  description: |
+    Timestamp of the event in microseconds since Unix epoch.
+- name: transaction.duration.us
+  type: long
+  description: |
+    Total duration of this transaction, in microseconds.
+- name: transaction.experience.cls
+  type: scaled_float
+  description: The Cumulative Layout Shift metric
+- name: transaction.experience.fid
+  type: scaled_float
+  description: The First Input Delay metric
+- name: transaction.experience.longtask.count
+  type: long
+  description: The total number of of longtasks
+- name: transaction.experience.longtask.max
+  type: scaled_float
+  description: The max longtask duration
+- name: transaction.experience.longtask.sum
+  type: scaled_float
+  description: The sum of longtask durations
+- name: transaction.experience.tbt
+  type: scaled_float
+  description: The Total Blocking Time metric
+- name: transaction.marks
+  type: object
+  description: |
+    A user-defined mapping of groups of marks in milliseconds.
+  dynamic: true
+- name: transaction.message.age.ms
+  type: long
+  description: |
+    Age of a message in milliseconds.
+- name: transaction.message.queue.name
+  type: keyword
+  description: |
+    Name of the message queue or topic where the message is published or received.
+- name: transaction.name
+  type: keyword
+  description: |
+    Generic designation of a transaction in the scope of a single service (eg. 'GET /users/:id').
+  multi_fields:
+    - name: text
+      type: text
+- name: transaction.result
+  type: keyword
+  description: |
+    The result of the transaction. HTTP status code for HTTP-related transactions.
+- name: transaction.sampled
+  type: boolean
+  description: |
+    Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have spans or context.
+- name: transaction.span_count.dropped
+  type: long
+  description: The total amount of dropped spans for this transaction.
+- name: transaction.type
+  type: keyword
+  description: |
+    Keyword of specific relevance in the service's domain (eg. 'request', 'backgroundjob', etc)
 - name: numeric_labels
   type: object
   dynamic: true


### PR DESCRIPTION
## Motivation/summary

Flatten `fields.yml` files, making them a bit easier to navigate. Rather than having to track indentation, we can grep for field names, prefixes, etc. This may also be necessary for [`subobjects: false`](https://www.elastic.co/guide/en/elasticsearch/reference/current/subobjects.html), when we get to it.

The changes is mechanical, using https://gist.github.com/axw/bba69ae5bc34179abc5e19744949f7bc

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A, this is a non-functional change.

## Related issues

None