### PR TITLE
Use old aggregation for 386 only, in 8.10

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -10,6 +10,34 @@ Third party libraries used by the Elastic APM Server project:
 
 
 --------------------------------------------------------------------------------
+Dependency : github.com/axiomhq/hyperloglog
+Version: v0.0.0-20230201085229-3ddf4bad03dc
+Licence type (autodetected): MIT
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/axiomhq/hyperloglog@v0.0.0-20230201085229-3ddf4bad03dc/LICENSE:
+
+Copyright (c) 2021, Axiom, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--------------------------------------------------------------------------------
 Dependency : github.com/cespare/xxhash/v2
 Version: v2.2.0
 Licence type (autodetected): MIT
@@ -7303,34 +7331,6 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-
---------------------------------------------------------------------------------
-Dependency : github.com/axiomhq/hyperloglog
-Version: v0.0.0-20230201085229-3ddf4bad03dc
-Licence type (autodetected): MIT
---------------------------------------------------------------------------------
-
-Contents of probable licence file $GOMODCACHE/github.com/axiomhq/hyperloglog@v0.0.0-20230201085229-3ddf4bad03dc/LICENSE:
-
-Copyright (c) 2021, Axiom, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 --------------------------------------------------------------------------------
 Dependency : github.com/beorn7/perks

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -26,7 +26,7 @@ https://github.com/elastic/apm-server/compare/8.9\...main[View commits]
 - Add permissions to reroute events in the integration package. {pull}11168[11168]
 
 [float]
