### PR TITLE
(docs): Fix commits link for released versions

### DIFF
--- a/changelogs/8.10.asciidoc
+++ b/changelogs/8.10.asciidoc
@@ -1,7 +1,7 @@
 [[release-notes-8.10]]
 == APM version 8.10
 
-https://github.com/elastic/apm-server/compare/8.10\...main[View commits]
+https://github.com/elastic/apm-server/compare/8.9\...8.10[View commits]
 
 * <<release-notes-8.10.0>>
 

--- a/changelogs/8.9.asciidoc
+++ b/changelogs/8.9.asciidoc
@@ -1,7 +1,7 @@
 [[release-notes-8.9]]
 == APM version 8.9
 
-https://github.com/elastic/apm-server/compare/8.9\...main[View commits]
+https://github.com/elastic/apm-server/compare/8.8\...8.9[View commits]
 
 * <<release-notes-8.9.1>>
 * <<release-notes-8.9.0>>


### PR DESCRIPTION
Fixes `View commits` link for `8.9` and `8.10`