### PR TITLE
docs: explain OTel sampling limitations

### DIFF
--- a/docs/open-telemetry.asciidoc
+++ b/docs/open-telemetry.asciidoc
@@ -466,16 +466,16 @@ https://github.com/elastic/apm-server/blob/main/dev_docs/otel.md#muxing-grpc-and
 [[open-telemetry-traces-limitations]]
 ===== OpenTelemetry traces
 
-* Traces of applications using `messaging` semantics might be wrongly displayed as `transactions` in the APM UI, while they should be considered `spans`. https://github.com/elastic/apm-server/issues/7001[#7001]
-* Inability to see Stack traces in spans
-* Inability in APM views to view the "Time Spent by Span Type" https://github.com/elastic/apm-server/issues/5747[#5747]
-* Metrics derived from traces (throughput, latency, and errors) are not accurate when traces are sampled before being ingested by Elastic {observability} (for example, by an OpenTelemetry Collector or OpenTelemetry {apm-agent} or SDK) https://github.com/elastic/apm/issues/472[#472]
+* Traces of applications using `messaging` semantics might be wrongly displayed as `transactions` in the APM UI, while they should be considered `spans` (see issue https://github.com/elastic/apm-server/issues/7001[#7001]).
+* Inability to see Stack traces in spans.
+* Inability in APM views to view the "Time Spent by Span Type"  (see issue https://github.com/elastic/apm-server/issues/5747[#5747]).
+* Metrics derived from traces (throughput, latency, and errors) are not accurate when traces are sampled before being ingested by Elastic {observability}, for example, by an OpenTelemetry Collector or OpenTelemetry {apm-agent} or SDK (see issue https://github.com/elastic/apm/issues/472[#472]). Consider using <<tail-based-sampling>> instead.
 
 [float]
 [[open-telemetry-metrics-limitations]]
 ===== OpenTelemetry metrics
 
-* Inability to see host metrics in Elastic Metrics Infrastructure view when using the OpenTelemetry Collector host metrics receiver https://github.com/elastic/apm-server/issues/5310[#5310]
+* Inability to see host metrics in Elastic Metrics Infrastructure view when using the OpenTelemetry Collector host metrics receiver (see issue https://github.com/elastic/apm-server/issues/5310[#5310]).
 
 [float]
 [[open-telemetry-otlp-limitations]]

--- a/docs/sampling.asciidoc
+++ b/docs/sampling.asciidoc
@@ -45,6 +45,14 @@ Again, the sample rates of `Service B` and `Service C` are ignored.
 
 image::./images/dt-sampling-example-2.png[Distributed tracing and head based sampling example two]
 
+**OpenTelemetry with head-based sampling**
+
+Head-based sampling is implemented in the APM agents and SDKs, and
+requires the sample rate to be propagated between services and the APM Server.
+This functionality is not currently supported by OpenTelemetry,
+which results in inaccurate APM throughput, latency, and error metrics.
+OpenTelemetry users should use tail-based sampling instead.
+
 [float]
 [[tail-based-sampling]]
 ==== Tail-based sampling
@@ -73,6 +81,11 @@ and `1` (`100%`) for traces with a `failure` outcome,
 the sampled traces would look something like this:
 
 image::./images/dt-sampling-example-3.png[Distributed tracing and tail based sampling example one]
+
+**OpenTelemetry with tail-based sampling**
+
+Tail-based sampling is implemented entirely in APM Server,
+and will work with traces sent by either Elastic APM agents or OpenTelemetry SDKs.
 
 [float]
 === Sampled data and visualizations


### PR DESCRIPTION
### Summary

This PR adds documentation explaining OpenTelemetry sampling compatibility to the Transaction sampling page. Thanks for a very descriptive issue, @axw!

* Closes https://github.com/elastic/apm-server/issues/9168.