### PR TITLE
fix: fall back to system memory if cgroup exceeds the available memory

### DIFF
--- a/internal/beater/beater.go
+++ b/internal/beater/beater.go
@@ -199,8 +199,8 @@ func (s *Runner) Run(ctx context.Context) error {
 			memLimit = float64(limit) / 1024 / 1024 / 1024 * 0.5
 		}
 		if memLimit > float64(limit) {
-			s.logger.Info("cgroup memory limit exceed available memory, falling back to total system memory")
-			memLimit = float64(limit)
+			s.logger.Info("cgroup memory limit exceed available memory, falling back to the total system memory")
+			memLimit = float64(limit) / 1024 / 1024 / 1024 * 0.5
 		}
 	}
 	if memLimit <= 0 {

--- a/internal/beater/beater.go
+++ b/internal/beater/beater.go
@@ -189,14 +189,18 @@ func (s *Runner) Run(ctx context.Context) error {
 			memLimit = float64(limit) / 1024 / 1024 / 1024 * 0.8
 		}
 	}
-	if memLimit <= 0 {
-		s.logger.Info("no cgroups detected, falling back to total system memory")
-		if limit, err := systemMemoryLimit(); err != nil {
-			s.logger.Warn(err)
-		} else {
+	if limit, err := systemMemoryLimit(); err != nil {
+		s.logger.Warn(err)
+	} else {
+		if memLimit <= 0 {
+			s.logger.Info("no cgroups detected, falling back to total system memory")
 			// If no cgroup limit is set, only return 50% of the total memory.
 			// to have a margin of safety for other processes.
 			memLimit = float64(limit) / 1024 / 1024 / 1024 * 0.5
+		}
+		if memLimit > float64(limit) {
+			s.logger.Info("cgroup memory limit exceed available memory, falling back to total system memory")
+			memLimit = float64(limit)
 		}
 	}
 	if memLimit <= 0 {


### PR DESCRIPTION
## Motivation/summary
I couldn't find any issue in the cgroup reading logic that would explain the bug in https://github.com/elastic/apm-server/pull/9868

On the other hand, it looks like `9223372036854771712` is the default value for cgroup v1 for unlimited memory (no limit).

I was able to reproduce the content of the limit_in_bytes file by creating a fedora 30 instance in aws and running a docker container inside of it. Then reading the memory limit inside the container:

```
# cat /sys/fs/cgroup/memory/memory.limit_in_bytes 
9223372036854771712
```

Note: fedora 30 is important as later versions are using cgroup v2

The PR is adding a fall back to system memory if cgroup returns a value that exceeds the total memory.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
