### PR TITLE
Define value for all constant_keyword fields in apmpackage

### DIFF
--- a/apmpackage/apm/changelog.yml
+++ b/apmpackage/apm/changelog.yml
@@ -1,5 +1,10 @@
 - version: generated
   changes:
+    - description: Define value for all constant_keyword fields; Use ecs for sampled_traces
+      type: bugfix
+      link: https://github.com/elastic/apm-server/pull/12219
+- version: 8.12.0
+  changes:
     - description: Add missing mappings for various fields
       type: enhancement
       link: https://github.com/elastic/apm-server/pull/12102

--- a/apmpackage/apm/data_stream/sampled_traces/fields/base-fields.yml
+++ b/apmpackage/apm/data_stream/sampled_traces/fields/base-fields.yml
@@ -1,12 +1,8 @@
 - name: '@timestamp'
-  type: date
-  description: Event timestamp.
+  external: ecs
 - name: data_stream.type
-  type: constant_keyword
-  description: Data stream type.
+  external: ecs
 - name: data_stream.dataset
-  type: constant_keyword
-  description: Data stream dataset.
+  external: ecs
 - name: data_stream.namespace
-  type: constant_keyword
-  description: Data stream namespace.
+  external: ecs

--- a/apmpackage/apm/data_stream/service_destination_interval_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/service_destination_interval_metrics/fields/fields.yml
@@ -1,8 +1,10 @@
 - name: metricset.name
   type: constant_keyword
+  value: service_destination
   description: Name of the set of metrics.
 - name: metricset.interval
   type: constant_keyword
+  value: {{ .Interval }}
   description: Metricset aggregation interval.
 - name: processor.event
   type: constant_keyword

--- a/apmpackage/apm/data_stream/service_summary_interval_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/service_summary_interval_metrics/fields/fields.yml
@@ -1,8 +1,10 @@
 - name: metricset.name
   type: constant_keyword
+  value: service_summary
   description: Name of the set of metrics.
 - name: metricset.interval
   type: constant_keyword
+  value: {{ .Interval }}
   description: Metricset aggregation interval.
 - name: processor.event
   type: constant_keyword

--- a/apmpackage/apm/data_stream/service_transaction_interval_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/service_transaction_interval_metrics/fields/fields.yml
@@ -1,8 +1,10 @@
 - name: metricset.name
   type: constant_keyword
+  value: service_transaction
   description: Name of the set of metrics.
 - name: metricset.interval
   type: constant_keyword
+  value: {{ .Interval }}
   description: Metricset aggregation interval.
 - name: processor.event
   type: constant_keyword

--- a/apmpackage/apm/data_stream/transaction_interval_metrics/fields/fields.yml
+++ b/apmpackage/apm/data_stream/transaction_interval_metrics/fields/fields.yml
@@ -1,5 +1,6 @@
 - name: metricset.interval
   type: constant_keyword
+  value: {{ .Interval }}
   description: Metricset aggregation interval.
 - name: faas.coldstart
   type: boolean
@@ -27,6 +28,7 @@
     Kubernetes pod name
 - name: metricset.name
   type: constant_keyword
+  value: transaction
   description: |
     Name of the set of metrics.
 - name: processor.event


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Define value for all `constant_keyword` fields in apmpackage to workaround Fleet upgrade bug. Under certain conditions, it is possible that apmpackage upgrade creates a lot of indices if constant_keyword does not have a value.

Targeting 8.12 branch because apmpackage has been moved to https://github.com/elastic/integrations/tree/main/packages/apm/data_stream on main.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

- Ingest APM data, upgrade package to a version that contains the fix, and verify that DS rollover is successful and mapping contains a value for constant keyword fields.

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
Closes #12159
