### PR TITLE
Fix fields def and ingest pipelines for agg templates

### DIFF
--- a/apmpackage/apm/data_stream/internal_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/internal_metrics/fields/fields.yml
@@ -163,9 +163,3 @@
   dynamic: true
   description: |
     Custom key/value pairs. Can be used to add meta information to events. Should not contain nested objects. All values are stored as scaled_float.
-- name: transaction.aggregation.overflow_count
-  type: long
-  description: Number of aggregation groups that overflowed for transaction metrics aggregation
-- name: service.aggregation.overflow_count
-  type: long
-  description: Number of aggregation groups that overflowed for service metrics aggregation.

--- a/apmpackage/apm/data_stream/service_destination_interval_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/apmpackage/apm/data_stream/service_destination_interval_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -7,3 +7,6 @@ processors:
       name: observer_ids
   - pipeline:
       name: ecs_version
+  - remove:
+      field: _metric_descriptions
+      ignore_missing: true

--- a/apmpackage/apm/data_stream/service_interval_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/apmpackage/apm/data_stream/service_interval_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -7,3 +7,6 @@ processors:
       name: observer_ids
   - pipeline:
       name: ecs_version
+  - remove:
+      field: _metric_descriptions
+      ignore_missing: true

--- a/apmpackage/apm/data_stream/service_interval_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/service_interval_metrics/fields/fields.yml
@@ -23,3 +23,6 @@
   dynamic: true
   description: |
     Custom key/value pairs. Can be used to add meta information to events. Should not contain nested objects. All values are stored as scaled_float.
+- name: service.aggregation.overflow_count
+  type: long
+  description: Number of aggregation groups that overflowed for service metrics aggregation.

--- a/apmpackage/apm/data_stream/transaction_interval_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/apmpackage/apm/data_stream/transaction_interval_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -7,3 +7,6 @@ processors:
       name: observer_ids
   - pipeline:
       name: ecs_version
+  - remove:
+      field: _metric_descriptions
+      ignore_missing: true

--- a/apmpackage/apm/data_stream/transaction_interval_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/transaction_interval_metrics/fields/fields.yml
@@ -78,3 +78,6 @@
   dynamic: true
   description: |
     Custom key/value pairs. Can be used to add meta information to events. Should not contain nested objects. All values are stored as scaled_float.
+- name: transaction.aggregation.overflow_count
+  type: long
+  description: Number of aggregation groups that overflowed for transaction metrics aggregation


### PR DESCRIPTION
## Motivation/summary

Between conflicting PRs where the datastream for aggregation metrics was changed from `metrics-internal` to `metrics-apm.{transaction, service, service_destination}-*` it seems that the changes for aggregation overflow buckets were not ported correctly. This PR moves the required fields to the correct package definitions and also fixes the ingest pipelines to remove `_metric_descriptions`.

## Checklist

~~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~~
~~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~~
~~- [ ] Documentation has been updated~~

## How to test these changes

NA

## Related issues

#9703 and #9648
