### PR TITLE
Set processor.* fields in mappings and ingest

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -288,11 +288,11 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/apm-data
-Version: v0.1.1-0.20230717081715-e5765b8f8d89
+Version: v0.1.1-0.20230718051649-b61afc507e0f
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/apm-data@v0.1.1-0.20230717081715-e5765b8f8d89/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/apm-data@v0.1.1-0.20230718051649-b61afc507e0f/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/dgraph-io/badger/v2 v2.2007.3-0.20201012072640-f5a7e0a1c83b
 	github.com/dustin/go-humanize v1.0.1
-	github.com/elastic/apm-data v0.1.1-0.20230717081715-e5765b8f8d89
+	github.com/elastic/apm-data v0.1.1-0.20230718051649-b61afc507e0f
 	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230717121825-061cb88e68e2
 	github.com/elastic/elastic-agent-client/v7 v7.1.2
 	github.com/elastic/elastic-agent-libs v0.3.9

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6 h1:8yY/I9
 github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6/go.mod h1:YvSRo5mw33fLEx1+DlK6L2VV43tJt5Eyel9n9XBcR+0=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/elastic/apm-data v0.1.1-0.20230717081715-e5765b8f8d89 h1:yox9Is9K781YI8WpHJ7IzN/iNqw0N9Ims9ER7ZoF3K8=
-github.com/elastic/apm-data v0.1.1-0.20230717081715-e5765b8f8d89/go.mod h1:lMTMoCWNadiDJih/tLechuMTtumEeedtKJlBOYAv030=
+github.com/elastic/apm-data v0.1.1-0.20230718051649-b61afc507e0f h1:D/2vtx8+h79wAORiv4rNRraFSJEIRltDbpm/31yRqNE=
+github.com/elastic/apm-data v0.1.1-0.20230718051649-b61afc507e0f/go.mod h1:lMTMoCWNadiDJih/tLechuMTtumEeedtKJlBOYAv030=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230717121825-061cb88e68e2 h1:3lB7AGvcZEGzV9TY23cz9UKh/8szgA8fQD+24P0X5n4=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230717121825-061cb88e68e2/go.mod h1:az1fOGOFvJBTLtC8289lI8F2kMY4NDNNkCdh1Chv4jE=
 github.com/elastic/elastic-agent-autodiscover v0.6.2 h1:7P3cbMBWXjbzA80rxitQjc+PiWyZ4I4F4LqrCYgYlNc=

