### PR TITLE
metrics: Count context.DeadlineExceeded as timeout

### DIFF
--- a/changelogs/8.7.asciidoc
+++ b/changelogs/8.7.asciidoc
@@ -15,6 +15,7 @@ https://github.com/elastic/apm-server/compare/v8.7.0\...v8.7.1[View commits]
 [float]
 ==== Bug fixes
 - Fix indexing failures for metric, error and log documents when `agent.activation_method` is set {pull}10522[10522]
+- metrics: Count context.DeadlineExceeded as timeout {pull}10594[10594]
 
 [float]
 [[release-notes-8.7.0]]

--- a/internal/beater/middleware/timeout_middleware.go
+++ b/internal/beater/middleware/timeout_middleware.go
@@ -35,7 +35,7 @@ func TimeoutMiddleware() Middleware {
 			h(c)
 
 			err := c.Request.Context().Err()
-			if errors.Is(err, context.Canceled) {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				c.Result.SetDefault(request.IDResponseErrorsTimeout)
 				c.Result.Err = tErr
 				c.Result.Body = tErr.Error()

--- a/internal/beater/middleware/timeout_middleware_test.go
+++ b/internal/beater/middleware/timeout_middleware_test.go
@@ -64,7 +64,7 @@ func TestTimeoutMiddleware(t *testing.T) {
 			ctx, cancel = context.WithTimeout(ctx, time.Nanosecond)
 			r := c.Request.WithContext(ctx)
 			c.Request = r
-			time.Sleep(10 * time.Millisecond)
+			time.Sleep(time.Second)
 		}))
 	})
 }

--- a/internal/beater/middleware/timeout_middleware_test.go
+++ b/internal/beater/middleware/timeout_middleware_test.go
@@ -58,7 +58,7 @@ func TestTimeoutMiddleware(t *testing.T) {
 			ctx, _ = context.WithTimeout(ctx, time.Nanosecond)
 			r := c.Request.WithContext(ctx)
 			c.Request = r
-			<-time.After(2 * time.Nanosecond)
+			<-time.After(100 * time.Nanosecond)
 		}))
 	})
 }

--- a/internal/beater/middleware/timeout_middleware_test.go
+++ b/internal/beater/middleware/timeout_middleware_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -29,24 +30,46 @@ import (
 )
 
 func TestTimeoutMiddleware(t *testing.T) {
-	var err error
-	m := TimeoutMiddleware()
-	h := request.Handler(func(c *request.Context) {
-		ctx := c.Request.Context()
-		ctx, cancel := context.WithCancel(ctx)
-		r := c.Request.WithContext(ctx)
-		c.Request = r
-		cancel()
+	t.Run("Cancelled", func(t *testing.T) {
+		var err error
+		h := request.Handler(func(c *request.Context) {
+			ctx := c.Request.Context()
+			ctx, cancel := context.WithCancel(ctx)
+			r := c.Request.WithContext(ctx)
+			c.Request = r
+			cancel()
+		})
+
+		h, err = TimeoutMiddleware()(h)
+		assert.NoError(t, err)
+
+		c := request.NewContext()
+		r, err := http.NewRequest("GET", "/", nil)
+		assert.NoError(t, err)
+		c.Reset(httptest.NewRecorder(), r)
+		h(c)
+
+		assert.Equal(t, http.StatusServiceUnavailable, c.Result.StatusCode)
 	})
+	t.Run("DeadlineExceeded", func(t *testing.T) {
+		var err error
+		h := request.Handler(func(c *request.Context) {
+			ctx := c.Request.Context()
+			ctx, _ = context.WithTimeout(ctx, time.Nanosecond)
+			r := c.Request.WithContext(ctx)
+			c.Request = r
+			<-time.After(2 * time.Nanosecond)
+		})
 
-	h, err = m(h)
-	assert.NoError(t, err)
+		h, err = TimeoutMiddleware()(h)
+		assert.NoError(t, err)
 
-	c := request.NewContext()
-	r, err := http.NewRequest("GET", "/", nil)
-	assert.NoError(t, err)
-	c.Reset(httptest.NewRecorder(), r)
-	h(c)
+		c := request.NewContext()
+		r, err := http.NewRequest("GET", "/", nil)
+		assert.NoError(t, err)
+		c.Reset(httptest.NewRecorder(), r)
+		h(c)
 
-	assert.Equal(t, http.StatusServiceUnavailable, c.Result.StatusCode)
+		assert.Equal(t, http.StatusServiceUnavailable, c.Result.StatusCode)
+	})
 }

--- a/internal/beater/middleware/timeout_middleware_test.go
+++ b/internal/beater/middleware/timeout_middleware_test.go
@@ -53,12 +53,18 @@ func TestTimeoutMiddleware(t *testing.T) {
 		}))
 	})
 	t.Run("DeadlineExceeded", func(t *testing.T) {
+		var cancel func()
+		defer func() {
+			if cancel != nil {
+				cancel()
+			}
+		}()
 		test(t, request.Handler(func(c *request.Context) {
 			ctx := c.Request.Context()
-			ctx, _ = context.WithTimeout(ctx, time.Nanosecond)
+			ctx, cancel = context.WithTimeout(ctx, time.Nanosecond)
 			r := c.Request.WithContext(ctx)
 			c.Request = r
-			<-time.After(100 * time.Nanosecond)
+			time.Sleep(10 * time.Millisecond)
 		}))
 	})
 }


### PR DESCRIPTION
## Motivation/summary

Fixes the response.errors.timeout counter.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

See fixed issue

## Related issues

Fixes #10593
