### PR TITLE
tf: configurable disk iops, GH configurable standalone apm instance size, use NVMe disk if available

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -8,6 +8,10 @@ on:
         required: false
         type: boolean
         default: false
+      standaloneInstanceSize:
+        description: 'AWS instance size of standalone APM Server, e.g. c6i.2xlarge'
+        required: false
+        type: string
       enableTailSampling:
         description: 'Enable tail-based sampling on the APM server'
         required: false
@@ -67,6 +71,7 @@ jobs:
       TF_VAR_private_key: ./id_rsa_terraform
       TF_VAR_public_key: ./id_rsa_terraform.pub
       TF_VAR_run_standalone: ${{ inputs.runStandalone || github.event.schedule=='0 0 1 * *' }}
+      TF_VAR_standalone_apm_server_instance_size: ${{ inputs.standaloneInstanceSize || 'c6i.2xlarge' }}
       TF_VAR_apm_server_tail_sampling: ${{ inputs.enableTailSampling || 'false' }} # set the default again otherwise schedules won't work
       TF_VAR_apm_server_tail_sampling_storage_limit: ${{ inputs.tailSamplingStorageLimit || '10GB' }} # set the default again otherwise schedules won't work
       RUN_STANDALONE: ${{ inputs.runStandalone || github.event.schedule=='0 0 1 * *' }}

--- a/testing/benchmark/main.tf
+++ b/testing/benchmark/main.tf
@@ -157,6 +157,7 @@ module "standalone_apm_server" {
   apm_instance_type   = var.standalone_apm_server_instance_size
   apm_volume_type     = var.standalone_apm_server_volume_type
   apm_volume_size     = var.apm_server_tail_sampling ? coalesce(var.standalone_apm_server_volume_size, 60) : var.standalone_apm_server_volume_size
+  apm_iops            = var.standalone_apm_server_iops
   apm_server_bin_path = var.apm_server_bin_path
   ea_managed          = false
 

--- a/testing/benchmark/variables.tf
+++ b/testing/benchmark/variables.tf
@@ -142,6 +142,12 @@ variable "standalone_apm_server_volume_size" {
   description = "Optional volume size in GB to use for APM Server VM"
 }
 
+variable "standalone_apm_server_iops" {
+  default     = null
+  type        = number
+  description = "Optional disk IOPS in GB to use for APM Server VM"
+}
+
 ## VPC Network settings
 
 variable "vpc_cidr" {

--- a/testing/infra/terraform/modules/standalone_apm_server/main.tf
+++ b/testing/infra/terraform/modules/standalone_apm_server/main.tf
@@ -172,6 +172,7 @@ resource "aws_instance" "apm" {
   root_block_device {
     volume_type = var.apm_volume_type
     volume_size = var.apm_volume_size
+    iops        = var.apm_iops
   }
 
   connection {

--- a/testing/infra/terraform/modules/standalone_apm_server/main.tf
+++ b/testing/infra/terraform/modules/standalone_apm_server/main.tf
@@ -182,6 +182,16 @@ resource "aws_instance" "apm" {
     private_key = file("${var.aws_provisioner_key_name}")
   }
 
+  // For instance types with 'd.' e.g. c6id.2xlarge, use the NVMe ssd as data disk.
+  provisioner "remote-exec" {
+    inline = length(regexall("d[.]", self.instance_type)) > 0 ? [
+      "sudo mkfs -t xfs /dev/nvme1n1",
+      "mkdir ~/data",
+      "sudo mount /dev/nvme1n1 ~/data",
+      "sudo chown $USER:$USER ~/data",
+    ] : []
+  }
+
   provisioner "file" {
     source      = "${var.apm_server_bin_path}/apm-server"
     destination = local.bin_path

--- a/testing/infra/terraform/modules/standalone_apm_server/variables.tf
+++ b/testing/infra/terraform/modules/standalone_apm_server/variables.tf
@@ -22,6 +22,12 @@ variable "apm_volume_size" {
   description = "Optional apm server volume size in GB override"
 }
 
+variable "apm_iops" {
+  default     = null
+  type        = number
+  description = "Optional apm server disk IOPS override"
+}
+
 variable "vpc_id" {
   description = "VPC ID to provision the EC2 instance"
   type        = string


### PR DESCRIPTION
<!-- Thanks for sending a pull request!

If this is your first contribution, please review and sign our contributor agreement -
https://www.elastic.co/contributor-agreement.

Guidelines:
 - Prefer small PRs, and split changes into multiple logical commits where they must
   be delivered in a single PR.
 - If the PR is incomplete and not yet ready for review, open it as a Draft.
 - Once the PR is marked ready for review it is expected to pass all tests and linting,
   and you should not force-push any changes.

See also https://github.com/elastic/apm-server/blob/main/CONTRIBUTING.md for more tips on contributing.
-->

## Motivation/summary

<!--
Describe your change in the title and description, and provide a motivation for the
change and rationale for the approach taken.
-->
- Configurable disk IOPS which is a required field for io2 volume type
- GH configurable standalone apm instance size
- Use NVMe disk for data directory for instance types with `d.`, e.g. c6id.2xlarge

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

<!--
Explain how this PR can be tested by the reviewer: commands, dependencies, steps, etc.
If it is self-explanatory, delete this section.
-->

## Related issues

<!--
Reference the related issue(s), and make use of magic keywords where it makes sense
https://help.github.com/articles/closing-issues-using-keywords/.
-->
