### PR TITLE
Mark most client.geo.* as dynamic in TestRUMXForwardedFor approvals

### DIFF
--- a/systemtest/approvals/TestRUMXForwardedFor.approved.json
+++ b/systemtest/approvals/TestRUMXForwardedFor.approved.json
@@ -13,7 +13,7 @@
             "5.5.0"
         ],
         "client.geo.city_name": [
-            "Perth"
+            "dynamic"
         ],
         "client.geo.continent_name": [
             "Oceania"
@@ -28,10 +28,10 @@
             "dynamic"
         ],
         "client.geo.region_iso_code": [
-            "AU-WA"
+            "dynamic"
         ],
         "client.geo.region_name": [
-            "Western Australia"
+            "dynamic"
         ],
         "client.ip": [
             "220.244.41.16"
@@ -132,7 +132,7 @@
             "5.5.0"
         ],
         "client.geo.city_name": [
-            "Perth"
+            "dynamic"
         ],
         "client.geo.continent_name": [
             "Oceania"
@@ -147,10 +147,10 @@
             "dynamic"
         ],
         "client.geo.region_iso_code": [
-            "AU-WA"
+            "dynamic"
         ],
         "client.geo.region_name": [
-            "Western Australia"
+            "dynamic"
         ],
         "client.ip": [
             "220.244.41.16"

--- a/systemtest/rum_test.go
+++ b/systemtest/rum_test.go
@@ -78,7 +78,10 @@ func TestRUMXForwardedFor(t *testing.T) {
 		"source.port",
 		// Do not assert the exact contents of the location field since they may change
 		// slightly depending on the IP lookup.
+		"client.geo.city_name",
 		"client.geo.location",
+		"client.geo.region_iso_code",
+		"client.geo.region_name",
 	)
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Mark client.geo.{city_name,location,region_iso_code,region_name} as dynamic in TestRUMXforwardedFor. This will make it consistent with other systemtest approvals.

Fix failing test:
```
 === Failed
=== FAIL: systemtest TestRUMXForwardedFor (1.54s)
    rum_test.go:73:   []any{
          	map[string]any{
          		... // 2 identical entries
          		"agent.name.text":             []any{string("rum-js")},
          		"agent.version":               []any{string("5.5.0")},
        - 		"client.geo.city_name":        []any{string("Perth")},
        + 		"client.geo.city_name":        []any{string("Melbourne")},
          		"client.geo.continent_name":   []any{string("Oceania")},
          		"client.geo.country_iso_code": []any{string("AU")},
          		"client.geo.country_name":     []any{string("Australia")},
          		"client.geo.location":         []any{string("dynamic")},
        - 		"client.geo.region_iso_code":  []any{string("AU-WA")},
        + 		"client.geo.region_iso_code":  []any{string("AU-VIC")},
        - 		"client.geo.region_name":      []any{string("Western Australia")},
        + 		"client.geo.region_name":      []any{string("Victoria")},
          		"client.ip":                   []any{string("220.244.41.16")},
          		"data_stream.dataset":         []any{string("apm.internal")},
          		... // 26 identical entries
          	},
          	map[string]any{
          		... // 2 identical entries
          		"agent.name.text":             []any{string("rum-js")},
          		"agent.version":               []any{string("5.5.0")},
        - 		"client.geo.city_name":        []any{string("Perth")},
        + 		"client.geo.city_name":        []any{string("Melbourne")},
          		"client.geo.continent_name":   []any{string("Oceania")},
          		"client.geo.country_iso_code": []any{string("AU")},
          		"client.geo.country_name":     []any{string("Australia")},
          		"client.geo.location":         []any{string("dynamic")},
        - 		"client.geo.region_iso_code":  []any{string("AU-WA")},
        + 		"client.geo.region_iso_code":  []any{string("AU-VIC")},
        - 		"client.geo.region_name":      []any{string("Western Australia")},
        + 		"client.geo.region_name":      []any{string("Victoria")},
          		"client.ip":                   []any{string("220.244.41.16")},
          		"data_stream.dataset":         []any{string("apm.rum")},
          		... // 27 identical entries
          	},
          }
        
        Test failed. Run `make check-approvals` to verify the diff.
        
    server.go:133: log file: /home/runner/work/apm-server/apm-server/systemtest/logs/TestRUMXForwardedFor/apm-server
```

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
