### PR TITLE
Expose local metrics to the batch processor

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -20,3 +20,14 @@ https://github.com/elastic/apm-server/compare/8.10\...main[View commits]
 [float]
 ==== Added
 - Support and define DLM data retention period in the apmpackage
+- Expose new metrics into the local batch processor {pull}[] :
+	- http.server.request.count
+	- http.server.response.valid.count
+	- http.server.response.errors.count
+	- http.server.errors.timeout
+	- http.server.errors.ratelimit
+	- grpc.server.request.count
+	- grpc.server.response.valid.count
+	- grpc.server.response.errors.count
+	- grpc.server.errors.timeout
+	- grpc.server.errors.ratelimit

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -20,7 +20,7 @@ https://github.com/elastic/apm-server/compare/8.10\...main[View commits]
 [float]
 ==== Added
 - Support and define DLM data retention period in the apmpackage
-- Expose new metrics into the local batch processor {pull}[] :
+- Expose new metrics into the local batch processor {pull}11582[11582] :
 	- http.server.request.count
 	- http.server.response.valid.count
 	- http.server.response.errors.count

--- a/docs/monitoring/monitoring-beats.asciidoc
+++ b/docs/monitoring/monitoring-beats.asciidoc
@@ -15,9 +15,13 @@ ifndef::serverless[]
 * <<monitoring-metricbeat-collection, {metricbeat} collection>> -
 {metricbeat} collects monitoring data from your {beatname_uc} instance
 and sends it directly to your monitoring cluster.
+* <<monitoring-local-collection, Local collection>> - Local collection sends
+select monitoring data directly to the standard indices of your monitoring
+cluster.
 endif::[]
 
 include::monitoring-internal-collection.asciidoc[]
+include::monitoring-local-collection.asciidoc[]
 
 ifndef::serverless[]
 include::monitoring-metricbeat.asciidoc[]

--- a/docs/monitoring/monitoring-local-collection.asciidoc
+++ b/docs/monitoring/monitoring-local-collection.asciidoc
@@ -1,0 +1,32 @@
+[[monitoring-local-collection]]
+= Use the select metrics emitted directly to your monitoring cluster
+++++
+<titleabbrev>Use local collection</titleabbrev>
+++++
+
+In 8.10 and later, we emit a selected set of metrics directly to the monitoring
+cluster.
+The benefit of using local collection instead of internal collection is that
+the metrics are sent directly to your main monitoring index, making it easier
+to view shared data.
+
+[[select-metrics]]
+== The select metrics
+
+We only ship a select list of metrics, to avoid overwhelming your monitoring cluster.
+If you need the entire set of metrics and traces we can expose, you should use
+<<configuration-instrumentation,Self Instrumentation>> instead of local
+collection.
+
+Here is the list of every metrics we currently expose:
+
+* http.server.request.count
+* http.server.response.valid.count
+* http.server.response.errors.count
+* http.server.errors.timeout
+* http.server.errors.ratelimit
+* grpc.server.request.count
+* grpc.server.response.valid.count
+* grpc.server.response.errors.count
+* grpc.server.errors.timeout
+* grpc.server.errors.ratelimit

--- a/internal/beater/beater.go
+++ b/internal/beater/beater.go
@@ -63,6 +63,7 @@ import (
 	"github.com/elastic/apm-server/internal/beater/interceptors"
 	javaattacher "github.com/elastic/apm-server/internal/beater/java_attacher"
 	"github.com/elastic/apm-server/internal/beater/ratelimit"
+	"github.com/elastic/apm-server/internal/beater/request"
 	"github.com/elastic/apm-server/internal/elasticsearch"
 	"github.com/elastic/apm-server/internal/idxmgmt"
 	"github.com/elastic/apm-server/internal/kibana"
@@ -311,7 +312,21 @@ func (s *Runner) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	localExporter := telemetry.NewMetricExporter()
+	localExporter := telemetry.NewMetricExporter(
+		telemetry.WithMetricFilter([]string{
+			"http.server." + string(request.IDRequestCount),
+			"http.server." + string(request.IDResponseValidCount),
+			"http.server." + string(request.IDResponseErrorsCount),
+			"http.server." + string(request.IDResponseErrorsTimeout),
+			"http.server." + string(request.IDResponseErrorsRateLimit),
+
+			"grpc.server." + string(request.IDRequestCount),
+			"grpc.server." + string(request.IDResponseValidCount),
+			"grpc.server." + string(request.IDResponseErrorsCount),
+			"grpc.server." + string(request.IDResponseErrorsTimeout),
+			"grpc.server." + string(request.IDResponseErrorsRateLimit),
+		}),
+	)
 	meterProvider := metric.NewMeterProvider(
 		metric.WithReader(exporter),
 		metric.WithReader(metric.NewPeriodicReader(localExporter)),


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

This is the last PR meant to expose local metrics to the batch processor, #10623.
It adds the HTTP and gRPC metrics to the allow list, so they are exposed to Kibana.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [x] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

This can be tested by booting the stack with `tilt up` and triggering a batch send with OTLP.

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
