### PR TITLE
action: export traces with the OTEL GH action

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,4 +1,4 @@
-name: ci-docs
+name: ci
 
 on:
   pull_request:

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,4 +1,4 @@
-name: ci
+name: ci-docs
 
 on:
   pull_request:

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -1,0 +1,20 @@
+---
+name: OpenTelemetry Export Trace
+
+on:
+  workflow_run:
+    types: [completed]
+
+jobs:
+  otel-export-trace:
+    name: OpenTelemetry Export Trace
+    runs-on: ubuntu-latest
+    steps:
+      - name: Export Workflow Trace
+        uses: inception-health/otel-export-trace-action@v1
+        with:
+          otlpEndpoint: "${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}"
+          otlpHeaders: "${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}"
+          otelServiceName: ${{ github.repository }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          runId: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -1,20 +1,16 @@
----
 name: OpenTelemetry Export Trace
 
 on:
   workflow_run:
+    workflows: [ci, ci-docs, system-test-reporter]
     types: [completed]
 
 jobs:
   otel-export-trace:
-    name: OpenTelemetry Export Trace
     runs-on: ubuntu-latest
     steps:
-      - name: Export Workflow Trace
-        uses: inception-health/otel-export-trace-action@v1
+      - uses: elastic/apm-pipeline-library/.github/actions/opentelemetry@current
         with:
-          otlpEndpoint: "${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}"
-          otlpHeaders: "${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}"
-          otelServiceName: ${{ github.repository }}
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          runId: ${{ github.event.workflow_run.id }}
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -2,7 +2,7 @@ name: OpenTelemetry Export Trace
 
 on:
   workflow_run:
-    workflows: [ci, ci-docs, system-test-reporter]
+    workflows: [ci, system-test-reporter]
     types: [completed]
 
 jobs:


### PR DESCRIPTION
## Motivation/summary

Back in the days we built the Jenkins OTEL integration, so let's use the same approach for the GH actions, so every workflow and step will be tracked as traces/spans.


## How to test these changes

See traces in the Elastic deployment

This has been already tested for quite sometime in some other projects


<img width="1845" alt="image" src="https://user-images.githubusercontent.com/2871786/212675487-e9fc2937-edbd-4d66-925f-a474e82a966c.png">


https://github.com/elastic/apm-pipeline-library/blob/main/.github/workflows/opentelemetry.yml