### PR TITLE
docs: Remove apm-server.aggregation.transactions.interval

### DIFF
--- a/docs/legacy/transaction-metrics.asciidoc
+++ b/docs/legacy/transaction-metrics.asciidoc
@@ -18,20 +18,12 @@ Example config file:
 apm-server:
   aggregation:
     transactions:
-      interval: 1m
+      max_groups: 10000
 ----
 
 [float]
 [[configuration-aggregation]]
 === Configuration options: `apm-server.aggregation.transactions.*`
-
-[[transactions-interval]]
-[float]
-==== `interval`
-
-Controls the frequency of metrics publication.
-
-Default: `1m`.
 
 [[transactions-max_groups]]
 [float]


### PR DESCRIPTION
Remove mention of `apm-server.aggregation.transactions.interval` config in docs as it is removed in #9846