### PR TITLE
Don't use Python venv for packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,5 +310,5 @@ release: $(MAGE) build/dependencies.csv
 	$(MAGE) package
 	@$(MAGE) ironbank
 
-build/dependencies.csv: $(PYTHON) go.mod
-	$(PYTHON) script/generate_notice.py ./x-pack/apm-server --csv $@
+build/dependencies.csv: go.mod
+	python3 script/generate_notice.py ./x-pack/apm-server --csv $@


### PR DESCRIPTION
## Motivation/summary

I accidentally merged a beats update to 7.17 that broke packaging, related to python requirements.
We don't need a virtualenv for packaging, just use the system python3 installation.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

https://apm-ci.elastic.co/job/apm-server/job/apm-server-package-mbp/job/7.17/713/