### PR TITLE
auto-bump: docs/version.asciidoc does not exist

### DIFF
--- a/script/update_go_version.sh
+++ b/script/update_go_version.sh
@@ -18,7 +18,7 @@ GOVERSION=$(go env GOVERSION | sed 's/^go//')
 find -name go.mod -execdir go get toolchain@$GOVERSION \;
 echo $GOVERSION > .go-version
 sed -i "s/golang:[[:digit:]]\+\(\.[[:digit:]]\+\)\{1,2\}/golang:$GOVERSION/" packaging/docker/Dockerfile
-sed -i "s/^:go-version:.*/:go-version: $GOVERSION/" docs/version.asciidoc
+[ -e "docs/version.asciidoc" ] && sed -i "s/^:go-version:.*/:go-version: $GOVERSION/" docs/version.asciidoc || echo "skipped"
 sed -i "s/\(\[Go\]\[golang-download\]\) [[:digit:]].*/\1 $GOMOD_VERSION.x/" README.md
 sed -i "s/toolchain go[[:digit:]]\+\(\.[[:digit:]]\+\)\{1,2\}/toolchain go$GOVERSION/" tools/go.mod
 sed -i "s/toolchain go[[:digit:]]\+\(\.[[:digit:]]\+\)\{1,2\}/toolchain go$GOVERSION/" internal/glog/go.mod

--- a/script/update_go_version.sh
+++ b/script/update_go_version.sh
@@ -18,7 +18,6 @@ GOVERSION=$(go env GOVERSION | sed 's/^go//')
 find -name go.mod -execdir go get toolchain@$GOVERSION \;
 echo $GOVERSION > .go-version
 sed -i "s/golang:[[:digit:]]\+\(\.[[:digit:]]\+\)\{1,2\}/golang:$GOVERSION/" packaging/docker/Dockerfile
-[ -e "docs/version.asciidoc" ] && sed -i "s/^:go-version:.*/:go-version: $GOVERSION/" docs/version.asciidoc || echo "skipped"
 sed -i "s/\(\[Go\]\[golang-download\]\) [[:digit:]].*/\1 $GOMOD_VERSION.x/" README.md
 sed -i "s/toolchain go[[:digit:]]\+\(\.[[:digit:]]\+\)\{1,2\}/toolchain go$GOVERSION/" tools/go.mod
 sed -i "s/toolchain go[[:digit:]]\+\(\.[[:digit:]]\+\)\{1,2\}/toolchain go$GOVERSION/" internal/glog/go.mod


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Recent changes in the docs removed the versions.asciidoc. 

Let's support it only if the file exists.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
