### PR TITLE
Update 8.10 changelogs

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,4 +1,4 @@
-include::./changelogs/head.asciidoc[]
+include::./changelogs/8.10.asciidoc[]
 include::./changelogs/8.9.asciidoc[]
 include::./changelogs/8.8.asciidoc[]
 include::./changelogs/8.7.asciidoc[]

--- a/changelogs/8.10.asciidoc
+++ b/changelogs/8.10.asciidoc
@@ -1,7 +1,13 @@
-[[release-notes-head]]
-== APM version HEAD
+[[release-notes-8.10]]
+== APM version 8.10
 
-https://github.com/elastic/apm-server/compare/8.9\...main[View commits]
+https://github.com/elastic/apm-server/compare/8.10\...main[View commits]
+
+* <<release-notes-8.10.0>>
+
+[float]
+[[release-notes-8.10.0]]
+=== APM version 8.10.0
 
 [float]
 ==== Breaking Changes

--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 
 **APM integration and APM Server**
 
+* <<release-notes-8.10>>
 * <<release-notes-8.9>>
 * <<release-notes-8.8>>
 * <<release-notes-8.7>>


### PR DESCRIPTION
Manual backport of https://github.com/elastic/apm-server/pull/11419/commits without `head.asciidoc`