### PR TITLE
ec_deployment: Add `drop_pipeline` variable

### DIFF
--- a/testing/benchmark/main.tf
+++ b/testing/benchmark/main.tf
@@ -47,6 +47,7 @@ module "ec_deployment" {
   apm_server_size       = var.apm_server_size
   apm_server_zone_count = var.apm_server_zone_count
   apm_index_shards      = var.apm_shards
+  drop_pipeline         = var.drop_pipeline
   apm_server_expvar     = true
   apm_server_pprof      = true
 

--- a/testing/benchmark/variables.tf
+++ b/testing/benchmark/variables.tf
@@ -80,6 +80,12 @@ variable "apm_shards" {
   description = "The number of shards to use for apm indices. Defaults to 0, doesn't modify the default values"
 }
 
+variable "drop_pipeline" {
+  default     = false
+  description = "Whether or not to install an Elasticsearch ingest pipeline to drop all incoming APM documents. Defaults to false"
+  type        = bool
+}
+
 ## Worker configuraiton
 
 variable "worker_region" {

--- a/testing/infra/terraform/modules/ec_deployment/.gitignore
+++ b/testing/infra/terraform/modules/ec_deployment/.gitignore
@@ -2,3 +2,4 @@ scripts/enable_expvar.sh
 scripts/secret_token.sh
 scripts/index_shards.sh
 scripts/custom-apm-integration-pkg.sh
+scripts/drop_pipeline.sh

--- a/testing/infra/terraform/modules/ec_deployment/README.md
+++ b/testing/infra/terraform/modules/ec_deployment/README.md
@@ -15,7 +15,7 @@ used to configure the module, please refer to the [EC Provider docs](https://reg
 
 | Name | Version |
 |------|---------|
-| <a name="provider_ec"></a> [ec](#provider\_ec) | >=0.4.1 |
+| <a name="provider_ec"></a> [ec](#provider\_ec) | 0.4.0 |
 | <a name="provider_external"></a> [external](#provider\_external) | n/a |
 | <a name="provider_local"></a> [local](#provider\_local) | n/a |
 | <a name="provider_null"></a> [null](#provider\_null) | n/a |
@@ -27,10 +27,12 @@ used to configure the module, please refer to the [EC Provider docs](https://reg
 | [ec_deployment.deployment](https://registry.terraform.io/providers/elastic/ec/latest/docs/resources/deployment) | resource |
 | [ec_deployment.deployment_monitor](https://registry.terraform.io/providers/elastic/ec/latest/docs/resources/deployment) | resource |
 | [local_file.custom_apm_integration_pkg](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [local_file.drop_pipeline](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.enable_expvar](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.secret_token](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.shard_settings](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [null_resource.custom_apm_integration_pkg](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.drop_pipeline](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.enable_expvar](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.secret_token](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.shard_settings](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
@@ -51,6 +53,7 @@ used to configure the module, please refer to the [EC Provider docs](https://reg
 | <a name="input_deployment_template"></a> [deployment\_template](#input\_deployment\_template) | Optional deployment template. Defaults to the CPU optimized template for GCP | `string` | `"gcp-compute-optimized-v2"` | no |
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Optional docker image overrides. The full map needs to be specified | `map(string)` | <pre>{<br>  "apm": "docker.elastic.co/cloud-release/elastic-agent-cloud",<br>  "elasticsearch": "docker.elastic.co/cloud-release/elasticsearch-cloud-ess",<br>  "kibana": "docker.elastic.co/cloud-release/kibana-cloud"<br>}</pre> | no |
 | <a name="input_docker_image_tag_override"></a> [docker\_image\_tag\_override](#input\_docker\_image\_tag\_override) | Optional docker image tag overrides, The full map needs to be specified | `map(string)` | <pre>{<br>  "apm": "",<br>  "elasticsearch": "",<br>  "kibana": ""<br>}</pre> | no |
+| <a name="input_drop_pipeline"></a> [drop\_pipeline](#input\_drop\_pipeline) | Whether or not to install an Elasticsearch ingest pipeline to drop all incoming APM documents. Defaults to false | `bool` | `false` | no |
 | <a name="input_elasticsearch_autoscale"></a> [elasticsearch\_autoscale](#input\_elasticsearch\_autoscale) | Optional autoscale the Elasticsearch cluster | `bool` | `false` | no |
 | <a name="input_elasticsearch_dedicated_masters"></a> [elasticsearch\_dedicated\_masters](#input\_elasticsearch\_dedicated\_masters) | Optionally use dedicated masters for the Elasticsearch cluster | `bool` | `false` | no |
 | <a name="input_elasticsearch_size"></a> [elasticsearch\_size](#input\_elasticsearch\_size) | Optional Elasticsearch instance size | `string` | `"8g"` | no |

--- a/testing/infra/terraform/modules/ec_deployment/scripts/drop_pipeline.tftpl
+++ b/testing/infra/terraform/modules/ec_deployment/scripts/drop_pipeline.tftpl
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eo
+
+ingest_pipelines=("logs-apm.app@custom" "logs-apm.error@custom" "metrics-apm.app@custom" "metrics-apm.internal@custom" "traces-apm.rum@custom" "traces-apm@custom")
+
+for tpl in $${ingest_pipelines[@]}; do
+  curl -s --fail-with-body -H 'Content-Type: application/json' -XPUT -u ${elasticsearch_username}:${elasticsearch_password} "${elasticsearch_url}/_ingest/pipeline/$${tpl}" -d '{
+  "processors": [
+    {
+      "drop": {}
+    }
+  ]
+}'
+done

--- a/testing/infra/terraform/modules/ec_deployment/variables.tf
+++ b/testing/infra/terraform/modules/ec_deployment/variables.tf
@@ -127,7 +127,15 @@ variable "apm_index_shards" {
 # Install custom APM integration package
 
 variable "custom_apm_integration_pkg_path" {
-  type = string
+  type        = string
   description = "Path to the zipped custom APM integration package, if empty custom apm integration pkg is not installed"
-  default = ""
+  default     = ""
+}
+
+# Install a custom pipeline to drop all the incoming APM documents. It can be
+# useful to benchmark the theoretical APM Server output.
+variable "drop_pipeline" {
+  default     = false
+  description = "Whether or not to install an Elasticsearch ingest pipeline to drop all incoming APM documents. Defaults to false"
+  type        = bool
 }

--- a/testing/infra/terraform/modules/rally_workers/README.md
+++ b/testing/infra/terraform/modules/rally_workers/README.md
@@ -17,10 +17,10 @@ This modules sets up [rally daemons](https://esrally.readthedocs.io/en/stable/ra
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
-| <a name="provider_google"></a> [google](#provider\_google) | 4.33.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.1.1 |
+| <a name="provider_google"></a> [google](#provider\_google) | >=4.27.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | >=3.1.1 |
 | <a name="provider_remote"></a> [remote](#provider\_remote) | >=0.1.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.1 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >=4.0.1 |
 
 ## Resources
 


### PR DESCRIPTION
## Motivation/summary

Introduces a new `drop_pipeline` variable which can be used to measure the theoretical maximum output from the APM Server.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

Enable `drop_pipeline` in `testing/benchmark`.

## Related issues

Seemed from #9180
