### PR TITLE
Added changelog for apm-data upgrade to 1.1

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -12,6 +12,7 @@ https://github.com/elastic/apm-server/compare/8.13\...main[View commits]
 [float]
 ==== Intake API Changes
 
+[float]
 ==== Added
 - OpenTelemetry Distro Name will now be used for `agent.name` and `agent.version` {pull}12940[12940]
 - Add support for setting the `host.id` via IntakeV2 {pull}12940[12940]

--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -12,5 +12,6 @@ https://github.com/elastic/apm-server/compare/8.13\...main[View commits]
 [float]
 ==== Intake API Changes
 
-[float]
 ==== Added
+- OpenTelemetry Distro Name will now be used for `agent.name` and `agent.version` {pull}12940[12940]
+- Add support for setting the `host.id` via IntakeV2 {pull}12940[12940]


### PR DESCRIPTION


## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] ~Documentation has been updated~

## How to test these changes

* https://github.com/elastic/apm-data/issues/200:
  * spin up any test application with any OTel-agent
  * Add `telemetry.distro.name` and `telemetry.distro.version` as resource-attributes. E.g. use the environment variable `OTEL_RESOURCE_ATTRIBUTES=telemetry.distro.name=mydistro,telemetry.distro.version=myversion`
  * Verify that the resulting traces (or metrics) have `agent.name` set to `opentelemetry/<language>/mydistro` and `agent.version` is `myversion`
  * Alternative: Directly send dummy data to the OTLP intake with those resource attributes set
* https://github.com/elastic/apm-data/issues/187
  * Use existing dummy data for an IntakeV2 request for generating a transaction
  * Add [system.host_id](https://github.com/elastic/apm-server/blob/main/docs/spec/v2/metadata.json#L444) with a value (e.g. `foobar`) to the `metdata`-json
  * verify that the resulting transaction now has `host.id` set to `foobar`

## Related issues

https://github.com/elastic/apm-data/issues/200
https://github.com/elastic/apm-data/issues/187