### PR TITLE
[8.7] docs: Clarify anonymous authentication details (#10227)

### DIFF
--- a/docs/empty.yml
+++ b/docs/empty.yml
@@ -1,0 +1,1 @@
+#delete me

--- a/docs/legacy/configuration-anonymous.asciidoc
+++ b/docs/legacy/configuration-anonymous.asciidoc
@@ -9,8 +9,12 @@ IMPORTANT: {deprecation-notice-config}
 If you're using {fleet} and the Elastic APM integration, please see <<input-apm>> instead.
 
 Elastic APM agents can send unauthenticated (anonymous) events to the APM Server.
-This is useful for agents that run on clients, like the Real User Monitoring (RUM) agent running in a browser,
-or the iOS/Swift agent running in a user application.
+An event is considered to be anonymous if no authentication token can be extracted from the incoming request.
+This is useful for agents that run on clients, like the Real User Monitoring (RUM)
+agent running in a browser, or the iOS/Swift agent running in a user application.
+
+Enable anonymous authentication in the APM Server to allow the
+ingestion of unauthenticated client-side APM data while still requiring authentication for server-side services.
 
 Example configuration:
 
@@ -23,13 +27,15 @@ apm-server.auth.anonymous.rate_limit.event_limit: 300
 apm-server.auth.anonymous.rate_limit.ip_limit: 1000
 ----
 
-The anonymous access configuration is ignored if authenticated communication is disabled.
+IMPORTANT: All anonymous access configuration is ignored if
+<<secure-communication-agents,authenticated communication>> is disabled.
 
 [float]
 [[config-auth-anon-rum]]
 === Real User Monitoring (RUM)
 
-Anonymous authentication must be enabled to collect RUM data.
+If an <<api-key-legacy,API key>> or <<secret-token-legacy,secret token>> is configured,
+then anonymous authentication must be enabled to collect RUM data.
 For this reason, anonymous auth will be enabled automatically if <<rum-enable,`apm-server.rum.enabled`>>
 is set to `true`, and <<config-auth-anon-enabled,`apm-server.auth.anonymous.enabled`>> is not explicitly defined.
 

--- a/docs/legacy/configuration-rum.asciidoc
+++ b/docs/legacy/configuration-rum.asciidoc
@@ -45,8 +45,12 @@ Specify the following options in the `apm-server.rum` section of the `apm-server
 To enable RUM support, set `apm-server.rum.enabled` to `true`.
 By default this is disabled.
 
-NOTE: Enabling RUM support automatically enables <<configuration-anonymous>>.
-Anonymous access is required as the RUM agent runs in end users' browsers.
+[NOTE]
+====
+If an <<api-key-legacy,API key>> or <<secret-token-legacy,secret token>> is configured,
+then enabling RUM support will automatically enable <<configuration-anonymous>>.
+Anonymous authentication is required as the RUM agent runs in the browser.
+====
 
 [float]
 [[event_rate.limit]]

--- a/docs/legacy/secure-communication-agents.asciidoc
+++ b/docs/legacy/secure-communication-agents.asciidoc
@@ -627,12 +627,26 @@ IMPORTANT: {deprecation-notice-config}
 If you've already upgraded, see <<anonymous-auth>>.
 
 Elastic APM agents can send unauthenticated (anonymous) events to the APM Server.
-This is useful for agents that run on clients, like the Real User Monitoring (RUM) agent running in a browser,
-or the iOS/Swift agent running in a user application.
-Incoming requests are considered to be anonymous if no authentication token can be extracted from the incoming request.
-By default, these anonymous requests are rejected and an authentication error is returned.
+An event is considered to be anonymous if no authentication token can be extracted from the incoming request.
+The APM Server's default response to these these requests depends on its configuration:
 
-Anonymous authentication must be enabled to collect RUM data.
+[options="header"]
+|====
+|Configuration |Default
+|An <<api-key,API key>> or <<secret-token,secret token>> is configured | Anonymous requests are rejected and an authentication error is returned.
+|No API key or secret token is configured | Anonymous requests are accepted by the APM Server.
+|====
+
+In some cases, however, it makes sense to allow both authenticated and anonymous requests.
+For example, it isn't possible to authenticate requests from front-end services as
+the secret token or API key can't be protected. This is the case with the Real User Monitoring (RUM)
+agent running in a browser, or the iOS/Swift agent running in a user application.
+However, you still likely want to authenticate requests from back-end services.
+To solve this problem, you can enable anonymous authentication in the APM Server to allow the
+ingestion of unauthenticated client-side APM data while still requiring authentication for server-side services.
+
+When an <<api-key,API key>> or <<secret-token,secret token>> is configured,
+anonymous authentication must be enabled to collect RUM data.
 To enable anonymous access, set either <<rum-enable,`apm-server.rum.enabled`>> or
 <<config-auth-anon-enabled,`apm-server.auth.anonymous.enabled`>> to `true`.
 

--- a/docs/secure-agent-communication.asciidoc
+++ b/docs/secure-agent-communication.asciidoc
@@ -252,19 +252,35 @@ In addition to setting the secret token, ensure the configured server URL uses `
 
 Elastic APM agents can send unauthenticated (anonymous) events to the APM Server.
 An event is considered to be anonymous if no authentication token can be extracted from the incoming request.
-By default, these anonymous requests are rejected and an authentication error is returned.
+The APM Server's default response to these these requests depends on its configuration:
 
-In some cases, however, it makes sense to allow anonymous requests -- for
-example, when using the Real User Monitoring (RUM) agent running in a browser,
-or the iOS/Swift agent running in a user application,
-it is not possible to hide or protect a secret token or API key.
-Thus, enabling anonymous authentication is required to ingest client-side APM data.
+[options="header"]
+|====
+|Configuration |Default
+|An <<api-key,API key>> or <<secret-token,secret token>> is configured | Anonymous requests are rejected and an authentication error is returned.
+|No API key or secret token is configured | Anonymous requests are accepted by the APM Server.
+|====
+
+In some cases, however, it makes sense to allow both authenticated and anonymous requests.
+For example, it isn't possible to authenticate requests from front-end services as
+the secret token or API key can't be protected. This is the case with the Real User Monitoring (RUM)
+agent running in a browser, or the iOS/Swift agent running in a user application.
+However, you still likely want to authenticate requests from back-end services.
+To solve this problem, you can enable anonymous authentication in the APM Server to allow the
+ingestion of unauthenticated client-side APM data while still requiring authentication for server-side services.
 
 [float]
 [[anonymous-auth-config]]
-=== Configuring anonymous authentication
+=== Configuring anonymous auth for client-side services
 
-There are a few configuration variables that can mitigate the impact of malicious requests to an
+[NOTE]
+====
+You can only enable and configure anonymous authentication if an <<api-key,API key>> or
+<<secret-token,secret token>> is configured. If neither are configured, these settings will be ignored.
+====
+
+When configuring anonymous authentication for client-side services,
+there are a few configuration variables that can mitigate the impact of malicious requests to an
 unauthenticated APM Server endpoint.
 
 Use the **Allowed anonymous agents** and **Allowed anonymous services** configs to ensure that the


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [docs: Clarify anonymous authentication details (#10227)](https://github.com/elastic/apm-server/pull/10227)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)