### PR TITLE
ci: support running smoke tests using the GitHub UI

### DIFF
--- a/.github/workflows/smoke-tests-ess.yml
+++ b/.github/workflows/smoke-tests-ess.yml
@@ -7,7 +7,12 @@ on:
       branch:
         required: true
         type: string
-
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'The branch to checkout'
+        required: true
+        type: string
 
 # limit the access of the generated GITHUB_TOKEN
 permissions:

--- a/.github/workflows/smoke-tests-os.yml
+++ b/.github/workflows/smoke-tests-os.yml
@@ -7,6 +7,12 @@ on:
       branch:
         required: true
         type: string
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'The branch to checkout'
+        required: true
+        type: string
 
 # limit the access of the generated GITHUB_TOKEN
 permissions:


### PR DESCRIPTION
for such it requires to listen for workflow_dispatch and then use the inputs

## Motivation/summary

As requested, team need to run the smoke tests in isolation in the CI to validate if changes work as expected.

The current pattern didn't allow to do so... this should help them

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
