### PR TITLE
ci: use ephemeral tokens instead of APM_SERVER_RELEASE_TOKEN

### DIFF
--- a/.github/workflows/run-minor-release.yml
+++ b/.github/workflows/run-minor-release.yml
@@ -19,7 +19,6 @@ permissions:
 env:
   JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
   SLACK_CHANNEL: "#apm-server"
-  GH_TOKEN: ${{ secrets.APM_SERVER_RELEASE_TOKEN }}
 
 jobs:
   prepare:
@@ -58,6 +57,18 @@ jobs:
             The `${{ github.repository }}@${{ env.RELEASE_BRANCH }}` branch will be created Today.
           thread-timestamp: ${{ needs.prepare.outputs.slack-thread || '' }}
 
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write",
+              "pull_requests": "write"
+            }
+
       - uses: actions/checkout@v4
         with:
           # 0 indicates all history for all branches and tags.
@@ -69,7 +80,7 @@ jobs:
       - name: Configure git user
         uses: elastic/oblt-actions/git/setup@v1
         with:
-          github-token: ${{ env.GH_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.token }}
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
@@ -80,6 +91,8 @@ jobs:
           git_commit_gpgsign: true
 
       - run: make minor-release
+        env:
+          GH_TOKEN: ${{ steps.get_token.outputs.token }}
 
       - if: success()
         uses: elastic/oblt-actions/slack/send@v1.9.1

--- a/.github/workflows/run-patch-release.yml
+++ b/.github/workflows/run-patch-release.yml
@@ -19,7 +19,6 @@ permissions:
 env:
   JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
   SLACK_CHANNEL: "#apm-server"
-  GH_TOKEN: ${{ secrets.APM_SERVER_RELEASE_TOKEN }}
 
 jobs:
   prepare:
@@ -56,13 +55,25 @@ jobs:
           # Use the makefile in the given release branch.
           ref: ${{ env.RELEASE_BRANCH }}
 
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write",
+              "pull_requests": "write"
+            }
+
       # Required to use a service account, otherwise PRs created by
       # GitHub bot won't trigger any CI builds.
       # See https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-537478081
       - name: Configure git user
         uses: elastic/oblt-actions/git/setup@v1
         with:
-          github-token: ${{ env.GH_TOKEN }}
+          github-token: ${{ steps.get_token.outputs.token }}
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
@@ -73,6 +84,8 @@ jobs:
           git_commit_gpgsign: true
 
       - run: make patch-release
+        env:
+          GH_TOKEN: ${{ steps.get_token.outputs.token }}
 
       - if: success()
         uses: elastic/oblt-actions/slack/send@v1


### PR DESCRIPTION
## Motivation/summary

Use ephemeral tokens , similarly done in https://github.com/elastic/apm-server/pull/14010

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
