### PR TITLE
Round servicetxmetrics event.success_count.sum

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -26,7 +26,7 @@ https://github.com/elastic/apm-server/compare/8.6\...main[View commits]
 [float]
 ==== Added
 - Metrics data streams now use synthetic source {pull}9756[9756]
-- Add `event.success_count` to transaction events and transaction metrics {pull}9819[9819]
+- Add `event.success_count` to transaction events and transaction metrics {pull}9819[9819] {pull}10165[10165]
 - Dedicated overflow buckets for transaction and service aggregation to limit cardinality {pull}9856[9856]
 - Automatically scale `MaxGroups` and `MaxTransactionGroups` based on available memory {pull}9856[9856]
 - Set `_doc_count` for service destination metrics {pull}9931[9931]

--- a/x-pack/apm-server/aggregation/servicetxmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/servicetxmetrics/aggregator.go
@@ -459,7 +459,7 @@ func makeMetricset(key aggregationKey, metrics serviceTxMetrics, totalCount int6
 		Event: model.Event{
 			SuccessCount: model.SummaryMetric{
 				Count: int64(math.Round(metrics.successCount + metrics.failureCount)),
-				Sum:   metrics.successCount,
+				Sum:   math.Round(metrics.successCount),
 			},
 		},
 	}

--- a/x-pack/apm-server/aggregation/servicetxmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/servicetxmetrics/aggregator_test.go
@@ -77,7 +77,7 @@ func TestAggregatorRun(t *testing.T) {
 	inputs := []input{
 		{serviceName: "ignored", agentName: "ignored", transactionType: "ignored", count: 0}, // ignored because count is zero
 
-		{serviceName: "backend", serviceLanguageName: "java", agentName: "java", transactionType: "request", outcome: "success", count: 2},
+		{serviceName: "backend", serviceLanguageName: "java", agentName: "java", transactionType: "request", outcome: "success", count: 2.1},
 		{serviceName: "backend", serviceLanguageName: "java", agentName: "java", transactionType: "request", outcome: "failure", count: 3},
 		{serviceName: "backend", serviceLanguageName: "java", agentName: "java", transactionType: "request", outcome: "unknown", count: 1},
 
@@ -127,10 +127,10 @@ func TestAggregatorRun(t *testing.T) {
 				Type: "request",
 				DurationSummary: model.SummaryMetric{
 					Count: 6,
-					Sum:   6000, // 6ms in micros
+					Sum:   6100, // 6.1ms in micros
 				},
 				DurationHistogram: model.Histogram{
-					Values: []float64{1000, 2000, 3000},
+					Values: []float64{1000, 2100, 3000},
 					Counts: []int64{1, 2, 3},
 				},
 			},


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

Fix a bug where `event.success_count.sum` is not rounded, causing >100% success rate.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~~
~~- [ ] Documentation has been updated~~

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->
- Ensure event.success_count.sum is rounded under sampling setup.

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
