### PR TITLE
Handle queue.* config for libbeat outputs

### DIFF
--- a/changelogs/8.10.asciidoc
+++ b/changelogs/8.10.asciidoc
@@ -19,6 +19,7 @@ https://github.com/elastic/apm-server/compare/8.9\...8.10[View commits]
 
 [float]
 ==== Bug fixes
+- Add back handling of `queue.*` config for libbeat outputs, such as logstash and kafka {pull}11534[11534]
 
 [float]
 ==== Intake API Changes

--- a/internal/beater/beater.go
+++ b/internal/beater/beater.go
@@ -844,7 +844,11 @@ func (s *Runner) newLibbeatFinalBatchProcessor(
 		output, err := outputs.Load(indexSupporter, beatInfo, stats, outputName, s.outputConfig.Config())
 		return outputName, output, err
 	}
-	pipeline, err := pipeline.Load(beatInfo, monitors, pipeline.Config{}, nopProcessingSupporter{}, outputFactory)
+	var pipelineConfig pipeline.Config
+	if err := s.rawConfig.Unpack(&pipelineConfig); err != nil {
+		return nil, nil, fmt.Errorf("failed to unpack libbeat pipeline config: %w", err)
+	}
+	pipeline, err := pipeline.Load(beatInfo, monitors, pipelineConfig, nopProcessingSupporter{}, outputFactory)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create libbeat output pipeline: %w", err)
 	}

--- a/systemtest/apmservertest/config.go
+++ b/systemtest/apmservertest/config.go
@@ -238,11 +238,19 @@ type InstrumentationConfig struct {
 type OutputConfig struct {
 	Console       *ConsoleOutputConfig       `json:"console,omitempty"`
 	Elasticsearch *ElasticsearchOutputConfig `json:"elasticsearch,omitempty"`
+	Logstash      *LogstashOutputConfig      `json:"logstash,omitempty"`
 }
 
 // ConsoleOutputConfig holds APM Server libbeat console output configuration.
 type ConsoleOutputConfig struct {
 	Enabled bool `json:"enabled"`
+}
+
+// LogstashOutputConfig holds APM Server libbeat logstash output configuration.
+type LogstashOutputConfig struct {
+	Enabled     bool     `json:"enabled"`
+	Hosts       []string `json:"hosts,omitempty"`
+	BulkMaxSize int      `json:"bulk_max_size,omitempty"`
 }
 
 // ElasticsearchOutputConfig holds APM Server libbeat Elasticsearch output configuration.

--- a/systemtest/go.mod
+++ b/systemtest/go.mod
@@ -57,6 +57,7 @@ require (
 	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/elastic/elastic-transport-go/v8 v8.3.0 // indirect
+	github.com/elastic/go-lumber v0.1.1 // indirect
 	github.com/elastic/go-sysinfo v1.7.1 // indirect
 	github.com/elastic/go-windows v1.0.1 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect

--- a/systemtest/go.sum
+++ b/systemtest/go.sum
@@ -93,6 +93,8 @@ github.com/elastic/elastic-transport-go/v8 v8.3.0 h1:DJGxovyQLXGr62e9nDMPSxRyWIO
 github.com/elastic/elastic-transport-go/v8 v8.3.0/go.mod h1:87Tcz8IVNe6rVSLdBux1o/PEItLtyabHU3naC7IoqKI=
 github.com/elastic/go-elasticsearch/v8 v8.8.1 h1:/OiP5Yex40q5eWpzFVQIS8jRE7SaEZrFkG9JbE6TXtY=
 github.com/elastic/go-elasticsearch/v8 v8.8.1/go.mod h1:GU1BJHO7WeamP7UhuElYwzzHtvf9SDmeVpSSy9+o6Qg=
+github.com/elastic/go-lumber v0.1.1 h1:aae5rSBnwBvdB0aShJ7AbOYPyvP1/wS/JIOC1A4D1DM=
+github.com/elastic/go-lumber v0.1.1/go.mod h1:DMVoFv7YM71enE9X5vWJWWv7wvQNtzXh7bPeKukDccY=
 github.com/elastic/go-sysinfo v1.7.1 h1:Wx4DSARcKLllpKT2TnFVdSUJOsybqMYCNQZq1/wO+s0=
 github.com/elastic/go-sysinfo v1.7.1/go.mod h1:i1ZYdU10oLNfRzq4vq62BEwD2fH8KaWh6eh0ikPT9F0=
 github.com/elastic/go-windows v1.0.0/go.mod h1:TsU0Nrp7/y3+VwE82FoZF8gC/XFg/Elz6CcloAxnPgU=
@@ -210,6 +212,7 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.11.2/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
 github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/systemtest/logstash_test.go
+++ b/systemtest/logstash_test.go
@@ -1,0 +1,79 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package systemtest_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-server/systemtest/apmservertest"
+	lumberserver "github.com/elastic/go-lumber/server"
+)
+
+func TestLogstashOutput(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { listener.Close() }) // ignore error; ls.Close closes it too
+
+	ls, err := lumberserver.NewWithListener(listener, lumberserver.V2(true))
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, ls.Close()) })
+
+	srv := apmservertest.NewUnstartedServerTB(t,
+		"-E", "queue.mem.events=20000",
+		"-E", "queue.mem.flush.min_events=10000",
+		"-E", "queue.mem.flush.timeout=60s",
+	)
+	srv.Config.Output = apmservertest.OutputConfig{
+		Logstash: &apmservertest.LogstashOutputConfig{
+			Enabled:     true,
+			BulkMaxSize: 5000,
+			Hosts:       []string{listener.Addr().String()},
+		},
+	}
+	require.NoError(t, srv.Start())
+
+	// Send 20000 events. We should receive 4 batches of 5000.
+	tracer := srv.Tracer()
+	for i := 0; i < 20; i++ {
+		for i := 0; i < 1000; i++ {
+			tx := tracer.StartTransaction("name", "type")
+			tx.End()
+		}
+		tracer.Flush(nil)
+	}
+	for i := 0; i < 4; i++ {
+		select {
+		case batch := <-ls.ReceiveChan():
+			batch.ACK()
+			assert.Len(t, batch.Events, 5000)
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for batch")
+		}
+	}
+	// Should be no more batches.
+	select {
+	case <-ls.ReceiveChan():
+		t.Error("unexpected batch received")
+	case <-time.After(100 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
## Motivation/summary

Unpack and pass `queue.*` config to libbeat. We were ignoring `queue.*` config when using libbeat outputs, such as logstash and kafka.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
~- [ ] Documentation has been updated~

## How to test these changes

See reproduction steps in https://github.com/elastic/apm-server/issues/11533

## Related issues

Closes https://github.com/elastic/apm-server/issues/11533