### PR TITLE
fix: update mergify queue config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@ queue_rules:
   - name: default
     conditions:
       - check-success=apm-ci/pr-merge
-      - check-success=system-test
+      - check-success=go-system-tests
       - check-success=lint
       - check-success=CLA
 pull_request_rules:


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

fix: update mergify queue config, one of the GitHub checks has changed its name. This is causing the updatecli PRs to stuck waiting for a workflow to finish.

