### PR TITLE
docs: remove included extension content

### DIFF
--- a/docs/apm-mutating-webhook.asciidoc
+++ b/docs/apm-mutating-webhook.asciidoc
@@ -1,4 +1,17 @@
-// Pulls the APM mutating webhook docs from here:
-// https://github.com/elastic/apm-mutating-webhook/blob/main/docs/apm-mutating-webhook.asciidoc
+[[apm-mutating-admission-webhook]]
+= APM Attacher
 
-include::{apm-webhook-repo-dir}/apm-mutating-webhook.asciidoc[]
+preview::[]
+
+The APM attacher for Kubernetes simplifies the instrumentation and configuration of your application pods.
+
+The attacher includes a webhook receiver that modifies pods so they are automatically
+instrumented by an Elastic APM agent, and a Helm chart that manages its lifecycle within
+Kubernetes.
+
+// Adding links in the next PR
+// The attacher includes a {apm-attacher-ref}/x.html[webhook receiver] that modifies pods so they are automatically
+// instrumented by an Elastic APM agent, and a {apm-attacher-ref}/x.html[Helm chart] that manages its lifecycle within
+// Kubernetes.
+
+Ready to get started? See {apm-attacher-ref}/apm-get-started-webhook.html[Instrument and configure pods] to get started.

--- a/docs/aws-lambda-extension.asciidoc
+++ b/docs/aws-lambda-extension.asciidoc
@@ -1,4 +1,14 @@
-// Pulls the AWS Lambda extension docs from here:
-// https://github.com/elastic/apm-aws-lambda/blob/main/docs/aws-lambda-extension.asciidoc
+[[monitoring-aws-lambda]]
+= Monitoring AWS Lambda Functions
 
-include::{apm-aws-repo-dir}/monitoring-aws-lambda.asciidoc[]
+Elastic APM lets you monitor your AWS Lambda functions.
+The natural integration of <<apm-distributed-tracing,distributed tracing>> into your AWS Lambda functions provides insights into the functions' execution and runtime behavior as well as their relationships and dependencies to other services.
+
+To get started with the setup of Elastic APM for your Lambda functions, checkout the language-specific guides:
+
+* {apm-node-ref}/lambda.html[Quick Start with APM on AWS Lambda - Node.js]
+* {apm-py-ref}/lambda-support.html[Quick Start with APM on AWS Lambda - Python]
+* {apm-java-ref}/aws-lambda.html[Quick Start with APM on AWS Lambda - Java]
+
+Or, see the {apm-lambda-ref}/aws-lambda-arch.html[architecture guide] to learn more about how the extension works,
+performance impacts, and more.

--- a/docs/integrations-index.asciidoc
+++ b/docs/integrations-index.asciidoc
@@ -5,8 +5,6 @@ include::./notices.asciidoc[]
 :apm-integration-docs:
 :apm-package-dir:        {docdir}/apm-package
 :obs-repo-dir:           {observability-docs-root}/docs/en
-:apm-aws-repo-dir:       {apm-aws-lambda-root}/docs
-:apm-webhook-repo-dir:   {apm-mutating-webhook-root}/docs
 
 :github_repo_link: https://github.com/elastic/apm-server/blob/v{version}
 ifeval::["{version}" == "8.0.0"]


### PR DESCRIPTION
### Summary

Removes included content for the Lambda extension and APM attacher.

### Related

For https://github.com/elastic/observability-docs/issues/2207.

Blocked by:

- [x] https://github.com/elastic/apm-aws-lambda/pull/325
~- [ ] https://github.com/elastic/docs/pull/2535~
- [x] https://github.com/elastic/apm-mutating-webhook/pull/63