### PR TITLE
fix: use observability namespace secrets

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
     DIAGNOSTIC_INTERVAL = "${params.DIAGNOSTIC_INTERVAL}"
     ES_LOG_LEVEL = "${params.ES_LOG_LEVEL}"
-    DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
+    DOCKER_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
   }
   options {

--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -8,7 +8,7 @@ pipeline {
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
     AWS_ACCOUNT_SECRET = 'secret/observability-team/ci/elastic-observability-aws-account-auth'
     EC_KEY_SECRET = 'secret/observability-team/ci/elastic-cloud/observability-pro'
-    BENCHMARK_ES_SECRET = 'secret/apm-team/ci/benchmark-cloud'
+    BENCHMARK_ES_SECRET = 'secret/observability-team/ci/benchmark-cloud'
     BENCHMARK_KIBANA_SECRET = 'secret/observability-team/ci/apm-benchmark-kibana'
     PNG_REPORT_FILE = 'out.png'
     TERRAFORM_VERSION = '1.1.9'

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -11,7 +11,7 @@ pipeline {
     NOTIFY_TO = 'build-apm+apm-server@elastic.co'
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
-    DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
+    DOCKER_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
     DRA_OUTPUT = 'release-manager.out'
     COMMIT = "${params?.COMMIT}"


### PR DESCRIPTION
## Motivation/Summary

Use secrets in the `observability` namespace instead of the `apm` namespace.
