### PR TITLE
Profiling: add cluster id in metrics docs

### DIFF
--- a/x-pack/apm-server/main.go
+++ b/x-pack/apm-server/main.go
@@ -308,10 +308,9 @@ func queryElasticsearchClusterName(client elasticsearch.Client, logger *logp.Log
 		logger.Warnf("failed to fetch cluster name from Elasticsearch: %v", err)
 		return "", nil
 	}
-	type response struct {
+	var r struct {
 		ClusterName string `json:"cluster_name"`
 	}
-	var r response
 	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
 		logger.Warnf("failed to parse Elasticsearch JSON response: %v", err)
 	}

--- a/x-pack/apm-server/main_test.go
+++ b/x-pack/apm-server/main_test.go
@@ -7,7 +7,13 @@ package main
 // This file is mandatory as otherwise the apm-server.test binary is not generated correctly.
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"io"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,4 +70,83 @@ func TestMonitoring(t *testing.T) {
 		assert.NotEqual(t, monitoring.MakeFlatSnapshot(), aggregationMonitoringSnapshot)
 		assert.NotEqual(t, monitoring.MakeFlatSnapshot(), tailSamplingMonitoringSnapshot)
 	}
+}
+
+func TestQueryElasticsearchClusterName(t *testing.T) {
+	const clusterName = "test-cluster-123"
+	cases := []struct {
+		name,
+		expectedResult,
+		body string
+		throwErr       bool
+		expectedLogMsg string
+	}{
+		{
+			name:           "valid_JSON_response_with_cluster_name",
+			expectedResult: clusterName,
+			body:           fmt.Sprintf(`{"cluster_name":"%s"}`, clusterName),
+		}, {
+			name:           "valid_JSON_response_without_cluster_name",
+			expectedResult: "",
+			body:           `{"anything":"42"}`,
+			expectedLogMsg: "failed to parse Elasticsearch JSON response",
+		}, {
+			name:           "invalid_JSON_response",
+			expectedResult: "",
+			body:           "::error::",
+			expectedLogMsg: "failed to parse Elasticsearch JSON response",
+		}, {
+			name:           "server_unresponsive",
+			expectedResult: "",
+			body:           "",
+			throwErr:       true,
+			expectedLogMsg: "failed to fetch cluster name from Elasticsearch",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			logger := logp.NewLogger("go_tests_apm_server", zap.Hooks(detectMessageInLog(t, tc.expectedLogMsg)))
+			mockedClient := mockEsClusterName{io.NopCloser(bytes.NewBufferString(tc.body)), tc.throwErr}
+			result, err := queryElasticsearchClusterName(&mockedClient, logger)
+			if tc.throwErr {
+				// Even when the server does not reply, we don't want to return an error to the caller
+				require.Nil(t, err)
+				assert.Empty(t, result)
+				return
+			}
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func detectMessageInLog(t *testing.T, contained string) func(zapcore.Entry) error {
+	return func(entry zapcore.Entry) error {
+		assert.Equal(t, entry.Level, logp.WarnLevel)
+		if !assert.Contains(t, entry.Message, contained) {
+			t.Fatalf("didn't find '%s' in log Message field", contained)
+		}
+		return nil
+	}
+}
+
+type mockEsClusterName struct {
+	body     io.ReadCloser
+	throwErr bool
+}
+
+func (c *mockEsClusterName) Perform(r *http.Request) (*http.Response, error) {
+	if c.throwErr {
+		return nil, fmt.Errorf("connection closed")
+	}
+	return &http.Response{
+		StatusCode: 200,
+		Body:       c.body,
+		Request:    r,
+	}, nil
+}
+
+func (c *mockEsClusterName) NewBulkIndexer(_ elasticsearch.BulkIndexerConfig) (elasticsearch.BulkIndexer, error) {
+	return nil, nil
 }

--- a/x-pack/apm-server/main_test.go
+++ b/x-pack/apm-server/main_test.go
@@ -10,11 +10,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"io"
 	"net/http"
 	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/x-pack/apm-server/profiling/collector.go
+++ b/x-pack/apm-server/profiling/collector.go
@@ -71,11 +71,8 @@ type ElasticCollector struct {
 // NewCollector returns a new ElasticCollector uses indexer for storing stack trace data in
 // Elasticsearch, and metricsIndexer for storing host agent metrics. Separate indexers are
 // used to allow for host agent metrics to be sent to a separate monitoring cluster.
-func NewCollector(
-	indexer elasticsearch.BulkIndexer,
-	metricsIndexer elasticsearch.BulkIndexer,
-	logger *logp.Logger,
-) *ElasticCollector {
+func NewCollector(indexer elasticsearch.BulkIndexer, metricsIndexer elasticsearch.BulkIndexer,
+	esClusterName string, logger *logp.Logger, ) *ElasticCollector {
 	sourceFiles, err := simplelru.NewLRU(sourceFileCacheSize, nil)
 	if err != nil {
 		log.Fatalf("Failed to create source file LRU: %v", err)

--- a/x-pack/apm-server/profiling/collector.go
+++ b/x-pack/apm-server/profiling/collector.go
@@ -73,8 +73,12 @@ type ElasticCollector struct {
 // NewCollector returns a new ElasticCollector uses indexer for storing stack trace data in
 // Elasticsearch, and metricsIndexer for storing host agent metrics. Separate indexers are
 // used to allow for host agent metrics to be sent to a separate monitoring cluster.
-func NewCollector(indexer elasticsearch.BulkIndexer, metricsIndexer elasticsearch.BulkIndexer,
-	esClusterID string, logger *logp.Logger) *ElasticCollector {
+func NewCollector(
+	indexer elasticsearch.BulkIndexer,
+	metricsIndexer elasticsearch.BulkIndexer,
+	esClusterID string,
+	logger *logp.Logger,
+) *ElasticCollector {
 	sourceFiles, err := simplelru.NewLRU(sourceFileCacheSize, nil)
 	if err != nil {
 		log.Fatalf("Failed to create source file LRU: %v", err)


### PR DESCRIPTION
## Motivation/summary

Profiling sends host-agent metrics into Elasticsearch for debugging purposes.
To improve our troubleshooting process in Cloud, we add in every metrics document the cluster ID.

## Checklist

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**? ✅ 
- Is its use being published in **telemetry** to enable product improvement? ⛔ 
- Have system tests been added to avoid regression? ✅ 

## How to test these changes

You can configure the metrics endpoint in the apm-server Fleet policy with the same endpoint where data are sent (apm-server.profiling.metrics.elasticsearch.hosts`) and you'll see the additional field in the documents in the `profiling-metrics` data stream.
