### PR TITLE
ci: migrate away from jenkins

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'microbenchmarks-pool' }
+  agent { label 'linux && immutable' }
   environment {
     REPO = 'apm-server'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -11,8 +11,6 @@ pipeline {
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
     DIAGNOSTIC_INTERVAL = "${params.DIAGNOSTIC_INTERVAL}"
     ES_LOG_LEVEL = "${params.ES_LOG_LEVEL}"
-    DOCKER_SECRET = 'secret/observability-team/ci/docker-registry/prod'
-    DOCKER_REGISTRY = 'docker.elastic.co'
   }
   options {
     timeout(time: 2, unit: 'HOURS')
@@ -28,7 +26,6 @@ pipeline {
     issueCommentTrigger("(${obltGitHubComments()}|^/package)")
   }
   parameters {
-    booleanParam(name: 'bench_ci', defaultValue: true, description: 'Enable benchmarks')
     booleanParam(name: 'release_ci', defaultValue: true, description: 'Enable build the release packages')
     string(name: 'ES_LOG_LEVEL', defaultValue: "error", description: 'Elasticsearch error level')
   }
@@ -80,37 +77,6 @@ pipeline {
               parameters: [string(name: 'COMMIT', value: "${env.GIT_BASE_COMMIT}")])
       }
     }
-		// Run the microbenchmarks for the current commit, send them to the benchmarks
-    // Elasticsearch cluster, and compare with the benchmark results from the most
-    // recent branch build.
-    stage('Benchmarking') {
-      options { skipDefaultCheckout() }
-      when {
-        beforeAgent true
-        allOf {
-          expression { return params.bench_ci }
-          expression { return env.ONLY_DOCS == "false" }
-        }
-      }
-      steps {
-        withGithubNotify(context: 'Benchmarking') {
-          deleteDir()
-          unstash 'source'
-          dir("${BASE_DIR}"){
-            withGoEnv(){
-              sh(label: 'Run benchmarks', script: './.ci/scripts/bench.sh')
-            }
-            sendBenchmarks(file: "bench.out", index: "benchmark-server")
-            generateGoBenchmarkDiff(file: 'bench.out', filter: 'exclude')
-          }
-        }
-      }
-      post {
-        cleanup {
-          deleteDir()
-        }
-      }
-    }
     // Run the packaging pipeline for branch builds. This should only be run
     // after all other stages succeed, to avoid publishing packages for a commit
     // with failing tests.
@@ -130,9 +96,6 @@ pipeline {
   post {
     always {
       deleteDir()
-    }
-    cleanup {
-      notifyBuildResult(goBenchmarkComment: true)
     }
   }
 }

--- a/.ci/scripts/bench.sh
+++ b/.ci/scripts/bench.sh
@@ -1,4 +1,193 @@
 #!/usr/bin/env bash
-set -euxo pipefail
 
