### PR TITLE
[main] docs: 8.5.3 release notes (#9753)

### DIFF
--- a/changelogs/8.5.asciidoc
+++ b/changelogs/8.5.asciidoc
@@ -3,9 +3,18 @@
 
 https://github.com/elastic/apm-server/compare/8.4\...8.5[View commits]
 
+* <<release-notes-8.5.3>>
 * <<release-notes-8.5.2>>
 * <<release-notes-8.5.1>>
 * <<release-notes-8.5.0>>
+
+[float]
+[[release-notes-8.5.3]]
+=== APM version 8.5.3
+
+[float]
+==== Bug fixes
+- OpenTelemetry GRPC Spans from the Javascript API/SDK/Instrumentations are now correctly transformed into transactions with type=`request` {pull}9308[9308]
 
 [float]
 [[release-notes-8.5.2]]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.5` to `main`:
 - [docs: 8.5.3 release notes (#9753)](https://github.com/elastic/apm-server/pull/9753)

<!--- Backport version: 8.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)