### PR TITLE
docs: Consistify links to commits in release notes

### DIFF
--- a/changelogs/8.10.asciidoc
+++ b/changelogs/8.10.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.10]]
 == APM version 8.10
 
-https://github.com/elastic/apm-server/compare/8.9\...8.10[View commits]
-
 * <<release-notes-8.10.4>>
 * <<release-notes-8.10.3>>
 * <<release-notes-8.10.2>>
@@ -13,6 +11,8 @@ https://github.com/elastic/apm-server/compare/8.9\...8.10[View commits]
 [[release-notes-8.10.4]]
 === APM version 8.10.4
 
+https://github.com/elastic/apm-server/compare/v8.10.3\...v8.10.4[View commits]
+
 [float]
 ==== Bug fixes
 
@@ -22,17 +22,23 @@ https://github.com/elastic/apm-server/compare/8.9\...8.10[View commits]
 [[release-notes-8.10.3]]
 === APM version 8.10.3
 
+https://github.com/elastic/apm-server/compare/v8.10.2\...v8.10.3[View commits]
+
 No significant changes.
 
 [float]
 [[release-notes-8.10.2]]
 === APM version 8.10.2
 
+https://github.com/elastic/apm-server/compare/v8.10.2\...v8.10.1[View commits]
+
 No significant changes.
 
 [float]
 [[release-notes-8.10.1]]
 === APM version 8.10.1
+
+https://github.com/elastic/apm-server/compare/v8.10.2\...v8.10.1[View commits]
 
 [float]
 ==== Bug fixes
@@ -41,6 +47,8 @@ Fix tail-based sampling discarding low throughput and low sample rate traces {pu
 [float]
 [[release-notes-8.10.0]]
 === APM version 8.10.0
+
+https://github.com/elastic/apm-server/compare/v8.9.2\...v8.10.0[View commits]
 
 [float]
 ==== Breaking Changes

--- a/changelogs/8.11.asciidoc
+++ b/changelogs/8.11.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.11]]
 == APM version 8.11
 
-https://github.com/elastic/apm-server/compare/8.10\...8.11[View commits]
-
 * <<release-notes-8.11.4>>
 * <<release-notes-8.11.3>>
 * <<release-notes-8.11.2>>
@@ -46,6 +44,8 @@ No significant changes.
 [float]
 [[release-notes-8.11.0]]
 === APM version 8.11.0
+
+https://github.com/elastic/apm-server/compare/v8.10.4\...v8.11.0[View commits]
 
 [float]
 ==== Breaking Changes

--- a/changelogs/8.12.asciidoc
+++ b/changelogs/8.12.asciidoc
@@ -1,13 +1,13 @@
 [[release-notes-8.12]]
 == APM version 8.12
 
-https://github.com/elastic/apm-server/compare/8.11\...8.12[View commits]
-
 * <<release-notes-8.12.0>>
 
 [float]
 [[release-notes-8.12.0]]
 === APM version 8.12.0
+
+https://github.com/elastic/apm-server/compare/v8.11.4\...v8.12.0[View commits]
 
 [float]
 ==== Breaking Changes

--- a/changelogs/8.5.asciidoc
+++ b/changelogs/8.5.asciidoc
@@ -12,6 +12,8 @@ https://github.com/elastic/apm-server/compare/8.4\...8.5[View commits]
 [[release-notes-8.5.3]]
 === APM version 8.5.3
 
+https://github.com/elastic/apm-server/compare/v8.5.2\...v8.5.3[View commits]
+
 [float]
 ==== Bug fixes
 - OpenTelemetry GRPC Spans from the Javascript API/SDK/Instrumentations are now correctly transformed into transactions with type=`request` {pull}9308[9308]

--- a/changelogs/8.6.asciidoc
+++ b/changelogs/8.6.asciidoc
@@ -30,6 +30,8 @@ https://github.com/elastic/apm-server/compare/v8.6.0\...v8.6.1[View commits]
 [[release-notes-8.6.0]]
 === APM version 8.6.0
 
+https://github.com/elastic/apm-server/compare/v8.5.3\...v8.6.0[View commits]
+
 [float]
 ==== Breaking Changes
 - `apm-server.decoder.*` stack monitoring metrics are no longer recorded {pull}9210[9210]

--- a/changelogs/8.7.asciidoc
+++ b/changelogs/8.7.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.7]]
 == APM version 8.7
 
-https://github.com/elastic/apm-server/compare/8.6\...8.7[View commits]
-
 * <<release-notes-8.7.2>>
 * <<release-notes-8.7.1>>
 * <<release-notes-8.7.0>>
@@ -34,6 +32,8 @@ https://github.com/elastic/apm-server/compare/v8.7.0\...v8.7.1[View commits]
 [float]
 [[release-notes-8.7.0]]
 === APM version 8.7.0
+
+https://github.com/elastic/apm-server/compare/v8.6.2\...v8.7.0[View commits]
 
 [float]
 ==== Breaking Changes

--- a/changelogs/8.8.asciidoc
+++ b/changelogs/8.8.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.8]]
 == APM version 8.8
 
-https://github.com/elastic/apm-server/compare/8.7\...8.8[View commits]
-
 * <<release-notes-8.8.2>>
 * <<release-notes-8.8.1>>
 * <<release-notes-8.8.0>>
@@ -30,6 +28,8 @@ https://github.com/elastic/apm-server/compare/v8.8.0\...v8.8.1[View commits]
 [float]
 [[release-notes-8.8.0]]
 === APM version 8.8.0
+
+https://github.com/elastic/apm-server/compare/v8.7.2\...v8.9.0[View commits]
 
 [float]
 ==== Breaking Changes

--- a/changelogs/8.9.asciidoc
+++ b/changelogs/8.9.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.9]]
 == APM version 8.9
 
-https://github.com/elastic/apm-server/compare/8.8\...8.9[View commits]
-
 * <<release-notes-8.9.2>>
 * <<release-notes-8.9.1>>
 * <<release-notes-8.9.0>>
@@ -28,6 +26,8 @@ No significant changes.
 [float]
 [[release-notes-8.9.0]]
 === APM version 8.9.0
+
+https://github.com/elastic/apm-server/compare/v8.8.2\...v8.9.0[View commits]
 
 [float]
 ==== Bug fixes


### PR DESCRIPTION
### Summary

In https://github.com/elastic/apm-server/pull/12390#pullrequestreview-1815171471, @carsonip called out inconsistencies in how we link to commit history in our release notes. This PR cleans up those inconsistencies.

Closes https://github.com/elastic/observability-docs/issues/3541.