### PR TITLE
changelog: add missing 7.17.27 changelog file

### DIFF
--- a/changelogs/7.17.asciidoc
+++ b/changelogs/7.17.asciidoc
@@ -1,0 +1,288 @@
+[[release-notes-7.17]]
+== APM version 7.17
+
+https://github.com/elastic/apm-server/compare/7.16\...7.17[View commits]
+
+* <<release-notes-7.17.27>>
+* <<release-notes-7.17.26>>
+* <<release-notes-7.17.25>>
+* <<release-notes-7.17.24>>
+* <<release-notes-7.17.23>>
+* <<release-notes-7.17.22>>
+* <<release-notes-7.17.21>>
+* <<release-notes-7.17.20>>
+* <<release-notes-7.17.19>>
+* <<release-notes-7.17.18>>
+* <<release-notes-7.17.17>>
+* <<release-notes-7.17.16>>
+* <<release-notes-7.17.15>>
+* <<release-notes-7.17.14>>
+* <<release-notes-7.17.13>>
+* <<release-notes-7.17.12>>
+* <<release-notes-7.17.11>>
+* <<release-notes-7.17.10>>
+* <<release-notes-7.17.9>>
+* <<release-notes-7.17.8>>
+* <<release-notes-7.17.7>>
+* <<release-notes-7.17.6>>
+* <<release-notes-7.17.5>>
+* <<release-notes-7.17.4>>
+* <<release-notes-7.17.3>>
+* <<release-notes-7.17.2>>
+* <<release-notes-7.17.1>>
+* <<release-notes-7.17.0>>
+
+[float]
+[[release-notes-7.17.27]]
+=== APM version 7.17.26
+
+https://github.com/elastic/apm-server/compare/v7.17.26\...v7.17.27[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.26]]
+=== APM version 7.17.26
+
+https://github.com/elastic/apm-server/compare/v7.17.25\...v7.17.26[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.25]]
+=== APM version 7.17.25
+
+https://github.com/elastic/apm-server/compare/v7.17.24\...v7.17.25[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.24]]
+=== APM version 7.17.24
+
+https://github.com/elastic/apm-server/compare/v7.17.23\...v7.17.24[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.23]]
+=== APM version 7.17.23
+
+https://github.com/elastic/apm-server/compare/v7.17.22\...v7.17.23[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.22]]
+=== APM version 7.17.22
+
+https://github.com/elastic/apm-server/compare/v7.17.21\...v7.17.22[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.21]]
+=== APM version 7.17.21
+
+https://github.com/elastic/apm-server/compare/v7.17.20\...v7.17.21[View commits]
+
+The <<known-issue-13031,known issue>> introduced in version `7.17.20` causing failure in APM-server startup due to failure to bootstrap the fleet-server has been resolved.
+
+[float]
+[[release-notes-7.17.20]]
+=== APM version 7.17.20
+
+https://github.com/elastic/apm-server/compare/v7.17.19\...v7.17.20[View commits]
+
+[float]
+[[known-issue-13031]]
+==== Known issue
+An issue with the failure to bootstrap fleet-server with self-signed certificates causes failures in APM-server startup. This is due to an update in beats dependencies where the certificate validation was completely rewritten.
+The issue also prevents bootstrapping fleet-server in ESS and thus causes failure in APM-server startup in ESS.
+This issue is planned to be fixed in version 7.17.21. We recommend skipping this version and waiting until the next version to upgrade.
+
+[float]
+[[release-notes-7.17.19]]
+=== APM version 7.17.19
+
+https://github.com/elastic/apm-server/compare/v7.17.18\...v7.17.19[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.18]]
+=== APM version 7.17.18
+
+https://github.com/elastic/apm-server/compare/v7.17.17\...v7.17.18[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.17]]
+=== APM version 7.17.17
+
+https://github.com/elastic/apm-server/compare/v7.17.16\...v7.17.17[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.16]]
+=== APM version 7.17.16
+
+https://github.com/elastic/apm-server/compare/v7.17.15\...v7.17.16[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.15]]
+=== APM version 7.17.15
+
+https://github.com/elastic/apm-server/compare/v7.17.14\...v7.17.15[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.14]]
+=== APM version 7.17.14
+
+https://github.com/elastic/apm-server/compare/v7.17.13\...v7.17.14[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.13]]
+=== APM version 7.17.13
+
+https://github.com/elastic/apm-server/compare/v7.17.12\...v7.17.13[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.12]]
+=== APM version 7.17.12
+
+https://github.com/elastic/apm-server/compare/v7.17.11\...v7.17.12[View commits]
+
+[float]
+==== Intake API Changes
+- Content-Type and Content-Encoding are no longer required for intake {pull}7686[7686]
+
+[float]
+[[release-notes-7.17.11]]
+=== APM version 7.17.11
+
+https://github.com/elastic/apm-server/compare/v7.17.10\...v7.17.11[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.10]]
+=== APM version 7.17.10
+
+https://github.com/elastic/apm-server/compare/v7.17.9\...v7.17.10[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.9]]
+=== APM version 7.17.9
+
+https://github.com/elastic/apm-server/compare/v7.17.8\...v7.17.9[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.8]]
+=== APM version 7.17.8
+
+https://github.com/elastic/apm-server/compare/v7.17.7\...v7.17.8[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.7]]
+=== APM version 7.17.7
+
+https://github.com/elastic/apm-server/compare/v7.17.6\...v7.17.7[View commits]
+
+[float]
+==== Breaking changes
+
+This APM release updates Go to version 1.18.5.
+The https://tip.golang.org/doc/go1.18#sha1[Go release notes] for this version note the following change to TLS:
+
+****
+**Rejecting SHA-1 certificates**
+
+`crypto/x509`` will now reject certificates signed with the SHA-1 hash function. This doesn't apply to self-signed root certificates. Practical attacks against SHA-1 https://shattered.io/[have been demonstrated since 2017] and publicly trusted Certificate Authorities have not issued SHA-1 certificates since 2015.
+
+This can be temporarily reverted by setting the `GODEBUG=x509sha1=1` environment variable. This option will be removed in a future release.
+****
+
+[float]
+[[release-notes-7.17.6]]
+=== APM version 7.17.6
+
+https://github.com/elastic/apm-server/compare/v7.17.5\...v7.17.6[View commits]
+
+[float]
+==== Bug fixes
+- Fix a bug where an event's transaction_id is ignored if no transaction object is set {pull}8820[8820]
+
+[float]
+[[release-notes-7.17.5]]
+=== APM version 7.17.5
+
+https://github.com/elastic/apm-server/compare/v7.17.4\...v7.17.5[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.4]]
+=== APM version 7.17.4
+
+https://github.com/elastic/apm-server/compare/v7.17.3\...v7.17.4[View commits]
+
+No significant changes.
+
+[float]
+[[release-notes-7.17.3]]
+=== APM version 7.17.3
+
+https://github.com/elastic/apm-server/compare/v7.17.2\...v7.17.3[View commits]
+
+[float]
+==== Bug fixes
+- APM Server will no longer set `_doc_count` fields when used with an old (<7.11.0) version of Elasticsearch. This metadata field was added in Elasticsearch 7.12.0; setting it in earlier versions causes problems on upgrade. {pull}7704[7704]
+
+[float]
+[[release-notes-7.17.2]]
+=== APM version 7.17.2
+
+https://github.com/elastic/apm-server/compare/v7.17.1\...v7.17.2[View commits]
+
+[float]
+==== Bug fixes
+- modelindexer: Fix indexing performance regression due to locking bug {pull}7649[7649]
+
+[float]
+[[release-notes-7.17.1]]
+=== APM version 7.17.1
+
+https://github.com/elastic/apm-server/compare/v7.17.0\...v7.17.1[View commits]
+
+[float]
+==== Bug fixes
+- Fix infinite loop in tail-based sampling subscriber causing high CPU and repeated Elasticsearch searches {pull}7211[7211]
+- Fix panic when processing OpenTelemetry histogram metrics without bounds {pull}7316[7316]
+- Fix waiting for events to be flushed when shutting down APM Server {pull}7352[7352]
+
+[float]
+[[release-notes-7.17.0]]
+=== APM version 7.17.0
+
+https://github.com/elastic/apm-server/compare/v7.16.3\...v7.17.0[View commits]
+
+[float]
+==== Changes
+- Change Docker base image from CentOS 7 to Ubuntu 20.04 {pull}7101[7101]


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

Update changelog for 7.17.27 patch release, and create missing 7.17.asciidoc changelog file on the main branch.

There were no significant changes for 7.17.27 see [commits](https://github.com/elastic/apm-server/compare/v7.17.26...7.17).