### PR TITLE
updatecli: remove duplicated condition

### DIFF
--- a/.ci/update-beats.yml
+++ b/.ci/update-beats.yml
@@ -1,6 +1,6 @@
 ---
 name: Bump beats
-pipelineid: 'update-beats-{{ requiredEnv "BRANCH_NAME" }}'
+pipelineid: 'updatecli-update-beats-{{ requiredEnv "BRANCH_NAME" }}'
 
 scms:
   default:
@@ -16,6 +16,7 @@ scms:
 
 actions:
   default:
+    title: '[updatecli] Update to elastic/beats@{{ source "beats" }}'
     kind: github/pullrequest
     scmid: default
     spec:
@@ -23,6 +24,12 @@ actions:
       labels:
         - automation
         - backport-skip
+      description: |-
+        ### What
+        `elastic/beats` automatic sync
+
+        *Changeset*
+        * https://github.com/elastic/beats/commit/{{ source "beats" }}
 
 sources:
   beats:
@@ -46,15 +53,6 @@ conditions:
       command: grep {{ source "beats" }} go.mod && exit 1 || exit 0
     failwhen: false
 
-
-conditions:
-  beats-version-check:
-    name: Check beats version
-    kind: shell
-    disablesourceinput: true
-    spec:
-      command: grep "BEATS_VERSION?={{ requiredEnv "BRANCH_NAME" }}" Makefile
-
 targets:
   beats:
     name: 'Update to elastic/beats@{{ source "beats" }}'
@@ -66,5 +64,3 @@ targets:
       environments:
         - name: PATH
         - name: HOME
-
-


### PR DESCRIPTION

<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

The backport automation somehow added an extra condition:
- https://github.com/elastic/apm-server/pull/12277/

Likely a missing backport, see https://github.com/elastic/apm-server/commits/main/.ci/update-beats.yml

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
