### PR TITLE
docs: add 8.6.1 release notes

### DIFF
--- a/changelogs/8.6.asciidoc
+++ b/changelogs/8.6.asciidoc
@@ -3,7 +3,14 @@
 
 https://github.com/elastic/apm-server/compare/8.5\...8.6[View commits]
 
+* <<release-notes-8.6.1>>
 * <<release-notes-8.6.0>>
+
+[float]
+[[release-notes-8.6.1]]
+=== APM version 8.6.1
+
+No significant changes.
 
 [float]
 [[release-notes-8.6.0]]


### PR DESCRIPTION
### Summary

Adds 8.6.1 release notes. No significant changes: https://github.com/elastic/apm-server/commits/74050838488eedf105c0bc794dfb72ec5f81d548
