### PR TITLE
dra: rename ubi8 for ubi9

### DIFF
--- a/.buildkite/scripts/dra.sh
+++ b/.buildkite/scripts/dra.sh
@@ -23,6 +23,12 @@ echo "--- Changing permissions for the release manager"
 sudo chown -R :1000 build/
 ls -l build/distributions/
 
+# as long as elastic/beats uses ubi8, the filenames contain the ubi8 term
+echo "--- Changing ubi8 name for ubi9"
+pushd build/distributions
+for file in apm-server-ubi8* ; do  mv $file ${file//ubi8/ubi9} ; done
+popd
+
 if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "true" ]]; then
   echo "--- :arrow_right: Release Manager does not run on PRs, skipping"
   exit 0


### PR DESCRIPTION

## Motivation/summary

APM Server in `7.17` uses the packaging system from `elastic/beats` but `elastic/beats` has not been updated to use `ubi9` yet.

This is the workaround until the upstream project moves to ubi9

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

Create some files and run the script locally
```
$ mkdir -p build/distributions
$ touch "build/distributions/apm-server-7.17.15-aarch64.rpm"
touch "build/distributions/apm-server-ubi8-7.17.15-linux-amd64.docker.tar.gz"
touch "build/distributions/apm-server-oss-7.17.15-linux-arm64.docker.tar.gz"
touch "build/distributions/apm-server-oss-7.17.15-SNAPSHOT-linux-arm64.docker.tar.gz"
touch "build/distributions/apm-server-7.17.15-linux-arm64.docker.tar.gz"
touch "build/distributions/apm-server-7.17.15-SNAPSHOT-linux-arm64.docker.tar.gz"
touch "build/distributions/apm-server-oss-7.17.15-SNAPSHOT-linux-amd64.docker.tar.gz"
touch "build/distributions/apm-server-oss-7.17.15-linux-amd64.docker.tar.gz"
touch "build/distributions/apm-server-7.17.15-linux-amd64.docker.tar.gz"
touch "build/distributions/apm-server-7.17.15-SNAPSHOT-linux-amd64.docker.tar.gz"
touch "build/distributions/apm-server-ubi8-7.17.15-linux-arm64.docker.tar.gz"
touch "build/distributions/apm-server-ubi8-7.17.15-SNAPSHOT-linux-amd64.docker.tar.gz"
touch "build/distributions/apm-server-ubi8-7.17.15-SNAPSHOT-linux-arm64.docker.tar.gz"

for file in apm-server-ubi8* ; do  mv $file ${file//ubi8/ubi9} ; done
```

<img width="1011" alt="image" src="https://github.com/elastic/apm-server/assets/2871786/e6f35fd6-5e68-4e6f-9d25-606f87b742cb">



I triggered [this build](https://buildkite.com/elastic/apm-server-package/builds/746) manually
## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
