### PR TITLE
systemtest: disable fleet ID verification pipeline

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -12,6 +12,9 @@
     - description: Remove unused `processor.event` field from logs data streams
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/11494
+    - description: Explicitly set `event.ingested` in traces-apm.sampled
+      type: enhancement
+      link: https://github.com/elastic/apm-server/pull/11623
 - version: "8.10.0"
   changes:
     - description: Add permissions to reroute to dedicated datasets for logs, metrics and traces

--- a/apmpackage/apm/data_stream/sampled_traces/elasticsearch/ingest_pipeline/default.yml
+++ b/apmpackage/apm/data_stream/sampled_traces/elasticsearch/ingest_pipeline/default.yml
@@ -5,3 +5,5 @@ processors:
       field: observer.id
       target_field: agent.ephemeral_id
       ignore_missing: true
+  - pipeline:
+      name: event_ingested

--- a/apmpackage/cmd/genpackage/pipelines.go
+++ b/apmpackage/cmd/genpackage/pipelines.go
@@ -44,6 +44,7 @@ func getCommonPipeline(name string, version *version.V) []map[string]interface{}
 		"client_geoip":     clientGeoIPPipeline,
 		"event_duration":   eventDurationPipeline,
 		"set_metrics":      setMetricsPipeline,
+		"event_ingested":   eventIngestedPipeline,
 	}
 	return commonPipelines[name]
 }
@@ -226,3 +227,15 @@ ctx.metricset.remove("samples");
 		},
 	},
 }
+
+// This pipeline sets `event.ingested` to the ingest timestamp, truncated
+// to seconds for storage efficiency.
+var eventIngestedPipeline = []map[string]interface{}{{
+	"date": map[string]interface{}{
+		"field":          "_ingest.timestamp",
+		"target_field":   "event.ingested",
+		"formats":        []interface{}{"ISO8601"},
+		"output_format":  "date_time_no_millis",
+		"ignore_failure": true,
+	},
+}}

--- a/systemtest/approvals/TestAgentConfig.approved.json
+++ b/systemtest/approvals/TestAgentConfig.approved.json
@@ -11,10 +11,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "labels": {
                 "etag": "dynamic"
             },
@@ -40,10 +36,6 @@
             },
             "ecs": {
                 "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
             },
             "labels": {
                 "etag": "dynamic"

--- a/systemtest/approvals/TestApprovedMetrics.approved.json
+++ b/systemtest/approvals/TestApprovedMetrics.approved.json
@@ -15,10 +15,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "go": {
                 "memstats": {
                     "heap": {
@@ -80,10 +76,6 @@
             },
             "ecs": {
                 "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
             },
             "host": {
                 "ip": "127.0.0.1"
@@ -153,10 +145,6 @@
             },
             "ecs": {
                 "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
             },
             "host": {
                 "ip": "127.0.0.1"
@@ -241,10 +229,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "host": {
                 "ip": "127.0.0.1"
             },
@@ -309,10 +293,6 @@
             },
             "ecs": {
                 "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
             },
             "faas": {
                 "billed_duration": 183,
@@ -383,10 +363,6 @@
             },
             "ecs": {
                 "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
             },
             "host": {
                 "ip": "127.0.0.1"

--- a/systemtest/approvals/TestCompressedSpans.approved.json
+++ b/systemtest/approvals/TestCompressedSpans.approved.json
@@ -12,8 +12,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": 1
             },
@@ -102,8 +100,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": 1
             },

--- a/systemtest/approvals/TestDropUnsampled.approved.json
+++ b/systemtest/approvals/TestDropUnsampled.approved.json
@@ -12,8 +12,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": 1
             },
@@ -90,8 +88,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "observer": {

--- a/systemtest/approvals/TestErrorIngest.approved.json
+++ b/systemtest/approvals/TestErrorIngest.approved.json
@@ -48,10 +48,6 @@
                     "message": "Cannot read property 'baz' of undefined"
                 }
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "host": {
                 "architecture": "x64",
                 "hostname": "node-name",

--- a/systemtest/approvals/TestIngestPipelineDataStreamMigration.approved.json
+++ b/systemtest/approvals/TestIngestPipelineDataStreamMigration.approved.json
@@ -73,7 +73,6 @@
                 "id": "b2da5288b2c3d7e79c42a636ca2fd99f"
             },
             "event": {
-                "agent_id_status": "missing",
                 "ingested": "dynamic"
             },
             "host": {
@@ -153,7 +152,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
                 "ingested": "dynamic"
             },
             "golang": {
@@ -273,7 +271,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
                 "ingested": "dynamic",
                 "outcome": "failure"
             },
@@ -325,7 +322,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
                 "ingested": "dynamic",
                 "outcome": "failure"
             },
