### PR TITLE
ci: Update failed benchmarks Slack notification

### DIFF
--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -100,7 +100,9 @@ pipeline {
           }
         }
         failure {
-          notifyBuildResult(slackNotify: true, slackComment: true)
+          dir("${BASE_DIR}") {
+            sendSlackReportFailureMessage()
+          }
         }
       }
     }
@@ -174,4 +176,24 @@ def sendSlackReportSuccessMessage() {
 
     slackSend(channel: "${env.SLACK_CHANNEL}", blocks: slackMessageBlocks)
   }
+}
+
+def sendSlackReportFailureMessage() {
+  slackMessageBlocks = [
+    [
+      "type": "section",
+      "text": [
+        "type": "mrkdwn",
+        "text": "Nightly benchmarks failed!\n\n <${env.BUILD_URL}|Jenkins Build ${env.BUILD_DISPLAY_NAME}>"
+      ]
+    ],
+    [
+      "type": "section",
+      "text": [
+        "type": "mrkdwn",
+        "text": "SDH Duty assignee, please have a look and follow this <https://github.com/elastic/observability-dev/blob/main/docs/apm/apm-server/runbooks/benchmarks.md|Runbook>!"
+      ]
+    ]
+  ]
+  slackSend(channel: "${env.SLACK_CHANNEL}", blocks: slackMessageBlocks)
 }

--- a/testing/benchmark/Makefile
+++ b/testing/benchmark/Makefile
@@ -60,6 +60,7 @@ terraform.tfvars:
 .PHONY: apmbench
 apmbench:
 	@echo "-> Building apmbench..."
+	@exit 1
 	@cd $(APMBENCH_PATH) && CGO_ENABLED=0 GOOS=$(APMBENCH_GOOS) GOARCH=$(APMBENCH_GOARCH) $(GO) build .
 
 .PHONY: init

--- a/testing/benchmark/Makefile
+++ b/testing/benchmark/Makefile
@@ -60,7 +60,6 @@ terraform.tfvars:
 .PHONY: apmbench
 apmbench:
 	@echo "-> Building apmbench..."
-	@exit 1
 	@cd $(APMBENCH_PATH) && CGO_ENABLED=0 GOOS=$(APMBENCH_GOOS) GOARCH=$(APMBENCH_GOARCH) $(GO) build .
 
 .PHONY: init


### PR DESCRIPTION
## Motivation/summary

Updates the failed benchmarks Slack notification to point to the newly created runbook.

