### PR TITLE
Universal Profiling: Refactor code into 'common' and 'libpf' packages

### DIFF
--- a/x-pack/apm-server/profiling/collecttraces.go
+++ b/x-pack/apm-server/profiling/collecttraces.go
@@ -6,11 +6,13 @@ package profiling
 
 import (
 	"fmt"
+
+	"github.com/elastic/apm-server/x-pack/apm-server/profiling/libpf"
 )
 
 // CollectTracesAndCounts reads the RPC request and builds a list of traces and their counts
 // using the libpf type. We export this function to allow other collectors to use the same logic.
-func CollectTracesAndCounts(in *AddCountsForTracesRequest) ([]TraceAndCounts, error) {
+func CollectTracesAndCounts(in *AddCountsForTracesRequest) ([]libpf.TraceAndCounts, error) {
 	hiTraceHashes := in.GetHiTraceHashes()
 	loTraceHashes := in.GetLoTraceHashes()
 	counts := in.GetCounts()
@@ -59,9 +61,9 @@ func CollectTracesAndCounts(in *AddCountsForTracesRequest) ([]TraceAndCounts, er
 		}
 	} // End sanity checks
 
-	traces := make([]TraceAndCounts, numTraces)
+	traces := make([]libpf.TraceAndCounts, numTraces)
 	for i := uint32(0); i < numTraces; i++ {
-		traceHash := NewTraceHash(hiTraceHashes[i], loTraceHashes[i])
+		traceHash := libpf.NewTraceHash(hiTraceHashes[i], loTraceHashes[i])
 		traces[i].Hash = traceHash
 		traces[i].Count = uint16(counts[i])
 		traces[i].Comm = uniqMetadata[commsIdx[i]]
@@ -78,7 +80,7 @@ func CollectTracesAndCounts(in *AddCountsForTracesRequest) ([]TraceAndCounts, er
 
 // CollectTracesAndFrames reads the RPC request and builds a list of traces and their frames
 // using the libpf type. We export this function to allow other collectors to use the same logic.
-func CollectTracesAndFrames(in *SetFramesForTracesRequest) ([]*Trace, error) {
+func CollectTracesAndFrames(in *SetFramesForTracesRequest) ([]*libpf.Trace, error) {
 	hiTraceHashes := in.GetHiTraceHashes()
 	loTraceHashes := in.GetLoTraceHashes()
 	frameCounts := in.GetFrameCounts()
@@ -150,22 +152,22 @@ func CollectTracesAndFrames(in *SetFramesForTracesRequest) ([]*Trace, error) {
 		}
 	} // End sanity checks
 
-	traces := make([]*Trace, numTraces)
+	traces := make([]*libpf.Trace, numTraces)
 	// Keeps track of current position in flattened arrays
 	j := 0
 	for i := uint32(0); i < numTraces; i++ {
 		numFrames := int(frameCounts[i])
-		trace := &Trace{
-			Hash:       NewTraceHash(hiTraceHashes[i], loTraceHashes[i]),
-			Files:      make([]FileID, numFrames),
-			Linenos:    make([]AddressOrLineno, numFrames),
-			FrameTypes: make([]InterpType, numFrames),
+		trace := &libpf.Trace{
+			Hash:       libpf.NewTraceHash(hiTraceHashes[i], loTraceHashes[i]),
+			Files:      make([]libpf.FileID, numFrames),
+			Linenos:    make([]libpf.AddressOrLineno, numFrames),
+			FrameTypes: make([]libpf.InterpType, numFrames),
 		}
 
 		for k := 0; k < numFrames; k++ {
-			trace.Files[k] = NewFileID(hiContainers[j], loContainers[j])
-			trace.Linenos[k] = AddressOrLineno(offsets[j])
-			trace.FrameTypes[k] = InterpType(types[j])
+			trace.Files[k] = libpf.NewFileID(hiContainers[j], loContainers[j])
+			trace.Linenos[k] = libpf.AddressOrLineno(offsets[j])
+			trace.FrameTypes[k] = libpf.InterpType(types[j])
 			j++
 		}
 

--- a/x-pack/apm-server/profiling/common/constants.go
+++ b/x-pack/apm-server/profiling/common/constants.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-package profiling
+package common
 
 const (
 	AllEventsIndex    = "profiling-events-all"

--- a/x-pack/apm-server/profiling/common/rle.go
+++ b/x-pack/apm-server/profiling/common/rle.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-package profiling
+package common
 
 import "io"
 

--- a/x-pack/apm-server/profiling/common/rle_test.go
+++ b/x-pack/apm-server/profiling/common/rle_test.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-package profiling
+package common
 
 import (
 	"bytes"

--- a/x-pack/apm-server/profiling/common/timestamp.go
+++ b/x-pack/apm-server/profiling/common/timestamp.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-package profiling
+package common
 
 import (
 	"time"

--- a/x-pack/apm-server/profiling/libpf/libpf.go
+++ b/x-pack/apm-server/profiling/libpf/libpf.go
@@ -2,7 +2,7 @@
 // or more contributor license agreements. Licensed under the Elastic License 2.0;
 // you may not use this file except in compliance with the Elastic License 2.0.
 
-package profiling
+package libpf
 
 import (
 	"encoding"


### PR DESCRIPTION
### Summary

This PR synchronizes (for the most part) `pf-elastic-collector` and the collector code in `apm-server` and should make further development and porting code between the two repositories easier.

- Moved `constants.go`, `encode.go`, `rle.go`, `rle_test.go` and `timestamp.go` into `common` package
- Moved `libpf` logic into `libpf` package

**Note:** This PR includes the #9828 commit, I will rebase on top of main once #9828 is merged.