### PR TITLE
fix: re-add max-procs to config options

### DIFF
--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -275,6 +275,10 @@ apm-server:
     # Configure curve types for ECDHE based cipher suites.
     #ssl.curve_types: []
 
+# Sets the maximum number of CPUs that can be executing simultaneously. The
+# default is the number of logical CPUs available in the system.
+#max_procs:
+
 #============================= Elastic Cloud =============================
 
 # These settings simplify using APM Server with the Elastic Cloud (https://cloud.elastic.co/).

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -275,6 +275,10 @@ apm-server:
     # Configure curve types for ECDHE based cipher suites.
     #ssl.curve_types: []
 
+# Sets the maximum number of CPUs that can be executing simultaneously. The
+# default is the number of logical CPUs available in the system.
+#max_procs:
+
 #============================= Elastic Cloud =============================
 
 # These settings simplify using APM Server with the Elastic Cloud (https://cloud.elastic.co/).


### PR DESCRIPTION

## Motivation/summary

Re-add `max-procs` to the yml file. 
<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->


## Related issues

Addressing https://github.com/elastic/apm-server/issues/10150#issuecomment-1451277028