### PR TITLE
golang: bump automation with updatecli and GH actions 

### DIFF
--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -1,0 +1,117 @@
+---
+name: Bump golang-version to latest version
+
+actions:
+  default:
+    title: '[updatecli] Bump Golang version to {{ source "latestGoVersion" }}'
+    kind: github/pullrequest
+    spec:
+      labels:
+        - backport-skip
+        - dependencies
+    scmid: default
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: '{{ requiredEnv "GIT_USER" }}'
+      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      owner: elastic
+      repository: apm-server
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GIT_USER" }}'
+      branch: main
+
+sources:
+  minor:
+    name: Get minor version in .go-version
+    kind: shell
+    transformers:
+      - findsubmatch:
+          pattern: '^\d+.(\d+).\d+$'
+          captureindex: 1
+    spec:
+      command: cat .go-version
+
+  latestGoVersion:
+    name: Get Latest Go Release
+    kind: githubrelease
+    dependson:
+      - minor
+    transformers:
+      - trimprefix: go
+    spec:
+      owner: golang
+      repository: go
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GIT_USER" }}'
+      versionfilter:
+        kind: regex
+        pattern: go1\.{{ source "minor" }}\.\d*$
+
+  gomod:
+    dependson:
+      - latestGoVersion
+    name: Get version in go.mod format
+    kind: shell
+    transformers:
+      - findsubmatch:
+          pattern: '^(\d+.\d+).\d*'
+          captureindex: 1
+    spec:
+      command: echo {{ source "latestGoVersion" }}
+
+conditions:
+  dockerTag:
+    name: Is docker image golang:{{ source "latestGoVersion" }} published
+    kind: dockerimage
+    spec:
+      image: golang
+      tag: '{{ source "latestGoVersion" }}'
+    sourceid: latestGoVersion
+
+  goDefaultVersion-check:
+    name: Check if defined golang version differs
+    kind: shell
+    sourceid: latestGoVersion
+    spec:
+      command: 'grep -v -q {{ source "latestGoVersion" }} .go-version #'
+
+targets:
+  update-go-version:
+    name: "Update .go-version"
+    sourceid: latestGoVersion
+    scmid: default
+    kind: file
+    spec:
+      content: '{{ source "latestGoVersion" }}'
+      file: .go-version
+      matchpattern: '\d+.\d+.\d+'
+  update-version-asciidoc:
+    name: "Update version.asciidoc"
+    sourceid: latestGoVersion
+    scmid: default
+    kind: file
+    spec:
+      file: docs/version.asciidoc
+      matchpattern: '(:go-version:) \d+.\d+.\d+'
+      replacepattern: '$1 {{ source "latestGoVersion" }}'
+  update-dockerfile:
+    name: "Update Dockerfile"
+    sourceid: latestGoVersion
+    scmid: default
+    kind: file
+    spec:
+      file: packaging/docker/Dockerfile
+      matchpattern: '(FROM golang):\d+.\d+.\d+'
+      replacepattern: '$1:{{ source "latestGoVersion" }}'
+  update-gomod:
+    name: "Update go.mod"
+    sourceid: gomod
+    scmid: default
+    kind: file
+    spec:
+      content: 'go {{ source "gomod" }}'
+      file: go.mod
+      matchpattern: 'go \d+.\d+'

--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -80,7 +80,7 @@ conditions:
 
 targets:
   update-go-version:
-    name: "Update .go-version"
+    name: 'Update .go-version with Golang version {{ source "latestGoVersion" }}'
     sourceid: latestGoVersion
     scmid: default
     kind: file
@@ -89,7 +89,7 @@ targets:
       file: .go-version
       matchpattern: '\d+.\d+.\d+'
   update-version-asciidoc:
-    name: "Update version.asciidoc"
+    name: 'Update version.asciidoc with Golang version {{ source "latestGoVersion" }}'
     sourceid: latestGoVersion
     scmid: default
     kind: file
@@ -98,7 +98,7 @@ targets:
       matchpattern: '(:go-version:) \d+.\d+.\d+'
       replacepattern: '$1 {{ source "latestGoVersion" }}'
   update-dockerfile:
-    name: "Update Dockerfile"
+    name: 'Update Dockerfile with Golang version {{ source "latestGoVersion" }}'
     sourceid: latestGoVersion
     scmid: default
     kind: file
@@ -107,11 +107,16 @@ targets:
       matchpattern: '(FROM golang):\d+.\d+.\d+'
       replacepattern: '$1:{{ source "latestGoVersion" }}'
   update-gomod:
-    name: "Update go.mod"
+    name: 'Update go.mod files with {{ source "gomod" }}'
     sourceid: gomod
     scmid: default
     kind: file
     spec:
       content: 'go {{ source "gomod" }}'
-      file: go.mod
+      files:
+        - go.mod
+        - cmd/intake-receiver/go.mod
+        - internal/glog/go.mod
+        - systemtest/go.mod
+        - tools/go.mod
       matchpattern: 'go \d+.\d+'

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -7,8 +7,7 @@ on:
     - cron: '0 20 * * 6'
 
 permissions:
-  pull-requests: write
-  contents: write
+  contents: read
 
 jobs:
   bump:
@@ -16,14 +15,9 @@ jobs:
     steps:
 
       - uses: actions/checkout@v3
-
-      - name: Setup Git
-        uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
-
-      - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@453502948b442d7b9a923de7b40cc7ce8628505c
-
-      - name: Run Updatecli
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: updatecli apply --config ./.ci/bump-golang.yml
+      - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: ./.ci/bump-golang.yml

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -1,0 +1,29 @@
+---
+name: bump-golang
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 20 * * 6'
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v3
+
+      - name: Setup Git
+        uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
+
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@453502948b442d7b9a923de7b40cc7ce8628505c
+
+      - name: Run Updatecli
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: updatecli apply --config ./.ci/bump-golang.yml

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows:
       - bump-elastic-stack-snapshot
+      - bump-golang
       - ci
       - system-test-reporter
       - update-beats


### PR DESCRIPTION
## What does this PR do?

Automate the golang bump within the project itself using [updatecli](https://www.updatecli.io/) and github actions

## Why is it important?

Remove the dependency with Jenkins and the definition of what to do in [apm-pipeline-library](https://github.com/elastic/apm-pipeline-library/blob/a3850732518748f2e71815c093d58cb071d0d8a3/.ci/.bump-go-release-version.yml#L33-L40)

Use updatecli that provide the tooling for bumping versions

## Issues

Similar to https://github.com/elastic/beats/pull/34458
Requires https://github.com/elastic/apm-pipeline-library/pull/2076

## Test

https://github.com/v1v/apm-server/pull/20 was created to test these changes on my forked repo using `1.19.4` for testing purposes


