### PR TITLE
Add 8.10.3 release notes

### DIFF
--- a/changelogs/8.10.asciidoc
+++ b/changelogs/8.10.asciidoc
@@ -3,9 +3,16 @@
 
 https://github.com/elastic/apm-server/compare/8.9\...8.10[View commits]
 
+* <<release-notes-8.10.3>>
 * <<release-notes-8.10.2>>
 * <<release-notes-8.10.1>>
 * <<release-notes-8.10.0>>
+
+[float]
+[[release-notes-8.10.3]]
+=== APM version 8.10.3
+
+No significant changes.
 
 [float]
 [[release-notes-8.10.2]]


### PR DESCRIPTION
Looking at the [commit history](https://github.com/elastic/apm-server/commits/8.10), all I see is chores and CLI and docs updates.