### PR TITLE
ci(release-minor): add apm- prefix to Asciidoc links and targets

### DIFF
--- a/release.mk
+++ b/release.mk
@@ -64,7 +64,7 @@ define CHANGELOG_TMPL
 [[release-notes-head]]
 == APM version HEAD
 
-https://github.com/elastic/apm-server/compare/$(RELEASE_BRANCH)\...main[View commits]
+https://github.com/elastic/apm-server/compare/$(RELEASE_VERSION)\...main[View commits]
 
 [float]
 ==== Breaking Changes
@@ -140,8 +140,8 @@ rename-changelog:
 	$(MAKE) common-changelog
 	@echo ">> rename-changelog"
 	echo "$$CHANGELOG_TMPL" > changelogs/head.asciidoc
-	@if ! grep -q 'release-notes-$(VERSION)' CHANGELOG.asciidoc ; then \
-		awk "NR==2{print \"* <<release-notes-$(VERSION)>>\"}1" CHANGELOG.asciidoc > CHANGELOG.asciidoc.new; \
+	@if ! grep -q 'apm-release-notes-$(VERSION)' CHANGELOG.asciidoc ; then \
+		awk "NR==2{print \"* <<apm-release-notes-$(VERSION)>>\"}1" CHANGELOG.asciidoc > CHANGELOG.asciidoc.new; \
 		mv CHANGELOG.asciidoc.new CHANGELOG.asciidoc ; \
 	fi
 	@if ! grep -q '$(VERSION).asciidoc' CHANGELOG.asciidoc ; then \

--- a/release.mk
+++ b/release.mk
@@ -64,7 +64,7 @@ define CHANGELOG_TMPL
 [[release-notes-head]]
 == APM version HEAD
 
-https://github.com/elastic/apm-server/compare/$(RELEASE_VERSION)\...main[View commits]
+https://github.com/elastic/apm-server/compare/$(RELEASE_BRANCH)\...main[View commits]
 
 [float]
 ==== Breaking Changes


### PR DESCRIPTION
## Motivation/summary

Release automation for minor releases does not:

* add apm- prefix to Asciidoc links and targets

That's caused by https://github.com/elastic/apm-server/pull/12820


## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Part of https://github.com/elastic/apm-server/issues/12989
