### PR TITLE
Universal Profiling: Fix error logging

### DIFF
--- a/x-pack/apm-server/profiling/collector.go
+++ b/x-pack/apm-server/profiling/collector.go
@@ -597,7 +597,7 @@ func (e *ElasticCollector) AddFallbackSymbols(ctx context.Context,
 				e.logger.With(
 					logp.Error(err),
 					logp.String("error_type", resp.Error.Type),
-				).Error("failed to index stackframe metadata: %s", resp.Error.Reason)
+				).Errorf("failed to index stackframe metadata: %s", resp.Error.Reason)
 			},
 		}, buf.Bytes())
 		if err != nil {


### PR DESCRIPTION
## Motivation/summary

`Error` was being called with a format string, switched to `Errorf`.

![Screen Shot 2022-11-16 at 8 08 42 AM](https://user-images.githubusercontent.com/77498532/202197084-045233d2-3ed0-4d79-8167-f023951f73cc.png)
