### PR TITLE
Enable synthetic source for metrics data streams

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -6,6 +6,9 @@
     - description: Change `ecs.version` to a `constant_keyword` field
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/9208
+    - description: Enable synthetic source for metrics data streams
+      type: enhancement
+      link: https://github.com/elastic/apm-server/pull/9215
 - version: "8.5.0"
   changes:
     - description: Add package settings to enable the experimental collection of service metrics

--- a/apmpackage/apm/data_stream/app_metrics/manifest.yml
+++ b/apmpackage/apm/data_stream/app_metrics/manifest.yml
@@ -10,6 +10,10 @@ elasticsearch:
       # as their names are application-specific and not
       # known ahead of time.
       dynamic: true
+      # Individual measurements are typically uninteresting, so
+      # use synthetic source to reduce storage size.
+      _source:
+        mode: synthetic
       # Install dynamic templates for use in dynamically
       # mapping complex application metrics.
       dynamic_templates:

--- a/apmpackage/apm/data_stream/internal_metrics/manifest.yml
+++ b/apmpackage/apm/data_stream/internal_metrics/manifest.yml
@@ -8,6 +8,10 @@ elasticsearch:
       # Internal metrics should have all fields strictly mapped;
       # we are in full control of the field names.
       dynamic: strict
+      # Individual measurements are typically uninteresting, so
+      # use synthetic source to reduce storage size.
+      _source:
+        mode: synthetic
       # We map transaction.duration.summary here because aggregate_metric_double
       # is not currently supported by package-spec.
       #

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -19,3 +19,4 @@ https://github.com/elastic/apm-server/compare/8.5\...main[View commits]
 
 [float]
 ==== Added
+- Metrics data streams now use synthetic source {pull}9215[9215]

--- a/systemtest/approvals.go
+++ b/systemtest/approvals.go
@@ -45,6 +45,7 @@ func ApproveEvents(t testing.TB, name string, hits []estest.SearchHit, dynamic .
 	// Ignore their values in comparisons, but compare
 	// existence: either the field exists in both, or neither.
 	dynamic = append([]string{
+		"ecs.version",
 		"event.ingested",
 		"observer.ephemeral_id",
 		"observer.hostname",

--- a/systemtest/approvals/TestAgentConfig.approved.json
+++ b/systemtest/approvals/TestAgentConfig.approved.json
@@ -3,9 +3,14 @@
         {
             "@timestamp": "dynamic",
             "agent_config_applied": 1,
-            "data_stream.dataset": "apm.internal",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.internal",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic"
@@ -13,7 +18,9 @@
             "labels": {
                 "etag": "dynamic"
             },
-            "metricset.name": "agent_config",
+            "metricset": {
+                "name": "agent_config"
+            },
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",

--- a/systemtest/approvals/TestAgentConfig.approved.json
+++ b/systemtest/approvals/TestAgentConfig.approved.json
@@ -9,7 +9,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",

--- a/systemtest/approvals/TestApprovedMetrics.approved.json
+++ b/systemtest/approvals/TestApprovedMetrics.approved.json
@@ -12,7 +12,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",
@@ -80,7 +80,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",
@@ -155,7 +155,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",
@@ -244,7 +244,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",
@@ -315,7 +315,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",
@@ -391,7 +391,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",

--- a/systemtest/approvals/TestApprovedMetrics.approved.json
+++ b/systemtest/approvals/TestApprovedMetrics.approved.json
@@ -6,23 +6,36 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm.app.1234_service_12a3",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.app.1234_service_12a3",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic"
             },
-            "go.memstats.heap.sys.bytes": 6520832,
+            "go": {
+                "memstats": {
+                    "heap": {
+                        "sys": {
+                            "bytes": 6520832
+                        }
+                    }
+                }
+            },
             "host": {
-                "ip": [
-                    "127.0.0.1"
-                ]
+                "ip": "127.0.0.1"
             },
             "labels": {
                 "tag1": "one"
             },
-            "metricset.name": "app",
+            "metricset": {
+                "name": "app"
+            },
             "numeric_labels": {
                 "tag2": 2
             },
@@ -61,22 +74,27 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.internal",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic"
             },
             "host": {
-                "ip": [
-                    "127.0.0.1"
-                ]
+                "ip": "127.0.0.1"
             },
             "labels": {
                 "tag1": "one"
             },
-            "metricset.name": "app",
+            "metricset": {
+                "name": "app"
+            },
             "numeric_labels": {
                 "tag2": 2
             },
@@ -103,8 +121,22 @@
                     "name": "node-1"
                 }
             },
