### PR TITLE
Fix tests on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 CHANGELOG.asciidoc merge=union
+**.ndjson text eol=lf

--- a/internal/beatcmd/beat_test.go
+++ b/internal/beatcmd/beat_test.go
@@ -46,9 +46,6 @@ func TestRunMaxProcs(t *testing.T) {
 		t.Run(fmt.Sprintf("%d_GOMAXPROCS", n), func(t *testing.T) {
 			t.Setenv("GOMAXPROCS", strconv.Itoa(n))
 			beat := newNopBeat(t, "output.console.enabled: true")
-
-			// Capture logs for testing.
-			logp.DevelopmentSetup(logp.ToObserverOutput())
 			logs := logp.ObserverLogs()
 
 			stop := runBeat(t, beat)

--- a/internal/beatcmd/cmd.go
+++ b/internal/beatcmd/cmd.go
@@ -69,7 +69,7 @@ func NewRootCommand(beatParams BeatParams) *cobra.Command {
 		rootCommand.PersistentFlags().AddGoFlag(flag.CommandLine.Lookup(flagName))
 	}
 
-	// Add logging-related flags to all commands, and add a pre-run that initialises logging.
+	// Add logging-related flags to all commands.
 	rootCommand.PersistentFlags().BoolVarP(&logVerbose, "v", "v", false, "Log at INFO level")
 	rootCommand.PersistentFlags().BoolVarP(&logStderr, "e", "e", false, "Log to stderr and disable syslog/file output")
 	rootCommand.PersistentFlags().StringArrayVarP(&logDebugSelectors, "d", "d", nil, "Enable certain debug selectors")

--- a/internal/beatcmd/logging.go
+++ b/internal/beatcmd/logging.go
@@ -1,0 +1,67 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beatcmd
+
+import (
+	"strings"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+var (
+	logVerbose        bool
+	logStderr         bool
+	logDebugSelectors []string
+	logEnvironment    logpEnvironmentVar
+	logOptions        []logp.Option
+)
+
+func configureLogging(cfg *Config) error {
+	logpConfig := logp.DefaultConfig(logp.DefaultEnvironment)
+	logpConfig.Beat = "apm-server"
+	if cfg.Logging != nil {
+		if err := cfg.Logging.Unpack(&logpConfig); err != nil {
+			return err
+		}
+	}
+
+	// Apply command line flags to the logging configuration.
+	if logpConfig.Level > logp.InfoLevel && logVerbose {
+		logpConfig.Level = logp.InfoLevel
+	}
+	if len(logDebugSelectors) > 0 {
+		for _, selectors := range logDebugSelectors {
+			logpConfig.Selectors = append(logpConfig.Selectors, strings.Split(selectors, ",")...)
+		}
+		logpConfig.Level = logp.DebugLevel
+	}
+	if logStderr {
+		logpConfig.ToStderr = true
+	} else {
+		// If the process is running in a container or managed by systemd, then log to stderr.
+		switch logEnvironment.env {
+		case logp.ContainerEnvironment, logp.SystemdEnvironment:
+			logpConfig.ToStderr = true
+		}
+	}
+	for _, opt := range logOptions {
+		opt(&logpConfig)
+	}
+
+	return logp.Configure(logpConfig)
+}

--- a/internal/beatcmd/logging_test.go
+++ b/internal/beatcmd/logging_test.go
@@ -1,0 +1,34 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package beatcmd
+
+import (
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+func init() {
+	// Configure tests to log at debug level, and to send
+	// logs to logp.ObserverLogs(). It is important to not
+	// log to files by default in tests, as logp will keep
+	// the files open and prevent tempory directories from
+	// being removed on Windows.
+	logOptions = append(logOptions,
+		logp.ToObserverOutput(),
+		logp.WithLevel(logp.DebugLevel),
+	)
+}


### PR DESCRIPTION
## Motivation/summary

- Disable logging to files in beatcmd tests, since the log files are kept open by logp and thus the temp dir can't be removed. This requires replacing logp/configure with some custom code.

- Perform Windows Service event handling in the beatcmd cobra command code, rather than in Beat.Run. This is necessary since the service functions can only be called once per process, as they create and close a global channel.

- Ensure *.ndjson testdata files have LF (not CRLF) line endings on Windows.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

Ensure `-E`, `-v`, `-e`, and `-d` flags work as they did in 8.6.

## Related issues

Found in https://github.com/elastic/apm-server/pull/9794