### PR TITLE
Update apm-data, use modelpb.IP

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -288,11 +288,11 @@ SOFTWARE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/elastic/apm-data
-Version: v0.1.1-0.20230705050140-e5828f1f7c8f
+Version: v0.1.1-0.20230717081715-e5765b8f8d89
 Licence type (autodetected): Apache-2.0
 --------------------------------------------------------------------------------
 
-Contents of probable licence file $GOMODCACHE/github.com/elastic/apm-data@v0.1.1-0.20230705050140-e5828f1f7c8f/LICENSE:
+Contents of probable licence file $GOMODCACHE/github.com/elastic/apm-data@v0.1.1-0.20230717081715-e5765b8f8d89/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/dgraph-io/badger/v2 v2.2007.3-0.20201012072640-f5a7e0a1c83b
 	github.com/dustin/go-humanize v1.0.1
-	github.com/elastic/apm-data v0.1.1-0.20230705050140-e5828f1f7c8f
+	github.com/elastic/apm-data v0.1.1-0.20230717081715-e5765b8f8d89
 	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230717121825-061cb88e68e2
 	github.com/elastic/elastic-agent-client/v7 v7.1.2
 	github.com/elastic/elastic-agent-libs v0.3.9

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6 h1:8yY/I9
 github.com/eapache/go-xerial-snappy v0.0.0-20230111030713-bf00bc1b83b6/go.mod h1:YvSRo5mw33fLEx1+DlK6L2VV43tJt5Eyel9n9XBcR+0=
 github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/elastic/apm-data v0.1.1-0.20230705050140-e5828f1f7c8f h1:vJUX3M0XlOo2DpdMuKk5UzjozBQAFYNrro9JWQqpcg4=
-github.com/elastic/apm-data v0.1.1-0.20230705050140-e5828f1f7c8f/go.mod h1:8HEBtP5evAcAvYeu/Nnn1yrdIoyECqm425/Ggs9JHv8=
+github.com/elastic/apm-data v0.1.1-0.20230717081715-e5765b8f8d89 h1:yox9Is9K781YI8WpHJ7IzN/iNqw0N9Ims9ER7ZoF3K8=
+github.com/elastic/apm-data v0.1.1-0.20230717081715-e5765b8f8d89/go.mod h1:lMTMoCWNadiDJih/tLechuMTtumEeedtKJlBOYAv030=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230717121825-061cb88e68e2 h1:3lB7AGvcZEGzV9TY23cz9UKh/8szgA8fQD+24P0X5n4=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20230717121825-061cb88e68e2/go.mod h1:az1fOGOFvJBTLtC8289lI8F2kMY4NDNNkCdh1Chv4jE=
 github.com/elastic/elastic-agent-autodiscover v0.6.2 h1:7P3cbMBWXjbzA80rxitQjc+PiWyZ4I4F4LqrCYgYlNc=

--- a/internal/beater/api/mux.go
+++ b/internal/beater/api/mux.go
@@ -311,7 +311,9 @@ func backendRequestMetadataFunc(cfg *config.Config) func(c *request.Context) *mo
 		}
 
 		if c.ClientIP.IsValid() {
-			e.Host = &modelpb.Host{Ip: []string{c.ClientIP.String()}}
+			e.Host = &modelpb.Host{
+				Ip: []*modelpb.IP{modelpb.Addr2IP(c.ClientIP)},
+			}
 		}
 		return &e
 	}
@@ -329,16 +331,16 @@ func rumRequestMetadataFunc(cfg *config.Config) func(c *request.Context) *modelp
 			e.UserAgent = &modelpb.UserAgent{Original: c.UserAgent}
 		}
 		if c.ClientIP.IsValid() {
-			e.Client = &modelpb.Client{Ip: c.ClientIP.String()}
+			e.Client = &modelpb.Client{Ip: modelpb.Addr2IP(c.ClientIP)}
 		}
 		if c.SourcePort != 0 || c.SourceIP.IsValid() {
 			e.Source = &modelpb.Source{Port: uint32(c.SourcePort)}
 			if c.SourceIP.IsValid() {
-				e.Source.Ip = c.SourceIP.String()
+				e.Source.Ip = modelpb.Addr2IP(c.SourceIP)
 			}
 		}
 		if c.SourceNATIP.IsValid() {
-			e.Source.Nat = &modelpb.NAT{Ip: c.SourceNATIP.String()}
+			e.Source.Nat = &modelpb.NAT{Ip: modelpb.Addr2IP(c.SourceNATIP)}
 		}
 		return &e
 	}

