### PR TITLE
Disable aggregation on GOARCH=386

### DIFF
--- a/x-pack/apm-server/aggregation.go
+++ b/x-pack/apm-server/aggregation.go
@@ -1,0 +1,30 @@
+//go:build !386
+
+package main
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/elastic/apm-server/internal/beater"
+	"github.com/elastic/apm-server/x-pack/apm-server/aggregation"
+)
+
+func newAggregationProcessors(args beater.ServerParams) ([]namedProcessor, error) {
+	var processors []namedProcessor
+
+	name := "LSM aggregator"
+	agg, err := aggregation.New(
+		args.Config.Aggregation.MaxServices,
+		args.Config.Aggregation.Transactions.MaxGroups,
+		args.Config.Aggregation.ServiceTransactions.MaxGroups,
+		args.Config.Aggregation.ServiceDestinations.MaxGroups,
+		args.BatchProcessor,
+		args.Logger,
+	)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating %s", name)
+	}
+	processors = append(processors, namedProcessor{name: name, processor: agg})
+
+	return processors, nil
+}

--- a/x-pack/apm-server/aggregation_386.go
+++ b/x-pack/apm-server/aggregation_386.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/elastic/apm-server/internal/beater"
+
+func newAggregationProcessors(args beater.ServerParams) ([]namedProcessor, error) {
+	return nil, nil
+}

--- a/x-pack/apm-server/main.go
+++ b/x-pack/apm-server/main.go
@@ -28,7 +28,6 @@ import (
 	"github.com/elastic/apm-data/model/modelprocessor"
 	"github.com/elastic/apm-server/internal/beatcmd"
 	"github.com/elastic/apm-server/internal/beater"
-	"github.com/elastic/apm-server/x-pack/apm-server/aggregation"
 	"github.com/elastic/apm-server/x-pack/apm-server/sampling"
 	"github.com/elastic/apm-server/x-pack/apm-server/sampling/eventstorage"
 )
@@ -92,19 +91,11 @@ type processor interface {
 func newProcessors(args beater.ServerParams) ([]namedProcessor, error) {
 	var processors []namedProcessor
 
-	name := "LSM aggregator"
-	agg, err := aggregation.New(
-		args.Config.Aggregation.MaxServices,
-		args.Config.Aggregation.Transactions.MaxGroups,
-		args.Config.Aggregation.ServiceTransactions.MaxGroups,
-		args.Config.Aggregation.ServiceDestinations.MaxGroups,
-		args.BatchProcessor,
-		args.Logger,
-	)
+	aggregationProcessors, err := newAggregationProcessors(args)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error creating %s", name)
+		return nil, err
 	}
-	processors = append(processors, namedProcessor{name: name, processor: agg})
+	processors = append(processors, aggregationProcessors...)
 
 	if args.Config.Sampling.Tail.Enabled {
 		const name = "tail sampler"


### PR DESCRIPTION
Temporary workaround to make builds pass

<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

Temporary workaround to disable aggregation on GOARCH=386 to stop builds failing.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
