### PR TITLE
metrics: Count GRPC codes.Canceled as timeout

### DIFF
--- a/changelogs/8.7.asciidoc
+++ b/changelogs/8.7.asciidoc
@@ -17,7 +17,7 @@ https://github.com/elastic/apm-server/compare/v8.7.0\...v8.7.1[View commits]
 - Fix indexing failures for metric, error and log documents when `agent.activation_method` is set {pull}10552[10552]
 - Use droppedspan outcome in service destination aggregation {pull}10592[10592]
 - metrics: Count context.DeadlineExceeded as timeout {pull}10594[10594]
-- metrics: Count GRPC codes.Canceled as timeout {pull}XXXX[XXXX]
+- metrics: Count GRPC codes.Canceled as timeout {pull}10605[10605]
 
 [float]
 [[release-notes-8.7.0]]

--- a/changelogs/8.7.asciidoc
+++ b/changelogs/8.7.asciidoc
@@ -17,6 +17,7 @@ https://github.com/elastic/apm-server/compare/v8.7.0\...v8.7.1[View commits]
 - Fix indexing failures for metric, error and log documents when `agent.activation_method` is set {pull}10552[10552]
 - Use droppedspan outcome in service destination aggregation {pull}10592[10592]
 - metrics: Count context.DeadlineExceeded as timeout {pull}10594[10594]
+- metrics: Count GRPC codes.Canceled as timeout {pull}XXXX[XXXX]
 
 [float]
 [[release-notes-8.7.0]]

--- a/internal/beater/interceptors/metrics.go
+++ b/internal/beater/interceptors/metrics.go
@@ -89,7 +89,7 @@ func Metrics(logger *logp.Logger) grpc.UnaryServerInterceptor {
 				switch s.Code() {
 				case codes.Unauthenticated:
 					m[request.IDResponseErrorsUnauthorized].Inc()
-				case codes.DeadlineExceeded:
+				case codes.DeadlineExceeded, codes.Canceled:
 					m[request.IDResponseErrorsTimeout].Inc()
 				case codes.ResourceExhausted:
 					m[request.IDResponseErrorsRateLimit].Inc()

--- a/internal/beater/interceptors/metrics_test.go
+++ b/internal/beater/interceptors/metrics_test.go
@@ -109,6 +109,21 @@ func TestMetrics(t *testing.T) {
 		},
 		{
 			f: func(ctx context.Context, req interface{}) (interface{}, error) {
+				return nil, status.Error(codes.Canceled, "request timed out")
+			},
+			monitoringInt: map[request.ResultID]int64{
+				request.IDRequestCount:               1,
+				request.IDResponseCount:              1,
+				request.IDResponseValidCount:         0,
+				request.IDResponseErrorsCount:        1,
+				request.IDResponseErrorsInternal:     0,
+				request.IDResponseErrorsRateLimit:    0,
+				request.IDResponseErrorsTimeout:      1,
+				request.IDResponseErrorsUnauthorized: 0,
+			},
+		},
+		{
+			f: func(ctx context.Context, req interface{}) (interface{}, error) {
 				return nil, status.Error(codes.ResourceExhausted, "rate limit exceeded")
 			},
 			monitoringInt: map[request.ResultID]int64{

--- a/internal/beater/request/result.go
+++ b/internal/beater/request/result.go
@@ -78,7 +78,6 @@ const (
 	IDResponseErrorsServiceUnavailable ResultID = "response.errors.unavailable"
 	// IDResponseErrorsInternal identifies responses where internal errors occured
 	IDResponseErrorsInternal ResultID = "response.errors.internal"
-	// IDResponseErrorsServiceUnavailable identifies responses where resource is unavailable
 )
 
 var (


### PR DESCRIPTION
## Motivation/summary

Updates the GRPC metrics interceptor to increment the timeout counter for requests with `code.Canceled`.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

See related issue.

## Related issues

Related to #10593 
