### PR TITLE
.ci: fix update-beats branch condition, take 2

### DIFF
--- a/.ci/update-beats.yml
+++ b/.ci/update-beats.yml
@@ -36,7 +36,6 @@ conditions:
   beats-version-check:
     name: Check beats version
     kind: shell
-    sourceid: beats
     disablesourceinput: true
     spec:
       command: grep "BEATS_VERSION?={{ requiredEnv "BRANCH_NAME" }}" Makefile


### PR DESCRIPTION
Remove `sourceid`, incompatible with `disablesourceinput`.