### PR TITLE
Revert some flattened fields to object type

### DIFF
--- a/apmpackage/apm/data_stream/error_logs/fields/fields.yml
+++ b/apmpackage/apm/data_stream/error_logs/fields/fields.yml
@@ -61,15 +61,18 @@
   description: |
     The original body of the monitored HTTP request.
 - name: http.request.env
-  type: flattened
+  type: object
+  dynamic: true
   description: |
     The CGI-like environment variables of the monitored HTTP request.
 - name: http.request.cookies
-  type: flattened
+  type: object
+  dynamic: true
   description: |
     The cookies of the monitored HTTP request.
 - name: http.request.headers
-  type: flattened
+  type: object
+  dynamic: true
   description: |
     The canonical headers of the monitored HTTP request.
 - name: http.response.finished
@@ -77,7 +80,8 @@
   description: |
     Used by the Node agent to indicate when in the response life cycle an error has occurred.
 - name: http.response.headers
-  type: flattened
+  type: object
+  dynamic: true
   description: |
     The canonical headers of the monitored HTTP response.
 - name: http.response.headers_sent

--- a/apmpackage/apm/data_stream/traces/fields/fields.yml
+++ b/apmpackage/apm/data_stream/traces/fields/fields.yml
@@ -61,15 +61,18 @@
   description: |
     The original body of the monitored HTTP request.
 - name: http.request.env
-  type: flattened
+  type: object
+  dynamic: true
   description: |
     The CGI-like environment variables of the monitored HTTP request.
 - name: http.request.cookies
-  type: flattened
+  type: object
+  dynamic: true
   description: |
     The cookies of the monitored HTTP request.
 - name: http.request.headers
-  type: flattened
+  type: object
+  dynamic: true
   description: |
     The canonical headers of the monitored HTTP request.
 - name: http.response.finished
@@ -77,7 +80,8 @@
   description: |
     Used by the Node agent to indicate when in the response life cycle an error has occurred.
 - name: http.response.headers
-  type: flattened
+  type: object
+  dynamic: true
   description: |
     The canonical headers of the monitored HTTP response.
 - name: http.response.headers_sent
@@ -287,9 +291,9 @@
   description: The message routing key
   index: false
 - name: span.message.headers
-  type: flattened
+  type: object
+  dynamic: true
   description: The message headers
-  index: false
 - name: span.message.age.ms
   type: long
   description: |
@@ -367,9 +371,9 @@
   description: The message routing key
   index: false
 - name: transaction.message.headers
-  type: flattened
+  type: object
+  dynamic: true
   description: The message headers
-  index: false
 - name: transaction.message.age.ms
   type: long
   description: |

--- a/systemtest/approvals/TestIntake/Errors.approved.json
+++ b/systemtest/approvals/TestIntake/Errors.approved.json
@@ -288,38 +288,34 @@
                 "original": "Hello World"
             }
         ],
