### PR TITLE
docs: APM agent config

### DIFF
--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -214,8 +214,8 @@ apm-server:
       #password: "changeme"
 
   #kibana:
-    # Required if running APM Server standalone to check if the APM package has been installed. Also
-    # required for APM agent configuration when using an output other than Elasticsearch.
+    # Required when `apm-server.agent.config.elasticsearch` is not set AND `output.elasticsearch`
+    # is not valid (either because it's not set or there aren't enough privileges).
     #enabled: false
 
     # Scheme and port can be left out and will be set to the default (`http` and `5601`).

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -214,7 +214,8 @@ apm-server:
       #password: "changeme"
 
   #kibana:
-    # Fallback method for fetching APM agent configurations.
+    # Required if running APM Server standalone to check if the APM package has been installed. Also
+    # required for APM agent configuration when using an output other than Elasticsearch.
     #enabled: false
 
     # Scheme and port can be left out and will be set to the default (`http` and `5601`).

--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -214,7 +214,7 @@ apm-server:
       #password: "changeme"
 
   #kibana:
-    # Enabled must be true to enable APM Agent configuration, and for fetching source maps uploaded through Kibana.
+    # Fallback method for fetching APM agent configurations.
     #enabled: false
 
     # Scheme and port can be left out and will be set to the default (`http` and `5601`).
@@ -226,6 +226,9 @@ apm-server:
     #protocol: "https"
     #username: "elastic"
     #password: "changeme"
+
+    # Optional authentication with an API key
+    #api_key: "id:api_key"
 
     # Optional HTTP path.
     #path: ""

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -214,8 +214,8 @@ apm-server:
       #password: "changeme"
 
   #kibana:
-    # Required if running APM Server standalone to check if the APM package has been installed. Also
-    # required for APM agent configuration when using an output other than Elasticsearch.
+    # Required when `apm-server.agent.config.elasticsearch` is not set AND `output.elasticsearch`
+    # is not valid (either because it's not set or there aren't enough privileges).
     #enabled: false
 
     # Scheme and port can be left out and will be set to the default (`http` and `5601`).

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -214,7 +214,8 @@ apm-server:
       #password: "changeme"
 
   #kibana:
-    # Fallback method for fetching APM agent configurations.
+    # Required if running APM Server standalone to check if the APM package has been installed. Also
+    # required for APM agent configuration when using an output other than Elasticsearch.
     #enabled: false
 
     # Scheme and port can be left out and will be set to the default (`http` and `5601`).

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -214,7 +214,7 @@ apm-server:
       #password: "changeme"
 
   #kibana:
-    # Enabled must be true to enable APM Agent configuration, and for fetching source maps uploaded through Kibana.
+    # Fallback method for fetching APM agent configurations.
     #enabled: false
 
     # Scheme and port can be left out and will be set to the default (`http` and `5601`).
@@ -226,6 +226,9 @@ apm-server:
     #protocol: "https"
     #username: "elastic"
     #password: "changeme"
+
+    # Optional authentication with an API key
+    #api_key: "id:api_key"
 
     # Optional HTTP path.
     #path: ""

--- a/docs/empty.yml
+++ b/docs/empty.yml
@@ -1,1 +1,0 @@
-#delete me

--- a/docs/empty2.yml
+++ b/docs/empty2.yml
@@ -1,1 +1,0 @@
-# delete me

