### PR TITLE
mergify: replace queue action for queue_rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,6 @@
 queue_rules:
   - name: default
+    merge_method: squash
     conditions:
       - check-success=test (macos-latest)
       - check-success=test (windows-latest)
@@ -150,7 +151,6 @@ pull_request_rules:
       - -conflict
     actions:
       queue:
-        method: squash
         name: default
   - name: delete updatecli branch after merging/closing it
     conditions:
@@ -213,7 +213,6 @@ pull_request_rules:
       - -conflict
     actions:
       queue:
-        method: squash
         name: default
   - name: backport patches to 8.5 branch
     conditions:


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

Use queue_rules instead of queue action

## Why

The queue action from workflow automation has deprecated all of its configuration options

https://changelog.mergify.com/changelog/queue-action-options-deprecation
