### PR TITLE
ci(release): update descriptions and use oblt-actions@v1

### DIFF
--- a/.github/workflows/prepare-release/action.yml
+++ b/.github/workflows/prepare-release/action.yml
@@ -32,7 +32,7 @@ runs:
   steps:
     - name: Send slack message when started
       id: slack-thread
-      uses: elastic/oblt-actions/slack/send@v1.8.0
+      uses: elastic/oblt-actions/slack/send@v1
       with:
         bot-token: ${{ inputs.slack-bot-token }}
         channel-id: ${{ env.SLACK_CHANNEL }}
@@ -89,7 +89,7 @@ runs:
         TAG: 'refs/tags/v${{ steps.generate.outputs.release-version }}'
 
     - if: failure()
-      uses: elastic/oblt-actions/slack/send@v1.8.0
+      uses: elastic/oblt-actions/slack/send@v1
       with:
         bot-token: ${{ inputs.slack-bot-token }}
         channel-id: ${{ env.SLACK_CHANNEL }}

--- a/.github/workflows/run-minor-release.yml
+++ b/.github/workflows/run-minor-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The version (semver format: major.minor.0)'
+        description: 'The new version to be set, normally the `minor +1` in the version in the main branch (semver format: major.minor.0)'
         required: true
         type: string
 
@@ -67,9 +67,9 @@ jobs:
       # GitHub bot won't trigger any CI builds.
       # See https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-537478081
       - name: Configure git user
-        uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
+        uses: elastic/oblt-actions/git/setup@v1
         with:
-          token: ${{ env.GH_TOKEN }}
+          github-token: ${{ env.GH_TOKEN }}
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0

--- a/.github/workflows/run-minor-release.yml
+++ b/.github/workflows/run-minor-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The new version to be set, normally the `minor +1` in the version in the main branch (semver format: major.minor.0)'
+        description: 'The new version to be set, normally the version in the main branch (semver format: major.minor.0)'
         required: true
         type: string
 

--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The version (semver format: major.minor.patch)'
+        description: 'The current version to be released, normally the `FF version` (semver format: major.minor.patch)'
         required: true
         type: string
 
@@ -60,9 +60,9 @@ jobs:
       # GitHub bot won't trigger any CI builds.
       # See https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-537478081
       - name: Configure git user
-        uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
+        uses: elastic/oblt-actions/git/setup@v1
         with:
-          token: ${{ env.GH_TOKEN }}
+          github-token: ${{ env.GH_TOKEN }}
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
@@ -75,7 +75,7 @@ jobs:
       - run: make patch-release
 
       - if: success()
-        uses: elastic/oblt-actions/slack/send@v1.9.1
+        uses: elastic/oblt-actions/slack/send@v1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ env.SLACK_CHANNEL }}
@@ -85,7 +85,7 @@ jobs:
           thread-timestamp: ${{ needs.prepare.outputs.slack-thread || '' }}
 
       - if: failure()
-        uses: elastic/oblt-actions/slack/send@v1.9.1
+        uses: elastic/oblt-actions/slack/send@v1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ env.SLACK_CHANNEL }}

--- a/dev_docs/RELEASES.md
+++ b/dev_docs/RELEASES.md
@@ -16,7 +16,7 @@ For patch releases, only the version on the existing major and minor version bra
 ## Day after Feature Freeze
 
 * Trigger release workflow manually
-  * For **patch releases**: run the [`run-patch-release`](https://github.com/elastic/apm-server/actions/workflows/run-patch-release.yml) workflow (In "Use workflow from", select `main` branch. Then in "The version", specify the **next** patch release version - es: on `8.14.2` feature freeze you will use `8.14.3`).
+  * For **patch releases**: run the [`run-patch-release`](https://github.com/elastic/apm-server/actions/workflows/run-patch-release.yml) workflow (In "Use workflow from", select `main` branch. Then in "The version", specify the **upcoming** patch release version - es: on `8.14.2` feature freeze you will use `8.14.2`).
     This workflow will: create the release branch; update version across codebase; commit and create PR targeting the release branch.
     Release notes for patch releases **must be manually added**:
     * Add a new section to the existing release notes file ([Sample PR](https://github.com/elastic/apm-server/pull/12680)).


### PR DESCRIPTION
## Motivation/summary

* Use `v1` version for `oblt-actions`
* Use `oblt-actions` rather than `apm-pipeline-library` <-- it's now deprecated
* Update the description so it explicitly explains the expected input parameter.

The `release.mk` is the one in charge of doing the `auto-bump`:
- for the patch release: https://github.com/elastic/apm-server/blob/0e77c56738a559900f37b8f37e1ec02e43239d36/release.mk#L45
- for the minor release: https://github.com/elastic/apm-server/blob/0e77c56738a559900f37b8f37e1ec02e43239d36/release.mk#L44


## Further details

* `.github/workflows/run-patch-release.yml` should be run using the `main` branch and the version to be released.
* `.github/workflows/run-minor-release.yml`  should be run using the `main` branch and the current version in `main`.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
