### PR TITLE
Fix servicemetrics aggregator name typo

### DIFF
--- a/x-pack/apm-server/main.go
+++ b/x-pack/apm-server/main.go
@@ -147,9 +147,9 @@ func newProcessors(args beater.ServerParams) ([]namedProcessor, error) {
 			HDRHistogramSignificantFigures: args.Config.Aggregation.Service.HDRHistogramSignificantFigures,
 		})
 		if err != nil {
-			return nil, errors.Wrapf(err, "error creating %s", spanName)
+			return nil, errors.Wrapf(err, "error creating %s", serviceName)
 		}
-		processors = append(processors, namedProcessor{name: spanName, processor: serviceAggregator})
+		processors = append(processors, namedProcessor{name: serviceName, processor: serviceAggregator})
 	}
 
 	if args.Config.Sampling.Tail.Enabled {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Fix typo in xpack main about servicemetrics aggregator name

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~~
~~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~~
~~- [ ] Documentation has been updated~~

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->
N/A

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
