### PR TITLE
Store outcome values in servicemetrics `transaction.success_count`

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -3,7 +3,7 @@
     - description: Enable synthetic source for metrics data streams
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/9756
-    - description: Change transaction.success_count type to aggregate_metric_double
+    - description: Remove `transaction.failure_count` and change `transaction.success_count` type to aggregate_metric_double
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/9791
 - version: "8.6.0"

--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -3,6 +3,9 @@
     - description: Enable synthetic source for metrics data streams
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/9756
+    - description: Change transaction.success_count type to aggregate_metric_double
+      type: enhancement
+      link: https://github.com/elastic/apm-server/pull/9791
 - version: "8.6.0"
   changes:
     - description: Change `ecs.version` to a `constant_keyword` field

--- a/apmpackage/apm/data_stream/internal_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/internal_metrics/fields/fields.yml
@@ -129,9 +129,6 @@
 - name: transaction.failure_count
   type: long
   description: "Count of transactions with 'event.outcome: failure'"
-- name: transaction.success_count
-  type: long
-  description: "Count of transactions with 'event.outcome: success'"
 - name: transaction.duration.histogram
   type: histogram
   description: |

--- a/apmpackage/apm/data_stream/internal_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/internal_metrics/fields/fields.yml
@@ -126,9 +126,6 @@
   type: keyword
   description: |
     Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', 'cache', etc).
-- name: transaction.failure_count
-  type: long
-  description: "Count of transactions with 'event.outcome: failure'"
 - name: transaction.duration.histogram
   type: histogram
   description: |

--- a/apmpackage/apm/data_stream/internal_metrics/manifest.yml
+++ b/apmpackage/apm/data_stream/internal_metrics/manifest.yml
@@ -25,6 +25,10 @@ elasticsearch:
                   type: aggregate_metric_double
                   metrics: [sum, value_count]
                   default_metric: sum
+            success_count:
+              type: aggregate_metric_double
+              metrics: [sum, value_count]
+              default_metric: sum
     settings:
       index:
         sort.field: "@timestamp"

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -10,7 +10,7 @@ https://github.com/elastic/apm-server/compare/8.5\...main[View commits]
 - `context.http.response.*_size` fields now enforce integer values {pull}9429[9429]
 - `observer.id` and `observer.ephemeral_id` are no longer added to APM documents {pull}9412[9412]
 - `timeseries.instance` has been removed from transaction metrics docs; it was never used {pull}9565[9565]
-- `transaction.success_count` type has changed to `aggregated_metric_double` {pull}9791[9791]
+- `transaction.failure_count` has been removed. `transaction.success_count` type has changed to `aggregated_metric_double` {pull}9791[9791]
 
 [float]
 ==== Deprecations

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -10,6 +10,7 @@ https://github.com/elastic/apm-server/compare/8.5\...main[View commits]
 - `context.http.response.*_size` fields now enforce integer values {pull}9429[9429]
 - `observer.id` and `observer.ephemeral_id` are no longer added to APM documents {pull}9412[9412]
 - `timeseries.instance` has been removed from transaction metrics docs; it was never used {pull}9565[9565]
+- `transaction.success_count` type has changed to `aggregated_metric_double` {pull}9791[9791]
 
 [float]
 ==== Deprecations

--- a/internal/model/modeldecoder/v2/transaction_test.go
+++ b/internal/model/modeldecoder/v2/transaction_test.go
@@ -280,6 +280,8 @@ func TestDecodeMapToTransactionModel(t *testing.T) {
 				"DurationSummary.Sum",
 				"FailureCount",
 				"SuccessCount",
+				"SuccessCount.Count",
+				"SuccessCount.Sum",
 				"Root":
 				return true
 			}

