### PR TITLE
populate date label/tag in terraform

### DIFF
--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -57,7 +57,7 @@ pipeline {
       steps {
         dir("${BASE_DIR}") {
           withGoEnv() {
-            dir(TESTING_BENCHMARK_DIR) {
+            dir("${TESTING_BENCHMARK_DIR}") {
               withTestClusterEnv() {
                 sh(label: 'Build apmbench', script: 'make apmbench $SSH_KEY terraform.tfvars')
                 sh(label: 'Spin up benchmark environment', script: '$(make docker-override-committed-version) && make init apply')
@@ -74,7 +74,7 @@ pipeline {
         always {
           dir("${BASE_DIR}") {
             withGoEnv() {
-              dir(TESTING_BENCHMARK_DIR) {
+              dir("${TESTING_BENCHMARK_DIR}") {
                 stashV2(name: 'benchmark_tfstate', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}")
                 archiveArtifacts(allowEmptyArchive: true,
                   artifacts: "${env.BENCHMARK_RESULT}",

--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -51,6 +51,7 @@ pipeline {
         TF_VAR_ENVIRONMENT= 'ci'
         TF_VAR_BRANCH = "${env.BRANCH_NAME.toLowerCase().replaceAll('[^a-z0-9-]', '-')}"
         TF_VAR_REPO = "${REPO}"
+        TF_VAR_CREATED_DATE = "${env.CREATED_DATE}"
         GOBENCH_TAGS = "branch=${BRANCH_NAME},commit=${GIT_BASE_COMMIT},pr=${CHANGE_ID},target_branch=${CHANGE_TARGET}"
       }
       steps {

--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -16,6 +16,7 @@ pipeline {
     JOB_GCS_BUCKET_STASH = 'apm-ci-temp'
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
     SLACK_CHANNEL = "#apm-server"
+    TESTING_BENCHMARK_DIR = 'testing/benchmark'
   }
   options {
     timeout(time: 3, unit: 'HOURS')
@@ -55,7 +56,7 @@ pipeline {
       steps {
         dir("${BASE_DIR}") {
           withGoEnv() {
-            dir("testing/benchmark") {
+            dir(TESTING_BENCHMARK_DIR) {
               withTestClusterEnv() {
                 sh(label: 'Build apmbench', script: 'make apmbench $SSH_KEY terraform.tfvars')
                 sh(label: 'Spin up benchmark environment', script: '$(make docker-override-committed-version) && make init apply')
@@ -72,7 +73,7 @@ pipeline {
         always {
           dir("${BASE_DIR}") {
             withGoEnv() {
-              dir("testing/benchmark") {
+              dir(TESTING_BENCHMARK_DIR) {
                 stashV2(name: 'benchmark_tfstate', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}")
                 archiveArtifacts(allowEmptyArchive: true,
                   artifacts: "${env.BENCHMARK_RESULT}",


### PR DESCRIPTION
## Motivation/summary

Populate the date when the resources are created and fixed some linting and cosmetic changes in the pipeline

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

In the CI 

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
