### PR TITLE
Add support for mobile UI filtering

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -3,6 +3,9 @@
     - description: Store app logs into service-specific data streams
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/10456
+    - description: Add `host` and `service.version` to span events
+      type: enhancement
+      link: https://github.com/elastic/apm-server/pull/10697
 - version: "8.7.1"
   changes:
     - description: Add missing `agent.activation_method` mapping to `logs-apm.app`, `metrics-apm.app`, `logs-apm.error` and `metrics-apm.internal`

--- a/apmpackage/apm/data_stream/traces/elasticsearch/ingest_pipeline/default.yml
+++ b/apmpackage/apm/data_stream/traces/elasticsearch/ingest_pipeline/default.yml
@@ -31,14 +31,12 @@ processors:
       # Remove some metadata from spans that is available in the parent transaction, to cut down on storage costs.
       if: ctx.processor?.event == 'span'
       field:
-        - host
         - process
         - user
         - user_agent
         - container
         - kubernetes
         - service.node
-        - service.version
         - service.language
         - service.runtime
         - service.framework

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -17,4 +17,4 @@ https://github.com/elastic/apm-server/compare/8.8\...main[View commits]
 
 [float]
 ==== Added
-- Span events now carry `host` and `service.version` attributes.
+- Span events now carry `host` and `service.version` attributes. {pull}10697[10697]

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -18,3 +18,4 @@ https://github.com/elastic/apm-server/compare/8.7\...main[View commits]
 
 [float]
 ==== Added
+- Span events now carry `host` and `service.version` attributes.

--- a/systemtest/approvals/TestCompressedSpans.approved.json
+++ b/systemtest/approvals/TestCompressedSpans.approved.json
@@ -15,6 +15,17 @@
                 "outcome": "success",
                 "success_count": 1
             },
+            "host": {
+                "architecture": "i386",
+                "hostname": "beowulf",
+                "ip": [
+                    "127.0.0.1"
+                ],
+                "name": "beowulf",
+                "os": {
+                    "platform": "minix"
+                }
+            },
             "observer": {
                 "hostname": "dynamic",
                 "type": "apm-server",
@@ -79,6 +90,17 @@
                 "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": 1
+            },
+            "host": {
+                "architecture": "i386",
+                "hostname": "beowulf",
+                "ip": [
+                    "127.0.0.1"
+                ],
+                "name": "beowulf",
+                "os": {
+                    "platform": "minix"
+                }
             },
             "observer": {
                 "hostname": "dynamic",

--- a/systemtest/approvals/TestIntake/Events.approved.json
+++ b/systemtest/approvals/TestIntake/Events.approved.json
@@ -420,6 +420,17 @@
                 "outcome": "success",
                 "success_count": 1
             },
