### PR TITLE
tf/ec_deployment: Match ESS defaults

### DIFF
--- a/testing/benchmark/main.tf
+++ b/testing/benchmark/main.tf
@@ -44,13 +44,14 @@ module "ec_deployment" {
   deployment_template    = var.deployment_template
   deployment_name_prefix = local.name_prefix
 
-  integrations_server   = true
   apm_server_size       = var.apm_server_size
   apm_server_zone_count = var.apm_server_zone_count
   apm_index_shards      = var.apm_shards
+  apm_server_expvar     = true
+  apm_server_pprof      = true
 
-  elasticsearch_size       = var.elasticsearch_size
-  elasticsearch_zone_count = var.elasticsearch_zone_count
+  elasticsearch_size              = var.elasticsearch_size
+  elasticsearch_zone_count        = var.elasticsearch_zone_count
   elasticsearch_dedicated_masters = var.elasticsearch_dedicated_masters
 
   docker_image              = var.docker_image_override

--- a/testing/cloud/main.tf
+++ b/testing/cloud/main.tf
@@ -11,9 +11,9 @@ terraform {
 provider "ec" {}
 
 locals {
-    docker_image_tag = regex("docker.elastic.co/.*:(.*)",file("${path.module}/../../docker-compose.yml"))[0]
-    match = regex("(?:(.*)(?:-.*)-(?:SNAPSHOT))|(.*)", local.docker_image_tag)
-    stack_version = local.match[0] != null ? format("%s-SNAPSHOT", local.match[0]) : local.match[1]
+  docker_image_tag = regex("docker.elastic.co/.*:(.*)", file("${path.module}/../../docker-compose.yml"))[0]
+  match            = regex("(?:(.*)(?:-.*)-(?:SNAPSHOT))|(.*)", local.docker_image_tag)
+  stack_version    = local.match[0] != null ? format("%s-SNAPSHOT", local.match[0]) : local.match[1]
 }
 
 module "ec_deployment" {
@@ -27,17 +27,14 @@ module "ec_deployment" {
 
   apm_server_size       = var.apm_server_size
   apm_server_zone_count = var.apm_server_zone_count
-  apm_server_expvar     = false
-  apm_server_pprof      = false
-  integrations_server   = true
 
   elasticsearch_size       = var.elasticsearch_size
   elasticsearch_zone_count = var.elasticsearch_zone_count
 
-  docker_image              = var.docker_image_override
+  docker_image = var.docker_image_override
   docker_image_tag_override = {
-    "elasticsearch": coalesce(var.docker_image_tag_override["elasticsearch"], local.docker_image_tag),
-    "kibana": coalesce(var.docker_image_tag_override["kibana"], local.docker_image_tag),
-    "apm": coalesce(var.docker_image_tag_override["apm"], local.docker_image_tag)
+    "elasticsearch" : coalesce(var.docker_image_tag_override["elasticsearch"], local.docker_image_tag),
+    "kibana" : coalesce(var.docker_image_tag_override["kibana"], local.docker_image_tag),
+    "apm" : coalesce(var.docker_image_tag_override["apm"], local.docker_image_tag)
   }
 }

--- a/testing/infra/terraform/modules/ec_deployment/README.md
+++ b/testing/infra/terraform/modules/ec_deployment/README.md
@@ -15,7 +15,7 @@ used to configure the module, please refer to the [EC Provider docs](https://reg
 
 | Name | Version |
 |------|---------|
-| <a name="provider_ec"></a> [ec](#provider\_ec) | >=0.4.1 |
+| <a name="provider_ec"></a> [ec](#provider\_ec) | 0.4.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | n/a |
 | <a name="provider_local"></a> [local](#provider\_local) | n/a |
 | <a name="provider_null"></a> [null](#provider\_null) | n/a |
@@ -42,8 +42,8 @@ used to configure the module, please refer to the [EC Provider docs](https://reg
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_apm_index_shards"></a> [apm\_index\_shards](#input\_apm\_index\_shards) | The number of shards to set for APM Indices | `number` | `0` | no |
-| <a name="input_apm_server_expvar"></a> [apm\_server\_expvar](#input\_apm\_server\_expvar) | Whether or not to enable APM Server's expvar endpoint. Defaults to true | `bool` | `true` | no |
-| <a name="input_apm_server_pprof"></a> [apm\_server\_pprof](#input\_apm\_server\_pprof) | Whether or not to enable APM Server's pprof endpoint. Defaults to true | `bool` | `true` | no |
+| <a name="input_apm_server_expvar"></a> [apm\_server\_expvar](#input\_apm\_server\_expvar) | Whether or not to enable APM Server's expvar endpoint. Defaults to false | `bool` | `false` | no |
+| <a name="input_apm_server_pprof"></a> [apm\_server\_pprof](#input\_apm\_server\_pprof) | Whether or not to enable APM Server's pprof endpoint. Defaults to false | `bool` | `false` | no |
 | <a name="input_apm_server_size"></a> [apm\_server\_size](#input\_apm\_server\_size) | Optional apm server instance size | `string` | `"1g"` | no |
 | <a name="input_apm_server_zone_count"></a> [apm\_server\_zone\_count](#input\_apm\_server\_zone\_count) | Optional apm server zone count | `number` | `1` | no |
 | <a name="input_custom_apm_integration_pkg_path"></a> [custom\_apm\_integration\_pkg\_path](#input\_custom\_apm\_integration\_pkg\_path) | Path to the zipped custom APM integration package, if empty custom apm integration pkg is not installed | `string` | `""` | no |
@@ -55,7 +55,7 @@ used to configure the module, please refer to the [EC Provider docs](https://reg
 | <a name="input_elasticsearch_dedicated_masters"></a> [elasticsearch\_dedicated\_masters](#input\_elasticsearch\_dedicated\_masters) | Optionally use dedicated masters for the Elasticsearch cluster | `bool` | `false` | no |
 | <a name="input_elasticsearch_size"></a> [elasticsearch\_size](#input\_elasticsearch\_size) | Optional Elasticsearch instance size | `string` | `"8g"` | no |
 | <a name="input_elasticsearch_zone_count"></a> [elasticsearch\_zone\_count](#input\_elasticsearch\_zone\_count) | Optional Elasticsearch zone count | `number` | `2` | no |
-| <a name="input_integrations_server"></a> [integrations\_server](#input\_integrations\_server) | Optionally use the integrations server block instead of the apm block | `bool` | `false` | no |
+| <a name="input_integrations_server"></a> [integrations\_server](#input\_integrations\_server) | Optionally disable the integrations server block and use the apm block (7.x only) | `bool` | `true` | no |
 | <a name="input_monitor_deployment"></a> [monitor\_deployment](#input\_monitor\_deployment) | Optionally monitor the deployment in a separate deployment | `bool` | `false` | no |
 | <a name="input_region"></a> [region](#input\_region) | Optional ESS or ECE region. Defaults to GCP US West 2 (Los Angeles) | `string` | `"gcp-us-west2"` | no |
 | <a name="input_stack_version"></a> [stack\_version](#input\_stack\_version) | Optional stack version | `string` | `"latest"` | no |

--- a/testing/infra/terraform/modules/ec_deployment/deployment.tf
+++ b/testing/infra/terraform/modules/ec_deployment/deployment.tf
@@ -141,8 +141,8 @@ resource "local_file" "shard_settings" {
 resource "local_file" "custom_apm_integration_pkg" {
   count = var.custom_apm_integration_pkg_path != "" ? 1 : 0
   content = templatefile("${path.module}/scripts/custom-apm-integration-pkg.tftpl", {
-    kibana_url       = ec_deployment.deployment.kibana.0.https_endpoint,
-    elastic_password = ec_deployment.deployment.elasticsearch_password,
+    kibana_url                      = ec_deployment.deployment.kibana.0.https_endpoint,
+    elastic_password                = ec_deployment.deployment.elasticsearch_password,
     custom_apm_integration_pkg_path = var.custom_apm_integration_pkg_path,
   })
   filename = "${path.module}/scripts/custom-apm-integration-pkg.sh"

--- a/testing/infra/terraform/modules/ec_deployment/variables.tf
+++ b/testing/infra/terraform/modules/ec_deployment/variables.tf
@@ -51,9 +51,9 @@ variable "apm_server_zone_count" {
 }
 
 variable "integrations_server" {
-  description = "Optionally use the integrations server block instead of the apm block"
+  description = "Optionally disable the integrations server block and use the apm block (7.x only)"
   type        = bool
-  default     = false
+  default     = true
 }
 
 # Elasticsearch topology
@@ -107,14 +107,14 @@ variable "docker_image" {
 # Enable APM Server's expvar
 
 variable "apm_server_expvar" {
-  default     = true
-  description = "Whether or not to enable APM Server's expvar endpoint. Defaults to true"
+  default     = false
+  description = "Whether or not to enable APM Server's expvar endpoint. Defaults to false"
   type        = bool
 }
 
 variable "apm_server_pprof" {
-  default     = true
-  description = "Whether or not to enable APM Server's pprof endpoint. Defaults to true"
+  default     = false
+  description = "Whether or not to enable APM Server's pprof endpoint. Defaults to false"
   type        = bool
 }
 

--- a/testing/smoke/main.tf
+++ b/testing/smoke/main.tf
@@ -34,8 +34,8 @@ variable "stack_version" {
 }
 
 variable "integrations_server" {
-  default     = false
-  description = "Optionally use the integrations_server resource"
+  default     = true
+  description = "Optionally disable the integrations server block and use the apm block (7.x only)"
   type        = bool
 }
 


### PR DESCRIPTION
## Motivation/summary

Updates the `ec_deployment` terraform module variables defaults to match the default variables in an ESS deployment.

- `integrations_server`: `false` => `true`
- `apm_server_expvar`: `true` => `false`
- `apm_server_pprof`: `true` => `false`

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
- [x] Documentation has been updated

## How to test these changes

N/A

## Related issues

Closes #9123
