### PR TITLE
terraform: use sensitive file resource

### DIFF
--- a/testing/infra/terraform/modules/ec_deployment/README.md
+++ b/testing/infra/terraform/modules/ec_deployment/README.md
@@ -26,11 +26,11 @@ used to configure the module, please refer to the [EC Provider docs](https://reg
 |------|------|
 | [ec_deployment.dedicated_observability_deployment](https://registry.terraform.io/providers/elastic/ec/0.5.1/docs/resources/deployment) | resource |
 | [ec_deployment.deployment](https://registry.terraform.io/providers/elastic/ec/0.5.1/docs/resources/deployment) | resource |
-| [local_file.custom_apm_integration_pkg](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [local_file.drop_pipeline](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [local_file.enable_features](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [local_file.secret_token](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [local_file.shard_settings](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
+| [local_sensitive_file.custom_apm_integration_pkg](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/sensitive_file) | resource |
+| [local_sensitive_file.drop_pipeline](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/sensitive_file) | resource |
+| [local_sensitive_file.enable_features](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/sensitive_file) | resource |
+| [local_sensitive_file.secret_token](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/sensitive_file) | resource |
+| [local_sensitive_file.shard_settings](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/sensitive_file) | resource |
 | [null_resource.custom_apm_integration_pkg](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.drop_pipeline](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.enable_features](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |

--- a/testing/infra/terraform/modules/ec_deployment/deployment.tf
+++ b/testing/infra/terraform/modules/ec_deployment/deployment.tf
@@ -113,7 +113,7 @@ resource "ec_deployment" "dedicated_observability_deployment" {
   kibana {}
 }
 
-resource "local_file" "enable_features" {
+resource "local_sensitive_file" "enable_features" {
   content = templatefile("${path.module}/scripts/enable_features.tftpl", {
     kibana_url                  = ec_deployment.deployment.kibana.0.https_endpoint,
     elastic_password            = ec_deployment.deployment.elasticsearch_password,
@@ -125,7 +125,7 @@ resource "local_file" "enable_features" {
   filename = "${path.module}/scripts/enable_features.sh"
 }
 
-resource "local_file" "secret_token" {
+resource "local_sensitive_file" "secret_token" {
   count = var.integrations_server ? 1 : 0
   content = templatefile("${path.module}/scripts/secret_token.tftpl", {
     kibana_url       = ec_deployment.deployment.kibana.0.https_endpoint,
@@ -134,7 +134,7 @@ resource "local_file" "secret_token" {
   filename = "${path.module}/scripts/secret_token.sh"
 }
 
-resource "local_file" "shard_settings" {
+resource "local_sensitive_file" "shard_settings" {
   count = var.apm_index_shards > 0 ? 1 : 0
   content = templatefile("${path.module}/scripts/index_shards.tftpl", {
     elasticsearch_url      = ec_deployment.deployment.elasticsearch.0.https_endpoint,
@@ -145,7 +145,7 @@ resource "local_file" "shard_settings" {
   filename = "${path.module}/scripts/index_shards.sh"
 }
 
-resource "local_file" "custom_apm_integration_pkg" {
+resource "local_sensitive_file" "custom_apm_integration_pkg" {
   count = var.custom_apm_integration_pkg_path != "" ? 1 : 0
   content = templatefile("${path.module}/scripts/custom-apm-integration-pkg.tftpl", {
     kibana_url                      = ec_deployment.deployment.kibana.0.https_endpoint,
@@ -229,7 +229,7 @@ resource "null_resource" "drop_pipeline" {
   }
 }
 
-resource "local_file" "drop_pipeline" {
+resource "local_sensitive_file" "drop_pipeline" {
   count = var.drop_pipeline ? 1 : 0
   content = templatefile("${path.module}/scripts/drop_pipeline.tftpl", {
     elasticsearch_url      = ec_deployment.deployment.elasticsearch.0.https_endpoint,

--- a/testing/infra/terraform/modules/ec_deployment/deployment.tf
+++ b/testing/infra/terraform/modules/ec_deployment/deployment.tf
@@ -157,7 +157,7 @@ resource "local_sensitive_file" "custom_apm_integration_pkg" {
 
 resource "null_resource" "enable_features" {
   triggers = {
-    shell_hash          = local_file.enable_features.id
+    shell_hash          = local_sensitive_file.enable_features.id
     integrations_server = var.integrations_server
   }
   provisioner "local-exec" {
@@ -171,7 +171,7 @@ resource "null_resource" "secret_token" {
   count = var.integrations_server ? 1 : 0
   triggers = {
     deployment_id = ec_deployment.deployment.id
-    shell_hash    = local_file.secret_token.0.id
+    shell_hash    = local_sensitive_file.secret_token.0.id
   }
   provisioner "local-exec" {
     command     = "scripts/secret_token.sh"
@@ -184,7 +184,7 @@ resource "null_resource" "shard_settings" {
   count = var.apm_index_shards > 0 ? 1 : 0
   triggers = {
     deployment_id = ec_deployment.deployment.id
-    shell_hash    = local_file.shard_settings.0.id
+    shell_hash    = local_sensitive_file.shard_settings.0.id
   }
   provisioner "local-exec" {
     command     = "scripts/index_shards.sh"
@@ -211,7 +211,7 @@ resource "null_resource" "custom_apm_integration_pkg" {
 # as {"value":"SECRET_TOKEN"}.
 data "external" "secret_token" {
   count       = var.integrations_server ? 1 : 0
-  depends_on  = [local_file.secret_token]
+  depends_on  = [local_sensitive_file.secret_token]
   program     = ["/bin/bash", "-c", "scripts/secret_token.sh"]
   working_dir = path.module
 }
@@ -220,7 +220,7 @@ resource "null_resource" "drop_pipeline" {
   count = var.drop_pipeline ? 1 : 0
   triggers = {
     deployment_id = ec_deployment.deployment.id
-    shell_hash    = local_file.drop_pipeline.0.id
+    shell_hash    = local_sensitive_file.drop_pipeline.0.id
   }
   provisioner "local-exec" {
     command     = "scripts/drop_pipeline.sh"


### PR DESCRIPTION
## Motivation/summary

Use https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/sensitive_file when setting the ephemeral credentials.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

I created a feature branch and ran the benchmarks workflow:
- https://github.com/elastic/apm-server/actions/runs/12669908313

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
