### PR TITLE
release(patch): use the makefile defined in the release branch

### DIFF
--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -24,6 +24,7 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
+      release-branch: ${{ steps.prepare.outputs.release-branch }}
       release-version: ${{ steps.prepare.outputs.release-version }}
       slack-thread: ${{ steps.prepare.outputs.slack-thread }}
     steps:
@@ -42,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ prepare ]
     env:
+      RELEASE_BRANCH: ${{ needs.prepare.outputs.release-branch }}
       RELEASE_VERSION: ${{ needs.prepare.outputs.release-version }}
     permissions:
       contents: write
@@ -50,6 +52,8 @@ jobs:
         with:
           # 0 indicates all history for all branches and tags.
           fetch-depth: 0
+          # Use the makefile in the given release branch.
+          ref: ${{ env.RELEASE_BRANCH }}
 
       # Required to use a service account, otherwise PRs created by
       # GitHub bot won't trigger any CI builds.


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

* patch releases should use the `release.mk` file  in the `release` branch
* minor releases should use the makefile in the `main` branch, there is a caveat that the make goals might differ between branches defined in `release.mk`

For the latter, I need to figure out whether to use a cloned repository in a different location, but for now, any changes in the `release.mk` should be backported to any of the active branches.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
