### PR TITLE
[Docs] Add 'container.id' to the list of fields used for log correlation

### DIFF
--- a/docs/log-correlation.asciidoc
+++ b/docs/log-correlation.asciidoc
@@ -41,6 +41,7 @@ In other scenarios, like for unstructured logs,
 you'll need to add APM identifiers to your logs in any easy to parse manner.
 
 Log correlation relies on these fields:
+
 - Service level: {ecs-ref}/ecs-service.html[`service.name`], {ecs-ref}/ecs-service.html[`service.version`], and {ecs-ref}/ecs-service.html[`service.environment`]
 - Trace level: {ecs-ref}/ecs-tracing.html[`trace.id`] and {ecs-ref}/ecs-tracing.html[`transaction.id`]
 - Container level: {ecs-ref}/ecs-container.html[`container.id`] when {ecs-ref}/ecs-service.html[`service.name`] is not available

--- a/docs/log-correlation.asciidoc
+++ b/docs/log-correlation.asciidoc
@@ -43,6 +43,7 @@ you'll need to add APM identifiers to your logs in any easy to parse manner.
 Log correlation relies on these fields:
 - Service level: {ecs-ref}/ecs-service.html[`service.name`], {ecs-ref}/ecs-service.html[`service.version`], and {ecs-ref}/ecs-service.html[`service.environment`]
 - Trace level: {ecs-ref}/ecs-tracing.html[`trace.id`] and {ecs-ref}/ecs-tracing.html[`transaction.id`]
+- Container level: {ecs-ref}/ecs-container.html[`container.id`] when {ecs-ref}/ecs-service.html[`service.name`] is not available
 
 The process for adding these fields will differ based the Agent you're using, the logging framework,
 and the type and structure of your logs.


### PR DESCRIPTION
Adds `container.id` to the list of fields used for log correlation.

Logs correlation logic on the service overview tab ([Kibana code](https://github.com/elastic/kibana/blob/0a120ab8ffb218a7c177a399ad456190aada49cf/x-pack/plugins/apm/public/components/app/service_logs/index.tsx#L79)):
- If the environment selector is set to 'All' in the UI we correlate on service name. KQL: `service.name: "my-service"`. If an environment is selected we correlate by service name and environment, if it exists. KQL: `(service.name: "my-service" and service.environment: "my-environment") or (service.name: "my-service" and not service.environment: *`)
- If there are container IDs we add (combine) a KQL statement to target logs with container IDs but no service.name: `or (container.id: "my-container-id" and not service.name: *)`

Logs correlation logic on the transaction tab ([Kibana code](https://github.com/elastic/kibana/blob/0a120ab8ffb218a7c177a399ad456190aada49cf/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/transaction_tabs.tsx#L177)):
- `trace.id` if it exists: `trace.id:"my-trace-id" OR (not trace.id:* AND "my-trace-id")` 