### PR TITLE
[systemtest] Get repo root correctly with go workspaces

### DIFF
--- a/systemtest/apmservertest/command.go
+++ b/systemtest/apmservertest/command.go
@@ -199,7 +199,18 @@ func getRepoRoot() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	repoRoot = filepath.Clean(strings.TrimSpace(string(output)))
+	// When go workspaces is enabled then go list lists all the module paths in
+	// the go workspace. This is hack to ensure we take what we required.
+	// TODO (lahsivjar): Better way to find repo root?
+	allPaths := strings.Split(strings.TrimSpace(string(output)), "\n")
+	var targetPath string
+	for _, path := range allPaths {
+		if strings.HasSuffix(path, "systemtest/..") {
+			targetPath = path
+			break
+		}
+	}
+	repoRoot = filepath.Clean(targetPath)
 	return repoRoot, nil
 }
 


### PR DESCRIPTION
## Motivation/summary

Fixes the repo root resolution when go workspace is in use. In this case the command `go list -m` will list all the modules in use by the go workspace and the current `getRepoRoot` cannot handle it correctly.

The changes the PR proposes is also kinda hacky, happy to hear if others have a better solution to finding the repo root or fixing the issue.

## Checklist

~~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~~
~~- [ ] Documentation has been updated~~

## How to test these changes

1. `cd systemtest`
2. `go work init`
3. `go work use <path_to_apm_tools>`
4. `go work use .`
5. `go test -v -count=1 ./...`

Tests should pass without errors.

## Related issues

N/A
