### PR TITLE
Otel exporter for internal telemetry

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -6129,6 +6129,217 @@ Contents of probable licence file $GOMODCACHE/go.opentelemetry.io/otel@v1.16.0/L
 
 
 --------------------------------------------------------------------------------
+Dependency : go.opentelemetry.io/otel/metric
+Version: v1.16.0
+Licence type (autodetected): Apache-2.0
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/go.opentelemetry.io/otel/metric@v1.16.0/LICENSE:
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+--------------------------------------------------------------------------------
 Dependency : go.opentelemetry.io/otel/sdk/metric
 Version: v0.39.0
 Licence type (autodetected): Apache-2.0
@@ -17134,217 +17345,6 @@ Licence type (autodetected): Apache-2.0
 
 Contents of probable licence file $GOMODCACHE/go.opentelemetry.io/collector/semconv@v0.81.0/LICENSE:
 
-
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
-
---------------------------------------------------------------------------------
-Dependency : go.opentelemetry.io/otel/metric
-Version: v1.16.0
-Licence type (autodetected): Apache-2.0
---------------------------------------------------------------------------------
-
-Contents of probable licence file $GOMODCACHE/go.opentelemetry.io/otel/metric@v1.16.0/LICENSE:
 
                                  Apache License
                            Version 2.0, January 2004

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	go.opentelemetry.io/collector/consumer v0.81.0
 	go.opentelemetry.io/collector/pdata v1.0.0-rcv0013
 	go.opentelemetry.io/otel v1.16.0
+	go.opentelemetry.io/otel/metric v1.16.0
 	go.opentelemetry.io/otel/sdk/metric v0.39.0
 	go.uber.org/automaxprocs v1.5.2
 	go.uber.org/zap v1.25.0
