### PR TITLE
[7.17] ci(release): automate release steps for the minor (#12233)

### DIFF
--- a/.github/workflows/prepare-release/action.yml
+++ b/.github/workflows/prepare-release/action.yml
@@ -1,0 +1,109 @@
+---
+name: prepare-release
+description: Common tasks for preparing minor and patch releases
+
+inputs:
+  type:
+    description: 'Release type (minor or patch)'
+    required: true
+  version:
+    description: 'The version'
+    required: true
+  vault-url:
+    description: 'Vault URL'
+    required: true
+  vault-role-id:
+    description: 'Vault role ID'
+    required: true
+  vault-secret-id:
+    description: 'Vault secret ID'
+    required: true
+
+outputs:
+  release-branch:
+    description: "Release branch (relevant for minor releases)"
+    value: ${{ steps.generate.outputs.release-branch }}
+  release-version:
+    description: "Release version"
+    value: ${{ steps.generate.outputs.release-version }}
+  slack-thread:
+    description: "Slack thread id"
+    value: ${{ steps.slack-thread.outputs.threadTimestamp }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Send slack message when started
+      id: slack-thread
+      uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+      with:
+        url: ${{ inputs.vault-url }}
+        roleId: ${{ inputs.vault-role-id }}
+        secretId: ${{ inputs.vault-secret-id }}
+        channel: ${{ env.SLACK_CHANNEL }}
+        message: ":wave: This is the thread for the ${{ inputs.type }} release `${{ github.repository }}@${{ env.VERSION }}`. (<${{ env.JOB_URL }}|workflow run>)"
+      env:
+        VERSION: ${{ inputs.version }}
+        JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+    - id: generate
+      run: |-
+        echo "release-branch=${VERSION%.*}" >> "${GITHUB_OUTPUT}"
+        echo "release-version=${VERSION}" >> "${GITHUB_OUTPUT}"
+      env:
+        VERSION: ${{ inputs.version }}
+      shell: 'bash'
+
+    - name: validate version format (minor only)
+      if: ${{ inputs.type == 'minor' && ! endsWith(inputs.version, '0') }}
+      run: |-
+        FAILURE_MESSAGE='version is not a minor one but a patch (only support for <major>.<minor>.0)'
+        echo "FAILURE_MESSAGE=${FAILURE_MESSAGE}" >> "$GITHUB_ENV"
+        echo "::error::${FAILURE_MESSAGE}" ; exit 1
+      shell: 'bash'
+
+    - name: validate version format (patch only)
+      if: ${{ inputs.type == 'patch' && endsWith(inputs.version, '0') }}
+      run: |-
+        FAILURE_MESSAGE='version is not a patch one but a minor (only support for <major>.<minor>.[1-9]+[0-9]*)'
+        echo "FAILURE_MESSAGE=${FAILURE_MESSAGE}" >> "$GITHUB_ENV"
+        echo "::error::${FAILURE_MESSAGE}" ; exit 1
+      shell: 'bash'
+
+    - name: validate if branch already exists (minor only)
+      if: ${{ inputs.type == 'minor' }}
+      run: |-
+        if git ls-remote --exit-code --heads https://github.com/${{ github.repository }}.git "$BRANCH" > /dev/null ; then
+          FAILURE_MESSAGE='Branch already exists. This is not a minor release.'
+          echo "FAILURE_MESSAGE=${FAILURE_MESSAGE}" >> "$GITHUB_ENV"
+          echo "::error::${FAILURE_MESSAGE}" ; exit 1
+        fi
+      shell: 'bash'
+      env:
+        BRANCH: ${{ steps.generate.outputs.release-branch }}
+
+    - name: validate if tag already exists
+      run: |-
+        if git ls-remote --exit-code https://github.com/${{ github.repository }}.git "$TAG" > /dev/null ; then
+          FAILURE_MESSAGE='Tag already exists.'
+          echo "FAILURE_MESSAGE=${FAILURE_MESSAGE}" >> "$GITHUB_ENV"
+          echo "::error::${FAILURE_MESSAGE}" ; exit 1
+        fi
+      shell: 'bash'
+      env:
+        TAG: 'refs/tags/v${{ steps.generate.outputs.release-version }}'
+
+    - uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+      if: failure()
+      with:
+        url: ${{ inputs.vault-url }}
+        roleId: ${{ inputs.vault-role-id }}
+        secretId: ${{ inputs.vault-secret-id }}
+        channel: ${{ env.SLACK_CHANNEL }}
+        threadTimestamp: ${{ steps.slack-thread.outputs.threadTimestamp || '' }}
+        message: |-
+          :fire: Something went wrong with the ${{ inputs.type }} release preparation. It failed with the below error message:
+          `${{ env.FAILURE_MESSAGE }}`.
+          See <${{ env.JOB_URL }}|logs>.
+      env:
+        JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/run-minor-release.yml
+++ b/.github/workflows/run-minor-release.yml
@@ -5,18 +5,105 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The version (semver format: major.minor.patch)'
+        description: 'The version (semver format: major.minor.0)'
         required: true
         type: string
+
+# Avoid concurrency so we can watch the releases correctly
+concurrency:
+  group: ${{ github.workflow }}
 
 permissions:
   contents: read
 
 env:
-  SLACK_CHANNEL: "#apm-server-test-release"
-  
+  JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  SLACK_CHANNEL: "#apm-server"
+
 jobs:
-  run-minor:
+  prepare:
     runs-on: ubuntu-latest
+    outputs:
+      release-branch: ${{ steps.prepare.outputs.release-branch }}
+      release-version: ${{ steps.prepare.outputs.release-version }}
+      slack-thread: ${{ steps.prepare.outputs.slack-thread }}
     steps:
       - uses: actions/checkout@v4
+      - id: prepare
+        uses: ./.github/workflows/prepare-release
+        with:
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          version: ${{ inputs.version }}
+          type: 'minor'
+
+  run-minor:
+    runs-on: ubuntu-latest
+    needs: [ prepare ]
+    env:
+      RELEASE_BRANCH: ${{ needs.prepare.outputs.release-branch }}
+      RELEASE_VERSION: ${{ needs.prepare.outputs.release-version }}
+    permissions:
+      contents: write
+    steps:
+
+      - uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          channel: ${{ env.SLACK_CHANNEL }}
+          threadTimestamp: ${{ needs.prepare.outputs.slack-thread || '' }}
+          message: |-
+            Feature freeze for `${{ github.repository }}@${{ env.RELEASE_VERSION }}` just started.
+            The `${{ github.repository }}@${{ env.RELEASE_BRANCH }}` branch will be created Today.
+
+      - uses: actions/checkout@v4
+        with:
+          # 0 indicates all history for all branches and tags.
+          fetch-depth: 0
+
+      # Required to use a service account, otherwise PRs created by
+      # GitHub bot won't trigger any CI builds.
+      # See https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-537478081
+      - name: Configure github token
+        uses: elastic/apm-pipeline-library/.github/actions/github-token@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Configure git user
+        uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
+        with:
+          username: ${{ env.GIT_USER }}
+          email: ${{ env.GIT_EMAIL }}
+          token: ${{ env.GITHUB_TOKEN }}
+
+      - run: make minor-release
+        env:
+          GH_TOKEN: ${{ env.GITHUB_TOKEN }}
+
+      - uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        if: success()
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          channel: ${{ env.SLACK_CHANNEL }}
+          threadTimestamp: ${{ needs.prepare.outputs.slack-thread || '' }}
+          message: |-
+            `${{ github.repository }}@${{ env.RELEASE_BRANCH }}` is now available.
+            The docs and other references are updated. You can start using it.
+
+      - uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        if: failure()
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          channel: ${{ env.SLACK_CHANNEL }}
+          threadTimestamp: ${{ needs.prepare.outputs.slack-thread || '' }}
+          message: |-
+            :fire: Something went wrong with the release. See <${{ env.JOB_URL }}|logs>.

--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -9,14 +9,55 @@ on:
         required: true
         type: string
 
+# Avoid concurrency so we can watch the releases correctly
+concurrency:
+  group: ${{ github.workflow }}
+
 permissions:
   contents: read
 
 env:
-  SLACK_CHANNEL: "#apm-server-test-release"
+  JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  SLACK_CHANNEL: "#apm-server"
 
 jobs:
-  run-patch:
+  prepare:
     runs-on: ubuntu-latest
+    outputs:
+      release-version: ${{ steps.prepare.outputs.release-version }}
+      slack-thread: ${{ steps.prepare.outputs.slack-thread }}
     steps:
       - uses: actions/checkout@v4
+
+      - id: prepare
+        uses: ./.github/workflows/prepare-release
+        with:
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          version: ${{ inputs.version }}
+          type: 'patch'
+
+  run-patch:
+    runs-on: ubuntu-latest
+    needs: [ prepare ]
+    env:
+      RELEASE_VERSION: ${{ needs.prepare.outputs.release-version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # 0 indicates all history for all branches and tags.
+          fetch-depth: 0
+
+      - run: make patch-release
+
+      - uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          channel: ${{ env.SLACK_CHANNEL }}
+          threadTimestamp: ${{ needs.prepare.outputs.slack-thread || '' }}
+          message: |-
+            Feature freeze for `${{ github.repository }}@${{ env.RELEASE_VERSION }}` is Today.
+            All the relevant PRs and issues have been created.

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ html_docs
 docker-compose.yml.bck
 Dockerfile.bck
 version.asciidoc.bck
+.bck

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 
 # Enforce use of modules.
 export GO111MODULE=on
+include release.mk
 
 # Ensure the Go version in .go_version is installed and used.
 GOROOT?=$(shell ./script/run_with_go_ver go env GOROOT)

--- a/release.mk
+++ b/release.mk
@@ -1,0 +1,297 @@
+.SILENT:
+MAKEFLAGS += --no-print-directory
+.SHELLFLAGS = -euc
+SHELL = /bin/bash
+export PATH := $(CURDIR)/bin:$(PATH)
+
+#######################
+## Tools
+#######################
+
+ifeq ($(OS),Darwin)
+	SED ?= sed -i ".bck"
+else
+	SED ?= sed -i
+endif
+
+ARCH = $(shell uname -m)
+ifeq ($(ARCH),x86_64)
+	YQ_ARCH ?= amd64
+else
+	YQ_ARCH ?= arm64
+endif
+ifeq ($(OS),Darwin)
+	YQ_BINARY ?= yq_darwin_$(YQ_ARCH)
+else
+	YQ_BINARY ?= yq_linux_$(YQ_ARCH)
+endif
+YQ ?= yq
+YQ_VERSION ?= v4.13.2
+
+
+#######################
+## Properties
+#######################
+PROJECT_MAJOR_VERSION ?= $(shell echo $(RELEASE_VERSION) | cut -f1 -d.)
+PROJECT_MINOR_VERSION ?= $(shell echo $(RELEASE_VERSION) | cut -f2 -d.)
+PROJECT_PATCH_VERSION ?= $(shell echo $(RELEASE_VERSION) | cut -f3 -d.)
+PROJECT_OWNER ?= elastic
+RELEASE_TYPE ?= minor
+
+RELEASE_BRANCH ?= $(PROJECT_MAJOR_VERSION).$(PROJECT_MINOR_VERSION)
+NEXT_PROJECT_MINOR_VERSION ?= $(PROJECT_MAJOR_VERSION).$(shell expr $(PROJECT_MINOR_VERSION) + 1).0
+NEXT_RELEASE ?= $(RELEASE_BRANCH).$(shell expr $(PROJECT_PATCH_VERSION) + 1)
+
+# BASE_BRANCH select by release type (default patch)
+ifeq ($(RELEASE_TYPE),minor)
+	BASE_BRANCH ?= main
+endif
+
+ifeq ($(RELEASE_TYPE),patch)
+	BASE_BRANCH ?= $(RELEASE_BRANCH)
+	LATEST_RELEASE ?= $(RELEASE_BRANCH).$(shell expr $(PROJECT_PATCH_VERSION) - 1)
+endif
+
+#######################
+## Templates
+#######################
+## Changelog template
+define CHANGELOG_TMPL
+[[release-notes-head]]
+== APM version HEAD
+
+https://github.com/elastic/apm-server/compare/$(RELEASE_BRANCH)\...main[View commits]
+
+[float]
+==== Breaking Changes
+
+[float]
+==== Deprecations
+
+[float]
+==== Intake API Changes
+
+[float]
+==== Added
+endef
+
+#######################
+## Public make goals
+#######################
+
+# This is the contract with the GitHub action .github/workflows/run-minor-release.yml.
+# The GitHub action will provide the below environment variables:
+#  - RELEASE_VERSION
+#
+.PHONY: minor-release
+minor-release:
+	@echo "INFO: Create release branch and update new version $(RELEASE_VERSION)"
+	$(MAKE) create-branch NAME=$(RELEASE_BRANCH) BASE=$(BASE_BRANCH)
+	$(MAKE) update-version VERSION=$(RELEASE_VERSION)
+	$(MAKE) update-version-makefile VERSION=$(PROJECT_MAJOR_VERSION)\.$(PROJECT_MINOR_VERSION)
+	$(MAKE) create-commit COMMIT_MESSAGE="[Release] update version $(RELEASE_VERSION)"
+
+	@echo "INFO: Create feature branch and update the versions. Target branch $(RELEASE_BRANCH)"
+	$(MAKE) create-branch NAME=changelog-$(RELEASE_BRANCH) BASE=$(RELEASE_BRANCH)
+	$(MAKE) update-changelog VERSION=$(RELEASE_BRANCH)
+	$(MAKE) create-commit COMMIT_MESSAGE="docs: Update changelogs for $(RELEASE_BRANCH) release"
+
+	@echo "INFO: Create feature branch and update the versions. Target branch $(BASE_BRANCH)"
+	$(MAKE) create-branch NAME=update-$(RELEASE_VERSION) BASE=$(BASE_BRANCH)
+	$(MAKE) update-docs VERSION=$(RELEASE_VERSION)
+	$(MAKE) update-mergify VERSION=$(RELEASE_BRANCH)
+	$(MAKE) update-version VERSION=$(NEXT_PROJECT_MINOR_VERSION)
+	$(MAKE) create-commit COMMIT_MESSAGE="[Release] update version $(NEXT_PROJECT_MINOR_VERSION)"
+	$(MAKE) rename-changelog VERSION=$(RELEASE_BRANCH)
+	$(MAKE) create-commit COMMIT_MESSAGE="[Release] update changelogs for $(RELEASE_BRANCH) release"
+
+	@echo "INFO: Push changes to $(PROJECT_OWNER)/apm-server and create the relevant Pull Requests"
+	git push origin $(RELEASE_BRANCH)
+	$(MAKE) create-pull-request BRANCH=update-$(RELEASE_VERSION) TARGET_BRANCH=$(BASE_BRANCH) TITLE="$(RELEASE_BRANCH): update docs, mergify, versions and changelogs"
+	$(MAKE) create-pull-request BRANCH=changelog-$(RELEASE_BRANCH) TARGET_BRANCH=$(RELEASE_BRANCH) TITLE="$(RELEASE_BRANCH): update docs"
+
+# This is the contract with the GitHub action .github/workflows/run-patch-release.yml
+# The GitHub action will provide the below environment variables:
+#  - RELEASE_VERSION
+#
+.PHONY: patch-release
+patch-release:
+	@echo "VERSION: $${RELEASE_VERSION}"
+	@echo 'TODO: prepare-patch-release'
+	@echo 'TODO: create-prs-patch-release'
+
+############################################
+## Internal make goals to bump versions
+############################################
+
+# Rename changelog file to generate something similar to https://github.com/elastic/apm-server/pull/12172
+.PHONY: rename-changelog
+export CHANGELOG_TMPL
+rename-changelog: VERSION=$${VERSION}
+rename-changelog:
+	$(MAKE) common-changelog
+	@echo ">> rename-changelog"
+	echo "$$CHANGELOG_TMPL" > changelogs/head.asciidoc
+	@if ! grep -q 'release-notes-$(VERSION)' CHANGELOG.asciidoc ; then \
+		awk "NR==2{print \"* <<release-notes-$(VERSION)>>\"}1" CHANGELOG.asciidoc > CHANGELOG.asciidoc.new; \
+		mv CHANGELOG.asciidoc.new CHANGELOG.asciidoc ; \
+	fi
+	@if ! grep -q '$(VERSION).asciidoc' CHANGELOG.asciidoc ; then \
+		$(SED) -E -e 's#(head.asciidoc\[\])#\1\ninclude::.\/changelogs\/$(VERSION).asciidoc[]#g' CHANGELOG.asciidoc; \
+	fi
+	@if ! grep -q 'release-notes-$(VERSION)' docs/release-notes.asciidoc ; then \
+		awk "NR==12{print \"* <<release-notes-$(VERSION)>>\"}1" docs/release-notes.asciidoc > docs/release-notes.asciidoc.new ; \
+		mv docs/release-notes.asciidoc.new docs/release-notes.asciidoc ; \
+	fi
+
+# Update changelog file to generate something similar to https://github.com/elastic/apm-server/pull/12220
+.PHONY: update-changelog
+update-changelog: VERSION=$${VERSION}
+update-changelog:
+	$(MAKE) common-changelog
+	@echo ">> update-changelog"
+	$(SED) 's#head#$(VERSION)#g' CHANGELOG.asciidoc
+
+# Common changelog file steps
+# TODO: changelogs/$(VERSION).asciidoc requires further manipulation to remove empty entries.
+.PHONY: common-changelog
+common-changelog: VERSION=$${VERSION}
+common-changelog:
+	@echo ">> common-changelog"
+	mv changelogs/head.asciidoc changelogs/$(VERSION).asciidoc
+	$(SED) 's#head#$(VERSION)#gI' changelogs/$(VERSION).asciidoc
+	$(SED) -E -e 's#(\...)main#\1$(VERSION)#g' changelogs/$(VERSION).asciidoc
+	awk "NR==5{print \"\n* <<release-notes-$(VERSION).0>>\n\n[float]\n[[release-notes-$(VERSION).0]]\n=== APM version $(VERSION).0\"}1" changelogs/$(VERSION).asciidoc > changelogs/$(VERSION).asciidoc.new
+	mv changelogs/$(VERSION).asciidoc.new changelogs/$(VERSION).asciidoc
+
+## Update project documentation.
+.PHONY: update-docs
+update-docs: VERSION=$${VERSION}
+update-docs: setup-yq
+	@echo ">> update-docs"
+	$(YQ) e --inplace '.[] |= with_entries((select(.value == "generated") | .value) ="$(VERSION)")' ./apmpackage/apm/changelog.yml; \
+	$(YQ) e --inplace '[{"version": "generated", "changes":[{"description": "Placeholder", "type": "enhancement", "link": "https://github.com/elastic/apm-server/pull/123"}]}] + .' ./apmpackage/apm/changelog.yml;
+
+## Update the references on .mergify.yml with the new minor release.
+.PHONY: update-mergify
+update-mergify: VERSION=$${VERSION}
+update-mergify:
+	@echo ">> update-mergify"
+	@if ! grep -q 'backport-$(VERSION)' .mergify.yml ; then \
+		echo "Update mergify with backport-$(VERSION)" ; \
+		echo '  - name: backport patches to $(VERSION) branch'                                  >> .mergify.yml ; \
+		echo '    conditions:'                                                                  >> .mergify.yml; \
+		echo '      - merged'                                                                   >> .mergify.yml; \
+		echo '      - base=main'                                                                >> .mergify.yml; \
+		echo '      - label=backport-$(VERSION)'                                                >> .mergify.yml; \
+		echo '    actions:'                                                                     >> .mergify.yml; \
+		echo '      backport:'                                                                  >> .mergify.yml; \
+		echo '        assignees:'                                                               >> .mergify.yml; \
+		echo '          - "{{ author }}"'                                                       >> .mergify.yml; \
+		echo '        branches:'                                                                >> .mergify.yml; \
+		echo '          - "$(VERSION)"'                                                         >> .mergify.yml; \
+		echo '        labels:'                                                                  >> .mergify.yml; \
+		echo '          - "backport"'                                                           >> .mergify.yml; \
+		echo '        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"' >> .mergify.yml; \
+	else \
+		echo "::warn::Mergify already contains backport-$(VERSION)"; \
+	fi
+
+## Update the version in the different files with the hardcoded version.
+.PHONY: update-version
+update-version: VERSION=$${VERSION}
+update-version:
+	@echo ">> update-version"
+	if [ -f "cmd/intake-receiver/version.go" ]; then \
+		$(SED) -E -e 's#(version[[:blank:]]*)=[[:blank:]]*"[0-9]+\.[0-9]+\.[0-9]+#\1= "$(VERSION)#g' cmd/intake-receiver/version.go; \
+	fi
+	if [ -f "internal/version/version.go" ]; then \
+		$(SED) -E -e 's#(Version[[:blank:]]*)=[[:blank:]]*"[0-9]+\.[0-9]+\.[0-9]+#\1= "$(VERSION)#g' internal/version/version.go; \
+	fi
+
+## Update the version in the different files with the hardcoded version. Legacy stuff
+## @DEPRECATED: likely in the 7.17 branch
+.PHONY: update-version-legacy
+update-version-legacy: VERSION=$${VERSION} PREVIOUS_VERSION=$${PREVIOUS_VERSION}
+update-version-legacy:
+	@echo ">> update-version-legacy"
+	if [ -f "cmd/version.go" ]; then \
+		$(SED) -E -e 's#(defaultBeatVersion[[:blank:]]*)=[[:blank:]]*"[0-9]+\.[0-9]+\.[0-9]+#\1= "$(VERSION)#g' cmd/version.go; \
+	fi
+	if [ -f "apmpackage/apm/changelog.yml" ]; then \
+		$(SED) -E -e 's#(version[[:blank:]]*):[[:blank:]]*"$(PREVIOUS_VERSION)#\1: "$(VERSION)#g' apmpackage/apm/changelog.yml; \
+	fi
+	if [ -f "apmpackage/apm/manifest.yml" ]; then \
+		$(SED) -E -e 's#(version[[:blank:]]*):[[:blank:]]*$(PREVIOUS_VERSION)#\1: $(VERSION)#g' apmpackage/apm/manifest.yml; \
+	fi
+
+## Update project version in the Makefile.
+.PHONY: update-version-makefile
+update-version-makefile: VERSION=$${VERSION}
+update-version-makefile:
+	@echo ">> update-version-makefile"
+	$(SED) -E -e 's#BEATS_VERSION\s*\?=\s*(([0-9]+\.[0-9]+)|main)#BEATS_VERSION\?=$(VERSION)#g' Makefile
+
+############################################
+## Internal make goals to interact with Git
+############################################
+
+## Create a new branch
+## It will delete the branch if it already exists before the creation.
+.PHONY: create-branch
+create-branch: NAME=$${NAME} BASE=$${BASE}
+create-branch:
+	@echo "::group::create-branch $(NAME)"
+	git checkout $(BASE)
+	git branch -D $(NAME) &>/dev/null || true
+	git checkout $(BASE) -b $(NAME)
+	@echo "::endgroup::"
+
+## Create a new commit only if there is a diff.
+.PHONY: create-commit
+create-commit:
+	$(MAKE) git-diff
+	@echo "::group::create-commit"
+	if [ ! -z "$$(git status -s)" ]; then \
+		git status -s; \
+		git add --all; \
+		git commit -a -m "$(COMMIT_MESSAGE)"; \
+	fi
+	@echo "::endgroup::"
+
+## @help:create-pull-request:Create pull request
+.PHONY: create-pull-request
+create-pull-request: BRANCH=$${BRANCH} TITLE=$${TITLE} TARGET_BRANCH=$${TARGET_BRANCH}
+create-pull-request:
+	@echo "::group::create-pull-request"
+	git push origin $(BRANCH)
+	gh pr create \
+		--title "$(TITLE)" \
+		--body "Merge as soon as $(TARGET_BRANCH) branch is created." \
+		--base $(TARGET_BRANCH) \
+		--head $(BRANCH) \
+		--label 'release' \
+		--reviewer "$(PROJECT_REVIEWERS)" \
+		--repo $(PROJECT_OWNER)/apm-server || echo "There is no changes"
+	@echo "::endgroup::"
+
+## Diff output
+.PHONY: git-diff
+git-diff:
+	@echo "::group::git-diff"
+	git --no-pager  diff || true
+	@echo "::endgroup::"
+
+############################################
+## Internal make goals to install tools
+############################################
+
+## @help:setup-yq:Install yq in CURDIR/bin/yq.
+.PHONY: setup-yq
+setup-yq:
+	if [ ! -x "$$(command -v $(YQ))" ] && [ ! -f "$(CURDIR)/bin/$(YQ)" ]; then \
+		echo ">> Downloading $(YQ) - $(YQ_VERSION)/$(YQ_BINARY)" ; \
+		curl -sSfL -o $(CURDIR)/bin/yq https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/$(YQ_BINARY) ; \
+		chmod +x $(CURDIR)/bin/$(YQ); \
+	fi
+


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [ci(release): automate release steps for the minor (#12233)](https://github.com/elastic/apm-server/pull/12233)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)