### PR TITLE
Grow docappender indexBuilder to desired capacity for performance

### DIFF
--- a/internal/beater/processors.go
+++ b/internal/beater/processors.go
@@ -108,6 +108,8 @@ func newDocappenderBatchProcessor(a *docappender.Appender) modelpb.ProcessBatchF
 				r.reset()
 				return err
 			}
+			r.indexBuilder.Grow(len(event.DataStream.Type) + 1 +
+				len(event.DataStream.Dataset) + 1 + len(event.DataStream.Namespace))
 			r.indexBuilder.WriteString(event.DataStream.Type)
 			r.indexBuilder.WriteByte('-')
 			r.indexBuilder.WriteString(event.DataStream.Dataset)


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
In docappender batch processor, grow the index string builder to the desired capacity in one go for better performance.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~~
~~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~~
~~- [ ] Documentation has been updated~~

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
