### PR TITLE
terraform: support TBS in standalone_apm_server

### DIFF
--- a/testing/benchmark/main.tf
+++ b/testing/benchmark/main.tf
@@ -157,6 +157,8 @@ module "standalone_apm_server" {
   vpc_id              = module.vpc.vpc_id
   aws_os              = "amzn2-ami-hvm-*-x86_64-ebs"
   apm_instance_type   = var.standalone_apm_server_instance_size
+  apm_volume_type     = var.standalone_apm_server_volume_type
+  apm_volume_size     = var.standalone_apm_server_volume_size
   apm_server_bin_path = var.apm_server_bin_path
   ea_managed          = false
 

--- a/testing/benchmark/main.tf
+++ b/testing/benchmark/main.tf
@@ -160,6 +160,9 @@ module "standalone_apm_server" {
   apm_server_bin_path = var.apm_server_bin_path
   ea_managed          = false
 
+  apm_server_tail_sampling               = var.apm_server_tail_sampling
+  apm_server_tail_sampling_storage_limit = var.apm_server_tail_sampling_storage_limit
+
   aws_provisioner_key_name = var.private_key
 
   elasticsearch_url      = module.moxy[0].moxy_url

--- a/testing/benchmark/terraform.tfvars.example
+++ b/testing/benchmark/terraform.tfvars.example
@@ -22,6 +22,10 @@ user_name = "USER"
 # The number of AZs the APM Server should span.
 # apm_server_zone_count = 2
 
+# Tail-based sampling settings of the APM Server.
+# apm_server_tail_sampling = false
+# apm_server_tail_sampling_storage_limit = "10GB"
+
 # The Elasticsearch cluster node size.
 # elasticsearch_size = "1g"
 
@@ -70,6 +74,10 @@ user_name = "USER"
 
 # Override the default APM Server VM size in standalone bench mode.
 # standalone_apm_server_instance_size = "c6i.2xlarge"
+
+# Override the default APM Server VM volume settings in standalone bench mode
+# standalone_apm_server_volume_type = "gp2"
+# standalone_apm_server_volume_size = 8
 
 # Override the default Moxy VM size in standalone bench mode.
 # standalone_moxy_instance_size = "c6i.4xlarge"

--- a/testing/benchmark/variables.tf
+++ b/testing/benchmark/variables.tf
@@ -131,11 +131,13 @@ variable "standalone_moxy_instance_size" {
 }
 
 variable "standalone_apm_server_volume_type" {
+  default     = null
   type        = string
   description = "Optional volume type to use for APM Server VM"
 }
 
 variable "standalone_apm_server_volume_size" {
+  default     = null
   type        = number
   description = "Optional volume size in GB to use for APM Server VM"
 }

--- a/testing/benchmark/variables.tf
+++ b/testing/benchmark/variables.tf
@@ -130,6 +130,16 @@ variable "standalone_moxy_instance_size" {
   description = "Optional instance type to use for moxy VM"
 }
 
+variable "standalone_apm_server_volume_type" {
+  type        = string
+  description = "Optional volume type to use for APM Server VM"
+}
+
+variable "standalone_apm_server_volume_size" {
+  type        = number
+  description = "Optional volume size in GB to use for APM Server VM"
+}
+
 ## VPC Network settings
 
 variable "vpc_cidr" {

--- a/testing/infra/terraform/modules/standalone_apm_server/README.md
+++ b/testing/infra/terraform/modules/standalone_apm_server/README.md
@@ -33,6 +33,8 @@ This module can be used to create a standalone APM Server deployment against a s
 |------|-------------|------|---------|:--------:|
 | <a name="input_apm_instance_type"></a> [apm\_instance\_type](#input\_apm\_instance\_type) | Optional apm server instance type overide | `string` | `""` | no |
 | <a name="input_apm_server_bin_path"></a> [apm\_server\_bin\_path](#input\_apm\_server\_bin\_path) | Optionally use the apm-server binary from the specified path instead | `string` | `""` | no |
+| <a name="input_apm_server_tail_sampling"></a> [apm\_server\_tail\_sampling](#input\_apm\_server\_tail\_sampling) | Whether or not to enable APM Server tail-based sampling. Defaults to false | `bool` | `false` | no |
+| <a name="input_apm_server_tail_sampling_storage_limit"></a> [apm\_server\_tail\_sampling\_storage\_limit](#input\_apm\_server\_tail\_sampling\_storage\_limit) | Storage size limit of APM Server tail-based sampling. Defaults to 10GB | `string` | `"10GB"` | no |
 | <a name="input_aws_os"></a> [aws\_os](#input\_aws\_os) | Optional aws EC2 instance OS | `string` | `""` | no |
 | <a name="input_aws_provisioner_key_name"></a> [aws\_provisioner\_key\_name](#input\_aws\_provisioner\_key\_name) | ssh key name to create the aws key pair and remote provision the EC2 instance | `string` | n/a | yes |
 | <a name="input_ea_managed"></a> [ea\_managed](#input\_ea\_managed) | Whether or not install Elastic Agent managed APM Server | `bool` | `false` | no |
@@ -40,7 +42,6 @@ This module can be used to create a standalone APM Server deployment against a s
 | <a name="input_elasticsearch_url"></a> [elasticsearch\_url](#input\_elasticsearch\_url) | The secure Elasticsearch URL | `string` | n/a | yes |
 | <a name="input_elasticsearch_username"></a> [elasticsearch\_username](#input\_elasticsearch\_username) | The Elasticsearch username | `string` | n/a | yes |
 | <a name="input_stack_version"></a> [stack\_version](#input\_stack\_version) | Optional stack version | `string` | `"latest"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Optional set of tags to use for all deployments | `map(string)` | `{}` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID to provision the EC2 instance | `string` | n/a | yes |
 
 ## Outputs

--- a/testing/infra/terraform/modules/standalone_apm_server/README.md
+++ b/testing/infra/terraform/modules/standalone_apm_server/README.md
@@ -35,8 +35,8 @@ This module can be used to create a standalone APM Server deployment against a s
 | <a name="input_apm_server_bin_path"></a> [apm\_server\_bin\_path](#input\_apm\_server\_bin\_path) | Optionally use the apm-server binary from the specified path instead | `string` | `""` | no |
 | <a name="input_apm_server_tail_sampling"></a> [apm\_server\_tail\_sampling](#input\_apm\_server\_tail\_sampling) | Whether or not to enable APM Server tail-based sampling. Defaults to false | `bool` | `false` | no |
 | <a name="input_apm_server_tail_sampling_storage_limit"></a> [apm\_server\_tail\_sampling\_storage\_limit](#input\_apm\_server\_tail\_sampling\_storage\_limit) | Storage size limit of APM Server tail-based sampling. Defaults to 10GB | `string` | `"10GB"` | no |
-| <a name="input_apm_volume_size"></a> [apm\_volume\_size](#input\_apm\_volume\_size) | Optional apm server volume size in GB override | `number` | n/a | yes |
-| <a name="input_apm_volume_type"></a> [apm\_volume\_type](#input\_apm\_volume\_type) | Optional apm server volume type override | `string` | n/a | yes |
+| <a name="input_apm_volume_size"></a> [apm\_volume\_size](#input\_apm\_volume\_size) | Optional apm server volume size in GB override | `number` | `null` | no |
+| <a name="input_apm_volume_type"></a> [apm\_volume\_type](#input\_apm\_volume\_type) | Optional apm server volume type override | `string` | `null` | no |
 | <a name="input_aws_os"></a> [aws\_os](#input\_aws\_os) | Optional aws EC2 instance OS | `string` | `""` | no |
 | <a name="input_aws_provisioner_key_name"></a> [aws\_provisioner\_key\_name](#input\_aws\_provisioner\_key\_name) | ssh key name to create the aws key pair and remote provision the EC2 instance | `string` | n/a | yes |
 | <a name="input_ea_managed"></a> [ea\_managed](#input\_ea\_managed) | Whether or not install Elastic Agent managed APM Server | `bool` | `false` | no |

--- a/testing/infra/terraform/modules/standalone_apm_server/README.md
+++ b/testing/infra/terraform/modules/standalone_apm_server/README.md
@@ -31,10 +31,12 @@ This module can be used to create a standalone APM Server deployment against a s
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_apm_instance_type"></a> [apm\_instance\_type](#input\_apm\_instance\_type) | Optional apm server instance type overide | `string` | `""` | no |
+| <a name="input_apm_instance_type"></a> [apm\_instance\_type](#input\_apm\_instance\_type) | Optional apm server instance type override | `string` | `""` | no |
 | <a name="input_apm_server_bin_path"></a> [apm\_server\_bin\_path](#input\_apm\_server\_bin\_path) | Optionally use the apm-server binary from the specified path instead | `string` | `""` | no |
 | <a name="input_apm_server_tail_sampling"></a> [apm\_server\_tail\_sampling](#input\_apm\_server\_tail\_sampling) | Whether or not to enable APM Server tail-based sampling. Defaults to false | `bool` | `false` | no |
 | <a name="input_apm_server_tail_sampling_storage_limit"></a> [apm\_server\_tail\_sampling\_storage\_limit](#input\_apm\_server\_tail\_sampling\_storage\_limit) | Storage size limit of APM Server tail-based sampling. Defaults to 10GB | `string` | `"10GB"` | no |
+| <a name="input_apm_volume_size"></a> [apm\_volume\_size](#input\_apm\_volume\_size) | Optional apm server volume size in GB override | `number` | n/a | yes |
+| <a name="input_apm_volume_type"></a> [apm\_volume\_type](#input\_apm\_volume\_type) | Optional apm server volume type override | `string` | n/a | yes |
 | <a name="input_aws_os"></a> [aws\_os](#input\_aws\_os) | Optional aws EC2 instance OS | `string` | `""` | no |
 | <a name="input_aws_provisioner_key_name"></a> [aws\_provisioner\_key\_name](#input\_aws\_provisioner\_key\_name) | ssh key name to create the aws key pair and remote provision the EC2 instance | `string` | n/a | yes |
 | <a name="input_ea_managed"></a> [ea\_managed](#input\_ea\_managed) | Whether or not install Elastic Agent managed APM Server | `bool` | `false` | no |

--- a/testing/infra/terraform/modules/standalone_apm_server/apm-server.yml.tftpl
+++ b/testing/infra/terraform/modules/standalone_apm_server/apm-server.yml.tftpl
@@ -14,6 +14,8 @@ apm-server:
     tail:
       enabled: ${apm_server_tail_sampling}
       storage_limit: ${apm_server_tail_sampling_storage_limit}
+      policies:
+        - sampling_rate: 0.1
 output:
   elasticsearch:
     hosts: [ ${elasticsearch_url} ]

--- a/testing/infra/terraform/modules/standalone_apm_server/apm-server.yml.tftpl
+++ b/testing/infra/terraform/modules/standalone_apm_server/apm-server.yml.tftpl
@@ -10,7 +10,10 @@ apm-server:
     enabled: true
   pprof:
     enabled: true
-  
+  sampling:
+    tail:
+      enabled: ${apm_server_tail_sampling}
+      storage_limit: ${apm_server_tail_sampling_storage_limit}
 output:
   elasticsearch:
     hosts: [ ${elasticsearch_url} ]

--- a/testing/infra/terraform/modules/standalone_apm_server/elastic-agent.yml.tftpl
+++ b/testing/infra/terraform/modules/standalone_apm_server/elastic-agent.yml.tftpl
@@ -29,6 +29,8 @@ inputs:
         tail:
           enabled: ${apm_server_tail_sampling}
           storage_limit: ${apm_server_tail_sampling_storage_limit}
+          policies:
+            - sampling_rate: 0.1
     logging.level: debug
     logging.to_files: true
     logging.files:

--- a/testing/infra/terraform/modules/standalone_apm_server/elastic-agent.yml.tftpl
+++ b/testing/infra/terraform/modules/standalone_apm_server/elastic-agent.yml.tftpl
@@ -25,6 +25,10 @@ inputs:
       rum:
         enabled: true
       host: '0.0.0.0:${apm_port}'
+      sampling:
+        tail:
+          enabled: ${apm_server_tail_sampling}
+          storage_limit: ${apm_server_tail_sampling_storage_limit}
     logging.level: debug
     logging.to_files: true
     logging.files:

--- a/testing/infra/terraform/modules/standalone_apm_server/main.tf
+++ b/testing/infra/terraform/modules/standalone_apm_server/main.tf
@@ -185,12 +185,14 @@ resource "aws_instance" "apm" {
   provisioner "file" {
     destination = local.conf_path
     content = templatefile(var.ea_managed ? "${path.module}/elastic-agent.yml.tftpl" : "${path.module}/apm-server.yml.tftpl", {
-      elasticsearch_url      = "${var.elasticsearch_url}",
-      elasticsearch_username = "${var.elasticsearch_username}",
-      elasticsearch_password = "${var.elasticsearch_password}",
-      apm_version            = "${var.stack_version}"
-      apm_secret_token       = "${random_password.apm_secret_token.result}"
-      apm_port               = "${local.apm_port}"
+      elasticsearch_url                      = "${var.elasticsearch_url}",
+      elasticsearch_username                 = "${var.elasticsearch_username}",
+      elasticsearch_password                 = "${var.elasticsearch_password}",
+      apm_version                            = "${var.stack_version}"
+      apm_secret_token                       = "${random_password.apm_secret_token.result}"
+      apm_port                               = "${local.apm_port}"
+      apm_server_tail_sampling               = "${var.apm_server_tail_sampling}"
+      apm_server_tail_sampling_storage_limit = "${var.apm_server_tail_sampling_storage_limit}"
     })
   }
 

--- a/testing/infra/terraform/modules/standalone_apm_server/main.tf
+++ b/testing/infra/terraform/modules/standalone_apm_server/main.tf
@@ -169,6 +169,11 @@ resource "aws_instance" "apm" {
   key_name               = aws_key_pair.provisioner_key.key_name
   monitoring             = false
 
+  root_block_device {
+    volume_type = var.apm_volume_type
+    volume_size = var.apm_volume_size
+  }
+
   connection {
     type        = "ssh"
     user        = local.image_ssh_users[var.aws_os]

--- a/testing/infra/terraform/modules/standalone_apm_server/variables.tf
+++ b/testing/infra/terraform/modules/standalone_apm_server/variables.tf
@@ -7,7 +7,17 @@ variable "aws_os" {
 variable "apm_instance_type" {
   default     = ""
   type        = string
-  description = "Optional apm server instance type overide"
+  description = "Optional apm server instance type override"
+}
+
+variable "apm_volume_type" {
+  type        = string
+  description = "Optional apm server volume type override"
+}
+
+variable "apm_volume_size" {
+  type        = number
+  description = "Optional apm server volume size in GB override"
 }
 
 variable "vpc_id" {

--- a/testing/infra/terraform/modules/standalone_apm_server/variables.tf
+++ b/testing/infra/terraform/modules/standalone_apm_server/variables.tf
@@ -54,3 +54,15 @@ variable "apm_server_bin_path" {
   type        = string
   description = "Optionally use the apm-server binary from the specified path instead"
 }
+
+variable "apm_server_tail_sampling" {
+  default     = false
+  description = "Whether or not to enable APM Server tail-based sampling. Defaults to false"
+  type        = bool
+}
+
+variable "apm_server_tail_sampling_storage_limit" {
+  default     = "10GB"
+  description = "Storage size limit of APM Server tail-based sampling. Defaults to 10GB"
+  type        = string
+}

--- a/testing/infra/terraform/modules/standalone_apm_server/variables.tf
+++ b/testing/infra/terraform/modules/standalone_apm_server/variables.tf
@@ -11,11 +11,13 @@ variable "apm_instance_type" {
 }
 
 variable "apm_volume_type" {
+  default     = null
   type        = string
   description = "Optional apm server volume type override"
 }
 
 variable "apm_volume_size" {
+  default     = null
   type        = number
   description = "Optional apm server volume size in GB override"
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Support TBS in testing/infra/terraform/modules/standalone_apm_server

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

Run `testing/benchmark` with tfvars
```
apm_server_tail_sampling = true
apm_server_tail_sampling_storage_limit = "30GB"
run_standalone = true
standalone_apm_server_instance_size = "c6id.2xlarge"
worker_instance_type = "c6i.4xlarge"
standalone_apm_server_volume_type = "gp3"
standalone_apm_server_volume_size = 40
```

Output should contain a non-zero tbs_lsm_size e.g.
```
BenchmarkAgentAll-512        871         163274501 ns/op                 0 error_responses/sec        2205 errors/sec        19059 events/sec          995.0 gc_cycles        1049 max_goroutines        937528464 max_heap_alloc          4870724 max_heap_objects     1078747136 max_rss              22.21 mean_available_indexers            16854 metrics/sec           0 spans/sec      30967789 tbs_lsm_size  148710064 tbs_vlog_size                 0 txs/sec      436651105 B/op   4260866 allocs/op
```

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->

Follow up to https://github.com/elastic/apm-server/pull/14985

Meta issue https://github.com/elastic/apm-server/issues/14931
