### PR TITLE
fix: cast event.duration to long in event_duration pipeline 

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -15,6 +15,9 @@
     - description: Add `event.success_count` for transaction events and transaction metrics. Rename `transaction.success_count` to `event.success_count` for service metrics.
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/9819
+    - description: Cast event.duration to long in event_duration pipeline
+      type: bugfix
+      link: https://github.com/elastic/apm-server/pull/9901
 - version: "8.6.0"
   changes:
     - description: Change `ecs.version` to a `constant_keyword` field

--- a/apmpackage/cmd/genpackage/pipelines.go
+++ b/apmpackage/cmd/genpackage/pipelines.go
@@ -157,7 +157,7 @@ var eventDurationPipeline = []map[string]interface{}{{
 		"source": strings.TrimSpace(`
 def durationNanos = ctx.event?.duration ?: 0;
 def eventType = ctx.processor.event;
-ctx.get(ctx.processor.event).duration = ["us": (int)(durationNanos/1000)];
+ctx.get(ctx.processor.event).duration = ["us": (long)(durationNanos/1000)];
 `),
 	},
 }, {

--- a/systemtest/approvals/TestOTLPGRPCTraces.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCTraces.approved.json
@@ -198,7 +198,7 @@
             },
             "transaction": {
                 "duration": {
-                    "us": 1000000
+                    "us": 31536000000000
                 },
                 "id": "b3ee9be3b687a611",
                 "name": "operation_name",

--- a/systemtest/otlp_test.go
+++ b/systemtest/otlp_test.go
@@ -93,7 +93,9 @@ func TestOTLPGRPCTraces(t *testing.T) {
 
 	err = withOTLPTracer(newOTLPTracerProvider(newOTLPTraceExporter(t, srv), sdktrace.WithResource(resource)), func(tracer trace.Tracer) {
 		startTime := time.Unix(123, 456)
-		endTime := startTime.Add(time.Second)
+		// create a span with 1y duration to make sure the final event.duration is
+		// correct for large values.
+		endTime := startTime.Add(time.Hour * 24 * 365)
 		_, span := tracer.Start(ctx, "operation_name", trace.WithTimestamp(startTime), trace.WithAttributes(
 			attribute.StringSlice("span_attribute_array", []string{"a", "b", "c"}),
 		))


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

The otel span start/end dates are used to compute the event
duration of the APM event, stored as a time.Duration.
The duration is converted to nanoseconds stored in an int64
field, however the values is casted to int in the event_duration
pipeline leading to an overflow if the original 64 bit value
cannot be casted safely to the 32-bit int.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Closes https://github.com/elastic/apm-server/issues/9780
