### PR TITLE
Fix service destination labels regression

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -62,6 +62,9 @@
     - description: Remove policy input var `service_metrics_enabled`
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/10109
+    - description: Add `event.{labels,numeric_labels}` to service destination metrics
+      type: enhancement
+      link: https://github.com/elastic/apm-server/pull/10297
 - version: "8.6.0"
   changes:
     - description: Change `ecs.version` to a `constant_keyword` field

--- a/apmpackage/apm/data_stream/service_destination_interval_metrics/fields/ecs.yml
+++ b/apmpackage/apm/data_stream/service_destination_interval_metrics/fields/ecs.yml
@@ -16,3 +16,6 @@
   name: service.environment
 - external: ecs
   name: service.name
+- external: ecs
+  name: labels
+  dynamic: true

--- a/apmpackage/apm/data_stream/service_destination_interval_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/service_destination_interval_metrics/fields/fields.yml
@@ -33,3 +33,8 @@
   type: long
   description: Aggregated duration of outgoing requests, in microseconds.
   unit: micros
+- name: numeric_labels
+  type: object
+  dynamic: true
+  description: |
+    Custom key/value pairs. Can be used to add meta information to events. Should not contain nested objects. All values are stored as scaled_float.

--- a/docs/data-model.asciidoc
+++ b/docs/data-model.asciidoc
@@ -331,8 +331,8 @@ You can filter and group by these dimensions (some of which are optional, for ex
 * `faas.id`: The unique identifier of the invoked serverless function
 * `faas.name`: The name of the lambda function
 * `faas.version`: The version of the lambda function
-* `labels`: Key-value object containing string labels set globaly by the APM agents.
-* `numeric_labels`: Key-value object containing numeric labels set globaly by the APM agents.
+* `labels`: Key-value object containing string labels set globally by the APM agents.
+* `numeric_labels`: Key-value object containing numeric labels set globally by the APM agents.
 --
 
 The `@timestamp` field of these documents holds the start of the aggregation interval.
@@ -363,6 +363,8 @@ You can filter and group by these dimensions:
 * `service.target.name`: The target service name, for example `customer_db`
 * `service.target.type`: The target service type, for example `mysql`
 * `metricset.interval`: A string with the aggregation interval the metricset represents.
+* `labels`: Key-value object containing string labels set globally by the APM agents.
+* `numeric_labels`: Key-value object containing numeric labels set globally by the APM agents.
 --
 
 The `@timestamp` field of these documents holds the start of the aggregation interval.

--- a/systemtest/aggregation_test.go
+++ b/systemtest/aggregation_test.go
@@ -151,6 +151,7 @@ func TestTransactionAggregationShutdown(t *testing.T) {
 }
 
 func TestServiceDestinationAggregation(t *testing.T) {
+	t.Setenv("ELASTIC_APM_GLOBAL_LABELS", "department_name=apm,organization=observability,company=elastic")
 	systemtest.CleanupElasticsearch(t)
 	srv := apmservertest.NewServerTB(t)
 
@@ -158,6 +159,9 @@ func TestServiceDestinationAggregation(t *testing.T) {
 	tracer := srv.Tracer()
 	timestamp, _ := time.Parse(time.RFC3339Nano, "2006-01-02T15:04:05.999999999Z") // should be truncated to 1s
 	tx := tracer.StartTransaction("name", "type")
+	// The label that's set below won't be set in the metricset labels since
+	// the labels will be set on the event and not in the metadata object.
+	tx.Context.SetLabel("mylabel", "myvalue")
 	for i := 0; i < 5; i++ {
 		span := tx.StartSpanOptions("name", "type", apm.SpanOptions{Start: timestamp})
 		span.Context.SetDestinationService(apm.DestinationServiceSpanContext{

--- a/systemtest/approvals/TestServiceDestinationAggregation.approved.json
+++ b/systemtest/approvals/TestServiceDestinationAggregation.approved.json
@@ -19,6 +19,11 @@
                 "ingested": "dynamic",
                 "outcome": "success"
             },
+            "labels": {
+                "company": "elastic",
+                "department_name": "apm",
+                "organization": "observability"
+            },
             "metricset": {
                 "interval": "10m",
                 "name": "service_destination"
@@ -72,6 +77,11 @@
                 "ingested": "dynamic",
                 "outcome": "success"
             },
+            "labels": {
+                "company": "elastic",
+                "department_name": "apm",
+                "organization": "observability"
+            },
             "metricset": {
                 "interval": "1m",
                 "name": "service_destination"
@@ -124,6 +134,11 @@
                 "agent_id_status": "missing",
                 "ingested": "dynamic",
                 "outcome": "success"
+            },
+            "labels": {
+                "company": "elastic",
+                "department_name": "apm",
+                "organization": "observability"
             },
             "metricset": {
                 "interval": "60m",


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

Fix regression introduced by #10056 where service destination labels are not stored successfully.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [x] Documentation has been updated

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

- Ensure that service destination labels are stored

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->

Related to #10045
