### PR TITLE
Increase benchmark timeout to 4 hours

### DIFF
--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -19,7 +19,7 @@ pipeline {
     TESTING_BENCHMARK_DIR = 'testing/benchmark'
   }
   options {
-    timeout(time: 3, unit: 'HOURS')
+    timeout(time: 4, unit: 'HOURS')
     buildDiscarder(logRotator(numToKeepStr: '100', artifactNumToKeepStr: '30', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Increase timeouts for benchmarks. Corrects failures such as: 
https://apm-ci.elastic.co/job/apm-server/job/benchmarks/job/main/172/

I believe this problem may have been introduced here: https://github.com/elastic/apm-server/pull/8649

The benchmarks take around 98 minutes to run. However, the timeout was not adjusted to accommodate a retry which would push the runtime over 3 hours.

This increases the timeout to 4 hours which should provide enough allowable runtime to accommodate a single retry. 

