### PR TITLE
apm-server.yml: fix comment for shutdown_timeout

### DIFF
--- a/apm-server.docker.yml
+++ b/apm-server.docker.yml
@@ -60,7 +60,7 @@ apm-server:
   #write_timeout: 30s
 
   # Maximum duration before releasing resources when shutting down the server.
-  #shutdown_timeout: 5s
+  #shutdown_timeout: 30s
 
   # Maximum permitted size in bytes of an event accepted by the server to be processed.
   #max_event_size: 307200
@@ -210,9 +210,9 @@ apm-server:
     #elasticsearch:
       # Array of hosts to connect to.
       # Scheme and port can be left out and will be set to the default (`http` and `9200`).
-      # In case you specify and additional path, the scheme is required: `http://localhost:9200/path`.
+      # In case you specify and additional path, the scheme is required: `http://elasticsearch:9200/path`.
       # IPv6 addresses should always be defined as: `https://[2001:db8::1]:9200`.
-      #hosts: ["localhost:9200"]
+      #hosts: ["elasticsearch:9200"]
 
       # Protocol - either `http` (default) or `https`.
       #protocol: "https"

--- a/apm-server.yml
+++ b/apm-server.yml
@@ -60,7 +60,7 @@ apm-server:
   #write_timeout: 30s
 
   # Maximum duration before releasing resources when shutting down the server.
-  #shutdown_timeout: 5s
+  #shutdown_timeout: 30s
 
   # Maximum permitted size in bytes of an event accepted by the server to be processed.
   #max_event_size: 307200


### PR DESCRIPTION
## Motivation/summary

The default shutdown timeout is 30s, not 5s.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
- [x] Documentation has been updated

## How to test these changes

N/A

## Related issues

None