### PR TITLE
apmpackage: remove `processor.name` field

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -1,8 +1,8 @@
 - version: generated
   changes:
-    - description: Placeholder
+    - description: Remove unused `processor.name` field
       type: enhancement
-      link: https://github.com/elastic/apm-server/pull/123
+      link: https://github.com/elastic/apm-server/pull/11437
 - version: "8.10.0"
   changes:
     - description: Add permissions to reroute to dedicated datasets for logs, metrics and traces

--- a/apmpackage/apm/data_stream/app_logs/fields/fields.yml
+++ b/apmpackage/apm/data_stream/app_logs/fields/fields.yml
@@ -35,10 +35,6 @@
   type: constant_keyword
   value: log
   description: Processor event.
-- name: processor.name
-  type: constant_keyword
-  value: log
-  description: Processor name.
 - name: service.framework.name
   type: keyword
   index: false

--- a/apmpackage/apm/data_stream/app_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/app_metrics/fields/fields.yml
@@ -31,10 +31,6 @@
   type: constant_keyword
   value: metric
   description: Processor event.
-- name: processor.name
-  type: constant_keyword
-  value: metric
-  description: Processor name.
 - name: service.framework.name
   type: keyword
   index: false

--- a/apmpackage/apm/data_stream/error_logs/fields/fields.yml
+++ b/apmpackage/apm/data_stream/error_logs/fields/fields.yml
@@ -102,10 +102,6 @@
   type: constant_keyword
   value: error
   description: Processor event.
-- name: processor.name
-  type: constant_keyword
-  value: error
-  description: Processor name.
 - name: service.framework.name
   type: keyword
   index: false

--- a/apmpackage/apm/data_stream/internal_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/internal_metrics/fields/fields.yml
@@ -62,10 +62,6 @@
   type: constant_keyword
   value: metric
   description: Processor event.
-- name: processor.name
-  type: constant_keyword
-  value: metric
-  description: Processor name.
 - name: service.framework.name
   type: keyword
   index: false

--- a/apmpackage/apm/data_stream/service_destination_interval_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/service_destination_interval_metrics/fields/fields.yml
@@ -8,10 +8,6 @@
   type: constant_keyword
   value: metric
   description: Processor event.
-- name: processor.name
-  type: constant_keyword
-  value: metric
-  description: Processor name.
 - name: service.target.name
   type: keyword
   description: Target service for which data is collected.

--- a/apmpackage/apm/data_stream/service_summary_interval_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/service_summary_interval_metrics/fields/fields.yml
@@ -8,10 +8,6 @@
   type: constant_keyword
   value: metric
   description: Processor event.
-- name: processor.name
-  type: constant_keyword
-  value: metric
-  description: Processor name.
 - name: service.language.name
   type: keyword
   description: |

--- a/apmpackage/apm/data_stream/service_transaction_interval_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/service_transaction_interval_metrics/fields/fields.yml
@@ -8,10 +8,6 @@
   type: constant_keyword
   value: metric
   description: Processor event.
-- name: processor.name
-  type: constant_keyword
-  value: metric
-  description: Processor name.
 - name: service.language.name
   type: keyword
   description: |

--- a/apmpackage/apm/data_stream/traces/fields/fields.yml
+++ b/apmpackage/apm/data_stream/traces/fields/fields.yml
@@ -136,10 +136,6 @@
 - name: processor.event
   type: keyword
   description: Processor event, either "transaction" or "span".
-- name: processor.name
-  type: constant_keyword
-  value: transaction
-  description: Processor name.
 - name: service.framework.name
   type: keyword
   index: false

--- a/apmpackage/apm/data_stream/transaction_interval_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/transaction_interval_metrics/fields/fields.yml
@@ -33,10 +33,6 @@
   type: constant_keyword
   value: metric
   description: Processor event.
-- name: processor.name
-  type: constant_keyword
-  value: metric
-  description: Processor name.
 - name: service.language.name
   type: keyword
   description: |

--- a/docs/otel-metrics.asciidoc
+++ b/docs/otel-metrics.asciidoc
@@ -38,7 +38,7 @@ include::{tab-widget-dir}/open-kibana-widget.asciidoc[]
 
 . Open the main menu, then click *Discover*.
 . Select `apm-*` as your index pattern.
-. Filter the data to only show documents with metrics: `processor.name :"metric"`
+. Filter the data to only show documents with metrics: `processor.event: "metric"`
 . Narrow your search with a known OpenTelemetry field. For example, if you have an `order_value` field, add `order_value: *` to your search to return
 only OpenTelemetry metrics documents.
 

--- a/systemtest/approvals/TestAgentConfig.approved.json
+++ b/systemtest/approvals/TestAgentConfig.approved.json
@@ -27,8 +27,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             }
         },
         {
@@ -58,8 +57,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             }
         }
     ]