--- a/internal/model/transaction.go
+++ b/internal/model/transaction.go
@@ -69,14 +69,11 @@ type Transaction struct {
 	// is subject to removal.
 	FailureCount int
 
-	// SuccessCount holds an aggregated count of transactions with the
-	// outcome "success". If SuccessCount is zero, it will be omitted from
-	// the output event.
-	//
-	// NOTE(axw) this is used only for service metrics, which are in technical
-	// preview. Do not use this field without discussion, as the field mapping
-	// is subject to removal.
-	SuccessCount int
+	// SuccessCount holds an aggregated count of transactions with different
+	// outcomes. A "failure" adds to the Count. A "success" adds to both the
+	// Count and the Sum. An "unknown" has no effect. If Count is zero, it
+	// will be omitted from the output event.
+	SuccessCount SummaryMetric
 
 	Marks          TransactionMarks
 	Message        *Message
@@ -115,8 +112,8 @@ func (e *Transaction) fields() mapstr.M {
 	if e.FailureCount != 0 {
 		transaction.set("failure_count", e.FailureCount)
 	}
-	if e.SuccessCount != 0 {
-		transaction.set("success_count", e.SuccessCount)
+	if e.SuccessCount.Count != 0 {
+		transaction.maybeSetMapStr("success_count", e.SuccessCount.fields())
 	}
 	transaction.maybeSetString("name", e.Name)
 	transaction.maybeSetString("result", e.Result)

--- a/internal/model/transaction.go
+++ b/internal/model/transaction.go
@@ -60,15 +60,6 @@ type Transaction struct {
 	// is subject to removal.
 	DurationSummary SummaryMetric
 
-	// FailureCount holds an aggregated count of transactions with the
-	// outcome "failure". If FailureCount is zero, it will be omitted from
-	// the output event.
-	//
-	// NOTE(axw) this is used only for service metrics, which are in technical
-	// preview. Do not use this field without discussion, as the field mapping
-	// is subject to removal.
-	FailureCount int
-
 	// SuccessCount holds an aggregated count of transactions with different
 	// outcomes. A "failure" adds to the Count. A "success" adds to both the
 	// Count and the Sum. An "unknown" has no effect. If Count is zero, it
@@ -108,9 +99,6 @@ func (e *Transaction) fields() mapstr.M {
 	transaction.maybeSetMapStr("duration.histogram", e.DurationHistogram.fields())
 	if e.DurationSummary.Count != 0 {
 		transaction.maybeSetMapStr("duration.summary", e.DurationSummary.fields())
-	}
-	if e.FailureCount != 0 {
-		transaction.set("failure_count", e.FailureCount)
 	}
 	if e.SuccessCount.Count != 0 {
 		transaction.maybeSetMapStr("success_count", e.SuccessCount.fields())

--- a/systemtest/approvals/TestServiceMetricsAggregation.approved.json
+++ b/systemtest/approvals/TestServiceMetricsAggregation.approved.json
@@ -40,7 +40,10 @@
                         "value_count": 2
                     }
                 },
-                "success_count": 2,
+                "success_count": {
+                    "sum": 2,
+                    "value_count": 2
+                },
                 "type": "type1"
             }
         },
@@ -84,7 +87,10 @@
                         "value_count": 2
                     }
                 },
-                "success_count": 2,
+                "success_count": {
+                    "sum": 2,
+                    "value_count": 2
+                },
                 "type": "type2"
             }
         }

--- a/x-pack/apm-server/aggregation/servicemetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/servicemetrics/aggregator.go
@@ -374,7 +374,10 @@ func makeMetricset(key aggregationKey, metrics serviceMetrics) model.APMEvent {
 		Transaction: &model.Transaction{
 			Type:         key.transactionType,
 			FailureCount: int(math.Round(metrics.failureCount)),
-			SuccessCount: int(math.Round(metrics.successCount)),
+			SuccessCount: model.SummaryMetric{
+				Count: int64(math.Round(metrics.successCount + metrics.failureCount)),
+				Sum:   metrics.successCount,
+			},
 			DurationSummary: model.SummaryMetric{
 				Count: metricCount,
 				Sum:   float64(time.Duration(math.Round(metrics.transactionDuration)).Microseconds()),

--- a/x-pack/apm-server/aggregation/servicemetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/servicemetrics/aggregator.go
@@ -372,8 +372,7 @@ func makeMetricset(key aggregationKey, metrics serviceMetrics) model.APMEvent {
 			Name:     metricsetName,
 		},
 		Transaction: &model.Transaction{
-			Type:         key.transactionType,
-			FailureCount: int(math.Round(metrics.failureCount)),
+			Type: key.transactionType,
 			SuccessCount: model.SummaryMetric{
 				Count: int64(math.Round(metrics.successCount + metrics.failureCount)),
 				Sum:   metrics.successCount,

--- a/x-pack/apm-server/aggregation/servicemetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/servicemetrics/aggregator_test.go
@@ -124,7 +124,6 @@ func TestAggregatorRun(t *testing.T) {
 				Count: 5,
 				Sum:   2,
 			},
-			FailureCount: 3,
 		},
 	}, {
 		Processor: model.MetricsetProcessor,

--- a/x-pack/apm-server/aggregation/servicemetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/servicemetrics/aggregator_test.go
@@ -120,7 +120,10 @@ func TestAggregatorRun(t *testing.T) {
 				Count: 6,
 				Sum:   6000, // 6ms in micros
 			},
-			SuccessCount: 2,
+			SuccessCount: model.SummaryMetric{
+				Count: 5,
+				Sum:   2,
+			},
 			FailureCount: 3,
 		},
 	}, {
@@ -279,7 +282,10 @@ func TestAggregatorMaxGroups(t *testing.T) {
 					Count: 1,
 					Sum:   100000,
 				},
-				SuccessCount: 1,
+				SuccessCount: model.SummaryMetric{
+					Count: 1,
+					Sum:   1,
+				},
 			},
 			Metricset: &model.Metricset{Name: "service", DocCount: 1},
 		}, m)


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

For service metrics, use field `transaction.success_count` to store the transaction success and failure counts for easier avg aggregation on the field.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [x] Documentation has been updated

## How to test these changes

1. Ensure that service metrics `transaction.success_count` is populated correctly
2. Try an avg aggregation on `transaction.success_count`

## Related issues

Related to #5243
