### PR TITLE
ironbank: ubi9:9.2

### DIFF
--- a/packaging/ironbank/Dockerfile
+++ b/packaging/ironbank/Dockerfile
@@ -3,8 +3,8 @@
 # Extract APM Server and make various file manipulations.
 ################################################################################
 ARG BASE_REGISTRY=registry1.dsop.io
-ARG BASE_IMAGE=ironbank/redhat/ubi/ubi8
-ARG BASE_TAG=8.8
+ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9
+ARG BASE_TAG=9.2
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS prep_files
 


### PR DESCRIPTION
## Motivation/summary

Use `ubi9:9.2` for the ironbank docker images

I looked for how it was done for some other projects and found the [golang-1.21 for ubit9](https://repo1.dso.mil/dsop/google/golang/ubi9/golang-1.21/-/blob/development/Dockerfile?ref_type=heads#L2) uses the minimal ubi9 version hence I could find the URL for the ubi9 one in [redhat/ubi/ubi9](https://registry1.dso.mil/harbor/projects/3/repositories/redhat%2Fubi%2Fubi9/artifacts-tab), see the below screenshot:

<img width="1115" alt="image" src="https://github.com/elastic/apm-server/assets/2871786/383a9df6-dcb1-49c5-aec3-c08921e8df70">


## Test


### Clone the ironbank repo and apply some changes to use the latest release

```bash
gh repo clone elastic/ironbank
```

Then I changed to use ubi9

```diff
diff --git a/src/observability/Makefile b/src/observability/Makefile
index 1fb18d4..391b5a5 100644
--- a/src/observability/Makefile
+++ b/src/observability/Makefile
@@ -17,9 +17,9 @@ endif
 BIN_DIR = $(CURDIR)
 
 export BASE_REGISTRY := docker.elastic.co
-export BASE_IMAGE := ubi8/ubi
+export BASE_IMAGE := ubi9/ubi
 export BASE_TAG := latest
-export STACK_VERSION = 8.4.1
+export STACK_VERSION = 8.10.2
 
 MAJOR ?= $(shell echo $(STACK_VERSION) | cut -f1 -d.)
 MINOR ?= $(shell echo $(STACK_VERSION) | cut -f2 -d.)
diff --git a/src/observability/apm-server/docker-compose.yml b/src/observability/apm-server/docker-compose.yml
index a4bcfcc..d5c2d3a 100644
--- a/src/observability/apm-server/docker-compose.yml
+++ b/src/observability/apm-server/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     ports:
       - 8200:8200
     image: dcar-apm-server:${STACK_VERSION}
+    platform: linux/amd64
     build:
       context: src
       network: host
@@ -38,6 +39,7 @@ services:
       - "-environment"
       - "container"
   elasticsearch:
+    platform: linux/amd64
     environment:
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
       - "transport.host=127.0.0.1"
@@ -74,6 +76,7 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
+    platform: linux/amd64
     environment:
       ELASTICSEARCH_HOSTS: http://elasticsearch:9200
       ELASTICSEARCH_USERNAME: "${KIBANA_ES_USER:-kibana_system_user}"
@@ -95,5 +98,6 @@ services:
 
   wait:
     image: busybox
+    platform: linux/amd64
     depends_on:
       beat: { condition: service_healthy }

```


### Build the apm-server docker image

```bash
$  make -C apm-server build

IN_DIR=/Users/vmartinez/workspaces/elastic/ironbank/src/observability/apm-server/..
BASE_REGISTRY=docker.elastic.co
BASE_IMAGE=ubi9/ubi
BASE_TAG=latest
STACK_VERSION=8.10.2
MAJOR=8
MINOR=10
PATCHNUM=2
LASTEST_MAJOR=8.9
CURRENT_MAJOR=8.10
LASTEST_PATCH=8.10.1
CURRENT_PATCH=8.10.2
ELASTIC_PRODUCT=apm-server
ELASTIC_PRODUCTS=apm-server
DOD_PROJECT=elastic/apm-server/apm-server
ELASTIC_PRODUCT=apm-server
ELASTIC_PRODUCT_DESCRIPTION=APM Server receives data from the Elastic APM agents and stores the data into Elasticsearch
ELASTIC_PRODUCT_URL=https://www.elastic.co/products/apm-server/apm-server
ELASTIC_PRODUCT_KEYWORDS=apm,observabilty,o11y,oblt,performance,monitoring,elastic,elasticsearch,golang
ELASTIC_PRODUCT_FILENAME=apm-server-8.10.2-linux-x86_64.tar.gz
ELASTIC_PRODUCT_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/apm-server/apm-server-8.10.2-linux-x86_64.tar.gz
[+] Building 1.6s (23/23) FINISHED                                                                                                                                    docker:desktop-linux
 => [beat internal] load build definition from Dockerfile                                                                                                                             0.0s
 => => transferring dockerfile: 3.30kB                                                                                                                                                0.0s
 => [beat internal] load .dockerignore                                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                                       0.0s
 => [beat internal] load metadata for docker.elastic.co/ubi9/ubi:latest                                                                                                               0.0s
 => [beat prep_files 1/7] FROM docker.elastic.co/ubi9/ubi:latest                                                                                                                      0.0s
 => [beat internal] load build context                                                                                                                                                0.1s
 => => transferring context: 25.73MB                                                                                                                                                  0.1s
 => [beat prep_files 2/7] RUN mkdir /usr/share/apm-server                                                                                                                             0.1s
 => [beat prep_files 3/7] WORKDIR /usr/share/apm-server                                                                                                                               0.0s
 => [beat stage-1  2/12] COPY LICENSE /licenses/elastic-apm-server                                                                                                                    0.0s
 => [beat prep_files 4/7] COPY --chown=1000:0 apm-server-8.10.2-linux-x86_64.tar.gz  .                                                                                                0.0s
 => [beat stage-1  3/12] COPY tinit /tinit                                                                                                                                            0.0s
 => [beat stage-1  4/12] RUN chmod +x /tinit                                                                                                                                          0.0s
 => [beat prep_files 5/7] RUN tar --strip-components=1 -zxf apm-server-8.10.2-linux-x86_64.tar.gz                                                                                     0.4s
 => [beat prep_files 6/7] RUN chmod -R g=u /usr/share/apm-server                                                                                                                      0.1s
 => [beat prep_files 7/7] RUN mkdir /usr/share/apm-server/data /usr/share/apm-server/logs &&     chown -R root:root /usr/share/apm-server &&     find /usr/share/apm-server -type d   0.1s
 => [beat stage-1  5/12] COPY --from=prep_files --chown=1000:0 /usr/share/apm-server /usr/share/apm-server                                                                            0.1s
 => [beat stage-1  6/12] WORKDIR /usr/share/apm-server                                                                                                                                0.0s
 => [beat stage-1  7/12] RUN ln -s /usr/share/apm-server /opt/apm-server                                                                                                              0.0s
 => [beat stage-1  8/12] RUN ln -s /usr/share/apm-server/apm-server /usr/bin/apm-server                                                                                               0.0s
 => [beat stage-1  9/12] RUN chmod -R g+w /usr/share/apm-server                                                                                                                       0.1s
 => [beat stage-1 10/12] RUN chmod go-w /usr/share/apm-server/apm-server.yml                                                                                                          0.0s
 => [beat stage-1 11/12] RUN find / -xdev -perm -4000 -exec chmod u-s {} +                                                                                                            0.1s
 => [beat stage-1 12/12] RUN groupadd --gid 1000 apm-server && useradd --uid 1000 --gid 1000 --home-dir /usr/share/apm-server --no-create-home apm-server                             0.0s
 => [beat] exporting to image                                                                                                                                                         0.2s
 => => exporting layers                                                                                                                                                               0.2s
 => => writing image sha256:87fbb5c1cf98923a1c71e7135e256bd7770f4c0d12b0583b0545cf21f4514526                                                                                          0.0s
 => => naming to docker.io/library/dcar-apm-server:8.10.2   
```

### Run smoke tests

```bash
$  make -C apm-server test 

Makefile:18: warning: overriding commands for target `test'
../Makefile:86: warning: ignoring old commands for target `test'
[+] Running 26/26
 ✔ elasticsearch 10 layers [⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                                                                       35.7s 
   ✔ f9175e7b73a4 Pull complete                                                                                                                                                       1.5s 
   ✔ e7294c716d1c Pull complete                                                                                                                                                       1.0s 
   ✔ fb9041eefb1e Pull complete                                                                                                                                                       0.4s 
   ✔ 89732bc75041 Pull complete                                                                                                                                                       1.0s 
   ✔ 1c2d91e42f0a Pull complete                                                                                                                                                      28.1s 
   ✔ 77d0edd0b6c4 Pull complete                                                                                                                                                       1.5s 
   ✔ 43cd41297455 Pull complete                                                                                                                                                       2.1s 
   ✔ 97454a393139 Pull complete                                                                                                                                                       2.2s 
   ✔ d26c8b72b5e9 Pull complete                                                                                                                                                       2.6s 
   ✔ 321f35bf0eb1 Pull complete                                                                                                                                                       2.9s 
 ✔ kibana 12 layers [⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿]      0B/0B      Pulled                                                                                                                            49.8s 
   ✔ 7f3995c921e5 Pull complete                                                                                                                                                       4.3s 
   ✔ 9f7ec44735b9 Pull complete                                                                                                                                                       3.7s 
   ✔ 950b0a480a11 Pull complete                                                                                                                                                       4.3s 
   ✔ 482caea0b292 Pull complete                                                                                                                                                       6.2s 
   ✔ 26143d77b3a2 Pull complete                                                                                                                                                       6.1s 
   ✔ e0a0bc2539a2 Pull complete                                                                                                                                                      28.7s 
   ✔ 091e96904bbe Pull complete                                                                                                                                                       6.7s 
   ✔ 655f8379a22f Pull complete                                                                                                                                                       7.4s 
   ✔ cf1567e2c8aa Pull complete                                                                                                                                                       8.0s 
   ✔ 162a9700ba1e Pull complete                                                                                                                                                       8.6s 
   ✔ 2274b790a8bf Pull complete                                                                                                                                                       9.3s 
   ✔ 562c75be0000 Pull complete                                                                                                                                                       9.8s 
 ✔ wait 1 layers [⣿]      0B/0B      Pulled                                                                                                                                           2.2s 
   ✔ 3f4d90098f5b Pull complete                                                                                                                                                       0.5s 
[+] Building 0.0s (0/0)                                                                                                                                               docker:desktop-linux
[+] Creating 5/4
 ✔ Network integration-testing           Created                                                                                                                                      0.0s 
 ✔ Container apm-server-elasticsearch-1  Created                                                                                                                                      0.5s 
 ✔ Container apm-server-beat-1           Created                                                                                                                                      0.1s 
 ✔ Container apm-server-kibana-1         Created                                                                                                                                      0.1s 
 ✔ Container apm-server-wait-1           Created                                                                                                                                      0.0s 
[+] Running 4/4
 ✔ Container apm-server-elasticsearch-1  Healthy                                                                                                                                      0.1s 
 ✔ Container apm-server-beat-1           Healthy                                                                                                                                      0.4s 
 ✔ Container apm-server-kibana-1         Started                                                                                                                                      0.5s 
 ✔ Container apm-server-wait-1           Started                                                                                                                                      0.1s 
8.10.2
```

### Inspect the docker image

```bash
$ docker inspect docker.io/library/dcar-apm-server:8.10.2 | jq '.[0].Config.Labels' 
{
  "architecture": "x86_64",
  "build-date": "2023-09-05T09:00:57",
  "com.docker.compose.project": "apm-server",
  "com.docker.compose.service": "beat",
  "com.docker.compose.version": "2.22.0",
  "com.redhat.component": "ubi9-container",
  "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
  "description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
  "distribution-scope": "public",
  "io.buildah.version": "1.29.0",
  "io.k8s.description": "The Universal Base Image is designed and engineered to be the base layer for all of your containerized applications, middleware and utilities. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
  "io.k8s.display-name": "Red Hat Universal Base Image 9",
  "io.openshift.expose-services": "",
  "io.openshift.tags": "base rhel9",
  "maintainer": "Red Hat, Inc.",
  "name": "ubi9",
  "release": "755",
  "summary": "Provides the latest release of Red Hat Universal Base Image 9.",
  "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi9/images/9.2-755",
  "vcs-ref": "6b5892a11894993e819f9a93ee1d7aaa80dc3a17",
  "vcs-type": "git",
  "vendor": "Red Hat, Inc.",
  "version": "9.2"
}

```

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
