### PR TITLE
sampling: Discard writes on full badger storage

### DIFF
--- a/x-pack/apm-server/sampling/eventstorage/badger.go
+++ b/x-pack/apm-server/sampling/eventstorage/badger.go
@@ -12,21 +12,34 @@ import (
 )
 
 const (
-	defaultValueLogFileSize = 128 * 1024 * 1024
+	defaultValueLogFileSize = 64 * 1024 * 1024
 )
 
 // OpenBadger creates or opens a Badger database with the specified location
 // and value log file size. If the value log file size is <= 0, the default
-// of 128MB will be used.
+// of 64MB will be used.
 //
 // NOTE(axw) only one badger.DB for a given storage directory may be open at any given time.
 func OpenBadger(storageDir string, valueLogFileSize int64) (*badger.DB, error) {
 	logger := logp.NewLogger(logs.Sampling)
-	badgerOpts := badger.DefaultOptions(storageDir)
-	badgerOpts.ValueLogFileSize = defaultValueLogFileSize
-	if valueLogFileSize > 0 {
-		badgerOpts.ValueLogFileSize = valueLogFileSize
+	// Tunable memory options:
+	//  - NumMemtables - default 5 in-mem tables (MaxTableSize default)
+	//  - NumLevelZeroTables - default 5 - number of L0 tables before compaction starts.
+	//  - NumLevelZeroTablesStall - number of L0 tables before writing stalls (waiting for compaction).
+	//  - IndexCacheSize - default all in mem, Each table has its own bloom filter and each bloom filter is approximately of 5 MB.
+	//  - MaxTableSize - Default 64MB
+	if valueLogFileSize <= 0 {
+		valueLogFileSize = defaultValueLogFileSize
 	}
-	badgerOpts.Logger = &LogpAdaptor{Logger: logger}
+	const tableLimit = 4
+	badgerOpts := badger.DefaultOptions(storageDir).
+		WithLogger(&LogpAdaptor{Logger: logger}).
+		WithTruncate(true).                          // Truncate unreadable files which cannot be read.
+		WithNumMemtables(tableLimit).                // in-memory tables.
+		WithNumLevelZeroTables(tableLimit).          // L0 tables.
+		WithNumLevelZeroTablesStall(tableLimit * 3). // Maintain the default 1-to-3 ratio before stalling.
+		WithMaxTableSize(int64(16 << 20)).           // Max LSM table or file size.
+		WithValueLogFileSize(valueLogFileSize)       // vlog file size.
+
 	return badger.Open(badgerOpts)
 }

--- a/x-pack/apm-server/sampling/eventstorage/sharded.go
+++ b/x-pack/apm-server/sampling/eventstorage/sharded.go
@@ -23,9 +23,10 @@ type ShardedReadWriter struct {
 
 func newShardedReadWriter(storage *Storage) *ShardedReadWriter {
 	s := &ShardedReadWriter{
-		// Create as many ReadWriters as there are CPUs,
-		// so we can ideally minimise lock contention.
-		readWriters: make([]lockedReadWriter, runtime.NumCPU()),
+		// Create as many ReadWriters as there are GOMAXPROCS, which considers
+		// cgroup quotas, so we can ideally minimise lock contention, and scale
+		// up accordingly with more CPU.
+		readWriters: make([]lockedReadWriter, runtime.GOMAXPROCS(0)),
 	}
 	for i := range s.readWriters {
 		s.readWriters[i].rw = storage.NewReadWriter()

--- a/x-pack/apm-server/sampling/eventstorage/storage_test.go
+++ b/x-pack/apm-server/sampling/eventstorage/storage_test.go
@@ -291,6 +291,11 @@ func TestStorageLimit(t *testing.T) {
 		"failed to flush pending writes: configured storage limit reached (current: %d, limit: 1)", lsm+vlog,
 	))
 	assert.ErrorIs(t, err, eventstorage.ErrLimitReached)
+
+	// Assert the stored write has been discarded.
+	var batch model.Batch
+	readWriter.ReadTraceEvents(traceID, &batch)
+	assert.Equal(t, 0, len(batch))
 }
 
 func badgerOptions() badger.Options {

--- a/x-pack/apm-server/sampling/pubsub/pubsub.go
+++ b/x-pack/apm-server/sampling/pubsub/pubsub.go
@@ -63,6 +63,9 @@ func (p *Pubsub) PublishSampledTraceIDs(ctx context.Context, traceIDs <-chan str
 	indexer, err := modelindexer.New(p.config.Client, modelindexer.Config{
 		CompressionLevel: p.config.CompressionLevel,
 		FlushInterval:    p.config.FlushInterval,
+		EventBufferSize:  100, // Reduce memory footprint
+		// Disable autoscaling for the TBS sampled traces published documents.
+		Scaling: modelindexer.ScalingConfig{Disabled: true},
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## Motivation/summary

Discards the badger transaction when the soft limit has reached. This fixes a problem where each of the sharded readWriters would accumulate events in the `badger.Tx` until the transaction is full. This led to ouf of memory issues when the storage soft limit is reached.

Additionally, reduce the number of sharded readWriters to `GOMAXPROCS` rather than using the `NumCPU()`, since the latter causes containerized workloads to have (mostly) greater number of sharded readWriters than it most likely has access to, which will also reduce the memory usage for TBS.

Last, modifies the options which are used to open the Badger database:

- `Truncate=true`: Allows space reclamationfor vlog unreadable files.
- `NumMemtables=4`: From 5.
- `NumLevelZeroTables=4`: From 5.
- `NumLevelZeroTablesStall=12`: From 15.
- `MaxTableSize=16MB`: From 64MB.
- `ValueLogFileSize=64MB`: From 128MB.

To reduce the overall memory that is consumed by TBS.

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

1. `apmbench -run Benchmark1000 -benchtime 5m -agents 128 -count 5 -detailed 2>&1 -warmup-time=0`
2. Ensure that a 2GB APM Server doesn't run out of memory.

## Related issues

Closes #9523
