### PR TITLE
feat: stores app logs in service-specific data stream

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -288,11 +288,11 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/apm-data
-Version: v0.1.1-0.20230223083125-b7f31c1a6768
+Version: v0.1.1-0.20230306102740-534660e4a151
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/apm-data@v0.1.1-0.20230223083125-b7f31c1a6768/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/apm-data@v0.1.1-0.20230306102740-534660e4a151/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -288,11 +288,11 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/apm-data
-Version: v0.1.1-0.20230306102740-534660e4a151
+Version: v0.1.1-0.20230309014206-3ad1a5caedc9
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/apm-data@v0.1.1-0.20230306102740-534660e4a151/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/apm-data@v0.1.1-0.20230309014206-3ad1a5caedc9/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -1,6 +1,6 @@
 - version: "generated"
   changes:
-    - description: Introduce apm logs data streams per service
+    - description: Store app logs into service-specific data streams
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/10456
 - version: "8.7.0"

--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -1,8 +1,8 @@
 - version: "generated"
   changes:
-    - description: Placeholder
+    - description: Introduce apm logs data streams per service
       type: enhancement
-      link: https://github.com/elastic/apm-server/pull/123
+      link: https://github.com/elastic/apm-server/pull/10456
 - version: "8.7.0"
   changes:
     - description: Introduce `metrics-apm.service-${interval}` data stream for service metrics (`1m`, `10m` and `60m`).

--- a/apmpackage/apm/data_stream/app_logs/manifest.yml
+++ b/apmpackage/apm/data_stream/app_logs/manifest.yml
@@ -1,6 +1,7 @@
 title: APM application logs
 type: logs
 dataset: apm.app
+dataset_is_prefix: true
 ilm_policy: logs-apm.app_logs-default_policy
 elasticsearch:
   index_template:

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -5,6 +5,7 @@ https://github.com/elastic/apm-server/compare/8.7\...main[View commits]
 
 [float]
 ==== Breaking Changes
+- Store app logs into service-specific data streams{pull}10456[10456]
 
 [float]
 ==== Deprecations

--- a/docs/data-streams.asciidoc
+++ b/docs/data-streams.asciidoc
@@ -82,6 +82,7 @@ Logs are stored in the following data streams:
 +
 // tag::logs-data-streams[]
 - APM error/exception logging: `logs-apm.error-<namespace>`
+- APM app logging: `logs-apm.app.<service.name>-<namespace>`
 // end::logs-data-streams[]
 
 [discrete]

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/dgraph-io/badger/v2 v2.2007.3-0.20201012072640-f5a7e0a1c83b
 	github.com/dustin/go-humanize v1.0.0
-	github.com/elastic/apm-data v0.1.1-0.20230306102740-534660e4a151
+	github.com/elastic/apm-data v0.1.1-0.20230309014206-3ad1a5caedc9
 	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230308093856-88b1cacdb103
 	github.com/elastic/elastic-agent-client/v7 v7.0.3
 	github.com/elastic/elastic-agent-libs v0.3.3

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/dgraph-io/badger/v2 v2.2007.3-0.20201012072640-f5a7e0a1c83b
 	github.com/dustin/go-humanize v1.0.0
-	github.com/elastic/apm-data v0.1.1-0.20230223083125-b7f31c1a6768
+	github.com/elastic/apm-data v0.1.1-0.20230306102740-534660e4a151
 	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230308093856-88b1cacdb103
 	github.com/elastic/elastic-agent-client/v7 v7.0.3
 	github.com/elastic/elastic-agent-libs v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -348,6 +348,8 @@ github.com/elastic/apm-data v0.1.1-0.20230223083125-b7f31c1a6768 h1:NdAseK5+GCJ6
 github.com/elastic/apm-data v0.1.1-0.20230223083125-b7f31c1a6768/go.mod h1:8oEk/myQSw+GHqxPD3e8Oz2qPMawcOH+t9HYZ51p+rE=
 github.com/elastic/apm-data v0.1.1-0.20230306102740-534660e4a151 h1:oD1mWvRXMXMizTpikVgKXj5VIn6/GXm8QZGyC3oKWL4=
 github.com/elastic/apm-data v0.1.1-0.20230306102740-534660e4a151/go.mod h1:8oEk/myQSw+GHqxPD3e8Oz2qPMawcOH+t9HYZ51p+rE=
