### PR TITLE
Bump version to 8.4.4

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -1,7 +1,7 @@
 # newer versions go on top
 #
 # change type can be one of: enhancement, bugfix, breaking-change
-- version: "8.4.3"
+- version: "8.4.4"
   changes:
     - description: Placeholder
       type: bugfix

--- a/cmd/intake-receiver/version.go
+++ b/cmd/intake-receiver/version.go
@@ -18,4 +18,4 @@
 package main
 
 // version matches the APM Server's version
-const version = "8.4.3"
+const version = "8.4.4"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -18,4 +18,4 @@
 package version
 
 // Version holds the APM Server version.
-const Version = "8.4.3"
+const Version = "8.4.4"


### PR DESCRIPTION
Prepare for `8.4.3` release. To be merged after `8.4.3` is cut.