### PR TITLE
fix: invert args order for prefix check in deprecation notice

### DIFF
--- a/internal/beatcmd/beat.go
+++ b/internal/beatcmd/beat.go
@@ -270,7 +270,7 @@ func (b *Beat) Run(ctx context.Context) error {
 	if runtime.GOOS == "darwin" {
 		if host, err := sysinfo.Host(); err != nil {
 			logger.Warnf("failed to retrieve kernel version, ignoring potential deprecation warning: %v", err)
-		} else if strings.HasPrefix("19.", host.Info().KernelVersion) {
+		} else if strings.HasPrefix(host.Info().KernelVersion, "19.") {
 			// macOS 10.15.x (catalina) means darwin kernel 19.y
 			logger.Warn("deprecation notice: support for macOS 10.15 will be removed in an upcoming version")
 		}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

_Recalling the exact syntax for the built-in stab() function, you make a sane assumption and call shoot(GUN, FOOT); The foot shoots your gun_

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
