### PR TITLE
Added field mappings for mobile use cases to error_logs schema

### DIFF
--- a/apmpackage/apm/data_stream/app_logs/fields/ecs.yml
+++ b/apmpackage/apm/data_stream/app_logs/fields/ecs.yml
@@ -75,6 +75,8 @@
 - external: ecs
   name: error.stack_trace
 - external: ecs
+  name: error.type
+- external: ecs
   name: event.dataset
 - external: ecs
   name: event.outcome

--- a/apmpackage/apm/data_stream/app_logs/fields/fields.yml
+++ b/apmpackage/apm/data_stream/app_logs/fields/fields.yml
@@ -60,6 +60,11 @@
   index: false
   description: |
     Version of the runtime used.
+- name: session.id
+  type: keyword
+  description: |
+    The ID of the session to which the event belongs.
+  ignore_above: 1024
 - name: faas.id
   type: keyword
   description: |

--- a/apmpackage/apm/data_stream/error_logs/fields/ecs.yml
+++ b/apmpackage/apm/data_stream/error_logs/fields/ecs.yml
@@ -77,7 +77,15 @@
 - external: ecs
   name: error.stack_trace
 - external: ecs
+  name: error.type
+- external: ecs
   name: event.outcome
+- external: ecs
+  name: event.type
+- external: ecs
+  name: event.category
+- external: ecs
+  name: event.kind
 - external: ecs
   name: host.architecture
 - external: ecs

--- a/apmpackage/apm/data_stream/error_logs/fields/fields.yml
+++ b/apmpackage/apm/data_stream/error_logs/fields/fields.yml
@@ -127,6 +127,11 @@
   index: false
   description: |
     Version of the runtime used.
+- name: session.id
+  type: keyword
+  description: |
+    The ID of the session to which the event belongs.
+  ignore_above: 1024
 - name: timestamp.us
   type: long
   description: |


### PR DESCRIPTION
Some of the fields for mobile logs and errors were missing in the field mappings:

- `session.id`
- `event.type`
- `event.kind`
- `event.category`
- `error.type`