### PR TITLE
Universal Profiling: Versioned RPC protocol

### DIFF
--- a/systemtest/profiling_test.go
+++ b/systemtest/profiling_test.go
@@ -111,7 +111,9 @@ func TestProfiling(t *testing.T) {
 	ctx := metadata.AppendToOutgoingContext(context.Background(),
 		"secretToken", secretToken,
 		"projectID", "123",
-		"hostID", "abc123")
+		"hostID", "abc123",
+		"rpcVersion", "1",
+	)
 
 	// We always insert 2 elements in KV indices for each test RPC below.
 	// All RPCs use a columnar format, where arrays of fields are bundled

--- a/x-pack/apm-server/profiling/collector.go
+++ b/x-pack/apm-server/profiling/collector.go
@@ -77,9 +77,10 @@ type ElasticCollector struct {
 	clusterID string
 }
 
-// NewCollector returns a new ElasticCollector uses indexer for storing stack trace data in
-// Elasticsearch, and metricsIndexer for storing host agent metrics. Separate indexers are
-// used to allow for host agent metrics to be sent to a separate monitoring cluster.
+// NewCollector returns a new ElasticCollector which uses indexer for storing stack trace
+// data in Elasticsearch, and metricsIndexer for storing host agent metrics. Separate
+// indexers are used to allow for host agent metrics to be sent to a separate monitoring
+// cluster.
 func NewCollector(
 	indexer esutil.BulkIndexer,
 	metricsIndexer esutil.BulkIndexer,
@@ -104,6 +105,8 @@ func NewCollector(
 		c.indexes[i] = fmt.Sprintf("%s-%dpow%02d", common.EventsIndexPrefix,
 			common.SamplingFactor, i+1)
 	}
+
+	rpcProtocolVersion = GetRPCVersion()
 	return c
 }
 

--- a/x-pack/apm-server/profiling/grpcext.go
+++ b/x-pack/apm-server/profiling/grpcext.go
@@ -20,6 +20,7 @@ const (
 	MetadataKeyHostname      = "hostname"
 	MetadataKeyKernelVersion = "kernelVersion"
 	MetadataKeyHostID        = "hostID"
+	MetadataKeyRPCVersion    = "rpcVersion"
 	// Tags will be auto base64 encoded/decoded
 	MetadataKeyTags = "tags-bin"
 )
@@ -36,8 +37,8 @@ func GetProjectID(ctx context.Context) uint32 {
 	// Metadata and host ID have been validated in auth interceptor,
 	// no need to error check here.
 	md, _ := metadata.FromIncomingContext(ctx)
-	projectIDs := GetFirstOrEmpty(md, MetadataKeyProjectID)
-	projectID64, _ := strconv.Atoi(projectIDs)
+	projectIDStr := GetFirstOrEmpty(md, MetadataKeyProjectID)
+	projectID64, _ := strconv.ParseUint(projectIDStr, 10, 32)
 	return uint32(projectID64)
 }
 
@@ -45,8 +46,8 @@ func GetHostID(ctx context.Context) uint64 {
 	// Metadata and host ID have been validated in auth interceptor,
 	// no need to error check here.
 	md, _ := metadata.FromIncomingContext(ctx)
-	hostIDs := GetFirstOrEmpty(md, MetadataKeyHostID)
-	hostID, _ := strconv.ParseUint(hostIDs, 16, 64)
+	hostIDStr := GetFirstOrEmpty(md, MetadataKeyHostID)
+	hostID, _ := strconv.ParseUint(hostIDStr, 16, 64)
 	return hostID
 }
 


### PR DESCRIPTION
Added checks for RPC protocol version mismatches. 

I tested with HA v2.4.1 and v2.5.2. HAs older than v2.4.1 (AFAIK we never made any such older version available to beta customers) that do not send RPC protocol version will error on startup. 

This should be part of the upcoming 8.7.1 release.