### PR TITLE
TBS: make storage_limit follow processor lifecycle; update TBS processor config

### DIFF
--- a/x-pack/apm-server/main.go
+++ b/x-pack/apm-server/main.go
@@ -147,7 +147,7 @@ func newTailSamplingProcessor(args beater.ServerParams) (*sampling.Processor, er
 		},
 		StorageConfig: sampling.StorageConfig{
 			DB:                    db,
-			Storage:               db.NewReadWriter(),
+			Storage:               db.NewStorageLimitReadWriter(tailSamplingConfig.StorageLimitParsed),
 			StorageLimit:          tailSamplingConfig.StorageLimitParsed,
 			TTL:                   tailSamplingConfig.TTL,
 			DiscardOnWriteFailure: tailSamplingConfig.DiscardOnWriteFailure,

--- a/x-pack/apm-server/main.go
+++ b/x-pack/apm-server/main.go
@@ -147,7 +147,7 @@ func newTailSamplingProcessor(args beater.ServerParams) (*sampling.Processor, er
 		},
 		StorageConfig: sampling.StorageConfig{
 			DB:                    db,
-			Storage:               db.NewStorageLimitReadWriter(tailSamplingConfig.StorageLimitParsed),
+			Storage:               db.NewReadWriter(tailSamplingConfig.StorageLimitParsed),
 			TTL:                   tailSamplingConfig.TTL,
 			DiscardOnWriteFailure: tailSamplingConfig.DiscardOnWriteFailure,
 		},

--- a/x-pack/apm-server/main.go
+++ b/x-pack/apm-server/main.go
@@ -148,7 +148,6 @@ func newTailSamplingProcessor(args beater.ServerParams) (*sampling.Processor, er
 		StorageConfig: sampling.StorageConfig{
 			DB:                    db,
 			Storage:               db.NewStorageLimitReadWriter(tailSamplingConfig.StorageLimitParsed),
-			StorageLimit:          tailSamplingConfig.StorageLimitParsed,
 			TTL:                   tailSamplingConfig.TTL,
 			DiscardOnWriteFailure: tailSamplingConfig.DiscardOnWriteFailure,
 		},

--- a/x-pack/apm-server/sampling/config.go
+++ b/x-pack/apm-server/sampling/config.go
@@ -238,6 +238,9 @@ func (config StorageConfig) validate() error {
 	if config.DB == nil {
 		return errors.New("DB unspecified")
 	}
+	if config.Storage == nil {
+		return errors.New("Storage unspecified")
+	}
 	if config.TTL <= 0 {
 		return errors.New("TTL unspecified or negative")
 	}

--- a/x-pack/apm-server/sampling/config.go
+++ b/x-pack/apm-server/sampling/config.go
@@ -108,9 +108,6 @@ type StorageConfig struct {
 	// Storage is the read writer to DB.
 	Storage eventstorage.RW
 
-	// StorageLimit for the TBS database, in bytes.
-	StorageLimit uint64
-
 	// TTL holds the amount of time before events and sampling decisions
 	// are expired from local storage.
 	TTL time.Duration

--- a/x-pack/apm-server/sampling/config_test.go
+++ b/x-pack/apm-server/sampling/config_test.go
@@ -73,6 +73,9 @@ func TestNewProcessorConfigInvalid(t *testing.T) {
 	assertInvalidConfigError("invalid storage config: DB unspecified")
 	config.DB = &eventstorage.StorageManager{}
 
+	assertInvalidConfigError("invalid storage config: Storage unspecified")
+	config.Storage = &eventstorage.SplitReadWriter{}
+
 	assertInvalidConfigError("invalid storage config: TTL unspecified or negative")
 	config.TTL = 1
 }

--- a/x-pack/apm-server/sampling/eventstorage/rw.go
+++ b/x-pack/apm-server/sampling/eventstorage/rw.go
@@ -62,15 +62,36 @@ type storageLimitChecker interface {
 	StorageLimit() uint64
 }
 
+type storageLimitCheckerFunc struct {
+	diskUsage, storageLimit func() uint64
+}
+
+func NewStorageLimitCheckerFunc(diskUsage, storageLimit func() uint64) storageLimitCheckerFunc {
+	return storageLimitCheckerFunc{
+		diskUsage:    diskUsage,
+		storageLimit: storageLimit,
+	}
+}
+
+func (f storageLimitCheckerFunc) DiskUsage() uint64 {
+	return f.diskUsage()
+}
+
+func (f storageLimitCheckerFunc) StorageLimit() uint64 {
+	return f.storageLimit()
+}
+
 // StorageLimitReadWriter is a RW that forbids Write* method calls based on disk usage and limit from storageLimitChecker.
 // If there is no limit or limit is not reached, method calls are passed through to nextRW.
 type StorageLimitReadWriter struct {
+	name    string
 	checker storageLimitChecker
 	nextRW  RW
 }
 
-func NewStorageLimitReadWriter(checker storageLimitChecker, nextRW RW) StorageLimitReadWriter {
+func NewStorageLimitReadWriter(name string, checker storageLimitChecker, nextRW RW) StorageLimitReadWriter {
 	return StorageLimitReadWriter{
+		name:    name,
 		checker: checker,
 		nextRW:  nextRW,
 	}
@@ -81,7 +102,7 @@ func (s StorageLimitReadWriter) checkStorageLimit() error {
 	if limit != 0 { // unlimited storage
 		usage := s.checker.DiskUsage()
 		if usage >= limit {
-			return fmt.Errorf("%w (current: %d, limit %d)", ErrLimitReached, usage, limit)
+			return fmt.Errorf("%s: %w (current: %d, limit %d)", s.name, ErrLimitReached, usage, limit)
 		}
 	}
 	return nil

--- a/x-pack/apm-server/sampling/eventstorage/rw_test.go
+++ b/x-pack/apm-server/sampling/eventstorage/rw_test.go
@@ -79,7 +79,7 @@ func TestStorageLimitReadWriter(t *testing.T) {
 		t.Run(fmt.Sprintf("limit=%d,usage=%d", tt.limit, tt.usage), func(t *testing.T) {
 			checker := mockChecker{limit: tt.limit, usage: tt.usage}
 			var callCount int
-			rw := eventstorage.NewStorageLimitReadWriter(checker, mockRW{
+			rw := eventstorage.NewStorageLimitReadWriter("foo_storage_limiter", checker, mockRW{
 				callback: func() {
 					callCount++
 				},

--- a/x-pack/apm-server/sampling/eventstorage/storage_bench_test.go
+++ b/x-pack/apm-server/sampling/eventstorage/storage_bench_test.go
@@ -18,7 +18,7 @@ import (
 func BenchmarkWriteTransaction(b *testing.B) {
 	test := func(b *testing.B, codec eventstorage.Codec, bigTX bool) {
 		sm := newStorageManager(b, eventstorage.WithCodec(codec))
-		readWriter := sm.NewReadWriter()
+		readWriter := sm.NewUnlimitedReadWriter()
 
 		traceID := hex.EncodeToString([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
 		transactionID := hex.EncodeToString([]byte{1, 2, 3, 4, 5, 6, 7, 8})
@@ -79,7 +79,7 @@ func BenchmarkReadEvents(b *testing.B) {
 		for _, count := range counts {
 			b.Run(fmt.Sprintf("%d events", count), func(b *testing.B) {
 				sm := newStorageManager(b, eventstorage.WithCodec(codec))
-				readWriter := sm.NewReadWriter()
+				readWriter := sm.NewUnlimitedReadWriter()
 
 				for i := 0; i < count; i++ {
 					transactionID := uuid.Must(uuid.NewV4()).String()
@@ -154,7 +154,7 @@ func BenchmarkReadEventsHit(b *testing.B) {
 		for _, hit := range []bool{false, true} {
 			b.Run(fmt.Sprintf("hit=%v", hit), func(b *testing.B) {
 				sm := newStorageManager(b)
-				readWriter := sm.NewReadWriter()
+				readWriter := sm.NewUnlimitedReadWriter()
 
 				traceIDs := make([]string, b.N)
 
@@ -185,7 +185,7 @@ func BenchmarkReadEventsHit(b *testing.B) {
 					}
 				}
 
-				readWriter = sm.NewReadWriter()
+				readWriter = sm.NewUnlimitedReadWriter()
 
 				b.ResetTimer()
 				var batch modelpb.Batch
@@ -224,7 +224,7 @@ func BenchmarkIsTraceSampled(b *testing.B) {
 
 	// Test with varying numbers of events in the trace.
 	sm := newStorageManager(b)
-	readWriter := sm.NewReadWriter()
+	readWriter := sm.NewUnlimitedReadWriter()
 
 	if err := readWriter.WriteTraceSampled(sampledTraceUUID.String(), true); err != nil {
 		b.Fatal(err)

--- a/x-pack/apm-server/sampling/eventstorage/storage_manager.go
+++ b/x-pack/apm-server/sampling/eventstorage/storage_manager.go
@@ -46,14 +46,6 @@ const (
 
 	// diskUsageFetchInterval is how often disk usage is fetched which is equivalent to how long disk usage is cached.
 	diskUsageFetchInterval = 1 * time.Second
-
-	// diskThresholdRatio controls the proportion of the disk to be filled at max, irrespective of db size.
-	// e.g. 0.9 means the last 10% of disk should not be written to.
-	diskThresholdRatio = 0.9
-
-	// dbStorageLimitFallback is the default fallback storage limit in bytes
-	// that applies when disk threshold cannot be enforced due to an error.
-	dbStorageLimitFallback = 5 << 30
 )
 
 type StorageManagerOptions func(*StorageManager)
@@ -68,10 +60,6 @@ func WithMeterProvider(mp metric.MeterProvider) StorageManagerOptions {
 	return func(sm *StorageManager) {
 		sm.meterProvider = mp
 	}
-}
-
-type diskStat struct {
-	used, total atomic.Uint64
 }
 
 // StorageManager encapsulates pebble.DB.

--- a/x-pack/apm-server/sampling/eventstorage/storage_manager.go
+++ b/x-pack/apm-server/sampling/eventstorage/storage_manager.go
@@ -341,11 +341,11 @@ func (sm *StorageManager) WriteSubscriberPosition(data []byte) error {
 // NewUnlimitedReadWriter returns a read writer with no storage limit.
 // For testing only.
 func (sm *StorageManager) NewUnlimitedReadWriter() StorageLimitReadWriter {
-	return sm.NewStorageLimitReadWriter(0)
+	return sm.NewReadWriter(0)
 }
 
-// NewStorageLimitReadWriter returns a read writer with storage limit.
-func (sm *StorageManager) NewStorageLimitReadWriter(storageLimit uint64) StorageLimitReadWriter {
+// NewReadWriter returns a read writer with storage limit.
+func (sm *StorageManager) NewReadWriter(storageLimit uint64) StorageLimitReadWriter {
 	splitRW := SplitReadWriter{
 		eventRW:    sm.eventStorage.NewReadWriter(),
 		decisionRW: sm.decisionStorage.NewReadWriter(),

--- a/x-pack/apm-server/sampling/eventstorage/storage_manager.go
+++ b/x-pack/apm-server/sampling/eventstorage/storage_manager.go
@@ -355,14 +355,14 @@ func (sm *StorageManager) NewStorageLimitReadWriter(storageLimit uint64) Storage
 		return storageLimit
 	}
 	if storageLimit == 0 {
-		sm.logger.Infof("setting storage_limit to unlimited")
+		sm.logger.Infof("setting database storage limit to unlimited")
 	} else {
-		sm.logger.Infof("setting storage_limit to %.1fgb", float64(storageLimit))
+		sm.logger.Infof("setting database storage limit to %.1fgb", float64(storageLimit))
 	}
 
 	// To limit db size to storage_limit
 	dbStorageLimitChecker := NewStorageLimitCheckerFunc(sm.dbSize, dbStorageLimit)
-	dbStorageLimitRW := NewStorageLimitReadWriter("storage_limit", dbStorageLimitChecker, splitRW)
+	dbStorageLimitRW := NewStorageLimitReadWriter("database storage limit", dbStorageLimitChecker, splitRW)
 
 	return dbStorageLimitRW
 }

--- a/x-pack/apm-server/sampling/eventstorage/storage_manager_bench_test.go
+++ b/x-pack/apm-server/sampling/eventstorage/storage_manager_bench_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func BenchmarkStorageManager_DiskUsage(b *testing.B) {
+func BenchmarkStorageManager_Size(b *testing.B) {
 	stopping := make(chan struct{})
 	defer close(stopping)
 	sm := newStorageManager(b)
-	go sm.Run(stopping, time.Second, 0)
-	rw := sm.NewReadWriter()
+	go sm.Run(stopping, time.Second)
+	rw := sm.NewUnlimitedReadWriter()
 	for i := 0; i < 1000; i++ {
 		traceID := uuid.Must(uuid.NewV4()).String()
 		txnID := uuid.Must(uuid.NewV4()).String()
@@ -29,7 +29,7 @@ func BenchmarkStorageManager_DiskUsage(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = sm.DiskUsage()
+		_, _ = sm.Size()
 	}
 	b.StopTimer()
 }

--- a/x-pack/apm-server/sampling/eventstorage/storage_manager_test.go
+++ b/x-pack/apm-server/sampling/eventstorage/storage_manager_test.go
@@ -32,7 +32,7 @@ func newStorageManagerNoCleanup(tb testing.TB, path string, opts ...eventstorage
 
 func TestStorageManager_samplingDecisionTTL(t *testing.T) {
 	sm := newStorageManager(t)
-	rw := sm.NewReadWriter()
+	rw := sm.NewUnlimitedReadWriter()
 	traceID := uuid.Must(uuid.NewV4()).String()
 	err := rw.WriteTraceSampled(traceID, true)
 	assert.NoError(t, err)
@@ -65,7 +65,7 @@ func TestStorageManager_samplingDecisionTTL(t *testing.T) {
 
 func TestStorageManager_eventTTL(t *testing.T) {
 	sm := newStorageManager(t)
-	rw := sm.NewReadWriter()
+	rw := sm.NewUnlimitedReadWriter()
 	traceID := uuid.Must(uuid.NewV4()).String()
 	txnID1 := uuid.Must(uuid.NewV4()).String()
 	txn1 := makeTransaction(txnID1, traceID)
@@ -119,7 +119,7 @@ func TestStorageManager_partitionID(t *testing.T) {
 	assert.NoError(t, sm.RotatePartitions())
 
 	// write to partition 1
-	err := sm.NewReadWriter().WriteTraceSampled(traceID, true)
+	err := sm.NewUnlimitedReadWriter().WriteTraceSampled(traceID, true)
 	assert.NoError(t, err)
 
 	assert.NoError(t, sm.Close())
@@ -127,7 +127,7 @@ func TestStorageManager_partitionID(t *testing.T) {
 	// it should read directly from partition 1 on startup instead of 0
 	sm = newStorageManagerNoCleanup(t, tmpDir)
 	defer sm.Close()
-	sampled, err := sm.NewReadWriter().IsTraceSampled(traceID)
+	sampled, err := sm.NewUnlimitedReadWriter().IsTraceSampled(traceID)
 	assert.NoError(t, err)
 	assert.True(t, sampled)
 }
@@ -136,29 +136,36 @@ func TestStorageManager_DiskUsage(t *testing.T) {
 	stopping := make(chan struct{})
 	defer close(stopping)
 	sm := newStorageManager(t)
-	go sm.Run(stopping, time.Second, 0)
-	old := sm.DiskUsage()
+	go sm.Run(stopping, time.Second)
 
-	err := sm.NewReadWriter().WriteTraceSampled("foo", true)
+	lsm, vlog := sm.Size()
+	oldSize := lsm + vlog
+
+	err := sm.NewUnlimitedReadWriter().WriteTraceSampled("foo", true)
 	require.NoError(t, err)
 
 	err = sm.Flush()
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
-		return sm.DiskUsage() > old
+		lsm, vlog := sm.Size()
+		newSize := lsm + vlog
+		return newSize > oldSize
 	}, 10*time.Second, 100*time.Millisecond)
 
-	old = sm.DiskUsage()
+	lsm, vlog = sm.Size()
+	oldSize = lsm + vlog
 
-	err = sm.NewReadWriter().WriteTraceEvent("foo", "bar", makeTransaction("bar", "foo"))
+	err = sm.NewUnlimitedReadWriter().WriteTraceEvent("foo", "bar", makeTransaction("bar", "foo"))
 	require.NoError(t, err)
 
 	err = sm.Flush()
 	require.NoError(t, err)
 
 	assert.Eventually(t, func() bool {
-		return sm.DiskUsage() > old
+		lsm, vlog := sm.Size()
+		newSize := lsm + vlog
+		return newSize > oldSize
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
@@ -167,9 +174,35 @@ func TestStorageManager_Run(t *testing.T) {
 	stopping := make(chan struct{})
 	sm := newStorageManager(t)
 	go func() {
-		assert.NoError(t, sm.Run(stopping, time.Second, 0))
+		assert.NoError(t, sm.Run(stopping, time.Second))
 		close(done)
 	}()
+	close(stopping)
+	<-done
+}
+
+func TestStorageManager_StorageLimit(t *testing.T) {
+	done := make(chan struct{})
+	stopping := make(chan struct{})
+	sm := newStorageManager(t)
+	go func() {
+		assert.NoError(t, sm.Run(stopping, time.Second))
+		close(done)
+	}()
+	require.NoError(t, sm.Flush())
+	lsm, _ := sm.Size()
+	assert.Greater(t, lsm, int64(1))
+
+	traceID := uuid.Must(uuid.NewV4()).String()
+	txnID := uuid.Must(uuid.NewV4()).String()
+	txn := makeTransaction(txnID, traceID)
+
+	small := sm.NewStorageLimitReadWriter(1)
+	assert.ErrorIs(t, small.WriteTraceEvent(traceID, txnID, txn), eventstorage.ErrLimitReached)
+
+	big := sm.NewStorageLimitReadWriter(10 << 10)
+	assert.NoError(t, big.WriteTraceEvent(traceID, txnID, txn))
+
 	close(stopping)
 	<-done
 }

--- a/x-pack/apm-server/sampling/eventstorage/storage_manager_test.go
+++ b/x-pack/apm-server/sampling/eventstorage/storage_manager_test.go
@@ -197,10 +197,10 @@ func TestStorageManager_StorageLimit(t *testing.T) {
 	txnID := uuid.Must(uuid.NewV4()).String()
 	txn := makeTransaction(txnID, traceID)
 
-	small := sm.NewStorageLimitReadWriter(1)
+	small := sm.NewReadWriter(1)
 	assert.ErrorIs(t, small.WriteTraceEvent(traceID, txnID, txn), eventstorage.ErrLimitReached)
 
-	big := sm.NewStorageLimitReadWriter(10 << 10)
+	big := sm.NewReadWriter(10 << 10)
 	assert.NoError(t, big.WriteTraceEvent(traceID, txnID, txn))
 
 	close(stopping)

--- a/x-pack/apm-server/sampling/processor.go
+++ b/x-pack/apm-server/sampling/processor.go
@@ -345,7 +345,7 @@ func (p *Processor) Run() error {
 		}
 	})
 	g.Go(func() error {
-		return p.config.DB.Run(p.stopping, p.config.TTL, p.config.StorageLimit)
+		return p.config.DB.Run(p.stopping, p.config.TTL)
 	})
 	g.Go(func() error {
 		// Subscribe to remotely sampled trace IDs. This is cancelled immediately when

--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -685,8 +685,7 @@ func TestStorageLimit(t *testing.T) {
 	lsm, vlog := config.DB.Size()
 	assert.Greater(t, lsm+vlog, int64(10<<10))
 
-	config.StorageLimit = 10 << 10 // Set the storage limit to smaller than existing storage
-	config.Storage = config.DB.NewStorageLimitReadWriter(config.StorageLimit)
+	config.Storage = config.DB.NewStorageLimitReadWriter(10 << 10) // Set the storage limit to smaller than existing storage
 
 	writeBatch(1000, config, func(b modelpb.Batch) {
 		assert.Len(t, b, 1000)
@@ -814,10 +813,9 @@ func newTempdirConfig(tb testing.TB) testConfig {
 				UUID: "local-apm-server",
 			},
 			StorageConfig: sampling.StorageConfig{
-				DB:           db,
-				Storage:      db.NewUnlimitedReadWriter(),
-				TTL:          30 * time.Minute,
-				StorageLimit: 0, // No storage limit.
+				DB:      db,
+				Storage: db.NewUnlimitedReadWriter(),
+				TTL:     30 * time.Minute,
 			},
 		},
 	}

--- a/x-pack/apm-server/sampling/processor_test.go
+++ b/x-pack/apm-server/sampling/processor_test.go
@@ -685,7 +685,7 @@ func TestStorageLimit(t *testing.T) {
 	lsm, vlog := config.DB.Size()
 	assert.Greater(t, lsm+vlog, int64(10<<10))
 
-	config.Storage = config.DB.NewStorageLimitReadWriter(10 << 10) // Set the storage limit to smaller than existing storage
+	config.Storage = config.DB.NewReadWriter(10 << 10) // Set the storage limit to smaller than existing storage
 
 	writeBatch(1000, config, func(b modelpb.Batch) {
 		assert.Len(t, b, 1000)


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
Fix a regression from #15235 where storage_limit does not follow processor lifecycle.
Remove storage limit from processor config.
Add storage to processor config validation.

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

~~- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)~~ Fixing a regression from an unreleased change
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->
Should be tested along #15235 . Ensure that EA hot reload applies the new storage limit by changing the integration policy.

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
