### PR TITLE
Make doc count use separate count instead of histogram total count

### DIFF
--- a/x-pack/apm-server/aggregation/servicetxmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/servicetxmetrics/aggregator.go
@@ -449,7 +449,7 @@ func makeMetricset(key aggregationKey, metrics serviceTxMetrics, totalCount int6
 		NumericLabels: key.NumericLabels,
 		Processor:     model.MetricsetProcessor,
 		Metricset: &model.Metricset{
-			DocCount: totalCount,
+			DocCount: metricCount,
 			Name:     metricsetName,
 			Interval: interval,
 		},

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -497,14 +497,14 @@ func (a *Aggregator) makeTransactionAggregationKey(event model.APMEvent, interva
 
 // makeMetricset makes a metricset event from key, counts, and values, with timestamp ts.
 func makeMetricset(key transactionAggregationKey, metrics transactionMetrics, totalCount int64, counts []int64, values []float64) model.APMEvent {
-	count := math.Round(metrics.count)
+	metricCount := math.Round(metrics.count)
 	var eventSuccessCount model.SummaryMetric
 	switch key.eventOutcome {
 	case "success":
-		eventSuccessCount.Count = int64(count)
-		eventSuccessCount.Sum = count
+		eventSuccessCount.Count = int64(metricCount)
+		eventSuccessCount.Sum = metricCount
 	case "failure":
-		eventSuccessCount.Count = int64(count)
+		eventSuccessCount.Count = int64(metricCount)
 	case "unknown":
 		// Keep both Count and Sum as 0.
 	}
@@ -562,7 +562,7 @@ func makeMetricset(key transactionAggregationKey, metrics transactionMetrics, to
 		Processor:     model.MetricsetProcessor,
 		Metricset: &model.Metricset{
 			Name:     metricsetName,
-			DocCount: totalCount,
+			DocCount: int64(metricCount),
 		},
 		Transaction: &model.Transaction{
 			Name:   key.transactionName,
@@ -574,7 +574,7 @@ func makeMetricset(key transactionAggregationKey, metrics transactionMetrics, to
 				Values: values,
 			},
 			DurationSummary: model.SummaryMetric{
-				Count: int64(count),
+				Count: int64(metricCount),
 				Sum:   float64(time.Duration(math.Round(metrics.sum)).Microseconds()),
 			},
 		},


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

For metricset doc count, use the new separate counter instead of histogram total count for best accuracy, since the histogram total count may involve rounding errors. Also removes the need to sum up counts from histogram.

e.g. if there are 3 events, each with count=1.3, the current doc count will be `math.round(1.3)*3` from histograms, but if we use the separate count, it will be `math.round(1.3*3)`.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~~
~~- [ ] Documentation has been updated~~

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->
- Check that txmetrics and servicetxmetrics doc count is correct, especially when sampling is enabled

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->

Following #10185 
