### PR TITLE
test: create a new registry instead of reusing the static default registry in monitoring tests

### DIFF
--- a/internal/beater/request/result_test.go
+++ b/internal/beater/request/result_test.go
@@ -190,7 +190,7 @@ func TestResult_Failure(t *testing.T) {
 }
 
 func TestDefaultMonitoringMapForRegistry(t *testing.T) {
-	mockRegistry := monitoring.Default.NewRegistry("mock-default")
+	mockRegistry := monitoring.NewRegistry().NewRegistry("mock-default")
 	m := DefaultMonitoringMapForRegistry(mockRegistry)
 	assert.Equal(t, 22, len(m))
 	for id := range m {
@@ -200,7 +200,7 @@ func TestDefaultMonitoringMapForRegistry(t *testing.T) {
 
 func TestMonitoringMapForRegistry(t *testing.T) {
 	keys := []ResultID{IDEventDroppedCount, IDResponseErrorsServiceUnavailable}
-	mockRegistry := monitoring.Default.NewRegistry("mock-with-keys")
+	mockRegistry := monitoring.NewRegistry().NewRegistry("mock-with-keys")
 	m := MonitoringMapForRegistry(mockRegistry, keys)
 	assert.Equal(t, 2, len(m))
 	for id := range m {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

`TestDefaultMonitoringMapForRegistry` and `TestMonitoringMapForRegistry` fails when running the tests multiple times

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

- go test -run=TestMonitoring -race -count=100 -failfast ./...
- go test -run=TestDefaultMonitoringMapForRegistry -race -count=100 -failfast ./...

## Related issues

Closes https://github.com/elastic/apm-server/issues/11172
Closes https://github.com/elastic/apm-server/issues/11171
