### PR TITLE
apmbench: makefile with shellflags

### DIFF
--- a/testing/benchmark/Makefile
+++ b/testing/benchmark/Makefile
@@ -24,6 +24,9 @@ SSH_OPTS ?= -o LogLevel=ERROR -o StrictHostKeyChecking=no
 SSH_KEY ?= ~/.ssh/id_rsa_terraform
 WORKER_IP = $(shell terraform output -raw public_ip)
 
+SHELL = /bin/bash
+.SHELLFLAGS = -o pipefail -c
+
 # This profile will also be used by the Terraform provider.
 export AWS_PROFILE ?= default
 


### PR DESCRIPTION
## Motivation/summary

to report errors if pipes in the makefile, as there are hidden errors when running the `run-benchmark`

```
[2022-11-27T05:00:10.351Z] --- FAIL: BenchmarkOTLPTraces-512
[2022-11-27T05:00:10.351Z] 2022/11/27 05:00:10 benchmark "BenchmarkOTLPTraces-512" failed
[2022-11-27T05:00:10.351Z] make[1]: Leaving directory '/var/lib/jenkins/workspace/apm-server_benchmarks_main/src/github.com/elastic/apm-server/testing/benchmark'
```


## Test

It fails as expected now

<img width="1098" alt="image" src="https://user-images.githubusercontent.com/2871786/204268958-f8836398-b376-4fbd-a84f-59bb1ed845ca.png">

While it was not failing in `main`:

<img width="1382" alt="image" src="https://user-images.githubusercontent.com/2871786/204269403-00ae903c-f3c4-478b-8a40-cf828ce23dc6.png">

https://apm-ci.elastic.co/blue/organizations/jenkins/apm-server%2Fbenchmarks/detail/main/163/pipeline