### PR TITLE
smoke: Remove usage of artifacts API

### DIFF
--- a/testing/smoke/basic-upgrade/test.sh
+++ b/testing/smoke/basic-upgrade/test.sh
@@ -5,8 +5,8 @@ set -eo pipefail
 # Load common lib
 . $(git rev-parse --show-toplevel)/testing/smoke/lib.sh
 
-# Load the latest versions except SNAPSHOTS
-VERSIONS=$(curl -s --fail https://artifacts-api.elastic.co/v1/versions | jq -r -c '[.versions[] | select(. | endswith("-SNAPSHOT") | not)] | sort')
+# Get all the versions from the current region.
+get_versions
 
 VERSION=${1}
 if [[ -z ${VERSION} ]] || [[ "${VERSION}" == "latest" ]]; then
@@ -18,15 +18,20 @@ MINOR_VERSION=$(echo ${VERSION} | cut -d '.' -f2 )
 
 if [[ ${MAJOR_VERSION} -eq 7 ]]; then
     ASSERT_EVENTS_FUNC=legacy_assertions
-    LATEST_VERSION=$(curl -s --fail https://artifacts-api.elastic.co/v1/versions/${MAJOR_VERSION}.${MINOR_VERSION} | jq -r '.version.builds[0].version')
-    PREV_LATEST_VERSION=$(echo ${MAJOR_VERSION}.${MINOR_VERSION}.$(( $(echo ${LATEST_VERSION} | cut -d '.' -f3) -1 )))
+    INTEGRATIONS_SERVER=false
+    get_latest_patch "${MAJOR_VERSION}.${MINOR_VERSION}"
+    LATEST_VERSION=${MAJOR_VERSION}.${MINOR_VERSION}.${LATEST_PATCH}
+    PREV_LATEST_VERSION=$(echo ${MAJOR_VERSION}.${MINOR_VERSION}.$(( ${LATEST_PATCH} -1 )))
 elif [[ ${MAJOR_VERSION} -eq 8 ]]; then
     ASSERT_EVENTS_FUNC=data_stream_assertions
-    LATEST_VERSION=$(echo ${VERSIONS} | jq -r "[.[] | select(. | contains(\"${VERSION}\"))] | last")
-    # https://artifacts-api.elastic.co/v1/versions only provides the last two
-    # major versions and minor versions. For that reason, we use a regex.
-    PREV_LATEST_VERSION=$(echo "${MAJOR_VERSION}.$(( ${MINOR_VERSION} -1 )).[0-9]?([0-9])\$")
     INTEGRATIONS_SERVER=true
+
+    get_latest_patch "${MAJOR_VERSION}.${MINOR_VERSION}"
+    LATEST_VERSION=${MAJOR_VERSION}.${MINOR_VERSION}.${LATEST_PATCH}
+
+    PREV_MINOR=$(( ${MINOR_VERSION} -1 ))
+    get_latest_patch "${MAJOR_VERSION}.${PREV_MINOR}"
+    PREV_LATEST_VERSION=${MAJOR_VERSION}.${PREV_MINOR}.${LATEST_PATCH}
 else
     echo "version ${VERSION} not supported"
     exit 5

--- a/testing/smoke/legacy-managed/test.sh
+++ b/testing/smoke/legacy-managed/test.sh
@@ -7,14 +7,18 @@ if [[ ${1} != 7.17 ]]; then
     exit 0
 fi
 
+. $(git rev-parse --show-toplevel)/testing/smoke/lib.sh
+
 VERSION=7.17
-LATEST_VERSION=$(curl -s --fail https://artifacts-api.elastic.co/v1/versions/${VERSION} | jq -r '.version.builds[0].version')
+get_versions
+get_latest_patch ${VERSION}
+LATEST_VERSION=${VERSION}.${LATEST_PATCH}
 
 echo "-> Running ${LATEST_VERSION} standalone to ${LATEST_VERSION} managed upgrade"
 
-. $(git rev-parse --show-toplevel)/testing/smoke/lib.sh
-
-trap "terraform_destroy" EXIT
+if [[ -z ${SKIP_DESTROY} ]]; then
+    trap "terraform_destroy" EXIT
+fi
 
 terraform_apply ${LATEST_VERSION}
 healthcheck 1

--- a/testing/smoke/main.tf
+++ b/testing/smoke/main.tf
@@ -12,7 +12,7 @@ provider "ec" {}
 
 module "ec_deployment" {
   source = "../../infra/terraform/modules/ec_deployment"
-  region = "gcp-us-west2"
+  region = var.region
 
   deployment_template    = "gcp-compute-optimized-v2"
   deployment_name_prefix = "smoke-upgrade"
@@ -37,6 +37,12 @@ variable "integrations_server" {
   default     = false
   description = "Optionally use the integrations_server resource"
   type        = bool
+}
+
+variable "region" {
+  default     = "gcp-us-west2"
+  description = "Optional ESS region where to run the smoke tests"
+  type        = string
 }
 
 output "apm_secret_token" {


### PR DESCRIPTION
## Motivation/summary

Removes the usage of the Elastic artifacts API, in favor of using the Elastic Cloud API to obtain all the stack pack versions available in the configured ESS region.

This approach is better than using the artifacts API for two reasons:

    1. Artifacts API and ESS regions may have different stack packs
    2. Unused artifacts are removed after 30 days.

By using the ESS API, we no longer will see failures due to a missing BC or old versions removed (or the `7.17.x` older versions).

Last, it also adds the `SKIP_DESTROY` conditional to all the `test.sh` scripts.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

Run smoke tests for version `7.17`:
`make smoketest/all SMOKETEST_VERSIONS=7.17`

## Related issues

Supersedes ##9225
