### PR TITLE
Fix mergify 7.17 status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,15 @@ jobs:
           cache: true
       - run: make apm-server
       - run: cd systemtest && go test -v -timeout=20m ./...
+
+  system-test:
+    runs-on: ubuntu-latest
+    needs:
+      - python-system-tests
+      - go-system-tests
+    steps:
+      - id: check
+        uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
+        with:
+          needs: ${{ toJSON(needs) }}
+      - run: ${{ steps.check.outputs.isSuccess }}


### PR DESCRIPTION
## Details

https://github.com/elastic/apm-server/pull/11194 is not mergable because it's waiting for the status check `system-test`. However, this check does not exist on `7.17`. 

This PR fixes it by creating a job named `system-test` that depends on the outcome of `go-system-tests` and `python-system-tests`.