### PR TITLE
fix: make sure the memory subsystem is available before accessing the memory limit

### DIFF
--- a/internal/beater/memlimit_cgroup.go
+++ b/internal/beater/memlimit_cgroup.go
@@ -55,6 +55,9 @@ func cgroupMemoryLimit(rdr *cgroup.Reader) (uint64, error) {
 		if err != nil {
 			return 0, fmt.Errorf("unable to read cgroup limits: %w", err)
 		}
+		if stats.Memory == nil {
+			return 0, fmt.Errorf("cgroup memory subsystem unavailable")
+		}
 		return stats.Memory.Mem.Limit.Bytes, nil
 	case cgroup.CgroupsV2:
 		stats, err := rdr.GetV2StatsForProcess(pid)

--- a/internal/beater/memlimit_cgroup.go
+++ b/internal/beater/memlimit_cgroup.go
@@ -64,6 +64,9 @@ func cgroupMemoryLimit(rdr *cgroup.Reader) (uint64, error) {
 		if err != nil {
 			return 0, fmt.Errorf("unable to read cgroup limits: %w", err)
 		}
+		if stats.Memory == nil {
+			return 0, fmt.Errorf("cgroup memory subsystem unavailable")
+		}
 		return stats.Memory.Mem.Max.Bytes.ValueOr(0), nil
 	}
 	return 0, errors.New("unsupported cgroup version")


### PR DESCRIPTION

<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary


## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues


Closes https://github.com/elastic/apm-server/issues/10097
