### PR TITLE
[7.17] docs: remove ILM delete phase

### DIFF
--- a/docs/ilm-how-to.asciidoc
+++ b/docs/ilm-how-to.asciidoc
@@ -13,40 +13,31 @@ See {ref}/index-lifecycle-management.html[ILM: Manage the index lifecycle] to le
 === Default policies
 
 The table below describes the default index lifecycle policy applied to each APM data stream.
-Each policy includes a rollover and delete definition:
+Each policy includes a rollover definition;
+using rollover indices prevents a single index from growing too large and optimizes indexing and search performance. Rollover, i.e. writing to a new index, occurs after either an age or size metric is met.
 
-* **Rollover**: Using rollover indices prevents a single index from growing too large and optimizes indexing and search performance. Rollover, i.e. writing to a new index, occurs after either an age or size metric is met.
-* **Delete**: The delete phase permanently removes the index after a time threshold is met.
-
-[cols="1,1,1",options="header"]
+[cols="1,1",options="header"]
 |===
 |Data stream
 |Rollover after
-|Delete after
 
 |`traces-apm`
 |30 days / 50 gb
-|10 days
 
 |`traces-apm.rum`
 |30 days / 50 gb
-|90 days
 
 |`metrics-apm.profiling`
 |30 days / 50 gb
-|10 days
 
 |`metrics-apm.internal`
 |30 days / 50 gb
-|90 days
 
 |`metrics-apm.app`
 |30 days / 50 gb
-|90 days
 
 |`logs-apm.error`
 |30 days / 50 gb
-|10 days
 
 |===
 


### PR DESCRIPTION
### Summary

> https://www.elastic.co/guide/en/apm/guide/7.17/ilm-how-to.html indicates that data streams created by 7.17 have a delete phase. This is not true - we added the delete phase in 8.0: https://github.com/elastic/apm-server/pull/6480
>
> We have no intention to change the ILM policy in 7.17, so we should update the docs.

* Closes https://github.com/elastic/apm-server/issues/9741.