### PR TITLE
terraform: add apm-server prefix to benchmarks

### DIFF
--- a/testing/benchmark/main.tf
+++ b/testing/benchmark/main.tf
@@ -26,13 +26,14 @@ locals {
     build        = var.BUILD_ID
     created_date = coalesce(var.CREATED_DATE, time_static.created_date.unix)
   }
+  project = "apm-server-benchmarks"
 }
 
 module "tags" {
   source = "../infra/terraform/modules/tags"
   # use the convention for team/shared owned resources if we are running in CI.
   # assume this is an individually owned resource otherwise.
-  project = startswith(var.user_name, "benchci") ? "benchmarks" : var.user_name
+  project = startswith(var.user_name, "benchci") ? local.project : "${local.project}-${var.user_name}"
 }
 
 provider "ec" {}

--- a/testing/benchmark/main.tf
+++ b/testing/benchmark/main.tf
@@ -40,6 +40,9 @@ provider "ec" {}
 
 provider "aws" {
   region = var.worker_region
+  default_tags {
+    tags = merge(local.ci_tags, module.tags.labels)
+  }
 }
 
 locals {

--- a/testing/infra/terraform/modules/rally_workers/main.tf
+++ b/testing/infra/terraform/modules/rally_workers/main.tf
@@ -1,6 +1,7 @@
 provider "google" {
-  project = var.gcp_project
-  region  = var.gcp_region
+  project        = var.gcp_project
+  region         = var.gcp_region
+  default_labels = module.tags
 }
 
 locals {

--- a/testing/infra/terraform/modules/soaktest_workers/main.tf
+++ b/testing/infra/terraform/modules/soaktest_workers/main.tf
@@ -72,10 +72,6 @@ resource "google_compute_instance" "worker" {
     access_config {}
   }
 
-  labels = merge(module.tags.labels, {
-    workspace = terraform.workspace
-  })
-
   metadata = {
     ssh-keys = "${local.ssh_user_name}:${data.tls_public_key.worker_login.public_key_openssh}"
   }

--- a/testing/infra/terraform/modules/soaktest_workers/provider.tf
+++ b/testing/infra/terraform/modules/soaktest_workers/provider.tf
@@ -2,4 +2,8 @@ provider "google" {
   project = var.gcp_project
   region  = var.gcp_region
   zone    = var.gcp_zone
+
+  default_labels = merge(module.tags.labels, {
+    workspace = terraform.workspace
+  })
 }


### PR DESCRIPTION
Adds the apm-server prefix to the benchmarks project tag to facilitate filtering for project.
