### PR TITLE
ci(dra): version should not include the qualifier

### DIFF
--- a/.buildkite/scripts/dra.sh
+++ b/.buildkite/scripts/dra.sh
@@ -13,8 +13,8 @@ set -eo pipefail
 # Either staging or snapshot
 TYPE="$1"
 
-## Read current version.
-VERSION=$(make get-version)
+## Read current version without the qualifier
+VERSION=$(make get-version-only)
 
 echo "--- Restoring Artifacts"
 buildkite-agent artifact download "build/**/*" .

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ endif
 get-version:
 	@echo $(APM_SERVER_VERSION)
 
-## get-version : Get the apm server version without the qualifier
+## get-version-only : Get the apm server version without the qualifier
 .PHONY: get-version-only
 get-version-only:
 	@echo $(APM_SERVER_ONLY_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,11 @@ endif
 get-version:
 	@echo $(APM_SERVER_VERSION)
 
+## get-version : Get the apm server version without the qualifier
+.PHONY: get-version-only
+get-version-only:
+	@echo $(APM_SERVER_ONLY_VERSION)
+
 # update-go-version updates .go-version, documentation, and build files
 # to use the most recent patch version for the major.minor Go version
 # defined in go.mod.


### PR DESCRIPTION

## Motivation/summary

When introducing the `qualifier`, the version changed. This should help keep the expected behaviour and use a new target goal to avoid the qualifier in the name.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

In the CI:

1) `dry-run mode` without `qualifier` -> https://buildkite.com/elastic/apm-server-package/builds/3707
2) `dry-run mode` with `qualifier` -> https://buildkite.com/elastic/apm-server-package/builds/3708

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
