### PR TITLE
fix: replace _realpath_ with _readlink -f_

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ PYTHON_ENV?=.
 PYTHON_VENV_DIR:=$(PYTHON_ENV)/build/ve/$(shell $(GO) env GOOS)
 PYTHON_BIN:=$(PYTHON_VENV_DIR)/bin
 PYTHON=$(PYTHON_BIN)/python
-CURRENT_DIR=$(shell dirname $(readlink -f $(firstword $(MAKEFILE_LIST))))
+CURRENT_DIR=$(shell dirname $(shell readlink -f $(firstword $(MAKEFILE_LIST))))
 
 # Create a local config.mk file to override configuration.
 -include config.mk

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ PYTHON_ENV?=.
 PYTHON_VENV_DIR:=$(PYTHON_ENV)/build/ve/$(shell $(GO) env GOOS)
 PYTHON_BIN:=$(PYTHON_VENV_DIR)/bin
 PYTHON=$(PYTHON_BIN)/python
-CURRENT_DIR=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+CURRENT_DIR=$(shell dirname $(readlink -f $(firstword $(MAKEFILE_LIST))))
 
 # Create a local config.mk file to override configuration.
 -include config.mk

--- a/testing/docker/elastic-agent/build.sh
+++ b/testing/docker/elastic-agent/build.sh
@@ -6,7 +6,7 @@
 
 set -eu
 
-REPO_ROOT=$(cd $(dirname $(realpath "$0"))/../../.. && pwd)
+REPO_ROOT=$(cd $(dirname $(readlink -f "$0"))/../../.. && pwd)
 
 DEFAULT_IMAGE_TAG=$(grep docker.elastic.co/kibana ${REPO_ROOT}/docker-compose.yml | cut -d: -f3)
 BASE_IMAGE="${BASE_IMAGE:-docker.elastic.co/beats/elastic-agent:$DEFAULT_IMAGE_TAG}"


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Avoid requirements to install `coreutils` on macOS by using `readlink` rather than `realpath`.  
<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Test on linux 


## How to test these changes

Could a reviewer with linux test this change please. 
