### PR TITLE
jenkins: support apmpackage when running a build through the UI

### DIFF
--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -65,10 +65,16 @@ pipeline {
         stage('apmpackage') {
           options { skipDefaultCheckout() }
           when {
-            allOf {
-              // The apmpackage stage gets triggered as described in https://github.com/elastic/apm-server/issues/6970
-              changeset pattern: '(internal/version/.*|apmpackage/.*)', comparator: 'REGEXP'
-              not { changeRequest() }
+            anyOf {
+              allOf {
+                // The apmpackage stage gets triggered as described in https://github.com/elastic/apm-server/issues/6970
+                changeset pattern: '(internal/version/.*|apmpackage/.*)', comparator: 'REGEXP'
+                not { changeRequest() }
+              }
+              // support for manually triggered in the UI
+              expression {
+                return = isUserTrigger()
+              }
             }
           }
           steps {

--- a/.ci/packaging.groovy
+++ b/.ci/packaging.groovy
@@ -72,9 +72,7 @@ pipeline {
                 not { changeRequest() }
               }
               // support for manually triggered in the UI
-              expression {
-                return = isUserTrigger()
-              }
+              triggeredBy cause: 'UserIdCause'
             }
           }
           steps {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Enable the apmpackage v2 and support for manual UI interactions

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
