### PR TITLE
chore: bring up to date `apm-server.yml` 

### DIFF
--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -275,33 +275,6 @@ apm-server:
     # Configure curve types for ECDHE based cipher suites.
     #ssl.curve_types: []
 
-#================================= General =================================
-
-# Data is buffered in a memory queue before it is published to the configured output.
-# The memory queue will present all available events (up to the outputs
-# bulk_max_size) to the output, the moment the output is ready to serve
-# another batch of events.
-#queue:
-  # Queue type by name (default 'mem').
-  #mem:
-    # Max number of events the queue can buffer.
-    #events: 4096
-
-    # Hints the minimum number of events stored in the queue,
-    # before providing a batch of events to the outputs.
-    # The default value is set to 2048.
-    # A value of 0 ensures events are immediately available
-    # to be sent to the outputs.
-    #flush.min_events: 2048
-
-    # Maximum duration after which events are available to the outputs,
-    # if the number of events stored in the queue is < `flush.min_events`.
-    #flush.timeout: 1s
-
-# Sets the maximum number of CPUs that can be executing simultaneously. The
-# default is the number of logical CPUs available in the system.
-#max_procs:
-
 #============================= Elastic Cloud =============================
 
 # These settings simplify using APM Server with the Elastic Cloud (https://cloud.elastic.co/).
@@ -340,14 +313,6 @@ output.elasticsearch:
   #username: "elastic"
   #password: "changeme"
 
-  # Dictionary of HTTP parameters to pass within the url with index operations.
-  #parameters:
-    #param1: value1
-    #param2: value2
-
-  # Number of workers per Elasticsearch host.
-  #worker: 1
-
   # Optional HTTP Path.
   #path: "/elasticsearch"
 
@@ -363,10 +328,6 @@ output.elasticsearch:
   # dropped. The default is 3.
   #max_retries: 3
 
-  # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
-  # The default is 50.
-  #bulk_max_size: 50
-
   # The number of seconds to wait before trying to reconnect to Elasticsearch
   # after a network error. After waiting backoff.init seconds, apm-server
   # tries to reconnect. If the attempt fails, the backoff timer is increased
@@ -380,6 +341,14 @@ output.elasticsearch:
 
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
+
+  # The bulk request size threshold, in bytes, before flushing to Elasticsearch.
+  # The value must have a suffix, e.g. `"2MB"`. The default is `1MB`.
+  #flush_bytes: 1MB
+
+  # The maximum duration to accumulate events for a bulk request before being flushed to Elasticsearch.
+  # The value must have a duration suffix, e.g. `"5s"`. The default is `1s`.
+  #flush_interval: 1s
 
   # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
   #ssl.enabled: true
@@ -429,27 +398,6 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
-
-  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
-  #kerberos.enabled: true
-
-  # Authentication type to use with Kerberos. Available options: keytab, password.
-  #kerberos.auth_type: password
-
-  # Path to the keytab file. It is used when auth_type is set to keytab.
-  #kerberos.keytab: /etc/elastic.keytab
-
-  # Path to the Kerberos configuration.
-  #kerberos.config_path: /etc/krb5.conf
-
-  # Name of the Kerberos user.
-  #kerberos.username: elastic
-
-  # Password of the Kerberos user. It is used when auth_type is set to password.
-  #kerberos.password: changeme
-
-  # Kerberos realm.
-  #kerberos.realm: ELASTIC
 
 
 #----------------------------- Console output -----------------------------
@@ -903,11 +851,6 @@ output.elasticsearch:
   # Set gzip compression level.
   #compression_level: 0
 
-  # Dictionary of HTTP parameters to pass within the URL with index operations.
-  #parameters:
-    #param1: value1
-    #param2: value2
-
   # Custom HTTP headers to add to each request.
   #headers:
   #  X-My-Header: Contents of the header
@@ -919,10 +862,6 @@ output.elasticsearch:
   # the indexing operation doesn't succeed after this many retries, the events are
   # dropped. The default is 3.
   #max_retries: 3
-
-  # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
-  # The default is 50.
-  #bulk_max_size: 50
 
   # The number of seconds to wait before trying to reconnect to Elasticsearch
   # after a network error. After waiting backoff.init seconds, apm-server
