### PR TITLE
docs: Add release notes for 8.11.2

### DIFF
--- a/changelogs/8.11.asciidoc
+++ b/changelogs/8.11.asciidoc
@@ -3,8 +3,17 @@
 
 https://github.com/elastic/apm-server/compare/8.10\...8.11[View commits]
 
+* <<release-notes-8.11.2>>
 * <<release-notes-8.11.1>>
 * <<release-notes-8.11.0>>
+
+[float]
+[[release-notes-8.11.2]]
+=== APM version 8.11.2
+
+https://github.com/elastic/apm-server/compare/v8.11.1\...v8.11.2[View commits]
+
+No significant changes.
 
 [float]
 [[release-notes-8.11.1]]


### PR DESCRIPTION
Adds 8.11.2 to 8.11 release notes page. Based on the commits on the 8.11 branch, it looks like it's mostly automated updates and docs updates. Does this look correct?

Related to https://github.com/elastic/dev/issues/2431