### PR TITLE
mage: set safe.directory for crossbuild

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -72,6 +72,15 @@ func Build() error {
 // GolangCrossBuild build the Beat binary inside of the golang-builder.
 // Do not use directly, use crossBuild instead.
 func GolangCrossBuild() error {
+	// beats/dev-tools sets the *beats* directory as a safe directory,
+	// we need to do the same for apm-server since we're out of tree.
+	repo, err := mage.GetProjectRepoInfo()
+	if err != nil {
+		panic(err)
+	}
+	if err := sh.Run("git", "config", "--global", "--add", "safe.directory", repo.RootDir); err != nil {
+		return err
+	}
 	return mage.GolangCrossBuild(mage.DefaultGolangCrossBuildArgs())
 }
 


### PR DESCRIPTION
## Motivation/summary

Like https://github.com/elastic/beats/pull/34614, but for the apm-server directory. Works around strict directory ownership checks that fail in the Docker crossbuild image. Only relevant to the 7.17 branch.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

`SNAPSHOT=true PLATFORMS=darwin/amd64 TYPES=docker mage package`

## Related issues

None