### PR TITLE
smoke-test: check if artifacts api is available

### DIFF
--- a/testing/smoke/basic-upgrade/test.sh
+++ b/testing/smoke/basic-upgrade/test.sh
@@ -22,8 +22,8 @@ if [[ ${MAJOR_VERSION} -eq 7 ]]; then
     ASSERT_EVENTS_FUNC=legacy_assertions
 
     # Check if the version is available.
-    if ! curl --fail ${ARTIFACTS_API}/versions/${MAJOR_VERSION}.${MINOR_VERSION} ; then
-        echo "-> Warning there are no new artifacts to be downloaded in artifacts-api.elastic.co ..."
+    if ! curl -s --fail ${ARTIFACTS_API}/versions/${MAJOR_VERSION}.${MINOR_VERSION} ; then
+        echo "-> Skipping there are no new artifacts to be downloaded in artifacts-api.elastic.co ..."
         exit 0
     fi
 

--- a/testing/smoke/legacy-managed/test.sh
+++ b/testing/smoke/legacy-managed/test.sh
@@ -11,8 +11,8 @@ VERSION=7.17
 ARTIFACTS_API=https://artifacts-api.elastic.co/v1
 
 # Check if the version is available.
-if ! curl --fail ${ARTIFACTS_API}/versions/${VERSION} ; then
-    echo "-> Warning there are no new artifacts to be downloaded in artifacts-api.elastic.co ..."
+if ! curl -s --fail ${ARTIFACTS_API}/versions/${VERSION} ; then
+    echo "-> Skipping there are no new artifacts to be downloaded in artifacts-api.elastic.co ..."
     exit 0
 fi
 

--- a/testing/smoke/legacy-managed/test.sh
+++ b/testing/smoke/legacy-managed/test.sh
@@ -8,6 +8,12 @@ if [[ ${1} != 7.17 ]]; then
 fi
 
 VERSION=7.17
