### PR TITLE
.github/workflows: add fake CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: ci
+
+on:
+  pull_request:
+
+# limit the access of the generated GITHUB_TOKEN
+permissions:
+  contents: read
+
+jobs:
+  system-test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No tests required to run"'
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No lint required to run"'


### PR DESCRIPTION
Add no-op 'system-test' and 'lint' jobs so the Mergify merge queue passes. These tasks are run by Jenkins at the moment.