### PR TITLE
[updatecli] Bump elastic stack version to 8.9.0-95ded584

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ x-logging: &default-logging
     max-size: "1g"
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.9.0-554074dc-SNAPSHOT
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.9.0-95ded584-SNAPSHOT
     ports:
       - 9200:9200
     healthcheck:
@@ -36,7 +36,7 @@ services:
     logging: *default-logging
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:8.9.0-554074dc-SNAPSHOT
+    image: docker.elastic.co/kibana/kibana:8.9.0-95ded584-SNAPSHOT
     ports:
       - 5601:5601
     healthcheck:
@@ -56,7 +56,7 @@ services:
     logging: *default-logging
 
   fleet-server:
-    image: docker.elastic.co/beats/elastic-agent:8.9.0-554074dc-SNAPSHOT
+    image: docker.elastic.co/beats/elastic-agent:8.9.0-95ded584-SNAPSHOT
     ports:
       - 8220:8220
     healthcheck:
@@ -85,7 +85,7 @@ services:
     logging: *default-logging
 
   metricbeat:
-    image: docker.elastic.co/beats/metricbeat:8.9.0-554074dc-SNAPSHOT
+    image: docker.elastic.co/beats/metricbeat:8.9.0-95ded584-SNAPSHOT
     environment:
       ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'
       ELASTICSEARCH_USERNAME: "${KIBANA_ES_USER:-admin}"

--- a/testing/infra/k8s/base/stack/apm-server.yaml
+++ b/testing/infra/k8s/base/stack/apm-server.yaml
@@ -3,7 +3,7 @@ kind: ApmServer
 metadata:
   name: apm-server
 spec:
-  version: 8.9.0-554074dc-SNAPSHOT
+  version: 8.9.0-95ded584-SNAPSHOT
   count: 1
   http:
     tls:

--- a/testing/infra/k8s/base/stack/elasticsearch.yaml
+++ b/testing/infra/k8s/base/stack/elasticsearch.yaml
@@ -3,7 +3,7 @@ kind: Elasticsearch
 metadata:
   name: elasticsearch
 spec:
-  version: 8.9.0-554074dc-SNAPSHOT
+  version: 8.9.0-95ded584-SNAPSHOT
   auth:
     fileRealm:
       - secretName: elasticsearch-admin

--- a/testing/infra/k8s/base/stack/kibana.yaml
+++ b/testing/infra/k8s/base/stack/kibana.yaml
@@ -3,7 +3,7 @@ kind: Kibana
 metadata:
   name: kibana
 spec:
-  version: 8.9.0-554074dc-SNAPSHOT
+  version: 8.9.0-95ded584-SNAPSHOT
   count: 1
   elasticsearchRef:
     name: elasticsearch


### PR DESCRIPTION


### What
Bump elastic stack version to 8.9.0-95ded584

---



<Actions>
    <action id="4b7f7310f6074ee88053f9e15fa443f8adf6e92eaebcd3137c7e8aeb698944a9">
        <h3>Bump elastic-stack to latest snapshot version</h3>
        <details id="8df91f7a44d0de5f780eb5c0d989f91ca538ac963b4dcf78f8b0b415754c3347">
            <summary>Update docker-compose.yml</summary>
        </details>
        <details id="72823de4b4e003ddc57f09421494c6cd4dfa235082e8fc8f9822093b1024abfb">
            <summary>Update k8s stack yaml files</summary>
        </details>
    </action>
</Actions>

---

<details><summary>Updatecli options</summary>
Most of Updatecli configuration is done via Updatecli manifest.
<ul>
<li>If you close this pullrequest, Updatecli will automatically reopen it, the next time it runs.</li>
<li>If you close this pullrequest, and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
</ul>
</details>

---

Action triggered automatically by [Updatecli](https://www.updatecli.io).

Feel free to report any issues at [github.com/updatecli/updatecli](https://github.com/updatecli/updatecli/issues/).
If you find this tool useful, do not hesitate to star our GitHub repository [github.com/updatecli/updatecli](https://github.com/updatecli/updatecli/stargazers) as a sign of appreciation.
Or tell us directly on our [chat](https://matrix.to/#/#Updatecli_community:gitter.im)

<img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="200" height="200">
