### PR TITLE
beater/config: treat null agent config as empty

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -18,6 +18,7 @@ https://github.com/elastic/apm-server/compare/8.5\...main[View commits]
 ==== Bug fixes
 - Set `error.id` for OpenTelemetry exception span events {pull}9372[9372]
 - Add an `apm-server` user to /etc/passwd in the Docker images {pull}9496[9496]
+- Null APM agent configuration entries are now treated as empty, and will not cause the server to exit with an error {pull}9546[9546]
 
 [float]
 ==== Intake API Changes

--- a/internal/beater/config/agentconfig.go
+++ b/internal/beater/config/agentconfig.go
@@ -54,9 +54,10 @@ type AgentConfig struct {
 
 func (s *AgentConfig) setup() error {
 	if s.Config == nil {
-		return errInvalidAgentConfigMissingConfig
+		// Config may be passed to APM Server as `null` when no attributes
+		// are defined in an APM Agent central configuration entry.
+		s.Config = make(map[string]string)
 	}
-
 	if s.Etag == "" {
 		m, err := json.Marshal(s)
 		if err != nil {

--- a/internal/beater/config/agentconfig_test.go
+++ b/internal/beater/config/agentconfig_test.go
@@ -1,0 +1,64 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/config"
+)
+
+// TestKibanaAgentConfig tests server configuration the legacy Kibana-based agent config implementation.
+func TestKibanaAgentConfig(t *testing.T) {
+	t.Run("InvalidValueTooSmall", func(t *testing.T) {
+		cfg, err := NewConfig(config.MustNewConfigFrom(map[string]string{"agent.config.cache.expiration": "123ms"}), nil)
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("InvalidUnit", func(t *testing.T) {
+		cfg, err := NewConfig(config.MustNewConfigFrom(map[string]string{"agent.config.cache.expiration": "1230ms"}), nil)
+		require.Error(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("Valid", func(t *testing.T) {
+		cfg, err := NewConfig(config.MustNewConfigFrom(map[string]string{"agent.config.cache.expiration": "123000ms"}), nil)
+		require.NoError(t, err)
+		assert.Equal(t, time.Second*123, cfg.KibanaAgentConfig.Cache.Expiration)
+	})
+}
+
+func TestAgentConfigs(t *testing.T) {
+	cfg, err := NewConfig(config.MustNewConfigFrom(`{"agent_config":[{"service.environment":"production","config":{"transaction_sample_rate":0.5}}]}`), nil)
+	require.NoError(t, err)
+	assert.NotNil(t, cfg)
+	assert.Len(t, cfg.AgentConfigs, 1)
+	assert.NotEmpty(t, cfg.AgentConfigs[0].Etag)
+
+	// The "config" attribute may come through as `null` when no config attributes are defined.
+	cfg, err = NewConfig(config.MustNewConfigFrom(`{"agent_config":[{"service.environment":"production","config":null}]}`), nil)
+	require.NoError(t, err)
+	assert.NotNil(t, cfg)
+	assert.Len(t, cfg.AgentConfigs, 1)
+	assert.NotEmpty(t, cfg.AgentConfigs[0].Etag)
+}

--- a/internal/beater/config/config.go
+++ b/internal/beater/config/config.go
@@ -37,10 +37,6 @@ const (
 	msgInvalidConfigAgentCfg = "invalid value for `apm-server.agent.config.cache.expiration`, only accepting full seconds"
 )
 
-var (
-	errInvalidAgentConfigMissingConfig = errors.New("agent_config: no config set")
-)
-
 // Config holds configuration information nested under the key `apm-server`
 type Config struct {
 	// Host holds the hostname or address that the server should bind to

--- a/internal/beater/config/config_test.go
+++ b/internal/beater/config/config_test.go
@@ -583,34 +583,6 @@ func TestTLSSettings(t *testing.T) {
 	})
 }
 
-func TestAgentConfig(t *testing.T) {
-	t.Run("InvalidValueTooSmall", func(t *testing.T) {
-		cfg, err := NewConfig(config.MustNewConfigFrom(map[string]string{"agent.config.cache.expiration": "123ms"}), nil)
-		require.Error(t, err)
-		assert.Nil(t, cfg)
-	})
-
-	t.Run("InvalidUnit", func(t *testing.T) {
-		cfg, err := NewConfig(config.MustNewConfigFrom(map[string]string{"agent.config.cache.expiration": "1230ms"}), nil)
-		require.Error(t, err)
-		assert.Nil(t, cfg)
-	})
-
-	t.Run("Valid", func(t *testing.T) {
-		cfg, err := NewConfig(config.MustNewConfigFrom(map[string]string{"agent.config.cache.expiration": "123000ms"}), nil)
-		require.NoError(t, err)
-		assert.Equal(t, time.Second*123, cfg.KibanaAgentConfig.Cache.Expiration)
-	})
-}
-
-func TestAgentConfigs(t *testing.T) {
-	cfg, err := NewConfig(config.MustNewConfigFrom(`{"agent_config":[{"service.environment":"production","config":{"transaction_sample_rate":0.5}}]}`), nil)
-	require.NoError(t, err)
-	assert.NotNil(t, cfg)
-	assert.Len(t, cfg.AgentConfigs, 1)
-	assert.NotEmpty(t, cfg.AgentConfigs[0].Etag)
-}
-
 func TestNewConfig_ESConfig(t *testing.T) {
 	ucfg, err := config.NewConfigFrom(`{
 		"rum.enabled": true,


### PR DESCRIPTION
## Motivation/summary

Allow a null `config` attribute in `agent_config` entries, treating it the same as an empty config map.

When no attributes are specified in an APM Agent central config entry, it will be added by APM UI to the APM integration policies as `{}`. Somewhere along the way to APM Server this is translated to `null`.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

See https://github.com/elastic/apm-server/issues/9545

## Related issues

Closes https://github.com/elastic/apm-server/issues/9545