-==== Aggregation improvements
+==== Aggregation improvements (except for 386 architecture)
 - Replace aggregation with LSM-based aggregator which has a lower memory footprint {pull}11117[11117]
 - Add `service.language.name` to service destination metrics {pull}11117[11117]
 - Modify per-service transaction groups limit to consider more than service.name; Add per-service service destination groups limit and per-service service transaction groups limit {pull}11117[11117]

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/elastic/apm-server
 go 1.20
 
 require (
+	github.com/axiomhq/hyperloglog v0.0.0-20230201085229-3ddf4bad03dc
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/dgraph-io/badger/v2 v2.2007.3-0.20201012072640-f5a7e0a1c83b
 	github.com/dustin/go-humanize v1.0.1
@@ -15,6 +16,7 @@ require (
 	github.com/elastic/gmux v0.2.0
 	github.com/elastic/go-docappender v0.2.1-0.20230724080315-b714d6181871
 	github.com/elastic/go-elasticsearch/v8 v8.9.0
+	github.com/elastic/go-hdrhistogram v0.1.0
 	github.com/elastic/go-sysinfo v1.11.0
 	github.com/elastic/go-ucfg v0.8.6
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible
@@ -64,7 +66,6 @@ require (
 	github.com/Shopify/sarama v1.38.1 // indirect
 	github.com/apache/thrift v0.18.1 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
-	github.com/axiomhq/hyperloglog v0.0.0-20230201085229-3ddf4bad03dc // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cockroachdb/errors v1.8.1 // indirect
@@ -86,7 +87,6 @@ require (
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/elastic/elastic-agent-shipper-client v0.5.1-0.20230228231646-f04347b666f3 // indirect
 	github.com/elastic/elastic-transport-go/v8 v8.3.0 // indirect
-	github.com/elastic/go-hdrhistogram v0.1.0 // indirect
 	github.com/elastic/go-licenser v0.4.1 // indirect
 	github.com/elastic/go-lumber v0.1.2-0.20220819171948-335fde24ea0f // indirect
 	github.com/elastic/go-structform v0.0.10 // indirect

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/elastic/elastic-agent-shipper-client v0.5.1-0.20230228231646-f04347b666f3 // indirect
 	github.com/elastic/elastic-transport-go/v8 v8.3.0 // indirect
+	github.com/elastic/go-hdrhistogram v0.1.0 // indirect
 	github.com/elastic/go-licenser v0.4.1 // indirect
 	github.com/elastic/go-lumber v0.1.2-0.20220819171948-335fde24ea0f // indirect
 	github.com/elastic/go-structform v0.0.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/elastic/go-docappender v0.2.1-0.20230724080315-b714d6181871 h1:8MRHKw
 github.com/elastic/go-docappender v0.2.1-0.20230724080315-b714d6181871/go.mod h1:yqBlaclEXBY6DCP3d28bf/HjJJcXhd2CCIy0kDuLNjQ=
 github.com/elastic/go-elasticsearch/v8 v8.9.0 h1:8xtmYjUkqtahl50E0Bg/wjKI7K63krJrrLipbNj/fCU=
 github.com/elastic/go-elasticsearch/v8 v8.9.0/go.mod h1:NGmpvohKiRHXI0Sw4fuUGn6hYOmAXlyCphKpzVBiqDE=
+github.com/elastic/go-hdrhistogram v0.1.0 h1:7UVeQ9MsO5c9h8RJeH2S2lXCGi9hQB/94W6Pjjqprc4=
+github.com/elastic/go-hdrhistogram v0.1.0/go.mod h1:NEl0wZTQXzwq7X2WBZGl5G3efcKbvv+r9mTZpXrIs78=
 github.com/elastic/go-licenser v0.3.1/go.mod h1:D8eNQk70FOCVBl3smCGQt/lv7meBeQno2eI1S5apiHQ=
 github.com/elastic/go-licenser v0.4.0/go.mod h1:V56wHMpmdURfibNBggaSBfqgPxyT1Tldns1i87iTEvU=
 github.com/elastic/go-licenser v0.4.1 h1:1xDURsc8pL5zYT9R29425J3vkHdt4RT5TNEMeRN48x4=

--- a/x-pack/apm-server/aggregation/baseaggregator/aggregator.go
+++ b/x-pack/apm-server/aggregation/baseaggregator/aggregator.go
@@ -1,0 +1,155 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package baseaggregator
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+// PublishFunc encapsulates the metric publishing function
+type PublishFunc func(context.Context, time.Duration) error
+
+// AggregatorConfig defined the common aggregator configuration.
+type AggregatorConfig struct {
+	// PublishFunc is the function that performs the actual publishing
+	// of aggregated events.
+	PublishFunc PublishFunc
+
+	// Logger is the logger for logging metrics aggregation/publishing.
+	//
+	// If Logger is nil, a new logger will be constructed.
+	Logger *logp.Logger
+
+	// RollUpIntervals are additional MetricsInterval for the aggregator to
+	// compute and publish metrics for. Each additional interval is constrained
+	// to the same rules as MetricsInterval, and will result in additional
+	// memory to be allocated.
+	RollUpIntervals []time.Duration
+
+	// Interval is the interval between publishing of aggregated metrics.
+	// There may be additional metrics reported at arbitrary times if the
+	// aggregation groups fill up.
+	Interval time.Duration
+}
+
+// Validate validates the aggregator config.
+func (cfg AggregatorConfig) Validate() error {
+	if cfg.PublishFunc == nil {
+		return errors.New("PublishFunc unspecified")
+	}
+	if cfg.Interval <= 0 {
+		return errors.New("Interval unspecified or negative")
+	}
+	if cfg.Logger == nil {
+		return errors.New("Logger unspecified")
+	}
+	for i, interval := range cfg.RollUpIntervals {
+		if interval <= 0 {
+			return errors.Errorf("RollUpIntervals[%d]: unspecified or negative", i)
+		}
+		if interval%cfg.Interval != 0 {
+			return errors.Errorf("RollUpIntervals[%d]: interval must be a multiple of MetricsInterval", i)
+		}
+	}
+	return nil
+}
+
+// Aggregator contains the basic methods for the metrics aggregators to embed.
+type Aggregator struct {
+	stopMu    sync.Mutex
+	stopping  chan struct{}
+	stopped   chan struct{}
+	publish   PublishFunc
+	Intervals []time.Duration
+
+	config AggregatorConfig
+}
+
+// New returns a new base Aggregator.
+func New(cfg AggregatorConfig) (*Aggregator, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid aggregator config")
+	}
+	return &Aggregator{
+		stopping:  make(chan struct{}),
+		stopped:   make(chan struct{}),
+		config:    cfg,
+		publish:   cfg.PublishFunc,
+		Intervals: append([]time.Duration{cfg.Interval}, cfg.RollUpIntervals...),
+	}, nil
+}
+
+// Run runs the Aggregator, periodically publishing and clearing aggregated
+// metrics. Run returns when either a fatal error occurs, or the Aggregator's
+// Stop method is invoked.
+func (a *Aggregator) Run() error {
+	ticker := time.NewTicker(a.config.Interval)
+	defer ticker.Stop()
+	defer func() {
+		a.stopMu.Lock()
+		defer a.stopMu.Unlock()
+		select {
+		case <-a.stopped:
+		default:
+			close(a.stopped)
+		}
+	}()
+	var stop bool
+	var ticks uint64
+	for !stop {
+		select {
+		case <-a.stopping:
+			stop = true
+		case <-ticker.C:
+			ticks++
+		}
+		// Publish the metricsets for all configured intervals.
+		for _, interval := range a.Intervals {
+			// Publish $interval MetricSets when:
+			//  - ticks * MetricsInterval % $interval == 0.
+			//  - Aggregator is stopped.
+			if !stop && (ticks*uint64(a.config.Interval))%uint64(interval) != 0 {
+				continue
+			}
+			if err := a.publish(context.Background(), interval); err != nil {
+				a.config.Logger.With(logp.Error(err)).Warnf(
+					"publishing of %s metrics failed: %s",
+					interval.String(), err,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+// Stop stops the Aggregator if it is running, waiting for it to flush any
+// aggregated metrics and return, or for the context to be cancelled.
+//
+// After Stop has been called the aggregator cannot be reused, as the Run
+// method will always return immediately.
+func (a *Aggregator) Stop(ctx context.Context) error {
+	a.stopMu.Lock()
+	select {
+	case <-a.stopped:
+	case <-a.stopping:
+		// Already stopping/stopped.
+	default:
+		close(a.stopping)
+	}
+	a.stopMu.Unlock()
+
+	select {
+	case <-a.stopped:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return nil
+}

--- a/x-pack/apm-server/aggregation/baseaggregator/space.go
+++ b/x-pack/apm-server/aggregation/baseaggregator/space.go
@@ -1,0 +1,41 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package baseaggregator
+
+import "github.com/pkg/errors"
+
+// Space models a backing array for aggregators to store their metrics. The backing
+// array pre-allocates the required number of entries to reduce GC overhead.
+//
+// Requires protection using mutexes for concurrent usage by the caller.
+// TODO: Update all aggregators to use Space.
+type Space[k any] struct {
+	index int
+	space []k
+}
+
+// NewSpace creates a new space given the max number of elements.
+func NewSpace[k any](limit int) *Space[k] {
+	return &Space[k]{
+		space: make([]k, limit),
+	}
+}
+
+// Next returns the next entry from the space or error if no more entries can be
+// returned.
+func (s *Space[k]) Next() (*k, error) {
+	if s.index == len(s.space) {
+		return nil, errors.New("all entries are used")
+	}
+	e := &s.space[s.index]
+	s.index++
+	return e, nil
+}
+
+// Reset resets the space to be reused. Note that reset doesn't reset the fields
+// for the struct and they must be updated or reset by the caller.
+func (s *Space[k]) Reset() {
+	s.index = 0
+}

--- a/x-pack/apm-server/aggregation/interval/string.go
+++ b/x-pack/apm-server/aggregation/interval/string.go
@@ -1,0 +1,19 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package interval
+
+import (
+	"fmt"
+	"time"
+)
+
+// FormatDuration formats the duration in minutes (when the duration >= 1m), or
+// seconds if smaller.
+func FormatDuration(d time.Duration) string {
+	if duration := d.Minutes(); duration >= 1 {
+		return fmt.Sprintf("%.0fm", duration)
+	}
+	return fmt.Sprintf("%.0fs", d.Seconds())
+}

--- a/x-pack/apm-server/aggregation/labels/labels.go
+++ b/x-pack/apm-server/aggregation/labels/labels.go
@@ -1,0 +1,149 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package labels
+
+import (
+	"encoding/binary"
+	"io"
+	"math"
+	"sort"
+
+	"github.com/elastic/apm-data/model/modelpb"
+)
+
+type AggregatedGlobalLabels struct {
+	labelKeys        []string
+	Labels           modelpb.Labels
+	numericLabelKeys []string
+	NumericLabels    modelpb.NumericLabels
+}
+
+func (a *AggregatedGlobalLabels) Write(w io.Writer) {
+	for _, key := range a.labelKeys {
+		label := a.Labels[key]
+		io.WriteString(w, key)
+		if label.Value != "" {
+			io.WriteString(w, label.Value)
+			continue
+		}
+		for _, v := range label.Values {
+			io.WriteString(w, v)
+		}
+	}
+	for _, key := range a.numericLabelKeys {
+		label := a.NumericLabels[key]
+		io.WriteString(w, key)
+		if label.Value != 0 {
+			var b [8]byte
+			binary.LittleEndian.PutUint64(b[:], math.Float64bits(label.Value))
+			w.Write(b[:])
+			continue
+		}
+		for _, v := range label.Values {
+			var b [8]byte
+			binary.LittleEndian.PutUint64(b[:], math.Float64bits(v))
+			w.Write(b[:])
+		}
+	}
+}
+
+func (a *AggregatedGlobalLabels) Read(event *modelpb.APMEvent) {
+	// Remove global labels for RUM services to avoid explosion of metric groups
+	// to track for servicetxmetrics.
+	// For consistency, this will remove labels for other aggregated metrics as well.
+	switch event.GetAgent().GetName() {
+	case "rum-js", "js-base", "android/java", "iOS/swift":
+		return
+	}
+
+	for k, v := range event.Labels {
+		if !v.Global {
+			continue
+		}
+		if a.Labels == nil {
+			a.Labels = make(modelpb.Labels)
+		}
+		if len(v.Values) > 0 {
+			a.Labels.SetSlice(k, v.Values)
+		} else {
+			a.Labels.Set(k, v.Value)
+		}
+		a.labelKeys = append(a.labelKeys, k)
+	}
+	for k, v := range event.NumericLabels {
+		if !v.Global {
+			continue
+		}
+		if a.NumericLabels == nil {
+			a.NumericLabels = make(modelpb.NumericLabels)
+		}
+		if len(v.Values) > 0 {
+			a.NumericLabels.SetSlice(k, v.Values)
+		} else {
+			a.NumericLabels.Set(k, v.Value)
+		}
+		a.numericLabelKeys = append(a.numericLabelKeys, k)
+	}
+	sort.Strings(a.labelKeys)
+	sort.Strings(a.numericLabelKeys)
+}
+
+func (a *AggregatedGlobalLabels) Equals(x *AggregatedGlobalLabels) bool {
+	return equalLabels(a.Labels, x.Labels) && equalNumericLabels(a.NumericLabels, x.NumericLabels)
+}
+
+// equalLabels returns true if the labels are equal. The Global property is
+// ignored since only global labels are compared.
+func equalLabels(l, labels modelpb.Labels) bool {
+	if len(l) != len(labels) {
+		return false
+	}
+	for key, localV := range l {
+		v, ok := labels[key]
+		if !ok {
+			return false
+		}
+		// If the slice value is set, ignore the Value field.
+		if len(v.Values) == 0 && v.Value != localV.Value {
+			return false
+		}
+		if len(v.Values) != len(localV.Values) {
+			return false
+		}
+		for i, value := range v.Values {
+			if localV.Values[i] != value {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// equalNumericLabels returns true if the labels are equal. The Global property
+// is ignored since only global labels are compared.
+func equalNumericLabels(l, labels modelpb.NumericLabels) bool {
+	if len(l) != len(labels) {
+		return false
+	}
+	for key, localV := range l {
+		v, ok := labels[key]
+		if !ok {
+			return false
+		}
+		// If the slice value is set, ignore the Value field.
+		if len(v.Values) == 0 && v.Value != localV.Value {
+			return false
+		}
+		if len(v.Values) != len(localV.Values) {
+			return false
+		}
+		for i, value := range v.Values {
+			if localV.Values[i] != value {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/x-pack/apm-server/aggregation/labels/labels_test.go
+++ b/x-pack/apm-server/aggregation/labels/labels_test.go
@@ -1,0 +1,185 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package labels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/apm-data/model/modelpb"
+)
+
+func TestLabelsEqual(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		a := modelpb.Labels{
+			"a": &modelpb.LabelValue{Value: "b"},
+			"b": &modelpb.LabelValue{Values: []string{"b", "c", "d", "e"}},
+			"c": &modelpb.LabelValue{Values: []string{"1", "2", "3"}},
+		}
+		b := modelpb.Labels{
+			"a": &modelpb.LabelValue{Value: "b"},
+			"b": &modelpb.LabelValue{Values: []string{"b", "c", "d", "e"}},
+			"c": &modelpb.LabelValue{Values: []string{"1", "2", "3"}, Value: "b"},
+		}
+		assert.True(t, equalLabels(a, b))
+		assert.True(t, equalLabels(b, a))
+	})
+	t.Run("false-length", func(t *testing.T) {
+		a := modelpb.Labels{
+			"a": &modelpb.LabelValue{Value: "b"},
+			"b": &modelpb.LabelValue{Values: []string{"b", "c", "d", "e"}},
+		}
+		b := modelpb.Labels{
+			"a": &modelpb.LabelValue{Value: "b"},
+			"b": &modelpb.LabelValue{Values: []string{"b", "c", "d", "e"}},
+			"c": &modelpb.LabelValue{Values: []string{"3", "2", "1"}, Value: "b"},
+		}
+		assert.False(t, equalLabels(a, b))
+		assert.False(t, equalLabels(b, a))
+	})
+	t.Run("false-elements-not-match", func(t *testing.T) {
+		a := modelpb.Labels{
+			"a": &modelpb.LabelValue{Value: "b"},
+			"b": &modelpb.LabelValue{Values: []string{"b", "c", "d", "e"}},
+			"d": &modelpb.LabelValue{Value: "c"},
+		}
+		b := modelpb.Labels{
+			"a": &modelpb.LabelValue{Value: "b"},
+			"b": &modelpb.LabelValue{Values: []string{"e", "c", "d", "b"}},
+			"c": &modelpb.LabelValue{Values: []string{"3", "2", "1"}, Value: "b"},
+		}
+		assert.False(t, equalLabels(a, b))
+		assert.False(t, equalLabels(b, a))
+	})
+	t.Run("false-values-not-match", func(t *testing.T) {
+		a := modelpb.Labels{
+			"a": &modelpb.LabelValue{Value: "c"},
+			"b": &modelpb.LabelValue{Values: []string{"b", "c", "d", "e"}},
+			"c": &modelpb.LabelValue{Values: []string{"3", "2", "1"}, Value: "b"},
+		}
+		b := modelpb.Labels{
+			"a": &modelpb.LabelValue{Value: "b"},
+			"b": &modelpb.LabelValue{Values: []string{"b", "c", "d", "e"}},
+			"c": &modelpb.LabelValue{Values: []string{"3", "2", "1"}, Value: "b"},
+		}
+		assert.False(t, equalLabels(a, b))
+		assert.False(t, equalLabels(b, a))
+	})
+	t.Run("false-slices-length-not-match", func(t *testing.T) {
+		a := modelpb.Labels{
+			"a": &modelpb.LabelValue{Value: "b"},
+			"b": &modelpb.LabelValue{Values: []string{"b", "c", "d"}},
+			"c": &modelpb.LabelValue{Values: []string{"3", "2", "1"}, Value: "b"},
+		}
+		b := modelpb.Labels{
+			"a": &modelpb.LabelValue{Value: "b"},
+			"b": &modelpb.LabelValue{Values: []string{"b", "c", "d", "e"}},
+			"c": &modelpb.LabelValue{Values: []string{"3", "2", "1"}, Value: "b"},
+		}
+		assert.False(t, equalLabels(a, b))
+		assert.False(t, equalLabels(b, a))
+	})
+	t.Run("false-slices-elements-not-match", func(t *testing.T) {
+		a := modelpb.Labels{
+			"a": &modelpb.LabelValue{Value: "b"},
+			"b": &modelpb.LabelValue{Values: []string{"b", "c", "d", "a"}},
+			"c": &modelpb.LabelValue{Values: []string{"3", "2", "1"}, Value: "b"},
+		}
+		b := modelpb.Labels{
+			"a": &modelpb.LabelValue{Value: "b"},
+			"b": &modelpb.LabelValue{Values: []string{"e", "c", "d", "b"}},
+			"c": &modelpb.LabelValue{Values: []string{"3", "2", "1"}, Value: "b"},
+		}
+		assert.False(t, equalLabels(a, b))
+		assert.False(t, equalLabels(b, a))
+	})
+}
+
+func TestNumericLabelsEqual(t *testing.T) {
+	t.Run("true", func(t *testing.T) {
+		a := modelpb.NumericLabels{
+			"a": &modelpb.NumericLabelValue{Value: 1},
+			"b": &modelpb.NumericLabelValue{Values: []float64{1.1, 1.2, 1.3, 1.4}},
+			"c": &modelpb.NumericLabelValue{Values: []float64{10, 20, 30}},
+		}
+		b := modelpb.NumericLabels{
+			"a": &modelpb.NumericLabelValue{Value: 1},
+			"b": &modelpb.NumericLabelValue{Values: []float64{1.1, 1.2, 1.3, 1.4}},
+			"c": &modelpb.NumericLabelValue{Values: []float64{10, 20, 30}, Value: 1},
+		}
+		assert.True(t, equalNumericLabels(a, b))
+		assert.True(t, equalNumericLabels(b, a))
+	})
+	t.Run("false-length", func(t *testing.T) {
+		a := modelpb.NumericLabels{
+			"a": &modelpb.NumericLabelValue{Value: 1},
+			"b": &modelpb.NumericLabelValue{Values: []float64{1.1, 1.2, 1.3, 1.4}},
+		}
+		b := modelpb.NumericLabels{
+			"a": &modelpb.NumericLabelValue{Value: 1},
+			"b": &modelpb.NumericLabelValue{Values: []float64{1.1, 1.2, 1.3, 1.4}},
+			"c": &modelpb.NumericLabelValue{Values: []float64{30, 20, 10}, Value: 1},
+		}
+		assert.False(t, equalNumericLabels(a, b))
+		assert.False(t, equalNumericLabels(b, a))
+	})
+	t.Run("false-elements-not-match", func(t *testing.T) {
+		a := modelpb.NumericLabels{
+			"a": &modelpb.NumericLabelValue{Value: 1},
+			"b": &modelpb.NumericLabelValue{Values: []float64{1.1, 1.2, 1.3, 1.4}},
+			"d": &modelpb.NumericLabelValue{Value: 2},
+		}
+		b := modelpb.NumericLabels{
+			"a": &modelpb.NumericLabelValue{Value: 1},
+			"b": &modelpb.NumericLabelValue{Values: []float64{1.1, 1.2, 1.3, 1.4}},
+			"c": &modelpb.NumericLabelValue{Values: []float64{30, 20, 10}, Value: 1},
+		}
+		assert.False(t, equalNumericLabels(a, b))
+		assert.False(t, equalNumericLabels(b, a))
+	})
+	t.Run("false-values-not-match", func(t *testing.T) {
+		a := modelpb.NumericLabels{
+			"a": &modelpb.NumericLabelValue{Value: 1},
+			"b": &modelpb.NumericLabelValue{Values: []float64{1.1, 1.2, 1.3, 1.4}},
+			"c": &modelpb.NumericLabelValue{Value: 2},
+		}
+		b := modelpb.NumericLabels{
+			"a": &modelpb.NumericLabelValue{Value: 1},
+			"b": &modelpb.NumericLabelValue{Values: []float64{1.1, 1.2, 1.3, 1.4}},
+			"c": &modelpb.NumericLabelValue{Values: []float64{30, 20, 10}, Value: 1},
+		}
+		assert.False(t, equalNumericLabels(a, b))
+		assert.False(t, equalNumericLabels(b, a))
+	})
+	t.Run("false-slices-length-not-match", func(t *testing.T) {
+		a := modelpb.NumericLabels{
+			"a": &modelpb.NumericLabelValue{Value: 1},
+			"b": &modelpb.NumericLabelValue{Values: []float64{1.1, 1.2, 1.3}},
+			"c": &modelpb.NumericLabelValue{Values: []float64{30, 20, 10}, Value: 1},
+		}
+		b := modelpb.NumericLabels{
+			"a": &modelpb.NumericLabelValue{Value: 1},
+			"b": &modelpb.NumericLabelValue{Values: []float64{1.1, 1.2, 1.3, 1.4}},
+			"c": &modelpb.NumericLabelValue{Values: []float64{30, 20, 10}, Value: 1},
+		}
+		assert.False(t, equalNumericLabels(a, b))
+		assert.False(t, equalNumericLabels(b, a))
+	})
+	t.Run("false-slices-elements-not-match", func(t *testing.T) {
+		a := modelpb.NumericLabels{
+			"a": &modelpb.NumericLabelValue{Value: 1},
+			"b": &modelpb.NumericLabelValue{Values: []float64{1.1, 1.2, 1.3, 1.5}},
+			"c": &modelpb.NumericLabelValue{Values: []float64{30, 20, 10}, Value: 1},
+		}
+		b := modelpb.NumericLabels{
+			"a": &modelpb.NumericLabelValue{Value: 1},
+			"b": &modelpb.NumericLabelValue{Values: []float64{1.1, 1.2, 1.3, 1.4}},
+			"c": &modelpb.NumericLabelValue{Values: []float64{30, 20, 10}, Value: 1},
+		}
+		assert.False(t, equalNumericLabels(a, b))
+		assert.False(t, equalNumericLabels(b, a))
+	})
+}

--- a/x-pack/apm-server/aggregation/servicesummarymetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/servicesummarymetrics/aggregator.go
@@ -1,0 +1,370 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package servicesummarymetrics
+
+import (
+	"context"
+	"encoding/binary"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/axiomhq/hyperloglog"
+	"github.com/cespare/xxhash/v2"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+
+	"github.com/elastic/apm-data/model/modelpb"
+	"github.com/elastic/apm-server/internal/logs"
+	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/baseaggregator"
+	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/interval"
+	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/labels"
+)
+
+const (
+	metricsetName       = "service_summary"
+	overflowServiceName = "_other"
+)
+
+// AggregatorConfig holds configuration for creating an Aggregator.
+type AggregatorConfig struct {
+	// BatchProcessor is a model.BatchProcessor for asynchronously
+	// processing metrics documents.
+	BatchProcessor modelpb.BatchProcessor
+
+	// Logger is the logger for logging metrics aggregation/publishing.
+	//
+	// If Logger is nil, a new logger will be constructed.
+	Logger *logp.Logger
+
+	// RollUpIntervals are additional MetricsInterval for the aggregator to
+	// compute and publish metrics for. Each additional interval is constrained
+	// to the same rules as MetricsInterval, and will result in additional
+	// memory to be allocated.
+	RollUpIntervals []time.Duration
+
+	// Interval is the interval between publishing of aggregated metrics.
+	Interval time.Duration
+
+	// MaxGroups is the maximum number of distinct service summary metrics to
+	// store within an aggregation period. Once this number of groups is
+	// reached, any new aggregation keys will be aggregated in a dedicated
+	// service group identified by `_other`.
+	MaxGroups int
+}
+
+// Validate validates the aggregator config.
+func (config AggregatorConfig) Validate() error {
+	if config.BatchProcessor == nil {
+		return errors.New("BatchProcessor unspecified")
+	}
+	if config.MaxGroups <= 0 {
+		return errors.New("MaxGroups unspecified or negative")
+	}
+	return nil
+}
+
+// Aggregator aggregates all events, periodically publishing service summary metrics.
+type Aggregator struct {
+	*baseaggregator.Aggregator
+	config  AggregatorConfig
+	metrics *aggregatorMetrics
+
+	mu sync.RWMutex
+	// These two metricsBuffer are set to the same size and act as buffers
+	// for caching and then publishing the metrics as batches.
+	active, inactive map[time.Duration]*metricsBuffer
+}
+
+type aggregatorMetrics struct {
+	activeGroups int64
+	overflow     int64
+}
+
+// NewAggregator returns a new Aggregator with the given config.
+func NewAggregator(config AggregatorConfig) (*Aggregator, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid aggregator config")
+	}
+	if config.Logger == nil {
+		config.Logger = logp.NewLogger(logs.ServiceSummaryMetrics)
+	}
+	aggregator := Aggregator{
+		config:   config,
+		metrics:  &aggregatorMetrics{},
+		active:   make(map[time.Duration]*metricsBuffer),
+		inactive: make(map[time.Duration]*metricsBuffer),
+	}
+	base, err := baseaggregator.New(baseaggregator.AggregatorConfig{
+		PublishFunc:     aggregator.publish, // inject local publish
+		Logger:          config.Logger,
+		Interval:        config.Interval,
+		RollUpIntervals: config.RollUpIntervals,
+	})
+	if err != nil {
+		return nil, err
+	}
+	aggregator.Aggregator = base
+	for _, interval := range aggregator.Intervals {
+		aggregator.active[interval] = newMetricsBuffer(config.MaxGroups)
+		aggregator.inactive[interval] = newMetricsBuffer(config.MaxGroups)
+	}
+	return &aggregator, nil
+}
+
+// CollectMonitoring may be called to collect monitoring metrics from the
+// aggregation. It is intended to be used with libbeat/monitoring.NewFunc.
+//
+// The metrics should be added to the "apm-server.aggregation.servicesummarymetrics" registry.
+func (a *Aggregator) CollectMonitoring(_ monitoring.Mode, V monitoring.Visitor) {
+	V.OnRegistryStart()
+	defer V.OnRegistryFinished()
+
+	activeGroups := int64(atomic.LoadInt64(&a.metrics.activeGroups))
+	overflowed := int64(atomic.LoadInt64(&a.metrics.overflow))
+	monitoring.ReportInt(V, "active_groups", activeGroups)
+	monitoring.ReportInt(V, "overflowed.total", overflowed)
+}
+
+func (a *Aggregator) publish(ctx context.Context, period time.Duration) error {
+	// We hold a.mu only long enough to swap the serviceSummaryMetrics. This will
+	// be blocked by serviceSummaryMetrics updates, which is OK, as we prefer not
+	// to block serviceSummaryMetrics updaters. After the lock is released nothing
+	// will be accessing a.inactive.
+	a.mu.Lock()
+
+	// EXPLAIN: We swap active <-> inactive, so that we're only working on the
+	// inactive property while publish is running. `a.active` is the buffer that
+	// receives/stores/updates the metricsets, once swapped, we're working on the
+	// `a.inactive` which we're going to process and publish.
+	current := a.active[period]
+	a.active[period], a.inactive[period] = a.inactive[period], current
+	a.mu.Unlock()
+
+	if current.entries == 0 {
+		a.config.Logger.Debugf("no service summary metrics to publish")
+		return nil
+	}
+
+	size := current.entries
+	if current.other != nil {
+		size++
+	}
+
+	intervalStr := interval.FormatDuration(period)
+	isMetricsPeriod := period == a.config.Interval
+	batch := make(modelpb.Batch, 0, size)
+	for key, metrics := range current.m {
+		for _, entry := range metrics {
+			m := makeMetricset(*entry, intervalStr)
+			batch = append(batch, m)
+		}
+		delete(current.m, key)
+	}
+	if current.other != nil {
+		overflowCount := current.otherCardinalityEstimator.Estimate()
+		if isMetricsPeriod {
+			atomic.AddInt64(&a.metrics.activeGroups, int64(current.entries))
+			atomic.AddInt64(&a.metrics.overflow, int64(overflowCount))
+		}
+		m := makeMetricset(*current.other, intervalStr)
+		m.Metricset.Samples = append(m.Metricset.Samples, &modelpb.MetricsetSample{
+			Name:  "service_summary.aggregation.overflow_count",
+			Value: float64(overflowCount),
+		})
+		batch = append(batch, m)
+	}
+
+	// Clean up everything.
+	current.entries = 0
+	current.other = nil
+	current.otherCardinalityEstimator = nil
+
+	a.config.Logger.Debugf("publishing %d metricsets", len(batch))
+	return a.config.BatchProcessor.ProcessBatch(ctx, &batch)
+}
+
+// ProcessBatch aggregates all service summary metrics.
+func (a *Aggregator) ProcessBatch(ctx context.Context, b *modelpb.Batch) error {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for _, event := range *b {
+		if event.Type() == modelpb.SpanEventType {
+			// Ignoring spans since they add no value.
+			continue
+		}
+		a.processEvent(event)
+	}
+	return nil
+}
+
+func (a *Aggregator) processEvent(event *modelpb.APMEvent) {
+	for _, interval := range a.Intervals {
+		key := makeAggregationKey(event, interval)
+		a.active[interval].storeOrUpdate(key, interval, a.config.Logger)
+	}
+}
+
+type metricsBuffer struct {
+	mu                        sync.RWMutex
+	m                         map[uint64][]*aggregationKey
+	other                     *aggregationKey
+	otherCardinalityEstimator *hyperloglog.Sketch
+
+	// Number of aggregation keys in m, excluding overflow bucket.
+	entries int
+
+	maxSize int
+}
+
+func newMetricsBuffer(maxSize int) *metricsBuffer {
+	return &metricsBuffer{
+		maxSize: maxSize,
+		m:       make(map[uint64][]*aggregationKey),
+	}
+}
+
+func (mb *metricsBuffer) storeOrUpdate(
+	key aggregationKey,
+	interval time.Duration,
+	logger *logp.Logger,
+) {
+	hash := key.hash()
+
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+
+	// Search in hash table with separate chaining.
+	entries, ok := mb.m[hash]
+	if ok {
+		ok = false
+		for _, old := range entries {
+			if old.equal(key) {
+				ok = true
+				break
+			}
+		}
+	}
+
+	if ok {
+		return
+	}
+
+	if mb.entries >= mb.maxSize {
+		if mb.otherCardinalityEstimator == nil {
+			logger.Warnf(`
+Service aggregation group limit of %d reached, new metric documents will be grouped
+under a dedicated bucket identified by service name '%s'.`[1:], mb.maxSize, overflowServiceName)
+			key = makeOverflowAggregationKey(interval)
+			mb.other = &key
+			mb.otherCardinalityEstimator = hyperloglog.New14()
+		}
+		mb.otherCardinalityEstimator.InsertHash(hash)
+	} else {
+		mb.m[hash] = append(mb.m[hash], &key)
+		mb.entries++
+	}
+}
+
+type aggregationKey struct {
+	labels.AggregatedGlobalLabels
+	comparable
+}
+
+func (k *aggregationKey) hash() uint64 {
+	var h xxhash.Digest
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(k.timestamp.UnixNano()))
+	h.Write(buf[:])
+
+	k.AggregatedGlobalLabels.Write(&h)
+	h.WriteString(k.agentName)
+	h.WriteString(k.serviceEnvironment)
+	h.WriteString(k.serviceName)
+	h.WriteString(k.serviceLanguageName)
+	return h.Sum64()
+}
+
+func (k *aggregationKey) equal(key aggregationKey) bool {
+	return k.comparable == key.comparable &&
+		k.AggregatedGlobalLabels.Equals(&key.AggregatedGlobalLabels)
+}
+
+type comparable struct {
+	timestamp time.Time
+
+	agentName           string
+	serviceName         string
+	serviceEnvironment  string
+	serviceLanguageName string
+}
+
+func makeAggregationKey(event *modelpb.APMEvent, interval time.Duration) aggregationKey {
+	key := aggregationKey{
+		comparable: comparable{
+			agentName:           event.GetAgent().GetName(),
+			serviceName:         event.GetService().GetName(),
+			serviceEnvironment:  event.GetService().GetEnvironment(),
+			serviceLanguageName: event.GetService().GetLanguage().GetName(),
+		},
+	}
+	if event.Timestamp != nil {
+		// Group metrics by time interval.
+		key.comparable.timestamp = event.Timestamp.AsTime().Truncate(interval)
+	}
+	key.AggregatedGlobalLabels.Read(event)
+	return key
+}
+
+func makeOverflowAggregationKey(interval time.Duration) aggregationKey {
+	return aggregationKey{
+		comparable: comparable{
+			// We are using `time.Now` here to align the overflow aggregation to
+			// the evaluation time rather than event time. This prevents us from
+			// cases of bad timestamps when the server receives some events with
+			// old timestamp and these events overflow causing the indexed event
+			// to have old timestamp too.
+			timestamp:   time.Now().Truncate(interval),
+			serviceName: overflowServiceName,
+		},
+	}
+}
+
+func makeMetricset(key aggregationKey, interval string) *modelpb.APMEvent {
+	var t *timestamppb.Timestamp
+	if !key.timestamp.IsZero() {
+		t = timestamppb.New(key.timestamp)
+	}
+	var agent *modelpb.Agent
+	if key.agentName != "" {
+		agent = &modelpb.Agent{Name: key.agentName}
+	}
+
+	var language *modelpb.Language
+	if key.serviceLanguageName != "" {
+		language = &modelpb.Language{
+			Name: key.serviceLanguageName,
+		}
+	}
+
+	return &modelpb.APMEvent{
+		Timestamp: t,
+		Service: &modelpb.Service{
+			Name:        key.serviceName,
+			Environment: key.serviceEnvironment,
+			Language:    language,
+		},
+		Agent:         agent,
+		Labels:        key.Labels,
+		NumericLabels: key.NumericLabels,
+		Metricset: &modelpb.Metricset{
+			Name:     metricsetName,
+			Interval: interval,
+		},
+	}
+}

--- a/x-pack/apm-server/aggregation/servicesummarymetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/servicesummarymetrics/aggregator.go
@@ -312,10 +312,10 @@ func makeAggregationKey(event *modelpb.APMEvent, interval time.Duration) aggrega
 			serviceLanguageName: event.GetService().GetLanguage().GetName(),
 		},
 	}
-	if event.Timestamp != 0 {
-		// Group metrics by time interval.
-		key.comparable.timestamp = time.Unix(0, int64(event.Timestamp)).Truncate(interval)
-	}
+
+	// Group metrics by time interval.
+	key.comparable.timestamp = time.Unix(0, int64(event.Timestamp)).Truncate(interval)
+
 	key.AggregatedGlobalLabels.Read(event)
 	return key
 }

--- a/x-pack/apm-server/aggregation/servicesummarymetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/servicesummarymetrics/aggregator_test.go
@@ -1,0 +1,376 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package servicesummarymetrics
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-data/model/modelpb"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+func TestNewAggregatorConfigInvalid(t *testing.T) {
+	report := makeErrBatchProcessor(nil)
+
+	type test struct {
+		config AggregatorConfig
+		err    string
+	}
+
+	for _, test := range []test{{
+		config: AggregatorConfig{},
+		err:    "BatchProcessor unspecified",
+	}, {
+		config: AggregatorConfig{
+			BatchProcessor: report,
+		},
+		err: "MaxGroups unspecified or negative",
+	}, {
+		config: AggregatorConfig{
+			BatchProcessor: report,
+			MaxGroups:      1,
+		},
+		err: "Interval unspecified or negative",
+	}} {
+		agg, err := NewAggregator(test.config)
+		require.Error(t, err)
+		require.Nil(t, agg)
+		assert.EqualError(t, err, "invalid aggregator config: "+test.err)
+	}
+}
+
+func TestAggregatorRun(t *testing.T) {
+	batches := make(chan modelpb.Batch, 3)
+	config := AggregatorConfig{
+		BatchProcessor:  makeChanBatchProcessor(batches),
+		Interval:        1 * time.Millisecond,
+		RollUpIntervals: []time.Duration{200 * time.Millisecond, time.Second},
+		MaxGroups:       1000,
+	}
+	agg, err := NewAggregator(config)
+	require.NoError(t, err)
+
+	apmEvents := []*modelpb.APMEvent{
+		{
+			Agent:   &modelpb.Agent{Name: "java"},
+			Service: &modelpb.Service{Name: "backend", Language: &modelpb.Language{Name: "java"}},
+			Event: &modelpb.Event{
+				Outcome:  "success",
+				Duration: durationpb.New(time.Millisecond),
+			},
+			Transaction: &modelpb.Transaction{
+				Name:                "transaction_name",
+				Type:                "request",
+				RepresentativeCount: 1,
+			},
+			Labels: modelpb.Labels{
+				"department_name": &modelpb.LabelValue{Global: true, Value: "apm"},
+				"organization":    &modelpb.LabelValue{Global: true, Value: "observability"},
+				"company":         &modelpb.LabelValue{Global: true, Value: "elastic"},
+			},
+			NumericLabels: modelpb.NumericLabels{
+				"user_id":     &modelpb.NumericLabelValue{Global: true, Value: 100},
+				"cost_center": &modelpb.NumericLabelValue{Global: true, Value: 10},
+			},
+		},
+		{
+			Agent: &modelpb.Agent{
+				Name:    "java",
+				Version: "unknown",
+			},
+			Service: &modelpb.Service{
+				Name:     "backend",
+				Language: &modelpb.Language{Name: "java"},
+			},
+			Message: "a random log message",
+			Event: &modelpb.Event{
+				Severity: uint64(plog.SeverityNumberInfo),
+			},
+			Log:   &modelpb.Log{Level: "Info"},
+			Span:  &modelpb.Span{Id: "0200000000000000"},
+			Trace: &modelpb.Trace{Id: "01000000000000000000000000000000"},
+			Labels: modelpb.Labels{
+				"department_name": &modelpb.LabelValue{Global: true, Value: "apm"},
+				"organization":    &modelpb.LabelValue{Global: true, Value: "observability"},
+				"company":         &modelpb.LabelValue{Global: true, Value: "elastic"},
+			},
+			NumericLabels: modelpb.NumericLabels{
+				"user_id":     &modelpb.NumericLabelValue{Global: true, Value: 100},
+				"cost_center": &modelpb.NumericLabelValue{Global: true, Value: 10},
+			},
+		},
+		{
+			Agent: &modelpb.Agent{
+				Name: "go",
+			},
+			Service: &modelpb.Service{
+				Name:     "backend",
+				Language: &modelpb.Language{Name: "go"},
+			},
+			Error: &modelpb.Error{},
+		},
+		{
+			Agent: &modelpb.Agent{
+				Name: "go",
+			},
+			Service: &modelpb.Service{
+				Name:        "backend",
+				Environment: "dev",
+				Language:    &modelpb.Language{Name: "go"},
+			},
+		},
+		{
+			Agent: &modelpb.Agent{
+				Name: "js-base",
+			},
+			Service: &modelpb.Service{
+				Name: "frontend",
+			},
+			Span: &modelpb.Span{
+				Type: "span_type",
+			},
+		},
+	}
+
+	var wg sync.WaitGroup
+	for _, in := range apmEvents {
+		wg.Add(1)
+		go func(in *modelpb.APMEvent) {
+			defer wg.Done()
+			batch := modelpb.Batch{in}
+			err := agg.ProcessBatch(context.Background(), &batch)
+			require.NoError(t, err)
+			assert.Equal(t, modelpb.Batch{in}, batch)
+		}(in)
+	}
+	wg.Wait()
+
+	// Start the aggregator after processing to ensure metrics are aggregated deterministically.
+	go agg.Run()
+	defer agg.Stop(context.Background())
+	// Stop the aggregator to ensure all metrics are published.
+	assert.NoError(t, agg.Stop(context.Background()))
+
+	for _, interval := range append([]time.Duration{config.Interval}, config.RollUpIntervals...) {
+		batch := expectBatch(t, batches)
+		metricsets := batchMetricsets(t, batch)
+		expected := []*modelpb.APMEvent{{
+			Metricset: &modelpb.Metricset{
+				Name: "service_summary", Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
+			},
+			Service: &modelpb.Service{Name: "backend", Language: &modelpb.Language{Name: "java"}},
+			Agent:   &modelpb.Agent{Name: "java"},
+			Labels: modelpb.Labels{
+				"department_name": &modelpb.LabelValue{Value: "apm"},
+				"organization":    &modelpb.LabelValue{Value: "observability"},
+				"company":         &modelpb.LabelValue{Value: "elastic"},
+			},
+			NumericLabels: modelpb.NumericLabels{
+				"user_id":     &modelpb.NumericLabelValue{Value: 100},
+				"cost_center": &modelpb.NumericLabelValue{Value: 10},
+			},
+		}, {
+			Metricset: &modelpb.Metricset{
+				Name: "service_summary", Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
+			},
+			Service: &modelpb.Service{Name: "backend", Language: &modelpb.Language{Name: "go"}},
+			Agent:   &modelpb.Agent{Name: "go"},
+		}, {
+			Metricset: &modelpb.Metricset{
+				Name: "service_summary", Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
+			},
+			Service: &modelpb.Service{Name: "backend", Environment: "dev", Language: &modelpb.Language{Name: "go"}},
+			Agent:   &modelpb.Agent{Name: "go"},
+		}}
+
+		assert.Equal(t, len(expected), len(metricsets))
+		assert.Empty(t, cmp.Diff(expected, metricsets,
+			protocmp.Transform(),
+			cmpopts.SortSlices(func(e1 *modelpb.APMEvent, e2 *modelpb.APMEvent) bool {
+				if e1.Agent.Name != e2.Agent.Name {
+					return e1.Agent.Name < e2.Agent.Name
+				}
+
+				return e1.Service.Environment < e2.Service.Environment
+
+			}),
+		))
+	}
+
+	select {
+	case <-batches:
+		t.Fatal("unexpected publish")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestAggregateTimestamp(t *testing.T) {
+	batches := make(chan modelpb.Batch, 1)
+	agg, err := NewAggregator(AggregatorConfig{
+		BatchProcessor: makeChanBatchProcessor(batches),
+		Interval:       30 * time.Second,
+		MaxGroups:      1000,
+	})
+	require.NoError(t, err)
+
+	t0 := time.Unix(0, 0).UTC()
+	for _, ts := range []time.Time{t0, t0.Add(15 * time.Second), t0.Add(30 * time.Second)} {
+		transaction := makeTransaction("service_name", "agent_name", "", "tx_type", "success", 100*time.Millisecond, 1)
+		transaction.Timestamp = timestamppb.New(ts)
+		batch := modelpb.Batch{transaction}
+		err = agg.ProcessBatch(context.Background(), &batch)
+		require.NoError(t, err)
+		assert.Empty(t, batchMetricsets(t, batch))
+	}
+
+	go agg.Run()
+	err = agg.Stop(context.Background()) // stop to flush
+	require.NoError(t, err)
+
+	batch := expectBatch(t, batches)
+	metricsets := batchMetricsets(t, batch)
+	require.Len(t, metricsets, 2)
+	sort.Slice(metricsets, func(i, j int) bool {
+		return metricsets[i].Timestamp.AsTime().Before(metricsets[j].Timestamp.AsTime())
+	})
+	assert.Equal(t, t0, metricsets[0].Timestamp.AsTime())
+	assert.Equal(t, t0.Add(30*time.Second), metricsets[1].Timestamp.AsTime())
+}
+
+func TestAggregatorOverflow(t *testing.T) {
+	maxGrps := 4
+	overflowCount := 100
+	txnDuration := 100 * time.Millisecond
+	batches := make(chan modelpb.Batch, 1)
+	agg, err := NewAggregator(AggregatorConfig{
+		BatchProcessor: makeChanBatchProcessor(batches),
+		Interval:       10 * time.Second,
+		MaxGroups:      maxGrps,
+	})
+	require.NoError(t, err)
+
+	batch := make(modelpb.Batch, maxGrps+overflowCount) // cause overflow
+	for i := 0; i < len(batch); i++ {
+		batch[i] = makeTransaction(
+			fmt.Sprintf("svc%d", i), "java", "agent", "tx_type", "success", txnDuration, 1,
+		)
+	}
+	go func(t *testing.T) {
+		t.Helper()
+		require.NoError(t, agg.Run())
+	}(t)
+	require.NoError(t, agg.ProcessBatch(context.Background(), &batch))
+	require.NoError(t, agg.Stop(context.Background()))
+	metricsets := batchMetricsets(t, expectBatch(t, batches))
+	require.Len(t, metricsets, maxGrps+1) // only one `other` metric should overflow
+
+	// assert monitoring
+	registry := monitoring.NewRegistry()
+	monitoring.NewFunc(registry, "servicesummarymetrics", agg.CollectMonitoring)
+	expectedMonitoring := monitoring.MakeFlatSnapshot()
+	expectedMonitoring.Ints["servicesummarymetrics.active_groups"] = int64(maxGrps)
+	expectedMonitoring.Ints["servicesummarymetrics.overflowed.total"] = int64(overflowCount)
+
+	var overflowEvent *modelpb.APMEvent
+	for i := range metricsets {
+		m := metricsets[i]
+		if m.Service.Name == "_other" {
+			if overflowEvent != nil {
+				require.Fail(t, "only one service should overflow")
+			}
+			overflowEvent = m
+		}
+	}
+	assert.Empty(t, cmp.Diff(&modelpb.APMEvent{
+		Service: &modelpb.Service{
+			Name: "_other",
+		},
+		Metricset: &modelpb.Metricset{
+			Name:     "service_summary",
+			Interval: "10s",
+			Samples: []*modelpb.MetricsetSample{
+				{
+					Name:  "service_summary.aggregation.overflow_count",
+					Value: float64(overflowCount),
+				},
+			},
+		},
+	}, overflowEvent,
+		protocmp.Transform(),
+		protocmp.IgnoreFields(&modelpb.APMEvent{}, "timestamp"),
+	))
+}
+
+func makeTransaction(
+	serviceName, serviceLanguageName, agentName, transactionType, outcome string,
+	duration time.Duration, count float64,
+) *modelpb.APMEvent {
+	return &modelpb.APMEvent{
+		Agent:   &modelpb.Agent{Name: agentName},
+		Service: &modelpb.Service{Name: serviceName, Language: &modelpb.Language{Name: serviceLanguageName}},
+		Event: &modelpb.Event{
+			Outcome:  outcome,
+			Duration: durationpb.New(duration),
+		},
+		Transaction: &modelpb.Transaction{
+			Name:                "transaction_name",
+			Type:                transactionType,
+			RepresentativeCount: count,
+		},
+	}
+}
+
+func makeErrBatchProcessor(err error) modelpb.BatchProcessor {
+	return modelpb.ProcessBatchFunc(func(context.Context, *modelpb.Batch) error { return err })
+}
+
+func makeChanBatchProcessor(ch chan<- modelpb.Batch) modelpb.BatchProcessor {
+	return modelpb.ProcessBatchFunc(func(ctx context.Context, batch *modelpb.Batch) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ch <- *batch:
+			return nil
+		}
+	})
+}
+
+func expectBatch(t *testing.T, ch <-chan modelpb.Batch) modelpb.Batch {
+	t.Helper()
+	select {
+	case batch := <-ch:
+		return batch
+	case <-time.After(time.Second * 5):
+		t.Fatal("expected publish")
+	}
+	panic("unreachable")
+}
+
+func batchMetricsets(t testing.TB, batch modelpb.Batch) []*modelpb.APMEvent {
+	var metricsets []*modelpb.APMEvent
+	for _, event := range batch {
+		if event.Metricset == nil {
+			continue
+		}
+		metricsets = append(metricsets, event)
+	}
+	return metricsets
+}

--- a/x-pack/apm-server/aggregation/servicetxmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/servicetxmetrics/aggregator.go
@@ -381,10 +381,9 @@ func makeAggregationKey(event *modelpb.APMEvent, interval time.Duration) aggrega
 			transactionType:     event.GetTransaction().GetType(),
 		},
 	}
-	if event.Timestamp != 0 {
-		// Group metrics by time interval.
-		key.comparable.timestamp = time.Unix(0, int64(event.Timestamp)).Truncate(interval)
-	}
+	// Group metrics by time interval.
+	key.comparable.timestamp = time.Unix(0, int64(event.Timestamp)).Truncate(interval)
+
 	key.AggregatedGlobalLabels.Read(event)
 	return key
 }

--- a/x-pack/apm-server/aggregation/servicetxmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/servicetxmetrics/aggregator.go
@@ -1,0 +1,527 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package servicetxmetrics
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/axiomhq/hyperloglog"
+	"github.com/cespare/xxhash/v2"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+	"github.com/elastic/go-hdrhistogram"
+
+	"github.com/elastic/apm-data/model/modelpb"
+	"github.com/elastic/apm-server/internal/logs"
+	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/baseaggregator"
+	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/interval"
+	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/labels"
+)
+
+const (
+	metricsetName       = "service_transaction"
+	overflowServiceName = "_other"
+
+	minDuration time.Duration = 0
+	maxDuration time.Duration = time.Hour
+
+	histogramCountScale = 1000
+)
+
+// AggregatorConfig holds configuration for creating an Aggregator.
+type AggregatorConfig struct {
+	// BatchProcessor is a model.BatchProcessor for asynchronously
+	// processing metrics documents.
+	BatchProcessor modelpb.BatchProcessor
+
+	// Logger is the logger for logging metrics aggregation/publishing.
+	//
+	// If Logger is nil, a new logger will be constructed.
+	Logger *logp.Logger
+
+	// RollUpIntervals are additional MetricsInterval for the aggregator to
+	// compute and publish metrics for. Each additional interval is constrained
+	// to the same rules as MetricsInterval, and will result in additional
+	// memory to be allocated.
+	RollUpIntervals []time.Duration
+
+	// Interval is the interval between publishing of aggregated metrics.
+	// There may be additional metrics reported at arbitrary times if the
+	// aggregation groups fill up.
+	Interval time.Duration
+
+	// MaxGroups is the maximum number of distinct service transaction metrics
+	// to store within an aggregation period. Once this number of groups is
+	// reached, any new aggregation keys will be aggregated in a dedicated
+	// service group identified by `_other`.
+	MaxGroups int
+
+	// HDRHistogramSignificantFigures is the number of significant figures
+	// to maintain in the HDR Histograms. HDRHistogramSignificantFigures
+	// must be in the range [1,5].
+	HDRHistogramSignificantFigures int
+}
+
+// Validate validates the aggregator config.
+func (config AggregatorConfig) Validate() error {
+	if config.BatchProcessor == nil {
+		return errors.New("BatchProcessor unspecified")
+	}
+	if config.MaxGroups <= 0 {
+		return errors.New("MaxGroups unspecified or negative")
+	}
+	if n := config.HDRHistogramSignificantFigures; n < 1 || n > 5 {
+		return errors.Errorf("HDRHistogramSignificantFigures (%d) outside range [1,5]", n)
+	}
+	return nil
+}
+
+// Aggregator aggregates service latency and throughput, periodically publishing service transaction metrics.
+type Aggregator struct {
+	*baseaggregator.Aggregator
+	config  AggregatorConfig
+	metrics *aggregatorMetrics
+
+	mu sync.RWMutex
+	// These two metricsBuffer are set to the same size and act as buffers
+	// for caching and then publishing the metrics as batches.
+	active, inactive map[time.Duration]*metricsBuffer
+
+	histogramPool sync.Pool
+}
+
+type aggregatorMetrics struct {
+	activeGroups int64
+	overflow     int64
+}
+
+// NewAggregator returns a new Aggregator with the given config.
+func NewAggregator(config AggregatorConfig) (*Aggregator, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid aggregator config")
+	}
+	if config.Logger == nil {
+		config.Logger = logp.NewLogger(logs.ServiceTransactionMetrics)
+	}
+	aggregator := Aggregator{
+		config:   config,
+		metrics:  &aggregatorMetrics{},
+		active:   make(map[time.Duration]*metricsBuffer),
+		inactive: make(map[time.Duration]*metricsBuffer),
+		histogramPool: sync.Pool{New: func() interface{} {
+			return hdrhistogram.New(
+				minDuration.Microseconds(),
+				maxDuration.Microseconds(),
+				config.HDRHistogramSignificantFigures,
+			)
+		}},
+	}
+	base, err := baseaggregator.New(baseaggregator.AggregatorConfig{
+		PublishFunc:     aggregator.publish, // inject local publish
+		Logger:          config.Logger,
+		Interval:        config.Interval,
+		RollUpIntervals: config.RollUpIntervals,
+	})
+	if err != nil {
+		return nil, err
+	}
+	aggregator.Aggregator = base
+	for _, interval := range aggregator.Intervals {
+		aggregator.active[interval] = newMetricsBuffer(config.MaxGroups, &aggregator.histogramPool)
+		aggregator.inactive[interval] = newMetricsBuffer(config.MaxGroups, &aggregator.histogramPool)
+	}
+	return &aggregator, nil
+}
+
+// CollectMonitoring may be called to collect monitoring metrics from the
+// aggregation. It is intended to be used with libbeat/monitoring.NewFunc.
+//
+// The metrics should be added to the "apm-server.aggregation.servicetxmetrics" registry.
+func (a *Aggregator) CollectMonitoring(_ monitoring.Mode, V monitoring.Visitor) {
+	V.OnRegistryStart()
+	defer V.OnRegistryFinished()
+
+	activeGroups := int64(atomic.LoadInt64(&a.metrics.activeGroups))
+	overflowed := int64(atomic.LoadInt64(&a.metrics.overflow))
+	monitoring.ReportInt(V, "active_groups", activeGroups)
+	monitoring.ReportInt(V, "overflowed.total", overflowed)
+}
+
+func (a *Aggregator) publish(ctx context.Context, period time.Duration) error {
+	// We hold a.mu only long enough to swap the serviceTxMetrics. This will
+	// be blocked by serviceTxMetrics updates, which is OK, as we prefer not
+	// to block serviceTxMetrics updaters. After the lock is released nothing
+	// will be accessing a.inactive.
+	a.mu.Lock()
+
+	// EXPLAIN: We swap active <-> inactive, so that we're only working on the
+	// inactive property while publish is running. `a.active` is the buffer that
+	// receives/stores/updates the metricsets, once swapped, we're working on the
+	// `a.inactive` which we're going to process and publish.
+	current := a.active[period]
+	a.active[period], a.inactive[period] = a.inactive[period], current
+	a.mu.Unlock()
+
+	if current.entries == 0 {
+		a.config.Logger.Debugf("no service transaction metrics to publish")
+		return nil
+	}
+
+	size := current.entries
+	if current.other != nil {
+		size++
+	}
+
+	isMetricsPeriod := period == a.config.Interval
+	intervalStr := interval.FormatDuration(period)
+	batch := make(modelpb.Batch, 0, size)
+	for key, metrics := range current.m {
+		for _, entry := range metrics {
+			// Record the metricset interval as metricset.interval.
+			m := makeMetricset(entry.aggregationKey, entry.serviceTxMetrics, intervalStr)
+			batch = append(batch, m)
+			entry.histogram.Reset()
+			a.histogramPool.Put(entry.histogram)
+			entry.histogram = nil
+		}
+		delete(current.m, key)
+	}
+	if current.other != nil {
+		overflowCount := current.otherCardinalityEstimator.Estimate()
+		if isMetricsPeriod {
+			atomic.AddInt64(&a.metrics.activeGroups, int64(current.entries))
+			atomic.AddInt64(&a.metrics.overflow, int64(overflowCount))
+		}
+		entry := current.other
+		// Record the metricset interval as metricset.interval.
+		m := makeMetricset(entry.aggregationKey, entry.serviceTxMetrics, intervalStr)
+		m.Metricset.Samples = append(m.Metricset.Samples, &modelpb.MetricsetSample{
+			Name:  "service_transaction.aggregation.overflow_count",
+			Value: float64(overflowCount),
+		})
+		batch = append(batch, m)
+		entry.histogram.Reset()
+		a.histogramPool.Put(entry.histogram)
+		entry.histogram = nil
+		current.other = nil
+		current.otherCardinalityEstimator = nil
+	}
+	current.entries = 0
+	a.config.Logger.Debugf("publishing %d metricsets", len(batch))
+	return a.config.BatchProcessor.ProcessBatch(ctx, &batch)
+}
+
+// ProcessBatch aggregates all service latency metrics.
+//
+// To contain cardinality of the aggregated metrics the following
+// limits are considered:
+//
+//   - MaxGroups: Limits the total number of services that the
+//     service transaction metrics aggregator produces. Once this limit is
+//     breached the metrics are aggregated in a dedicated bucket
+//     with `service.name` as `_other`.
+func (a *Aggregator) ProcessBatch(ctx context.Context, b *modelpb.Batch) error {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for _, event := range *b {
+		tx := event.Transaction
+		if event.Type() == modelpb.TransactionEventType && tx != nil {
+			a.processTransaction(event)
+		}
+	}
+	return nil
+}
+
+func (a *Aggregator) processTransaction(event *modelpb.APMEvent) {
+	if event.Transaction == nil || event.Transaction.RepresentativeCount <= 0 {
+		return
+	}
+	for _, interval := range a.Intervals {
+		key := makeAggregationKey(event, interval)
+		metrics := makeServiceTxMetrics(event)
+		a.active[interval].storeOrUpdate(key, metrics, interval, a.config.Logger)
+	}
+}
+
+type metricsBuffer struct {
+	mu                        sync.RWMutex
+	m                         map[uint64][]*metricsMapEntry
+	other                     *metricsMapEntry
+	otherCardinalityEstimator *hyperloglog.Sketch
+	space                     []metricsMapEntry
+	entries                   int
+
+	maxSize int
+
+	histogramPool *sync.Pool
+}
+
+func newMetricsBuffer(maxSize int, histogramPool *sync.Pool) *metricsBuffer {
+	return &metricsBuffer{
+		maxSize: maxSize,
+		// keep one reserved entry for overflow bucket
+		space:         make([]metricsMapEntry, maxSize+1),
+		m:             make(map[uint64][]*metricsMapEntry),
+		histogramPool: histogramPool,
+	}
+}
+
+type metricsMapEntry struct {
+	aggregationKey
+	serviceTxMetrics
+}
+
+func (mb *metricsBuffer) storeOrUpdate(
+	key aggregationKey,
+	metrics serviceTxMetrics,
+	interval time.Duration,
+	logger *logp.Logger,
+) {
+	// hash does not use the serviceTxMetrics so it is safe to call concurrently.
+	hash := key.hash()
+
+	// Full lock because serviceTxMetrics cannot be updated atomically.
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+
+	var entry *metricsMapEntry
+	entries, ok := mb.m[hash]
+	if ok {
+		for offset, old := range entries {
+			if old.aggregationKey.equal(key) {
+				entry = entries[offset]
+				break
+			}
+		}
+	}
+	if entry == nil && mb.entries >= mb.maxSize && mb.other != nil {
+		entry = mb.other
+		// axiomhq/hyerloglog uses metrohash but here we are using
+		// xxhash. Metrohash has better performance but since we are
+		// already calculating xxhash we can use it directly.
+		mb.otherCardinalityEstimator.InsertHash(hash)
+	}
+	if entry != nil {
+		entry.recordMetrics(metrics)
+		return
+	}
+	if mb.entries >= mb.maxSize {
+		logger.Warnf(`
+Service aggregation group limit of %d reached, new metric documents will be grouped
+under a dedicated bucket identified by service name '%s'.`[1:], mb.maxSize, overflowServiceName)
+		mb.other = &mb.space[len(mb.space)-1]
+		mb.otherCardinalityEstimator = hyperloglog.New14()
+		mb.otherCardinalityEstimator.InsertHash(hash)
+		entry = mb.other
+		key = makeOverflowAggregationKey(key, interval)
+	} else {
+		entry = &mb.space[mb.entries]
+		mb.m[hash] = append(entries, entry)
+		mb.entries++
+	}
+	entry.aggregationKey = key
+	entry.serviceTxMetrics = serviceTxMetrics{
+		histogram: mb.histogramPool.Get().(*hdrhistogram.Histogram),
+	}
+	entry.recordMetrics(metrics)
+}
+
+type aggregationKey struct {
+	labels.AggregatedGlobalLabels
+	comparable
+}
+
+func (k *aggregationKey) hash() uint64 {
+	var h xxhash.Digest
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(k.timestamp.UnixNano()))
+	h.Write(buf[:])
+
+	k.AggregatedGlobalLabels.Write(&h)
+	h.WriteString(k.agentName)
+	h.WriteString(k.serviceEnvironment)
+	h.WriteString(k.serviceName)
+	h.WriteString(k.serviceLanguageName)
+	h.WriteString(k.transactionType)
+	return h.Sum64()
+}
+
+func (k *aggregationKey) equal(key aggregationKey) bool {
+	return k.comparable == key.comparable &&
+		k.AggregatedGlobalLabels.Equals(&key.AggregatedGlobalLabels)
+}
+
+type comparable struct {
+	timestamp time.Time
+
+	agentName           string
+	serviceName         string
+	serviceEnvironment  string
+	serviceLanguageName string
+	transactionType     string
+}
+
+func makeAggregationKey(event *modelpb.APMEvent, interval time.Duration) aggregationKey {
+	key := aggregationKey{
+		comparable: comparable{
+
+			agentName:           event.GetAgent().GetName(),
+			serviceName:         event.GetService().GetName(),
+			serviceEnvironment:  event.GetService().GetEnvironment(),
+			serviceLanguageName: event.GetService().GetLanguage().GetName(),
+			transactionType:     event.GetTransaction().GetType(),
+		},
+	}
+	if event.Timestamp != nil {
+		// Group metrics by time interval.
+		key.comparable.timestamp = event.Timestamp.AsTime().Truncate(interval)
+	}
+	key.AggregatedGlobalLabels.Read(event)
+	return key
+}
+
+func makeOverflowAggregationKey(oldKey aggregationKey, interval time.Duration) aggregationKey {
+	return aggregationKey{
+		comparable: comparable{
+			// We are using `time.Now` here to align the overflow aggregation to
+			// the evaluation time rather than event time. This prevents us from
+			// cases of bad timestamps when the server receives some events with
+			// old timestamp and these events overflow causing the indexed event
+			// to have old timestamp too.
+			timestamp:   time.Now().Truncate(interval),
+			serviceName: overflowServiceName,
+		},
+	}
+}
+
+type serviceTxMetrics struct {
+	histogram           *hdrhistogram.Histogram
+	transactionDuration float64
+	transactionCount    float64
+	failureCount        float64
+	successCount        float64
+}
+
+func (m *serviceTxMetrics) recordMetrics(other serviceTxMetrics) {
+	m.transactionCount += other.transactionCount
+	m.transactionDuration += other.transactionDuration * other.transactionCount
+	m.successCount += other.successCount
+	m.failureCount += other.failureCount
+
+	count := int64(math.Round(other.transactionCount * histogramCountScale))
+	m.histogram.RecordValuesAtomic(time.Duration(other.transactionDuration).Microseconds(), count)
+}
+
+func (m *serviceTxMetrics) histogramBuckets() (totalCount uint64, counts []uint64, values []float64) {
+	// From https://www.elastic.co/guide/en/elasticsearch/reference/current/histogram.html:
+	//
+	// "For the High Dynamic Range (HDR) histogram mode, the values array represents
+	// fixed upper limits of each bucket interval, and the counts array represents
+	// the number of values that are attributed to each interval."
+	distribution := m.histogram.Distribution()
+	counts = make([]uint64, 0, len(distribution))
+	values = make([]float64, 0, len(distribution))
+	for _, b := range distribution {
+		if b.Count <= 0 {
+			continue
+		}
+		count := uint64(math.Round(float64(b.Count) / histogramCountScale))
+		counts = append(counts, count)
+		values = append(values, float64(b.To))
+		totalCount += count
+	}
+	return totalCount, counts, values
+}
+
+func makeServiceTxMetrics(event *modelpb.APMEvent) serviceTxMetrics {
+	transactionCount := event.Transaction.RepresentativeCount
+	metrics := serviceTxMetrics{
+		transactionDuration: float64(event.Event.Duration.AsDuration()),
+		transactionCount:    transactionCount,
+	}
+	switch event.Event.Outcome {
+	case "failure":
+		metrics.failureCount = transactionCount
+	case "success":
+		metrics.successCount = transactionCount
+	}
+	return metrics
+}
+
+// makeMetricset creates a metricset with key, metrics, and interval.
+// It uses result from histogram for Transaction.DurationSummary and DocCount to avoid discrepancy and UI weirdness.
+// Event.SuccessCount will maintain separate counts, which may be different from histogram count,
+// but is acceptable since it is used for calculating error ratio.
+func makeMetricset(key aggregationKey, metrics serviceTxMetrics, interval string) *modelpb.APMEvent {
+	totalCount, counts, values := metrics.histogramBuckets()
+
+	transactionDurationSummary := modelpb.SummaryMetric{
+		Count: totalCount,
+	}
+	for i, v := range values {
+		transactionDurationSummary.Sum += v * float64(counts[i])
+	}
+
+	var t *timestamppb.Timestamp
+	if !key.timestamp.IsZero() {
+		t = timestamppb.New(key.timestamp)
+	}
+
+	var event *modelpb.Event
+	if metrics.successCount != 0 || metrics.failureCount != 0 {
+		event = &modelpb.Event{
+			SuccessCount: &modelpb.SummaryMetric{
+				Count: uint64(math.Round(metrics.successCount + metrics.failureCount)),
+				Sum:   math.Round(metrics.successCount),
+			},
+		}
+	}
+
+	var agent *modelpb.Agent
+	if key.agentName != "" {
+		agent = &modelpb.Agent{Name: key.agentName}
+	}
+
+	var language *modelpb.Language
+	if key.serviceLanguageName != "" {
+		language = &modelpb.Language{
+			Name: key.serviceLanguageName,
+		}
+	}
+
+	return &modelpb.APMEvent{
+		Timestamp: t,
+		Service: &modelpb.Service{
+			Name:        key.serviceName,
+			Environment: key.serviceEnvironment,
+			Language:    language,
+		},
+		Agent:         agent,
+		Labels:        key.Labels,
+		NumericLabels: key.NumericLabels,
+		Metricset: &modelpb.Metricset{
+			DocCount: totalCount,
+			Name:     metricsetName,
+			Interval: interval,
+		},
+		Transaction: &modelpb.Transaction{
+			Type:            key.transactionType,
+			DurationSummary: &transactionDurationSummary,
+			DurationHistogram: &modelpb.Histogram{
+				Counts: counts,
+				Values: values,
+			},
+		},
+		Event: event,
+	}
+}

--- a/x-pack/apm-server/aggregation/servicetxmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/servicetxmetrics/aggregator_test.go
@@ -1,0 +1,415 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package servicetxmetrics
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/elastic/apm-data/model/modelpb"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+func TestNewAggregatorConfigInvalid(t *testing.T) {
+	report := makeErrBatchProcessor(nil)
+
+	type test struct {
+		config AggregatorConfig
+		err    string
+	}
+
+	for _, test := range []test{{
+		config: AggregatorConfig{},
+		err:    "BatchProcessor unspecified",
+	}, {
+		config: AggregatorConfig{
+			BatchProcessor: report,
+		},
+		err: "MaxGroups unspecified or negative",
+	}, {
+		config: AggregatorConfig{
+			BatchProcessor:                 report,
+			MaxGroups:                      1,
+			HDRHistogramSignificantFigures: 1,
+		},
+		err: "Interval unspecified or negative",
+	}} {
+		agg, err := NewAggregator(test.config)
+		require.Error(t, err)
+		require.Nil(t, agg)
+		assert.EqualError(t, err, "invalid aggregator config: "+test.err)
+	}
+}
+
+func TestAggregatorRun(t *testing.T) {
+	batches := make(chan modelpb.Batch, 3)
+	config := AggregatorConfig{
+		BatchProcessor:                 makeChanBatchProcessor(batches),
+		Interval:                       1 * time.Millisecond,
+		RollUpIntervals:                []time.Duration{200 * time.Millisecond, time.Second},
+		MaxGroups:                      1000,
+		HDRHistogramSignificantFigures: 5,
+	}
+	agg, err := NewAggregator(config)
+	require.NoError(t, err)
+
+	type input struct {
+		serviceName         string
+		serviceEnvironment  string
+		serviceLanguageName string
+		agentName           string
+		transactionType     string
+		outcome             string
+		count               float64
+	}
+
+	inputs := []input{
+		{serviceName: "ignored", agentName: "ignored", transactionType: "ignored", count: 0}, // ignored because count is zero
+
+		{serviceName: "backend", serviceLanguageName: "java", agentName: "java", transactionType: "request", outcome: "success", count: 2.1},
+		{serviceName: "backend", serviceLanguageName: "java", agentName: "java", transactionType: "request", outcome: "failure", count: 3},
+		{serviceName: "backend", serviceLanguageName: "java", agentName: "java", transactionType: "request", outcome: "unknown", count: 1},
+
+		{serviceName: "backend", serviceLanguageName: "go", agentName: "go", transactionType: "request", outcome: "unknown", count: 1},
+		{serviceName: "backend", serviceLanguageName: "go", agentName: "go", transactionType: "background", outcome: "unknown", count: 1},
+
+		{serviceName: "frontend", serviceLanguageName: "js", agentName: "rum-js", transactionType: "page-load", outcome: "unknown", count: 1},
+		{serviceName: "frontend", serviceLanguageName: "js", serviceEnvironment: "staging", agentName: "rum-js", transactionType: "page-load", outcome: "unknown", count: 1},
+	}
+
+	var wg sync.WaitGroup
+	for _, in := range inputs {
+		wg.Add(1)
+		go func(in input) {
+			defer wg.Done()
+			transaction := makeTransaction(
+				in.serviceName, in.serviceLanguageName, in.agentName, in.transactionType,
+				in.outcome, time.Millisecond, in.count,
+			)
+			transaction.Service.Environment = in.serviceEnvironment
+
+			batch := modelpb.Batch{transaction}
+			err := agg.ProcessBatch(context.Background(), &batch)
+			require.NoError(t, err)
+			assert.Equal(t, modelpb.Batch{transaction}, batch)
+		}(in)
+	}
+	wg.Wait()
+
+	// Start the aggregator after processing to ensure metrics are aggregated deterministically.
+	go agg.Run()
+	defer agg.Stop(context.Background())
+	// Stop the aggregator to ensure all metrics are published.
+	assert.NoError(t, agg.Stop(context.Background()))
+
+	for _, interval := range append([]time.Duration{config.Interval}, config.RollUpIntervals...) {
+		batch := expectBatch(t, batches)
+		metricsets := batchMetricsets(t, batch)
+		expected := []*modelpb.APMEvent{{
+			Metricset: &modelpb.Metricset{
+				Name: "service_transaction", DocCount: 6, Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
+			},
+			Service: &modelpb.Service{Name: "backend", Language: &modelpb.Language{Name: "java"}},
+			Agent:   &modelpb.Agent{Name: "java"},
+			Transaction: &modelpb.Transaction{
+				Type: "request",
+				DurationSummary: &modelpb.SummaryMetric{
+					Count: 6,
+					Sum:   6000, // estimated from histogram
+				},
+				DurationHistogram: &modelpb.Histogram{
+					Values: []float64{1000},
+					Counts: []uint64{6},
+				},
+			},
+			Event: &modelpb.Event{
+				SuccessCount: &modelpb.SummaryMetric{
+					Count: 5,
+					Sum:   2,
+				},
+			},
+		}, {
+			Metricset: &modelpb.Metricset{
+				Name: "service_transaction", DocCount: 1, Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
+			},
+			Service: &modelpb.Service{Name: "backend", Language: &modelpb.Language{Name: "go"}},
+			Agent:   &modelpb.Agent{Name: "go"},
+			Transaction: &modelpb.Transaction{
+				Type: "request",
+				DurationSummary: &modelpb.SummaryMetric{
+					Count: 1,
+					Sum:   1000, // 1ms in micros
+				},
+				DurationHistogram: &modelpb.Histogram{
+					Values: []float64{1000},
+					Counts: []uint64{1},
+				},
+			},
+		}, {
+			Metricset: &modelpb.Metricset{
+				Name: "service_transaction", DocCount: 1, Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
+			},
+			Service: &modelpb.Service{Name: "backend", Language: &modelpb.Language{Name: "go"}},
+			Agent:   &modelpb.Agent{Name: "go"},
+			Transaction: &modelpb.Transaction{
+				Type: "background",
+				DurationSummary: &modelpb.SummaryMetric{
+					Count: 1,
+					Sum:   1000, // 1ms in micros
+				},
+				DurationHistogram: &modelpb.Histogram{
+					Values: []float64{1000},
+					Counts: []uint64{1},
+				},
+			},
+		}, {
+			Metricset: &modelpb.Metricset{
+				Name: "service_transaction", DocCount: 1, Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
+			},
+			Service: &modelpb.Service{Name: "frontend", Language: &modelpb.Language{Name: "js"}},
+			Agent:   &modelpb.Agent{Name: "rum-js"},
+			Transaction: &modelpb.Transaction{
+				Type: "page-load",
+				DurationSummary: &modelpb.SummaryMetric{
+					Count: 1,
+					Sum:   1000, // 1ms in micros
+				},
+				DurationHistogram: &modelpb.Histogram{
+					Values: []float64{1000},
+					Counts: []uint64{1},
+				},
+			},
+		}, {
+			Metricset: &modelpb.Metricset{
+				Name: "service_transaction", DocCount: 1, Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
+			},
+			Service: &modelpb.Service{Name: "frontend", Environment: "staging", Language: &modelpb.Language{Name: "js"}},
+			Agent:   &modelpb.Agent{Name: "rum-js"},
+			Transaction: &modelpb.Transaction{
+				Type: "page-load",
+				DurationSummary: &modelpb.SummaryMetric{
+					Count: 1,
+					Sum:   1000, // 1ms in micros
+				},
+				DurationHistogram: &modelpb.Histogram{
+					Values: []float64{1000},
+					Counts: []uint64{1},
+				},
+			},
+		}}
+
+		assert.Equal(t, len(expected), len(metricsets))
+		sorter := func(events []*modelpb.APMEvent) func(i, j int) bool {
+			return func(i, j int) bool {
+				e1 := events[i]
+				e2 := events[j]
+				if e1.Transaction.Type != e2.Transaction.Type {
+					return e1.Transaction.Type < e2.Transaction.Type
+				}
+
+				if e1.Agent.Name != e2.Agent.Name {
+					return e1.Agent.Name < e2.Agent.Name
+				}
+
+				return e1.Service.Environment < e2.Service.Environment
+			}
+		}
+		sort.Slice(expected, sorter(expected))
+		sort.Slice(metricsets, sorter(metricsets))
+		assert.Empty(t, cmp.Diff(expected, metricsets, protocmp.Transform()))
+	}
+
+	select {
+	case <-batches:
+		t.Fatal("unexpected publish")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestAggregateTimestamp(t *testing.T) {
+	batches := make(chan modelpb.Batch, 1)
+	agg, err := NewAggregator(AggregatorConfig{
+		BatchProcessor:                 makeChanBatchProcessor(batches),
+		Interval:                       30 * time.Second,
+		MaxGroups:                      1000,
+		HDRHistogramSignificantFigures: 1,
+	})
+	require.NoError(t, err)
+
+	t0 := time.Unix(0, 0).UTC()
+	for _, ts := range []time.Time{t0, t0.Add(15 * time.Second), t0.Add(30 * time.Second)} {
+		transaction := makeTransaction("service_name", "agent_name", "", "tx_type", "success", 100*time.Millisecond, 1)
+		transaction.Timestamp = timestamppb.New(ts)
+		batch := modelpb.Batch{transaction}
+		err = agg.ProcessBatch(context.Background(), &batch)
+		require.NoError(t, err)
+		assert.Empty(t, batchMetricsets(t, batch))
+	}
+
+	go agg.Run()
+	err = agg.Stop(context.Background()) // stop to flush
+	require.NoError(t, err)
+
+	batch := expectBatch(t, batches)
+	metricsets := batchMetricsets(t, batch)
+	require.Len(t, metricsets, 2)
+	sort.Slice(metricsets, func(i, j int) bool {
+		return metricsets[i].Timestamp.AsTime().Before(metricsets[j].Timestamp.AsTime())
+	})
+	assert.Equal(t, t0, metricsets[0].Timestamp.AsTime())
+	assert.Equal(t, t0.Add(30*time.Second), metricsets[1].Timestamp.AsTime())
+}
+
+func TestAggregatorOverflow(t *testing.T) {
+	maxGrps := 4
+	overflowCount := 100
+	txnDuration := 100 * time.Millisecond
+	batches := make(chan modelpb.Batch, 1)
+	agg, err := NewAggregator(AggregatorConfig{
+		BatchProcessor:                 makeChanBatchProcessor(batches),
+		Interval:                       10 * time.Second,
+		MaxGroups:                      maxGrps,
+		HDRHistogramSignificantFigures: 5,
+	})
+	require.NoError(t, err)
+
+	batch := make(modelpb.Batch, maxGrps+overflowCount) // cause overflow
+	for i := 0; i < len(batch); i++ {
+		batch[i] = makeTransaction(
+			fmt.Sprintf("svc%d", i), "agent", "java", "tx_type", "success", txnDuration, 1,
+		)
+	}
+	go func(t *testing.T) {
+		t.Helper()
+		require.NoError(t, agg.Run())
+	}(t)
+	require.NoError(t, agg.ProcessBatch(context.Background(), &batch))
+	require.NoError(t, agg.Stop(context.Background()))
+	metricsets := batchMetricsets(t, expectBatch(t, batches))
+	require.Len(t, metricsets, maxGrps+1) // only one `other` metric should overflow
+
+	// assert monitoring
+	registry := monitoring.NewRegistry()
+	monitoring.NewFunc(registry, "servicetxmetrics", agg.CollectMonitoring)
+	expectedMonitoring := monitoring.MakeFlatSnapshot()
+	expectedMonitoring.Ints["servicetxmetrics.active_groups"] = int64(maxGrps)
+	expectedMonitoring.Ints["servicetxmetrics.overflowed.total"] = int64(overflowCount)
+	assert.Equal(t, expectedMonitoring, monitoring.CollectFlatSnapshot(
+		registry, monitoring.Full, false,
+	))
+
+	var overflowEvent *modelpb.APMEvent
+	for i := range metricsets {
+		m := metricsets[i]
+		if m.Service.Name == "_other" {
+			if overflowEvent != nil {
+				require.Fail(t, "only one service should overflow")
+			}
+			overflowEvent = m
+		}
+	}
+	assert.Empty(t, cmp.Diff(&modelpb.APMEvent{
+		Service: &modelpb.Service{
+			Name: "_other",
+		},
+		Transaction: &modelpb.Transaction{
+			DurationSummary: &modelpb.SummaryMetric{
+				Count: uint64(overflowCount),
+				Sum:   float64(int64(overflowCount) * txnDuration.Microseconds()),
+			},
+			DurationHistogram: &modelpb.Histogram{
+				Values: []float64{float64(txnDuration.Microseconds())},
+				Counts: []uint64{uint64(overflowCount)},
+			},
+		},
+		Event: &modelpb.Event{
+			SuccessCount: &modelpb.SummaryMetric{
+				Count: uint64(overflowCount),
+				Sum:   float64(overflowCount),
+			},
+		},
+		Metricset: &modelpb.Metricset{
+			Name:     "service_transaction",
+			DocCount: uint64(overflowCount),
+			Interval: "10s",
+			Samples: []*modelpb.MetricsetSample{
+				{
+					Name:  "service_transaction.aggregation.overflow_count",
+					Value: float64(overflowCount),
+				},
+			},
+		},
+	}, overflowEvent,
+		protocmp.Transform(),
+		protocmp.IgnoreFields(&modelpb.APMEvent{}, "timestamp"),
+	))
+}
+
+func makeTransaction(
+	serviceName, serviceLanguageName, agentName, transactionType, outcome string,
+	duration time.Duration, count float64,
+) *modelpb.APMEvent {
+	return &modelpb.APMEvent{
+		Agent:   &modelpb.Agent{Name: agentName},
+		Service: &modelpb.Service{Name: serviceName, Language: &modelpb.Language{Name: serviceLanguageName}},
+		Event: &modelpb.Event{
+			Outcome:  outcome,
+			Duration: durationpb.New(duration),
+		},
+		Transaction: &modelpb.Transaction{
+			Name:                "transaction_name",
+			Type:                transactionType,
+			RepresentativeCount: count,
+		},
+	}
+}
+
+func makeErrBatchProcessor(err error) modelpb.BatchProcessor {
+	return modelpb.ProcessBatchFunc(func(context.Context, *modelpb.Batch) error { return err })
+}
+
+func makeChanBatchProcessor(ch chan<- modelpb.Batch) modelpb.BatchProcessor {
+	return modelpb.ProcessBatchFunc(func(ctx context.Context, batch *modelpb.Batch) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ch <- *batch:
+			return nil
+		}
+	})
+}
+
+func expectBatch(t *testing.T, ch <-chan modelpb.Batch) modelpb.Batch {
+	t.Helper()
+	select {
+	case batch := <-ch:
+		return batch
+	case <-time.After(time.Second * 5):
+		t.Fatal("expected publish")
+	}
+	panic("unreachable")
+}
+
+func batchMetricsets(t testing.TB, batch modelpb.Batch) []*modelpb.APMEvent {
+	var metricsets []*modelpb.APMEvent
+	for _, event := range batch {
+		if event.Metricset == nil {
+			continue
+		}
+		metricsets = append(metricsets, event)
+	}
+	return metricsets
+}

--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
@@ -465,10 +465,10 @@ func makeAggregationKey(
 			resource: resource,
 		},
 	}
