### PR TITLE
ci(check-docker-compose): run for all the active branches

### DIFF
--- a/.github/workflows/check-docker-compose.yml
+++ b/.github/workflows/check-docker-compose.yml
@@ -10,10 +10,26 @@ permissions:
   contents: read
 
 jobs:
-  check-docker-compose:
+  filter:
     runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      matrix: ${{ steps.generator.outputs.matrix }}
+    steps:
+      - id: generator
+        uses: elastic/apm-pipeline-library/.github/actions/elastic-stack-snapshot-branches@current
+
+  check-docker-compose:
+    needs:
+      - filter
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.filter.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
@@ -22,9 +38,23 @@ jobs:
             go.sum
             tools/go.sum
       - run: make check-docker-compose
+
+  all-check-docker-compose:
+    name: All check-docker-compose
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - check-docker-compose
+    steps:
+      - id: check
+        uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
+        with:
+          needs: ${{ toJSON(needs) }}
+      - run: ${{ steps.check.outputs.isSuccess }}
       - if: failure()
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
         with:
+          status: ${{ steps.check.outputs.status }}
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
## Motivation/summary

Run `check-docker-compose` for all the active branches in the APM Server (`main`, `7.17` and `8.12` now)


See this [build](https://github.com/elastic/apm-server/actions/runs/7888014145) that ran this PR to validate it works as expected

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