+            "host": {
+                "architecture": "amd64",
+                "hostname": "node-name",
+                "ip": [
+                    "127.0.0.1"
+                ],
+                "name": "host1",
+                "os": {
+                    "platform": "Linux"
+                }
+            },
             "http": {
                 "request": {
                     "method": "GET"

--- a/systemtest/approvals/TestIntake/MinimalEvents.approved.json
+++ b/systemtest/approvals/TestIntake/MinimalEvents.approved.json
@@ -184,6 +184,11 @@
                 "ingested": "dynamic",
                 "outcome": "unknown"
             },
+            "host": {
+                "ip": [
+                    "127.0.0.1"
+                ]
+            },
             "observer": {
                 "hostname": "dynamic",
                 "type": "apm-server",
@@ -227,6 +232,11 @@
                 "agent_id_status": "missing",
                 "ingested": "dynamic",
                 "outcome": "unknown"
+            },
+            "host": {
+                "ip": [
+                    "127.0.0.1"
+                ]
             },
             "observer": {
                 "hostname": "dynamic",

--- a/systemtest/approvals/TestIntake/Spans.approved.json
+++ b/systemtest/approvals/TestIntake/Spans.approved.json
@@ -45,6 +45,17 @@
                 "outcome": "success",
                 "success_count": 1
             },
+            "host": {
+                "architecture": "x64",
+                "hostname": "node-name",
+                "ip": [
+                    "127.0.0.1"
+                ],
+                "name": "node-name",
+                "os": {
+                    "platform": "darwin"
+                }
+            },
             "http": {
                 "request": {
                     "method": "GET"
@@ -204,6 +215,17 @@
                 "ingested": "dynamic",
                 "outcome": "unknown"
             },
+            "host": {
+                "architecture": "x64",
+                "hostname": "node-name",
+                "ip": [
+                    "127.0.0.1"
+                ],
+                "name": "node-name",
+                "os": {
+                    "platform": "darwin"
+                }
+            },
             "labels": {
                 "tag1": "label1"
             },
@@ -221,7 +243,8 @@
             },
             "service": {
                 "environment": "staging",
-                "name": "backendspans"
+                "name": "backendspans",
+                "version": "5.1.3"
             },
             "span": {
                 "action": "call",
@@ -279,6 +302,17 @@
                 "ingested": "dynamic",
                 "outcome": "unknown"
             },
+            "host": {
+                "architecture": "x64",
+                "hostname": "node-name",
+                "ip": [
+                    "127.0.0.1"
+                ],
+                "name": "node-name",
+                "os": {
+                    "platform": "darwin"
+                }
+            },
             "labels": {
                 "tag1": "value1",
                 "tag4": "true"
@@ -301,7 +335,8 @@
             },
             "service": {
                 "environment": "staging",
-                "name": "backendspans"
+                "name": "backendspans",
+                "version": "5.1.3"
             },
             "span": {
                 "duration": {
@@ -360,6 +395,17 @@
                 "ingested": "dynamic",
                 "outcome": "unknown"
             },
+            "host": {
+                "architecture": "x64",
+                "hostname": "node-name",
+                "ip": [
+                    "127.0.0.1"
+                ],
+                "name": "node-name",
+                "os": {
+                    "platform": "darwin"
+                }
+            },
             "labels": {
                 "tag1": "label1"
             },
@@ -377,7 +423,8 @@
             },
             "service": {
                 "environment": "prod",
-                "name": "backendspans"
+                "name": "backendspans",
+                "version": "5.1.3"
             },
             "span": {
                 "duration": {
@@ -436,6 +483,17 @@
                 "outcome": "success",
                 "success_count": 1
             },
+            "host": {
+                "architecture": "x64",
+                "hostname": "node-name",
+                "ip": [
+                    "127.0.0.1"
+                ],
+                "name": "node-name",
+                "os": {
+                    "platform": "darwin"
+                }
+            },
             "labels": {
                 "tag1": "label1"
             },
@@ -453,7 +511,8 @@
             },
             "service": {
                 "environment": "staging",
-                "name": "backendspans"
+                "name": "backendspans",
+                "version": "5.1.3"
             },
             "span": {
                 "action": "query",
@@ -526,6 +585,17 @@
                 "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": 1
+            },
+            "host": {
+                "architecture": "x64",
+                "hostname": "node-name",
+                "ip": [
+                    "127.0.0.1"
+                ],
+                "name": "node-name",
+                "os": {
+                    "platform": "darwin"
+                }
             },
             "http": {
                 "request": {
@@ -690,6 +760,17 @@
                 "ingested": "dynamic",
                 "outcome": "unknown"
             },
+            "host": {
+                "architecture": "x64",
+                "hostname": "node-name",
+                "ip": [
+                    "127.0.0.1"
+                ],
+                "name": "node-name",
+                "os": {
+                    "platform": "darwin"
+                }
+            },
             "labels": {
                 "tag1": "label1"
             },
@@ -707,7 +788,8 @@
             },
             "service": {
                 "environment": "staging",
-                "name": "backendspans"
+                "name": "backendspans",
+                "version": "5.1.3"
             },
             "span": {
                 "action": "receive",
@@ -782,6 +864,17 @@
                 "outcome": "success",
                 "success_count": 1
             },
+            "host": {
+                "architecture": "x64",
+                "hostname": "node-name",
+                "ip": [
+                    "127.0.0.1"
+                ],
+                "name": "node-name",
+                "os": {
+                    "platform": "darwin"
+                }
+            },
             "labels": {
                 "tag1": "label1"
             },
@@ -799,7 +892,8 @@
             },
             "service": {
                 "environment": "staging",
-                "name": "backendspans"
+                "name": "backendspans",
+                "version": "5.1.3"
             },
             "span": {
                 "action": "query.custom",
@@ -865,6 +959,17 @@
                 "outcome": "success",
                 "success_count": 1
             },
+            "host": {
+                "architecture": "x64",
+                "hostname": "node-name",
+                "ip": [
+                    "127.0.0.1"
+                ],
+                "name": "node-name",
+                "os": {
+                    "platform": "darwin"
+                }
+            },
             "labels": {
                 "tag1": "label1"
             },
