### PR TITLE
Fix a panic caused by accepting new grpc connections during shutdown

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -16,6 +16,7 @@ https://github.com/elastic/apm-server/compare/8.6\...main[View commits]
 [float]
 ==== Bug fixes
 - We no longer unconditionally block shutdown for 5 seconds when tail-based sampling is enabled {pull}9838[9838]
+- Fix a panic caused by accepting new grpc connections during shutdown {pull}10013[10013]
 
 [float]
 ==== Intake API Changes

--- a/internal/beater/server.go
+++ b/internal/beater/server.go
@@ -215,8 +215,11 @@ func (s server) run(ctx context.Context) error {
 	})
 	g.Go(func() error {
 		<-ctx.Done()
-		s.grpcServer.GracefulStop()
+		// httpServer should stop before grpcServer to avoid a panic caused by placing a new connection into
+		// a closed grpc connection channel during shutdown.
+		// See https://github.com/elastic/gmux/issues/13
 		s.httpServer.stop()
+		s.grpcServer.GracefulStop()
 		return nil
 	})
 	if err := g.Wait(); err != http.ErrServerClosed {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
There is a possible panic related to gmux. It is due to the order we shutdown httpServer and grpcServer. Occasionally when a new grpc connection comes in after grpcServer shutdown and before httpServer shutdown, the program panics.
See https://github.com/elastic/gmux/issues/13

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
