### PR TITLE
buildkite: package definition

### DIFF
--- a/.buildkite/package.yml
+++ b/.buildkite/package.yml
@@ -1,0 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+
+steps:
+  - label: "Example test"
+    command: echo "Hello!"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -37,9 +37,11 @@ spec:
       repository: elastic/apm-server
       pipeline_file: ".buildkite/package.yml"
       provider_settings:
+        # TODO: delete this section once the BK pipeline works as expected.
+        build_pull_request_forks: true # Enable builds from forks.
         # Will not create any builds based on GitHub activity but it will be
-				# triggered using the GitHub Buildkite composite action.
-        trigger_mode: none
+        # triggered using the GitHub Buildkite composite action.
+        #trigger_mode: none
       cancel_intermediate_builds: false
       skip_intermediate_builds: false
       teams:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,3 +13,37 @@ spec:
   type: tool
   owner: group:apm-server
   lifecycle: production
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-apm-server-package
+  description: Buildkite Pipeline for packaging the APM Server
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/apm-server-package
+
+spec:
+  type: buildkite-pipeline
+  owner: group:apm-server
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: apm-server
+    spec:
+      repository: elastic/apm-server
+      pipeline_file: ".buildkite/package.yml"
+      provider_settings:
+        # Will not create any builds based on GitHub activity but it will be
+				# triggered using the GitHub Buildkite composite action.
+        trigger_mode: none
+      cancel_intermediate_builds: false
+      skip_intermediate_builds: false
+      teams:
+        apm-server: {}
+        observablt-robots: {}
+        everyone:
+          access_level: READ_ONLY

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -38,7 +38,7 @@ spec:
       pipeline_file: ".buildkite/package.yml"
       provider_settings:
         # TODO: delete this section once the BK pipeline works as expected.
-        build_pull_request_forks: true # Enable builds from forks.
+        build_branches: false # Disable builds from branches.
         # Will not create any builds based on GitHub activity but it will be
         # triggered using the GitHub Buildkite composite action.
         #trigger_mode: none


### PR DESCRIPTION
## Motivation/summary

Add Buildkite pipeline definition in the catalog-info.json.

So we can start migrating the Jenkins packaging.

This pipeline will eventually run using https://github.com/elastic/apm-pipeline-library/tree/main/.github/actions/buildkite but for now we will enable the PRs from the origin only. So I can test https://github.com/elastic/apm-server/pull/11374 in isolation.

## How to test these changes

Cannot test these changes on a PR at the moment. `Terrazzo` uses this file then a Buildkite pipeline will be created.

## Related issues

Notifies https://github.com/elastic/apm-server/pull/11374
