### PR TITLE
mergify: auto-merge backports from mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,6 +2,9 @@ queue_rules:
   - name: default
     conditions:
       - check-success=apm-ci/pr-merge
+      - check-success=system-test
+      - check-success=lint
+      - check-success=CLA
 pull_request_rules:
   - name: ask to resolve conflict
     conditions:
@@ -139,7 +142,6 @@ pull_request_rules:
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
   - name: squash and merge updatecli PRs after CI passes
     conditions:
-      - check-success=apm-ci/pr-merge
       - label=automation
       - head~=^updatecli
     actions:
@@ -191,6 +193,18 @@ pull_request_rules:
       comment:
         message: |
           This pull request has not been merged yet. Could you please review and merge it @{{ assignee | join(', @') }}? 🙏
+  - name: auto-merge for 7\. or 8\. branches when CI passes
+    conditions:
+      - base~=^(7|8)\.
+      - label=backport
+      - author=mergify[bot]
+    actions:
+      review:
+        type: APPROVE
+        message: Automatically approving mergify
+      queue:
+        method: squash
+        name: default
   - name: backport patches to 8.5 branch
     conditions:
       - merged

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -193,9 +193,8 @@ pull_request_rules:
       comment:
         message: |
           This pull request has not been merged yet. Could you please review and merge it @{{ assignee | join(', @') }}? 🙏
-  - name: auto-merge for 7\. or 8\. branches when CI passes
+  - name: auto-merge backport branches when CI passes
     conditions:
-      - base~=^(7|8)\.
       - label=backport
       - author=mergify[bot]
     actions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -144,6 +144,7 @@ pull_request_rules:
     conditions:
       - label=automation
       - head~=^updatecli
+      - -conflict
     actions:
       queue:
         method: squash
@@ -193,10 +194,11 @@ pull_request_rules:
       comment:
         message: |
           This pull request has not been merged yet. Could you please review and merge it @{{ assignee | join(', @') }}? 🙏
-  - name: auto-merge backport branches when CI passes
+  - name: squash and merge backport PRs after CI passes
     conditions:
       - label=backport
       - author=mergify[bot]
+      - -conflict
     actions:
       review:
         type: APPROVE


### PR DESCRIPTION
## Motivation/summary

Use the same implementation as https://github.com/elastic/fleet-server/pull/168 so automated backports that are generated by mergify will be auto-merged if they passed in the CI.

It uses a few conditions:
- generated by `mergify`
- with a `backport` label
- without conflicts

I also added a few more conditions in the queue rule to reflect the change to GitHub actions, since it used Jenkins commit status checks only