### PR TITLE
test: use maxmind db test ip to reduce flaky test

### DIFF
--- a/systemtest/approvals/TestOTLPGRPCLogsClientIP.approved.json
+++ b/systemtest/approvals/TestOTLPGRPCLogsClientIP.approved.json
@@ -9,29 +9,20 @@
         "agent.version": [
             "unknown"
         ],
-        "client.geo.city_name": [
-            "dynamic"
-        ],
         "client.geo.continent_name": [
             "Europe"
         ],
         "client.geo.country_iso_code": [
-            "DE"
+            "SE"
         ],
         "client.geo.country_name": [
-            "Germany"
+            "Sweden"
         ],
         "client.geo.location": [
             "dynamic"
         ],
-        "client.geo.region_iso_code": [
-            "dynamic"
-        ],
-        "client.geo.region_name": [
-            "dynamic"
-        ],
         "client.ip": [
-            "178.162.206.244"
+            "89.160.20.128"
         ],
         "data_stream.dataset": [
             "apm.app.unknown"
@@ -73,7 +64,7 @@
             "unknown"
         ],
         "source.ip": [
-            "178.162.206.244"
+            "89.160.20.128"
         ],
         "source.nat.ip": [
             "127.0.0.1"

--- a/systemtest/otlp_test.go
+++ b/systemtest/otlp_test.go
@@ -504,7 +504,7 @@ func TestOTLPGRPCLogsClientIP(t *testing.T) {
 	defer cancel()
 
 	// Override local IP address to be found in "GeoLite2-City.mmdb".
-	md := metadata.New(map[string]string{"X-Forwarded-For": "178.162.206.244"})
+	md := metadata.New(map[string]string{"X-Forwarded-For": "89.160.20.128"})
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
 	conn, err := grpc.Dial(serverAddr(srv), grpc.WithInsecure(), grpc.WithBlock(), grpc.WithDefaultCallOptions(grpc.UseCompressor("gzip")))


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Update test to use IP from https://github.com/maxmind/MaxMind-DB/blame/main/source-data/GeoIP2-City-Test.json to reduce flaky test and stable output

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Closes https://github.com/elastic/apm-server/issues/13073
