### PR TITLE
kibana: add x-elastic-product-origin header to the client

### DIFF
--- a/internal/kibana/client.go
+++ b/internal/kibana/client.go
@@ -41,6 +41,10 @@ type Client struct {
 func NewClient(cfg ClientConfig) (*Client, error) {
 	// Never fetch the Kibana version; we don't use it.
 	cfg.IgnoreVersion = true
+	if cfg.Headers == nil {
+		cfg.Headers = make(map[string]string)
+	}
+	cfg.Headers["X-Elastic-Product-Origin"] = "observability"
 	client, err := kibana.NewClientWithConfig(
 		&cfg, "apm-server",
 		version.VersionWithQualifier(),

--- a/internal/kibana/client_test.go
+++ b/internal/kibana/client_test.go
@@ -92,6 +92,7 @@ func TestClientHeaders(t *testing.T) {
 
 	assert.Equal(t, "Basic dXNlcjpwYXNz", headers.Get("Authorization"))
 	assert.Equal(t, []string{"abc", "123"}, headers.Values("Combined"))
+	assert.Equal(t, "observability", headers.Get("X-Elastic-Product-Origin"))
 }
 
 func TestClientSend(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->

This PR adds `x-elastic-product-origin` to Kibana API client similarly to how it's done for Elasticsearch client in https://github.com/elastic/apm-server/blob/1ea24d2176b2c09abeb5be24d5deabc67da94445/internal/elasticsearch/client.go#L94

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [x] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [x] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
