### PR TITLE
ci: Allow system-tests check to be set as required

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -6,6 +6,7 @@ on:
     # this workflow when code changes also contain docs changes:
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths
     paths-ignore: # This expression needs to match the paths ignored on ci.yml.
+      - '**' # Ignore all file changes, except for the below.
       - '!**.md'
       - '!**.asciidoc'
       - '!**.png'

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,0 +1,19 @@
+name: ci
+
+on:
+  pull_request:
+    paths: # This expression needs to match the paths ignored on ci.yml.
+      - '**.md'
+      - '**.asciidoc'
+      - '**.png'
+      - '**.svg'
+
+# limit the access of the generated GITHUB_TOKEN
+permissions:
+  contents: read
+
+jobs:
+  system-test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No tests required to run"'

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -2,11 +2,14 @@ name: ci
 
 on:
   pull_request:
-    paths: # This expression needs to match the paths ignored on ci.yml.
-      - '**.md'
-      - '**.asciidoc'
-      - '**.png'
-      - '**.svg'
+    # We use a negated paths-ignore expression since using 'paths' would trigger
+    # this workflow when code changes also contain docs changes:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths
+    paths-ignore: # This expression needs to match the paths ignored on ci.yml.
+      - '!**.md'
+      - '!**.asciidoc'
+      - '!**.png'
+      - '!**.svg'
 
 # limit the access of the generated GITHUB_TOKEN
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,17 @@ on:
       - main
       - 7.1*
       - 8.*
-    paths-ignore:
+    paths-ignore: # When updating the list of expressions also update ci-docs.yml
       - '**.md'
       - '**.asciidoc'
+      - '**.png'
+      - '**.svg'
   pull_request:
-    paths-ignore:
+    paths-ignore: # When updating the list of expressions also update ci-docs.yml
       - '**.md'
       - '**.asciidoc'
+      - '**.png'
+      - '**.svg'
 
 # limit the access of the generated GITHUB_TOKEN
 permissions:


### PR DESCRIPTION
## Motivation/summary

Follows GitHub's guidance on how to create a step with the same name as the required action so that a status check may be set as required in a protected branch.

see: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
