### PR TITLE
Log number of bytes read from HTTP request body

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -20,3 +20,4 @@ https://github.com/elastic/apm-server/compare/8.12\...main[View commits]
 ==== Added
 - map OTel's `span.Status: Unset` to `event.outcome: success` instead of `event.outcome: unknown`
 - Add support for Otel code.stacktrace {pull}12096[12096]
+- `http.request.body.bytes` now reports the bytes read from request body even if Content-Length is -1 {pull}12451[12451]

--- a/internal/beater/middleware/log_middleware.go
+++ b/internal/beater/middleware/log_middleware.go
@@ -46,6 +46,7 @@ func LogMiddleware() Middleware {
 			}
 			h(c)
 			c.Logger = c.Logger.With("event.duration", time.Since(c.Timestamp))
+			c.Logger = c.Logger.With("http.request.body.bytes", c.RequestBodyBytes())
 			if c.MultipleWriteAttempts() {
 				c.Logger.Warn("multiple write attempts")
 			}
@@ -74,9 +75,6 @@ func loggerWithRequestContext(c *request.Context) *logp.Logger {
 	}
 	if c.ClientIP.IsValid() && c.ClientIP != c.SourceIP {
 		logger = logger.With("client.ip", c.ClientIP.String())
-	}
-	if c.Request.ContentLength != -1 {
-		logger = logger.With("http.request.body.bytes", c.Request.ContentLength)
 	}
 	return logger
 }


### PR DESCRIPTION
## Motivation/summary

If Content-Length is not -1, report that in http.request.body.bytes, otherwise report the number of bytes read from the body. This can be useful for monitoring the rate of bytes ingested, even when agents use chunked encoding to stream data to the server.

## Checklist

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

1. Using `curl` send some requests to `/intake/v2/events`, with and without `Tranfer-Encoding: chunked`
2. Verify that the HTTP request logs report the request body size is reported correctly

## Related issues

None