-            "system.process.cgroup.memory.mem.limit.bytes": 2048,
-            "system.process.cgroup.memory.mem.usage.bytes": 1024,
+            "system": {
+                "process": {
+                    "cgroup": {
+                        "memory": {
+                            "mem": {
+                                "limit": {
+                                    "bytes": 2048
+                                },
+                                "usage": {
+                                    "bytes": 1024
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "user": {
                 "email": "user@mail.com",
                 "id": "axb123hg",
@@ -117,22 +149,27 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm.app.1234_service_12a3",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.app.1234_service_12a3",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic"
             },
             "host": {
-                "ip": [
-                    "127.0.0.1"
-                ]
+                "ip": "127.0.0.1"
             },
             "labels": {
                 "tag1": "one"
             },
-            "metricset.name": "app",
+            "metricset": {
+                "name": "app"
+            },
             "numeric_labels": {
                 "tag2": 2
             },
@@ -159,14 +196,36 @@
                     "name": "node-1"
                 }
             },
-            "system.process.cgroup.cpu.cfs.period.us": 1024,
-            "system.process.cgroup.cpu.cfs.quota.us": 2048,
-            "system.process.cgroup.cpu.id": 2048,
-            "system.process.cgroup.cpu.stats.periods": 2048,
-            "system.process.cgroup.cpu.stats.throttled.ns": 2048,
-            "system.process.cgroup.cpu.stats.throttled.periods": 2048,
-            "system.process.cgroup.cpuacct.id": 2048,
-            "system.process.cgroup.cpuacct.total.ns": 2048,
+            "system": {
+                "process": {
+                    "cgroup": {
+                        "cpu": {
+                            "cfs": {
+                                "period": {
+                                    "us": 1024
+                                },
+                                "quota": {
+                                    "us": 2048
+                                }
+                            },
+                            "id": 2048,
+                            "stats": {
+                                "periods": 2048,
+                                "throttled": {
+                                    "ns": 2048,
+                                    "periods": 2048
+                                }
+                            }
+                        },
+                        "cpuacct": {
+                            "id": 2048,
+                            "total": {
+                                "ns": 2048
+                            }
+                        }
+                    }
+                }
+            },
             "user": {
                 "email": "user@mail.com",
                 "id": "axb123hg",
@@ -179,17 +238,20 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm.app.1234_service_12a3",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.app.1234_service_12a3",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic"
             },
             "host": {
-                "ip": [
-                    "127.0.0.1"
-                ]
+                "ip": "127.0.0.1"
             },
             "labels": {
                 "tag1": "one"
@@ -206,7 +268,9 @@
                     3.3
                 ]
             },
-            "metricset.name": "app",
+            "metricset": {
+                "name": "app"
+            },
             "numeric_labels": {
                 "tag2": 2
             },
@@ -245,31 +309,36 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.internal",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic"
             },
             "faas": {
+                "billed_duration": 183,
                 "coldstart": true,
+                "coldstart_duration": 422.97,
+                "duration": 182.43,
                 "execution": "6f7f0961f83442118a7af6fe80b88d56",
-                "id": "arn:aws:lambda:us-east-2:123456789012:function:custom-runtime"
+                "id": "arn:aws:lambda:us-east-2:123456789012:function:custom-runtime",
+                "timeout": 5000
             },
-            "faas.billed_duration": 183,
-            "faas.coldstart_duration": 422.9700012207031,
-            "faas.duration": 182.42999267578125,
-            "faas.timeout": 5000,
             "host": {
-                "ip": [
-                    "127.0.0.1"
-                ]
+                "ip": "127.0.0.1"
             },
             "labels": {
                 "tag1": "one"
             },
-            "metricset.name": "app",
+            "metricset": {
+                "name": "app"
+            },
             "numeric_labels": {
                 "tag2": 2
             },
@@ -296,8 +365,14 @@
                     "name": "node-1"
                 }
             },
