### PR TITLE
Add otel span code.stacktrace field

### DIFF
--- a/apmpackage/apm/data_stream/traces/fields/fields.yml
+++ b/apmpackage/apm/data_stream/traces/fields/fields.yml
@@ -275,6 +275,10 @@
   description: |
     The approximate number of spans represented, based on the inverse sampling rate.
     This will only be set when the sampling rate is known.
+- name: span.code.stacktrace
+  type: text
+  description: |
+    OTel stack trace
 - name: timestamp.us
   type: long
   description: |


### PR DESCRIPTION
## Motivation/summary

Adds the `span.code.stacktrace` field to store the `code.stacktrace` field added in otel semantic conventions: https://github.com/open-telemetry/semantic-conventions/pull/435

## Checklist

- [ ] decide on having a top-level field `code.stacktrace` or keep in within the `span` namespace with `span.code.stacktrace`.
- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

## Related issues


