### PR TITLE
feat: add histogram support to service metrics

### DIFF
--- a/internal/beater/config/aggregation.go
+++ b/internal/beater/config/aggregation.go
@@ -29,8 +29,9 @@ const (
 	defaultServiceDestinationAggregationInterval  = time.Minute
 	defaultServiceDestinationAggregationMaxGroups = 10000
 
-	defaultServiceAggregationInterval  = time.Minute
-	defaultServiceAggregationMaxGroups = 10000
+	defaultServiceAggregationInterval                       = time.Minute
+	defaultServiceAggregationMaxGroups                      = 10000
+	defaultServiceAggregationHDRHistogramSignificantFigures = 5
 )
 
 // AggregationConfig holds configuration related to various metrics aggregations.
@@ -55,9 +56,10 @@ type ServiceDestinationAggregationConfig struct {
 
 // ServiceAggregationConfig holds configuration related to service metrics aggregation.
 type ServiceAggregationConfig struct {
-	Enabled   bool          `config:"enabled"`
-	Interval  time.Duration `config:"interval" validate:"min=1"`
-	MaxGroups int           `config:"max_groups" validate:"min=1"`
+	Enabled                        bool          `config:"enabled"`
+	Interval                       time.Duration `config:"interval" validate:"min=1"`
+	MaxGroups                      int           `config:"max_groups" validate:"min=1"`
+	HDRHistogramSignificantFigures int           `config:"hdrhistogram_significant_figures" validate:"min=1, max=5"`
 }
 
 func defaultAggregationConfig() AggregationConfig {
@@ -75,9 +77,10 @@ func defaultAggregationConfig() AggregationConfig {
 			// NOTE(axw) service metrics are in technical preview,
 			// disabled by default. Once proven, they may be always
 			// enabled in a future release, without configuration.
-			Enabled:   false,
-			Interval:  defaultServiceAggregationInterval,
-			MaxGroups: defaultServiceAggregationMaxGroups,
+			Enabled:                        false,
+			Interval:                       defaultServiceAggregationInterval,
+			MaxGroups:                      defaultServiceAggregationMaxGroups,
+			HDRHistogramSignificantFigures: defaultServiceAggregationHDRHistogramSignificantFigures,
 		},
 	}
 }

--- a/internal/beater/config/config_test.go
+++ b/internal/beater/config/config_test.go
@@ -261,8 +261,9 @@ func TestUnpackConfig(t *testing.T) {
 						MaxGroups: 456,
 					},
 					Service: ServiceAggregationConfig{
-						Interval:  time.Minute,
-						MaxGroups: 457,
+						Interval:                       time.Minute,
+						MaxGroups:                      457,
+						HDRHistogramSignificantFigures: 5,
 					},
 				},
 				Sampling: SamplingConfig{
@@ -428,8 +429,9 @@ func TestUnpackConfig(t *testing.T) {
 						MaxGroups: 10000,
 					},
 					Service: ServiceAggregationConfig{
-						Interval:  time.Minute,
-						MaxGroups: 10000,
+						Interval:                       time.Minute,
+						MaxGroups:                      10000,
+						HDRHistogramSignificantFigures: 5,
 					},
 				},
 				Sampling: SamplingConfig{

--- a/systemtest/approvals/TestServiceMetricsAggregation.approved.json
+++ b/systemtest/approvals/TestServiceMetricsAggregation.approved.json
@@ -35,6 +35,14 @@
             },
             "transaction": {
                 "duration": {
+                    "histogram": {
+                        "counts": [
+                            2
+                        ],
+                        "values": [
+                            1000003
+                        ]
+                    },
                     "summary": {
                         "sum": 2000000,
                         "value_count": 2
@@ -82,6 +90,14 @@
             },
             "transaction": {
                 "duration": {
+                    "histogram": {
+                        "counts": [
+                            2
+                        ],
+                        "values": [
+                            1000003
+                        ]
+                    },
                     "summary": {
                         "sum": 2000000,
                         "value_count": 2

--- a/x-pack/apm-server/aggregation/servicemetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/servicemetrics/aggregator.go
@@ -291,18 +291,19 @@ func (mb *metricsBuffer) storeOrUpdate(key aggregationKey, metrics serviceMetric
 	entry := &mb.space[mb.entries]
 	entry.aggregationKey = key
 
+	entry.serviceMetrics = serviceMetrics{
+		transactionDuration: metrics.transactionDuration,
+		transactionCount:    metrics.transactionCount,
+		failureCount:        metrics.failureCount,
+		successCount:        metrics.successCount,
+	}
+
 	if entry.serviceMetrics.histogram == nil {
-		entry.serviceMetrics = serviceMetrics{
-			transactionDuration: metrics.transactionDuration,
-			transactionCount:    metrics.transactionCount,
-			failureCount:        metrics.failureCount,
-			successCount:        metrics.successCount,
-			histogram: hdrhistogram.New(
-				minDuration.Microseconds(),
-				maxDuration.Microseconds(),
-				mb.significantFigures,
-			),
-		}
+		entry.histogram = hdrhistogram.New(
+			minDuration.Microseconds(),
+			maxDuration.Microseconds(),
+			mb.significantFigures,
+		)
 	} else {
 		entry.serviceMetrics.histogram.Reset()
 	}

--- a/x-pack/apm-server/main.go
+++ b/x-pack/apm-server/main.go
@@ -132,9 +132,10 @@ func newProcessors(args beater.ServerParams) ([]namedProcessor, error) {
 		const serviceName = "service metrics aggregation"
 		args.Logger.Infof("creating %s with config: %+v", serviceName, args.Config.Aggregation.Service)
 		serviceAggregator, err := servicemetrics.NewAggregator(servicemetrics.AggregatorConfig{
-			BatchProcessor: args.BatchProcessor,
-			Interval:       args.Config.Aggregation.Service.Interval,
-			MaxGroups:      args.Config.Aggregation.Service.MaxGroups,
+			BatchProcessor:                 args.BatchProcessor,
+			Interval:                       args.Config.Aggregation.Service.Interval,
+			MaxGroups:                      args.Config.Aggregation.Service.MaxGroups,
+			HDRHistogramSignificantFigures: args.Config.Aggregation.Service.HDRHistogramSignificantFigures,
 		})
 		if err != nil {
 			return nil, errors.Wrapf(err, "error creating %s", spanName)


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Add histograms to service metrics.
Add histogram significant digit setting. (default 5)
Update tests.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Closes https://github.com/elastic/apm-server/issues/9656
