### PR TITLE
fix: use dropped spans outcome in spanmetrics aggregation

### DIFF
--- a/changelogs/8.7.asciidoc
+++ b/changelogs/8.7.asciidoc
@@ -15,6 +15,7 @@ https://github.com/elastic/apm-server/compare/v8.7.0\...v8.7.1[View commits]
 [float]
 ==== Bug fixes
 - Fix indexing failures for metric, error and log documents when `agent.activation_method` is set {pull}10522[10522]
+- Use droppedspan outcome in spanmetrics aggregation {pull}10592[10592]
 
 [float]
 [[release-notes-8.7.0]]

--- a/changelogs/8.7.asciidoc
+++ b/changelogs/8.7.asciidoc
@@ -15,7 +15,7 @@ https://github.com/elastic/apm-server/compare/v8.7.0\...v8.7.1[View commits]
 [float]
 ==== Bug fixes
 - Fix indexing failures for metric, error and log documents when `agent.activation_method` is set {pull}10552[10552]
-- Use droppedspan outcome in spanmetrics aggregation {pull}10592[10592]
+- Use droppedspan outcome in service destination aggregation {pull}10592[10592]
 
 [float]
 [[release-notes-8.7.0]]

--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
@@ -259,6 +259,7 @@ func (a *Aggregator) processSpan(event *model.APMEvent) {
 	for _, interval := range a.Intervals {
 		key := makeAggregationKey(
 			event,
+			event.Event.Outcome,
 			event.Span.DestinationService.Resource,
 			serviceTargetType,
 			serviceTargetName,
@@ -285,6 +286,7 @@ func (a *Aggregator) processDroppedSpanStats(event *model.APMEvent, dss model.Dr
 	for _, interval := range a.Intervals {
 		key := makeAggregationKey(
 			event,
+			dss.Outcome,
 			dss.DestinationServiceResource,
 			dss.ServiceTargetType,
 			dss.ServiceTargetName,
@@ -436,7 +438,7 @@ func (k *aggregationKey) equal(key aggregationKey) bool {
 }
 
 func makeAggregationKey(
-	event *model.APMEvent, resource, targetType, targetName, spanName string, interval time.Duration,
+	event *model.APMEvent, outcome, resource, targetType, targetName, spanName string, interval time.Duration,
 ) aggregationKey {
 	key := aggregationKey{
 		comparable: comparable{
@@ -448,7 +450,7 @@ func makeAggregationKey(
 			agentName:          event.Agent.Name,
 
 			spanName: spanName,
-			outcome:  event.Event.Outcome,
+			outcome:  outcome,
 
 			targetType: targetType,
 			targetName: targetName,

--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator_test.go
@@ -467,7 +467,7 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 	batch := expectBatch(t, batches)
 	metricsets := batchMetricsets(t, batch)
 
-	assert.ElementsMatch(t, []model.APMEvent{
+	assert.Empty(t, cmp.Diff([]model.APMEvent{
 		{
 			Agent: model.Agent{Name: "go"},
 			Service: model.Service{
@@ -526,7 +526,9 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 				},
 			},
 		},
-	}, metricsets)
+	}, metricsets, cmpopts.IgnoreTypes(netip.Addr{}), cmpopts.SortSlices(func(e1 model.APMEvent, e2 model.APMEvent) bool {
+		return e1.Span.DestinationService.Resource < e2.Span.DestinationService.Resource
+	})))
 }
 
 func TestAggregateHalfCapacityNoSpanName(t *testing.T) {

--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator_test.go
@@ -513,7 +513,7 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 			Service: model.Service{
 				Name: "go-service",
 			},
-			Event:     model.Event{Outcome: "success"},
+			Event:     model.Event{Outcome: "unknown"},
 			Processor: model.MetricsetProcessor,
 			Metricset: &model.Metricset{Name: "service_destination", Interval: "0s", DocCount: 4},
 			Span: &model.Span{


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Use the correct outcome when creating the aggregation keys: use the outcome from dropped span stats instead of the current event outcome

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Closes https://github.com/elastic/apm-server/issues/10543
