### PR TITLE
[7.17] Better links to ESS data stream migration guide

### DIFF
--- a/docs/legacy/configuration-process.asciidoc
+++ b/docs/legacy/configuration-process.asciidoc
@@ -199,6 +199,9 @@ Events will be written to `traces-*`, `logs-*`, and `metrics-*` data streams.
 Enabling data streams disables the setup of index templates, ILM policies, and ingest pipelines.
 Defaults to false.
 
+WARNING: Other steps are required to switch to data streams.
+Please see <<upgrade-to-data-streams>> before changing this setting.
+
 [[data_streams.wait_for_integration]]
 [float]
 ==== `wait_for_integration`

--- a/docs/upgrading-to-datastreams.asciidoc
+++ b/docs/upgrading-to-datastreams.asciidoc
@@ -27,8 +27,9 @@ Data streams offer a number of benefits over classic indices:
 [[considerations-data-streams]]
 === Data streams considerations
 
-* Users on {ece} require additional steps prior to migrating, like configuring TLS certificates for the connection between APM Server and {es}
-* RUM sourcemaps are not working with data streams in 7.16 -- this will be fixed in 8.0
+* Users on {ece} require additional steps prior to migrating, like configuring TLS certificates for the connection between APM Server and {es}.
+* Users on {ess} must follow the <<apm-integration-upgrade-steps-ess>> guide.
+* RUM source maps are not working with data streams in version 7.17. This bug is fixed in version 8.0.
 
 [discrete]
 [[apm-data-streams-upgrade-steps]]


### PR DESCRIPTION
### Summary

> The idea is to:
> 
> Add a warning in the config option and link to the actual migration guide.
> Update the Data Streams considerations section to also contain a link to the upgrade guide.


* Closes https://github.com/elastic/apm-server/issues/9278.