### PR TITLE
bench: tear down the environment within the post-cleanup stage

### DIFF
--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -79,11 +79,13 @@ pipeline {
           }
         }
         cleanup {
-          dir("${BASE_DIR}") {
-            withGoEnv() {
-              dir("${TESTING_BENCHMARK_DIR}") {
-                withTestClusterEnv() {
-                  sh(label: 'Tear down benchmark environment', script: 'make destroy')
+          stage('Tear down'){
+            dir("${BASE_DIR}") {
+              withGoEnv() {
+                dir("${TESTING_BENCHMARK_DIR}") {
+                  withTestClusterEnv() {
+                    sh(label: 'Tear down benchmark environment', script: 'make destroy')
+                  }
                 }
               }
             }

--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -79,13 +79,11 @@ pipeline {
           }
         }
         cleanup {
-          stage('Tear down'){
-            dir("${BASE_DIR}") {
-              withGoEnv() {
-                dir("${TESTING_BENCHMARK_DIR}") {
-                  withTestClusterEnv() {
-                    sh(label: 'Tear down benchmark environment', script: 'make destroy')
-                  }
+          dir("${BASE_DIR}") {
+            withGoEnv() {
+              dir("${TESTING_BENCHMARK_DIR}") {
+                withTestClusterEnv() {
+                  sh(label: 'Tear down benchmark environment', script: 'make destroy')
                 }
               }
             }

--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -73,14 +73,15 @@ pipeline {
       }
       post {
         always {
+          dir("${BASE_DIR}/${TESTING_BENCHMARK_DIR}") {
+            stashV2(name: 'benchmark_tfstate', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}")
+            archiveArtifacts(artifacts: "${env.BENCHMARK_RESULT}", allowEmptyArchive: true)
+          }
+        }
+        cleanup {
           dir("${BASE_DIR}") {
             withGoEnv() {
               dir("${TESTING_BENCHMARK_DIR}") {
-                stashV2(name: 'benchmark_tfstate', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}")
-                archiveArtifacts(allowEmptyArchive: true,
-                  artifacts: "${env.BENCHMARK_RESULT}",
-                  defaultExcludes: false
-                )
                 withTestClusterEnv() {
                   sh(label: 'Tear down benchmark environment', script: 'make destroy')
                 }


### PR DESCRIPTION
Split the post build to run the `cleanup` for the tearing down process only

> cleanup
Run the steps in this post condition after every other post condition has been evaluated, regardless of the Pipeline or stage’s status.