### PR TITLE
docs: update docs versions 7.17.9

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,4 +18,4 @@
 package cmd
 
 // name matches github.com/elastic/beats/v7/dev-tools/mage/settings.go parseBeatVersion
-const defaultBeatVersion = "7.17.10"
+const defaultBeatVersion = "7.17.9"


### PR DESCRIPTION
Updates docs versions to 7.17.9.

Merge before the final Release build.