### PR TITLE
Allow configurable client count for rally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,12 +297,13 @@ RALLY_CLIENT_OPTIONS?=basic_auth_user:'admin',basic_auth_password:'changeme'
 RALLY_FLAGS?=--pipeline=benchmark-only --client-options="$(RALLY_CLIENT_OPTIONS)" $(RALLY_EXTRA_FLAGS)
 RALLY_BULK_SIZE?=5000
 RALLY_GENCORPORA_REPLAY_COUNT?=1
+RALLY_BULK_CLIENTS?=1
 
 .PHONY: rally
 rally: $(PYTHON_BIN)/esrally testing/rally/corpora
 	@$(PYTHON_BIN)/esrally race \
 		--track-path=testing/rally \
-		--track-params=expected_cluster_health:yellow,bulk_size:$(RALLY_BULK_SIZE) \
+		--track-params=expected_cluster_health:yellow,bulk_size:$(RALLY_BULK_SIZE),bulk_clients:$(RALLY_BULK_CLIENTS) \
 		--kill-running-processes \
 		$(RALLY_FLAGS)
 

--- a/testing/infra/terraform/modules/rally_workers/README.md
+++ b/testing/infra/terraform/modules/rally_workers/README.md
@@ -51,6 +51,7 @@ This modules sets up [rally daemons](https://esrally.readthedocs.io/en/stable/ra
 | <a name="input_elasticsearch_username"></a> [elasticsearch\_username](#input\_elasticsearch\_username) | Elasticsearch username to use for benchmark with rally | `string` | n/a | yes |
 | <a name="input_gcp_project"></a> [gcp\_project](#input\_gcp\_project) | GCP Project name | `string` | `"elastic-apm"` | no |
 | <a name="input_gcp_region"></a> [gcp\_region](#input\_gcp\_region) | GCP region | `string` | `"us-west2"` | no |
+| <a name="input_rally_bulk_clients"></a> [rally\_bulk\_clients](#input\_rally\_bulk\_clients) | Number of clients to use for rally bulk requests | `number` | `10` | no |
 | <a name="input_rally_bulk_size"></a> [rally\_bulk\_size](#input\_rally\_bulk\_size) | Bulk size to use for rally track | `number` | `5000` | no |
 | <a name="input_rally_cluster_status"></a> [rally\_cluster\_status](#input\_rally\_cluster\_status) | Expected cluster status for rally | `string` | `"green"` | no |
 | <a name="input_rally_dir"></a> [rally\_dir](#input\_rally\_dir) | Directory path with rally corpora and track file | `string` | n/a | yes |

--- a/testing/infra/terraform/modules/rally_workers/main.tf
+++ b/testing/infra/terraform/modules/rally_workers/main.tf
@@ -245,7 +245,7 @@ ${local.remote_python_bin_path}/esrally race \
   --load-driver-hosts=${join(",", google_compute_instance.rally_nodes[*].network_interface[0].network_ip)} \
   --client-options=use_ssl:true,basic_auth_user:${var.elasticsearch_username},basic_auth_password:${var.elasticsearch_password} \
   --track-path=${local.remote_working_dir}/rally \
-  --track-params=expected_cluster_health:${var.rally_cluster_status},bulk_size:${var.rally_bulk_size} \
+  --track-params=expected_cluster_health:${var.rally_cluster_status},bulk_size:${var.rally_bulk_size},bulk_clients:${var.rally_bulk_clients} \
   --kill-running-process \
   --pipeline=benchmark-only \
   --report-file=${local.remote_working_dir}/${local.remote_rally_summary_file}

--- a/testing/infra/terraform/modules/rally_workers/variables.tf
+++ b/testing/infra/terraform/modules/rally_workers/variables.tf
@@ -58,3 +58,9 @@ variable "rally_bulk_size" {
   description = "Bulk size to use for rally track"
   default     = 5000
 }
+
+variable "rally_bulk_clients" {
+  type        = number
+  description = "Number of clients to use for rally bulk requests"
+  default     = 10
+}

--- a/testing/rally-cloud/Makefile
+++ b/testing/rally-cloud/Makefile
@@ -3,6 +3,7 @@ ROOT_DIR=$(shell git rev-parse --show-toplevel)
 APM_SERVER_VERSION=$(shell $(MAKE) -C $(ROOT_DIR) get-version)
 APM_INTEGRATION_PKG_PATH=$(ROOT_DIR)/build/packages/apm-$(APM_SERVER_VERSION).zip
 RALLY_GENCORPORA_REPLAY_COUNT?=10
+RALLY_BULK_CLIENTS?=10
 
 include $(ROOT_DIR)/go.mk
 
@@ -14,6 +15,7 @@ init:
 plan:
 	@terraform plan \
 		-var 'rally_workers_resource_prefix=$(USER_NAME)' \
+		-var 'rally_bulk_clients=$(RALLY_BULK_CLIENTS)' \
 		-var 'custom_apm_integration_pkg_path=$(APM_INTEGRATION_PKG_PATH)'
 
 .PHONY: apply
@@ -21,12 +23,14 @@ apply: rally/corpora
 	$(MAKE) -C $(ROOT_DIR) build-package
 	@terraform apply -auto-approve \
 		-var 'rally_workers_resource_prefix=$(USER_NAME)' \
+		-var 'rally_bulk_clients=$(RALLY_BULK_CLIENTS)' \
 		-var 'custom_apm_integration_pkg_path=$(APM_INTEGRATION_PKG_PATH)'
 
 .PHONY: destroy
 destroy:
 	@terraform destroy -auto-approve \
 		-var 'rally_workers_resource_prefix=$(USER_NAME)' \
+		-var 'rally_bulk_clients=$(RALLY_BULK_CLIENTS)' \
 		-var 'custom_apm_integration_pkg_path=$(APM_INTEGRATION_PKG_PATH)'
 
 # Generate corpora to be used in cloud testing using rally-cloud tf script

--- a/testing/rally-cloud/main.tf
+++ b/testing/rally-cloud/main.tf
@@ -44,6 +44,7 @@ module "rally_workers" {
   rally_worker_count   = var.rally_worker_count
   rally_cluster_status = var.rally_cluster_status
   rally_bulk_size      = var.rally_bulk_size
+  rally_bulk_clients   = var.rally_bulk_clients
 
   elasticsearch_url      = module.ec_deployment.elasticsearch_url
   elasticsearch_username = module.ec_deployment.elasticsearch_username

--- a/testing/rally-cloud/variables.tf
+++ b/testing/rally-cloud/variables.tf
@@ -73,3 +73,9 @@ variable "rally_worker_count" {
   description = "Number of rally worker nodes"
   default     = 2
 }
+
+variable "rally_bulk_clients" {
+  type        = number
+  description = "Number of clients to use for rally bulk requests"
+  default     = 10
+}

--- a/testing/rally/track.json
+++ b/testing/rally/track.json
@@ -33,7 +33,8 @@
       "operation": {
         "operation-type": "bulk",
         "bulk-size": {{bulk_size}}
-      }
+      },
+      "clients": {{bulk_clients}}
     },
     {
       "operation": {


### PR DESCRIPTION
## Motivation/summary

Make client count configurable for rally.

## Checklist

~~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~~
~~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~~
- [x] Documentation has been updated

## How to test these changes

Details in the [README](https://github.com/elastic/apm-server/blob/main/testing/rally-cloud/README.md).

## Related issues

Closes #9283 
