### PR TITLE
apmpackage: add unit for decoded_body_size

### DIFF
--- a/apmpackage/apm/data_stream/traces/fields/fields.yml
+++ b/apmpackage/apm/data_stream/traces/fields/fields.yml
@@ -73,6 +73,7 @@
     The size (in octets) received from the fetch (HTTP or cache), of the payload body, before removing any applied content-codings.
 - name: http.response.decoded_body_size
   type: long
+  unit: byte
   index: false
   description: |
     The size (in octets) received from the fetch (HTTP or cache) of the message body, after removing any applied content-codings.


### PR DESCRIPTION
## Motivation/summary

Add `unit: byte` to `http.response.decoded_body_size`. Found to be missing in https://github.com/elastic/apm-server/pull/9429#issuecomment-1337695145

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

Check the field mapping for unit in field metadata

## Related issues

None