### PR TITLE
Set _doc_count for spans / transactions

### DIFF
--- a/apmpackage/apm/data_stream/rum_traces/elasticsearch/ingest_pipeline/default.yml
+++ b/apmpackage/apm/data_stream/rum_traces/elasticsearch/ingest_pipeline/default.yml
@@ -38,4 +38,22 @@ processors:
         - service.framework
       ignore_missing: true
       ignore_failure: true
+  - script:
+      lang: painless
+      source: |
+        def representative_count = ctx?.span?.representative_count != null ? ctx?.span?.representative_count : ctx?.transaction?.representative_count;
+          
+        if(representative_count == null) {
+        return;
+        }
+        
+        int doc_count = (int)representative_count;
+        
+        double decimal = representative_count - doc_count;
+        
+        if (decimal > Math.random()) {
+        doc_count += 1;
+        }
+        
+        ctx._doc_count = doc_count;
 

--- a/apmpackage/apm/data_stream/traces/elasticsearch/ingest_pipeline/default.yml
+++ b/apmpackage/apm/data_stream/traces/elasticsearch/ingest_pipeline/default.yml
@@ -35,3 +35,21 @@ processors:
       value: 0
       ignore_failure: true
   # end of event.success_count logic
+  - script:
+      lang: painless
+      source: |
+        def representative_count = ctx?.span?.representative_count != null ? ctx?.span?.representative_count : ctx?.transaction?.representative_count;
+          
+        if(representative_count == null) {
+        return;
+        }
+        
+        int doc_count = (int)representative_count;
+        
+        double decimal = representative_count - doc_count;
+        
+        if (decimal > Math.random()) {
+        doc_count += 1;
+        }
+        
+        ctx._doc_count = doc_count;

