### PR TITLE
docs: Remove references to rollovers where a rollover is not required

### DIFF
--- a/docs/apm-data-security.asciidoc
+++ b/docs/apm-data-security.asciidoc
@@ -483,18 +483,6 @@ TIP: If you prefer using a GUI, you can instead open {kib} and navigate to
 **Stack Management** -> **Ingest Pipelines** -> **Create pipeline**.
 Use the same naming convention explained previously to ensure your new pipeline matches the correct APM data stream.
 
-**Roll over the data stream (optional)**
-
-Pipeline changes are not applied retroactively to existing indices.
-For changes to take effect immediately, you must create a new write index for the data stream.
-This can be done with the {es} {ref}/indices-rollover-index.html[Rollover API].
-For example, to roll over the default application traces data stream, with a `namespace` of "default", run:
-
-[source,console]
-----
-POST /traces-apm-default/_rollover/
-----
-
 That's it! Passwords will now be redacted from your APM HTTP body data.
 
 To learn more about ingest pipelines, see <<custom-index-template>>.

--- a/docs/ingest-pipelines.asciidoc
+++ b/docs/ingest-pipelines.asciidoc
@@ -60,7 +60,6 @@ The process for creating a custom ingest pipeline is as follows:
 
 * Create a pipeline with processors specific to your use case
 * Add the newly created pipeline to an `@custom` pipeline that matches an APM data stream
-* Roll over your data stream
 
 If you prefer more guidance, see one of these tutorials:
 


### PR DESCRIPTION
## Motivation/summary

Removes references to rollovers where a rollover is not required (when nothing is changing in the data streams index template or component templates).

@felixbarny how far back should this be backported?

## Related issues

Closes https://github.com/elastic/apm-server/issues/11593