@@ -386,7 +382,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
                 "ingested": "dynamic"
             },
             "host": {
@@ -465,7 +460,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
                 "ingested": "dynamic"
             },
             "host": {
@@ -538,8 +532,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "failure"
             },
             "observer": {
@@ -652,7 +644,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
                 "ingested": "dynamic",
                 "outcome": "failure"
             },

--- a/systemtest/approvals/TestIntake/Errors.approved.json
+++ b/systemtest/approvals/TestIntake/Errors.approved.json
@@ -229,10 +229,6 @@
                     ]
                 }
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "host": {
                 "architecture": "x64",
                 "hostname": "node-name",
@@ -418,10 +414,6 @@
                 "grouping_name": "Cannot read property 'baz' no defined",
                 "id": "cdefab0123456789"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "host": {
                 "architecture": "x64",
                 "hostname": "node-name",
@@ -543,10 +535,6 @@
                     ]
                 }
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "host": {
                 "architecture": "x64",
                 "hostname": "node-name",
@@ -663,10 +651,6 @@
                 "grouping_key": "c3868d6704b923014eaffea034e70a3d",
                 "grouping_name": null,
                 "id": "cdefab0123456780"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
             },
             "host": {
                 "architecture": "x64",
@@ -788,10 +772,6 @@
                     "level": "custom log level",
                     "message": "Cannot read property 'baz' of undefined"
                 }
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
             },
             "host": {
                 "architecture": "x64",

--- a/systemtest/approvals/TestIntake/ErrorsTxID.approved.json
+++ b/systemtest/approvals/TestIntake/ErrorsTxID.approved.json
@@ -145,10 +145,6 @@
                     ]
                 }
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "host": {
                 "architecture": "amd64",
                 "hostname": "node-name",

--- a/systemtest/approvals/TestIntake/Events.approved.json
+++ b/systemtest/approvals/TestIntake/Events.approved.json
@@ -146,10 +146,6 @@
                     ]
                 }
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "host": {
                 "architecture": "amd64",
                 "hostname": "node-name",
@@ -317,10 +313,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "host": {
                 "architecture": "amd64",
                 "hostname": "node-name",
@@ -420,8 +412,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": 1
             },
@@ -597,8 +587,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": 1
             },

