### PR TITLE
ironbank: bump version to 8.8

### DIFF
--- a/packaging/ironbank/Dockerfile
+++ b/packaging/ironbank/Dockerfile
@@ -4,7 +4,7 @@
 ################################################################################
 ARG BASE_REGISTRY=registry1.dsop.io
 ARG BASE_IMAGE=ironbank/redhat/ubi/ubi8
-ARG BASE_TAG=8.7
+ARG BASE_TAG=8.8
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS prep_files
 


### PR DESCRIPTION
## Motivation/summary

> The Container Hardening Team (CHT) has identified a few of the Elastic images with UBI 8.7 as a base image.  This image is now EOL and 8.8 is the latest but will be EOL in the first quarter of 2024, so the CHT is recommending moving to UBI 9.x, which is being updated more often by Red Hat with security fixes.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

In the CI and with the unified release automation


## Further detail 

I'd propose to bump the version to the next minor and then work around supporting 9.x in a follow up



## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
