### PR TITLE
[8.17] Fix CI failure due to docs/spec/v2/span.json

### DIFF
--- a/docs/spec/v2/span.json
+++ b/docs/spec/v2/span.json
@@ -188,9 +188,6 @@
                 "object"
               ],
               "properties": {
-                "body": {
-                  "description": "The http request body usually as a string, but may be a dictionary for multipart/form-data content"
-                },
                 "id": {
                   "description": "ID holds the unique identifier for the http request.",
                   "type": [


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
`make check-full` is failing on 8.17 and 8.16 branch due to `docs/spec/v2/span.json`. The `docs/spec/v2/span.json` in 8.16 and 8.17 branch is actually newer than what it should be.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
