### PR TITLE
Remove empty deprecations and add breaking changes [8.10]

### DIFF
--- a/changelogs/8.10.asciidoc
+++ b/changelogs/8.10.asciidoc
@@ -15,9 +15,6 @@ https://github.com/elastic/apm-server/compare/8.9\...8.10[View commits]
 - Event protobuf encoding for tail-based sampling changed (to a more efficient encoding) for event timestamp and duration {pull}11386[11386]
 
 [float]
-==== Deprecations
-
-[float]
 ==== Bug fixes
 - Add back handling of `queue.*` config for libbeat outputs, such as logstash and kafka {pull}11534[11534]
 - Fix panic on missing `transaction.dropped_spans_stats.duration` field {pull}11117[11117]

--- a/docs/apm-breaking.asciidoc
+++ b/docs/apm-breaking.asciidoc
@@ -7,6 +7,20 @@
 This section describes the breaking changes and deprecations introduced in this release
 and previous minor versions.
 
+// tag::810-bc[]
+[float]
+[[breaking-changes-8.10]]
+=== 8.10
+
+The following breaking changes are introduced in APM version 8.10.0:
+
+- Aggregated metrics now consider global labels to be part of a service's identity, and high cardinality global labels may cause services to be obscured.
+For more details, see https://github.com/elastic/apm-server/pull/11386[PR #11386].
+
+- Event protobuf encoding for tail-based sampling changed to a more efficient encoding for event timestamp and duration
+For more details, see https://github.com/elastic/apm-server/pull/11386[PR #11386].
+// end::810-bc[]
+
 // tag::87-bc[]
 [float]
 [[breaking-changes-8.7]]


### PR DESCRIPTION
### Summary

* There are no deprecations in the 8.10 release notes. This PR removes the deprecations heading.
* This PR adds the two breaking changes in 8.10 to our breaking changes page.