### PR TITLE
Use local Kibana in Tiltfile if available

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,3 +1,44 @@
+def printup(*args):
+  if config.tilt_subcommand == "up":
+    print(*args)
+
+config.define_bool('local-kibana')
+
+parsed_config = config.parse()
+
+script_dir = os.path.join(config.main_dir, 'script')
+
+default_kibana_port = 5601
+kibana_host = "localhost"
+kibana_base_path = ""
+
+# checks whether (dev mode) kibana is already running at given port,
+# and returns the URL it is redirected to
+def discover_kibana():
+
+    default_kibana_host = "localhost"
+
+    count = int(
+      str(
+        local("lsof -n -i :%s | grep LISTEN | wc -l | tr -d ' '" % default_kibana_port, quiet=True, echo_off=True)
+      ).strip()
+    )
+
+    if count <= 0:
+      fail("No service found on port " + str(default_kibana_port))
+      return None
+
+
+    kibana_redirect_url = str(
+      local(
+        "curl --fail -s -I -o /dev/null -w '%{redirect_url}' " + 'http://{}:{}'.format(default_kibana_host, default_kibana_port) + ' || [ $? -eq 7 ]',
+        quiet=True,
+        echo_off=True
+      )
+    ).strip().replace("http://", "")
+
+    return kibana_redirect_url
+
 custom_build(
   'apm-server',
   'DOCKER_BUILDKIT=1 docker build -t $EXPECTED_REF -f packaging/docker/Dockerfile .',
@@ -5,27 +46,60 @@ custom_build(
   ignore = ['**/*_test.go', 'tools/**', 'systemtest/**', 'docs/**'],
 )
 
+k8s_yaml(kustomize('testing/infra/k8s/overlays/local'))
+
+k8s_kind('ApmServer', image_json_path='{.spec.image}')
+k8s_kind('Elasticsearch')
+
+
+# Conditionally set up Kibana resource
+discovered_kibana_url = discover_kibana() if "local-kibana" in parsed_config else None
+
+if discovered_kibana_url and config.tilt_subcommand == "up":
+  printup("Waiting until local Kibana is ready at {}".format(discovered_kibana_url))
+  
+  # get only the path from the URL so we can pass it separately to APM Server
+  url = discovered_kibana_url
+  if "://" in discovered_kibana_url:
+    url = url.split("://")[1]
+  kibana_base_path = url.split("/", 1)[1] if "/" in url else ""
+
+
+  local_resource(
+    "init_kibana_system_user",
+    cmd = """curl -s -X POST -H "Content-Type: application/json" -d '{"username":"kibana_system_user", "password":"changeme", "roles": [ "kibana_system"]}' http://admin:changeme@localhost:9200/_security/user/kibana_system_user""",
+    resource_deps=["elasticsearch"]
+  )
+
+  local_resource(
+    'kibana',
+    cmd=[ os.path.join(script_dir, 'wait_for_kibana.sh'), "http://admin:changeme@{}".format(discovered_kibana_url)],
+    resource_deps=["init_kibana_system_user"],
+    links=["http://localhost:5601"]
+  )
+
+else:
+  printup("Starting Kibana as a container")
+
+  k8s_kind('Kibana')
+  k8s_resource('kibana', port_forwards=default_kibana_port, resource_deps=['elasticsearch'])
+    
 # Build and install the APM integration package whenever source under
 # "apmpackage" changes.
-script_dir = os.path.join(config.main_dir, 'script')
 run_with_go_ver = os.path.join(script_dir, 'run_with_go_ver')
+
+
 local_resource(
   'apmpackage',
   cmd = [os.path.join(script_dir, 'run_with_go_ver'), 'go', 'run', './cmd/runapm -init'],
   dir = 'systemtest',
   deps = ['apmpackage'],
   resource_deps=['kibana'],
+  env={ "KIBANA_HOST": kibana_host, "KIBANA_BASE_PATH": kibana_base_path, "KIBANA_PORT": str(default_kibana_port) }
 )
-
-k8s_yaml(kustomize('testing/infra/k8s/overlays/local'))
-
-k8s_kind('ApmServer', image_json_path='{.spec.image}')
-k8s_kind('Kibana')
-k8s_kind('Elasticsearch')
 
 k8s_resource('elastic-operator', objects=['eck-trial-license:Secret:elastic-system'])
 k8s_resource('apm-server', port_forwards=8200)
-k8s_resource('kibana', port_forwards=5601)
 k8s_resource('elasticsearch', port_forwards=9200, objects=['elasticsearch-admin:Secret:default'])
 
 # Delete ECK entirely on `tilt down`, to ensure `tilt up` starts from a clean slate.
@@ -38,6 +112,7 @@ if config.tilt_subcommand == "down":
 
 # Add a button for sending trace events and metrics to APM Server.
 load('ext://uibutton', 'cmd_button')
+
 cmd_button(
   'apm-server:sendotlp',
   argv=['sh', '-c', 'cd systemtest && %s go run ./cmd/sendotlp' % run_with_go_ver],

--- a/script/wait_for_kibana.sh
+++ b/script/wait_for_kibana.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+if ! which jq > /dev/null; then
+  echo "This script needs jq to be installed"
+  exit 1
+fi
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <url>"
+  exit 1
+fi
+
+url="$1"
+
+# this scripts waits until Kibana is available
+max_retries=5
+initial_delay=2
+max_delay=32
+timeout=60
+
+retries=0
+current_delay=$initial_delay
+start_time=$(date +%s)
+
+while [ $retries -lt $max_retries ]; do
+
+  response=$(curl -s -w "\n%{http_code}" $url/api/status -m 3)
+
+  body=$(echo "$response" | sed '$d')
+
+  # Extract the status code
+  status_code=$(echo "$response" | tail -n1)
+
+  message=""
+
+  if [ "$status_code" -ne "200" ]; then
+    message+="URL call to $url/api/status failed with status code $status_code. Response was: "$body""
+  elif [ "$response" ]; then
+    available=$(echo $response | jq '.status.core.elasticsearch.level == "available"')
+    
+    if [ available ]; then
+      echo "Kibana is available"
+      exit 0
+    fi
+
+    message+="Elasticsearch is not yet available"
+  fi
+
+  if [ ! "$message" ]; then
+    exit 0
+  fi
+
+  if [ $retries -eq 0 ]; then
+    # trigger a restart in case it's not up and running
+    echo "Restarting Kibana"
+    touch -c "../kibana/config/kibana.dev.yml"
+  fi
+    
+  echo "$message. Retrying with exponential backoff..."
+  sleep $current_delay
+
+  retries=$((retries + 1))
+  elapsed_time=$(($(date +%s) - start_time))
+
+  if [ $elapsed_time -ge $timeout ]; then
+    echo "Timeout reached."
+    exit 1
+  fi
+
+  current_delay=$((current_delay * 2))
+  if [ $current_delay -gt $max_delay ]; then
+    current_delay=$max_delay
+  fi
+done
+
+echo "Max retries reached."
+exit 1

--- a/systemtest/apmservertest/config.go
+++ b/systemtest/apmservertest/config.go
@@ -34,10 +34,11 @@ const (
 	defaultElasticsearchUser = "apm_server_user"
 	defaultElasticsearchPass = "changeme"
 
-	defaultKibanaHost = "localhost"
-	defaultKibanaPort = "5601"
-	defaultKibanaUser = "apm_user_ro"
-	defaultKibanaPass = "changeme"
+	defaultKibanaHost     = "localhost"
+	defaultKibanaPort     = "5601"
+	defaultKibanaUser     = "apm_user_ro"
+	defaultKibanaPass     = "changeme"
+	defaultKibanaBasePath = ""
 )
 
 // Config holds APM Server configuration.
@@ -387,6 +388,7 @@ func DefaultConfig() Config {
 					getenvDefault("KIBANA_HOST", defaultKibanaHost),
 					KibanaPort(),
 				),
+				Path: getenvDefault("KIBANA_BASE_PATH", defaultKibanaBasePath),
 			}).String(),
 			Username: getenvDefault("KIBANA_USER", defaultKibanaUser),
 			Password: getenvDefault("KIBANA_PASS", defaultKibanaPass),

