### PR TITLE
Fix systemd.tpl file to use all arguments

### DIFF
--- a/testing/infra/terraform/modules/soaktest_workers/systemd.tpl
+++ b/testing/infra/terraform/modules/soaktest_workers/systemd.tpl
@@ -16,8 +16,8 @@ ExecStart=${apmsoak_executable_path} \
   -server ${apm_server_url} \
   -secret-token ${apm_secret_token} \
   -event-rate ${apm_loadgen_event_rate} \
-  -agents-replicas ${apm_loadgen_agents_replicas}
-  -rewrite-timestamps ${apm_loadgen_rewrite_timestamps}
+  -agents-replicas ${apm_loadgen_agents_replicas} \
+  -rewrite-timestamps ${apm_loadgen_rewrite_timestamps} \
   -rewrite-ids ${apm_loadgen_rewrite_ids}
 
 [Install]


### PR DESCRIPTION
PR https://github.com/elastic/apm-server/pull/10661 updated the apmsoak to use rewrite flags, however, there was a typo due to which systemd was ignoring the new arguments.