### PR TITLE
update-beats: only update beats module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ update-beats: update-beats-module update
 
 .PHONY: update-beats-module
 update-beats-module:
-	$(GO) get -d -u $(BEATS_MODULE)@$(BEATS_VERSION) && $(GO) mod tidy
+	$(GO) get -d $(BEATS_MODULE)@$(BEATS_VERSION) && $(GO) mod tidy
 
 .PHONY: update-beats-docs
 update-beats-docs:


### PR DESCRIPTION
## Motivation/summary

Remove the `-u` flag, which instructs `go get` to update other dependencies too. These should be updated explicitly and intentionally, not as a byproduct of updating libbeat.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

https://github.com/elastic/apm-server/actions/runs/4365568437/jobs/7634381785