### PR TITLE
apmpackage: prepare for metrics output schema change

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -3,6 +3,9 @@
     - description: Placeholder
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/123
+    - description: Handle `metricset.samples` from apm-server
+      type: enhancement
+      link: https://github.com/elastic/apm-server/pull/10794
 - version: "8.8.0"
   changes:
     - description: Store app logs into service-specific data streams

--- a/apmpackage/apm/data_stream/app_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/apmpackage/apm/data_stream/app_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -13,23 +13,5 @@ processors:
       name: process_ppid
   - pipeline:
       name: client_geoip
-  - script:
-      # TODO(axw) handle unit in metric descriptions.
-      # See https://github.com/elastic/elasticsearch/issues/72536
-      if: ctx._metric_descriptions != null
-      source: |
-        Map dynamic_templates = new HashMap();
-        for (entry in ctx._metric_descriptions.entrySet()) {
-          String name = entry.getKey();
-          Map description = entry.getValue();
-          String metric_type = description.type;
-          if (metric_type == "histogram") {
-            dynamic_templates[name] = "histogram";
-          } else if (metric_type == "summary") {
-            dynamic_templates[name] = "summary";
-          } else {
-            dynamic_templates[name] = "double";
-          }
-        }
-        ctx._dynamic_templates = dynamic_templates;
-        ctx.remove("_metric_descriptions");
+  - pipeline:
+      name: set_metrics

--- a/apmpackage/apm/data_stream/internal_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/apmpackage/apm/data_stream/internal_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -14,9 +14,11 @@ processors:
   - pipeline:
       name: client_geoip
   - remove:
-      field: _metric_descriptions
-      ignore_missing: true
-  - remove:
       # Removed in 8.6.0
       field: timeseries.instance
+      ignore_missing: true
+  - pipeline:
+      name: set_metrics
+  - remove:
+      field: _dynamic_templates
       ignore_missing: true

--- a/apmpackage/apm/data_stream/service_destination_interval_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/apmpackage/apm/data_stream/service_destination_interval_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -7,6 +7,8 @@ processors:
       name: observer_ids
   - pipeline:
       name: ecs_version
+  - pipeline:
+      name: set_metrics
   - remove:
-      field: _metric_descriptions
+      field: _dynamic_templates
       ignore_missing: true

--- a/apmpackage/apm/data_stream/service_summary_interval_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/apmpackage/apm/data_stream/service_summary_interval_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -7,6 +7,8 @@ processors:
       name: observer_ids
   - pipeline:
       name: ecs_version
+  - pipeline:
+      name: set_metrics
   - remove:
-      field: _metric_descriptions
+      field: _dynamic_templates
       ignore_missing: true

--- a/apmpackage/apm/data_stream/service_transaction_interval_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/apmpackage/apm/data_stream/service_transaction_interval_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -7,6 +7,8 @@ processors:
       name: observer_ids
   - pipeline:
       name: ecs_version
+  - pipeline:
+      name: set_metrics
   - remove:
-      field: _metric_descriptions
+      field: _dynamic_templates
       ignore_missing: true

--- a/apmpackage/apm/data_stream/transaction_interval_metrics/elasticsearch/ingest_pipeline/default.yml
+++ b/apmpackage/apm/data_stream/transaction_interval_metrics/elasticsearch/ingest_pipeline/default.yml
@@ -7,6 +7,8 @@ processors:
       name: observer_ids
   - pipeline:
       name: ecs_version
+  - pipeline:
+      name: set_metrics
   - remove:
-      field: _metric_descriptions
+      field: _dynamic_templates
       ignore_missing: true


### PR DESCRIPTION
## Motivation/summary

Metrics produced by apm-server (apm-data)
will soon change. Update the ingest pipelines
to cater for this change. There is no change
to how metrics are indexed; the ingest pipeline
takes care of restructuring things.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
~- [ ] Documentation has been updated~

## How to test these changes

N/A non-functional change until we update apm-data

## Related issues

https://github.com/elastic/apm-server/issues/3565