-BENCH_COUNT=6 make bench | tee bench.out
+# Bash strict mode
+set -eo pipefail
+
+# Found current script directory
+RELATIVE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Found project directory
+BASE_PROJECT="$(dirname "$(dirname "${RELATIVE_DIR}")")"
+
+# Constants
+readonly BENCH_FILENAME="bench.out"
+readonly BENCH_LAST_FILENAME="bench.last"
+readonly BENCH_DIFF_FILENAME="bench.diff"
+readonly BENCH_RESULT_INDEX=""benchmark-server""
+readonly BENCH_RESULT_PATH="${BASE_PROJECT}/${BENCH_FILENAME}"
+readonly BENCH_LAST_PATH="${BASE_PROJECT}/${BENCH_LAST_FILENAME}"
+readonly BENCH_DIFF_PATH="${BASE_PROJECT}/${BENCH_DIFF_FILENAME}"
+
+#######################################
+# Emit request to buildkite to find the last successful build.
+# Ref: https://buildkite.com/docs/apis/rest-api/builds#list-builds-for-a-pipeline
+# Globals:
+#   BUILDKITE_TOKEN: Buildkite token
+#   BUILDKITE_ORGANIZATION_SLUG: Organisation slug
+#   BUILDKITE_PIPELINE_NAME: Pipeline name
+#   REPO: Target repository
+# Outputs:
+#   buildkite json response
+# Returns:
+#   0 if the request succeed.
+#   1 otherwise.
+#######################################
+function buildkite::req_last_build {
+  curl -sSL --fail --show-error -H "Authorization: Bearer ${BUILDKITE_TOKEN}" "https://api.buildkite.com/v2/organizations/${BUILDKITE_ORGANIZATION_SLUG}/pipelines/${BUILDKITE_PIPELINE_NAME}/builds?state[]=passed" \
+    | jq -r "[.[] | select(.env.repo == \"${REPO}\")] | sort_by(.finished_at) | .[-1]"
+}
+
+#######################################
+# Emit request to buildkite to list artifacts for a given build.
+# Ref: https://buildkite.com/docs/apis/rest-api/artifacts#list-artifacts-for-a-build
+# Globals:
+#   BUILDKITE_TOKEN: Buildkite token
+#   BUILDKITE_ORGANIZATION_SLUG: Organisation slug
+#   BUILDKITE_PIPELINE_NAME: Pipeline name
+#   BUILDKITE_BUILD_NUMBER: Build number
+# Outputs:
+#   buildkite json response
+# Returns:
+#   0 if the request succeed.
+#   1 otherwise.
+#######################################
+function buildkite::req_build_artifacts {
+  curl -sSL --fail --show-error -H "Authorization: Bearer ${BUILDKITE_TOKEN}" "https://api.buildkite.com/v2/organizations/${BUILDKITE_ORGANIZATION_SLUG}/pipelines/${BUILDKITE_PIPELINE_NAME}/builds/${BUILDKITE_BUILD_NUMBER}/artifacts"
+}
+
+#######################################
+# Emit request to buildkite to download an artifact.
+# Globals:
+#   BUILDKITE_DOWNLOAD_URL: Buildkite artifact download url
+#   BUILDKITE_TOKEN: Buildkite token
+#   TARGET_PATH: Absolute path where to write the downloaded file
+# Returns:
+#   0 if the request succeed.
+#   1 otherwise.
+#######################################
+function buildkite::req_download_artifact {
+  curl -sSL --fail --show-error -o "${TARGET_PATH}" -H "Authorization: Bearer ${BUILDKITE_TOKEN}" "${BUILDKITE_DOWNLOAD_URL}"
+}
+
+#######################################
+# Search an artifact in the last successful build that match provided filename.
+# Globals:
+#   BUILDKITE_TOKEN: Buildkite token
+#   BUILDKITE_ORGANIZATION_SLUG: Organisation slug
+#   BUILDKITE_PIPELINE_NAME: Pipeline name
+#   BUILDKITE_BUILD_NUMBER: Build number
+#   FILENAME: File name to match
+# Outputs:
+#   buildkite json response
+# Returns:
+#   0 if the request succeed.
+#   1 otherwise.
+#######################################
+function buildkite::search_build_artifact {
+  buildkite::req_build_artifacts \
+    | jq "[.[] | select(.filename == \"${FILENAME}\")] | .[0]"
+}
+
+#######################################
+# Download the matching artifact in the last successful build.
+# Globals:
+#   BUILDKITE_TOKEN: Buildkite token
+#   BUILDKITE_ORGANIZATION_SLUG: Organisation slug
+#   BUILDKITE_PIPELINE_NAME: Pipeline name
+#   BUILDKITE_BUILD_NUMBER: Build number
+#   FILENAME: File name to match
+#   TARGET_PATH: Absolute path where to write the downloaded file
+# Outputs:
+#   buildkite json response
+# Returns:
+#   0 if the request succeed.
+#   1 otherwise.
+#######################################
+function buildkite::download_last_artifact {
+  # Find last successful build
+  local response_last_build; response_last_build="$(buildkite::req_last_build)"
+  if [ "${response_last_build}" == "null" ]; then
+    echo "There isn't any successful previous build"
+    return 0
+  fi
+  local build_number; build_number=$(echo "${response_last_build}" | jq -r '.number')
+
+  # Extract build artifact
+  local response_build_artifact; response_build_artifact=$(BUILDKITE_BUILD_NUMBER="${build_number}" buildkite::search_build_artifact)
+  if [ "${response_last_build}" == "null" ]; then
+    echo "There isn't any artifact to download"
+    return 0
+  fi
+
+  local download_url; download_url=$(echo "${response_build_artifact}" | jq -r '.download_url')
+
+  # Download last artifact
+  BUILDKITE_DOWNLOAD_URL="${download_url}" buildkite::req_download_artifact
+}
+
+## Buildkite specific configuration
+if [ "${CI}" == "true" ] ; then
+  # If HOME is not set then use the Buildkite workspace
+  # that's normally happening when running in the CI
+  # owned by Elastic.
+  if [ -z "${HOME}" ] ; then
+    export HOME="${BUILDKITE_BUILD_CHECKOUT_PATH}"
+  fi
+  if [ -z "${USER}" ] ; then
+    export USER="ci"
+  fi
+
+  # Validate env vars
+  [ -z "${BUILDKITE_AGENT_ACCESS_TOKEN}" ] && echo "Environment variable 'BUILDKITE_AGENT_ACCESS_TOKEN' must be defined" && exit 1;
+  [ -z "${BUILDKITE_ORGANIZATION_SLUG}" ] && echo "Environment variable 'BUILDKITE_ORGANIZATION_SLUG' must be defined" && exit 1;
+  [ -z "${BUILDKITE_PIPELINE_NAME}" ] && echo "Environment variable 'BUILDKITE_PIPELINE_NAME' must be defined" && exit 1;
+  [ -z "${ES_USER_SECRET}" ] && echo "Environment variable 'ES_USER_SECRET' must be defined" && exit 1;
+  [ -z "${ES_PASS_SECRET}" ] && echo "Environment variable 'ES_PASS_SECRET' must be defined" && exit 1;
+  [ -z "${ES_URL_SECRET}" ] && echo "Environment variable 'ES_URL_SECRET' must be defined" && exit 1;
+  [ -z "${REPO}" ] && echo "Environment variable 'REPO' must be defined" && exit 1;
+  export BUILDKITE_TOKEN="${BUILDKITE_TOKEN_SECRET}"
+
+  # Redirect go env to current dir
+  export GOROOT="${BASE_PROJECT}/.go"
+  export GOPATH="${BASE_PROJECT}/go"
+  export PATH="${GOPATH}/bin:${PATH}"
+
+  # Install g (go version manager)
+  curl -sSL https://git.io/g-install | bash -s -- -y
+
+  # Install specific version
+  g install $(cat .go-version)
+
+  # Make sure gomod can be deleted automatically as part of the CI
+  function teardown {
+    local arg=${?}
+    # see https://github.com/golang/go/issues/31481#issuecomment-485008558
+    chmod -R u+w "${GOPATH}"
+    exit ${arg}
+  }
+  trap teardown EXIT
+fi
+
+# Run benchmark
+echo "--- Execute benchmarks"
+BENCH_COUNT=6 make bench | tee "${BENCH_RESULT_PATH}"
+
+if [ "${CI}" == "true" ] ; then
+  # Upload artifact
+  echo "--- Upload bench results"
+  buildkite-agent artifact upload "${BENCH_RESULT_PATH}"
+
+  # Send benchmark results
+  echo "--- Send benchmark results"
+  go install github.com/elastic/gobench@latest
+  gobench -index "${BENCH_RESULT_INDEX}" -es "${ES_URL_SECRET}" --es-username "${ES_USER_SECRET}" --es-password "${ES_PASS_SECRET}" < "${BENCH_RESULT_PATH}"
+
+  # Download artifact from a previous build
+  echo "--- Download last bench results if exists"
+  TARGET_PATH="${BENCH_LAST_PATH}" FILENAME="${BENCH_FILENAME}" buildkite::download_last_artifact
+  if [ -f "${BENCH_LAST_PATH}" ]; then
+    go install golang.org/x/perf/cmd/...@latest
+    benchstat "${BENCH_LAST_PATH}" "${BENCH_RESULT_PATH}" | grep -v 'all equal' | grep -v '~' | tee "${BENCH_DIFF_PATH}"
+    buildkite-agent artifact upload "${BENCH_DIFF_PATH}"
+  fi
+fi

