### PR TITLE
catalog-info: support main, release branches or feature branches

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -36,6 +36,12 @@ spec:
     spec:
       repository: elastic/apm-server
       pipeline_file: ".buildkite/package.yml"
+      provider_settings:
+        build_branches: true
+        build_pull_requests: true
+        build_tags: false
+        filter_enabled: true
+        filter_condition: build.branch == "main" || build.branch =~ /^[0-9]+\.[0-9]+$$/ || build.branch =~ /^feature\//
       cancel_intermediate_builds: false
       skip_intermediate_builds: false
       teams:


### PR DESCRIPTION


## Motivation/summary

Enable what to run for the apm-server-package buildkite pipeline explicitly. For some reason, default parameters are not honoured...

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

In the CI

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
