### PR TITLE
Revert "backstage: add tags and consumesApi"

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -23,15 +23,11 @@ metadata:
   links:
     - title: Pipeline
       url: https://buildkite.com/elastic/apm-server-package
-  tags:
-    - buildkite
-    - dra
+
 spec:
   type: buildkite-pipeline
   owner: group:apm-server
   system: buildkite
-  consumesApis:
-    - active-branches
   implementation:
     apiVersion: buildkite.elastic.dev/v1
     kind: Pipeline


### PR DESCRIPTION
Reverts elastic/apm-server#12497

Unfortunately the current backstage implementation does not support all the YAML syntax in https://backstage.io/docs/features/software-catalog/descriptor-format/

so `consumesApis` is not supported in resources but in components.

Hence I'll revert this