### PR TITLE
github-actions: support for copying the backport labels

### DIFF
--- a/.github/workflows/mergify-labels-copier.yml
+++ b/.github/workflows/mergify-labels-copier.yml
@@ -1,7 +1,7 @@
 name: mergify backport labels copier
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
 
@@ -13,7 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.head_ref, 'mergify/bp/')
     permissions:
+      # Add GH labels
       pull-requests: write
+      # See https://github.com/cli/cli/issues/6274
+      repository-projects: read
     steps:
       - uses: elastic/oblt-actions/mergify/labels-copier@v1
         with:

--- a/.github/workflows/mergify-labels-copier.yml
+++ b/.github/workflows/mergify-labels-copier.yml
@@ -1,0 +1,20 @@
+name: mergify backport labels copier
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  contents: read
+
+jobs:
+  mergify-backport-labels-copier:
+    runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'mergify/bp/')
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: elastic/oblt-actions/mergify/labels-copier@v1
+        with:
+          excluded-labels-regex: "backport-*"

--- a/.github/workflows/mergify-labels-copier.yml
+++ b/.github/workflows/mergify-labels-copier.yml
@@ -17,4 +17,4 @@ jobs:
     steps:
       - uses: elastic/oblt-actions/mergify/labels-copier@v1
         with:
-          excluded-labels-regex: "backport-*"
+          excluded-labels-regex: "^backport-*"


### PR DESCRIPTION
## Motivation/summary

Help with copying the GitHub labels for the backported PRs created by Mergify.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

Requires https://github.com/elastic/oblt-actions/pull/207