--- a/systemtest/approvals/TestApprovedMetrics.approved.json
+++ b/systemtest/approvals/TestApprovedMetrics.approved.json
@@ -49,8 +49,7 @@
                 "pid": 1234
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -107,8 +106,7 @@
                 "pid": 1234
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -181,8 +179,7 @@
                 "pid": 1234
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -281,8 +278,7 @@
                 "pid": 1234
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -348,8 +344,7 @@
                 "pid": 1234
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -417,8 +412,7 @@
                 "pid": 1234
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {

--- a/systemtest/approvals/TestIntake/Events.approved.json
+++ b/systemtest/approvals/TestIntake/Events.approved.json
@@ -366,8 +366,7 @@
                 "title": "/usr/lib/jvm/java-10-openjdk-amd64/bin/java"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "environment": "production",

--- a/systemtest/approvals/TestIntake/Metricsets.approved.json
+++ b/systemtest/approvals/TestIntake/Metricsets.approved.json
@@ -49,8 +49,7 @@
                 "pid": 1234
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -107,8 +106,7 @@
                 "pid": 1234
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -181,8 +179,7 @@
                 "pid": 1234
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -281,8 +278,7 @@
                 "pid": 1234
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -348,8 +344,7 @@
                 "pid": 1234
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -417,8 +412,7 @@
                 "pid": 1234
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {

--- a/systemtest/approvals/TestIntake/MinimalEvents.approved.json
+++ b/systemtest/approvals/TestIntake/MinimalEvents.approved.json
@@ -157,8 +157,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "name": "1234_service-12a3"

--- a/systemtest/approvals/TestOTLPGRPCMetrics_counter.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCMetrics_counter.approved.json
@@ -28,8 +28,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {

--- a/systemtest/approvals/TestOTLPGRPCMetrics_histogram.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCMetrics_histogram.approved.json
@@ -41,8 +41,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {

--- a/systemtest/approvals/TestOTLPGRPCMetrics_summary.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCMetrics_summary.approved.json
@@ -27,8 +27,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {

--- a/systemtest/approvals/TestRUMXForwardedFor.approved.json
+++ b/systemtest/approvals/TestRUMXForwardedFor.approved.json
@@ -39,8 +39,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "name": "rum-js-test"

--- a/systemtest/approvals/TestServiceDestinationAggregation.approved.json
+++ b/systemtest/approvals/TestServiceDestinationAggregation.approved.json
@@ -34,8 +34,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -95,8 +94,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -156,8 +154,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {

--- a/systemtest/approvals/TestServiceSummaryMetricsAggregation.approved.json
+++ b/systemtest/approvals/TestServiceSummaryMetricsAggregation.approved.json
@@ -27,8 +27,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -64,8 +63,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -101,8 +99,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {

--- a/systemtest/approvals/TestServiceSummaryMetricsAggregationOverflow.approved.json
+++ b/systemtest/approvals/TestServiceSummaryMetricsAggregationOverflow.approved.json
@@ -24,8 +24,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "name": "_other"
@@ -60,8 +59,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "name": "_other"
@@ -96,8 +94,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "name": "_other"
@@ -135,8 +132,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "environment": "prod",
@@ -173,8 +169,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "environment": "prod",
@@ -211,8 +206,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "environment": "prod",
@@ -249,8 +243,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "environment": "test",
@@ -287,8 +280,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "environment": "test",
@@ -325,8 +317,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "environment": "test",

--- a/systemtest/approvals/TestServiceTransactionMetricsAggregation.approved.json
+++ b/systemtest/approvals/TestServiceTransactionMetricsAggregation.approved.json
@@ -32,8 +32,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -91,8 +90,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -150,8 +148,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -209,8 +206,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -268,8 +264,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -327,8 +322,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {

--- a/systemtest/approvals/TestTransactionAggregation.approved.json
+++ b/systemtest/approvals/TestTransactionAggregation.approved.json
@@ -40,8 +40,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -117,8 +116,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -194,8 +192,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -271,8 +268,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -348,8 +344,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -425,8 +420,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -537,8 +531,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "environment": "staging",
@@ -652,8 +645,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "environment": "staging",
@@ -767,8 +759,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "environment": "staging",

--- a/systemtest/approvals/TestTransactionAggregationShutdown.approved.json
+++ b/systemtest/approvals/TestTransactionAggregationShutdown.approved.json
@@ -40,8 +40,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -117,8 +116,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -194,8 +192,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {

--- a/systemtest/approvals/TestTransactionDroppedSpansStatsMetrics.approved.json
+++ b/systemtest/approvals/TestTransactionDroppedSpansStatsMetrics.approved.json
@@ -29,8 +29,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -84,8 +83,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -139,8 +137,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -194,8 +191,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -249,8 +245,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {
@@ -304,8 +299,7 @@
                 "version": "dynamic"
             },
             "processor": {
-                "event": "metric",
-                "name": "metric"
+                "event": "metric"
             },
             "service": {
                 "language": {


### PR DESCRIPTION
## Motivation/summary

This field is not used by the UI, and is redundant; its value can always be inferred from `data_stream.dataset`.

See https://github.com/elastic/kibana/issues/161718#issuecomment-1638294156

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
~- [ ] Documentation has been updated~

## How to test these changes

Verify that apm-server 8.9.0 can still index into an 8.11.0 deployment

## Related issues

https://github.com/elastic/kibana/issues/161718