### PR TITLE
smoke: Rename max_primary_shard_size to max_size

### DIFF
--- a/testing/smoke/lib.sh
+++ b/testing/smoke/lib.sh
@@ -262,15 +262,15 @@ legacy_assert_ilm() {
         SUCCESS=false
     fi
     local ILM_HOT_PHASE=$(echo ${ILM_PHASES} | jq '.hot')
-    local ILM_HOT_PHASE_MAX_SIZE=$(echo ${ILM_HOT_PHASE} | jq -r '.actions.rollover.max_primary_shard_size')
+    local ILM_HOT_PHASE_MAX_SIZE=$(echo ${ILM_HOT_PHASE} | jq -r '.actions.rollover.max_size')
     local ILM_HOT_PHASE_MAX_AGE=$(echo ${ILM_HOT_PHASE} | jq -r '.actions.rollover.max_age')
     if [[ "${ILM_HOT_PHASE_MAX_SIZE}" != "${EXPECTED_MAX_SIZE}" ]]; then
-        echo "-> Invalid ILM policy ${LEGACY_ILM_POLICY}; expected hot phase max_primary_shard_size ${EXPECTED_MAX_SIZE} got ${ILM_HOT_PHASE_MAX_SIZE}"
+        echo "-> Invalid ILM policy \"${LEGACY_ILM_POLICY}\"; expected hot phase \"max_age\" ${EXPECTED_MAX_SIZE} got ${ILM_HOT_PHASE_MAX_SIZE}"
         echo "${ILM_HOT_PHASE}"
         SUCCESS=false
     fi
     if [[ "${ILM_HOT_PHASE_MAX_AGE}" != "${EXPECTED_MAX_AGE}" ]]; then
-        echo "-> Invalid ILM policy ${LEGACY_ILM_POLICY}; expected hot phase max_age ${EXPECTED_MAX_AGE} got ${ILM_HOT_PHASE_MAX_AGE}"
+        echo "-> Invalid ILM policy \"${LEGACY_ILM_POLICY}\"; expected hot phase \"max_age\" ${EXPECTED_MAX_AGE} got ${ILM_HOT_PHASE_MAX_AGE}"
         echo "${ILM_HOT_PHASE}"
         SUCCESS=false
     fi


### PR DESCRIPTION
## Motivation/summary

Updates the legacy smoke test ILM policy size field name. It appears to have changed recently from `max_primary_shard_size` to `max_size`.

## Smoke test output

```
-> Invalid ILM policy apm-rollover-30-days; expected hot phase max_primary_shard_size 50gb got null
{
  "min_age": "0ms",
  "actions": {
    "set_priority": {
      "priority": 100
    },
    "rollover": {
      "max_size": "50gb",
      "max_age": "30d"
    }
  }
}
```

Full log: https://github.com/elastic/apm-server/actions/runs/6765796976/job/18385971031


Closes #11872