### PR TITLE
Bump up version to 8.13.1

### DIFF
--- a/cmd/intake-receiver/version.go
+++ b/cmd/intake-receiver/version.go
@@ -18,4 +18,4 @@
 package main
 
 // version matches the APM Server's version
-const version = "8.13.0"
+const version = "8.13.1"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -18,4 +18,4 @@
 package version
 
 // Version holds the APM Server version.
-const Version = "8.13.0"
+const Version = "8.13.1"


### PR DESCRIPTION
Not entirely sure if this should have been done by automation or if I needed to trigger a job. I have created an issue for documenting how to use the automation/CI steps: https://github.com/elastic/apm-server/issues/12864