### PR TITLE
Revert workaround for missing `fleet.hosts`

### DIFF
--- a/internal/beater/beater.go
+++ b/internal/beater/beater.go
@@ -234,11 +234,6 @@ func (s *Runner) Run(ctx context.Context) error {
 				}
 			}()
 		}
-
-		// BUG(axw) fleet.hosts isn't being sent to APM Server in ESS, so assume co-location.
-		if len(s.fleetConfig.Hosts) == 0 {
-			s.fleetConfig.Hosts = []string{"https://localhost:8220"}
-		}
 	}
 
 	if s.config.JavaAttacherConfig.Enabled {


### PR DESCRIPTION
## Motivation/summary

This is no longer needed, with https://github.com/elastic/elastic-agent/pull/1802, and it triggers a panic in ESS after upgrading from 7.x deployments.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

1. Create a 7.17.x ESS deployment
2. Upgrade to 8.6
3. Make sure APM Server comes up and is accessible

## Related issues

None