### PR TITLE
test: Add TBS whitebox test for ErrTxnTooBig handling

### DIFF
--- a/x-pack/apm-server/sampling/eventstorage/storage_whitebox_test.go
+++ b/x-pack/apm-server/sampling/eventstorage/storage_whitebox_test.go
@@ -1,0 +1,93 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License 2.0;
+// you may not use this file except in compliance with the Elastic License 2.0.
+
+package eventstorage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/apm-data/model/modelpb"
+)
+
+func newReadWriter(tb testing.TB) *ReadWriter {
+	tempdir := tb.TempDir()
+	opts := badger.DefaultOptions("").WithLogger(nil)
+	opts = opts.WithInMemory(false)
+	opts = opts.WithDir(tempdir).WithValueDir(tempdir)
+
+	db, err := badger.Open(opts)
+	if err != nil {
+		panic(err)
+	}
+
+	store := New(db, ProtobufCodec{})
+	readWriter := store.NewReadWriter()
+	tb.Cleanup(func() { readWriter.Close() })
+
+	return readWriter
+}
+
+func TestDeleteTraceEvent_ErrTxnTooBig(t *testing.T) {
+	readWriter := newReadWriter(t)
+
+	traceID, transactionID := writeEvent(t, readWriter)
+	assert.True(t, eventExists(t, readWriter, traceID, transactionID))
+
+	fillTxnUntilTxnTooBig(readWriter.txn)
+
+	err := readWriter.DeleteTraceEvent(traceID, transactionID)
+	assert.NoError(t, err)
+
+	assert.False(t, eventExists(t, readWriter, traceID, transactionID))
+}
+
+func TestWriteTraceEvent_ErrTxnTooBig(t *testing.T) {
+	readWriter := newReadWriter(t)
+
+	fillTxnUntilTxnTooBig(readWriter.txn)
+
+	traceID, transactionID := writeEvent(t, readWriter)
+	assert.True(t, eventExists(t, readWriter, traceID, transactionID))
+}
+
+func writeEvent(t *testing.T, readWriter *ReadWriter) (traceID, transactionID string) {
+	traceID = uuid.Must(uuid.NewV4()).String()
+	transactionID = uuid.Must(uuid.NewV4()).String()
+	transaction := modelpb.APMEvent{Transaction: &modelpb.Transaction{Id: transactionID}}
+	err := readWriter.WriteTraceEvent(traceID, transactionID, &transaction, WriterOpts{
+		TTL:                 time.Minute,
+		StorageLimitInBytes: 0,
+	})
+	assert.NoError(t, err)
+	return
+}
+
+func eventExists(t *testing.T, readWriter *ReadWriter, traceID, transactionID string) (ok bool) {
+	var batch modelpb.Batch
+	err := readWriter.ReadTraceEvents(traceID, &batch)
+	require.NoError(t, err)
+	for _, e := range batch {
+		if e.GetTransaction().GetId() == transactionID {
+			ok = true
+		}
+	}
+	return
+}
+
+func fillTxnUntilTxnTooBig(txn *badger.Txn) {
+	var err error
+	for {
+		if err == badger.ErrTxnTooBig {
+			break
+		}
+		entry := badger.NewEntry([]byte{0}, []byte{})
+		err = txn.SetEntry(entry)
+	}
+}

--- a/x-pack/apm-server/sampling/eventstorage/storage_whitebox_test.go
+++ b/x-pack/apm-server/sampling/eventstorage/storage_whitebox_test.go
@@ -26,6 +26,7 @@ func newReadWriter(tb testing.TB) *ReadWriter {
 	if err != nil {
 		panic(err)
 	}
+	tb.Cleanup(func() { db.Close() })
 
 	store := New(db, ProtobufCodec{})
 	readWriter := store.NewReadWriter()


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

Add a whitebox test for ErrTxnTooBig handling in TBS storage. Existing storage_test.go is in a separate package, making it unable to access private fields under ReadWriter.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->

Useful to verify https://github.com/elastic/apm-server/pull/12509