### PR TITLE
changelog: Remove apmpackage constant_keyword fix from 8.12.1

### DIFF
--- a/changelogs/8.12.asciidoc
+++ b/changelogs/8.12.asciidoc
@@ -12,7 +12,6 @@ https://github.com/elastic/apm-server/compare/v8.12.0\...v8.12.1[View commits]
 
 [float]
 ==== Bug fixes
-- Define value for all constant_keyword fields in apmpackage to fix integration upgrade issues in rare cases {pull}12219[12219]
 - Tail-based sampling: Fix missing entry TTL in badger.ErrTxnTooBig handling {pull}12453[12453]
 - Tail-based sampling: Compute entry size before writing and flush to avoid losing events silently due to storage limit {pull}12120[12120]
 - APM instrumentation: Use UpDownCounter for docsActive and availableBulkIndexer {pull}12179[12179]


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

Pull apmpackage constant_keyword entry from 8.12.1 changelog. The fix did not go into 8.12.1 due to automation issues. See #12219

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
