### PR TITLE
feat: migrate decoders to protobuf

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -288,11 +288,11 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/apm-data
-Version: v0.1.1-0.20230615110856-5cae1b218218
+Version: v0.1.1-0.20230618124432-0acd047d5d2c
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/apm-data@v0.1.1-0.20230615110856-5cae1b218218/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/apm-data@v0.1.1-0.20230618124432-0acd047d5d2c/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/dgraph-io/badger/v2 v2.2007.3-0.20201012072640-f5a7e0a1c83b
 	github.com/dustin/go-humanize v1.0.1
-	github.com/elastic/apm-data v0.1.1-0.20230615110856-5cae1b218218
+	github.com/elastic/apm-data v0.1.1-0.20230618124432-0acd047d5d2c
 	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230615211647-139a8bf9e199
 	github.com/elastic/elastic-agent-client/v7 v7.1.2
 	github.com/elastic/elastic-agent-libs v0.3.9

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6 h1:8yY/I9
 github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6/go.mod h1:YvSRo5mw33fLEx1+DlK6L2VV43tJt5Eyel9n9XBcR+0=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/elastic/apm-data v0.1.1-0.20230615110856-5cae1b218218 h1:sXDV54vFv/+dpJcWx60756bqb73OE2x1FMBLUPCpAf0=
-github.com/elastic/apm-data v0.1.1-0.20230615110856-5cae1b218218/go.mod h1:2ZtuB/ipMCv+732o4ad/5MadDHSko4Z4CRFCtx2CfSw=
+github.com/elastic/apm-data v0.1.1-0.20230618124432-0acd047d5d2c h1:742/YkvnG+0PXqH2wR5ewlNLVB9g6XCPNrQcGBYaZAU=
+github.com/elastic/apm-data v0.1.1-0.20230618124432-0acd047d5d2c/go.mod h1:2ZtuB/ipMCv+732o4ad/5MadDHSko4Z4CRFCtx2CfSw=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230615211647-139a8bf9e199 h1:Ixr8BuP4eus39MPl+kLcDRvQqibWwKkNQJWpOE0QoHI=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230615211647-139a8bf9e199/go.mod h1:lAPR+jtv6hHCRgDaKkUUL4xRRWVIIgb3ZQRC52cyVZo=
 github.com/elastic/elastic-agent-autodiscover v0.6.1 h1:vXR+3QVDL7Ij7IMKul13iIiDmM66HsX6MS6I0T4O8gw=

--- a/systemtest/aggregation_test.go
+++ b/systemtest/aggregation_test.go
@@ -37,7 +37,6 @@ import (
 )
 
 func TestTransactionAggregation(t *testing.T) {
-	t.Skip("TODO FIX")
 	systemtest.CleanupElasticsearch(t)
 	srv := apmservertest.NewUnstartedServerTB(t)
 	srv.Config.Monitoring = &apmservertest.MonitoringConfig{

--- a/systemtest/huge_traces_test.go
+++ b/systemtest/huge_traces_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestTransactionDroppedSpansStats(t *testing.T) {
-	t.Skip("TODO  FIX")
 	// Disable span compression.
 	t.Setenv("ELASTIC_APM_SPAN_COMPRESSION_ENABLED", "false")
 	systemtest.CleanupElasticsearch(t)

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -550,7 +550,7 @@ func makeMetricset(key transactionAggregationKey, metrics transactionMetrics, in
 
 	var container *modelpb.Container
 	if key.containerID != "" {
-		container = &modelpb.Container{Name: key.containerID}
+		container = &modelpb.Container{Id: key.containerID}
 	}
 
 	var hostOs *modelpb.OS


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

This is a small PR to fix an issue with aggregation tests.

Also bump the apm-data library and reenable the broke tests.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Related to https://github.com/elastic/apm-data/issues/52
Blocked by https://github.com/elastic/apm-data/pull/63