-        "http.request.cookies": [
-            {
-                "c1": "v1",
-                "c2": "v2"
-            }
+        "http.request.cookies.c1": [
+            "v1"
         ],
-        "http.request.env": [
-            {
-                "GATEWAY_INTERFACE": "CGI/1.1",
-                "SERVER_SOFTWARE": "nginx"
-            }
+        "http.request.cookies.c2": [
+            "v2"
         ],
-        "http.request.headers": [
-            {
-                "Array": [
-                    "foo",
-                    "bar",
-                    "baz"
-                ],
-                "Content-Type": [
-                    "text/html"
-                ],
-                "Cookie": [
-                    "c1=v1,c2=v2"
-                ],
-                "Some-Other-Header": [
-                    "foo"
-                ],
-                "User-Agent": [
-                    "Mozilla Chrome Edge"
-                ]
-            }
+        "http.request.env.GATEWAY_INTERFACE": [
+            "CGI/1.1"
+        ],
+        "http.request.env.SERVER_SOFTWARE": [
+            "nginx"
+        ],
+        "http.request.headers.Array": [
+            "foo",
+            "bar",
+            "baz"
+        ],
+        "http.request.headers.Content-Type": [
+            "text/html"
+        ],
+        "http.request.headers.Cookie": [
+            "c1=v1,c2=v2"
+        ],
+        "http.request.headers.Some-Other-Header": [
+            "foo"
+        ],
+        "http.request.headers.User-Agent": [
+            "Mozilla Chrome Edge"
         ],
         "http.request.method": [
             "POST"
@@ -330,12 +326,8 @@
         "http.response.finished": [
             true
         ],
-        "http.response.headers": [
-            {
-                "Content-Type": [
-                    "application/json"
-                ]
-            }
+        "http.response.headers.Content-Type": [
+            "application/json"
         ],
         "http.response.headers_sent": [
             true

--- a/systemtest/approvals/TestIntake/ErrorsTxID.approved.json
+++ b/systemtest/approvals/TestIntake/ErrorsTxID.approved.json
@@ -189,37 +189,33 @@
                 "original": "HelloWorld"
             }
         ],
-        "http.request.cookies": [
-            {
-                "c1": "v1",
-                "c2": "v2"
-            }
+        "http.request.cookies.c1": [
+            "v1"
         ],
-        "http.request.env": [
-            {
-                "GATEWAY_INTERFACE": "CGI/1.1",
-                "SERVER_SOFTWARE": "nginx"
-            }
+        "http.request.cookies.c2": [
+            "v2"
         ],
-        "http.request.headers": [
-            {
-                "Content-Length": [
-                    "0"
-                ],
-                "Cookie": [
-                    "c1=v1",
-                    "c2=v2"
-                ],
-                "Elastic-Apm-Traceparent": [
-                    "00-8c21b4b556467a0b17ae5da959b5f388-31301f1fb2998121-01"
-                ],
-                "Forwarded": [
-                    "for=192.168.0.1"
-                ],
-                "Host": [
-                    "opbeans-java:3000"
-                ]
-            }
+        "http.request.env.GATEWAY_INTERFACE": [
+            "CGI/1.1"
+        ],
+        "http.request.env.SERVER_SOFTWARE": [
+            "nginx"
+        ],
+        "http.request.headers.Content-Length": [
+            "0"
+        ],
+        "http.request.headers.Cookie": [
+            "c1=v1",
+            "c2=v2"
+        ],
+        "http.request.headers.Elastic-Apm-Traceparent": [
+            "00-8c21b4b556467a0b17ae5da959b5f388-31301f1fb2998121-01"
+        ],
+        "http.request.headers.Forwarded": [
+            "for=192.168.0.1"
+        ],
+        "http.request.headers.Host": [
+            "opbeans-java:3000"
         ],
         "http.request.method": [
             "POST"
@@ -227,12 +223,8 @@
         "http.response.finished": [
             true
         ],
-        "http.response.headers": [
-            {
-                "Content-Type": [
-                    "application/json"
-                ]
-            }
+        "http.response.headers.Content-Type": [
+            "application/json"
         ],
         "http.response.headers_sent": [
             true

--- a/systemtest/approvals/TestIntake/Events.approved.json
+++ b/systemtest/approvals/TestIntake/Events.approved.json
@@ -192,37 +192,33 @@
                 "original": "HelloWorld"
             }
         ],
-        "http.request.cookies": [
-            {
-                "c1": "v1",
-                "c2": "v2"
-            }
+        "http.request.cookies.c1": [
+            "v1"
         ],
-        "http.request.env": [
-            {
-                "GATEWAY_INTERFACE": "CGI/1.1",
-                "SERVER_SOFTWARE": "nginx"
-            }
+        "http.request.cookies.c2": [
+            "v2"
         ],
-        "http.request.headers": [
-            {
-                "Content-Length": [
-                    "0"
-                ],
-                "Cookie": [
-                    "c1=v1",
-                    "c2=v2"
-                ],
-                "Elastic-Apm-Traceparent": [
-                    "00-8c21b4b556467a0b17ae5da959b5f388-31301f1fb2998121-01"
-                ],
-                "Forwarded": [
-                    "for=192.168.0.1"
-                ],
-                "Host": [
-                    "opbeans-java:3000"
-                ]
-            }
+        "http.request.env.GATEWAY_INTERFACE": [
+            "CGI/1.1"
+        ],
+        "http.request.env.SERVER_SOFTWARE": [
+            "nginx"
+        ],
+        "http.request.headers.Content-Length": [
+            "0"
+        ],
+        "http.request.headers.Cookie": [
+            "c1=v1",
+            "c2=v2"
+        ],
+        "http.request.headers.Elastic-Apm-Traceparent": [
+            "00-8c21b4b556467a0b17ae5da959b5f388-31301f1fb2998121-01"
+        ],
+        "http.request.headers.Forwarded": [
+            "for=192.168.0.1"
+        ],
+        "http.request.headers.Host": [
+            "opbeans-java:3000"
         ],
         "http.request.method": [
             "POST"
@@ -230,12 +226,8 @@
         "http.response.finished": [
             true
         ],
-        "http.response.headers": [
-            {
-                "Content-Type": [
-                    "application/json"
-                ]
-            }
+        "http.response.headers.Content-Type": [
+            "application/json"
         ],
         "http.response.headers_sent": [
             true
@@ -604,12 +596,8 @@
         "http.response.encoded_body_size": [
             356
         ],
-        "http.response.headers": [
-            {
-                "Content-Type": [
-                    "application/json"
-                ]
-            }
+        "http.response.headers.Content-Type": [
+            "application/json"
         ],
         "http.response.status_code": [
             302
@@ -850,34 +838,30 @@
                 }
             }
         ],
-        "http.request.cookies": [
-            {
-                "c1": "v1",
-                "c2": "v2"
-            }
+        "http.request.cookies.c1": [
+            "v1"
         ],
-        "http.request.env": [
-            {
-                "GATEWAY_INTERFACE": "CGI/1.1",
-                "SERVER_SOFTWARE": "nginx"
-            }
+        "http.request.cookies.c2": [
+            "v2"
         ],
-        "http.request.headers": [
-            {
-                "Content-Type": [
-                    "text/html"
-                ],
-                "Cookie": [
-                    "c1=v1,c2=v2"
-                ],
-                "Elastic-Apm-Traceparent": [
-                    "00-33a0bd4cceff0370a7c57d807032688e-69feaabc5b88d7e8-01"
-                ],
-                "User-Agent": [
-                    "Mozilla/5.0(Macintosh;IntelMacOSX10_10_5)AppleWebKit/537.36(KHTML,likeGecko)Chrome/51.0.2704.103Safari/537.36",
-                    "MozillaChromeEdge"
-                ]
-            }
+        "http.request.env.GATEWAY_INTERFACE": [
+            "CGI/1.1"
+        ],
+        "http.request.env.SERVER_SOFTWARE": [
+            "nginx"
+        ],
+        "http.request.headers.Content-Type": [
+            "text/html"
+        ],
+        "http.request.headers.Cookie": [
+            "c1=v1,c2=v2"
+        ],
+        "http.request.headers.Elastic-Apm-Traceparent": [
+            "00-33a0bd4cceff0370a7c57d807032688e-69feaabc5b88d7e8-01"
+        ],
+        "http.request.headers.User-Agent": [
+            "Mozilla/5.0(Macintosh;IntelMacOSX10_10_5)AppleWebKit/537.36(KHTML,likeGecko)Chrome/51.0.2704.103Safari/537.36",
+            "MozillaChromeEdge"
         ],
         "http.request.method": [
             "POST"
@@ -891,12 +875,8 @@
         "http.response.finished": [
             true
         ],
-        "http.response.headers": [
-            {
-                "Content-Type": [
-                    "application/json"
-                ]
-            }
+        "http.response.headers.Content-Type": [
+            "application/json"
         ],
         "http.response.headers_sent": [
             true

--- a/systemtest/approvals/TestIntake/Transactions.approved.json
+++ b/systemtest/approvals/TestIntake/Transactions.approved.json
@@ -181,16 +181,12 @@
         "transaction.message.body": [
             "user created"
         ],
-        "transaction.message.headers": [
-            {
-                "Involved_services": [
-                    "user",
-                    "auth"
-                ],
-                "User_id": [
-                    "1ax3"
-                ]
-            }
+        "transaction.message.headers.Involved_services": [
+            "user",
+            "auth"
+        ],
+        "transaction.message.headers.User_id": [
+            "1ax3"
         ],
         "transaction.message.queue.name": [
             "new_users"
@@ -529,39 +525,35 @@
                 }
             }
         ],
-        "http.request.cookies": [
-            {
-                "c1": "v1",
-                "c2": "v2"
-            }
+        "http.request.cookies.c1": [
+            "v1"
         ],
-        "http.request.env": [
-            {
-                "GATEWAY_INTERFACE": "CGI/1.1",
-                "SERVER_SOFTWARE": "nginx"
-            }
+        "http.request.cookies.c2": [
+            "v2"
         ],
-        "http.request.headers": [
-            {
-                "Array": [
-                    "foo",
-                    "bar",
-                    "baz"
-                ],
-                "Content-Type": [
-                    "text/html"
-                ],
-                "Cookie": [
-                    "c1=v1, c2=v2"
-                ],
-                "Some-Other-Header": [
-                    "foo"
-                ],
-                "User-Agent": [
-                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
-                    "Mozilla Chrome Edge"
-                ]
-            }
+        "http.request.env.GATEWAY_INTERFACE": [
+            "CGI/1.1"
+        ],
+        "http.request.env.SERVER_SOFTWARE": [
+            "nginx"
+        ],
+        "http.request.headers.Array": [
+            "foo",
+            "bar",
+            "baz"
+        ],
+        "http.request.headers.Content-Type": [
+            "text/html"
+        ],
+        "http.request.headers.Cookie": [
+            "c1=v1, c2=v2"
+        ],
+        "http.request.headers.Some-Other-Header": [
+            "foo"
+        ],
+        "http.request.headers.User-Agent": [
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
+            "Mozilla Chrome Edge"
         ],
         "http.request.method": [
             "POST"
@@ -578,12 +570,8 @@
         "http.response.finished": [
             true
         ],
-        "http.response.headers": [
-            {
-                "Content-Type": [
-                    "application/json"
-                ]
-            }
+        "http.response.headers.Content-Type": [
+            "application/json"
         ],
         "http.response.headers_sent": [
             true

--- a/systemtest/approvals/TestIntake/TransactionsHugeTraces.approved.json
+++ b/systemtest/approvals/TestIntake/TransactionsHugeTraces.approved.json
@@ -104,39 +104,35 @@
                 }
             }
         ],
-        "http.request.cookies": [
-            {
-                "c1": "v1",
-                "c2": "v2"
-            }
+        "http.request.cookies.c1": [
+            "v1"
         ],
-        "http.request.env": [
-            {
-                "GATEWAY_INTERFACE": "CGI/1.1",
-                "SERVER_SOFTWARE": "nginx"
-            }
+        "http.request.cookies.c2": [
+            "v2"
         ],
-        "http.request.headers": [
-            {
-                "Array": [
-                    "foo",
-                    "bar",
-                    "baz"
-                ],
-                "Content-Type": [
-                    "text/html"
-                ],
-                "Cookie": [
-                    "c1=v1, c2=v2"
-                ],
-                "Some-Other-Header": [
-                    "foo"
-                ],
-                "User-Agent": [
-                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
-                    "Mozilla Chrome Edge"
-                ]
-            }
+        "http.request.env.GATEWAY_INTERFACE": [
+            "CGI/1.1"
+        ],
+        "http.request.env.SERVER_SOFTWARE": [
+            "nginx"
+        ],
+        "http.request.headers.Array": [
+            "foo",
+            "bar",
+            "baz"
+        ],
+        "http.request.headers.Content-Type": [
+            "text/html"
+        ],
+        "http.request.headers.Cookie": [
+            "c1=v1, c2=v2"
+        ],
+        "http.request.headers.Some-Other-Header": [
+            "foo"
+        ],
+        "http.request.headers.User-Agent": [
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
+            "Mozilla Chrome Edge"
         ],
         "http.request.method": [
             "POST"
@@ -153,12 +149,8 @@
         "http.response.finished": [
             true
         ],
-        "http.response.headers": [
-            {
-                "Content-Type": [
-                    "application/json"
-                ]
-            }
+        "http.response.headers.Content-Type": [
+            "application/json"
         ],
         "http.response.headers_sent": [
             true

--- a/systemtest/approvals/TestIntake/UnknownSpanType.approved.json
+++ b/systemtest/approvals/TestIntake/UnknownSpanType.approved.json
@@ -254,38 +254,34 @@
                 }
             }
         ],
-        "http.request.cookies": [
-            {
-                "c1": "v1",
-                "c2": "v2"
-            }
+        "http.request.cookies.c1": [
+            "v1"
         ],
-        "http.request.env": [
-            {
-                "GATEWAY_INTERFACE": "CGI/1.1",
-                "SERVER_SOFTWARE": "nginx"
-            }
+        "http.request.cookies.c2": [
+            "v2"
         ],
-        "http.request.headers": [
-            {
-                "Array": [
-                    "foo",
-                    "bar",
-                    "baz"
-                ],
-                "Content-Type": [
-                    "text/html"
-                ],
-                "Cookie": [
-                    "c1=v1,c2=v2"
-                ],
-                "Some-Other-Header": [
-                    "foo"
-                ],
-                "User-Agent": [
-                    "Mozilla Chrome Edge"
-                ]
-            }
+        "http.request.env.GATEWAY_INTERFACE": [
+            "CGI/1.1"
+        ],
+        "http.request.env.SERVER_SOFTWARE": [
+            "nginx"
+        ],
+        "http.request.headers.Array": [
+            "foo",
+            "bar",
+            "baz"
+        ],
+        "http.request.headers.Content-Type": [
+            "text/html"
+        ],
+        "http.request.headers.Cookie": [
+            "c1=v1,c2=v2"
+        ],
+        "http.request.headers.Some-Other-Header": [
+            "foo"
+        ],
+        "http.request.headers.User-Agent": [
+            "Mozilla Chrome Edge"
         ],
         "http.request.method": [
             "POST"
@@ -296,12 +292,8 @@
         "http.response.finished": [
             true
         ],
-        "http.response.headers": [
-            {
-                "Content-Type": [
-                    "application/json"
-                ]
-            }
+        "http.response.headers.Content-Type": [
+            "application/json"
         ],
         "http.response.headers_sent": [
             true

--- a/systemtest/approvals/TestRUMRoutingIntegration.approved.json
+++ b/systemtest/approvals/TestRUMRoutingIntegration.approved.json
@@ -836,12 +836,8 @@
         "event.outcome": [
             "success"
         ],
-        "http.request.headers": [
-            {
-                "Accept": [
-                    "application/json"
-                ]
-            }
+        "http.request.headers.Accept": [
+            "application/json"
         ],
         "http.request.method": [
             "GET"
@@ -855,12 +851,8 @@
         "http.response.encoded_body_size": [
             690
         ],
-        "http.response.headers": [
-            {
-                "Content-Type": [
-                    "application/json"
-                ]
-            }
+        "http.response.headers.Content-Type": [
+            "application/json"
         ],
         "http.response.status_code": [
             200


### PR DESCRIPTION
## Motivation/summary

Revert some fields from flattened back to object to align with how we will dynamically map those fields in the future. We keep a few APM-specific fields that may cause mapping conflicts as flattened for now.

Object-type fields:
 - `http.request.env.*`
 - `http.request.cookies.*`
 - `http.request.headers.*`
 - `http.response.headers.*`
 - `span.message.headers.*`
 - `transaction.message.headers.*`

Flattened-type fields:
 - `error.custom` (APM-specific arbitrary object structure)
 - `error.exception.attributes` (APM-specific arbitrary object structure)
 - `error.exception.stacktrace` (APM-specific structured stack trace)
 - `error.log.stacktrace` (APM-specific structured stack trace)
 - `http.request.body` (may be either a string or object, and object fields are arbitrary so therefore may cause conflicts)
 - `span.stacktrace` (APM-specific structured stack trace)
 - `transaction.custom` (APM-specific arbitrary object structure)

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~ (reverts an unreleased change made in https://github.com/elastic/apm-server/pull/12102)
~- [ ] Documentation has been updated~

## How to test these changes

- Check that error/exception stack traces show up correctly in APM UI
- Check that HTTP request/response headers show up in APM UI

## Related issues

https://github.com/elastic/apm-server/issues/11528
https://github.com/elastic/apm-server/issues/11529