### PR TITLE
Fix incorrect labels definition for systemtest

### DIFF
--- a/systemtest/aggregation_test.go
+++ b/systemtest/aggregation_test.go
@@ -310,7 +310,12 @@ func TestServiceTransactionMetricsAggregationLabels(t *testing.T) {
 func TestServiceTransactionMetricsAggregationLabelsRUM(t *testing.T) {
 	t.Setenv("ELASTIC_APM_GLOBAL_LABELS", "department_name=apm,organization=observability,company=elastic")
 	systemtest.CleanupElasticsearch(t)
-	srv := apmservertest.NewServerTB(t)
+	srv := apmservertest.NewUnstartedServerTB(t)
+	srv.Config.RUM = &apmservertest.RUMConfig{
+		Enabled: true,
+	}
+	err := srv.Start()
+	require.NoError(t, err)
 
 	rumPayloadWithLabels := `{"metadata":{"service":{"name":"rum-js-test","agent":{"name":"rum-js","version":"5.5.0"}},"labels": {"tag0": null, "tag1": "one", "tag2": 2}}}
 {"transaction":{"trace_id":"611f4fa950f04631aaaaaaaaaaaaaaaa","id":"611f4fa950f04631","type":"page-load","duration":643,"span_count":{"started":0}}}

--- a/systemtest/aggregation_test.go
+++ b/systemtest/aggregation_test.go
@@ -312,7 +312,7 @@ func TestServiceTransactionMetricsAggregationLabelsRUM(t *testing.T) {
 	systemtest.CleanupElasticsearch(t)
 	srv := apmservertest.NewServerTB(t)
 
-	rumPayloadWithLabels := `{"metadata":{"service":{"name":"rum-js-test","agent":{"name":"rum-js","version":"5.5.0"}}},"labels": {"tag0": null, "tag1": "one", "tag2": 2}}
+	rumPayloadWithLabels := `{"metadata":{"service":{"name":"rum-js-test","agent":{"name":"rum-js","version":"5.5.0"}},"labels": {"tag0": null, "tag1": "one", "tag2": 2}}}
 {"transaction":{"trace_id":"611f4fa950f04631aaaaaaaaaaaaaaaa","id":"611f4fa950f04631","type":"page-load","duration":643,"span_count":{"started":0}}}
 `
 	systemtest.SendBackendEventsLiteral(t, srv.URL, rumPayloadWithLabels)

--- a/systemtest/apmservertest/config.go
+++ b/systemtest/apmservertest/config.go
@@ -392,9 +392,6 @@ func DefaultConfig() Config {
 			Password: getenvDefault("KIBANA_PASS", defaultKibanaPass),
 		},
 		Output: defaultOutputConfig(),
-		RUM: &RUMConfig{
-			Enabled: true,
-		},
 	}
 }
 

--- a/systemtest/apmservertest/config.go
+++ b/systemtest/apmservertest/config.go
@@ -392,6 +392,9 @@ func DefaultConfig() Config {
 			Password: getenvDefault("KIBANA_PASS", defaultKibanaPass),
 		},
 		Output: defaultOutputConfig(),
+		RUM: &RUMConfig{
+			Enabled: true,
+		},
 	}
 }
 


### PR DESCRIPTION
`labels` should be inside `metadata` rather than at the same level as `metadata`:

```
{
    "metadata": {
        "service": {...},
        "labels": {...},
        ...
    }
}
```