### PR TITLE
Update apm-data

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -288,11 +288,11 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/apm-data
-Version: v0.1.1-0.20230628080651-9f67b9cdd993
+Version: v0.1.1-0.20230705050140-e5828f1f7c8f
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/apm-data@v0.1.1-0.20230628080651-9f67b9cdd993/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/apm-data@v0.1.1-0.20230705050140-e5828f1f7c8f/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/dgraph-io/badger/v2 v2.2007.3-0.20201012072640-f5a7e0a1c83b
 	github.com/dustin/go-humanize v1.0.1
-	github.com/elastic/apm-data v0.1.1-0.20230628080651-9f67b9cdd993
+	github.com/elastic/apm-data v0.1.1-0.20230705050140-e5828f1f7c8f
 	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230703165328-f7fa407aff97
 	github.com/elastic/elastic-agent-client/v7 v7.1.2
 	github.com/elastic/elastic-agent-libs v0.3.9

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6 h1:8yY/I9
 github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6/go.mod h1:YvSRo5mw33fLEx1+DlK6L2VV43tJt5Eyel9n9XBcR+0=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/elastic/apm-data v0.1.1-0.20230628080651-9f67b9cdd993 h1:getNVnFnGrKoBQSHkyuimzQnJ+LJB1MOmdXzP+hOnqU=
-github.com/elastic/apm-data v0.1.1-0.20230628080651-9f67b9cdd993/go.mod h1:8HEBtP5evAcAvYeu/Nnn1yrdIoyECqm425/Ggs9JHv8=
+github.com/elastic/apm-data v0.1.1-0.20230705050140-e5828f1f7c8f h1:vJUX3M0XlOo2DpdMuKk5UzjozBQAFYNrro9JWQqpcg4=
+github.com/elastic/apm-data v0.1.1-0.20230705050140-e5828f1f7c8f/go.mod h1:8HEBtP5evAcAvYeu/Nnn1yrdIoyECqm425/Ggs9JHv8=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230703165328-f7fa407aff97 h1:bleuI8zppZT1kp0ic1WfzCWCkTksuHVmCJGMgUqM6mE=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230703165328-f7fa407aff97/go.mod h1:8FXKorDErciGKioyZYTJP5oE+dSwRE0SDKHwG5tpqiQ=
 github.com/elastic/elastic-agent-autodiscover v0.6.2 h1:7P3cbMBWXjbzA80rxitQjc+PiWyZ4I4F4LqrCYgYlNc=

--- a/internal/beater/beater.go
+++ b/internal/beater/beater.go
@@ -467,6 +467,10 @@ func (s *Runner) Run(ctx context.Context) error {
 		modelpb.ProcessBatchFunc(rateLimitBatchProcessor),
 		modelpb.ProcessBatchFunc(authorizeEventIngestProcessor),
 
+		// Add a model processor that removes `event.received`, which is added by
+		// apm-data, but which we don't yet map.
+		modelpb.ProcessBatchFunc(removeEventReceivedBatchProcessor),
+
 		// Pre-process events before they are sent to the final processors for
 		// aggregation, sampling, and indexing.
 		modelprocessor.SetHostHostname{},

--- a/internal/beater/processors.go
+++ b/internal/beater/processors.go
@@ -84,6 +84,17 @@ func newObserverBatchProcessor() modelpb.ProcessBatchFunc {
 	}
 }
 
+// TODO remove this once we have added `event.received` to the
+// data stream mappings, in 8.10.
+func removeEventReceivedBatchProcessor(ctx context.Context, batch *modelpb.Batch) error {
+	for _, event := range *batch {
+		if event.Event != nil && event.Event.Received != nil {
+			event.Event.Received = nil
+		}
+	}
+	return nil
+}
+
 func newDocappenderBatchProcessor(a *docappender.Appender) modelpb.ProcessBatchFunc {
 	var pool sync.Pool
 	pool.New = func() any {

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -461,7 +461,7 @@ func makeOverflowAggregationKey(
 func makeTransactionAggregationKey(event *modelpb.APMEvent, interval time.Duration) transactionAggregationKey {
 	key := transactionAggregationKey{
 		comparable: comparable{
-			traceRoot:         event.GetParent().GetId() == "",
+			traceRoot:         event.GetParentId() == "",
 			transactionName:   event.GetTransaction().GetName(),
 			transactionResult: event.GetTransaction().GetResult(),
 			transactionType:   event.GetTransaction().GetType(),

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
@@ -725,7 +725,7 @@ func TestAggregationFields(t *testing.T) {
 			Name:   input.Transaction.Name,
 			Type:   input.Transaction.Type,
 			Result: input.Transaction.Result,
-			Root:   input.GetParent().GetId() == "",
+			Root:   input.GetParentId() == "",
 			DurationHistogram: &modelpb.Histogram{
 				Counts: []int64{expectedCount},
 				Values: []float64{0},
@@ -778,7 +778,7 @@ func TestAggregationFields(t *testing.T) {
 		// Parent.ID only impacts aggregation as far as grouping root and
 		// non-root traces.
 		for _, value := range []string{"something", "anything"} {
-			input.Parent.Id = value
+			input.ParentId = value
 			agg.AggregateTransaction(&input)
 			agg.AggregateTransaction(&input)
 		}

--- a/x-pack/apm-server/sampling/processor.go
+++ b/x-pack/apm-server/sampling/processor.go
@@ -227,7 +227,7 @@ func (p *Processor) processTransaction(event *modelpb.APMEvent) (report, stored 
 		return false, false, err
 	}
 
-	if event.GetParent().GetId() != "" {
+	if event.GetParentId() != "" {
 		// Non-root transaction: write to local storage while we wait
 		// for a sampling decision.
 		return false, true, p.eventStore.WriteTraceEvent(

--- a/x-pack/apm-server/sampling/processor_bench_test.go
+++ b/x-pack/apm-server/sampling/processor_bench_test.go
@@ -41,17 +41,14 @@ func BenchmarkProcess(b *testing.B) {
 			transaction := &modelpb.Transaction{
 				Id: hex.EncodeToString(transactionID),
 			}
-			spanParent := modelpb.Parent{
-				Id: hex.EncodeToString(transactionID),
-			}
 			span := &modelpb.Span{
 				Id: hex.EncodeToString(spanID),
 			}
 			batch := modelpb.Batch{
 				{Trace: &trace, Transaction: transaction},
-				{Trace: &trace, Span: span, Parent: &spanParent},
-				{Trace: &trace, Span: span, Parent: &spanParent},
-				{Trace: &trace, Span: span, Parent: &spanParent},
+				{Trace: &trace, Span: span, ParentId: transaction.Id},
+				{Trace: &trace, Span: span, ParentId: transaction.Id},
+				{Trace: &trace, Span: span, ParentId: transaction.Id},
 			}
 			if err := processor.ProcessBatch(context.Background(), &batch); err != nil {
 				b.Fatal(err)


### PR DESCRIPTION
## Motivation/summary

Fixes a panic in handling Jaeger's sampler.type attribute. This bug hasn't been released, it was introduced while making the switch to modelpb.

This includes an apm-data change which sets `event.received` on decoded events. This is removed with a processor until we have added the mapping.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

https://github.com/elastic/apm-data/pull/104