### PR TITLE
fix: use 7.17.22-SNAPSHOT instead of 7.17.22 temporarilly

### DIFF
--- a/testing/smoke/basic-upgrade/test.sh
+++ b/testing/smoke/basic-upgrade/test.sh
@@ -45,6 +45,18 @@ fi
 
 echo "-> Running basic upgrade smoke test for version ${VERSION}"
 
+# temporary fix to use SNAPSHOT image as 7.17.22 is broken
+if [ $LATEST_VERSION == "7.17.22" ]; then 
+    echo "using 7.17.22-SNAPSHOT instead of 7.17.22 temporarily"
+    LATEST_VERSION="${LATEST_VERSION}-SNAPSHOT"
+fi
+
+# temporary fix to use SNAPSHOT image as 7.17.22 is broken
+if [ $PREV_LATEST_VERSION == "7.17.22" ]; then 
+    echo "using 7.17.22-SNAPSHOT instead of 7.17.22 temporarily"
+    PREV_LATEST_VERSION="${PREV_LATEST_VERSION}-SNAPSHOT"
+fi
+
 if [[ -z ${SKIP_DESTROY} ]]; then
     trap "terraform_destroy" EXIT
 fi

--- a/testing/smoke/legacy-managed/test.sh
+++ b/testing/smoke/legacy-managed/test.sh
@@ -21,6 +21,12 @@ else
     ASSERTION_VERSION=${LATEST_VERSION}
 fi
 
+# temporary fix to use SNAPSHOT image as 7.17.22 is broken
+if [ $LATEST_VERSION == "7.17.22" ]; then 
+    echo "using 7.17.22-SNAPSHOT instead of 7.17.22 temporarily"
+    LATEST_VERSION="${LATEST_VERSION}-SNAPSHOT"
+fi
+
 echo "-> Running ${LATEST_VERSION} standalone to ${LATEST_VERSION} managed upgrade"
 
 if [[ -z ${SKIP_DESTROY} ]]; then

--- a/testing/smoke/legacy-standalone-major-managed/test.sh
+++ b/testing/smoke/legacy-standalone-major-managed/test.sh
@@ -27,6 +27,19 @@ else
     ASSERTION_NEXT_MAJOR_LATEST=${NEXT_MAJOR_LATEST}
 fi
 
+# temporary fix to use SNAPSHOT image as 7.17.22 is broken
+if [ $LATEST_VERSION == "7.17.22" ]; then 
+    echo "using 7.17.22-SNAPSHOT instead of 7.17.22 temporarily"
+    LATEST_VERSION="${LATEST_VERSION}-SNAPSHOT"
+fi
+
+# temporary fix to use SNAPSHOT image as 7.17.22 is broken
+if [ $NEXT_MAJOR_LATEST == "7.17.22" ]; then 
+    echo "using 7.17.22-SNAPSHOT instead of 7.17.22 temporarily"
+    NEXT_MAJOR_LATEST="${NEXT_MAJOR_LATEST}-SNAPSHOT"
+fi
+
+
 echo "-> Running ${LATEST_VERSION} standalone to ${NEXT_MAJOR_LATEST} to ${NEXT_MAJOR_LATEST} managed"
 
 if [[ -z ${SKIP_DESTROY} ]]; then


### PR DESCRIPTION
## Motivation/summary

Temporarily use `7.17.22-SNAPSHOT` for smoke tests when the desired version is 7.17.22.

Previously the `7.17.22-SNAPSHOT` image was [broken](https://github.com/elastic/apm-server/pull/13147#issuecomment-2133906637) and now it's fixed. Now the `7.17.22` is broken for the same reason, and more recent build `7.17.22-SNAPSHOT` is now working. Until `7.17.22` is properly fixed, we should use 7.17.22-SNAPSHOT.


## How to test these changes

```
(cd testing/smoke/legacy-standalone-major-managed && EC_API_KEY=redacted ./test.sh 7.17)
(cd testing/smoke/legacy-managed && EC_API_KEY=redacted ./test.sh 7.17)
```

## Related issues
https://github.com/elastic/apm-server/pull/13147
<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
