### PR TITLE
CHANGELOG: add bug fix entry for dropped_spans_stats.duration

### DIFF
--- a/changelogs/8.10.asciidoc
+++ b/changelogs/8.10.asciidoc
@@ -20,7 +20,7 @@ https://github.com/elastic/apm-server/compare/8.9\...8.10[View commits]
 [float]
 ==== Bug fixes
 - Add back handling of `queue.*` config for libbeat outputs, such as logstash and kafka {pull}11534[11534]
-- Accept empty object for `transaction.dropped_spans_stats.duration` field {pull}11117[11117]
+- Handle nil `transaction.dropped_spans_stats.duration` gracefully {pull}11117[11117]
 
 [float]
 ==== Intake API Changes

--- a/changelogs/8.10.asciidoc
+++ b/changelogs/8.10.asciidoc
@@ -20,7 +20,7 @@ https://github.com/elastic/apm-server/compare/8.9\...8.10[View commits]
 [float]
 ==== Bug fixes
 - Add back handling of `queue.*` config for libbeat outputs, such as logstash and kafka {pull}11534[11534]
-- Handle nil `transaction.dropped_spans_stats.duration` gracefully {pull}11117[11117]
+- Fix panic on missing `transaction.dropped_spans_stats.duration` field {pull}11117[11117]
 
 [float]
 ==== Intake API Changes

--- a/changelogs/8.10.asciidoc
+++ b/changelogs/8.10.asciidoc
@@ -20,6 +20,7 @@ https://github.com/elastic/apm-server/compare/8.9\...8.10[View commits]
 [float]
 ==== Bug fixes
 - Add back handling of `queue.*` config for libbeat outputs, such as logstash and kafka {pull}11534[11534]
+- Accept empty object for `transaction.dropped_spans_stats.duration` field {pull}11117[11117]
 
 [float]
 ==== Intake API Changes


### PR DESCRIPTION
Update changelog to include a bug fix for `transaction.dropped_spans_stats.duration` that is now able to accept an empty object