### PR TITLE
docs: Restore keystore docs 

### DIFF
--- a/docs/command-reference.asciidoc
+++ b/docs/command-reference.asciidoc
@@ -34,6 +34,7 @@ ifdef::serverless[]
 endif::serverless[]
 
 :help-command-short-desc: Shows help for any command
+:keystore-command-short-desc: Manages the <<keystore,secrets keystore>>
 :modules-command-short-desc: Manages configured modules
 :package-command-short-desc: Packages the configuration and executable into a zip file
 :remove-command-short-desc: Removes the specified function from your serverless environment
@@ -106,6 +107,9 @@ ifdef::apm-server[]
 endif::[]
 |<<export-command,`export`>> |{export-command-short-desc}.
 |<<help-command,`help`>> |{help-command-short-desc}.
+ifndef::serverless[]
+|<<keystore-command,`keystore`>> |{keystore-command-short-desc}.
+endif::[]
 ifeval::["{beatname_lc}"=="functionbeat"]
 |<<package-command,`package`>> |{package-command-short-desc}.
 |<<remove-command,`remove`>> |{remove-command-short-desc}.
@@ -429,6 +433,65 @@ Specifies the name of the command to show help for.
 -----
 {beatname_lc} help export
 -----
+
+ifndef::serverless[]
+[float]
+[[keystore-command]]
+==== `keystore` command
+
+{keystore-command-short-desc}.
+
+*SYNOPSIS*
+
+["source","sh",subs="attributes"]
+----
+{beatname_lc} keystore SUBCOMMAND [FLAGS]
+----
+
+*`SUBCOMMAND`*
+
+*`add KEY`*::
+Adds the specified key to the keystore. Use the `--force` flag to overwrite an
+existing key. Use the `--stdin` flag to pass the value through `stdin`.
+
+*`create`*::
+Creates a keystore to hold secrets. Use the `--force` flag to overwrite the
+existing keystore.
+
+*`list`*::
+Lists the keys in the keystore.
+
+*`remove KEY`*::
+Removes the specified key from the keystore.
+
+*FLAGS*
+
+*`--force`*::
+Valid with the `add` and `create` subcommands. When used with `add`, overwrites
+the specified key. When used with `create`, overwrites the keystore.
+
+*`--stdin`*::
+When used with `add`, uses the stdin as the source of the key's value.
+
+*`-h, --help`*::
+Shows help for the `keystore` command.
+
+
+{global-flags}
+
+*EXAMPLES*
+
+["source","sh",subs="attributes"]
+-----
+{beatname_lc} keystore create
+{beatname_lc} keystore add ES_PWD
+{beatname_lc} keystore remove ES_PWD
+{beatname_lc} keystore list
+-----
+
+See <<keystore>> for more examples.
+
+endif::[]
 
 ifeval::["{beatname_lc}"=="functionbeat"]
 [float]

--- a/docs/keystore.asciidoc
+++ b/docs/keystore.asciidoc
@@ -35,8 +35,8 @@ name, the APM Server keystore lets you specify arbitrary names that you can
 reference in the APM Server configuration.
 
 To create and manage keys, use the `keystore` command.
-// See the <<keystore-command,command reference>> for the full command syntax,
-// including optional flags.
+See the <<keystore-command,command reference>> for the full command syntax,
+including optional flags.
 
 NOTE: The `keystore` command must be run by the same user who will run
 APM Server.

