### PR TITLE
functionaltests: increase timeout and print error logs

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -47,7 +47,7 @@ jobs:
 
       - run: |
           export TF_VAR_CREATED_DATE=$(date +%s)
-          cd functionaltests && go test -v -timeout=20m -target "${{ matrix.environment }}" ./
+          cd functionaltests && go test -v -timeout=30m -target "${{ matrix.environment }}" ./
 
   notify:
     if: always()

--- a/functionaltests/8_15_test.go
+++ b/functionaltests/8_15_test.go
@@ -148,5 +148,10 @@ func TestUpgrade_8_15_4_to_8_16_0(t *testing.T) {
 
 	res, err := ecc.GetESErrorLogs(ctx)
 	require.NoError(t, err)
-	assert.Zero(t, res.Hits.Total.Value)
+	if !assert.Zero(t, res.Hits.Total.Value, "expected no error logs, but found some") {
+		t.Log("found error logs:")
+		for _, h := range res.Hits.Hits {
+			t.Log(h.Source_)
+		}
+	}
 }


### PR DESCRIPTION
## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

We observed some failures in the `functionaltests` pipeline due to:
- infra cleanup exceeding the 20m timeout
- unexpected Elasticsearch errors

This PR increases the timeout to 30 minutes (from emphirical evidence test runs where lasting around the 16 minutes mark) to overcome future timeouts.

To handle unexpected Elasticsearch error this PR adds a print of the retrieved document sources. This will help troubleshoot errors and act appropriately (errors may not necessarily be due to APM upgrade or related to the test being run).

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
