### PR TITLE
test: fix BenchmarkOTLPTraces consistently failing

### DIFF
--- a/systemtest/benchtest/main.go
+++ b/systemtest/benchtest/main.go
@@ -54,10 +54,11 @@ type benchmark struct {
 	f    BenchmarkFunc
 }
 
-func runBenchmark(f BenchmarkFunc) (testing.BenchmarkResult, bool, error) {
+func runBenchmark(f BenchmarkFunc) (testing.BenchmarkResult, bool, bool, error) {
 	// Run the benchmark. testing.Benchmark will invoke the function
 	// multiple times, but only returns the final result.
-	var ok bool
+	var failed bool
+	var skipped bool
 	var collector *expvar.Collector
 	result := testing.Benchmark(func(b *testing.B) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -67,7 +68,7 @@ func runBenchmark(f BenchmarkFunc) (testing.BenchmarkResult, bool, error) {
 		collector, err = expvar.StartNewCollector(ctx, server, 100*time.Millisecond)
 		if err != nil {
 			b.Error(err)
-			ok = !b.Failed()
+			failed = b.Failed()
 			return
 		}
 
@@ -95,12 +96,13 @@ func runBenchmark(f BenchmarkFunc) (testing.BenchmarkResult, bool, error) {
 				b.Error("failed to wait for APM server to be inactive")
 			}
 		}
-		ok = !b.Failed()
+		failed = b.Failed()
+		skipped = b.Skipped()
 	})
 	if result.Extra != nil {
 		addExpvarMetrics(&result, collector, benchConfig.Detailed)
 	}
-	return result, ok, nil
+	return result, failed, skipped, nil
 }
 
 func addExpvarMetrics(result *testing.BenchmarkResult, collector *expvar.Collector, detailed bool) {
@@ -223,11 +225,14 @@ func Run(allBenchmarks ...BenchmarkFunc) error {
 			name := fullBenchmarkName(benchmark.name, agents)
 			for i := 0; i < int(benchConfig.Count); i++ {
 				profileChan := profiles.record(name)
-				result, ok, err := runBenchmark(benchmark.f)
+				result, failed, skipped, err := runBenchmark(benchmark.f)
 				if err != nil {
 					return err
 				}
-				if !ok {
+				if skipped {
+					continue
+				}
+				if failed {
 					fmt.Fprintf(os.Stderr, "--- FAIL: %s\n", name)
 					return fmt.Errorf("benchmark %q failed", name)
 				} else {


### PR DESCRIPTION


<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

the benchmark function can panic or call runtime.Goexit under the hood (FailNow/SkipNow) stopping the goroutine. That will cause the benhmark executor to report the benchmark as a failure which is a big if the test was skipped.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Closes https://github.com/elastic/apm-server/issues/9844
