### PR TITLE
testing(cloud): remove missing Makefile target dep

### DIFF
--- a/internal/beater/beater.go
+++ b/internal/beater/beater.go
@@ -356,7 +356,7 @@ func (s *Runner) Run(ctx context.Context) error {
 	ratelimitStore, err := ratelimit.NewStore(
 		s.config.AgentAuth.Anonymous.RateLimit.IPLimit,
 		s.config.AgentAuth.Anonymous.RateLimit.EventLimit,
-		3, // burst mulitiplier
+		3, // burst multiplier
 	)
 	if err != nil {
 		return err

--- a/testing/cloud/Makefile
+++ b/testing/cloud/Makefile
@@ -27,9 +27,9 @@ USER_KIBANA_DOCKER_IMAGE=docker.elastic.co/observability-ci/${USER_NAME}-kibana
 # use in the deployment.
 ##############################################################################
 
-docker_image.auto.tfvars: kibana_docker_image elastic_agent_docker_image
+docker_image.auto.tfvars: elastic_agent_docker_image
 	@echo 'docker_image_override={"elasticsearch":"${ELASTICSEARCH_DOCKER_IMAGE}","kibana":"${KIBANA_DOCKER_IMAGE}","apm":"${CI_ELASTIC_AGENT_DOCKER_IMAGE}"}' > $@
-	@echo 'docker_image_tag_override={"elasticsearch":"${IMAGE_TAG}","kibana":"${CUSTOM_IMAGE_TAG}","apm":"${CUSTOM_IMAGE_TAG}"}' >> $@
+	@echo 'docker_image_tag_override={"elasticsearch":"${IMAGE_TAG}","kibana":"${IMAGE_TAG}","apm":"${CUSTOM_IMAGE_TAG}"}' >> $@
 
 ##############################################################################
 # Terraform shortcut rules.


### PR DESCRIPTION
## Motivation/summary

While investigating an issue, I found out a couple of problems in the testing setup.

## How to test these changes

```
cd testing/cloud
make docker_image.auto.tfvars
make apply
```

Before this PR, this would throw an error on a missing dependency.

Then clean it up

```
make destroy
```

