### PR TITLE
docs: fix range of sample_rate for TBS

### DIFF
--- a/docs/configure/sampling.asciidoc
+++ b/docs/configure/sampling.asciidoc
@@ -91,7 +91,7 @@ See <<tail-based-sampling>> to learn more.
 The sample rate to apply to trace events matching this policy.
 Required in each policy.
 
-The sample rate must be greater than `0` and less than or equal to `1`.
+The sample rate must be greater than or equal to `0` and less than or equal to `1`.
 For example, a `sample_rate` of `0.01` means that 1% of trace events matching the policy will be sampled.
 A `sample_rate` of `1` means that 100% of trace events matching the policy will be sampled. (int)
 


### PR DESCRIPTION
We support `sample_rate` range `[0, 1]`, update the docs to reflect the same.