### PR TITLE
mergify: cannot create and auto-approve the same user

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -200,9 +200,6 @@ pull_request_rules:
       - author=mergify[bot]
       - -conflict
     actions:
-      review:
-        type: APPROVE
-        message: Automatically approving mergify
       queue:
         method: squash
         name: default


### PR DESCRIPTION
It's not allowed to use the same user to create PRs and approve them

<img width="934" alt="image" src="https://user-images.githubusercontent.com/2871786/229073057-631b8656-a76f-4ec8-9cba-bfa534f82827.png">

https://github.com/elastic/apm-server/pull/10544/checks?check_run_id=12420261076