### PR TITLE
test: move TestProfiling to standalone APM Server

### DIFF
--- a/systemtest/apmservertest/config.go
+++ b/systemtest/apmservertest/config.go
@@ -71,7 +71,7 @@ type Config struct {
 	Output OutputConfig `json:"output"`
 
 	// ProfilingConfig holds configuration related to profiling.
-	Profiling *ProfilingConfig `json:"apm-server.profiling"`
+	Profiling *ProfilingConfig `json:"apm-server.profiling,omitempty"`
 }
 
 // Args formats cfg as a list of arguments to pass to apm-server,

--- a/systemtest/apmservertest/config.go
+++ b/systemtest/apmservertest/config.go
@@ -69,6 +69,9 @@ type Config struct {
 
 	// Output holds configuration for the libbeat output.
 	Output OutputConfig `json:"output"`
+
+	// ProfilingConfig holds configuration related to profiling.
+	Profiling *ProfilingConfig `json:"apm-server.profiling"`
 }
 
 // Args formats cfg as a list of arguments to pass to apm-server,
@@ -167,6 +170,28 @@ type TailSamplingPolicy struct {
 	TraceName          string  `json:"trace.name,omitempty"`
 	TraceOutcome       string  `json:"trace.outcome,omitempty"`
 	SampleRate         float64 `json:"sample_rate"`
+}
+
+// ProfilingConfig holds configuration related to profiling.
+type ProfilingConfig struct {
+	Enabled bool `json:"enabled"`
+
+	// ESConfig holds Elasticsearch configuration for writing
+	// profiling stacktrace events and metadata documents.
+	ESConfig *ElasticsearchOutputConfig `json:"elasticsearch"`
+
+	// MetricsESConfig holds Elasticsearch configuration for
+	// writing profiling host agent metric documents.
+	MetricsESConfig *ElasticsearchOutputConfig `json:"metrics.elasticsearch"`
+
+	// ILMConfig
+	ILMConfig *ProfilingILMConfig `json:"keyvalue_retention"`
+}
+
+type ProfilingILMConfig struct {
+	Age         time.Duration `json:"age"`
+	SizeInBytes uint64        `json:"size_bytes"`
+	Interval    time.Duration `json:"execution_interval"`
 }
 
 // RUMConfig holds APM Server RUM configuration.

--- a/systemtest/apmservertest/config.go
+++ b/systemtest/apmservertest/config.go
@@ -183,15 +183,6 @@ type ProfilingConfig struct {
 	// MetricsESConfig holds Elasticsearch configuration for
 	// writing profiling host agent metric documents.
 	MetricsESConfig *ElasticsearchOutputConfig `json:"metrics.elasticsearch"`
-
-	// ILMConfig
-	ILMConfig *ProfilingILMConfig `json:"keyvalue_retention"`
-}
-
-type ProfilingILMConfig struct {
-	Age         time.Duration `json:"age"`
-	SizeInBytes uint64        `json:"size_bytes"`
-	Interval    time.Duration `json:"execution_interval"`
 }
 
 // RUMConfig holds APM Server RUM configuration.

--- a/systemtest/profiling_test.go
+++ b/systemtest/profiling_test.go
@@ -55,8 +55,8 @@ func TestProfiling(t *testing.T) {
 	defer cleanupProfiling()
 	defer systemtest.InvalidateAPIKeys(t)
 
-	// APM Server is running as an Elastic Agent integration,
-	// which means it is provided an API Key with narrow
+	// APM Server is running in standalone mode, which means
+	// it is using the default elasticsearch credentials with narrow
 	// privileges. We must inject an additional API Key for
 	// the profiling code to write to profiling-* indices.
 	var apiKey struct {


### PR DESCRIPTION


<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Reduce fleet dependency in test and improve test time.
TestProfiling time went from 32s to 10s

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
