### PR TITLE
[8.7] docs: move location of included content (#10646)

### DIFF
--- a/docs/monitor.asciidoc
+++ b/docs/monitor.asciidoc
@@ -60,7 +60,7 @@ If {agent} is already running, you must stop it.
 Use the command that work with your system:
 +
 --
-include::{obs-repo-dir}/ingest-management/tab-widgets/stop-widget.asciidoc[]
+include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/stop-widget.asciidoc[]
 --
 
 . Start {agent}
@@ -68,7 +68,7 @@ include::{obs-repo-dir}/ingest-management/tab-widgets/stop-widget.asciidoc[]
 Use the command that work with your system:
 +
 --
-include::{obs-repo-dir}/ingest-management/tab-widgets/start-widget.asciidoc[]
+include::{ingest-docs-root}/docs/en/ingest-management/tab-widgets/start-widget.asciidoc[]
 --
 
 [float]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [docs: move location of included content (#10646)](https://github.com/elastic/apm-server/pull/10646)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)