@@ -986,27 +925,6 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
-
-  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
-  #kerberos.enabled: true
-
-  # Authentication type to use with Kerberos. Available options: keytab, password.
-  #kerberos.auth_type: password
-
-  # Path to the keytab file. It is used when auth_type is set to keytab.
-  #kerberos.keytab: /etc/elastic.keytab
-
-  # Path to the Kerberos configuration.
-  #kerberos.config_path: /etc/krb5.conf
-
-  # Name of the Kerberos user.
-  #kerberos.username: elastic
-
-  # Password of the Kerberos user. It is used when auth_type is set to password.
-  #kerberos.password: changeme
-
-  # Kerberos realm.
-  #kerberos.realm: ELASTIC
 
   #metrics.period: 10s
   #state.period: 1m

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -342,6 +342,14 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
+  # The bulk request size threshold, in bytes, before flushing to {es}.
+  # The value must have a suffix, e.g. `"1MB"`. The default is `5MB`.
+  #flush_bytes: 5MB
+
+  # The maximum duration to accumulate events for a bulk request before being flushed to {es}.
+  # The value must have a duration suffix, e.g. `"5s"`. The default is `1s`.
+  #flush_interval: 1s
+
   # Enable custom SSL settings. Set to false to ignore custom SSL settings for secure communication.
   #ssl.enabled: true
 

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -342,11 +342,11 @@ output.elasticsearch:
   # Configure http request timeout before failing an request to Elasticsearch.
   #timeout: 90
 
-  # The bulk request size threshold, in bytes, before flushing to {es}.
-  # The value must have a suffix, e.g. `"1MB"`. The default is `5MB`.
-  #flush_bytes: 5MB
+  # The bulk request size threshold, in bytes, before flushing to Elasticsearch.
+  # The value must have a suffix, e.g. `"2MB"`. The default is `1MB`.
+  #flush_bytes: 1MB
 
-  # The maximum duration to accumulate events for a bulk request before being flushed to {es}.
+  # The maximum duration to accumulate events for a bulk request before being flushed to Elasticsearch.
   # The value must have a duration suffix, e.g. `"5s"`. The default is `1s`.
   #flush_interval: 1s
 

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -275,33 +275,6 @@ apm-server:
     # Configure curve types for ECDHE based cipher suites.
     #ssl.curve_types: []
 
-#================================= General =================================
-
-# Data is buffered in a memory queue before it is published to the configured output.
-# The memory queue will present all available events (up to the outputs
-# bulk_max_size) to the output, the moment the output is ready to serve
-# another batch of events.
-#queue:
-  # Queue type by name (default 'mem').
-  #mem:
-    # Max number of events the queue can buffer.
-    #events: 4096
-
-    # Hints the minimum number of events stored in the queue,
-    # before providing a batch of events to the outputs.
-    # The default value is set to 2048.
-    # A value of 0 ensures events are immediately available
-    # to be sent to the outputs.
-    #flush.min_events: 2048
-
-    # Maximum duration after which events are available to the outputs,
-    # if the number of events stored in the queue is < `flush.min_events`.
-    #flush.timeout: 1s
-
-# Sets the maximum number of CPUs that can be executing simultaneously. The
-# default is the number of logical CPUs available in the system.
-#max_procs:
-
 #============================= Elastic Cloud =============================
 
 # These settings simplify using APM Server with the Elastic Cloud (https://cloud.elastic.co/).
@@ -340,14 +313,6 @@ output.elasticsearch:
   #username: "elastic"
   #password: "changeme"
 
-  # Dictionary of HTTP parameters to pass within the url with index operations.
-  #parameters:
-    #param1: value1
-    #param2: value2
-
-  # Number of workers per Elasticsearch host.
-  #worker: 1
-
   # Optional HTTP Path.
   #path: "/elasticsearch"
 
@@ -362,10 +327,6 @@ output.elasticsearch:
   # the indexing operation doesn't succeed after this many retries, the events are
   # dropped. The default is 3.
   #max_retries: 3
