### PR TITLE
10m,60m metrics: Update delete phase to 180d, 390d

### DIFF
--- a/apmpackage/apm/data_stream/service_destination_interval_metrics/elasticsearch/ilm/default_policy.10m.json
+++ b/apmpackage/apm/data_stream/service_destination_interval_metrics/elasticsearch/ilm/default_policy.10m.json
@@ -13,7 +13,7 @@
                 }
             },
             "delete": {
-                "min_age": "120d",
+                "min_age": "180d",
                 "actions": {
                     "delete": {}
                 }

--- a/apmpackage/apm/data_stream/service_destination_interval_metrics/elasticsearch/ilm/default_policy.60m.json
+++ b/apmpackage/apm/data_stream/service_destination_interval_metrics/elasticsearch/ilm/default_policy.60m.json
@@ -13,7 +13,7 @@
                 }
             },
             "delete": {
-                "min_age": "240d",
+                "min_age": "390d",
                 "actions": {
                     "delete": {}
                 }

--- a/apmpackage/apm/data_stream/service_summary_interval_metrics/elasticsearch/ilm/default_policy.10m.json
+++ b/apmpackage/apm/data_stream/service_summary_interval_metrics/elasticsearch/ilm/default_policy.10m.json
@@ -13,7 +13,7 @@
                 }
             },
             "delete": {
-                "min_age": "120d",
+                "min_age": "180d",
                 "actions": {
                     "delete": {}
                 }

--- a/apmpackage/apm/data_stream/service_summary_interval_metrics/elasticsearch/ilm/default_policy.60m.json
+++ b/apmpackage/apm/data_stream/service_summary_interval_metrics/elasticsearch/ilm/default_policy.60m.json
@@ -13,7 +13,7 @@
                 }
             },
             "delete": {
-                "min_age": "240d",
+                "min_age": "390d",
                 "actions": {
                     "delete": {}
                 }

--- a/apmpackage/apm/data_stream/service_transaction_interval_metrics/elasticsearch/ilm/default_policy.10m.json
+++ b/apmpackage/apm/data_stream/service_transaction_interval_metrics/elasticsearch/ilm/default_policy.10m.json
@@ -13,7 +13,7 @@
                 }
             },
             "delete": {
-                "min_age": "120d",
+                "min_age": "180d",
                 "actions": {
                     "delete": {}
                 }

--- a/apmpackage/apm/data_stream/service_transaction_interval_metrics/elasticsearch/ilm/default_policy.60m.json
+++ b/apmpackage/apm/data_stream/service_transaction_interval_metrics/elasticsearch/ilm/default_policy.60m.json
@@ -13,7 +13,7 @@
                 }
             },
             "delete": {
-                "min_age": "240d",
+                "min_age": "390d",
                 "actions": {
                     "delete": {}
                 }

--- a/apmpackage/apm/data_stream/transaction_interval_metrics/elasticsearch/ilm/default_policy.10m.json
+++ b/apmpackage/apm/data_stream/transaction_interval_metrics/elasticsearch/ilm/default_policy.10m.json
@@ -13,7 +13,7 @@
                 }
             },
             "delete": {
-                "min_age": "120d",
+                "min_age": "180d",
                 "actions": {
                     "delete": {}
                 }

--- a/apmpackage/apm/data_stream/transaction_interval_metrics/elasticsearch/ilm/default_policy.60m.json
+++ b/apmpackage/apm/data_stream/transaction_interval_metrics/elasticsearch/ilm/default_policy.60m.json
@@ -13,7 +13,7 @@
                 }
             },
             "delete": {
-                "min_age": "240d",
+                "min_age": "390d",
                 "actions": {
                     "delete": {}
                 }


### PR DESCRIPTION
## Motivation/summary

Updates the 10m and 60m delete phase for all the "rolled up" aggregated metrics to 180d and 390d respectively:

    - service_destination
    - service_summary
    - service_transaction
    - transaction

## How to test these changes

Install the APM package and validate that the ILM policies delete phase are correct.
