### PR TITLE
fix: correct base Docker image names

### DIFF
--- a/packaging/ironbank/Dockerfile
+++ b/packaging/ironbank/Dockerfile
@@ -3,7 +3,7 @@
 # Extract APM Server and make various file manipulations.
 ################################################################################
 ARG BASE_REGISTRY=registry1.dsop.io
-ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9
+ARG BASE_IMAGE=redhat/ubi/ubi9
 ARG BASE_TAG=9.2
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} AS prep_files

--- a/packaging/ironbank/hardening_manifest.yaml
+++ b/packaging/ironbank/hardening_manifest.yaml
@@ -13,7 +13,7 @@ tags:
 
 # Build args passed to Dockerfile ARGs
 args:
-  BASE_IMAGE: "ironbank/redhat/ubi/ubi9"
+  BASE_IMAGE: "redhat/ubi/ubi9"
   BASE_TAG: "9.2"
   ELASTIC_STACK: "${APM_SERVER_VERSION}"
   ELASTIC_PRODUCT: "apm-server"


### PR DESCRIPTION
## Motivation/summary

The path for the UBI 8.x and UBI 9.x Docker images is different. This PR corrects the name of the Docker images.

https://repo1.dso.mil/dsop/elastic/apm-server/apm-server/-/merge_requests/92