### PR TITLE
ci: fix ONLY_DOCS condition

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -56,7 +56,7 @@ pipeline {
             }
             env.PACKAGING_UPDATED = isGitRegionMatch(patterns: ["^packaging.*"])
             // Skip all the stages except docs for PR's with asciidoc changes only
-            setEnvVar('ONLY_DOCS', isPR() ? isGitRegionMatch(patterns: [ '.*\\.asciidoc' ], comparator: 'regexp', shouldMatchAll: true) : false)
+            setEnvVar('ONLY_DOCS', isPR() ? isGitRegionMatch(patterns: [ '.*\\.asciidoc' ], shouldMatchAll: true) : false)
           }
         }
       }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -13,7 +13,6 @@ pipeline {
     ES_LOG_LEVEL = "${params.ES_LOG_LEVEL}"
     DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
-    ONLY_DOCS = "false"
   }
   options {
     timeout(time: 2, unit: 'HOURS')
@@ -57,9 +56,7 @@ pipeline {
             }
             env.PACKAGING_UPDATED = isGitRegionMatch(patterns: ["^packaging.*"])
             // Skip all the stages except docs for PR's with asciidoc changes only
-            whenTrue(isPR()) {
-              setEnvVar('ONLY_DOCS', isGitRegionMatch(patterns: [ '.*\\.asciidoc' ], comparator: 'regexp', shouldMatchAll: true))
-            }
+            setEnvVar('ONLY_DOCS', isPR() ? isGitRegionMatch(patterns: [ '.*\\.asciidoc' ], comparator: 'regexp', shouldMatchAll: true) : false)
           }
         }
       }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Skipping certain stages if only asciidoc files were changed did not work as expected. The reason is that environment variables defined in the `environment {}` block cannot be overridden. Therefore, `env.ONLY_DOCS` always stayed `"false"`.

Also see: https://github.com/elastic/apm-server/issues/9704#issuecomment-1352450206
<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

1. Create a new PR based on this branch which only has changes to asciidoc files.
1. Check if pipeline is executing the following stages (it should not)
   - Unit tests - linux/amd64 
   - Unit tests - linux/arm64
 
<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Closes #9704 

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
