### PR TITLE
functionaltests: handle terraform output errors

### DIFF
--- a/functionaltests/8_15_test.go
+++ b/functionaltests/8_15_test.go
@@ -40,7 +40,7 @@ func TestUpgrade_8_15_4_to_8_16_0(t *testing.T) {
 	start := time.Now()
 	ctx := context.Background()
 
-	t.Log("creating deploment with terraform")
+	t.Log("creating deployment with terraform")
 	tf, err := terraform.New(t, t.Name())
 	require.NoError(t, err)
 	ecTarget := terraform.Var("ec_target", *target)
@@ -60,11 +60,16 @@ func TestUpgrade_8_15_4_to_8_16_0(t *testing.T) {
 	})
 
 	var escfg esclient.Config
-	tf.Output("apm_url", &escfg.APMServerURL)
-	tf.Output("es_url", &escfg.ElasticsearchURL)
-	tf.Output("username", &escfg.Username)
-	tf.Output("password", &escfg.Password)
-	tf.Output("kb_url", &escfg.KibanaURL)
+	err = tf.Output("apm_url", &escfg.APMServerURL)
+	require.NoError(t, err)
+	err = tf.Output("es_url", &escfg.ElasticsearchURL)
+	require.NoError(t, err)
+	err = tf.Output("username", &escfg.Username)
+	require.NoError(t, err)
+	err = tf.Output("password", &escfg.Password)
+	require.NoError(t, err)
+	err = tf.Output("kb_url", &escfg.KibanaURL)
+	require.NoError(t, err)
 
 	t.Logf("created deployment %s", escfg.KibanaURL)
 

--- a/functionaltests/internal/terraform/runner.go
+++ b/functionaltests/internal/terraform/runner.go
@@ -84,7 +84,10 @@ func (t *Runner) Destroy(ctx context.Context, vars ...tfexec.DestroyOption) erro
 }
 
 func (t *Runner) Output(name string, res any) error {
-	o := t.outputs[name]
+	o, ok := t.outputs[name]
+	if !ok {
+		return fmt.Errorf("output named %s not found", name)
+	}
 	if err := json.Unmarshal(o.Value, res); err != nil {
 		return fmt.Errorf("cannot unmarshal output: %w", err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Code in functionaltests relying on `terraform.Runner.Output()` was not checking errors. If for any reason the output
value is wrong and the function returns an error this was ignored and the test would proceed, failing at a later
stage with ambiguous errors.

Add a clarifying error if the requested output name is not available from the Terraform outputs.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->
Run the functionaltests. I tested it locally.

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
