### PR TITLE
backport: Add 8.12 branch

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -304,3 +304,17 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+  - name: backport patches to 8.12 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-8.12
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.12"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"

--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -1,5 +1,10 @@
 - version: generated
   changes:
+    - description: Placeholder
+      type: enhancement
+      link: https://github.com/elastic/apm-server/pull/123
+- version: 8.12.0
+  changes:
     - description: Add missing mappings for various fields
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/12102

--- a/cmd/intake-receiver/version.go
+++ b/cmd/intake-receiver/version.go
@@ -18,4 +18,4 @@
 package main
 
 // version matches the APM Server's version
-const version = "8.12.0"
+const version = "8.13.0"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -18,4 +18,4 @@
 package version
 
 // Version holds the APM Server version.
-const Version = "8.12.0"
+const Version = "8.13.0"


### PR DESCRIPTION
Merge as soon as 8.12 branch was created. Auto-merge is not yet supported, see https://github.com/Mergifyio/mergify-engine/discussions/2821