@@ -150,7 +151,6 @@ require (
 	go.elastic.co/apm/module/apmzap/v2 v2.4.3 // indirect
 	go.elastic.co/ecszap v1.0.1 // indirect
 	go.opentelemetry.io/collector/semconv v0.81.0 // indirect
-	go.opentelemetry.io/otel/metric v1.16.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.16.0 // indirect
 	go.opentelemetry.io/otel/trace v1.16.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/internal/telemetry/metric_exporter.go
+++ b/internal/telemetry/metric_exporter.go
@@ -135,7 +135,14 @@ func addMetric(sm metricdata.Metrics, ms metricsets) error {
 	case metricdata.Histogram[float64]:
 		// Float Histogram
 	case metricdata.Sum[int64]:
-		// Int Sum
+		for _, dp := range m.DataPoints {
+			sample := modelpb.MetricsetSample{
+				Name:  sm.Name,
+				Type:  modelpb.MetricType_METRIC_TYPE_COUNTER,
+				Value: float64(dp.Value),
+			}
+			ms.upsert(dp.Time, dp.Attributes, &sample)
+		}
 	case metricdata.Sum[float64]:
 		for _, dp := range m.DataPoints {
 			sample := modelpb.MetricsetSample{
@@ -146,9 +153,23 @@ func addMetric(sm metricdata.Metrics, ms metricsets) error {
 			ms.upsert(dp.Time, dp.Attributes, &sample)
 		}
 	case metricdata.Gauge[int64]:
-		// Int Gauge
+		for _, dp := range m.DataPoints {
+			sample := modelpb.MetricsetSample{
+				Name:  sm.Name,
+				Type:  modelpb.MetricType_METRIC_TYPE_GAUGE,
+				Value: float64(dp.Value),
+			}
+			ms.upsert(dp.Time, dp.Attributes, &sample)
+		}
 	case metricdata.Gauge[float64]:
-		// Float Gauge
+		for _, dp := range m.DataPoints {
+			sample := modelpb.MetricsetSample{
+				Name:  sm.Name,
+				Type:  modelpb.MetricType_METRIC_TYPE_GAUGE,
+				Value: dp.Value,
+			}
+			ms.upsert(dp.Time, dp.Attributes, &sample)
+		}
 	default:
 		return fmt.Errorf("unknown metric type %q", m)
 	}

--- a/internal/telemetry/metric_exporter.go
+++ b/internal/telemetry/metric_exporter.go
@@ -76,10 +76,6 @@ func (e *MetricExporter) Export(ctx context.Context, rm *metricdata.ResourceMetr
 			Name:     "apm-server",
 			Language: &modelpb.Language{Name: "go"},
 		},
-		Agent: &modelpb.Agent{
-			Name:    "internal",
-			Version: "unknown",
-		},
 		Event: &modelpb.Event{
 			Received: modelpb.FromTime(now),
 		},

--- a/internal/telemetry/metric_exporter.go
+++ b/internal/telemetry/metric_exporter.go
@@ -32,57 +32,6 @@ import (
 	"github.com/elastic/apm-data/model/modelpb"
 )
 
-var customHistogramBoundaries = []float64{
-	0.00390625, 0.00552427, 0.0078125, 0.0110485, 0.015625, 0.0220971, 0.03125,
-	0.0441942, 0.0625, 0.0883883, 0.125, 0.176777, 0.25, 0.353553, 0.5, 0.707107,
-	1, 1.41421, 2, 2.82843, 4, 5.65685, 8, 11.3137, 16, 22.6274, 32, 45.2548, 64,
-	90.5097, 128, 181.019, 256, 362.039, 512, 724.077, 1024, 1448.15, 2048,
-	2896.31, 4096, 5792.62, 8192, 11585.2, 16384, 23170.5, 32768, 46341.0, 65536,
-	92681.9, 131072,
-}
-
-type Config struct {
-	TemporalitySelector metric.TemporalitySelector
-	AggregationSelector metric.AggregationSelector
-}
-type ConfigOption func(Config) Config
-
-func newConfig(opts ...ConfigOption) Config {
-	config := Config{}
-	for _, opt := range opts {
-		config = opt(config)
-	}
-
-	if config.TemporalitySelector == nil {
-		config.TemporalitySelector = defaultTemporalitySelector
-	}
-	if config.AggregationSelector == nil {
-		config.AggregationSelector = defaultAggregationSelector
-	}
-
-	return config
-}
-
-func defaultTemporalitySelector(ik metric.InstrumentKind) metricdata.Temporality {
-	switch ik {
-	case metric.InstrumentKindCounter, metric.InstrumentKindObservableCounter, metric.InstrumentKindHistogram:
-		return metricdata.DeltaTemporality
-	}
-	return metric.DefaultTemporalitySelector(ik)
-}
-
-func defaultAggregationSelector(ik metric.InstrumentKind) aggregation.Aggregation {
-	switch ik {
-	case metric.InstrumentKindHistogram:
-		return aggregation.ExplicitBucketHistogram{
-			Boundaries: customHistogramBoundaries,
-			NoMinMax:   false,
-		}
-	default:
-		return metric.DefaultAggregationSelector(ik)
-	}
-}
-
 // NewMetricExporter initializes a new MetricExporter
 func NewMetricExporter(p modelpb.BatchProcessor, opts ...ConfigOption) *MetricExporter {
 	cfg := newConfig(opts...)

--- a/internal/telemetry/metric_exporter.go
+++ b/internal/telemetry/metric_exporter.go
@@ -1,0 +1,97 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package telemetry
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/aggregation"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/elastic/apm-data/model/modelpb"
+)
+
+type Config struct {
+	TemporalitySelector metric.TemporalitySelector
+	AggregationSelector metric.AggregationSelector
+}
+type ConfigOption func(Config) Config
+
+func newConfig(opts ...ConfigOption) Config {
+	config := Config{}
+	for _, opt := range opts {
+		config = opt(config)
+	}
+
+	if config.TemporalitySelector == nil {
+		config.TemporalitySelector = func(metric.InstrumentKind) metricdata.Temporality {
+			return metricdata.CumulativeTemporality
+		}
+	}
+	if config.AggregationSelector == nil {
+		config.AggregationSelector = metric.DefaultAggregationSelector
+	}
+
+	return config
+}
+
+// NewMetricExporter initializes a new MetricExporter
+func NewMetricExporter(p modelpb.BatchProcessor, opts ...ConfigOption) *MetricExporter {
+	cfg := newConfig(opts...)
+
+	return &MetricExporter{
+		processor: p,
+
+		temporalitySelector: cfg.TemporalitySelector,
+		aggregationSelector: cfg.AggregationSelector,
+	}
+}
+
+// MetricExporter is an OpenTelemetry metric Reader which retrieves metrics,
+// filters them and emits them to the specified consumer
+type MetricExporter struct {
+	processor modelpb.BatchProcessor
+
+	temporalitySelector metric.TemporalitySelector
+	aggregationSelector metric.AggregationSelector
+}
+
+// Temporality returns the Temporality to use for an instrument kind.
+func (e *MetricExporter) Temporality(k metric.InstrumentKind) metricdata.Temporality {
+	return e.temporalitySelector(k)
+}
+
+// Aggregation returns the Aggregation to use for an instrument kind.
+func (e *MetricExporter) Aggregation(k metric.InstrumentKind) aggregation.Aggregation {
+	return e.aggregationSelector(k)
+}
+
+func (e *MetricExporter) Export(ctx context.Context, rm *metricdata.ResourceMetrics) error {
+	batch := modelpb.Batch{}
+
+	return e.processor.ProcessBatch(ctx, &batch)
+}
+
+func (e *MetricExporter) ForceFlush(ctx context.Context) error {
+	return ctx.Err()
+}
+
+func (e *MetricExporter) Shutdown(ctx context.Context) error {
+	return nil
+}

--- a/internal/telemetry/metric_exporter.go
+++ b/internal/telemetry/metric_exporter.go
@@ -33,6 +33,8 @@ import (
 )
 
 // NewMetricExporter initializes a new MetricExporter
+// This export logic is heavily inspired from the OTLP input in apm-data.
+// https://github.com/elastic/apm-data/blob/main/input/otlp/metrics.go
 func NewMetricExporter(p modelpb.BatchProcessor, opts ...ConfigOption) *MetricExporter {
 	cfg := newConfig(opts...)
 

--- a/internal/telemetry/metric_exporter.go
+++ b/internal/telemetry/metric_exporter.go
@@ -214,7 +214,7 @@ func buildHistogram[T int64 | float64](dp metricdata.HistogramDataPoint[T]) *mod
 	bounds := make([]float64, 0, len(dp.Bounds))
 	counts := make([]uint64, 0, len(dp.BucketCounts))
 
-	for i, _ := range dp.BucketCounts {
+	for i := range dp.BucketCounts {
 		bound, count := computeCountAndBounds(i, dp.Bounds, dp.BucketCounts)
 		if count == 0 {
 			continue

--- a/internal/telemetry/metric_exporter.go
+++ b/internal/telemetry/metric_exporter.go
@@ -104,8 +104,8 @@ func (e *MetricExporter) Export(ctx context.Context, rm *metricdata.ResourceMetr
 			}
 			event.Metricset = &modelpb.Metricset{Samples: metrs, Name: "app"}
 			if ms.attributes.Len() > 0 {
-				event.Labels = modelpb.Labels(event.Labels).Clone()
-				event.NumericLabels = modelpb.NumericLabels(event.NumericLabels).Clone()
+				event.Labels = modelpb.Labels{}
+				event.NumericLabels = modelpb.NumericLabels{}
 
 				iter := ms.attributes.Iter()
 				for iter.Next() {

--- a/internal/telemetry/metric_exporter_config.go
+++ b/internal/telemetry/metric_exporter_config.go
@@ -23,6 +23,8 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
+// Override default otel/prometheus boundaries, as we skip empty buckets and therefore able to use more accurate and higher range boundaries.
+// See https://github.com/elastic/apm/blob/5791498e9569ef9111615ef439e1cbf0b7fd7c18/specs/agents/metrics-otel.md#histogram-aggregation
 var customHistogramBoundaries = []float64{
 	0.00390625, 0.00552427, 0.0078125, 0.0110485, 0.015625, 0.0220971, 0.03125,
 	0.0441942, 0.0625, 0.0883883, 0.125, 0.176777, 0.25, 0.353553, 0.5, 0.707107,

--- a/internal/telemetry/metric_exporter_config.go
+++ b/internal/telemetry/metric_exporter_config.go
@@ -1,0 +1,95 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package telemetry
+
+import (
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/aggregation"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+var customHistogramBoundaries = []float64{
+	0.00390625, 0.00552427, 0.0078125, 0.0110485, 0.015625, 0.0220971, 0.03125,
+	0.0441942, 0.0625, 0.0883883, 0.125, 0.176777, 0.25, 0.353553, 0.5, 0.707107,
+	1, 1.41421, 2, 2.82843, 4, 5.65685, 8, 11.3137, 16, 22.6274, 32, 45.2548, 64,
+	90.5097, 128, 181.019, 256, 362.039, 512, 724.077, 1024, 1448.15, 2048,
+	2896.31, 4096, 5792.62, 8192, 11585.2, 16384, 23170.5, 32768, 46341.0, 65536,
+	92681.9, 131072,
+}
+
+type Config struct {
+	TemporalitySelector metric.TemporalitySelector
+	AggregationSelector metric.AggregationSelector
+}
+type ConfigOption func(Config) Config
+
+func newConfig(opts ...ConfigOption) Config {
+	config := Config{}
+	for _, opt := range opts {
+		config = opt(config)
+	}
+
+	if config.TemporalitySelector == nil {
+		config.TemporalitySelector = defaultTemporalitySelector
+	}
+	if config.AggregationSelector == nil {
+		config.AggregationSelector = defaultAggregationSelector
+	}
+
+	return config
+}
+
+func defaultTemporalitySelector(ik metric.InstrumentKind) metricdata.Temporality {
+	switch ik {
+	case metric.InstrumentKindCounter, metric.InstrumentKindObservableCounter, metric.InstrumentKindHistogram:
+		return metricdata.DeltaTemporality
+	}
+	return metric.DefaultTemporalitySelector(ik)
+}
+
+func defaultAggregationSelector(ik metric.InstrumentKind) aggregation.Aggregation {
+	switch ik {
+	case metric.InstrumentKindHistogram:
+		return aggregation.ExplicitBucketHistogram{
+			Boundaries: customHistogramBoundaries,
+			NoMinMax:   false,
+		}
+	default:
+		return metric.DefaultAggregationSelector(ik)
+	}
+}
+
+// WithAggregationSelector configure the Aggregation Selector the exporter will
+// use. If no AggregationSelector is provided the DefaultAggregationSelector is
+// used.
+func WithAggregationSelector(agg metric.AggregationSelector) ConfigOption {
+	return func(cfg Config) Config {
+		cfg.AggregationSelector = agg
+		return cfg
+	}
+}
+
+// WithTemporalitySelector configure the Aggregation Selector the exporter will
+// use. If no AggregationSelector is provided the DefaultAggregationSelector is
+// used.
+func WithTemporalitySelector(temporality metric.TemporalitySelector) ConfigOption {
+	return func(cfg Config) Config {
+		cfg.TemporalitySelector = temporality
+		return cfg
+	}
+}

--- a/internal/telemetry/metric_exporter_config.go
+++ b/internal/telemetry/metric_exporter_config.go
@@ -33,6 +33,7 @@ var customHistogramBoundaries = []float64{
 }
 
 type Config struct {
+	MetricFilter        []string
 	TemporalitySelector metric.TemporalitySelector
 	AggregationSelector metric.AggregationSelector
 }
@@ -71,6 +72,17 @@ func defaultAggregationSelector(ik metric.InstrumentKind) aggregation.Aggregatio
 		}
 	default:
 		return metric.DefaultAggregationSelector(ik)
+	}
+}
+
+// WithMetricFilter configured the metrics filter. Any metric filtered here
+// will be the only ones to be exported. All other metrics will be ignored.
+//
+// Defaults to not exporting anything.
+func WithMetricFilter(f []string) ConfigOption {
+	return func(cfg Config) Config {
+		cfg.MetricFilter = f
+		return cfg
 	}
 }
 

--- a/internal/telemetry/metric_exporter_config_test.go
+++ b/internal/telemetry/metric_exporter_config_test.go
@@ -1,0 +1,68 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/aggregation"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestNewExporterConfig(t *testing.T) {
+	aggregationSelector := func(metric.InstrumentKind) aggregation.Aggregation { return nil }
+	temporalitySelector := func(metric.InstrumentKind) metricdata.Temporality { return metricdata.CumulativeTemporality }
+
+	testCases := []struct {
+		name       string
+		options    []ConfigOption
+		wantConfig Config
+	}{
+		{
+			name:       "Default",
+			options:    nil,
+			wantConfig: Config{},
+		},
+		{
+			name: "WithAggregationSelector",
+			options: []ConfigOption{
+				WithAggregationSelector(aggregationSelector),
+			},
+			wantConfig: Config{},
+		},
+		{
+			name: "WithTemporalitySelector",
+			options: []ConfigOption{
+				WithTemporalitySelector(temporalitySelector),
+			},
+			wantConfig: Config{},
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newConfig(tt.options...)
+			// tested by TestConfigManualReaderOptions
+			cfg.AggregationSelector = nil
+			cfg.TemporalitySelector = nil
+
+			assert.Equal(t, tt.wantConfig, cfg)
+		})
+	}
+}

--- a/internal/telemetry/metric_exporter_test.go
+++ b/internal/telemetry/metric_exporter_test.go
@@ -46,9 +46,9 @@ func TestMetricExporter(t *testing.T) {
 		expectedBatch modelpb.Batch
 	}{
 		{
-			name: "with a float64 counter",
+			name: "with an int64 counter",
 			recordMetrics: func(ctx context.Context, meter metric.Meter) {
-				counter, err := meter.Float64Counter("sum_metric")
+				counter, err := meter.Int64Counter("sum_metric")
 				assert.NoError(t, err)
 				counter.Add(ctx, 5, metric.WithAttributes(attribute.Key("A").String("B")))
 			},
@@ -60,6 +60,66 @@ func TestMetricExporter(t *testing.T) {
 						Name: "app",
 						Samples: []*modelpb.MetricsetSample{
 							{Name: "sum_metric", Value: 5, Type: modelpb.MetricType_METRIC_TYPE_COUNTER},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with a float64 counter",
+			recordMetrics: func(ctx context.Context, meter metric.Meter) {
+				counter, err := meter.Float64Counter("sum_metric")
+				assert.NoError(t, err)
+				counter.Add(ctx, 3.14, metric.WithAttributes(attribute.Key("A").String("B")))
+			},
+			expectedBatch: modelpb.Batch{
+				{
+					Agent:   &agent,
+					Service: &service,
+					Metricset: &modelpb.Metricset{
+						Name: "app",
+						Samples: []*modelpb.MetricsetSample{
+							{Name: "sum_metric", Value: 3.14, Type: modelpb.MetricType_METRIC_TYPE_COUNTER},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with an int64 gauge",
+			recordMetrics: func(ctx context.Context, meter metric.Meter) {
+				counter, err := meter.Int64UpDownCounter("gauge_metric")
+				assert.NoError(t, err)
+				counter.Add(ctx, 5, metric.WithAttributes(attribute.Key("A").String("B")))
+			},
+			expectedBatch: modelpb.Batch{
+				{
+					Agent:   &agent,
+					Service: &service,
+					Metricset: &modelpb.Metricset{
+						Name: "app",
+						Samples: []*modelpb.MetricsetSample{
+							{Name: "gauge_metric", Value: 5, Type: modelpb.MetricType_METRIC_TYPE_COUNTER},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "with a float64 gauge",
+			recordMetrics: func(ctx context.Context, meter metric.Meter) {
+				counter, err := meter.Float64UpDownCounter("gauge_metric")
+				assert.NoError(t, err)
+				counter.Add(ctx, 3.14, metric.WithAttributes(attribute.Key("A").String("B")))
+			},
+			expectedBatch: modelpb.Batch{
+				{
+					Agent:   &agent,
+					Service: &service,
+					Metricset: &modelpb.Metricset{
+						Name: "app",
+						Samples: []*modelpb.MetricsetSample{
+							{Name: "gauge_metric", Value: 3.14, Type: modelpb.MetricType_METRIC_TYPE_COUNTER},
 						},
 					},
 				},

--- a/internal/telemetry/metric_exporter_test.go
+++ b/internal/telemetry/metric_exporter_test.go
@@ -63,6 +63,7 @@ func TestMetricExporter(t *testing.T) {
 				{
 					Agent:   &agent,
 					Service: &service,
+					Labels:  modelpb.Labels{"code": {Value: "200"}, "method": {Value: "GET"}},
 					Metricset: &modelpb.Metricset{
 						Name: "app",
 						Samples: []*modelpb.MetricsetSample{
@@ -80,6 +81,7 @@ func TestMetricExporter(t *testing.T) {
 				{
 					Agent:   &agent,
 					Service: &service,
+					Labels:  modelpb.Labels{"code": {Value: "302"}, "method": {Value: "GET"}},
 					Metricset: &modelpb.Metricset{
 						Name: "app",
 						Samples: []*modelpb.MetricsetSample{
@@ -114,6 +116,7 @@ func TestMetricExporter(t *testing.T) {
 				{
 					Agent:   &agent,
 					Service: &service,
+					Labels:  modelpb.Labels{"code": {Value: "200"}, "method": {Value: "GET"}},
 					Metricset: &modelpb.Metricset{
 						Name: "app",
 						Samples: []*modelpb.MetricsetSample{
@@ -131,6 +134,7 @@ func TestMetricExporter(t *testing.T) {
 				{
 					Agent:   &agent,
 					Service: &service,
+					Labels:  modelpb.Labels{"code": {Value: "302"}, "method": {Value: "GET"}},
 					Metricset: &modelpb.Metricset{
 						Name: "app",
 						Samples: []*modelpb.MetricsetSample{
@@ -158,6 +162,7 @@ func TestMetricExporter(t *testing.T) {
 				{
 					Agent:   &agent,
 					Service: &service,
+					Labels:  modelpb.Labels{"A": {Value: "B"}},
 					Metricset: &modelpb.Metricset{
 						Name: "app",
 						Samples: []*modelpb.MetricsetSample{
@@ -178,6 +183,7 @@ func TestMetricExporter(t *testing.T) {
 				{
 					Agent:   &agent,
 					Service: &service,
+					Labels:  modelpb.Labels{"A": {Value: "B"}},
 					Metricset: &modelpb.Metricset{
 						Name: "app",
 						Samples: []*modelpb.MetricsetSample{
@@ -198,6 +204,7 @@ func TestMetricExporter(t *testing.T) {
 				{
 					Agent:   &agent,
 					Service: &service,
+					Labels:  modelpb.Labels{"A": {Value: "B"}},
 					Metricset: &modelpb.Metricset{
 						Name: "app",
 						Samples: []*modelpb.MetricsetSample{
@@ -218,6 +225,7 @@ func TestMetricExporter(t *testing.T) {
 				{
 					Agent:   &agent,
 					Service: &service,
+					Labels:  modelpb.Labels{"A": {Value: "B"}},
 					Metricset: &modelpb.Metricset{
 						Name: "app",
 						Samples: []*modelpb.MetricsetSample{

--- a/internal/telemetry/metric_exporter_test.go
+++ b/internal/telemetry/metric_exporter_test.go
@@ -1,0 +1,49 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+
+	"github.com/elastic/apm-data/model/modelpb"
+)
+
+func TestMetricExporter(t *testing.T) {
+	p := modelpb.ProcessBatchFunc(func(ctx context.Context, b *modelpb.Batch) error {
+		fmt.Fprintf(os.Stdout, "%#v\n", b)
+		return nil
+	})
+	e := NewMetricExporter(p)
+
+	provider := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(e)),
+	)
+	meter := provider.Meter("test")
+
+	counter, err := meter.Float64Counter("foo")
+	assert.NoError(t, err)
+	counter.Add(context.Background(), 5)
+
+	provider.Shutdown(context.Background())
+}

--- a/internal/telemetry/metric_exporter_test.go
+++ b/internal/telemetry/metric_exporter_test.go
@@ -37,7 +37,6 @@ import (
 
 func TestMetricExporter(t *testing.T) {
 	service := modelpb.Service{Name: "apm-server", Language: &modelpb.Language{Name: "go"}}
-	agent := modelpb.Agent{Name: "internal", Version: "unknown"}
 
 	for _, tt := range []struct {
 		name string
@@ -74,7 +73,6 @@ func TestMetricExporter(t *testing.T) {
 			},
 			expectedBatch: modelpb.Batch{
 				{
-					Agent:   &agent,
 					Service: &service,
 					Labels:  modelpb.Labels{"code": {Value: "200"}, "method": {Value: "GET"}},
 					Metricset: &modelpb.Metricset{
@@ -92,7 +90,6 @@ func TestMetricExporter(t *testing.T) {
 					},
 				},
 				{
-					Agent:   &agent,
 					Service: &service,
 					Labels:  modelpb.Labels{"code": {Value: "302"}, "method": {Value: "GET"}},
 					Metricset: &modelpb.Metricset{
@@ -160,7 +157,6 @@ func TestMetricExporter(t *testing.T) {
 			},
 			expectedBatch: modelpb.Batch{
 				{
-					Agent:   &agent,
 					Service: &service,
 					Labels:  modelpb.Labels{"code": {Value: "200"}, "method": {Value: "GET"}},
 					Metricset: &modelpb.Metricset{
@@ -178,7 +174,6 @@ func TestMetricExporter(t *testing.T) {
 					},
 				},
 				{
-					Agent:   &agent,
 					Service: &service,
 					Labels:  modelpb.Labels{"code": {Value: "302"}, "method": {Value: "GET"}},
 					Metricset: &modelpb.Metricset{
@@ -209,7 +204,6 @@ func TestMetricExporter(t *testing.T) {
 			},
 			expectedBatch: modelpb.Batch{
 				{
-					Agent:   &agent,
 					Service: &service,
 					Labels:  modelpb.Labels{"A": {Value: "B"}},
 					Metricset: &modelpb.Metricset{
@@ -233,7 +227,6 @@ func TestMetricExporter(t *testing.T) {
 			},
 			expectedBatch: modelpb.Batch{
 				{
-					Agent:   &agent,
 					Service: &service,
 					Labels:  modelpb.Labels{"A": {Value: "B"}},
 					Metricset: &modelpb.Metricset{
@@ -257,7 +250,6 @@ func TestMetricExporter(t *testing.T) {
 			},
 			expectedBatch: modelpb.Batch{
 				{
-					Agent:   &agent,
 					Service: &service,
 					Labels:  modelpb.Labels{"A": {Value: "B"}},
 					Metricset: &modelpb.Metricset{
@@ -281,7 +273,6 @@ func TestMetricExporter(t *testing.T) {
 			},
 			expectedBatch: modelpb.Batch{
 				{
-					Agent:   &agent,
 					Service: &service,
 					Labels:  modelpb.Labels{"A": {Value: "B"}},
 					Metricset: &modelpb.Metricset{

--- a/internal/telemetry/metric_exporter_test.go
+++ b/internal/telemetry/metric_exporter_test.go
@@ -20,30 +20,110 @@ package telemetry
 import (
 	"context"
 	"fmt"
-	"os"
+	"sort"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/elastic/apm-data/model/modelpb"
 )
 
 func TestMetricExporter(t *testing.T) {
-	p := modelpb.ProcessBatchFunc(func(ctx context.Context, b *modelpb.Batch) error {
-		fmt.Fprintf(os.Stdout, "%#v\n", b)
-		return nil
+	service := modelpb.Service{Name: "apm-server", Language: &modelpb.Language{Name: "go"}}
+	agent := modelpb.Agent{Name: "internal", Version: "unknown"}
+
+	for _, tt := range []struct {
+		name string
+
+		recordMetrics func(ctx context.Context, meter metric.Meter)
+		expectedBatch modelpb.Batch
+	}{
+		{
+			name: "with a float64 counter",
+			recordMetrics: func(ctx context.Context, meter metric.Meter) {
+				counter, err := meter.Float64Counter("sum_metric")
+				assert.NoError(t, err)
+				counter.Add(ctx, 5, metric.WithAttributes(attribute.Key("A").String("B")))
+			},
+			expectedBatch: modelpb.Batch{
+				{
+					Agent:   &agent,
+					Service: &service,
+					Metricset: &modelpb.Metricset{
+						Name: "app",
+						Samples: []*modelpb.MetricsetSample{
+							{Name: "sum_metric", Value: 5, Type: modelpb.MetricType_METRIC_TYPE_COUNTER},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			var batch modelpb.Batch
+
+			p := modelpb.ProcessBatchFunc(func(ctx context.Context, b *modelpb.Batch) error {
+				batch = append(batch, (*b)...)
+				return nil
+			})
+			e := NewMetricExporter(p)
+
+			provider := sdkmetric.NewMeterProvider(
+				sdkmetric.WithReader(sdkmetric.NewPeriodicReader(e)),
+			)
+			meter := provider.Meter("test")
+
+			tt.recordMetrics(ctx, meter)
+
+			provider.Shutdown(context.Background())
+
+			assertEventsMatch(t, tt.expectedBatch, batch)
+		})
+	}
+}
+
+func assertEventsMatch(t *testing.T, expected []*modelpb.APMEvent, actual []*modelpb.APMEvent) {
+	t.Helper()
+	sort.Slice(expected, func(i, j int) bool {
+		return strings.Compare(expected[i].String(), expected[j].String()) == -1
 	})
-	e := NewMetricExporter(p)
+	sort.Slice(actual, func(i, j int) bool {
+		return strings.Compare(actual[i].String(), actual[j].String()) == -1
+	})
 
-	provider := sdkmetric.NewMeterProvider(
-		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(e)),
+	now := modelpb.FromTime(time.Now())
+	for i, e := range actual {
+		assert.InDelta(t, now, e.Timestamp, float64((2 * time.Second).Nanoseconds()))
+		e.Timestamp = 0
+		assert.InDelta(t, now, e.Event.Received, float64((2 * time.Second).Nanoseconds()))
+		e.Event.Received = 0
+		if expected[i].Event == nil {
+			e.Event = nil
+		}
+	}
+
+	diff := cmp.Diff(
+		expected, actual,
+		protocmp.Transform(),
+		// Ignore order of events and their metrics. Some other slices
+		// have a defined order (e.g. histogram counts/values), so we
+		// don't ignore the order of all slices.
+		//
+		// Comparing string representations is a bit of a hack; ideally
+		// we would use like https://github.com/google/go-cmp/issues/67
+		protocmp.SortRepeated(func(x, y *modelpb.MetricsetSample) bool {
+			return fmt.Sprint(x) < fmt.Sprint(y)
+		}),
 	)
-	meter := provider.Meter("test")
-
-	counter, err := meter.Float64Counter("foo")
-	assert.NoError(t, err)
-	counter.Add(context.Background(), 5)
-
-	provider.Shutdown(context.Background())
+	if diff != "" {
+		t.Fatal(diff)
+	}
 }

--- a/internal/telemetry/metric_exporter_test.go
+++ b/internal/telemetry/metric_exporter_test.go
@@ -72,7 +72,7 @@ func TestMetricExporter(t *testing.T) {
 								Type: modelpb.MetricType_METRIC_TYPE_HISTOGRAM,
 								Histogram: &modelpb.Histogram{
 									Counts: []uint64{1},
-									Values: []float64{2.5},
+									Values: []float64{3.414215},
 								},
 							},
 						},
@@ -90,7 +90,7 @@ func TestMetricExporter(t *testing.T) {
 								Type: modelpb.MetricType_METRIC_TYPE_HISTOGRAM,
 								Histogram: &modelpb.Histogram{
 									Counts: []uint64{1},
-									Values: []float64{7.5},
+									Values: []float64{9.65685},
 								},
 							},
 						},
@@ -107,7 +107,37 @@ func TestMetricExporter(t *testing.T) {
 					attribute.Key("code").String("200"),
 					attribute.Key("method").String("GET"),
 				))
+				counter.Record(ctx, 3.4, metric.WithAttributes(
+					attribute.Key("code").String("200"),
+					attribute.Key("method").String("GET"),
+				))
+				counter.Record(ctx, 3.4, metric.WithAttributes(
+					attribute.Key("code").String("200"),
+					attribute.Key("method").String("GET"),
+				))
+
 				counter.Record(ctx, 5.5, metric.WithAttributes(
+					attribute.Key("code").String("302"),
+					attribute.Key("method").String("GET"),
+				))
+				counter.Record(ctx, 5.5, metric.WithAttributes(
+					attribute.Key("code").String("302"),
+					attribute.Key("method").String("GET"),
+				))
+				counter.Record(ctx, 5.5, metric.WithAttributes(
+					attribute.Key("code").String("302"),
+					attribute.Key("method").String("GET"),
+				))
+
+				counter.Record(ctx, 11.2, metric.WithAttributes(
+					attribute.Key("code").String("302"),
+					attribute.Key("method").String("GET"),
+				))
+				counter.Record(ctx, 11.2, metric.WithAttributes(
+					attribute.Key("code").String("302"),
+					attribute.Key("method").String("GET"),
+				))
+				counter.Record(ctx, 11.2, metric.WithAttributes(
 					attribute.Key("code").String("302"),
 					attribute.Key("method").String("GET"),
 				))
@@ -124,8 +154,8 @@ func TestMetricExporter(t *testing.T) {
 								Name: "histogram_metric",
 								Type: modelpb.MetricType_METRIC_TYPE_HISTOGRAM,
 								Histogram: &modelpb.Histogram{
-									Counts: []uint64{1},
-									Values: []float64{2.5},
+									Values: []float64{3.414215},
+									Counts: []uint64{3},
 								},
 							},
 						},
@@ -142,8 +172,8 @@ func TestMetricExporter(t *testing.T) {
 								Name: "histogram_metric",
 								Type: modelpb.MetricType_METRIC_TYPE_HISTOGRAM,
 								Histogram: &modelpb.Histogram{
-									Counts: []uint64{1},
-									Values: []float64{7.5},
+									Values: []float64{4.828425, 9.65685},
+									Counts: []uint64{3, 3},
 								},
 							},
 						},


### PR DESCRIPTION
## Motivation/summary

This sets up an OpenTelemetry exporter to collect internal metrics, export them as internal APM events and send them to the processor.

It is the boilerplate for #10623, yet no metrics are emitted yet. So this code isn't used at the moment.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [x] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

This PR is unit-tested.

## Related issues

* #10623
