### PR TITLE
test: use more stable ip in otlp grpc logs ip system test

### DIFF
--- a/systemtest/approvals/TestOTLPGRPCLogsClientIP.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCLogsClientIP.approved.json
@@ -8,18 +8,15 @@
             },
             "client": {
                 "geo": {
-                    "city_name": "dynamic",
                     "continent_name": "Europe",
-                    "country_iso_code": "ES",
-                    "country_name": "Spain",
+                    "country_iso_code": "DE",
+                    "country_name": "Germany",
                     "location": {
                         "lat": "dynamic",
                         "lon": "dynamic"
-                    },
-                    "region_iso_code": "dynamic",
-                    "region_name": "dynamic"
+                    }
                 },
-                "ip": "195.55.79.118"
+                "ip": "178.162.206.244"
             },
             "data_stream": {
                 "dataset": "apm.app.unknown",
@@ -51,7 +48,7 @@
                 "name": "unknown"
             },
             "source": {
-                "ip": "195.55.79.118",
+                "ip": "178.162.206.244",
                 "nat": {
                     "ip": "127.0.0.1"
                 }

--- a/systemtest/otlp_test.go
+++ b/systemtest/otlp_test.go
@@ -464,7 +464,7 @@ func TestOTLPGRPCLogsClientIP(t *testing.T) {
 	defer cancel()
 
 	// Override local IP address to be found in "GeoLite2-City.mmdb".
-	md := metadata.New(map[string]string{"X-Forwarded-For": "195.55.79.118"})
+	md := metadata.New(map[string]string{"X-Forwarded-For": "178.162.206.244"})
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	conn, err := grpc.Dial(serverAddr(srv), grpc.WithInsecure(), grpc.WithBlock(), grpc.WithDefaultCallOptions(grpc.UseCompressor("gzip")))
@@ -478,7 +478,7 @@ func TestOTLPGRPCLogsClientIP(t *testing.T) {
 	require.NoError(t, err)
 
 	result := estest.ExpectDocs(t, systemtest.Elasticsearch, "logs-apm*", nil)
-	approvaltest.ApproveEvents(t, t.Name(), result.Hits.Hits, "client.geo.city_name", "client.geo.location.lat", "client.geo.location.lon", "client.geo.region_iso_code", "client.geo.region_name")
+	approvaltest.ApproveEvents(t, t.Name(), result.Hits.Hits, "client.geo.location.lat", "client.geo.location.lon")
 }
 
 func newMobileLogs(body interface{}) plog.Logs {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Replace custom ip with pingdom probe server (more stable)

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
