### PR TITLE
action: lint is mandatory but doc changes don't need it

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -21,3 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No tests required to run"'
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No lint required to run"'


### PR DESCRIPTION
## Motivation/summary

`lint` check is mandatory regardless of the changes, so `ci-docs.yml` is workaround to skip checks when the CI does. not run for docs changes.

Otherwise, it might mislead contributors since the lint check will not allow merging docs only PRs.

cc @bmorelli25 