### PR TITLE
docs: remove mention of 'fields' config

### DIFF
--- a/docs/configure/output.asciidoc
+++ b/docs/configure/output.asciidoc
@@ -27,27 +27,4 @@ When using outputs other than {es}, `source_mapping.elasticsearch` must be set f
 Be sure to update `source_mapping.index_pattern` if source maps are stored in the non-default location.
 See <<config-sourcemapping-elasticsearch>> for more details.
 
-[[libbeat-configuration-fields]]
-[float]
-== `fields`
-
-Fields are optional tags that can be added to the documents that APM Server outputs.
-They are defined at the top-level in your configuration file, and will apply to any configured output.
-Fields can be scalar values, arrays, dictionaries, or any nested combination of these.
-By default, the fields that you specify here will be grouped under a `fields` sub-dictionary in the output document.
-
-Example using the {es} output:
-
-[source,yaml]
-------------------------------------------------------------------------------
-fields: {project: "myproject", instance-id: "574734885120952459"}
-#-------------------------- Elasticsearch output --------------------------
-output.elasticsearch:
-  hosts: ["localhost:9200"]
-------------------------------------------------------------------------------
-
-To store the custom fields as top-level fields, set the `fields_under_root` option to true.
-This is not recommended as when new fields are added to APM documents backward compatibility cannot be ensured.
-
-
 include::outputs/outputs-list.asciidoc[tag=outputs-include]


### PR DESCRIPTION
## Motivation/summary

We have not supported this since 8.0, when we switched to the new Elasticsearch output.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
- [x] Documentation has been updated

## How to test these changes

N/A

## Related issues

None