### PR TITLE
docs: Remove references to `processor.event`

### DIFF
--- a/changelogs/8.10.asciidoc
+++ b/changelogs/8.10.asciidoc
@@ -47,6 +47,7 @@ Fix tail-based sampling discarding low throughput and low sample rate traces {pu
 - Aggregated metrics now consider global labels to be part of a service's identity, and high cardinality global labels may cause services to be obscured {pull}11386[11386]
 - Event protobuf encoding for tail-based sampling changed (to a more efficient encoding) for event timestamp and duration {pull}11386[11386]
 - Use object notation for data_stream fields {pull}11311[11311]
+- Removed `processor.event` and `processor.name` from the data model {pull}11028[11028]
 
 [float]
 ==== Bug fixes

--- a/docs/configure/outputs/logstash.asciidoc
+++ b/docs/configure/outputs/logstash.asciidoc
@@ -184,7 +184,7 @@ APM Server sends the following `@metadata` to {ls}:
 <2> The current version of APM Server.
 
 In addition to `@metadata`, APM Server provides other potentially useful fields, like the
-`processor.event` field and `data_stream` fields, which can be used to conditionally operate on
+`data_stream` field, which can be used to conditionally operate on
 {apm-guide-ref}/data-model.html[event types], namespaces, or datasets.
 
 As an example, you might want to use {ls} to route all `metric` events to the same custom metrics data stream,
@@ -194,7 +194,7 @@ rather than to service-specific data streams:
 ----
 output {
   if [@metadata][beat] == "apm-server" { <1>
-    if [processor][event] == "metric" { <2>
+    if [data_stream][type] == "metrics" { <2>
       elasticsearch {
         index => "%{[data_stream][type]}-custom-%{[data_stream][namespace]}" <3>
         action => "create" <4>

--- a/docs/data-model.asciidoc
+++ b/docs/data-model.asciidoc
@@ -236,9 +236,7 @@ and {apm-go-ref-v}/metrics.html[Go runtime] metrics in the Go Agent.
 Infrastructure and application metrics are important sources of information when debugging production systems,
 which is why we've made it easy to filter metrics for specific hosts or containers in the {kib} {kibana-ref}/metrics.html[metrics overview].
 
-Metrics have the `processor.event` property set to `metric`.
-
-TIP: Most agents limit keyword fields (e.g. `processor.event`) to 1024 characters,
+TIP: Most agents limit keyword fields to 1024 characters,
 non-keyword fields (e.g. `system.memory.total`) to 10,000 characters.
 
 Metrics are stored in metric indices.

--- a/docs/otel-metrics.asciidoc
+++ b/docs/otel-metrics.asciidoc
@@ -38,7 +38,7 @@ include::{tab-widget-dir}/open-kibana-widget.asciidoc[]
 
 . Open the main menu, then click *Discover*.
 . Select `apm-*` as your index pattern.
-. Filter the data to only show documents with metrics: `processor.event: "metric"`
+. Filter the data to only show documents with metrics: `[data_stream][type]: "metrics"`
 . Narrow your search with a known OpenTelemetry field. For example, if you have an `order_value` field, add `order_value: *` to your search to return
 only OpenTelemetry metrics documents.
 


### PR DESCRIPTION
## Motivation/summary

Removes references to `processor.event`, which was removed in v8.10.0. A couple notes:

* In [#11989](https://github.com/elastic/apm-server/issues/11989), @marclop mentioned users who use `[processor][event]` in Logstash for routing purposes in [Logstash configuration pipeline](https://www.elastic.co/guide/en/apm/guide/current/logstash-output.html#ls-config-pipeline), but I found a few other references that I _think_ should be removed (but let me know if not).
* I _think_ for `[data_stream][type]` you would have to be `metrics` (plural) instead of `metric`. Is that right?
* I guessed this would be considered a breaking change, but I wasn't completely sure.

## Checklist

- [x] @colleenmcginnis first draft
- [ ] @marclop @bmorelli25  review
- [ ] @colleenmcginnis address feedback

## Related issues

Closes https://github.com/elastic/apm-server/issues/11989