### PR TITLE
Test beatcmd logging configuration

### DIFF
--- a/internal/beatcmd/logging.go
+++ b/internal/beatcmd/logging.go
@@ -31,12 +31,12 @@ var (
 	logOptions        []logp.Option
 )
 
-func configureLogging(cfg *Config) error {
-	logpConfig := logp.DefaultConfig(logEnvironment.env)
+func buildLoggingConfig(cfg *Config, env logp.Environment, stderr bool, debugSelectors []string, opts ...logp.Option) (logp.Config, error) {
+	logpConfig := logp.DefaultConfig(env)
 	logpConfig.Beat = "apm-server"
 	if cfg.Logging != nil {
 		if err := cfg.Logging.Unpack(&logpConfig); err != nil {
-			return err
+			return logpConfig, err
 		}
 	}
 
@@ -44,18 +44,26 @@ func configureLogging(cfg *Config) error {
 	if logpConfig.Level > logp.InfoLevel && logVerbose {
 		logpConfig.Level = logp.InfoLevel
 	}
-	if len(logDebugSelectors) > 0 {
-		for _, selectors := range logDebugSelectors {
+	if len(debugSelectors) > 0 {
+		for _, selectors := range debugSelectors {
 			logpConfig.Selectors = append(logpConfig.Selectors, strings.Split(selectors, ",")...)
 		}
 		logpConfig.Level = logp.DebugLevel
 	}
-	if logStderr {
+	if stderr {
 		logpConfig.ToStderr = true
 	}
-	for _, opt := range logOptions {
+	for _, opt := range opts {
 		opt(&logpConfig)
 	}
 
+	return logpConfig, nil
+}
+
+func configureLogging(cfg *Config) error {
+	logpConfig, err := buildLoggingConfig(cfg, logEnvironment.env, logStderr, logDebugSelectors, logOptions...)
+	if err != nil {
+		return err
+	}
 	return logp.Configure(logpConfig)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

This is the automated test-plan for #10666.
It introduces a new `buildLoggingConfig` method, which doesn't rely on anything global, so we can test its content, and `configureLogging` can just call it.

Test failure before the changes made in the linked PR:

```
=== RUN   TestBuildLoggingConfigPerEnvironment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_an_empty_config_and_default_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_an_logging_config_specified_and_default_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/when_logging_to_stderr_and_default_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_debug_selectors_and_default_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_options_and_default_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_an_empty_config_and_systemd_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:1, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 1,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_an_empty_config_and_systemd_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_an_logging_config_specified_and_systemd_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:1, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 1,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_an_logging_config_specified_and_systemd_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/when_logging_to_stderr_and_systemd_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:true, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:1, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:true, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 1,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/when_logging_to_stderr_and_systemd_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_debug_selectors_and_systemd_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string{"hello", "world", "bonjour"}, toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:1, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string{"hello", "world", "bonjour"}, toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -28,3 +28,3 @@
                                  },
                                - environment: (logp.Environment) 1,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_debug_selectors_and_systemd_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_options_and_systemd_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:1, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 1,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_options_and_systemd_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_an_empty_config_and_container_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:2, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 2,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_an_empty_config_and_container_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_an_logging_config_specified_and_container_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:2, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 2,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_an_logging_config_specified_and_container_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/when_logging_to_stderr_and_container_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:true, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:2, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:true, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 2,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/when_logging_to_stderr_and_container_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_debug_selectors_and_container_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string{"hello", "world", "bonjour"}, toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:2, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string{"hello", "world", "bonjour"}, toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -28,3 +28,3 @@
                                  },
                                - environment: (logp.Environment) 2,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_debug_selectors_and_container_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_options_and_container_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:2, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 2,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_options_and_container_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_an_empty_config_and_macos_service_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:3, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 3,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_an_empty_config_and_macos_service_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_an_logging_config_specified_and_macos_service_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:3, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 3,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_an_logging_config_specified_and_macos_service_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/when_logging_to_stderr_and_macos_service_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:true, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:3, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:true, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 3,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/when_logging_to_stderr_and_macos_service_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_debug_selectors_and_macos_service_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string{"hello", "world", "bonjour"}, toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:3, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string{"hello", "world", "bonjour"}, toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -28,3 +28,3 @@
                                  },
                                - environment: (logp.Environment) 3,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_debug_selectors_and_macos_service_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_options_and_macos_service_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:3, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 3,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_options_and_macos_service_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_an_empty_config_and_windows_service_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:4, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 4,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_an_empty_config_and_windows_service_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_an_logging_config_specified_and_windows_service_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:4, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 4,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_an_logging_config_specified_and_windows_service_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/when_logging_to_stderr_and_windows_service_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:true, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:4, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:true, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 4,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/when_logging_to_stderr_and_windows_service_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_debug_selectors_and_windows_service_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string{"hello", "world", "bonjour"}, toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:4, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string{"hello", "world", "bonjour"}, toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -28,3 +28,3 @@
                                  },
                                - environment: (logp.Environment) 4,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_debug_selectors_and_windows_service_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_options_and_windows_service_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:4, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 4,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_options_and_windows_service_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_an_empty_config_and_<invalid>_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:5, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 5,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_an_empty_config_and_<invalid>_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_an_logging_config_specified_and_<invalid>_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:5, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 5,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_an_logging_config_specified_and_<invalid>_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/when_logging_to_stderr_and_<invalid>_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:true, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:5, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:0, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:true, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 5,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/when_logging_to_stderr_and_<invalid>_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_debug_selectors_and_<invalid>_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string{"hello", "world", "bonjour"}, toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:5, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string{"hello", "world", "bonjour"}, toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -28,3 +28,3 @@
                                  },
                                - environment: (logp.Environment) 5,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_debug_selectors_and_<invalid>_environment
=== RUN   TestBuildLoggingConfigPerEnvironment/with_options_and_<invalid>_environment
    logging_test.go:133:
                Error Trace:    /Users/dmathieu/code/src/github.com/elastic/apm-server/internal/beatcmd/logging_test.go:133
                Error:          Not equal:
                                expected: logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:5, addCaller:true, development:false}
                                actual  : logp.Config{Beat:"apm-server", Level:-1, Selectors:[]string(nil), toObserver:false, toIODiscard:false, ToStderr:false, ToSyslog:false, ToFiles:false, ToEventLog:false, Files:logp.FileConfig{Path:"", Name:"", MaxSize:0xa00000, MaxBackups:0x7, Permissions:0x180, Interval:0, RotateOnStartup:true, RedirectStderr:false}, Metrics:logp.MetricsConfig{Enabled:true, Period:30000000000}, environment:0, addCaller:true, development:false}

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -24,3 +24,3 @@
                                  },
                                - environment: (logp.Environment) 5,
                                + environment: (logp.Environment) 0,
                                  addCaller: (bool) true,
                Test:           TestBuildLoggingConfigPerEnvironment/with_options_and_<invalid>_environment
--- FAIL: TestBuildLoggingConfigPerEnvironment (0.00s)
```

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

For functional changes, consider:
~- Is it observable through the addition of either **logging** or **metrics**?~
~- Is its use being published in **telemetry** to enable product improvement?~
~- Have system tests been added to avoid regression?~

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

This PR is adding more tests. As long as those pass, we are good.

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