--- a/systemtest/approvals/TestIntake/Metricsets.approved.json
+++ b/systemtest/approvals/TestIntake/Metricsets.approved.json
@@ -15,10 +15,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "go": {
                 "memstats": {
                     "heap": {
@@ -80,10 +76,6 @@
             },
             "ecs": {
                 "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
             },
             "host": {
                 "ip": "127.0.0.1"
@@ -153,10 +145,6 @@
             },
             "ecs": {
                 "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
             },
             "host": {
                 "ip": "127.0.0.1"
@@ -241,10 +229,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "host": {
                 "ip": "127.0.0.1"
             },
@@ -309,10 +293,6 @@
             },
             "ecs": {
                 "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
             },
             "faas": {
                 "billed_duration": 183,
@@ -383,10 +363,6 @@
             },
             "ecs": {
                 "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
             },
             "host": {
                 "ip": "127.0.0.1"

--- a/systemtest/approvals/TestIntake/MinimalEvents.approved.json
+++ b/systemtest/approvals/TestIntake/MinimalEvents.approved.json
@@ -19,10 +19,6 @@
                     "message": "error log message"
                 }
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "host": {
                 "ip": [
                     "127.0.0.1"
@@ -61,10 +57,6 @@
                 "grouping_key": "3a1fb5609458fbb132b44d8fc7cde104",
                 "grouping_name": "error exception message",
                 "id": "abcdef0123456790"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
             },
             "host": {
                 "ip": [
@@ -105,10 +97,6 @@
                 "grouping_name": null,
                 "id": "abcdef0123456791"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "host": {
                 "ip": [
                     "127.0.0.1"
@@ -141,10 +129,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "host": {
                 "ip": "127.0.0.1"
             },
@@ -175,8 +159,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -226,8 +208,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -277,8 +257,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {

--- a/systemtest/approvals/TestIntake/Spans.approved.json
+++ b/systemtest/approvals/TestIntake/Spans.approved.json
@@ -45,8 +45,6 @@
                 "port": 5432
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": 1
             },
@@ -263,8 +261,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -397,8 +393,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -537,8 +531,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -671,8 +663,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": 1
             },
@@ -821,8 +811,6 @@
                 "port": 5432
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": 1
             },
@@ -1043,8 +1031,6 @@
                 "ip": "0:0::0:1"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -1193,8 +1179,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": 1
             },
@@ -1335,8 +1319,6 @@
                 "port": 8080
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": 1
             },
@@ -1489,8 +1471,6 @@
                 "port": 5432
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": 1
             },

--- a/systemtest/approvals/TestIntake/Transactions.approved.json
+++ b/systemtest/approvals/TestIntake/Transactions.approved.json
@@ -39,8 +39,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -202,8 +200,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -353,8 +349,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": 1
             },
@@ -590,8 +584,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -763,8 +755,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "faas": {

--- a/systemtest/approvals/TestIntake/TransactionsHugeTraces.approved.json
+++ b/systemtest/approvals/TestIntake/TransactionsHugeTraces.approved.json
@@ -51,8 +51,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": 1
             },

--- a/systemtest/approvals/TestIntake/UnknownSpanType.approved.json
+++ b/systemtest/approvals/TestIntake/UnknownSpanType.approved.json
@@ -15,8 +15,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": 1
             },
