### PR TITLE
benchmarks: move to gcp-cpu-optimized template

### DIFF
--- a/testing/benchmark/variables.tf
+++ b/testing/benchmark/variables.tf
@@ -20,7 +20,7 @@ variable "ess_region" {
 }
 
 variable "deployment_template" {
-  default     = "gcp-compute-optimized-v3"
+  default     = "gcp-cpu-optimized"
   description = "Optional deployment template. Defaults to the CPU optimized template for GCP"
   type        = string
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

The old `gcp-compute-optimized-v3` template seems to be deprecated according to [doc](https://www.elastic.co/guide/en/cloud/current/ec-regions-templates-instances.html) and no longer supported see the [run](https://github.com/elastic/apm-server/actions/runs/11633239770/job/32397978828). This PR updates the benchmarks ESS template to use `gcp-cpu-optimized` instead.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
