### PR TITLE
dependabot: use git-status instead of git-diff

### DIFF
--- a/.github/workflows/update-dependabot-pr.yml
+++ b/.github/workflows/update-dependabot-pr.yml
@@ -26,14 +26,14 @@ jobs:
       - name: Update NOTICE.txt
         run: make notice
       - name: Debug diff
-        run: git diff-index HEAD -- NOTICE.txt
+        run: git status --porcelain
       - name: Check if NOTICE.txt has changed
         id: check-notice-diff
         run: |
-          if git diff-index --quiet HEAD -- NOTICE.txt; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          else
+          if git status --porcelain | grep -q 'NOTICE.txt'; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Debug output
         run: |-


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

dependabot PRs still are getting empty commits when merging the main branch into it.

From what I understand `git diff` behaves differently if it's a merge commit. But I could not get it working with `git diff`.

Hence, I'm replacing the command with `git status --porcelain` + `grep`. I was able to reproduce and test it in my fork https://github.com/reakaleek/apm-server/actions/runs/10290457526/workflow?pr=22#L31. 

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
