### PR TITLE
apmsoak: Allow rewriting global labels

### DIFF
--- a/systemtest/loadgen/config/config.go
+++ b/systemtest/loadgen/config/config.go
@@ -41,7 +41,7 @@ var Config struct {
 	RewriteSpanNames          bool
 	RewriteTransactionNames   bool
 	RewriteTransactionTypes   bool
-	ReplaceGlobalLabels       string
+	RewriteGlobalLabels       string
 	Headers                   map[string]string
 }
 
@@ -141,8 +141,8 @@ func init() {
 		)
 	}
 	flag.StringVar(
-		&Config.ReplaceGlobalLabels,
-		"replace-global-labels",
+		&Config.RewriteGlobalLabels,
+		"rewrite-global-labels",
 		"",
 		"replace global labels in events with the specified string",
 	)

--- a/systemtest/loadgen/config/config.go
+++ b/systemtest/loadgen/config/config.go
@@ -41,6 +41,7 @@ var Config struct {
 	RewriteSpanNames          bool
 	RewriteTransactionNames   bool
 	RewriteTransactionTypes   bool
+	ReplaceGlobalLabels       string
 	Headers                   map[string]string
 }
 
@@ -139,6 +140,12 @@ func init() {
 			fmt.Sprintf("replace `%s` in events", field),
 		)
 	}
+	flag.StringVar(
+		&Config.ReplaceGlobalLabels,
+		"replace-global-labels",
+		"",
+		"replace global labels in events with the specified string",
+	)
 
 	// For configs that can be set via environment variables, set the required
 	// flags from env if they are not explicitly provided via command line

--- a/systemtest/loadgen/config/config.go
+++ b/systemtest/loadgen/config/config.go
@@ -144,7 +144,7 @@ func init() {
 		&Config.RewriteGlobalLabels,
 		"rewrite-global-labels",
 		"",
-		"replace global labels in events with the specified string",
+		"replace global labels in events with the specified string, e.g. {\"foo\":\"bar\"}",
 	)
 
 	// For configs that can be set via environment variables, set the required

--- a/systemtest/loadgen/eventhandler.go
+++ b/systemtest/loadgen/eventhandler.go
@@ -49,7 +49,7 @@ type EventHandlerParams struct {
 	RewriteTransactionNames   bool
 	RewriteTransactionTypes   bool
 	RewriteTimestamps         bool
-	ReplaceGlobalLabels       string
+	RewriteGlobalLabels       string
 	Headers                   map[string]string
 }
 
@@ -77,6 +77,6 @@ func NewEventHandler(p EventHandlerParams) (*eventhandler.Handler, error) {
 		RewriteTransactionNames:   p.RewriteTransactionNames,
 		RewriteTransactionTypes:   p.RewriteTransactionTypes,
 		RewriteTimestamps:         p.RewriteTimestamps,
-		ReplaceGlobalLabels:       p.ReplaceGlobalLabels,
+		RewriteGlobalLabels:       p.RewriteGlobalLabels,
 	})
 }

--- a/systemtest/loadgen/eventhandler.go
+++ b/systemtest/loadgen/eventhandler.go
@@ -49,6 +49,7 @@ type EventHandlerParams struct {
 	RewriteTransactionNames   bool
 	RewriteTransactionTypes   bool
 	RewriteTimestamps         bool
+	ReplaceGlobalLabels       string
 	Headers                   map[string]string
 }
 
@@ -76,5 +77,6 @@ func NewEventHandler(p EventHandlerParams) (*eventhandler.Handler, error) {
 		RewriteTransactionNames:   p.RewriteTransactionNames,
 		RewriteTransactionTypes:   p.RewriteTransactionTypes,
 		RewriteTimestamps:         p.RewriteTimestamps,
+		ReplaceGlobalLabels:       p.ReplaceGlobalLabels,
 	})
 }

--- a/systemtest/loadgen/eventhandler/handler.go
+++ b/systemtest/loadgen/eventhandler/handler.go
@@ -155,6 +155,9 @@ type Config struct {
 	// RewriteTransactionTypes controls the rewriting of `transaction.type`
 	// in events.
 	RewriteTransactionTypes bool
+
+	// ReplaceGlobalLabels replaces metadata.labels with the specified string.
+	ReplaceGlobalLabels string
 }
 
 // New creates a new Handler with config.
@@ -387,6 +390,12 @@ func (h *Handler) writeEvents(w *pooledWriter, b batch, baseTimestamp time.Time,
 		metadata, err = randomizeASCIIField(metadata, "metadata.service.node.configured_name", randomBits, &w.idBuf)
 		if err != nil {
 			return fmt.Errorf("failed to rewrite `service.node.name`: %w", err)
+		}
+	}
+	if h.config.ReplaceGlobalLabels != "" {
+		metadata, err = sjson.SetRawBytes(metadata, "metadata.labels", []byte(h.config.ReplaceGlobalLabels))
+		if err != nil {
+			return fmt.Errorf("failed to rewrite `labels`: %w", err)
 		}
 	}
 	w.Write(metadata)

--- a/systemtest/loadgen/eventhandler/handler.go
+++ b/systemtest/loadgen/eventhandler/handler.go
@@ -156,8 +156,8 @@ type Config struct {
 	// in events.
 	RewriteTransactionTypes bool
 
-	// ReplaceGlobalLabels replaces metadata.labels with the specified string.
-	ReplaceGlobalLabels string
+	// RewriteGlobalLabels replaces metadata.labels with the specified string.
+	RewriteGlobalLabels string
 }
 
 // New creates a new Handler with config.
