### PR TITLE
.github: unrevert notification change

### DIFF
--- a/.github/workflows/update-beats.yml
+++ b/.github/workflows/update-beats.yml
@@ -37,7 +37,7 @@ jobs:
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: ./.ci/update-beats.yml
-      - if: always()
+      - if: failure()
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
         with:
           vaultUrl: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
Redo https://github.com/elastic/apm-server/pull/10294, which seems to have been reverted in a merge.