### PR TITLE
docs: fix getting started instructions

### DIFF
--- a/docs/getting-started-apm-server.asciidoc
+++ b/docs/getting-started-apm-server.asciidoc
@@ -344,6 +344,7 @@ Update `kibana.yml` to include the following, then restart {kib}.
 ----
 xpack.fleet.packages:
 - name: apm
+  version: latest
 ----
 +
 See {kibana-ref}/settings.html[Configure Kibana] to learn more about how to edit the Kibana configuration file.


### PR DESCRIPTION
## Motivation/summary

`xpack.fleet.packages` requires a version for each installed package. This should be set to "latest" to use the bundled package.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
- [x] Documentation has been updated

## How to test these changes

Run through the getting started instructions.

## Related issues

None