### PR TITLE
ci: remove update-beats daily from Jenkins

### DIFF
--- a/.ci/schedule-daily.groovy
+++ b/.ci/schedule-daily.groovy
@@ -20,7 +20,6 @@ pipeline {
   stages {
     stage('Nighly update Beats builds') {
       steps {
-        updateBeatsBuilds(branches: ['main', '8.<minor>', '8.<next-patch>', '7.<minor>'])
         runWindowsBuilds(branches: ['main', '8.<minor>', '8.<next-patch>', '7.<minor>'])
         runSmokeTestsOs(branches: ['main', '8.<minor>', '8.<next-patch>'])
         runSmokeTestsEss(branches: ['main'])
@@ -31,13 +30,6 @@ pipeline {
     cleanup {
       notifyBuildResult(prComment: false)
     }
-  }
-}
-
-def updateBeatsBuilds(Map args = [:]) {
-  def branches = getBranchesFromAliases(aliases: args.branches)
-  branches.each { branch ->
-    build(job: "apm-server/update-beats-mbp/${branch}", wait: false, propagate: false)
   }
 }
 


### PR DESCRIPTION
## Motivation/summary

Update Beats is not anymore a Jenkins specific task but an updatecli CI agnostic running on GitHub actions.

## Related issues

Leftover from https://github.com/elastic/apm-server/pull/10179
