### PR TITLE
changelog: fix #12176 backport entry

### DIFF
--- a/changelogs/8.12.asciidoc
+++ b/changelogs/8.12.asciidoc
@@ -13,6 +13,7 @@ https://github.com/elastic/apm-server/compare/v8.11.4\...v8.12.0[View commits]
 ==== Breaking Changes
 - The unsupported apm_data_stream_migration ingest pipeline has been removed {pull}12102[12102].
 - "publish_ready" is always false in the "GET /" response until events are received by apm-server {pull}12150[12150]
+- Reverts a breaking change that ignored the beat name. This is visible in Stack Monitoring {pull}12176[12176]
 - A bug has been introduced, so that `traces-apm@custom` ingest pipeline is now additionally applied to data streams `traces-apm.sampled-*` and `traces-apm.rum-*` and applied twice for `traces-apm-*`. See more details and information around a fix in the Known Issues section.
 
 [float]

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -5,7 +5,6 @@ https://github.com/elastic/apm-server/compare/8.12\...main[View commits]
 
 [float]
 ==== Breaking Changes
-- Reverts a breaking change that ignored the beat name. This is visible in Stack Monitoring {pull}12176[12176]
 
 [float]
 ==== Bug fixes


### PR DESCRIPTION
PR #12176 changelog should be done in 8.12, not head. #12224 backport is
causing conflicts.

<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
