### PR TITLE
[docs] Add instructions for Docker image verification

### DIFF
--- a/docs/legacy/copied-from-beats/docs/shared-docker.asciidoc
+++ b/docs/legacy/copied-from-beats/docs/shared-docker.asciidoc
@@ -41,7 +41,7 @@ docker pull {dockerimage}
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
 wget https://artifacts.elastic.co/cosign.pub
-cosign verify --key cosign.pub {docker-repo}:{version}
+cosign verify --key cosign.pub {dockerimage}:{version}
 ------------------------------------------------
 +
 For details about this step, refer to {ref}/docker.html#docker-verify-signature[Verify the {es} Docker image signature] in the {es} documentation.

--- a/docs/legacy/copied-from-beats/docs/shared-docker.asciidoc
+++ b/docs/legacy/copied-from-beats/docs/shared-docker.asciidoc
@@ -18,7 +18,7 @@ Elastic license levels.
 ===== Pull the image
 
 Obtaining {beatname_uc} for Docker is as simple as issuing a +docker pull+ command
-against the Elastic Docker registry.
+against the Elastic Docker registry and then, optionally, verifying the image.
 
 ifeval::["{release-state}"=="unreleased"]
 
@@ -29,10 +29,22 @@ endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
 
+. Pull the Docker image:
++
 ["source", "sh", subs="attributes"]
 ------------------------------------------------
 docker pull {dockerimage}
 ------------------------------------------------
+
+. Verify the Docker image:
++
+["source", "sh", subs="attributes"]
+------------------------------------------------
+wget https://artifacts.elastic.co/cosign.pub
+cosign verify --key cosign.pub {docker-repo}:{version}
+------------------------------------------------
++
+For details about this step, refer to {ref}/docker.html#docker-verify-signature[Verify the {es} Docker image signature] in the {es} documentation.
 
 endif::[]
 


### PR DESCRIPTION
This updates the legacy [Run APM Server on Docker](https://www.elastic.co/guide/en/apm/guide/current/running-on-docker.html) page with a step to validate the Docker image. I'm not sure if we update these legacy docs anymore, but based on the issue linked below I think this is an important addition.

Rel: https://github.com/elastic/dev/issues/2002

Preview

--- 
![Screenshot 2023-05-23 at 2 51 37 PM](https://github.com/elastic/apm-server/assets/41695641/5d38906e-7983-4697-9b1c-11c062a1c08e)
