### PR TITLE
fix: always use background context to update metrics

### DIFF
--- a/internal/model/modelprocessor/eventcounter.go
+++ b/internal/model/modelprocessor/eventcounter.go
@@ -55,7 +55,7 @@ func NewEventCounter(mp metric.MeterProvider) *EventCounter {
 // ProcessBatch counts events in b, grouping by APMEvent.Processor.Event.
 func (c *EventCounter) ProcessBatch(ctx context.Context, b *modelpb.Batch) error {
 	for _, event := range *b {
-		c.eventCounters[event.Type()].Add(ctx, 1)
+		c.eventCounters[event.Type()].Add(context.Background(), 1)
 	}
 	return nil
 }

--- a/x-pack/apm-server/sampling/processor.go
+++ b/x-pack/apm-server/sampling/processor.go
@@ -105,11 +105,11 @@ func (p *Processor) ProcessBatch(ctx context.Context, batch *modelpb.Batch) erro
 		var err error
 		switch event.Type() {
 		case modelpb.TransactionEventType:
-			p.eventMetrics.processed.Add(ctx, 1)
-			report, stored, err = p.processTransaction(ctx, event)
+			p.eventMetrics.processed.Add(context.Background(), 1)
+			report, stored, err = p.processTransaction(event)
 		case modelpb.SpanEventType:
-			p.eventMetrics.processed.Add(ctx, 1)
-			report, stored, err = p.processSpan(ctx, event)
+			p.eventMetrics.processed.Add(context.Background(), 1)
+			report, stored, err = p.processSpan(event)
 		default:
 			continue
 		}
@@ -136,18 +136,18 @@ func (p *Processor) ProcessBatch(ctx context.Context, batch *modelpb.Batch) erro
 			i--
 		}
 
-		p.updateProcessorMetrics(ctx, report, stored, failed)
+		p.updateProcessorMetrics(report, stored, failed)
 	}
 	*batch = events
 	return nil
 }
 
-func (p *Processor) updateProcessorMetrics(ctx context.Context, report, stored, failedWrite bool) {
+func (p *Processor) updateProcessorMetrics(report, stored, failedWrite bool) {
 	if failedWrite {
-		p.eventMetrics.failedWrites.Add(ctx, 1)
+		p.eventMetrics.failedWrites.Add(context.Background(), 1)
 	}
 	if stored {
-		p.eventMetrics.stored.Add(ctx, 1)
+		p.eventMetrics.stored.Add(context.Background(), 1)
 	} else if !report {
 		// We only increment the "dropped" counter if
 		// we neither reported nor stored the event, so
@@ -158,15 +158,15 @@ func (p *Processor) updateProcessorMetrics(ctx context.Context, report, stored, 
 		// The counter does not include events that are
 		// implicitly dropped, i.e. stored and never
 		// indexed.
-		p.eventMetrics.dropped.Add(ctx, 1)
+		p.eventMetrics.dropped.Add(context.Background(), 1)
 	}
 }
 
-func (p *Processor) processTransaction(ctx context.Context, event *modelpb.APMEvent) (report, stored bool, _ error) {
+func (p *Processor) processTransaction(event *modelpb.APMEvent) (report, stored bool, _ error) {
 	if !event.Transaction.Sampled {
 		// (Head-based) unsampled transactions are passed through
 		// by the tail sampler.
-		p.eventMetrics.headUnsampled.Add(ctx, 1)
+		p.eventMetrics.headUnsampled.Add(context.Background(), 1)
 		return true, false, nil
 	}
 
@@ -177,7 +177,7 @@ func (p *Processor) processTransaction(ctx context.Context, event *modelpb.APMEv
 		// if it was sampled.
 		report := traceSampled
 		if report {
-			p.eventMetrics.sampled.Add(ctx, 1)
+			p.eventMetrics.sampled.Add(context.Background(), 1)
 		}
 		return report, false, nil
 	case eventstorage.ErrNotFound:
@@ -229,7 +229,7 @@ sampling policies without service name specified.
 	return false, true, p.eventStore.WriteTraceEvent(event.Trace.Id, event.Transaction.Id, event)
 }
 
-func (p *Processor) processSpan(ctx context.Context, event *modelpb.APMEvent) (report, stored bool, _ error) {
+func (p *Processor) processSpan(event *modelpb.APMEvent) (report, stored bool, _ error) {
 	traceSampled, err := p.eventStore.IsTraceSampled(event.Trace.Id)
 	if err != nil {
 		if err == eventstorage.ErrNotFound {
@@ -240,7 +240,7 @@ func (p *Processor) processSpan(ctx context.Context, event *modelpb.APMEvent) (r
 	}
 	// Tail-sampling decision has been made, report or drop the event.
 	if traceSampled {
-		p.eventMetrics.sampled.Add(ctx, 1)
+		p.eventMetrics.sampled.Add(context.Background(), 1)
 	}
 	return traceSampled, false, nil
 }


### PR DESCRIPTION
## Motivation/summary

propagating the request context means the metric might not be updated if the context is done

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
