### PR TITLE
fix: do not overwrite logging options in containers or systemd environment

### DIFF
--- a/internal/beatcmd/logging.go
+++ b/internal/beatcmd/logging.go
@@ -32,7 +32,7 @@ var (
 )
 
 func configureLogging(cfg *Config) error {
-	logpConfig := logp.DefaultConfig(logp.DefaultEnvironment)
+	logpConfig := logp.DefaultConfig(logEnvironment.env)
 	logpConfig.Beat = "apm-server"
 	if cfg.Logging != nil {
 		if err := cfg.Logging.Unpack(&logpConfig); err != nil {
@@ -52,12 +52,6 @@ func configureLogging(cfg *Config) error {
 	}
 	if logStderr {
 		logpConfig.ToStderr = true
-	} else {
-		// If the process is running in a container or managed by systemd, then log to stderr.
-		switch logEnvironment.env {
-		case logp.ContainerEnvironment, logp.SystemdEnvironment:
-			logpConfig.ToStderr = true
-		}
 	}
 	for _, opt := range logOptions {
 		opt(&logpConfig)


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Properly set the logging environment and leave the fallback to the agent-libs library.
Do not overwrite logging options with the stderr config.

`logp.Configure` should default to stderr if no other options is passed in container/systemd environments

This should fix the options for smoke test, allowing us to retrieve the apm-server log.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Closes https://github.com/elastic/apm-server/issues/10619