-            "system.memory.actual.free": 54525952,
-            "system.memory.total": 134217728,
+            "system": {
+                "memory": {
+                    "actual": {
+                        "free": 54525952
+                    },
+                    "total": 134217728
+                }
+            },
             "user": {
                 "email": "user@mail.com",
                 "id": "axb123hg",
@@ -310,24 +385,29 @@
                 "name": "elastic-node",
                 "version": "3.14.0"
             },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.internal",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic"
             },
             "host": {
-                "ip": [
-                    "127.0.0.1"
-                ]
+                "ip": "127.0.0.1"
             },
             "labels": {
                 "some": "abc",
                 "success": "true",
                 "tag1": "one"
             },
-            "metricset.name": "span_breakdown",
+            "metricset": {
+                "name": "span_breakdown"
+            },
             "numeric_labels": {
                 "code": 200,
                 "tag2": 2
@@ -358,7 +438,9 @@
             "span": {
                 "self_time": {
                     "count": 1,
-                    "sum.us": 633
+                    "sum": {
+                        "us": 633
+                    }
                 },
                 "subtype": "mysql",
                 "type": "db"

--- a/systemtest/approvals/TestIngestPipelineDataStreamMigration.approved.json
+++ b/systemtest/approvals/TestIngestPipelineDataStreamMigration.approved.json
@@ -151,26 +151,41 @@
                 "namespace": "migrated",
                 "type": "metrics"
             },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic"
             },
-            "golang.goroutines": 11,
-            "golang.heap.allocations.active": 6160384,
-            "golang.heap.allocations.allocated": 4579688,
-            "golang.heap.allocations.frees": 39979,
-            "golang.heap.allocations.idle": 5701632,
-            "golang.heap.allocations.mallocs": 44520,
-            "golang.heap.allocations.objects": 4541,
-            "golang.heap.allocations.total": 8834120,
-            "golang.heap.gc.cpu_fraction": 0.00031759519816489074,
-            "golang.heap.gc.next_gc_limit": 8842488,
-            "golang.heap.gc.total_count": 3,
-            "golang.heap.gc.total_pause.ns": 178493,
-            "golang.heap.system.obtained": 11862016,
-            "golang.heap.system.released": 3989504,
-            "golang.heap.system.stack": 720896,
-            "golang.heap.system.total": 20268040,
+            "golang": {
+                "goroutines": 11,
+                "heap": {
+                    "allocations": {
+                        "active": 6160384,
+                        "allocated": 4579688,
+                        "frees": 39979,
+                        "idle": 5701632,
+                        "mallocs": 44520,
+                        "objects": 4541,
+                        "total": 8834120
+                    },
+                    "gc": {
+                        "cpu_fraction": 0.0003175952,
+                        "next_gc_limit": 8842488,
+                        "total_count": 3,
+                        "total_pause": {
+                            "ns": 178493
+                        }
+                    },
+                    "system": {
+                        "obtained": 11862016,
+                        "released": 3989504,
+                        "stack": 720896,
+                        "total": 20268040
+                    }
+                }
+            },
             "host": {
                 "architecture": "amd64",
                 "hostname": "corduroy",
@@ -180,7 +195,9 @@
                     "platform": "linux"
                 }
             },
-            "metricset.name": "app",
+            "metricset": {
+                "name": "app"
+            },
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",
@@ -190,9 +207,7 @@
                 "version": "dynamic"
             },
             "process": {
-                "args": [
-                    "/tmp/go-build1405913256/b001/exe/main"
-                ],
+                "args": "/tmp/go-build1405913256/b001/exe/main",
                 "parent": {
                     "pid": 4009763
                 },
@@ -217,12 +232,36 @@
                     "version": "go1.18.1"
                 }
             },
-            "system.cpu.total.norm.pct": 0.022556390977443663,
-            "system.memory.actual.free": 33981652992,
-            "system.memory.total": 46108971008,
-            "system.process.cpu.total.norm.pct": 0.002506265664160401,
-            "system.process.memory.rss.bytes": 15187968,
-            "system.process.memory.size": 1485594624
+            "system": {
+                "cpu": {
+                    "total": {
+                        "norm": {
+                            "pct": 0.02255639
+                        }
+                    }
+                },
+                "memory": {
+                    "actual": {
+                        "free": 33981653000
+                    },
+                    "total": 46108971000
+                },
+                "process": {
+                    "cpu": {
+                        "total": {
+                            "norm": {
+                                "pct": 0.0025062656
+                            }
+                        }
+                    },
+                    "memory": {
+                        "rss": {
+                            "bytes": 15187968
+                        },
+                        "size": 1485594620
+                    }
+                }
+            }
         },
         {
             "@timestamp": "2022-09-12T03:52:51.178Z",
@@ -238,6 +277,9 @@
                 "namespace": "migrated",
                 "type": "metrics"
             },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic"