-	if event.Timestamp != 0 {
-		// Group metrics by time interval.
-		key.comparable.timestamp = time.Unix(0, int64(event.Timestamp)).Truncate(interval)
-	}
+
+	// Group metrics by time interval.
+	key.comparable.timestamp = time.Unix(0, int64(event.Timestamp)).Truncate(interval)
+
 	key.AggregatedGlobalLabels.Read(event)
 	return key
 }

--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator.go
@@ -1,0 +1,548 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package spanmetrics
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/axiomhq/hyperloglog"
+	"github.com/cespare/xxhash/v2"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/elastic/apm-data/model/modelpb"
+	"github.com/elastic/apm-server/internal/logs"
+	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/baseaggregator"
+	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/interval"
+	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/labels"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+const (
+	metricsetName       = "service_destination"
+	overflowServiceName = "_other"
+)
+
+// AggregatorConfig holds configuration for creating an Aggregator.
+type AggregatorConfig struct {
+	// BatchProcessor is a model.BatchProcessor for asynchronously
+	// processing metrics documents.
+	BatchProcessor modelpb.BatchProcessor
+
+	// Logger is the logger for logging metrics aggregation/publishing.
+	//
+	// If Logger is nil, a new logger will be constructed.
+	Logger *logp.Logger
+
+	// RollUpIntervals are additional MetricsInterval for the aggregator to
+	// compute and publish metrics for. Each additional interval is constrained
+	// to the same rules as MetricsInterval, and will result in additional
+	// memory to be allocated.
+	RollUpIntervals []time.Duration
+
+	// Interval is the interval between publishing of aggregated metrics.
+	// There may be additional metrics reported at arbitrary times if the
+	// aggregation groups fill up.
+	Interval time.Duration
+
+	// MaxGroups is the maximum number of distinct service destination
+	// group metrics to store within an aggregation period. Once this
+	// number of groups is reached, any new aggregation keys will be
+	// aggregated in a dedicated service group identified by `_other`.
+	//
+	// Some agents continue to send high cardinality span names, e.g.
+	// Elasticsearch spans may contain a document ID
+	// (see https://github.com/elastic/apm/issues/439). To protect against
+	// this, once MaxGroups becomes 50% full then we will stop aggregating
+	// on span.name.
+	MaxGroups int
+}
+
+// Validate validates the aggregator config.
+func (config AggregatorConfig) Validate() error {
+	if config.BatchProcessor == nil {
+		return errors.New("BatchProcessor unspecified")
+	}
+	if config.MaxGroups <= 0 {
+		return errors.New("MaxGroups unspecified or negative")
+	}
+	return nil
+}
+
+// Aggregator aggregates transaction durations, periodically publishing histogram spanMetrics.
+type Aggregator struct {
+	*baseaggregator.Aggregator
+	config  AggregatorConfig
+	metrics *aggregatorMetrics
+
+	mu sync.RWMutex
+	// These two metricsBuffer are set to the same size and act as buffers
+	// for caching and then publishing the metrics as batches.
+	active, inactive map[time.Duration]*metricsBuffer
+}
+
+type aggregatorMetrics struct {
+	activeGroups int64
+	overflow     int64
+}
+
+// NewAggregator returns a new Aggregator with the given config.
+func NewAggregator(config AggregatorConfig) (*Aggregator, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid aggregator config")
+	}
+	if config.Logger == nil {
+		config.Logger = logp.NewLogger(logs.SpanMetrics)
+	}
+	aggregator := Aggregator{
+		config:   config,
+		metrics:  &aggregatorMetrics{},
+		active:   make(map[time.Duration]*metricsBuffer),
+		inactive: make(map[time.Duration]*metricsBuffer),
+	}
+	base, err := baseaggregator.New(baseaggregator.AggregatorConfig{
+		PublishFunc:     aggregator.publish, // inject local publish
+		Logger:          config.Logger,
+		Interval:        config.Interval,
+		RollUpIntervals: config.RollUpIntervals,
+	})
+	if err != nil {
+		return nil, err
+	}
+	aggregator.Aggregator = base
+	for _, interval := range aggregator.Intervals {
+		aggregator.active[interval] = newMetricsBuffer(config.MaxGroups)
+		aggregator.inactive[interval] = newMetricsBuffer(config.MaxGroups)
+	}
+	return &aggregator, nil
+}
+
+// CollectMonitoring may be called to collect monitoring metrics from the
+// aggregation. It is intended to be used with libbeat/monitoring.NewFunc.
+//
+// The metrics should be added to the "apm-server.aggregation.spanmetrics" registry.
+func (a *Aggregator) CollectMonitoring(_ monitoring.Mode, V monitoring.Visitor) {
+	V.OnRegistryStart()
+	defer V.OnRegistryFinished()
+
+	activeGroups := int64(atomic.LoadInt64(&a.metrics.activeGroups))
+	overflowed := int64(atomic.LoadInt64(&a.metrics.overflow))
+	monitoring.ReportInt(V, "active_groups", activeGroups)
+	monitoring.ReportInt(V, "overflowed.total", overflowed)
+}
+
+func (a *Aggregator) publish(ctx context.Context, period time.Duration) error {
+	// We hold a.mu only long enough to swap the spanMetrics. This will
+	// be blocked by spanMetrics updates, which is OK, as we prefer not
+	// to block spanMetrics updaters. After the lock is released nothing
+	// will be accessing a.inactive.
+	a.mu.Lock()
+
+	// EXPLAIN: We swap active <-> inactive, so that we're only working on the
+	// inactive property while publish is running. `a.active` is the buffer that
+	// receives/stores/updates the metricsets, once swapped, we're working on the
+	// `a.inactive` which we're going to process and publish.
+	current := a.active[period]
+	a.active[period], a.inactive[period] = a.inactive[period], current
+	a.mu.Unlock()
+
+	if current.entries == 0 {
+		a.config.Logger.Debugf("no span metrics to publish")
+		return nil
+	}
+
+	size := current.entries
+	if current.other != nil {
+		size++
+	}
+
+	intervalStr := interval.FormatDuration(period)
+	isMetricsPeriod := period == a.config.Interval
+	batch := make(modelpb.Batch, 0, size)
+	for hash, entries := range current.m {
+		for _, entry := range entries {
+			event := makeMetricset(entry.aggregationKey, entry.spanMetrics)
+			// Record the metricset interval as metricset.interval.
+			event.Metricset.Interval = intervalStr
+			batch = append(batch, event)
+		}
+		delete(current.m, hash)
+	}
+	if current.other != nil {
+		overflowCount := current.otherCardinalityEstimator.Estimate()
+		if isMetricsPeriod {
+			atomic.AddInt64(&a.metrics.activeGroups, int64(current.entries))
+			atomic.AddInt64(&a.metrics.overflow, int64(overflowCount))
+		}
+		entry := current.other
+		m := makeMetricset(entry.aggregationKey, entry.spanMetrics)
+		m.Metricset.Interval = intervalStr
+		m.Metricset.Samples = append(m.Metricset.Samples, &modelpb.MetricsetSample{
+			Name:  "service_destination.aggregation.overflow_count",
+			Value: float64(overflowCount),
+		})
+		m.Metricset.DocCount = overflowCount
+		batch = append(batch, m)
+		current.other = nil
+		current.otherCardinalityEstimator = nil
+	}
+	current.entries = 0
+	a.config.Logger.Debugf("%s interval: publishing %d metricsets", period, len(batch))
+	return a.config.BatchProcessor.ProcessBatch(ctx, &batch)
+}
+
+// ProcessBatch aggregates all spans contained in "b".
+// It also aggregates transactions where transaction.DroppedSpansStats > 0.
+//
+// This method is expected to be used immediately prior to publishing
+// the events.
+func (a *Aggregator) ProcessBatch(ctx context.Context, b *modelpb.Batch) error {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for _, event := range *b {
+		eventType := event.Type()
+		if eventType == modelpb.SpanEventType {
+			a.processSpan(event)
+			continue
+		}
+
+		tx := event.Transaction
+		if eventType == modelpb.TransactionEventType && tx != nil {
+			for _, dss := range tx.DroppedSpansStats {
+				a.processDroppedSpanStats(event, dss)
+			}
+			// NOTE(marclop) The event.Transaction.DroppedSpansStats is unset
+			// via the `modelprocessor.DroppedSpansStatsDiscarder` appended just
+			// before the Elasticsearch publisher.
+			continue
+		}
+	}
+	return nil
+}
+
+func (a *Aggregator) processSpan(event *modelpb.APMEvent) {
+	if event.Service.Target == nil &&
+		(event.Span.DestinationService == nil || event.Span.DestinationService.Resource == "") {
+		return
+	}
+
+	if event.Span.RepresentativeCount <= 0 {
+		// RepresentativeCount is zero when the sample rate is unknown.
+		// We cannot calculate accurate span metrics without the sample
+		// rate, so we don't calculate any at all in this case.
+		return
+	}
+
+	// For composite spans we use the composite sum duration, which is the sum of
+	// pre-aggregated spans and excludes time gaps that are counted in the reported
+	// span duration. For non-composite spans we just use the reported span duration.
+	count := 1
+	duration := event.Event.Duration.AsDuration()
+	if event.Span.Composite != nil {
+		count = int(event.Span.Composite.Count)
+		duration = time.Duration(event.Span.Composite.Sum * float64(time.Millisecond))
+	}
+
+	var serviceTargetType, serviceTargetName string
+	if event.Service.Target != nil {
+		serviceTargetType = event.Service.Target.Type
+		serviceTargetName = event.Service.Target.Name
+	}
+	metrics := spanMetrics{
+		count: float64(count) * event.Span.RepresentativeCount,
+		sum:   float64(duration) * event.Span.RepresentativeCount,
+	}
+
+	var resource string
+	if event.Span.DestinationService != nil {
+		resource = event.Span.DestinationService.Resource
+	}
+
+	for _, interval := range a.Intervals {
+		key := makeAggregationKey(
+			event,
+			event.Event.Outcome,
+			resource,
+			serviceTargetType,
+			serviceTargetName,
+			event.Span.Name,
+			interval,
+		)
+		a.active[interval].storeOrUpdate(key, metrics, interval, a.config.Logger)
+	}
+}
+
+func (a *Aggregator) processDroppedSpanStats(event *modelpb.APMEvent, dss *modelpb.DroppedSpanStats) {
+	representativeCount := event.Transaction.RepresentativeCount
+	if representativeCount <= 0 {
+		// RepresentativeCount is zero when the sample rate is unknown.
+		// We cannot calculate accurate span metrics without the sample
+		// rate, so we don't calculate any at all in this case.
+		return
+	}
+
+	metrics := spanMetrics{
+		count: float64(dss.Duration.Count) * representativeCount,
+		sum:   float64(dss.Duration.Sum.AsDuration()) * representativeCount,
+	}
+	for _, interval := range a.Intervals {
+		key := makeAggregationKey(
+			event,
+			dss.Outcome,
+			dss.DestinationServiceResource,
+			dss.ServiceTargetType,
+			dss.ServiceTargetName,
+
+			// BUG(axw) dropped span statistics do not contain span name.
+			// Capturing the service name requires changes to Elastic APM agents.
+			"",
+
+			interval,
+		)
+		a.active[interval].storeOrUpdate(key, metrics, interval, a.config.Logger)
+	}
+}
+
+type metricsBuffer struct {
+	mu sync.RWMutex
+	m  map[uint64][]*metricsMapEntry
+	// Number of metricsMapEntry in m. May not equal to len(m) in case of hash collision.
+	// Does not include overflow bucket.
+	entries int
+
+	other                     *metricsMapEntry
+	otherCardinalityEstimator *hyperloglog.Sketch
+
+	maxSize int
+}
+
+func newMetricsBuffer(maxSize int) *metricsBuffer {
+	return &metricsBuffer{
+		maxSize: maxSize,
+		m:       make(map[uint64][]*metricsMapEntry),
+	}
+}
+
+type metricsMapEntry struct {
+	aggregationKey
+	spanMetrics
+}
+
+func (mb *metricsBuffer) storeOrUpdate(
+	key aggregationKey,
+	value spanMetrics,
+	interval time.Duration,
+	logger *logp.Logger,
+) {
+	// hash does not use the spanMetrics so it is safe to call concurrently.
+	hash := key.hash()
+
+	mb.mu.Lock()
+	defer mb.mu.Unlock()
+
+	find := func(hash uint64, key aggregationKey) (*metricsMapEntry, bool) {
+		// This function should only be called when caller is holding the lock mb.mu.
+		// It takes separate hash and key arguments so that hash can be computed
+		// before acquiring the lock.
+		entries, ok := mb.m[hash]
+		if ok {
+			for _, old := range entries {
+				if old.aggregationKey.equal(key) {
+					return old, true
+				}
+			}
+		}
+		return nil, false
+	}
+
+	old, ok := find(hash, key)
+	if !ok {
+		half := mb.maxSize / 2
+		if mb.entries >= half {
+			// To protect against agents that send high cardinality
+			// span names, stop aggregating on span.name once the
+			// number of groups reaches 50% capacity.
+			key.spanName = ""
+			hash = key.hash()
+			old, ok = find(hash, key)
+		}
+		if !ok {
+			if mb.entries >= mb.maxSize {
+				if mb.other == nil {
+					logger.Warnf(`
+Service aggregation group limit of %d reached, new metric documents will be grouped
+under a dedicated bucket identified by service name '%s'.`[1:], mb.maxSize, overflowServiceName)
+					mb.otherCardinalityEstimator = hyperloglog.New14()
+					mb.other = &metricsMapEntry{aggregationKey: makeOverflowAggregationKey(key, interval)}
+				}
+				old, ok = mb.other, true
+				mb.otherCardinalityEstimator.InsertHash(hash)
+			} else {
+				mb.m[hash] = append(mb.m[hash], &metricsMapEntry{
+					aggregationKey: key,
+					spanMetrics:    spanMetrics{count: value.count, sum: value.sum},
+				})
+				mb.entries++
+				return
+			}
+		}
+	}
+
+	old.spanMetrics = spanMetrics{count: value.count + old.count, sum: value.sum + old.sum}
+}
+
+type aggregationKey struct {
+	labels.AggregatedGlobalLabels
+	comparable
+}
+
+type comparable struct {
+	timestamp time.Time
+
+	// origin
+	serviceName        string
+	serviceEnvironment string
+	agentName          string
+
+	// operation (span)
+	spanName string
+	outcome  string
+
+	// target
+	targetType string
+	targetName string
+
+	// destination
+	resource string
+}
+
+func (k *aggregationKey) hash() uint64 {
+	var h xxhash.Digest
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(k.timestamp.UnixNano()))
+	h.Write(buf[:])
+
+	k.AggregatedGlobalLabels.Write(&h)
+	h.WriteString(k.serviceName)
+	h.WriteString(k.serviceEnvironment)
+	h.WriteString(k.agentName)
+	h.WriteString(k.spanName)
+	h.WriteString(k.outcome)
+	h.WriteString(k.targetType)
+	h.WriteString(k.targetName)
+	h.WriteString(k.resource)
+	return h.Sum64()
+}
+
+func (k *aggregationKey) equal(key aggregationKey) bool {
+	return k.comparable == key.comparable &&
+		k.AggregatedGlobalLabels.Equals(&key.AggregatedGlobalLabels)
+}
+
+func makeAggregationKey(
+	event *modelpb.APMEvent, outcome, resource, targetType, targetName, spanName string, interval time.Duration,
+) aggregationKey {
+	key := aggregationKey{
+		comparable: comparable{
+
+			serviceName:        event.Service.Name,
+			serviceEnvironment: event.Service.Environment,
+			agentName:          event.Agent.Name,
+
+			spanName: spanName,
+			outcome:  outcome,
+
+			targetType: targetType,
+			targetName: targetName,
+
+			resource: resource,
+		},
+	}
+	if event.Timestamp != nil {
+		// Group metrics by time interval.
+		key.comparable.timestamp = event.Timestamp.AsTime().Truncate(interval)
+	}
+	key.AggregatedGlobalLabels.Read(event)
+	return key
+}
+
+func makeOverflowAggregationKey(oldKey aggregationKey, interval time.Duration) aggregationKey {
+	return aggregationKey{
+		comparable: comparable{
+			// We are using `time.Now` here to align the overflow aggregation to
+			// the evaluation time rather than event time. This prevents us from
+			// cases of bad timestamps when the server receives some events with
+			// old timestamp and these events overflow causing the indexed event
+			// to have old timestamp too.
+			timestamp:   time.Now().Truncate(interval),
+			serviceName: overflowServiceName,
+		},
+	}
+}
+
+type spanMetrics struct {
+	count float64
+	sum   float64
+}
+
+func makeMetricset(key aggregationKey, metrics spanMetrics) *modelpb.APMEvent {
+	var target *modelpb.ServiceTarget
+	if key.targetName != "" || key.targetType != "" {
+		target = &modelpb.ServiceTarget{
+			Type: key.targetType,
+			Name: key.targetName,
+		}
+	}
+	var t *timestamppb.Timestamp
+	if !key.timestamp.IsZero() {
+		t = timestamppb.New(key.timestamp)
+	}
+
+	var agent *modelpb.Agent
+	if key.agentName != "" {
+		agent = &modelpb.Agent{Name: key.agentName}
+	}
+
+	var event *modelpb.Event
+	if key.outcome != "" {
+		event = &modelpb.Event{
+			Outcome: key.outcome,
+		}
+	}
+
+	return &modelpb.APMEvent{
+		Timestamp: t,
+		Agent:     agent,
+		Service: &modelpb.Service{
+			Name:        key.serviceName,
+			Environment: key.serviceEnvironment,
+			Target:      target,
+		},
+		Labels:        key.Labels,
+		NumericLabels: key.NumericLabels,
+		Event:         event,
+		Metricset: &modelpb.Metricset{
+			Name:     metricsetName,
+			DocCount: uint64(math.Round(metrics.count)),
+		},
+		Span: &modelpb.Span{
+			Name: key.spanName,
+			DestinationService: &modelpb.DestinationService{
+				Resource: key.resource,
+				ResponseTime: &modelpb.AggregatedDuration{
+					Count: uint64(math.Round(metrics.count)),
+					Sum:   durationpb.New(time.Duration(math.Round(metrics.sum))),
+				},
+			},
+		},
+	}
+}

