### PR TITLE
.github: fix benchmark workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -106,7 +106,7 @@ jobs:
         run: make apmbench $SSH_KEY terraform.tfvars
 
       - name: Override docker committed version
-        if: ${{ !github.event.inputs.runOnStable }}
+        if: ${{ ! inputs.runOnStable }}
         run: make docker-override-committed-version
 
       - name: Spin up benchmark environment
@@ -118,11 +118,11 @@ jobs:
           echo "-> infra setup done"
 
       - name: Run benchmarks autotuned
-        if: ${{ github.event.inputs.benchmarkAgents == '' }}
+        if: ${{ inputs.benchmarkAgents == '' }}
         run: make run-benchmark-autotuned index-benchmark-results
 
       - name: Run benchmarks self tuned
-        if: ${{ github.event.inputs.benchmarkAgents != '' }}
+        if: ${{ inputs.benchmarkAgents != '' }}
         run: make run-benchmark index-benchmark-results
 
       - name: Download PNG


### PR DESCRIPTION
## Motivation/summary

I ran the benchmarks workflow on a branch, and noticed that it did not build a custom Docker image, despite me not checking the "Run the benchmarks on the latest stable version" box. On the other hand, the scheduled runs do build a custom Docker image.

After digging, I found this in the Github Actions docs (https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs):

> The workflow will also receive the inputs in the github.event.inputs context. **The information in the inputs context and github.event.inputs context is identical except that the inputs context preserves Boolean values as Booleans instead of converting them to strings.** The choice type resolves to a string and is a single selectable option.

We have been trying to use a boolean operator on a string, since we're using `github.event.inputs`. Changing to `inputs` to resolve that.

## Checklist

~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
~- [ ] Documentation has been updated~

## How to test these changes

N/A

## Related issues

None