--- a/internal/agentcfg/reporter.go
+++ b/internal/agentcfg/reporter.go
@@ -88,7 +88,6 @@ func (r Reporter) Run(ctx context.Context) error {
 		for etag := range applied {
 			batch = append(batch, &modelpb.APMEvent{
 				Timestamp: timestamppb.Now(),
-				Processor: modelpb.MetricsetProcessor(),
 				Labels:    modelpb.Labels{"etag": {Value: etag}},
 				Metricset: &modelpb.Metricset{
 					Name: "agent_config",

--- a/internal/agentcfg/reporter_test.go
+++ b/internal/agentcfg/reporter_test.go
@@ -81,8 +81,7 @@ func TestReportFetch(t *testing.T) {
 	// reported in exactly the same order they were fetched.
 	assert.Empty(t, cmp.Diff([]*modelpb.APMEvent{
 		{
-			Processor: modelpb.MetricsetProcessor(),
-			Labels:    modelpb.Labels{"etag": {Value: "abc123"}},
+			Labels: modelpb.Labels{"etag": {Value: "abc123"}},
 			Metricset: &modelpb.Metricset{
 				Name: "agent_config",
 				Samples: []*modelpb.MetricsetSample{
@@ -91,8 +90,7 @@ func TestReportFetch(t *testing.T) {
 			},
 		},
 		{
-			Processor: modelpb.MetricsetProcessor(),
-			Labels:    modelpb.Labels{"etag": {Value: "def456"}},
+			Labels: modelpb.Labels{"etag": {Value: "def456"}},
 			Metricset: &modelpb.Metricset{
 				Name: "agent_config",
 				Samples: []*modelpb.MetricsetSample{

--- a/internal/beater/server_test.go
+++ b/internal/beater/server_test.go
@@ -724,7 +724,7 @@ func TestWrapServer(t *testing.T) {
 			args.BatchProcessor = modelpb.ProcessBatchFunc(func(ctx context.Context, batch *modelpb.Batch) error {
 				for i := range *batch {
 					event := (*batch)[i]
-					if !event.Processor.IsTransaction() {
+					if event.Type() != modelpb.TransactionEventType {
 						continue
 					}
 					// Add a label to test that everything

--- a/internal/model/modelprocessor/eventcounter_test.go
+++ b/internal/model/modelprocessor/eventcounter_test.go
@@ -32,9 +32,9 @@ import (
 func TestEventCounter(t *testing.T) {
 	batch := modelpb.Batch{
 		{},
-		{Processor: modelpb.TransactionProcessor()},
-		{Processor: modelpb.SpanProcessor()},
-		{Processor: modelpb.TransactionProcessor()},
+		{Transaction: &modelpb.Transaction{Type: "transaction_type"}},
+		{Span: &modelpb.Span{Type: "span_type"}},
+		{Transaction: &modelpb.Transaction{Type: "transaction_type"}},
 	}
 
 	expected := monitoring.MakeFlatSnapshot()

--- a/internal/model/modelprocessor/tracer_test.go
+++ b/internal/model/modelprocessor/tracer_test.go
@@ -55,19 +55,12 @@ func TestTracer(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			batch := modelpb.Batch{
-				{},
-				{Processor: modelpb.TransactionProcessor()},
-				{Processor: modelpb.SpanProcessor()},
-				{Processor: modelpb.TransactionProcessor()},
-			}
-
 			rt := apmtest.NewRecordingTracer()
 			tx := rt.Tracer.StartTransaction("testTx", "")
 			ctx := apm.ContextWithTransaction(context.Background(), tx)
 
 			processor := NewTracer("testSpan", tt.processor)
-			err := processor.ProcessBatch(ctx, &batch)
+			err := processor.ProcessBatch(ctx, &modelpb.Batch{})
 			assert.Equal(t, tt.expectedErr, err)
 
 			tx.End()

--- a/internal/publish/pub_test.go
+++ b/internal/publish/pub_test.go
@@ -154,7 +154,6 @@ func BenchmarkPublisher(b *testing.B) {
 
 	batch := modelpb.Batch{
 		&modelpb.APMEvent{
-			Processor: modelpb.TransactionProcessor(),
 			Timestamp: timestamppb.Now(),
 		},
 	}

--- a/systemtest/approvals/TestCompressedSpans.approved.json
+++ b/systemtest/approvals/TestCompressedSpans.approved.json
@@ -39,8 +39,7 @@
                 "title": "systemtest.test"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "language": {
@@ -131,8 +130,7 @@
                 "title": "systemtest.test"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "language": {

--- a/systemtest/approvals/TestDropUnsampled.approved.json
+++ b/systemtest/approvals/TestDropUnsampled.approved.json
@@ -36,8 +36,7 @@
                 "title": "systemtest.test"
             },
             "processor": {
-                "event": "transaction",
-                "name": "transaction"
+                "event": "transaction"
             },
             "service": {
                 "language": {
@@ -97,8 +96,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "transaction",
-                "name": "transaction"
+                "event": "transaction"
             },
             "service": {
                 "name": "allowed"

--- a/systemtest/approvals/TestErrorIngest.approved.json
+++ b/systemtest/approvals/TestErrorIngest.approved.json
@@ -91,10 +91,6 @@
                 "pid": 1234,
                 "title": "node"
             },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
             "service": {
                 "environment": "staging",
                 "framework": {

--- a/systemtest/approvals/TestIntake/Errors.approved.json
+++ b/systemtest/approvals/TestIntake/Errors.approved.json
@@ -319,10 +319,6 @@
                 "pid": 1234,
                 "title": "node"
             },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
             "service": {
                 "environment": "staging",
                 "framework": {
@@ -460,10 +456,6 @@
                 "pid": 1234,
                 "title": "node"
             },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
             "service": {
                 "environment": "staging",
                 "framework": {
@@ -587,10 +579,6 @@
                 "pid": 1234,
                 "title": "node"
             },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
             "service": {
                 "environment": "staging",
                 "framework": {
@@ -711,10 +699,6 @@
                 },
                 "pid": 1234,
                 "title": "node"
-            },
-            "processor": {
-                "event": "error",
-                "name": "error"
             },
             "service": {
                 "environment": "testing",
@@ -839,10 +823,6 @@
                 },
                 "pid": 1234,
                 "title": "node"
-            },
-            "processor": {
-                "event": "error",
-                "name": "error"
             },
             "service": {
                 "environment": "staging",

--- a/systemtest/approvals/TestIntake/ErrorsTxID.approved.json
+++ b/systemtest/approvals/TestIntake/ErrorsTxID.approved.json
@@ -240,10 +240,6 @@
                 "pid": 1234,
                 "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
             },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
             "service": {
                 "environment": "production",
                 "framework": {

--- a/systemtest/approvals/TestIntake/Events.approved.json
+++ b/systemtest/approvals/TestIntake/Events.approved.json
@@ -241,10 +241,6 @@
                 "pid": 1234,
                 "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
             },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
             "service": {
                 "environment": "production",
                 "framework": {
@@ -486,8 +482,7 @@
                 "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "production",
@@ -698,8 +693,7 @@
                 "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
             },
             "processor": {
-                "event": "transaction",
-                "name": "transaction"
+                "event": "transaction"
             },
             "service": {
                 "environment": "production",

--- a/systemtest/approvals/TestIntake/MinimalEvents.approved.json
+++ b/systemtest/approvals/TestIntake/MinimalEvents.approved.json
@@ -32,10 +32,6 @@
                 "type": "apm-server",
                 "version": "dynamic"
             },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
             "service": {
                 "name": "1234_service-12a3"
             },
@@ -77,10 +73,6 @@
                 "type": "apm-server",
                 "version": "dynamic"
             },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
             "service": {
                 "name": "1234_service-12a3"
             },
@@ -120,10 +112,6 @@
                 "hostname": "dynamic",
                 "type": "apm-server",
                 "version": "dynamic"
-            },
-            "processor": {
-                "event": "error",
-                "name": "error"
             },
             "service": {
                 "name": "1234_service-12a3"
@@ -198,8 +186,7 @@
                 "id": "ab23456a89012345"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "name": "1234_service-12a3"
@@ -248,8 +235,7 @@
                 "id": "ab23456a89012345"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "name": "1234_service-12a3"
@@ -295,8 +281,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "transaction",
-                "name": "transaction"
+                "event": "transaction"
             },
             "service": {
                 "name": "1234_service-12a3"

--- a/systemtest/approvals/TestIntake/Spans.approved.json
+++ b/systemtest/approvals/TestIntake/Spans.approved.json
@@ -103,8 +103,7 @@
                 "title": "node"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "staging",
@@ -308,8 +307,7 @@
                 "title": "node"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "staging",
@@ -446,8 +444,7 @@
                 "title": "node"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "staging",
@@ -580,8 +577,7 @@
                 "title": "node"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "prod",
@@ -714,8 +710,7 @@
                 "title": "node"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "staging",
@@ -874,8 +869,7 @@
                 "title": "node"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "staging",
@@ -1083,8 +1077,7 @@
                 "title": "node"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "staging",
@@ -1233,8 +1226,7 @@
                 "title": "node"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "staging",
@@ -1374,8 +1366,7 @@
                 "title": "node"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "staging",
@@ -1539,8 +1530,7 @@
                 "title": "node"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "staging",

--- a/systemtest/approvals/TestIntake/Transactions.approved.json
+++ b/systemtest/approvals/TestIntake/Transactions.approved.json
@@ -88,8 +88,7 @@
                 "title": "node"
             },
             "processor": {
-                "event": "transaction",
-                "name": "transaction"
+                "event": "transaction"
             },
             "service": {
                 "environment": "staging",
@@ -247,8 +246,7 @@
                 "title": "node"
             },
             "processor": {
-                "event": "transaction",
-                "name": "transaction"
+                "event": "transaction"
             },
             "service": {
                 "environment": "staging",
@@ -452,8 +450,7 @@
                 "title": "node"
             },
             "processor": {
-                "event": "transaction",
-                "name": "transaction"
+                "event": "transaction"
             },
             "service": {
                 "environment": "staging",
@@ -630,8 +627,7 @@
                 "title": "node"
             },
             "processor": {
-                "event": "transaction",
-                "name": "transaction"
+                "event": "transaction"
             },
             "service": {
                 "environment": "testing",
@@ -803,8 +799,7 @@
                 "title": "node"
             },
             "processor": {
-                "event": "transaction",
-                "name": "transaction"
+                "event": "transaction"
             },
             "service": {
                 "environment": "staging",

--- a/systemtest/approvals/TestIntake/TransactionsHugeTraces.approved.json
+++ b/systemtest/approvals/TestIntake/TransactionsHugeTraces.approved.json
@@ -158,8 +158,7 @@
                 "title": "node"
             },
             "processor": {
-                "event": "transaction",
-                "name": "transaction"
+                "event": "transaction"
             },
             "service": {
                 "environment": "staging",

--- a/systemtest/approvals/TestIntake/UnknownSpanType.approved.json
+++ b/systemtest/approvals/TestIntake/UnknownSpanType.approved.json
@@ -65,8 +65,7 @@
                 "title": "node"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "staging",
@@ -270,8 +269,7 @@
                 "title": "node"
             },
             "processor": {
-                "event": "transaction",
-                "name": "transaction"
+                "event": "transaction"
             },
             "service": {
                 "environment": "staging",

--- a/systemtest/approvals/TestIntakeLog/with_faas.approved.json
+++ b/systemtest/approvals/TestIntakeLog/with_faas.approved.json
@@ -16,7 +16,8 @@
             "data_stream.type": "logs",
             "event": {
                 "agent_id_status": "missing",
-                "ingested": "dynamic"
+                "ingested": "dynamic",
+                "kind": "event"
             },
             "faas": {
                 "coldstart": true,
@@ -66,10 +67,6 @@
                 },
                 "pid": 1234,
                 "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
-            },
-            "processor": {
-                "event": "log",
-                "name": "log"
             },
             "service": {
                 "environment": "production",

--- a/systemtest/approvals/TestIntakeLog/with_flat_ecs_fields.approved.json
+++ b/systemtest/approvals/TestIntakeLog/with_flat_ecs_fields.approved.json
@@ -17,7 +17,8 @@
             "event": {
                 "agent_id_status": "missing",
                 "dataset": "accesslog",
-                "ingested": "dynamic"
+                "ingested": "dynamic",
+                "kind": "event"
             },
             "faas": {
                 "coldstart": true,
@@ -85,10 +86,6 @@
                     "name": "testThread"
                 },
                 "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
-            },
-            "processor": {
-                "event": "log",
-                "name": "log"
             },
             "service": {
                 "environment": "prod",

--- a/systemtest/approvals/TestIntakeLog/with_nested_ecs_fields.approved.json
+++ b/systemtest/approvals/TestIntakeLog/with_nested_ecs_fields.approved.json
@@ -17,7 +17,8 @@
             "event": {
                 "agent_id_status": "missing",
                 "dataset": "accesslog",
-                "ingested": "dynamic"
+                "ingested": "dynamic",
+                "kind": "event"
             },
             "faas": {
                 "coldstart": true,
@@ -85,10 +86,6 @@
                     "name": "testThread"
                 },
                 "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
-            },
-            "processor": {
-                "event": "log",
-                "name": "log"
             },
             "service": {
                 "environment": "prod",

--- a/systemtest/approvals/TestIntakeLog/with_nested_ecs_fields_overrides_flat_fields.approved.json
+++ b/systemtest/approvals/TestIntakeLog/with_nested_ecs_fields_overrides_flat_fields.approved.json
@@ -17,7 +17,8 @@
             "event": {
                 "agent_id_status": "missing",
                 "dataset": "accesslog",
-                "ingested": "dynamic"
+                "ingested": "dynamic",
+                "kind": "event"
             },
             "faas": {
                 "coldstart": true,
@@ -85,10 +86,6 @@
                     "name": "testThread"
                 },
                 "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
-            },
-            "processor": {
-                "event": "log",
-                "name": "log"
             },
             "service": {
                 "environment": "prod",

--- a/systemtest/approvals/TestIntakeLog/with_timestamp.approved.json
+++ b/systemtest/approvals/TestIntakeLog/with_timestamp.approved.json
@@ -16,7 +16,8 @@
             "data_stream.type": "logs",
             "event": {
                 "agent_id_status": "missing",
-                "ingested": "dynamic"
+                "ingested": "dynamic",
+                "kind": "event"
             },
             "host": {
                 "architecture": "amd64",
@@ -61,10 +62,6 @@
                 },
                 "pid": 1234,
                 "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
-            },
-            "processor": {
-                "event": "log",
-                "name": "log"
             },
             "service": {
                 "environment": "production",

--- a/systemtest/approvals/TestIntakeLog/with_timestamp_as_str.approved.json
+++ b/systemtest/approvals/TestIntakeLog/with_timestamp_as_str.approved.json
@@ -16,7 +16,8 @@
             "data_stream.type": "logs",
             "event": {
                 "agent_id_status": "missing",
-                "ingested": "dynamic"
+                "ingested": "dynamic",
+                "kind": "event"
             },
             "host": {
                 "architecture": "amd64",
@@ -61,10 +62,6 @@
                 },
                 "pid": 1234,
                 "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
-            },
-            "processor": {
-                "event": "log",
-                "name": "log"
             },
             "service": {
                 "environment": "production",

--- a/systemtest/approvals/TestIntakeLog/without_timestamp.approved.json
+++ b/systemtest/approvals/TestIntakeLog/without_timestamp.approved.json
@@ -16,7 +16,8 @@
             "data_stream.type": "logs",
             "event": {
                 "agent_id_status": "missing",
-                "ingested": "dynamic"
+                "ingested": "dynamic",
+                "kind": "event"
             },
             "host": {
                 "architecture": "amd64",
@@ -61,10 +62,6 @@
                 },
                 "pid": 1234,
                 "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
-            },
-            "processor": {
-                "event": "log",
-                "name": "log"
             },
             "service": {
                 "environment": "production",

--- a/systemtest/approvals/TestJaeger/batch_0.approved.json
+++ b/systemtest/approvals/TestJaeger/batch_0.approved.json
@@ -42,10 +42,6 @@
             "parent": {
                 "id": "7be2fd98d0973be3"
             },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
             "service": {
                 "language": {
                     "name": "Go"
@@ -108,10 +104,6 @@
             },
             "parent": {
                 "id": "7be2fd98d0973be3"
-            },
-            "processor": {
-                "event": "error",
-                "name": "error"
             },
             "service": {
                 "language": {
@@ -176,10 +168,6 @@
             "parent": {
                 "id": "7be2fd98d0973be3"
             },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
             "service": {
                 "language": {
                     "name": "Go"
@@ -213,7 +201,8 @@
             "data_stream.type": "logs",
             "event": {
                 "agent_id_status": "missing",
-                "ingested": "dynamic"
+                "ingested": "dynamic",
+                "kind": "event"
             },
             "host": {
                 "hostname": "host01",
@@ -234,10 +223,6 @@
                 "type": "apm-server",
                 "version": "dynamic"
             },
-            "processor": {
-                "event": "log",
-                "name": "log"
-            },
             "service": {
                 "language": {
                     "name": "Go"
@@ -266,7 +251,8 @@
             "data_stream.type": "logs",
             "event": {
                 "agent_id_status": "missing",
-                "ingested": "dynamic"
+                "ingested": "dynamic",
+                "kind": "event"
             },
             "host": {
                 "hostname": "host01",
@@ -285,10 +271,6 @@
                 "type": "apm-server",
                 "version": "dynamic"
             },
-            "processor": {
-                "event": "log",
-                "name": "log"
-            },
             "service": {
                 "language": {
                     "name": "Go"
@@ -317,7 +299,8 @@
             "data_stream.type": "logs",
             "event": {
                 "agent_id_status": "missing",
-                "ingested": "dynamic"
+                "ingested": "dynamic",
+                "kind": "event"
             },
             "host": {
                 "hostname": "host01",
@@ -335,10 +318,6 @@
                 "hostname": "dynamic",
                 "type": "apm-server",
                 "version": "dynamic"
-            },
-            "processor": {
-                "event": "log",
-                "name": "log"
             },
             "service": {
                 "language": {
@@ -394,8 +373,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "transaction",
-                "name": "transaction"
+                "event": "transaction"
             },
             "service": {
                 "language": {

--- a/systemtest/approvals/TestJaeger/batch_1.approved.json
+++ b/systemtest/approvals/TestJaeger/batch_1.approved.json
@@ -45,10 +45,6 @@
             "parent": {
                 "id": "333295bfb438ea03"
             },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
             "service": {
                 "language": {
                     "name": "Go"
@@ -109,10 +105,6 @@
             },
             "parent": {
                 "id": "614811d6c498bfb0"
-            },
-            "processor": {
-                "event": "error",
-                "name": "error"
             },
             "service": {
                 "language": {
@@ -175,10 +167,6 @@
             "parent": {
                 "id": "0242ee3774d9eab1"
             },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
             "service": {
                 "language": {
                     "name": "Go"
@@ -207,7 +195,8 @@
             "data_stream.type": "logs",
             "event": {
                 "agent_id_status": "missing",
-                "ingested": "dynamic"
+                "ingested": "dynamic",
+                "kind": "event"
             },
             "host": {
                 "hostname": "host01",
@@ -227,10 +216,6 @@
             },
             "parent": {
                 "id": "7be2fd98d0973be3"
-            },
-            "processor": {
-                "event": "log",
-                "name": "log"
             },
             "service": {
                 "language": {
@@ -283,8 +268,7 @@
                 "id": "7be2fd98d0973be3"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "language": {
@@ -345,8 +329,7 @@
                 "id": "7be2fd98d0973be3"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "language": {
@@ -407,8 +390,7 @@
                 "id": "7be2fd98d0973be3"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "language": {
@@ -469,8 +451,7 @@
                 "id": "7be2fd98d0973be3"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "language": {
@@ -532,8 +513,7 @@
                 "id": "7be2fd98d0973be3"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "language": {
@@ -594,8 +574,7 @@
                 "id": "7be2fd98d0973be3"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "language": {
@@ -657,8 +636,7 @@
                 "id": "7be2fd98d0973be3"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "language": {
@@ -719,8 +697,7 @@
                 "id": "7be2fd98d0973be3"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "language": {
@@ -781,8 +758,7 @@
                 "id": "7be2fd98d0973be3"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "language": {
@@ -843,8 +819,7 @@
                 "id": "7be2fd98d0973be3"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "language": {
@@ -905,8 +880,7 @@
                 "id": "7be2fd98d0973be3"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "language": {
@@ -967,8 +941,7 @@
                 "id": "7be2fd98d0973be3"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "language": {
@@ -1029,8 +1002,7 @@
                 "id": "7be2fd98d0973be3"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "language": {
@@ -1091,8 +1063,7 @@
                 "id": "7be2fd98d0973be3"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "language": {

--- a/systemtest/approvals/TestNoMatchingSourcemap.approved.json
+++ b/systemtest/approvals/TestNoMatchingSourcemap.approved.json
@@ -26,8 +26,7 @@
                 "id": "611f4fa950f04631"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "name": "apm-agent-js"

--- a/systemtest/approvals/TestOTLPGRPCLogs.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCLogs.approved.json
@@ -29,10 +29,6 @@
                 "type": "apm-server",
                 "version": "dynamic"
             },
-            "processor": {
-                "event": "log",
-                "name": "log"
-            },
             "service": {
                 "language": {
                     "name": "go"

--- a/systemtest/approvals/TestOTLPGRPCTraces.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCTraces.approved.json
@@ -54,10 +54,6 @@
             "parent": {
                 "id": "b3ee9be3b687a611"
             },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
             "service": {
                 "framework": {
                     "name": "systemtest"
@@ -90,7 +86,8 @@
             "data_stream.type": "logs",
             "event": {
                 "agent_id_status": "missing",
-                "ingested": "dynamic"
+                "ingested": "dynamic",
+                "kind": "event"
             },
             "labels": {
                 "resource_attribute_array": [
@@ -116,10 +113,6 @@
                 "hostname": "dynamic",
                 "type": "apm-server",
                 "version": "dynamic"
-            },
-            "processor": {
-                "event": "log",
-                "name": "log"
             },
             "service": {
                 "framework": {
@@ -181,8 +174,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "transaction",
-                "name": "transaction"
+                "event": "transaction"
             },
             "service": {
                 "framework": {

--- a/systemtest/approvals/TestRUMErrorSourcemapping/absolute_bundle_filepath/standalone.approved.json
+++ b/systemtest/approvals/TestRUMErrorSourcemapping/absolute_bundle_filepath/standalone.approved.json
@@ -266,10 +266,6 @@
                 "type": "apm-server",
                 "version": "dynamic"
             },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
             "service": {
                 "name": "apm-agent-js",
                 "version": "1.0.1"

--- a/systemtest/approvals/TestRUMErrorSourcemapping/relative_bundle_filepath/standalone.approved.json
+++ b/systemtest/approvals/TestRUMErrorSourcemapping/relative_bundle_filepath/standalone.approved.json
@@ -266,10 +266,6 @@
                 "type": "apm-server",
                 "version": "dynamic"
             },
-            "processor": {
-                "event": "error",
-                "name": "error"
-            },
             "service": {
                 "name": "apm-agent-js",
                 "version": "1.0.1"

--- a/systemtest/approvals/TestRUMRoutingIntegration.approved.json
+++ b/systemtest/approvals/TestRUMRoutingIntegration.approved.json
@@ -44,8 +44,7 @@
                 "id": "ec2e280be8345240"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "prod",
@@ -129,8 +128,7 @@
                 "id": "ec2e280be8345240"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "prod",
@@ -202,8 +200,7 @@
                 "id": "ec2e280be8345240"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "prod",
@@ -275,8 +272,7 @@
                 "id": "bbd8bcc3be14d814"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "prod",
@@ -349,8 +345,7 @@
                 "id": "ec2e280be8345240"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "prod",
@@ -411,8 +406,7 @@
                 "id": "ec2e280be8345240"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "prod",
@@ -512,8 +506,7 @@
                 "id": "ec2e280be8345240"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "prod",
@@ -584,8 +577,7 @@
                 "id": "ec2e280be8345240"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "environment": "prod",
@@ -669,8 +661,7 @@
                 "id": "1ef08ac234fca23b455d9e27c660f1ab"
             },
             "processor": {
-                "event": "transaction",
-                "name": "transaction"
+                "event": "transaction"
             },
             "service": {
                 "environment": "prod",

--- a/systemtest/approvals/TestRUMSpanSourcemapping.approved.json
+++ b/systemtest/approvals/TestRUMSpanSourcemapping.approved.json
@@ -26,8 +26,7 @@
                 "id": "611f4fa950f04631"
             },
             "processor": {
-                "event": "span",
-                "name": "transaction"
+                "event": "span"
             },
             "service": {
                 "name": "apm-agent-js"

--- a/systemtest/approvals/TestRUMXForwardedFor.approved.json
+++ b/systemtest/approvals/TestRUMXForwardedFor.approved.json
@@ -106,8 +106,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "transaction",
-                "name": "transaction"
+                "event": "transaction"
             },
             "service": {
                 "name": "rum-js-test"

--- a/systemtest/approvals/TestTransactionDroppedSpansStatsTransaction.approved.json
+++ b/systemtest/approvals/TestTransactionDroppedSpansStatsTransaction.approved.json
@@ -36,8 +36,7 @@
                 "title": "systemtest.test"
             },
             "processor": {
-                "event": "transaction",
-                "name": "transaction"
+                "event": "transaction"
             },
             "service": {
                 "language": {

--- a/systemtest/go.mod
+++ b/systemtest/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/docker/docker v23.0.3+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/elastic/apm-perf v0.0.0-20230608162138-29920c01cfd6
-	github.com/elastic/apm-tools v0.0.0-20230710072437-2700b8f3f6d4
+	github.com/elastic/apm-tools v0.0.0-20230712130005-87efbbd3dafd
 	github.com/elastic/go-elasticsearch/v8 v8.8.1
 	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38
 	github.com/hashicorp/go-multierror v1.1.1

--- a/systemtest/go.sum
+++ b/systemtest/go.sum
@@ -87,6 +87,8 @@ github.com/elastic/apm-perf v0.0.0-20230608162138-29920c01cfd6 h1:xT0z9yPjU0Csoq
 github.com/elastic/apm-perf v0.0.0-20230608162138-29920c01cfd6/go.mod h1:zK9WN3ehaqmWNgGCDtLpJ3ensSTsZ+N+T4TD11fQPx0=
 github.com/elastic/apm-tools v0.0.0-20230710072437-2700b8f3f6d4 h1:R1geTjfQUMlo75M9dOQJk/1b8WK66bbXm2X1hSS3GfY=
 github.com/elastic/apm-tools v0.0.0-20230710072437-2700b8f3f6d4/go.mod h1:cA38VtF9v5JAzmIKAgL8PHMSsrWtaWrI5OSjvCG+DDM=
+github.com/elastic/apm-tools v0.0.0-20230712130005-87efbbd3dafd h1:5elmFJcigfMwDGLVsb0jHCyYZKOVVHDsblOrTMHrqLo=
+github.com/elastic/apm-tools v0.0.0-20230712130005-87efbbd3dafd/go.mod h1:cA38VtF9v5JAzmIKAgL8PHMSsrWtaWrI5OSjvCG+DDM=
 github.com/elastic/elastic-transport-go/v8 v8.3.0 h1:DJGxovyQLXGr62e9nDMPSxRyWION0Bh6d9eCFBriiHo=
 github.com/elastic/elastic-transport-go/v8 v8.3.0/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=
 github.com/elastic/go-elasticsearch/v8 v8.8.1 h1:/OiP5Yex40q5eWpzFVQIS8jRE7SaEZrFkG9JbE6TXtY=

--- a/x-pack/apm-server/aggregation/servicesummarymetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/servicesummarymetrics/aggregator.go
@@ -194,8 +194,8 @@ func (a *Aggregator) ProcessBatch(ctx context.Context, b *modelpb.Batch) error {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	for _, event := range *b {
-		// Ignoring spans since they add no value.
-		if event.Processor.IsSpan() {
+		if event.Type() == modelpb.SpanEventType {
+			// Ignoring spans since they add no value.
 			continue
 		}
 		a.processEvent(event)
@@ -362,7 +362,6 @@ func makeMetricset(key aggregationKey, interval string) *modelpb.APMEvent {
 		Agent:         agent,
 		Labels:        key.Labels,
 		NumericLabels: key.NumericLabels,
-		Processor:     modelpb.MetricsetProcessor(),
 		Metricset: &modelpb.Metricset{
 			Name:     metricsetName,
 			Interval: interval,

--- a/x-pack/apm-server/aggregation/servicesummarymetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/servicesummarymetrics/aggregator_test.go
@@ -76,7 +76,6 @@ func TestAggregatorRun(t *testing.T) {
 				Outcome:  "success",
 				Duration: durationpb.New(time.Millisecond),
 			},
-			Processor: modelpb.TransactionProcessor(),
 			Transaction: &modelpb.Transaction{
 				Name:                "transaction_name",
 				Type:                "request",
@@ -93,7 +92,6 @@ func TestAggregatorRun(t *testing.T) {
 			},
 		},
 		{
-			Processor: modelpb.LogProcessor(),
 			Agent: &modelpb.Agent{
 				Name:    "java",
 				Version: "unknown",
@@ -120,7 +118,6 @@ func TestAggregatorRun(t *testing.T) {
 			},
 		},
 		{
-			Processor: modelpb.ErrorProcessor(),
 			Agent: &modelpb.Agent{
 				Name: "go",
 			},
@@ -128,9 +125,9 @@ func TestAggregatorRun(t *testing.T) {
 				Name:     "backend",
 				Language: &modelpb.Language{Name: "go"},
 			},
+			Error: &modelpb.Error{},
 		},
 		{
-			Processor: modelpb.MetricsetProcessor(),
 			Agent: &modelpb.Agent{
 				Name: "go",
 			},
@@ -141,12 +138,14 @@ func TestAggregatorRun(t *testing.T) {
 			},
 		},
 		{
-			Processor: modelpb.SpanProcessor(),
 			Agent: &modelpb.Agent{
 				Name: "js-base",
 			},
 			Service: &modelpb.Service{
 				Name: "frontend",
+			},
+			Span: &modelpb.Span{
+				Type: "span_type",
 			},
 		},
 	}
@@ -174,7 +173,6 @@ func TestAggregatorRun(t *testing.T) {
 		batch := expectBatch(t, batches)
 		metricsets := batchMetricsets(t, batch)
 		expected := []*modelpb.APMEvent{{
-			Processor: modelpb.MetricsetProcessor(),
 			Metricset: &modelpb.Metricset{
 				Name: "service_summary", Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
 			},
@@ -190,14 +188,12 @@ func TestAggregatorRun(t *testing.T) {
 				"cost_center": &modelpb.NumericLabelValue{Value: 10},
 			},
 		}, {
-			Processor: modelpb.MetricsetProcessor(),
 			Metricset: &modelpb.Metricset{
 				Name: "service_summary", Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
 			},
 			Service: &modelpb.Service{Name: "backend", Language: &modelpb.Language{Name: "go"}},
 			Agent:   &modelpb.Agent{Name: "go"},
 		}, {
-			Processor: modelpb.MetricsetProcessor(),
 			Metricset: &modelpb.Metricset{
 				Name: "service_summary", Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
 			},
@@ -307,7 +303,6 @@ func TestAggregatorOverflow(t *testing.T) {
 		Service: &modelpb.Service{
 			Name: "_other",
 		},
-		Processor: modelpb.MetricsetProcessor(),
 		Metricset: &modelpb.Metricset{
 			Name:     "service_summary",
 			Interval: "10s",
@@ -335,7 +330,6 @@ func makeTransaction(
 			Outcome:  outcome,
 			Duration: durationpb.New(duration),
 		},
-		Processor: modelpb.TransactionProcessor(),
 		Transaction: &modelpb.Transaction{
 			Name:                "transaction_name",
 			Type:                transactionType,

--- a/x-pack/apm-server/aggregation/servicetxmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/servicetxmetrics/aggregator.go
@@ -235,7 +235,7 @@ func (a *Aggregator) ProcessBatch(ctx context.Context, b *modelpb.Batch) error {
 	defer a.mu.RUnlock()
 	for _, event := range *b {
 		tx := event.Transaction
-		if event.Processor.IsTransaction() && tx != nil {
+		if event.Type() == modelpb.TransactionEventType && tx != nil {
 			a.processTransaction(event)
 		}
 	}
@@ -509,7 +509,6 @@ func makeMetricset(key aggregationKey, metrics serviceTxMetrics, interval string
 		Agent:         agent,
 		Labels:        key.Labels,
 		NumericLabels: key.NumericLabels,
-		Processor:     modelpb.MetricsetProcessor(),
 		Metricset: &modelpb.Metricset{
 			DocCount: totalCount,
 			Name:     metricsetName,

--- a/x-pack/apm-server/aggregation/servicetxmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/servicetxmetrics/aggregator_test.go
@@ -119,7 +119,6 @@ func TestAggregatorRun(t *testing.T) {
 		batch := expectBatch(t, batches)
 		metricsets := batchMetricsets(t, batch)
 		expected := []*modelpb.APMEvent{{
-			Processor: modelpb.MetricsetProcessor(),
 			Metricset: &modelpb.Metricset{
 				Name: "service_transaction", DocCount: 6, Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
 			},
@@ -143,7 +142,6 @@ func TestAggregatorRun(t *testing.T) {
 				},
 			},
 		}, {
-			Processor: modelpb.MetricsetProcessor(),
 			Metricset: &modelpb.Metricset{
 				Name: "service_transaction", DocCount: 1, Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
 			},
@@ -161,7 +159,6 @@ func TestAggregatorRun(t *testing.T) {
 				},
 			},
 		}, {
-			Processor: modelpb.MetricsetProcessor(),
 			Metricset: &modelpb.Metricset{
 				Name: "service_transaction", DocCount: 1, Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
 			},
@@ -179,7 +176,6 @@ func TestAggregatorRun(t *testing.T) {
 				},
 			},
 		}, {
-			Processor: modelpb.MetricsetProcessor(),
 			Metricset: &modelpb.Metricset{
 				Name: "service_transaction", DocCount: 1, Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
 			},
@@ -197,7 +193,6 @@ func TestAggregatorRun(t *testing.T) {
 				},
 			},
 		}, {
-			Processor: modelpb.MetricsetProcessor(),
 			Metricset: &modelpb.Metricset{
 				Name: "service_transaction", DocCount: 1, Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
 			},
@@ -330,7 +325,6 @@ func TestAggregatorOverflow(t *testing.T) {
 		Service: &modelpb.Service{
 			Name: "_other",
 		},
-		Processor: modelpb.MetricsetProcessor(),
 		Transaction: &modelpb.Transaction{
 			DurationSummary: &modelpb.SummaryMetric{
 				Count: int64(overflowCount),
@@ -375,7 +369,6 @@ func makeTransaction(
 			Outcome:  outcome,
 			Duration: durationpb.New(duration),
 		},
-		Processor: modelpb.TransactionProcessor(),
 		Transaction: &modelpb.Transaction{
 			Name:                "transaction_name",
 			Type:                transactionType,

--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator_test.go
@@ -119,8 +119,7 @@ func TestAggregatorRun(t *testing.T) {
 								Name: trgNameX,
 							},
 						},
-						Event:     &modelpb.Event{Outcome: "success"},
-						Processor: modelpb.MetricsetProcessor(),
+						Event: &modelpb.Event{Outcome: "success"},
 						Metricset: &modelpb.Metricset{
 							Name:     "service_destination",
 							Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
@@ -155,8 +154,7 @@ func TestAggregatorRun(t *testing.T) {
 								Name: trgNameZ,
 							},
 						},
-						Event:     &modelpb.Event{Outcome: "failure"},
-						Processor: modelpb.MetricsetProcessor(),
+						Event: &modelpb.Event{Outcome: "failure"},
 						Metricset: &modelpb.Metricset{
 							Name:     "service_destination",
 							Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
@@ -191,8 +189,7 @@ func TestAggregatorRun(t *testing.T) {
 								Name: trgNameZ,
 							},
 						},
-						Event:     &modelpb.Event{Outcome: "success"},
-						Processor: modelpb.MetricsetProcessor(),
+						Event: &modelpb.Event{Outcome: "success"},
 						Metricset: &modelpb.Metricset{
 							Name:     "service_destination",
 							Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
@@ -227,8 +224,7 @@ func TestAggregatorRun(t *testing.T) {
 								Name: trgNameZ,
 							},
 						},
-						Event:     &modelpb.Event{Outcome: "success"},
-						Processor: modelpb.MetricsetProcessor(),
+						Event: &modelpb.Event{Outcome: "success"},
 						Metricset: &modelpb.Metricset{
 							Name:     "service_destination",
 							Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
@@ -285,8 +281,7 @@ func TestAggregatorRun(t *testing.T) {
 								Name: trgNameZ,
 							},
 						},
-						Event:     &modelpb.Event{Outcome: "success"},
-						Processor: modelpb.MetricsetProcessor(),
+						Event: &modelpb.Event{Outcome: "success"},
 						Metricset: &modelpb.Metricset{
 							Name:     "service_destination",
 							Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
@@ -328,8 +323,7 @@ func TestAggregatorRun(t *testing.T) {
 						Service: &modelpb.Service{
 							Name: "service-A",
 						},
-						Event:     &modelpb.Event{Outcome: "success"},
-						Processor: modelpb.MetricsetProcessor(),
+						Event: &modelpb.Event{Outcome: "success"},
 						Metricset: &modelpb.Metricset{
 							Name:     "service_destination",
 							Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
@@ -462,7 +456,6 @@ func TestAggregateCompositeSpan(t *testing.T) {
 			},
 		},
 		Event:     &modelpb.Event{Outcome: "success"},
-		Processor: modelpb.MetricsetProcessor(),
 		Metricset: &modelpb.Metricset{Name: "service_destination", Interval: "0s", DocCount: 50},
 		Span: &modelpb.Span{
 			Name: "service-A:final_destination",
@@ -504,8 +497,8 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 			Outcome:  "success",
 			Duration: durationpb.New(10 * time.Second),
 		},
-		Processor: modelpb.TransactionProcessor(),
 		Transaction: &modelpb.Transaction{
+			Type:                "transaction_type",
 			RepresentativeCount: 2,
 			DroppedSpansStats: []*modelpb.DroppedSpanStats{
 				{
@@ -537,8 +530,8 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 			Outcome:  "success",
 			Duration: durationpb.New(10 * time.Second),
 		},
-		Processor: modelpb.TransactionProcessor(),
 		Transaction: &modelpb.Transaction{
+			Type:                "transaction_type",
 			RepresentativeCount: 1,
 			DroppedSpansStats: []*modelpb.DroppedSpanStats{
 				{
@@ -556,8 +549,8 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 	}
 
 	txWithNoRepresentativeCount := modelpb.APMEvent{
-		Processor: modelpb.TransactionProcessor(),
 		Transaction: &modelpb.Transaction{
+			Type:                "transaction_type",
 			RepresentativeCount: 0,
 			DroppedSpansStats:   make([]*modelpb.DroppedSpanStats, 1),
 		},
@@ -585,7 +578,6 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 				Name: "go-service",
 			},
 			Event:     &modelpb.Event{Outcome: "success"},
-			Processor: modelpb.MetricsetProcessor(),
 			Metricset: &modelpb.Metricset{Name: "service_destination", Interval: "0s", DocCount: 20},
 			Span: &modelpb.Span{
 				DestinationService: &modelpb.DestinationService{
@@ -607,7 +599,6 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 				},
 			},
 			Event:     &modelpb.Event{Outcome: "success"},
-			Processor: modelpb.MetricsetProcessor(),
 			Metricset: &modelpb.Metricset{Name: "service_destination", Interval: "0s", DocCount: 10},
 			Span: &modelpb.Span{
 				DestinationService: &modelpb.DestinationService{
@@ -625,7 +616,6 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 				Name: "go-service",
 			},
 			Event:     &modelpb.Event{Outcome: "unknown"},
-			Processor: modelpb.MetricsetProcessor(),
 			Metricset: &modelpb.Metricset{Name: "service_destination", Interval: "0s", DocCount: 4},
 			Span: &modelpb.Span{
 				DestinationService: &modelpb.DestinationService{
@@ -765,7 +755,6 @@ func TestAggregatorOverflow(t *testing.T) {
 		Service: &modelpb.Service{
 			Name: "_other",
 		},
-		Processor: modelpb.MetricsetProcessor(),
 		Metricset: &modelpb.Metricset{
 			Name:     "service_destination",
 			DocCount: int64(overflowCount),
@@ -805,8 +794,8 @@ func makeSpan(
 			Outcome:  outcome,
 			Duration: durationpb.New(duration),
 		},
-		Processor: modelpb.SpanProcessor(),
 		Span: &modelpb.Span{
+			Type:                "span_type",
 			Name:                serviceName + ":" + destinationServiceResource,
 			RepresentativeCount: count,
 		},

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -275,7 +275,7 @@ func (a *Aggregator) publish(ctx context.Context, period time.Duration) error {
 // the metrics are aggregated into `_other` buckets to contain cardinality.
 func (a *Aggregator) ProcessBatch(ctx context.Context, b *modelpb.Batch) error {
 	for _, event := range *b {
-		if !event.Processor.IsTransaction() {
+		if event.Type() != modelpb.TransactionEventType {
 			continue
 		}
 		a.AggregateTransaction(event)
@@ -656,7 +656,6 @@ func makeMetricset(key transactionAggregationKey, metrics transactionMetrics, in
 		Faas:          faas,
 		Labels:        key.AggregatedGlobalLabels.Labels,
 		NumericLabels: key.AggregatedGlobalLabels.NumericLabels,
-		Processor:     modelpb.MetricsetProcessor(),
 		Metricset: &modelpb.Metricset{
 			Name:     metricsetName,
 			DocCount: totalCount,

--- a/x-pack/apm-server/sampling/eventstorage/storage_bench_test.go
+++ b/x-pack/apm-server/sampling/eventstorage/storage_bench_test.go
@@ -214,7 +214,7 @@ func (nopCodec) EncodeEvent(*modelpb.APMEvent) ([]byte, error)          { return
 
 func makeTransaction(id, traceID string) *modelpb.APMEvent {
 	return &modelpb.APMEvent{
-		Transaction: &modelpb.Transaction{Id: id},
+		Transaction: &modelpb.Transaction{Type: "type", Id: id},
 		Service: &modelpb.Service{
 			Name:        "myname",
 			Version:     "version",
@@ -232,7 +232,6 @@ func makeTransaction(id, traceID string) *modelpb.APMEvent {
 				Name: "serviceNode",
 			},
 		},
-		Processor: modelpb.TransactionProcessor(),
 		Labels: modelpb.Labels{
 			"key": &modelpb.LabelValue{
 				Value: "value",

--- a/x-pack/apm-server/sampling/groups_test.go
+++ b/x-pack/apm-server/sampling/groups_test.go
@@ -27,9 +27,9 @@ func TestTraceGroupsPolicies(t *testing.T) {
 			Event: &modelpb.Event{
 				Outcome: traceOutcome,
 			},
-			Processor: modelpb.TransactionProcessor(),
-			Trace:     &modelpb.Trace{Id: uuid.Must(uuid.NewV4()).String()},
+			Trace: &modelpb.Trace{Id: uuid.Must(uuid.NewV4()).String()},
 			Transaction: &modelpb.Transaction{
+				Type: "type",
 				Name: traceName,
 				Id:   uuid.Must(uuid.NewV4()).String(),
 			},
@@ -101,9 +101,9 @@ func TestTraceGroupsMax(t *testing.T) {
 				Service: &modelpb.Service{
 					Name: serviceName,
 				},
-				Processor: modelpb.TransactionProcessor(),
-				Trace:     &modelpb.Trace{Id: uuid.Must(uuid.NewV4()).String()},
+				Trace: &modelpb.Trace{Id: uuid.Must(uuid.NewV4()).String()},
 				Transaction: &modelpb.Transaction{
+					Type: "type",
 					Name: "whatever",
 					Id:   uuid.Must(uuid.NewV4()).String(),
 				},
@@ -114,9 +114,9 @@ func TestTraceGroupsMax(t *testing.T) {
 	}
 
 	admitted, err := groups.sampleTrace(&modelpb.APMEvent{
-		Processor: modelpb.TransactionProcessor(),
-		Trace:     &modelpb.Trace{Id: uuid.Must(uuid.NewV4()).String()},
+		Trace: &modelpb.Trace{Id: uuid.Must(uuid.NewV4()).String()},
 		Transaction: &modelpb.Transaction{
+			Type: "type",
 			Name: "overflow",
 			Id:   uuid.Must(uuid.NewV4()).String(),
 		},
@@ -136,9 +136,11 @@ func TestTraceGroupReservoirResize(t *testing.T) {
 	sendTransactions := func(n int) {
 		for i := 0; i < n; i++ {
 			groups.sampleTrace(&modelpb.APMEvent{
-				Processor:   modelpb.TransactionProcessor(),
-				Trace:       &modelpb.Trace{Id: "0102030405060708090a0b0c0d0e0f10"},
-				Transaction: &modelpb.Transaction{Id: "0102030405060708"},
+				Trace: &modelpb.Trace{Id: "0102030405060708090a0b0c0d0e0f10"},
+				Transaction: &modelpb.Transaction{
+					Type: "type",
+					Id:   "0102030405060708",
+				},
 			})
 		}
 	}
@@ -175,9 +177,11 @@ func TestTraceGroupReservoirResizeMinimum(t *testing.T) {
 	sendTransactions := func(n int) {
 		for i := 0; i < n; i++ {
 			groups.sampleTrace(&modelpb.APMEvent{
-				Processor:   modelpb.TransactionProcessor(),
-				Trace:       &modelpb.Trace{Id: "0102030405060708090a0b0c0d0e0f10"},
-				Transaction: &modelpb.Transaction{Id: "0102030405060708"},
+				Trace: &modelpb.Trace{Id: "0102030405060708090a0b0c0d0e0f10"},
+				Transaction: &modelpb.Transaction{
+					Type: "type",
+					Id:   "0102030405060708",
+				},
 			})
 		}
 	}
@@ -209,22 +213,19 @@ func TestTraceGroupsRemoval(t *testing.T) {
 	for i := 0; i < 10000; i++ {
 		_, err := groups.sampleTrace(&modelpb.APMEvent{
 			Service:     &modelpb.Service{Name: "many"},
-			Processor:   modelpb.TransactionProcessor(),
-			Transaction: &modelpb.Transaction{},
+			Transaction: &modelpb.Transaction{Type: "type"},
 		})
 		assert.NoError(t, err)
 	}
 	_, err := groups.sampleTrace(&modelpb.APMEvent{
 		Service:     &modelpb.Service{Name: "few"},
-		Processor:   modelpb.TransactionProcessor(),
-		Transaction: &modelpb.Transaction{},
+		Transaction: &modelpb.Transaction{Type: "type"},
 	})
 	assert.NoError(t, err)
 
 	_, err = groups.sampleTrace(&modelpb.APMEvent{
 		Service:     &modelpb.Service{Name: "another"},
-		Processor:   modelpb.TransactionProcessor(),
-		Transaction: &modelpb.Transaction{},
+		Transaction: &modelpb.Transaction{Type: "type"},
 	})
 	assert.Equal(t, errTooManyTraceGroups, err)
 
@@ -232,8 +233,7 @@ func TestTraceGroupsRemoval(t *testing.T) {
 	// will not be affected by the limit...
 	_, err = groups.sampleTrace(&modelpb.APMEvent{
 		Service:     &modelpb.Service{Name: "defined"},
-		Processor:   modelpb.TransactionProcessor(),
-		Transaction: &modelpb.Transaction{},
+		Transaction: &modelpb.Transaction{Type: "type"},
 	})
 	assert.NoError(t, err)
 
@@ -241,8 +241,7 @@ func TestTraceGroupsRemoval(t *testing.T) {
 	// a matching dynamic policy.
 	_, err = groups.sampleTrace(&modelpb.APMEvent{
 		Service:     &modelpb.Service{Name: "defined_later"},
-		Processor:   modelpb.TransactionProcessor(),
-		Transaction: &modelpb.Transaction{},
+		Transaction: &modelpb.Transaction{Type: "type"},
 	})
 	assert.Equal(t, errTooManyTraceGroups, err)
 
@@ -253,8 +252,7 @@ func TestTraceGroupsRemoval(t *testing.T) {
 	// We should now be able to add another trace group.
 	_, err = groups.sampleTrace(&modelpb.APMEvent{
 		Service:     &modelpb.Service{Name: "another"},
-		Processor:   modelpb.TransactionProcessor(),
-		Transaction: &modelpb.Transaction{},
+		Transaction: &modelpb.Transaction{Type: "type"},
 	})
 	assert.NoError(t, err)
 }
@@ -274,9 +272,9 @@ func BenchmarkTraceGroups(b *testing.B) {
 		// Duration is non-zero to ensure transactions have a non-zero chance of
 		// being sampled.
 		tx := modelpb.APMEvent{
-			Processor: modelpb.TransactionProcessor(),
-			Event:     &modelpb.Event{Duration: durationpb.New(time.Second)},
+			Event: &modelpb.Event{Duration: durationpb.New(time.Second)},
 			Transaction: &modelpb.Transaction{
+				Type: "type",
 				Name: uuid.Must(uuid.NewV4()).String(),
 			},
 		}

--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -39,11 +39,11 @@ func TestProcessUnsampled(t *testing.T) {
 	defer processor.Stop(context.Background())
 
 	in := modelpb.Batch{{
-		Processor: modelpb.TransactionProcessor(),
 		Trace: &modelpb.Trace{
 			Id: "0102030405060708090a0b0c0d0e0f10",
 		},
 		Transaction: &modelpb.Transaction{
+			Type:    "type",
 			Id:      "0102030405060708",
 			Sampled: false,
 		},
@@ -92,33 +92,33 @@ func TestProcessAlreadyTailSampled(t *testing.T) {
 	defer processor.Stop(context.Background())
 
 	transaction1 := modelpb.APMEvent{
-		Processor: modelpb.TransactionProcessor(),
-		Trace:     &trace1,
+		Trace: &trace1,
 		Transaction: &modelpb.Transaction{
+			Type:    "type",
 			Id:      "0102030405060708",
 			Sampled: true,
 		},
 	}
 	span1 := modelpb.APMEvent{
-		Processor: modelpb.SpanProcessor(),
-		Trace:     &trace1,
+		Trace: &trace1,
 		Span: &modelpb.Span{
-			Id: "0102030405060709",
+			Type: "type",
+			Id:   "0102030405060709",
 		},
 	}
 	transaction2 := modelpb.APMEvent{
-		Processor: modelpb.TransactionProcessor(),
-		Trace:     &trace2,
+		Trace: &trace2,
 		Transaction: &modelpb.Transaction{
+			Type:    "type",
 			Id:      "0102030405060710",
 			Sampled: true,
 		},
 	}
 	span2 := modelpb.APMEvent{
-		Processor: modelpb.SpanProcessor(),
-		Trace:     &trace2,
+		Trace: &trace2,
 		Span: &modelpb.Span{
-			Id: "0102030405060711",
+			Type: "type",
+			Id:   "0102030405060711",
 		},
 	}
 
@@ -169,35 +169,35 @@ func TestProcessLocalTailSampling(t *testing.T) {
 	trace1 := modelpb.Trace{Id: "0102030405060708090a0b0c0d0e0f10"}
 	trace2 := modelpb.Trace{Id: "0102030405060708090a0b0c0d0e0f11"}
 	trace1Events := modelpb.Batch{{
-		Processor: modelpb.TransactionProcessor(),
-		Trace:     &trace1,
-		Event:     &modelpb.Event{Duration: durationpb.New(123 * time.Millisecond)},
+		Trace: &trace1,
+		Event: &modelpb.Event{Duration: durationpb.New(123 * time.Millisecond)},
 		Transaction: &modelpb.Transaction{
+			Type:    "type",
 			Id:      "0102030405060708",
 			Sampled: true,
 		},
 	}, {
-		Processor: modelpb.SpanProcessor(),
-		Trace:     &trace1,
-		Event:     &modelpb.Event{Duration: durationpb.New(123 * time.Millisecond)},
+		Trace: &trace1,
+		Event: &modelpb.Event{Duration: durationpb.New(123 * time.Millisecond)},
 		Span: &modelpb.Span{
-			Id: "0102030405060709",
+			Type: "type",
+			Id:   "0102030405060709",
 		},
 	}}
 	trace2Events := modelpb.Batch{{
-		Processor: modelpb.TransactionProcessor(),
-		Trace:     &trace2,
-		Event:     &modelpb.Event{Duration: durationpb.New(456 * time.Millisecond)},
+		Trace: &trace2,
+		Event: &modelpb.Event{Duration: durationpb.New(456 * time.Millisecond)},
 		Transaction: &modelpb.Transaction{
+			Type:    "type",
 			Id:      "0102030405060710",
 			Sampled: true,
 		},
 	}, {
-		Processor: modelpb.SpanProcessor(),
-		Trace:     &trace2,
-		Event:     &modelpb.Event{Duration: durationpb.New(456 * time.Millisecond)},
+		Trace: &trace2,
+		Event: &modelpb.Event{Duration: durationpb.New(456 * time.Millisecond)},
 		Span: &modelpb.Span{
-			Id: "0102030405060711",
+			Type: "type",
+			Id:   "0102030405060711",
 		},
 	}}
 
@@ -290,10 +290,10 @@ func TestProcessLocalTailSamplingUnsampled(t *testing.T) {
 		traceID := uuid.Must(uuid.NewV4()).String()
 		traceIDs[i] = traceID
 		batch := modelpb.Batch{{
-			Processor: modelpb.TransactionProcessor(),
-			Trace:     &modelpb.Trace{Id: traceID},
-			Event:     &modelpb.Event{Duration: durationpb.New(time.Millisecond)},
+			Trace: &modelpb.Trace{Id: traceID},
+			Event: &modelpb.Event{Duration: durationpb.New(time.Millisecond)},
 			Transaction: &modelpb.Transaction{
+				Type:    "type",
 				Id:      traceID,
 				Sampled: true,
 			},
@@ -361,11 +361,11 @@ func TestProcessLocalTailSamplingPolicyOrder(t *testing.T) {
 		_, err := rng.Read(traceIDBytes[:])
 		require.NoError(t, err)
 		events[i] = &modelpb.APMEvent{
-			Service:   &service,
-			Processor: modelpb.TransactionProcessor(),
-			Trace:     &modelpb.Trace{Id: fmt.Sprintf("%x", traceIDBytes[:])},
-			Event:     &modelpb.Event{Duration: durationpb.New(123 * time.Millisecond)},
+			Service: &service,
+			Trace:   &modelpb.Trace{Id: fmt.Sprintf("%x", traceIDBytes[:])},
+			Event:   &modelpb.Event{Duration: durationpb.New(123 * time.Millisecond)},
 			Transaction: &modelpb.Transaction{
+				Type:    "type",
 				Name:    "trace_name",
 				Id:      fmt.Sprintf("%x", traceIDBytes[8:]),
 				Sampled: true,
@@ -431,11 +431,11 @@ func TestProcessRemoteTailSampling(t *testing.T) {
 	traceID1 := "0102030405060708090a0b0c0d0e0f10"
 	traceID2 := "0102030405060708090a0b0c0d0e0f11"
 	trace1Events := modelpb.Batch{{
-		Processor: modelpb.SpanProcessor(),
-		Trace:     &modelpb.Trace{Id: traceID1},
-		Event:     &modelpb.Event{Duration: durationpb.New(123 * time.Millisecond)},
+		Trace: &modelpb.Trace{Id: traceID1},
+		Event: &modelpb.Event{Duration: durationpb.New(123 * time.Millisecond)},
 		Span: &modelpb.Span{
-			Id: "0102030405060709",
+			Type: "type",
+			Id:   "0102030405060709",
 		},
 	}}
 
@@ -515,11 +515,11 @@ func TestGroupsMonitoring(t *testing.T) {
 
 	for i := 0; i < config.MaxDynamicServices+2; i++ {
 		err := processor.ProcessBatch(context.Background(), &modelpb.Batch{{
-			Service:   &modelpb.Service{Name: fmt.Sprintf("service_%d", i)},
-			Processor: modelpb.TransactionProcessor(),
-			Trace:     &modelpb.Trace{Id: uuid.Must(uuid.NewV4()).String()},
-			Event:     &modelpb.Event{Duration: durationpb.New(123 * time.Millisecond)},
+			Service: &modelpb.Service{Name: fmt.Sprintf("service_%d", i)},
+			Trace:   &modelpb.Trace{Id: uuid.Must(uuid.NewV4()).String()},
+			Event:   &modelpb.Event{Duration: durationpb.New(123 * time.Millisecond)},
 			Transaction: &modelpb.Transaction{
+				Type:    "type",
 				Id:      "0102030405060709",
 				Sampled: i < config.MaxDynamicServices+1,
 			},
@@ -548,10 +548,10 @@ func TestStorageMonitoring(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		traceID := uuid.Must(uuid.NewV4()).String()
 		batch := modelpb.Batch{{
-			Processor: modelpb.TransactionProcessor(),
-			Trace:     &modelpb.Trace{Id: traceID},
-			Event:     &modelpb.Event{Duration: durationpb.New(123 * time.Millisecond)},
+			Trace: &modelpb.Trace{Id: traceID},
+			Event: &modelpb.Event{Duration: durationpb.New(123 * time.Millisecond)},
 			Transaction: &modelpb.Transaction{
+				Type:    "type",
 				Id:      traceID,
 				Sampled: true,
 			},
@@ -602,11 +602,11 @@ func TestStorageGC(t *testing.T) {
 		for i := 0; i < n; i++ {
 			traceID := uuid.Must(uuid.NewV4()).String()
 			batch := modelpb.Batch{{
-				Processor: modelpb.SpanProcessor(),
-				Trace:     &modelpb.Trace{Id: traceID},
-				Event:     &modelpb.Event{Duration: durationpb.New(123 * time.Millisecond)},
+				Trace: &modelpb.Trace{Id: traceID},
+				Event: &modelpb.Event{Duration: durationpb.New(123 * time.Millisecond)},
 				Span: &modelpb.Span{
-					Id: traceID,
+					Type: "type",
+					Id:   traceID,
 				},
 			}}
 			err := processor.ProcessBatch(context.Background(), &batch)
@@ -673,10 +673,12 @@ func TestStorageLimit(t *testing.T) {
 		for i := 0; i < n; i++ {
 			traceID := uuid.Must(uuid.NewV4()).String()
 			batch = append(batch, &modelpb.APMEvent{
-				Processor: modelpb.SpanProcessor(),
-				Trace:     &modelpb.Trace{Id: traceID},
-				Event:     &modelpb.Event{Duration: durationpb.New(123 * time.Millisecond)},
-				Span:      &modelpb.Span{Id: traceID},
+				Trace: &modelpb.Trace{Id: traceID},
+				Event: &modelpb.Event{Duration: durationpb.New(123 * time.Millisecond)},
+				Span: &modelpb.Span{
+					Type: "type",
+					Id:   traceID,
+				},
 			})
 		}
 		err = processor.ProcessBatch(context.Background(), &batch)
@@ -759,9 +761,9 @@ func TestGracefulShutdown(t *testing.T) {
 	var batch modelpb.Batch
 	for i := 0; i < totalTraces; i++ {
 		batch = append(batch, &modelpb.APMEvent{
-			Processor: modelpb.TransactionProcessor(),
-			Trace:     &modelpb.Trace{Id: traceIDGen(i)},
+			Trace: &modelpb.Trace{Id: traceIDGen(i)},
 			Transaction: &modelpb.Transaction{
+				Type:    "type",
 				Id:      fmt.Sprintf("tx%d", i),
 				Sampled: true,
 			},


### PR DESCRIPTION
## Motivation/summary

Set `processor.event` and `processor.name` in `constant_keyword` mappings and in ingest pipelines.
This allows us to remove setting, storing, and propagating these legacy fields in apm-data.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

Ensure documents from an older apm-server can still be ingested with the new pipeline.

## Related issues

https://github.com/elastic/apm-data/pull/79