--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator_test.go
@@ -1,0 +1,861 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package spanmetrics
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/elastic/apm-data/model/modelpb"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+func BenchmarkAggregateSpan(b *testing.B) {
+	agg, err := NewAggregator(AggregatorConfig{
+		BatchProcessor: makeErrBatchProcessor(nil),
+		Interval:       time.Minute,
+		MaxGroups:      1000,
+	})
+	require.NoError(b, err)
+
+	span := makeSpan("test_service", "agent", "test_destination", "trg_type", "trg_name", "success", time.Second, 1)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = agg.ProcessBatch(context.Background(), &modelpb.Batch{span})
+		}
+	})
+}
+
+func TestNewAggregatorConfigInvalid(t *testing.T) {
+	report := makeErrBatchProcessor(nil)
+
+	type test struct {
+		config AggregatorConfig
+		err    string
+	}
+
+	for _, test := range []test{{
+		config: AggregatorConfig{},
+		err:    "BatchProcessor unspecified",
+	}, {
+		config: AggregatorConfig{
+			BatchProcessor: report,
+		},
+		err: "MaxGroups unspecified or negative",
+	}, {
+		config: AggregatorConfig{
+			BatchProcessor: report,
+			MaxGroups:      1,
+		},
+		err: "Interval unspecified or negative",
+	}} {
+		agg, err := NewAggregator(test.config)
+		require.Error(t, err)
+		require.Nil(t, agg)
+		assert.EqualError(t, err, "invalid aggregator config: "+test.err)
+	}
+}
+
+func TestAggregatorRun(t *testing.T) {
+	type input struct {
+		serviceName string
+		agentName   string
+		destination string
+		targetType  string
+		targetName  string
+		outcome     string
+		count       float64
+	}
+
+	destinationX := "destination-X"
+	destinationZ := "destination-Z"
+	trgTypeX := "trg-type-X"
+	trgNameX := "trg-name-X"
+	trgTypeZ := "trg-type-Z"
+	trgNameZ := "trg-name-Z"
+
+	for _, tt := range []struct {
+		name string
+
+		inputs []input
+
+		getExpectedEvents func(time.Time, time.Duration) []*modelpb.APMEvent
+	}{
+		{
+			name: "with destination and service targets",
+
+			inputs: []input{
+				{serviceName: "service-A", agentName: "java", destination: destinationZ, targetType: trgTypeZ, targetName: trgNameZ, outcome: "success", count: 2},
+				{serviceName: "service-A", agentName: "java", destination: destinationX, targetType: trgTypeX, targetName: trgNameX, outcome: "success", count: 1},
+				{serviceName: "service-B", agentName: "python", destination: destinationZ, targetType: trgTypeZ, targetName: trgNameZ, outcome: "success", count: 1},
+				{serviceName: "service-A", agentName: "java", destination: destinationZ, targetType: trgTypeZ, targetName: trgNameZ, outcome: "success", count: 1},
+				{serviceName: "service-A", agentName: "java", destination: destinationZ, targetType: trgTypeZ, targetName: trgNameZ, outcome: "success", count: 0},
+				{serviceName: "service-A", agentName: "java", destination: destinationZ, targetType: trgTypeZ, targetName: trgNameZ, outcome: "failure", count: 1},
+			},
+
+			getExpectedEvents: func(now time.Time, interval time.Duration) []*modelpb.APMEvent {
+				return []*modelpb.APMEvent{
+					{
+						Timestamp: timestamppb.New(now.Truncate(interval)),
+						Agent:     &modelpb.Agent{Name: "java"},
+						Service: &modelpb.Service{
+							Name: "service-A",
+							Target: &modelpb.ServiceTarget{
+								Type: trgTypeX,
+								Name: trgNameX,
+							},
+						},
+						Event: &modelpb.Event{Outcome: "success"},
+						Metricset: &modelpb.Metricset{
+							Name:     "service_destination",
+							Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
+							DocCount: 100,
+						},
+						Span: &modelpb.Span{
+							Name: "service-A:" + destinationX,
+							DestinationService: &modelpb.DestinationService{
+								Resource: destinationX,
+								ResponseTime: &modelpb.AggregatedDuration{
+									Count: 100,
+									Sum:   durationpb.New(10 * time.Second),
+								},
+							},
+						},
+						Labels: modelpb.Labels{
+							"department_name": &modelpb.LabelValue{Value: "apm"},
+							"organization":    &modelpb.LabelValue{Value: "observability"},
+							"company":         &modelpb.LabelValue{Value: "elastic"},
+						},
+						NumericLabels: modelpb.NumericLabels{
+							"user_id":     &modelpb.NumericLabelValue{Value: 100},
+							"cost_center": &modelpb.NumericLabelValue{Value: 10},
+						},
+					}, {
+						Timestamp: timestamppb.New(now.Truncate(interval)),
+						Agent:     &modelpb.Agent{Name: "java"},
+						Service: &modelpb.Service{
+							Name: "service-A",
+							Target: &modelpb.ServiceTarget{
+								Type: trgTypeZ,
+								Name: trgNameZ,
+							},
+						},
+						Event: &modelpb.Event{Outcome: "failure"},
+						Metricset: &modelpb.Metricset{
+							Name:     "service_destination",
+							Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
+							DocCount: 100,
+						},
+						Span: &modelpb.Span{
+							Name: "service-A:" + destinationZ,
+							DestinationService: &modelpb.DestinationService{
+								Resource: destinationZ,
+								ResponseTime: &modelpb.AggregatedDuration{
+									Count: 100,
+									Sum:   durationpb.New(10 * time.Second),
+								},
+							},
+						},
+						Labels: modelpb.Labels{
+							"department_name": &modelpb.LabelValue{Value: "apm"},
+							"organization":    &modelpb.LabelValue{Value: "observability"},
+							"company":         &modelpb.LabelValue{Value: "elastic"},
+						},
+						NumericLabels: modelpb.NumericLabels{
+							"user_id":     &modelpb.NumericLabelValue{Value: 100},
+							"cost_center": &modelpb.NumericLabelValue{Value: 10},
+						},
+					}, {
+						Timestamp: timestamppb.New(now.Truncate(interval)),
+						Agent:     &modelpb.Agent{Name: "java"},
+						Service: &modelpb.Service{
+							Name: "service-A",
+							Target: &modelpb.ServiceTarget{
+								Type: trgTypeZ,
+								Name: trgNameZ,
+							},
+						},
+						Event: &modelpb.Event{Outcome: "success"},
+						Metricset: &modelpb.Metricset{
+							Name:     "service_destination",
+							Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
+							DocCount: 300,
+						},
+						Span: &modelpb.Span{
+							Name: "service-A:" + destinationZ,
+							DestinationService: &modelpb.DestinationService{
+								Resource: destinationZ,
+								ResponseTime: &modelpb.AggregatedDuration{
+									Count: 300,
+									Sum:   durationpb.New(30 * time.Second),
+								},
+							},
+						},
+						Labels: modelpb.Labels{
+							"department_name": &modelpb.LabelValue{Value: "apm"},
+							"organization":    &modelpb.LabelValue{Value: "observability"},
+							"company":         &modelpb.LabelValue{Value: "elastic"},
+						},
+						NumericLabels: modelpb.NumericLabels{
+							"user_id":     &modelpb.NumericLabelValue{Value: 100},
+							"cost_center": &modelpb.NumericLabelValue{Value: 10},
+						},
+					}, {
+						Timestamp: timestamppb.New(now.Truncate(interval)),
+						Agent:     &modelpb.Agent{Name: "python"},
+						Service: &modelpb.Service{
+							Name: "service-B",
+							Target: &modelpb.ServiceTarget{
+								Type: trgTypeZ,
+								Name: trgNameZ,
+							},
+						},
+						Event: &modelpb.Event{Outcome: "success"},
+						Metricset: &modelpb.Metricset{
+							Name:     "service_destination",
+							Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
+							DocCount: 100,
+						},
+						Span: &modelpb.Span{
+							Name: "service-B:" + destinationZ,
+							DestinationService: &modelpb.DestinationService{
+								Resource: destinationZ,
+								ResponseTime: &modelpb.AggregatedDuration{
+									Count: 100,
+									Sum:   durationpb.New(10 * time.Second),
+								},
+							},
+						},
+						Labels: modelpb.Labels{
+							"department_name": &modelpb.LabelValue{Value: "apm"},
+							"organization":    &modelpb.LabelValue{Value: "observability"},
+							"company":         &modelpb.LabelValue{Value: "elastic"},
+						},
+						NumericLabels: modelpb.NumericLabels{
+							"user_id":     &modelpb.NumericLabelValue{Value: 100},
+							"cost_center": &modelpb.NumericLabelValue{Value: 10},
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "with no destination and no service target",
+
+			inputs: []input{
+				{serviceName: "service-A", agentName: "java", outcome: "success", count: 1},
+			},
+			getExpectedEvents: func(now time.Time, interval time.Duration) []*modelpb.APMEvent {
+				return []*modelpb.APMEvent{}
+			},
+		},
+		{
+			name: "with no destination and a service target",
+
+			inputs: []input{
+				{serviceName: "service-A", agentName: "java", targetType: trgTypeZ, targetName: trgNameZ, outcome: "success", count: 1},
+			},
+			getExpectedEvents: func(now time.Time, interval time.Duration) []*modelpb.APMEvent {
+				return []*modelpb.APMEvent{
+					{
+						Timestamp: timestamppb.New(now.Truncate(interval)),
+						Agent:     &modelpb.Agent{Name: "java"},
+						Service: &modelpb.Service{
+							Name: "service-A",
+							Target: &modelpb.ServiceTarget{
+								Type: trgTypeZ,
+								Name: trgNameZ,
+							},
+						},
+						Event: &modelpb.Event{Outcome: "success"},
+						Metricset: &modelpb.Metricset{
+							Name:     "service_destination",
+							Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
+							DocCount: 100,
+						},
+						Span: &modelpb.Span{
+							Name: "service-A:",
+							DestinationService: &modelpb.DestinationService{
+								ResponseTime: &modelpb.AggregatedDuration{
+									Count: 100,
+									Sum:   durationpb.New(10 * time.Second),
+								},
+							},
+						},
+						Labels: modelpb.Labels{
+							"department_name": &modelpb.LabelValue{Value: "apm"},
+							"organization":    &modelpb.LabelValue{Value: "observability"},
+							"company":         &modelpb.LabelValue{Value: "elastic"},
+						},
+						NumericLabels: modelpb.NumericLabels{
+							"user_id":     &modelpb.NumericLabelValue{Value: 100},
+							"cost_center": &modelpb.NumericLabelValue{Value: 10},
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "with a destination and no service target",
+
+			inputs: []input{
+				{serviceName: "service-A", agentName: "java", destination: destinationZ, outcome: "success", count: 1},
+			},
+			getExpectedEvents: func(now time.Time, interval time.Duration) []*modelpb.APMEvent {
+				return []*modelpb.APMEvent{
+					{
+						Timestamp: timestamppb.New(now.Truncate(interval)),
+						Agent:     &modelpb.Agent{Name: "java"},
+						Service: &modelpb.Service{
+							Name: "service-A",
+						},
+						Event: &modelpb.Event{Outcome: "success"},
+						Metricset: &modelpb.Metricset{
+							Name:     "service_destination",
+							Interval: fmt.Sprintf("%.0fs", interval.Seconds()),
+							DocCount: 100,
+						},
+						Span: &modelpb.Span{
+							Name: "service-A:" + destinationZ,
+							DestinationService: &modelpb.DestinationService{
+								Resource: destinationZ,
+								ResponseTime: &modelpb.AggregatedDuration{
+									Count: 100,
+									Sum:   durationpb.New(10 * time.Second),
+								},
+							},
+						},
+						Labels: modelpb.Labels{
+							"department_name": &modelpb.LabelValue{Value: "apm"},
+							"organization":    &modelpb.LabelValue{Value: "observability"},
+							"company":         &modelpb.LabelValue{Value: "elastic"},
+						},
+						NumericLabels: modelpb.NumericLabels{
+							"user_id":     &modelpb.NumericLabelValue{Value: 100},
+							"cost_center": &modelpb.NumericLabelValue{Value: 10},
+						},
+					},
+				}
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			batches := make(chan modelpb.Batch, 3)
+			config := AggregatorConfig{
+				BatchProcessor:  makeChanBatchProcessor(batches),
+				Interval:        10 * time.Millisecond,
+				RollUpIntervals: []time.Duration{200 * time.Millisecond, time.Second},
+				MaxGroups:       1000,
+			}
+			agg, err := NewAggregator(config)
+			require.NoError(t, err)
+
+			var wg sync.WaitGroup
+			now := time.Now()
+
+			for _, in := range tt.inputs {
+				wg.Add(1)
+				go func(in input) {
+					defer wg.Done()
+					span := makeSpan(in.serviceName, in.agentName, in.destination, in.targetType, in.targetName, in.outcome, 100*time.Millisecond, in.count)
+					span.Timestamp = timestamppb.New(now)
+					batch := modelpb.Batch{span}
+					for i := 0; i < 100; i++ {
+						err := agg.ProcessBatch(context.Background(), &batch)
+						require.NoError(t, err)
+						assert.Equal(t, modelpb.Batch{span}, batch)
+					}
+				}(in)
+			}
+			wg.Wait()
+
+			// Start the aggregator after processing to ensure metrics are aggregated deterministically.
+			go agg.Run()
+			defer agg.Stop(context.Background())
+			// Stop the aggregator to ensure all metrics are published.
+			assert.NoError(t, agg.Stop(context.Background()))
+
+			for _, interval := range append([]time.Duration{config.Interval}, config.RollUpIntervals...) {
+				expectedEvents := tt.getExpectedEvents(now, interval)
+
+				if len(expectedEvents) == 0 {
+					select {
+					case <-batches:
+						assert.Fail(t, "unexpected publish")
+					case <-time.After(100 * time.Millisecond):
+					}
+				} else {
+					metricsets := batchMetricsets(t, expectBatch(t, batches))
+					assert.Empty(t, cmp.Diff(expectedEvents, metricsets,
+						protocmp.Transform(),
+						cmpopts.SortSlices(func(x, y *modelpb.APMEvent) bool {
+							if x.Span.Name != y.Span.Name {
+								return x.Span.Name < y.Span.Name
+							}
+							if x.Event.Outcome != y.Event.Outcome {
+								return x.Event.Outcome < y.Event.Outcome
+							}
+							return x.Agent.Name < y.Agent.Name
+						}),
+					))
+				}
+			}
+
+			select {
+			case <-batches:
+				t.Fatal("unexpected publish")
+			case <-time.After(100 * time.Millisecond):
+			}
+		})
+	}
+
+}
+
+func TestAggregateCompositeSpan(t *testing.T) {
+	batches := make(chan modelpb.Batch, 1)
+	agg, err := NewAggregator(AggregatorConfig{
+		BatchProcessor: makeChanBatchProcessor(batches),
+		Interval:       10 * time.Millisecond,
+		MaxGroups:      1000,
+	})
+	require.NoError(t, err)
+
+	span := makeSpan("service-A", "java", "final_destination", "trg_type", "trg_name", "success", time.Second, 2)
+	span.Span.Composite = &modelpb.Composite{Count: 25, Sum: 700 /* milliseconds */}
+	err = agg.ProcessBatch(context.Background(), &modelpb.Batch{span})
+	require.NoError(t, err)
+
+	// Start the aggregator after processing to ensure metrics are aggregated deterministically.
+	go agg.Run()
+	defer agg.Stop(context.Background())
+
+	batch := expectBatch(t, batches)
+	metricsets := batchMetricsets(t, batch)
+
+	assert.Empty(t, cmp.Diff([]*modelpb.APMEvent{{
+		Agent: &modelpb.Agent{Name: "java"},
+		Service: &modelpb.Service{
+			Name: "service-A",
+			Target: &modelpb.ServiceTarget{
+				Type: "trg_type",
+				Name: "trg_name",
+			},
+		},
+		Event:     &modelpb.Event{Outcome: "success"},
+		Metricset: &modelpb.Metricset{Name: "service_destination", Interval: "0s", DocCount: 50},
+		Span: &modelpb.Span{
+			Name: "service-A:final_destination",
+			DestinationService: &modelpb.DestinationService{
+				Resource: "final_destination",
+				ResponseTime: &modelpb.AggregatedDuration{
+					Count: 50,
+					Sum:   durationpb.New(1400 * time.Millisecond),
+				},
+			},
+		},
+		Labels: modelpb.Labels{
+			"department_name": &modelpb.LabelValue{Value: "apm"},
+			"organization":    &modelpb.LabelValue{Value: "observability"},
+			"company":         &modelpb.LabelValue{Value: "elastic"},
+		},
+		NumericLabels: modelpb.NumericLabels{
+			"user_id":     &modelpb.NumericLabelValue{Value: 100},
+			"cost_center": &modelpb.NumericLabelValue{Value: 10},
+		},
+	}}, metricsets, protocmp.Transform()))
+}
+
+func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
+	batches := make(chan modelpb.Batch, 1)
+	agg, err := NewAggregator(AggregatorConfig{
+		BatchProcessor: makeChanBatchProcessor(batches),
+		Interval:       10 * time.Millisecond,
+		MaxGroups:      1000,
+	})
+	require.NoError(t, err)
+
+	txWithoutServiceTarget := modelpb.APMEvent{
+		Agent: &modelpb.Agent{Name: "go"},
+		Service: &modelpb.Service{
+			Name: "go-service",
+		},
+		Event: &modelpb.Event{
+			Outcome:  "success",
+			Duration: durationpb.New(10 * time.Second),
+		},
+		Transaction: &modelpb.Transaction{
+			Type:                "transaction_type",
+			RepresentativeCount: 2,
+			DroppedSpansStats: []*modelpb.DroppedSpanStats{
+				{
+					DestinationServiceResource: "https://elasticsearch:9200",
+					Outcome:                    "success",
+					Duration: &modelpb.AggregatedDuration{
+						Count: 10,
+						Sum:   durationpb.New(1500 * time.Microsecond),
+					},
+				},
+				{
+					DestinationServiceResource: "mysql://mysql:3306",
+					Outcome:                    "unknown",
+					Duration: &modelpb.AggregatedDuration{
+						Count: 2,
+						Sum:   durationpb.New(3000 * time.Microsecond),
+					},
+				},
+			},
+		},
+	}
+
+	txWithServiceTarget := modelpb.APMEvent{
+		Agent: &modelpb.Agent{Name: "go"},
+		Service: &modelpb.Service{
+			Name: "go-service",
+		},
+		Event: &modelpb.Event{
+			Outcome:  "success",
+			Duration: durationpb.New(10 * time.Second),
+		},
+		Transaction: &modelpb.Transaction{
+			Type:                "transaction_type",
+			RepresentativeCount: 1,
+			DroppedSpansStats: []*modelpb.DroppedSpanStats{
+				{
+					DestinationServiceResource: "postgres/testdb",
+					ServiceTargetType:          "postgres",
+					ServiceTargetName:          "testdb",
+					Outcome:                    "success",
+					Duration: &modelpb.AggregatedDuration{
+						Count: 10,
+						Sum:   durationpb.New(1500 * time.Microsecond),
+					},
+				},
+			},
+		},
+	}
+
+	txWithNoRepresentativeCount := modelpb.APMEvent{
+		Transaction: &modelpb.Transaction{
+			Type:                "transaction_type",
+			RepresentativeCount: 0,
+			DroppedSpansStats:   make([]*modelpb.DroppedSpanStats, 1),
+		},
+	}
+	err = agg.ProcessBatch(
+		context.Background(),
+		&modelpb.Batch{
+			&txWithoutServiceTarget,
+			&txWithServiceTarget,
+			&txWithNoRepresentativeCount,
+		})
+	require.NoError(t, err)
+
+	// Start the aggregator after processing to ensure metrics are aggregated deterministically.
+	go agg.Run()
+	defer agg.Stop(context.Background())
+
+	batch := expectBatch(t, batches)
+	metricsets := batchMetricsets(t, batch)
+
+	assert.Empty(t, cmp.Diff([]*modelpb.APMEvent{
+		{
+			Agent: &modelpb.Agent{Name: "go"},
+			Service: &modelpb.Service{
+				Name: "go-service",
+			},
+			Event:     &modelpb.Event{Outcome: "success"},
+			Metricset: &modelpb.Metricset{Name: "service_destination", Interval: "0s", DocCount: 20},
+			Span: &modelpb.Span{
+				DestinationService: &modelpb.DestinationService{
+					Resource: "https://elasticsearch:9200",
+					ResponseTime: &modelpb.AggregatedDuration{
+						Count: 20,
+						Sum:   durationpb.New(3000 * time.Microsecond),
+					},
+				},
+			},
+		},
+		{
+			Agent: &modelpb.Agent{Name: "go"},
+			Service: &modelpb.Service{
+				Name: "go-service",
+				Target: &modelpb.ServiceTarget{
+					Type: "postgres",
+					Name: "testdb",
+				},
+			},
+			Event:     &modelpb.Event{Outcome: "success"},
+			Metricset: &modelpb.Metricset{Name: "service_destination", Interval: "0s", DocCount: 10},
+			Span: &modelpb.Span{
+				DestinationService: &modelpb.DestinationService{
+					Resource: "postgres/testdb",
+					ResponseTime: &modelpb.AggregatedDuration{
+						Count: 10,
+						Sum:   durationpb.New(1500 * time.Microsecond),
+					},
+				},
+			},
+		},
+		{
+			Agent: &modelpb.Agent{Name: "go"},
+			Service: &modelpb.Service{
+				Name: "go-service",
+			},
+			Event:     &modelpb.Event{Outcome: "unknown"},
+			Metricset: &modelpb.Metricset{Name: "service_destination", Interval: "0s", DocCount: 4},
+			Span: &modelpb.Span{
+				DestinationService: &modelpb.DestinationService{
+					Resource: "mysql://mysql:3306",
+					ResponseTime: &modelpb.AggregatedDuration{
+						Count: 4,
+						Sum:   durationpb.New(6000 * time.Microsecond),
+					},
+				},
+			},
+		},
+	}, metricsets,
+		protocmp.Transform(),
+		cmpopts.SortSlices(func(e1 *modelpb.APMEvent, e2 *modelpb.APMEvent) bool {
+			return e1.Span.DestinationService.Resource < e2.Span.DestinationService.Resource
+		})))
+}
+
+func TestAggregateHalfCapacityNoSpanName(t *testing.T) {
+	batches := make(chan modelpb.Batch, 1)
+	agg, err := NewAggregator(AggregatorConfig{
+		BatchProcessor: makeChanBatchProcessor(batches),
+		Interval:       10 * time.Millisecond,
+		MaxGroups:      4,
+	})
+	require.NoError(t, err)
+
+	err = agg.ProcessBatch(
+		context.Background(),
+		&modelpb.Batch{
+			makeSpan("service", "agent", "dest1", "target_type", "target1", "success", 100*time.Millisecond, 1),
+			makeSpan("service", "agent", "dest2", "target_type", "target2", "success", 100*time.Millisecond, 1),
+			makeSpan("service", "agent", "dest3", "target_type", "target3", "success", 100*time.Millisecond, 1),
+			makeSpan("service", "agent", "dest4", "target_type", "target4", "success", 100*time.Millisecond, 1),
+		},
+	)
+	require.NoError(t, err)
+
+	// Start the aggregator after processing to ensure metrics are aggregated deterministically.
+	go agg.Run()
+	defer agg.Stop(context.Background())
+
+	batch := expectBatch(t, batches)
+	metricsets := batchMetricsets(t, batch)
+
+	actualDestinationSpanNames := make(map[string]string)
+	for _, ms := range metricsets {
+		actualDestinationSpanNames[ms.Span.DestinationService.Resource] = ms.Span.Name
+	}
+	assert.Equal(t, map[string]string{
+		"dest1": "service:dest1",
+		"dest2": "service:dest2",
+		// After 50% capacity (4 buckets with our configuration) is reached,
+		// the remaining metrics are aggregated without span.name.
+		"dest3": "",
+		"dest4": "",
+	}, actualDestinationSpanNames)
+}
+
+func TestAggregateTimestamp(t *testing.T) {
+	batches := make(chan modelpb.Batch, 1)
+	agg, err := NewAggregator(AggregatorConfig{
+		BatchProcessor: makeChanBatchProcessor(batches),
+		Interval:       30 * time.Second,
+		MaxGroups:      1000,
+	})
+	require.NoError(t, err)
+
+	t0 := time.Unix(0, 0).UTC()
+	for _, ts := range []time.Time{t0, t0.Add(15 * time.Second), t0.Add(30 * time.Second)} {
+		span := makeSpan("service_name", "agent_name", "destination", "trg_type", "trg_name", "success", 100*time.Millisecond, 1)
+		span.Timestamp = timestamppb.New(ts)
+		batch := modelpb.Batch{span}
+		err = agg.ProcessBatch(context.Background(), &batch)
+		require.NoError(t, err)
+		assert.Empty(t, batchMetricsets(t, batch))
+	}
+
+	go agg.Run()
+	err = agg.Stop(context.Background()) // stop to flush
+	require.NoError(t, err)
+
+	batch := expectBatch(t, batches)
+	metricsets := batchMetricsets(t, batch)
+	require.Len(t, metricsets, 2)
+	sort.Slice(metricsets, func(i, j int) bool {
+		return metricsets[i].Timestamp.AsTime().Before(metricsets[j].Timestamp.AsTime())
+	})
+	assert.Equal(t, t0, metricsets[0].Timestamp.AsTime())
+	assert.Equal(t, t0.Add(30*time.Second), metricsets[1].Timestamp.AsTime())
+}
+
+func TestAggregatorOverflow(t *testing.T) {
+	maxGrps := 4
+	overflowCount := 100
+	duration := 100 * time.Millisecond
+	batches := make(chan modelpb.Batch, 1)
+	agg, err := NewAggregator(AggregatorConfig{
+		BatchProcessor: makeChanBatchProcessor(batches),
+		Interval:       10 * time.Second,
+		MaxGroups:      maxGrps,
+	})
+	require.NoError(t, err)
+
+	batch := make(modelpb.Batch, maxGrps+overflowCount) // cause overflow
+	for i := 0; i < len(batch); i++ {
+		batch[i] = makeSpan("service", "agent", fmt.Sprintf("destination%d", i),
+			fmt.Sprintf("trg_type_%d", i), fmt.Sprintf("trg_name_%d", i), "success", duration, 1)
+	}
+	go func(t *testing.T) {
+		t.Helper()
+		require.NoError(t, agg.Run())
+	}(t)
+	require.NoError(t, agg.ProcessBatch(context.Background(), &batch))
+	require.NoError(t, agg.Stop(context.Background()))
+	metricsets := batchMetricsets(t, expectBatch(t, batches))
+	require.Len(t, metricsets, maxGrps+1) // only one `other` metric should overflow
+
+	// assert monitoring
+	registry := monitoring.NewRegistry()
+	monitoring.NewFunc(registry, "spanmetrics", agg.CollectMonitoring)
+	expectedMonitoring := monitoring.MakeFlatSnapshot()
+	expectedMonitoring.Ints["spanmetrics.active_groups"] = int64(maxGrps)
+	expectedMonitoring.Ints["spanmetrics.overflowed.total"] = int64(overflowCount)
+
+	var overflowEvent *modelpb.APMEvent
+	for i := range metricsets {
+		m := metricsets[i]
+		if m.Service.Name == "_other" {
+			if overflowEvent != nil {
+				require.Fail(t, "only one service should overflow")
+			}
+			overflowEvent = m
+		}
+	}
+	assert.Empty(t, cmp.Diff(&modelpb.APMEvent{
+		Service: &modelpb.Service{
+			Name: "_other",
+		},
+		Metricset: &modelpb.Metricset{
+			Name:     "service_destination",
+			DocCount: uint64(overflowCount),
+			Interval: "10s",
+			Samples: []*modelpb.MetricsetSample{
+				{
+					Name:  "service_destination.aggregation.overflow_count",
+					Value: float64(overflowCount),
+				},
+			},
+		},
+		Span: &modelpb.Span{
+			Name: "",
+			DestinationService: &modelpb.DestinationService{
+				Resource: "",
+				ResponseTime: &modelpb.AggregatedDuration{
+					Count: uint64(overflowCount),
+					Sum:   durationpb.New(time.Duration(duration.Nanoseconds() * int64(overflowCount))),
+				},
+			},
+		},
+	}, overflowEvent,
+		protocmp.Transform(),
+		protocmp.IgnoreMessages(&timestamppb.Timestamp{}),
+	))
+}
+
+func makeSpan(
+	serviceName, agentName, destinationServiceResource, targetType, targetName, outcome string,
+	duration time.Duration,
+	count float64,
+) *modelpb.APMEvent {
+	event := modelpb.APMEvent{
+		Agent:   &modelpb.Agent{Name: agentName},
+		Service: &modelpb.Service{Name: serviceName},
+		Event: &modelpb.Event{
+			Outcome:  outcome,
+			Duration: durationpb.New(duration),
+		},
+		Span: &modelpb.Span{
+			Type:                "span_type",
+			Name:                serviceName + ":" + destinationServiceResource,
+			RepresentativeCount: count,
+		},
+		Labels: modelpb.Labels{
+			"department_name": &modelpb.LabelValue{Global: true, Value: "apm"},
+			"organization":    &modelpb.LabelValue{Global: true, Value: "observability"},
+			"company":         &modelpb.LabelValue{Global: true, Value: "elastic"},
+		},
+		NumericLabels: modelpb.NumericLabels{
+			"user_id":     &modelpb.NumericLabelValue{Global: true, Value: 100},
+			"cost_center": &modelpb.NumericLabelValue{Global: true, Value: 10},
+		},
+	}
+	if destinationServiceResource != "" {
+		event.Span.DestinationService = &modelpb.DestinationService{
+			Resource: destinationServiceResource,
+		}
+	}
+	if targetType != "" {
+		event.Service.Target = &modelpb.ServiceTarget{
+			Type: targetType,
+			Name: targetName,
+		}
+	}
+	return &event
+}
+
+func makeErrBatchProcessor(err error) modelpb.BatchProcessor {
+	return modelpb.ProcessBatchFunc(func(context.Context, *modelpb.Batch) error { return err })
+}
+
+func makeChanBatchProcessor(ch chan<- modelpb.Batch) modelpb.BatchProcessor {
+	return modelpb.ProcessBatchFunc(func(ctx context.Context, batch *modelpb.Batch) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ch <- *batch:
+			return nil
+		}
+	})
+}
+
+func expectBatch(t *testing.T, ch <-chan modelpb.Batch) modelpb.Batch {
+	t.Helper()
+	select {
+	case batch := <-ch:
+		return batch
+	case <-time.After(time.Second * 5):
+		t.Fatal("expected publish")
+	}
+	panic("unreachable")
+}
+
+func batchMetricsets(t testing.TB, batch modelpb.Batch) []*modelpb.APMEvent {
+	var metricsets []*modelpb.APMEvent
+	for _, event := range batch {
+		if event.Metricset == nil {
+			continue
+		}
+		metricsets = append(metricsets, event)
+	}
+	return metricsets
+}

--- a/x-pack/apm-server/aggregation/spanmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/spanmetrics/aggregator_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
-	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/elastic/apm-data/model/modelpb"
 	"github.com/elastic/elastic-agent-libs/monitoring"
@@ -110,7 +108,7 @@ func TestAggregatorRun(t *testing.T) {
 			getExpectedEvents: func(now time.Time, interval time.Duration) []*modelpb.APMEvent {
 				return []*modelpb.APMEvent{
 					{
-						Timestamp: timestamppb.New(now.Truncate(interval)),
+						Timestamp: uint64(now.Truncate(interval).UnixNano()),
 						Agent:     &modelpb.Agent{Name: "java"},
 						Service: &modelpb.Service{
 							Name: "service-A",
@@ -131,7 +129,7 @@ func TestAggregatorRun(t *testing.T) {
 								Resource: destinationX,
 								ResponseTime: &modelpb.AggregatedDuration{
 									Count: 100,
-									Sum:   durationpb.New(10 * time.Second),
+									Sum:   uint64(10 * time.Second),
 								},
 							},
 						},
@@ -145,7 +143,7 @@ func TestAggregatorRun(t *testing.T) {
 							"cost_center": &modelpb.NumericLabelValue{Value: 10},
 						},
 					}, {
-						Timestamp: timestamppb.New(now.Truncate(interval)),
+						Timestamp: uint64(now.Truncate(interval).UnixNano()),
 						Agent:     &modelpb.Agent{Name: "java"},
 						Service: &modelpb.Service{
 							Name: "service-A",
@@ -166,7 +164,7 @@ func TestAggregatorRun(t *testing.T) {
 								Resource: destinationZ,
 								ResponseTime: &modelpb.AggregatedDuration{
 									Count: 100,
-									Sum:   durationpb.New(10 * time.Second),
+									Sum:   uint64(10 * time.Second),
 								},
 							},
 						},
@@ -180,7 +178,7 @@ func TestAggregatorRun(t *testing.T) {
 							"cost_center": &modelpb.NumericLabelValue{Value: 10},
 						},
 					}, {
-						Timestamp: timestamppb.New(now.Truncate(interval)),
+						Timestamp: uint64(now.Truncate(interval).UnixNano()),
 						Agent:     &modelpb.Agent{Name: "java"},
 						Service: &modelpb.Service{
 							Name: "service-A",
@@ -201,7 +199,7 @@ func TestAggregatorRun(t *testing.T) {
 								Resource: destinationZ,
 								ResponseTime: &modelpb.AggregatedDuration{
 									Count: 300,
-									Sum:   durationpb.New(30 * time.Second),
+									Sum:   uint64(30 * time.Second),
 								},
 							},
 						},
@@ -215,7 +213,7 @@ func TestAggregatorRun(t *testing.T) {
 							"cost_center": &modelpb.NumericLabelValue{Value: 10},
 						},
 					}, {
-						Timestamp: timestamppb.New(now.Truncate(interval)),
+						Timestamp: uint64(now.Truncate(interval).UnixNano()),
 						Agent:     &modelpb.Agent{Name: "python"},
 						Service: &modelpb.Service{
 							Name: "service-B",
@@ -236,7 +234,7 @@ func TestAggregatorRun(t *testing.T) {
 								Resource: destinationZ,
 								ResponseTime: &modelpb.AggregatedDuration{
 									Count: 100,
-									Sum:   durationpb.New(10 * time.Second),
+									Sum:   uint64(10 * time.Second),
 								},
 							},
 						},
@@ -272,7 +270,7 @@ func TestAggregatorRun(t *testing.T) {
 			getExpectedEvents: func(now time.Time, interval time.Duration) []*modelpb.APMEvent {
 				return []*modelpb.APMEvent{
 					{
-						Timestamp: timestamppb.New(now.Truncate(interval)),
+						Timestamp: uint64(now.Truncate(interval).UnixNano()),
 						Agent:     &modelpb.Agent{Name: "java"},
 						Service: &modelpb.Service{
 							Name: "service-A",
@@ -292,7 +290,7 @@ func TestAggregatorRun(t *testing.T) {
 							DestinationService: &modelpb.DestinationService{
 								ResponseTime: &modelpb.AggregatedDuration{
 									Count: 100,
-									Sum:   durationpb.New(10 * time.Second),
+									Sum:   uint64(10 * time.Second),
 								},
 							},
 						},
@@ -318,7 +316,7 @@ func TestAggregatorRun(t *testing.T) {
 			getExpectedEvents: func(now time.Time, interval time.Duration) []*modelpb.APMEvent {
 				return []*modelpb.APMEvent{
 					{
-						Timestamp: timestamppb.New(now.Truncate(interval)),
+						Timestamp: uint64(now.Truncate(interval).UnixNano()),
 						Agent:     &modelpb.Agent{Name: "java"},
 						Service: &modelpb.Service{
 							Name: "service-A",
@@ -335,7 +333,7 @@ func TestAggregatorRun(t *testing.T) {
 								Resource: destinationZ,
 								ResponseTime: &modelpb.AggregatedDuration{
 									Count: 100,
-									Sum:   durationpb.New(10 * time.Second),
+									Sum:   uint64(10 * time.Second),
 								},
 							},
 						},
@@ -372,7 +370,7 @@ func TestAggregatorRun(t *testing.T) {
 				go func(in input) {
 					defer wg.Done()
 					span := makeSpan(in.serviceName, in.agentName, in.destination, in.targetType, in.targetName, in.outcome, 100*time.Millisecond, in.count)
-					span.Timestamp = timestamppb.New(now)
+					span.Timestamp = uint64(now.UnixNano())
 					batch := modelpb.Batch{span}
 					for i := 0; i < 100; i++ {
 						err := agg.ProcessBatch(context.Background(), &batch)
@@ -463,7 +461,7 @@ func TestAggregateCompositeSpan(t *testing.T) {
 				Resource: "final_destination",
 				ResponseTime: &modelpb.AggregatedDuration{
 					Count: 50,
-					Sum:   durationpb.New(1400 * time.Millisecond),
+					Sum:   uint64(1400 * time.Millisecond),
 				},
 			},
 		},
@@ -495,7 +493,7 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 		},
 		Event: &modelpb.Event{
 			Outcome:  "success",
-			Duration: durationpb.New(10 * time.Second),
+			Duration: uint64(10 * time.Second),
 		},
 		Transaction: &modelpb.Transaction{
 			Type:                "transaction_type",
@@ -506,7 +504,7 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 					Outcome:                    "success",
 					Duration: &modelpb.AggregatedDuration{
 						Count: 10,
-						Sum:   durationpb.New(1500 * time.Microsecond),
+						Sum:   uint64(1500 * time.Microsecond),
 					},
 				},
 				{
@@ -514,7 +512,7 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 					Outcome:                    "unknown",
 					Duration: &modelpb.AggregatedDuration{
 						Count: 2,
-						Sum:   durationpb.New(3000 * time.Microsecond),
+						Sum:   uint64(3000 * time.Microsecond),
 					},
 				},
 			},
@@ -528,7 +526,7 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 		},
 		Event: &modelpb.Event{
 			Outcome:  "success",
-			Duration: durationpb.New(10 * time.Second),
+			Duration: uint64(10 * time.Second),
 		},
 		Transaction: &modelpb.Transaction{
 			Type:                "transaction_type",
@@ -541,7 +539,7 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 					Outcome:                    "success",
 					Duration: &modelpb.AggregatedDuration{
 						Count: 10,
-						Sum:   durationpb.New(1500 * time.Microsecond),
+						Sum:   uint64(1500 * time.Microsecond),
 					},
 				},
 			},
@@ -584,7 +582,7 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 					Resource: "https://elasticsearch:9200",
 					ResponseTime: &modelpb.AggregatedDuration{
 						Count: 20,
-						Sum:   durationpb.New(3000 * time.Microsecond),
+						Sum:   uint64(3000 * time.Microsecond),
 					},
 				},
 			},
@@ -605,7 +603,7 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 					Resource: "postgres/testdb",
 					ResponseTime: &modelpb.AggregatedDuration{
 						Count: 10,
-						Sum:   durationpb.New(1500 * time.Microsecond),
+						Sum:   uint64(1500 * time.Microsecond),
 					},
 				},
 			},
@@ -622,7 +620,7 @@ func TestAggregateTransactionDroppedSpansStats(t *testing.T) {
 					Resource: "mysql://mysql:3306",
 					ResponseTime: &modelpb.AggregatedDuration{
 						Count: 4,
-						Sum:   durationpb.New(6000 * time.Microsecond),
+						Sum:   uint64(6000 * time.Microsecond),
 					},
 				},
 			},
@@ -687,7 +685,7 @@ func TestAggregateTimestamp(t *testing.T) {
 	t0 := time.Unix(0, 0).UTC()
 	for _, ts := range []time.Time{t0, t0.Add(15 * time.Second), t0.Add(30 * time.Second)} {
 		span := makeSpan("service_name", "agent_name", "destination", "trg_type", "trg_name", "success", 100*time.Millisecond, 1)
-		span.Timestamp = timestamppb.New(ts)
+		span.Timestamp = uint64(ts.UnixNano())
 		batch := modelpb.Batch{span}
 		err = agg.ProcessBatch(context.Background(), &batch)
 		require.NoError(t, err)
@@ -702,10 +700,10 @@ func TestAggregateTimestamp(t *testing.T) {
 	metricsets := batchMetricsets(t, batch)
 	require.Len(t, metricsets, 2)
 	sort.Slice(metricsets, func(i, j int) bool {
-		return metricsets[i].Timestamp.AsTime().Before(metricsets[j].Timestamp.AsTime())
+		return metricsets[i].Timestamp < metricsets[j].Timestamp
 	})
-	assert.Equal(t, t0, metricsets[0].Timestamp.AsTime())
-	assert.Equal(t, t0.Add(30*time.Second), metricsets[1].Timestamp.AsTime())
+	assert.Equal(t, uint64(t0.UnixNano()), metricsets[0].Timestamp)
+	assert.Equal(t, uint64(t0.Add(30*time.Second).UnixNano()), metricsets[1].Timestamp)
 }
 
 func TestAggregatorOverflow(t *testing.T) {
@@ -772,13 +770,13 @@ func TestAggregatorOverflow(t *testing.T) {
 				Resource: "",
 				ResponseTime: &modelpb.AggregatedDuration{
 					Count: uint64(overflowCount),
-					Sum:   durationpb.New(time.Duration(duration.Nanoseconds() * int64(overflowCount))),
+					Sum:   uint64(duration.Nanoseconds() * int64(overflowCount)),
 				},
 			},
 		},
 	}, overflowEvent,
 		protocmp.Transform(),
-		protocmp.IgnoreMessages(&timestamppb.Timestamp{}),
+		protocmp.IgnoreFields(&modelpb.APMEvent{}, "timestamp"),
 	))
 }
 
@@ -792,7 +790,7 @@ func makeSpan(
 		Service: &modelpb.Service{Name: serviceName},
 		Event: &modelpb.Event{
 			Outcome:  outcome,
-			Duration: durationpb.New(duration),
+			Duration: uint64(duration),
 		},
 		Span: &modelpb.Span{
 			Type:                "span_type",

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -499,10 +499,9 @@ func makeTransactionAggregationKey(event *modelpb.APMEvent, interval time.Durati
 			faasVersion:     event.GetFaas().GetVersion(),
 		},
 	}
-	if event.Timestamp != 0 {
-		// Group metrics by time interval.
-		key.comparable.timestamp = time.Unix(0, int64(event.Timestamp)).Truncate(interval)
-	}
+	// Group metrics by time interval.
+	key.comparable.timestamp = time.Unix(0, int64(event.Timestamp)).Truncate(interval)
+
 	if event.Faas != nil {
 		key.comparable.faasColdstart = nullableBoolFromPtr(event.Faas.ColdStart)
 	}

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator.go
@@ -1,0 +1,989 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package txmetrics
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/axiomhq/hyperloglog"
+	"github.com/cespare/xxhash/v2"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+	"github.com/elastic/go-hdrhistogram"
+
+	"github.com/elastic/apm-data/model/modelpb"
+	"github.com/elastic/apm-server/internal/logs"
+	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/baseaggregator"
+	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/interval"
+	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/labels"
+)
+
+const (
+	minDuration time.Duration = 0
+	maxDuration time.Duration = time.Hour
+
+	// We scale transaction counts in the histogram, which only permits storing
+	// integer counts, to allow for fractional transactions due to sampling.
+	//
+	// e.g. if the sampling rate is 0.4, then each sampled transaction has a
+	// representative count of 2.5 (1/0.4). If we receive two such transactions
+	// we will record a count of 5000 (2 * 2.5 * histogramCountScale). When we
+	// publish metrics, we will scale down to 5 (5000 / histogramCountScale).
+	histogramCountScale = 1000
+
+	metricsetName = "transaction"
+
+	// overflowBucketName is an identifier to denote overflow buckets
+	overflowBucketName = "_other"
+
+	// overflowLoggerRateLimit is the maximum frequency at which overflow logs
+	// are logged.
+	overflowLoggerRateLimit = time.Minute
+)
+
+// Aggregator aggregates transaction durations, periodically publishing histogram metrics.
+type Aggregator struct {
+	*baseaggregator.Aggregator
+	config  AggregatorConfig
+	metrics *aggregatorMetrics
+
+	overflowLogger *logp.Logger
+
+	mu               sync.RWMutex
+	active, inactive map[time.Duration]*metrics
+
+	histogramPool sync.Pool
+}
+
+type aggregatorMetrics struct {
+	mu                      sync.RWMutex
+	activeGroups            int64
+	txnGroupsOverflow       int64
+	perSvcTxnGroupsOverflow int64
+	servicesOverflow        int64
+}
+
+// AggregatorConfig holds configuration for creating an Aggregator.
+type AggregatorConfig struct {
+	// BatchProcessor is a model.BatchProcessor for asynchronously processing metrics documents.
+	BatchProcessor modelpb.BatchProcessor
+
+	// Logger is the logger for logging histogram aggregation/publishing.
+	//
+	// If Logger is nil, a new logger will be constructed.
+	Logger *logp.Logger
+
+	// MaxTransactionGroups is the maximum number of distinct transaction
+	// group metrics to store within an aggregation period. Once this number
+	// of groups has been reached, any new aggregation keys will be aggregated
+	// in a dedicated service group identified by `_other`.
+	MaxTransactionGroups int
+
+	// MaxTransactionGroupsPerService is the maximum number of distinct
+	// transaction group per service to store within an aggregation period.
+	//
+	// When the limit on per service transaction group is reached the new
+	// transactions will be aggregated in a dedicated transaction group
+	// per service identified by `_other`.
+	MaxTransactionGroupsPerService int
+
+	// MaxServices is the maximum number of distinct services that the
+	// transaction groups will aggregate for.
+	//
+	// When the limit on service count is reached a new service, identified
+	// by name `_other` will be used to aggregate all transactions within a
+	// single bucket.
+	MaxServices int
+
+	// MetricsInterval is the interval between publishing of aggregated
+	// metrics. There may be additional metrics reported at arbitrary
+	// times if the aggregation groups fill up.
+	MetricsInterval time.Duration
+
+	// RollUpIntervals are additional MetricsInterval for the aggregator to
+	// compute and publish metrics for. Each additional interval is constrained
+	// to the same rules as MetricsInterval, and will result in additional
+	// memory to be allocated.
+	RollUpIntervals []time.Duration
+
+	// HDRHistogramSignificantFigures is the number of significant figures
+	// to maintain in the HDR Histograms. HDRHistogramSignificantFigures
+	// must be in the range [1,5].
+	HDRHistogramSignificantFigures int
+}
+
+// Validate validates the aggregator config.
+func (config AggregatorConfig) Validate() error {
+	if config.BatchProcessor == nil {
+		return errors.New("BatchProcessor unspecified")
+	}
+	if config.MaxTransactionGroups <= 0 {
+		return errors.New("MaxTransactionGroups unspecified or negative")
+	}
+	if config.MaxTransactionGroupsPerService <= 0 {
+		return errors.New("MaxTransactionGroupsPerService unspecified or negative")
+	}
+	if config.MaxServices <= 0 {
+		return errors.New("MaxServices unspecified or negative")
+	}
+	if n := config.HDRHistogramSignificantFigures; n < 1 || n > 5 {
+		return errors.Errorf("HDRHistogramSignificantFigures (%d) outside range [1,5]", n)
+	}
+	return nil
+}
+
+// NewAggregator returns a new Aggregator with the given config.
+func NewAggregator(config AggregatorConfig) (*Aggregator, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid aggregator config")
+	}
+	if config.Logger == nil {
+		config.Logger = logp.NewLogger(logs.TransactionMetrics)
+	}
+	aggregator := Aggregator{
+		config:         config,
+		metrics:        &aggregatorMetrics{},
+		overflowLogger: config.Logger.WithOptions(logs.WithRateLimit(overflowLoggerRateLimit)),
+		active:         make(map[time.Duration]*metrics),
+		inactive:       make(map[time.Duration]*metrics),
+		histogramPool: sync.Pool{New: func() interface{} {
+			return hdrhistogram.New(
+				minDuration.Microseconds(),
+				maxDuration.Microseconds(),
+				config.HDRHistogramSignificantFigures,
+			)
+		}},
+	}
+	base, err := baseaggregator.New(baseaggregator.AggregatorConfig{
+		PublishFunc:     aggregator.publish, // inject local publish
+		Logger:          config.Logger,
+		Interval:        config.MetricsInterval,
+		RollUpIntervals: config.RollUpIntervals,
+	})
+	if err != nil {
+		return nil, err
+	}
+	aggregator.Aggregator = base
+	for _, interval := range aggregator.Intervals {
+		aggregator.active[interval] = newMetrics(config.MaxTransactionGroups, config.MaxServices)
+		aggregator.inactive[interval] = newMetrics(config.MaxTransactionGroups, config.MaxServices)
+	}
+	return &aggregator, nil
+}
+
+// CollectMonitoring may be called to collect monitoring metrics from the
+// aggregation. It is intended to be used with libbeat/monitoring.NewFunc.
+//
+// The metrics should be added to the "apm-server.aggregation.txmetrics" registry.
+func (a *Aggregator) CollectMonitoring(_ monitoring.Mode, V monitoring.Visitor) {
+	V.OnRegistryStart()
+	defer V.OnRegistryFinished()
+
+	metrics := a.metrics
+
+	a.metrics.mu.RLock()
+	defer a.metrics.mu.RUnlock()
+
+	totalOverflow := metrics.servicesOverflow + metrics.perSvcTxnGroupsOverflow + metrics.txnGroupsOverflow
+	monitoring.ReportInt(V, "active_groups", metrics.activeGroups)
+	monitoring.ReportNamespace(V, "overflowed", func() {
+		monitoring.ReportInt(V, "services", metrics.servicesOverflow)
+		monitoring.ReportInt(V, "per_service_txn_groups", metrics.perSvcTxnGroupsOverflow)
+		monitoring.ReportInt(V, "txn_groups", metrics.txnGroupsOverflow)
+		monitoring.ReportInt(V, "total", totalOverflow)
+	})
+}
+
+func (a *Aggregator) publish(ctx context.Context, period time.Duration) error {
+	// We hold a.mu only long enough to swap the metrics. This will
+	// be blocked by metrics updates, which is OK, as we prefer not
+	// to block metrics updaters. After the lock is released nothing
+	// will be accessing a.inactive.
+	a.mu.Lock()
+	current := a.active[period]
+	a.active[period], a.inactive[period] = a.inactive[period], current
+	a.mu.Unlock()
+
+	if current.entries == 0 {
+		// The condition will hold even for overflow since an overflow cannot
+		// happen without adding some transaction groups.
+		a.config.Logger.Debugf("no metrics to publish")
+		return nil
+	}
+
+	var servicesOverflow, perSvcTxnGroupsOverflow, txnGroupsOverflow int64
+	isMetricsPeriod := period == a.config.MetricsInterval
+	intervalStr := interval.FormatDuration(period)
+	totalActiveGroups := current.entries + current.overflowedEntries
+	batch := make(modelpb.Batch, 0, totalActiveGroups)
+	for svc, svcEntry := range current.m {
+		for _, entries := range svcEntry.m {
+			for _, entry := range entries {
+				// Record the metricset interval as metricset.interval.
+				event := makeMetricset(entry.transactionAggregationKey, entry.transactionMetrics, intervalStr)
+				batch = append(batch, event)
+				entry.reset(&a.histogramPool)
+			}
+		}
+		if svcEntry.other != nil {
+			overflowCount := int64(svcEntry.otherCardinalityEstimator.Estimate())
+			if isMetricsPeriod {
+				if svc == overflowBucketName {
+					servicesOverflow += overflowCount
+				} else if svcEntry.entries >= a.config.MaxTransactionGroupsPerService {
+					perSvcTxnGroupsOverflow += overflowCount
+				} else {
+					txnGroupsOverflow += overflowCount
+				}
+			}
+			entry := svcEntry.other
+			// Record the metricset interval as metricset.interval.
+			m := makeMetricset(entry.transactionAggregationKey, entry.transactionMetrics, intervalStr)
+			m.Metricset.Samples = append(m.Metricset.Samples, &modelpb.MetricsetSample{
+				Name:  "transaction.aggregation.overflow_count",
+				Value: float64(overflowCount),
+			})
+			batch = append(batch, m)
+			entry.reset(&a.histogramPool)
+		}
+		svcEntry.reset()
+	}
+	if isMetricsPeriod {
+		a.metrics.mu.Lock()
+		a.metrics.activeGroups += int64(totalActiveGroups)
+		a.metrics.servicesOverflow += servicesOverflow
+		a.metrics.perSvcTxnGroupsOverflow += perSvcTxnGroupsOverflow
+		a.metrics.txnGroupsOverflow += txnGroupsOverflow
+		a.metrics.mu.Unlock()
+	}
+	current.reset()
+
+	a.config.Logger.Debugf("%s interval: publishing %d metricsets", period, len(batch))
+	return a.config.BatchProcessor.ProcessBatch(ctx, &batch)
+}
+
+// ProcessBatch aggregates all transactions contained in "b". On overflow
+// the metrics are aggregated into `_other` buckets to contain cardinality.
+func (a *Aggregator) ProcessBatch(ctx context.Context, b *modelpb.Batch) error {
+	for _, event := range *b {
+		if event.Type() != modelpb.TransactionEventType {
+			continue
+		}
+		a.AggregateTransaction(event)
+	}
+	return nil
+}
+
+// AggregateTransaction aggregates transaction metrics.
+//
+// If the transaction cannot be aggregated due to the maximum number
+// of transaction groups being exceeded, then a metricset APMEvent will
+// be returned which should be published immediately, along with the
+// transaction. Otherwise, the returned event will be the zero value.
+//
+// To contain the cardinality of the aggregated metrics the following
+// limits are considered:
+//
+//   - MaxTransactionGroupsPerService: Limits the maximum number of
+//     transactions that a specific service can produce in one aggregation
+//     interval. Once the limit is breached the new transactions are
+//     aggregated under a dedicated bucket with `transaction.name` as `_other`.
+//   - MaxTransactionGroups: Limits the  maximum number of transaction groups
+//     that the aggregator can produce in one aggregation interval. Once the
+//     limit is breached the new transactions are aggregated in the `_other`
+//     transaction bucket of their corresponding services.
+//   - MaxServices: Limits the maximum number of services that the aggregator
+//     can aggregate over. Once this limit is breached the metrics will be
+//     aggregated in the `_other` transaction bucket of a dedicated service
+//     with `service.name` as `_other`.
+func (a *Aggregator) AggregateTransaction(event *modelpb.APMEvent) {
+	count := event.Transaction.RepresentativeCount
+	if count <= 0 {
+		return
+	}
+	for _, interval := range a.Intervals {
+		key := makeTransactionAggregationKey(event, interval)
+		if err := a.updateTransactionMetrics(key, count, event.GetEvent().GetDuration().AsDuration(), interval); err != nil {
+			a.config.Logger.Errorf("failed to aggregate transaction: %w", err)
+		}
+	}
+}
+
+func (a *Aggregator) updateTransactionMetrics(key transactionAggregationKey, count float64, duration, interval time.Duration) error {
+	// Ensure duration is within HDR histogram's bounds
+	if duration < minDuration {
+		duration = minDuration
+	} else if duration > maxDuration {
+		duration = maxDuration
+	}
+
+	hash := key.hash()
+	// Get a read lock over the aggregator to ensure that the active metrics is not
+	// published when updater is processing.
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	m := a.active[interval]
+
+	// Get a read lock over the metrics to search for a pre-existing transaction group
+	// entry.
+	m.mu.RLock()
+	_, entry, offset := m.searchMetricsEntry(hash, key, 0)
+	m.mu.RUnlock()
+	if entry != nil {
+		entry.recordDuration(duration, count)
+		return nil
+	}
+
+	// If cannot find a pre-existing transaction group then acquire a write lock in
+	// order to create a new transaction group. To protect against race conditions due
+	// to manual upgrade of lock search for the transaction group again.
+	var svc *svcMetricsMapEntry
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	svc, entry, _ = m.searchMetricsEntry(hash, key, offset)
+	if entry != nil {
+		entry.recordDuration(duration, count)
+		return nil
+	}
+
+	// If all attempts to search for existing transaction group have failed then a new
+	// transaction group is created as per the following criteria:
+	// 1. If the service exists:
+	//    1.a. If the number of transaction groups for the service is less than the
+	//         limit for max per service transaction group, then create a new group.
+	//    1.b. If the max per service transaction group limit is breached then record
+	//         the metrics in the transaction group overflow bucket for the service.
+	// 2. If the service doesn't exist:
+	//    2.a. If the number of services is less than max services, then create a new
+	//         service and record data as per criteria 1.
+	//    2.b. If the max_services limit is breached, then record the metrics in the
+	//         service overflow bucket.
+	var err error
+	var svcOverflow, perSvcTxnOverflow, txnOverflow bool
+	if svc == nil {
+		// consider service overflow only if a new service needs to be created.
+		svcOverflow = m.services >= a.config.MaxServices
+		svc, err = m.newServiceEntry(key.serviceName, svcOverflow)
+		if err != nil {
+			return err
+		}
+	}
+	perSvcTxnOverflow = svc.entries >= a.config.MaxTransactionGroupsPerService
+	txnOverflow = m.entries >= a.config.MaxTransactionGroups
+
+	// If metrics are overflowing then make sure to update the cardinality estimator
+	// as well as overwrite the key with the overflow key.
+	overflow := svcOverflow || perSvcTxnOverflow || txnOverflow
+	if overflow {
+		// For `_other` service we only account for `_other` transaction bucket.
+		key = makeOverflowAggregationKey(key, svcOverflow, interval)
+		a.logOverflow(key.serviceName, interval, svcOverflow, perSvcTxnOverflow, txnOverflow)
+	}
+	entry, err = m.newMetricsEntry(svc, hash, key, &a.histogramPool, overflow)
+	if err != nil {
+		return err
+	}
+	entry.recordDuration(duration, count)
+	return nil
+}
+
+func (a *Aggregator) logOverflow(svcName string, interval time.Duration, svcOverflow, perSvcTxnOverflow, txnOverflow bool) {
+	if svcOverflow {
+		a.overflowLogger.Warnf(`
+%s Service limit of %d reached, new metric documents will be grouped under a dedicated
+overflow bucket identified by service name '%s'.`[1:],
+			interval.String(),
+			a.config.MaxServices,
+			overflowBucketName,
+		)
+	}
+	if perSvcTxnOverflow {
+		a.overflowLogger.Warnf(`
+%s Transaction group limit of %d reached for service %s, new metric documents will be grouped
+under a dedicated bucket identified by transaction name '%s'. This is typically
+caused by ineffective transaction grouping, e.g. by creating many unique transaction
+names.
+If you are using an agent with 'use_path_as_transaction_name' enabled, it may cause
+high cardinality. If your agent supports the 'transaction_name_groups' option, setting
+that configuration option appropriately, may lead to better results.`[1:],
+			interval.String(),
+			a.config.MaxTransactionGroupsPerService,
+			svcName,
+			overflowBucketName,
+		)
+	}
+	a.overflowLogger.Warnf(`
+%s Overall transaction group limit of %d reached, new metric documents will be grouped
+under a dedicated bucket identified by transaction name '%s'. This is typically
+caused by ineffective transaction grouping, e.g. by creating many unique transaction
+names.
+If you are using an agent with 'use_path_as_transaction_name' enabled, it may cause
+high cardinality. If your agent supports the 'transaction_name_groups' option, setting
+that configuration option appropriately, may lead to better results.`[1:],
+		interval.String(),
+		a.config.MaxTransactionGroups,
+		overflowBucketName,
+	)
+}
+
+func makeOverflowAggregationKey(
+	oldKey transactionAggregationKey,
+	svcOverflow bool,
+	interval time.Duration,
+) transactionAggregationKey {
+	svcName := oldKey.serviceName
+	if svcOverflow {
+		svcName = overflowBucketName
+	}
+	return transactionAggregationKey{
+		comparable: comparable{
+			// We are using `time.Now` here to align the overflow aggregation to
+			// the evaluation time rather than event time. This prevents us from
+			// cases of bad timestamps when the server receives some events with
+			// old timestamp and these events overflow causing the indexed event
+			// to have old timestamp too.
+			timestamp:       time.Now().Truncate(interval),
+			transactionName: overflowBucketName,
+			serviceName:     svcName,
+		},
+	}
+}
+
+func makeTransactionAggregationKey(event *modelpb.APMEvent, interval time.Duration) transactionAggregationKey {
+	key := transactionAggregationKey{
+		comparable: comparable{
+			traceRoot:         event.GetParentId() == "",
+			transactionName:   event.GetTransaction().GetName(),
+			transactionResult: event.GetTransaction().GetResult(),
+			transactionType:   event.GetTransaction().GetType(),
+			eventOutcome:      event.GetEvent().GetOutcome(),
+
+			agentName:             event.GetAgent().GetName(),
+			serviceEnvironment:    event.GetService().GetEnvironment(),
+			serviceName:           event.GetService().GetName(),
+			serviceVersion:        event.GetService().GetVersion(),
+			serviceNodeName:       event.GetService().GetNode().GetName(),
+			serviceRuntimeName:    event.GetService().GetRuntime().GetName(),
+			serviceRuntimeVersion: event.GetService().GetRuntime().GetVersion(),
+
+			serviceLanguageName:    event.GetService().GetLanguage().GetName(),
+			serviceLanguageVersion: event.GetService().GetLanguage().GetVersion(),
+
+			hostHostname:      event.GetHost().GetHostname(),
+			hostName:          event.GetHost().GetName(),
+			hostOSPlatform:    event.GetHost().GetOs().GetPlatform(),
+			containerID:       event.GetContainer().GetId(),
+			kubernetesPodName: event.GetKubernetes().GetPodName(),
+
+			cloudProvider:         event.GetCloud().GetProvider(),
+			cloudRegion:           event.GetCloud().GetRegion(),
+			cloudAvailabilityZone: event.GetCloud().GetAvailabilityZone(),
+			cloudServiceName:      event.GetCloud().GetServiceName(),
+			cloudAccountID:        event.GetCloud().GetAccountId(),
+			cloudAccountName:      event.GetCloud().GetAccountName(),
+			cloudProjectID:        event.GetCloud().GetProjectId(),
+			cloudProjectName:      event.GetCloud().GetProjectName(),
+			cloudMachineType:      event.GetCloud().GetMachineType(),
+
+			faasID:          event.GetFaas().GetId(),
+			faasTriggerType: event.GetFaas().GetTriggerType(),
+			faasName:        event.GetFaas().GetName(),
+			faasVersion:     event.GetFaas().GetVersion(),
+		},
+	}
+	if event.Timestamp != nil {
+		// Group metrics by time interval.
+		key.comparable.timestamp = event.Timestamp.AsTime().Truncate(interval)
+	}
+	if event.Faas != nil {
+		key.comparable.faasColdstart = nullableBoolFromPtr(event.Faas.ColdStart)
+	}
+	key.AggregatedGlobalLabels.Read(event)
+	return key
+}
+
+// makeMetricset creates a metricset with key, metrics, and interval.
+// It uses result from histogram for Transaction.DurationSummary and DocCount to avoid discrepancy and UI weirdness.
+func makeMetricset(key transactionAggregationKey, metrics transactionMetrics, interval string) *modelpb.APMEvent {
+	totalCount, counts, values := metrics.histogramBuckets()
+
+	var eventSuccessCount *modelpb.SummaryMetric
+	switch key.eventOutcome {
+	case "success":
+		eventSuccessCount = &modelpb.SummaryMetric{
+			Count: totalCount,
+			Sum:   float64(totalCount),
+		}
+	case "failure":
+		eventSuccessCount = &modelpb.SummaryMetric{
+			Count: totalCount,
+		}
+	case "unknown":
+		// Keep both Count and Sum as 0.
+	}
+
+	var t *timestamppb.Timestamp
+	if !key.timestamp.IsZero() {
+		t = timestamppb.New(key.timestamp)
+	}
+
+	transactionDurationSummary := modelpb.SummaryMetric{
+		Count: totalCount,
+	}
+	for i, v := range values {
+		transactionDurationSummary.Sum += v * float64(counts[i])
+	}
+
+	var agent *modelpb.Agent
+	if key.agentName != "" {
+		agent = &modelpb.Agent{Name: key.agentName}
+	}
+
+	var container *modelpb.Container
+	if key.containerID != "" {
+		container = &modelpb.Container{Id: key.containerID}
+	}
+
+	var hostOs *modelpb.OS
+	if key.hostOSPlatform != "" {
+		hostOs = &modelpb.OS{
+			Platform: key.hostOSPlatform,
+		}
+	}
+
+	var language *modelpb.Language
+	if key.serviceLanguageName != "" || key.serviceLanguageVersion != "" {
+		language = &modelpb.Language{
+			Name:    key.serviceLanguageName,
+			Version: key.serviceLanguageVersion,
+		}
+	}
+
+	var serviceRuntime *modelpb.Runtime
+	if key.serviceRuntimeName != "" || key.serviceRuntimeVersion != "" {
+		serviceRuntime = &modelpb.Runtime{
+			Name:    key.serviceRuntimeName,
+			Version: key.serviceRuntimeVersion,
+		}
+	}
+
+	var serviceNode *modelpb.ServiceNode
+	if key.serviceNodeName != "" {
+		serviceNode = &modelpb.ServiceNode{
+			Name: key.serviceNodeName,
+		}
+	}
+
+	var cloud *modelpb.Cloud
+	if key.cloudProvider != "" || key.cloudRegion != "" || key.cloudAvailabilityZone != "" || key.cloudServiceName != "" || key.cloudAccountID != "" ||
+		key.cloudAccountName != "" || key.cloudMachineType != "" || key.cloudProjectID != "" || key.cloudProjectName != "" {
+		cloud = &modelpb.Cloud{
+			Provider:         key.cloudProvider,
+			Region:           key.cloudRegion,
+			AvailabilityZone: key.cloudAvailabilityZone,
+			ServiceName:      key.cloudServiceName,
+			AccountId:        key.cloudAccountID,
+			AccountName:      key.cloudAccountName,
+			MachineType:      key.cloudMachineType,
+			ProjectId:        key.cloudProjectID,
+			ProjectName:      key.cloudProjectName,
+		}
+	}
+
+	var hostStr *modelpb.Host
+	if key.hostHostname != "" || key.hostName != "" || hostOs != nil {
+		hostStr = &modelpb.Host{
+			Hostname: key.hostHostname,
+			Name:     key.hostName,
+			Os:       hostOs,
+		}
+	}
+
+	var service *modelpb.Service
+	if key.serviceName != "" || key.serviceVersion != "" || serviceNode != nil || key.serviceEnvironment != "" || serviceRuntime != nil || language != nil {
+		service = &modelpb.Service{
+			Name:        key.serviceName,
+			Version:     key.serviceVersion,
+			Node:        serviceNode,
+			Environment: key.serviceEnvironment,
+			Runtime:     serviceRuntime,
+			Language:    language,
+		}
+	}
+
+	var kube *modelpb.Kubernetes
+	if key.kubernetesPodName != "" {
+		kube = &modelpb.Kubernetes{PodName: key.kubernetesPodName}
+	}
+
+	var faas *modelpb.Faas
+	if key.faasColdstart.isSet || key.faasID != "" || key.faasTriggerType != "" || key.faasName != "" || key.faasVersion != "" {
+		faas = &modelpb.Faas{
+			ColdStart:   key.faasColdstart.toPtr(),
+			Id:          key.faasID,
+			TriggerType: key.faasTriggerType,
+			Name:        key.faasName,
+			Version:     key.faasVersion,
+		}
+	}
+
+	var eventStr *modelpb.Event
+	if key.eventOutcome != "" || eventSuccessCount != nil {
+		eventStr = &modelpb.Event{
+			Outcome:      key.eventOutcome,
+			SuccessCount: eventSuccessCount,
+		}
+	}
+
+	return &modelpb.APMEvent{
+		Timestamp:     t,
+		Agent:         agent,
+		Container:     container,
+		Kubernetes:    kube,
+		Service:       service,
+		Cloud:         cloud,
+		Host:          hostStr,
+		Event:         eventStr,
+		Faas:          faas,
+		Labels:        key.AggregatedGlobalLabels.Labels,
+		NumericLabels: key.AggregatedGlobalLabels.NumericLabels,
+		Metricset: &modelpb.Metricset{
+			Name:     metricsetName,
+			DocCount: totalCount,
+			Interval: interval,
+		},
+		Transaction: &modelpb.Transaction{
+			Name:   key.transactionName,
+			Type:   key.transactionType,
+			Result: key.transactionResult,
+			Root:   key.traceRoot,
+			DurationHistogram: &modelpb.Histogram{
+				Counts: counts,
+				Values: values,
+			},
+			DurationSummary: &transactionDurationSummary,
+		},
+	}
+}
+
+type metrics struct {
+	mu       sync.RWMutex
+	space    *baseaggregator.Space[metricsMapEntry]
+	svcSpace *baseaggregator.Space[svcMetricsMapEntry]
+	m        map[string]*svcMetricsMapEntry
+	// entries refer to the total number of tx groups getting aggregated excluding
+	// overflow. Used to identify overflow limit breaches as they only account for
+	// non-overflow groups.
+	entries int
+	// overflowedEntries refer to the total number of overflowed transaction groups
+	// getting aggregated.
+	overflowedEntries int
+	// services refer to the total number of services getting aggregated excluding
+	// overflow. Used to identify overflow limit breaches as they only account for
+	// non-overflow services.
+	services int
+}
+
+func newMetrics(maxGroups, maxServices int) *metrics {
+	return &metrics{
+		// Total number of entries = 1 per txn + 1 overflow per svc + 1 `_other` svc
+		space: baseaggregator.NewSpace[metricsMapEntry](maxGroups + maxServices + 1),
+		// keep 1 reserved entry for `_other` service
+		svcSpace: baseaggregator.NewSpace[svcMetricsMapEntry](maxServices + 1),
+		m:        make(map[string]*svcMetricsMapEntry),
+	}
+}
+
+func (m *metrics) searchMetricsEntry(
+	hash uint64,
+	key transactionAggregationKey,
+	offset int,
+) (*svcMetricsMapEntry, *metricsMapEntry, int) {
+	svc, ok := m.m[key.serviceName]
+	if !ok {
+		return nil, nil, offset
+	}
+	entries, ok := svc.m[hash]
+	if !ok {
+		return svc, nil, offset
+	}
+	for ; offset < len(entries); offset++ {
+		entry := entries[offset]
+		if entry.transactionAggregationKey.equal(key) {
+			return svc, entry, offset + 1
+		}
+	}
+	// return offset to indicate the next index that should be searched in future
+	// to continue looking for the aggregation key. This will be useful when read
+	// lock is upgraded to write lock and we need to attempt another search to
+	// handle race conditions.
+	return svc, nil, offset
+}
+
+// newServiceEntry creates a new entry for a given service name. If overflow is true then
+// it either creates a entry for overflow or returns the previously created entry.
+func (m *metrics) newServiceEntry(svcName string, overflow bool) (*svcMetricsMapEntry, error) {
+	var err error
+	if overflow {
+		// put the overflow bucket as a service map to avoid handling it separately
+		// while publishing the metrics.
+		svc, ok := m.m[overflowBucketName]
+		if !ok {
+			svc, err = m.svcSpace.Next()
+			if err != nil {
+				return nil, err
+			}
+			m.m[overflowBucketName] = svc
+		}
+		return svc, nil
+	}
+
+	svc, err := m.svcSpace.Next()
+	if err != nil {
+		return nil, err
+	}
+	if svc.m == nil {
+		svc.m = make(map[uint64][]*metricsMapEntry)
+	}
+	m.m[svcName] = svc
+	m.services++
+	return svc, nil
+}
+
+// newMetricsEntry creates a new entry for a transaction group metric. If overflow is true then
+// it either creates a entry for overflow or returns the previously created entry.
+func (m *metrics) newMetricsEntry(
+	svc *svcMetricsMapEntry,
+	hash uint64,
+	key transactionAggregationKey,
+	histogramPool *sync.Pool,
+	overflow bool,
+) (*metricsMapEntry, error) {
+	getNewMetricsMapEntry := func() (*metricsMapEntry, error) {
+		entry, err := m.space.Next()
+		if err != nil {
+			return nil, err
+		}
+		entry.transactionAggregationKey = key
+		entry.transactionMetrics = transactionMetrics{
+			histogram: histogramPool.Get().(*hdrhistogram.Histogram),
+		}
+		return entry, nil
+	}
+	if overflow {
+		if svc.other == nil {
+			entry, err := getNewMetricsMapEntry()
+			if err != nil {
+				return nil, err
+			}
+			svc.other = entry
+			svc.otherCardinalityEstimator = hyperloglog.New14()
+			m.overflowedEntries++
+		}
+		svc.otherCardinalityEstimator.InsertHash(hash)
+		return svc.other, nil
+	}
+
+	entry, err := getNewMetricsMapEntry()
+	if err != nil {
+		return entry, err
+	}
+	svc.m[hash] = append(svc.m[hash], entry)
+	m.entries++
+	svc.entries++
+	return entry, nil
+}
+
+func (m *metrics) reset() {
+	for k := range m.m {
+		delete(m.m, k)
+	}
+	m.entries = 0
+	m.services = 0
+	m.space.Reset()
+	m.svcSpace.Reset()
+}
+
+type svcMetricsMapEntry struct {
+	m                         map[uint64][]*metricsMapEntry
+	other                     *metricsMapEntry
+	otherCardinalityEstimator *hyperloglog.Sketch
+	// entries refer to the total transaction groups getting aggregated excluding overflow.
+	// Used to identify overflow limit breaches as they only account for non-overflow groups.
+	entries int
+}
+
+func (s *svcMetricsMapEntry) reset() {
+	for k := range s.m {
+		delete(s.m, k)
+	}
+	s.other = nil
+	s.otherCardinalityEstimator = nil
+	s.entries = 0
+}
+
+type metricsMapEntry struct {
+	transactionMetrics
+	transactionAggregationKey
+}
+
+func (e *metricsMapEntry) reset(pool *sync.Pool) {
+	e.histogram.Reset()
+	pool.Put(e.histogram)
+	e.histogram = nil
+}
+
+type nullableBool struct {
+	isSet bool
+	val   bool
+}
+
+func (nb nullableBool) toPtr() *bool {
+	if !nb.isSet {
+		return nil
+	}
+	return &nb.val
+}
+
+func nullableBoolFromPtr(b *bool) nullableBool {
+	return nullableBool{
+		isSet: b != nil,
+		val:   b != nil && *b,
+	}
+}
+
+// comparable contains the fields with types which can be compared with the
+// equal operator '=='.
+type comparable struct {
+	timestamp              time.Time
+	faasColdstart          nullableBool
+	faasID                 string
+	faasName               string
+	faasVersion            string
+	agentName              string
+	hostOSPlatform         string
+	kubernetesPodName      string
+	cloudProvider          string
+	cloudRegion            string
+	cloudAvailabilityZone  string
+	cloudServiceName       string
+	cloudAccountID         string
+	cloudAccountName       string
+	cloudMachineType       string
+	cloudProjectID         string
+	cloudProjectName       string
+	serviceEnvironment     string
+	serviceName            string
+	serviceVersion         string
+	serviceNodeName        string
+	serviceRuntimeName     string
+	serviceRuntimeVersion  string
+	serviceLanguageName    string
+	serviceLanguageVersion string
+	transactionName        string
+	transactionResult      string
+	transactionType        string
+	eventOutcome           string
+	faasTriggerType        string
+	hostHostname           string
+	hostName               string
+	containerID            string
+	traceRoot              bool
+}
+
+// NOTE(axw) the dimensions should be kept in sync with docs/data-model.asciidoc
+// for the current documentation on the APM Server model.
+type transactionAggregationKey struct {
+	labels.AggregatedGlobalLabels
+	comparable
+}
+
+func (k *transactionAggregationKey) hash() uint64 {
+	var h xxhash.Digest
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(k.timestamp.UnixNano()))
+	h.Write(buf[:])
+	if k.traceRoot {
+		h.WriteString("1")
+	}
+	if k.faasColdstart.isSet && k.faasColdstart.val {
+		h.WriteString("1")
+	}
+	k.AggregatedGlobalLabels.Write(&h)
+	h.WriteString(k.agentName)
+	h.WriteString(k.containerID)
+	h.WriteString(k.hostHostname)
+	h.WriteString(k.hostName)
+	h.WriteString(k.hostOSPlatform)
+	h.WriteString(k.kubernetesPodName)
+	h.WriteString(k.cloudProvider)
+	h.WriteString(k.cloudRegion)
+	h.WriteString(k.cloudAvailabilityZone)
+	h.WriteString(k.cloudServiceName)
+	h.WriteString(k.cloudAccountID)
+	h.WriteString(k.cloudAccountName)
+	h.WriteString(k.cloudMachineType)
+	h.WriteString(k.cloudProjectID)
+	h.WriteString(k.cloudProjectName)
+	h.WriteString(k.serviceEnvironment)
+	h.WriteString(k.serviceName)
+	h.WriteString(k.serviceVersion)
+	h.WriteString(k.serviceNodeName)
+	h.WriteString(k.serviceRuntimeName)
+	h.WriteString(k.serviceRuntimeVersion)
+	h.WriteString(k.serviceLanguageName)
+	h.WriteString(k.serviceLanguageVersion)
+	h.WriteString(k.transactionName)
+	h.WriteString(k.transactionResult)
+	h.WriteString(k.transactionType)
+	h.WriteString(k.eventOutcome)
+	h.WriteString(k.faasID)
+	h.WriteString(k.faasTriggerType)
+	h.WriteString(k.faasName)
+	h.WriteString(k.faasVersion)
+	return h.Sum64()
+}
+
+func (k *transactionAggregationKey) equal(key transactionAggregationKey) bool {
+	return k.comparable == key.comparable &&
+		k.AggregatedGlobalLabels.Equals(&key.AggregatedGlobalLabels)
+}
+
+type transactionMetrics struct {
+	histogram *hdrhistogram.Histogram
+}
+
+func (m *transactionMetrics) recordDuration(d time.Duration, n float64) {
+	count := int64(math.Round(n * histogramCountScale))
+	m.histogram.RecordValuesAtomic(d.Microseconds(), count)
+}
+
+func (m *transactionMetrics) histogramBuckets() (totalCount uint64, counts []uint64, values []float64) {
+	// From https://www.elastic.co/guide/en/elasticsearch/reference/current/histogram.html:
+	//
+	// "For the High Dynamic Range (HDR) histogram mode, the values array represents
+	// fixed upper limits of each bucket interval, and the counts array represents
+	// the number of values that are attributed to each interval."
+	distribution := m.histogram.Distribution()
+	counts = make([]uint64, 0, len(distribution))
+	values = make([]float64, 0, len(distribution))
+	for _, b := range distribution {
+		if b.Count <= 0 {
+			continue
+		}
+		count := uint64(math.Round(float64(b.Count) / histogramCountScale))
+		counts = append(counts, count)
+		values = append(values, float64(b.To))
+		totalCount += count
+	}
+	return totalCount, counts, values
+}

--- a/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
+++ b/x-pack/apm-server/aggregation/txmetrics/aggregator_test.go
@@ -1,0 +1,899 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package txmetrics_test
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/elastic/apm-data/model/modelpb"
+	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/txmetrics"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/monitoring"
+)
+
+func TestNewAggregatorConfigInvalid(t *testing.T) {
+	batchProcessor := makeErrBatchProcessor(nil)
+
+	type test struct {
+		config txmetrics.AggregatorConfig
+		err    string
+	}
+
+	for _, test := range []test{{
+		config: txmetrics.AggregatorConfig{},
+		err:    "BatchProcessor unspecified",
+	}, {
+		config: txmetrics.AggregatorConfig{
+			BatchProcessor: batchProcessor,
+		},
+		err: "MaxTransactionGroups unspecified or negative",
+	}, {
+		config: txmetrics.AggregatorConfig{
+			BatchProcessor:       batchProcessor,
+			MaxTransactionGroups: 1,
+		},
+		err: "MaxTransactionGroupsPerService unspecified or negative",
+	}, {
+		config: txmetrics.AggregatorConfig{
+			BatchProcessor:                 batchProcessor,
+			MaxTransactionGroups:           1,
+			MaxTransactionGroupsPerService: 1,
+		},
+		err: "MaxServices unspecified or negative",
+	}, {
+		config: txmetrics.AggregatorConfig{
+			BatchProcessor:                 batchProcessor,
+			MaxTransactionGroups:           1,
+			MaxTransactionGroupsPerService: 1,
+			MaxServices:                    1,
+			HDRHistogramSignificantFigures: 5,
+		},
+		err: "Interval unspecified or negative",
+	}, {
+		config: txmetrics.AggregatorConfig{
+			BatchProcessor:                 batchProcessor,
+			MaxTransactionGroups:           1,
+			MaxTransactionGroupsPerService: 1,
+			MaxServices:                    1,
+			MetricsInterval:                time.Nanosecond,
+			HDRHistogramSignificantFigures: 6,
+		},
+		err: "HDRHistogramSignificantFigures (6) outside range [1,5]",
+	}} {
+		agg, err := txmetrics.NewAggregator(test.config)
+		require.Error(t, err)
+		require.Nil(t, agg)
+		assert.EqualError(t, err, "invalid aggregator config: "+test.err)
+	}
+}
+
+func TestTxnAggregator_ResetAfterPublish(t *testing.T) {
+	batches := make(chan modelpb.Batch, 1)
+	agg, err := txmetrics.NewAggregator(txmetrics.AggregatorConfig{
+		BatchProcessor:                 makeChanBatchProcessor(batches),
+		MaxServices:                    3,
+		MaxTransactionGroups:           3,
+		MaxTransactionGroupsPerService: 2,
+		MetricsInterval:                100 * time.Millisecond,
+		HDRHistogramSignificantFigures: 5,
+	})
+	assert.NoError(t, err)
+	batch := modelpb.Batch{
+		&modelpb.APMEvent{
+			Event: &modelpb.Event{
+				Outcome:  "success",
+				Duration: durationpb.New(time.Second),
+			},
+			Transaction: &modelpb.Transaction{
+				Type:                "type",
+				Name:                "txn1",
+				RepresentativeCount: 1,
+			},
+			Service: &modelpb.Service{Name: "svc1"},
+		},
+	}
+	go func(t *testing.T) {
+		t.Helper()
+		require.NoError(t, agg.Run())
+	}(t)
+
+	registry := monitoring.NewRegistry()
+	monitoring.NewFunc(registry, "txmetrics", agg.CollectMonitoring)
+	for i := 0; i < 5; i++ {
+		// The repition count should be set to be higher than 2 because
+		// the aggregators use two datastructures: active and inactive.
+
+		// Each batch has the same transactions configured to not overflow
+		require.NoError(t, agg.ProcessBatch(context.Background(), &batch))
+		batchMetricsets(t, expectBatch(t, batches))
+		expectedMonitoring := monitoring.MakeFlatSnapshot()
+		// active_groups is a counter so it will increase for every iteration
+		// there should be no expected overflow
+		expectedMonitoring.Ints["txmetrics.active_groups"] = int64(i + 1)
+		expectedMonitoring.Ints["txmetrics.overflowed.per_service_txn_groups"] = 0
+		expectedMonitoring.Ints["txmetrics.overflowed.txn_groups"] = 0
+		expectedMonitoring.Ints["txmetrics.overflowed.services"] = 0
+		expectedMonitoring.Ints["txmetrics.overflowed.total"] = 0
+		assert.Equal(t, expectedMonitoring, monitoring.CollectFlatSnapshot(
+			registry,
+			monitoring.Full,
+			false,
+		))
+	}
+}
+
+func TestTxnAggregatorProcessBatch(t *testing.T) {
+	const txnDuration = 100 * time.Millisecond
+	for _, tc := range []struct {
+		// all unique txns are distributed in unique services sequentially
+		// for 7 transactions and 3 services; first three service will receive
+		// 2 txns and the last one will receive 1 txn.
+		// Note that practically uniqueTxnCount will always be >= uniqueServices.
+		name string
+
+		// aggregation limits
+		maxServicesLimit        int
+		maxTxnGroupsLimit       int
+		maxTxnGroupsPerSvcLimit int
+
+		// load distribution of unique transactions across services
+		uniqueTxnCount int
+		uniqueServices int
+
+		expectedActiveGroups int
+		// expectedOverflowReasonPerSvcTxnGrps represent total number of txn groups
+		// that overflowed due to per service txn group limit assuming all servies
+		// overflow equally. These will be recorded in the `transaction.name: _other`
+		// and the corresponding service name documents.
+		expectedOverflowReasonPerSvcTxnGrps int
+		// expectedOverflowReasonTxnGrps represent total number of txn groups that
+		// overflowed due to max txn groups limit. These will be recorded in the
+		// `transaction.name: _other` and the corresponding service name documents.
+		expectedOverflowReasonTxnGrps int
+		// expectedOverflowReasonSvc represents total number of txn groups that
+		// overflowed due to max services limit. These will be recorded in the
+		// `transaction.name: _other` and the `service.name: _other` document.
+		expectedOverflowReasonSvc int
+	}{
+		{
+			name: "no_overflow",
+
+			maxServicesLimit:        10,
+			maxTxnGroupsPerSvcLimit: 10,
+			maxTxnGroupsLimit:       100,
+
+			uniqueTxnCount: 100,
+			uniqueServices: 10,
+
+			expectedActiveGroups:                100,
+			expectedOverflowReasonPerSvcTxnGrps: 0,
+			expectedOverflowReasonTxnGrps:       0,
+			expectedOverflowReasonSvc:           0,
+		},
+		{
+			name: "overflow_for_max_per_svc_txn_grps",
+
+			maxServicesLimit:        20,
+			maxTxnGroupsPerSvcLimit: 10,
+			maxTxnGroupsLimit:       100,
+
+			uniqueTxnCount: 100,
+			uniqueServices: 5,
+
+			expectedActiveGroups:                55, // 10 txn groups + 1 overflow per service
+			expectedOverflowReasonPerSvcTxnGrps: 50,
+			expectedOverflowReasonTxnGrps:       0,
+			expectedOverflowReasonSvc:           0,
+		},
+		{
+			name: "overflow_for_max_txn_grps",
+
+			maxServicesLimit:        20,
+			maxTxnGroupsPerSvcLimit: 10,
+			maxTxnGroupsLimit:       100,
+
+			uniqueTxnCount: 200,
+			uniqueServices: 20,
+
+			expectedActiveGroups:                120,
+			expectedOverflowReasonPerSvcTxnGrps: 0,
+			expectedOverflowReasonTxnGrps:       100,
+			expectedOverflowReasonSvc:           0,
+		},
+		{
+			name: "overflow_for_max_svcs",
+
+			maxServicesLimit:        10,
+			maxTxnGroupsPerSvcLimit: 10,
+			maxTxnGroupsLimit:       100,
+
+			uniqueTxnCount: 200,
+			uniqueServices: 20,
+
+			expectedActiveGroups:                101,
+			expectedOverflowReasonPerSvcTxnGrps: 0,
+			expectedOverflowReasonTxnGrps:       0,
+			expectedOverflowReasonSvc:           100,
+		},
+		{
+			name: "overflow_for_max_svcs_and_max_per_svc_txn_grps",
+
+			maxServicesLimit:        10,
+			maxTxnGroupsPerSvcLimit: 10,
+			maxTxnGroupsLimit:       100,
+
+			uniqueTxnCount: 400,
+			uniqueServices: 20,
+
+			expectedActiveGroups:                111,
+			expectedOverflowReasonPerSvcTxnGrps: 100,
+			expectedOverflowReasonTxnGrps:       0,
+			expectedOverflowReasonSvc:           200,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			batches := make(chan modelpb.Batch, 1)
+			agg, err := txmetrics.NewAggregator(txmetrics.AggregatorConfig{
+				BatchProcessor:                 makeChanBatchProcessor(batches),
+				MaxServices:                    tc.maxServicesLimit,
+				MaxTransactionGroups:           tc.maxTxnGroupsLimit,
+				MaxTransactionGroupsPerService: tc.maxTxnGroupsPerSvcLimit,
+				MetricsInterval:                30 * time.Second,
+				HDRHistogramSignificantFigures: 5,
+			})
+			require.NoError(t, err)
+
+			repCount := 1
+			batch := make(modelpb.Batch, tc.uniqueTxnCount*repCount)
+			for i := 0; i < len(batch); i++ {
+				batch[i] = &modelpb.APMEvent{
+					Event: &modelpb.Event{
+						Outcome:  "success",
+						Duration: durationpb.New(txnDuration),
+					},
+					Transaction: &modelpb.Transaction{
+						Type:                "type",
+						Name:                fmt.Sprintf("foo%d", i%tc.uniqueTxnCount),
+						RepresentativeCount: 1,
+					},
+					Service: &modelpb.Service{Name: fmt.Sprintf("svc%d", i%tc.uniqueServices)},
+				}
+			}
+			go func(t *testing.T) {
+				t.Helper()
+				require.NoError(t, agg.Run())
+			}(t)
+			require.NoError(t, agg.ProcessBatch(context.Background(), &batch))
+			require.NoError(t, agg.Stop(context.Background()))
+			metricsets := batchMetricsets(t, expectBatch(t, batches))
+			expectedMonitoring := monitoring.MakeFlatSnapshot()
+
+			expectedMonitoring.Ints["txmetrics.active_groups"] = int64(tc.expectedActiveGroups)
+			expectedMonitoring.Ints["txmetrics.overflowed.per_service_txn_groups"] = int64(tc.expectedOverflowReasonPerSvcTxnGrps)
+			expectedMonitoring.Ints["txmetrics.overflowed.txn_groups"] = int64(tc.expectedOverflowReasonTxnGrps)
+			expectedMonitoring.Ints["txmetrics.overflowed.services"] = int64(tc.expectedOverflowReasonSvc)
+			expectedMonitoring.Ints["txmetrics.overflowed.total"] = int64(
+				tc.expectedOverflowReasonPerSvcTxnGrps + tc.expectedOverflowReasonTxnGrps + tc.expectedOverflowReasonSvc)
+			registry := monitoring.NewRegistry()
+			monitoring.NewFunc(registry, "txmetrics", agg.CollectMonitoring)
+			assert.Equal(t, expectedMonitoring, monitoring.CollectFlatSnapshot(
+				registry,
+				monitoring.Full,
+				false, // expvar
+			))
+
+			var expectedOverflowMetricsets []*modelpb.APMEvent
+			var totalOverflowSvcCount int
+			totalOverflowIntoAllSvcBuckets := tc.expectedOverflowReasonPerSvcTxnGrps + tc.expectedOverflowReasonTxnGrps
+			// Assuming that all services in the test will overflow equally, any overflow due to max
+			// transaction groups or per service transaction group limit limit will overflow into the
+			// corresponding service's overflow bucket uptil the max services limit.
+			if totalOverflowIntoAllSvcBuckets > 0 {
+				totalOverflowSvcCount = tc.uniqueServices
+				if tc.uniqueServices > tc.maxServicesLimit {
+					totalOverflowSvcCount = tc.maxServicesLimit
+				}
+			}
+			// If there are any overflows due to the max services limit then the overflow
+			// will be aggregated under a special `service.name: _other` bucket.
+			if tc.expectedOverflowReasonSvc > 0 {
+				expectedOverflowMetricsets = append(
+					expectedOverflowMetricsets,
+					createOverflowMetricset(tc.expectedOverflowReasonSvc, repCount, txnDuration),
+				)
+			}
+			for i := 0; i < totalOverflowSvcCount; i++ {
+				totalOverflowForEachSvcBuckets := totalOverflowIntoAllSvcBuckets / totalOverflowSvcCount
+				expectedOverflowMetricsets = append(
+					expectedOverflowMetricsets,
+					createOverflowMetricset(totalOverflowForEachSvcBuckets, repCount, txnDuration),
+				)
+			}
+			var expectedMetrics []*modelpb.APMEvent
+			var finalMetricset []*modelpb.APMEvent
+			for _, v := range metricsets {
+				if v.Transaction.Name == "_other" {
+					finalMetricset = append(finalMetricset, v)
+				}
+			}
+			for _, a := range expectedOverflowMetricsets {
+				if a.Transaction.Name == "_other" {
+					expectedMetrics = append(expectedMetrics, a)
+				}
+			}
+			assert.Empty(t, cmp.Diff(
+				expectedMetrics,
+				finalMetricset,
+				protocmp.Transform(),
+				protocmp.IgnoreFields(&modelpb.APMEvent{}, "timestamp"),
+				protocmp.IgnoreFields(&modelpb.Service{}, "name"),
+				cmpopts.SortSlices(func(a, b *modelpb.APMEvent) bool {
+					return a.GetService().GetName() < b.GetService().GetName()
+				}),
+			))
+		})
+	}
+}
+
+func TestAggregatorRun(t *testing.T) {
+	batches := make(chan modelpb.Batch, 6)
+	config := txmetrics.AggregatorConfig{
+		BatchProcessor:                 makeChanBatchProcessor(batches),
+		MaxTransactionGroups:           2,
+		MaxTransactionGroupsPerService: 2,
+		MaxServices:                    2,
+		MetricsInterval:                10 * time.Millisecond,
+		RollUpIntervals:                []time.Duration{200 * time.Millisecond, time.Second},
+		HDRHistogramSignificantFigures: 1,
+	}
+	agg, err := txmetrics.NewAggregator(config)
+	require.NoError(t, err)
+
+	intervals := append([]time.Duration{config.MetricsInterval}, config.RollUpIntervals...)
+	now := time.Now().UTC()
+	for i := 0; i < 1000; i++ {
+		event := modelpb.APMEvent{
+			Event:     &modelpb.Event{Duration: durationpb.New(time.Second)},
+			Timestamp: timestamppb.New(now),
+			Labels: modelpb.Labels{
+				"department_name": &modelpb.LabelValue{Global: true, Value: "apm"},
+				"organization":    &modelpb.LabelValue{Global: true, Value: "observability"},
+				"company":         &modelpb.LabelValue{Global: true, Value: "elastic"},
+			},
+			NumericLabels: modelpb.NumericLabels{
+				"user_id":     &modelpb.NumericLabelValue{Global: true, Value: 100},
+				"cost_center": &modelpb.NumericLabelValue{Global: true, Value: 10},
+			},
+			Transaction: &modelpb.Transaction{
+				Type:                "type",
+				Name:                "T-1000",
+				RepresentativeCount: 1,
+			},
+		}
+		if i%2 == 0 {
+			event.Event = &modelpb.Event{Duration: durationpb.New(100 * time.Millisecond)}
+		}
+		agg.AggregateTransaction(&event)
+	}
+	for i := 0; i < 800; i++ {
+		event := modelpb.APMEvent{
+			Event:     &modelpb.Event{Duration: durationpb.New(time.Second)},
+			Timestamp: timestamppb.New(now),
+			Transaction: &modelpb.Transaction{
+				Type:                "type",
+				Name:                "T-800",
+				RepresentativeCount: 2.5,
+			},
+		}
+		if i%2 == 0 {
+			event.Event = &modelpb.Event{Duration: durationpb.New(100 * time.Millisecond)}
+		}
+		agg.AggregateTransaction(&event)
+	}
+
+	go agg.Run()
+	defer agg.Stop(context.Background())
+	// Stop the aggregator to ensure all metrics are published.
+	assert.NoError(t, agg.Stop(context.Background()))
+
+	for i := 0; i < 3; i++ {
+		batch := expectBatch(t, batches)
+		metricsets := batchMetricsets(t, batch)
+		require.Len(t, metricsets, 2)
+		sort.Slice(metricsets, func(i, j int) bool {
+			return metricsets[i].Transaction.Name < metricsets[j].Transaction.Name
+		})
+
+		assert.Equal(t, "T-1000", metricsets[0].Transaction.Name)
+		assert.Equal(t, modelpb.Labels{
+			"department_name": &modelpb.LabelValue{Value: "apm"},
+			"organization":    &modelpb.LabelValue{Value: "observability"},
+			"company":         &modelpb.LabelValue{Value: "elastic"},
+		}, modelpb.Labels(metricsets[0].Labels))
+		assert.Equal(t, modelpb.NumericLabels{
+			"user_id":     &modelpb.NumericLabelValue{Value: 100},
+			"cost_center": &modelpb.NumericLabelValue{Value: 10},
+		}, modelpb.NumericLabels(metricsets[0].NumericLabels))
+		assert.Equal(t, []uint64{500, 500}, metricsets[0].Transaction.DurationHistogram.Counts)
+		assert.Equal(t, "T-800", metricsets[1].Transaction.Name)
+		assert.Empty(t, metricsets[1].Labels)
+		assert.Empty(t, metricsets[1].NumericLabels)
+		assert.Equal(t, []uint64{1000, 1000}, metricsets[1].Transaction.DurationHistogram.Counts)
+		for _, event := range metricsets {
+			actual := event.Timestamp.AsTime()
+			if event.Timestamp == nil {
+				actual = time.Time{}
+			}
+			assert.Equal(t, now.Truncate(intervals[i]), actual)
+			assert.Equal(t, fmt.Sprintf("%.0fs", intervals[i].Seconds()), event.Metricset.Interval)
+		}
+	}
+
+	select {
+	case <-batches:
+		t.Fatal("unexpected publish")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestAggregatorRunPublishErrors(t *testing.T) {
+	batches := make(chan modelpb.Batch, 1)
+	chanBatchProcessor := makeChanBatchProcessor(batches)
+	processBatchErr := errors.New("report failed")
+	var batchProcessor modelpb.ProcessBatchFunc = func(ctx context.Context, batch *modelpb.Batch) error {
+		if err := chanBatchProcessor(ctx, batch); err != nil {
+			return err
+		}
+		return processBatchErr
+	}
+
+	core, observed := observer.New(zapcore.DebugLevel)
+	logger := logp.NewLogger("foo", zap.WrapCore(func(in zapcore.Core) zapcore.Core {
+		return zapcore.NewTee(in, core)
+	}))
+
+	agg, err := txmetrics.NewAggregator(txmetrics.AggregatorConfig{
+		BatchProcessor:                 batchProcessor,
+		MaxTransactionGroups:           2,
+		MaxTransactionGroupsPerService: 1,
+		MaxServices:                    2,
+		MetricsInterval:                10 * time.Millisecond,
+		HDRHistogramSignificantFigures: 1,
+		Logger:                         logger,
+	})
+	require.NoError(t, err)
+
+	go agg.Run()
+	defer agg.Stop(context.Background())
+
+	for i := 0; i < 2; i++ {
+		agg.AggregateTransaction(&modelpb.APMEvent{
+			Transaction: &modelpb.Transaction{
+				Type:                "type",
+				Name:                "T-1000",
+				RepresentativeCount: 1,
+			},
+		})
+		expectBatch(t, batches)
+	}
+
+	// Wait for aggregator to stop before checking logs, to ensure we don't race with logging.
+	assert.NoError(t, agg.Stop(context.Background()))
+
+	logs := observed.FilterMessageSnippet("report failed").All()
+	assert.Len(t, logs, 2)
+	for _, record := range logs {
+		require.Len(t, record.Context, 1)
+		assert.Equal(t, "error", record.Context[0].Key)
+		assert.Equal(t, processBatchErr, record.Context[0].Interface)
+	}
+}
+
+func TestAggregateRepresentativeCount(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		representativeCounts []float64
+		expectedCount        uint64
+	}{
+		{
+			name:                 "int",
+			representativeCounts: []float64{2},
+			expectedCount:        2,
+		},
+		{
+			name:                 "float",
+			representativeCounts: []float64{1.50},
+			expectedCount:        2,
+		},
+		{
+			name:                 "mix",
+			representativeCounts: []float64{1, 1.5},
+			expectedCount:        3,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			batches := make(chan modelpb.Batch, 1)
+			agg, err := txmetrics.NewAggregator(txmetrics.AggregatorConfig{
+				BatchProcessor:                 makeChanBatchProcessor(batches),
+				MaxTransactionGroups:           1,
+				MaxTransactionGroupsPerService: 1,
+				MaxServices:                    1,
+				MetricsInterval:                time.Microsecond,
+				HDRHistogramSignificantFigures: 1,
+			})
+			require.NoError(t, err)
+
+			for _, rc := range tc.representativeCounts {
+				agg.AggregateTransaction(&modelpb.APMEvent{
+					Transaction: &modelpb.Transaction{
+						Type:                "type",
+						Name:                "foo",
+						RepresentativeCount: rc,
+					},
+				})
+			}
+
+			go agg.Run()
+			require.NoError(t, agg.Stop(context.Background()))
+
+			batch := expectBatch(t, batches)
+			metricsets := batchMetricsets(t, batch)
+			require.Len(t, metricsets, 1)
+			require.Nil(t, metricsets[0].Metricset.Samples)
+			require.NotNil(t, metricsets[0].Transaction)
+			durationHistogram := metricsets[0].Transaction.DurationHistogram
+			assert.Equal(t, []uint64{tc.expectedCount}, durationHistogram.Counts)
+		})
+	}
+}
+
+func TestAggregateTimestamp(t *testing.T) {
+	batches := make(chan modelpb.Batch, 1)
+	agg, err := txmetrics.NewAggregator(txmetrics.AggregatorConfig{
+		BatchProcessor:                 makeChanBatchProcessor(batches),
+		MaxTransactionGroups:           2,
+		MaxTransactionGroupsPerService: 2,
+		MaxServices:                    2,
+		MetricsInterval:                30 * time.Second,
+		HDRHistogramSignificantFigures: 1,
+	})
+	require.NoError(t, err)
+
+	t0 := time.Unix(0, 0).UTC()
+	for _, ts := range []time.Time{t0, t0.Add(15 * time.Second), t0.Add(30 * time.Second)} {
+		agg.AggregateTransaction(&modelpb.APMEvent{
+			Timestamp: timestamppb.New(ts),
+			Transaction: &modelpb.Transaction{
+				Type:                "type",
+				Name:                "name",
+				RepresentativeCount: 1,
+			},
+		})
+	}
+
+	go agg.Run()
+	err = agg.Stop(context.Background()) // stop to flush
+	require.NoError(t, err)
+
+	batch := expectBatch(t, batches)
+	metricsets := batchMetricsets(t, batch)
+	require.Len(t, metricsets, 2)
+	sort.Slice(metricsets, func(i, j int) bool {
+		return metricsets[i].Timestamp.AsTime().Before(metricsets[j].Timestamp.AsTime())
+	})
+	assert.Equal(t, t0, metricsets[0].Timestamp.AsTime())
+	assert.Equal(t, t0.Add(30*time.Second), metricsets[1].Timestamp.AsTime())
+}
+
+func TestHDRHistogramSignificantFigures(t *testing.T) {
+	testHDRHistogramSignificantFigures(t, 1)
+	testHDRHistogramSignificantFigures(t, 2)
+	testHDRHistogramSignificantFigures(t, 3)
+	testHDRHistogramSignificantFigures(t, 4)
+	testHDRHistogramSignificantFigures(t, 5)
+}
+
+func testHDRHistogramSignificantFigures(t *testing.T, sigfigs int) {
+	t.Run(fmt.Sprintf("%d_sigfigs", sigfigs), func(t *testing.T) {
+		batches := make(chan modelpb.Batch, 1)
+		agg, err := txmetrics.NewAggregator(txmetrics.AggregatorConfig{
+			BatchProcessor:                 makeChanBatchProcessor(batches),
+			MaxTransactionGroups:           2,
+			MaxTransactionGroupsPerService: 1,
+			MaxServices:                    2,
+			MetricsInterval:                10 * time.Millisecond,
+			HDRHistogramSignificantFigures: sigfigs,
+		})
+		require.NoError(t, err)
+
+		// The following values will be recorded in either 1, 2, 3, 4, or 5
+		// buckets according to the configured number of significant figures.
+		for _, duration := range []time.Duration{
+			100000 * time.Microsecond,
+			101000 * time.Microsecond,
+			101100 * time.Microsecond,
+			101110 * time.Microsecond,
+			101111 * time.Microsecond,
+		} {
+			agg.AggregateTransaction(&modelpb.APMEvent{
+				Event: &modelpb.Event{Duration: durationpb.New(duration)},
+				Transaction: &modelpb.Transaction{
+					Type:                "type",
+					Name:                "T-1000",
+					RepresentativeCount: 1,
+				},
+			})
+		}
+
+		go agg.Run()
+		defer agg.Stop(context.Background())
+
+		batch := expectBatch(t, batches)
+		metricsets := batchMetricsets(t, batch)
+		require.Len(t, metricsets, 1)
+
+		require.Nil(t, metricsets[0].Metricset.Samples)
+		require.NotNil(t, metricsets[0].Transaction)
+		durationHistogram := metricsets[0].Transaction.DurationHistogram
+		assert.Len(t, durationHistogram.Counts, len(durationHistogram.Values))
+		assert.Len(t, durationHistogram.Counts, sigfigs)
+	})
+}
+
+func TestAggregationFields(t *testing.T) {
+	t.Skip("TODO FIX")
+	batches := make(chan modelpb.Batch, 1)
+	agg, err := txmetrics.NewAggregator(txmetrics.AggregatorConfig{
+		BatchProcessor:                 makeChanBatchProcessor(batches),
+		MaxTransactionGroups:           1000,
+		MaxTransactionGroupsPerService: 100,
+		MaxServices:                    3,
+		MetricsInterval:                100 * time.Millisecond,
+		HDRHistogramSignificantFigures: 1,
+	})
+	require.NoError(t, err)
+	go agg.Run()
+	defer agg.Stop(context.Background())
+
+	input := modelpb.APMEvent{
+		Transaction: &modelpb.Transaction{
+			Type:                "type",
+			RepresentativeCount: 1,
+		},
+		Event:      &modelpb.Event{},
+		Agent:      &modelpb.Agent{},
+		Service:    &modelpb.Service{Node: &modelpb.ServiceNode{}, Language: &modelpb.Language{}, Runtime: &modelpb.Runtime{}},
+		Container:  &modelpb.Container{},
+		Kubernetes: &modelpb.Kubernetes{},
+		Cloud:      &modelpb.Cloud{},
+		Host:       &modelpb.Host{Os: &modelpb.OS{}},
+		Faas:       &modelpb.Faas{},
+	}
+	inputFields := []*string{
+		&input.Transaction.Name,
+		&input.Transaction.Result,
+		&input.Transaction.Type,
+		&input.Event.Outcome,
+		&input.Agent.Name,
+		&input.Service.Environment,
+		&input.Service.Name,
+		&input.Service.Version,
+		&input.Service.Node.Name,
+		&input.Container.Id,
+		&input.Kubernetes.PodName,
+		&input.Cloud.Provider,
+		&input.Cloud.Region,
+		&input.Cloud.AvailabilityZone,
+		&input.Cloud.AccountId,
+		&input.Cloud.AccountName,
+		&input.Cloud.ProjectId,
+		&input.Cloud.ProjectName,
+		&input.Cloud.MachineType,
+		&input.Cloud.ServiceName,
+		&input.Service.Language.Name,
+		&input.Service.Language.Version,
+		&input.Service.Runtime.Name,
+		&input.Service.Runtime.Version,
+		&input.Host.Os.Platform,
+		&input.Faas.Id,
+		&input.Faas.TriggerType,
+		&input.Faas.Name,
+		&input.Faas.Version,
+	}
+	boolPtrInputFields := []**bool{
+		&input.Faas.ColdStart,
+	}
+
+	var expected []*modelpb.APMEvent
+	addExpectedCount := func(expectedCount uint64) {
+		expectedEvent := proto.Clone(&input).(*modelpb.APMEvent)
+		expectedEvent.Transaction = &modelpb.Transaction{
+			Name:   input.Transaction.Name,
+			Type:   input.Transaction.Type,
+			Result: input.Transaction.Result,
+			Root:   input.GetParentId() == "",
+			DurationHistogram: &modelpb.Histogram{
+				Counts: []uint64{expectedCount},
+				Values: []float64{0},
+			},
+			DurationSummary: &modelpb.SummaryMetric{
+				Count: expectedCount,
+				Sum:   0,
+			},
+		}
+		expectedEvent.Event.Outcome = input.Event.Outcome
+		expectedEvent.Metricset = &modelpb.Metricset{
+			Name:     "transaction",
+			DocCount: expectedCount,
+			Interval: "0s",
+		}
+		expected = append(expected, expectedEvent)
+	}
+	for _, field := range inputFields {
+		for _, value := range []string{"something", "anything"} {
+			*field = value
+			agg.AggregateTransaction(&input)
+			agg.AggregateTransaction(&input)
+			addExpectedCount(2)
+		}
+	}
+	for _, field := range boolPtrInputFields {
+		for _, value := range []bool{false, true} {
+			value := value
+			*field = &value
+			agg.AggregateTransaction(&input)
+			agg.AggregateTransaction(&input)
+			addExpectedCount(2)
+		}
+		*field = nil
+	}
+
+	if false {
+		// Hostname is complex: if any kubernetes fields are set, then
+		// it is taken from Kubernetes.Node.Name, and DetectedHostname
+		// is ignored.
+		input.Kubernetes.PodName = ""
+		for _, value := range []string{"something", "anything"} {
+			input.Host.Hostname = value
+			agg.AggregateTransaction(&input)
+			agg.AggregateTransaction(&input)
+			addExpectedCount(2)
+		}
+
+		// Parent.ID only impacts aggregation as far as grouping root and
+		// non-root traces.
+		for _, value := range []string{"something", "anything"} {
+			input.ParentId = value
+			agg.AggregateTransaction(&input)
+			agg.AggregateTransaction(&input)
+		}
+		addExpectedCount(4)
+	}
+
+	batch := expectBatch(t, batches)
+	metricsets := batchMetricsets(t, batch)
+	assert.Empty(t, cmp.Diff(expected, metricsets,
+		protocmp.Transform(),
+		protocmp.IgnoreEmptyMessages(),
+		cmpopts.SortSlices(func(x, y *modelpb.APMEvent) bool {
+			if x.GetTransaction().GetName() != y.GetTransaction().GetName() {
+				return x.GetTransaction().GetName() < y.GetTransaction().GetName()
+			}
+			if x.GetEvent().GetOutcome() != y.GetEvent().GetOutcome() {
+				return x.GetEvent().GetOutcome() < y.GetEvent().GetOutcome()
+			}
+			return x.GetAgent().GetName() < y.GetAgent().GetName()
+		}),
+	))
+}
+
+func BenchmarkAggregateTransaction(b *testing.B) {
+	agg, err := txmetrics.NewAggregator(txmetrics.AggregatorConfig{
+		BatchProcessor:                 makeErrBatchProcessor(nil),
+		MaxTransactionGroups:           1000,
+		MaxTransactionGroupsPerService: 100,
+		MaxServices:                    1000,
+		MetricsInterval:                time.Minute,
+		HDRHistogramSignificantFigures: 2,
+	})
+	require.NoError(b, err)
+
+	event := modelpb.APMEvent{
+		Event: &modelpb.Event{Duration: durationpb.New(time.Millisecond)},
+		Transaction: &modelpb.Transaction{
+			Type:                "type",
+			Name:                "T-1000",
+			RepresentativeCount: 1,
+		},
+	}
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			agg.AggregateTransaction(&event)
+		}
+	})
+}
+
+func makeErrBatchProcessor(err error) modelpb.ProcessBatchFunc {
+	return func(context.Context, *modelpb.Batch) error { return err }
+}
+
+func makeChanBatchProcessor(ch chan<- modelpb.Batch) modelpb.ProcessBatchFunc {
+	return func(ctx context.Context, batch *modelpb.Batch) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ch <- *batch:
+			return nil
+		}
+	}
+}
+
+func expectBatch(t *testing.T, ch <-chan modelpb.Batch) modelpb.Batch {
+	t.Helper()
+	select {
+	case batch := <-ch:
+		return batch
+	case <-time.After(time.Second):
+		t.Fatal("expected publish")
+	}
+	panic("unreachable")
+}
+
+func batchMetricsets(t testing.TB, batch modelpb.Batch) []*modelpb.APMEvent {
+	var metricsets []*modelpb.APMEvent
+	for _, event := range batch {
+		if event.Metricset == nil {
+			continue
+		}
+		metricsets = append(metricsets, event)
+	}
+	return metricsets
+}
+
+func createOverflowMetricset(overflowCount, repCount int, txnDuration time.Duration) *modelpb.APMEvent {
+	return &modelpb.APMEvent{
+		Service: &modelpb.Service{},
+		Transaction: &modelpb.Transaction{
+			Name: "_other",
+			DurationHistogram: &modelpb.Histogram{
+				Counts: []uint64{uint64(overflowCount * repCount)},
+				Values: []float64{float64(txnDuration.Microseconds())},
+			},
+			DurationSummary: &modelpb.SummaryMetric{
+				Count: uint64(overflowCount * repCount),
+				Sum:   float64(time.Duration(float64(overflowCount*repCount) * float64(txnDuration)).Microseconds()),
+			},
+		},
+		Metricset: &modelpb.Metricset{
+			Name:     "transaction",
+			DocCount: uint64(overflowCount * repCount),
+			Interval: "30s",
+			Samples: []*modelpb.MetricsetSample{
+				{
+					Name:  "transaction.aggregation.overflow_count",
+					Value: float64(overflowCount),
+				},
+			},
+		},
+	}
+}

