### PR TITLE
buildkite: docker login

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -65,7 +65,7 @@ get_os_details() {
 }
 
 if command -v docker &>/dev/null; then
-    echo "--- Prepare docker context :docker:"
+    echo "--- Prepare Elastic docker context :docker:"
     DOCKER_REGISTRY_SECRET_PATH="secret/ci/elastic-apm-server/docker-elastic-observability"
     DOCKER_USERNAME_SECRET=$(retry 5 vault kv get -field username "${DOCKER_REGISTRY_SECRET_PATH}")
     DOCKER_PASSWORD_SECRET=$(retry 5 vault kv get -field password "${DOCKER_REGISTRY_SECRET_PATH}")
@@ -74,6 +74,14 @@ if command -v docker &>/dev/null; then
     unset DOCKER_USERNAME_SECRET DOCKER_PASSWORD_SECRET
     export DOCKER_REGISTRY_SECRET
     retry 4 docker pull --quiet docker.elastic.co/infra/release-manager:latest
+
+    echo "--- Prepare dockerhub context :docker:"
+    DOCKER_REGISTRY_SECRET_PATH="kv/ci-shared/observability-ci/docker-hub-observability"
+    DOCKER_USERNAME_SECRET=$(retry 5 vault kv get -field username "${DOCKER_REGISTRY_SECRET_PATH}")
+    DOCKER_PASSWORD_SECRET=$(retry 5 vault kv get -field password "${DOCKER_REGISTRY_SECRET_PATH}")
+    DOCKERHUB_REGISTRY_SECRET=$(retry 5 vault kv get -field registry "${DOCKER_REGISTRY_SECRET_PATH}")
+    docker login -u "${DOCKER_USERNAME_SECRET}" -p "${DOCKER_PASSWORD_SECRET}" "${DOCKERHUB_REGISTRY_SECRET}"
+    unset DOCKER_USERNAME_SECRET DOCKER_PASSWORD_SECRET
 fi
 
 echo "--- Setting up the :golang: environment..."

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -9,4 +9,5 @@ unset VAULT_SECRET
 
 if command -v docker &>/dev/null; then
   docker logout $DOCKER_REGISTRY_SECRET
+  docker logout $DOCKERHUB_REGISTRY_SECRET
 fi


### PR DESCRIPTION
this should help with environmental issues when accessing docker.hub

<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Docker login so no issues with quota limit in Dockerhub.

Fixes
```
ERROR: failed to solve: golang:1.20.7: failed to copy: httpReadSeeker: failed open: unexpected status code 
https://registry-1.docker.io/v2/library/golang/manifests/sha256:7fcc2684ef0de5f7730be51a493d26289756356a3c385ce6374b86d31d0be446: 429 Too Many Requests - Server message: toomanyrequests: 
You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
--
  | make: *** [packaging.mk:42: build/docker/apm-server-8.10.0-SNAPSHOT.txt] Error 1
```

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

In the CI, this is a feature branch so it triggered [this](https://buildkite.com/elastic/apm-server-package/builds/352#018a5015-00cb-4646-968f-d2c53f8a70aa) build in Buildkite and docker login was done as part of the [`pre-command` hook](https://buildkite.com/docs/agent/v3/hooks)


<img width="1437" alt="image" src="https://github.com/elastic/apm-server/assets/2871786/50aabe99-56f9-422c-885b-9dadaf83bc53">


## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
