### PR TITLE
Terraform: Pin version to `0.5.1` for now

### DIFF
--- a/testing/benchmark/main.tf
+++ b/testing/benchmark/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = ">=0.5.0"
+      version = "0.5.1"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/testing/cloud/main.tf
+++ b/testing/cloud/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = ">=0.5.0"
+      version = "0.5.1"
     }
   }
 }

--- a/testing/infra/terraform/modules/ec_deployment/terraform.tf
+++ b/testing/infra/terraform/modules/ec_deployment/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = ">=0.5.0"
+      version = "0.5.1"
     }
   }
 }

--- a/testing/rally-cloud/main.tf
+++ b/testing/rally-cloud/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     ec = {
       source  = "elastic/ec"
-      version = ">=0.5.0"
+      version = "0.5.1"
     }
   }
 }

--- a/testing/smoke/main.tf
+++ b/testing/smoke/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = ">=0.5.0"
+      version = "0.5.1"
     }
   }
 }

--- a/testing/smoke/supported-os/main.tf
+++ b/testing/smoke/supported-os/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ec = {
       source  = "elastic/ec"
-      version = ">=0.4.1"
+      version = "0.5.1"
     }
   }
 }


### PR DESCRIPTION
Avoid a bunch of automated failures due to a breaking 0.6.0 version of the provider being available
