### PR TITLE
benchtest: break out of infinite loop and fix goroutine leak

### DIFF
--- a/systemtest/benchtest/expvar/metrics.go
+++ b/systemtest/benchtest/expvar/metrics.go
@@ -211,11 +211,10 @@ func (c *Collector) start(ctx context.Context, serverURL string, period time.Dur
 	go func() {
 		defer c.cleanup()
 
-	outer:
 		for {
 			select {
 			case <-ctx.Done():
-				break outer
+				return
 			case <-errChan:
 				return
 			case m := <-outChan:
@@ -237,11 +236,10 @@ func run(ctx context.Context, serverURL string, period time.Duration) (<-chan ex
 			close(outChan)
 		}()
 
-	outer:
 		for {
 			select {
 			case <-ctx.Done():
-				break outer
+				return
 			case <-ticker.C:
 				var e expvar
 				ctxWithTimeout, cancel := context.WithTimeout(ctx, period)
@@ -251,14 +249,14 @@ func run(ctx context.Context, serverURL string, period time.Duration) (<-chan ex
 					select {
 					case errChan <- err:
 					case <-ctx.Done():
-						break outer
+						return
 					}
 					return
 				}
 				select {
 				case outChan <- e:
 				case <-ctx.Done():
-					break outer
+					return
 				}
 			}
 		}

--- a/systemtest/benchtest/expvar/metrics.go
+++ b/systemtest/benchtest/expvar/metrics.go
@@ -249,7 +249,6 @@ func run(ctx context.Context, serverURL string, period time.Duration) (<-chan ex
 					select {
 					case errChan <- err:
 					case <-ctx.Done():
-						return
 					}
 					return
 				}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Another goroutine leak in benchtest:

```
--- FAIL: TestWatchMetricNonBlocking (1.51s)
    leaks.go:78: found unexpected goroutines:
        [Goroutine 29 in state chan send, with github.com/elastic/apm-server/systemtest/benchtest/expvar.run.func1 on top of the stack:
        goroutine 29 [chan send]:
        github.com/elastic/apm-server/systemtest/benchtest/expvar.run.func1()
                /apm-server/systemtest/benchtest/expvar/metrics.go:251 +0x105
        created by github.com/elastic/apm-server/systemtest/benchtest/expvar.run
                /apm-server/systemtest/benchtest/expvar/metrics.go:231 +0x110
        [originating from goroutine 35]:
        github.com/elastic/apm-server/systemtest/benchtest/expvar.run(...)
                /apm-server/systemtest/benchtest/expvar/metrics.go:255 +0x110
        github.com/elastic/apm-server/systemtest/benchtest/expvar.(*Collector).start(...)
                /apm-server/systemtest/benchtest/expvar/metrics.go:210 +0xf6
        github.com/elastic/apm-server/systemtest/benchtest/expvar.TestAggregate(...)
                /apm-server/systemtest/benchtest/expvar/metrics_test.go:52 +0x1aa
        github.com/elastic/apm-server/systemtest/benchtest/expvar.StartNewCollector(...)
                /apm-server/systemtest/benchtest/expvar/metrics.go:80 +0x10b
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        created by testing.(*T).Run
                /usr/lib/go/src/testing/testing.go:1629 +0x3ea
        [originating from goroutine 1]:
        testing.(*T).Run(...)
                /usr/lib/go/src/testing/testing.go:1630 +0x3ea
        testing.runTests.func1(...)
                /usr/lib/go/src/testing/testing.go:2035 +0x45
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        testing.runTests(...)
                /usr/lib/go/src/testing/testing.go:2040 +0x489
        testing.(*M).Run(...)
                /usr/lib/go/src/testing/testing.go:1906 +0x63a
        main.main(...)
                _testmain.go:57 +0x1aa
        
         Goroutine 277 in state chan send, with github.com/elastic/apm-server/systemtest/benchtest/expvar.run.func1 on top of the stack:
        goroutine 277 [chan send]:
        github.com/elastic/apm-server/systemtest/benchtest/expvar.run.func1()
                /apm-server/systemtest/benchtest/expvar/metrics.go:248 +0x1fb
        created by github.com/elastic/apm-server/systemtest/benchtest/expvar.run
                /apm-server/systemtest/benchtest/expvar/metrics.go:231 +0x110
        [originating from goroutine 202]:
        github.com/elastic/apm-server/systemtest/benchtest/expvar.run(...)
                /apm-server/systemtest/benchtest/expvar/metrics.go:255 +0x110
        github.com/elastic/apm-server/systemtest/benchtest/expvar.(*Collector).start(...)
                /apm-server/systemtest/benchtest/expvar/metrics.go:210 +0xf6
        github.com/elastic/apm-server/systemtest/benchtest/expvar.TestWatchMetricNonBlocking(...)
                /apm-server/systemtest/benchtest/expvar/metrics_test.go:119 +0x1aa
        github.com/elastic/apm-server/systemtest/benchtest/expvar.StartNewCollector(...)
                /apm-server/systemtest/benchtest/expvar/metrics.go:80 +0x10b
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        created by testing.(*T).Run
                /usr/lib/go/src/testing/testing.go:1629 +0x3ea
        [originating from goroutine 1]:
        testing.(*T).Run(...)
                /usr/lib/go/src/testing/testing.go:1630 +0x3ea
        testing.runTests.func1(...)
                /usr/lib/go/src/testing/testing.go:2035 +0x45
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        testing.runTests(...)
                /usr/lib/go/src/testing/testing.go:2040 +0x489
        testing.(*M).Run(...)
                /usr/lib/go/src/testing/testing.go:1906 +0x63a
        main.main(...)
                _testmain.go:57 +0x1aa
        ]
```

Once the ctx is done the return statement will break out of the `select` and the parent for loop will run forever repeating the same loop.
Another side effect is that `defer c.cleanup()` is unreachable code as the goroutine will never finish.
Finally, sending to `errChan` or `outChan` could potentially block forever causing another goroutine leak if the function reading from the channels has already completed.



## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
