### PR TITLE
[DOCS] Remove Cosign x-ref to ES book from Docker docs

### DIFF
--- a/docs/shared-docker.asciidoc
+++ b/docs/shared-docker.asciidoc
@@ -39,12 +39,21 @@ docker pull {dockerimage}
 . Verify the Docker image:
 +
 ["source", "sh", subs="attributes"]
-------------------------------------------------
+----
 wget https://artifacts.elastic.co/cosign.pub
-cosign verify --key cosign.pub {dockerimage}:{version}
-------------------------------------------------
+cosign verify --key cosign.pub {dockerimage}
+----
 +
-For details about this step, refer to {ref}/docker.html#docker-verify-signature[Verify the {es} Docker image signature] in the {es} documentation.
+The `cosign` command prints the check results and the signature payload in JSON format:
++
+[source,sh,subs="attributes"]
+----
+Verification for {dockerimage} --
+The following checks were performed on each of these signatures:
+  - The cosign claims were validated
+  - Existence of the claims in the transparency log was verified offline
+  - The signatures were verified against the specified public key
+----
 
 endif::[]
 


### PR DESCRIPTION
**Problem:**
The [APM Server Docker docs](https://www.elastic.co/guide/en/apm/guide/8.9/running-on-docker.html) include an x-ref to the Elasticsearch docs for image verification. I recently removed this section as part of https://github.com/elastic/elasticsearch/pull/99371.

**Solution:**
Replace the x-ref with info about image verification.