### PR TITLE
Remove global labels from agg key for RUM services

### DIFF
--- a/changelogs/8.7.asciidoc
+++ b/changelogs/8.7.asciidoc
@@ -18,6 +18,7 @@ https://github.com/elastic/apm-server/compare/v8.7.0\...v8.7.1[View commits]
 - Use droppedspan outcome in service destination aggregation {pull}10592[10592]
 - metrics: Count context.DeadlineExceeded as timeout {pull}10594[10594]
 - metrics: Count GRPC codes.Canceled as timeout {pull}10605[10605]
+- Remove global labels from aggregations for RUM services {pull}10624[10624]
 
 [float]
 [[release-notes-8.7.0]]

--- a/systemtest/aggregation_test.go
+++ b/systemtest/aggregation_test.go
@@ -305,6 +305,43 @@ func TestServiceTransactionMetricsAggregationLabels(t *testing.T) {
 	assert.ElementsMatch(t, metricsets, docs)
 }
 
+// TestServiceTransactionMetricsAggregationLabelsRUM checks that RUM labels are ignored for aggregation
+func TestServiceTransactionMetricsAggregationLabelsRUM(t *testing.T) {
+	t.Setenv("ELASTIC_APM_GLOBAL_LABELS", "department_name=apm,organization=observability,company=elastic")
+	systemtest.CleanupElasticsearch(t)
+	srv := apmservertest.NewServerTB(t)
+
+	rumPayloadWithLabels := `{"metadata":{"service":{"name":"rum-js-test","agent":{"name":"rum-js","version":"5.5.0"}}},"labels": {"tag0": null, "tag1": "one", "tag2": 2}}
+{"transaction":{"trace_id":"611f4fa950f04631aaaaaaaaaaaaaaaa","id":"611f4fa950f04631","type":"page-load","duration":643,"span_count":{"started":0}}}
+`
+	systemtest.SendBackendEventsLiteral(t, srv.URL, rumPayloadWithLabels)
+
+	// Wait for the transaction to be indexed, indicating that Elasticsearch
+	// indices have been setup and we should not risk triggering the shutdown
+	// timeout while waiting for the aggregated metrics to be indexed.
+	systemtest.Elasticsearch.ExpectDocs(t, "traces-apm*",
+		estest.TermQuery{Field: "processor.event", Value: "transaction"},
+	)
+	// Stop server to ensure metrics are flushed on shutdown.
+	assert.NoError(t, srv.Close())
+	result := systemtest.Elasticsearch.ExpectDocs(t, "metrics-apm.service_transaction*", estest.BoolQuery{
+		Filter: []interface{}{
+			estest.TermQuery{Field: "metricset.name", Value: "service_transaction"},
+		},
+	})
+
+	docs := unmarshalMetricsetDocs(t, result.Hits.Hits)
+	var metricsets []metricsetDoc
+	for _, interval := range []string{"1m", "10m", "60m"} {
+		metricsets = append(metricsets, metricsetDoc{
+			Trasaction:        metricsetTransaction{Type: "page-load"},
+			MetricsetInterval: interval,
+			MetricsetName:     "service_transaction",
+		})
+	}
+	assert.ElementsMatch(t, metricsets, docs)
+}
+
 func TestServiceSummaryMetricsAggregation(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
 	srv := apmservertest.NewServerTB(t)

--- a/x-pack/apm-server/aggregation/labels/labels.go
+++ b/x-pack/apm-server/aggregation/labels/labels.go
@@ -54,7 +54,7 @@ func (a *AggregatedGlobalLabels) Read(event *model.APMEvent) {
 	// to track for servicetxmetrics.
 	// For consistency, this will remove labels for other aggregated metrics as well.
 	switch event.Agent.Name {
-	case "rum-js", "js-base":
+	case "rum-js", "js-base", "android/java", "iOS/swift":
 		return
 	}
 

--- a/x-pack/apm-server/aggregation/labels/labels.go
+++ b/x-pack/apm-server/aggregation/labels/labels.go
@@ -50,6 +50,14 @@ func (a *AggregatedGlobalLabels) Write(w io.Writer) {
 }
 
 func (a *AggregatedGlobalLabels) Read(event *model.APMEvent) {
+	// Remove global labels for RUM services to avoid explosion of metric groups
+	// to track for servicetxmetrics.
+	// For consistency, this will remove labels for other aggregated metrics as well.
+	switch event.Agent.Name {
+	case "rum-js", "js-base":
+		return
+	}
+
 	for k, v := range event.Labels {
 		if !v.Global {
 			continue


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Remove global labels for RUM services to avoid explosion of metric groups to track for servicetxmetrics. For consistency, this will remove labels for other aggregated metrics as well. Agent name "rum-js", "js-base", "android/java", "iOS/swift" are considered as RUM in this case.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->
- Send RUM events with global different labels, verify that they are aggregated into the same group, and that the resulting aggregation document does not contain global labels.

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->

Closes #10532 
