### PR TITLE
Keep making aggregation keys if there is no destination

### DIFF
--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
@@ -227,9 +227,6 @@ func (a *Aggregator) ProcessBatch(ctx context.Context, b *model.Batch) error {
 }
 
 func (a *Aggregator) processSpan(event *model.APMEvent) {
-	if event.Span.DestinationService == nil || event.Span.DestinationService.Resource == "" {
-		return
-	}
 	if event.Span.RepresentativeCount <= 0 {
 		// RepresentativeCount is zero when the sample rate is unknown.
 		// We cannot calculate accurate span metrics without the sample
@@ -256,11 +253,17 @@ func (a *Aggregator) processSpan(event *model.APMEvent) {
 		count: float64(count) * event.Span.RepresentativeCount,
 		sum:   float64(duration) * event.Span.RepresentativeCount,
 	}
+
+	var resource string
+	if event.Span.DestinationService != nil && event.Span.DestinationService.Resource != "" {
+		resource = event.Span.DestinationService.Resource
+	}
+
 	for _, interval := range a.Intervals {
 		key := makeAggregationKey(
 			event,
 			event.Event.Outcome,
-			event.Span.DestinationService.Resource,
+			resource,
 			serviceTargetType,
 			serviceTargetName,
 			event.Span.Name,

--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator_test.go
@@ -262,7 +262,40 @@ func TestAggregatorRun(t *testing.T) {
 				{serviceName: "service-A", agentName: "java", outcome: "success", count: 1},
 			},
 			getExpectedEvents: func(now time.Time, interval time.Duration) []model.APMEvent {
-				return []model.APMEvent{}
+				return []model.APMEvent{
+					{
+						Timestamp: now.Truncate(interval),
+						Agent:     model.Agent{Name: "java"},
+						Service: model.Service{
+							Name: "service-A",
+						},
+						Event:     model.Event{Outcome: "success"},
+						Processor: model.MetricsetProcessor,
+						Metricset: &model.Metricset{
+							Name:     "service_destination",
+							Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
+							DocCount: 100,
+						},
+						Span: &model.Span{
+							Name: "service-A:",
+							DestinationService: &model.DestinationService{
+								ResponseTime: model.AggregatedDuration{
+									Count: 100,
+									Sum:   10 * time.Second,
+								},
+							},
+						},
+						Labels: model.Labels{
+							"department_name": model.LabelValue{Value: "apm"},
+							"organization":    model.LabelValue{Value: "observability"},
+							"company":         model.LabelValue{Value: "elastic"},
+						},
+						NumericLabels: model.NumericLabels{
+							"user_id":     model.NumericLabelValue{Value: 100},
+							"cost_center": model.NumericLabelValue{Value: 10},
+						},
+					},
+				}
 			},
 		},
 		{
@@ -272,7 +305,44 @@ func TestAggregatorRun(t *testing.T) {
 				{serviceName: "service-A", agentName: "java", targetType: trgTypeZ, targetName: trgNameZ, outcome: "success", count: 1},
 			},
 			getExpectedEvents: func(now time.Time, interval time.Duration) []model.APMEvent {
-				return []model.APMEvent{}
+				return []model.APMEvent{
+					{
+						Timestamp: now.Truncate(interval),
+						Agent:     model.Agent{Name: "java"},
+						Service: model.Service{
+							Name: "service-A",
+							Target: &model.ServiceTarget{
+								Type: trgTypeZ,
+								Name: trgNameZ,
+							},
+						},
+						Event:     model.Event{Outcome: "success"},
+						Processor: model.MetricsetProcessor,
+						Metricset: &model.Metricset{
+							Name:     "service_destination",
+							Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
+							DocCount: 100,
+						},
+						Span: &model.Span{
+							Name: "service-A:",
+							DestinationService: &model.DestinationService{
+								ResponseTime: model.AggregatedDuration{
+									Count: 100,
+									Sum:   10 * time.Second,
+								},
+							},
+						},
+						Labels: model.Labels{
+							"department_name": model.LabelValue{Value: "apm"},
+							"organization":    model.LabelValue{Value: "observability"},
+							"company":         model.LabelValue{Value: "elastic"},
+						},
+						NumericLabels: model.NumericLabels{
+							"user_id":     model.NumericLabelValue{Value: 100},
+							"cost_center": model.NumericLabelValue{Value: 10},
+						},
+					},
+				}
 			},
 		},
 		{


### PR DESCRIPTION
## Motivation/summary

If no service destination has been set, we can still keep creating aggregation keys, with a blank resource.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] **N/A** Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [x] **Should be N/A** Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

This is unit-tested

## Related issues

Closes https://github.com/elastic/apm-server/issues/10531
