### PR TITLE
apmsoak: Add option to rewrite transaction type

### DIFF
--- a/systemtest/loadgen/config/config.go
+++ b/systemtest/loadgen/config/config.go
@@ -40,6 +40,7 @@ var Config struct {
 	RewriteServiceTargetNames bool
 	RewriteSpanNames          bool
 	RewriteTransactionNames   bool
+	RewriteTransactionTypes   bool
 	Headers                   map[string]string
 }
 
@@ -128,6 +129,7 @@ func init() {
 		"service.target.name": &Config.RewriteServiceTargetNames,
 		"span.name":           &Config.RewriteSpanNames,
 		"transaction.name":    &Config.RewriteTransactionNames,
+		"transaction.type":    &Config.RewriteTransactionTypes,
 	}
 	for field, config := range rewriteNames {
 		flag.BoolVar(

--- a/systemtest/loadgen/eventhandler.go
+++ b/systemtest/loadgen/eventhandler.go
@@ -47,6 +47,7 @@ type EventHandlerParams struct {
 	RewriteServiceTargetNames bool
 	RewriteSpanNames          bool
 	RewriteTransactionNames   bool
+	RewriteTransactionTypes   bool
 	RewriteTimestamps         bool
 	Headers                   map[string]string
 }
@@ -73,6 +74,7 @@ func NewEventHandler(p EventHandlerParams) (*eventhandler.Handler, error) {
 		RewriteServiceTargetNames: p.RewriteServiceTargetNames,
 		RewriteSpanNames:          p.RewriteSpanNames,
 		RewriteTransactionNames:   p.RewriteTransactionNames,
+		RewriteTransactionTypes:   p.RewriteTransactionTypes,
 		RewriteTimestamps:         p.RewriteTimestamps,
 	})
 }

--- a/systemtest/soaktest/soaktest.go
+++ b/systemtest/soaktest/soaktest.go
@@ -70,6 +70,7 @@ func runAgent(ctx context.Context, expr string, limiter *rate.Limiter, rng *rand
 		RewriteServiceTargetNames: loadgencfg.Config.RewriteServiceTargetNames,
 		RewriteSpanNames:          loadgencfg.Config.RewriteSpanNames,
 		RewriteTransactionNames:   loadgencfg.Config.RewriteTransactionNames,
+		RewriteTransactionTypes:   loadgencfg.Config.RewriteTransactionTypes,
 		RewriteTimestamps:         loadgencfg.Config.RewriteTimestamps,
 		Headers:                   headers,
 	})


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

apmsoak: Add option to rewrite transaction type to simulate high cardinality service transaction groups.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
