### PR TITLE
fix: Update `FlushBytes` parsing/defaults

### DIFF
--- a/changelogs/head.asciidoc
+++ b/changelogs/head.asciidoc
@@ -9,6 +9,7 @@ https://github.com/elastic/apm-server/compare/8.14\...main[View commits]
 - Avoid data race due to reuse of `bytes.Buffer` in ES bulk requests {pull}13155[13155]
 - APM Server now relies on the Elasticsearch apm-data plugin's index templates, which reverts some unsafe uses of `flattened` field types {pull}12066[12066]
 - Add `error.id` to jaeger errors {pull}13196[13196]
+- Fix a performance regression for apm servers which don't specify `output.elasticsearch.flush_bytes` {pull}13576[13576]
 
 [float]
 ==== Breaking Changes

--- a/internal/beater/beater.go
+++ b/internal/beater/beater.go
@@ -733,7 +733,7 @@ func (s *Runner) newDocappenderConfig(tracer *apm.Tracer, memLimit float64) (
 		} `config:"autoscaling"`
 	}
 	// Default to 1mib flushes, which is the default for go-docappender.
-	// esConfig.FlushBytes = "1 mib"
+	esConfig.FlushBytes = "1 mib"
 	esConfig.FlushInterval = time.Second
 	esConfig.Config = elasticsearch.DefaultConfig()
 	esConfig.MaxIdleConnsPerHost = 10

--- a/internal/beater/beater_test.go
+++ b/internal/beater/beater_test.go
@@ -29,10 +29,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.elastic.co/apm/v2/apmtest"
+	"go.uber.org/zap"
 
 	"github.com/elastic/apm-server/internal/beater/config"
 	"github.com/elastic/apm-server/internal/elasticsearch"
+	agentconfig "github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/monitoring"
+	"github.com/elastic/go-docappender/v2"
 )
 
 func TestStoreUsesRUMElasticsearchConfig(t *testing.T) {
@@ -151,4 +155,75 @@ func newMockClusterUUIDClient(t testing.TB, clusterUUID string) *elasticsearch.C
 	client, err := elasticsearch.NewClient(config)
 	require.NoError(t, err)
 	return client
+}
+
+func TestRunnerNewDocappenderConfig(t *testing.T) {
+	var tc = []struct {
+		memSize         float64
+		wantMaxRequests int
+		wantDocBufSize  int
+	}{
+		{memSize: 1, wantMaxRequests: 11, wantDocBufSize: 819},
+		{memSize: 2, wantMaxRequests: 13, wantDocBufSize: 1638},
+		{memSize: 4, wantMaxRequests: 16, wantDocBufSize: 3276},
+		{memSize: 8, wantMaxRequests: 22, wantDocBufSize: 6553},
+	}
+	for _, c := range tc {
+		t.Run(fmt.Sprintf("default/%vgb", c.memSize), func(t *testing.T) {
+			r := Runner{
+				elasticsearchOutputConfig: agentconfig.NewConfig(),
+				logger:                    logp.NewLogger("test"),
+			}
+			docCfg, esCfg, err := r.newDocappenderConfig(nil, c.memSize)
+			require.NoError(t, err)
+			assert.Equal(t, docappender.Config{
+				Logger:             zap.New(r.logger.Core(), zap.WithCaller(true)),
+				CompressionLevel:   5,
+				RequireDataStream:  true,
+				FlushInterval:      time.Second,
+				FlushBytes:         1024 * 1024,
+				MaxRequests:        c.wantMaxRequests,
+				DocumentBufferSize: c.wantDocBufSize,
+			}, docCfg)
+			assert.Equal(t, &elasticsearch.Config{
+				Hosts:               elasticsearch.Hosts{"localhost:9200"},
+				Backoff:             elasticsearch.DefaultBackoffConfig,
+				Protocol:            "http",
+				CompressionLevel:    5,
+				Timeout:             5 * time.Second,
+				MaxRetries:          3,
+				MaxIdleConnsPerHost: c.wantMaxRequests,
+			}, esCfg)
+		})
+		t.Run(fmt.Sprintf("override/%vgb", c.memSize), func(t *testing.T) {
+			r := Runner{
+				elasticsearchOutputConfig: agentconfig.MustNewConfigFrom(map[string]interface{}{
+					"flush_bytes":    "500 kib",
+					"flush_interval": "2s",
+					"max_requests":   50,
+				}),
+				logger: logp.NewLogger("test"),
+			}
+			docCfg, esCfg, err := r.newDocappenderConfig(nil, c.memSize)
+			require.NoError(t, err)
+			assert.Equal(t, docappender.Config{
+				Logger:             zap.New(r.logger.Core(), zap.WithCaller(true)),
+				CompressionLevel:   5,
+				RequireDataStream:  true,
+				FlushInterval:      2 * time.Second,
+				FlushBytes:         500 * 1024,
+				MaxRequests:        50,
+				DocumentBufferSize: c.wantDocBufSize,
+			}, docCfg)
+			assert.Equal(t, &elasticsearch.Config{
+				Hosts:               elasticsearch.Hosts{"localhost:9200"},
+				Backoff:             elasticsearch.DefaultBackoffConfig,
+				Protocol:            "http",
+				CompressionLevel:    5,
+				Timeout:             5 * time.Second,
+				MaxRetries:          3,
+				MaxIdleConnsPerHost: 50,
+			}, esCfg)
+		})
+	}
 }


### PR DESCRIPTION
## Motivation/summary

Updates the `FlushBytes` setting to default to 1 mib and only override to 24kb if the user has explicitly set it to 24kb.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
~- [ ] Documentation has been updated~

## How to test these changes

1. Spin up an APM Server and send data to it (without this fix).
2. Look at the request length for Elasticsearch requests and verify they're smaller than 50kb and very close to 24kb (26kb)
3. Now start apm sever with the code in this PR and send data to it
4. Verify that the flush size is significantly higher than before and if you sent enough data it should be ~1MB.

## Related issues

Fixes #13024
