### PR TITLE
Update release docs

### DIFF
--- a/dev_docs/RELEASES.md
+++ b/dev_docs/RELEASES.md
@@ -19,7 +19,9 @@ For patch releases, only the version on the existing major and minor version bra
     * Minor version: 
       Create new changelog file from [changelogs/head.asciidoc](https://github.com/elastic/apm-server/blob/main/changelogs/head.asciidoc)
       If changes should not be backported, keep them in the _changelogs/head.asciidoc_ file.
-    * Patch version: Add new section to existing release notes. ([Sample PR](https://github.com/elastic/apm-server/pull/2064/files))
+      Don't forget to `include` and link to the new file. [(Sample PR)](https://github.com/elastic/apm-server/pull/7956/files)
+    * Patch version: Add a new section to existing release notes. ([Sample PR](https://github.com/elastic/apm-server/pull/8313/files))
+  * Add `@elastic/obs-docs` as a reviewer.
 
 ## Day after Feature Freeze
 * For minor releases, cut a new release branch from `main` and update them.


### PR DESCRIPTION
### Summary

Some of the recent APM Server release notes PRs (8.5, 8.4, 8.3.3, 7.17.6) have missed required Asciidoc syntax, like links, and include statements—there's a lot of syntax to remember. This PR proposes a small update to the release docs:

* Updates the existing changelog PR to a more recent example and adds a new example for patch version updates.
* Adds a request for `@elastic/obs-docs` to be added as a reviewer to release note PRs.