### PR TITLE
Minor changes to support running system tests with x-pack-apm

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -18,6 +18,9 @@
     - description: Remove `ecs.version` from all data streams
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/11632
+    - description: always set {span,transaction}.duration in traces-*
+      type: enhancement
+      link: https://github.com/elastic/apm-server/pull/11638
 - version: "8.10.0"
   changes:
     - description: Add permissions to reroute to dedicated datasets for logs, metrics and traces

--- a/apmpackage/cmd/genpackage/pipelines.go
+++ b/apmpackage/cmd/genpackage/pipelines.go
@@ -155,11 +155,16 @@ var clientGeoIPPipeline = []map[string]interface{}{{
 // `event.duration`. See https://github.com/elastic/apm-server/issues/5999.
 var eventDurationPipeline = []map[string]interface{}{{
 	"script": map[string]interface{}{
-		"if": "ctx.processor?.event != null && ctx.get(ctx.processor.event) != null && ctx.get(ctx.processor.event)?.duration == null",
+		"if": "ctx.processor?.event != null && ctx.get(ctx.processor.event)?.duration == null",
 		"source": strings.TrimSpace(`
 def durationNanos = ctx.event?.duration ?: 0;
 def eventType = ctx.processor.event;
-ctx.get(ctx.processor.event).duration = ["us": (long)(durationNanos/1000)];
+def rootObject = ctx.get(eventType);
+if (rootObject == null) {
+  rootObject = [:];
+  ctx[eventType] = rootObject;
+}
+rootObject.duration = ["us": (long)(durationNanos/1000)];
 `),
 	},
 }, {

--- a/systemtest/errorgrouping_test.go
+++ b/systemtest/errorgrouping_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/tidwall/gjson"
+	"github.com/stretchr/testify/require"
 	"go.elastic.co/apm/v2"
 
 	"github.com/elastic/apm-server/systemtest"
@@ -48,7 +48,9 @@ func TestErrorGroupingName(t *testing.T) {
 
 	var names []string
 	for _, hit := range result.Hits.Hits {
-		names = append(names, gjson.GetBytes(hit.RawSource, "error.grouping_name").String())
+		values := hit.Fields["error.grouping_name"]
+		require.Len(t, values, 1)
+		names = append(names, values[0].(string))
 	}
 
 	assert.ElementsMatch(t, []string{

--- a/systemtest/ingest_test.go
+++ b/systemtest/ingest_test.go
@@ -123,10 +123,11 @@ func TestIngestPipelineEventDuration(t *testing.T) {
 	}
 
 	tests := []test{{
-		// No transaction.* field, no update.
-		source: `{"@timestamp": "2022-02-15", "observer": {"version": "8.2.0"}, "processor": {"event": "transaction"}}`,
+		// No transaction.* field, no event.duration: set transaction.duration.us to zero.
+		source:                        `{"@timestamp": "2022-02-15", "observer": {"version": "8.2.0"}, "processor": {"event": "transaction"}}`,
+		expectedTransactionDurationUS: 0.0,
 	}, {
-		// Set transaction.duration.us to zero if event.duration not found.
+		// transaction exists without duration.us, no event.duration: set transaction.duration.us to zero.
 		source:                        `{"@timestamp": "2022-02-15", "observer": {"version": "8.2.0"}, "processor": {"event": "transaction"}, "transaction": {}}`,
 		expectedTransactionDurationUS: 0.0,
 	}, {
@@ -151,30 +152,31 @@ func TestIngestPipelineEventDuration(t *testing.T) {
 		}, &indexResponse)
 		require.NoError(t, err)
 
-		var doc struct {
-			Source json.RawMessage `json:"_source"`
-		}
-		_, err = systemtest.Elasticsearch.Do(context.Background(), esapi.GetRequest{
-			Index:      indexResponse.Index,
-			DocumentID: indexResponse.ID,
-		}, &doc)
-		require.NoError(t, err)
+		result := estest.ExpectDocs(t, systemtest.Elasticsearch, indexResponse.Index, espoll.TermQuery{
+			Field: "_id",
+			Value: indexResponse.ID,
+		})
+
+		require.Len(t, result.Hits.Hits, 1)
+		doc := result.Hits.Hits[0]
 
 		// event.duration should always be removed.
-		assert.False(t, gjson.GetBytes(doc.Source, "event.duration").Exists())
+		assert.NotContains(t, doc.Fields, "event.duration")
 
-		transactionDurationUS := gjson.GetBytes(doc.Source, "transaction.duration.us")
+		transactionDurationUS := doc.Fields["transaction.duration.us"]
 		if test.expectedTransactionDurationUS != nil {
-			assert.Equal(t, test.expectedTransactionDurationUS, transactionDurationUS.Value())
+			require.Len(t, transactionDurationUS, 1)
+			assert.Equal(t, test.expectedTransactionDurationUS, transactionDurationUS[0])
 		} else {
-			assert.False(t, transactionDurationUS.Exists())
+			assert.Nil(t, transactionDurationUS)
 		}
 
-		spanDurationUS := gjson.GetBytes(doc.Source, "span.duration.us")
+		spanDurationUS := doc.Fields["span.duration.us"]
 		if test.expectedSpanDurationUS != nil {
-			assert.Equal(t, test.expectedSpanDurationUS, spanDurationUS.Value())
+			require.Len(t, spanDurationUS, 1)
+			assert.Equal(t, test.expectedSpanDurationUS, spanDurationUS[0])
 		} else {
-			assert.False(t, spanDurationUS.Exists())
+			assert.Nil(t, spanDurationUS)
 		}
 	}
 }


### PR DESCRIPTION
## Motivation/summary

These are some of the changes needed for the system tests to pass when using the x-pack-apm ES plugin templates and pipelines (https://github.com/elastic/elasticsearch/pull/97546), rather than the Fleet integration package ones. There will be more changes needed, which we'll add later when we remove the data streams from the integration package.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

https://github.com/elastic/elasticsearch/pull/97546