### PR TITLE
test: set memqueue min_events to 0 when using null output

### DIFF
--- a/internal/beater/beatertest/server.go
+++ b/internal/beater/beatertest/server.go
@@ -108,7 +108,8 @@ func NewUnstartedServer(t testing.TB, opts ...option) *Server {
 	require.NoError(t, err)
 	if !outputConfig.Output.IsSet() {
 		err = cfg.Merge(map[string]any{
-			"output.null": map[string]any{},
+			"output.null":                map[string]any{},
+			"queue.mem.flush.min_events": 0,
 		})
 		require.NoError(t, err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

A null output is using a memqueue under the hood, buffering events and leading to delayed ack. On shutdown/close the Acker is hanging/waiting for the events to be acknowledged which happens after the timeout is hit.
This happens on multiple tests, particularly on TestServerCORS, causing a severe slowdown.

Set queue.mem.flush.min_events to 0 to flush immediately.

TestServerCORS time went from 30s to 0.07s

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

Run `go test -v ./internal/beater/. -run=TestServerCORS` before and after.

Observe test time going from 30s to ~0.05s

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
