### PR TITLE
Makefile: ensure $PATH for mage is absolute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ release-manager-snapshot: release
 release-manager-release: release
 
 .PHONY: release
-release: export PATH:=$(dir $(BIN_MAGE)):$(PATH)
+release: export PATH:=$(realpath $(dir $(BIN_MAGE))):$(PATH)
 release: $(MAGE) build/dependencies.csv
 	$(GO) mod download all
 	$(MAGE) package


### PR DESCRIPTION
## Motivation/summary

Fix build issues like https://apm-ci.elastic.co/blue/organizations/jenkins/apm-server%2Fapm-server-package-mbp/detail/7.17/668/pipeline/. In recent versions of Go's os/exec, executing a program that resolves relative to the working directory will result in an error. We fix this by ensuring the addition to $PATH is absolute.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

None