### PR TITLE
package: honour `.go-version` content when creating docker images

### DIFF
--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -96,15 +96,6 @@ targets:
       content: '{{ source "latestGoVersion" }}'
       file: .go-version
       matchpattern: '\d+.\d+.\d+'
-  update-dockerfile:
-    name: 'Update Dockerfile with Golang version {{ source "latestGoVersion" }}'
-    sourceid: latestGoVersion
-    scmid: default
-    kind: file
-    spec:
-      file: packaging/docker/Dockerfile
-      matchpattern: '(FROM golang):\d+.\d+.\d+'
-      replacepattern: '$1:{{ source "latestGoVersion" }}'
   update-gomod:
     name: 'Update go.mod files with {{ source "gomod" }}'
     sourceid: gomod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: systemtest/go.mod
+          go-version-file: go.mod
           cache: true
       - run: make package-snapshot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,13 @@ jobs:
         with:
           name: test-results
           path: 'build/*.xml'
+
+  test-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: systemtest/go.mod
+          cache: true
+      - run: make package-snapshot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,5 +85,5 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false
       - run: make package-snapshot

--- a/go.mk
+++ b/go.mk
@@ -7,6 +7,7 @@ GITROOT ?= $(shell git rev-parse --show-toplevel)
 
 # Ensure the Go version in .go-version is installed and used.
 GOROOT?=$(shell $(GITROOT)/script/run_with_go_ver go env GOROOT)
+GOLANG_VERSION=$(shell cat $(GITROOT)/.go-version)
 GO:=$(GOROOT)/bin/go
 GOARCH:=$(shell $(GO) env GOARCH)
 export PATH:=$(GOROOT)/bin:$(PATH)

--- a/packaging.mk
+++ b/packaging.mk
@@ -38,7 +38,7 @@ build/docker/apm-server-ubi-%.txt: DOCKER_BUILD_ARGS+=--build-arg BASE_IMAGE=doc
 
 .PHONY: $(DOCKER_IMAGES)
 $(DOCKER_IMAGES):
-	mkdir -p $(@D)
+	@mkdir -p $(@D)
 	docker build --iidfile="$(@)" --build-arg GOLANG_VERSION=$(GOLANG_VERSION) --build-arg VERSION=$(VERSION) $(DOCKER_BUILD_ARGS) -f packaging/docker/Dockerfile .
 
 # Docker image tarballs. We distribute UBI8 Docker images only for AMD64.

--- a/packaging.mk
+++ b/packaging.mk
@@ -38,8 +38,8 @@ build/docker/apm-server-ubi-%.txt: DOCKER_BUILD_ARGS+=--build-arg BASE_IMAGE=doc
 
 .PHONY: $(DOCKER_IMAGES)
 $(DOCKER_IMAGES):
-	@mkdir -p $(@D)
-	docker build --iidfile="$(@)" --build-arg VERSION=$(VERSION) $(DOCKER_BUILD_ARGS) -f packaging/docker/Dockerfile .
+	mkdir -p $(@D)
+	docker build --iidfile="$(@)" --build-arg GOLANG_VERSION=$(GOLANG_VERSION) --build-arg VERSION=$(VERSION) $(DOCKER_BUILD_ARGS) -f packaging/docker/Dockerfile .
 
 # Docker image tarballs. We distribute UBI8 Docker images only for AMD64.
 DOCKER_IMAGE_SUFFIX := docker-image$(if $(findstring arm64,$(GOARCH)),-arm64).tar.gz

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,8 +1,9 @@
 ARG BASE_IMAGE=ubuntu:22.04
+ARG GOLANG_VERSION
 
 # Build the apm-server binary. The golang image version is kept
 # up to date with go.mod by Makefile.
-FROM golang:1.22.2 as builder
+FROM golang:${GOLANG_VERSION} as builder
 WORKDIR /src
 COPY go.mod go.sum /src/
 COPY internal/glog/go.mod /src/internal/glog/go.mod


### PR DESCRIPTION
## Motivation/summary

Avoid an explicit hardcoded value in the `Dockerfile` but honour the `.go-version` content. For such, the `GOLANG_VERSION` is created on the fly when running `make package*`

This helps reduce the steps when bumping the Golang version and the chances that something goes side-ways like it happened to me recently, and I needed to create a new follow-up:
- https://github.com/elastic/apm-server/pull/12969

I also enabled `make package-snapshot` as part of the CI to help detect breaking changes before merging. Otherwise, we only detect them when the DRA runs in Buildkite.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
