### PR TITLE
feat: use latest apm-data to set success `event.outcome` when otel span.Status is Unset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dgraph-io/badger/v2 v2.2007.3-0.20201012072640-f5a7e0a1c83b
 	github.com/dustin/go-humanize v1.0.1
 	github.com/elastic/apm-aggregation v0.0.0-20230815024520-e75a37d9ddd6
-	github.com/elastic/apm-data v0.1.1-0.20231019120308-82201b991ae5
+	github.com/elastic/apm-data v0.1.1-0.20231212041654-b2a4dabeb6e3
 	github.com/elastic/beats/v7 v7.0.0-alpha2.0.20231204124921-be42a3369f94
 	github.com/elastic/elastic-agent-client/v7 v7.5.0
 	github.com/elastic/elastic-agent-libs v0.7.2

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/elastic/apm-aggregation v0.0.0-20230815024520-e75a37d9ddd6 h1:Js+C3HE
 github.com/elastic/apm-aggregation v0.0.0-20230815024520-e75a37d9ddd6/go.mod h1:ba3gaJCuhxXN/O5AuiI56xxd6DukQdVOK0NfpzBntNo=
 github.com/elastic/apm-data v0.1.1-0.20231019120308-82201b991ae5 h1:URlDi0TZetSAo8KAIbaMZQhM5EG8+SDgs0jTen7WvMg=
 github.com/elastic/apm-data v0.1.1-0.20231019120308-82201b991ae5/go.mod h1:z4iJVl8vyQa5v5o7UapWGHTsycBKsKfJfILuf2TZpYo=
+github.com/elastic/apm-data v0.1.1-0.20231212041654-b2a4dabeb6e3 h1:pavWRIAjsPregjeLBOFlm6UBDbsVYXGuQh+ancXJNiw=
+github.com/elastic/apm-data v0.1.1-0.20231212041654-b2a4dabeb6e3/go.mod h1:z4iJVl8vyQa5v5o7UapWGHTsycBKsKfJfILuf2TZpYo=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20231204124921-be42a3369f94 h1:HGuZZvCTJHfw67Kv/3Dko1HRx2oWNc3ktz9xL7xRyu8=
 github.com/elastic/beats/v7 v7.0.0-alpha2.0.20231204124921-be42a3369f94/go.mod h1:C3d6os2PiO+aRDft33aQq94OwX0w83tut1R19QSWGB4=
 github.com/elastic/elastic-agent-autodiscover v0.6.4 h1:K+xC7OGgcy4fLXVuGgOGLs+eXCqRnRg2SQQinxP+KsA=


### PR DESCRIPTION
## Motivation/summary

_Note: Changelog can be updated after https://github.com/elastic/apm-server/pull/12172 is merged_

The latest [apm-data](https://github.com/elastic/apm-data/pull/188) has changed how we map `span.Status: Unset` when processing otel inputs. Currently, we set `event.outcome: unknown` when such input is received, but we decided to map it to `event.outcome: success`. 

This PR lets APM Server reflects this enhancement.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)~
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes
Ingest Otel data, make sure the span.Status is Unset. Then check the transaction doc containing `event.outcome: success`

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
