### PR TITLE
Update go-elasticsearch to v8.6.0 (#9684)

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1599,11 +1599,11 @@ Contents of probable licence file $GOMODCACHE/github.com/elastic/go-docappender@
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/go-elasticsearch/v8
-Version: v8.5.0
+Version: v8.6.0
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/go-elasticsearch/v8@v8.5.0/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/go-elasticsearch/v8@v8.6.0/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/elastic/elastic-agent-system-metrics v0.4.5-0.20220927192933-25a985b07d51
 	github.com/elastic/gmux v0.2.0
 	github.com/elastic/go-docappender v0.1.0
-	github.com/elastic/go-elasticsearch/v8 v8.5.0
+	github.com/elastic/go-elasticsearch/v8 v8.6.0
 	github.com/elastic/go-hdrhistogram v0.1.0
 	github.com/elastic/go-sysinfo v1.9.0
 	github.com/elastic/go-ucfg v0.8.6

--- a/go.sum
+++ b/go.sum
@@ -366,6 +366,8 @@ github.com/elastic/go-docappender v0.1.0 h1:odP2SZICpMQH5FSt3iIStDJwe4FYMKPpyqv/
 github.com/elastic/go-docappender v0.1.0/go.mod h1:mqNQzslgwiz6/BpSNzxC3g26sf7jZF4h1H60l9kYC+w=
 github.com/elastic/go-elasticsearch/v8 v8.5.0 h1:p6j6RFztHvkIg0NaUlfR0OnRmVdCG6Zyfy+bPKMpKp4=
 github.com/elastic/go-elasticsearch/v8 v8.5.0/go.mod h1:Usvydt+x0dv9a1TzEUaovqbJor8rmOHy5dSmPeMAE2k=
+github.com/elastic/go-elasticsearch/v8 v8.6.0 h1:xMaSe8jIh7NHzmNo9YBkewmaD2Pr+tX+zLkXxhieny4=
+github.com/elastic/go-elasticsearch/v8 v8.6.0/go.mod h1:Usvydt+x0dv9a1TzEUaovqbJor8rmOHy5dSmPeMAE2k=
 github.com/elastic/go-hdrhistogram v0.1.0 h1:7UVeQ9MsO5c9h8RJeH2S2lXCGi9hQB/94W6Pjjqprc4=
 github.com/elastic/go-hdrhistogram v0.1.0/go.mod h1:NEl0wZTQXzwq7X2WBZGl5G3efcKbvv+r9mTZpXrIs78=
 github.com/elastic/go-libaudit/v2 v2.3.2 h1:qWNcA3nkwNEGh1UBDbDTVF55KR6SM1W2Ji1LGDqFEpw=


### PR DESCRIPTION
Contains memory and CPU consumption improvements and is used by Universal Profiling.

As previously discussed in #9684. I built and tested the profiling code with both apm-server current and apm-server v8.6.0.