### PR TITLE
[updatecli] Bump elastic stack version to 7.17.11-b843b253

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       fleet-server: { condition: service_healthy }
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.11-874490f1-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.11-b843b253-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -62,7 +62,7 @@ services:
       - "./testing/docker/elasticsearch/users_roles:/usr/share/elasticsearch/config/users_roles"
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.17.11-874490f1-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:7.17.11-b843b253-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -86,7 +86,7 @@ services:
       package-registry: { condition: service_healthy }
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:7.17.11-874490f1-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:7.17.11-b843b253-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:


### PR DESCRIPTION



<Actions>
    <action id="e7b15d7621f18f4f5d7e346e637973c496f7dd2755e718f15b909d23a1a8076f">
        <h3>Bump elastic-stack to latest snapshot version</h3>
        <details id="8df91f7a44d0de5f780eb5c0d989f91ca538ac963b4dcf78f8b0b415754c3347">
            <summary>Update docker-compose.yml</summary>
        </details>
    </action>
</Actions>

---

<details><summary>Updatecli options</summary>
Most of Updatecli configuration is done via Updatecli manifest.
<ul>
<li>If you close this pullrequest, Updatecli will automatically reopen it, the next time it runs.</li>
<li>If you close this pullrequest, and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
</ul>
</details>

---

Action triggered automatically by [Updatecli](https://www.updatecli.io).

Feel free to report any issues at [github.com/updatecli/updatecli](https://github.com/updatecli/updatecli/issues/).
If you find this tool useful, do not hesitate to star our GitHub repository [github.com/updatecli/updatecli](https://github.com/updatecli/updatecli/stargazers) as a sign of appreciation.
Or tell us directly on our [chat](https://matrix.to/#/#Updatecli_community:gitter.im)

<img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="200" height="200">
