### PR TITLE
[DOCS] Removes link to master

### DIFF
--- a/docs/guide/apm-release-notes.asciidoc
+++ b/docs/guide/apm-release-notes.asciidoc
@@ -144,7 +144,7 @@ Inferred spans with async profiler::
 
 Identifying a problematic service is only half of the battle when diagnosing application slowdowns.
 The Elastic APM Java Agent provides a new way to get method-level insights into your code:
-https://www.elastic.co/guide/en/apm/agent/java/master/java-method-monitoring.html[inferred spans with async-profiler].
+{apm-java-ref}/java-method-monitoring.html[inferred spans with async-profiler]
 This can help you diagnose slow requests due to heavy computations, inefficient algorithms,
 or similar problems not related to interactions between services.
 // end::notable-v77-highlights[]

--- a/docs/guide/apm-release-notes.asciidoc
+++ b/docs/guide/apm-release-notes.asciidoc
@@ -144,7 +144,7 @@ Inferred spans with async profiler::
 
 Identifying a problematic service is only half of the battle when diagnosing application slowdowns.
 The Elastic APM Java Agent provides a new way to get method-level insights into your code:
-{apm-java-ref}/java-method-monitoring.html[inferred spans with async-profiler]
+{apm-java-ref}/java-method-monitoring.html[inferred spans with async-profiler].
 This can help you diagnose slow requests due to heavy computations, inefficient algorithms,
 or similar problems not related to interactions between services.
 // end::notable-v77-highlights[]


### PR DESCRIPTION
## Motivation/summary

Relates to https://github.com/elastic/docs/pull/3160

This PR fixes the following broken link:

```
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/get-started/7.8/release-highlights-7.7.0.html contains broken links to:
--
  | INFO:build_docs:   - en/apm/agent/java/master/java-method-monitoring.html
```

## Checklist

- [x] Documentation has been updated
