### PR TITLE
udpatecli: support bump golang for 7.17

### DIFF
--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -27,7 +27,7 @@ scms:
       owner: elastic
       repository: apm-server
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      branch: main
+      branch: '{{ requiredEnv "GITHUB_BRANCH" }}'
       commitusingapi: true
 
 sources:

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -21,8 +21,31 @@ jobs:
           command: --experimental apply --config .ci/bump-golang.yml
         env:
           GITHUB_TOKEN: ${{ secrets.UPDATECLI_GH_TOKEN }}
+          GITHUB_BRANCH: 'main'
 
-      - if: ${{ failure() }}
+  bump-7:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@v4
+
+      - uses: elastic/oblt-actions/updatecli/run@v1.9.1
+        with:
+          command: --experimental apply --config .ci/bump-golang.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.UPDATECLI_GH_TOKEN }}
+          GITHUB_BRANCH: '7.17'
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: [bump, bump-7]
+    if: always()
+    steps:
+      - id: check
+        uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
+        with:
+          needs: ${{ toJSON(needs) }}
+      - if: ${{ steps.check.outputs.isSuccess == 'false' }}
         uses: elastic/oblt-actions/slack/send@v1.9.1
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -26,8 +26,9 @@ jobs:
   bump-7:
     runs-on: ubuntu-latest
     steps:
-
       - uses: actions/checkout@v4
+        with:
+          ref: '7.17'
 
       - uses: elastic/oblt-actions/updatecli/run@v1.9.1
         with:


### PR DESCRIPTION
## Motivation/summary

7.17 branch uses a different go-version, let's enable the auto-bump

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

Locally using the `updatecli` or in the CI using a feature branch:
- https://github.com/elastic/apm-server/actions/runs/9779430585


But it requires to checkout the 7.17 branch too, so we need to test it out after merging it 

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
