### PR TITLE
[DOCS] Specific callout to anonymous settings & auth in APM Server legacy

### DIFF
--- a/docs/legacy/configuration-anonymous.asciidoc
+++ b/docs/legacy/configuration-anonymous.asciidoc
@@ -23,6 +23,8 @@ apm-server.auth.anonymous.rate_limit.event_limit: 300
 apm-server.auth.anonymous.rate_limit.ip_limit: 1000
 ----
 
+The anonymous access configuration is ignored if authenticated communication is disabled.
+
 [float]
 [[config-auth-anon-rum]]
 === Real User Monitoring (RUM)


### PR DESCRIPTION
Anonymous settings are considered only if at least one authentication method is enabled

## Motivation/summary

Users might be misled into thinking that `apm-server.auth.anonymous.allow_...` setting is also taken into account.
Without any authentication method (https://www.elastic.co/guide/en/apm/guide/current/secure-communication-agents.html), the `apm-server.auth.anonymous.allow_...` are ignored.

## Checklist

- [ ] Rephrase if necessary
- [ ] Backport
