### PR TITLE
fix: set 8.12.2 version instead of 8.12.3

### DIFF
--- a/cmd/intake-receiver/version.go
+++ b/cmd/intake-receiver/version.go
@@ -18,4 +18,4 @@
 package main
 
 // version matches the APM Server's version
-const version = "8.12.3"
+const version = "8.12.2"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -18,4 +18,4 @@
 package version
 
 // Version holds the APM Server version.
-const Version = "8.12.3"
+const Version = "8.12.2"


### PR DESCRIPTION
set version to 8.12.2 instead of 8.12.3 to fix smoke test