### PR TITLE
ci: remove all the stages that run in GH actions

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -25,12 +25,9 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger("(${obltGitHubComments()}|^run\\W+(?:the\\W+)?(package)\\W+tests|^/test|^^/package)")
+    issueCommentTrigger("(${obltGitHubComments()}|^/package)")
   }
   parameters {
-    booleanParam(name: 'Run_As_Main_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on main branch.')
-    booleanParam(name: 'test_ci', defaultValue: true, description: 'Enable test')
-    booleanParam(name: 'test_sys_env_ci', defaultValue: true, description: 'Enable system and environment test')
     booleanParam(name: 'bench_ci', defaultValue: true, description: 'Enable benchmarks')
     booleanParam(name: 'release_ci', defaultValue: true, description: 'Enable build the release packages')
     string(name: 'ES_LOG_LEVEL', defaultValue: "error", description: 'Elasticsearch error level')
@@ -61,126 +58,59 @@ pipeline {
         }
       }
     }
-
-    // Run unit tests, benchmarks, and packaging in parallel.
-    stage('Build and test') {
-      failFast false
-      parallel {
-        stage('Unit tests - linux/amd64') {
-          agent { label 'linux && immutable' }
-          options { skipDefaultCheckout() }
-          environment {
-            PATH = "${env.PATH}:${env.WORKSPACE}/bin"
-            HOME = "${env.WORKSPACE}"
-          }
-          when {
-            beforeAgent true
-            allOf {
-              expression { return params.test_ci }
-              expression { return env.ONLY_DOCS == "false" }
-            }
-          }
-          steps {
-            withGithubNotify(context: 'Unit tests - linux/amd64', tab: 'tests') {
-              deleteDir()
-              unstash 'source'
-              dir("${BASE_DIR}"){
-                withGoEnv(){
-                  sh(label: 'Run Unit tests', script: './.ci/scripts/unit-test.sh')
-                }
-              }
-            }
-          }
-          post {
-            always {
-              dir("${BASE_DIR}/build"){
-                publishHTML(target: [
-                  allowMissing: true,
-                  keepAll: true,
-                  reportDir: ".",
-                  reportFiles: 'TEST-*.html',
-                  reportName: 'Coverage-Sourcecode-Files',
-                  reportTitles: 'Coverage'])
-                cobertura(autoUpdateHealth: false,
-                  autoUpdateStability: false,
-                  coberturaReportFile: "TEST-*_cov.xml",
-                  conditionalCoverageTargets: '70, 0, 0',
-                  failNoReports: false,
-                  failUnhealthy: false,
-                  failUnstable: false,
-                  lineCoverageTargets: '80, 0, 0',
-                  maxNumberOfBuilds: 0,
-                  methodCoverageTargets: '80, 0, 0',
-                  onlyStable: false,
-                  sourceEncoding: 'ASCII',
-                  zoomCoverageChart: false)
-                junit(allowEmptyResults: true,
-                  keepLongStdio: true,
-                  testResults: "TEST-*.xml")
-              }
-            }
-          }
-        }
-
-        // Run the microbenchmarks for the current commit, send them to the benchmarks
-        // Elasticsearch cluster, and compare with the benchmark results from the most
-        // recent branch build.
-        stage('Benchmarking') {
-          agent { label 'microbenchmarks-pool' }
-          options { skipDefaultCheckout() }
-          when {
-            beforeAgent true
-            allOf {
-              expression { return params.bench_ci }
-              expression { return env.ONLY_DOCS == "false" }
-            }
-          }
-          steps {
-            withGithubNotify(context: 'Benchmarking') {
-              deleteDir()
-              unstash 'source'
-              dir("${BASE_DIR}"){
-                withGoEnv(){
-                  sh(label: 'Run benchmarks', script: './.ci/scripts/bench.sh')
-                }
-                sendBenchmarks(file: "bench.out", index: "benchmark-server")
-                generateGoBenchmarkDiff(file: 'bench.out', filter: 'exclude')
-              }
-            }
-          }
-          post {
-            cleanup {
-              deleteDir()
-            }
-          }
-        }
-
-        // Run the packaging pipeline for a PR, when requested.
-        stage('Downstream - Package - PR') {
-          options { skipDefaultCheckout() }
-          when {
-            beforeAgent true
-            allOf {
-              expression { return params.release_ci }
-              expression { return env.ONLY_DOCS == "false" }
-              changeRequest()
-              anyOf {
-                expression { return env.PACKAGING_UPDATED != "false" }
-                expression { return env.GITHUB_COMMENT?.contains('package tests') || env.GITHUB_COMMENT?.contains('/package')}
-                expression { return params.Run_As_Main_Branch }
-              }
-            }
-          }
-          steps {
-            build(job: "apm-server/apm-server-package-mbp/${env.JOB_BASE_NAME}",
-                  propagate: false,
-                  wait: false,
-                  parameters: [string(name: 'COMMIT', value: "${env.GIT_BASE_COMMIT}")])
+		// Run the packaging pipeline for a PR, when requested.
+    stage('Downstream - Package - PR') {
+      options { skipDefaultCheckout() }
+      when {
+        beforeAgent true
+        allOf {
+          expression { return params.release_ci }
+          expression { return env.ONLY_DOCS == "false" }
+          changeRequest()
+          anyOf {
+            expression { return env.PACKAGING_UPDATED != "false" }
+            expression { return env.GITHUB_COMMENT?.contains('package tests') || env.GITHUB_COMMENT?.contains('/package')}
           }
         }
       }
+      steps {
+        build(job: "apm-server/apm-server-package-mbp/${env.JOB_BASE_NAME}",
+              propagate: false,
+              wait: false,
+              parameters: [string(name: 'COMMIT', value: "${env.GIT_BASE_COMMIT}")])
+      }
     }
-
+		// Run the microbenchmarks for the current commit, send them to the benchmarks
+    // Elasticsearch cluster, and compare with the benchmark results from the most
+    // recent branch build.
+    stage('Benchmarking') {
+      options { skipDefaultCheckout() }
+      when {
+        beforeAgent true
+        allOf {
+          expression { return params.bench_ci }
+          expression { return env.ONLY_DOCS == "false" }
+        }
+      }
+      steps {
+        withGithubNotify(context: 'Benchmarking') {
+          deleteDir()
+          unstash 'source'
+          dir("${BASE_DIR}"){
+            withGoEnv(){
+              sh(label: 'Run benchmarks', script: './.ci/scripts/bench.sh')
+            }
+            sendBenchmarks(file: "bench.out", index: "benchmark-server")
+            generateGoBenchmarkDiff(file: 'bench.out', filter: 'exclude')
+          }
+        }
+      }
+      post {
+        cleanup {
+          deleteDir()
+        }
+      }
+    }
     // Run the packaging pipeline for branch builds. This should only be run
     // after all other stages succeed, to avoid publishing packages for a commit
     // with failing tests.

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'linux && immutable' }
+  agent { label 'microbenchmarks-pool' }
   environment {
     REPO = 'apm-server'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -128,6 +128,9 @@ pipeline {
     }
   }
   post {
+    always {
+      deleteDir()
+    }
     cleanup {
       notifyBuildResult(goBenchmarkComment: true)
     }


### PR DESCRIPTION


## Motivation/summary

Simplify the parallel stages since UTs are already running on GH actions

<img width="1377" alt="image" src="https://user-images.githubusercontent.com/2871786/227171466-8cc04547-fb8a-4d72-b3f2-104b9bbf6f9b.png">

So I removed the parallel meta-stage and execute in sequential steps since `Downstream - Package - PR` does nothing but triggering another build, hence there is no need to run in parallel.

## Follow ups

Report test-coverage similarly done in https://github.com/elastic/elastic-serverless-forwarder/pull/294