--- a/docs/keystore.asciidoc
+++ b/docs/keystore.asciidoc
@@ -1,0 +1,107 @@
+[[keystore]]
+=== Secrets keystore for secure settings
+
+++++
+<titleabbrev>Secrets keystore</titleabbrev>
+++++
+
+When you configure APM Server, you might need to specify sensitive settings,
+such as passwords. Rather than relying on file system permissions to protect
+these values, you can use the APM Server keystore to securely store secret
+values for use in configuration settings.
+
+After adding a key and its secret value to the keystore, you can use the key in
+place of the secret value when you configure sensitive settings.
+
+The syntax for referencing keys is identical to the syntax for environment
+variables:
+
+`${KEY}`
+
+Where KEY is the name of the key.
+
+For example, imagine that the keystore contains a key called `ES_PWD` with the
+value `yourelasticsearchpassword`:
+
+* In the configuration file, use `output.elasticsearch.password: "${ES_PWD}"`
+* On the command line, use: `-E "output.elasticsearch.password=\${ES_PWD}"`
+
+When APM Server unpacks the configuration, it resolves keys before resolving
+environment variables and other variables.
+
+Notice that the APM Server keystore differs from the {es} keystore.
+Whereas the {es} keystore lets you store `elasticsearch.yml` values by
+name, the APM Server keystore lets you specify arbitrary names that you can
+reference in the APM Server configuration.
+
+To create and manage keys, use the `keystore` command.
+// See the <<keystore-command,command reference>> for the full command syntax,
+// including optional flags.
+
+NOTE: The `keystore` command must be run by the same user who will run
+APM Server.
+
+[discrete]
+[[creating-keystore]]
+=== Create a keystore
+
+To create a secrets keystore, use:
+
+[source,sh]
+-----
+apm-server keystore create
+-----
+
+APM Server creates the keystore in the directory defined by the `path.data`
+configuration setting.
+
+[discrete]
+[[add-keys-to-keystore]]
+=== Add keys
+
+To store sensitive values, such as authentication credentials for {es},
+use the `keystore add` command:
+
+[source,sh]
+-----
+apm-server keystore add ES_PWD
+-----
+
+When prompted, enter a value for the key.
+
+To overwrite an existing key's value, use the `--force` flag:
+
+[source,sh]
+-----
+apm-server keystore add ES_PWD --force
+-----
+
+To pass the value through stdin, use the `--stdin` flag. You can also use
+`--force`:
+
+[source,sh]
+-----
+cat /file/containing/setting/value | apm-server keystore add ES_PWD --stdin --force
+-----
+
+[discrete]
+[[list-settings]]
+=== List keys
+
+To list the keys defined in the keystore, use:
+
+[source,sh]
+-----
+apm-server keystore list
+-----
+
+[discrete]
+[[remove-settings]]
+=== Remove keys
+
+To remove a key from the keystore, use:
+
+[source,sh]
+-----
+apm-server keystore remove ES_PWD
+-----

--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -12,7 +12,9 @@ for basic installation and running instructions.
 This section includes additional information on how to set up and run APM Server, including:
 
 * <<directory-layout>>
+* <<keystore>>
 * <<command-line-options>>
+* <<tune-data-ingestion>>
 * <<high-availability>>
 * <<running-on-docker>>
 

--- a/docs/setting-up-and-running.asciidoc
+++ b/docs/setting-up-and-running.asciidoc
@@ -18,6 +18,8 @@ This section includes additional information on how to set up and run APM Server
 
 include::{docdir}/shared-directory-layout.asciidoc[]
 
+include::{docdir}/keystore.asciidoc[]
+
 include::{docdir}/command-reference.asciidoc[]
 
 include::{docdir}/data-ingestion.asciidoc[]


### PR DESCRIPTION
## Motivation/summary

Restores keystore docs removed in https://github.com/elastic/apm-server/pull/10791. I wasn't sure how much to restore, but this is how I approached it:

* I restored the _Secrets keystore for secure settings_ page @axw mentioned in the initial request (https://github.com/elastic/apm-server/commit/14795813b7de89b650861fb53e213f7ce20e9b8f).
* I restore the keystore section on the command reference page (https://github.com/elastic/apm-server/commit/d4e92123a827b6b09111d53673ecb6d48d8602fa).
* I did _not_ add back links to the keystore docs (like [this](https://github.com/elastic/apm-server/pull/10791/files#diff-be59b287152ede1ecc02d9b58caba93dbb5fe5841ec35247ec8ec9bb26f1f0a0L235-L236), [this](https://github.com/elastic/apm-server/pull/10791/files#diff-566f3a69b2c9ccfb121f55864353b2004cf9b640d73c93070d39ef23b3ebdbe8L557), and [this](https://github.com/elastic/apm-server/pull/10791/files#diff-1138d88d0b6076a10da5145ff818ca6fafebe7fbedbce70f5b4ebe3e8d6d95b3L29)) because it looked like some of those docs might have changed since the keystore docs were removed. Let me know if we should add them back.

### Questions

* How far back should I backport these changes?
* Should I add a note on the _Secrets keystore for secure settings_ page similar to the note at the top of the [APM Server command reference](https://www.elastic.co/guide/en/apm/guide/current/command-line-options.html) page to clarify that the content only applies to the APM Server binary installation method? 

## Checklist

- [ ] @colleenmcginnis restore docs
- [ ] @axw / @elastic/apm-server review and answer the questions listed above
- [ ] @colleenmcginnis address feedback
- [ ] @elastic/apm-server review, merge

## Related issues

Closes https://github.com/elastic/apm-server/issues/11637
