### PR TITLE
Make machine type configurable for rally nodes

### DIFF
--- a/testing/infra/terraform/modules/rally_workers/README.md
+++ b/testing/infra/terraform/modules/rally_workers/README.md
@@ -51,6 +51,7 @@ This modules sets up [rally daemons](https://esrally.readthedocs.io/en/stable/ra
 | <a name="input_elasticsearch_username"></a> [elasticsearch\_username](#input\_elasticsearch\_username) | Elasticsearch username to use for benchmark with rally | `string` | n/a | yes |
 | <a name="input_gcp_project"></a> [gcp\_project](#input\_gcp\_project) | GCP Project name | `string` | `"elastic-apm"` | no |
 | <a name="input_gcp_region"></a> [gcp\_region](#input\_gcp\_region) | GCP region | `string` | `"us-west2"` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine type for rally nodes | `string` | `"e2-small"` | no |
 | <a name="input_rally_bulk_size"></a> [rally\_bulk\_size](#input\_rally\_bulk\_size) | Bulk size to use for rally track | `number` | `5000` | no |
 | <a name="input_rally_cluster_status"></a> [rally\_cluster\_status](#input\_rally\_cluster\_status) | Expected cluster status for rally | `string` | `"green"` | no |
 | <a name="input_rally_dir"></a> [rally\_dir](#input\_rally\_dir) | Directory path with rally corpora and track file | `string` | n/a | yes |

--- a/testing/infra/terraform/modules/rally_workers/main.tf
+++ b/testing/infra/terraform/modules/rally_workers/main.tf
@@ -74,7 +74,7 @@ resource "google_compute_instance" "rally_nodes" {
   # 1 rally node is for coordinator and others for distributing load generators
   count        = 1 + var.rally_worker_count
   name         = "${var.resource_prefix}-rally-nodes-${count.index}"
-  machine_type = "e2-micro"
+  machine_type = "${var.machine_type}"
   zone         = data.google_compute_zones.available.names[0]
 
   boot_disk {

--- a/testing/infra/terraform/modules/rally_workers/variables.tf
+++ b/testing/infra/terraform/modules/rally_workers/variables.tf
@@ -15,6 +15,12 @@ variable "gcp_region" {
   default     = "us-west2"
 }
 
+variable "machine_type" {
+  type        = string
+  description = "Machine type for rally nodes"
+  default     = "e2-small"
+}
+
 variable "elasticsearch_url" {
   type        = string
   description = "Elasticsearch URL to benchmark with rally"

--- a/testing/rally-cloud/README.md
+++ b/testing/rally-cloud/README.md
@@ -14,6 +14,17 @@ the first time
 4. Run `EC_API_KEY=<ec_api_key> make apply` to create the required infra and run
 rally.
 
-The rally benchmark will execute everytime `make apply` is called however, the infrastucture
-will be created only once. After testing is done make sure to destroy all
-infrastructure using `EC_API_KEY=<ec_api_key> make destroy`
+The rally benchmark will execute everytime `make apply` is called however, the
+infrastucture will be created only once. After testing is done make sure to
+destroy all infrastructure using `EC_API_KEY=<ec_api_key> make destroy`
+
+## How to choose the correct rally setup for your benchmarks?
+
+For benchmarks with small corpora sizes, the defaults configuration should be
+good. However, for bigger benchmarks rally nodes or machine type might need to
+be scaled. Checking the metrics for the rally-nodes on GCP is a good point to
+start. If the utilization of the nodes is too high then we can tweak two
+parameters:
+
+1. Increase the number of clients and workers so that rally can divide the work.
+2. Vertically scale up machine used for rally nodes by changing machine type.

--- a/testing/rally-cloud/main.tf
+++ b/testing/rally-cloud/main.tf
@@ -35,11 +35,11 @@ module "ec_deployment" {
 module "rally_workers" {
   source = "../infra/terraform/modules/rally_workers"
 
-  gcp_project = var.gcp_project
-  gcp_region  = var.gcp_region
+  gcp_project     = var.gcp_project
+  gcp_region      = var.gcp_region
+  machine_type    = var.rally_machine_type
 
-  resource_prefix = var.rally_workers_resource_prefix
-
+  resource_prefix      = var.rally_workers_resource_prefix
   rally_dir            = var.rally_dir
   rally_worker_count   = var.rally_worker_count
   rally_cluster_status = var.rally_cluster_status

--- a/testing/rally-cloud/variables.tf
+++ b/testing/rally-cloud/variables.tf
@@ -45,6 +45,12 @@ variable "gcp_region" {
   default     = "us-west2"
 }
 
+variable "rally_machine_type" {
+  type        = string
+  description = "Machine type for rally nodes"
+  default     = "e2-small"
+}
+
 variable "rally_workers_resource_prefix" {
   type        = string
   description = "Prefix to add to created resource for rally workers"


### PR DESCRIPTION
## Motivation/summary

Make machine type configurable for rally nodes. Also, upgrade the default machine type to `e2-small` which gives us 1GB more RAM and more burst CPU time.

## Checklist

~~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~~
~~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~~
- [x] Documentation has been updated

## How to test these changes

Details in the [README](https://github.com/elastic/apm-server/blob/main/testing/rally-cloud/README.md).

## Related issues

N/A