@@ -251,7 +293,9 @@
                     "platform": "linux"
                 }
             },
-            "metricset.name": "span_breakdown",
+            "metricset": {
+                "name": "span_breakdown"
+            },
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",
@@ -261,9 +305,7 @@
                 "version": "dynamic"
             },
             "process": {
-                "args": [
-                    "/tmp/go-build1405913256/b001/exe/main"
-                ],
+                "args": "/tmp/go-build1405913256/b001/exe/main",
                 "parent": {
                     "pid": 4009763
                 },
@@ -291,7 +333,9 @@
             "span": {
                 "self_time": {
                     "count": 1,
-                    "sum.us": 15
+                    "sum": {
+                        "us": 15
+                    }
                 },
                 "type": "app"
             },
@@ -314,6 +358,9 @@
                 "namespace": "migrated",
                 "type": "metrics"
             },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic"
@@ -327,7 +374,9 @@
                     "platform": "linux"
                 }
             },
-            "metricset.name": "span_breakdown",
+            "metricset": {
+                "name": "span_breakdown"
+            },
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",
@@ -337,9 +386,7 @@
                 "version": "dynamic"
             },
             "process": {
-                "args": [
-                    "/tmp/go-build1405913256/b001/exe/main"
-                ],
+                "args": "/tmp/go-build1405913256/b001/exe/main",
                 "parent": {
                     "pid": 4009763
                 },
@@ -367,7 +414,9 @@
             "span": {
                 "self_time": {
                     "count": 1,
-                    "sum.us": 10220
+                    "sum": {
+                        "us": 10220
+                    }
                 },
                 "type": "type"
             },
@@ -386,12 +435,17 @@
                 "namespace": "migrated",
                 "type": "metrics"
             },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic",
                 "outcome": "failure"
             },
-            "metricset.name": "service_destination",
+            "metricset": {
+                "name": "service_destination"
+            },
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",
@@ -413,7 +467,9 @@
                         "resource": "dest_resource",
                         "response_time": {
                             "count": 1,
-                            "sum.us": 10220
+                            "sum": {
+                                "us": 10220
+                            }
                         }
                     }
                 }
@@ -421,7 +477,6 @@
         },
         {
             "@timestamp": "2022-09-12T03:52:00.000Z",
-            "_doc_count": 1,
             "agent": {
                 "name": "go"
             },
@@ -433,6 +488,9 @@
                 "namespace": "migrated",
                 "type": "metrics"
             },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic",
@@ -442,7 +500,9 @@
                 "hostname": "corduroy",
                 "name": "corduroy"
             },
-            "metricset.name": "transaction",
+            "metricset": {
+                "name": "transaction"
+            },
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",
@@ -465,13 +525,15 @@
                 "instance": "main:name:5b6121c8e3ec693e"
             },
             "transaction": {
-                "duration.histogram": {
-                    "counts": [
-                        1
-                    ],
-                    "values": [
-                        10239
-                    ]
+                "duration": {
+                    "histogram": {
+                        "counts": [
+                            1
+                        ],
+                        "values": [
+                            10239
+                        ]
+                    }
                 },
                 "name": "name",
                 "root": true,

--- a/systemtest/approvals/TestIngestPipelineDataStreamMigration.approved.json
+++ b/systemtest/approvals/TestIngestPipelineDataStreamMigration.approved.json
@@ -152,7 +152,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",
@@ -278,7 +278,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",
@@ -359,7 +359,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",
@@ -436,7 +436,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",
@@ -489,7 +489,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",

--- a/systemtest/approvals/TestOTLPGRPCMetrics.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCMetrics.approved.json
@@ -12,7 +12,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",
@@ -55,7 +55,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",

--- a/systemtest/approvals/TestOTLPGRPCMetrics.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCMetrics.approved.json
@@ -6,14 +6,21 @@
                 "name": "otlp",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm.app.unknown",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.app.unknown",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic"
             },
-            "metricset.name": "app",
+            "metricset": {
+                "name": "app"
+            },
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",
@@ -42,9 +49,14 @@
                 "name": "opentelemetry/go",
                 "version": "1.8.0"
             },
