### PR TITLE
systemtest/loadgen: support ID randomisation

### DIFF
--- a/systemtest/benchtest/clients.go
+++ b/systemtest/benchtest/clients.go
@@ -105,6 +105,7 @@ func NewEventHandler(tb testing.TB, p string, l *rate.Limiter) *eventhandler.Han
 		URL:               serverCfg.ServerURL.String(),
 		Token:             serverCfg.SecretToken,
 		Limiter:           l,
+		RewriteIDs:        serverCfg.RewriteIDs,
 		RewriteTimestamps: serverCfg.RewriteTimestamps,
 	})
 	if err != nil {

--- a/systemtest/loadgen/config/config.go
+++ b/systemtest/loadgen/config/config.go
@@ -32,6 +32,7 @@ var Config struct {
 	APIKey            string
 	Secure            bool
 	MaxEPM            int
+	RewriteIDs        bool
 	RewriteTimestamps bool
 }
 
@@ -78,6 +79,13 @@ func init() {
 		"rewrite-timestamps",
 		false,
 		"rewrite event timestamps every iteration, maintaining relative offsets",
+	)
+
+	flag.BoolVar(
+		&Config.RewriteIDs,
+		"rewrite-ids",
+		false,
+		"rewrite event IDs every iteration, maintaining event relationships",
 	)
 
 	// For configs that can be set via environment variables, set the required

--- a/systemtest/loadgen/eventhandler.go
+++ b/systemtest/loadgen/eventhandler.go
@@ -19,6 +19,7 @@ package loadgen
 
 import (
 	"embed"
+	"math/rand"
 	"path/filepath"
 
 	"golang.org/x/time/rate"
@@ -39,6 +40,8 @@ type EventHandlerParams struct {
 	Token             string
 	APIKey            string
 	Limiter           *rate.Limiter
+	Rand              *rand.Rand
+	RewriteIDs        bool
 	RewriteTimestamps bool
 }
 
@@ -57,6 +60,8 @@ func NewEventHandler(p EventHandlerParams) (*eventhandler.Handler, error) {
 		Transport:         transp,
 		Storage:           events,
 		Limiter:           p.Limiter,
+		Rand:              p.Rand,
+		RewriteIDs:        p.RewriteIDs,
 		RewriteTimestamps: p.RewriteTimestamps,
 	})
 }

--- a/systemtest/loadgen/eventhandler/handler.go
+++ b/systemtest/loadgen/eventhandler/handler.go
@@ -21,15 +21,19 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	cryptorand "crypto/rand"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io/fs"
+	"math/bits"
+	"math/rand"
 	"sync"
 	"time"
 
 	"github.com/klauspost/compress/zlib"
 	"github.com/tidwall/gjson"
-	"github.com/tidwall/sjson"
+	"go.elastic.co/fastjson"
 	"golang.org/x/time/rate"
 )
 
