### PR TITLE
actions: use go-version-file: .go-version

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,12 +14,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Fetch Go version from .go-version
-      run: echo "GO_VERSION=$(cat .go-version)" >> $GITHUB_ENV
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: .go-version
         cache: true
     - name: Run tests
-      run: |-
-        go test -v ./...
+      run: go test -v ./...


### PR DESCRIPTION
 ## What does this PR do?

Use the `setup-go` action with the `go-version-file` input so it reads the file `.go-version`

## Why is it important?

Avoid the logic to read and create env variables and use the undocumented `.go-version-file` 

See https://github.com/actions/setup-go/pull/295