### PR TITLE
fix: backport changes in the ci docs workflow

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -17,6 +17,14 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    strategy:
+      matrix:
+        os: ['macos-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - run: 'echo "No tests required to run"'
+      
   system-test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
fix: backport changes in the ci docs workflow

there are two checks not backported