### PR TITLE
[8.7] action: lint is mandatory but doc changes don't need it (#10564)

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -21,3 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "No tests required to run"'
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No lint required to run"'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [action: lint is mandatory but doc changes don't need it (#10564)](https://github.com/elastic/apm-server/pull/10564)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)