### PR TITLE
release: update patch-release workflow to match expectations

### DIFF
--- a/release.mk
+++ b/release.mk
@@ -138,9 +138,9 @@ patch-release:
 	$(MAKE) update-version VERSION=$(RELEASE_VERSION)
 	$(MAKE) update-version-makefile VERSION=$(PROJECT_MAJOR_VERSION)\.$(PROJECT_MINOR_VERSION)
 	$(MAKE) update-version-legacy VERSION=$(NEXT_RELEASE) PREVIOUS_VERSION=$(CURRENT_RELEASE)
-	$(MAKE) create-commit COMMIT_MESSAGE="docs: update docs versions to $(RELEASE_VERSION)"
+	$(MAKE) create-commit COMMIT_MESSAGE="$(RELEASE_BRANCH): update versions to $(RELEASE_VERSION)"
 	@echo "INFO: Push changes to $(PROJECT_OWNER)/apm-server and create the relevant Pull Requests"
-	$(MAKE) create-pull-request BRANCH=$(BRANCH_PATCH) TARGET_BRANCH=$(RELEASE_BRANCH) TITLE="$(RELEASE_VERSION): update docs" BODY="Merge before the final Release build."
+	$(MAKE) create-pull-request BRANCH=$(BRANCH_PATCH) TARGET_BRANCH=$(RELEASE_BRANCH) TITLE="$(RELEASE_VERSION): update versions" BODY="Merge on request by the Release Manager."
 
 ############################################
 ## Internal make goals to bump versions


### PR DESCRIPTION
While following the release process for 8.14.2 I noticed that the `run-patch-release` workflow is creating a PR mentioning docs, while in reality it only updates versions. See https://github.com/elastic/apm-server/pull/13515 (I updated the title and body, commit message still refers to docs).

This is also misleading as the current body mention merging it before the last build candidate while such changes should be merged when requested by the Release Manager. This PR updates that workflow to reflect that.