--- a/systemtest/approvals/TestCompressedSpans.approved.json
+++ b/systemtest/approvals/TestCompressedSpans.approved.json
@@ -2,6 +2,7 @@
     "events": [
         {
             "@timestamp": "1970-01-01T00:00:00.000Z",
+            "_doc_count": 1,
             "agent": {
                 "name": "go",
                 "version": "0.0.0"
@@ -93,6 +94,7 @@
         },
         {
             "@timestamp": "1970-01-01T00:00:00.050Z",
+            "_doc_count": 1,
             "agent": {
                 "name": "go",
                 "version": "0.0.0"

--- a/systemtest/approvals/TestIntake/Events.approved.json
+++ b/systemtest/approvals/TestIntake/Events.approved.json
@@ -401,6 +401,7 @@
         },
         {
             "@timestamp": "2019-10-21T11:30:44.929Z",
+            "_doc_count": 1,
             "agent": {
                 "activation_method": "some_activation_method",
                 "ephemeral_id": "e71be9ac-93b0-44b9-a997-5638f6ccfc36",
@@ -564,6 +565,7 @@
         },
         {
             "@timestamp": "2019-10-21T11:30:44.929Z",
+            "_doc_count": 1,
             "agent": {
                 "activation_method": "some_activation_method",
                 "ephemeral_id": "e71be9ac-93b0-44b9-a997-5638f6ccfc36",

--- a/systemtest/approvals/TestIntake/MinimalEvents.approved.json
+++ b/systemtest/approvals/TestIntake/MinimalEvents.approved.json
@@ -160,6 +160,7 @@
         },
         {
             "@timestamp": "dynamic",
+            "_doc_count": 1,
             "agent": {
                 "name": "elastic-node",
                 "version": "3.14.0"
@@ -209,6 +210,7 @@
         },
         {
             "@timestamp": "dynamic",
+            "_doc_count": 1,
             "agent": {
                 "name": "elastic-node",
                 "version": "3.14.0"
@@ -258,6 +260,7 @@
         },
         {
             "@timestamp": "dynamic",
+            "_doc_count": 1,
             "agent": {
                 "name": "elastic-node",
                 "version": "3.14.0"

--- a/systemtest/approvals/TestIntake/Spans.approved.json
+++ b/systemtest/approvals/TestIntake/Spans.approved.json
@@ -2,6 +2,7 @@
     "events": [
         {
             "@timestamp": "2018-07-30T18:53:42.281Z",
+            "_doc_count": 1,
             "agent": {
                 "activation_method": "some_activation_method",
                 "ephemeral_id": "justanid",
@@ -224,6 +225,7 @@
         },
         {
             "@timestamp": "2018-07-30T18:53:42.281Z",
+            "_doc_count": 1,
             "agent": {
                 "activation_method": "some_activation_method",
                 "name": "elastic-node",
@@ -356,6 +358,7 @@
         },
         {
             "@timestamp": "2018-07-30T18:53:42.281Z",
+            "_doc_count": 1,
             "agent": {
                 "activation_method": "some_activation_method",
                 "name": "elastic-node",
@@ -494,6 +497,7 @@
         },
         {
             "@timestamp": "2018-07-30T18:53:42.281Z",
+            "_doc_count": 1,
             "agent": {
                 "activation_method": "some_activation_method",
                 "name": "elastic-node",
@@ -626,6 +630,7 @@
         },
         {
             "@timestamp": "2021-07-06T11:58:05.682Z",
+            "_doc_count": 1,
             "agent": {
                 "activation_method": "some_activation_method",
                 "name": "elastic-node",
@@ -768,6 +773,7 @@
         },
         {
             "@timestamp": "2018-07-30T18:53:42.281Z",
+            "_doc_count": 1,
             "agent": {
                 "activation_method": "some_activation_method",
                 "ephemeral_id": "justanid",
@@ -990,6 +996,7 @@
         },
         {
             "@timestamp": "2018-07-30T18:53:42.281Z",
+            "_doc_count": 1,
             "agent": {
                 "activation_method": "some_activation_method",
                 "name": "elastic-node",
@@ -1137,6 +1144,7 @@
         },
         {
             "@timestamp": "2018-07-30T18:53:42.281Z",
+            "_doc_count": 1,
             "agent": {
                 "activation_method": "some_activation_method",
                 "name": "elastic-node",
@@ -1277,6 +1285,7 @@
         },
         {
             "@timestamp": "2018-07-30T18:33:03.584Z",
+            "_doc_count": 1,
             "agent": {
                 "activation_method": "some_activation_method",
                 "name": "elastic-node",
@@ -1428,6 +1437,7 @@
         },
         {
             "@timestamp": "2018-07-30T18:53:42.281Z",
+            "_doc_count": 1,
             "agent": {
                 "activation_method": "some_activation_method",
                 "ephemeral_id": "justanid",

--- a/systemtest/approvals/TestIntake/Transactions.approved.json
+++ b/systemtest/approvals/TestIntake/Transactions.approved.json
@@ -2,6 +2,7 @@
     "events": [
         {
             "@timestamp": "2017-05-30T18:53:27.154Z",
+            "_doc_count": 1,
             "agent": {
                 "activation_method": "some_activation_method",
                 "name": "elastic-node",
@@ -160,6 +161,7 @@
         },
         {
             "@timestamp": "2017-05-30T18:53:27.154Z",
+            "_doc_count": 1,
             "agent": {
                 "activation_method": "some_activation_method",
                 "name": "elastic-node",
@@ -294,6 +296,7 @@
         },
         {
             "@timestamp": "2017-05-30T18:53:27.154Z",
+            "_doc_count": 1,
             "agent": {
                 "activation_method": "some_activation_method",
                 "name": "elastic-node",
@@ -537,6 +540,7 @@
         },
         {
             "@timestamp": "2018-07-30T18:53:42.281Z",
+            "_doc_count": 1,
             "agent": {
                 "activation_method": "some_activation_method",
                 "ephemeral_id": "justanid",
@@ -696,6 +700,7 @@
         },
         {
             "@timestamp": "2021-09-15T20:11:06.365Z",
+            "_doc_count": 1,
             "agent": {
                 "activation_method": "some_activation_method",
                 "name": "elastic-node",

--- a/systemtest/approvals/TestIntake/TransactionsHugeTraces.approved.json
+++ b/systemtest/approvals/TestIntake/TransactionsHugeTraces.approved.json
@@ -2,6 +2,7 @@
     "events": [
         {
             "@timestamp": "2017-05-30T18:53:27.154Z",
+            "_doc_count": 1,
             "agent": {
                 "activation_method": "some_activation_method",
                 "name": "elastic-node",

--- a/systemtest/approvals/TestIntake/UnknownSpanType.approved.json
+++ b/systemtest/approvals/TestIntake/UnknownSpanType.approved.json
@@ -2,6 +2,7 @@
     "events": [
         {
             "@timestamp": "2017-05-30T18:53:27.154Z",
+            "_doc_count": 1,
             "agent": {
                 "name": "elastic-node",
                 "version": "3.14.0"
@@ -161,6 +162,7 @@
         },
         {
             "@timestamp": "2017-05-30T18:53:27.154Z",
+            "_doc_count": 1,
             "agent": {
                 "name": "js-base",
                 "version": "1.3"

--- a/systemtest/approvals/TestJaeger/batch_1.approved.json
+++ b/systemtest/approvals/TestJaeger/batch_1.approved.json
@@ -235,6 +235,7 @@
         },
         {
             "@timestamp": "2019-12-20T07:41:45.132Z",
+            "_doc_count": 1,
             "agent": {
                 "ephemeral_id": "2e3f8db3eb77fae0",
                 "name": "Jaeger/Go",
@@ -297,6 +298,7 @@
         },
         {
             "@timestamp": "2019-12-20T07:41:45.089Z",
+            "_doc_count": 1,
             "agent": {
                 "ephemeral_id": "2e3f8db3eb77fae0",
                 "name": "Jaeger/Go",
@@ -358,6 +360,7 @@
         },
         {
             "@timestamp": "2019-12-20T07:41:45.186Z",
+            "_doc_count": 1,
             "agent": {
                 "ephemeral_id": "2e3f8db3eb77fae0",
                 "name": "Jaeger/Go",
@@ -419,6 +422,7 @@
         },
         {
             "@timestamp": "2019-12-20T07:41:45.113Z",
+            "_doc_count": 1,
             "agent": {
                 "ephemeral_id": "2e3f8db3eb77fae0",
                 "name": "Jaeger/Go",
@@ -480,6 +484,7 @@
         },
         {
             "@timestamp": "2019-12-20T07:41:44.973Z",
+            "_doc_count": 1,
             "agent": {
                 "ephemeral_id": "2e3f8db3eb77fae0",
                 "name": "Jaeger/Go",
@@ -542,6 +547,7 @@
         },
         {
             "@timestamp": "2019-12-20T07:41:45.125Z",
+            "_doc_count": 1,
             "agent": {
                 "ephemeral_id": "2e3f8db3eb77fae0",
                 "name": "Jaeger/Go",
@@ -603,6 +609,7 @@
         },
         {
             "@timestamp": "2019-12-20T07:41:45.054Z",
+            "_doc_count": 1,
             "agent": {
                 "ephemeral_id": "2e3f8db3eb77fae0",
                 "name": "Jaeger/Go",
@@ -665,6 +672,7 @@
         },
         {
             "@timestamp": "2019-12-20T07:41:45.101Z",
+            "_doc_count": 1,
             "agent": {
                 "ephemeral_id": "2e3f8db3eb77fae0",
                 "name": "Jaeger/Go",
@@ -726,6 +734,7 @@
         },
         {
             "@timestamp": "2019-12-20T07:41:45.007Z",
+            "_doc_count": 1,
             "agent": {
                 "ephemeral_id": "2e3f8db3eb77fae0",
                 "name": "Jaeger/Go",
@@ -787,6 +796,7 @@
         },
         {
             "@timestamp": "2019-12-20T07:41:45.172Z",
+            "_doc_count": 1,
             "agent": {
                 "ephemeral_id": "2e3f8db3eb77fae0",
                 "name": "Jaeger/Go",
@@ -848,6 +858,7 @@
         },
         {
             "@timestamp": "2019-12-20T07:41:45.029Z",
+            "_doc_count": 1,
             "agent": {
                 "ephemeral_id": "2e3f8db3eb77fae0",
                 "name": "Jaeger/Go",
@@ -909,6 +920,7 @@
         },
         {
             "@timestamp": "2019-12-20T07:41:45.040Z",
+            "_doc_count": 1,
             "agent": {
                 "ephemeral_id": "2e3f8db3eb77fae0",
                 "name": "Jaeger/Go",
@@ -970,6 +982,7 @@
         },
         {
             "@timestamp": "2019-12-20T07:41:44.954Z",
+            "_doc_count": 1,
             "agent": {
                 "ephemeral_id": "2e3f8db3eb77fae0",
                 "name": "Jaeger/Go",
@@ -1031,6 +1044,7 @@
         },
         {
             "@timestamp": "2019-12-20T07:41:45.016Z",
+            "_doc_count": 1,
             "agent": {
                 "ephemeral_id": "2e3f8db3eb77fae0",
                 "name": "Jaeger/Go",

--- a/systemtest/approvals/TestOTLPGRPCTraces.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCTraces.approved.json
@@ -132,6 +132,7 @@
         },
         {
             "@timestamp": "1970-01-01T00:02:03.000Z",
+            "_doc_count": 1,
             "agent": {
                 "name": "opentelemetry/go",
                 "version": "1.16.0"

--- a/systemtest/approvals/TestTransactionDroppedSpansStatsTransaction.approved.json
+++ b/systemtest/approvals/TestTransactionDroppedSpansStatsTransaction.approved.json
@@ -2,6 +2,7 @@
     "events": [
         {
             "@timestamp": "dynamic",
+            "_doc_count": 1,
             "agent": {
                 "name": "go",
                 "version": "0.0.0"


### PR DESCRIPTION
We've recently had a few requests for upscaling spans and transactions, either when falling back to sampled events in the UI, or for custom dashboards. Currently, throughput drops, which makes it hard to use custom dashboards. Latency and failure results can be skewed. If we set _doc_count to the value of representative_count, Elasticsearch aggregations will automatically upscale results. This PR makes that change. 

See:
- https://github.com/elastic/kibana/issues/160757
- https://github.com/elastic/kibana/issues/160585