### PR TITLE
Universal Profiling: Fix for GRPC compression not being enabled

### DIFF
--- a/x-pack/apm-server/profiling/collector.go
+++ b/x-pack/apm-server/profiling/collector.go
@@ -19,6 +19,7 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/hashicorp/golang-lru/simplelru"
 	"google.golang.org/grpc/codes"
+	_ "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 


### PR DESCRIPTION
If this import does not exist, the backend will drop compressed RPCs as `Unimplemented`.

Was previously removed in:
https://github.com/elastic/apm-server/commit/06b1a97767942ce52e65cd07a80980679c1198ba

```
internal/otel_collector/config/configgrpc/gzip.go:19:	_ "google.golang.org/grpc/encoding/gzip"
internal/otel_collector/config/configgrpc/configgrpc.go:34:	"google.golang.org/grpc/encoding/gzip"
```

**TODO:**

- ~Looking into updating tests~ DONE
