### PR TITLE
.ci: fix update-beats branch condition, take 3

### DIFF
--- a/.ci/update-beats.yml
+++ b/.ci/update-beats.yml
@@ -32,14 +32,6 @@ sources:
       key: '.[0].sha'
 
 
-conditions:
-  beats-version-check:
-    name: Check beats version
-    kind: shell
-    disablesourceinput: true
-    spec:
-      command: grep "BEATS_VERSION?={{ requiredEnv "BRANCH_NAME" }}" Makefile
-
 targets:
   beats:
     name: 'Update to elastic/beats@{{ source "beats" }}'


### PR DESCRIPTION
Remove the condition altogether. The Github Action already checks which branches are active releases. If we should still have this check, I think it should be a separate Github Action step, and not an updatecli condition.