### PR TITLE
[DOCS] Add OpenTelemetry intake API to OpenAPI document

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,3 +8,11 @@
 > * A list of all **breaking changes** are documented in [`changelogs/all-breaking-changes.asciidoc`](/changelogs/all-breaking-changes.asciidoc).
 > * **Sample data sets** that are injected into the docs are in the [`docs/data/`](/docs/data/) directory.
 > * **Specifications** that are injected into the docs are in the [`docs/spec/`](/docs/spec/) directory.
+
+To generate the bundled files in the [`docs/spec/openapi`](/docs/spec/openapi) directory, use [redocly bundle](https://redocly.com/docs/cli/commands/bundle/). For example:
+
+```
+npx @redocly/cli bundle apm-openapi.yaml --output bundled.yaml --ext yaml
+npx @redocly/cli bundle apm-openapi.yaml --output bundled.json --ext json
+```
+

--- a/docs/spec/openapi/apm-openapi.yaml
+++ b/docs/spec/openapi/apm-openapi.yaml
@@ -20,6 +20,12 @@ tags:
   - name: event intake
     description: The events intake API is the internal protocol that APM agents use to talk to the APM Server.
     x-displayName: APM event intake
+  - name: opentelemetry intake
+    description: >
+      The OpenTelemetry intake API uses the OpenTelemetry Protocol (OTLP) to send traces, metrics, and logs to APM Server.
+      OTLP is the default transfer protocol for OpenTelemetry and is supported natively by APM Server.
+      APM Server supports two OTLP communication protocols on the same port: OTLP/HTTP (protobuf) and OTLP/gRPC.
+    x-displayName: APM OpenTelemetry intake
   - name: server info
     description: APIs that query general APM Server information.
     x-displayName: APM server information
@@ -225,6 +231,108 @@ paths:
       responses:
         '202':
           description: Successful response; all events succeeded.
+  /opentelemetry.proto.collector.metrics.v1.MetricsService/Export:
+    post:
+      summary: Send OTLP metrics
+      description: >
+        APM Server supports receiving metrics over the OpenTelemetry Protocol (OTLP).
+        This API uses the OTLP/gRPC communication protocol.
+      operationId: postOtlpGrpcMetrics
+      tags:
+        - opentelemetry intake
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: OK
+  /opentelemetry.proto.collector.trace.v1.TraceService/Export:
+    post:
+      summary: Send OTLP traces
+      description: >
+        APM Server supports receiving traces over the OpenTelemetry Protocol (OTLP).
+        This API uses the OTLP/gRPC communication protocol.
+      operationId: postOtlpGrpcTraces
+      tags:
+        - opentelemetry intake
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: OK
+  /opentelemetry.proto.collector.logs.v1.LogsService/Export:
+    post:
+      summary: Send OTLP logs
+      description: >
+        APM Server supports receiving logs over the OpenTelemetry Protocol (OTLP).
+        This API uses the OTLP/gRPC communication protocol.
+      operationId: postOtlpGrpcLogs
+      tags:
+        - opentelemetry intake
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: OK
+  /v1/metrics:
+    post:
+      summary: Send OTLP metrics
+      description: >
+        APM Server supports receiving metrics over the OpenTelemetry Protocol (OTLP).
+        This API uses the OTLP/HTTP (protobuf) communication protocol.
+      operationId: postOtlpHttpMetrics
+      tags:
+        - opentelemetry intake
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: OK
+  /v1/traces:
+    post:
+      summary: Send OTLP traces
+      description: >
+        APM Server supports receiving traces over the OpenTelemetry Protocol (OTLP).
+        This API uses the OTLP/HTTP (protobuf) communication protocol.
+      operationId: postOtlpHttpTraces
+      tags:
+        - opentelemetry intake
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: OK
+  /v1/logs:
+    post:
+      summary: Send OTLP logs
+      description: >
+        APM Server supports receiving logs over the OpenTelemetry Protocol (OTLP).
+        This API uses the OTLP/HTTP (protobuf) communication protocol.
+      operationId: postOtlpHttpLogs
+      tags:
+        - opentelemetry intake
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: OK
 components:
   securitySchemes:
     apiKeyAuth:

--- a/docs/spec/openapi/bundled.json
+++ b/docs/spec/openapi/bundled.json
@@ -37,6 +37,11 @@
       "x-displayName": "APM event intake"
     },
     {
+      "name": "opentelemetry intake",
+      "description": "The OpenTelemetry intake API uses the OpenTelemetry Protocol (OTLP) to send traces, metrics, and logs to APM Server. OTLP is the default transfer protocol for OpenTelemetry and is supported natively by APM Server. APM Server supports two OTLP communication protocols on the same port: OTLP/HTTP (protobuf) and OTLP/gRPC.\n",
+      "x-displayName": "APM OpenTelemetry intake"
+    },
+    {
       "name": "server info",
       "description": "APIs that query general APM Server information.",
       "x-displayName": "APM server information"
@@ -344,6 +349,150 @@
         "responses": {
           "202": {
             "description": "Successful response; all events succeeded."
+          }
+        }
+      }
+    },
+    "/opentelemetry.proto.collector.metrics.v1.MetricsService/Export": {
+      "post": {
+        "summary": "Send OTLP metrics",
+        "description": "APM Server supports receiving metrics over the OpenTelemetry Protocol (OTLP). This API uses the OTLP/gRPC communication protocol.\n",
+        "operationId": "postOtlpGrpcMetrics",
+        "tags": [
+          "opentelemetry intake"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/opentelemetry.proto.collector.trace.v1.TraceService/Export": {
+      "post": {
+        "summary": "Send OTLP traces",
+        "description": "APM Server supports receiving traces over the OpenTelemetry Protocol (OTLP). This API uses the OTLP/gRPC communication protocol.\n",
+        "operationId": "postOtlpGrpcTraces",
+        "tags": [
+          "opentelemetry intake"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/opentelemetry.proto.collector.logs.v1.LogsService/Export": {
+      "post": {
+        "summary": "Send OTLP logs",
+        "description": "APM Server supports receiving logs over the OpenTelemetry Protocol (OTLP). This API uses the OTLP/gRPC communication protocol.\n",
+        "operationId": "postOtlpGrpcLogs",
+        "tags": [
+          "opentelemetry intake"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/v1/metrics": {
+      "post": {
+        "summary": "Send OTLP metrics",
+        "description": "APM Server supports receiving metrics over the OpenTelemetry Protocol (OTLP). This API uses the OTLP/HTTP (protobuf) communication protocol.\n",
+        "operationId": "postOtlpHttpMetrics",
+        "tags": [
+          "opentelemetry intake"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/v1/traces": {
+      "post": {
+        "summary": "Send OTLP traces",
+        "description": "APM Server supports receiving traces over the OpenTelemetry Protocol (OTLP). This API uses the OTLP/HTTP (protobuf) communication protocol.\n",
+        "operationId": "postOtlpHttpTraces",
+        "tags": [
+          "opentelemetry intake"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/v1/logs": {
+      "post": {
+        "summary": "Send OTLP logs",
+        "description": "APM Server supports receiving logs over the OpenTelemetry Protocol (OTLP). This API uses the OTLP/HTTP (protobuf) communication protocol.\n",
+        "operationId": "postOtlpHttpLogs",
+        "tags": [
+          "opentelemetry intake"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
           }
         }
       }

--- a/docs/spec/openapi/bundled.yaml
+++ b/docs/spec/openapi/bundled.yaml
@@ -20,6 +20,10 @@ tags:
   - name: event intake
     description: The events intake API is the internal protocol that APM agents use to talk to the APM Server.
     x-displayName: APM event intake
+  - name: opentelemetry intake
+    description: |
+      The OpenTelemetry intake API uses the OpenTelemetry Protocol (OTLP) to send traces, metrics, and logs to APM Server. OTLP is the default transfer protocol for OpenTelemetry and is supported natively by APM Server. APM Server supports two OTLP communication protocols on the same port: OTLP/HTTP (protobuf) and OTLP/gRPC.
+    x-displayName: APM OpenTelemetry intake
   - name: server info
     description: APIs that query general APM Server information.
     x-displayName: APM server information
@@ -219,6 +223,102 @@ paths:
       responses:
         '202':
           description: Successful response; all events succeeded.
+  /opentelemetry.proto.collector.metrics.v1.MetricsService/Export:
+    post:
+      summary: Send OTLP metrics
+      description: |
+        APM Server supports receiving metrics over the OpenTelemetry Protocol (OTLP). This API uses the OTLP/gRPC communication protocol.
+      operationId: postOtlpGrpcMetrics
+      tags:
+        - opentelemetry intake
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: OK
+  /opentelemetry.proto.collector.trace.v1.TraceService/Export:
+    post:
+      summary: Send OTLP traces
+      description: |
+        APM Server supports receiving traces over the OpenTelemetry Protocol (OTLP). This API uses the OTLP/gRPC communication protocol.
+      operationId: postOtlpGrpcTraces
+      tags:
+        - opentelemetry intake
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: OK
+  /opentelemetry.proto.collector.logs.v1.LogsService/Export:
+    post:
+      summary: Send OTLP logs
+      description: |
+        APM Server supports receiving logs over the OpenTelemetry Protocol (OTLP). This API uses the OTLP/gRPC communication protocol.
+      operationId: postOtlpGrpcLogs
+      tags:
+        - opentelemetry intake
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: OK
+  /v1/metrics:
+    post:
+      summary: Send OTLP metrics
+      description: |
+        APM Server supports receiving metrics over the OpenTelemetry Protocol (OTLP). This API uses the OTLP/HTTP (protobuf) communication protocol.
+      operationId: postOtlpHttpMetrics
+      tags:
+        - opentelemetry intake
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: OK
+  /v1/traces:
+    post:
+      summary: Send OTLP traces
+      description: |
+        APM Server supports receiving traces over the OpenTelemetry Protocol (OTLP). This API uses the OTLP/HTTP (protobuf) communication protocol.
+      operationId: postOtlpHttpTraces
+      tags:
+        - opentelemetry intake
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: OK
+  /v1/logs:
+    post:
+      summary: Send OTLP logs
+      description: |
+        APM Server supports receiving logs over the OpenTelemetry Protocol (OTLP). This API uses the OTLP/HTTP (protobuf) communication protocol.
+      operationId: postOtlpHttpLogs
+      tags:
+        - opentelemetry intake
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: OK
 components:
   securitySchemes:
     apiKeyAuth:


### PR DESCRIPTION
Relates to https://github.com/elastic/apm-server/issues/12903

This PR updates the OpenAPI specification to include details from https://www.elastic.co/guide/en/observability/current/apm-api-otlp.html

There were no details about the type of request and response received from these APIs, so I've left them generic for now.