### PR TITLE
Added new JVM metrics to apmpackage

### DIFF
--- a/apmpackage/apm/data_stream/internal_metrics/fields/jvm_metrics.yml
+++ b/apmpackage/apm/data_stream/internal_metrics/fields/jvm_metrics.yml
@@ -56,8 +56,26 @@
   metric_type: gauge
   unit: ms
   index: false
-- name: jvm.gc.alloc
+- name: jvm.memory.non_heap.pool.used
   type: long
   metric_type: gauge
   unit: byte
+  index: false
+- name: jvm.memory.non_heap.pool.committed
+  type: long
+  metric_type: gauge
+  unit: byte
+  index: false
+- name: jvm.memory.non_heap.pool.max
+  type: long
+  metric_type: gauge
+  unit: byte
+  index: false
+- name: jvm.fd.used
+  type: long
+  metric_type: gauge
+  index: false
+- name: jvm.fd.max
+  type: long
+  metric_type: gauge
   index: false


### PR DESCRIPTION
Adds the new JVM metrics added via https://github.com/elastic/apm-agent-java/pull/3147 to the `apmpackage`.
This PR waits on https://github.com/elastic/apm-data/pull/127 and will be updated to include the update `apm-data` dependency when that PR is merged and released.