### PR TITLE
test: always close agent container, even if the test did not fail

### DIFF
--- a/systemtest/fleet_test.go
+++ b/systemtest/fleet_test.go
@@ -182,6 +182,7 @@ func newAPMIntegrationConfig(t testing.TB, vars, config map[string]interface{}) 
 	agent.Stderr = &output
 	agent.FleetEnrollmentToken = enrollmentAPIKey.APIKey
 	t.Cleanup(func() {
+		defer agent.Close()
 		// Log the elastic-agent container output if the test fails.
 		if !t.Failed() {
 			return
@@ -192,7 +193,6 @@ func newAPMIntegrationConfig(t testing.TB, vars, config map[string]interface{}) 
 			io.Copy(os.Stdout, log)
 			log.Close()
 		}
-		agent.Close()
 	})
 
 	// Start elastic-agent with port 8200 exposed, and wait for the server to service


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

The `copyLogs` goroutine was leaking along with the agent docker container.
The goroutine would block reading the container logs: 
https://github.com/elastic/apm-server/blob/95a10bf326c6982bd19a89f2654a8b0a5c1ee59b/systemtest/containers.go#L409

Note the usage of `Follow: true` in the log options.

Stacktrace of the leaking goroutine:

```
         Goroutine 117 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
        goroutine 117 [IO wait]:
        internal/poll.runtime_pollWait(0x7fc6e880f190, 0x72)
                /usr/lib/go/src/runtime/netpoll.go:306 +0x89
        internal/poll.(*pollDesc).wait(0xc0002cbe00?, 0xc0005f5000?, 0x0)
                /usr/lib/go/src/internal/poll/fd_poll_runtime.go:84 +0x32
        internal/poll.(*pollDesc).waitRead(...)
                /usr/lib/go/src/internal/poll/fd_poll_runtime.go:89
        internal/poll.(*FD).Read(0xc0002cbe00, {0xc0005f5000, 0x1000, 0x1000})
                /usr/lib/go/src/internal/poll/fd_unix.go:167 +0x299
        net.(*netFD).Read(0xc0002cbe00, {0xc0005f5000?, 0xe03a56c402875587?, 0x4?})
                /usr/lib/go/src/net/fd_posix.go:55 +0x29
        net.(*conn).Read(0xc000016f90, {0xc0005f5000?, 0xc000137a48?, 0x7?})
                /usr/lib/go/src/net/net.go:183 +0x45
        net/http.(*persistConn).Read(0xc0005cac60, {0xc0005f5000?, 0x0?, 0x0?})
                /usr/lib/go/src/net/http/transport.go:1943 +0x4e
        bufio.(*Reader).fill(0xc0005cd020)
                /usr/lib/go/src/bufio/bufio.go:106 +0xff
        bufio.(*Reader).ReadSlice(0xc0005cd020, 0x3?)
                /usr/lib/go/src/bufio/bufio.go:372 +0x2f
        net/http/internal.readChunkLine(0xc0005f51f0?)
                /usr/lib/go/src/net/http/internal/chunked.go:129 +0x25
        net/http/internal.(*chunkedReader).beginChunk(0xc0005e8f00)
                /usr/lib/go/src/net/http/internal/chunked.go:48 +0x28
        net/http/internal.(*chunkedReader).Read(0xc0005e8f00, {0xc000986000?, 0x417900?, 0x20000?})
                /usr/lib/go/src/net/http/internal/chunked.go:98 +0x156
        net/http.(*body).readLocked(0xc0005ee3c0, {0xc000986000?, 0x0?, 0x418eee?})
                /usr/lib/go/src/net/http/transfer.go:839 +0x3c
        net/http.(*body).Read(0x1472350?, {0xc000986000?, 0x51412f?, 0xc000296000?})
                /usr/lib/go/src/net/http/transfer.go:831 +0x125
        net/http.(*bodyEOFSignal).Read(0xc0005ee400, {0xc000986000, 0x8009, 0x8009})
                /usr/lib/go/src/net/http/transport.go:2792 +0x142
        github.com/docker/docker/pkg/stdcopy.StdCopy({0x15a8600, 0xc00037c930}, {0x15a8600, 0xc00037c930}, {0x15aaf20, 0xc0005ee400})
                /go/pkg/mod/github.com/docker/docker@v20.10.17+incompatible/pkg/stdcopy/stdcopy.go:108 +0x444
        github.com/elastic/apm-server/systemtest.(*ElasticAgentContainer).copyLogs(0xc0001c4800, {0x15a8600, 0xc00037c930}, {0x15a8600?, 0xc00037c930})
                /apm-server/systemtest/containers.go:409 +0x305
        github.com/elastic/apm-server/systemtest.(*ElasticAgentContainer).Start.func1()
                /apm-server/systemtest/containers.go:348 +0xb7
        created by github.com/elastic/apm-server/systemtest.(*ElasticAgentContainer).Start
                /apm-server/systemtest/containers.go:338 +0x505
        [originating from goroutine 78]:
        github.com/elastic/apm-server/systemtest.(*ElasticAgentContainer).Start(...)
                /apm-server/systemtest/containers.go:352 +0x505
        github.com/elastic/apm-server/systemtest_test.newAPMIntegrationConfig(...)
                /apm-server/systemtest/fleet_test.go:207 +0x41a
        github.com/elastic/apm-server/systemtest_test.TestFleetIntegration(...)
                /apm-server/systemtest/fleet_test.go:50 +0xaa
        github.com/elastic/apm-server/systemtest_test.newAPMIntegration(...)
                /apm-server/systemtest/fleet_test.go:175 +0x91
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        created by testing.(*T).Run
                /usr/lib/go/src/testing/testing.go:1629 +0x3ea
        [originating from goroutine 1]:
        testing.(*T).Run(...)
                /usr/lib/go/src/testing/testing.go:1630 +0x3ea
        testing.runTests.func1(...)
                /usr/lib/go/src/testing/testing.go:2035 +0x45
        testing.tRunner(...)
                /usr/lib/go/src/testing/testing.go:1579 +0x10b
        testing.runTests(...)
                /usr/lib/go/src/testing/testing.go:2040 +0x489
        testing.(*M).Run(...)
                /usr/lib/go/src/testing/testing.go:1906 +0x63a
        github.com/elastic/apm-server/systemtest.TestMain(...)
                /apm-server/systemtest/main_test.go:80 +0x118
        reflect.ValueOf(...)
                /usr/lib/go/src/reflect/value.go:3148 +0x1d3
```



## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
