### PR TITLE
[main] docs: redirects for removed pages (#10894)

### DIFF
--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -326,3 +326,97 @@ Please see <<troubleshoot-apm>>.
 
 This page has moved.
 Please see <<configuring-howto-apm-server>>.
+
+[role="exclude",id="events-api"]
+=== Events Intake API
+
+[discrete]
+[[events-api-errors]]
+==== Errors
+
+This page has been deleted.
+Please see <<apm-overview>>.
+
+[role="exclude",id="intake-api"]
+=== API
+
+This page has been deleted.
+Please see <<apm-overview>>.
+
+[role="exclude",id="metadata-api"]
+=== Metadata
+
+[discrete]
+[[metadata-schema]]
+==== Errors
+
+This page has been deleted.
+Please see <<apm-overview>>.
+
+[role="exclude",id="errors"]
+=== Errors
+
+This page has been deleted.
+Please see <<apm-overview>>.
+
+[role="exclude",id="transaction-spans"]
+=== Spans
+
+This page has been deleted.
+Please see <<apm-overview>>.
+
+[role="exclude",id="transactions"]
+=== Transactions
+
+This page has been deleted.
+Please see <<apm-overview>>.
+
+[role="exclude",id="legacy-apm-overview"]
+=== Legacy APM Overview
+
+This page has been deleted.
+Please see <<apm-overview>>.
+
+[role="exclude",id="apm-components"]
+=== Components and documentation
+
+This page has been deleted.
+Please see <<apm-overview>>.
+
+[role="exclude",id="configuring-ingest-node"]
+=== Parse data using ingest node pipelines
+
+This page has been deleted.
+Please see <<apm-overview>>.
+
+[role="exclude",id="overview"]
+=== Legacy APM Server Reference
+
+This page has been deleted.
+Please see <<apm-overview>>.
+
+[role="exclude",id="metadata"]
+=== Metadata
+
+This page has been deleted.
+Please see <<apm-overview>>.
+
+[role="exclude",id="distributed-tracing"]
+=== Distributed tracing
+
+This page has been deleted.
+Please see <<apm-overview>>.
+
+[role="exclude",id="sourcemaps"]
+=== How to apply source maps to error stack traces when using minified bundles
+
+[discrete]
+[[sourcemap-rum-generate]]
+==== Sourcemap RUM Generate
+
+[discrete]
+[[sourcemap-rum-upload]]
+==== Sourcemap RUM upload
+
+This page has been deleted.
+Please see <<apm-overview>>.


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.8` to `main`:
 - [docs: redirects for removed pages (#10894)](https://github.com/elastic/apm-server/pull/10894)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)