### PR TITLE
action: run microbenchmark on branches

### DIFF
--- a/.github/workflows/microbenchmark.yml
+++ b/.github/workflows/microbenchmark.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - "8.[0-9]+"
     paths-ignore:
       - '**.md'
       - '**.asciidoc'

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -6,10 +6,12 @@ on:
       - bump-elastic-stack-snapshot
       - bump-golang
       - ci
+      - microbenchmark
       - system-test-reporter
-      - update-beats
       - smoke-tests-os
       - smoke-tests-ess
+      - Terraform Format
+      - update-beats
     types: [completed]
 
 jobs:


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

microbenchmarks were enabled for all the branches and also for PRs, see https://github.com/elastic/apm-server/pull/8533

I'll enable it only for the active branches, when a push event happens.