### PR TITLE
mergify: remove backport-8.x enforcement

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -174,20 +174,9 @@ pull_request_rules:
           branches, such as:
           * `backport-7.17` is the label to automatically backport to the 7.17 branch.
           * `backport-8./d` is the label to automatically backport to the `8./d` branch. `/d` is the digit.
+          * `backport-9./d` is the label to automatically backport to the `9./d` branch. `/d` is the digit.
           * `backport-8.x` is the label to automatically backport to the `8.x` branch.
 
-  - name: add backport-8.x for the all the PRs targeting main if no skipped or assigned already
-    conditions:
-      - -label~=^(backport-skip|backport-8.x)$
-      - base=main
-    actions:
-      comment:
-        message: |
-          `backport-8.x` has been added to help with the transition to the new branch `8.x`.
-          If you don't need it please use `backport-skip` label.
-      label:
-        add:
-          - backport-8.x
   - name: remove backport-skip label
     conditions:
       - label~=^backport-\d


### PR DESCRIPTION
## Motivation/summary

No more enforcement to 8.x and main parity; 9.0 is becoming a thing
## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
