### PR TITLE
auto-bump: docs/version.asciidoc does not exist

### DIFF
--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -96,15 +96,6 @@ targets:
       content: '{{ source "latestGoVersion" }}'
       file: .go-version
       matchpattern: '\d+.\d+.\d+'
-  update-version-asciidoc:
-    name: 'Update version.asciidoc with Golang version {{ source "latestGoVersion" }}'
-    sourceid: latestGoVersion
-    scmid: default
-    kind: file
-    spec:
-      file: docs/version.asciidoc
-      matchpattern: '(:go-version:) \d+.\d+.\d+'
-      replacepattern: '$1 {{ source "latestGoVersion" }}'
   update-dockerfile:
     name: 'Update Dockerfile with Golang version {{ source "latestGoVersion" }}'
     sourceid: latestGoVersion


### PR DESCRIPTION
## Motivation/summary

`docs/version.asciidoc` was removed in https://github.com/elastic/apm-server/pull/12341

Hence updating the `updatecli` pipeline definition accordingly.


## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Update [package changelog.yml](https://github.com/elastic/apm-server/blob/main/apmpackage/apm/changelog.yml) (only if changes to `apmpackage` have been made)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