@@ -176,8 +174,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success"
             },
             "host": {

--- a/systemtest/approvals/TestIntakeLog/with_faas.approved.json
+++ b/systemtest/approvals/TestIntakeLog/with_faas.approved.json
@@ -17,8 +17,6 @@
                 "type": "logs"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "kind": "event"
             },
             "faas": {

--- a/systemtest/approvals/TestIntakeLog/with_flat_ecs_fields.approved.json
+++ b/systemtest/approvals/TestIntakeLog/with_flat_ecs_fields.approved.json
@@ -17,9 +17,7 @@
                 "type": "logs"
             },
             "event": {
-                "agent_id_status": "missing",
                 "dataset": "accesslog",
-                "ingested": "dynamic",
                 "kind": "event"
             },
             "faas": {

--- a/systemtest/approvals/TestIntakeLog/with_nested_ecs_fields.approved.json
+++ b/systemtest/approvals/TestIntakeLog/with_nested_ecs_fields.approved.json
@@ -17,9 +17,7 @@
                 "type": "logs"
             },
             "event": {
-                "agent_id_status": "missing",
                 "dataset": "accesslog",
-                "ingested": "dynamic",
                 "kind": "event"
             },
             "faas": {

--- a/systemtest/approvals/TestIntakeLog/with_nested_ecs_fields_overrides_flat_fields.approved.json
+++ b/systemtest/approvals/TestIntakeLog/with_nested_ecs_fields_overrides_flat_fields.approved.json
@@ -17,9 +17,7 @@
                 "type": "logs"
             },
             "event": {
-                "agent_id_status": "missing",
                 "dataset": "accesslog",
-                "ingested": "dynamic",
                 "kind": "event"
             },
             "faas": {

--- a/systemtest/approvals/TestIntakeLog/with_timestamp.approved.json
+++ b/systemtest/approvals/TestIntakeLog/with_timestamp.approved.json
@@ -17,8 +17,6 @@
                 "type": "logs"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "kind": "event"
             },
             "host": {

--- a/systemtest/approvals/TestIntakeLog/with_timestamp_as_str.approved.json
+++ b/systemtest/approvals/TestIntakeLog/with_timestamp_as_str.approved.json
@@ -17,8 +17,6 @@
                 "type": "logs"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "kind": "event"
             },
             "host": {

--- a/systemtest/approvals/TestIntakeLog/without_timestamp.approved.json
+++ b/systemtest/approvals/TestIntakeLog/without_timestamp.approved.json
@@ -17,8 +17,6 @@
                 "type": "logs"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "kind": "event"
             },
             "host": {

--- a/systemtest/approvals/TestJaeger/batch_0.approved.json
+++ b/systemtest/approvals/TestJaeger/batch_0.approved.json
@@ -24,10 +24,7 @@
                     "message": "Retrying GetDriver after error"
                 }
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
+            "event": {},
             "host": {
                 "hostname": "host01",
                 "ip": [
@@ -92,10 +89,7 @@
                     "message": "Retrying GetDriver after error"
                 }
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
+            "event": {},
             "host": {
                 "hostname": "host01",
                 "ip": [
@@ -160,10 +154,7 @@
                     "message": "Retrying GetDriver after error"
                 }
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
+            "event": {},
             "host": {
                 "hostname": "host01",
                 "ip": [
@@ -217,8 +208,6 @@
                 "type": "logs"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "kind": "event"
             },
             "host": {
@@ -272,8 +261,6 @@
                 "type": "logs"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "kind": "event"
             },
             "host": {
@@ -325,8 +312,6 @@
                 "type": "logs"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "kind": "event"
             },
             "host": {
@@ -378,8 +363,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {

--- a/systemtest/approvals/TestJaeger/batch_1.approved.json
+++ b/systemtest/approvals/TestJaeger/batch_1.approved.json
@@ -24,10 +24,7 @@
                     "message": "redis timeout"
                 }
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
+            "event": {},
             "host": {
                 "hostname": "host01",
                 "ip": [
@@ -87,10 +84,7 @@
                     "message": "redis timeout"
                 }
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
+            "event": {},
             "host": {
                 "hostname": "host01",
                 "ip": [
@@ -150,10 +144,7 @@
                     "message": "redis timeout"
                 }
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
+            "event": {},
             "host": {
                 "hostname": "host01",
                 "ip": [
@@ -202,8 +193,6 @@
                 "type": "logs"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "kind": "event"
             },
             "host": {
@@ -254,8 +243,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "failure",
                 "success_count": 0
             },
@@ -318,8 +305,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -381,8 +366,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -444,8 +427,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -507,8 +488,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "failure",
                 "success_count": 0
             },
@@ -571,8 +550,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -634,8 +611,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "failure",
                 "success_count": 0
             },
@@ -698,8 +673,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -761,8 +734,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -824,8 +795,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -887,8 +856,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -950,8 +917,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -1013,8 +978,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {
@@ -1076,8 +1039,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "host": {

--- a/systemtest/approvals/TestNoMatchingSourcemap.approved.json
+++ b/systemtest/approvals/TestNoMatchingSourcemap.approved.json
@@ -15,8 +15,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "observer": {

--- a/systemtest/approvals/TestOTLPGRPCLogs.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCLogs.approved.json
@@ -12,8 +12,6 @@
                 "type": "logs"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "severity": 9
             },
             "labels": {

--- a/systemtest/approvals/TestOTLPGRPCMetrics_counter.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCMetrics_counter.approved.json
@@ -15,10 +15,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "metricset": {
                 "name": "app"
             },

--- a/systemtest/approvals/TestOTLPGRPCMetrics_histogram.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCMetrics_histogram.approved.json
@@ -14,10 +14,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "histogram": {
                 "counts": [
                     1,

--- a/systemtest/approvals/TestOTLPGRPCMetrics_summary.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCMetrics_summary.approved.json
@@ -14,10 +14,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "metricset": {
                 "name": "app"
             },

--- a/systemtest/approvals/TestOTLPGRPCTraces.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCTraces.approved.json
@@ -24,10 +24,7 @@
                 "id": "dynamic",
                 "stack_trace": "not an actual real stack trace"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
+            "event": {},
             "labels": {
                 "resource_attribute_array": [
                     "a",
@@ -92,8 +89,6 @@
                 "type": "logs"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "kind": "event"
             },
             "labels": {
@@ -152,8 +147,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "labels": {

--- a/systemtest/approvals/TestRUMErrorSourcemapping/absolute_bundle_filepath/standalone.approved.json
+++ b/systemtest/approvals/TestRUMErrorSourcemapping/absolute_bundle_filepath/standalone.approved.json
@@ -253,10 +253,6 @@
                     ]
                 }
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "http": {
                 "request": {
                     "referrer": "http://localhost:8000/test/e2e/"

--- a/systemtest/approvals/TestRUMErrorSourcemapping/relative_bundle_filepath/standalone.approved.json
+++ b/systemtest/approvals/TestRUMErrorSourcemapping/relative_bundle_filepath/standalone.approved.json
@@ -253,10 +253,6 @@
                     ]
                 }
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "http": {
                 "request": {
                     "referrer": "http://localhost:8000/test/e2e/"

--- a/systemtest/approvals/TestRUMRoutingIntegration.approved.json
+++ b/systemtest/approvals/TestRUMRoutingIntegration.approved.json
@@ -17,8 +17,6 @@
                 "port": 8003
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success"
             },
             "http": {
@@ -103,8 +101,6 @@
                 "port": 8000
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success"
             },
             "http": {
@@ -185,8 +181,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "labels": {
@@ -251,8 +245,6 @@
                 "port": 8003
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success"
             },
             "http": {
@@ -334,8 +326,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "labels": {
@@ -397,8 +387,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success"
             },
             "labels": {
@@ -492,8 +480,6 @@
                 "port": 8000
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "http": {
@@ -572,8 +558,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "labels": {
@@ -635,8 +619,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success"
             },
             "http": {

--- a/systemtest/approvals/TestRUMSpanSourcemapping.approved.json
+++ b/systemtest/approvals/TestRUMSpanSourcemapping.approved.json
@@ -15,8 +15,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "observer": {

--- a/systemtest/approvals/TestRUMXForwardedFor.approved.json
+++ b/systemtest/approvals/TestRUMXForwardedFor.approved.json
@@ -26,10 +26,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "metricset": {
                 "name": "span_breakdown"
             },
@@ -97,8 +93,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "observer": {

--- a/systemtest/approvals/TestServiceDestinationAggregation.approved.json
+++ b/systemtest/approvals/TestServiceDestinationAggregation.approved.json
@@ -15,8 +15,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success"
             },
             "labels": {
@@ -75,8 +73,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success"
             },
             "labels": {
@@ -135,8 +131,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success"
             },
             "labels": {

--- a/systemtest/approvals/TestServiceSummaryMetricsAggregation.approved.json
+++ b/systemtest/approvals/TestServiceSummaryMetricsAggregation.approved.json
@@ -13,10 +13,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "metricset": {
                 "interval": "10m",
                 "name": "service_summary"
@@ -49,10 +45,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "metricset": {
                 "interval": "1m",
                 "name": "service_summary"
@@ -84,10 +76,6 @@
             },
             "ecs": {
                 "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
             },
             "metricset": {
                 "interval": "60m",

--- a/systemtest/approvals/TestServiceSummaryMetricsAggregationOverflow.approved.json
+++ b/systemtest/approvals/TestServiceSummaryMetricsAggregationOverflow.approved.json
@@ -10,10 +10,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "metricset": {
                 "interval": "10m",
                 "name": "service_summary"
@@ -45,10 +41,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "metricset": {
                 "interval": "1m",
                 "name": "service_summary"
@@ -79,10 +71,6 @@
             },
             "ecs": {
                 "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
             },
             "metricset": {
                 "interval": "60m",
@@ -118,10 +106,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "metricset": {
                 "interval": "10m",
                 "name": "service_summary"
@@ -155,10 +139,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "metricset": {
                 "interval": "1m",
                 "name": "service_summary"
@@ -191,10 +171,6 @@
             },
             "ecs": {
                 "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
             },
             "metricset": {
                 "interval": "60m",
@@ -229,10 +205,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "metricset": {
                 "interval": "10m",
                 "name": "service_summary"
@@ -266,10 +238,6 @@
             "ecs": {
                 "version": "dynamic"
             },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
-            },
             "metricset": {
                 "interval": "1m",
                 "name": "service_summary"
@@ -302,10 +270,6 @@
             },
             "ecs": {
                 "version": "dynamic"
-            },
-            "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic"
             },
             "metricset": {
                 "interval": "60m",

--- a/systemtest/approvals/TestServiceTransactionMetricsAggregation.approved.json
+++ b/systemtest/approvals/TestServiceTransactionMetricsAggregation.approved.json
@@ -15,8 +15,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "success_count": {
                     "sum": 2,
                     "value_count": 2
@@ -73,8 +71,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "success_count": {
                     "sum": 2,
                     "value_count": 2
@@ -131,8 +127,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "success_count": {
                     "sum": 2,
                     "value_count": 2
@@ -189,8 +183,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "success_count": {
                     "sum": 2,
                     "value_count": 2
@@ -247,8 +239,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "success_count": {
                     "sum": 2,
                     "value_count": 2
@@ -305,8 +295,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "success_count": {
                     "sum": 2,
                     "value_count": 2

--- a/systemtest/approvals/TestTransactionAggregation.approved.json
+++ b/systemtest/approvals/TestTransactionAggregation.approved.json
@@ -15,8 +15,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": {
                     "sum": 5,
@@ -91,8 +89,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": {
                     "sum": 5,
@@ -167,8 +163,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": {
                     "sum": 5,
@@ -243,8 +237,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": {
                     "sum": 10,
@@ -319,8 +311,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": {
                     "sum": 10,
@@ -395,8 +385,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": {
                     "sum": 10,
@@ -493,8 +481,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "faas": {
@@ -607,8 +593,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "faas": {
@@ -721,8 +705,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "unknown"
             },
             "faas": {

--- a/systemtest/approvals/TestTransactionAggregationShutdown.approved.json
+++ b/systemtest/approvals/TestTransactionAggregationShutdown.approved.json
@@ -15,8 +15,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": {
                     "sum": 1,
@@ -91,8 +89,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": {
                     "sum": 1,
@@ -167,8 +163,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": {
                     "sum": 1,

--- a/systemtest/approvals/TestTransactionDroppedSpansStatsMetrics.approved.json
+++ b/systemtest/approvals/TestTransactionDroppedSpansStatsMetrics.approved.json
@@ -15,8 +15,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success"
             },
             "metricset": {
@@ -69,8 +67,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success"
             },
             "metricset": {
@@ -123,8 +119,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success"
             },
             "metricset": {
@@ -177,8 +171,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success"
             },
             "metricset": {
@@ -231,8 +223,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success"
             },
             "metricset": {
@@ -285,8 +275,6 @@
                 "version": "dynamic"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success"
             },
             "metricset": {

--- a/systemtest/approvals/TestTransactionDroppedSpansStatsTransaction.approved.json
+++ b/systemtest/approvals/TestTransactionDroppedSpansStatsTransaction.approved.json
@@ -12,8 +12,6 @@
                 "type": "traces"
             },
             "event": {
-                "agent_id_status": "missing",
-                "ingested": "dynamic",
                 "outcome": "success",
                 "success_count": 1
             },

--- a/testing/docker/kibana/kibana.yml
+++ b/testing/docker/kibana/kibana.yml
@@ -5,6 +5,10 @@ telemetry.enabled: false
 xpack.security.encryptionKey: fhjskloppd678ehkdfdlliverpoolfcr
 xpack.encryptedSavedObjects.encryptionKey: fhjskloppd678ehkdfdlliverpoolfcr
 
+# Disable the Fleet agent ID verification pipeline,
+# which sets Fleet-specific fields that we don't want.
+xpack.fleet.agentIdVerificationEnabled: false
+
 xpack.fleet.packages:
   - name: fleet_server
     version: latest


### PR DESCRIPTION
## Motivation/summary

Disable the pipeline so `event.agent_id_status` and `event.ingested` are not set by the Fleet final pipeline. We explicitly set `event.ingested` in `traces-apm.sampled` for tail-based sampling's internal usage.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
~- [ ] Documentation has been updated~

## How to test these changes

Run system tests with and without the `xpack.fleet.agentIdVerificationEnabled` change to `testing/docker/kibana/kibana.yml`. Ignoring the approval diffs, the tests should all pass.

## Related issues

https://github.com/elastic/elasticsearch/pull/97546