### PR TITLE
benchmarks: Update dashboard, visualization size

### DIFF
--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -64,15 +64,15 @@ pipeline {
             retryWithSleep(retries: 3, seconds: 5, backoff: true) {
               dockerLogin(secret: "${DOCKER_SECRET}", registry: "${DOCKER_REGISTRY}")
             }
-            dir("${TESTING_BENCHMARK_DIR}") {
-              withTestClusterEnv() {
-                sh(label: 'Build apmbench', script: 'make apmbench $SSH_KEY terraform.tfvars')
-                sh(label: 'Spin up benchmark environment', script: 'make docker-override-committed-version init apply; echo "-> infra setup done"')
-                withESBenchmarkEnv() {
-                  sh(label: 'Run benchmarks', script: 'make run-benchmark-autotuned index-benchmark-results')
-                }
-              }
-            }
+            // dir("${TESTING_BENCHMARK_DIR}") {
+            //   withTestClusterEnv() {
+            //     sh(label: 'Build apmbench', script: 'make apmbench $SSH_KEY terraform.tfvars')
+            //     sh(label: 'Spin up benchmark environment', script: 'make docker-override-committed-version init apply; echo "-> infra setup done"')
+            //     withESBenchmarkEnv() {
+            //       sh(label: 'Run benchmarks', script: 'make run-benchmark-autotuned index-benchmark-results')
+            //     }
+            //   }
+            // }
           }
           downloadPNGReport()
         }