--- a/docs/legacy/configuration-agent-config.asciidoc
+++ b/docs/legacy/configuration-agent-config.asciidoc
@@ -1,0 +1,78 @@
+[[configure-agent-config]]
+== Configure APM agent configuration
+
+++++
+<titleabbrev>APM agent configuration</titleabbrev>
+++++
+
+IMPORTANT: {deprecation-notice-config}
+
+APM agent configuration allows you to fine-tune your APM agents from within the APM app.
+Changes are automatically propagated to your APM agents, so there's no need to redeploy your applications.
+
+To learn more about this feature, see {kibana-ref}/agent-configuration.html[APM agent configuration].
+
+Here's a sample configuration:
+
+[source,yaml]
+----
+apm-server.agent.config.cache.expiration: 45s
+apm-server.agent.config.elasticsearch.api_key: TiNAGG4BaaMdaH1tRfuU:KnR6yE41RrSowb0kQ0HWoA
+----
+
+[float]
+=== APM agent configuration options
+
+You can specify the following options in the `apm-server.agent.config` section of the
++{beatname_lc}.yml+ config file:
+
+[float]
+[[agent-config-cache]]
+==== `apm-server.agent.config.cache.expiration`
+
+When using APM agent configuration, information fetched from {es} will be cached in memory for some time.
+Specify the cache expiration time via this setting. Defaults to `30s` (30 seconds).
+
+[float]
+[[agnent-config-authentication]]
+=== Authentication credentials
+
+For APM Server legacy users,
+APM agent configuration is automatically fetched from {es} using the `output.elasticsearch`
+configuration. Use these authentication configuration variables to fine-tune permission access.
+
+When using a Fleet-managed APM Server or Elastic Agent standalone-managed APM Server,
+you must use these authentication credentials to provide access to {es}.
+
+[float]
+==== `apm-server.agent.config.elasticsearch.username`
+
+The basic authentication username for connecting to {es}.
+
+[float]
+==== `apm-server.agent.config.elasticsearch.password`
+
+The basic authentication password for connecting to {es}.
+
+[float]
+==== `apm-server.agent.config.elasticsearch.api_key`
+
+Authentication with an API key. Formatted as `id:api_key`
+
+[float]
+=== Common problems
+
+You may see the following HTTP 403 error from APM Server when it attempts to fetch APM agent configuration:
+
+[source,log]
+----
+"Your Elasticsearch configuration does not support agent config queries. Check your configurations at `output.elasticsearch` or `apm-server.agent.config.elasticsearch`."
+----
+
+This occurs because the user or API key set in either `apm-server.agent.config.elasticsearch` or `output.elasticsearch`
+(if `apm-server.agent.config.elasticsearch` is not set) does not have adequate permissions to read source maps from {es}.
+
+To fix this error, add the following index-level privileges to the API key:
+
+* `read` privileges on the `.apm-agent-configuration` index
+* `allow_restricted_indices: true`

--- a/docs/legacy/configuration-agent-config.asciidoc
+++ b/docs/legacy/configuration-agent-config.asciidoc
@@ -34,15 +34,13 @@ When using APM agent configuration, information fetched from {es} will be cached
 Specify the cache expiration time via this setting. Defaults to `30s` (30 seconds).
 
 [float]
-[[agnent-config-authentication]]
+[[agent-config-authentication]]
 === Authentication credentials
 
-For APM Server legacy users,
+For APM Server legacy users and Elastic Agent standalone-managed APM Server,
 APM agent configuration is automatically fetched from {es} using the `output.elasticsearch`
-configuration. Use these authentication configuration variables to fine-tune permission access.
-
-When using a Fleet-managed APM Server or Elastic Agent standalone-managed APM Server,
-you must use these authentication credentials to provide access to {es}.
+configuration. If `output.elasticsearch` isn't set or doesn't have sufficient privileges,
+use these authentication configuration variables provide {es} access.
 
 [float]
 ==== `apm-server.agent.config.elasticsearch.username`

--- a/docs/legacy/configuration-agent-config.asciidoc
+++ b/docs/legacy/configuration-agent-config.asciidoc
@@ -62,11 +62,20 @@ Authentication with an API key. Formatted as `id:api_key`
 [float]
 === Common problems
 