@@ -886,7 +991,8 @@
                 "target": {
                     "name": "localhost:8080",
                     "type": ""
-                }
+                },
+                "version": "5.1.3"
             },
             "span": {
                 "action": "request",
@@ -959,6 +1065,17 @@
                 "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": 1
+            },
+            "host": {
+                "architecture": "x64",
+                "hostname": "node-name",
+                "ip": [
+                    "127.0.0.1"
+                ],
+                "name": "node-name",
+                "os": {
+                    "platform": "darwin"
+                }
             },
             "http": {
                 "request": {

--- a/systemtest/approvals/TestIntake/UnknownSpanType.approved.json
+++ b/systemtest/approvals/TestIntake/UnknownSpanType.approved.json
@@ -15,6 +15,15 @@
                 "outcome": "success",
                 "success_count": 1
             },
+            "host": {
+                "architecture": "x64",
+                "ip": [
+                    "127.0.0.1"
+                ],
+                "os": {
+                    "platform": "darwin"
+                }
+            },
             "http": {
                 "request": {
                     "method": "GET"
@@ -40,7 +49,8 @@
             },
             "service": {
                 "environment": "staging",
-                "name": "1234_service-12a3"
+                "name": "1234_service-12a3",
+                "version": "5.1.3"
             },
             "span": {
                 "db": {

--- a/systemtest/approvals/TestJaeger/batch_1.approved.json
+++ b/systemtest/approvals/TestJaeger/batch_1.approved.json
@@ -261,6 +261,13 @@
                 "outcome": "failure",
                 "success_count": 0
             },
+            "host": {
+                "hostname": "host01",
+                "ip": [
+                    "10.0.0.13"
+                ],
+                "name": "host01"
+            },
             "labels": {
                 "param_driverID": "T752547C"
             },
@@ -309,6 +316,13 @@
                 "agent_id_status": "missing",
                 "ingested": "dynamic",
                 "outcome": "unknown"
+            },
+            "host": {
+                "hostname": "host01",
+                "ip": [
+                    "10.0.0.13"
+                ],
+                "name": "host01"
             },
             "labels": {
                 "param_driverID": "T781861C"
@@ -359,6 +373,13 @@
                 "ingested": "dynamic",
                 "outcome": "unknown"
             },
+            "host": {
+                "hostname": "host01",
+                "ip": [
+                    "10.0.0.13"
+                ],
+                "name": "host01"
+            },
             "labels": {
                 "param_driverID": "T757338C"
             },
@@ -407,6 +428,13 @@
                 "agent_id_status": "missing",
                 "ingested": "dynamic",
                 "outcome": "unknown"
+            },
+            "host": {
+                "hostname": "host01",
+                "ip": [
+                    "10.0.0.13"
+                ],
+                "name": "host01"
             },
             "labels": {
                 "param_driverID": "T708771C"
@@ -458,6 +486,13 @@
                 "outcome": "failure",
                 "success_count": 0
             },
+            "host": {
+                "hostname": "host01",
+                "ip": [
+                    "10.0.0.13"
+                ],
+                "name": "host01"
+            },
             "labels": {
                 "param_driverID": "T762465C"
             },
@@ -506,6 +541,13 @@
                 "agent_id_status": "missing",
                 "ingested": "dynamic",
                 "outcome": "unknown"
+            },
+            "host": {
+                "hostname": "host01",
+                "ip": [
+                    "10.0.0.13"
+                ],
+                "name": "host01"
             },
             "labels": {
                 "param_driverID": "T710624C"
@@ -557,6 +599,13 @@
                 "outcome": "failure",
                 "success_count": 0
             },
+            "host": {
+                "hostname": "host01",
+                "ip": [
+                    "10.0.0.13"
+                ],
+                "name": "host01"
+            },
             "labels": {
                 "param_driverID": "T781861C"
             },
@@ -605,6 +654,13 @@
                 "agent_id_status": "missing",
                 "ingested": "dynamic",
                 "outcome": "unknown"
+            },
+            "host": {
+                "hostname": "host01",
+                "ip": [
+                    "10.0.0.13"
+                ],
+                "name": "host01"
             },
             "labels": {
                 "param_driverID": "T705860C"
@@ -655,6 +711,13 @@
                 "ingested": "dynamic",
                 "outcome": "unknown"
             },
+            "host": {
+                "hostname": "host01",
+                "ip": [
+                    "10.0.0.13"
+                ],
+                "name": "host01"
+            },
             "labels": {
                 "param_driverID": "T762465C"
             },
@@ -703,6 +766,13 @@
                 "agent_id_status": "missing",
                 "ingested": "dynamic",
                 "outcome": "unknown"
+            },
+            "host": {
+                "hostname": "host01",
+                "ip": [
+                    "10.0.0.13"
+                ],
+                "name": "host01"
             },
             "labels": {
                 "param_driverID": "T752547C"
@@ -753,6 +823,13 @@
                 "ingested": "dynamic",
                 "outcome": "unknown"
             },
+            "host": {
+                "hostname": "host01",
+                "ip": [
+                    "10.0.0.13"
+                ],
+                "name": "host01"
+            },
             "labels": {
                 "param_driverID": "T752110C"
             },
@@ -801,6 +878,13 @@
                 "agent_id_status": "missing",
                 "ingested": "dynamic",
                 "outcome": "unknown"
+            },
+            "host": {
+                "hostname": "host01",
+                "ip": [
+                    "10.0.0.13"
+                ],
+                "name": "host01"
             },
             "labels": {
                 "param_driverID": "T757670C"
@@ -851,6 +935,13 @@
                 "ingested": "dynamic",
                 "outcome": "unknown"
             },
+            "host": {
+                "hostname": "host01",
+                "ip": [
+                    "10.0.0.13"
+                ],
+                "name": "host01"
+            },
             "labels": {
                 "param_location": "728,326"
             },
@@ -899,6 +990,13 @@
                 "agent_id_status": "missing",
                 "ingested": "dynamic",
                 "outcome": "unknown"
+            },
+            "host": {
+                "hostname": "host01",
+                "ip": [
+                    "10.0.0.13"
+                ],
+                "name": "host01"
             },
             "labels": {
                 "param_driverID": "T712515C"


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary
The mobile ui wants to filter data based on host.os.version & service.version. Http spans are a key part of the mobile ui, and when filters are added for either of these attributes all http related charts will be empty.

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
https://github.com/elastic/apm-agent-ios/issues/145