### PR TITLE
systemtest: fix flaky TestProfiling test

### DIFF
--- a/systemtest/profiling_test.go
+++ b/systemtest/profiling_test.go
@@ -171,19 +171,17 @@ func TestProfiling(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Perform queries and assertions on KV indices, after waiting more than the default index refresh interval
-	<-time.After(4 * time.Second)
-	result := systemtest.Elasticsearch.ExpectMinDocs(t, expectedKVDocs, "profiling-executables", nil)
+	// Perform queries and assertions on KV indices. We use wildcard searches below to prevent
+	// the searches from failing immediately when the indices haven't yet been created.
+	result := systemtest.Elasticsearch.ExpectMinDocs(t, expectedKVDocs, "profiling-executables-next*", nil)
 	systemtest.ApproveEvents(t, t.Name()+"/executables", result.Hits.Hits, "@timestamp")
 
-	result = systemtest.Elasticsearch.ExpectMinDocs(t, expectedKVDocs, "profiling-stackframes", nil)
+	result = systemtest.Elasticsearch.ExpectMinDocs(t, expectedKVDocs, "profiling-stackframes-next*", nil)
 	systemtest.ApproveEvents(t, t.Name()+"/stackframes", result.Hits.Hits)
 
-	result = systemtest.Elasticsearch.ExpectMinDocs(t, expectedKVDocs, "profiling-stacktraces", nil)
+	result = systemtest.Elasticsearch.ExpectMinDocs(t, expectedKVDocs, "profiling-stacktraces-next*", nil)
 	systemtest.ApproveEvents(t, t.Name()+"/stacktraces", result.Hits.Hits)
 
-	// We're using a wildcard below to prevent the search from failing
-	// when the index hasn't yet been created.
 	result = systemtest.Elasticsearch.ExpectDocs(t, "profiling-events-all*", nil)
 	systemtest.ApproveEvents(t, t.Name()+"/events", result.Hits.Hits)
 


### PR DESCRIPTION
## Motivation/summary

Use a wildcard search so search doesn't fail immediately if the index does not exist. Append "-next*", as just "*" would include
the "-next" indices.

Without this change, we get intermittent failures like this:

```
=== RUN   TestProfiling
2022/11/18 13:42:50 Starting container id: 44bcb8ce19a5 image: elastic-agent-systemtest:8.7.0-eb092238-SNAPSHOT
2022/11/18 13:42:50 Waiting for container id 44bcb8ce19a5 image: elastic-agent-systemtest:8.7.0-eb092238-SNAPSHOT
2022/11/18 13:42:57 Container is ready id: 44bcb8ce19a5 image: elastic-agent-systemtest:8.7.0-eb092238-SNAPSHOT
    profiling_test.go:176: [404 Not Found] {"error":{"root_cause":[{"type":"index_not_found_exception","reason":"no such index [profiling-executables]","resource.type":"index_or_alias","resource.id":"profiling-executables","index_uuid":"_na_","index":"profiling-executables"}],"type":"index_not_found_exception","reason":"no such index [profiling-executables]","resource.type":"index_or_alias","resource.id":"profiling-executables","index_uuid":"_na_","index":"profiling-executables"},"status":404}
    fleet_test.go:189: elastic-agent logs: {"log.level":"info","@timestamp":"2022-11-18T13:42:51.778Z","log.origin":{"file.name":"cmd/enroll_cmd.go","file.line":469},"message":"Starting enrollment to URL: https://fleet-server:8220/","ecs.version":"1.6.0"}
        Successfully enrolled the Elastic Agent.
        {"log.level":"info","@timestamp":"2022-11-18T13:42:52.956Z","log.origin":{"file.name":"cmd/enroll_cmd.go","file.line":269},"message":"Elastic Agent might not be running; unable to trigger restart","ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:53.202Z","log.origin":{"file.name":"cmd/run.go","file.line":165},"message":"APM instrumentation disabled","ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:53.203Z","log.origin":{"file.name":"application/application.go","file.line":40},"message":"Gathered system information","ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:53.213Z","log.origin":{"file.name":"application/application.go","file.line":46},"message":"Detected available inputs and outputs","inputs":["kafka","synthetics/icmp","packet","cel","httpjson","netflow","system/metrics","osquery","audit/file_integrity","cloudbeat/cis_eks","apm","cloudbeat","oracle/metrics","containerd/metrics","aws-s3","log","synthetics/synthetics","mongodb/metrics","postgresql/metrics","uwsgi/metrics","awsfargate/metrics","cloudbeat/cis_k8s","redis","windows/metrics","azure/metrics","docker","syslog","filestream","docker/metrics","aws-cloudwatch","http_endpoint","udp","beat/metrics","audit/auditd","gcp-pubsub","logstash/metrics","mssql/metrics","container","linux/metrics","cloudfoundry/metrics","azure-eventhub","o365audit","tcp","fleet-server","kubernetes/metrics","aws/metrics","syncgateway/metrics","audit/system","winlog","synthetics/tcp","elasticsearch/metrics","http/metrics","cloudfoundry","journald","redis/metrics","mqtt","synthetics/http","kibana/metrics","unix","mysql/metrics"],"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:53.213Z","log.origin":{"file.name":"capabilities/capabilities.go","file.line":54},"message":"Capabilities file not found in /usr/share/elastic-agent/state/capabilities.yml","ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:53.213Z","log.origin":{"file.name":"application/application.go","file.line":52},"message":"Determined allowed capabilities","ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:53.432Z","log.origin":{"file.name":"application/application.go","file.line":104},"message":"Parsed configuration and determined agent is managed by Fleet","ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:53.434Z","log.logger":"api","log.origin":{"file.name":"api/server.go","file.line":68},"message":"Starting stats endpoint","ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:53.434Z","log.logger":"api","log.origin":{"file.name":"api/server.go","file.line":70},"message":"Metrics endpoint listening on: 127.0.0.1:6791 (configured: http://localhost:6791)","ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:53.436Z","log.logger":"composable.providers.docker","log.origin":{"file.name":"docker/docker.go","file.line":44},"message":"Docker provider skipped, unable to connect: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?","ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:54.061Z","log.origin":{"file.name":"fleet/fleet_gateway.go","file.line":145},"message":"Fleet gateway started","ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:55.491Z","log.origin":{"file.name":"upgrade/upgrade.go","file.line":98},"message":"Source URI changed from \"https://artifacts.elastic.co/downloads/\" to \"https://artifacts.elastic.co/downloads/\"","ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:55.496Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":645},"message":"Updating running component model","ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:56.425Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":323},"message":"New component created","component":{"id":"apm-default","state":"Starting","message":"Starting: spawned pid '26'","inputs":[{"id":"apm-default-6e239840-a30e-4c6d-9dab-39ae1fe82ff8","state":"Starting","message":"Starting: spawned pid '26'"}],"output":{"id":"apm-default","state":"Starting","message":"Starting: spawned pid '26'"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:56.529Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":323},"message":"New component created","component":{"id":"filestream-monitoring","state":"Starting","message":"Starting: spawned pid '35'","inputs":[{"id":"filestream-monitoring-filestream-monitoring-agent","state":"Starting","message":"Starting: spawned pid '35'"}],"output":{"id":"filestream-monitoring","state":"Starting","message":"Starting: spawned pid '35'"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:57.362Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":323},"message":"New component created","component":{"id":"beat/metrics-monitoring","state":"Starting","message":"Starting: spawned pid '45'","inputs":[{"id":"beat/metrics-monitoring-metrics-monitoring-beats","state":"Starting","message":"Starting: spawned pid '45'"}],"output":{"id":"beat/metrics-monitoring","state":"Starting","message":"Starting: spawned pid '45'"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:57.646Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":323},"message":"New component created","component":{"id":"http/metrics-monitoring","state":"Starting","message":"Starting: spawned pid '54'","inputs":[{"id":"http/metrics-monitoring-metrics-monitoring-agent","state":"Starting","message":"Starting: spawned pid '54'"}],"output":{"id":"http/metrics-monitoring","state":"Starting","message":"Starting: spawned pid '54'"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:57.654Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"apm-default","state":"Healthy","message":"Healthy: communicating with pid '26'","inputs":[{"id":"apm-default-6e239840-a30e-4c6d-9dab-39ae1fe82ff8","state":"Starting","message":"Starting: spawned pid '26'"}],"output":{"id":"apm-default","state":"Starting","message":"Starting: spawned pid '26'"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:57.662Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"apm-default","state":"Healthy","message":"Healthy: communicating with pid '26'","inputs":[{"id":"apm-default-6e239840-a30e-4c6d-9dab-39ae1fe82ff8","state":"Configuring","message":"found reloader for 'input'"}],"output":{"id":"apm-default","state":"Healthy","message":"reloaded output component"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:57.662Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"apm-default","state":"Healthy","message":"Healthy: communicating with pid '26'","inputs":[{"id":"apm-default-6e239840-a30e-4c6d-9dab-39ae1fe82ff8","state":"Healthy","message":"beat reloaded"}],"output":{"id":"apm-default","state":"Healthy","message":"reloaded output component"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:57.666Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"filestream-monitoring","state":"Healthy","message":"Healthy: communicating with pid '35'","inputs":[{"id":"filestream-monitoring-filestream-monitoring-agent","state":"Starting","message":"Starting: spawned pid '35'"}],"output":{"id":"filestream-monitoring","state":"Starting","message":"Starting: spawned pid '35'"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:57.686Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"filestream-monitoring","state":"Healthy","message":"Healthy: communicating with pid '35'","inputs":[{"id":"filestream-monitoring-filestream-monitoring-agent","state":"Configuring","message":"found reloader for 'input'"}],"output":{"id":"filestream-monitoring","state":"Healthy","message":"reloaded output component"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:57.690Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"filestream-monitoring","state":"Healthy","message":"Healthy: communicating with pid '35'","inputs":[{"id":"filestream-monitoring-filestream-monitoring-agent","state":"Healthy","message":"beat reloaded"}],"output":{"id":"filestream-monitoring","state":"Healthy","message":"reloaded output component"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:57.690Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"beat/metrics-monitoring","state":"Healthy","message":"Healthy: communicating with pid '45'","inputs":[{"id":"beat/metrics-monitoring-metrics-monitoring-beats","state":"Starting","message":"Starting: spawned pid '45'"}],"output":{"id":"beat/metrics-monitoring","state":"Starting","message":"Starting: spawned pid '45'"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:57.695Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"beat/metrics-monitoring","state":"Healthy","message":"Healthy: communicating with pid '45'","inputs":[{"id":"beat/metrics-monitoring-metrics-monitoring-beats","state":"Configuring","message":"found reloader for 'input'"}],"output":{"id":"beat/metrics-monitoring","state":"Configuring","message":"reloading output component"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:57.696Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"beat/metrics-monitoring","state":"Healthy","message":"Healthy: communicating with pid '45'","inputs":[{"id":"beat/metrics-monitoring-metrics-monitoring-beats","state":"Configuring","message":"found reloader for 'input'"}],"output":{"id":"beat/metrics-monitoring","state":"Healthy","message":"reloaded output component"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:57.700Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"beat/metrics-monitoring","state":"Healthy","message":"Healthy: communicating with pid '45'","inputs":[{"id":"beat/metrics-monitoring-metrics-monitoring-beats","state":"Healthy","message":"beat reloaded"}],"output":{"id":"beat/metrics-monitoring","state":"Healthy","message":"reloaded output component"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:57.996Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"http/metrics-monitoring","state":"Healthy","message":"Healthy: communicating with pid '54'","inputs":[{"id":"http/metrics-monitoring-metrics-monitoring-agent","state":"Starting","message":"Starting: spawned pid '54'"}],"output":{"id":"http/metrics-monitoring","state":"Starting","message":"Starting: spawned pid '54'"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:58.001Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"http/metrics-monitoring","state":"Healthy","message":"Healthy: communicating with pid '54'","inputs":[{"id":"http/metrics-monitoring-metrics-monitoring-agent","state":"Configuring","message":"found reloader for 'input'"}],"output":{"id":"http/metrics-monitoring","state":"Configuring","message":"reloading output component"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:58.001Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"http/metrics-monitoring","state":"Healthy","message":"Healthy: communicating with pid '54'","inputs":[{"id":"http/metrics-monitoring-metrics-monitoring-agent","state":"Configuring","message":"found reloader for 'input'"}],"output":{"id":"http/metrics-monitoring","state":"Healthy","message":"reloaded output component"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:58.009Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"http/metrics-monitoring","state":"Healthy","message":"Healthy: communicating with pid '54'","inputs":[{"id":"http/metrics-monitoring-metrics-monitoring-agent","state":"Healthy","message":"beat reloaded"}],"output":{"id":"http/metrics-monitoring","state":"Healthy","message":"reloaded output component"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:58.429Z","log.origin":{"file.name":"upgrade/upgrade.go","file.line":98},"message":"Source URI changed from \"https://artifacts.elastic.co/downloads/\" to \"https://artifacts.elastic.co/downloads/\"","ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:58.431Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":645},"message":"Updating running component model","ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:58.437Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"apm-default","state":"Healthy","message":"Healthy: communicating with pid '26'","inputs":[{"id":"apm-default-6e239840-a30e-4c6d-9dab-39ae1fe82ff8","state":"Configuring","message":"found reloader for 'input'"}],"output":{"id":"apm-default","state":"Healthy","message":"reloaded output component"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:58.437Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"apm-default","state":"Healthy","message":"Healthy: communicating with pid '26'","inputs":[{"id":"apm-default-6e239840-a30e-4c6d-9dab-39ae1fe82ff8","state":"Healthy","message":"beat reloaded"}],"output":{"id":"apm-default","state":"Healthy","message":"reloaded output component"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:58.438Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"filestream-monitoring","state":"Healthy","message":"Healthy: communicating with pid '35'","inputs":[{"id":"filestream-monitoring-filestream-monitoring-agent","state":"Configuring","message":"found reloader for 'input'"}],"output":{"id":"filestream-monitoring","state":"Configuring","message":"reloading output component"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:58.438Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"filestream-monitoring","state":"Healthy","message":"Healthy: communicating with pid '35'","inputs":[{"id":"filestream-monitoring-filestream-monitoring-agent","state":"Configuring","message":"found reloader for 'input'"}],"output":{"id":"filestream-monitoring","state":"Healthy","message":"reloaded output component"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:58.439Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"filestream-monitoring","state":"Healthy","message":"Healthy: communicating with pid '35'","inputs":[{"id":"filestream-monitoring-filestream-monitoring-agent","state":"Healthy","message":"beat reloaded"}],"output":{"id":"filestream-monitoring","state":"Healthy","message":"reloaded output component"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:58.440Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"http/metrics-monitoring","state":"Healthy","message":"Healthy: communicating with pid '54'","inputs":[{"id":"http/metrics-monitoring-metrics-monitoring-agent","state":"Configuring","message":"found reloader for 'input'"}],"output":{"id":"http/metrics-monitoring","state":"Configuring","message":"reloading output component"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:58.441Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"http/metrics-monitoring","state":"Healthy","message":"Healthy: communicating with pid '54'","inputs":[{"id":"http/metrics-monitoring-metrics-monitoring-agent","state":"Configuring","message":"found reloader for 'input'"}],"output":{"id":"http/metrics-monitoring","state":"Healthy","message":"reloaded output component"}},"ecs.version":"1.6.0"}
        {"log.level":"info","@timestamp":"2022-11-18T13:42:58.442Z","log.origin":{"file.name":"coordinator/coordinator.go","file.line":325},"message":"Existing component state changed","component":{"id":"http/metrics-monitoring","state":"Healthy","message":"Healthy: communicating with pid '54'","inputs":[{"id":"http/metrics-monitoring-metrics-monitoring-agent","state":"Healthy","message":"beat reloaded"}],"output":{"id":"http/metrics-monitoring","state":"Healthy","message":"reloaded output component"}},"ecs.version":"1.6.0"}
--- FAIL: TestProfiling (23.35s)
```

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

None