### PR TITLE
feat: steady rate load generation for loadgen

### DIFF
--- a/dev_docs/TESTING.md
+++ b/dev_docs/TESTING.md
@@ -85,8 +85,7 @@ be set to `true` if any of `-blockprofile`, `-cpuprofile`, `-memprofile` or `-mu
 
 The default behavior of `apmbench` is to send the captured events to the target APM Server as fast as possible
 with the configured number of `-agents`. The `-agents` flag determines how many concurrent goroutines will be used
-to send the events to the APM Server in parallel. The `-max-rate` can be used to specify rate of events, as `eps`
-or `epm` to send to the APM server instead of the default behaviour. To benchmark the APM Server in setup similar
+to send the events to the APM Server in parallel. The `-event-rate` can be used to specify rate of events, as `{events}/{interval}` format to send to the APM server instead of the default behaviour. For example, `1000/1s` or `10000/5s`. To benchmark the APM Server in setup similar
 to what we'd see in production, the number of agents should be high (>`500`).
 
 By default, `apmbench` will warm up the APM Server by sending events for N duration to the APM Server before any of the
@@ -112,8 +111,8 @@ $ go run main.go -h
 Usage of /var/folders/k9/z1yw8fsn0sjbl5yy7z2rsdpr0000gn/T/go-build4164012609/b001/exe/main:
   -agents-replicas int
     	Number of agents replicas to use, each replica launches 4 agents, one for each type (default 1)
-  -max-rate value
-    	Max event rate as epm or eps with burst size=max(1000, 2*eps), <= 0 values evaluate to Inf (default 0epm)
+  -event-rate value
+    	Event rate in format of {burst}/{interval}, 0/s evaluates to Inf (default 0/s)
   -secret-token string
     	secret token for APM Server
   -secure

--- a/systemtest/benchtest/main.go
+++ b/systemtest/benchtest/main.go
@@ -72,7 +72,7 @@ func runBenchmark(f BenchmarkFunc) (testing.BenchmarkResult, bool, bool, error) 
 			return
 		}
 
-		limiter := loadgen.GetNewLimiter(loadgencfg.Config.MaxEPM)
+		limiter := loadgen.GetNewLimiter(loadgencfg.Config.EventRate.Burst, loadgencfg.Config.EventRate.Interval)
 		b.ResetTimer()
 		signal := make(chan bool)
 		// f can panic or call runtime.Goexit, stopping the goroutine.
@@ -250,7 +250,7 @@ func Run(allBenchmarks ...BenchmarkFunc) error {
 // warmup sends events to the remote APM Server using the specified number of
 // agents for the specified duration.
 func warmup(agents int, duration time.Duration, url, token string) error {
-	rl := loadgen.GetNewLimiter(loadgencfg.Config.MaxEPM)
+	rl := loadgen.GetNewLimiter(loadgencfg.Config.EventRate.Burst, loadgencfg.Config.EventRate.Interval)
 	h, err := loadgen.NewEventHandler(loadgen.EventHandlerParams{
 		Path:    `*.ndjson`,
 		URL:     url,

--- a/systemtest/gencorpora/gencorpora.go
+++ b/systemtest/gencorpora/gencorpora.go
@@ -84,7 +84,7 @@ func Run(rootCtx context.Context) error {
 }
 
 func generateLoad(ctx context.Context, serverURL string, replayCount int) error {
-	inf := loadgen.GetNewLimiter(0)
+	inf := loadgen.GetNewLimiter(0, 0)
 	handler, err := loadgen.NewEventHandler(loadgen.EventHandlerParams{
 		Path:    `*.ndjson`,
 		URL:     serverURL,

--- a/systemtest/loadgen/eventhandler/handler.go
+++ b/systemtest/loadgen/eventhandler/handler.go
@@ -299,7 +299,8 @@ func (h *Handler) sendBatch(
 func (h *Handler) sendHTTPRequest(ctx context.Context, b batch, baseTimestamp time.Time, randomBits uint64) error {
 	// if len(b.events) == burst, it will wait for full interval
 	// if len(b.events) < burst, it will wait shorter time than interval - interval will be shifted
-	// len(b.events) > burst cannot happen
+	// len(b.events) > burst cannot happen, because the caller
+	// arranges for batches to be split as needed.
 	if err := h.config.Limiter.WaitN(ctx, len(b.events)); err != nil {
 		return err
 	}

--- a/systemtest/soaktest/soaktest.go
+++ b/systemtest/soaktest/soaktest.go
@@ -32,7 +32,7 @@ import (
 )
 
 func RunBlocking(ctx context.Context) error {
-	limiter := loadgen.GetNewLimiter(loadgencfg.Config.MaxEPM)
+	limiter := loadgen.GetNewLimiter(loadgencfg.Config.EventRate.Burst, loadgencfg.Config.EventRate.Interval)
 	g, gCtx := errgroup.WithContext(ctx)
 
 	// Create a Rand with the same seed for each agent, so we randomise their IDs consistently.
@@ -83,4 +83,5 @@ func runAgent(ctx context.Context, expr string, limiter *rate.Limiter, rng *rand
 			}
 		}
 	}
+	return nil
 }

--- a/testing/apmsoak/main.tf
+++ b/testing/apmsoak/main.tf
@@ -24,7 +24,7 @@ module "soaktest_workers" {
   apm_server_url              = var.apm_server_url
   apm_secret_token            = var.apm_secret_token
   apm_api_key                 = var.apm_api_key
-  apm_loadgen_max_rate        = var.apm_loadgen_max_rate
+  apm_loadgen_event_rate      = var.apm_loadgen_event_rate
   apm_loadgen_agents_replicas = var.apm_loadgen_agents_replicas
 
   elastic_agent_version  = var.elastic_agent_version

--- a/testing/apmsoak/terraform.tfvars.example
+++ b/testing/apmsoak/terraform.tfvars.example
@@ -20,9 +20,9 @@ gcp_zone = "us-west2-b"
 # API Key for auth against the given server URL
 # apm_api_key = "<api_key>"
 
-# Max rate at which events will be sent to the APM server
-# Defaults to `4000eps` (i.e. 4000 events per second)
-# apm_loadgen_max_rate = "8000eps"
+# Event rate at which events will be sent to the APM server
+# Defaults to `4000/s` (i.e. 4000 events per second)
+# apm_loadgen_event_rate = "4000/s"
 
 # Number of agents replicas to use, each replica launches 4 agents, one for each type
 # Defaults to `2`

--- a/testing/apmsoak/variables.tf
+++ b/testing/apmsoak/variables.tf
@@ -39,10 +39,10 @@ variable "apm_api_key" {
   sensitive   = true
 }
 
-variable "apm_loadgen_max_rate" {
+variable "apm_loadgen_event_rate" {
   type        = string
-  description = "Max load generation rate"
-  default     = "4000eps"
+  description = "Load generation rate"
+  default     = "4000/s"
 }
 
 variable "apm_loadgen_agents_replicas" {

--- a/testing/benchmark/Makefile
+++ b/testing/benchmark/Makefile
@@ -11,7 +11,7 @@ BENCHMARK_TIME ?= 2m
 BENCHMARK_RUN ?= Benchmark
 BENCHMARK_RESULT ?= benchmark-result.txt
 BENCHMARK_DETAILED ?= true
-BENCHMARK_MAX_RATE ?= 0epm
+BENCHMARK_EVENT_RATE ?= 0/s
 
 GOBENCH_INDEX ?= apmbench-v2
 GOBENCH_USERNAME ?= admin
@@ -78,7 +78,7 @@ log-benckmark-profile:
 	@echo "Running benchmarks..."
 	@echo "Benchmark warmup time: $(BENCHMARK_WARMUP_TIME)"
 	@echo "Benchmark agents: $(BENCHMARK_AGENTS)"
-	@echo "Benchmark max rate: $(BENCHMARK_MAX_RATE)"
+	@echo "Benchmark event rate: $(BENCHMARK_EVENT_RATE)"
 	@echo "Benchmark count: $(BENCHMARK_COUNT)"
 	@echo "Benchmark duration: $(BENCHMARK_TIME)"
 	@echo "Benchmark run expression : $(BENCHMARK_RUN)"
@@ -87,7 +87,7 @@ log-benckmark-profile:
 run-benchmark: log-benckmark-profile
 	@ssh $(SSH_OPTS) -i $(SSH_KEY) $(SSH_USER)@$(WORKER_IP) ". .envrc && bin/apmbench -run='$(BENCHMARK_RUN)' \
 	-benchtime=$(BENCHMARK_TIME) -count=$(BENCHMARK_COUNT) -warmup-time=$(BENCHMARK_WARMUP_TIME) \
-	-agents=$(BENCHMARK_AGENTS) -detailed=$(BENCHMARK_DETAILED) -max-rate=$(BENCHMARK_MAX_RATE)" 2>&1 | tee $(BENCHMARK_RESULT)
+	-agents=$(BENCHMARK_AGENTS) -detailed=$(BENCHMARK_DETAILED) -event-rate=$(BENCHMARK_EVENT_RATE)" 2>&1 | tee $(BENCHMARK_RESULT)
 
 .PHONY: run-benchmark-autotuned
 run-benchmark-autotuned:

--- a/testing/infra/terraform/modules/soaktest_workers/README.md
+++ b/testing/infra/terraform/modules/soaktest_workers/README.md
@@ -34,7 +34,7 @@ This module sets up worker with load generation binary for soaktest configured a
 |------|-------------|------|---------|:--------:|
 | <a name="input_apm_api_key"></a> [apm\_api\_key](#input\_apm\_api\_key) | API Key for auth against the given server URL | `string` | n/a | yes |
 | <a name="input_apm_loadgen_agents_replicas"></a> [apm\_loadgen\_agents\_replicas](#input\_apm\_loadgen\_agents\_replicas) | Number of agents replicas to use, each replica launches 4 agents, one for each type | `string` | n/a | yes |
-| <a name="input_apm_loadgen_max_rate"></a> [apm\_loadgen\_max\_rate](#input\_apm\_loadgen\_max\_rate) | Max load generation rate | `string` | n/a | yes |
+| <a name="input_apm_loadgen_event_rate"></a> [apm\_loadgen\_event\_rate](#input\_apm\_loadgen\_event\_rate) | Load generation rate | `string` | n/a | yes |
 | <a name="input_apm_secret_token"></a> [apm\_secret\_token](#input\_apm\_secret\_token) | Secret token for auth against the given server URL | `string` | n/a | yes |
 | <a name="input_apm_server_url"></a> [apm\_server\_url](#input\_apm\_server\_url) | APM Server URL for sending the generated load | `string` | n/a | yes |
 | <a name="input_apmsoak_bin_path"></a> [apmsoak\_bin\_path](#input\_apmsoak\_bin\_path) | Path where the apmsoak binary resides on the local machine | `string` | n/a | yes |

--- a/testing/infra/terraform/modules/soaktest_workers/main.tf
+++ b/testing/infra/terraform/modules/soaktest_workers/main.tf
@@ -9,7 +9,7 @@ locals {
       var.apm_server_url,
       var.apm_secret_token,
       var.apm_api_key,
-      var.apm_loadgen_max_rate,
+      var.apm_loadgen_event_rate,
       var.apm_loadgen_agents_replicas,
       var.elastic_agent_version,
       var.fleet_url,
@@ -125,7 +125,7 @@ resource "google_compute_instance" "worker" {
         apm_server_url              = var.apm_server_url,
         apm_secret_token            = var.apm_secret_token,
         apm_api_key                 = var.apm_api_key,
-        apm_loadgen_max_rate        = var.apm_loadgen_max_rate,
+        apm_loadgen_event_rate        = var.apm_loadgen_event_rate,
         apm_loadgen_agents_replicas = var.apm_loadgen_agents_replicas,
       }
     )

--- a/testing/infra/terraform/modules/soaktest_workers/systemd.tpl
+++ b/testing/infra/terraform/modules/soaktest_workers/systemd.tpl
@@ -16,7 +16,7 @@ ExecStart=${apmsoak_executable_path} \
   -server ${apm_server_url} \
   -secret-token ${apm_secret_token} \
   -api_key ${apm_api_key} \
-  -max-rate ${apm_loadgen_max_rate} \
+  -event-rate ${apm_loadgen_event_rate} \
   -agents-replicas ${apm_loadgen_agents_replicas}
 
 [Install]

--- a/testing/infra/terraform/modules/soaktest_workers/variables.tf
+++ b/testing/infra/terraform/modules/soaktest_workers/variables.tf
@@ -38,9 +38,9 @@ variable "apm_api_key" {
   sensitive   = true
 }
 
-variable "apm_loadgen_max_rate" {
+variable "apm_loadgen_event_rate" {
   type        = string
-  description = "Max load generation rate"
+  description = "Load generation rate"
 }
 
 variable "apm_loadgen_agents_replicas" {


### PR DESCRIPTION
## Motivation/summary
Support for configuring the burst size and interval to verify the server's ability to handle sustained bursty workloads. 

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
- [x] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues
closes #10444
<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