-You may see the following HTTP 403 error from APM Server when it attempts to fetch APM agent configuration:
+You may see either of the following HTTP 403 errors from APM Server when it attempts to fetch APM agent configuration:
+
+APM agent log:
 
 [source,log]
 ----
 "Your Elasticsearch configuration does not support agent config queries. Check your configurations at `output.elasticsearch` or `apm-server.agent.config.elasticsearch`."
+----
+
+APM Server log:
+
+[source,log]
+----
+rejecting fetch request: no valid elasticsearch config
 ----
 
 This occurs because the user or API key set in either `apm-server.agent.config.elasticsearch` or `output.elasticsearch`

--- a/docs/legacy/configure-kibana-endpoint.asciidoc
+++ b/docs/legacy/configure-kibana-endpoint.asciidoc
@@ -7,7 +7,11 @@
 
 IMPORTANT: {deprecation-notice-config}
 
-Starting in version 8.7.0, APM agent configurations will be fetched directly from {es}.
+You must configure the {kib} endpoint if running APM Server standalone--this allows APM Server to verify that
+the APM package has been installed. The {kib} endpoint is also equired for APM agent configuration when using
+an output other than {es}.
+
+For all other use-cases, starting in version 8.7.0, APM agent configurations will be fetched directly from {es}.
 Configuring and enabling the {kib} endpoint is only used as a fallback.
 Please see <<configure-agent-config>> instead.
 

--- a/docs/legacy/configure-kibana-endpoint.asciidoc
+++ b/docs/legacy/configure-kibana-endpoint.asciidoc
@@ -7,10 +7,9 @@
 
 IMPORTANT: {deprecation-notice-config}
 
-Configuring the {kib} endpoint is required for
-{kibana-ref}/agent-configuration.html[APM Agent configuration in {kib}].
-You configure the endpoint in the `apm-server.kibana` section of the
-+{beatname_lc}.yml+ config file.
+Starting in version 8.7.0, APM agent configurations will be fetched directly from {es}.
+Configuring and enabling the {kib} endpoint is only used as a fallback.
+Please see <<configure-agent-config>> instead.
 
 Here's a sample configuration:
 
@@ -19,17 +18,6 @@ Here's a sample configuration:
 apm-server.kibana.enabled: true
 apm-server.kibana.host: "http://localhost:5601"
 ----
-
-[float]
-=== Considerations
-
-* If your setup uses a <<config-secret-token,secret token>> for Agent/Server communication,
-the same token is used to secure this endpoint.
-* It's important to still set relevant defaults locally in each Agent's configuration.
-If APM Server is unreachable, slow to respond, returns an error, etc.,
-defaults set in the agent will apply according to their precedence.
-* APM Server needs sufficient {kib} privileges to manage central configuration.
-See <<privileges-agent-central-config>> for a list of required privileges.
 
 [float]
 === {kib} endpoint configuration options
@@ -87,6 +75,11 @@ The basic authentication username for connecting to {kib}.
 The basic authentication password for connecting to {kib}.
 
 [float]
+==== `apm-server.kibana.api_key`
+
+Authentication with an API key. Formatted as `id:api_key`
+
+[float]
 [[kibana-path-option]]
 ==== `apm-server.kibana.path`
 
@@ -114,15 +107,3 @@ apm-server.kibana.ssl.key: "/etc/pki/client/cert.key"
 
 For information on the additional SSL configuration options,
 see <<configuration-ssl>>.
-
-[float]
-=== Agent Config configuration options
-
-You can specify the following options in the `apm-server.agent.config` section of the
-+{beatname_lc}.yml+ config file:
-
-[float]
-==== `agent.config.cache.expiration`
-
-When using APM Agent configuration, information fetched from {kib} will be cached in memory.
-This setting specifies the time before cache key expiration. Defaults to 30 seconds.

--- a/docs/legacy/configuring.asciidoc
+++ b/docs/legacy/configuring.asciidoc
@@ -11,6 +11,7 @@ If you've already upgraded, please see <<input-apm>> instead.
 include::{libbeat-dir}/shared/configuring-intro.asciidoc[]
 
 * <<configuration-process>>