+github.com/elastic/apm-data v0.1.1-0.20230309014206-3ad1a5caedc9 h1:nj0nBnU3hI/h3s4+6CnyOTcQqwH7U6y/2i1XM44wOaU=
+github.com/elastic/apm-data v0.1.1-0.20230309014206-3ad1a5caedc9/go.mod h1:8oEk/myQSw+GHqxPD3e8Oz2qPMawcOH+t9HYZ51p+rE=
 github.com/elastic/bayeux v1.0.5 h1:UceFq01ipmT3S8DzFK+uVAkbCdiPR0Bqei8qIGmUeY0=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230308093856-88b1cacdb103 h1:B/31FLQzrRg8bWqUfs+CplgkB/UacXfTrl/e9HQy1Zg=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230308093856-88b1cacdb103/go.mod h1:5B9LEX2eUXlvjtyouE4x58EEOIcGH1mu+HH/5daM67Y=

--- a/go.sum
+++ b/go.sum
@@ -346,6 +346,8 @@ github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFP
 github.com/eclipse/paho.mqtt.golang v1.3.5 h1:sWtmgNxYM9P2sP+xEItMozsR3w0cqZFlqnNN1bdl41Y=
 github.com/elastic/apm-data v0.1.1-0.20230223083125-b7f31c1a6768 h1:NdAseK5+GCJ6GjORNrg36ALFDwUPUJAUHgRXZWtyMRg=
 github.com/elastic/apm-data v0.1.1-0.20230223083125-b7f31c1a6768/go.mod h1:8oEk/myQSw+GHqxPD3e8Oz2qPMawcOH+t9HYZ51p+rE=
+github.com/elastic/apm-data v0.1.1-0.20230306102740-534660e4a151 h1:oD1mWvRXMXMizTpikVgKXj5VIn6/GXm8QZGyC3oKWL4=
+github.com/elastic/apm-data v0.1.1-0.20230306102740-534660e4a151/go.mod h1:8oEk/myQSw+GHqxPD3e8Oz2qPMawcOH+t9HYZ51p+rE=
 github.com/elastic/bayeux v1.0.5 h1:UceFq01ipmT3S8DzFK+uVAkbCdiPR0Bqei8qIGmUeY0=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230308093856-88b1cacdb103 h1:B/31FLQzrRg8bWqUfs+CplgkB/UacXfTrl/e9HQy1Zg=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230308093856-88b1cacdb103/go.mod h1:5B9LEX2eUXlvjtyouE4x58EEOIcGH1mu+HH/5daM67Y=

--- a/systemtest/approvals/TestIntakeLog/with_faas.approved.json
+++ b/systemtest/approvals/TestIntakeLog/with_faas.approved.json
@@ -10,7 +10,7 @@
             "container": {
                 "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
             },
