### PR TITLE
ci(dra): support 8.x in addition to feature branches

### DIFF
--- a/.buildkite/scripts/dra.sh
+++ b/.buildkite/scripts/dra.sh
@@ -35,7 +35,10 @@ dra_command=collect
 BRANCHES_URL=https://storage.googleapis.com/artifacts-api/snapshots/branches.json
 curl -s "${BRANCHES_URL}" > active-branches.json
 # as long as `8.x` is not in the active branches, we will explicitly add the condition.
-if [ "$BUILDKITE_BRANCH" == "8.x" ] || ! grep -q "\"$BUILDKITE_BRANCH\"" active-branches.json ; then
+if [ "$BUILDKITE_BRANCH" == "8.x" ] || grep -q "\"$BUILDKITE_BRANCH\"" active-branches.json ; then
+  echo "--- :arrow_right: Release Manager only supports the current active branches and 8.x, running"
+else
+  # If no active branches are found, let's see if it is a feature branch.
   echo "--- :arrow_right: Release Manager only supports the current active branches, skipping"
   echo "BUILDKITE_BRANCH=$BUILDKITE_BRANCH"
   echo "BUILDKITE_COMMIT=$BUILDKITE_COMMIT"
@@ -52,9 +55,6 @@ if [ "$BUILDKITE_BRANCH" == "8.x" ] || ! grep -q "\"$BUILDKITE_BRANCH\"" active-
     MAJOR_MINOR=${VERSION%.*}
     if curl -s "https://storage.googleapis.com/artifacts-api/snapshots/main.json" | grep -q "$VERSION" ; then
       DRA_BRANCH=main
-    elif [ "$BUILDKITE_BRANCH" == "8.x" ] ; then
-      # as long as `8.x` is not in the active branches, we will explicitly add the condition.
-      DRA_BRANCH=8.x
     else
       if curl -s "https://storage.googleapis.com/artifacts-api/snapshots/$MAJOR_MINOR.json" | grep -q "$VERSION" ; then
         DRA_BRANCH="$MAJOR_MINOR"


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

https://github.com/elastic/apm-server/pull/14038 added support for the DRA in 8.x but it only enabled partially when targeting feature branches. I read the conditional in the reverse order.

Now, this will evaluate if the branch is in the list of supported branches or 8.x

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