+* <<configure-agent-config>>
 * <<configuration-anonymous>>
 * <<configuration-instrumentation>>
 * <<jaeger-reference>>

--- a/docs/legacy/configuring.asciidoc
+++ b/docs/legacy/configuring.asciidoc
@@ -25,6 +25,8 @@ include::{libbeat-dir}/shared/configuring-intro.asciidoc[]
 
 include::./configuration-process.asciidoc[]
 
+include::./configuration-agent-config.asciidoc[]
+
 include::./configuration-anonymous.asciidoc[]
 
 include::{libbeat-dir}/shared-instrumentation.asciidoc[]

--- a/docs/legacy/copied-from-beats/outputs/elasticsearch/docs/elasticsearch.asciidoc
+++ b/docs/legacy/copied-from-beats/outputs/elasticsearch/docs/elasticsearch.asciidoc
@@ -41,7 +41,7 @@ output.elasticsearch:
 ----
 output.elasticsearch:
   hosts: ["https://myEShost:9200"]
-  api_key: "KnR6yE41RrSowb0kQ0HWoA"
+  api_key: "ZCV7VnwBgnX0T19fN8Qe:KnR6yE41RrSowb0kQ0HWoA"
 ----
 
 *PKI certificate authentication:*

--- a/docs/legacy/tab-widgets/jaeger-sampling.asciidoc
+++ b/docs/legacy/tab-widgets/jaeger-sampling.asciidoc
@@ -4,11 +4,7 @@ Visit the {kibana-ref}/agent-configuration.html[Agent configuration] page in the
 // end::ess[]
 
 // tag::self-managed[]
-APM Agent central configuration requires the <<setup-kibana-endpoint,{kib} endpoint>> to be configured.
-To enable the {kib} endpoint, set <<kibana-enabled>> to `true`,
-and point <<kibana-host>> at the {kib} host that APM Server will communicate with.
+Visit the {kibana-ref}/agent-configuration.html[Agent configuration] page in the {apm-app} to add a new sampling rate.
 
-Once configured,
-visit the {kibana-ref}/agent-configuration.html[Agent configuration] page in the {apm-app} to add a new sampling rate.
-
+If you run into problems, see <<configure-agent-config>> to learn more.
 // end::self-managed[]


### PR DESCRIPTION
# Summary

- [x] Scrubs all mentions of agent config from https://www.elastic.co/guide/en/apm/guide/current/setup-kibana-endpoint.html
- [x] Creates a new page that documents `apm-server.agent.config.*`
- [x] Updates yml config files

* For https://github.com/elastic/apm-server/issues/9982
* Closes https://github.com/elastic/apm-server/issues/9350
* Closes https://github.com/elastic/apm-server/issues/10046

## Next

The following tasks remain for https://github.com/elastic/apm-server/issues/9982.

#### APM agent docs:

All APM agent documentation currently links to our [Kibana docs on Central config](https://www.elastic.co/guide/en/kibana/8.6/agent-configuration.html). In addition, the following agents mention `kibana.enabled`, which should be removed:

- [ ] Go: https://www.elastic.co/guide/en/apm/agent/go/current/configuration.html#config-central-config
- [ ] Node.js: https://www.elastic.co/guide/en/apm/agent/nodejs/current/configuration.html#central-config
- [ ] Ruby: https://www.elastic.co/guide/en/apm/agent/ruby/current/configuration.html#config-central-config
- [ ] RUM: https://www.elastic.co/guide/en/apm/agent/rum-js/current/configuration.html#central-config

#### Kibana docs:

- [ ] Update https://www.elastic.co/guide/en/kibana/8.6/agent-configuration.html to link to the new `apm-server.agent.config.*` documentation in APM Server.
- [ ] Are privilege updates required? https://www.elastic.co/guide/en/kibana/8.6/apm-app-central-config-user.html