### PR TITLE
Bump 8.14 to 8.14.2

### DIFF
--- a/cmd/intake-receiver/version.go
+++ b/cmd/intake-receiver/version.go
@@ -18,4 +18,4 @@
 package main
 
 // version matches the APM Server's version
-const version = "8.14.1"
+const version = "8.14.2"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -18,4 +18,4 @@
 package version
 
 // Version holds the APM Server version.
-const Version = "8.14.1"
+const Version = "8.14.2"


### PR DESCRIPTION
Bump `8.14` branch to `8.14.2`

To be merged after `8.14.1` release.
