### PR TITLE
docs: Add release notes for 7.17.16

### DIFF
--- a/changelogs/7.17.asciidoc
+++ b/changelogs/7.17.asciidoc
@@ -3,6 +3,7 @@
 
 https://github.com/elastic/apm-server/compare/7.16\...7.17[View commits]
 
+* <<release-notes-7.17.16>>
 * <<release-notes-7.17.15>>
 * <<release-notes-7.17.14>>
 * <<release-notes-7.17.13>>
@@ -19,6 +20,14 @@ https://github.com/elastic/apm-server/compare/7.16\...7.17[View commits]
 * <<release-notes-7.17.2>>
 * <<release-notes-7.17.1>>
 * <<release-notes-7.17.0>>
+
+[float]
+[[release-notes-7.17.16]]
+=== APM version 7.17.16
+
+https://github.com/elastic/apm-server/compare/v7.17.15\...v7.17.16[View commits]
+
+No significant changes.
 
 [float]
 [[release-notes-7.17.15]]


### PR DESCRIPTION
Adds 7.17.16 to the 7.17 release notes page. Based on the commits, it looks like it's mostly automated updates.

Does this look correct?

Related: https://github.com/elastic/dev/issues/2435