### PR TITLE
Add 8.8.2 release notes

### DIFF
--- a/changelogs/8.8.asciidoc
+++ b/changelogs/8.8.asciidoc
@@ -13,7 +13,9 @@ https://github.com/elastic/apm-server/compare/8.7\...8.8[View commits]
 
 https://github.com/elastic/apm-server/compare/v8.8.1\...v8.8.2[View commits]
 
-No significant changes.
+[float]
+==== Bug fixes
+- Added CA certificates bundle to the Docker images {pull}11015[11015]
 
 [float]
 [[release-notes-8.8.1]]

--- a/changelogs/8.8.asciidoc
+++ b/changelogs/8.8.asciidoc
@@ -3,8 +3,17 @@
 
 https://github.com/elastic/apm-server/compare/8.7\...8.8[View commits]
 
+* <<release-notes-8.8.2>>
 * <<release-notes-8.8.1>>
 * <<release-notes-8.8.0>>
+
+[float]
+[[release-notes-8.8.2]]
+=== APM Server version 8.8.2
+
+https://github.com/elastic/apm-server/compare/v8.8.1\...v8.8.2[View commits]
+
+No significant changes.
 
 [float]
 [[release-notes-8.8.1]]


### PR DESCRIPTION
### Summary

Adds the 8.8.2 release notes. I didn't notice anything noteworthy in the [commits](https://github.com/elastic/apm-server/commits/8.8). Please double-check and **merge** this PR if everything looks good (because I can't merge).