### PR TITLE
ci: notify build status on slack

### DIFF
--- a/.github/workflows/smoke-tests-ess.yml
+++ b/.github/workflows/smoke-tests-ess.yml
@@ -65,3 +65,23 @@ jobs:
       - if: always()
         name: Teardown smoke test infra
         run: make smoketest/cleanup TEST_DIR=${{ matrix.test }}
+
+  all-smoke-tests-ess:
+    name: All Smoke Tests ESS
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - smoke-tests-ess
+    steps:
+      - id: check
+        uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
+        with:
+          needs: ${{ toJSON(needs) }}
+      - uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
+        with:
+          status: ${{ steps.check.outputs.status }}
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          slackChannel: "#apm-server"
+          message: "Build result for Smoke Tests ESS"

--- a/.github/workflows/smoke-tests-schedule.yml
+++ b/.github/workflows/smoke-tests-schedule.yml
@@ -35,6 +35,25 @@ jobs:
       branch: ${{ matrix.branch }}
     secrets: inherit
 
+  all-smoke-tests-os:
+    name: All Smoke Tests OS
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - smoke-tests-os
+    steps:
+      - id: check
+        uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
+        with:
+          needs: ${{ toJSON(needs) }}
+      - uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
+        with:
+          status: ${{ steps.check.outputs.status }}
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          slackChannel: "#apm-server"
+
   smoke-tests-ess:
     name: Run smoke tests ESS
     uses: ./.github/workflows/smoke-tests-ess.yml


### PR DESCRIPTION
## What is the change being made?

* Add build status notification on Slack for Smoke tests.

## Why is the change being made?

* We migrate from Jenkins to GitHub Actions.
* Before, we had a notification after each build on Slack.
* This PR re-introduce the same mechanism on GitHub Actions.

## How has this been tested?

* The workflow has been triggered using `gh workflow run smoke-tests-schedule.yml --ref feature/build-status`
* The result can be found [here](https://github.com/elastic/apm-server/actions/runs/5126180964).