+# Check if the version is available.
+if ! curl --fail https://artifacts-api.elastic.co/v1/versions/${VERSION} ; then
+    echo "-> Warning there are no new artifacts to be downloaded in artifacts-api.elastic.co ..."
+    exit 0
+fi
+
 LATEST_VERSION=$(curl -s --fail https://artifacts-api.elastic.co/v1/versions/${VERSION} | jq -r '.version.builds[0].version')
 
 echo "-> Running ${LATEST_VERSION} standalone to ${LATEST_VERSION} managed upgrade"

--- a/testing/smoke/legacy-managed/test.sh
+++ b/testing/smoke/legacy-managed/test.sh
@@ -3,18 +3,20 @@
 set -eo pipefail
 
 if [[ ${1} != 7.17 ]]; then
-    echo "-> Skipping smoke test..."
+    echo "-> Skipping smoke test [${1}]..."
     exit 0
 fi
 
 VERSION=7.17
+ARTIFACTS_API=https://artifacts-api.elastic.co/v1
+
 # Check if the version is available.
-if ! curl --fail https://artifacts-api.elastic.co/v1/versions/${VERSION} ; then
+if ! curl --fail ${ARTIFACTS_API}/versions/${VERSION} ; then
     echo "-> Warning there are no new artifacts to be downloaded in artifacts-api.elastic.co ..."
     exit 0
 fi
 
-LATEST_VERSION=$(curl -s --fail https://artifacts-api.elastic.co/v1/versions/${VERSION} | jq -r '.version.builds[0].version')
+LATEST_VERSION=$(curl -s --fail ${ARTIFACTS_API}/versions/${VERSION} | jq -r '.version.builds[0].version')
 
 echo "-> Running ${LATEST_VERSION} standalone to ${LATEST_VERSION} managed upgrade"
 

--- a/testing/smoke/legacy-standalone-major-managed/test.sh
+++ b/testing/smoke/legacy-standalone-major-managed/test.sh
@@ -14,8 +14,8 @@ ARTIFACTS_API=https://artifacts-api.elastic.co/v1
 VERSIONS=$(curl -s --fail ${ARTIFACTS_API}/versions | jq -r -c '[.versions[] | select(. | endswith("-SNAPSHOT") | not)] | sort')
 NEXT_MAJOR_LATEST=$(echo ${VERSIONS} | jq -r '[.[] | select(. | startswith("8"))] | last')
 # Check if the version is available.
-if ! curl --fail ${ARTIFACTS_API}/versions/${VERSION} ; then
-    echo "-> Warning there are no new artifacts to be downloaded in artifacts-api.elastic.co ..."
+if ! curl -s --fail ${ARTIFACTS_API}/versions/${VERSION} ; then
+    echo "-> Skipping there are no new artifacts to be downloaded in artifacts-api.elastic.co ..."
     exit 0
 fi
 LATEST_VERSION=$(curl -s --fail ${ARTIFACTS_API}/v1/versions/${VERSION} | jq -r '.version.builds[0].version')

--- a/testing/smoke/legacy-standalone-major-managed/test.sh
+++ b/testing/smoke/legacy-standalone-major-managed/test.sh
@@ -12,6 +12,11 @@ VERSION=7.17
 # Load all versions except SNAPSHOTS
 VERSIONS=$(curl -s --fail https://artifacts-api.elastic.co/v1/versions | jq -r -c '[.versions[] | select(. | endswith("-SNAPSHOT") | not)] | sort')
 NEXT_MAJOR_LATEST=$(echo ${VERSIONS} | jq -r '[.[] | select(. | startswith("8"))] | last')
+# Check if the version is available.
+if ! curl --fail https://artifacts-api.elastic.co/v1/versions/${VERSION} ; then
+    echo "-> Warning there are no new artifacts to be downloaded in artifacts-api.elastic.co ..."
+    exit 0
+fi
 LATEST_VERSION=$(curl -s --fail https://artifacts-api.elastic.co/v1/versions/${VERSION} | jq -r '.version.builds[0].version')
 
 echo "-> Running ${LATEST_VERSION} standalone to ${NEXT_MAJOR_LATEST} to ${NEXT_MAJOR_LATEST} managed"

--- a/testing/smoke/legacy-standalone-major-managed/test.sh
+++ b/testing/smoke/legacy-standalone-major-managed/test.sh
@@ -3,21 +3,22 @@
 set -eo pipefail
 
 if [[ ${1} != 7.17 ]]; then
-    echo "-> Skipping smoke test..."
+    echo "-> Skipping smoke test [${1}]..."
     exit 0
 fi
 
 VERSION=7.17
+ARTIFACTS_API=https://artifacts-api.elastic.co/v1
 
 # Load all versions except SNAPSHOTS
-VERSIONS=$(curl -s --fail https://artifacts-api.elastic.co/v1/versions | jq -r -c '[.versions[] | select(. | endswith("-SNAPSHOT") | not)] | sort')
+VERSIONS=$(curl -s --fail ${ARTIFACTS_API}/versions | jq -r -c '[.versions[] | select(. | endswith("-SNAPSHOT") | not)] | sort')
 NEXT_MAJOR_LATEST=$(echo ${VERSIONS} | jq -r '[.[] | select(. | startswith("8"))] | last')
 # Check if the version is available.
-if ! curl --fail https://artifacts-api.elastic.co/v1/versions/${VERSION} ; then
+if ! curl --fail ${ARTIFACTS_API}/versions/${VERSION} ; then
     echo "-> Warning there are no new artifacts to be downloaded in artifacts-api.elastic.co ..."
     exit 0
 fi
-LATEST_VERSION=$(curl -s --fail https://artifacts-api.elastic.co/v1/versions/${VERSION} | jq -r '.version.builds[0].version')
+LATEST_VERSION=$(curl -s --fail ${ARTIFACTS_API}/v1/versions/${VERSION} | jq -r '.version.builds[0].version')
 
 echo "-> Running ${LATEST_VERSION} standalone to ${NEXT_MAJOR_LATEST} to ${NEXT_MAJOR_LATEST} managed"
 


### PR DESCRIPTION
### What

Artifacts older than 30 days are not available in the artifacts-api.

This will provide further details when that happens otherwise the information provided by the `test.sh` is not useful in the CI

### Follow up

To define what to do in the future, so @elastic/apm-server I'll let you decide what to do