--- a/x-pack/apm-server/aggregation_386.go
+++ b/x-pack/apm-server/aggregation_386.go
@@ -4,8 +4,94 @@
 
 package main
 
-import "github.com/elastic/apm-server/internal/beater"
+import (
+	"github.com/elastic/apm-server/internal/beater"
+	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/servicesummarymetrics"
+	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/servicetxmetrics"
+	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/spanmetrics"
+	"github.com/elastic/apm-server/x-pack/apm-server/aggregation/txmetrics"
+)
 
 func newAggregationProcessors(args beater.ServerParams) ([]namedProcessor, error) {
-	return nil, nil
+	var processors []namedProcessor
+
+	const txName = "transaction metrics aggregation"
+	args.Logger.Infof("creating %s with config: %+v", txName, args.Config.Aggregation.Transactions)
+	agg, err := txmetrics.NewAggregator(txmetrics.AggregatorConfig{
+		BatchProcessor:                 args.BatchProcessor,
+		MaxTransactionGroups:           args.Config.Aggregation.Transactions.MaxTransactionGroups,
+		MetricsInterval:                metricsInterval,
+		RollUpIntervals:                rollUpMetricsIntervals,
+		MaxTransactionGroupsPerService: int(math.Ceil(0.1 * float64(args.Config.Aggregation.Transactions.MaxTransactionGroups))),
+		MaxServices:                    args.Config.Aggregation.Transactions.MaxServices,
+		HDRHistogramSignificantFigures: args.Config.Aggregation.Transactions.HDRHistogramSignificantFigures,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating %s", txName)
+	}
+	processors = append(processors, namedProcessor{name: txName, processor: agg})
+	aggregationMonitoringRegistry.Remove("txmetrics")
+	monitoring.NewFunc(aggregationMonitoringRegistry, "txmetrics", agg.CollectMonitoring, monitoring.Report)
+
+	const spanName = "service destination metrics aggregation"
+	args.Logger.Infof("creating %s with config: %+v", spanName, args.Config.Aggregation.ServiceDestinations)
+	spanAggregator, err := spanmetrics.NewAggregator(spanmetrics.AggregatorConfig{
+		BatchProcessor:  args.BatchProcessor,
+		Interval:        metricsInterval,
+		RollUpIntervals: rollUpMetricsIntervals,
+		MaxGroups:       args.Config.Aggregation.ServiceDestinations.MaxGroups,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating %s", spanName)
+	}
+	processors = append(processors, namedProcessor{name: spanName, processor: spanAggregator})
+	aggregationMonitoringRegistry.Remove("spanmetrics")
+	monitoring.NewFunc(
+		aggregationMonitoringRegistry,
+		"spanmetrics",
+		spanAggregator.CollectMonitoring,
+		monitoring.Report,
+	)
+
+	const serviceTxName = "service transaction metrics aggregation"
+	args.Logger.Infof("creating %s with config: %+v", serviceTxName, args.Config.Aggregation.ServiceTransactions)
+	serviceTxAggregator, err := servicetxmetrics.NewAggregator(servicetxmetrics.AggregatorConfig{
+		BatchProcessor:                 args.BatchProcessor,
+		Interval:                       metricsInterval,
+		RollUpIntervals:                rollUpMetricsIntervals,
+		MaxGroups:                      args.Config.Aggregation.ServiceTransactions.MaxGroups,
+		HDRHistogramSignificantFigures: args.Config.Aggregation.ServiceTransactions.HDRHistogramSignificantFigures,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating %s", serviceTxName)
+	}
+	processors = append(processors, namedProcessor{name: serviceTxName, processor: serviceTxAggregator})
+	aggregationMonitoringRegistry.Remove("servicetxmetrics")
+	monitoring.NewFunc(
+		aggregationMonitoringRegistry,
+		"servicetxmetrics",
+		serviceTxAggregator.CollectMonitoring,
+		monitoring.Report,
+	)
+
+	const serviceSummaryName = "service summary metrics aggregation"
+	args.Logger.Infof("creating %s with config: %+v", serviceSummaryName, args.Config.Aggregation.ServiceTransactions)
+	serviceSummaryAggregator, err := servicesummarymetrics.NewAggregator(servicesummarymetrics.AggregatorConfig{
+		BatchProcessor:  args.BatchProcessor,
+		Interval:        metricsInterval,
+		RollUpIntervals: rollUpMetricsIntervals,
+		MaxGroups:       args.Config.Aggregation.ServiceTransactions.MaxGroups,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "error creating %s", serviceSummaryName)
+	}
+	processors = append(processors, namedProcessor{name: serviceSummaryName, processor: serviceSummaryAggregator})
+	aggregationMonitoringRegistry.Remove("servicesummarymetrics")
+	monitoring.NewFunc(
+		aggregationMonitoringRegistry,
+		"servicesummarymetrics",
+		serviceSummaryAggregator.CollectMonitoring,
+		monitoring.Report,
+	)
+	return processor
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

Target branch: 8.10 (PR target branch needs to be updated once 8.10 branch is ready)
This is only for 8.10. Use old aggregation code for 386, and new LSM aggregation code otherwise.

Notes for 386 aggregation:
- (Undocumented config) HDR histogram significant figures is no longer configurable
- (Undocumented config) `aggregation.transactions.max_services` is moved to `aggregation.max_services`

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->
- Run system test for 386. Expect a few failures regarding new service.language.name in service destination metrics

To run system tests in 32 bit:
```
diff --git a/internal/beatcmd/cmd.go b/internal/beatcmd/cmd.go
index a312ebecd..9a8c2b08b 100644
--- a/internal/beatcmd/cmd.go
+++ b/internal/beatcmd/cmd.go
@@ -34,7 +34,7 @@ import (
 // NewRootCommand takes a BeatParams, which will be passed to
 // commands that must create an instance of APM Server.
 func NewRootCommand(beatParams BeatParams) *cobra.Command {
-       if err := platformcheck.CheckNativePlatformCompat(); err != nil {
+       if err := platformcheck.CheckNativePlatformCompat(); false && err != nil {
                fmt.Fprintf(os.Stderr, "Failed to initialize: %v\n", err)
                os.Exit(1)
        }
diff --git a/systemtest/apmservertest/command.go b/systemtest/apmservertest/command.go
index 8e6ebe8a2..b6bbc594e 100644
--- a/systemtest/apmservertest/command.go
+++ b/systemtest/apmservertest/command.go
@@ -34,7 +34,7 @@ import (
 // ServerCommand returns a ServerCmd (wrapping os/exec) for running
 // apm-server with args.
 func ServerCommand(ctx context.Context, subcommand string, args ...string) *ServerCmd {
-       binary, buildErr := BuildServerBinary(runtime.GOOS, runtime.GOARCH)
+       binary, buildErr := BuildServerBinary(runtime.GOOS, "386")
        if buildErr != nil {
                // Dummy command; Start etc. will return the build error.
                binary = "/usr/bin/false"

```

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->

Closes #11394 
