### PR TITLE
Add request duration local metrics

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -22,11 +22,13 @@ https://github.com/elastic/apm-server/compare/8.10\...main[View commits]
 - Support and define DLM data retention period in the apmpackage
 - Expose new metrics into the local batch processor {pull}11582[11582] :
 	- http.server.request.count
+	- http.server.request.duration
 	- http.server.response.valid.count
 	- http.server.response.errors.count
 	- http.server.errors.timeout
 	- http.server.errors.ratelimit
 	- grpc.server.request.count
+	- grpc.server.request.duration
 	- grpc.server.response.valid.count
 	- grpc.server.response.errors.count
 	- grpc.server.errors.timeout

--- a/docs/monitoring/monitoring-local-collection.asciidoc
+++ b/docs/monitoring/monitoring-local-collection.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Use local collection</titleabbrev>
 ++++
 
-In 8.10 and later, we emit a selected set of metrics directly to the monitoring
+In 8.11 and later, we emit a selected set of metrics directly to the monitoring
 cluster.
 The benefit of using local collection instead of internal collection is that
 the metrics are sent directly to your main monitoring index, making it easier
@@ -21,11 +21,13 @@ collection.
 Here is the list of every metrics we currently expose:
 
 * http.server.request.count
+* http.server.request.duration
 * http.server.response.valid.count
 * http.server.response.errors.count
 * http.server.errors.timeout
 * http.server.errors.ratelimit
 * grpc.server.request.count
+* grpc.server.request.duration
 * grpc.server.response.valid.count
 * grpc.server.response.errors.count
 * grpc.server.errors.timeout

