### PR TITLE
dra: only move if file does not exist

### DIFF
--- a/.buildkite/scripts/dra.sh
+++ b/.buildkite/scripts/dra.sh
@@ -23,21 +23,7 @@ echo "--- Changing permissions for the release manager"
 sudo chown -R :1000 build/
 ls -l build/distributions/
 
-if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "true" ]]; then
-  echo "--- :arrow_right: Release Manager does not run on PRs, skipping"
-  exit 0
-fi
-
-curl -s https://storage.googleapis.com/artifacts-api/snapshots/branches.json > active-branches.json
-if ! grep -q "\"$BUILDKITE_BRANCH\"" active-branches.json ; then
-  echo "--- :arrow_right: Release Manager only supports the current active branches, skipping"
-  echo "BUILDKITE_BRANCH=$BUILDKITE_BRANCH"
-  echo "BUILDKITE_COMMIT=$BUILDKITE_COMMIT"
-  echo "VERSION=$VERSION"
-  echo "Supported branches:"
-  cat active-branches.json
-  exit 0
-fi
+BUILDKITE_BRANCH=7.17
 
 dra() {
   local workflow=$1

--- a/.buildkite/scripts/dra.sh
+++ b/.buildkite/scripts/dra.sh
@@ -23,7 +23,21 @@ echo "--- Changing permissions for the release manager"
 sudo chown -R :1000 build/
 ls -l build/distributions/
 
-BUILDKITE_BRANCH=7.17
+if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "true" ]]; then
+  echo "--- :arrow_right: Release Manager does not run on PRs, skipping"
+  exit 0
+fi
+
+curl -s https://storage.googleapis.com/artifacts-api/snapshots/branches.json > active-branches.json
+if ! grep -q "\"$BUILDKITE_BRANCH\"" active-branches.json ; then
+  echo "--- :arrow_right: Release Manager only supports the current active branches, skipping"
+  echo "BUILDKITE_BRANCH=$BUILDKITE_BRANCH"
+  echo "BUILDKITE_COMMIT=$BUILDKITE_COMMIT"
+  echo "VERSION=$VERSION"
+  echo "Supported branches:"
+  cat active-branches.json
+  exit 0
+fi
 
 dra() {
   local workflow=$1

--- a/.ci/scripts/prepare-release-manager.sh
+++ b/.ci/scripts/prepare-release-manager.sh
@@ -23,16 +23,14 @@ cp build/distributions/dependencies.csv \
 #       or the unified release process the one to do the transformation
 for i in build/distributions/*linux-arm64.docker.tar.gz*
 do
-  NEW_FILE=${i/linux-arm64.docker.tar.gz/docker-image-arm64.tar.gz}
-  if [ ! -e "${NEW_FILE}" ] ; then
-    mv "$i" "${NEW_FILE}"
+  if [ -e "$i" ] ; then
+    mv "$i" "${i/linux-arm64.docker.tar.gz/docker-image-arm64.tar.gz}"
   fi
 done
 
 for i in build/distributions/*linux-amd64.docker.tar.gz*
 do
-  NEW_FILE=${i/linux-amd64.docker.tar.gz/docker-image.tar.gz}
-  if [ ! -e "${NEW_FILE}" ] ; then
-    mv "$i" "${NEW_FILE}"
+  if [ -e "$i" ] ; then
+    mv "$i" "${i/linux-amd64.docker.tar.gz/docker-image.tar.gz}"
   fi
 done

--- a/.ci/scripts/prepare-release-manager.sh
+++ b/.ci/scripts/prepare-release-manager.sh
@@ -23,10 +23,16 @@ cp build/distributions/dependencies.csv \
 #       or the unified release process the one to do the transformation
 for i in build/distributions/*linux-arm64.docker.tar.gz*
 do
-    mv "$i" "${i/linux-arm64.docker.tar.gz/docker-image-arm64.tar.gz}"
+  NEW_FILE=${i/linux-arm64.docker.tar.gz/docker-image-arm64.tar.gz}
+  if [ ! -e "${NEW_FILE}" ] ; then
+    mv "$i" "${NEW_FILE}"
+  fi
 done
 
 for i in build/distributions/*linux-amd64.docker.tar.gz*
 do
-    mv "$i" "${i/linux-amd64.docker.tar.gz/docker-image.tar.gz}"
+  NEW_FILE=${i/linux-amd64.docker.tar.gz/docker-image.tar.gz}
+  if [ ! -e "${NEW_FILE}" ] ; then
+    mv "$i" "${NEW_FILE}"
+  fi
 done


### PR DESCRIPTION
## Motivation/summary

Running the two DRA workflows with mv will make the second attempt fail.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

I tried in the CI by creating a feature branch and [comment out ](https://github.com/elastic/apm-server/pull/11477/commits/86979d983e169ab5aa146baebc0c9e3d9423e4c5) some part of the pipeline

then It worked

<img width="1589" alt="image" src="https://github.com/elastic/apm-server/assets/2871786/a5eac945-5f32-4365-b9bc-a1474291c54b">


## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
