### PR TITLE
github-action: use finer-grained token

### DIFF
--- a/.github/workflows/run-minor-release.yml
+++ b/.github/workflows/run-minor-release.yml
@@ -19,6 +19,7 @@ permissions:
 env:
   JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
   SLACK_CHANNEL: "#apm-server"
+  GH_TOKEN: ${{ secrets.APM_SERVER_RELEASE_TOKEN }}
 
 jobs:
   prepare:
@@ -67,23 +68,14 @@ jobs:
       # Required to use a service account, otherwise PRs created by
       # GitHub bot won't trigger any CI builds.
       # See https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-537478081
-      - name: Configure github token
-        uses: elastic/apm-pipeline-library/.github/actions/github-token@current
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-
       - name: Configure git user
         uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
         with:
           username: ${{ env.GIT_USER }}
           email: ${{ env.GIT_EMAIL }}
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ env.GH_TOKEN }}
 
       - run: make minor-release
-        env:
-          GH_TOKEN: ${{ env.GITHUB_TOKEN }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
         if: success()

--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -19,6 +19,7 @@ permissions:
 env:
   JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
   SLACK_CHANNEL: "#apm-server"
+  GH_TOKEN: ${{ secrets.APM_SERVER_RELEASE_TOKEN }}
 
 jobs:
   prepare:
@@ -58,23 +59,14 @@ jobs:
       # Required to use a service account, otherwise PRs created by
       # GitHub bot won't trigger any CI builds.
       # See https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-537478081
-      - name: Configure github token
-        uses: elastic/apm-pipeline-library/.github/actions/github-token@current
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-
       - name: Configure git user
         uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
         with:
           username: ${{ env.GIT_USER }}
           email: ${{ env.GIT_EMAIL }}
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ env.GH_TOKEN }}
 
       - run: make patch-release
-        env:
-          GH_TOKEN: ${{ env.GITHUB_TOKEN }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
         if: success()


### PR DESCRIPTION
## Motivation/summary

User finer-grained token to create a new minor branch or raise a Pull Request.

## Alternatives

Use the GitHub action token with the correct scope, but any PRs won't trigger any build. So reviewers will need to close and re-open the PR. @elastic/obs-ds-intake-services , what do you think?

Pros:
- Fully supported with GitHub actions.
- No need to maintain a finer-grained token that needs to be rotated every X days/weeks 

Cons:
- Reopen PRs.


## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
