### PR TITLE
ci(smoke-tests): set id-token when running other workflows

### DIFF
--- a/.github/workflows/smoke-tests-schedule.yml
+++ b/.github/workflows/smoke-tests-schedule.yml
@@ -30,6 +30,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare-smoke-tests-os.outputs.matrix) }}
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/smoke-tests-os.yml
     with:
       branch: ${{ matrix.branch }}
@@ -37,6 +40,9 @@ jobs:
 
   smoke-tests-ess:
     name: Run smoke tests ESS
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/smoke-tests-ess.yml
     with:
       branch: 'main'


### PR DESCRIPTION
## Motivation/summary

permissions need to be set explicitly when calling other workflows even if those workflows already have got the permissions set.

Fixes

```
[Invalid workflow file: .github/workflows/smoke-tests-schedule.yml#L27](https://github.com/elastic/apm-server/actions/runs/9672905228/workflow)
The workflow is not valid. .github/workflows/smoke-tests-schedule.yml (Line: 27, Col: 3): Error calling workflow 'elastic/apm-server/.github/workflows/smoke-tests-os.yml@4cf627cb98d0624f5206dfbfa30f88f64794c739'. The nested job 'smoke-tests-os' is requesting 'id-token: write', but is only allowed 'id-token: none'.
```

See https://github.com/elastic/apm-server/actions/runs/9672905228

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
