### PR TITLE
testing/k8s: Set memory limit, deployment strategy

### DIFF
--- a/testing/infra/k8s/base/stack/apm-server.yaml
+++ b/testing/infra/k8s/base/stack/apm-server.yaml
@@ -13,7 +13,19 @@ spec:
     name: fleet-server
   deployment:
     replicas: 1
+    strategy:
+      # Can be changed to "Replace" for extremely memory limited environments.
+      type: "RollingUpdate"
     podTemplate:
       spec:
+        containers:
+        - name: agent
+          resources:
+            limits:
+              cpu: 1
+              memory: "2Gi"
+            requests:
+              cpu: 1
+              memory: "1Gi"
         securityContext:
           runAsUser: 0

--- a/testing/infra/k8s/base/stack/fleet-server.yaml
+++ b/testing/infra/k8s/base/stack/fleet-server.yaml
@@ -14,5 +14,12 @@ spec:
     replicas: 1
     podTemplate:
       spec:
+        containers:
+        - name: agent
+          resources:
+            limits:
+              memory: "512Mi"
+            requests:
+              memory: "256Mi"
         securityContext:
           runAsUser: 0

--- a/testing/infra/k8s/base/stack/kibana.yaml
+++ b/testing/infra/k8s/base/stack/kibana.yaml
@@ -16,6 +16,11 @@ spec:
     spec:
       containers:
       - name: kibana
+        resources:
+          limits:
+            memory: "1Gi"
+          requests:
+            memory: "512Mi"
         readinessProbe:
           initialDelaySeconds: 10
           periodSeconds: 10

--- a/testing/infra/k8s/overlays/local/kustomization.yaml
+++ b/testing/infra/k8s/overlays/local/kustomization.yaml
@@ -4,6 +4,24 @@ resources:
 
 patches:
 - patch: |-
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      name: elastic-operator
+      namespace: elastic-system
+    spec:
+      selector:
+        control-plane: elastic-operator
+      template:
+        spec:
+          containers:
+            - name: manager
+              resources:
+                limits:
+                  memory: "512Mi"
+                requests:
+                  memory: "256Mi"
+- patch: |-
     apiVersion: agent.k8s.elastic.co/v1alpha1
     kind: Agent
     metadata:

--- a/testing/infra/k8s/overlays/local/kustomization.yaml
+++ b/testing/infra/k8s/overlays/local/kustomization.yaml
@@ -20,7 +20,7 @@ patches:
                 limits:
                   memory: "512Mi"
                 requests:
-                  memory: "256Mi"
+                  memory: "150Mi"
 - patch: |-
     apiVersion: agent.k8s.elastic.co/v1alpha1
     kind: Agent


### PR DESCRIPTION
## Motivation/summary

Updates the resource "limits" and "requests" for fleet-server, the ECK operator and the apm-server so memory is allocated a bit better in machines with limited RAM.

## How to test these changes

Non functional changes

## Related issues

None
