### PR TITLE
dependabot: fix content param

### DIFF
--- a/.github/workflows/update-dependabot-pr.yml
+++ b/.github/workflows/update-dependabot-pr.yml
@@ -32,7 +32,7 @@ jobs:
           export SHA=$(git rev-parse "$BRANCH:$FILE_TO_COMMIT")
           gh api --method PUT "/repos/${REPO}/contents/$FILE_TO_COMMIT" \
             --field message="Update $FILE_TO_COMMIT" \
-            --field content="@<(base64 -i $FILE_TO_COMMIT)" \
+            --field content=@<(base64 -i $FILE_TO_COMMIT) \
             --field sha="${SHA}" \
             --field branch="${BRANCH}"
         env:


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Fixes the content param in the gh api call in the update-dependebot-pr workflow

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
