### PR TITLE
[automation] update elastic stack version for testing 7.17.8-a281a566

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       fleet-server: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.8-1d146f89-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.8-a281a566-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -62,7 +62,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.17.8-1d146f89-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.17.8-a281a566-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -86,7 +86,7 @@ services:
       package-registry: { condition: service_healthy }
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:7.17.8-1d146f89-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:7.17.8-a281a566-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Fri, 4 Nov 2022 13:53:36 GMT, release_branch:7.17, prefix:, end_time:Fri, 4 Nov 2022 20:38:56 GMT, manifest_version:2.1.0, version:7.17.8-SNAPSHOT, branch:7.17, build_id:7.17.8-a281a566, build_duration_seconds:24320]