### PR TITLE
[docs] Add references to the 8.17 changelog in CHANGELOG.asciidoc

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,4 +1,5 @@
 // tag::list[]
+* <<apm-release-notes-8.17>>
 * <<apm-release-notes-8.16>>
 * <<apm-release-notes-8.15>>
 * <<apm-release-notes-8.14>>
@@ -20,6 +21,7 @@
 
 // tag::includes[]
 include::./changelogs/head.asciidoc[]
+include::./changelogs/8.17.asciidoc[]
 include::./changelogs/8.16.asciidoc[]
 include::./changelogs/8.15.asciidoc[]
 include::./changelogs/8.14.asciidoc[]


### PR DESCRIPTION
## Motivation/summary

In https://github.com/elastic/apm-server/pull/14929, the 8.17 changelog was added to the `main` branch, but it is not referenced in the `CHANGELOG.asciidoc` file, so it's not being built in [the docs](https://www.elastic.co/guide/en/observability/master/apm-release-notes.html).  

This is blocking https://github.com/elastic/observability-docs/pull/4667. 

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Documentation has been updated

## How to test these changes

View the docs preview after it's done building:

* [x] [Release notes](https://apm-server_bk_14932.docs-preview.app.elstc.co/guide/en/observability/master/apm-release-notes.html) should include a list item linking to the 8.17 changelog
* [x] [APM version 8.17](https://apm-server_bk_14932.docs-preview.app.elstc.co/guide/en/observability/master/apm-release-notes-8.17.html) should exist

## Related issues

https://github.com/elastic/apm-server/pull/14929
