### PR TITLE
Fix OS Smoke tests

### DIFF
--- a/testing/infra/terraform/modules/standalone_apm_server/latest_elastic_agent.sh
+++ b/testing/infra/terraform/modules/standalone_apm_server/latest_elastic_agent.sh
@@ -8,4 +8,4 @@ if [[ -z ${VERSION} ]] || [[ "${VERSION}" == "latest" ]]; then
 fi
 LATEST_BUILD=$(curl -s "https://artifacts-api.elastic.co/v1/versions/${VERSION}/builds/" | jq -r '.builds[0]')
 
-curl -s "https://artifacts-api.elastic.co/v1/versions/${VERSION}/builds/${LATEST_BUILD}/projects/elastic-agent" | jq -r ".project.packages | {deb: .\"elastic-agent-${VERSION}-amd64.deb\".url, rpm: .\"elastic-agent-${VERSION}-x86_64.rpm\".url }"
+curl -s "https://artifacts-api.elastic.co/v1/versions/${VERSION}/builds/${LATEST_BUILD}/projects/elastic-agent-package" | jq -r ".project.packages | {deb: .\"elastic-agent-${VERSION}-amd64.deb\".url, rpm: .\"elastic-agent-${VERSION}-x86_64.rpm\".url }"


### PR DESCRIPTION
## Motivation/summary

`elastic-agent` was split into two package, `elastic-agent-package` and `elastic-agent-core`, causing the installation script to fail obtaining the correct URL.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
