### PR TITLE
packaging: disable --strict.perms for Docker

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -66,17 +66,21 @@ ENV PATH=/usr/share/apm-server:$PATH
 # /proc/self/cgroup.
 ENV LIBBEAT_MONITORING_CGROUPS_HIERARCHY_OVERRIDE=/
 
+# Disable libbeat's strict permissions checking, which is not relevant when
+# running in Docker.
+ENV BEAT_STRICT_PERMS=false
+
 COPY --chmod=0755 packaging/docker/docker-entrypoint /usr/local/bin/docker-entrypoint
 COPY --chmod=0644 licenses/ELASTIC-LICENSE-2.0.txt NOTICE.txt /licenses/
 
-# NOTE(axw) apm-server.yml and data/ must be owned by apm-server
-# to allow the image to be run with a non-root user.
+# Copy files world-readable, and create the data directory world-writeable,
+# to permit running the container with arbitrary UIDs and GIDs.
 WORKDIR /usr/share/apm-server
-COPY --chmod=0640 --chown=1000:0 apm-server.yml ./apm-server.yml
+COPY --chmod=0644 apm-server.yml ./apm-server.yml
 COPY --chmod=0755 --from=builder /src/apm-server ./apm-server
 RUN sed -i 's/localhost:8200/0.0.0.0:8200/' apm-server.yml
 RUN sed -i 's/localhost:9200/elasticsearch:9200/' apm-server.yml
-RUN mkdir --mode=0775 data && chown 1000 data
+RUN mkdir --mode=0777 data
 RUN echo 'apm-server:*:1000:0::/usr/share/apm-server:/bin/false' >> /etc/passwd
 
 USER apm-server


### PR DESCRIPTION
## Motivation/summary

Disable strict permission checks in Docker and make the config file world-readable and data directory world-writeable. This permits running the image with arbitrary UIDs and GIDs.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

```bash
make package-docker
docker run --rm --user 123:456 $(cat build/docker/apm-server-ubi8-8.7.0.txt) /usr/share/apm-server/apm-server keystore create
```

## Related issues

https://github.com/elastic/cloud-on-k8s/issues/6227