### PR TITLE
feat: migrate metadata decoding to protobuf

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -288,11 +288,11 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/apm-data
-Version: v0.1.1-0.20230618124432-0acd047d5d2c
+Version: v0.1.1-0.20230619091308-3ff577541509
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/apm-data@v0.1.1-0.20230618124432-0acd047d5d2c/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/apm-data@v0.1.1-0.20230619091308-3ff577541509/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/dgraph-io/badger/v2 v2.2007.3-0.20201012072640-f5a7e0a1c83b
 	github.com/dustin/go-humanize v1.0.1
-	github.com/elastic/apm-data v0.1.1-0.20230618124432-0acd047d5d2c
+	github.com/elastic/apm-data v0.1.1-0.20230619091308-3ff577541509
 	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230615211647-139a8bf9e199
 	github.com/elastic/elastic-agent-client/v7 v7.1.2
 	github.com/elastic/elastic-agent-libs v0.3.9

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6 h1:8yY/I9
 github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6/go.mod h1:YvSRo5mw33fLEx1+DlK6L2VV43tJt5Eyel9n9XBcR+0=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/elastic/apm-data v0.1.1-0.20230618124432-0acd047d5d2c h1:742/YkvnG+0PXqH2wR5ewlNLVB9g6XCPNrQcGBYaZAU=
-github.com/elastic/apm-data v0.1.1-0.20230618124432-0acd047d5d2c/go.mod h1:2ZtuB/ipMCv+732o4ad/5MadDHSko4Z4CRFCtx2CfSw=
+github.com/elastic/apm-data v0.1.1-0.20230619091308-3ff577541509 h1:u6By1eNybxB1OQ12PN5sx/xfwwpxIfLSPWlIjXqs9LA=
+github.com/elastic/apm-data v0.1.1-0.20230619091308-3ff577541509/go.mod h1:2ZtuB/ipMCv+732o4ad/5MadDHSko4Z4CRFCtx2CfSw=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230615211647-139a8bf9e199 h1:Ixr8BuP4eus39MPl+kLcDRvQqibWwKkNQJWpOE0QoHI=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230615211647-139a8bf9e199/go.mod h1:lAPR+jtv6hHCRgDaKkUUL4xRRWVIIgb3ZQRC52cyVZo=
 github.com/elastic/elastic-agent-autodiscover v0.6.1 h1:vXR+3QVDL7Ij7IMKul13iIiDmM66HsX6MS6I0T4O8gw=

--- a/internal/beater/api/intake/handler.go
+++ b/internal/beater/api/intake/handler.go
@@ -18,10 +18,8 @@
 package intake
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -31,7 +29,6 @@ import (
 	"github.com/elastic/elastic-agent-libs/monitoring"
 
 	"github.com/elastic/apm-data/input/elasticapm"
-	"github.com/elastic/apm-data/model"
 	"github.com/elastic/apm-data/model/modelpb"
 	"github.com/elastic/apm-server/internal/beater/auth"
 	"github.com/elastic/apm-server/internal/beater/headers"
@@ -59,27 +56,13 @@ var (
 	errInvalidContentType = errors.New("invalid content type")
 )
 
-// StreamHandler is an interface for handling an Elastic APM agent ND-JSON event
-// stream, implemented by processor/stream.
-type StreamHandler interface {
-	HandleStream(
-		ctx context.Context,
-		async bool,
-		base model.APMEvent,
-		stream io.Reader,
-		batchSize int,
-		processor modelpb.BatchProcessor,
-		out *elasticapm.Result,
-	) error
-}
-
 // RequestMetadataFunc is a function type supplied to Handler for extracting
 // metadata from the request. This is used for conditionally injecting the
 // source IP address as `client.ip` for RUM.
-type RequestMetadataFunc func(*request.Context) model.APMEvent
+type RequestMetadataFunc func(*request.Context) *modelpb.APMEvent
 
 // Handler returns a request.Handler for managing intake requests for backend and rum events.
-func Handler(handler StreamHandler, requestMetadataFunc RequestMetadataFunc, batchProcessor modelpb.BatchProcessor) request.Handler {
+func Handler(handler elasticapm.StreamHandler, requestMetadataFunc RequestMetadataFunc, batchProcessor modelpb.BatchProcessor) request.Handler {
 	return func(c *request.Context) {
 		if err := validateRequest(c); err != nil {
 			writeError(c, err)

--- a/internal/beater/api/intake/handler_test.go
+++ b/internal/beater/api/intake/handler_test.go
@@ -35,7 +35,6 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	"github.com/elastic/apm-data/input/elasticapm"
-	"github.com/elastic/apm-data/model"
 	"github.com/elastic/apm-data/model/modelpb"
 	"github.com/elastic/apm-server/internal/beater/config"
 	"github.com/elastic/apm-server/internal/beater/headers"
@@ -178,7 +177,7 @@ func TestIntakeHandlerMonitoring(t *testing.T) {
 	streamHandler := streamHandlerFunc(func(
 		ctx context.Context,
 		async bool,
-		base model.APMEvent,
+		base *modelpb.APMEvent,
 		stream io.Reader,
 		batchSize int,
 		processor modelpb.BatchProcessor,
@@ -290,14 +289,14 @@ func compressedRequest(t *testing.T, compressionType string, compressPayload boo
 	return req
 }
 
-func emptyRequestMetadata(*request.Context) model.APMEvent {
-	return model.APMEvent{}
+func emptyRequestMetadata(*request.Context) *modelpb.APMEvent {
+	return &modelpb.APMEvent{}
 }
 
 type streamHandlerFunc func(
 	ctx context.Context,
 	async bool,
-	base model.APMEvent,
+	base *modelpb.APMEvent,
 	stream io.Reader,
 	batchSize int,
 	processor modelpb.BatchProcessor,
@@ -307,7 +306,7 @@ type streamHandlerFunc func(
 func (f streamHandlerFunc) HandleStream(
 	ctx context.Context,
 	async bool,
-	base model.APMEvent,
+	base *modelpb.APMEvent,
 	stream io.Reader,
 	batchSize int,
 	processor modelpb.BatchProcessor,


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Last "big" change related to the protobuf work:
- migrate metadata decoding to protobuf
- update leftover tests to use modelpb

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Blocked by https://github.com/elastic/apm-data/pull/67
Blocked by https://github.com/elastic/apm-server/pull/11013
Related to https://github.com/elastic/apm-data/issues/52
