### PR TITLE
updatecli: verify commits

### DIFF
--- a/.ci/bump-elastic-stack-snapshot.yml
+++ b/.ci/bump-elastic-stack-snapshot.yml
@@ -20,13 +20,12 @@ scms:
   default:
     kind: github
     spec:
-      user: '{{ requiredEnv "GIT_USER" }}'
-      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
       owner: elastic
       repository: apm-server
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
       branch: '{{ requiredEnv "BRANCH" }}'
+      commitusingapi: true
 
 sources:
   latestVersion:

--- a/.github/workflows/bump-elastic-stack.yml
+++ b/.github/workflows/bump-elastic-stack.yml
@@ -36,5 +36,7 @@ jobs:
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: ./.ci/bump-elastic-stack-snapshot.yml
+          command: '--experimental apply'
         env:
           BRANCH: ${{ matrix.branch }}
+          GITHUB_ACTOR: ${{ github.actor }}


### PR DESCRIPTION
## Motivation/summary

Leverage https://github.com/updatecli/updatecli/issues/1914 and support [commit signature verifications](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)


## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

I tested it in a playground:
- https://github.com/v1v/updatecli-demo/pull/43/commits

And also in my fork, for such I used this set of changes and tweaked a [bit](https://github.com/v1v/apm-server/pull/42) my main branch,

Then https://github.com/v1v/apm-server/pull/43/commits was created

## Related issues

Then if it works as expected in the CI, changes will be applied to the remaining updatecli manifests