### PR TITLE
Update shared-docker.asciidoc

### DIFF
--- a/docs/shared-docker.asciidoc
+++ b/docs/shared-docker.asciidoc
@@ -2,7 +2,7 @@
 ==== Run {beatname_uc} on Docker
 
 Docker images for {beatname_uc} are available from the Elastic Docker
-registry. The base image is https://hub.docker.com/_/centos/[centos:7].
+registry. The base image is https://hub.docker.com/_/ubuntu[ubuntu:20.04].
 
 A list of all published Docker images and tags is available at
 https://www.docker.elastic.co[www.docker.elastic.co].


### PR DESCRIPTION
Update base image reference in docs from CentOS to Ubuntu. CentOS is unsupported/unmaintained and this reference might discourage potential users. 
