### PR TITLE
compliance: Tag CSP resources according to policy

### DIFF
--- a/testing/benchmark/main.tf
+++ b/testing/benchmark/main.tf
@@ -14,12 +14,17 @@ terraform {
 
 locals {
   ci_tags = {
-    environment  = var.ENVIRONMENT
-    repo         = var.REPO
+    environment  = coalesce(var.ENVIRONMENT, "dev")
+    repo         = coalesce(var.REPO, "apm-server")
     branch       = var.BRANCH
     build        = var.BUILD_ID
     created_date = var.CREATED_DATE
   }
+}
+
+module "tags" {
+  source  = "../infra/terraform/modules/tags"
+  project = "benchmarks"
 }
 
 provider "ec" {}
@@ -27,12 +32,12 @@ provider "ec" {}
 provider "aws" {
   region = var.worker_region
   default_tags {
-    tags = local.ci_tags
+    tags = merge(local.ci_tags, module.tags.tags)
   }
 }
 
 locals {
-  name_prefix = "${var.user_name}-bench"
+  name_prefix = "${coalesce(var.user_name, "unknown-user")}-bench"
 }
 
 module "ec_deployment" {
@@ -58,7 +63,7 @@ module "ec_deployment" {
   docker_image              = var.docker_image_override
   docker_image_tag_override = var.docker_image_tag_override
 
-  tags = local.ci_tags
+  tags = merge(local.ci_tags, local.tags)
 }
 
 module "benchmark_worker" {

--- a/testing/infra/terraform/modules/rally_workers/README.md
+++ b/testing/infra/terraform/modules/rally_workers/README.md
@@ -22,6 +22,12 @@ This modules sets up [rally daemons](https://esrally.readthedocs.io/en/stable/ra
 | <a name="provider_remote"></a> [remote](#provider\_remote) | >=0.1.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | >=4.0.1 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_tags"></a> [tags](#module\_tags) | ../tags | n/a |
+
 ## Resources
 
 | Name | Type |

--- a/testing/infra/terraform/modules/soaktest_workers/README.md
+++ b/testing/infra/terraform/modules/soaktest_workers/README.md
@@ -10,6 +10,12 @@ This module sets up worker with load generation binary for soaktest configured a
 | <a name="provider_google"></a> [google](#provider\_google) | n/a |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_tags"></a> [tags](#module\_tags) | ../tags | n/a |
+
 ## Resources
 
 | Name | Type |

--- a/testing/infra/terraform/modules/soaktest_workers/main.tf
+++ b/testing/infra/terraform/modules/soaktest_workers/main.tf
@@ -16,6 +16,11 @@ locals {
   ))
 }
 
+module "tags" {
+  source  = "../tags"
+  project = "soaktests"
+}
+
 resource "tls_private_key" "worker_login" {
   algorithm = "RSA"
   rsa_bits  = "4096"
@@ -67,10 +72,9 @@ resource "google_compute_instance" "worker" {
     access_config {}
   }
 
-  labels = {
-    team      = "apm-server"
+  labels = merge(module.tags.labels, {
     workspace = terraform.workspace
-  }
+  })
 
   metadata = {
     ssh-keys = "${local.ssh_user_name}:${data.tls_public_key.worker_login.public_key_openssh}"

--- a/testing/infra/terraform/modules/tags/README.md
+++ b/testing/infra/terraform/modules/tags/README.md
@@ -1,5 +1,5 @@
 <!-- BEGIN_TF_DOCS -->
-## Rally worker module
+## Default tags module
 
 This modules exports the default tags / labels to use on Cloud Service Providers based on the Elastic tagging policy.
 

--- a/testing/infra/terraform/modules/tags/README.md
+++ b/testing/infra/terraform/modules/tags/README.md
@@ -1,0 +1,18 @@
+<!-- BEGIN_TF_DOCS -->
+## Rally worker module
+
+This modules exports the default tags / labels to use on Cloud Service Providers based on the Elastic tagging policy.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_project"></a> [project](#input\_project) | The value to use for the project tag/label | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_labels"></a> [labels](#output\_labels) | Labels for CSP resources |
+| <a name="output_tags"></a> [tags](#output\_tags) | Tags for CSP resources |
+<!-- END_TF_DOCS -->

--- a/testing/infra/terraform/modules/tags/header.md
+++ b/testing/infra/terraform/modules/tags/header.md
@@ -1,3 +1,3 @@
-## Rally worker module
+## Default tags module
 
 This modules exports the default tags / labels to use on Cloud Service Providers based on the Elastic tagging policy.

--- a/testing/infra/terraform/modules/tags/header.md
+++ b/testing/infra/terraform/modules/tags/header.md
@@ -1,0 +1,3 @@
+## Rally worker module
+
+This modules exports the default tags / labels to use on Cloud Service Providers based on the Elastic tagging policy.

--- a/testing/infra/terraform/modules/tags/output.tf
+++ b/testing/infra/terraform/modules/tags/output.tf
@@ -1,0 +1,18 @@
+locals {
+  tags = {
+    "division" : "engineering"
+    "org" : "observability"
+    "team" : "apm-server"
+    "project" : var.project
+  }
+}
+
+output "tags" {
+  value       = local.tags
+  description = "Tags for CSP resources"
+}
+
+output "labels" {
+  value       = local.tags
+  description = "Labels for CSP resources"
+}

--- a/testing/infra/terraform/modules/tags/vars.tf
+++ b/testing/infra/terraform/modules/tags/vars.tf
@@ -1,0 +1,3 @@
+variable "project" {
+  description = "The value to use for the project tag/label"
+}


### PR DESCRIPTION
## Motivation/summary

Introduces a new `tags` in `testing/infra/terraform/modules/tags` which defines the default CSP tags and accepts a `project` variable, to define the purpose of each importing module.

Also re-formats a few files, and updates the default values for a couple of unknown variables if unset.

## How to test these changes

N/A

## Related issues

CSP tagging policy.
