### PR TITLE
TBS: perf: Reduce allocs slightly in write and delete

### DIFF
--- a/x-pack/apm-server/sampling/eventstorage/storage.go
+++ b/x-pack/apm-server/sampling/eventstorage/storage.go
@@ -248,7 +248,13 @@ func estimateSize(e *badger.Entry) int64 {
 
 // DeleteTraceEvent deletes the trace event from storage.
 func (rw *ReadWriter) DeleteTraceEvent(traceID, id string) error {
-	key := append(append([]byte(traceID), ':'), id...)
+	var buf bytes.Buffer
+	buf.Grow(len(traceID) + 1 + len(id))
+	buf.WriteString(traceID)
+	buf.WriteByte(':')
+	buf.WriteString(id)
+	key := buf.Bytes()
+
 	err := rw.txn.Delete(key)
 	// If the transaction is already too big to accommodate the new entry, flush
 	// the existing transaction and set the entry on a new one, otherwise,


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Slightly reduce allocs in WriteTraceEvent and DeleteTraceEvent. Perf gain is insignificant.

```
goos: linux
goarch: amd64
pkg: github.com/elastic/apm-server/x-pack/apm-server/sampling/eventstorage
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                                             │  before.out  │              after.out              │
                                             │    sec/op    │    sec/op     vs base               │
ShardedWriteTransactionUncontended-16          152.1n ± 13%   152.0n ±  9%        ~ (p=0.729 n=6)
ShardedWriteTransactionContended-16            903.4n ±  2%   888.8n ±  1%   -1.62% (p=0.015 n=6)
WriteTransaction/proto_codec-16                672.4n ±  6%   613.6n ±  2%   -8.74% (p=0.002 n=6)
WriteTransaction/proto_codec_big_tx-16         1.728µ ±  6%   1.643µ ±  1%   -4.95% (p=0.002 n=6)
WriteTransaction/nop_codec-16                  476.6n ±  0%   447.9n ±  1%   -6.04% (p=0.002 n=6)
WriteTransaction/nop_codec_big_tx-16           470.6n ±  2%   446.1n ±  2%   -5.22% (p=0.002 n=6)
ReadEvents/proto_codec/0_events-16             746.7n ±  2%   736.8n ±  6%        ~ (p=0.554 n=6)
ReadEvents/proto_codec/1_events-16             7.684µ ±  4%   7.638µ ±  2%        ~ (p=0.699 n=6)
ReadEvents/proto_codec/10_events-16            29.35µ ±  8%   29.23µ ±  5%        ~ (p=0.394 n=6)
ReadEvents/proto_codec/100_events-16           220.2µ ±  2%   220.2µ ±  4%        ~ (p=0.589 n=6)
ReadEvents/proto_codec/199_events-16           418.9µ ±  6%   420.2µ ±  7%        ~ (p=0.394 n=6)
ReadEvents/proto_codec/399_events-16           723.7µ ±  1%   716.5µ ±  4%        ~ (p=0.240 n=6)
ReadEvents/proto_codec/1000_events-16          1.500m ±  2%   1.489m ±  3%        ~ (p=0.818 n=6)
ReadEvents/proto_codec_big_tx/0_events-16      742.8n ±  4%   736.6n ±  2%        ~ (p=0.699 n=6)
ReadEvents/proto_codec_big_tx/1_events-16      13.46µ ±  4%   13.24µ ±  5%        ~ (p=0.180 n=6)
ReadEvents/proto_codec_big_tx/10_events-16     86.23µ ±  6%   95.64µ ±  9%  +10.91% (p=0.041 n=6)
ReadEvents/proto_codec_big_tx/100_events-16    715.9µ ±  4%   717.3µ ±  4%        ~ (p=0.699 n=6)
ReadEvents/proto_codec_big_tx/199_events-16    1.416m ±  3%   1.412m ±  3%        ~ (p=0.937 n=6)
ReadEvents/proto_codec_big_tx/399_events-16    2.667m ±  2%   2.634m ±  1%        ~ (p=0.132 n=6)
ReadEvents/proto_codec_big_tx/1000_events-16   6.285m ±  3%   6.347m ±  2%        ~ (p=0.589 n=6)
ReadEvents/nop_codec/0_events-16               750.2n ±  4%   744.6n ±  1%        ~ (p=0.310 n=6)
ReadEvents/nop_codec/1_events-16               7.046µ ±  3%   7.132µ ±  5%        ~ (p=0.485 n=6)
ReadEvents/nop_codec/10_events-16              25.95µ ±  8%   24.82µ ±  3%        ~ (p=0.240 n=6)
ReadEvents/nop_codec/100_events-16             245.3µ ± 15%   182.7µ ±  3%  -25.52% (p=0.002 n=6)
ReadEvents/nop_codec/199_events-16             430.8µ ± 19%   348.8µ ± 18%  -19.04% (p=0.041 n=6)
ReadEvents/nop_codec/399_events-16             588.2µ ±  2%   747.6µ ±  3%  +27.09% (p=0.002 n=6)
ReadEvents/nop_codec/1000_events-16            1.184m ±  1%   1.272m ± 19%        ~ (p=1.000 n=6)
ReadEvents/nop_codec_big_tx/0_events-16        763.6n ±  2%   754.6n ±  5%        ~ (p=0.699 n=6)
ReadEvents/nop_codec_big_tx/1_events-16        6.932µ ±  7%   7.020µ ±  7%        ~ (p=0.394 n=6)
ReadEvents/nop_codec_big_tx/10_events-16       24.76µ ±  7%   24.95µ ±  3%        ~ (p=0.589 n=6)
ReadEvents/nop_codec_big_tx/100_events-16      185.0µ ±  7%   183.6µ ±  7%        ~ (p=0.699 n=6)
ReadEvents/nop_codec_big_tx/199_events-16      351.0µ ±  4%   349.0µ ±  1%        ~ (p=0.699 n=6)
ReadEvents/nop_codec_big_tx/399_events-16      586.5µ ±  2%   586.7µ ±  4%        ~ (p=1.000 n=6)
ReadEvents/nop_codec_big_tx/1000_events-16     1.180m ±  4%   1.182m ±  3%        ~ (p=0.699 n=6)
ReadEventsHit/bigTX=true/hit=false-16          15.50µ ± 32%   14.65µ ± 20%        ~ (p=0.310 n=6)
ReadEventsHit/bigTX=true/hit=true-16           179.2µ ±  4%   177.8µ ±  1%        ~ (p=0.394 n=6)
ReadEventsHit/bigTX=false/hit=false-16         17.08µ ± 20%   17.43µ ± 22%        ~ (p=1.000 n=6)
ReadEventsHit/bigTX=false/hit=true-16          138.3µ ±  3%   140.3µ ±  2%        ~ (p=0.240 n=6)
IsTraceSampled/sampled-16                      175.4n ±  4%   170.8n ±  1%   -2.59% (p=0.006 n=6)
IsTraceSampled/unsampled-16                    177.0n ±  5%   172.2n ±  2%   -2.74% (p=0.002 n=6)
IsTraceSampled/unknown-16                      896.9n ± 14%   913.6n ± 11%        ~ (p=0.589 n=6)
geomean                                        27.45µ         27.10µ         -1.30%

                                             │  before.out   │               after.out                │
                                             │     B/op      │     B/op       vs base                 │
ShardedWriteTransactionUncontended-16            385.5 ±  1%     320.0 ±  1%  -16.99% (p=0.002 n=6)
ShardedWriteTransactionContended-16              447.0 ±  0%     379.0 ±  1%  -15.21% (p=0.002 n=6)
WriteTransaction/proto_codec-16                  285.0 ±  0%     253.0 ±  0%  -11.23% (p=0.002 n=6)
WriteTransaction/proto_codec_big_tx-16           645.0 ±  0%     613.0 ±  0%   -4.96% (p=0.002 n=6)
WriteTransaction/nop_codec-16                    261.0 ±  0%     229.0 ±  0%  -12.26% (p=0.002 n=6)
WriteTransaction/nop_codec_big_tx-16             261.0 ±  0%     229.0 ±  0%  -12.26% (p=0.002 n=6)
ReadEvents/proto_codec/0_events-16               312.0 ±  0%     312.0 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/proto_codec/1_events-16             3.105Ki ±  0%   3.104Ki ±  0%        ~ (p=0.188 n=6)
ReadEvents/proto_codec/10_events-16            14.09Ki ±  0%   14.09Ki ±  1%        ~ (p=0.937 n=6)
ReadEvents/proto_codec/100_events-16           118.9Ki ±  1%   118.9Ki ±  1%        ~ (p=0.699 n=6)
ReadEvents/proto_codec/199_events-16           197.6Ki ±  0%   197.6Ki ±  0%        ~ (p=0.457 n=6)
ReadEvents/proto_codec/399_events-16           336.0Ki ±  1%   335.8Ki ±  1%        ~ (p=0.418 n=6)
ReadEvents/proto_codec/1000_events-16          719.9Ki ±  0%   720.1Ki ±  0%        ~ (p=0.485 n=6)
ReadEvents/proto_codec_big_tx/0_events-16        312.0 ±  0%     312.0 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/proto_codec_big_tx/1_events-16      6.297Ki ±  0%   6.296Ki ±  0%        ~ (p=0.102 n=6)
ReadEvents/proto_codec_big_tx/10_events-16     43.17Ki ±  0%   43.16Ki ±  0%        ~ (p=0.416 n=6)
ReadEvents/proto_codec_big_tx/100_events-16    402.6Ki ±  0%   402.9Ki ±  0%        ~ (p=0.180 n=6)
ReadEvents/proto_codec_big_tx/199_events-16    690.8Ki ±  0%   691.0Ki ±  0%        ~ (p=0.974 n=6)
ReadEvents/proto_codec_big_tx/399_events-16    1.223Mi ±  0%   1.224Mi ±  0%        ~ (p=0.589 n=6)
ReadEvents/proto_codec_big_tx/1000_events-16   2.846Mi ±  0%   2.845Mi ±  0%        ~ (p=0.219 n=6)
ReadEvents/nop_codec/0_events-16                 312.0 ±  0%     312.0 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/nop_codec/1_events-16               2.680Ki ±  0%   2.683Ki ±  0%        ~ (p=0.470 n=6)
ReadEvents/nop_codec/10_events-16              10.28Ki ±  0%   10.28Ki ±  0%        ~ (p=0.390 n=6)
ReadEvents/nop_codec/100_events-16             80.96Ki ±  1%   81.10Ki ±  1%        ~ (p=1.000 n=6)
ReadEvents/nop_codec/199_events-16             132.0Ki ±  1%   132.6Ki ±  1%        ~ (p=0.240 n=6)
ReadEvents/nop_codec/399_events-16             210.8Ki ±  0%   211.6Ki ±  1%        ~ (p=0.065 n=6)
ReadEvents/nop_codec/1000_events-16            428.8Ki ±  1%   429.9Ki ±  2%        ~ (p=0.699 n=6)
ReadEvents/nop_codec_big_tx/0_events-16          312.0 ±  0%     312.0 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/nop_codec_big_tx/1_events-16        2.680Ki ±  0%   2.682Ki ±  0%        ~ (p=1.000 n=6)
ReadEvents/nop_codec_big_tx/10_events-16       10.27Ki ±  0%   10.25Ki ±  0%        ~ (p=0.331 n=6)
ReadEvents/nop_codec_big_tx/100_events-16      81.33Ki ±  1%   81.45Ki ±  1%        ~ (p=0.394 n=6)
ReadEvents/nop_codec_big_tx/199_events-16      132.4Ki ±  1%   132.7Ki ±  1%        ~ (p=0.240 n=6)
ReadEvents/nop_codec_big_tx/399_events-16      211.1Ki ±  2%   210.9Ki ±  2%        ~ (p=0.310 n=6)
ReadEvents/nop_codec_big_tx/1000_events-16     435.2Ki ±  2%   429.2Ki ±  2%        ~ (p=0.394 n=6)
ReadEventsHit/bigTX=true/hit=false-16          5.787Ki ± 45%   6.188Ki ± 89%        ~ (p=0.310 n=6)
ReadEventsHit/bigTX=true/hit=true-16           126.2Ki ±  0%   126.2Ki ±  0%        ~ (p=0.418 n=6)
ReadEventsHit/bigTX=false/hit=false-16         4.327Ki ± 20%   4.327Ki ± 38%        ~ (p=0.727 n=6)
ReadEventsHit/bigTX=false/hit=true-16          43.08Ki ±  0%   43.08Ki ±  0%        ~ (p=1.000 n=6)
IsTraceSampled/sampled-16                        176.0 ±  0%     176.0 ±  0%        ~ (p=1.000 n=6) ¹
IsTraceSampled/unsampled-16                      176.0 ±  0%     176.0 ±  0%        ~ (p=1.000 n=6) ¹
IsTraceSampled/unknown-16                        334.0 ± 25%     343.0 ± 15%        ~ (p=0.699 n=6)
geomean                                        12.53Ki         12.33Ki         -1.66%
¹ all samples are equal

                                             │  before.out  │               after.out               │
                                             │  allocs/op   │  allocs/op    vs base                 │
ShardedWriteTransactionUncontended-16           5.000 ±  0%    4.000 ±  0%  -20.00% (p=0.002 n=6)
ShardedWriteTransactionContended-16             5.000 ±  0%    4.000 ±  0%  -20.00% (p=0.002 n=6)
WriteTransaction/proto_codec-16                 5.000 ±  0%    4.000 ±  0%  -20.00% (p=0.002 n=6)
WriteTransaction/proto_codec_big_tx-16          5.000 ±  0%    4.000 ±  0%  -20.00% (p=0.002 n=6)
WriteTransaction/nop_codec-16                   4.000 ±  0%    3.000 ±  0%  -25.00% (p=0.002 n=6)
WriteTransaction/nop_codec_big_tx-16            4.000 ±  0%    3.000 ±  0%  -25.00% (p=0.002 n=6)
ReadEvents/proto_codec/0_events-16              7.000 ±  0%    7.000 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/proto_codec/1_events-16              43.00 ±  0%    43.00 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/proto_codec/10_events-16             141.0 ±  0%    141.0 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/proto_codec/100_events-16           1.041k ±  0%   1.041k ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/proto_codec/199_events-16           1.536k ±  0%   1.536k ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/proto_codec/399_events-16           2.337k ±  0%   2.336k ±  0%        ~ (p=1.000 n=6)
ReadEvents/proto_codec/1000_events-16          4.538k ±  0%   4.538k ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/proto_codec_big_tx/0_events-16       7.000 ±  0%    7.000 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/proto_codec_big_tx/1_events-16       98.00 ±  0%    98.00 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/proto_codec_big_tx/10_events-16      691.0 ±  0%    691.0 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/proto_codec_big_tx/100_events-16    6.541k ±  0%   6.541k ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/proto_codec_big_tx/199_events-16    12.48k ±  0%   12.48k ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/proto_codec_big_tx/399_events-16    24.28k ±  0%   24.28k ±  0%        ~ (p=0.864 n=6)
ReadEvents/proto_codec_big_tx/1000_events-16   59.54k ±  0%   59.54k ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/nop_codec/0_events-16                7.000 ±  0%    7.000 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/nop_codec/1_events-16                38.00 ±  0%    38.00 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/nop_codec/10_events-16               99.00 ±  0%    99.00 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/nop_codec/100_events-16              639.0 ±  0%    639.0 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/nop_codec/199_events-16              936.0 ±  0%    936.0 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/nop_codec/399_events-16             1.336k ±  0%   1.335k ±  0%        ~ (p=0.242 n=6)
ReadEvents/nop_codec/1000_events-16            2.336k ±  0%   2.336k ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/nop_codec_big_tx/0_events-16         7.000 ±  0%    7.000 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/nop_codec_big_tx/1_events-16         38.00 ±  0%    38.00 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/nop_codec_big_tx/10_events-16        99.00 ±  0%    99.00 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/nop_codec_big_tx/100_events-16       639.0 ±  0%    639.0 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/nop_codec_big_tx/199_events-16       936.0 ±  0%    936.0 ±  0%        ~ (p=1.000 n=6) ¹
ReadEvents/nop_codec_big_tx/399_events-16      1.336k ±  0%   1.336k ±  0%        ~ (p=1.000 n=6)
ReadEvents/nop_codec_big_tx/1000_events-16     2.336k ±  0%   2.336k ±  0%        ~ (p=1.000 n=6) ¹
ReadEventsHit/bigTX=true/hit=false-16           46.50 ± 33%    47.50 ±  7%        ~ (p=0.777 n=6)
ReadEventsHit/bigTX=true/hit=true-16            918.0 ±  0%    918.0 ±  0%        ~ (p=1.000 n=6) ¹
ReadEventsHit/bigTX=false/hit=false-16          50.00 ± 16%    50.00 ± 32%        ~ (p=0.727 n=6)
ReadEventsHit/bigTX=false/hit=true-16           643.0 ±  0%    643.0 ±  0%        ~ (p=1.000 n=6) ¹
IsTraceSampled/sampled-16                       1.000 ±  0%    1.000 ±  0%        ~ (p=1.000 n=6) ¹
IsTraceSampled/unsampled-16                     1.000 ±  0%    1.000 ±  0%        ~ (p=1.000 n=6) ¹
IsTraceSampled/unknown-16                       5.000 ±  0%    5.000 ±  0%        ~ (p=1.000 n=6) ¹
geomean                                         138.7          133.9         -3.47%
¹ all samples are equal
```

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~~
~~- [ ] Documentation has been updated~~

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->
No tests needed

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
