### PR TITLE
TBS: perf: Pool APMEvent in sampling decision handler

### DIFF
--- a/x-pack/apm-server/sampling/eventstorage/storage.go
+++ b/x-pack/apm-server/sampling/eventstorage/storage.go
@@ -288,16 +288,16 @@ func (rw *ReadWriter) ReadTraceEvents(traceID string, out *modelpb.Batch) error 
 		}
 		switch item.UserMeta() {
 		case entryMetaTraceEvent:
-			var event modelpb.APMEvent
+			event := modelpb.APMEventFromVTPool()
 			if err := item.Value(func(data []byte) error {
-				if err := rw.s.codec.DecodeEvent(data, &event); err != nil {
+				if err := rw.s.codec.DecodeEvent(data, event); err != nil {
 					return fmt.Errorf("codec failed to decode event: %w", err)
 				}
 				return nil
 			}); err != nil {
 				return err
 			}
-			*out = append(*out, &event)
+			*out = append(*out, event)
 		default:
 			// Unknown entry meta: ignore.
 			continue

--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -429,10 +429,14 @@ func TestProcessRemoteTailSampling(t *testing.T) {
 
 	reported := make(chan modelpb.Batch)
 	config.BatchProcessor = modelpb.ProcessBatchFunc(func(ctx context.Context, batch *modelpb.Batch) error {
+		batchCopy := make(modelpb.Batch, len(*batch))
+		for i := range *batch {
+			batchCopy[i] = (*batch)[i].CloneVT()
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case reported <- *batch:
+		case reported <- batchCopy:
 			return nil
 		}
 	})

--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -429,14 +429,10 @@ func TestProcessRemoteTailSampling(t *testing.T) {
 
 	reported := make(chan modelpb.Batch)
 	config.BatchProcessor = modelpb.ProcessBatchFunc(func(ctx context.Context, batch *modelpb.Batch) error {
-		batchCopy := make(modelpb.Batch, len(*batch))
-		for i := range *batch {
-			batchCopy[i] = (*batch)[i].CloneVT()
-		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case reported <- batchCopy:
+		case reported <- batch.Clone():
 			return nil
 		}
 	})


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Pool APMEvent struct in ReadTraceEvents for ~20% perf gain.

Benchmarks (with uncommitted benchmark change):
```
diff --git a/x-pack/apm-server/sampling/eventstorage/storage_bench_test.go b/x-pack/apm-server/sampling/eventstorage/storage_bench_test.go
index 3c5bafcf1..c86898bc8 100644
--- a/x-pack/apm-server/sampling/eventstorage/storage_bench_test.go
+++ b/x-pack/apm-server/sampling/eventstorage/storage_bench_test.go
@@ -128,6 +128,9 @@ func BenchmarkReadEvents(b *testing.B) {
 							count, len(batch),
 						))
 					}
+					for i := range batch {
+						batch[i].ReturnToVTPool()
+					}
 				}
 			})
 		}
```

Benchstat:
```
goos: linux
goarch: amd64
pkg: github.com/elastic/apm-server/x-pack/apm-server/sampling/eventstorage
cpu: 11th Gen Intel(R) Core(TM) i7-11800H @ 2.30GHz
                                             │ before-pool.out │           after-pool.out            │
                                             │     sec/op      │    sec/op     vs base               │
ReadEvents/proto_codec/0_events-16                738.7n ±  6%   973.8n ± 18%  +31.84% (p=0.002 n=6)
ReadEvents/proto_codec/1_events-16                7.562µ ±  6%   9.656µ ± 21%  +27.70% (p=0.017 n=6)
ReadEvents/proto_codec/10_events-16               28.86µ ±  8%   31.14µ ±  6%   +7.93% (p=0.026 n=6)
ReadEvents/proto_codec/100_events-16              220.8µ ±  6%   216.2µ ±  7%        ~ (p=0.240 n=6)
ReadEvents/proto_codec/199_events-16              414.4µ ±  5%   412.7µ ±  6%        ~ (p=0.485 n=6)
ReadEvents/proto_codec/399_events-16              712.0µ ±  2%   697.3µ ±  7%        ~ (p=0.240 n=6)
ReadEvents/proto_codec/1000_events-16             1.511m ±  2%   1.506m ±  9%        ~ (p=0.937 n=6)
ReadEvents/proto_codec_big_tx/0_events-16         750.1n ±  2%   738.3n ±  6%        ~ (p=0.180 n=6)
ReadEvents/proto_codec_big_tx/1_events-16         13.29µ ±  4%   11.65µ ±  6%  -12.30% (p=0.002 n=6)
ReadEvents/proto_codec_big_tx/10_events-16        82.53µ ±  6%   68.22µ ±  3%  -17.34% (p=0.002 n=6)
ReadEvents/proto_codec_big_tx/100_events-16       712.9µ ±  7%   537.6µ ±  3%  -24.59% (p=0.002 n=6)
ReadEvents/proto_codec_big_tx/199_events-16       1.398m ±  1%   1.073m ±  1%  -23.24% (p=0.002 n=6)
ReadEvents/proto_codec_big_tx/399_events-16       2.635m ±  2%   2.008m ±  5%  -23.81% (p=0.002 n=6)
ReadEvents/proto_codec_big_tx/1000_events-16      6.293m ±  9%   4.799m ±  6%  -23.74% (p=0.002 n=6)
ReadEvents/nop_codec/0_events-16                  750.3n ±  4%   736.1n ±  1%        ~ (p=0.180 n=6)
ReadEvents/nop_codec/1_events-16                  7.017µ ±  9%   7.636µ ±  5%        ~ (p=0.065 n=6)
ReadEvents/nop_codec/10_events-16                 25.34µ ± 13%   26.14µ ±  3%        ~ (p=0.180 n=6)
ReadEvents/nop_codec/100_events-16                184.3µ ±  6%   188.0µ ±  5%        ~ (p=0.394 n=6)
ReadEvents/nop_codec/199_events-16                359.6µ ±  6%   360.8µ ±  6%        ~ (p=0.818 n=6)
ReadEvents/nop_codec/399_events-16                590.4µ ±  3%   625.2µ ±  4%   +5.90% (p=0.009 n=6)
ReadEvents/nop_codec/1000_events-16               1.186m ±  2%   1.270m ±  4%   +7.10% (p=0.002 n=6)
ReadEvents/nop_codec_big_tx/0_events-16           737.8n ±  3%   747.2n ±  1%        ~ (p=0.132 n=6)
ReadEvents/nop_codec_big_tx/1_events-16           7.194µ ±  3%   7.572µ ±  8%   +5.25% (p=0.041 n=6)
ReadEvents/nop_codec_big_tx/10_events-16          24.66µ ±  5%   25.93µ ±  3%   +5.15% (p=0.002 n=6)
ReadEvents/nop_codec_big_tx/100_events-16         182.6µ ±  3%   188.4µ ±  4%        ~ (p=0.093 n=6)
ReadEvents/nop_codec_big_tx/199_events-16         402.5µ ± 37%   359.7µ ±  2%        ~ (p=0.065 n=6)
ReadEvents/nop_codec_big_tx/399_events-16         765.3µ ±  5%   610.0µ ±  4%  -20.29% (p=0.002 n=6)
ReadEvents/nop_codec_big_tx/1000_events-16        1.198m ± 22%   1.245m ±  2%        ~ (p=0.065 n=6)
geomean                                           92.64µ         90.07µ         -2.78%

                                             │ before-pool.out │             after-pool.out             │
                                             │      B/op       │     B/op       vs base                 │
ReadEvents/proto_codec/0_events-16                  312.0 ± 0%      312.0 ± 0%        ~ (p=1.000 n=6) ¹
ReadEvents/proto_codec/1_events-16                3.102Ki ± 0%    2.522Ki ± 0%  -18.68% (p=0.002 n=6)
ReadEvents/proto_codec/10_events-16              14.100Ki ± 0%    8.328Ki ± 0%  -40.94% (p=0.002 n=6)
ReadEvents/proto_codec/100_events-16             118.82Ki ± 0%    61.06Ki ± 1%  -48.61% (p=0.002 n=6)
ReadEvents/proto_codec/199_events-16             197.33Ki ± 0%    82.45Ki ± 1%  -58.22% (p=0.002 n=6)
ReadEvents/proto_codec/399_events-16              335.7Ki ± 1%    105.4Ki ± 3%  -68.60% (p=0.002 n=6)
ReadEvents/proto_codec/1000_events-16             719.5Ki ± 0%    144.0Ki ± 5%  -79.99% (p=0.002 n=6)
ReadEvents/proto_codec_big_tx/0_events-16           312.0 ± 0%      312.0 ± 0%        ~ (p=1.000 n=6) ¹
ReadEvents/proto_codec_big_tx/1_events-16         6.297Ki ± 0%    4.361Ki ± 0%  -30.74% (p=0.002 n=6)
ReadEvents/proto_codec_big_tx/10_events-16        43.22Ki ± 0%    23.79Ki ± 0%  -44.97% (p=0.002 n=6)
ReadEvents/proto_codec_big_tx/100_events-16       402.6Ki ± 0%    210.0Ki ± 0%  -47.84% (p=0.002 n=6)
ReadEvents/proto_codec_big_tx/199_events-16       690.9Ki ± 0%    307.6Ki ± 0%  -55.48% (p=0.002 n=6)
ReadEvents/proto_codec_big_tx/399_events-16      1252.6Ki ± 0%    486.5Ki ± 0%  -61.16% (p=0.002 n=6)
ReadEvents/proto_codec_big_tx/1000_events-16     2913.9Ki ± 0%   1009.1Ki ± 1%  -65.37% (p=0.002 n=6)
ReadEvents/nop_codec/0_events-16                    312.0 ± 0%      312.0 ± 0%        ~ (p=1.000 n=6) ¹
ReadEvents/nop_codec/1_events-16                  2.681Ki ± 0%    2.338Ki ± 0%  -12.77% (p=0.002 n=6)
ReadEvents/nop_codec/10_events-16                10.268Ki ± 0%    6.863Ki ± 1%  -33.16% (p=0.002 n=6)
ReadEvents/nop_codec/100_events-16                81.51Ki ± 0%    46.40Ki ± 2%  -43.08% (p=0.002 n=6)
ReadEvents/nop_codec/199_events-16               132.46Ki ± 0%    64.33Ki ± 2%  -51.44% (p=0.002 n=6)
ReadEvents/nop_codec/399_events-16               210.91Ki ± 1%    74.72Ki ± 1%  -64.57% (p=0.002 n=6)
ReadEvents/nop_codec/1000_events-16              428.40Ki ± 0%    87.19Ki ± 3%  -79.65% (p=0.002 n=6)
ReadEvents/nop_codec_big_tx/0_events-16             312.0 ± 0%      312.0 ± 0%        ~ (p=1.000 n=6) ¹
ReadEvents/nop_codec_big_tx/1_events-16           2.680Ki ± 0%    2.336Ki ± 0%  -12.84% (p=0.002 n=6)
ReadEvents/nop_codec_big_tx/10_events-16         10.282Ki ± 0%    6.856Ki ± 1%  -33.32% (p=0.002 n=6)
ReadEvents/nop_codec_big_tx/100_events-16         80.98Ki ± 1%    46.38Ki ± 2%  -42.72% (p=0.002 n=6)
ReadEvents/nop_codec_big_tx/199_events-16        131.48Ki ± 1%    64.13Ki ± 2%  -51.22% (p=0.002 n=6)
ReadEvents/nop_codec_big_tx/399_events-16        212.07Ki ± 1%    74.58Ki ± 1%  -64.83% (p=0.002 n=6)
ReadEvents/nop_codec_big_tx/1000_events-16       432.27Ki ± 1%    87.70Ki ± 1%  -79.71% (p=0.002 n=6)
geomean                                           39.26Ki         20.36Ki       -48.14%
¹ all samples are equal

                                             │ before-pool.out │            after-pool.out            │
                                             │    allocs/op    │  allocs/op   vs base                 │
ReadEvents/proto_codec/0_events-16                  7.000 ± 0%    7.000 ± 0%        ~ (p=1.000 n=6) ¹
ReadEvents/proto_codec/1_events-16                  43.00 ± 0%    41.00 ± 0%   -4.65% (p=0.002 n=6)
ReadEvents/proto_codec/10_events-16                 141.0 ± 0%    121.0 ± 0%  -14.18% (p=0.002 n=6)
ReadEvents/proto_codec/100_events-16               1041.0 ± 0%    841.0 ± 0%  -19.21% (p=0.002 n=6)
ReadEvents/proto_codec/199_events-16               1.536k ± 0%   1.138k ± 0%  -25.91% (p=0.002 n=6)
ReadEvents/proto_codec/399_events-16               2.336k ± 0%   1.538k ± 0%  -34.15% (p=0.002 n=6)
ReadEvents/proto_codec/1000_events-16              4.538k ± 0%   2.541k ± 0%  -44.01% (p=0.002 n=6)
ReadEvents/proto_codec_big_tx/0_events-16           7.000 ± 0%    7.000 ± 0%        ~ (p=1.000 n=6) ¹
ReadEvents/proto_codec_big_tx/1_events-16           98.00 ± 0%    81.00 ± 0%  -17.35% (p=0.002 n=6)
ReadEvents/proto_codec_big_tx/10_events-16          691.0 ± 0%    521.0 ± 0%  -24.60% (p=0.002 n=6)
ReadEvents/proto_codec_big_tx/100_events-16        6.541k ± 0%   4.842k ± 0%  -25.97% (p=0.002 n=6)
ReadEvents/proto_codec_big_tx/199_events-16       12.481k ± 0%   9.100k ± 0%  -27.09% (p=0.002 n=6)
ReadEvents/proto_codec_big_tx/399_events-16        24.28k ± 0%   17.51k ± 0%  -27.87% (p=0.002 n=6)
ReadEvents/proto_codec_big_tx/1000_events-16       59.54k ± 0%   42.62k ± 0%  -28.42% (p=0.002 n=6)
ReadEvents/nop_codec/0_events-16                    7.000 ± 0%    7.000 ± 0%        ~ (p=1.000 n=6) ¹
ReadEvents/nop_codec/1_events-16                    38.00 ± 0%    37.00 ± 0%   -2.63% (p=0.002 n=6)
ReadEvents/nop_codec/10_events-16                   99.00 ± 0%    89.00 ± 0%  -10.10% (p=0.002 n=6)
ReadEvents/nop_codec/100_events-16                  639.0 ± 0%    539.0 ± 0%  -15.65% (p=0.002 n=6)
ReadEvents/nop_codec/199_events-16                  936.0 ± 0%    737.0 ± 0%  -21.26% (p=0.002 n=6)
ReadEvents/nop_codec/399_events-16                 1336.0 ± 0%    937.0 ± 0%  -29.87% (p=0.002 n=6)
ReadEvents/nop_codec/1000_events-16                2.336k ± 0%   1.337k ± 0%  -42.77% (p=0.002 n=6)
ReadEvents/nop_codec_big_tx/0_events-16             7.000 ± 0%    7.000 ± 0%        ~ (p=1.000 n=6) ¹
ReadEvents/nop_codec_big_tx/1_events-16             38.00 ± 0%    37.00 ± 0%   -2.63% (p=0.002 n=6)
ReadEvents/nop_codec_big_tx/10_events-16            99.00 ± 0%    89.00 ± 0%  -10.10% (p=0.002 n=6)
ReadEvents/nop_codec_big_tx/100_events-16           639.0 ± 0%    539.0 ± 0%  -15.65% (p=0.002 n=6)
ReadEvents/nop_codec_big_tx/199_events-16           936.0 ± 0%    737.0 ± 0%  -21.26% (p=0.002 n=6)
ReadEvents/nop_codec_big_tx/399_events-16          1336.0 ± 0%    937.0 ± 0%  -29.87% (p=0.002 n=6)
ReadEvents/nop_codec_big_tx/1000_events-16         2.336k ± 0%   1.337k ± 0%  -42.77% (p=0.002 n=6)
geomean                                             439.0         349.6       -20.35%
¹ all samples are equal
```

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~~
~~- [ ] Documentation has been updated~~

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

Check that TBS works as normal

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
