### PR TITLE
docs: remove breaking change tags

### DIFF
--- a/docs/apm-breaking.asciidoc
+++ b/docs/apm-breaking.asciidoc
@@ -4,12 +4,6 @@
 [[apm-breaking]]
 === Breaking Changes
 
-// These tagged regions are required for the stack-docs repo includes
-// tag::88-bc[]
-// end::88-bc[]
-// tag::notable-v8-breaking-changes[]
-// end::notable-v8-breaking-changes[]
-
 This section describes the breaking changes and deprecations introduced in this release
 and previous minor versions.
 


### PR DESCRIPTION
## Motivation/summary

With https://github.com/elastic/stack-docs/pull/2495 merged, we no longer need tags to reuse breaking changes in the Stack Install/Upgrade guide.

## Checklist

- [x] Documentation has been updated

## Related issues

https://github.com/elastic/platform-docs-team/issues/143
