### PR TITLE
Better logs on reading TBS subscriber position

### DIFF
--- a/x-pack/apm-server/sampling/processor.go
+++ b/x-pack/apm-server/sampling/processor.go
@@ -7,6 +7,7 @@ package sampling
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -557,13 +558,13 @@ func readSubscriberPosition(logger *logp.Logger, storageDir string) (pubsub.Subs
 	if errors.Is(err, os.ErrNotExist) {
 		return pos, nil
 	} else if err != nil {
-		return pos, err
+		return pos, fmt.Errorf("error reading subscriber position file: %w", err)
 	}
 	err = json.Unmarshal(data, &pos)
 	if err != nil {
 		logger.With(logp.Error(err)).With(logp.ByteString("file", data)).Debug("failed to read subscriber position")
 	}
-	return pos, err
+	return pos, fmt.Errorf("error parsing subscriber position file: %w", err)
 }
 
 func writeSubscriberPosition(storageDir string, pos pubsub.SubscriberPosition) error {

--- a/x-pack/apm-server/sampling/processor.go
+++ b/x-pack/apm-server/sampling/processor.go
@@ -563,8 +563,9 @@ func readSubscriberPosition(logger *logp.Logger, storageDir string) (pubsub.Subs
 	err = json.Unmarshal(data, &pos)
 	if err != nil {
 		logger.With(logp.Error(err)).With(logp.ByteString("file", data)).Debug("failed to read subscriber position")
+		return pos, fmt.Errorf("error parsing subscriber position file: %w", err)
 	}
-	return pos, fmt.Errorf("error parsing subscriber position file: %w", err)
+	return pos, nil
 }
 
 func writeSubscriberPosition(storageDir string, pos pubsub.SubscriberPosition) error {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

Return a better error for clearer "tail sampler aborted" log

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

- start apm-server with tbs enabled
- go into data directory, truncate the subscriber position file
- start apm-server again
- expect to see `{"log.level":"error","@timestamp":"2024-03-04T11:31:57.906Z","log.logger":"beater","log.origin":{"function":"main.runServerWithProcessors.func1","file.name":"apm-server/main.go","file.line":207},"message":"tail sampler aborted","service.name":"apm-server","error":{"message":"error parsing subscriber position file: unexpected end of JSON input"},"ecs.version":"1.6.0"}`

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
