### PR TITLE
Remove `apm-server.decoder.*` metrics

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -5,6 +5,7 @@ https://github.com/elastic/apm-server/compare/8.5\...main[View commits]
 
 [float]
 ==== Breaking Changes
+- `apm-server.decoder.*` stack monitoring metrics are no longer recorded {pull}9210[9210]
 
 [float]
 ==== Deprecations

--- a/internal/beater/request/context_test.go
+++ b/internal/beater/request/context_test.go
@@ -228,7 +228,6 @@ func TestContextResetContentEncoding(t *testing.T) {
 			if contentEncoding != "" {
 				r.Header.Set("Content-Encoding", contentEncoding)
 			}
-			originalContentLength := r.ContentLength
 
 			c := Context{
 				Request:        r,
@@ -237,8 +236,6 @@ func TestContextResetContentEncoding(t *testing.T) {
 			}
 
 			c.Reset(w, r)
-			assert.Equal(t, originalContentLength, c.OriginalContentLength)
-			assert.Equal(t, expectedContentEncoding, c.ContentEncoding)
 			assertReaderContents(t, expectedBody, c.Request.Body)
 		})
 	}


### PR DESCRIPTION
## Motivation/summary

These are not used by stack monitoring, and I don't think they have ever been useful for supportability, so let's remove them.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

Closes #9079