### PR TITLE
[8.7] docs: remove head.asciidoc

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,4 +1,3 @@
-include::./changelogs/head.asciidoc[]
 include::./changelogs/8.7.asciidoc[]
 include::./changelogs/8.6.asciidoc[]
 include::./changelogs/8.5.asciidoc[]


### PR DESCRIPTION
Fixes a failing 8.7 doc build.