### PR TITLE
ci: note that golang bumps require an upstream PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,25 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - run: make publish-docker-images
+
+  # Only for forked PRs, when changing the .go-version, then we need to note that the wolfi docker image needs to be
+  # validated
+  validate-wolfi-docker-image:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true || github.actor == 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@c65cd883420fd2eb864698a825fc4162dd94482c # v44.5.7
+        with:
+          files: .go-version
+
+      - name: If .go-version changed validate docker image is available.
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          echo "If you change the .go-version please use a branch in the upstream repository to validate the wolfi images with test-package-and-push."
+          echo "Otherwise, this validation will run and fail the CI build."
+          echo "Please validate the wolfi image is available by running the following command:"
+          echo "::notice::docker pull docker.elastic.co/wolfi/go:$(cat .go-version)"
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
   # validated
   validate-wolfi-docker-image:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true || github.actor == 'dependabot[bot]'
+    if: ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true ) || github.actor == 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
       - name: Get changed files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,4 +134,6 @@ jobs:
           echo "Otherwise, this validation will run and fail the CI build."
           echo "Please validate the wolfi image is available by running the following command:"
           echo "::notice::docker pull docker.elastic.co/wolfi/go:$(cat .go-version)"
+          echo "If they are available you could skip this validation."
+          echo "However, we recommend to use an upstream branch to run the CI specialised steps for the packaging system."
           exit 1


### PR DESCRIPTION
## Motivation/summary


The CI only validates that wolfi docker images are available when running on upstream PRs or branches. It does not support forked PRs or dependabot, it's not possible to access the GitHub secrets for security reasons.

Therefore, if the `.go-version` file gets changed through a forked PR, then we only know if the packaging will work after merging it.

I'd suggest any changes to `.go-version` should always go through upstream branches and PRs. 

This is the way we can know things work as expected before merging anything.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
