### PR TITLE
Use apm-server latest for macro benchmarks

### DIFF
--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -66,7 +66,7 @@ pipeline {
             dir("${TESTING_BENCHMARK_DIR}") {
               withTestClusterEnv() {
                 sh(label: 'Build apmbench', script: 'make apmbench $SSH_KEY terraform.tfvars')
-                sh(label: 'Spin up benchmark environment', script: '$(make docker-override-committed-version) && make init apply; echo "-> done"')
+                sh(label: 'Spin up benchmark environment', script: 'make docker-override-committed-version && make init apply; echo "-> done"')
                 // withESBenchmarkEnv() {
                 //   sh(label: 'Run benchmarks', script: 'make run-benchmark-autotuned index-benchmark-results')
                 // }

--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -60,6 +60,9 @@ pipeline {
       steps {
         dir("${BASE_DIR}") {
           withGoEnv() {
+            retryWithSleep(retries: 3, seconds: 5, backoff: true) {
+              dockerLogin(secret: "${DOCKER_SECRET}", registry: "${DOCKER_REGISTRY}")
+            }
             dir("${TESTING_BENCHMARK_DIR}") {
               withTestClusterEnv() {
                 sh(label: 'Build apmbench', script: 'make apmbench $SSH_KEY terraform.tfvars')

--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -66,10 +66,10 @@ pipeline {
             dir("${TESTING_BENCHMARK_DIR}") {
               withTestClusterEnv() {
                 sh(label: 'Build apmbench', script: 'make apmbench $SSH_KEY terraform.tfvars')
-                //sh(label: 'Spin up benchmark environment', script: '$(make docker-override-committed-version) && make init apply')
-                withESBenchmarkEnv() {
-                  sh(label: 'Run benchmarks', script: 'make run-benchmark-autotuned index-benchmark-results')
-                }
+                sh(label: 'Spin up benchmark environment', script: '$(make docker-override-committed-version) && make init apply')
+                // withESBenchmarkEnv() {
+                //   sh(label: 'Run benchmarks', script: 'make run-benchmark-autotuned index-benchmark-results')
+                // }
               }
             }
           }

--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -66,7 +66,7 @@ pipeline {
             dir("${TESTING_BENCHMARK_DIR}") {
               withTestClusterEnv() {
                 sh(label: 'Build apmbench', script: 'make apmbench $SSH_KEY terraform.tfvars')
-                sh(label: 'Spin up benchmark environment', script: '$(make docker-override-committed-version) && make init apply')
+                //sh(label: 'Spin up benchmark environment', script: '$(make docker-override-committed-version) && make init apply')
                 withESBenchmarkEnv() {
                   sh(label: 'Run benchmarks', script: 'make run-benchmark-autotuned index-benchmark-results')
                 }

--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -67,9 +67,9 @@ pipeline {
               withTestClusterEnv() {
                 sh(label: 'Build apmbench', script: 'make apmbench $SSH_KEY terraform.tfvars')
                 sh(label: 'Spin up benchmark environment', script: 'make docker-override-committed-version init apply; echo "-> infra setup done"')
-                // withESBenchmarkEnv() {
-                //   sh(label: 'Run benchmarks', script: 'make run-benchmark-autotuned index-benchmark-results')
-                // }
+                withESBenchmarkEnv() {
+                  sh(label: 'Run benchmarks', script: 'make run-benchmark-autotuned index-benchmark-results')
+                }
               }
             }
           }

--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -17,6 +17,8 @@ pipeline {
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
     SLACK_CHANNEL = "#apm-server"
     TESTING_BENCHMARK_DIR = 'testing/benchmark'
+    DOCKER_SECRET = 'secret/observability-team/ci/docker-registry/prod'
+    DOCKER_REGISTRY = 'docker.elastic.co'
   }
   options {
     timeout(time: 8, unit: 'HOURS')

--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -66,7 +66,7 @@ pipeline {
             dir("${TESTING_BENCHMARK_DIR}") {
               withTestClusterEnv() {
                 sh(label: 'Build apmbench', script: 'make apmbench $SSH_KEY terraform.tfvars')
-                sh(label: 'Spin up benchmark environment', script: 'make docker-override-committed-version && make init apply; echo "-> done"')
+                sh(label: 'Spin up benchmark environment', script: 'make docker-override-committed-version init apply; echo "-> infra setup done"')
                 // withESBenchmarkEnv() {
                 //   sh(label: 'Run benchmarks', script: 'make run-benchmark-autotuned index-benchmark-results')
                 // }

--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -66,7 +66,7 @@ pipeline {
             dir("${TESTING_BENCHMARK_DIR}") {
               withTestClusterEnv() {
                 sh(label: 'Build apmbench', script: 'make apmbench $SSH_KEY terraform.tfvars')
-                sh(label: 'Spin up benchmark environment', script: '$(make docker-override-committed-version) && make init apply')
+                sh(label: 'Spin up benchmark environment', script: '$(make docker-override-committed-version) && make init apply; echo "-> done"')
                 // withESBenchmarkEnv() {
                 //   sh(label: 'Run benchmarks', script: 'make run-benchmark-autotuned index-benchmark-results')
                 // }

--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,6 @@ cmd/intake-receiver/events
 terraform.tfstate
 terraform.tfstate.backup
 terraform.tfvars
-testing/benchmark/.envrc
-testing/benchmark/benchmark-result.txt
 testing/smoke/**/tf.log
 testing/smoke/**/apm-server-*.ndjson
 testing/smoke/**/provisioner_key*

--- a/testing/benchmark/.gitignore
+++ b/testing/benchmark/.gitignore
@@ -1,1 +1,3 @@
 docker_image.auto.tfvars
+.envrc
+benchmark-result.txt

--- a/testing/benchmark/.gitignore
+++ b/testing/benchmark/.gitignore
@@ -1,0 +1,1 @@
+docker_image.auto.tfvars

--- a/testing/benchmark/Makefile
+++ b/testing/benchmark/Makefile
@@ -154,9 +154,7 @@ cleanup-elasticsearch:
 kibana_docker_image: build_kibana_docker_image
 	docker push ${CI_KIBANA_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG}
 build_kibana_docker_image:
-	@echo "-> Building APM package"
 	$(MAKE) -C ${REPO_ROOT} build-package
-	@echo "-> Building Kibana docker image"
 	docker build -t ${CI_KIBANA_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG} \
 		-f "${REPO_ROOT}/testing/docker/kibana/Dockerfile-apmpackage" \
 		--build-arg KIBANA_IMAGE=${KIBANA_DOCKER_IMAGE}:${IMAGE_TAG} \
@@ -171,7 +169,6 @@ build_kibana_docker_image:
 elastic_agent_docker_image: build_elastic_agent_docker_image
 	docker push "${CI_ELASTIC_AGENT_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG}"
 build_elastic_agent_docker_image:
-	@echo "-> Building Elastic Agent docker image"
 	@env BASE_IMAGE=${ELASTIC_AGENT_DOCKER_IMAGE}:${ELASTIC_AGENT_IMAGE_TAG} GOARCH=amd64 \
 		bash ${REPO_ROOT}/testing/docker/elastic-agent/build.sh \
 		     -t ${CI_ELASTIC_AGENT_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG}

--- a/testing/benchmark/Makefile
+++ b/testing/benchmark/Makefile
@@ -25,7 +25,7 @@ SSH_KEY ?= ~/.ssh/id_rsa_terraform
 WORKER_IP = $(shell terraform output -raw public_ip)
 
 SHELL = /bin/bash
-.SHELLFLAGS = -o pipefail -c
+.SHELLFLAGS = -o pipefail -x -c
 
 # This profile will also be used by the Terraform provider.
 export AWS_PROFILE ?= default

--- a/testing/benchmark/Makefile
+++ b/testing/benchmark/Makefile
@@ -122,7 +122,9 @@ IMAGE_TAG?=$(shell grep docker.elastic.co/kibana ${REPO_ROOT}/docker-compose.yml
 # The timestamp must be included to force images to be pulled.
 USER_NAME?=${USER}
 CUSTOM_IMAGE_TAG:=${IMAGE_TAG}-${USER_NAME}-$(shell date +%s)
+ELASTIC_AGENT_DOCKER_IMAGE?=docker.elastic.co/cloud-release/elastic-agent-cloud
 ELASTICSEARCH_DOCKER_IMAGE=docker.elastic.co/cloud-release/elasticsearch-cloud-ess
+KIBANA_DOCKER_IMAGE=docker.elastic.co/cloud-release/kibana-cloud
 CI_KIBANA_DOCKER_IMAGE=docker.elastic.co/observability-ci/kibana
 CI_ELASTIC_AGENT_DOCKER_IMAGE=docker.elastic.co/observability-ci/elastic-agent
 

--- a/testing/benchmark/Makefile
+++ b/testing/benchmark/Makefile
@@ -133,10 +133,6 @@ ELASTIC_AGENT_IMAGE_TAG?=${IMAGE_TAG}
 docker-override-committed-version: docker_image.auto.tfvars kibana_docker_image elastic_agent_docker_image
 	@echo '-> docker image override completed'
 
-docker_image.auto.tfvars:
-	@echo 'docker_image_override={"elasticsearch":"${ELASTICSEARCH_DOCKER_IMAGE}","kibana":"${CI_KIBANA_DOCKER_IMAGE}","apm":"${CI_ELASTIC_AGENT_DOCKER_IMAGE}"}' > $@
-	@echo 'docker_image_tag_override={"elasticsearch":"${IMAGE_TAG}","kibana":"${CUSTOM_IMAGE_TAG}","apm":"${CUSTOM_IMAGE_TAG}"}' >> $@
-
 .PHONY: cleanup-elasticsearch
 cleanup-elasticsearch:
 	$(eval ELASTICSEARCH_URL = $(shell terraform output elasticsearch_url))
@@ -145,6 +141,15 @@ cleanup-elasticsearch:
 	$(eval APM_DATA_STREAMS = traces-apm*,metrics-apm*,logs-apm*)
 	@ echo "-> Deleting APM Server data streams..."
 	@ curl -u $(ELASTICSEARCH_USER):$(ELASTICSEARCH_PASS) -XDELETE $(ELASTICSEARCH_URL)/_data_stream/$(APM_DATA_STREAMS)
+
+##############################################################################
+# Target for creating a .tfvars file, defining the custom Docker images to
+# use in the deployment.
+##############################################################################
+
+docker_image.auto.tfvars:
+	@echo 'docker_image_override={"elasticsearch":"${ELASTICSEARCH_DOCKER_IMAGE}","kibana":"${CI_KIBANA_DOCKER_IMAGE}","apm":"${CI_ELASTIC_AGENT_DOCKER_IMAGE}"}' > $@
+	@echo 'docker_image_tag_override={"elasticsearch":"${IMAGE_TAG}","kibana":"${CUSTOM_IMAGE_TAG}","apm":"${CUSTOM_IMAGE_TAG}"}' >> $@
 
 ##############################################################################
 # Targets for building and pushing custom Kibana and Elastic Agent images.

--- a/testing/benchmark/Makefile
+++ b/testing/benchmark/Makefile
@@ -37,6 +37,7 @@ all: $(SSH_KEY) terraform.tfvars apmbench auth apply
 
 MAKEFILE_PATH:=$(abspath $(lastword ${MAKEFILE_LIST}))
 MAKEFILE_DIR:=$(dir ${MAKEFILE_PATH})
+REPO_ROOT:=$(abspath ${MAKEFILE_DIR}/../../)
 
 include ${MAKEFILE_DIR}/../../go.mk
 
@@ -116,10 +117,19 @@ $(SSH_KEY):
 ssh:
 	@ssh $(SSH_OPTS) -i $(SSH_KEY) $(SSH_USER)@$(WORKER_IP)
 
+IMAGE_TAG?=$(shell grep docker.elastic.co/kibana ${REPO_ROOT}/docker-compose.yml | cut -d: -f3)
+# Tag custom images with the username and current timestamp.
+# The timestamp must be included to force images to be pulled.
+USER_NAME?=${USER}
+CUSTOM_IMAGE_TAG:=${IMAGE_TAG}-${USER_NAME}-$(shell date +%s)
+ELASTICSEARCH_DOCKER_IMAGE=docker.elastic.co/cloud-release/elasticsearch-cloud-ess
+CI_KIBANA_DOCKER_IMAGE=docker.elastic.co/observability-ci/kibana
+CI_ELASTIC_AGENT_DOCKER_IMAGE=docker.elastic.co/observability-ci/elastic-agent
+
 .PHONY: docker-override-committed-version
-docker-override-committed-version:
-	$(eval TAG := $(shell grep docker.elastic.co/ ../../docker-compose.yml |grep SNAPSHOT| cut -d ':' -f3|uniq))
-	@echo 'export TF_VAR_docker_image_tag_override={"elasticsearch":"$(TAG)","kibana":"$(TAG)","apm":"$(TAG)"}'
+docker-override-committed-version: kibana_docker_image elastic_agent_docker_image
+	@echo 'export TF_VAR_docker_image_override={"elasticsearch":"${ELASTICSEARCH_DOCKER_IMAGE}","kibana":"${CI_KIBANA_DOCKER_IMAGE}","apm":"${CI_ELASTIC_AGENT_DOCKER_IMAGE}"}'
+	@echo 'export TF_VAR_docker_image_tag_override={"elasticsearch":"${IMAGE_TAG}","kibana":"${CUSTOM_IMAGE_TAG}","apm":"${CUSTOM_IMAGE_TAG}"}'
 
 .PHONY: cleanup-elasticsearch
 cleanup-elasticsearch:
@@ -129,3 +139,33 @@ cleanup-elasticsearch:
 	$(eval APM_DATA_STREAMS = traces-apm*,metrics-apm*,logs-apm*)
 	@ echo "-> Deleting APM Server data streams..."
 	@ curl -u $(ELASTICSEARCH_USER):$(ELASTICSEARCH_PASS) -XDELETE $(ELASTICSEARCH_URL)/_data_stream/$(APM_DATA_STREAMS)
+
+##############################################################################
+# Targets for building and pushing custom Kibana and Elastic Agent images.
+##############################################################################
+
+# kibana_docker_image builds the Cloud Kibana image with the local
+# APM integration package injected. The image will be based off the
+# stack version defined in ${REPO_ROOT}/.env, unless overridden.
+.PHONY: build_kibana_docker_image
+kibana_docker_image: build_kibana_docker_image
+	docker push ${CI_KIBANA_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG}
+build_kibana_docker_image:
+	$(MAKE) -C ${REPO_ROOT} build-package
+	docker build -t ${CI_KIBANA_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG} \
+		-f "${REPO_ROOT}/testing/docker/kibana/Dockerfile-apmpackage" \
+		--build-arg KIBANA_IMAGE=${KIBANA_DOCKER_IMAGE}:${IMAGE_TAG} \
+		--platform linux/amd64 \
+		"${REPO_ROOT}/build/packages"
+
+# elastic_agent_docker_image builds the Cloud Elastic Agent image
+# with the local APM Server binary injected. The image will be based
+# off the stack version defined in ${REPO_ROOT}/docker-compose.yml,
+# unless overridden.
+.PHONY: build_elastic_agent_docker_image
+elastic_agent_docker_image: build_elastic_agent_docker_image
+	docker push "${CI_ELASTIC_AGENT_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG}"
+build_elastic_agent_docker_image:
+	@env BASE_IMAGE=${ELASTIC_AGENT_DOCKER_IMAGE}:${ELASTIC_AGENT_IMAGE_TAG} GOARCH=amd64 \
+		bash ${REPO_ROOT}/testing/docker/elastic-agent/build.sh \
+		     -t ${CI_ELASTIC_AGENT_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG}

--- a/testing/benchmark/Makefile
+++ b/testing/benchmark/Makefile
@@ -130,9 +130,12 @@ CI_ELASTIC_AGENT_DOCKER_IMAGE=docker.elastic.co/observability-ci/elastic-agent
 ELASTIC_AGENT_IMAGE_TAG?=${IMAGE_TAG}
 
 .PHONY: docker-override-committed-version
-docker-override-committed-version: kibana_docker_image elastic_agent_docker_image
-	@echo 'export TF_VAR_docker_image_override={"elasticsearch":"${ELASTICSEARCH_DOCKER_IMAGE}","kibana":"${CI_KIBANA_DOCKER_IMAGE}","apm":"${CI_ELASTIC_AGENT_DOCKER_IMAGE}"}'
-	@echo 'export TF_VAR_docker_image_tag_override={"elasticsearch":"${IMAGE_TAG}","kibana":"${CUSTOM_IMAGE_TAG}","apm":"${CUSTOM_IMAGE_TAG}"}'
+docker-override-committed-version: docker_image.auto.tfvars kibana_docker_image elastic_agent_docker_image
+	@echo '-> done'
+
+docker_image.auto.tfvars:
+	@echo 'docker_image_override={"elasticsearch":"${ELASTICSEARCH_DOCKER_IMAGE}","kibana":"${CI_KIBANA_DOCKER_IMAGE}","apm":"${CI_ELASTIC_AGENT_DOCKER_IMAGE}"}' > $@
+	@echo 'docker_image_tag_override={"elasticsearch":"${IMAGE_TAG}","kibana":"${CUSTOM_IMAGE_TAG}","apm":"${CUSTOM_IMAGE_TAG}"}' >> $@
 
 .PHONY: cleanup-elasticsearch
 cleanup-elasticsearch:

--- a/testing/benchmark/Makefile
+++ b/testing/benchmark/Makefile
@@ -127,6 +127,7 @@ ELASTICSEARCH_DOCKER_IMAGE=docker.elastic.co/cloud-release/elasticsearch-cloud-e
 KIBANA_DOCKER_IMAGE=docker.elastic.co/cloud-release/kibana-cloud
 CI_KIBANA_DOCKER_IMAGE=docker.elastic.co/observability-ci/kibana
 CI_ELASTIC_AGENT_DOCKER_IMAGE=docker.elastic.co/observability-ci/elastic-agent
+ELASTIC_AGENT_IMAGE_TAG?=${IMAGE_TAG}
 
 .PHONY: docker-override-committed-version
 docker-override-committed-version: kibana_docker_image elastic_agent_docker_image
@@ -153,7 +154,9 @@ cleanup-elasticsearch:
 kibana_docker_image: build_kibana_docker_image
 	docker push ${CI_KIBANA_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG}
 build_kibana_docker_image:
+	@echo "-> Building APM package"
 	$(MAKE) -C ${REPO_ROOT} build-package
+	@echo "-> Building Kibana docker image"
 	docker build -t ${CI_KIBANA_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG} \
 		-f "${REPO_ROOT}/testing/docker/kibana/Dockerfile-apmpackage" \
 		--build-arg KIBANA_IMAGE=${KIBANA_DOCKER_IMAGE}:${IMAGE_TAG} \
@@ -168,6 +171,7 @@ build_kibana_docker_image:
 elastic_agent_docker_image: build_elastic_agent_docker_image
 	docker push "${CI_ELASTIC_AGENT_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG}"
 build_elastic_agent_docker_image:
+	@echo "-> Building Elastic Agent docker image"
 	@env BASE_IMAGE=${ELASTIC_AGENT_DOCKER_IMAGE}:${ELASTIC_AGENT_IMAGE_TAG} GOARCH=amd64 \
 		bash ${REPO_ROOT}/testing/docker/elastic-agent/build.sh \
 		     -t ${CI_ELASTIC_AGENT_DOCKER_IMAGE}:${CUSTOM_IMAGE_TAG}

--- a/testing/benchmark/Makefile
+++ b/testing/benchmark/Makefile
@@ -131,7 +131,7 @@ ELASTIC_AGENT_IMAGE_TAG?=${IMAGE_TAG}
 
 .PHONY: docker-override-committed-version
 docker-override-committed-version: docker_image.auto.tfvars kibana_docker_image elastic_agent_docker_image
-	@echo '-> done'
+	@echo '-> docker image override completed'
 
 docker_image.auto.tfvars:
 	@echo 'docker_image_override={"elasticsearch":"${ELASTICSEARCH_DOCKER_IMAGE}","kibana":"${CI_KIBANA_DOCKER_IMAGE}","apm":"${CI_ELASTIC_AGENT_DOCKER_IMAGE}"}' > $@

--- a/testing/benchmark/Makefile
+++ b/testing/benchmark/Makefile
@@ -25,7 +25,7 @@ SSH_KEY ?= ~/.ssh/id_rsa_terraform
 WORKER_IP = $(shell terraform output -raw public_ip)
 
 SHELL = /bin/bash
-.SHELLFLAGS = -o pipefail -x -c
+.SHELLFLAGS = -o pipefail -c
 
 # This profile will also be used by the Terraform provider.
 export AWS_PROFILE ?= default

--- a/testing/benchmark/README.md
+++ b/testing/benchmark/README.md
@@ -78,18 +78,27 @@ Helper commands
 - `terraform.tfvars`: Copies the examples tfvars and sets the `user_name` var with to `$USER`.
 - `apmbench`: Compiles the `apmbench` binary from the provided location (`APMBENCH_PATH`).
 
-### Override the docker image tag
+### Override the docker image  and image tag
+
+Running `make docker-override-committed-version` will create new docker images for `kibana` and `elastic-agent`
+with local `apm` package and `apm-server` and a Terraform variable file. The file named 
+`docker_image.auto.tfvars` contains Terraform Docker image Terraform variables overrides. This file is not 
+overridden automatically, you need to remove it manually if present.
+
+#### Override docker image tag
 
 It is possible to override the tag of the docker image that is run in the remote ESS deployment. You can
 specify any of the avilable tags (such as `8.3.0-SNAPSHOT` or a more specific tag `8.3.0-c655cda8-SNAPSHOT`).
-Alternatively, you can run evaluate the output of `make docker-override-committed-version` in your shell,
-to have use the committed tags in the `docker-compose.yml` file: `eval $(make docker-override-committed-version)`.
+Alternatively, you can run `make docker-override-committed-version` in your shell, to have use the committed
+tags in the `docker-compose.yml` file in the repository root.
 
-### Override the docker image
+#### Override the docker image
 
 It is also possible to override the docker image to one that is allowed to run in ESS. For more information
 on which repositories can be used, please refer to our internal docs. To override the docker image, you'll need
 to specify the full object of images that is defined in `variables.tf`: `docker_image_override`.
+Alternatively, you can run `make docker-override-committed-version` in your shell, to have use the committed
+tags in the `docker-compose.yml` file in the repository root.
 
 ### Set APM index shards
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
The APM macro Benchmarks currently use the last committed Elastic Agent docker image for the APM Server's daily benchmarks. This introduce a dependency on all other components to be built correctly to use the latest `apm-server` code: in case a dependant build fails, the Elastic Agent docker image is not updated. The result of this behaviour is that macro benchmarks may target a older-than-main version of `apm-server`, delaying the feedback loop on recent code changes.

This PR aims at removing this dependency by always building an Elastic Agent docker container that contains the latest `apm-server` code from the `main` branch of this repository. As macro benchmarks target `apm-server` performances, we don't care too much about the version of the Elastic Agent (as long as is reasonably new - a couple of weeks old is ok) but we care to run benchmarks against the most recent version of `apm-server`.

This PR updates the `Make` targets currently used to override docker image tags to build custom Kibana and Elastic Agent images with the latest `apm-server` code.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->

Closes #10315
