### PR TITLE
test: ignore client.geo fields in system tests

### DIFF
--- a/systemtest/approvals/TestIntake/Errors.approved.json
+++ b/systemtest/approvals/TestIntake/Errors.approved.json
@@ -10,16 +10,13 @@
             },
             "client": {
                 "geo": {
-                    "city_name": "Sheridan",
                     "continent_name": "North America",
                     "country_iso_code": "US",
                     "country_name": "United States",
                     "location": {
-                        "lat": 40.1405,
-                        "lon": -86.2209
-                    },
-                    "region_iso_code": "US-IN",
-                    "region_name": "Indiana"
+                        "lat": "dynamic",
+                        "lon": "dynamic"
+                    }
                 },
                 "ip": "12.53.12.1"
             },

--- a/systemtest/approvals/TestIntake/Events.approved.json
+++ b/systemtest/approvals/TestIntake/Events.approved.json
@@ -565,16 +565,13 @@
             },
             "client": {
                 "geo": {
-                    "city_name": "Sheridan",
                     "continent_name": "North America",
                     "country_iso_code": "US",
                     "country_name": "United States",
                     "location": {
-                        "lat": 40.1405,
-                        "lon": -86.2209
-                    },
-                    "region_iso_code": "US-IN",
-                    "region_name": "Indiana"
+                        "lat": "dynamic",
+                        "lon": "dynamic"
+                    }
                 },
                 "ip": "12.53.12.1"
             },

--- a/systemtest/approvals/TestIntake/Transactions.approved.json
+++ b/systemtest/approvals/TestIntake/Transactions.approved.json
@@ -307,16 +307,13 @@
             },
             "client": {
                 "geo": {
-                    "city_name": "Sheridan",
                     "continent_name": "North America",
                     "country_iso_code": "US",
                     "country_name": "United States",
                     "location": {
-                        "lat": 40.1405,
-                        "lon": -86.2209
-                    },
-                    "region_iso_code": "US-IN",
-                    "region_name": "Indiana"
+                        "lat": "dynamic",
+                        "lon": "dynamic"
+                    }
                 },
                 "ip": "12.53.12.1"
             },

--- a/systemtest/approvals/TestIntake/TransactionsHugeTraces.approved.json
+++ b/systemtest/approvals/TestIntake/TransactionsHugeTraces.approved.json
@@ -9,16 +9,13 @@
             },
             "client": {
                 "geo": {
-                    "city_name": "Sheridan",
                     "continent_name": "North America",
                     "country_iso_code": "US",
                     "country_name": "United States",
                     "location": {
-                        "lat": 40.1405,
-                        "lon": -86.2209
-                    },
-                    "region_iso_code": "US-IN",
-                    "region_name": "Indiana"
+                        "lat": "dynamic",
+                        "lon": "dynamic"
+                    }
                 },
                 "ip": "12.53.12.1"
             },

--- a/systemtest/approvals/TestOTLPGRPCLogsClientIP.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCLogsClientIP.approved.json
@@ -8,13 +8,16 @@
             },
             "client": {
                 "geo": {
+                    "city_name": "dynamic",
                     "continent_name": "Europe",
                     "country_iso_code": "ES",
                     "country_name": "Spain",
                     "location": {
-                        "lat": 40.4172,
-                        "lon": -3.684
-                    }
+                        "lat": "dynamic",
+                        "lon": "dynamic"
+                    },
+                    "region_iso_code": "dynamic",
+                    "region_name": "dynamic"
                 },
                 "ip": "195.55.79.118"
             },

--- a/systemtest/intake_test.go
+++ b/systemtest/intake_test.go
@@ -56,6 +56,7 @@ func TestIntake(t *testing.T) {
 			result := estest.ExpectMinDocs(t, systemtest.Elasticsearch,
 				response.Accepted, "traces-apm*,metrics-apm*,logs-apm*", nil,
 			)
+			tc.dynamicFields = append(tc.dynamicFields, "client.geo.city_name", "client.geo.location.lat", "client.geo.location.lon", "client.geo.region_iso_code", "client.geo.region_name")
 			approvaltest.ApproveEvents(t, t.Name(), result.Hits.Hits, tc.dynamicFields...)
 		})
 	}

--- a/systemtest/otlp_test.go
+++ b/systemtest/otlp_test.go
@@ -478,7 +478,7 @@ func TestOTLPGRPCLogsClientIP(t *testing.T) {
 	require.NoError(t, err)
 
 	result := estest.ExpectDocs(t, systemtest.Elasticsearch, "logs-apm*", nil)
-	approvaltest.ApproveEvents(t, t.Name(), result.Hits.Hits)
+	approvaltest.ApproveEvents(t, t.Name(), result.Hits.Hits, "client.geo.city_name", "client.geo.location.lat", "client.geo.location.lon", "client.geo.region_iso_code", "client.geo.region_name")
 }
 
 func newMobileLogs(body interface{}) plog.Logs {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

CI is failing on main. Ignore client geo fields to make it pass

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
