### PR TITLE
benchmarks: Increase AWS token duration to `5h`

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -88,7 +88,7 @@ jobs:
 
       - uses: elastic/oblt-actions/aws/auth@v1
         with:
-          role-duration-seconds: 14400 # 4 hours
+          role-duration-seconds: 18000 # 5 hours
 
       - uses: google-github-actions/get-secretmanager-secrets@dc4a1392bad0fd60aee00bb2097e30ef07a1caae # v2.1.3
         with:


### PR DESCRIPTION
Should fix the token duration expiration issues: https://github.com/elastic/apm-server/actions/runs/9797871743/attempts/1