### PR TITLE
ci: Disable failing benchmark report

### DIFF
--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -68,9 +68,7 @@ pipeline {
               }
             }
           }
-          // NOTE(marclop) The current PNG report isn't useful for a few reasons
-          // and is also making the build fail. Disabled until that is fixed.
-          // downloadPNGReport()
+          downloadPNGReport()
         }
       }
       post {
@@ -91,13 +89,11 @@ pipeline {
             }
           }
         }
-        // NOTE(marclop) The current PNG report isn't useful for a few reasons
-        // and is also making the build fail. Disabled until that is fixed.
-        // success {
-        //   dir("${BASE_DIR}") {
-        //     sendSlackReportSuccessMessage()
-        //   }
-        // }
+        success {
+          dir("${BASE_DIR}") {
+            sendSlackReportSuccessMessage()
+          }
+        }
         failure {
           notifyBuildResult(slackNotify: true, slackComment: true)
         }

--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -129,9 +129,11 @@ def downloadPNGReport() {
              'password': 'KIBANA_PASSWORD',
              'kibana_url': 'KIBANA_ENDPOINT']
    ) {
+    // These steps should not fail the build if something goes wrong
     sh(label: 'Run unit tests',
-       script: '.ci/scripts/download-png-from-kibana.sh $KIBANA_ENDPOINT $KIBANA_USER $KIBANA_PASSWORD $PNG_REPORT_FILE')
-    archiveArtifacts(allowEmptyArchive: false, artifacts: "${env.PNG_REPORT_FILE}")
+       script: '.ci/scripts/download-png-from-kibana.sh $KIBANA_ENDPOINT $KIBANA_USER $KIBANA_PASSWORD $PNG_REPORT_FILE',
+       returnStatus: true)
+    archiveArtifacts(allowEmptyArchive: true, artifacts: "${env.PNG_REPORT_FILE}")
   }
 }
 

--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -68,7 +68,9 @@ pipeline {
               }
             }
           }
-          downloadPNGReport()
+          // NOTE(marclop) The current PNG report isn't useful for a few reasons
+          // and is also making the build fail. Disabled until that is fixed.
+          // downloadPNGReport()
         }
       }
       post {
@@ -89,11 +91,13 @@ pipeline {
             }
           }
         }
-        success {
-          dir("${BASE_DIR}") {
-            sendSlackReportSuccessMessage()
-          }
-        }
+        // NOTE(marclop) The current PNG report isn't useful for a few reasons
+        // and is also making the build fail. Disabled until that is fixed.
+        // success {
+        //   dir("${BASE_DIR}") {
+        //     sendSlackReportSuccessMessage()
+        //   }
+        // }
         failure {
           notifyBuildResult(slackNotify: true, slackComment: true)
         }


### PR DESCRIPTION
## Motivation/summary

Disables the Kibana PNG download and reporting to Slack. Main reason is that it causes the build to fail unnecessarily.
