### PR TITLE
fix: correct smoke tests os idempotency

### DIFF
--- a/testing/smoke/test_supported_os.sh
+++ b/testing/smoke/test_supported_os.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-KEY_NAME="provisioner_key"
+KEY_NAME="provisioner_key_$(date +%s)"
 
 ssh-keygen -f ${KEY_NAME} -N ""
 


### PR DESCRIPTION
## What is the change being made?

* Add date suffix to ensure uniqueness regarding key pair creation. 

## Why is the change being made?

* Smoke Tests OS fails from time to time when the key pair already exists.
* The key pair already exists when the terraform destroy cleanup fails.
* To avoid this issue, we can ensure name uniqueness.
* A cleanup task will be added in `cloud-reaper` as a fallback. 

## How has this been tested?

* Define `EC_API_KEY` and `AWS_PROFILE` environment variables.
* Ensure you have a valid AWS profile setup.
* Move to `testing/smoke/supported-os` and run `./test.sh 8.7.2-SNAPSHOT`.