### PR TITLE
CI: only notify Slack of update-beats on failure

### DIFF
--- a/.github/workflows/update-beats.yml
+++ b/.github/workflows/update-beats.yml
@@ -30,7 +30,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           BRANCH_NAME: ${{ github.ref_name }}
         run: updatecli apply --config ./.ci/update-beats.yml
-      - if: always()
+      - if: failure()
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
         with:
           vaultUrl: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
## Motivation/summary

Stop spamming Slack with `update-beats` messages on every commit.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

None