### PR TITLE
feat: replace apm-server group with obs-ds-intake-services

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,7 +11,7 @@ metadata:
 
 spec:
   type: tool
-  owner: group:apm-server
+  owner: group:obs-ds-intake-services
   lifecycle: production
 
 ---
@@ -26,7 +26,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:apm-server
+  owner: group:obs-ds-intake-services
   system: buildkite
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -45,7 +45,7 @@ spec:
       cancel_intermediate_builds: false
       skip_intermediate_builds: false
       teams:
-        apm-server: {}
+        obs-ds-intake-services: {}
         observablt-robots: {}
         everyone:
           access_level: READ_ONLY


### PR DESCRIPTION


<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

the apm-server group is deprecated and obs-ds-intake-services should be used instead.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
