### PR TITLE
.ci: fix update-beats branch condition

### DIFF
--- a/.ci/update-beats.yml
+++ b/.ci/update-beats.yml
@@ -37,6 +37,7 @@ conditions:
     name: Check beats version
     kind: shell
     sourceid: beats
+    disablesourceinput: true
     spec:
       command: grep "BEATS_VERSION?={{ requiredEnv "BRANCH_NAME" }}" Makefile
 


### PR DESCRIPTION
Set `disablesourceinput: true` on the update-beats branch condition to stop the commit hash being added to the command line.