### PR TITLE
helm: create a Helm chart for apm-server binary

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: apm-server
+description: The APM Server receives data from Elastic APM agents and transforms it into Elasticsearch documents.
+home: https://elastic.co/apm
+type: application
+version: 0.1.0
+appVersion: "8.10.4"

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,64 @@
+{{- define "image_version" -}}
+{{- default .Chart.AppVersion .Values.version }}
+{{- end }}
+
+{{- define "secret_token" -}}
+{{- if .Release.IsInstall -}}
+{{ (default (randAlphaNum 20) .Values.secret_token) }}
+{{- else -}}
+{{ $config := index (lookup "v1" "Secret" .Release.Namespace "apm-server-config").data "apm-server.yml" | b64dec | fromYaml }}
+{{ (index $config "apm-server").auth.secret_token }}
+{{- end }}
+{{- end }}
+
+{{- define "tls_certificate" -}}
+{{- if .Release.IsInstall -}}
+{{- $cert := genSelfSignedCert .Chart.Name (list "127.0.0.1") (list "localhost") 365 -}}
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
+{{- else -}}
+{{ $tls := (lookup "v1" "Secret" .Release.Namespace "apm-server-tls").data }}
+  tls.crt: {{ index $tls "tls.crt" }}
+  tls.key: {{ index $tls "tls.key" }}
+{{- end -}}
+{{- end -}}
+
+{{- define "pod_spec" -}}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/version: {{ include "image_version" . }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/version: {{ include "image_version" . }}
+    spec:
+      containers:
+      - name: apm-server
+        image: "docker.elastic.co/apm/apm-server:{{ include "image_version" . }}"
+        command: ['./apm-server', '-c', '/etc/apm-server/apm-server.yml', '--environment=container', '-E', 'apm-server.host=:8200']
+        ports:
+        - containerPort: 8200
+        volumeMounts:
+        - name: apm-server-config
+          mountPath: /etc/apm-server
+          readOnly: true
+        - name: apm-server-tls
+          mountPath: /usr/share/apm-server/tls
+          readOnly: true
+        - name: apm-server-data
+          mountPath: /usr/share/apm-server/data
+      volumes:
+      - name: apm-server-config
+        secret:
+          secretName: apm-server-config
+          items:
+          - key: apm-server.yml
+            path: apm-server.yml
+      - name: apm-server-tls
+        secret:
+          secretName: apm-server-tls
+      - name: apm-server-data
+        {{- (.Values.storage).data | toYaml | nindent 8 }}
+{{- end -}}

--- a/helm/templates/config.yaml
+++ b/helm/templates/config.yaml
@@ -1,0 +1,30 @@
+{{- $secret_token := include "secret_token" . -}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: apm-server-config
+stringData:
+  apm-server.yml: |
+    apm-server:
+      auth:
+        secret_token: {{ $secret_token }}
+      ssl:
+        enabled: {{ default true (.Values.tls).enabled }}
+        certificate: /usr/share/apm-server/tls/tls.crt
+        key: /usr/share/apm-server/tls/tls.key
+      sampling:
+        tail: {{ .Values.tail_based_sampling | toYaml | nindent 10 }}
+    output:
+      elasticsearch:
+        hosts: [{{ (.Values.elasticsearch).host }}]
+        username: {{ (.Values.elasticsearch).username }}
+        password: {{ (.Values.elasticsearch).password }}
+        api_key: {{ (.Values.elasticsearch).api_key }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: apm-server-token
+stringData:
+  secret_token: {{ $secret_token }}

--- a/helm/templates/daemonset.yaml
+++ b/helm/templates/daemonset.yaml
@@ -1,0 +1,8 @@
+{{- if (.Values.daemonset).enabled -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Chart.Name }}
+spec:
+  {{ include "pod_spec" . }}
+{{- end -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,19 @@
+{{- if (.Values.deployment).enabled -}}
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .Chart.Name }}
+spec:
+  selector:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+  ports:
+  - port: 8200
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+spec:
+  replicas: {{ default 1 (.Values.deployment).replicas }}
+  {{ include "pod_spec" . }}
+{{- end -}}

--- a/helm/templates/tls.yaml
+++ b/helm/templates/tls.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: apm-server-tls
+data:
+  {{ include "tls_certificate" . }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,29 @@
+deployment:
+  enabled: true
+  replicas: 3
+
+daemonset:
+  enabled: false
+
+tls:
+  enabled: true
+
+tail_based_sampling:
+  enabled: true
+  storage_limit: "10GB"
+  policies:
+  - trace.outcome: "failure"
+    sample_rate: 1.0 # sample 100% of failed traces
+  - sample_rate: 0.1 # sample 10% of all other traces
+
+elasticsearch:
+  host: ""
+  username: elastic
+  password: ""
+  api_key: ""
+
+storage:
+  # data defines the volume configuration for apm-server's data directory.
+  data:
+    emptyDir:
+      sizeLimit: "10Gi"


### PR DESCRIPTION
## Motivation/summary

WIP, experimental Helm chart for deploying APM Server standalone in Kubernetes, either as a Deployment+Service, or as a DaemonSet.

Each pod gets a volume for its data directory, defaulting to emptyDir but configurable through Helm values. The Helm chart generates a self-signed TLS certificate and a random secret token. The chart's values currently enable tail-based sampling by default for testing/demonstration purposes; this would be switched to disabled later.

## Checklist

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

## How to test these changes

1. Clone the PR
2. Create an Elastic Cloud deployment (for Elasticsearch & Kibana)
4. `helm install <name> ./helm --set elasticsearch.host=https://....es.elastic-cloud.com:443 --set elasticsearch.username=elastic --set elasticsearch.password=<password>`

## Related issues

https://github.com/elastic/apm-server/issues/2107