### PR TITLE
action: support for DRA

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+##
+##  This script prepares the Vault context and required tooling
+##  for the release and snapshot pipelines.
+##
+##  NOTE: *_SECRET or *_TOKEN env variables are masked, hence if you'd like to avoid any
+##        surprises please use the suffix _SECRET or _TOKEN for those values that contain
+##        any sensitive data. Buildkite can mask those values automatically
+##
+
+set -eo pipefail
+
+echo "--- Prepare vault context :vault:"
+VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-apm-server/internal-ci-approle)
+export VAULT_ROLE_ID_SECRET
+
+VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-apm-server/internal-ci-approle)
+export VAULT_SECRET_ID_SECRET
+
+VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-apm-server/internal-ci-approle)
+export VAULT_ADDR
+
+echo "--- Install tools"

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+##
+##  Cleanup the created env variables on the fly.
+##
+
+unset VAULT_ROLE_ID_SECRET
+unset VAULT_ADDR_SECRET
+unset VAULT_SECRET_ID_SECRET

--- a/.buildkite/package.yml
+++ b/.buildkite/package.yml
@@ -1,0 +1,49 @@
+notify:
+  - slack:
+      channels:
+        - "#apm-server"
+
+env:
+  IMAGE_UBUNTU_X86_64: "family/core-ubuntu-2004"
+  IMAGE_UBUNTU_ARM_64: "core-ubuntu-2004-aarch64"
+
+steps:
+  - group: "Package"
+    key: "package"
+    steps:
+      - label: "Package Ubuntu-20 x86_64"
+        key: "package-x86-64"
+        command: ".buildkite/scripts/package.sh {{matrix.type}}"
+        agents:
+          provider: "gcp"
+          image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "c2-standard-16"
+        matrix:
+          setup:
+            type:
+            - "snapshot"
+            - "staging"
+
+      - label: "Package Ubuntu-20 aarch64"
+        key: "package-arm"
+        command: ".buildkite/scripts/package.sh {{matrix.type}}"
+        agents:
+          provider: "aws"
+          imagePrefix: "${IMAGE_UBUNTU_ARM_64}"
+          instanceType: "t4g.2xlarge"
+        matrix:
+          setup:
+            type:
+            - "snapshot"
+            - "staging"
+
+  - label: "DRA"
+    key: "dra"
+    command: ".buildkite/scripts/dra.sh"
+    agents:
+      provider: "gcp"
+      image: "${IMAGE_UBUNTU_X86_64}"
+      machineType: "c2-standard-16"
+    depends_on:
+      - step: "package"
+        allow_failure: false

--- a/.buildkite/scripts/dra.sh
+++ b/.buildkite/scripts/dra.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+##
+##  It relies on the .buildkite/hooks/pre-command so the Vault and other tooling
+##  are prepared automatically by buildkite.
+##
+##  Required environment variables passed when running the Buildkite pipeline:
+##   * BRANCH_NAME
+##   * DRA_WORKFLOW
+##   * GITHUB_SHA
+##
+
+set -eo pipefail
+
+### TODO: retry a few times just in case docker.elastic.co is not accessible
+docker pull --quiet docker.elastic.co/infra/release-manager:latest
+
+## Read current version.
+VERSION=$(make get-version)
+
+### TODO: fetch all the generated artifacts
+# BK artifact API call
+
+### TODO: retry a few times just in case some infra issues, like the vault accessing.
+docker run --rm \
+  --name release-manager \
+  -e VAULT_ADDR \
+  -e VAULT_ROLE_ID_SECRET \
+  -e VAULT_SECRET_ID_SECRET \
+  --mount type=bind,readonly=false,src=$(pwd),target=/artifacts \
+  docker.elastic.co/infra/release-manager:latest \
+    cli collect \
+    --project apm-server \
+    --branch $BRANCH_NAME \
+    --commit $GITHUB_SHA \
+    --workflow $DRA_WORKFLOW \
+    --artifact-set main \
+    --version $VERSION

--- a/.buildkite/scripts/package.sh
+++ b/.buildkite/scripts/package.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+##
+##  Builds the distribution packages: tarballs, RPMs, Docker images, etc.
+##  It runs for both linux/amd64 and linux/arm64. On linux/amd64 it builds all packages;
+##  on linux/arm64 it builds only Docker images.
+##
+
+set -eo pipefail
+
+TYPE="$1"
+PLATFORM_TYPE=$(uname -m)
+
+MAKE_GOAL=package
+if [[ ${PLATFORM_TYPE} == "arm" || ${PLATFORM_TYPE} == "aarch64" ]]; then
+  MAKE_GOAL=package-docker
+fi
+
+if [[ ${TYPE} == "snapshot" ]]; then
+  MAKE_GOAL="${MAKE_GOAL}-snapshot"
+fi
+
+make $MAKE_GOAL
+
+# BK artifact API call

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -7,6 +7,7 @@ on:
       - bump-golang
       - ci
       - microbenchmark
+      - package
       - system-test-reporter
       - smoke-tests-os
       - smoke-tests-ess

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,59 @@
+name: package
+
+on:
+  workflow_call: ~
+  push:
+    branches:
+      - main
+      - 7.1*
+      - 8.*
+    paths-ignore: # When updating the list of expressions also update ci-docs.yml
+      - '**.md'
+      - '**.asciidoc'
+      - '**.png'
+      - '**.svg'
+  pull_request:
+    paths-ignore: # When updating the list of expressions also update ci-docs.yml
+      - '**.md'
+      - '**.asciidoc'
+      - '**.png'
+      - '**.svg'
+
+# limit the access of the generated GITHUB_TOKEN
+permissions:
+  contents: read
+
+jobs:
+  buildkite:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dra-workflow: ["snapshot", "staging"]
+    steps:
+      # exclude if main and staging
+      # exclude if branch is not supported anymore isBranchUnifiedReleaseAvailable()
+      - uses: actions/checkout@v3
+
+      - id: buildkite
+        name: Run buildkite pipeline
+        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: apm-server-package
+          triggerMessage: "${{ matrix.dra-workflow }} - ${{ github.repository }}@${{ github.ref_name }}"
+          waitFor: true
+          printBuildLogs: true
+          buildEnvVars: |
+            GITHUB_SHA=${{ github.sha }}
+            BRANCH_NAME=${{ github.ref_name }}
+            DRA_WORKFLOW=${{ matrix.dra-workflow }}
+
+      - if: failure()
+        uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          slackChannel: "#apm-server"


### PR DESCRIPTION
## Motivation/summary

Use GitHub actions and Buildkite to package and run the DRA.

This will run on push events or manually.

## How to test these changes

In the CI

## Related issues

Requires https://github.com/elastic/apm-server/pull/11373 and https://github.com/elastic/apm-server/pull/11399


## Tasks

- [ ] exclude if main and staging.
- [ ] exclude if branch is not supported anymore isBranchUnifiedReleaseAvailable()
- [ ] upload/download artifacts so they can be consumed when running the DRA.
- [ ] Add pipeline in the catalog entry