-
-  # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
-  # The default is 50.
-  #bulk_max_size: 50
 
   # The number of seconds to wait before trying to reconnect to Elasticsearch
   # after a network error. After waiting backoff.init seconds, apm-server
@@ -429,27 +390,6 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
-
-  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
-  #kerberos.enabled: true
-
-  # Authentication type to use with Kerberos. Available options: keytab, password.
-  #kerberos.auth_type: password
-
-  # Path to the keytab file. It is used when auth_type is set to keytab.
-  #kerberos.keytab: /etc/elastic.keytab
-
-  # Path to the Kerberos configuration.
-  #kerberos.config_path: /etc/krb5.conf
-
-  # Name of the Kerberos user.
-  #kerberos.username: elastic
-
-  # Password of the Kerberos user. It is used when auth_type is set to password.
-  #kerberos.password: changeme
-
-  # Kerberos realm.
-  #kerberos.realm: ELASTIC
 
 
 #----------------------------- Console output -----------------------------
@@ -903,11 +843,6 @@ output.elasticsearch:
   # Set gzip compression level.
   #compression_level: 0
 
-  # Dictionary of HTTP parameters to pass within the URL with index operations.
-  #parameters:
-    #param1: value1
-    #param2: value2
-
   # Custom HTTP headers to add to each request.
   #headers:
   #  X-My-Header: Contents of the header
@@ -919,10 +854,6 @@ output.elasticsearch:
   # the indexing operation doesn't succeed after this many retries, the events are
   # dropped. The default is 3.
   #max_retries: 3
-
-  # The maximum number of events to bulk in a single Elasticsearch bulk API index request.
-  # The default is 50.
-  #bulk_max_size: 50
 
   # The number of seconds to wait before trying to reconnect to Elasticsearch
   # after a network error. After waiting backoff.init seconds, apm-server
@@ -986,27 +917,6 @@ output.elasticsearch:
   # Configure what types of renegotiation are supported. Valid options are
   # never, once, and freely. Default is never.
   #ssl.renegotiation: never
-
-  # Enable Kerberos support. Kerberos is automatically enabled if any Kerberos setting is set.
-  #kerberos.enabled: true
-
-  # Authentication type to use with Kerberos. Available options: keytab, password.
-  #kerberos.auth_type: password
-
-  # Path to the keytab file. It is used when auth_type is set to keytab.
-  #kerberos.keytab: /etc/elastic.keytab
-
-  # Path to the Kerberos configuration.
-  #kerberos.config_path: /etc/krb5.conf
-
-  # Name of the Kerberos user.
-  #kerberos.username: elastic
-
-  # Password of the Kerberos user. It is used when auth_type is set to password.
-  #kerberos.password: changeme
-
-  # Kerberos realm.
-  #kerberos.realm: ELASTIC
 
   #metrics.period: 10s
   #state.period: 1m

--- a/docs/legacy/copied-from-beats/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/docs/legacy/copied-from-beats/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -434,7 +434,7 @@ endif::[]
 ===== `flush_bytes`
 
 The bulk request size threshold, in bytes, before flushing to {es}.
-The value must have a suffix, e.g. `"1MB"`. The default is `5MB`.
+The value must have a suffix, e.g. `"2MB"`. The default is `1MB`.
 
 ===== `flush_interval`
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
There have been config changes but not all the changes were reflected in `apm-server.yml` so it needed to be brought up to date.

### Removed:
- `queue.*`
- `max_procs`
- `output.elasticsearch.parameters`, `output.elasticsearch.worker`, `output.elasticsearch.bulk_max_size`, `output.elasticsearch.kerberos`
- `monitoring.elasticsearch.parameters`, `monitoring.elasticsearch.bulk_max_size`, `monitoring.elasticsearch.kerberos`

### Added:
- `output.elasticsearch.flush_bytes`
- `output.elasticsearch.flush_interval`

In addition to that, as [requested](https://github.com/elastic/apm-server/issues/10150#issuecomment-1435938582), I've tested whether `cloud.id` and `cloud.auth` still works or not. I verified that it still works since I was able to send data to Elasticsearch from my local apm-server using those credentials.

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->


## Related issues
closes https://github.com/elastic/apm-server/issues/10150
<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
