### PR TITLE
Support string format for timestamp

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -17,6 +17,7 @@ Set error.id for OpenTelemetry exception span events {pull}9372[9372]
 
 [float]
 ==== Intake API Changes
+- experimental:[] Add support for string timestamp format(`2006-01-02T15:04:05.999-0700`) {pull}9376[9376]
 
 [float]
 ==== Added

--- a/internal/model/modeldecoder/nullable/nullable.go
+++ b/internal/model/modeldecoder/nullable/nullable.go
@@ -27,10 +27,6 @@ import (
 	jsoniter "github.com/json-iterator/go"
 )
 
-const (
-	dateTimeWithZ = "2006-01-02T15:04:05.999-0700"
-)
-
 func init() {
 	jsoniter.RegisterTypeDecoderFunc("nullable.String", func(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 		switch iter.WhatIsNext() {
@@ -90,7 +86,7 @@ func init() {
 			(*((*TimeMicrosUnix)(ptr))).isSet = true
 		case jsoniter.StringValue:
 			tstr := iter.ReadString()
-			t, err := time.Parse(dateTimeWithZ, tstr)
+			t, err := time.Parse("2006-01-02T15:04:05.999-0700", tstr)
 			if err != nil {
 				iter.Error = errors.New("invalid input format for timestamp received")
 				return

--- a/internal/model/modeldecoder/nullable/nullable_test.go
+++ b/internal/model/modeldecoder/nullable/nullable_test.go
@@ -234,6 +234,8 @@ func TestTimeMicrosUnix(t *testing.T) {
 	}{
 		{name: "valid", input: `{"tms":1599996822281000}`, isSet: true,
 			val: "2020-09-13 11:33:42.281 +0000 UTC"},
+		{name: "valid-with-str-tms", input: `{"tms":"2022-10-17T14:15:30.111+0800"}`, isSet: true,
+			val: "2022-10-17 06:15:30.111 +0000 UTC"},
 		{name: "null", input: `{"tms":null}`, val: time.Time{}.String()},
 		{name: "invalid-type", input: `{"tms":""}`, fail: true, isSet: true},
 		{name: "invalid-type", input: `{"tms":123.56}`, fail: true, isSet: true},


### PR DESCRIPTION
Add support for string formatted timestamp.

## Motivation/summary

See [this comment 
](https://github.com/elastic/apm-server/pull/9349#issuecomment-1278968410)
## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~~
~~- [ ] Documentation has been updated~~

## How to test these changes


1. Create a request body for the `log` event type:
```json
{"metadata":{"process":{"pid":1234,"title":"/usr/lib/jvm/java-10-openjdk-amd64/bin/java","ppid":1,"argv":["-v"]},"system":{"architecture":"amd64","detected_hostname":"8ec7ceb99074","configured_hostname":"host1","platform":"Linux","container":{"id":"8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"},"kubernetes":{"namespace":"default","pod":{"uid":"b17f231da0ad128dc6c6c0b2e82f6f303d3893e3","name":"instrumented-java-service"},"node":{"name":"node-name"}}},"service":{"name":"1234_service-12a3","version":"4.3.0","node":{"configured_name":"8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"},"environment":"production","language":{"name":"Java","version":"10.0.2"},"agent":{"version":"1.10.0","name":"java","ephemeral_id":"e71be9ac-93b0-44b9-a997-5638f6ccfc36"},"framework":{"name":"spring","version":"5.0.0"},"runtime":{"name":"Java","version":"10.0.2"}},"labels":{"group":"experimental","ab_testing":true,"segment":5}}}
{"log": {"message": "test log message with timestamp", "@timestamp": "2006-01-02T15:04:05.999-0700"}}
```

2. Send a curl request with the above request body:
```bash
curl -i -H "Content-type: application/x-ndjson" -H "Authorization: Bearer {APM_SERVER_SECRET_TOKEN}" --data-binary @<request_body_path> {APM_SERVER_URL}:8200/intake/v2/events
```

## Related issues

Related to #9100 
