### PR TITLE
feat: migrate r8 deobfuscator to protobuf

### DIFF
--- a/internal/r8/deobfuscator.go
+++ b/internal/r8/deobfuscator.go
@@ -23,12 +23,12 @@ import (
 	"io"
 	"regexp"
 
-	"github.com/elastic/apm-data/model"
+	"github.com/elastic/apm-data/model/modelpb"
 )
 
 // StacktraceType groups frames belonging to a single class as well as frames that represent the same method call.
 type StacktraceType struct {
-	methods map[string][]*model.StacktraceFrame // Maps method references to all the frames where it appears.
+	methods map[string][]*modelpb.StacktraceFrame // Maps method references to all the frames where it appears.
 }
 
 var (
@@ -39,7 +39,7 @@ var (
 // Deobfuscate mutates the stacktrace by searching for those items through the mapFile, looking
 // for their de-obfuscated names and replacing the ones in the original stacktrace by their real names found within the mapFile.
 // Note that not all the stacktrace items might be present in the mapFile, for those cases, those frames will remain untouched.
-func Deobfuscate(stacktrace *model.Stacktrace, mapFile io.Reader) error {
+func Deobfuscate(stacktrace *[]*modelpb.StacktraceFrame, mapFile io.Reader) error {
 	types, err := groupUniqueTypes(stacktrace)
 	if err != nil {
 		return err
@@ -54,7 +54,7 @@ func Deobfuscate(stacktrace *model.Stacktrace, mapFile io.Reader) error {
 
 // Iterates over the stacktrace and groups the frames by classname, along with its methods, which are grouped by
 // the method name.
-func groupUniqueTypes(stacktrace *model.Stacktrace) (map[string]StacktraceType, error) {
+func groupUniqueTypes(stacktrace *[]*modelpb.StacktraceFrame) (map[string]StacktraceType, error) {
 	var types = make(map[string]StacktraceType)
 
 	for _, frame := range *stacktrace {
@@ -71,13 +71,13 @@ func groupUniqueTypes(stacktrace *model.Stacktrace) (map[string]StacktraceType, 
 		typeItem, ok := types[typeName]
 		if !ok {
 			typeItem = StacktraceType{
-				methods: make(map[string][]*model.StacktraceFrame),
+				methods: make(map[string][]*modelpb.StacktraceFrame),
 			}
 			types[typeName] = typeItem
 		}
 		_, ok = typeItem.methods[methodName]
 		if !ok {
-			typeItem.methods[methodName] = make([]*model.StacktraceFrame, 0)
+			typeItem.methods[methodName] = make([]*modelpb.StacktraceFrame, 0)
 		}
 		typeItem.methods[methodName] = append(typeItem.methods[methodName], frame)
 
@@ -106,6 +106,9 @@ func resolveMappings(types map[string]StacktraceType, mapReader io.Reader) error
 				currentType = &stacktraceType
 				for _, frames := range stacktraceType.methods {
 					for _, frame := range frames {
+						if frame.Original == nil {
+							frame.Original = &modelpb.Original{}
+						}
 						// Multiple frames might point to the same class, so we need to deobfuscate the class name for them all.
 						frame.Original.Classname = obfuscatedName
 						frame.Classname = typeMatch[1]

--- a/internal/r8/deobfuscator_test.go
+++ b/internal/r8/deobfuscator_test.go
@@ -21,10 +21,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/elastic/apm-data/model/modelpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/elastic/apm-data/model"
 )
 
 type FrameValidation struct {
@@ -43,7 +42,7 @@ func TestSimpleLineDeobfuscation(t *testing.T) {
 	// Expected output:
 	// at androidx.appcompat.view.menu.MenuBuilder.dispatchMenuItemSelected(Unknown Source:4)
 	frame := createStacktraceFrame(4, "Unknown Source", "androidx.appcompat.view.menu.e", "f")
-	stacktrace := model.Stacktrace{frame}
+	stacktrace := []*modelpb.StacktraceFrame{frame}
 
 	mapFilePath := "../../testdata/r8/deobfuscator/1/mapping"
 	reader, err := os.Open(mapFilePath)
@@ -72,7 +71,7 @@ func TestDeobfuscateCompressedLine(t *testing.T) {
 	//																				co.elastic.apm.opbeans.HomeActivity.setUpBottomNavigation$lambda-0
 	//																				onMenuItemSelected
 	frame := createStacktraceFrame(11, "SourceFile", "i6.f", "a")
-	stacktrace := model.Stacktrace{frame}
+	stacktrace := []*modelpb.StacktraceFrame{frame}
 
 	mapFilePath := "../../testdata/r8/deobfuscator/1/mapping"
 	reader, err := os.Open(mapFilePath)
@@ -101,7 +100,7 @@ func TestDeobfuscateClassNameOnlyWhenMethodIsNotObfuscated(t *testing.T) {
 	// Expected output:
 	// at androidx.appcompat.app.AppCompatActivity.onStart(Unknown Source:0)
 	frame := createStacktraceFrame(0, "Unknown Source", "d.e", "onStart")
-	stacktrace := model.Stacktrace{frame}
+	stacktrace := []*modelpb.StacktraceFrame{frame}
 
 	mapFilePath := "../../testdata/r8/deobfuscator/2/mapping"
 	reader, err := os.Open(mapFilePath)
@@ -155,7 +154,7 @@ func TestDeobfuscateMultipleLines(t *testing.T) {
 	//at okhttp3.internal.http.RealInterceptorChain.proceed(SourceFile:7)
 	//at co.elastic.apm.opbeans.app.di.ApplicationModule$provideOkHttpClient$$inlined$-addInterceptor$1.intercept(SourceFile:5)
 
-	stacktrace := &model.Stacktrace{
+	stacktrace := &[]*modelpb.StacktraceFrame{
 		createStacktraceFrame(2103, "Class.java", "java.lang.Class", "getMethod"),
 		createStacktraceFrame(1724, "Class.java", "java.lang.Class", "getMethod"),
 		createStacktraceFrame(32, "Unknown Source", "m1.b", "e"),
@@ -285,7 +284,7 @@ intercept`,
 	})
 }
 
-func verifyFrames(t *testing.T, frames []*model.StacktraceFrame, validations []FrameValidation) {
+func verifyFrames(t *testing.T, frames []*modelpb.StacktraceFrame, validations []FrameValidation) {
 	assert.Equal(t, len(validations), len(frames))
 
 	for index, frame := range frames {
@@ -293,18 +292,20 @@ func verifyFrames(t *testing.T, frames []*model.StacktraceFrame, validations []F
 	}
 }
 
-func verifyFrame(t *testing.T, frame *model.StacktraceFrame, validation FrameValidation) {
+func verifyFrame(t *testing.T, frame *modelpb.StacktraceFrame, validation FrameValidation) {
 	assert.Equal(t, validation.updated, frame.SourcemapUpdated)
-	assert.Equal(t, validation.originalClassname, frame.Original.Classname)
-	assert.Equal(t, validation.originalFunction, frame.Original.Function)
-	assert.Nil(t, frame.Original.Lineno)
+	assert.Equal(t, validation.originalClassname, frame.GetOriginal().GetClassname())
+	assert.Equal(t, validation.originalFunction, frame.GetOriginal().GetFunction())
+	if frame.Original != nil {
+		assert.Nil(t, frame.Original.Lineno)
+	}
 	assert.Equal(t, validation.classname, frame.Classname)
 	assert.Equal(t, validation.function, frame.Function)
 	assert.Equal(t, validation.lineno, *frame.Lineno)
 }
 
-func createStacktraceFrame(lineno uint32, fileName string, className string, function string) *model.StacktraceFrame {
-	frame := model.StacktraceFrame{
+func createStacktraceFrame(lineno uint32, fileName string, className string, function string) *modelpb.StacktraceFrame {
+	frame := modelpb.StacktraceFrame{
 		Lineno:    &lineno,
 		Filename:  fileName,
 		Classname: className,

--- a/internal/r8/deobfuscator_test.go
+++ b/internal/r8/deobfuscator_test.go
@@ -21,9 +21,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/elastic/apm-data/model/modelpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-data/model/modelpb"
 )
 
 type FrameValidation struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Required to completely remove `model` package

No effect on production code since the class is unused

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Related to https://github.com/elastic/apm-data/issues/52
