### PR TITLE
Customization for benchmarks manual runs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -7,6 +7,11 @@ on:
         description: 'The system profile used to run the benchmarks'
         required: false
         type: string
+      runOnStable:
+        description: 'Run the benchmarks on the latest stable version'
+        required: false
+        type: boolean
+        default: false
   schedule:
     - cron: '0 17 * * *'
 
@@ -85,10 +90,14 @@ jobs:
       - name: Build apmbench
         run: make apmbench $SSH_KEY terraform.tfvars
 
+      - name: Override docker committed version
+        if: ${{ !github.event.inputs.runOnStable }}
+        run: make docker-override-committed-version
+
       - name: Spin up benchmark environment
         id: deploy
         run: |
-          make docker-override-committed-version init apply
+          make init apply
           admin_console_url=$(terraform output -raw admin_console_url)
           echo "admin_console_url=$admin_console_url" >> "$GITHUB_OUTPUT"
           echo "-> infra setup done"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -39,8 +39,6 @@ jobs:
       TF_VAR_ENVIRONMENT: ci
       TF_VAR_REPO: ${{ github.repository }}
       GOBENCH_TAGS: branch=${{ github.head_ref || github.ref }},commit=${{ github.sha }},target_branch=${{ github.base_ref }}
-
-      BENCHMARK_AGENTS: ${{ inputs.benchmarkAgents || 64 }}
     steps:
       - uses: actions/checkout@v3
 
@@ -57,6 +55,10 @@ jobs:
           echo "TF_VAR_BRANCH=${SLUGGED_BRANCH_NAME}" >> "$GITHUB_ENV"
           echo "TF_VAR_CREATED_AT=${CREATED_AT}" >> "$GITHUB_ENV"
           echo "USER=benchci-$SLUGGED_BRANCH_NAME-$CREATED_AT" >> "$GITHUB_ENV"
+
+          if [ ! -z "${{ inputs.benchmarkAgents }}" ]; then
+            echo "BENCHMARK_AGENTS=${{ inputs.benchmarkAgents }}" >> "$GITHUB_ENV"
+          fi
 
       - uses: hashicorp/vault-action@v2.6.0
         env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -111,11 +111,11 @@ jobs:
           echo "-> infra setup done"
 
       - name: Run benchmarks autotuned
-        if: ${{ !github.event.inputs.benchmarkAgents == '' }}
+        if: ${{ github.event.inputs.benchmarkAgents == '' }}
         run: make run-benchmark-autotuned index-benchmark-results
 
       - name: Run benchmarks self tuned
-        if: ${{ !github.event.inputs.benchmarkAgents != '' }}
+        if: ${{ github.event.inputs.benchmarkAgents != '' }}
         run: make run-benchmark index-benchmark-results
 
       - name: Download PNG

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,6 +12,10 @@ on:
         required: false
         type: boolean
         default: false
+      benchmarkAgents:
+        description: 'Set the number of agents to send data to the APM Server'
+        required: false
+        type: string
   schedule:
     - cron: '0 17 * * *'
 
@@ -35,6 +39,8 @@ jobs:
       TF_VAR_ENVIRONMENT: ci
       TF_VAR_REPO: ${{ github.repository }}
       GOBENCH_TAGS: branch=${{ github.head_ref || github.ref }},commit=${{ github.sha }},target_branch=${{ github.base_ref }}
+
+      BENCHMARK_AGENTS: ${{ inputs.benchmarkAgents || 64 }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,6 +2,11 @@ name: benchmarks
 
 on:
   workflow_dispatch:
+    inputs:
+      profile:
+        description: 'The system profile used to run the benchmarks'
+        required: false
+        type: string
   schedule:
     - cron: '0 17 * * *'
 
@@ -20,7 +25,7 @@ jobs:
       SSH_KEY: ./id_rsa_terraform
       TF_VAR_private_key: ./id_rsa_terraform
       TF_VAR_public_key: ./id_rsa_terraform.pub
-      TFVARS_SOURCE: 'system-profiles/8GBx1zone.tfvars' # // Default to use an 8gb profile
+      TFVARS_SOURCE: ${{ inputs.profile || 'system-profiles/8GBx1zone.tfvars' }} # // Default to use an 8gb profile
       TF_VAR_BUILD_ID: ${{ github.run_id }}
       TF_VAR_ENVIRONMENT: ci
       TF_VAR_REPO: ${{ github.repository }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -110,8 +110,13 @@ jobs:
           echo "admin_console_url=$admin_console_url" >> "$GITHUB_OUTPUT"
           echo "-> infra setup done"
 
-      - name: Run benchmarks
+      - name: Run benchmarks autotuned
+        if: ${{ !github.event.inputs.benchmarkAgents == '' }}
         run: make run-benchmark-autotuned index-benchmark-results
+
+      - name: Run benchmarks self tuned
+        if: ${{ !github.event.inputs.benchmarkAgents != '' }}
+        run: make run-benchmark index-benchmark-results
 
       - name: Download PNG
         run: >-

--- a/testing/benchmark/README.md
+++ b/testing/benchmark/README.md
@@ -116,4 +116,4 @@ the benchmarks without destroying the deployment.
 Reporting data is taken from the https://`<replace-with-kibana-benchmark-url>`/app/dashboards#/view/a5bc8390-2f8e-11ed-a369-052d8245fa04?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30d,to:now))
 It's possible to add or modify any metric.
 
-Naming convention for mertics: `[metic_name]_(1w|2w|3w)`. The slack message contains an image and metric details (when CSV reporting is back in Kibana)
+Naming convention for metrics: `[metric_name]_(1w|2w|3w)`. The slack message contains an image and metric details (when CSV reporting is back in Kibana)

--- a/testing/benchmark/README.md
+++ b/testing/benchmark/README.md
@@ -57,6 +57,7 @@ The main commands are:
 
 - `all` (default): runs `auth`, `apmbench`, creates the config files and runs terraform apply.
 - `auth`: Re-generate AWS credentials, they will expire after 4h.
+- `run-benchmark-autotuned`: Run the benchmarks with a computed `BENCHMARK_AGENTS`.
 - `run-benchmark`: Run the benchmarks, can configured by tweaking:
   - `BENCHMARK_WARMUP_TIME`: Set the amount of time to warm the APM Server for. Defaults to `5m`.
   - `BENCHMARK_AGENTS`: Set the number of agents to send data to the APM Server. Defaults to `64`.


### PR DESCRIPTION
## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

Since benchmarks moves to GH Actions, we lost some customization possibilities. This allows setting some attributes (the ones I need for #7842), while keeping the same defaults for the cronjobs.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] **NA** Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] **NA** Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [x] **NA** Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

This can be tested by manually running the workflow.
A test run: https://github.com/elastic/apm-server/actions/runs/5973256723/job/16205170670

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
