### PR TITLE
Update OTel head-based sampling limitation

### DIFF
--- a/docs/sampling.asciidoc
+++ b/docs/sampling.asciidoc
@@ -47,11 +47,20 @@ image::./images/dt-sampling-example-2.png[Distributed tracing and head based sam
 
 **OpenTelemetry with head-based sampling**
 
-Head-based sampling is implemented in the APM agents and SDKs, and
-requires the sample rate to be propagated between services and the APM Server.
-This functionality is not currently supported by OpenTelemetry,
-which results in inaccurate APM throughput, latency, and error metrics.
+Head-based sampling is implemented directly in the APM agents and SDKs.
+The sample rate must be propagated between services and the managed intake service in order to produce accurate metrics.
+
+OpenTelemetry offers multiple samplers. However, most samplers do not propagate the sample rate.
+This results in inaccurate span-based metrics, like APM throughput, latency, and error metrics.
+
+For accurate span-based metrics when using head-based sampling with OpenTelemetry, you must use 
+a [consistent probability sampler](https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/).
+These samplers propagate the sample rate between services and the managed intake service, resulting in accurate metrics.
+
+NOTE: At the time of this writing, OpenTelemetry does not offer consistent probability samplers in all languanges.
 OpenTelemetry users should consider using tail-based sampling instead.
++
+Refer to the documentation of your favorite OpenTelemetry agent or SDK for more information on the availability of consistent probability samplers.
 
 [float]
 [[tail-based-sampling]]

--- a/docs/sampling.asciidoc
+++ b/docs/sampling.asciidoc
@@ -57,7 +57,7 @@ For accurate span-based metrics when using head-based sampling with OpenTelemetr
 a [consistent probability sampler](https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/).
 These samplers propagate the sample rate between services and the managed intake service, resulting in accurate metrics.
 
-NOTE: At the time of this writing, OpenTelemetry does not offer consistent probability samplers in all languanges.
+NOTE: OpenTelemetry does not offer consistent probability samplers in all languanges.
 OpenTelemetry users should consider using tail-based sampling instead.
 +
 Refer to the documentation of your favorite OpenTelemetry agent or SDK for more information on the availability of consistent probability samplers.


### PR DESCRIPTION
### Summary

For https://github.com/elastic/staging-serverless-observability-docs/issues/153.
Related to https://github.com/elastic/staging-serverless-observability-docs/pull/178.

This PR updates our OpenTelemetry head-based sampling documentation based on the fantastic overview provided by @gregkalapos in https://github.com/elastic/staging-serverless-observability-docs/pull/178.
