### PR TITLE
8.8.1 changelog: indexing failures for 10m and 60m data streams

### DIFF
--- a/changelogs/8.8.asciidoc
+++ b/changelogs/8.8.asciidoc
@@ -14,6 +14,7 @@ https://github.com/elastic/apm-server/compare/v8.8.0\...v8.8.1[View commits]
 
 [float]
 ==== Bug fixes
+- Fix indexing failures for 10m and 60m aggregation rollup data streams after upgrading from 8.7.x to 8.8.0. See Fleet changelog for details.
 
 [float]
 [[release-notes-8.8.0]]


### PR DESCRIPTION
Update 8.8.1 changelog to include a bugfix that lives in Fleet.