### PR TITLE
Fix service summary overflow bucket regression

### DIFF
--- a/apmpackage/apm/data_stream/service_summary_interval_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/apmpackage/apm/data_stream/service_summary_interval_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -7,3 +7,6 @@ processors:
       name: observer_ids
   - pipeline:
       name: ecs_version
+  - remove:
+      field: _metric_descriptions
+      ignore_missing: true

--- a/systemtest/aggregation_test.go
+++ b/systemtest/aggregation_test.go
@@ -328,6 +328,51 @@ func TestServiceSummaryMetricsAggregation(t *testing.T) {
 	systemtest.ApproveEvents(t, t.Name(), result.Hits.Hits)
 }
 
+func TestServiceSummaryMetricsAggregationOverflow(t *testing.T) {
+	systemtest.CleanupElasticsearch(t)
+	srv := apmservertest.NewUnstartedServerTB(t)
+	srv.Config.Aggregation = &apmservertest.AggregationConfig{
+		ServiceTransactionMaxGroups: 2,
+	}
+	require.NoError(t, srv.Start())
+
+	f := func(env string) {
+		t.Setenv("ELASTIC_APM_ENVIRONMENT", env)
+		timestamp, _ := time.Parse(time.RFC3339Nano, "2006-01-02T15:04:05.999999999Z") // should be truncated to 1s
+		tracer := srv.Tracer()
+		tx := tracer.StartTransactionOptions("name", "type", apm.TransactionOptions{Start: timestamp})
+		tx.Duration = time.Second
+		tx.End()
+		tracer.Flush(nil)
+	}
+	f("dev")
+	f("staging")
+	f("prod")
+	f("test")
+
+	// Wait for the transaction to be indexed, indicating that Elasticsearch
+	// indices have been setup and we should not risk triggering the shutdown
+	// timeout while waiting for the aggregated metrics to be indexed.
+	systemtest.Elasticsearch.ExpectMinDocs(t, 4, "traces-apm*",
+		estest.TermQuery{Field: "processor.event", Value: "transaction"},
+	)
+	// Stop server to ensure metrics are flushed on shutdown.
+	assert.NoError(t, srv.Close())
+	systemtest.Elasticsearch.ExpectMinDocs(t, 3, "metrics-apm.service_summary*",
+		estest.BoolQuery{
+			Must: []interface{}{
+				estest.TermQuery{Field: "metricset.name", Value: "service_summary"},
+				estest.TermQuery{Field: "service.name", Value: "_other"},
+			},
+		},
+	)
+	result := systemtest.Elasticsearch.ExpectMinDocs(t, 9, "metrics-apm.service_summary*",
+		estest.TermQuery{Field: "metricset.name", Value: "service_summary"},
+	)
+	// Ignore timestamp because overflow bucket uses time.Now()
+	systemtest.ApproveEvents(t, t.Name(), result.Hits.Hits, "@timestamp")
+}
+
 func TestNonDefaultRollupIntervalHiddenDataStream(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
 	srv := apmservertest.NewServerTB(t)

--- a/systemtest/aggregation_test.go
+++ b/systemtest/aggregation_test.go
@@ -336,7 +336,7 @@ func TestServiceSummaryMetricsAggregationOverflow(t *testing.T) {
 	}
 	require.NoError(t, srv.Start())
 
-	f := func(env string) {
+	sendTransaction := func(env string) {
 		t.Setenv("ELASTIC_APM_ENVIRONMENT", env)
 		timestamp, _ := time.Parse(time.RFC3339Nano, "2006-01-02T15:04:05.999999999Z") // should be truncated to 1s
 		tracer := srv.Tracer()
@@ -345,10 +345,10 @@ func TestServiceSummaryMetricsAggregationOverflow(t *testing.T) {
 		tx.End()
 		tracer.Flush(nil)
 	}
-	f("dev")
-	f("staging")
-	f("prod")
-	f("test")
+	sendTransaction("dev")
+	sendTransaction("staging")
+	sendTransaction("prod")
+	sendTransaction("test")
 
 	// Wait for the transaction to be indexed, indicating that Elasticsearch
 	// indices have been setup and we should not risk triggering the shutdown

--- a/systemtest/apmservertest/config.go
+++ b/systemtest/apmservertest/config.go
@@ -72,6 +72,9 @@ type Config struct {
 
 	// ProfilingConfig holds configuration related to profiling.
 	Profiling *ProfilingConfig `json:"apm-server.profiling,omitempty"`
+
+	// AggregationConfig holds configuration related to aggregation.
+	Aggregation *AggregationConfig `json:"apm-server.aggregation,omitempty"`
 }
 
 // Args formats cfg as a list of arguments to pass to apm-server,
@@ -318,6 +321,11 @@ func durationString(d time.Duration) string {
 		return ""
 	}
 	return d.String()
+}
+
+// AggregationConfig holds configuration related to aggregation.
+type AggregationConfig struct {
+	ServiceTransactionMaxGroups int `json:"service_transactions.max_groups,omitempty"`
 }
 
 func configArgs(cfg Config, extra map[string]interface{}) ([]string, error) {

--- a/systemtest/approvals.go
+++ b/systemtest/approvals.go
@@ -74,6 +74,7 @@ var apmEventSortFields = []string{
 	"transaction.type",
 	"span.type",
 	"service.name",
+	"service.environment",
 	"message",
 	"metricset.interval", // useful to sort different interval metric sets.
 	"@timestamp",         // last resort before _id; order is generally guaranteed

--- a/systemtest/approvals/TestServiceSummaryMetricsAggregationOverflow.approved.json
+++ b/systemtest/approvals/TestServiceSummaryMetricsAggregationOverflow.approved.json
@@ -152,6 +152,82 @@
                 "name": "go"
             },
             "data_stream": {
+                "dataset": "apm.service_summary.1m",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "agent_id_status": "missing",
+                "ingested": "dynamic"
+            },
+            "metricset": {
+                "interval": "1m",
+                "name": "service_summary"
+            },
+            "observer": {
+                "hostname": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "environment": "dev",
+                "language": {
+                    "name": "go"
+                },
+                "name": "systemtest"
+            }
+        },
+        {
+            "@timestamp": "dynamic",
+            "agent": {
+                "name": "go"
+            },
+            "data_stream": {
+                "dataset": "apm.service_summary.60m",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "agent_id_status": "missing",
+                "ingested": "dynamic"
+            },
+            "metricset": {
+                "interval": "60m",
+                "name": "service_summary"
+            },
+            "observer": {
+                "hostname": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "environment": "dev",
+                "language": {
+                    "name": "go"
+                },
+                "name": "systemtest"
+            }
+        },
+        {
+            "@timestamp": "dynamic",
+            "agent": {
+                "name": "go"
+            },
+            "data_stream": {
                 "dataset": "apm.service_summary.10m",
                 "namespace": "default",
                 "type": "metrics"
@@ -215,44 +291,6 @@
                 "name": "metric"
             },
             "service": {
-                "environment": "dev",
-                "language": {
-                    "name": "go"
-                },
-                "name": "systemtest"
-            }
-        },
-        {
-            "@timestamp": "dynamic",
-            "agent": {
-                "name": "go"
-            },
-            "data_stream": {
-                "dataset": "apm.service_summary.1m",
-                "namespace": "default",
-                "type": "metrics"
-            },
-            "ecs": {
-                "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
-            "metricset": {
-                "interval": "1m",
-                "name": "service_summary"
-            },
-            "observer": {
-                "hostname": "dynamic",
-                "type": "apm-server",
-                "version": "dynamic"
-            },
-            "processor": {
-                "event": "metric",
-                "name": "metric"
-            },
-            "service": {
                 "environment": "staging",
                 "language": {
                     "name": "go"
@@ -292,44 +330,6 @@
             },
             "service": {
                 "environment": "staging",
-                "language": {
-                    "name": "go"
-                },
-                "name": "systemtest"
-            }
-        },
-        {
-            "@timestamp": "dynamic",
-            "agent": {
-                "name": "go"
-            },
-            "data_stream": {
-                "dataset": "apm.service_summary.60m",
-                "namespace": "default",
-                "type": "metrics"
-            },
-            "ecs": {
-                "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
-            "metricset": {
-                "interval": "60m",
-                "name": "service_summary"
-            },
-            "observer": {
-                "hostname": "dynamic",
-                "type": "apm-server",
-                "version": "dynamic"
-            },
-            "processor": {
-                "event": "metric",
-                "name": "metric"
-            },
-            "service": {
-                "environment": "dev",
                 "language": {
                     "name": "go"
                 },

--- a/systemtest/approvals/TestServiceSummaryMetricsAggregationOverflow.approved.json
+++ b/systemtest/approvals/TestServiceSummaryMetricsAggregationOverflow.approved.json
@@ -1,0 +1,340 @@
+{
+    "events": [
+        {
+            "@timestamp": "dynamic",
+            "data_stream": {
+                "dataset": "apm.service_summary.10m",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "agent_id_status": "missing",
+                "ingested": "dynamic"
+            },
+            "metricset": {
+                "interval": "10m",
+                "name": "service_summary"
+            },
+            "observer": {
+                "hostname": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "name": "_other"
+            },
+            "service_summary": {
+                "aggregation": {
+                    "overflow_count": 2
+                }
+            }
+        },
+        {
+            "@timestamp": "dynamic",
+            "data_stream": {
+                "dataset": "apm.service_summary.1m",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "agent_id_status": "missing",
+                "ingested": "dynamic"
+            },
+            "metricset": {
+                "interval": "1m",
+                "name": "service_summary"
+            },
+            "observer": {
+                "hostname": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "name": "_other"
+            },
+            "service_summary": {
+                "aggregation": {
+                    "overflow_count": 2
+                }
+            }
+        },
+        {
+            "@timestamp": "dynamic",
+            "data_stream": {
+                "dataset": "apm.service_summary.60m",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "agent_id_status": "missing",
+                "ingested": "dynamic"
+            },
+            "metricset": {
+                "interval": "60m",
+                "name": "service_summary"
+            },
+            "observer": {
+                "hostname": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "name": "_other"
+            },
+            "service_summary": {
+                "aggregation": {
+                    "overflow_count": 2
+                }
+            }
+        },
+        {
+            "@timestamp": "dynamic",
+            "agent": {
+                "name": "go"
+            },
+            "data_stream": {
+                "dataset": "apm.service_summary.10m",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "agent_id_status": "missing",
+                "ingested": "dynamic"
+            },
+            "metricset": {
+                "interval": "10m",
+                "name": "service_summary"
+            },
+            "observer": {
+                "hostname": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "environment": "dev",
+                "language": {
+                    "name": "go"
+                },
+                "name": "systemtest"
+            }
+        },
+        {
+            "@timestamp": "dynamic",
+            "agent": {
+                "name": "go"
+            },
+            "data_stream": {
+                "dataset": "apm.service_summary.10m",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "agent_id_status": "missing",
+                "ingested": "dynamic"
+            },
+            "metricset": {
+                "interval": "10m",
+                "name": "service_summary"
+            },
+            "observer": {
+                "hostname": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "environment": "staging",
+                "language": {
+                    "name": "go"
+                },
+                "name": "systemtest"
+            }
+        },
+        {
+            "@timestamp": "dynamic",
+            "agent": {
+                "name": "go"
+            },
+            "data_stream": {
+                "dataset": "apm.service_summary.1m",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "agent_id_status": "missing",
+                "ingested": "dynamic"
+            },
+            "metricset": {
+                "interval": "1m",
+                "name": "service_summary"
+            },
+            "observer": {
+                "hostname": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "environment": "dev",
+                "language": {
+                    "name": "go"
+                },
+                "name": "systemtest"
+            }
+        },
+        {
+            "@timestamp": "dynamic",
+            "agent": {
+                "name": "go"
+            },
+            "data_stream": {
+                "dataset": "apm.service_summary.1m",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "agent_id_status": "missing",
+                "ingested": "dynamic"
+            },
+            "metricset": {
+                "interval": "1m",
+                "name": "service_summary"
+            },
+            "observer": {
+                "hostname": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "environment": "staging",
+                "language": {
+                    "name": "go"
+                },
+                "name": "systemtest"
+            }
+        },
+        {
+            "@timestamp": "dynamic",
+            "agent": {
+                "name": "go"
+            },
+            "data_stream": {
+                "dataset": "apm.service_summary.60m",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "agent_id_status": "missing",
+                "ingested": "dynamic"
+            },
+            "metricset": {
+                "interval": "60m",
+                "name": "service_summary"
+            },
+            "observer": {
+                "hostname": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "environment": "staging",
+                "language": {
+                    "name": "go"
+                },
+                "name": "systemtest"
+            }
+        },
+        {
+            "@timestamp": "dynamic",
+            "agent": {
+                "name": "go"
+            },
+            "data_stream": {
+                "dataset": "apm.service_summary.60m",
+                "namespace": "default",
+                "type": "metrics"
+            },
+            "ecs": {
+                "version": "dynamic"
+            },
+            "event": {
+                "agent_id_status": "missing",
+                "ingested": "dynamic"
+            },
+            "metricset": {
+                "interval": "60m",
+                "name": "service_summary"
+            },
+            "observer": {
+                "hostname": "dynamic",
+                "type": "apm-server",
+                "version": "dynamic"
+            },
+            "processor": {
+                "event": "metric",
+                "name": "metric"
+            },
+            "service": {
+                "environment": "dev",
+                "language": {
+                    "name": "go"
+                },
+                "name": "systemtest"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

Fix regression introduced in #10061 where service summary overflow bucket did not work.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

- Retest #10061: Ensure that service summary overflow bucket works

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->

Related to #9654
