### PR TITLE
feat: consume APM configuration over the elastic-agent control protocol

### DIFF
--- a/internal/beater/waitready.go
+++ b/internal/beater/waitready.go
@@ -25,6 +25,7 @@ import (
 
 	"go.elastic.co/apm/v2"
 
+	"github.com/elastic/apm-server/internal/instrumentation"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
@@ -33,11 +34,12 @@ import (
 func waitReady(
 	ctx context.Context,
 	interval time.Duration,
-	tracer *apm.Tracer,
+	provider *instrumentation.Provider,
 	logger *logp.Logger,
 	check func(context.Context) error,
 ) error {
 	logger.Info("blocking ingestion until all preconditions are satisfied")
+	tracer := provider.Tracer()
 	tx := tracer.StartTransaction("wait_for_preconditions", "init")
 	defer tx.End()
 	ctx = apm.ContextWithTransaction(ctx, tx)

--- a/internal/instrumentation/config.go
+++ b/internal/instrumentation/config.go
@@ -1,0 +1,39 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package instrumentation
+
+import "github.com/elastic/elastic-agent-libs/config"
+
+type cfg struct {
+	isManaged bool
+	baseCfg   *config.C
+}
+
+type Option func(*cfg)
+
+func WithBaseCfg(baseCfg *config.C) Option {
+	return func(c *cfg) {
+		c.baseCfg = baseCfg
+	}
+}
+
+func IsManaged(t bool) Option {
+	return func(c *cfg) {
+		c.isManaged = t
+	}
+}

--- a/internal/instrumentation/provider.go
+++ b/internal/instrumentation/provider.go
@@ -1,0 +1,161 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package instrumentation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sync/atomic"
+
+	"go.elastic.co/apm/module/apmotel/v2"
+	"go.elastic.co/apm/v2"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/elastic/apm-server/internal/version"
+	"github.com/elastic/beats/v7/libbeat/instrumentation"
+	"github.com/elastic/elastic-agent-client/v7/pkg/client"
+	"github.com/elastic/elastic-agent-libs/config"
+)
+
+type Provider struct {
+	tracer   atomic.Value
+	cancel   context.CancelFunc
+	listener net.Listener
+}
+
+func New(opts ...Option) (*Provider, error) {
+	cfg := &cfg{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	p := &Provider{}
+
+	if !cfg.isManaged && false {
+		if err := p.updateTracer(cfg.baseCfg); err != nil {
+			return nil, fmt.Errorf("failed to update tracer: %w", err)
+		}
+
+		return p, nil
+	}
+
+	ver := client.VersionInfo{
+		Name:    "apm-server",
+		Version: version.Version,
+		//BuildHash: version.CommitHash(),
+	}
+	c, _, err := client.NewV2FromReader(os.Stdin, ver)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new v2 client: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if err := c.Start(ctx); err != nil {
+		cancel()
+		return nil, fmt.Errorf("failed to start agent v2 client: %w", err)
+	}
+
+	p.cancel = cancel
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case change := <-c.UnitChanges():
+				if change.Triggers == client.TriggeredAPMChange {
+					apmConfig := change.Unit.Expected().APMConfig.Elastic
+					bb, err := protojson.Marshal(apmConfig)
+					if err != nil {
+						panic(err)
+					}
+					var m map[string]any
+					if err := json.Unmarshal(bb, &m); err != nil {
+						panic(err)
+					}
+					newCfg, err := config.NewConfigFrom(m)
+					if err != nil {
+						panic(err)
+					}
+
+					if err := p.updateTracer(newCfg); err != nil {
+						panic(err)
+					}
+				}
+			case err := <-c.Errors():
+				if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, io.EOF) {
+					fmt.Fprintf(os.Stderr, "GRPC client error: %+v\n", err)
+				}
+			}
+		}
+	}()
+
+	return p, nil
+}
+
+func (p *Provider) updateTracer(rawConfig *config.C) error {
+	instrumentation, err := instrumentation.New(rawConfig, "apm-server", version.Version)
+	if err != nil {
+		return fmt.Errorf("failed to create instrumentation: %w", err)
+	}
+
+	tracer := instrumentation.Tracer()
+	p.listener = instrumentation.Listener()
+
+	tracerProvider, err := apmotel.NewTracerProvider(apmotel.WithAPMTracer(tracer))
+	if err != nil {
+		return fmt.Errorf("failed to create trace provider: %w", err)
+	}
+	otel.SetTracerProvider(tracerProvider)
+
+	exporter, err := apmotel.NewGatherer()
+	if err != nil {
+		return fmt.Errorf("failed to create gatherer: %w", err)
+	}
+	meterProvider := metric.NewMeterProvider(
+		metric.WithReader(exporter),
+	)
+	otel.SetMeterProvider(meterProvider)
+	tracer.RegisterMetricsGatherer(exporter)
+
+	p.tracer.Store(tracer)
+
+	return nil
+}
+
+func (p *Provider) Tracer() *apm.Tracer {
+	return p.tracer.Load().(*apm.Tracer)
+}
+
+func (p *Provider) Listener() net.Listener {
+	return p.listener
+}
+
+func (p *Provider) Close() error {
+	p.Tracer().Close()
+	p.cancel()
+	return nil
+}

