### PR TITLE
docs: fix incorrect filenames in a document for Windows

### DIFF
--- a/docs/getting-started-apm-server.asciidoc
+++ b/docs/getting-started-apm-server.asciidoc
@@ -284,12 +284,12 @@ If you are running Windows XP, you may need to download and install PowerShell.
 [source,shell]
 ----------------------------------------------------------------------
 PS > cd 'C:\Program Files\APM-Server'
-PS C:\Program Files\APM-Server> .\install-service-apm-server.ps1
+PS C:\Program Files\APM-Server> .\install-service.ps1
 ----------------------------------------------------------------------
 
 NOTE: If script execution is disabled on your system,
 you need to set the execution policy for the current session to allow the script to run.
-For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service-apm-server.ps1`.
+For example: `PowerShell.exe -ExecutionPolicy UnRestricted -File .\install-service.ps1`.
 
 endif::[]
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

After 8.5.0, the file name was changed from install-service-apm-server.ps1 to install-service.ps1, but it was not modified in the document.
I corrected an incorrect filename in the documentation for Windows.

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [X] Documentation has been updated