@@ -392,8 +392,8 @@ func (h *Handler) writeEvents(w *pooledWriter, b batch, baseTimestamp time.Time,
 			return fmt.Errorf("failed to rewrite `service.node.name`: %w", err)
 		}
 	}
-	if h.config.ReplaceGlobalLabels != "" {
-		metadata, err = sjson.SetRawBytes(metadata, "metadata.labels", []byte(h.config.ReplaceGlobalLabels))
+	if h.config.RewriteGlobalLabels != "" {
+		metadata, err = sjson.SetRawBytes(metadata, "metadata.labels", []byte(h.config.RewriteGlobalLabels))
 		if err != nil {
 			return fmt.Errorf("failed to rewrite `labels`: %w", err)
 		}

--- a/systemtest/loadgen/eventhandler/handler_test.go
+++ b/systemtest/loadgen/eventhandler/handler_test.go
@@ -170,9 +170,9 @@ func withRewriteSpanNames(rewrite bool) newHandlerOption {
 	}
 }
 
-func withReplaceGlobalLabels(labelsObjStr string) newHandlerOption {
+func withRewriteGlobalLabels(labelsObjStr string) newHandlerOption {
 	return func(config *Config) {
-		config.ReplaceGlobalLabels = labelsObjStr
+		config.RewriteGlobalLabels = labelsObjStr
 	}
 }
 
@@ -763,7 +763,7 @@ func TestHandlerSendBatchesRewriteTransactionTypes(t *testing.T) {
 	run(t, true)
 }
 
-func TestHandlerSendBatchesReplaceGlobalLabels(t *testing.T) {
+func TestHandlerSendBatchesRewriteGlobalLabels(t *testing.T) {
 	originalPayload := fmt.Sprintf(`
 {"metadata":{}}
 {"transaction":{}}
@@ -776,7 +776,7 @@ func TestHandlerSendBatchesReplaceGlobalLabels(t *testing.T) {
 		t.Run(fmt.Sprintf(`labelsObjStr="%s"`, labelsObjStr), func(t *testing.T) {
 			handler, srv := newHandler(t,
 				withStorage(fs),
-				withReplaceGlobalLabels(labelsObjStr),
+				withRewriteGlobalLabels(labelsObjStr),
 				withRand(rand.New(rand.NewSource(123456))), // known seed
 			)
 			_, err := handler.SendBatches(context.Background())
@@ -891,7 +891,7 @@ func BenchmarkSendBatches(b *testing.B) {
 	b.Run("rewrite_span_names", func(b *testing.B) {
 		run(b, withRewriteSpanNames(true))
 	})
-	b.Run("replace_global_labels", func(b *testing.B) {
-		run(b, withReplaceGlobalLabels(`{"a":"aa","b":"bb","c":"cc","num0":0,num1":1.1,"num2":2.2}`))
+	b.Run("rewrite_global_labels", func(b *testing.B) {
+		run(b, withRewriteGlobalLabels(`{"a":"aa","b":"bb","c":"cc","num0":0,num1":1.1,"num2":2.2}`))
 	})
 }

--- a/systemtest/soaktest/soaktest.go
+++ b/systemtest/soaktest/soaktest.go
@@ -72,6 +72,7 @@ func runAgent(ctx context.Context, expr string, limiter *rate.Limiter, rng *rand
 		RewriteTransactionNames:   loadgencfg.Config.RewriteTransactionNames,
 		RewriteTransactionTypes:   loadgencfg.Config.RewriteTransactionTypes,
 		RewriteTimestamps:         loadgencfg.Config.RewriteTimestamps,
+		ReplaceGlobalLabels:       loadgencfg.Config.ReplaceGlobalLabels,
 		Headers:                   headers,
 	})
 	if err != nil {

--- a/systemtest/soaktest/soaktest.go
+++ b/systemtest/soaktest/soaktest.go
@@ -72,7 +72,7 @@ func runAgent(ctx context.Context, expr string, limiter *rate.Limiter, rng *rand
 		RewriteTransactionNames:   loadgencfg.Config.RewriteTransactionNames,
 		RewriteTransactionTypes:   loadgencfg.Config.RewriteTransactionTypes,
 		RewriteTimestamps:         loadgencfg.Config.RewriteTimestamps,
-		ReplaceGlobalLabels:       loadgencfg.Config.ReplaceGlobalLabels,
+		RewriteGlobalLabels:       loadgencfg.Config.RewriteGlobalLabels,
 		Headers:                   headers,
 	})
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Add an option to apmsoak such that global labels can be replaced with a constant JSON string specified in the `-rewrite-global-labels` argument. It will be directly placed into `metadata.labels`. This will allow us to simulate events with a large number of labels. 

However, this is not designed to simulate different labels between batches as there complexity around randomizing global labels, e.g. number of labels, length of key, length of value, string vs numeric values. It functions a little different from the existing `rewrite*` options as they are flags and have randomization while this accepts a constant string argument.

Example usage:
```
apmsoak -rewrite-global-labels '{"foo":"bar","num":1.1,"bar":"baz"}'
```

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
