### PR TITLE
feat: wait for interval and sends events at once

### DIFF
--- a/systemtest/benchtest/main.go
+++ b/systemtest/benchtest/main.go
@@ -267,7 +267,7 @@ func warmup(agents int, duration time.Duration, url, token string) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			h.WarmUpServer(ctx)
+			h.SendBatchesInLoop(ctx)
 		}()
 	}
 	wg.Wait()

--- a/systemtest/loadgen/eventhandler/handler.go
+++ b/systemtest/loadgen/eventhandler/handler.go
@@ -279,7 +279,7 @@ func (h *Handler) SendBatchesInLoop(ctx context.Context) error {
 			if _, err := h.sendBatches(ctx, &s); err != nil {
 				return err
 			}
-			// reset after batches so it doesn't exceed th limit
+			// safeguard `s.sent` so that it doesn't exceed math.MaxInt
 			// but keep the remainder so the next batches know where to start
 			if s.burst > 0 {
 				s.sent = s.sent % s.burst

--- a/systemtest/loadgen/eventhandler/handler.go
+++ b/systemtest/loadgen/eventhandler/handler.go
@@ -312,16 +312,16 @@ func (h *Handler) sendBatch(
 			h.queuedEvents += len(events)
 			return sent, nil
 		}
-		// if queuedEvents exist, need to allow (burst - queued event) events from current batch
+		// if queuedEvents > 0, need to use (burst - queued event) events from current batch
 		n -= h.queuedEvents
 		tb := batch{
 			metadata: b.metadata,
 			events:   events[:n],
 		}
 
-		// the number of events equal to burst is collected from above step
+		// the number of events equal to burst are collected from above steps
 		// wait for the burst size to ensure the limiter to block for the interval
-		// then send all the queued batches
+		// then send all the events
 		if err := h.config.Limiter.WaitN(ctx, burst); err != nil {
 			return sent, err
 		}

--- a/systemtest/loadgen/eventhandler/handler_test.go
+++ b/systemtest/loadgen/eventhandler/handler_test.go
@@ -449,6 +449,7 @@ func TestHandlerSendBatchesRewriteServiceNames(t *testing.T) {
 
 	originalPayload := fmt.Sprintf(`
 {"metadata":{"service":{"name":"%s"}}}
+{"transaction":{}}
 `[1:], serviceName)
 
 	fs := fstest.MapFS{"foo.ndjson": {Data: []byte(originalPayload)}}
@@ -493,6 +494,7 @@ func TestHandlerSendBatchesRewriteServiceNodeNames(t *testing.T) {
 
 	originalPayload := fmt.Sprintf(`
 {"metadata":{"service":{"node":{"configured_name":"%s"}}}}
+{"transaction":{}}
 `[1:], serviceNodeName)
 
 	fs := fstest.MapFS{"foo.ndjson": {Data: []byte(originalPayload)}}

--- a/systemtest/loadgen/eventhandler/handler_test.go
+++ b/systemtest/loadgen/eventhandler/handler_test.go
@@ -722,7 +722,6 @@ func TestHandlerInLoop(t *testing.T) {
 		// the total number of events in batches are smaller than burst
 		// in this case it should call multiple sendBatches to meet the target burst
 		h, srv := newHandler(t, withRateLimiter(rate.NewLimiter(40*rate.Every(time.Second), 40)))
-		fmt.Println("[1] burst:", h.config.Limiter.Burst())
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		err := h.SendBatchesInLoop(ctx)

--- a/systemtest/loadgen/eventhandler/handler_test.go
+++ b/systemtest/loadgen/eventhandler/handler_test.go
@@ -293,10 +293,8 @@ func TestHandlerSendBatches(t *testing.T) {
 		n, _ := handler.SendBatches(ctx)
 		// 12 (1st sec) sent, wait for 2 sec to send events
 		// cancelling at 2nd sec shows queued batches
-		assert.Equal(t, 2, len(handler.batches))       // Ensure there are 2 batches.
-		assert.Equal(t, 1, len(handler.queuedBatches)) // Ensure there are 1 queued batch from previous batch.
-		assert.Equal(t, 4, handler.queuedEvents)       // Ensure there are 4 remaining events from 1st batch (length of 1st batch: 16)
-		assert.Equal(t, 12, srv.received)              // no events sent until next interval (only first burst)
+		assert.Equal(t, 2, len(handler.batches)) // Ensure there are 2 batches.
+		assert.Equal(t, 12, srv.received)        // no events sent until next interval (only first burst)
 		assert.Equal(t, 12, n)
 	})
 	t.Run("success-dequeue-events-and-send-at-next-interval", func(t *testing.T) {
@@ -305,9 +303,7 @@ func TestHandlerSendBatches(t *testing.T) {
 		defer cancel()
 		n, _ := handler.SendBatches(ctx)
 		// 12 (1st sec) + 12 (3rd sec)
-		// cancelling at 2nd sec shows queued batches
-		assert.Equal(t, 2, len(handler.batches)) // Ensure there are 2 batches.
-		assert.Equal(t, 24, srv.received)        // Ensure the burst is sent at the next interval
+		assert.Equal(t, 24, srv.received) // Ensure the events are sent after 2 seconds
 		assert.Equal(t, 24, n)
 	})
 }

--- a/systemtest/loadgen/eventhandler/handler_test.go
+++ b/systemtest/loadgen/eventhandler/handler_test.go
@@ -286,6 +286,30 @@ func TestHandlerSendBatches(t *testing.T) {
 		assert.Equal(t, 2, len(handler.batches)) // Ensure there are 2 batches.
 		assert.Equal(t, 4, srv.requestCount)     // a batch split into 2 requests.
 	})
+	t.Run("success-queue-when-batch-size-is-smaller-than-burst", func(t *testing.T) {
+		handler, srv := newHandler(t, withRateLimiter(rate.NewLimiter(6, 12))) // event rate = 12/2sec
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		n, _ := handler.SendBatches(ctx)
+		// 12 (1st sec) sent, wait for 2 sec to send events
+		// cancelling at 2nd sec shows queued batches
+		assert.Equal(t, 2, len(handler.batches))       // Ensure there are 2 batches.
+		assert.Equal(t, 1, len(handler.queuedBatches)) // Ensure there are 1 queued batch from previous batch.
+		assert.Equal(t, 4, handler.queuedEvents)       // Ensure there are 4 remaining events from 1st batch (length of 1st batch: 16)
+		assert.Equal(t, 12, srv.received)              // no events sent until next interval (only first burst)
+		assert.Equal(t, 12, n)
+	})
+	t.Run("success-dequeue-events-and-send-at-next-interval", func(t *testing.T) {
+		handler, srv := newHandler(t, withRateLimiter(rate.NewLimiter(6, 12))) // event rate = 12/2sec
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		n, _ := handler.SendBatches(ctx)
+		// 12 (1st sec) + 12 (3rd sec)
+		// cancelling at 2nd sec shows queued batches
+		assert.Equal(t, 2, len(handler.batches)) // Ensure there are 2 batches.
+		assert.Equal(t, 24, srv.received)        // Ensure the burst is sent at the next interval
+		assert.Equal(t, 24, n)
+	})
 }
 
 func TestHandlerSendBatchesRewriteTimestamps(t *testing.T) {

--- a/systemtest/soaktest/soaktest.go
+++ b/systemtest/soaktest/soaktest.go
@@ -77,16 +77,9 @@ func runAgent(ctx context.Context, expr string, limiter *rate.Limiter, rng *rand
 		return err
 	}
 
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		default:
-			_, err = handler.SendBatches(ctx)
-			if err != nil {
-				return err
-			}
-		}
+	if err := handler.SendBatchesInLoop(ctx); err != nil {
+		return err
 	}
+
 	return nil
 }


### PR DESCRIPTION
## Motivation/summary
if event rate is `n/t`,
Send a burst of `n` data every `t` rather than spread the load over duration `t`

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes
TBC

## Related issues
closes #10575 