### PR TITLE
updated the setting breadcrumb from `Stack Management / Index Lifecycle Management` to `Stack Management / Index Lifecycle Policies`

### DIFF
--- a/docs/ilm-how-to.asciidoc
+++ b/docs/ilm-how-to.asciidoc
@@ -54,7 +54,7 @@ Each policy includes a rollover and delete definition:
 |===
 
 The APM index lifecycle policies can be viewed in {kib}.
-Navigate to *{stack-manage-app}* / *Index Lifecycle Management*, and search for `apm`.
+Navigate to *{stack-manage-app}* / *Index Lifecycle Policies*, and search for `apm`.
 
 TIP: Default {ilm-init} policies can change between minor versions.
 This is not considered a breaking change as index management should continually improve and adapt to new features.


### PR DESCRIPTION
Users reading the docs tend to get lost when a setting or page mentioned in the docs is now what they see or have from the application.

- Updated <https://www.elastic.co/guide/en/apm/guide/current/ilm-how-to.html#index-lifecycle-policies-default> settings path from `Stack Management / Index Lifecycle Management` to `Stack Management / Index Lifecycle Policies`

## Checklist

- [x] Documentation has been updated

