### PR TITLE
systemtest: Fix flaky TestIntake

### DIFF
--- a/systemtest/intake_test.go
+++ b/systemtest/intake_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestIntake(t *testing.T) {
-	srv := apmservertest.NewServerTB(t)
 	for _, tc := range []struct {
 		filename      string
 		name          string
@@ -49,8 +48,11 @@ func TestIntake(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			srv := apmservertest.NewServerTB(t)
 			systemtest.CleanupElasticsearch(t)
 			response := systemtest.SendBackendEventsPayload(t, srv.URL, "../testdata/intake-v2/"+tc.filename)
+			// Since we are just waiting for traces/metrics/logs and that they should go through almost immediately,
+			// there shouldn't be any aggregated metrics.
 			result := estest.ExpectMinDocs(t, systemtest.Elasticsearch,
 				response.Accepted, "traces-apm*,metrics-apm*,logs-apm*", nil,
 			)


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

Since all subtests in TestIntake share the same APM server, if it takes >1m to run, there will be aggregated metrics in the query result, causing TestIntake to fail. Now every test case will start its own APM server. This causes TestIntake runtime to increase from 17s to 24s.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
