### PR TITLE
systemtest/loadgen: add `-rewrite-*-names` flags

### DIFF
--- a/systemtest/loadgen/config/config.go
+++ b/systemtest/loadgen/config/config.go
@@ -28,14 +28,19 @@ import (
 )
 
 var Config struct {
-	ServerURL         *url.URL
-	SecretToken       string
-	APIKey            string
-	Secure            bool
-	EventRate         RateFlag
-	RewriteIDs        bool
-	RewriteTimestamps bool
-	Headers           map[string]string
+	ServerURL                 *url.URL
+	SecretToken               string
+	APIKey                    string
+	Secure                    bool
+	EventRate                 RateFlag
+	RewriteIDs                bool
+	RewriteTimestamps         bool
+	RewriteServiceNames       bool
+	RewriteServiceNodeNames   bool
+	RewriteServiceTargetNames bool
+	RewriteSpanNames          bool
+	RewriteTransactionNames   bool
+	Headers                   map[string]string
 }
 
 type RateFlag struct {
@@ -116,6 +121,22 @@ func init() {
 		},
 	)
 	flag.Var(&Config.EventRate, "event-rate", "Event rate in format of {burst}/{interval}. For example, 200/5s, <= 0 values evaluate to Inf (default 0/s)")
+
+	rewriteNames := map[string]*bool{
+		"service.name":        &Config.RewriteServiceNames,
+		"service.node.name":   &Config.RewriteServiceNodeNames,
+		"service.target.name": &Config.RewriteServiceTargetNames,
+		"span.name":           &Config.RewriteSpanNames,
+		"transaction.name":    &Config.RewriteTransactionNames,
+	}
+	for field, config := range rewriteNames {
+		flag.BoolVar(
+			config,
+			fmt.Sprintf("rewrite-%ss", strings.Replace(field, ".", "-", -1)),
+			false,
+			fmt.Sprintf("replace `%s` in events", field),
+		)
+	}
 
 	// For configs that can be set via environment variables, set the required
 	// flags from env if they are not explicitly provided via command line

--- a/systemtest/loadgen/eventhandler.go
+++ b/systemtest/loadgen/eventhandler.go
@@ -35,15 +35,20 @@ import (
 var events embed.FS
 
 type EventHandlerParams struct {
-	Path              string
-	URL               string
-	Token             string
-	APIKey            string
-	Limiter           *rate.Limiter
-	Rand              *rand.Rand
-	RewriteIDs        bool
-	RewriteTimestamps bool
-	Headers           map[string]string
+	Path                      string
+	URL                       string
+	Token                     string
+	APIKey                    string
+	Limiter                   *rate.Limiter
+	Rand                      *rand.Rand
+	RewriteIDs                bool
+	RewriteServiceNames       bool
+	RewriteServiceNodeNames   bool
+	RewriteServiceTargetNames bool
+	RewriteSpanNames          bool
+	RewriteTransactionNames   bool
+	RewriteTimestamps         bool
+	Headers                   map[string]string
 }
 
 // NewEventHandler creates a eventhandler which loads the files matching the
@@ -57,12 +62,17 @@ func NewEventHandler(p EventHandlerParams) (*eventhandler.Handler, error) {
 	}
 	transp := eventhandler.NewTransport(t.Client, p.URL, p.Token, p.APIKey, p.Headers)
 	return eventhandler.New(eventhandler.Config{
-		Path:              filepath.Join("events", p.Path),
-		Transport:         transp,
-		Storage:           events,
-		Limiter:           p.Limiter,
-		Rand:              p.Rand,
-		RewriteIDs:        p.RewriteIDs,
-		RewriteTimestamps: p.RewriteTimestamps,
+		Path:                      filepath.Join("events", p.Path),
+		Transport:                 transp,
+		Storage:                   events,
+		Limiter:                   p.Limiter,
+		Rand:                      p.Rand,
+		RewriteIDs:                p.RewriteIDs,
+		RewriteServiceNames:       p.RewriteServiceNames,
+		RewriteServiceNodeNames:   p.RewriteServiceNodeNames,
+		RewriteServiceTargetNames: p.RewriteServiceTargetNames,
+		RewriteSpanNames:          p.RewriteSpanNames,
+		RewriteTransactionNames:   p.RewriteTransactionNames,
+		RewriteTimestamps:         p.RewriteTimestamps,
 	})
 }

--- a/systemtest/soaktest/soaktest.go
+++ b/systemtest/soaktest/soaktest.go
@@ -58,15 +58,20 @@ func RunBlocking(ctx context.Context) error {
 
 func runAgent(ctx context.Context, expr string, limiter *rate.Limiter, rng *rand.Rand, headers map[string]string) error {
 	handler, err := loadgen.NewEventHandler(loadgen.EventHandlerParams{
-		Path:              expr,
-		URL:               loadgencfg.Config.ServerURL.String(),
-		Token:             loadgencfg.Config.SecretToken,
-		APIKey:            loadgencfg.Config.APIKey,
-		Limiter:           limiter,
-		Rand:              rng,
-		RewriteIDs:        loadgencfg.Config.RewriteIDs,
-		RewriteTimestamps: loadgencfg.Config.RewriteTimestamps,
-		Headers:           headers,
+		Path:                      expr,
+		URL:                       loadgencfg.Config.ServerURL.String(),
+		Token:                     loadgencfg.Config.SecretToken,
+		APIKey:                    loadgencfg.Config.APIKey,
+		Limiter:                   limiter,
+		Rand:                      rng,
+		RewriteIDs:                loadgencfg.Config.RewriteIDs,
+		RewriteServiceNames:       loadgencfg.Config.RewriteServiceNames,
+		RewriteServiceNodeNames:   loadgencfg.Config.RewriteServiceNodeNames,
+		RewriteServiceTargetNames: loadgencfg.Config.RewriteServiceTargetNames,
+		RewriteSpanNames:          loadgencfg.Config.RewriteSpanNames,
+		RewriteTransactionNames:   loadgencfg.Config.RewriteTransactionNames,
+		RewriteTimestamps:         loadgencfg.Config.RewriteTimestamps,
+		Headers:                   headers,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## Motivation/summary

Add flags for apmsoak to rewrite name fields:

```
-rewrite-service-names service.name
      replace service.name in events
-rewrite-service-node-names service.node.name
      replace service.node.name in events
-rewrite-service-target-names service.target.name
      replace service.target.name in events
-rewrite-span-names span.name
      replace span.name in events
-rewrite-transaction-names transaction.name
      replace transaction.name in events
```

If any of these flags are specified, then the corresponding fields will be rewritten by replacing ASCII letters and digits with a random rune of the same category.

These flags are intended for testing the impacts of high cardinality.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

Run `apmsoak` with each flag in turn, verifying the corresponding event fields are randomised.

## Related issues

Closes #10446