### PR TITLE
ci: Populate `USER` variable with build id

### DIFF
--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -46,6 +46,7 @@ pipeline {
         TF_VAR_public_key = "./id_rsa_terraform.pub"
         BENCHMARK_RESULT = "benchmark-result.txt"
         TFVARS_SOURCE = "system-profiles/8GBx1zone.tfvars" // Default to use an 8gb profile
+        USER = "benchci-${env.BUILD_ID}" // use build as prefix
         // cloud tags
         TF_VAR_BUILD_ID = "${env.BUILD_ID}"
         TF_VAR_ENVIRONMENT= 'ci'


### PR DESCRIPTION
## Motivation/summary

Populates the empty variable `USER` with `bench-ci-<build_id>` to avoid jobs from running into collisions should any of the previous jobs fail to clean up the resources properly.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

Failing nightly benchmarks