### PR TITLE
Benchmark reporting: fixed Kibana request timezone and stack version

### DIFF
--- a/.ci/scripts/download-png-from-kibana.sh
+++ b/.ci/scripts/download-png-from-kibana.sh
@@ -6,7 +6,7 @@ kibana_pwd=$3
 png_output_file=${4:-'out.png'}
 table_width_px=${5:-850}
 
-png_url_path=$(curl -XPOST --silent -L -u "$kibana_user:$kibana_pwd" -H 'kbn-xsrf: true' "$kibana_host/api/reporting/generate/pngV2?jobParams=%28browserTimezone%3AEurope%2FBerlin%2Clayout%3A%28dimensions%3A%28height%3A0%2Cwidth%3A$table_width_px%29%2Cid%3Apreserve_layout%29%2ClocatorParams%3A%28id%3ADASHBOARD_APP_LOCATOR%2Cparams%3A%28dashboardId%3Aa5bc8390-2f8e-11ed-a369-052d8245fa04%2CpreserveSavedFilters%3A%21t%2CtimeRange%3A%28from%3Anow-30d%2Cto%3Anow%29%2CuseHash%3A%21f%2CviewMode%3Aview%29%2Cversion%3A%278.3.2%27%29%2CobjectType%3Adashboard%2Ctitle%3Aapp_bench_diff_shifts_slack%2Cversion%3A%278.3.2%27%29" \
+png_url_path=$(curl -XPOST --silent -L -u "$kibana_user:$kibana_pwd" -H 'kbn-xsrf: true' "$kibana_host/api/reporting/generate/pngV2?jobParams=%28layout%3A%28dimensions%3A%28height%3A0%2Cwidth%3A$table_width_px%29%2Cid%3Apreserve_layout%29%2ClocatorParams%3A%28id%3ADASHBOARD_APP_LOCATOR%2Cparams%3A%28dashboardId%3Aa5bc8390-2f8e-11ed-a369-052d8245fa04%2CpreserveSavedFilters%3A%21t%2CtimeRange%3A%28from%3Anow-30d%2Cto%3Anow%29%2CuseHash%3A%21f%2CviewMode%3Aview%29%2CobjectType%3Adashboard%2Ctitle%3Aapp_bench_diff_shifts_slack%29" \
 | jq -r '.path')
 
 echo "PNG URL path: $png_url_path"


### PR DESCRIPTION
## Motivation/summary
Due to incorrect time zone and version request parameters we had wrong PNG screenshot in slack report

## How to test these changes
Ideally wait for the next benckmark execution
