### PR TITLE
Bump up version to 8.15.1

### DIFF
--- a/cmd/intake-receiver/version.go
+++ b/cmd/intake-receiver/version.go
@@ -18,4 +18,4 @@
 package main
 
 // version matches the APM Server's version
-const version = "8.15.0"
+const version = "8.15.1"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -18,4 +18,4 @@
 package version
 
 // Version holds the APM Server version.
-const Version = "8.15.0"
+const Version = "8.15.1"


### PR DESCRIPTION
Release of 8.15.0 today requires bumping the versions to 8.15.1
