### PR TITLE
test: use atomic values to resolve race condition in systemtests

### DIFF
--- a/systemtest/loadgen/eventhandler/handler_test.go
+++ b/systemtest/loadgen/eventhandler/handler_test.go
@@ -276,8 +276,8 @@ func TestHandlerSendBatches(t *testing.T) {
 		n, err := handler.SendBatches(ctx)
 		// 16 + 9 (1st sec) < 32 (total send)
 		assert.Error(t, err)
-		assert.Equal(t, 2, len(handler.batches)) // Ensure there are 2 batches.
-		assert.Equal(t, int64(16), srv.received.Load())        // Only the first batch is read
+		assert.Equal(t, 2, len(handler.batches))        // Ensure there are 2 batches.
+		assert.Equal(t, int64(16), srv.received.Load()) // Only the first batch is read
 		assert.Equal(t, 16, n)
 	})
 	t.Run("success-with-batch-bigger-than-burst", func(t *testing.T) {
@@ -289,9 +289,9 @@ func TestHandlerSendBatches(t *testing.T) {
 
 		// the payload is not equal as two metadata are added
 		assert.Equal(t, int64(32), srv.received.Load())
-		assert.Equal(t, 32, n)                   // Ensure there are 32 events (minus metadata).
-		assert.Equal(t, 2, len(handler.batches)) // Ensure there are 2 batches.
-		assert.Equal(t, int64(4), srv.requestCount.Load())     // a batch split into 2 requests.
+		assert.Equal(t, 32, n)                             // Ensure there are 32 events (minus metadata).
+		assert.Equal(t, 2, len(handler.batches))           // Ensure there are 2 batches.
+		assert.Equal(t, int64(4), srv.requestCount.Load()) // a batch split into 2 requests.
 	})
 	t.Run("success-queue-when-batch-size-is-smaller-than-burst", func(t *testing.T) {
 		handler, srv := newHandler(t, withRateLimiter(rate.NewLimiter(6, 12))) // event rate = 12/2sec
@@ -300,8 +300,8 @@ func TestHandlerSendBatches(t *testing.T) {
 		n, _ := handler.SendBatches(ctx)
 		// 12 (1st sec) sent, wait for 2 sec to send events
 		// cancelling at 2nd sec shows queued batches
-		assert.Equal(t, 2, len(handler.batches)) // Ensure there are 2 batches.
-		assert.Equal(t, int64(12), srv.received.Load())        // no events sent until next interval (only first burst)
+		assert.Equal(t, 2, len(handler.batches))        // Ensure there are 2 batches.
+		assert.Equal(t, int64(12), srv.received.Load()) // no events sent until next interval (only first burst)
 		assert.Equal(t, 12, n)
 	})
 	t.Run("success-dequeue-events-and-send-at-next-interval", func(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Found a few race conditions while investigation flaky tests

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

run systemtests with the `-race` flag

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
