### PR TITLE
.ci: don't only publish packages on main

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -398,14 +398,6 @@ def signUnpublishedArtifactsWithElastic(builtPackagesPath, glob) {
 }
 
 def uploadUnpublishedToPackageStorage(builtPackagesPath, packageZips) {
-  def dryRun = env.BRANCH_NAME != 'main'
-  if (dryRun) {
-    packageZips.each {
-      echo "Dry run: not publishing ${it}"
-    }
-    return
-  }
-
   dir(builtPackagesPath) {
     withGCPEnv(secret: env.PACKAGE_STORAGE_UPLOADER_GCP_SERVICE_ACCOUNT) {
       withCredentials([string(credentialsId: env.PACKAGE_STORAGE_UPLOADER_CREDENTIALS, variable: 'TOKEN')]) {


### PR DESCRIPTION
## Motivation/summary

Package changes aren't being published on branches other than main; we may need to push fixes after feature freeze. We already have a check to filter out PRs.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

Backport to 8.6, make sure changes to apmpackage result in a new package being published to EPR.

## Related issues

None