--- a/.github/workflows/microbenchmark.yml
+++ b/.github/workflows/microbenchmark.yml
@@ -1,0 +1,40 @@
+---
+
+name: microbenchmark
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - '**.asciidoc'
+
+# limit the access of the generated GITHUB_TOKEN
+permissions:
+  contents: read
+
+jobs:
+  microbenchmark:
+    runs-on: ubuntu-latest
+    # wait up to 1 hour
+    timeout-minutes: 60
+    steps:
+      - id: buildkite
+        name: Run buildkite pipeline
+        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: apm-agent-microbenchmark
+          triggerMessage: "${{ github.repository }}@${{ github.ref_name }}"
+          waitFor: true
+          printBuildLogs: true
+          buildEnvVars: |
+            script=.ci/scripts/bench.sh
+            repo=apm-server
+            sha=${{ github.sha }}
+            BRANCH_NAME=${{ github.ref_name }}
+            REPO=apm-server


### PR DESCRIPTION
## What is the change being made?
* Migrate microbenchmarks away from Jenkins.
* Use microbenchmark bridge running in Buildkite from GitHub Actions.

## Why is the change being made?
* Jenkins is deprecated and will be shut down by the end of the year.

## How has this been tested?
Ref: https://github.com/elastic/apm-server/actions/runs/5680035679