### PR TITLE
github-action: gpg sign for push is not supported

### DIFF
--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -71,7 +71,6 @@ jobs:
           passphrase: ${{ secrets.APM_SERVER_RELEASE_PASSPHRASE }}
           git_user_signingkey: true
           git_commit_gpgsign: true
-          git_push_gpgsign: true
 
       - run: make patch-release
 


### PR DESCRIPTION
## Motivation/summary

Leftover only in `main`. GitHub does not support signed pushes.
## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
