### PR TITLE
fix: bump memlimit check to 30s interval

### DIFF
--- a/internal/beatcmd/beat.go
+++ b/internal/beatcmd/beat.go
@@ -351,7 +351,7 @@ func (b *Beat) Run(ctx context.Context) error {
 	})
 
 	slogger := slog.New(zapslog.NewHandler(logger.Core()))
-	if err := adjustMemlimit(1*time.Second, slogger); err != nil {
+	if err := adjustMemlimit(30*time.Second, slogger); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Motivation/summary

use correct interval for memlimit check

Followup https://github.com/elastic/apm-server/pull/14882

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