-            "data_stream.dataset": "apm.app",
+            "data_stream.dataset": "apm.app.1234_service_12a3",
             "data_stream.namespace": "default",
             "data_stream.type": "logs",
             "event": {

--- a/systemtest/approvals/TestIntakeLog/with_flat_ecs_fields.approved.json
+++ b/systemtest/approvals/TestIntakeLog/with_flat_ecs_fields.approved.json
@@ -10,7 +10,7 @@
             "container": {
                 "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
             },
-            "data_stream.dataset": "apm.app",
+            "data_stream.dataset": "apm.app.testsvc",
             "data_stream.namespace": "default",
             "data_stream.type": "logs",
             "event": {

--- a/systemtest/approvals/TestIntakeLog/with_nested_ecs_fields.approved.json
+++ b/systemtest/approvals/TestIntakeLog/with_nested_ecs_fields.approved.json
@@ -10,7 +10,7 @@
             "container": {
                 "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
             },
-            "data_stream.dataset": "apm.app",
+            "data_stream.dataset": "apm.app.testsvc",
             "data_stream.namespace": "default",
             "data_stream.type": "logs",
             "event": {

--- a/systemtest/approvals/TestIntakeLog/with_nested_ecs_fields_overrides_flat_fields.approved.json
+++ b/systemtest/approvals/TestIntakeLog/with_nested_ecs_fields_overrides_flat_fields.approved.json
@@ -10,7 +10,7 @@
             "container": {
                 "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
             },
-            "data_stream.dataset": "apm.app",
+            "data_stream.dataset": "apm.app.testsvc",
             "data_stream.namespace": "default",
             "data_stream.type": "logs",
             "event": {

--- a/systemtest/approvals/TestIntakeLog/with_timestamp.approved.json
+++ b/systemtest/approvals/TestIntakeLog/with_timestamp.approved.json
@@ -10,7 +10,7 @@
             "container": {
                 "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
             },
-            "data_stream.dataset": "apm.app",
+            "data_stream.dataset": "apm.app.1234_service_12a3",
             "data_stream.namespace": "default",
             "data_stream.type": "logs",
             "event": {

--- a/systemtest/approvals/TestIntakeLog/with_timestamp_as_str.approved.json
+++ b/systemtest/approvals/TestIntakeLog/with_timestamp_as_str.approved.json
@@ -10,7 +10,7 @@
             "container": {
                 "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
             },
-            "data_stream.dataset": "apm.app",
+            "data_stream.dataset": "apm.app.1234_service_12a3",
             "data_stream.namespace": "default",
             "data_stream.type": "logs",
             "event": {

--- a/systemtest/approvals/TestIntakeLog/without_timestamp.approved.json
+++ b/systemtest/approvals/TestIntakeLog/without_timestamp.approved.json
@@ -10,7 +10,7 @@
             "container": {
                 "id": "8ec7ceb990749e79b37f6dc6cd3628633618d6ce412553a552a0fa6b69419ad4"
             },
-            "data_stream.dataset": "apm.app",
+            "data_stream.dataset": "apm.app.1234_service_12a3",
             "data_stream.namespace": "default",
             "data_stream.type": "logs",
             "event": {

--- a/systemtest/approvals/TestJaeger/batch_0.approved.json
+++ b/systemtest/approvals/TestJaeger/batch_0.approved.json
@@ -208,7 +208,7 @@
                 "name": "Jaeger/Go",
                 "version": "2.20.1"
             },
-            "data_stream.dataset": "apm.app",
+            "data_stream.dataset": "apm.app.driver",
             "data_stream.namespace": "default",
             "data_stream.type": "logs",
             "event": {
@@ -258,7 +258,7 @@
                 "name": "Jaeger/Go",
                 "version": "2.20.1"
             },
-            "data_stream.dataset": "apm.app",
+            "data_stream.dataset": "apm.app.driver",
             "data_stream.namespace": "default",
             "data_stream.type": "logs",
             "event": {
@@ -306,7 +306,7 @@
                 "name": "Jaeger/Go",
                 "version": "2.20.1"
             },
-            "data_stream.dataset": "apm.app",
+            "data_stream.dataset": "apm.app.driver",
             "data_stream.namespace": "default",
             "data_stream.type": "logs",
             "event": {

--- a/systemtest/approvals/TestJaeger/batch_1.approved.json
+++ b/systemtest/approvals/TestJaeger/batch_1.approved.json
@@ -202,7 +202,7 @@
                 "name": "Jaeger/Go",
                 "version": "2.20.1"
             },
-            "data_stream.dataset": "apm.app",
+            "data_stream.dataset": "apm.app.redis",
             "data_stream.namespace": "default",
             "data_stream.type": "logs",
             "event": {

--- a/systemtest/approvals/TestOTLPGRPCLogs.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCLogs.approved.json
@@ -6,7 +6,7 @@
                 "name": "otlp/go",
                 "version": "unknown"
             },
-            "data_stream.dataset": "apm.app",
+            "data_stream.dataset": "apm.app.unknown",
             "data_stream.namespace": "default",
             "data_stream.type": "logs",
             "event": {

--- a/systemtest/approvals/TestOTLPGRPCTraces.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCTraces.approved.json
@@ -85,7 +85,7 @@
                 "name": "opentelemetry/go",
                 "version": "1.8.0"
             },
-            "data_stream.dataset": "apm.app",
+            "data_stream.dataset": "apm.app.unknown_service_systemtest_test",
             "data_stream.namespace": "default",
             "data_stream.type": "logs",
             "event": {

--- a/systemtest/intake_log_test.go
+++ b/systemtest/intake_log_test.go
@@ -18,6 +18,7 @@
 package systemtest_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/elastic/apm-server/systemtest"
@@ -33,50 +34,58 @@ func TestIntakeLog(t *testing.T) {
 	tests := []struct {
 		Name            string
 		Message         string
+		ServiceName     string
 		ExpectedMinDocs int
 		DynamicFields   []string
 	}{
 		{
 			Name:            "without_timestamp",
 			Message:         "test log message without timestamp",
+			ServiceName:     "1234_service_12a3",
 			ExpectedMinDocs: 1,
 			DynamicFields:   []string{"@timestamp"},
 		},
 		{
 			Name:            "with_timestamp",
 			Message:         "test log message with timestamp",
+			ServiceName:     "1234_service_12a3",
 			ExpectedMinDocs: 1,
 		},
 		{
 			Name:            "with_timestamp_as_str",
 			Message:         "test log message with string timestamp",
+			ServiceName:     "1234_service_12a3",
 			ExpectedMinDocs: 1,
 		},
 		{
 			Name:            "with_faas",
 			Message:         "test log message with faas",
+			ServiceName:     "1234_service_12a3",
 			ExpectedMinDocs: 1,
 		},
 		{
 			Name:            "with_flat_ecs_fields",
 			Message:         "test log message with ecs fields",
+			ServiceName:     "testsvc",
 			ExpectedMinDocs: 1,
 		},
 		{
 			Name:            "with_nested_ecs_fields",
 			Message:         "test log message with nested ecs fields",
+			ServiceName:     "testsvc",
 			ExpectedMinDocs: 1,
 		},
 		{
 			Name:            "with_nested_ecs_fields_overrides_flat_fields",
 			Message:         "test log message with override of flat ecs fields by nested ecs fields",
+			ServiceName:     "testsvc",
 			ExpectedMinDocs: 1,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			result := systemtest.Elasticsearch.ExpectMinDocs(t, test.ExpectedMinDocs, "logs-apm.app-*", estest.BoolQuery{
+			result := systemtest.Elasticsearch.ExpectMinDocs(t, test.ExpectedMinDocs, fmt.Sprintf("logs-apm.app.%s-*", test.ServiceName), estest.BoolQuery{
 				Filter: []interface{}{
 					estest.TermQuery{Field: "processor.event", Value: "log"},
 					estest.MatchPhraseQuery{Field: "message", Value: test.Message},


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
As described in #10291, we want to store app logs per service to follow best practices for the data stream naming convention.

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [x] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes
1. Spin up tilt
2. Fire some events to intake endpoints
example:
```
curl --request POST \
  --url http://localhost:8200/intake/v2/events \
  --header 'content-type: application/x-ndjson' \
  --data '{"metadata":{"service":{"name":"test-service-1","version":"4.3.0","environment":"production", "language":{"name":"Java","version":"10.0.2"},"agent":{"version":"1.10.0","name":"java"}}, "labels":{"group":"experimental","ab_testing":true,"segment":5}}}
{"log": {"message": "test log message without timestamp"}}
{"log": {"trace.id": "trace-id", "transaction.id": "txn-id", "log.level": "warn", "log":{"logger":"testLogger","origin":{"file":{"name":"testFile","line":10},"function":"testFunc"}},"service":{"name":"test-service-2","version":"v1.0.0","environment":"prod"},"message": "test log message with nested ecs fields", "@timestamp": 1662616049000000}}'
```
3. Go to Kibana, check the datastreams created with the service names by querying:
```
GET logs-apm.app*/_search 
{
  "_source": "false"
}

# datastrteam `logs-apm.app.test_service_1-default` and `logs-apm.app.test_service_2-default` are created
```
4. Also check the correct index pattern is created.
<img width="721" alt="image" src="https://user-images.githubusercontent.com/16660866/223911133-006f926f-1264-44dc-87d1-6744845053b3.png">

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues
closes #10291 
depends on https://github.com/elastic/apm-data/pull/23