--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -79,19 +79,19 @@ pipeline {
       }
       post {
         always {
-          dir("${BASE_DIR}/${TESTING_BENCHMARK_DIR}") {
-            stashV2(name: 'benchmark_tfstate', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}")
-            archiveArtifacts(artifacts: "${env.BENCHMARK_RESULT}", allowEmptyArchive: true)
-          }
+          // dir("${BASE_DIR}/${TESTING_BENCHMARK_DIR}") {
+          //   stashV2(name: 'benchmark_tfstate', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}")
+          //   archiveArtifacts(artifacts: "${env.BENCHMARK_RESULT}", allowEmptyArchive: true)
+          // }
         }
         cleanup {
           dir("${BASE_DIR}") {
             withGoEnv() {
-              dir("${TESTING_BENCHMARK_DIR}") {
-                withTestClusterEnv() {
-                  sh(label: 'Tear down benchmark environment', script: 'make destroy')
-                }
-              }
+              // dir("${TESTING_BENCHMARK_DIR}") {
+              //   withTestClusterEnv() {
+              //     sh(label: 'Tear down benchmark environment', script: 'make destroy')
+              //   }
+              // }
             }
           }
         }

--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -43,6 +43,7 @@ pipeline {
         retry(2)
       }
       environment {
+        RUNBOOK = "<https://github.com/elastic/observability-dev/blob/main/docs/apm/apm-server/runbooks/benchmarks.md|Runbook>"
         SSH_KEY = "./id_rsa_terraform"
         TF_VAR_private_key = "./id_rsa_terraform"
         TF_VAR_public_key = "./id_rsa_terraform.pub"
@@ -154,7 +155,7 @@ def sendSlackReportSuccessMessage() {
         "type": "section",
         "text": [
           "type": "mrkdwn",
-          "text": "Nightly benchmarks succesfully executed\n\n <${env.BUILD_URL}|Jenkins Build ${env.BUILD_DISPLAY_NAME}>"
+          "text": "Benchmarks in `${BRANCH_NAME}` branch succeeded! SDH assignee, please investigate any performance regressions following this ${RUNBOOK}.\n\n <${env.BUILD_URL}|Jenkins Build ${env.BUILD_DISPLAY_NAME}>"
         ]
       ],
       [
@@ -184,14 +185,7 @@ def sendSlackReportFailureMessage() {
       "type": "section",
       "text": [
         "type": "mrkdwn",
-        "text": "Nightly benchmarks failed!\n\n <${env.BUILD_URL}|Jenkins Build ${env.BUILD_DISPLAY_NAME}>"
-      ]
-    ],
-    [
-      "type": "section",
-      "text": [
-        "type": "mrkdwn",
-        "text": "SDH Duty assignee, please have a look and follow this <https://github.com/elastic/observability-dev/blob/main/docs/apm/apm-server/runbooks/benchmarks.md|Runbook>!"
+        "text": "Benchmarks in `${BRANCH_NAME}` failed! SDH Duty assignee, please have a look and follow this ${RUNBOOK}!\n\n <${env.BUILD_URL}|Jenkins Build ${env.BUILD_DISPLAY_NAME}>"
       ]
     ]
   ]

--- a/.ci/benchmarks.groovy
+++ b/.ci/benchmarks.groovy
@@ -78,12 +78,12 @@ pipeline {
         }
       }
       post {
-        always {
-          // dir("${BASE_DIR}/${TESTING_BENCHMARK_DIR}") {
-          //   stashV2(name: 'benchmark_tfstate', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}")
-          //   archiveArtifacts(artifacts: "${env.BENCHMARK_RESULT}", allowEmptyArchive: true)
-          // }
-        }
+        // always {
+        //   dir("${BASE_DIR}/${TESTING_BENCHMARK_DIR}") {
+        //     stashV2(name: 'benchmark_tfstate', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}")
+        //     archiveArtifacts(artifacts: "${env.BENCHMARK_RESULT}", allowEmptyArchive: true)
+        //   }
+        // }
         cleanup {
           dir("${BASE_DIR}") {
             withGoEnv() {

--- a/.ci/scripts/download-png-from-kibana.sh
+++ b/.ci/scripts/download-png-from-kibana.sh
@@ -10,14 +10,14 @@ JOB_PARAMS=$(echo "
 (
   layout:(
     dimensions:(
-      height:400,
+      height:636,
       width:${table_width_px}
     ),id:preserve_layout
   ),
   locatorParams:(
     id:DASHBOARD_APP_LOCATOR,
     params:(
-      dashboardId:a5bc8390-2f8e-11ed-a369-052d8245fa04,
+      dashboardId:8b56efd0-e7ff-11ec-a01b-a55f13ba6a8b,
       preserveSavedFilters:!t,
       timeRange:(
         from:now-30d,

--- a/.ci/scripts/download-png-from-kibana.sh
+++ b/.ci/scripts/download-png-from-kibana.sh
@@ -17,7 +17,7 @@ JOB_PARAMS=$(echo "
   locatorParams:(
     id:DASHBOARD_APP_LOCATOR,
     params:(
-      dashboardId:8b56efd0-e7ff-11ec-a01b-a55f13ba6a8b,
+      dashboardId:a5bc8390-2f8e-11ed-a369-052d8245fa04,
       preserveSavedFilters:!t,
       timeRange:(
         from:now-30d,
@@ -25,17 +25,15 @@ JOB_PARAMS=$(echo "
       ),
       useHash:!f,
       viewMode:view
-    ),
-    version:'8.3.2'
+    )
   ),
   objectType:dashboard,
-  title:app_bench_diff_shifts_slack,
-  version:'8.3.2'
+  title:app_bench_diff_shifts_slack
 )
 " | tr -d "[:space:]")
 
 
-png_url_path=$(curl -XPOST -v -L -u "$kibana_user:$kibana_pwd" -H 'kbn-xsrf: true' --data-urlencode "jobParams=${JOB_PARAMS}" $kibana_host/api/reporting/generate/pngV2 | jq -r '.path')
+png_url_path=$(curl -XPOST -L -u "$kibana_user:$kibana_pwd" -H 'kbn-xsrf: true' --data-urlencode "jobParams=${JOB_PARAMS}" $kibana_host/api/reporting/generate/pngV2 | jq -r '.path')
 
 
 echo "PNG URL path: $png_url_path"

--- a/testing/benchmark/Makefile
+++ b/testing/benchmark/Makefile
@@ -59,7 +59,7 @@ terraform.tfvars:
 
 .PHONY: apmbench
 apmbench:
-	@echo "-> Building apmbench..."; exit 1
+	@echo "-> Building apmbench..."
 	@cd $(APMBENCH_PATH) && CGO_ENABLED=0 GOOS=$(APMBENCH_GOOS) GOARCH=$(APMBENCH_GOARCH) $(GO) build .
 
 .PHONY: init

--- a/testing/benchmark/Makefile
+++ b/testing/benchmark/Makefile
@@ -59,7 +59,7 @@ terraform.tfvars:
 
 .PHONY: apmbench
 apmbench:
-	@echo "-> Building apmbench..."
+	@echo "-> Building apmbench..."; exit 1
 	@cd $(APMBENCH_PATH) && CGO_ENABLED=0 GOOS=$(APMBENCH_GOOS) GOARCH=$(APMBENCH_GOARCH) $(GO) build .
 
 .PHONY: init


### PR DESCRIPTION
## Motivation/summary

Updates the dashboard ID to contain a `branch:main` filter expression and also updates the height of the reported visualization to include up to 2 weeks of history in the attached PNG.