-            "data_stream.dataset": "apm.app.unknown_service_systemtest_test",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.app.unknown_service_systemtest_test",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic"
@@ -64,7 +76,9 @@
                     10000
                 ]
             },
-            "metricset.name": "app",
+            "metricset": {
+                "name": "app"
+            },
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",

--- a/systemtest/approvals/TestRUMXForwardedFor.approved.json
+++ b/systemtest/approvals/TestRUMXForwardedFor.approved.json
@@ -24,7 +24,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",

--- a/systemtest/approvals/TestRUMXForwardedFor.approved.json
+++ b/systemtest/approvals/TestRUMXForwardedFor.approved.json
@@ -18,14 +18,21 @@
                 },
                 "ip": "220.244.41.16"
             },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.internal",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic"
             },
-            "metricset.name": "span_breakdown",
+            "metricset": {
+                "name": "span_breakdown"
+            },
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",
@@ -49,7 +56,9 @@
             "span": {
                 "self_time": {
                     "count": 1,
-                    "sum.us": 633
+                    "sum": {
+                        "us": 633
+                    }
                 },
                 "subtype": "http",
                 "type": "external"

--- a/systemtest/approvals/TestServiceDestinationAggregation.approved.json
+++ b/systemtest/approvals/TestServiceDestinationAggregation.approved.json
@@ -11,7 +11,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",

--- a/systemtest/approvals/TestServiceDestinationAggregation.approved.json
+++ b/systemtest/approvals/TestServiceDestinationAggregation.approved.json
@@ -5,15 +5,22 @@
             "agent": {
                 "name": "go"
             },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.internal",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic",
                 "outcome": "success"
             },
-            "metricset.name": "service_destination",
+            "metricset": {
+                "name": "service_destination"
+            },
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",
@@ -37,7 +44,9 @@
                         "resource": "resource",
                         "response_time": {
                             "count": 5,
-                            "sum.us": 5000000
+                            "sum": {
+                                "us": 5000000
+                            }
                         }
                     }
                 },

