### PR TITLE
beater: remove ServerParams.Managed

### DIFF
--- a/internal/beater/api/mux_test.go
+++ b/internal/beater/api/mux_test.go
@@ -165,7 +165,6 @@ func (m muxBuilder) build(cfg *config.Config) (http.Handler, error) {
 		agentcfg.NewDirectFetcher(nil),
 		ratelimitStore,
 		m.SourcemapFetcher,
-		m.Managed,
 		func() bool { return true },
 	)
 }

--- a/internal/beater/beater.go
+++ b/internal/beater/beater.go
@@ -427,7 +427,6 @@ func (s *Runner) Run(ctx context.Context) error {
 	// wrap depending on the configuration in order to inject behaviour.
 	serverParams := ServerParams{
 		Config:                 s.config,
-		Managed:                s.fleetConfig != nil,
 		Namespace:              s.config.DataStreams.Namespace,
 		Logger:                 s.logger,
 		Tracer:                 tracer,

--- a/internal/beater/otlp/http_test.go
+++ b/internal/beater/otlp/http_test.go
@@ -187,7 +187,7 @@ func newHTTPServer(t *testing.T, batchProcessor model.BatchProcessor) string {
 	ratelimitStore, _ := ratelimit.NewStore(1000, 1000, 1000)
 	router, err := api.NewMux(
 		cfg, batchProcessor, auth, agentcfg.NewDirectFetcher(nil),
-		ratelimitStore, nil, false, func() bool { return true })
+		ratelimitStore, nil, func() bool { return true })
 	require.NoError(t, err)
 	srv := http.Server{Handler: router}
 	t.Cleanup(func() {

--- a/internal/beater/server.go
+++ b/internal/beater/server.go
@@ -75,9 +75,6 @@ type ServerParams struct {
 	// Config is the configuration used for running the APM Server.
 	Config *config.Config
 
-	// Managed indicates that the server is managed by Fleet.
-	Managed bool
-
 	// Namespace holds the data stream namespace for the server.
 	Namespace string
 
@@ -173,7 +170,7 @@ func newServer(args ServerParams, listener net.Listener) (server, error) {
 	router, err := api.NewMux(
 		args.Config, args.BatchProcessor,
 		args.Authenticator, args.AgentConfig, args.RateLimitStore,
-		args.SourcemapFetcher, args.Managed, publishReady,
+		args.SourcemapFetcher, publishReady,
 	)
 	if err != nil {
 		return server{}, err

--- a/internal/beater/tracing.go
+++ b/internal/beater/tracing.go
@@ -48,7 +48,6 @@ func newTracerServer(cfg *config.Config, listener net.Listener, logger *logp.Log
 		agentConfigFetcher,
 		ratelimitStore,
 		nil,                         // no sourcemap store
-		false,                       // not managed
 		func() bool { return true }, // ready for publishing
 	)
 	if err != nil {

--- a/x-pack/apm-server/main_test.go
+++ b/x-pack/apm-server/main_test.go
@@ -58,7 +58,6 @@ func TestMonitoring(t *testing.T) {
 			Logger:                 logp.NewLogger(""),
 			Tracer:                 apmtest.DiscardTracer,
 			BatchProcessor:         modelprocessor.Nop{},
-			Managed:                true,
 			Namespace:              "default",
 			NewElasticsearchClient: elasticsearch.NewClient,
 		}, func(ctx context.Context, args beater.ServerParams) error {


### PR DESCRIPTION
## Motivation/summary

We no longer need to propagate throughout APM Server whether it is Fleet-managed, so remove this field.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

None