--- a/systemtest/kibana.go
+++ b/systemtest/kibana.go
@@ -111,13 +111,24 @@ func InitFleetPackage() error {
 	systemtestDir := filepath.Dir(filename)
 	repoRoot := filepath.Join(systemtestDir, "..")
 
-	// Locate the integration package zip.
-	cmd := exec.Command("make", "--no-print-directory", "get-version")
+	// Build the integration package.
+	log.Printf("Building package")
+	cmd := exec.Command("make", "build-package")
 	cmd.Dir = repoRoot
 	output, err := cmd.Output()
+
 	if err != nil {
 		return err
 	}
+
+	// Locate the integration package zip.
+	cmd = exec.Command("make", "--no-print-directory", "get-version")
+	cmd.Dir = repoRoot
+	output, err = cmd.Output()
+	if err != nil {
+		return err
+	}
+
 	packageVersion := strings.TrimSpace(string(output))
 	packagesBuildDir := filepath.Join(systemtestDir, "..", "build", "packages")
 	packageFilename := filepath.Join(packagesBuildDir, fmt.Sprintf("apm-%s.zip", packageVersion))


### PR DESCRIPTION
Closes https://github.com/elastic/apm-dev/issues/937.

In short:
- if `--local-kibana` is set, checks port 5601 to see if there is a service running
- if it is, see if it is a Docker container or Kibana running locally in development mode
- if it's Kibana running locally, spawn a wait script that checks whether ES is available. this allows the user to start Kibana locally, without a working ES connection, and wait with installing the package until Kibana is available
- if there is no local Kibana, start the Kibana container
- Wait until either the local Kibana or the Kibana container is available when installing the package

I've added `KIBANA_BASE_PATH` to apm-server because in development mode, Kibana is often running on a different path rather than just the root. 