--- a/systemtest/approvals/TestServiceMetricsAggregation.approved.json
+++ b/systemtest/approvals/TestServiceMetricsAggregation.approved.json
@@ -2,18 +2,24 @@
     "events": [
         {
             "@timestamp": "2006-01-02T15:04:05.000Z",
-            "_doc_count": 2,
             "agent": {
                 "name": "go"
             },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.internal",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic"
             },
-            "metricset.name": "service",
+            "metricset": {
+                "name": "service"
+            },
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",
@@ -29,9 +35,11 @@
                 "name": "systemtest"
             },
             "transaction": {
-                "duration.summary": {
-                    "sum": 2000000,
-                    "value_count": 2
+                "duration": {
+                    "summary": {
+                        "sum": 2000000,
+                        "value_count": 2
+                    }
                 },
                 "success_count": 2,
                 "type": "type1"
@@ -39,18 +47,24 @@
         },
         {
             "@timestamp": "2006-01-02T15:04:05.000Z",
-            "_doc_count": 2,
             "agent": {
                 "name": "go"
             },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.internal",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic"
             },
-            "metricset.name": "service",
+            "metricset": {
+                "name": "service"
+            },
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",
@@ -66,9 +80,11 @@
                 "name": "systemtest"
             },
             "transaction": {
-                "duration.summary": {
-                    "sum": 2000000,
-                    "value_count": 2
+                "duration": {
+                    "summary": {
+                        "sum": 2000000,
+                        "value_count": 2
+                    }
                 },
                 "success_count": 2,
                 "type": "type2"

--- a/systemtest/approvals/TestServiceMetricsAggregation.approved.json
+++ b/systemtest/approvals/TestServiceMetricsAggregation.approved.json
@@ -11,7 +11,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",
@@ -56,7 +56,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",

--- a/systemtest/approvals/TestTransactionAggregation.approved.json
+++ b/systemtest/approvals/TestTransactionAggregation.approved.json
@@ -33,7 +33,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",
@@ -125,7 +125,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",
@@ -197,7 +197,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",

--- a/systemtest/approvals/TestTransactionAggregation.approved.json
+++ b/systemtest/approvals/TestTransactionAggregation.approved.json
@@ -2,7 +2,6 @@
     "events": [
         {
             "@timestamp": "2021-09-15T20:11:06.000Z",
-            "_doc_count": 1,
             "agent": {
                 "name": "elastic-node"
             },
@@ -28,9 +27,14 @@
             "container": {
                 "id": "container-id"
             },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.internal",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic",
@@ -38,7 +42,9 @@
             },
             "faas": {
                 "coldstart": false,
-                "trigger.type": "http"
+                "trigger": {
+                    "type": "http"
+                }
             },
             "host": {
                 "hostname": "node-name",
@@ -55,7 +61,9 @@
             "labels": {
                 "tag1": "one"
             },
-            "metricset.name": "transaction",
+            "metricset": {
+                "name": "transaction"
+            },
             "numeric_labels": {
                 "tag2": 2
             },
@@ -90,13 +98,15 @@
                 "instance": "1234_service-12a3:faas:2a7054ba528b6bef"
             },
             "transaction": {
-                "duration.histogram": {
-                    "counts": [
-                        1
-                    ],
-                    "values": [
-                        38911
-                    ]
+                "duration": {
+                    "histogram": {
+                        "counts": [
+                            1
+                        ],
+                        "values": [
+                            38911
+                        ]
+                    }
                 },
                 "name": "faas",
                 "result": "success",
@@ -106,13 +116,17 @@
         },
         {
             "@timestamp": "2006-01-02T15:04:05.000Z",
-            "_doc_count": 5,
             "agent": {
                 "name": "go"
             },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.internal",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic",
@@ -125,7 +139,9 @@
                     "platform": "minix"
                 }
             },
-            "metricset.name": "transaction",
+            "metricset": {
+                "name": "transaction"
+            },
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",
@@ -155,13 +171,15 @@
                 "instance": "systemtest:abc:954c62c5a2b8d0dd"
             },
             "transaction": {
-                "duration.histogram": {
-                    "counts": [
-                        5
-                    ],
-                    "values": [
-                        1003519
-                    ]
+                "duration": {
+                    "histogram": {
+                        "counts": [
+                            5
+                        ],
+                        "values": [
+                            1003519
+                        ]
+                    }
                 },
                 "name": "abc",
                 "root": true,
@@ -170,13 +188,17 @@
         },
         {
             "@timestamp": "2006-01-02T15:04:05.000Z",
-            "_doc_count": 10,
             "agent": {
                 "name": "go"
             },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.internal",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic",
@@ -189,7 +211,9 @@
                     "platform": "minix"
                 }
             },
-            "metricset.name": "transaction",
+            "metricset": {
+                "name": "transaction"
+            },
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",
@@ -219,13 +243,15 @@
                 "instance": "systemtest:def:3f14f7166cf7659e"
             },
             "transaction": {
-                "duration.histogram": {
-                    "counts": [
-                        10
-                    ],
-                    "values": [
-                        1003519
-                    ]
+                "duration": {
+                    "histogram": {
+                        "counts": [
+                            10
+                        ],
+                        "values": [
+                            1003519
+                        ]
+                    }
                 },
                 "name": "def",
                 "root": true,

--- a/systemtest/approvals/TestTransactionAggregationShutdown.approved.json
+++ b/systemtest/approvals/TestTransactionAggregationShutdown.approved.json
@@ -11,7 +11,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",

--- a/systemtest/approvals/TestTransactionAggregationShutdown.approved.json
+++ b/systemtest/approvals/TestTransactionAggregationShutdown.approved.json
@@ -2,13 +2,17 @@
     "events": [
         {
             "@timestamp": "2006-01-02T15:00:00.000Z",
-            "_doc_count": 1,
             "agent": {
                 "name": "go"
             },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.internal",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic",
@@ -21,7 +25,9 @@
                     "platform": "minix"
                 }
             },
-            "metricset.name": "transaction",
+            "metricset": {
+                "name": "transaction"
+            },
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",
@@ -51,13 +57,15 @@
                 "instance": "systemtest:name:942a34484a40cac3"
             },
             "transaction": {
-                "duration.histogram": {
-                    "counts": [
-                        1
-                    ],
-                    "values": [
-                        1003519
-                    ]
+                "duration": {
+                    "histogram": {
+                        "counts": [
+                            1
+                        ],
+                        "values": [
+                            1003519
+                        ]
+                    }
                 },
                 "name": "name",
                 "root": true,

--- a/systemtest/approvals/TestTransactionDroppedSpansStatsMetrics.approved.json
+++ b/systemtest/approvals/TestTransactionDroppedSpansStatsMetrics.approved.json
@@ -11,7 +11,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",
@@ -60,7 +60,7 @@
                 "type": "metrics"
             },
             "ecs": {
-                "version": "8.6.0-dev"
+                "version": "dynamic"
             },
             "event": {
                 "agent_id_status": "missing",

--- a/systemtest/approvals/TestTransactionDroppedSpansStatsMetrics.approved.json
+++ b/systemtest/approvals/TestTransactionDroppedSpansStatsMetrics.approved.json
@@ -5,15 +5,22 @@
             "agent": {
                 "name": "go"
             },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.internal",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic",
                 "outcome": "success"
             },
-            "metricset.name": "service_destination",
+            "metricset": {
+                "name": "service_destination"
+            },
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",
@@ -34,7 +41,9 @@
                         "resource": "elasticsearch",
                         "response_time": {
                             "count": 4,
-                            "sum.us": 3600
+                            "sum": {
+                                "us": 3600
+                            }
                         }
                     }
                 }
@@ -45,15 +54,22 @@
             "agent": {
                 "name": "go"
             },
-            "data_stream.dataset": "apm.internal",
-            "data_stream.namespace": "default",
-            "data_stream.type": "metrics",
+            "data_stream": {
+                "dataset": "apm.internal",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "8.6.0-dev"
+            },
             "event": {
                 "agent_id_status": "missing",
                 "ingested": "dynamic",
                 "outcome": "success"
             },
-            "metricset.name": "service_destination",
+            "metricset": {
+                "name": "service_destination"
+            },
             "observer": {
                 "ephemeral_id": "dynamic",
                 "hostname": "dynamic",
@@ -74,7 +90,9 @@
                         "resource": "redis",
                         "response_time": {
                             "count": 50,
-                            "sum.us": 5000
+                            "sum": {
+                                "us": 5000
+                            }
                         }
                     }
                 }

