### PR TITLE
ci: fix type of release

### DIFF
--- a/.github/workflows/prepare-release/action.yml
+++ b/.github/workflows/prepare-release/action.yml
@@ -17,6 +17,9 @@ outputs:
   release-branch:
     description: "Release branch (relevant for minor releases)"
     value: ${{ steps.generate.outputs.release-branch }}
+  release-type:
+    description: "Release type"
+    value: ${{ inputs.type }}
   release-version:
     description: "Release version"
     value: ${{ steps.generate.outputs.release-version }}

--- a/.github/workflows/run-minor-release.yml
+++ b/.github/workflows/run-minor-release.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release-branch: ${{ steps.prepare.outputs.release-branch }}
+      release-type: ${{ steps.prepare.outputs.release-type }}
       release-version: ${{ steps.prepare.outputs.release-version }}
       slack-thread: ${{ steps.prepare.outputs.slack-thread }}
     steps:
@@ -42,6 +43,7 @@ jobs:
     needs: [ prepare ]
     env:
       RELEASE_BRANCH: ${{ needs.prepare.outputs.release-branch }}
+      RELEASE_TYPE: ${{ needs.prepare.outputs.release-type }}
       RELEASE_VERSION: ${{ needs.prepare.outputs.release-version }}
     permissions:
       contents: write

--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release-branch: ${{ steps.prepare.outputs.release-branch }}
+      release-type: ${{ steps.prepare.outputs.release-type }}
       release-version: ${{ steps.prepare.outputs.release-version }}
       slack-thread: ${{ steps.prepare.outputs.slack-thread }}
     steps:
@@ -43,6 +44,7 @@ jobs:
     needs: [ prepare ]
     env:
       RELEASE_BRANCH: ${{ needs.prepare.outputs.release-branch }}
+      RELEASE_TYPE: ${{ needs.prepare.outputs.release-type }}
       RELEASE_VERSION: ${{ needs.prepare.outputs.release-version }}
     permissions:
       contents: write


### PR DESCRIPTION


## Motivation/summary

`RELEASE_TYPE` is an env variable required when running the release steps. Defaulted to `minor` and that's the reason it didn't work with the `run-patch-release`.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
