### PR TITLE
Switch built-in ILM rollover policies from max_size to max_primary_shard_size

### DIFF
--- a/apmpackage/apm/data_stream/app_logs/elasticsearch/ilm/default_policy.json
+++ b/apmpackage/apm/data_stream/app_logs/elasticsearch/ilm/default_policy.json
@@ -5,7 +5,7 @@
                 "actions": {
                     "rollover": {
                         "max_age": "30d",
-                        "max_size": "50gb"
+                        "max_primary_shard_size": "50gb"
                     },
                     "set_priority": {
                         "priority": 100

--- a/apmpackage/apm/data_stream/app_metrics/elasticsearch/ilm/default_policy.json
+++ b/apmpackage/apm/data_stream/app_metrics/elasticsearch/ilm/default_policy.json
@@ -5,7 +5,7 @@
                 "actions": {
                     "rollover": {
                         "max_age": "30d",
-                        "max_size": "50gb"
+                        "max_primary_shard_size": "50gb"
                     },
                     "set_priority": {
                         "priority": 100

--- a/apmpackage/apm/data_stream/error_logs/elasticsearch/ilm/default_policy.json
+++ b/apmpackage/apm/data_stream/error_logs/elasticsearch/ilm/default_policy.json
@@ -5,7 +5,7 @@
                 "actions": {
                     "rollover": {
                         "max_age": "30d",
-                        "max_size": "50gb"
+                        "max_primary_shard_size": "50gb"
                     },
                     "set_priority": {
                         "priority": 100

--- a/apmpackage/apm/data_stream/internal_metrics/elasticsearch/ilm/default_policy.json
+++ b/apmpackage/apm/data_stream/internal_metrics/elasticsearch/ilm/default_policy.json
@@ -5,7 +5,7 @@
                 "actions": {
                     "rollover": {
                         "max_age": "30d",
-                        "max_size": "50gb"
+                        "max_primary_shard_size": "50gb"
                     },
                     "set_priority": {
                         "priority": 100

--- a/apmpackage/apm/data_stream/rum_traces/elasticsearch/ilm/default_policy.json
+++ b/apmpackage/apm/data_stream/rum_traces/elasticsearch/ilm/default_policy.json
@@ -5,7 +5,7 @@
                 "actions": {
                     "rollover": {
                         "max_age": "30d",
-                        "max_size": "50gb"
+                        "max_primary_shard_size": "50gb"
                     },
                     "set_priority": {
                         "priority": 100

--- a/apmpackage/apm/data_stream/service_destination_interval_metrics/elasticsearch/ilm/default_policy.10m.json
+++ b/apmpackage/apm/data_stream/service_destination_interval_metrics/elasticsearch/ilm/default_policy.10m.json
@@ -5,7 +5,7 @@
                 "actions": {
                     "rollover": {
                         "max_age": "14d",
-                        "max_size": "50gb"
+                        "max_primary_shard_size": "50gb"
                     },
                     "set_priority": {
                         "priority": 100

--- a/apmpackage/apm/data_stream/service_destination_interval_metrics/elasticsearch/ilm/default_policy.1m.json
+++ b/apmpackage/apm/data_stream/service_destination_interval_metrics/elasticsearch/ilm/default_policy.1m.json
@@ -5,7 +5,7 @@
                 "actions": {
                     "rollover": {
                         "max_age": "7d",
-                        "max_size": "50gb"
+                        "max_primary_shard_size": "50gb"
                     },
                     "set_priority": {
                         "priority": 100

--- a/apmpackage/apm/data_stream/service_destination_interval_metrics/elasticsearch/ilm/default_policy.60m.json
+++ b/apmpackage/apm/data_stream/service_destination_interval_metrics/elasticsearch/ilm/default_policy.60m.json
@@ -5,7 +5,7 @@
                 "actions": {
                     "rollover": {
                         "max_age": "30d",
-                        "max_size": "50gb"
+                        "max_primary_shard_size": "50gb"
                     },
                     "set_priority": {
                         "priority": 100

--- a/apmpackage/apm/data_stream/service_summary_interval_metrics/elasticsearch/ilm/default_policy.10m.json
+++ b/apmpackage/apm/data_stream/service_summary_interval_metrics/elasticsearch/ilm/default_policy.10m.json
@@ -5,7 +5,7 @@
                 "actions": {
                     "rollover": {
                         "max_age": "14d",
-                        "max_size": "50gb"
+                        "max_primary_shard_size": "50gb"
                     },
                     "set_priority": {
                         "priority": 100

--- a/apmpackage/apm/data_stream/service_summary_interval_metrics/elasticsearch/ilm/default_policy.1m.json
+++ b/apmpackage/apm/data_stream/service_summary_interval_metrics/elasticsearch/ilm/default_policy.1m.json
@@ -5,7 +5,7 @@
                 "actions": {
                     "rollover": {
                         "max_age": "7d",
-                        "max_size": "50gb"
+                        "max_primary_shard_size": "50gb"
                     },
                     "set_priority": {
                         "priority": 100

--- a/apmpackage/apm/data_stream/service_summary_interval_metrics/elasticsearch/ilm/default_policy.60m.json
+++ b/apmpackage/apm/data_stream/service_summary_interval_metrics/elasticsearch/ilm/default_policy.60m.json
@@ -5,7 +5,7 @@
                 "actions": {
                     "rollover": {
                         "max_age": "30d",
-                        "max_size": "50gb"
+                        "max_primary_shard_size": "50gb"
                     },
                     "set_priority": {
                         "priority": 100

--- a/apmpackage/apm/data_stream/service_transaction_interval_metrics/elasticsearch/ilm/default_policy.10m.json
+++ b/apmpackage/apm/data_stream/service_transaction_interval_metrics/elasticsearch/ilm/default_policy.10m.json
@@ -5,7 +5,7 @@
                 "actions": {
                     "rollover": {
                         "max_age": "14d",
-                        "max_size": "50gb"
+                        "max_primary_shard_size": "50gb"
                     },
                     "set_priority": {
                         "priority": 100

--- a/apmpackage/apm/data_stream/service_transaction_interval_metrics/elasticsearch/ilm/default_policy.1m.json
+++ b/apmpackage/apm/data_stream/service_transaction_interval_metrics/elasticsearch/ilm/default_policy.1m.json
@@ -5,7 +5,7 @@
                 "actions": {
                     "rollover": {
                         "max_age": "7d",
-                        "max_size": "50gb"
+                        "max_primary_shard_size": "50gb"
                     },
                     "set_priority": {
                         "priority": 100

--- a/apmpackage/apm/data_stream/service_transaction_interval_metrics/elasticsearch/ilm/default_policy.60m.json
+++ b/apmpackage/apm/data_stream/service_transaction_interval_metrics/elasticsearch/ilm/default_policy.60m.json
@@ -5,7 +5,7 @@
                 "actions": {
                     "rollover": {
                         "max_age": "30d",
-                        "max_size": "50gb"
+                        "max_primary_shard_size": "50gb"
                     },
                     "set_priority": {
                         "priority": 100

--- a/apmpackage/apm/data_stream/traces/elasticsearch/ilm/default_policy.json
+++ b/apmpackage/apm/data_stream/traces/elasticsearch/ilm/default_policy.json
@@ -5,7 +5,7 @@
                 "actions": {
                     "rollover": {
                         "max_age": "30d",
-                        "max_size": "50gb"
+                        "max_primary_shard_size": "50gb"
                     },
                     "set_priority": {
                         "priority": 100

--- a/apmpackage/apm/data_stream/transaction_interval_metrics/elasticsearch/ilm/default_policy.10m.json
+++ b/apmpackage/apm/data_stream/transaction_interval_metrics/elasticsearch/ilm/default_policy.10m.json
@@ -5,7 +5,7 @@
                 "actions": {
                     "rollover": {
                         "max_age": "14d",
-                        "max_size": "50gb"
+                        "max_primary_shard_size": "50gb"
                     },
                     "set_priority": {
                         "priority": 100

--- a/apmpackage/apm/data_stream/transaction_interval_metrics/elasticsearch/ilm/default_policy.1m.json
+++ b/apmpackage/apm/data_stream/transaction_interval_metrics/elasticsearch/ilm/default_policy.1m.json
@@ -5,7 +5,7 @@
                 "actions": {
                     "rollover": {
                         "max_age": "7d",
-                        "max_size": "50gb"
+                        "max_primary_shard_size": "50gb"
                     },
                     "set_priority": {
                         "priority": 100

--- a/apmpackage/apm/data_stream/transaction_interval_metrics/elasticsearch/ilm/default_policy.60m.json
+++ b/apmpackage/apm/data_stream/transaction_interval_metrics/elasticsearch/ilm/default_policy.60m.json
@@ -5,7 +5,7 @@
                 "actions": {
                     "rollover": {
                         "max_age": "30d",
-                        "max_size": "50gb"
+                        "max_primary_shard_size": "50gb"
                     },
                     "set_priority": {
                         "priority": 100

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -7,6 +7,10 @@ https://github.com/elastic/apm-server/compare/8.11\...main[View commits]
 ==== Breaking Changes
 
 [float]
+==== Bug fixes
+- Switch built-in ILM rollover policies from max_size to max_primary_shard_size {pull}11729[11729].
+
+[float]
 ==== Deprecations
 
 [float]

--- a/testing/smoke/lib.sh
+++ b/testing/smoke/lib.sh
@@ -262,15 +262,15 @@ legacy_assert_ilm() {
         SUCCESS=false
     fi
     local ILM_HOT_PHASE=$(echo ${ILM_PHASES} | jq '.hot')
-    local ILM_HOT_PHASE_MAX_SIZE=$(echo ${ILM_HOT_PHASE} | jq -r '.actions.rollover.max_size')
+    local ILM_HOT_PHASE_MAX_SIZE=$(echo ${ILM_HOT_PHASE} | jq -r '.actions.rollover.max_primary_shard_size')
     local ILM_HOT_PHASE_MAX_AGE=$(echo ${ILM_HOT_PHASE} | jq -r '.actions.rollover.max_age')
     if [[ "${ILM_HOT_PHASE_MAX_SIZE}" != "${EXPECTED_MAX_SIZE}" ]]; then
-        echo "-> Invalid ILM policy ${LEGACY_ILM_POLICY}; expected hot phase max_size ${EXPECTED_MAX_SIZE} got ${ILM_HOT_PHASE_MAX_SIZE}"
+        echo "-> Invalid ILM policy ${LEGACY_ILM_POLICY}; expected hot phase max_primary_shard_size ${EXPECTED_MAX_SIZE} got ${ILM_HOT_PHASE_MAX_SIZE}"
         echo "${ILM_HOT_PHASE}"
         SUCCESS=false
     fi
     if [[ "${ILM_HOT_PHASE_MAX_AGE}" != "${EXPECTED_MAX_AGE}" ]]; then
-        echo "-> Invalid ILM policy ${LEGACY_ILM_POLICY}; expected hot phase max_size ${EXPECTED_MAX_AGE} got ${ILM_HOT_PHASE_MAX_AGE}"
+        echo "-> Invalid ILM policy ${LEGACY_ILM_POLICY}; expected hot phase max_age ${EXPECTED_MAX_AGE} got ${ILM_HOT_PHASE_MAX_AGE}"
         echo "${ILM_HOT_PHASE}"
         SUCCESS=false
     fi


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

In the Kibana UI, when looking at ILM policies related to apm-server, I see warnings:

**Maximum index size is deprecated and will be removed in a future version. Use maximum primary shard size instead.**

To avoid confusion for the end-user, I recommend that the same changes which were done in elasticsearch's default ILM policies be done for apm-server:


Related to:
*  https://github.com/elastic/elasticsearch/issues/63026
* https://github.com/elastic/elasticsearch/pull/69995 by @joegallo

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)


## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
Fixes: #11728