--- a/internal/publish/pub.go
+++ b/internal/publish/pub.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"go.elastic.co/apm/v2"
 	"go.elastic.co/fastjson"
 
 	"github.com/elastic/beats/v7/libbeat/beat"
@@ -47,7 +46,6 @@ type Reporter func(context.Context, PendingReq) error
 // concurrent HTTP requests trying to publish at the same time is limited.
 type Publisher struct {
 	stopped chan struct{}
-	tracer  *apm.Tracer
 	client  beat.Client
 
 	mu              sync.RWMutex
@@ -73,10 +71,9 @@ var (
 //
 // GOMAXPROCS goroutines are started for forwarding events to libbeat.
 // Stop must be called to close the beat.Client and free resources.
-func NewPublisher(pipeline beat.Pipeline, tracer *apm.Tracer) (*Publisher, error) {
+func NewPublisher(pipeline beat.Pipeline) (*Publisher, error) {
 	processingCfg := beat.ProcessingConfig{}
 	p := &Publisher{
-		tracer:  tracer,
 		stopped: make(chan struct{}),
 
 		// One request will be actively processed by the

--- a/internal/publish/pub_test.go
+++ b/internal/publish/pub_test.go
@@ -31,8 +31,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.elastic.co/apm/v2/apmtest"
-
 	"github.com/elastic/beats/v7/libbeat/beat"
 	"github.com/elastic/beats/v7/libbeat/idxmgmt"
 	"github.com/elastic/beats/v7/libbeat/outputs"
@@ -52,7 +50,7 @@ func TestPublisherStop(t *testing.T) {
 	// Create a pipeline with a limited queue size and no outputs,
 	// so we can simulate a pipeline that blocks indefinitely.
 	pipeline, client := newBlockingPipeline(t)
-	publisher, err := publish.NewPublisher(pipeline, apmtest.DiscardTracer)
+	publisher, err := publish.NewPublisher(pipeline)
 	require.NoError(t, err)
 	defer func() {
 		cancelledContext, cancel := context.WithCancel(context.Background())
@@ -88,7 +86,7 @@ func TestPublisherStop(t *testing.T) {
 
 func TestPublisherStopShutdownInactive(t *testing.T) {
 	pipeline, _ := newBlockingPipeline(t)
-	publisher, err := publish.NewPublisher(pipeline, apmtest.DiscardTracer)
+	publisher, err := publish.NewPublisher(pipeline)
 	require.NoError(t, err)
 
 	// There are no active events, so the publisher should stop immediately
@@ -153,7 +151,6 @@ func BenchmarkPublisher(b *testing.B) {
 	acker.Open()
 	publisher, err := publish.NewPublisher(
 		pipetool.WithACKer(pipeline, acker),
-		apmtest.DiscardTracer,
 	)
 	require.NoError(b, err)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Consume APM configuration over the elastic-agent control protocol. Pin elastic-agent-client version to 7.6.0 until beats is updated.

Create a new instrumentation package to retrieve the tracer dynamically. It might need some changes in go-docappender and other packages to allow updating the tracer.


## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

Testing is a nightmare and can't be easily performed. We can't run elastic-agent locally and the ea-managed apm-server system test is broken.
Current approach is to start the ea-managed smoke test, manually install elastic-agent, upload apm-server binary to replace the apm-server component and restart elastic-agent.

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
