### PR TITLE
Remove redundant aggregation groups on `faas.coldstart` in transaction metrics

### DIFF
--- a/changelogs/8.7.asciidoc
+++ b/changelogs/8.7.asciidoc
@@ -19,6 +19,7 @@ https://github.com/elastic/apm-server/compare/v8.7.0\...v8.7.1[View commits]
 - metrics: Count context.DeadlineExceeded as timeout {pull}10594[10594]
 - metrics: Count GRPC codes.Canceled as timeout {pull}10605[10605]
 - Remove global labels from aggregations for RUM services {pull}10624[10624]
+- Remove redundant aggregation groups on `faas.coldstart` in transaction metrics {pull}10635[10635]
 
 [float]
 [[release-notes-8.7.0]]

--- a/systemtest/aggregation_test.go
+++ b/systemtest/aggregation_test.go
@@ -63,6 +63,7 @@ func TestTransactionAggregation(t *testing.T) {
 	// when it does.
 	faasPayload := `{"metadata": {"service": {"name": "1234_service-12a3","node": {"configured_name": "node-123"},"version": "5.1.3","environment": "staging","language": {"name": "ecmascript","version": "8"},"runtime": {"name": "node","version": "8.0.0"},"framework": {"name": "Express","version": "1.2.3"},"agent": {"name": "elastic-node","version": "3.14.0"}},"user": {"id": "123user", "username": "bar", "email": "bar@user.com"}, "labels": {"tag0": null, "tag1": "one", "tag2": 2}, "process": {"pid": 1234,"ppid": 6789,"title": "node","argv": ["node","server.js"]},"system": {"hostname": "prod1.example.com","architecture": "x64","platform": "darwin", "container": {"id": "container-id"}, "kubernetes": {"namespace": "namespace1", "pod": {"uid": "pod-uid", "name": "pod-name"}, "node": {"name": "node-name"}}},"cloud":{"account":{"id":"account_id","name":"account_name"},"availability_zone":"cloud_availability_zone","instance":{"id":"instance_id","name":"instance_name"},"machine":{"type":"machine_type"},"project":{"id":"project_id","name":"project_name"},"provider":"cloud_provider","region":"cloud_region","service":{"name":"lambda"}}}}
 {"transaction": { "name": "faas", "type": "lambda", "result": "success", "id": "142e61450efb8574", "trace_id": "eb56529a1f461c5e7e2f66ecb075e983", "subtype": null, "action": null, "duration": 38.853, "timestamp": 1631736666365048, "sampled": true, "context": { "cloud": { "origin": { "account": { "id": "abc123" }, "provider": "aws", "region": "us-east-1", "service": { "name": "serviceName" } } }, "service": { "origin": { "id": "abc123", "name": "service-name", "version": "1.0" } }, "user": {}, "tags": {}, "custom": { } }, "sync": true, "span_count": { "started": 0 }, "outcome": "unknown", "faas": { "coldstart": false, "execution": "2e13b309-23e1-417f-8bf7-074fc96bc683", "trigger": { "request_id": "FuH2Cir_vHcEMUA=", "type": "http" } }, "sample_rate": 1 } }
+{"transaction": { "name": "faas", "type": "lambda", "result": "success", "id": "142e61450efb8575", "trace_id": "eb56529a1f461c5e7e2f66ecb075e984", "subtype": null, "action": null, "duration": 38.853, "timestamp": 1631736666365049, "sampled": true, "context": { "cloud": { "origin": { "account": { "id": "abc123" }, "provider": "aws", "region": "us-east-1", "service": { "name": "serviceName" } } }, "service": { "origin": { "id": "abc123", "name": "service-name", "version": "1.0" } }, "user": {}, "tags": {}, "custom": { } }, "sync": true, "span_count": { "started": 0 }, "outcome": "unknown", "faas": { "coldstart": false, "execution": "2e13b309-23e1-417f-8bf7-074fc96bc684", "trigger": { "request_id": "FuH2Cir_vHcEMUB=", "type": "http" } }, "sample_rate": 1 } }
 `
 	systemtest.SendBackendEventsLiteral(t, srv.URL, faasPayload)
 	tracer.Flush(nil)
@@ -119,7 +120,7 @@ func TestTransactionAggregation(t *testing.T) {
 	assert.Equal(t, []aggregationBucket{
 		{Key: "def", DocCount: 30}, // 10 * 3 buckets
 		{Key: "abc", DocCount: 15}, // 5 * 3 buckets
-		{Key: "faas", DocCount: 3}, // 1 * 3 buckets
+		{Key: "faas", DocCount: 6}, // 2 * 3 buckets
 	}, aggregationResult.Buckets)
 }
 

--- a/systemtest/approvals/TestTransactionAggregation.approved.json
+++ b/systemtest/approvals/TestTransactionAggregation.approved.json
@@ -464,7 +464,7 @@
         },
         {
             "@timestamp": "2021-09-15T20:10:00.000Z",
-            "_doc_count": 1,
+            "_doc_count": 2,
             "agent": {
                 "name": "elastic-node"
             },
@@ -560,15 +560,15 @@
                 "duration": {
                     "histogram": {
                         "counts": [
-                            1
+                            2
                         ],
                         "values": [
                             38911
                         ]
                     },
                     "summary": {
-                        "sum": 38911,
-                        "value_count": 1
+                        "sum": 77822,
+                        "value_count": 2
                     }
                 },
                 "name": "faas",
@@ -579,7 +579,7 @@
         },
         {
             "@timestamp": "2021-09-15T20:11:00.000Z",
-            "_doc_count": 1,
+            "_doc_count": 2,
             "agent": {
                 "name": "elastic-node"
             },
@@ -675,15 +675,15 @@
                 "duration": {
                     "histogram": {
                         "counts": [
-                            1
+                            2
                         ],
                         "values": [
                             38911
                         ]
                     },
                     "summary": {
-                        "sum": 38911,
-                        "value_count": 1
+                        "sum": 77822,
+                        "value_count": 2
                     }
                 },
                 "name": "faas",
@@ -694,7 +694,7 @@
         },
         {
             "@timestamp": "2021-09-15T20:00:00.000Z",
-            "_doc_count": 1,
+            "_doc_count": 2,
             "agent": {
                 "name": "elastic-node"
             },
@@ -790,15 +790,15 @@
                 "duration": {
                     "histogram": {
                         "counts": [
-                            1
+                            2
                         ],
                         "values": [
                             38911
                         ]
                     },
                     "summary": {
-                        "sum": 38911,
-                        "value_count": 1
+                        "sum": 77822,
+                        "value_count": 2
                     }
                 },
                 "name": "faas",

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -496,7 +496,7 @@ func makeTransactionAggregationKey(event model.APMEvent, interval time.Duration)
 			cloudProjectName:      event.Cloud.ProjectName,
 			cloudMachineType:      event.Cloud.MachineType,
 
-			faasColdstart:   event.FAAS.Coldstart,
+			faasColdstart:   nullableBoolFromPtr(event.FAAS.Coldstart),
 			faasID:          event.FAAS.ID,
 			faasTriggerType: event.FAAS.TriggerType,
 			faasName:        event.FAAS.Name,
@@ -572,7 +572,7 @@ func makeMetricset(key transactionAggregationKey, metrics transactionMetrics, in
 			SuccessCount: eventSuccessCount,
 		},
 		FAAS: model.FAAS{
-			Coldstart:   key.faasColdstart,
+			Coldstart:   key.faasColdstart.toPtr(),
 			ID:          key.faasID,
 			TriggerType: key.faasTriggerType,
 			Name:        key.faasName,
@@ -767,11 +767,30 @@ func (e *metricsMapEntry) reset(pool *sync.Pool) {
 	e.histogram = nil
 }
 
+type nullableBool struct {
+	isSet bool
+	val   bool
+}
+
+func (nb nullableBool) toPtr() *bool {
+	if !nb.isSet {
+		return nil
+	}
+	return &nb.val
+}
+
+func nullableBoolFromPtr(b *bool) nullableBool {
+	return nullableBool{
+		isSet: b != nil,
+		val:   b != nil && *b,
+	}
+}
+
 // comparable contains the fields with types which can be compared with the
 // equal operator '=='.
 type comparable struct {
 	timestamp              time.Time
-	faasColdstart          *bool
+	faasColdstart          nullableBool
 	faasID                 string
 	faasName               string
 	faasVersion            string
@@ -821,7 +840,7 @@ func (k *transactionAggregationKey) hash() uint64 {
 	if k.traceRoot {
 		h.WriteString("1")
 	}
-	if k.faasColdstart != nil && *k.faasColdstart {
+	if k.faasColdstart.isSet && k.faasColdstart.val {
 		h.WriteString("1")
 	}
 	k.AggregatedGlobalLabels.Write(&h)


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

Remove redundant aggregation groups on `faas.coldstart` in transaction metrics by introducing a nullable bool for `faas.coldstart` in transaction metrics aggregation key comparable.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

- Send 2 non-nil faas.coldstart and make sure they correctly group and aggregate into 1 metric document per interval

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->

Closes #10621 
