### PR TITLE
ci: fix benchmarks cleanup

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -134,102 +134,102 @@ jobs:
           admin_console_url=$(terraform output -raw admin_console_url)
           echo "admin_console_url=$admin_console_url" >> "$GITHUB_OUTPUT"
           echo "-> infra setup done"
-#      - name: Run benchmarks autotuned
-#        if: ${{ inputs.benchmarkAgents == '' }}
-#        run: make run-benchmark-autotuned
-#
-#      - name: Run benchmarks self tuned
-#        if: ${{ inputs.benchmarkAgents != '' }}
-#        run: make run-benchmark
-#
-#      - name: Cat standalone server logs
-#        if: ${{ env.RUN_STANDALONE == 'true' && failure() }}
-#        run: make cat-apm-server-logs
-#
-#      - name: Index benchmarks result
-#        run: make index-benchmark-results
-#
-#      - name: Download PNG
-#        run: >-
-#          ${{ github.workspace }}/.ci/scripts/download-png-from-kibana.sh
-#          ${{ secrets.KIBANA_BENCH_ENDPOINT }}
-#          ${{ secrets.KIBANA_BENCH_USERNAME }}
-#          ${{ secrets.KIBANA_BENCH_PASSWORD }}
-#          $PNG_REPORT_FILE
-#
-#      - name: Upload PNG
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: kibana-png-report
-#          path: ${{ env.WORKING_DIRECTORY }}/${{ env.PNG_REPORT_FILE }}
-#          if-no-files-found: error
-#
-#      - name: Upload PNG to AWS S3
-#        id: s3-upload-png
-#        env:
-#          AWS_DEFAULT_REGION: us-east-1
-#        run: |
-#          DEST_NAME="github-run-id-${{ github.run_id }}.png"
-#          aws s3 --debug cp ${{ env.PNG_REPORT_FILE }} s3://elastic-apm-server-benchmark-reports/${DEST_NAME}
-#          echo "png_report_url=https://elastic-apm-server-benchmark-reports.s3.amazonaws.com/${DEST_NAME}" >> "$GITHUB_OUTPUT"
-#
-#      - name: Upload benchmark result
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: benchmark-result
-#          path: ${{ env.WORKING_DIRECTORY }}/${{ env.BENCHMARK_RESULT }}
-#          if-no-files-found: error
-#
-#      # The next section injects CPU profile collected by apmbench into the build.
-#      # By copying the profile, uploading it to the artifacts and pushing it
-#      # via a PR to update default.pgo.
-#
-#      - name: Copy CPU profile
-#        run: make cp-cpuprof
-#
-#      - name: Upload CPU profile
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: cpu-profile
-#          path: ${{ env.WORKING_DIRECTORY }}/${{ env.BENCHMARK_CPU_OUT }}
-#          if-no-files-found: error
-#
-#      - name: Get token
-#        id: get_token
-#        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-#        with:
-#          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
-#          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
-#          permissions: >-
-#            {
-#              "contents": "write",
-#              "pull_requests": "write"
-#            }
-#
-#      # Required to use a service account, otherwise PRs created by
-#      # GitHub bot won't trigger any CI builds.
-#      # See https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-537478081
-#      - name: Configure git user
-#        uses: elastic/oblt-actions/git/setup@v1
-#        with:
-#          github-token: ${{ steps.get_token.outputs.token }}
-#
-#      - name: Import GPG key
-#        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
-#        with:
-#          gpg_private_key: ${{ secrets.APM_SERVER_RELEASE_GPG_PRIVATE_KEY }}
-#          passphrase: ${{ secrets.APM_SERVER_RELEASE_PASSPHRASE }}
-#          git_user_signingkey: true
-#          git_commit_gpgsign: true
-#
-#      - name: Open PGO PR
-#        if: ${{ env.RUN_STANDALONE == 'true' }}
-#        run: ${{ github.workspace }}/.ci/scripts/push-pgo-pr.sh
-#        env:
-#          WORKSPACE_PATH: ${{ github.workspace }}
-#          PROFILE_PATH: ${{ env.WORKING_DIRECTORY }}/${{ env.BENCHMARK_CPU_OUT }}
-#          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
-#          WORKFLOW: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+      - name: Run benchmarks autotuned
+        if: ${{ inputs.benchmarkAgents == '' }}
+        run: make run-benchmark-autotuned
+
+      - name: Run benchmarks self tuned
+        if: ${{ inputs.benchmarkAgents != '' }}
+        run: make run-benchmark
+
+      - name: Cat standalone server logs
+        if: ${{ env.RUN_STANDALONE == 'true' && failure() }}
+        run: make cat-apm-server-logs
+
+      - name: Index benchmarks result
+        run: make index-benchmark-results
+
+      - name: Download PNG
+        run: >-
+          ${{ github.workspace }}/.ci/scripts/download-png-from-kibana.sh
+          ${{ secrets.KIBANA_BENCH_ENDPOINT }}
+          ${{ secrets.KIBANA_BENCH_USERNAME }}
+          ${{ secrets.KIBANA_BENCH_PASSWORD }}
+          $PNG_REPORT_FILE
+
+      - name: Upload PNG
+        uses: actions/upload-artifact@v4
+        with:
+          name: kibana-png-report
+          path: ${{ env.WORKING_DIRECTORY }}/${{ env.PNG_REPORT_FILE }}
+          if-no-files-found: error
+
+      - name: Upload PNG to AWS S3
+        id: s3-upload-png
+        env:
+          AWS_DEFAULT_REGION: us-east-1
+        run: |
+          DEST_NAME="github-run-id-${{ github.run_id }}.png"
+          aws s3 --debug cp ${{ env.PNG_REPORT_FILE }} s3://elastic-apm-server-benchmark-reports/${DEST_NAME}
+          echo "png_report_url=https://elastic-apm-server-benchmark-reports.s3.amazonaws.com/${DEST_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload benchmark result
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-result
+          path: ${{ env.WORKING_DIRECTORY }}/${{ env.BENCHMARK_RESULT }}
+          if-no-files-found: error
+
+      # The next section injects CPU profile collected by apmbench into the build.
+      # By copying the profile, uploading it to the artifacts and pushing it
+      # via a PR to update default.pgo.
+
+      - name: Copy CPU profile
+        run: make cp-cpuprof
+
+      - name: Upload CPU profile
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpu-profile
+          path: ${{ env.WORKING_DIRECTORY }}/${{ env.BENCHMARK_CPU_OUT }}
+          if-no-files-found: error
+
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write",
+              "pull_requests": "write"
+            }
+
+      # Required to use a service account, otherwise PRs created by
+      # GitHub bot won't trigger any CI builds.
+      # See https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-537478081
+      - name: Configure git user
+        uses: elastic/oblt-actions/git/setup@v1
+        with:
+          github-token: ${{ steps.get_token.outputs.token }}
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
+        with:
+          gpg_private_key: ${{ secrets.APM_SERVER_RELEASE_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.APM_SERVER_RELEASE_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Open PGO PR
+        if: ${{ env.RUN_STANDALONE == 'true' }}
+        run: ${{ github.workspace }}/.ci/scripts/push-pgo-pr.sh
+        env:
+          WORKSPACE_PATH: ${{ github.workspace }}
+          PROFILE_PATH: ${{ env.WORKING_DIRECTORY }}/${{ env.BENCHMARK_CPU_OUT }}
+          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
+          WORKFLOW: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
 
       # Secrets are rotated daily, if the benchmarks run between the rotation window, then
       # there is a high chance things will stop working

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,6 +34,7 @@ env:
   BENCHMARK_CPU_OUT: default.pgo
   BENCHMARK_RESULT: benchmark-result.txt
   WORKING_DIRECTORY: testing/benchmark
+  RUN_STANDALONE: ${{ inputs.runStandalone || github.event.schedule=='0 5 */5 * *' }}
 
 permissions:
   contents: read
@@ -51,7 +52,8 @@ jobs:
       SSH_KEY: ./id_rsa_terraform
       TF_VAR_private_key: ./id_rsa_terraform
       TF_VAR_public_key: ./id_rsa_terraform.pub
-      RUN_STANDALONE: ${{ inputs.runStandalone || github.event.schedule=='0 5 */5 * *' }}
+      TF_VAR_run_standalone: ${{ env.RUN_STANDALONE }}
+
       TFVARS_SOURCE: ${{ inputs.profile || 'system-profiles/8GBx1zone.tfvars' }} # // Default to use an 8gb profile
       TF_VAR_BUILD_ID: ${{ github.run_id }}
       TF_VAR_ENVIRONMENT: ci
@@ -133,10 +135,6 @@ jobs:
           admin_console_url=$(terraform output -raw admin_console_url)
           echo "admin_console_url=$admin_console_url" >> "$GITHUB_OUTPUT"
           echo "-> infra setup done"
-        env:
-          TF_VAR_worker_region: ${{ env.AWS_REGION }}
-          TF_VAR_run_standalone: ${{ env.RUN_STANDALONE }}
-
 #      - name: Run benchmarks autotuned
 #        if: ${{ inputs.benchmarkAgents == '' }}
 #        run: make run-benchmark-autotuned

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -137,102 +137,102 @@ jobs:
           TF_VAR_worker_region: ${{ env.AWS_REGION }}
           TF_VAR_run_standalone: ${{ env.RUN_STANDALONE }}
 
-      - name: Run benchmarks autotuned
-        if: ${{ inputs.benchmarkAgents == '' }}
-        run: make run-benchmark-autotuned
-
-      - name: Run benchmarks self tuned
-        if: ${{ inputs.benchmarkAgents != '' }}
-        run: make run-benchmark
-
-      - name: Cat standalone server logs
-        if: ${{ env.RUN_STANDALONE == 'true' && failure() }}
-        run: make cat-apm-server-logs
-
-      - name: Index benchmarks result
-        run: make index-benchmark-results
-
-      - name: Download PNG
-        run: >-
-          ${{ github.workspace }}/.ci/scripts/download-png-from-kibana.sh
-          ${{ secrets.KIBANA_BENCH_ENDPOINT }}
-          ${{ secrets.KIBANA_BENCH_USERNAME }}
-          ${{ secrets.KIBANA_BENCH_PASSWORD }}
-          $PNG_REPORT_FILE
-
-      - name: Upload PNG
-        uses: actions/upload-artifact@v4
-        with:
-          name: kibana-png-report
-          path: ${{ env.WORKING_DIRECTORY }}/${{ env.PNG_REPORT_FILE }}
-          if-no-files-found: error
-
-      - name: Upload PNG to AWS S3
-        id: s3-upload-png
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-        run: |
-          DEST_NAME="github-run-id-${{ github.run_id }}.png"
-          aws s3 --debug cp ${{ env.PNG_REPORT_FILE }} s3://elastic-apm-server-benchmark-reports/${DEST_NAME}
-          echo "png_report_url=https://elastic-apm-server-benchmark-reports.s3.amazonaws.com/${DEST_NAME}" >> "$GITHUB_OUTPUT"
-
-      - name: Upload benchmark result
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-result
-          path: ${{ env.WORKING_DIRECTORY }}/${{ env.BENCHMARK_RESULT }}
-          if-no-files-found: error
-
-      # The next section injects CPU profile collected by apmbench into the build.
-      # By copying the profile, uploading it to the artifacts and pushing it
-      # via a PR to update default.pgo.
-
-      - name: Copy CPU profile
-        run: make cp-cpuprof
-      
-      - name: Upload CPU profile
-        uses: actions/upload-artifact@v4
-        with:
-          name: cpu-profile
-          path: ${{ env.WORKING_DIRECTORY }}/${{ env.BENCHMARK_CPU_OUT }}
-          if-no-files-found: error
-
-      - name: Get token
-        id: get_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-        with:
-          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
-          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
-          permissions: >-
-            {
-              "contents": "write",
-              "pull_requests": "write"
-            }
-
-      # Required to use a service account, otherwise PRs created by
-      # GitHub bot won't trigger any CI builds.
-      # See https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-537478081
-      - name: Configure git user
-        uses: elastic/oblt-actions/git/setup@v1
-        with:
-          github-token: ${{ steps.get_token.outputs.token }}
-
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
-        with:
-          gpg_private_key: ${{ secrets.APM_SERVER_RELEASE_GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.APM_SERVER_RELEASE_PASSPHRASE }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-
-      - name: Open PGO PR
-        if: ${{ env.RUN_STANDALONE == 'true' }}
-        run: ${{ github.workspace }}/.ci/scripts/push-pgo-pr.sh
-        env:
-          WORKSPACE_PATH: ${{ github.workspace }}
-          PROFILE_PATH: ${{ env.WORKING_DIRECTORY }}/${{ env.BENCHMARK_CPU_OUT }}
-          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
-          WORKFLOW: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
+#      - name: Run benchmarks autotuned
+#        if: ${{ inputs.benchmarkAgents == '' }}
+#        run: make run-benchmark-autotuned
+#
+#      - name: Run benchmarks self tuned
+#        if: ${{ inputs.benchmarkAgents != '' }}
+#        run: make run-benchmark
+#
+#      - name: Cat standalone server logs
+#        if: ${{ env.RUN_STANDALONE == 'true' && failure() }}
+#        run: make cat-apm-server-logs
+#
+#      - name: Index benchmarks result
+#        run: make index-benchmark-results
+#
+#      - name: Download PNG
+#        run: >-
+#          ${{ github.workspace }}/.ci/scripts/download-png-from-kibana.sh
+#          ${{ secrets.KIBANA_BENCH_ENDPOINT }}
+#          ${{ secrets.KIBANA_BENCH_USERNAME }}
+#          ${{ secrets.KIBANA_BENCH_PASSWORD }}
+#          $PNG_REPORT_FILE
+#
+#      - name: Upload PNG
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: kibana-png-report
+#          path: ${{ env.WORKING_DIRECTORY }}/${{ env.PNG_REPORT_FILE }}
+#          if-no-files-found: error
+#
+#      - name: Upload PNG to AWS S3
+#        id: s3-upload-png
+#        env:
+#          AWS_DEFAULT_REGION: us-east-1
+#        run: |
+#          DEST_NAME="github-run-id-${{ github.run_id }}.png"
+#          aws s3 --debug cp ${{ env.PNG_REPORT_FILE }} s3://elastic-apm-server-benchmark-reports/${DEST_NAME}
+#          echo "png_report_url=https://elastic-apm-server-benchmark-reports.s3.amazonaws.com/${DEST_NAME}" >> "$GITHUB_OUTPUT"
+#
+#      - name: Upload benchmark result
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: benchmark-result
+#          path: ${{ env.WORKING_DIRECTORY }}/${{ env.BENCHMARK_RESULT }}
+#          if-no-files-found: error
+#
+#      # The next section injects CPU profile collected by apmbench into the build.
+#      # By copying the profile, uploading it to the artifacts and pushing it
+#      # via a PR to update default.pgo.
+#
+#      - name: Copy CPU profile
+#        run: make cp-cpuprof
+#
+#      - name: Upload CPU profile
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: cpu-profile
+#          path: ${{ env.WORKING_DIRECTORY }}/${{ env.BENCHMARK_CPU_OUT }}
+#          if-no-files-found: error
+#
+#      - name: Get token
+#        id: get_token
+#        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+#        with:
+#          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+#          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+#          permissions: >-
+#            {
+#              "contents": "write",
+#              "pull_requests": "write"
+#            }
+#
+#      # Required to use a service account, otherwise PRs created by
+#      # GitHub bot won't trigger any CI builds.
+#      # See https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-537478081
+#      - name: Configure git user
+#        uses: elastic/oblt-actions/git/setup@v1
+#        with:
+#          github-token: ${{ steps.get_token.outputs.token }}
+#
+#      - name: Import GPG key
+#        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
+#        with:
+#          gpg_private_key: ${{ secrets.APM_SERVER_RELEASE_GPG_PRIVATE_KEY }}
+#          passphrase: ${{ secrets.APM_SERVER_RELEASE_PASSPHRASE }}
+#          git_user_signingkey: true
+#          git_commit_gpgsign: true
+#
+#      - name: Open PGO PR
+#        if: ${{ env.RUN_STANDALONE == 'true' }}
+#        run: ${{ github.workspace }}/.ci/scripts/push-pgo-pr.sh
+#        env:
+#          WORKSPACE_PATH: ${{ github.workspace }}
+#          PROFILE_PATH: ${{ env.WORKING_DIRECTORY }}/${{ env.BENCHMARK_CPU_OUT }}
+#          GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
+#          WORKFLOW: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
 
       # Secrets are rotated daily, if the benchmarks run between the rotation window, then
       # there is a high chance things will stop working

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -34,7 +34,6 @@ env:
   BENCHMARK_CPU_OUT: default.pgo
   BENCHMARK_RESULT: benchmark-result.txt
   WORKING_DIRECTORY: testing/benchmark
-  RUN_STANDALONE: ${{ inputs.runStandalone || github.event.schedule=='0 5 */5 * *' }}
 
 permissions:
   contents: read
@@ -52,8 +51,8 @@ jobs:
       SSH_KEY: ./id_rsa_terraform
       TF_VAR_private_key: ./id_rsa_terraform
       TF_VAR_public_key: ./id_rsa_terraform.pub
-      TF_VAR_run_standalone: ${{ env.RUN_STANDALONE }}
-
+      TF_VAR_run_standalone: ${{ inputs.runStandalone || github.event.schedule=='0 5 */5 * *' }}
+      RUN_STANDALONE: ${{ inputs.runStandalone || github.event.schedule=='0 5 */5 * *' }}
       TFVARS_SOURCE: ${{ inputs.profile || 'system-profiles/8GBx1zone.tfvars' }} # // Default to use an 8gb profile
       TF_VAR_BUILD_ID: ${{ github.run_id }}
       TF_VAR_ENVIRONMENT: ci


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary


The benchmarks workflow does not clean up all the resources it's creating.

In this [workflow run](https://github.com/elastic/apm-server/actions/runs/11183981002) you can see that the [Spin up benchmark environment](https://github.com/elastic/apm-server/actions/runs/11183981002/job/31093763569#step:15:729) step creates 22 resources.

But the [Teardown benchmark environment](https://github.com/elastic/apm-server/actions/runs/11183981002/job/31093763569#step:30:381) only deletes 9 resources.

The reason for it is the differently passed `TF_VAR_*` environment variables in both steps.

This change fixes it and aligns the passed tf vars to both apply and destroy.

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

I was able to test this change in https://github.com/elastic/apm-server/actions/runs/11277362803/job/31363323001, where you can find 22 resources being destroyed.

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
