### PR TITLE
systemtest: fix TestMonitoring flakiness

### DIFF
--- a/systemtest/go.mod
+++ b/systemtest/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jaegertracing/jaeger v1.18.1
 	github.com/klauspost/compress v1.11.13
-	github.com/mitchellh/mapstructure v1.1.2
 	github.com/spf13/cobra v1.1.3
 	github.com/stretchr/testify v1.8.1
 	github.com/testcontainers/testcontainers-go v0.18.0

--- a/systemtest/go.sum
+++ b/systemtest/go.sum
@@ -457,7 +457,6 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mjibson/esc v0.2.0/go.mod h1:9Hw9gxxfHulMF5OJKCyhYD7PzlSdhzXyaGEBRPH1OPs=
 github.com/moby/patternmatcher v0.5.0 h1:YCZgJOeULcxLw1Q+sVR636pmS7sPEn1Qo2iAN6M7DBo=

--- a/systemtest/monitoring_test.go
+++ b/systemtest/monitoring_test.go
@@ -23,9 +23,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 
 	"github.com/elastic/apm-server/systemtest"
 	"github.com/elastic/apm-server/systemtest/apmservertest"
@@ -47,7 +47,7 @@ func TestAPMServerMonitoring(t *testing.T) {
 	assert.Equal(t, "elasticsearch", state.Output.Name)
 
 	doc := getBeatsMonitoringStats(t, srv, nil)
-	assert.Contains(t, doc.Metrics, "apm-server")
+	assert.True(t, gjson.GetBytes(doc.Metrics, "apm-server").Exists())
 }
 
 func TestMonitoring(t *testing.T) {
@@ -67,56 +67,41 @@ func TestMonitoring(t *testing.T) {
 	systemtest.Elasticsearch.ExpectMinDocs(t, N, "traces-*", nil)
 
 	var metrics struct {
-		Libbeat map[string]interface{}
-		Output  map[string]interface{}
+		Libbeat json.RawMessage
+		Output  json.RawMessage
 	}
-	getBeatsMonitoringStats(t, srv, &metrics)
-	// Remove the output.write.bytes key since there isn't a way to assert the
-	// writtenBytes at this layer.
-	if o := metrics.Libbeat["output"].(map[string]interface{}); len(o) > 0 {
-		if w := o["write"].(map[string]interface{}); len(w) > 0 {
-			if w["bytes"] != nil {
-				delete(w, "bytes")
-			}
-		}
-	}
-	assert.Equal(t, map[string]interface{}{
-		"output": map[string]interface{}{
-			"events": map[string]interface{}{
-				"acked":   float64(N),
-				"active":  0.0,
-				"batches": 1.0,
-				"failed":  0.0,
-				"toomany": 0.0,
-				"total":   float64(N),
-			},
-			"type":  "elasticsearch",
-			"write": map[string]interface{}{},
-		},
-		"pipeline": map[string]interface{}{
-			"events": map[string]interface{}{
-				"total": float64(N),
-			},
-		},
-	}, metrics.Libbeat)
-	if es := metrics.Output["elasticsearch"].(map[string]interface{}); len(es) > 0 {
-		if br := es["bulk_requests"].(map[string]interface{}); len(br) > 0 {
-			assert.Greater(t, br["available"], float64(10))
-			delete(br, "available")
-		}
-	}
-	assert.Equal(t, map[string]interface{}{
-		"elasticsearch": map[string]interface{}{
-			"bulk_requests": map[string]interface{}{
-				"completed": 1.0,
-			},
-			"indexers": map[string]interface{}{
-				"active":    float64(1),
-				"created":   0.0,
-				"destroyed": 0.0,
-			},
-		},
-	}, metrics.Output)
+
+	assert.Eventually(t, func() bool {
+		metrics.Libbeat = nil
+		metrics.Output = nil
+		getBeatsMonitoringStats(t, srv, &metrics)
+		acked := gjson.GetBytes(metrics.Libbeat, "output.events.acked")
+		return acked.Int() == N
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// Assert the presence of output.write.bytes, and that it is non-zero;
+	// the exact value may change over time, and that is not relevant to this test.
+	outputWriteBytes := gjson.GetBytes(metrics.Libbeat, "output.write.bytes")
+	assert.NotZero(t, outputWriteBytes.Int())
+
+	// Assert there was a non-zero number of batches written. There's no
+	// guarantee that a single batch is written.
+	batches := gjson.GetBytes(metrics.Libbeat, "output.events.batches")
+	assert.NotZero(t, batches.Int())
+
+	assert.Equal(t, int64(0), gjson.GetBytes(metrics.Libbeat, "output.events.active").Int())
+	assert.Equal(t, int64(0), gjson.GetBytes(metrics.Libbeat, "output.events.failed").Int())
+	assert.Equal(t, int64(0), gjson.GetBytes(metrics.Libbeat, "output.events.toomany").Int())
+	assert.Equal(t, int64(N), gjson.GetBytes(metrics.Libbeat, "output.events.total").Int())
+	assert.Equal(t, int64(N), gjson.GetBytes(metrics.Libbeat, "pipeline.events.total").Int())
+	assert.Equal(t, "elasticsearch", gjson.GetBytes(metrics.Libbeat, "output.type").Str)
+
+	bulkRequestsAvailable := gjson.GetBytes(metrics.Output, "elasticsearch.bulk_requests.available")
+	assert.Greater(t, bulkRequestsAvailable.Int(), int64(10))
+	assert.Equal(t, batches.Int(), gjson.GetBytes(metrics.Output, "elasticsearch.bulk_requests.completed").Int())
+	assert.Equal(t, int64(1), gjson.GetBytes(metrics.Output, "elasticsearch.indexers.active").Int())
+	assert.Zero(t, gjson.GetBytes(metrics.Output, "elasticsearch.indexers.created").Int())
+	assert.Zero(t, gjson.GetBytes(metrics.Output, "elasticsearch.indexers.destroyed").Int())
 }
 
 func TestAPMServerMonitoringBuiltinUser(t *testing.T) {
@@ -165,9 +150,9 @@ func getBeatsMonitoring(t testing.TB, srv *apmservertest.Server, type_ string, o
 	if out != nil {
 		switch doc.Type {
 		case "beats_state":
-			assert.NoError(t, mapstructure.Decode(doc.State, out))
+			assert.NoError(t, json.Unmarshal(doc.State, out))
 		case "beats_stats":
-			assert.NoError(t, mapstructure.Decode(doc.Metrics, out))
+			assert.NoError(t, json.Unmarshal(doc.Metrics, out))
 		}
 	}
 	return &doc
@@ -182,11 +167,11 @@ type beatsMonitoringDoc struct {
 }
 
 type BeatsState struct {
-	State map[string]interface{} `json:"state"`
+	State json.RawMessage `json:"state"`
 }
 
 type BeatsStats struct {
-	Metrics map[string]interface{} `json:"metrics"`
+	Metrics json.RawMessage `json:"metrics"`
 }
 
 func newFastMonitoringConfig() *apmservertest.MonitoringConfig {

--- a/systemtest/sampling_test.go
+++ b/systemtest/sampling_test.go
@@ -177,7 +177,7 @@ func TestTailSampling(t *testing.T) {
 					Policies int
 				}
 			}
-		} `mapstructure:"apm-server"`
+		} `json:"apm-server"`
 	}
 	getBeatsMonitoringState(t, srv1, &state)
 	assert.True(t, state.APMServer.Sampling.Tail.Enabled)


### PR DESCRIPTION
## Motivation/summary

Make the test a little more lenient to changes in the number of Elasticsearch bulk requests. Use `assert.Eventually` to wait until the server has indexed the expected number of events.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

None