### PR TITLE
Fix OTel span type determinism

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -288,11 +288,11 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/apm-data
-Version: v0.1.1-0.20230620075806-2adc91044663
+Version: v0.1.1-0.20230621033210-b54f466bde7a
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/apm-data@v0.1.1-0.20230620075806-2adc91044663/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/apm-data@v0.1.1-0.20230621033210-b54f466bde7a/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -13,6 +13,7 @@ https://github.com/elastic/apm-server/compare/8.8\...main[View commits]
 ==== Bug fixes
 - Limit the amount of concurrent OTLP requests being processed in parallel {pull}10987[10987].
 - Added CA certificates bundle to the Docker images {pull}11015[11015]
+- Derivation of transaction and span type from OTLP spans is now deterministic {pull}11036[11036]
 
 [float]
 ==== Intake API Changes

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/dgraph-io/badger/v2 v2.2007.3-0.20201012072640-f5a7e0a1c83b
 	github.com/dustin/go-humanize v1.0.1
-	github.com/elastic/apm-data v0.1.1-0.20230620075806-2adc91044663
+	github.com/elastic/apm-data v0.1.1-0.20230621033210-b54f466bde7a
 	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230620141752-bdb67bc10dbb
 	github.com/elastic/elastic-agent-client/v7 v7.1.2
 	github.com/elastic/elastic-agent-libs v0.3.9

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6 h1:8yY/I9
 github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6/go.mod h1:YvSRo5mw33fLEx1+DlK6L2VV43tJt5Eyel9n9XBcR+0=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/elastic/apm-data v0.1.1-0.20230620075806-2adc91044663 h1:YQBtvzVZur8wd5I1tyuAV4s0KjUjkM4ImX61YsHLrfQ=
-github.com/elastic/apm-data v0.1.1-0.20230620075806-2adc91044663/go.mod h1:8HEBtP5evAcAvYeu/Nnn1yrdIoyECqm425/Ggs9JHv8=
+github.com/elastic/apm-data v0.1.1-0.20230621033210-b54f466bde7a h1:8j3kCo3eGHXvFMlNktS613ZN73AnoDpPHnFQywhatSU=
+github.com/elastic/apm-data v0.1.1-0.20230621033210-b54f466bde7a/go.mod h1:8HEBtP5evAcAvYeu/Nnn1yrdIoyECqm425/Ggs9JHv8=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230620141752-bdb67bc10dbb h1:UUQGsxFyEIb8dUR5kFYT3Fjl15Re6vMGD3GRP4v9i38=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230620141752-bdb67bc10dbb/go.mod h1:5fEGVnaNWMPordHT4eWfGY8Sz4HwuthJ9G32hAXFYQk=
 github.com/elastic/elastic-agent-autodiscover v0.6.1 h1:vXR+3QVDL7Ij7IMKul13iIiDmM66HsX6MS6I0T4O8gw=


### PR DESCRIPTION
## Motivation/summary

See https://github.com/elastic/apm-data/pull/53

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

1. Send OTel spans with a combination of `db.*`, `messaging.*`, `rpc.*`, and `http.*` attributes
2. Ensure that span type is based on the descending order of preference `db --> messaging --> rpc --> http --> anything else`

## Related issues

https://github.com/elastic/apm-data/issues/43