### PR TITLE
Removed auth from secret-token configuration path

### DIFF
--- a/docs/tab-widgets/secret-token.asciidoc
+++ b/docs/tab-widgets/secret-token.asciidoc
@@ -12,6 +12,6 @@ Set the secret token in `apm-server.yaml`:
 
 [source,yaml]
 ----
-apm-server.auth.secret_token: <secret-token>
+apm-server.secret_token: <secret-token>
 ----
 // end::binary[]


### PR DESCRIPTION
The apm-server.yml (v 8.10.4) doesn't have the section 'apm-server.auth.secret-token'  but 'apm-server.secret-token'
