### PR TITLE
Fix rsync command to not fail on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ testing/infra/terraform/modules/%/README.md: .FORCE
 # and just keep the JSON Schema there.
 docs/spec: go.mod
 	@$(GO) mod download github.com/elastic/apm-data
-	rsync -v --delete --chmod=D755 --chmod=F644 -r $$($(GO) list -m -f {{.Dir}} github.com/elastic/apm-data)/input/elasticapm/docs/spec ./docs
+	rsync -v --delete --chmod=Du+rwx,go+rx --chmod=Fu+rw,go+r -r $$($(GO) list -m -f {{.Dir}} github.com/elastic/apm-data)/input/elasticapm/docs/spec ./docs
 
 ##############################################################################
 # Beats synchronisation.


### PR DESCRIPTION
## Motivation/summary

`make docs/spec` was failing in macos with the below error. The PR attempts to fix this (hopefully for all cases).
```
$ make docs/spec                                                                                                                                                [15:12:34]
rsync -v --delete --chmod=D755 --chmod=F644 -r $(/opt/homebrew/Cellar/go/1.19.3/libexec/bin/go list -m -f {{.Dir}} github.com/elastic/apm-data)/input/elasticapm/docs/spec ./docs
rsync: Invalid argument passed to --chmod (D755)
rsync error: syntax or usage error (code 1) at /AppleInternal/Library/BuildRoots/a0876c02-1788-11ed-b9c4-96898e02b808/Library/Caches/com.apple.xbs/Sources/rsync/rsync/main.c(1337) [client=2.6.9]
make: *** [docs/spec] Error 1
```

## Checklist

~~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~~
~~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~~
~~- [ ] Documentation has been updated~~

## How to test these changes

1. Run `make docs/spec` on mac
2. Confirm success

## Related issues

Nil
