### PR TITLE
test: fix system test panic on compile error and avoid double close

### DIFF
--- a/systemtest/aggregation_test.go
+++ b/systemtest/aggregation_test.go
@@ -38,7 +38,7 @@ import (
 
 func TestTransactionAggregation(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewUnstartedServerTB(t)
+	srv := apmservertest.NewUnstartedServer()
 	srv.Config.Monitoring = &apmservertest.MonitoringConfig{
 		Enabled:       true,
 		MetricsPeriod: 100 * time.Millisecond,
@@ -125,7 +125,8 @@ func TestTransactionAggregation(t *testing.T) {
 
 func TestTransactionAggregationShutdown(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewServerTB(t)
+	srv := apmservertest.NewUnstartedServer()
+	require.NoError(t, srv.Start())
 
 	// Send a transaction to the server to be aggregated.
 	tracer := srv.Tracer()
@@ -152,7 +153,8 @@ func TestTransactionAggregationShutdown(t *testing.T) {
 
 func TestServiceDestinationAggregation(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewServerTB(t)
+	srv := apmservertest.NewUnstartedServer()
+	require.NoError(t, srv.Start())
 
 	// Send spans to the server to be aggregated.
 	tracer := srv.Tracer()
@@ -185,7 +187,8 @@ func TestServiceDestinationAggregation(t *testing.T) {
 func TestTransactionAggregationLabels(t *testing.T) {
 	t.Setenv("ELASTIC_APM_GLOBAL_LABELS", "department_name=apm,organization=observability,company=elastic")
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewServerTB(t)
+	srv := apmservertest.NewUnstartedServer()
+	require.NoError(t, srv.Start())
 
 	tracer := srv.Tracer()
 	tx := tracer.StartTransaction("name", "type")
@@ -229,7 +232,7 @@ func TestTransactionAggregationLabels(t *testing.T) {
 
 func TestServiceTransactionMetricsAggregation(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewUnstartedServerTB(t)
+	srv := apmservertest.NewUnstartedServer()
 	err := srv.Start()
 	require.NoError(t, err)
 
@@ -261,7 +264,7 @@ func TestServiceTransactionMetricsAggregation(t *testing.T) {
 func TestServiceTransactionMetricsAggregationLabels(t *testing.T) {
 	t.Setenv("ELASTIC_APM_GLOBAL_LABELS", "department_name=apm,organization=observability,company=elastic")
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewUnstartedServerTB(t)
+	srv := apmservertest.NewUnstartedServer()
 	err := srv.Start()
 	require.NoError(t, err)
 
@@ -307,7 +310,7 @@ func TestServiceTransactionMetricsAggregationLabels(t *testing.T) {
 
 func TestServiceSummaryMetricsAggregation(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewUnstartedServerTB(t)
+	srv := apmservertest.NewUnstartedServer()
 	err := srv.Start()
 	require.NoError(t, err)
 
@@ -336,7 +339,7 @@ func TestServiceSummaryMetricsAggregation(t *testing.T) {
 
 func TestNonDefaultRollupIntervalHiddenDataStream(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewUnstartedServerTB(t)
+	srv := apmservertest.NewUnstartedServer()
 	err := srv.Start()
 	require.NoError(t, err)
 

--- a/systemtest/aggregation_test.go
+++ b/systemtest/aggregation_test.go
@@ -38,7 +38,7 @@ import (
 
 func TestTransactionAggregation(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewUnstartedServer()
+	srv := apmservertest.NewUnstartedServerTB(t)
 	srv.Config.Monitoring = &apmservertest.MonitoringConfig{
 		Enabled:       true,
 		MetricsPeriod: 100 * time.Millisecond,
@@ -125,8 +125,7 @@ func TestTransactionAggregation(t *testing.T) {
 
 func TestTransactionAggregationShutdown(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewUnstartedServer()
-	require.NoError(t, srv.Start())
+	srv := apmservertest.NewServerTB(t)
 
 	// Send a transaction to the server to be aggregated.
 	tracer := srv.Tracer()
@@ -153,8 +152,7 @@ func TestTransactionAggregationShutdown(t *testing.T) {
 
 func TestServiceDestinationAggregation(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewUnstartedServer()
-	require.NoError(t, srv.Start())
+	srv := apmservertest.NewServerTB(t)
 
 	// Send spans to the server to be aggregated.
 	tracer := srv.Tracer()
@@ -187,8 +185,7 @@ func TestServiceDestinationAggregation(t *testing.T) {
 func TestTransactionAggregationLabels(t *testing.T) {
 	t.Setenv("ELASTIC_APM_GLOBAL_LABELS", "department_name=apm,organization=observability,company=elastic")
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewUnstartedServer()
-	require.NoError(t, srv.Start())
+	srv := apmservertest.NewServerTB(t)
 
 	tracer := srv.Tracer()
 	tx := tracer.StartTransaction("name", "type")
@@ -232,9 +229,7 @@ func TestTransactionAggregationLabels(t *testing.T) {
 
 func TestServiceTransactionMetricsAggregation(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewUnstartedServer()
-	err := srv.Start()
-	require.NoError(t, err)
+	srv := apmservertest.NewServerTB(t)
 
 	timestamp, _ := time.Parse(time.RFC3339Nano, "2006-01-02T15:04:05.999999999Z") // should be truncated to 1s
 	tracer := srv.Tracer()
@@ -264,9 +259,7 @@ func TestServiceTransactionMetricsAggregation(t *testing.T) {
 func TestServiceTransactionMetricsAggregationLabels(t *testing.T) {
 	t.Setenv("ELASTIC_APM_GLOBAL_LABELS", "department_name=apm,organization=observability,company=elastic")
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewUnstartedServer()
-	err := srv.Start()
-	require.NoError(t, err)
+	srv := apmservertest.NewServerTB(t)
 
 	tracer := srv.Tracer()
 	tx := tracer.StartTransaction("name", "type")
@@ -310,9 +303,7 @@ func TestServiceTransactionMetricsAggregationLabels(t *testing.T) {
 
 func TestServiceSummaryMetricsAggregation(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewUnstartedServer()
-	err := srv.Start()
-	require.NoError(t, err)
+	srv := apmservertest.NewServerTB(t)
 
 	timestamp, _ := time.Parse(time.RFC3339Nano, "2006-01-02T15:04:05.999999999Z") // should be truncated to 1s
 	tracer := srv.Tracer()
@@ -339,9 +330,7 @@ func TestServiceSummaryMetricsAggregation(t *testing.T) {
 
 func TestNonDefaultRollupIntervalHiddenDataStream(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewUnstartedServer()
-	err := srv.Start()
-	require.NoError(t, err)
+	srv := apmservertest.NewServerTB(t)
 
 	timestamp, _ := time.Parse(time.RFC3339Nano, "2006-01-02T15:04:05.999999999Z") // should be truncated to 1s
 	tracer := srv.Tracer()

--- a/systemtest/apmservertest/server_test.go
+++ b/systemtest/apmservertest/server_test.go
@@ -40,8 +40,6 @@ func TestMain(m *testing.M) {
 func TestNewServerTB(t *testing.T) {
 	srv := apmservertest.NewServerTB(t)
 	require.NotNil(t, srv)
-	err := srv.Close()
-	assert.NoError(t, err)
 }
 
 func TestNewUnstartedServerTB(t *testing.T) {
@@ -81,9 +79,6 @@ func TestServerStartTLS(t *testing.T) {
 	tracer.StartTransaction("name", "type").End()
 	tracer.Flush(nil)
 	assert.Zero(t, tracer.Stats().Errors)
-
-	err = srv.Close()
-	assert.NoError(t, err)
 }
 
 func TestExpvar(t *testing.T) {

--- a/systemtest/huge_traces_test.go
+++ b/systemtest/huge_traces_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"go.elastic.co/apm/v2"
 
 	"github.com/elastic/apm-server/systemtest"
@@ -35,8 +34,7 @@ func TestTransactionDroppedSpansStats(t *testing.T) {
 	// Disable span compression.
 	t.Setenv("ELASTIC_APM_SPAN_COMPRESSION_ENABLED", "false")
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewUnstartedServer()
-	require.NoError(t, srv.Start())
+	srv := apmservertest.NewServerTB(t)
 
 	tracer := srv.Tracer()
 	tx := tracer.StartTransaction("huge-traces", "type")

--- a/systemtest/huge_traces_test.go
+++ b/systemtest/huge_traces_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.elastic.co/apm/v2"
 
 	"github.com/elastic/apm-server/systemtest"
@@ -34,7 +35,8 @@ func TestTransactionDroppedSpansStats(t *testing.T) {
 	// Disable span compression.
 	t.Setenv("ELASTIC_APM_SPAN_COMPRESSION_ENABLED", "false")
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewServerTB(t)
+	srv := apmservertest.NewUnstartedServer()
+	require.NoError(t, srv.Start())
 
 	tracer := srv.Tracer()
 	tx := tracer.StartTransaction("huge-traces", "type")

--- a/systemtest/jaeger_test.go
+++ b/systemtest/jaeger_test.go
@@ -95,9 +95,7 @@ func sendJaegerBatch(
 
 func TestJaegerSampling(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewUnstartedServerTB(t)
-	err := srv.Start()
-	require.NoError(t, err)
+	srv := apmservertest.NewServerTB(t)
 
 	conn, err := grpc.Dial(serverAddr(srv), grpc.WithInsecure())
 	require.NoError(t, err)

--- a/systemtest/logging_test.go
+++ b/systemtest/logging_test.go
@@ -40,9 +40,7 @@ import (
 
 func TestAPMServerGRPCRequestLoggingValid(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewUnstartedServer()
-	err := srv.Start()
-	require.NoError(t, err)
+	srv := apmservertest.NewServerTB(t)
 	addr := serverAddr(srv)
 	conn, err := grpc.Dial(addr, grpc.WithInsecure())
 	require.NoError(t, err)
@@ -82,9 +80,7 @@ func TestAPMServerGRPCRequestLoggingValid(t *testing.T) {
 }
 
 func TestAPMServerRequestLoggingValid(t *testing.T) {
-	srv := apmservertest.NewUnstartedServer()
-	require.NoError(t, srv.Start())
-
+	srv := apmservertest.NewServerTB(t)
 	eventsURL := srv.URL + "/intake/v2/events"
 
 	// Send a request to the server with a single valid event.

--- a/systemtest/logging_test.go
+++ b/systemtest/logging_test.go
@@ -40,7 +40,7 @@ import (
 
 func TestAPMServerGRPCRequestLoggingValid(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewUnstartedServerTB(t)
+	srv := apmservertest.NewUnstartedServer()
 	err := srv.Start()
 	require.NoError(t, err)
 	addr := serverAddr(srv)
@@ -82,7 +82,9 @@ func TestAPMServerGRPCRequestLoggingValid(t *testing.T) {
 }
 
 func TestAPMServerRequestLoggingValid(t *testing.T) {
-	srv := apmservertest.NewServerTB(t)
+	srv := apmservertest.NewUnstartedServer()
+	require.NoError(t, srv.Start())
+
 	eventsURL := srv.URL + "/intake/v2/events"
 
 	// Send a request to the server with a single valid event.


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Trying to run system tests if there is a compile error will result in the error being printed to stderr followed by a nil pointer dereference:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4b50f9]

goroutine 98 [running]:
os.(*Process).signal(0xc0004aab60?, {0x15a7998?, 0x1f0e850?})
        /usr/lib/go/src/os/exec_unix.go:63 +0x39
os.(*Process).Signal(...)
        /usr/lib/go/src/os/exec.go:138
github.com/elastic/apm-server/systemtest/apmservertest.interruptProcess(...)
        /apm-server/systemtest/apmservertest/server_unix.go:31
github.com/elastic/apm-server/systemtest/apmservertest.(*Server).Close(0xc0004aab60)
        /apm-server/systemtest/apmservertest/server.go:434 +0x5a
github.com/elastic/apm-server/systemtest/apmservertest.NewUnstartedServerTB.func1.1()
        /apm-server/systemtest/apmservertest/server.go:138 +0x26
created by github.com/elastic/apm-server/systemtest/apmservertest.NewUnstartedServerTB.func1
        /apm-server/systemtest/apmservertest/server.go:138 +0x1a5
```

Additionally: closing apmservertest twice results in a silent error.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
