### PR TITLE
ci(minor): docs are not in this repository anymore

### DIFF
--- a/release.mk
+++ b/release.mk
@@ -147,10 +147,6 @@ rename-changelog:
 	@if ! grep -q '$(VERSION).asciidoc' CHANGELOG.asciidoc ; then \
 		$(SED) -E -e 's#(head.asciidoc\[\])#\1\ninclude::.\/changelogs\/$(VERSION).asciidoc[]#g' CHANGELOG.asciidoc; \
 	fi
-	@if ! grep -q 'release-notes-$(VERSION)' docs/release-notes.asciidoc ; then \
-		awk "NR==12{print \"* <<release-notes-$(VERSION)>>\"}1" docs/release-notes.asciidoc > docs/release-notes.asciidoc.new ; \
-		mv docs/release-notes.asciidoc.new docs/release-notes.asciidoc ; \
-	fi
 
 # Update changelog file to generate something similar to https://github.com/elastic/apm-server/pull/12220
 .PHONY: update-changelog


### PR DESCRIPTION
## Motivation/summary

> As of 8.12, most documentation source files have moved to the [elastic/observability-docs](https://github.com/elastic/observability-docs) repo and been integrated into the Observability guide ([docs/en/observability/apm/](https://github.com/elastic/observability-docs/tree/main/docs/en/observability/apm)).

Hence, the automation for creating a new minor does not need to support the docs.


## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
