### PR TITLE
ci(dra): fix Vault variables

### DIFF
--- a/.buildkite/scripts/dra.sh
+++ b/.buildkite/scripts/dra.sh
@@ -80,9 +80,9 @@ dra() {
   set -x
   docker run --rm \
     --name release-manager \
-    -e VAULT_ADDR \
-    -e VAULT_ROLE_ID \
-    -e VAULT_SECRET_ID \
+    -e VAULT_ADDR="${VAULT_ADDR_SECRET}" \
+    -e VAULT_ROLE_ID="${VAULT_ROLE_ID_SECRET}" \
+    -e VAULT_SECRET_ID="${VAULT_SECRET}" \
     --mount type=bind,readonly=false,src=$(pwd),target=/artifacts \
     docker.elastic.co/infra/release-manager:latest \
       cli "$command" \


### PR DESCRIPTION
## Motivation/summary

https://github.com/elastic/apm-server/pull/15274 introduced the regression, but it seems the DRA does not honour those variables when using the `list` instead of `collect` action, hence the BK Pipelien that got triggered didn't catch that error.


They should be masked, so we are good to use `set -x`. Unfortunately we need to use the suffix SECRET to mask and then the name of the variables cannot be changed


## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
