### PR TITLE
Update release-notes.asciidoc

### DIFF
--- a/docs/release-notes.asciidoc
+++ b/docs/release-notes.asciidoc
@@ -9,6 +9,7 @@ This section summarizes the changes in each release.
 
 **APM integration and APM Server**
 
+* <<release-notes-8.11>>
 * <<release-notes-8.10>>
 * <<release-notes-8.9>>
 * <<release-notes-8.8>>


### PR DESCRIPTION
This change from https://github.com/elastic/apm-server/pull/11761 didn't make it into 8.11.