### PR TITLE
fix: specify correct path for tools/go.mod when running benchmark 

### DIFF
--- a/testing/benchmark/Makefile
+++ b/testing/benchmark/Makefile
@@ -105,7 +105,7 @@ run-benchmark-autotuned:
 
 .PHONY: index-benchmark-results
 index-benchmark-results: _default-gobench-vars
-	@cat $(BENCHMARK_RESULT) | go run -modfile=tools/go.mod github.com/elastic/gobench -es $(GOBENCH_HOST) -es-username $(GOBENCH_USERNAME) -es-password $(GOBENCH_PASSWORD) \
+	@cat $(BENCHMARK_RESULT) | go run -modfile=$(GITROOT)/tools/go.mod github.com/elastic/gobench -es $(GOBENCH_HOST) -es-username $(GOBENCH_USERNAME) -es-password $(GOBENCH_PASSWORD) \
 	-index $(GOBENCH_INDEX) -tag "$(GOBENCH_DEFAULT_TAGS),$(GOBENCH_TAGS)"
 
 .PHONY: _default-gobench-vars


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

Benchmark fails with the following error message:
```
go: open tools/go.mod: no such file or directory
cat: write error: Broken pipe
```

This is caused by specifying the wrong path for the target file; the working directory is `apm-server/testing/apmbenech` and the target file is in `apm-server/tools/go.mod`
```
make[1]: Entering directory '/home/runner/work/apm-server/apm-server/testing/benchmark'
```

fix it by specifying the correct path for the `tools/go.mod` file by using `GITROOT`:
https://github.com/elastic/apm-server/blob/ab4b728811ea24923064b8a6d9218cdc7acbb0d9/go.mk#L6

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] ~Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~
- [ ] ~Documentation has been updated~

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->

Introduced by https://github.com/elastic/apm-server/pull/13421/files