--- a/systemtest/metrics_test.go
+++ b/systemtest/metrics_test.go
@@ -151,10 +151,7 @@ func TestApplicationMetrics(t *testing.T) {
 	for _, fieldName := range expectedFields {
 		var found bool
 		for _, hit := range result.Hits.Hits {
-			// Metrics are written with dotted field names rather than
-			// as hierarchical objects, so escape dots in the gjson path.
-			path := strings.Replace(fieldName, ".", "\\.", -1)
-			if gjson.GetBytes(hit.RawSource, path).Exists() {
+			if gjson.GetBytes(hit.RawSource, fieldName).Exists() {
 				found = true
 				break
 			}
@@ -237,5 +234,6 @@ func unmarshalMetricsetDoc(t testing.TB, hit *estest.SearchHit) metricsetDoc {
 	if err := hit.UnmarshalSource(&doc); err != nil {
 		t.Fatal(err)
 	}
+	doc.MetricsetName = gjson.GetBytes(hit.RawSource, "metricset").Get("name").String()
 	return doc
 }


### PR DESCRIPTION
## Motivation/summary

Enable synthetic source by default for APM's metrics data streams. See https://github.com/elastic/apm-server/issues/9010 for motiviation.

It is possible to disable synthetic source by modifying the `@custom` component template, e.g.

```
PUT /_component_template/metrics-apm.app@custom
{
  "template": {
    "mappings": {
      "_source": {}
    }
  }
}
```

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
~- [ ] Documentation has been updated~

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

1. Send some transactions, spans with `service.target.*`, and custom application metrics
2. Confirm that synthetic source is enabled for the APM metrics data streams (internal & app)
3. Confirm that transaction metrics and service dependencies are visualised in the APM UI
4. Confirm that application metrics can be visualised in Lens
5. Confirm that the (synthetic) source can be visualised for all events in Discover
6. Modify component templates for metrics data streams to disable synthetic source (see Summary section for instructions) and roll over; send more data and ensure source is not synthetic

## Related issues

Closes #9010