@@ -62,8 +66,10 @@ type event struct {
 //
 // It is safe to make concurrent calls to Handler methods.
 type Handler struct {
-	config       Config
-	writerPool   sync.Pool
+	mu         sync.Mutex // guards config.Rand
+	config     Config
+	writerPool sync.Pool
+
 	batches      []batch
 	minTimestamp time.Time // across all batches
 }
@@ -92,6 +98,13 @@ type Config struct {
 	// event batches.
 	Transport *Transport
 
+	// Rand, if non-nil, will be used for field randomization.
+	//
+	// If Rand is nil, then a new Rand will be created, seeded with
+	// a value read from crypto/rand. If Rand is supplied (non-nil),
+	// it must not be invoked concurrently by any other goroutines.
+	Rand *rand.Rand
+
 	// RewriteTimestamps controls whether event timestamps are rewritten
 	// during replay.
 	//
@@ -103,6 +116,21 @@ type Config struct {
 	// event's timestamp and the smallest timestamp; this is then added
 	// to the current time as recorded when SendBatches is invoked.
 	RewriteTimestamps bool
+
+	// RewriteIDs controls whether trace, transaction, span, and error
+	// event IDs are rewritten.
+	//
+	// If this is false, then the original IDs are unmodified.
+	//
+	// If this is true, then for each call to SendBatches the event IDs
+	// will be adjusted as follows: first, we generate a random 64-bit
+	// integer. Next, for each event ID whose value is entirely hex
+	// digits, we will decode each hex digit to a 4-bit value, XOR it
+	// with the next 4 bits in the randon number (rotating left), and
+	// then re-encode as a hex digit. Note that we intentionally use a
+	// single random value to ensure IDs are randomised consistently,
+	// such that event relationships are maintained.
+	RewriteIDs bool
 }
 
 // New creates a new Handler with config.
@@ -112,6 +140,14 @@ func New(config Config) (*Handler, error) {
 	}
 	if config.Limiter == nil {
 		config.Limiter = rate.NewLimiter(rate.Inf, 0)
+	}
+	if config.Rand == nil {
+		var rngseed int64
+		err := binary.Read(cryptorand.Reader, binary.LittleEndian, &rngseed)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate seed for math/rand: %w", err)
+		}
+		config.Rand = rand.New(rand.NewSource(rngseed))
 	}
 
 	h := Handler{
@@ -205,10 +241,14 @@ func New(config Config) (*Handler, error) {
 // SendBatches sends the loaded trace data to the configured transport,
 // returning the total number of documents sent and any transport errors.
 func (h *Handler) SendBatches(ctx context.Context) (int, error) {
+	h.mu.Lock()
+	randomBits := h.config.Rand.Uint64()
+	h.mu.Unlock()
+
 	baseTimestamp := time.Now().UTC()
 	var sentEvents int
 	for _, batch := range h.batches {
-		sent, err := h.sendBatch(ctx, batch, baseTimestamp)
+		sent, err := h.sendBatch(ctx, batch, baseTimestamp, randomBits)
 		if err != nil {
 			return sentEvents, err
 		}
@@ -217,7 +257,12 @@ func (h *Handler) SendBatches(ctx context.Context) (int, error) {
 	return sentEvents, nil
 }
 
-func (h *Handler) sendBatch(ctx context.Context, b batch, baseTimestamp time.Time) (int, error) {
+func (h *Handler) sendBatch(
+	ctx context.Context,
+	b batch,
+	baseTimestamp time.Time,
+	randomBits uint64,
+) (int, error) {
 	// TODO add an option to send events with a steady event rate;
 	// if the batch is larger than the event rate, it must then be
 	// split into smaller batches.
@@ -240,31 +285,97 @@ func (h *Handler) sendBatch(ctx context.Context, b batch, baseTimestamp time.Tim
 	w.Write(b.metadata)
 	w.Write(newlineBytes)
 	for _, event := range b.events {
-		payload := event.payload
-		if h.config.RewriteTimestamps && !event.timestamp.IsZero() {
-			// We always encode rewritten timestamps as strings,
-			// so we don't lose any precision when offsetting by
-			// either the base timestamp, or the minimum timestamp
-			// across all the batches; string-formatted timestamps
-			// may have nanosecond precision.
-			offset := event.timestamp.Sub(h.minTimestamp)
-			timestamp := baseTimestamp.Add(offset)
-			timestampString := timestamp.Format(time.RFC3339Nano)
-
-			var err error
-			path := event.objectType + ".timestamp"
-			payload, err = sjson.SetBytes(payload, path, timestampString)
-			if err != nil {
-				return 0, fmt.Errorf("failed to rewrite timestamp: %w", err)
-			}
+		if !h.config.RewriteTimestamps && !h.config.RewriteIDs {
+			w.Write(event.payload)
+			w.Write(newlineBytes)
+			continue
 		}
-		w.Write(payload)
+		w.rewriteBuf.RawByte('{')
+		w.rewriteBuf.String(event.objectType)
+		w.rewriteBuf.RawString(":{")
+		gjson.GetBytes(event.payload, event.objectType).ForEach(func(key, value gjson.Result) bool {
+			if key.Index > 1 {
+				w.rewriteBuf.RawByte(',')
+			}
+			w.rewriteBuf.RawString(key.Raw)
+			w.rewriteBuf.RawByte(':')
+			switch key.Str {
+			case "timestamp":
+				if h.config.RewriteTimestamps && !event.timestamp.IsZero() {
+					// We always encode rewritten timestamps as strings,
+					// so we don't lose any precision when offsetting by
+					// either the base timestamp, or the minimum timestamp
+					// across all the batches; string-formatted timestamps
+					// may have nanosecond precision.
+					offset := event.timestamp.Sub(h.minTimestamp)
+					timestamp := baseTimestamp.Add(offset)
+					w.rewriteBuf.RawByte('"')
+					w.rewriteBuf.Time(timestamp, time.RFC3339Nano)
+					w.rewriteBuf.RawByte('"')
+				} else {
+					w.rewriteBuf.RawString(value.Raw)
+				}
+			case "id", "parent_id", "trace_id", "transaction_id":
+				if h.config.RewriteIDs && randomizeTraceID(&w.idBuf, value.Str, randomBits) {
+					w.rewriteBuf.RawByte('"')
+					w.rewriteBuf.RawBytes(w.idBuf.Bytes())
+					w.rewriteBuf.RawByte('"')
+					w.idBuf.Reset()
+				} else {
+					w.rewriteBuf.RawString(value.Raw)
+				}
+			default:
+				w.rewriteBuf.RawString(value.Raw)
+			}
+			return true
+		})
+		w.rewriteBuf.RawString("}}")
+		w.Write(w.rewriteBuf.Bytes())
 		w.Write(newlineBytes)
+		w.rewriteBuf.Reset()
 	}
 	if err := send(ctx); err != nil {
 		return 0, err
 	}
 	return len(b.events), nil
+}
+
+func randomizeTraceID(out *bytes.Buffer, in string, randomBits uint64) bool {
+	n := len(in)
+	for i := 0; i < n; i++ {
+		b := in[i]
+		if !((b >= '0' && b <= '9') ||
+			(b >= 'a' && b <= 'f') ||
+			(b >= 'A' && b <= 'F')) {
+			// Not all hex.
+			return false
+		}
+	}
+
+	out.Grow(n)
+	for i := 0; i < n; i++ {
+		b := in[i]
+
+		var h uint8
+		switch {
+		case b >= '0' && b <= '9':
+			h = b - '0'
+		case b >= 'a' && b <= 'f':
+			h = 10 + (b - 'a')
+		case b >= 'A' && b <= 'F':
+			h = 10 + (b - 'A')
+		}
+		h = (h ^ uint8(randomBits)) & 0x0f
+		randomBits = bits.RotateLeft64(randomBits, 4)
+
+		if h < 10 {
+			b = '0' + h
+		} else {
+			b = 'a' + (h - 10)
+		}
+		out.WriteByte(b)
+	}
+	return true
 }
 
 // WarmUpServer will "warm up" the remote APM Server by sending events until
@@ -278,7 +389,7 @@ func (h *Handler) WarmUpServer(ctx context.Context) error {
 				return ctx.Err()
 			default:
 			}
-			if _, err := h.sendBatch(ctx, batch, baseTimestamp); err != nil {
+			if _, err := h.sendBatch(ctx, batch, baseTimestamp, 0); err != nil {
 				return err
 			}
 		}
@@ -286,11 +397,15 @@ func (h *Handler) WarmUpServer(ctx context.Context) error {
 }
 
 type pooledWriter struct {
-	buf bytes.Buffer
+	rewriteBuf fastjson.Writer
+	idBuf      bytes.Buffer
+	buf        bytes.Buffer
 	*zlib.Writer
 }
 
 func (pw *pooledWriter) Reset() {
+	pw.rewriteBuf.Reset()
+	pw.idBuf.Reset()
 	pw.buf.Reset()
 	pw.Writer.Reset(&pw.buf)
 }

--- a/systemtest/soaktest/soaktest.go
+++ b/systemtest/soaktest/soaktest.go
@@ -19,6 +19,10 @@ package soaktest
 
 import (
 	"context"
+	cryptorand "crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
 
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
@@ -31,11 +35,20 @@ func RunBlocking(ctx context.Context) error {
 	limiter := loadgen.GetNewLimiter(loadgencfg.Config.MaxEPM)
 	g, gCtx := errgroup.WithContext(ctx)
 
+	// Create a Rand with the same seed for each agent, so we randomise their IDs consistently.
+	//rand :=
+	var rngseed int64
+	err := binary.Read(cryptorand.Reader, binary.LittleEndian, &rngseed)
+	if err != nil {
+		return fmt.Errorf("failed to generate seed for math/rand: %w", err)
+	}
+
 	for i := 0; i < soakConfig.AgentsReplicas; i++ {
 		for _, expr := range []string{`go*.ndjson`, `nodejs*.ndjson`, `python*.ndjson`, `ruby*.ndjson`} {
 			expr := expr
 			g.Go(func() error {
-				return runAgent(gCtx, expr, limiter)
+				rng := rand.New(rand.NewSource(rngseed))
+				return runAgent(gCtx, expr, limiter, rng)
 			})
 		}
 	}
@@ -43,13 +56,15 @@ func RunBlocking(ctx context.Context) error {
 	return g.Wait()
 }
 
-func runAgent(ctx context.Context, expr string, limiter *rate.Limiter) error {
+func runAgent(ctx context.Context, expr string, limiter *rate.Limiter, rng *rand.Rand) error {
 	handler, err := loadgen.NewEventHandler(loadgen.EventHandlerParams{
 		Path:              expr,
 		URL:               loadgencfg.Config.ServerURL.String(),
 		Token:             loadgencfg.Config.SecretToken,
 		APIKey:            loadgencfg.Config.APIKey,
 		Limiter:           limiter,
+		Rand:              rng,
+		RewriteIDs:        loadgencfg.Config.RewriteIDs,
 		RewriteTimestamps: loadgencfg.Config.RewriteTimestamps,
 	})
 	if err != nil {


### PR DESCRIPTION
## Motivation/summary

Add an option to `apmsoak` and `apmbench` to rewrite `trace.id`, `transaction.id`, `span.id`, `parent.id`, and `error.id`. These are rewritten only if their contents are entirely hex digits.

For each iteration (each call to `Handler.SendBatches`) we will calculate a random number and use it to mutate the IDs. IDs are mutated consistently to ensure relationships between events are maintained, e.g. to ensure `parent.id` will match a `span.id` value.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

1. Run `apmsoak` for 1-2 minutes
2. Pick some traces at random in the APM UI, confirm that there are duplicate events
3. Delete APM data streams
4. Run `apmsoak -rewrite-ids` for 1-2 minutes
5. Pick some traces at random in the APM UI, confirm that there are no duplicate events

## Related issues

https://github.com/elastic/apm-server/issues/10446