### PR TITLE
Pin EC stack version to 8.x in CI

### DIFF
--- a/testing/benchmark/variables.tf
+++ b/testing/benchmark/variables.tf
@@ -20,7 +20,8 @@ variable "deployment_template" {
 }
 
 variable "stack_version" {
-  default     = "latest"
+  # Use the latest 8 version until 9 is ready.
+  default     = "8.?.?"
   description = "Optional stack version"
   type        = string
 }

--- a/testing/cloud/variables.tf
+++ b/testing/cloud/variables.tf
@@ -13,7 +13,8 @@ variable "deployment_template" {
 }
 
 variable "stack_version" {
-  default     = "latest"
+  # Use the latest 8 version until 9 is ready.
+  default     = "8.?.?"
   description = "Optional stack version"
   type        = string
 }

--- a/testing/infra/terraform/modules/ec_deployment/variables.tf
+++ b/testing/infra/terraform/modules/ec_deployment/variables.tf
@@ -19,7 +19,8 @@ variable "deployment_template" {
 }
 
 variable "stack_version" {
-  default     = "latest"
+  # Use the latest 8 version until 9 is ready.
+  default     = "8.?.?"
   description = "Optional stack version"
   type        = string
 }

--- a/testing/infra/terraform/modules/standalone_apm_server/variables.tf
+++ b/testing/infra/terraform/modules/standalone_apm_server/variables.tf
@@ -28,7 +28,8 @@ variable "elasticsearch_password" {
 }
 
 variable "stack_version" {
-  default     = "latest"
+  # Use the latest 8 version until 9 is ready.
+  default     = "8.?.?"
   description = "Optional stack version"
   type        = string
 }

--- a/testing/rally-cloud/variables.tf
+++ b/testing/rally-cloud/variables.tf
@@ -11,9 +11,10 @@ variable "deployment_template" {
 }
 
 variable "stack_version" {
+  # Use the latest 8 version until 9 is ready.
+  default     = "8.?.?"
   type        = string
   description = "Optional stack version"
-  default     = "latest"
 }
 
 variable "elasticsearch_size" {

--- a/testing/smoke/lib.sh
+++ b/testing/smoke/lib.sh
@@ -41,7 +41,8 @@ get_latest_snapshot() {
     if [ $RC -ne 0 ]; then echo "${RES}"; fi
     # NOTE: semver with SNAPSHOT is not working when using the sort_by function in jq,
     #       that's the reason for transforming the SNAPSHOT in a semver 4 digits.
-    VERSIONS=$(echo "${RES}" | jq -r -c '[.stacks[].version | select(. | contains("-SNAPSHOT"))] | sort' | sed 's#-SNAPSHOT#.0#g' | jq -r -c ' sort_by(.| split(".") | map(tonumber))' | sed 's#.0"#-SNAPSHOT"#g' | jq -r -c .)
+    # Filter out 9.0.0 temporarily until it's ready.
+    VERSIONS=$(echo "${RES}" | jq -r -c '[.stacks[].version | select(. | startswith("9.0.0") | not) | select(. | contains("-SNAPSHOT"))] | sort' | sed 's#-SNAPSHOT#.0#g' | jq -r -c ' sort_by(.| split(".") | map(tonumber))' | sed 's#.0"#-SNAPSHOT"#g' | jq -r -c .)
 }
 
 get_latest_snapshot_for_version() {

--- a/testing/smoke/managed/main.tf
+++ b/testing/smoke/managed/main.tf
@@ -77,7 +77,8 @@ variable "aws_provisioner_key_name" {
 }
 
 variable "stack_version" {
-  default     = "latest"
+  # Use the latest 8 version until 9 is ready.
+  default     = "8.?.?"
   description = "Optional stack version"
   type        = string
 }

--- a/testing/smoke/supported-os/main.tf
+++ b/testing/smoke/supported-os/main.tf
@@ -77,7 +77,8 @@ variable "aws_provisioner_key_name" {
 }
 
 variable "stack_version" {
-  default     = "latest"
+  # Use the latest 8 version until 9 is ready.
+  default     = "8.?.?"
   description = "Optional stack version"
   type        = string
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

This PR pins EC stack version in CI to the latest 8.x version until 9.x is ready.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

All relevant CI pipelines should be using latest 8.x stack version.

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
