### PR TITLE
ci: retry if DRA failed

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -46,7 +46,7 @@ pipeline {
   }
   stages {
     stage('Filter build') {
-      agent { label 'ubuntu-18 && immutable' }
+      agent { label 'ubuntu-22 && immutable' }
       options { skipDefaultCheckout() }
       when {
         beforeAgent true
@@ -171,7 +171,13 @@ pipeline {
             expression { return env.IS_BRANCH_AVAILABLE == "true" }
           }
           steps {
-            runReleaseManager(type: 'snapshot', outputFile: env.DRA_OUTPUT)
+            // retryWithSleep and withNode can be remove once https://github.com/elastic/release-eng/issues/456
+            // (internal only) is fixed.
+            retryWithSleep(retries: 3, seconds: 15, backoff: true) {
+              withNode(labels: 'ubuntu-22 && immutable', forceWorkspace: true) {
+                runReleaseManager(type: 'snapshot', outputFile: env.DRA_OUTPUT)
+              }
+            }
           }
           post {
             failure {
@@ -194,7 +200,13 @@ pipeline {
             }
           }
           steps {
-            runReleaseManager(type: 'staging', outputFile: env.DRA_OUTPUT)
+            // retryWithSleep and withNode can be remove once https://github.com/elastic/release-eng/issues/456
+            // (internal only) is fixed.
+            retryWithSleep(retries: 3, seconds: 15, backoff: true) {
+              withNode(labels: 'ubuntu-22 && immutable', forceWorkspace: true) {
+                runReleaseManager(type: 'staging', outputFile: env.DRA_OUTPUT)
+              }
+            }
           }
           post {
             failure {


### PR DESCRIPTION
## Motivation/summary

Rerun automatically when DRA failed regardless of the failure in a any CI runner

This will with the known issue related to the ephemeral tokens which some times cause issues.

A similar approach has been done for Beats, see https://github.com/elastic/beats/pull/35506

Additionally, I bumped the version from 18 to 22.

