### PR TITLE
test: close tracer in logging test and avoid goroutine leak

### DIFF
--- a/systemtest/logging_test.go
+++ b/systemtest/logging_test.go
@@ -152,6 +152,8 @@ func validMetadataJSON() string {
 	tracer := apmtest.NewRecordingTracer()
 	tracer.StartTransaction("name", "type").End()
 	tracer.Flush(nil)
+	defer tracer.Close()
+
 	system, process, service, labels := tracer.Metadata()
 
 	var w fastjson.Writer


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

More goroutine leaks in logging tests:

```
         Goroutine 100 in state select, with go.elastic.co/apm/v2.(*Tracer).loop on top of the stack:
        goroutine 100 [select]:
        go.elastic.co/apm/v2.(*Tracer).loop(0xc000392820)
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:1019 +0xd1f
        created by go.elastic.co/apm/v2.newTracer
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:540 +0xd6a
        [originating from goroutine 46]:
        go.elastic.co/apm/v2.newTracer(...)
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:541 +0xd6a
        go.elastic.co/apm/v2.NewTracerOptions(...)
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:446 +0x98
        go.elastic.co/apm/v2/apmtest.NewRecordingTracer(...)
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/apmtest/recorder.go:36 +0x74
        github.com/elastic/apm-server/systemtest_test.validMetadataJSON(...)
                /apm-server/systemtest/logging_test.go:155 +0x2e
        github.com/elastic/apm-server/systemtest_test.TestAPMServerRequestLoggingValid(...)
                /apm-server/systemtest/logging_test.go:95 +0x235
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        created by testing.(*T).Run
                /usr/lib/go/src/testing/testing.go:1629 +0x3ea
        [originating from goroutine 1]:
        testing.(*T).Run(...)
                /usr/lib/go/src/testing/testing.go:1630 +0x3ea
        testing.runTests.func1(...)
                /usr/lib/go/src/testing/testing.go:2035 +0x45
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        testing.runTests(...)
                /usr/lib/go/src/testing/testing.go:2040 +0x489
        testing.(*M).Run(...)
                /usr/lib/go/src/testing/testing.go:1906 +0x63a
        github.com/elastic/apm-server/systemtest.TestMain(...)
                /apm-server/systemtest/main_test.go:80 +0x118
        reflect.ValueOf(...)
                /usr/lib/go/src/reflect/value.go:3148 +0x1d3
        
         Goroutine 101 in state chan receive, with go.elastic.co/apm/v2.(*Tracer).loop.func2 on top of the stack:
        goroutine 101 [chan receive]:
        go.elastic.co/apm/v2.(*Tracer).loop.func2()
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:912 +0x214
        created by go.elastic.co/apm/v2.(*Tracer).loop
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:909 +0x3fd
        [originating from goroutine 100]:
        go.elastic.co/apm/v2.(*Tracer).loop(...)
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:924 +0x3fd
        created by go.elastic.co/apm/v2.newTracer
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:540 +0xd6a
        [originating from goroutine 46]:
        go.elastic.co/apm/v2.newTracer(...)
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:541 +0xd6a
        go.elastic.co/apm/v2.NewTracerOptions(...)
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:446 +0x98
        go.elastic.co/apm/v2/apmtest.NewRecordingTracer(...)
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/apmtest/recorder.go:36 +0x74
        github.com/elastic/apm-server/systemtest_test.validMetadataJSON(...)
                /apm-server/systemtest/logging_test.go:155 +0x2e
        github.com/elastic/apm-server/systemtest_test.TestAPMServerRequestLoggingValid(...)
                /apm-server/systemtest/logging_test.go:95 +0x235
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        created by testing.(*T).Run
                /usr/lib/go/src/testing/testing.go:1629 +0x3ea
        [originating from goroutine 1]:
        testing.(*T).Run(...)
                /usr/lib/go/src/testing/testing.go:1630 +0x3ea
        testing.runTests.func1(...)
                /usr/lib/go/src/testing/testing.go:2035 +0x45
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        testing.runTests(...)
                /usr/lib/go/src/testing/testing.go:2040 +0x489
        testing.(*M).Run(...)
                /usr/lib/go/src/testing/testing.go:1906 +0x63a
        github.com/elastic/apm-server/systemtest.TestMain(...)
                /apm-server/systemtest/main_test.go:80 +0x118
        reflect.ValueOf(...)
                /usr/lib/go/src/reflect/value.go:3148 +0x1d3
        
         Goroutine 126 in state chan receive, with go.elastic.co/apm/v2.(*Tracer).loop.func2 on top of the stack:
        goroutine 126 [chan receive]:
        go.elastic.co/apm/v2.(*Tracer).loop.func2()
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:912 +0x214
        created by go.elastic.co/apm/v2.(*Tracer).loop
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:909 +0x3fd
        [originating from goroutine 125]:
        go.elastic.co/apm/v2.(*Tracer).loop(...)
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:924 +0x3fd
        created by go.elastic.co/apm/v2.newTracer
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:540 +0xd6a
        [originating from goroutine 46]:
        go.elastic.co/apm/v2.newTracer(...)
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:541 +0xd6a
        go.elastic.co/apm/v2.NewTracerOptions(...)
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:446 +0x98
        go.elastic.co/apm/v2/apmtest.NewRecordingTracer(...)
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/apmtest/recorder.go:36 +0x74
        github.com/elastic/apm-server/systemtest_test.validMetadataJSON(...)
                /apm-server/systemtest/logging_test.go:155 +0x2e
        github.com/elastic/apm-server/systemtest_test.TestAPMServerRequestLoggingValid(...)
                /apm-server/systemtest/logging_test.go:103 +0x32a
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        created by testing.(*T).Run
                /usr/lib/go/src/testing/testing.go:1629 +0x3ea
        [originating from goroutine 1]:
        testing.(*T).Run(...)
                /usr/lib/go/src/testing/testing.go:1630 +0x3ea
        testing.runTests.func1(...)
                /usr/lib/go/src/testing/testing.go:2035 +0x45
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        testing.runTests(...)
                /usr/lib/go/src/testing/testing.go:2040 +0x489
        testing.(*M).Run(...)
                /usr/lib/go/src/testing/testing.go:1906 +0x63a
        github.com/elastic/apm-server/systemtest.TestMain(...)
                /apm-server/systemtest/main_test.go:80 +0x118
        reflect.ValueOf(...)
                /usr/lib/go/src/reflect/value.go:3148 +0x1d3
        
         Goroutine 125 in state select, with go.elastic.co/apm/v2.(*Tracer).loop on top of the stack:
        goroutine 125 [select]:
        go.elastic.co/apm/v2.(*Tracer).loop(0xc000392d00)
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:1019 +0xd1f
        created by go.elastic.co/apm/v2.newTracer
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:540 +0xd6a
        [originating from goroutine 46]:
        go.elastic.co/apm/v2.newTracer(...)
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:541 +0xd6a
        go.elastic.co/apm/v2.NewTracerOptions(...)
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/tracer.go:446 +0x98
        go.elastic.co/apm/v2/apmtest.NewRecordingTracer(...)
                /go/pkg/mod/go.elastic.co/apm/v2@v2.1.1-0.20220810211444-b8542dccafec/apmtest/recorder.go:36 +0x74
        github.com/elastic/apm-server/systemtest_test.validMetadataJSON(...)
                /apm-server/systemtest/logging_test.go:155 +0x2e
        github.com/elastic/apm-server/systemtest_test.TestAPMServerRequestLoggingValid(...)
                /apm-server/systemtest/logging_test.go:103 +0x32a
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        created by testing.(*T).Run
                /usr/lib/go/src/testing/testing.go:1629 +0x3ea
        [originating from goroutine 1]:
        testing.(*T).Run(...)
                /usr/lib/go/src/testing/testing.go:1630 +0x3ea
        testing.runTests.func1(...)
                /usr/lib/go/src/testing/testing.go:2035 +0x45
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        testing.runTests(...)
                /usr/lib/go/src/testing/testing.go:2040 +0x489
        testing.(*M).Run(...)
                /usr/lib/go/src/testing/testing.go:1906 +0x63a
        github.com/elastic/apm-server/systemtest.TestMain(...)
                /apm-server/systemtest/main_test.go:80 +0x118
        reflect.ValueOf(...)
                /usr/lib/go/src/reflect/value.go:3148 +0x1d3
        ]
```

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