--- a/internal/beater/api/mux_test.go
+++ b/internal/beater/api/mux_test.go
@@ -53,7 +53,7 @@ func TestBackendRequestMetadata(t *testing.T) {
 	c.ClientIP = netip.MustParseAddr("127.0.0.1")
 	event = backendRequestMetadataFunc(cfg)(c)
 	assert.Equal(t, tNow, event.Timestamp.AsTime())
-	assert.Equal(t, &modelpb.Host{Ip: []string{c.ClientIP.String()}}, event.Host)
+	assert.Equal(t, &modelpb.Host{Ip: []*modelpb.IP{modelpb.Addr2IP(c.ClientIP)}}, event.Host)
 }
 
 func TestRUMRequestMetadata(t *testing.T) {
@@ -70,8 +70,8 @@ func TestRUMRequestMetadata(t *testing.T) {
 	c = &request.Context{Timestamp: tNow, ClientIP: ip, SourceIP: ip, UserAgent: "firefox"}
 	event = rumRequestMetadataFunc(cfg)(c)
 	assert.Equal(t, tNow, event.Timestamp.AsTime())
-	assert.Equal(t, &modelpb.Client{Ip: c.ClientIP.String()}, event.Client)
-	assert.Equal(t, &modelpb.Source{Ip: c.SourceIP.String()}, event.Source)
+	assert.Equal(t, &modelpb.Client{Ip: modelpb.Addr2IP(c.ClientIP)}, event.Client)
+	assert.Equal(t, &modelpb.Source{Ip: modelpb.Addr2IP(c.SourceIP)}, event.Source)
 	assert.Equal(t, &modelpb.UserAgent{Original: c.UserAgent}, event.UserAgent)
 }
 

--- a/internal/beater/otlp/clientmetadata_test.go
+++ b/internal/beater/otlp/clientmetadata_test.go
@@ -33,10 +33,10 @@ import (
 )
 
 func TestSetClientMetadata(t *testing.T) {
-	netip1234 := "1.2.3.4"
-	ip1234 := net.ParseIP("1.2.3.4")
-	ip5678 := netip.MustParseAddr("5.6.7.8")
-	ip10 := netip.MustParseAddr("10.10.10.10")
+	modelpbIP1234 := modelpb.MustParseIP("1.2.3.4")
+	netIP1234 := net.ParseIP("1.2.3.4")
+	netipAddr5678 := netip.MustParseAddr("5.6.7.8")
+	netipAddr10 := netip.MustParseAddr("10.10.10.10")
 
 	for _, test := range []struct {
 		ctx      context.Context
@@ -45,20 +45,20 @@ func TestSetClientMetadata(t *testing.T) {
 	}{{
 		ctx: context.Background(),
 		in: &modelpb.APMEvent{
-			Client: &modelpb.Client{Ip: netip1234},
+			Client: &modelpb.Client{Ip: modelpbIP1234},
 		},
 		expected: &modelpb.APMEvent{
-			Client: &modelpb.Client{Ip: netip1234},
+			Client: &modelpb.Client{Ip: modelpbIP1234},
 		},
 	}, {
 		ctx: context.Background(),
 		in: &modelpb.APMEvent{
 			Agent:  &modelpb.Agent{Name: "iOS/swift"},
-			Client: &modelpb.Client{Ip: netip1234},
+			Client: &modelpb.Client{Ip: modelpbIP1234},
 		},
 		expected: &modelpb.APMEvent{
 			Agent:  &modelpb.Agent{Name: "iOS/swift"},
-			Client: &modelpb.Client{Ip: netip1234},
+			Client: &modelpb.Client{Ip: modelpbIP1234},
 		},
 	}, {
 		ctx: context.Background(),
@@ -72,11 +72,11 @@ func TestSetClientMetadata(t *testing.T) {
 		ctx: context.Background(),
 		in: &modelpb.APMEvent{
 			Agent:  &modelpb.Agent{Name: "android/java"},
-			Client: &modelpb.Client{Ip: netip1234},
+			Client: &modelpb.Client{Ip: modelpbIP1234},
 		},
 		expected: &modelpb.APMEvent{
 			Agent:  &modelpb.Agent{Name: "android/java"},
-			Client: &modelpb.Client{Ip: netip1234},
+			Client: &modelpb.Client{Ip: modelpbIP1234},
 		},
 	}, {
 		ctx: context.Background(),
@@ -88,64 +88,64 @@ func TestSetClientMetadata(t *testing.T) {
 		},
 	}, {
 		ctx: interceptors.ContextWithClientMetadata(context.Background(), interceptors.ClientMetadataValues{
-			SourceAddr: &net.TCPAddr{IP: ip1234, Port: 4321},
-			ClientIP:   ip5678,
+			SourceAddr: &net.TCPAddr{IP: netIP1234, Port: 4321},
+			ClientIP:   netipAddr5678,
 		}),
 		in: &modelpb.APMEvent{
 			Agent: &modelpb.Agent{Name: "iOS/swift"},
 		},
 		expected: &modelpb.APMEvent{
 			Agent:  &modelpb.Agent{Name: "iOS/swift"},
-			Client: &modelpb.Client{Ip: ip5678.String()},
-			Source: &modelpb.Source{Ip: netip1234, Port: 4321},
+			Client: &modelpb.Client{Ip: modelpb.Addr2IP(netipAddr5678)},
+			Source: &modelpb.Source{Ip: modelpbIP1234, Port: 4321},
 		},
 	}, {
 		ctx: interceptors.ContextWithClientMetadata(context.Background(), interceptors.ClientMetadataValues{
-			SourceAddr:  &net.TCPAddr{IP: ip1234, Port: 4321},
-			SourceNATIP: ip10,
-			ClientIP:    ip5678,
+			SourceAddr:  &net.TCPAddr{IP: netIP1234, Port: 4321},
+			SourceNATIP: netipAddr10,
+			ClientIP:    netipAddr5678,
 		}),
 		in: &modelpb.APMEvent{
 			Agent: &modelpb.Agent{Name: "iOS/swift"},
 		},
 		expected: &modelpb.APMEvent{
 			Agent:  &modelpb.Agent{Name: "iOS/swift"},
-			Client: &modelpb.Client{Ip: ip5678.String()},
+			Client: &modelpb.Client{Ip: modelpb.Addr2IP(netipAddr5678)},
 			Source: &modelpb.Source{
-				Ip:   netip1234,
+				Ip:   modelpbIP1234,
 				Port: 4321,
-				Nat:  &modelpb.NAT{Ip: ip10.String()},
+				Nat:  &modelpb.NAT{Ip: modelpb.Addr2IP(netipAddr10)},
 			},
 		},
 	}, {
 		ctx: interceptors.ContextWithClientMetadata(context.Background(), interceptors.ClientMetadataValues{
-			SourceAddr: &net.TCPAddr{IP: ip1234, Port: 4321},
-			ClientIP:   ip5678,
+			SourceAddr: &net.TCPAddr{IP: netIP1234, Port: 4321},
+			ClientIP:   netipAddr5678,
 		}),
 		in: &modelpb.APMEvent{
 			Agent: &modelpb.Agent{Name: "android/java"},
 		},
 		expected: &modelpb.APMEvent{
 			Agent:  &modelpb.Agent{Name: "android/java"},
-			Client: &modelpb.Client{Ip: ip5678.String()},
-			Source: &modelpb.Source{Ip: netip1234, Port: 4321},
+			Client: &modelpb.Client{Ip: modelpb.Addr2IP(netipAddr5678)},
+			Source: &modelpb.Source{Ip: modelpbIP1234, Port: 4321},
 		},
 	}, {
 		ctx: interceptors.ContextWithClientMetadata(context.Background(), interceptors.ClientMetadataValues{
-			SourceAddr:  &net.TCPAddr{IP: ip1234, Port: 4321},
-			SourceNATIP: ip10,
-			ClientIP:    ip5678,
+			SourceAddr:  &net.TCPAddr{IP: netIP1234, Port: 4321},
+			SourceNATIP: netipAddr10,
+			ClientIP:    netipAddr5678,
 		}),
 		in: &modelpb.APMEvent{
 			Agent: &modelpb.Agent{Name: "android/java"},
 		},
 		expected: &modelpb.APMEvent{
 			Agent:  &modelpb.Agent{Name: "android/java"},
-			Client: &modelpb.Client{Ip: ip5678.String()},
+			Client: &modelpb.Client{Ip: modelpb.Addr2IP(netipAddr5678)},
 			Source: &modelpb.Source{
-				Ip:   netip1234,
+				Ip:   modelpbIP1234,
 				Port: 4321,
-				Nat:  &modelpb.NAT{Ip: ip10.String()},
+				Nat:  &modelpb.NAT{Ip: modelpb.Addr2IP(netipAddr10)},
 			},
 		},
 	}} {


### PR DESCRIPTION
## Motivation/summary

Update apm-data. IPs now have a structured type, switch over to that.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

https://github.com/elastic/apm-data/pull/110