### PR TITLE
Record tbs disk usage stats in benchtest

### DIFF
--- a/systemtest/benchtest/expvar/expvar.go
+++ b/systemtest/benchtest/expvar/expvar.go
@@ -36,6 +36,7 @@ type expvar struct {
 	LibbeatStats
 	ElasticResponseStats
 	OTLPResponseStats
+	TailSamplingStats
 
 	// UncompressedBytes holds the number of bytes of uncompressed
 	// data that the server has read from the Elastic APM events
@@ -70,6 +71,11 @@ type LibbeatStats struct {
 	TotalEvents    int64 `json:"libbeat.output.events.total"`
 	Goroutines     int64 `json:"beat.runtime.goroutines"`
 	RSSMemoryBytes int64 `json:"beat.memstats.rss"`
+}
+
+type TailSamplingStats struct {
+	TBSLsmSize  int64 `json:"apm-server.sampling.tail.storage.lsm_size"`
+	TBSVlogSize int64 `json:"apm-server.sampling.tail.storage.value_log_size"`
 }
 
 func queryExpvar(ctx context.Context, out *expvar, srv string) error {
@@ -113,6 +119,7 @@ func queryExpvar(ctx context.Context, out *expvar, srv string) error {
 		aggregateResponseStats(s.ElasticResponseStats, &result.ElasticResponseStats)
 		aggregateOTLPResponseStats(s.OTLPResponseStats, &result.OTLPResponseStats)
 		aggregateLibbeatStats(s.LibbeatStats, &result.LibbeatStats)
+		aggregateTailSamplingStats(s.TailSamplingStats, &result.TailSamplingStats)
 		result.UncompressedBytes += s.UncompressedBytes
 		result.AvailableBulkRequests += s.AvailableBulkRequests
 	}
@@ -204,4 +211,9 @@ func aggregateOTLPResponseStats(from OTLPResponseStats, to *OTLPResponseStats) {
 	to.TotalOTLPTracesResponses += from.TotalOTLPTracesResponses
 	to.ErrorOTLPTracesResponses += from.ErrorOTLPTracesResponses
 	to.ErrorOTLPMetricsResponses += from.ErrorOTLPMetricsResponses
+}
+
+func aggregateTailSamplingStats(from TailSamplingStats, to *TailSamplingStats) {
+	to.TBSLsmSize += from.TBSLsmSize
+	to.TBSVlogSize += from.TBSVlogSize
 }

--- a/systemtest/benchtest/expvar/metrics.go
+++ b/systemtest/benchtest/expvar/metrics.go
@@ -47,6 +47,8 @@ const (
 	ErrorElasticResponses
 	ErrorOTLPTracesResponses
 	ErrorOTLPMetricsResponses
+	TBSLsmSize
+	TBSVlogSize
 )
 
 type AggregateStats struct {
@@ -164,6 +166,8 @@ func (c *Collector) accumulate(e expvar) {
 	c.processMetric(MemBytes, int64(e.TotalAlloc))
 	c.processMetric(HeapAlloc, int64(e.HeapAlloc))
 	c.processMetric(HeapObjects, int64(e.HeapObjects))
+	c.processMetric(TBSLsmSize, e.TBSLsmSize)
+	c.processMetric(TBSVlogSize, e.TBSVlogSize)
 }
 
 func (c *Collector) processMetric(m Metric, val int64) {

--- a/systemtest/benchtest/main.go
+++ b/systemtest/benchtest/main.go
@@ -122,6 +122,8 @@ func addExpvarMetrics(result *testing.BenchmarkResult, collector *expvar.Collect
 		result.Extra["max_heap_alloc"] = float64(collector.Get(expvar.HeapAlloc).Max)
 		result.Extra["max_heap_objects"] = float64(collector.Get(expvar.HeapObjects).Max)
 		result.Extra["mean_available_indexers"] = float64(collector.Get(expvar.AvailableBulkRequests).Mean)
+		result.Extra["tbs_lsm_size"] = float64(collector.Get(expvar.TBSLsmSize).Max)
+		result.Extra["tbs_vlog_size"] = float64(collector.Get(expvar.TBSVlogSize).Max)
 	}
 
 	// Record the number of error responses returned by the server: lower is better.

--- a/systemtest/benchtest/main_test.go
+++ b/systemtest/benchtest/main_test.go
@@ -141,6 +141,8 @@ func TestAddExpvarMetrics(t *testing.T) {
 				`"apm-server.processor.span.transformations": 5`,
 				`"apm-server.processor.metric.transformations": 9`,
 				`"apm-server.processor.error.transformations": 3`,
+				`"apm-server.sampling.tail.storage.lsm_size": 10`,
+				`"apm-server.sampling.tail.storage.value_log_size": 11`,
 				`"beat.runtime.goroutines": 4`,
 				`"beat.memstats.rss": 1048576`,
 				`"output.elasticsearch.bulk_requests.available": 0`,
@@ -165,6 +167,8 @@ func TestAddExpvarMetrics(t *testing.T) {
 				"max_heap_objects":        102,
 				"mean_available_indexers": 0,
 				"error_responses/sec":     1,
+				"tbs_lsm_size":            10,
+				"tbs_vlog_size":           11,
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Record TBS lsm size and vlog size in benchtest to facilitate TBS improvements when running benchmarks using gh actions following #14985 

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
Meta issue #14931
