### PR TITLE
buildkite: skip branch validation if UI build

### DIFF
--- a/.buildkite/scripts/dra.sh
+++ b/.buildkite/scripts/dra.sh
@@ -28,15 +28,21 @@ if [[ "${BUILDKITE_PULL_REQUEST:-false}" == "true" ]]; then
   exit 0
 fi
 
-curl -s https://storage.googleapis.com/artifacts-api/snapshots/branches.json > active-branches.json
-if ! grep -q "\"$BUILDKITE_BRANCH\"" active-branches.json ; then
-  echo "--- :arrow_right: Release Manager only supports the current active branches, skipping"
-  echo "BUILDKITE_BRANCH=$BUILDKITE_BRANCH"
-  echo "BUILDKITE_COMMIT=$BUILDKITE_COMMIT"
-  echo "VERSION=$VERSION"
-  echo "Supported branches:"
-  cat active-branches.json
-  exit 0
+# If the source of the event is running the Buildkite pipeline through the UI
+# then no branch validation.
+# This is handy when the branch is not available in the Unified Release yet.
+# Normally that's caused during the FF windows and last a couple of days.
+if [[ "${BUILDKITE_SOURCE:-x}" != "ui" ]]; then
+  curl -s https://storage.googleapis.com/artifacts-api/snapshots/branches.json > active-branches.json
+  if ! grep -q "\"$BUILDKITE_BRANCH\"" active-branches.json ; then
+    echo "--- :arrow_right: Release Manager only supports the current active branches, skipping"
+    echo "BUILDKITE_BRANCH=$BUILDKITE_BRANCH"
+    echo "BUILDKITE_COMMIT=$BUILDKITE_COMMIT"
+    echo "VERSION=$VERSION"
+    echo "Supported branches:"
+    cat active-branches.json
+    exit 0
+  fi
 fi
 
 dra() {


### PR DESCRIPTION
## Motivation/summary

Utilise the [BUILDKITE_SOURCE](https://buildkite.com/docs/pipelines/environment-variables#BUILDKITE_SOURCE) environment variable when running the DRA. If the Buildkite pipeline is triggered manually, this will skip the branch validation.

<img width="798" alt="image" src="https://github.com/elastic/apm-server/assets/2871786/11bca441-bd4a-4db5-bf15-096acd3c198d">

This is handy when the Unified Release process has not produced any artifacts for `main` yet, and `main` still points to the newly created minor branch. Normally it takes a few days to have new artifacts for `main` pointing to a new minor version.

https://github.com/elastic/apm-pipeline-library/blob/main/.ci/generate-snapshots.sh is the crazy script that generates the `branches.json` file.


## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