--- a/internal/beater/beater.go
+++ b/internal/beater/beater.go
@@ -315,12 +315,14 @@ func (s *Runner) Run(ctx context.Context) error {
 	localExporter := telemetry.NewMetricExporter(
 		telemetry.WithMetricFilter([]string{
 			"http.server." + string(request.IDRequestCount),
+			"http.server.request.duration",
 			"http.server." + string(request.IDResponseValidCount),
 			"http.server." + string(request.IDResponseErrorsCount),
 			"http.server." + string(request.IDResponseErrorsTimeout),
 			"http.server." + string(request.IDResponseErrorsRateLimit),
 
 			"grpc.server." + string(request.IDRequestCount),
+			"grpc.server.request.duration",
 			"grpc.server." + string(request.IDResponseValidCount),
 			"grpc.server." + string(request.IDResponseErrorsCount),
 			"grpc.server." + string(request.IDResponseErrorsTimeout),

--- a/internal/beater/interceptors/metrics_test.go
+++ b/internal/beater/interceptors/metrics_test.go
@@ -71,7 +71,7 @@ func TestMetrics(t *testing.T) {
 		name          string
 		f             func(ctx context.Context, req interface{}) (interface{}, error)
 		monitoringInt map[request.ResultID]int64
-		expectedOtel  map[string]int64
+		expectedOtel  map[string]interface{}
 	}{
 		{
 			name: "with an error",
@@ -87,7 +87,7 @@ func TestMetrics(t *testing.T) {
 				request.IDResponseErrorsTimeout:      0,
 				request.IDResponseErrorsUnauthorized: 0,
 			},
-			expectedOtel: map[string]int64{
+			expectedOtel: map[string]interface{}{
 				"grpc.server." + string(request.IDRequestCount):        1,
 				"grpc.server." + string(request.IDResponseCount):       1,
 				"grpc.server." + string(request.IDResponseErrorsCount): 1,
@@ -108,7 +108,7 @@ func TestMetrics(t *testing.T) {
 				request.IDResponseErrorsTimeout:      0,
 				request.IDResponseErrorsUnauthorized: 1,
 			},
-			expectedOtel: map[string]int64{
+			expectedOtel: map[string]interface{}{
 				"grpc.server." + string(request.IDRequestCount):               1,
 				"grpc.server." + string(request.IDResponseCount):              1,
 				"grpc.server." + string(request.IDResponseErrorsCount):        1,
@@ -130,7 +130,7 @@ func TestMetrics(t *testing.T) {
 				request.IDResponseErrorsTimeout:      1,
 				request.IDResponseErrorsUnauthorized: 0,
 			},
-			expectedOtel: map[string]int64{
+			expectedOtel: map[string]interface{}{
 				"grpc.server." + string(request.IDRequestCount):          1,
 				"grpc.server." + string(request.IDResponseCount):         1,
 				"grpc.server." + string(request.IDResponseErrorsCount):   1,
@@ -152,7 +152,7 @@ func TestMetrics(t *testing.T) {
 				request.IDResponseErrorsTimeout:      1,
 				request.IDResponseErrorsUnauthorized: 0,
 			},
-			expectedOtel: map[string]int64{
+			expectedOtel: map[string]interface{}{
 				"grpc.server." + string(request.IDRequestCount):          1,
 				"grpc.server." + string(request.IDResponseCount):         1,
 				"grpc.server." + string(request.IDResponseErrorsCount):   1,
@@ -174,7 +174,7 @@ func TestMetrics(t *testing.T) {
 				request.IDResponseErrorsTimeout:      0,
 				request.IDResponseErrorsUnauthorized: 0,
 			},
-			expectedOtel: map[string]int64{
+			expectedOtel: map[string]interface{}{
 				"grpc.server." + string(request.IDRequestCount):            1,
 				"grpc.server." + string(request.IDResponseCount):           1,
 				"grpc.server." + string(request.IDResponseErrorsCount):     1,
@@ -196,7 +196,7 @@ func TestMetrics(t *testing.T) {
 				request.IDResponseErrorsTimeout:      0,
 				request.IDResponseErrorsUnauthorized: 0,
 			},
-			expectedOtel: map[string]int64{
+			expectedOtel: map[string]interface{}{
 				"grpc.server." + string(request.IDRequestCount):       1,
 				"grpc.server." + string(request.IDResponseCount):      1,
 				"grpc.server." + string(request.IDResponseValidCount): 1,

--- a/internal/beater/interceptors/metrics_test.go
+++ b/internal/beater/interceptors/metrics_test.go
@@ -91,6 +91,8 @@ func TestMetrics(t *testing.T) {
 				"grpc.server." + string(request.IDRequestCount):        1,
 				"grpc.server." + string(request.IDResponseCount):       1,
 				"grpc.server." + string(request.IDResponseErrorsCount): 1,
+
+				"grpc.server.request.duration": 1,
 			},
 		},
 		{
@@ -113,6 +115,8 @@ func TestMetrics(t *testing.T) {
 				"grpc.server." + string(request.IDResponseCount):              1,
 				"grpc.server." + string(request.IDResponseErrorsCount):        1,
 				"grpc.server." + string(request.IDResponseErrorsUnauthorized): 1,
+
+				"grpc.server.request.duration": 1,
 			},
 		},
 		{
@@ -135,6 +139,8 @@ func TestMetrics(t *testing.T) {
 				"grpc.server." + string(request.IDResponseCount):         1,
 				"grpc.server." + string(request.IDResponseErrorsCount):   1,
 				"grpc.server." + string(request.IDResponseErrorsTimeout): 1,
+
+				"grpc.server.request.duration": 1,
 			},
 		},
 		{
@@ -157,6 +163,8 @@ func TestMetrics(t *testing.T) {
 				"grpc.server." + string(request.IDResponseCount):         1,
 				"grpc.server." + string(request.IDResponseErrorsCount):   1,
 				"grpc.server." + string(request.IDResponseErrorsTimeout): 1,
+
+				"grpc.server.request.duration": 1,
 			},
 		},
 		{
@@ -179,6 +187,8 @@ func TestMetrics(t *testing.T) {
 				"grpc.server." + string(request.IDResponseCount):           1,
 				"grpc.server." + string(request.IDResponseErrorsCount):     1,
 				"grpc.server." + string(request.IDResponseErrorsRateLimit): 1,
+
+				"grpc.server.request.duration": 1,
 			},
 		},
 		{
@@ -200,6 +210,8 @@ func TestMetrics(t *testing.T) {
 				"grpc.server." + string(request.IDRequestCount):       1,
 				"grpc.server." + string(request.IDResponseCount):      1,
 				"grpc.server." + string(request.IDResponseValidCount): 1,
+
+				"grpc.server.request.duration": 1,
 			},
 		},
 	} {

--- a/internal/beater/middleware/monitoring_middleware.go
+++ b/internal/beater/middleware/monitoring_middleware.go
@@ -20,6 +20,7 @@ package middleware
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
@@ -28,11 +29,16 @@ import (
 	"github.com/elastic/elastic-agent-libs/monitoring"
 )
 
+const (
+	requestDurationHistogram = "request.duration"
+)
+
 type monitoringMiddleware struct {
 	meter metric.Meter
 
-	ints     map[request.ResultID]*monitoring.Int
-	counters map[request.ResultID]metric.Int64Counter
+	ints       map[request.ResultID]*monitoring.Int
+	counters   map[string]metric.Int64Counter
+	histograms map[string]metric.Int64Histogram
 }
 
 func (m *monitoringMiddleware) Middleware() Middleware {
@@ -40,22 +46,25 @@ func (m *monitoringMiddleware) Middleware() Middleware {
 		return func(c *request.Context) {
 			ctx := context.Background()
 
-			m.getMetric(request.IDRequestCount).Add(ctx, 1)
+			m.getCounter(string(request.IDRequestCount)).Add(ctx, 1)
 			m.inc(request.IDRequestCount)
 
+			start := time.Now()
 			h(c)
+			duration := time.Since(start)
+			m.getHistogram(requestDurationHistogram, metric.WithUnit("ms")).Record(ctx, duration.Milliseconds())
 
-			m.getMetric(request.IDResponseCount).Add(ctx, 1)
+			m.getCounter(string(request.IDResponseCount)).Add(ctx, 1)
 			m.inc(request.IDResponseCount)
 			if c.Result.StatusCode >= http.StatusBadRequest {
-				m.getMetric(request.IDResponseErrorsCount).Add(ctx, 1)
+				m.getCounter(string(request.IDResponseErrorsCount)).Add(ctx, 1)
 				m.inc(request.IDResponseErrorsCount)
 			} else {
-				m.getMetric(request.IDResponseValidCount).Add(ctx, 1)
+				m.getCounter(string(request.IDResponseValidCount)).Add(ctx, 1)
 				m.inc(request.IDResponseValidCount)
 			}
 
-			m.getMetric(c.Result.ID).Add(ctx, 1)
+			m.getCounter(string(c.Result.ID)).Add(ctx, 1)
 			m.inc(c.Result.ID)
 		}, nil
 
@@ -68,14 +77,25 @@ func (m *monitoringMiddleware) inc(id request.ResultID) {
 	}
 }
 
-func (m *monitoringMiddleware) getMetric(n request.ResultID) metric.Int64Counter {
+func (m *monitoringMiddleware) getCounter(n string) metric.Int64Counter {
 	name := "http.server." + n
 	if met, ok := m.counters[name]; ok {
 		return met
 	}
 
-	nm, _ := m.meter.Int64Counter(string(name))
+	nm, _ := m.meter.Int64Counter(name)
 	m.counters[name] = nm
+	return nm
+}
+
+func (m *monitoringMiddleware) getHistogram(n string, opts ...metric.Int64HistogramOption) metric.Int64Histogram {
+	name := "http.server." + n
+	if met, ok := m.histograms[name]; ok {
+		return met
+	}
+
+	nm, _ := m.meter.Int64Histogram(name, opts...)
+	m.histograms[name] = nm
 	return nm
 }
 
@@ -87,9 +107,10 @@ func MonitoringMiddleware(m map[request.ResultID]*monitoring.Int, mp metric.Mete
 	}
 
 	mid := &monitoringMiddleware{
-		meter:    mp.Meter("internal/beater/middleware"),
-		ints:     m,
-		counters: map[request.ResultID]metric.Int64Counter{},
+		meter:      mp.Meter("internal/beater/middleware"),
+		ints:       m,
+		counters:   map[string]metric.Int64Counter{},
+		histograms: map[string]metric.Int64Histogram{},
 	}
 
 	return mid.Middleware()

--- a/internal/beater/middleware/monitoring_middleware_test.go
+++ b/internal/beater/middleware/monitoring_middleware_test.go
@@ -40,7 +40,7 @@ func TestMonitoringHandler(t *testing.T) {
 	checkMonitoring := func(t *testing.T,
 		h func(*request.Context),
 		expected map[request.ResultID]int,
-		expectedOtel map[string]int64,
+		expectedOtel map[string]interface{},
 		m map[request.ResultID]*monitoring.Int,
 	) {
 		reader := sdkmetric.NewManualReader(sdkmetric.WithTemporalitySelector(
@@ -68,11 +68,13 @@ func TestMonitoringHandler(t *testing.T) {
 				request.IDResponseErrorsCount:     1,
 				request.IDResponseErrorsForbidden: 1,
 			},
-			map[string]int64{
+			map[string]interface{}{
 				"http.server." + string(request.IDRequestCount):            1,
 				"http.server." + string(request.IDResponseCount):           1,
 				"http.server." + string(request.IDResponseErrorsCount):     1,
 				"http.server." + string(request.IDResponseErrorsForbidden): 1,
+
+				"http.server.request.duration": 1,
 			},
 			mockMonitoring,
 		)
@@ -87,11 +89,13 @@ func TestMonitoringHandler(t *testing.T) {
 				request.IDResponseValidCount:    1,
 				request.IDResponseValidAccepted: 1,
 			},
-			map[string]int64{
+			map[string]interface{}{
 				"http.server." + string(request.IDRequestCount):          1,
 				"http.server." + string(request.IDResponseCount):         1,
 				"http.server." + string(request.IDResponseValidCount):    1,
 				"http.server." + string(request.IDResponseValidAccepted): 1,
+
+				"http.server.request.duration": 1,
 			},
 			mockMonitoring,
 		)
@@ -106,11 +110,13 @@ func TestMonitoringHandler(t *testing.T) {
 				request.IDResponseValidCount: 1,
 				request.IDUnset:              1,
 			},
-			map[string]int64{
+			map[string]interface{}{
 				"http.server." + string(request.IDRequestCount):       1,
 				"http.server." + string(request.IDResponseCount):      1,
 				"http.server." + string(request.IDResponseValidCount): 1,
 				"http.server." + string(request.IDUnset):              1,
+
+				"http.server.request.duration": 1,
 			},
 			mockMonitoring,
 		)
@@ -125,11 +131,13 @@ func TestMonitoringHandler(t *testing.T) {
 				request.IDResponseErrorsCount:    1,
 				request.IDResponseErrorsInternal: 1,
 			},
-			map[string]int64{
+			map[string]interface{}{
 				"http.server." + string(request.IDRequestCount):           1,
 				"http.server." + string(request.IDResponseCount):          1,
 				"http.server." + string(request.IDResponseErrorsCount):    1,
 				"http.server." + string(request.IDResponseErrorsInternal): 1,
+
+				"http.server.request.duration": 1,
 			},
 			mockMonitoring)
 	})
@@ -138,11 +146,13 @@ func TestMonitoringHandler(t *testing.T) {
 		checkMonitoring(t,
 			HandlerIdle,
 			map[request.ResultID]int{},
-			map[string]int64{
+			map[string]interface{}{
 				"http.server." + string(request.IDRequestCount):       1,
 				"http.server." + string(request.IDResponseCount):      1,
 				"http.server." + string(request.IDResponseValidCount): 1,
 				"http.server." + string(request.IDUnset):              1,
+
+				"http.server.request.duration": 1,
 			},
 			mockMonitoringNil,
 		)


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

This introduces the `(http|grpc).request.duration` metrics, and exports them with the local exporter.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

This can be tested by running apm-server with tilt.

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
