### PR TITLE
feat(fips): use xxhash for error grouping key in fips mode

### DIFF
--- a/internal/beater/beater.go
+++ b/internal/beater/beater.go
@@ -19,7 +19,6 @@ package beater
 
 import (
 	"context"
-	"crypto/md5"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -479,7 +478,7 @@ func (s *Runner) Run(ctx context.Context) error {
 		modelprocessor.SetHostHostname{},
 		modelprocessor.SetServiceNodeName{},
 		modelprocessor.SetGroupingKey{
-			NewHash: md5.New,
+			NewHash: groupingKeyHash,
 		},
 		modelprocessor.SetErrorMessage{},
 	}

--- a/internal/beater/groupingkey_fips.go
+++ b/internal/beater/groupingkey_fips.go
@@ -1,0 +1,30 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build requirefips
+
+package beater
+
+import (
+	"hash"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+var groupingKeyHash = func() hash.Hash {
+	return xxhash.New()
+}

--- a/internal/beater/groupingkey_nofips.go
+++ b/internal/beater/groupingkey_nofips.go
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !requirefips
+
+package beater
+
+import (
+	"crypto/md5"
+)
+
+var groupingKeyHash = md5.New


### PR DESCRIPTION
## Motivation/summary

we can't use md5 in a fips environment so switch to xxhash to be consistent with 9.0

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues
closes https://github.com/elastic/apm-server/issues/15840
<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
