### PR TITLE
[automation] update elastic stack version for testing 8.5.0-eb17cbd2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.0-bdb74671-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.5.0-eb17cbd2-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -31,7 +31,7 @@ services:
       - "./testing/docker/elasticsearch/ingest-geoip:/usr/share/elasticsearch/config/ingest-geoip"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.5.0-bdb74671-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.5.0-eb17cbd2-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -50,7 +50,7 @@ services:
       - "./testing/docker/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml"
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:8.5.0-bdb74671-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:8.5.0-eb17cbd2-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:
@@ -78,7 +78,7 @@ services:
       - "./testing/docker/fleet-server/key.pem:/etc/pki/tls/private/fleet-server-key.pem"
 
   metricbeat:
-    image: docker.elastic.co/beats/metricbeat:8.5.0-bdb74671-SNAPSHOT
+    image: docker.elastic.co/beats/metricbeat:8.5.0-eb17cbd2-SNAPSHOT
     environment:
       ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'
       ELASTICSEARCH_USERNAME: "${KIBANA_ES_USER:-admin}"


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Wed, 26 Oct 2022 00:17:52 GMT, release_branch:8.5, prefix:, end_time:Wed, 26 Oct 2022 08:03:41 GMT, manifest_version:2.1.0, version:8.5.0-SNAPSHOT, branch:8.5, build_id:8.5.0-eb17cbd2, build_duration_seconds:27949]