### PR TITLE
terraform: add tags module

### DIFF
--- a/functionaltests/TestUpgrade_8_15_4_to_8_16_0/main.tf
+++ b/functionaltests/TestUpgrade_8_15_4_to_8_16_0/main.tf
@@ -15,4 +15,6 @@ module "ec_deployment" {
   elasticsearch_zone_count = 1
 
   stack_version = var.stack_version
+
+  tags = merge(local.ci_tags, module.tags.tags)
 }

--- a/testing/cloud/main.tf
+++ b/testing/cloud/main.tf
@@ -8,6 +8,11 @@ terraform {
   }
 }
 
+module "tags" {
+  source = "../infra/terraform/modules/tags"
+  project = "cloud"
+}
+
 provider "ec" {}
 
 locals {
@@ -39,4 +44,6 @@ module "ec_deployment" {
     "kibana" : coalesce(var.docker_image_tag_override["kibana"], local.docker_image_tag),
     "apm" : coalesce(var.docker_image_tag_override["apm"], local.docker_image_tag)
   }
+
+  tags = module.tags.tags
 }

--- a/testing/cloud/main.tf
+++ b/testing/cloud/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 module "tags" {
-  source = "../infra/terraform/modules/tags"
+  source  = "../infra/terraform/modules/tags"
   project = "cloud"
 }
 


### PR DESCRIPTION


## Motivation/summary

The current CI integration with the Terraform `ec_deployment` uses OIDC; hence, it uses the robots automation, but unfortunately, if `ephemeral:true` is not set and the `tear-down` steps fail in the CI, those resources are not deleted automatically but manually.

We want to enforce using `ephemeral:true` in all the Terraform resources using `ec`, the `ephemeral:true` was added as part of https://github.com/elastic/apm-server/pull/14179

But I didn't see the `tags` to be set for the `cloud` and `functional tests` that run in the CI or can run.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
