### PR TITLE
test: close response body in TestServerRoot and fix goroutine leak

### DIFF
--- a/internal/beater/server_test.go
+++ b/internal/beater/server_test.go
@@ -116,6 +116,7 @@ func TestServerRoot(t *testing.T) {
 		if testCase.assertions != nil {
 			testCase.assertions(t, res)
 		}
+		assert.NoError(t, res.Body.Close())
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Similar to other PRs.

There was another gourine leak:

```
         Goroutine 203 in state select, with net/http.(*persistConn).readLoop on top of the stack:
        goroutine 203 [select]:
        net/http.(*persistConn).readLoop(0xc0001245a0)
                /usr/lib/go/src/net/http/transport.go:2227 +0xd85
        created by net/http.(*Transport).dialConn
                /usr/lib/go/src/net/http/transport.go:1765 +0x16ea
        [originating from goroutine 201]:
        net/http.(*Transport).dialConn(...)
                /usr/lib/go/src/net/http/transport.go:1766 +0x16ea
        net/http.(*Transport).dialConnFor(...)
                /usr/lib/go/src/net/http/transport.go:1456 +0xb0
        created by net/http.(*Transport).queueForDial
                /usr/lib/go/src/net/http/transport.go:1425 +0x3ea
        [originating from goroutine 86]:
        net/http.(*Transport).queueForDial(...)
                /usr/lib/go/src/net/http/transport.go:1426 +0x3ea
        net/http.(*Transport).getConn(...)
                /usr/lib/go/src/net/http/transport.go:1383 +0x4dd
        net/http.(*Transport).roundTrip(...)
                /usr/lib/go/src/net/http/transport.go:590 +0x79e
        net/http.(*Transport).RoundTrip(...)
                /usr/lib/go/src/net/http/roundtrip.go:17 +0x19
        net/http.send(...)
                /usr/lib/go/src/net/http/client.go:252 +0x5f7
        net/http.(*Client).send(...)
                /usr/lib/go/src/net/http/client.go:176 +0x9b
        net/http.(*Client).do(...)
                /usr/lib/go/src/net/http/client.go:716 +0x8fb
        net/http.(*Client).Do(...)
                /usr/lib/go/src/net/http/client.go:582 +0x205
        github.com/elastic/apm-server/internal/beater_test.TestServerRoot.func2(...)
                /apm-server/internal/beater/server_test.go:85 +0x1f1
        github.com/elastic/apm-server/internal/beater_test.TestServerRoot(...)
                /apm-server/internal/beater/server_test.go:116 +0x2f8
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        created by testing.(*T).Run
                /usr/lib/go/src/testing/testing.go:1629 +0x3ea
        [originating from goroutine 1]:
        testing.(*T).Run(...)
                /usr/lib/go/src/testing/testing.go:1630 +0x3ea
        testing.runTests.func1(...)
                /usr/lib/go/src/testing/testing.go:2035 +0x45
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        testing.runTests(...)
                /usr/lib/go/src/testing/testing.go:2040 +0x489
        testing.(*M).Run(...)
                /usr/lib/go/src/testing/testing.go:1906 +0x63a
        main.main(...)
                _testmain.go:95 +0x1aa
        
         Goroutine 204 in state select, with net/http.(*persistConn).writeLoop on top of the stack:
        goroutine 204 [select]:
        net/http.(*persistConn).writeLoop(0xc0001245a0)
                /usr/lib/go/src/net/http/transport.go:2410 +0xf2
        created by net/http.(*Transport).dialConn
                /usr/lib/go/src/net/http/transport.go:1766 +0x173d
        [originating from goroutine 201]:
        net/http.(*Transport).dialConn(...)
                /usr/lib/go/src/net/http/transport.go:1767 +0x173d
        net/http.(*Transport).dialConnFor(...)
                /usr/lib/go/src/net/http/transport.go:1456 +0xb0
        created by net/http.(*Transport).queueForDial
                /usr/lib/go/src/net/http/transport.go:1425 +0x3ea
        [originating from goroutine 86]:
        net/http.(*Transport).queueForDial(...)
                /usr/lib/go/src/net/http/transport.go:1426 +0x3ea
        net/http.(*Transport).getConn(...)
                /usr/lib/go/src/net/http/transport.go:1383 +0x4dd
        net/http.(*Transport).roundTrip(...)
                /usr/lib/go/src/net/http/transport.go:590 +0x79e
        net/http.(*Transport).RoundTrip(...)
                /usr/lib/go/src/net/http/roundtrip.go:17 +0x19
        net/http.send(...)
                /usr/lib/go/src/net/http/client.go:252 +0x5f7
        net/http.(*Client).send(...)
                /usr/lib/go/src/net/http/client.go:176 +0x9b
        net/http.(*Client).do(...)
                /usr/lib/go/src/net/http/client.go:716 +0x8fb
        net/http.(*Client).Do(...)
                /usr/lib/go/src/net/http/client.go:582 +0x205
        github.com/elastic/apm-server/internal/beater_test.TestServerRoot.func2(...)
                /apm-server/internal/beater/server_test.go:85 +0x1f1
        github.com/elastic/apm-server/internal/beater_test.TestServerRoot(...)
                /apm-server/internal/beater/server_test.go:116 +0x2f8
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        created by testing.(*T).Run
                /usr/lib/go/src/testing/testing.go:1629 +0x3ea
        [originating from goroutine 1]:
        testing.(*T).Run(...)
                /usr/lib/go/src/testing/testing.go:1630 +0x3ea
        testing.runTests.func1(...)
                /usr/lib/go/src/testing/testing.go:2035 +0x45
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        testing.runTests(...)
                /usr/lib/go/src/testing/testing.go:2040 +0x489
        testing.(*M).Run(...)
                /usr/lib/go/src/testing/testing.go:1906 +0x63a
        main.main(...)
                _testmain.go:95 +0x1aa
```

To reproduce: 
- add `t.Cleanup(func() { goleak.VerifyNone(t) })` as the first line of `TestServerRoot`
- run the test with tracebackancestors `GODEBUG=tracebackancestors=10 go test -run=TestServerRoot ./...`

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
