### PR TITLE
testing/docker/elastic-agent: don't use realpath

### DIFF
--- a/testing/docker/elastic-agent/build.sh
+++ b/testing/docker/elastic-agent/build.sh
@@ -6,7 +6,7 @@
 
 set -eu
 
-REPO_ROOT=$(cd $(dirname $(realpath "$0"))/../../.. && pwd)
+REPO_ROOT=$(cd $(dirname "$0")/../../.. && pwd)
 
 DEFAULT_IMAGE_TAG=$(grep docker.elastic.co/kibana ${REPO_ROOT}/docker-compose.yml | cut -d: -f3)
 BASE_IMAGE="${BASE_IMAGE:-docker.elastic.co/beats/elastic-agent:$DEFAULT_IMAGE_TAG}"


### PR DESCRIPTION
## Motivation/summary

There's no need for realpath, since we're using the resulting path without changing directories. This removes the need for installing coreutils on macOS.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

`tilt up`

## Related issues

None