### PR TITLE
dra: support two workflows in the same context

### DIFF
--- a/.ci/scripts/prepare-release-manager.sh
+++ b/.ci/scripts/prepare-release-manager.sh
@@ -15,7 +15,7 @@ FINAL_VERSION=$VERSION-SNAPSHOT
 if [ "$TYPE" != "snapshot" ] ; then
   FINAL_VERSION=$VERSION
 fi
-mv build/distributions/dependencies.csv \
+cp build/distributions/dependencies.csv \
    build/distributions/dependencies-"$FINAL_VERSION".csv
 
 # rename docker files to support the unified release format.


### PR DESCRIPTION
## Motivation/summary

Copy will help running the two different DRA workflows sequentially using the same set of binaries.

Otherwise, it will fail since the file was already renamed in the previous DRA workflow.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
