### PR TITLE
beatcmd: make GOMAXPROCS test more robust

### DIFF
--- a/internal/beatcmd/beat.go
+++ b/internal/beatcmd/beat.go
@@ -337,7 +337,7 @@ func (b *Beat) Run(ctx context.Context) error {
 	}
 
 	g.Go(func() error {
-		return adjustMaxProcs(ctx, 30*time.Second, diffInfof(logger), logger.Errorf)
+		return adjustMaxProcs(ctx, 30*time.Second, logger)
 	})
 
 	logSystemInfo(b.Info)


### PR DESCRIPTION
## Motivation/summary

TestAdjustMaxProcs* tests have been failing intermittently, particularly on the macOS GitHub action. The tests assume that the timer will run at least 10 times, with a ticker duration of 1ms and total duration of 50ms. This is not guaranteed, and is causing failures on slow CI machines.

The two tests are replaced with one test which checks that duplicate logs are suppressed, and that changes to the GOMAXPROCS environment variable are picked up and trigger a log message. The latter implictly tests that the ticker is effective. The code-under-test is simple enough that we can rely on manual code inspection to ensure the correct duration is used.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

None