### PR TITLE
release(package): force chmod permissions without write permissions in the groups

### DIFF
--- a/packaging.mk
+++ b/packaging.mk
@@ -162,7 +162,8 @@ $(ARCHIVE_PREFIX)-windows-x86_64 $(ARCHIVE_PREFIX)-SNAPSHOT-windows-x86_64: \
 
 $(ARCHIVE_PREFIX)-%:
 	@rm -fr $@ && mkdir -p $@
-	cp $(filter-out build/apm-server-%, $^) $@
+# the apm-server.yml requires 644 permissions, let's avoid the issues with umask
+	install -m 640 $(filter-out build/apm-server-%, $^) $@
 	cp $(filter build/apm-server-%, $^) $@/apm-server$(suffix $(filter build/apm-server-%, $^))
 
 $(DISTDIR)/%.tar.gz: $(ARCHIVES_DIR)/%


### PR DESCRIPTION
## Motivation/summary

Linux package `apm-server.yml` has incorrect file mode 664, causing an error on startup

## Checklist

<!--
Delete irrelevant items. The changelog should only be updated for user-facing changes.
Once the PR is ready for review there should be no unticked boxes.
-->

- [ ] Update [CHANGELOG.asciidoc](https://github.com/elastic/apm-server/blob/main/CHANGELOG.asciidoc)
- [ ] Documentation has been updated

For functional changes, consider:
- Is it observable through the addition of either **logging** or **metrics**?
- Is its use being published in **telemetry** to enable product improvement?
- Have system tests been added to avoid regression?

## How to test these changes

Download `tar.gz` files from https://buildkite.com/elastic/apm-server-package/builds/4008

Then

```bash
$ ls -l apm-server-9.1.0-linux-arm64
total 129632
-rw-r-----@ 1 vmartinez  staff      3859 Feb  9 14:13 LICENSE.txt
-rw-r-----@ 1 vmartinez  staff    943755 Feb  9 14:13 NOTICE.txt
-rwxrwxr-x@ 1 vmartinez  staff  56754328 Feb  9 14:13 apm-server
-rw-r-----@ 1 vmartinez  staff     39268 Feb  9 14:13 apm-server.yml
-rw-r-----@ 1 vmartinez  staff   8621110 Feb  9 14:13 java-attacher.jar
```

If you compare to what's the current settings in my local with `umask 0022` and `umask 0002`

```
$ wget https://artifacts-staging.elastic.co/apm-server/9.1.0-alpha1-3ac48d47/downloads/apm-server/apm-server-9.1.0-alpha1-linux-arm64.tar.gz
$ tar xvzf apm-server-9.1.0-alpha1-linux-arm64.tar.gz 
$ ls -l apm-server-9.1.0-alpha1-linux-arm64
total 129632
-rw-r--r--  1 vmartinez  wheel      3859 Feb  8 01:14 LICENSE.txt
-rw-r--r--  1 vmartinez  wheel    943755 Feb  8 01:14 NOTICE.txt
-rwxr-xr-x  1 vmartinez  wheel  56754328 Feb  8 01:14 apm-server
-rw-r--r--  1 vmartinez  wheel     39268 Feb  8 01:14 apm-server.yml
-rw-r--r--  1 vmartinez  wheel   8621110 Feb  8 01:14 java-attacher.jar
$ rm -rf apm-server-9.1.0-alpha1-linux-arm64* 
$ umask 0002
$ wget https://artifacts-staging.elastic.co/apm-server/9.1.0-alpha1-3ac48d47/downloads/apm-server/apm-server-9.1.0-alpha1-linux-arm64.tar.gz
$ tar xvzf apm-server-9.1.0-alpha1-linux-arm64.tar.gz 
$ ls -l apm-server-9.1.0-alpha1-linux-arm64  
total 129632
-rw-rw-r--  1 vmartinez  wheel      3859 Feb  8 01:14 LICENSE.txt
-rw-rw-r--  1 vmartinez  wheel    943755 Feb  8 01:14 NOTICE.txt
-rwxrwxr-x  1 vmartinez  wheel  56754328 Feb  8 01:14 apm-server
-rw-rw-r--  1 vmartinez  wheel     39268 Feb  8 01:14 apm-server.yml
-rw-rw-r--  1 vmartinez  wheel   8621110 Feb  8 01:14 java-attacher.jar
```

You can see the file permissions is `640` instead `644` or `664`.

## Related issues

Closes https://github.com/elastic/apm-server/issues/15592