### PR TITLE
add 'fleet' activation method to the Java attacher (for telemetry)

### DIFF
--- a/internal/beater/java_attacher/java_attacher.go
+++ b/internal/beater/java_attacher/java_attacher.go
@@ -390,7 +390,7 @@ func (j *JavaAttacher) attachJVMCommand(ctx context.Context, jvm *jvmDetails) *e
 	args := []string{
 		"-jar", attacherJar,
 		"--log-level", "debug",
-		"-C","activation_method=FLEET",
+		"--config", "activation_method=FLEET",
 		"--include-pid", strconv.Itoa(jvm.pid),
 	}
 	if j.downloadAgentVersion != "" {

--- a/internal/beater/java_attacher/java_attacher.go
+++ b/internal/beater/java_attacher/java_attacher.go
@@ -390,6 +390,7 @@ func (j *JavaAttacher) attachJVMCommand(ctx context.Context, jvm *jvmDetails) *e
 	args := []string{
 		"-jar", attacherJar,
 		"--log-level", "debug",
+		"-C","activation_method=FLEET",
 		"--include-pid", strconv.Itoa(jvm.pid),
 	}
 	if j.downloadAgentVersion != "" {

--- a/internal/beater/java_attacher/java_attacher_nonwindows_test.go
+++ b/internal/beater/java_attacher/java_attacher_nonwindows_test.go
@@ -81,7 +81,7 @@ func TestBuildCommandWithTempJar(t *testing.T) {
 	assert.NotEqual(t, attacherJar, "")
 	require.NotEqual(t, bundledJavaAttacher, attacherJar)
 	want := filepath.FromSlash(fmt.Sprintf("/home/someuser/java_home/bin/java -jar %v", attacherJar)) +
-		" --log-level debug --include-pid 12345 --download-agent-version 1.27.0 --config server_url=http://myhost:8200"
+		" --log-level debug --config activation_method=FLEET --include-pid 12345 --download-agent-version 1.27.0 --config server_url=http://myhost:8200"
 
 	cmdArgs := strings.Join(command.Args, " ")
 	assert.Equal(t, want, cmdArgs)
@@ -95,6 +95,7 @@ func TestBuildCommandWithTempJar(t *testing.T) {
 	cmdArgs = strings.Join(command.Args, " ")
 	assert.Contains(t, cmdArgs, "--config server_url=http://myhost:8200")
 	assert.Contains(t, cmdArgs, "--config service_name=my-cool-service")
+	assert.Contains(t, cmdArgs, "--config activation_method=FLEET")
 }
 
 func TestTempDirCreation(t *testing.T) {

--- a/internal/beater/java_attacher/java_attacher_windows_test.go
+++ b/internal/beater/java_attacher/java_attacher_windows_test.go
@@ -47,7 +47,7 @@ func TestBuildCommandWithBundledJar(t *testing.T) {
 	}
 	command := attacher.attachJVMCommand(context.Background(), jvm)
 	want := filepath.FromSlash("/home/someuser/java_home/bin/java -jar java-attacher.jar") +
-		" --log-level debug --include-pid 12345 --download-agent-version 1.27.0 --config server_url=http://myhost:8200"
+		" --log-level debug --config activation_method=FLEET --include-pid 12345 --download-agent-version 1.27.0 --config server_url=http://myhost:8200"
 
 	cmdArgs := strings.Join(command.Args, " ")
 	assert.Equal(t, want, cmdArgs)


### PR DESCRIPTION
## Motivation/summary

for https://github.com/elastic/apm-agent-java/issues/2878 (part of https://github.com/elastic/apm/issues/725)

## How to test these changes

When a Java application has the Java agent attached by the APM server, running the agent at DEBUG log_level should produce a line similar to
```
2022-12-13 14:30:56,147 [elastic-apm-remote-config-poller] DEBUG co.elastic.apm.agent.configuration.ActivationType - findType() returning FLEET
```
with the critical point being that `FLEET` is logged as the value returned

## Related issues

https://github.com/elastic/apm-agent-java/issues/2878
https://github.com/elastic/apm/issues/725
