### PR TITLE
docs: add 7.17.8 release notes

### DIFF
--- a/changelogs/7.17.asciidoc
+++ b/changelogs/7.17.asciidoc
@@ -3,6 +3,7 @@
 
 https://github.com/elastic/apm-server/compare/7.16\...7.17[View commits]
 
+* <<release-notes-7.17.8>>
 * <<release-notes-7.17.7>>
 * <<release-notes-7.17.6>>
 * <<release-notes-7.17.5>>
@@ -11,6 +12,14 @@ https://github.com/elastic/apm-server/compare/7.16\...7.17[View commits]
 * <<release-notes-7.17.2>>
 * <<release-notes-7.17.1>>
 * <<release-notes-7.17.0>>
+
+[float]
+[[release-notes-7.17.8]]
+=== APM version 7.17.8
+
+https://github.com/elastic/apm-server/compare/v7.17.7\...v7.17.8[View commits]
+
+No significant changes.
 
 [float]
 [[release-notes-7.17.7]]


### PR DESCRIPTION
### Summary

Adds the 7.17.8 release notes. There is only one notable commit to 7.17 since 7.17.7 was released, and it is a doc fix.