### PR TITLE
action: avoid fail fast and checkout branch

### DIFF
--- a/.github/workflows/bump-elastic-stack.yml
+++ b/.github/workflows/bump-elastic-stack.yml
@@ -24,9 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [filter]
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.filter.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
 
       - name: Setup Git
         uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
@@ -39,4 +42,3 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           BRANCH: ${{ matrix.branch }}
         run: updatecli apply --config ./.ci/bump-elastic-stack-snapshot.yml
-


### PR DESCRIPTION
## Motivation/summary

Release branches might have a different set of files to be updated. Hence it's required to checkout the given branch to run the `updatecli`


## Related issues

https://github.com/elastic/apm-server/pull/10222