### PR TITLE
benchmarks: add SetMemoryLimit to apmbench so it doesn't go OOM

### DIFF
--- a/systemtest/cmd/apmbench/main.go
+++ b/systemtest/cmd/apmbench/main.go
@@ -26,12 +26,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/go-sysinfo"
 	"go.elastic.co/apm/v2"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"golang.org/x/time/rate"
 
 	"github.com/elastic/apm-server/systemtest/benchtest"
+	"github.com/elastic/go-sysinfo"
 )
 
 func Benchmark1000Transactions(b *testing.B, l *rate.Limiter) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

In benchmarks workflow apm-perf occasionally goes OOM, this change sets memory limit to 90% of host memory to prevent OOM happening again. 

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
