### PR TITLE
[7.16] docs: remove aws includes (#9253)

### DIFF
--- a/docs/aws-lambda-extension.asciidoc
+++ b/docs/aws-lambda-extension.asciidoc
@@ -1,9 +1,6 @@
 [[monitoring-aws-lambda]]
 = Monitoring AWS Lambda Functions
 
-<<<<<<< HEAD
-include::{apm-aws-repo-dir}/aws-lambda-extension.asciidoc[]
-=======
 Elastic APM lets you monitor your AWS Lambda functions.
 The natural integration of <<apm-distributed-tracing,distributed tracing>> into your AWS Lambda functions provides insights into the functions' execution and runtime behavior as well as their relationships and dependencies to other services.
 
@@ -15,4 +12,3 @@ To get started with the setup of Elastic APM for your Lambda functions, checkout
 
 Or, see the {apm-lambda-ref}/aws-lambda-arch.html[architecture guide] to learn more about how the extension works,
 performance impacts, and more.
->>>>>>> 1446ccc61... docs: remove aws includes (#9253)

--- a/docs/aws-lambda-extension.asciidoc
+++ b/docs/aws-lambda-extension.asciidoc
@@ -1,4 +1,18 @@
-// Pulls the AWS Lambda extension docs from here:
-// https://github.com/elastic/apm-aws-lambda/blob/main/docs/aws-lambda-extension.asciidoc
+[[monitoring-aws-lambda]]
+= Monitoring AWS Lambda Functions
 
+<<<<<<< HEAD
 include::{apm-aws-repo-dir}/aws-lambda-extension.asciidoc[]
+=======
+Elastic APM lets you monitor your AWS Lambda functions.
+The natural integration of <<apm-distributed-tracing,distributed tracing>> into your AWS Lambda functions provides insights into the functions' execution and runtime behavior as well as their relationships and dependencies to other services.
+
+To get started with the setup of Elastic APM for your Lambda functions, checkout the language-specific guides:
+
+* {apm-node-ref}/lambda.html[Quick Start with APM on AWS Lambda - Node.js]
+* {apm-py-ref}/lambda-support.html[Quick Start with APM on AWS Lambda - Python]
+* {apm-java-ref}/aws-lambda.html[Quick Start with APM on AWS Lambda - Java]
+
+Or, see the {apm-lambda-ref}/aws-lambda-arch.html[architecture guide] to learn more about how the extension works,
+performance impacts, and more.
+>>>>>>> 1446ccc61... docs: remove aws includes (#9253)

--- a/docs/features.asciidoc
+++ b/docs/features.asciidoc
@@ -13,7 +13,7 @@
 * <<log-correlation>>
 * <<cross-cluster-search>>
 * <<span-compression>>
-* <<aws-lambda-extension>>
+* <<monitoring-aws-lambda>>
 
 include::./apm-data-security.asciidoc[]
 

--- a/docs/integrations-index.asciidoc
+++ b/docs/integrations-index.asciidoc
@@ -5,7 +5,6 @@ include::./notices.asciidoc[]
 :apm-integration-docs:
 :apm-package-dir:    {docdir}/apm-package
 :obs-repo-dir:       {observability-docs-root}/docs/en
-:apm-aws-repo-dir:       {apm-aws-lambda-root}/docs
 
 :github_repo_link: https://github.com/elastic/apm-server/blob/v{version}
 ifeval::["{version}" == "8.0.0"]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.3` to `7.16`:
 - [docs: remove aws includes (#9253)](https://github.com/elastic/apm-server/pull/9253)

<!--- Backport version: 8.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)