### PR TITLE
[automation] update elastic stack version for testing 8.6.0-91e609be

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.6.0-39d183e3-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.6.0-91e609be-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -31,7 +31,7 @@ services:
       - "./testing/docker/elasticsearch/ingest-geoip:/usr/share/elasticsearch/config/ingest-geoip"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.6.0-39d183e3-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.6.0-91e609be-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -50,7 +50,7 @@ services:
       - "./testing/docker/kibana/kibana.yml:/usr/share/kibana/config/kibana.yml"
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:8.6.0-39d183e3-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:8.6.0-91e609be-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:
@@ -78,7 +78,7 @@ services:
       - "./testing/docker/fleet-server/key.pem:/etc/pki/tls/private/fleet-server-key.pem"
 
   metricbeat:
-    image: docker.elastic.co/beats/metricbeat:8.6.0-39d183e3-SNAPSHOT
+    image: docker.elastic.co/beats/metricbeat:8.6.0-91e609be-SNAPSHOT
     environment:
       ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'
       ELASTICSEARCH_USERNAME: "${KIBANA_ES_USER:-admin}"

--- a/testing/infra/k8s/base/stack/apm-server.yaml
+++ b/testing/infra/k8s/base/stack/apm-server.yaml
@@ -4,7 +4,7 @@ metadata:
   name: apm-server
   namespace: default
 spec:
-  version: 8.6.0-39d183e3-SNAPSHOT
+  version: 8.6.0-91e609be-SNAPSHOT
   mode: fleet
   policyID: eck-apm-server
   kibanaRef:

--- a/testing/infra/k8s/base/stack/elasticsearch.yaml
+++ b/testing/infra/k8s/base/stack/elasticsearch.yaml
@@ -3,7 +3,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.6.0-39d183e3-SNAPSHOT
+  version: 8.6.0-91e609be-SNAPSHOT
   auth:
     fileRealm:
       - secretName: elasticsearch-admin

--- a/testing/infra/k8s/base/stack/fleet-server.yaml
+++ b/testing/infra/k8s/base/stack/fleet-server.yaml
@@ -3,7 +3,7 @@ kind: Agent
 metadata:
   name: fleet-server
 spec:
-  version: 8.6.0-39d183e3-SNAPSHOT
+  version: 8.6.0-91e609be-SNAPSHOT
   mode: fleet
   fleetServerEnabled: true
   elasticsearchRefs:

--- a/testing/infra/k8s/base/stack/kibana.yaml
+++ b/testing/infra/k8s/base/stack/kibana.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.6.0-39d183e3-SNAPSHOT
+  version: 8.6.0-91e609be-SNAPSHOT
   count: 1
   elasticsearchRef:
     name: elasticsearch

--- a/testing/infra/k8s/overlays/local/kustomization.yaml
+++ b/testing/infra/k8s/overlays/local/kustomization.yaml
@@ -39,4 +39,4 @@ patches:
       # image_json_path for overriding the apm-server image (see above),
       # and we use the same CRD kind for both apm-server and fleet-server.
       # As soon as you specify image_json_path, it *must* match an image.
-      image: docker.elastic.co/beats/elastic-agent:8.6.0-39d183e3-SNAPSHOT
+      image: docker.elastic.co/beats/elastic-agent:8.6.0-91e609be-SNAPSHOT


### PR DESCRIPTION
### What 
 Bump stack version with the latest one. 
 ### Further details 
 [start_time:Thu, 5 Jan 2023 00:17:41 GMT, release_branch:8.6, prefix:, end_time:Thu, 5 Jan 2023 04:34:28 GMT, manifest_version:2.1.0, version:8.6.0-SNAPSHOT, branch:8.6, build_id:8.6.0-91e609be, build_duration_seconds:15407]