### PR TITLE
dependabot: only commit NOTICE.txt if it changed

### DIFF
--- a/.github/workflows/update-dependabot-pr.yml
+++ b/.github/workflows/update-dependabot-pr.yml
@@ -25,8 +25,19 @@ jobs:
           go-version-file: go.mod
       - name: Update NOTICE.txt
         run: make notice
+      - name: Check if NOTICE.txt has changed
+        id: check-notice-diff
+        run: |
+          git diff --exit-code NOTICE.txt
+          result="$?"
+          if [[ "$result" -eq 0 ]]; then
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
       # inspired by https://gist.github.com/swinton/03e84635b45c78353b1f71e41007fc7c
       - name: Commit changes (signed)
+        if: steps.check-notice-diff.outputs.changed
         run: |
           export BRANCH=${GITHUB_REF#refs/heads/}
           export SHA=$(git rev-parse "$BRANCH:$FILE_TO_COMMIT")


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

The [update-dependabot-pr](https://github.com/elastic/apm-server/blob/main/.github/workflows/update-dependabot-pr.yml) workflow is also pushing empty commits if the NOTICE.txt file did not change.

This change makes sure the NOTICE.txt file has changed before attempting to push a commit.

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
