### PR TITLE
smoketest: install the specific apm-server and elastic-agent version instead of latest

### DIFF
--- a/testing/infra/terraform/modules/standalone_apm_server/latest_apm_server.sh
+++ b/testing/infra/terraform/modules/standalone_apm_server/latest_apm_server.sh
@@ -2,7 +2,10 @@
 
 set -eo pipefail
 
-LATEST_STACK=$(curl -s "https://artifacts-api.elastic.co/v1/versions" | jq -r '.versions[-1]')
-LATEST_BUILD=$(curl -s "https://artifacts-api.elastic.co/v1/versions/${LATEST_STACK}/builds/" | jq -r '.builds[0]')
+VERSION=${1}
+if [[ -z ${VERSION} ]] || [[ "${VERSION}" == "latest" ]]; then
+    VERSION=$(curl -s "https://artifacts-api.elastic.co/v1/versions" | jq -r '.versions[-1]')
+fi
+LATEST_BUILD=$(curl -s "https://artifacts-api.elastic.co/v1/versions/${VERSION}/builds/" | jq -r '.builds[0]')
 
-curl -s "https://artifacts-api.elastic.co/v1/versions/${LATEST_STACK}/builds/${LATEST_BUILD}/projects/apm-server" | jq -r ".project.packages | {deb: .\"apm-server-${LATEST_STACK}-amd64.deb\".url, rpm: .\"apm-server-${LATEST_STACK}-x86_64.rpm\".url }"
+curl -s "https://artifacts-api.elastic.co/v1/versions/${VERSION}/builds/${LATEST_BUILD}/projects/apm-server" | jq -r ".project.packages | {deb: .\"apm-server-${VERSION}-amd64.deb\".url, rpm: .\"apm-server-${VERSION}-x86_64.rpm\".url }"

--- a/testing/infra/terraform/modules/standalone_apm_server/latest_elastic_agent.sh
+++ b/testing/infra/terraform/modules/standalone_apm_server/latest_elastic_agent.sh
@@ -2,7 +2,10 @@
 
 set -eo pipefail
 
-LATEST_STACK=$(curl -s "https://artifacts-api.elastic.co/v1/versions" | jq -r '.versions[-1]')
-LATEST_BUILD=$(curl -s "https://artifacts-api.elastic.co/v1/versions/${LATEST_STACK}/builds/" | jq -r '.builds[0]')
+VERSION=${1}
+if [[ -z ${VERSION} ]] || [[ "${VERSION}" == "latest" ]]; then
+    VERSION=$(curl -s "https://artifacts-api.elastic.co/v1/versions" | jq -r '.versions[-1]')
+fi
+LATEST_BUILD=$(curl -s "https://artifacts-api.elastic.co/v1/versions/${VERSION}/builds/" | jq -r '.builds[0]')
 
-curl -s "https://artifacts-api.elastic.co/v1/versions/${LATEST_STACK}/builds/${LATEST_BUILD}/projects/elastic-agent" | jq -r ".project.packages | {deb: .\"elastic-agent-${LATEST_STACK}-amd64.deb\".url, rpm: .\"elastic-agent-${LATEST_STACK}-x86_64.rpm\".url }"
+curl -s "https://artifacts-api.elastic.co/v1/versions/${VERSION}/builds/${LATEST_BUILD}/projects/elastic-agent" | jq -r ".project.packages | {deb: .\"elastic-agent-${VERSION}-amd64.deb\".url, rpm: .\"elastic-agent-${VERSION}-x86_64.rpm\".url }"

--- a/testing/infra/terraform/modules/standalone_apm_server/main.tf
+++ b/testing/infra/terraform/modules/standalone_apm_server/main.tf
@@ -157,11 +157,11 @@ resource "null_resource" "apm_server_log" {
 }
 
 data "external" "latest_elastic_agent" {
-  program = ["bash", "${path.module}/latest_elastic_agent.sh"]
+  program = ["bash", "${path.module}/latest_elastic_agent.sh", "${var.stack_version}"]
 }
 
 data "external" "latest_apm_server" {
-  program = ["bash", "${path.module}/latest_apm_server.sh"]
+  program = ["bash", "${path.module}/latest_apm_server.sh", "${var.stack_version}"]
 }
 
 resource "aws_key_pair" "provisioner_key" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Smoketests on older branches are failing because thhey are installing the latest apm-server/elastic-agent version, leading to an ingestion in elasticsearch which is refusing because of the version check (8.10.0 vs 8.8.0).

This PR update the script to fetch the correct version 

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Related to https://github.com/elastic/apm-server/issues/11281
